### PR TITLE
feat: cleanup dist directories when dev mode ends

### DIFF
--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import * as fse from "fs-extra";
 import signalExit from "signal-exit";
 import prettyMs from "pretty-ms";
 import WebSocket from "ws";
@@ -75,6 +76,11 @@ export async function watch(
       }
     })
   );
+
+  signalExit(() => {
+    fse.emptyDirSync(config.assetsBuildDirectory);
+    fse.emptyDirSync(config.serverBuildDirectory);
+  });
 
   console.log(`💿 Built in ${prettyMs(Date.now() - start)}`);
 }


### PR DESCRIPTION
Currently we have massive build folders that are left around after a dev server instance is closed. This is due to us writing uniquely hashed files per incremental build. Let's just fully empty the build folders for now.