### PR TITLE
wip: feat: remove `sideEffects: false` requirement

### DIFF
--- a/fixtures/gists-app/package.json
+++ b/fixtures/gists-app/package.json
@@ -36,6 +36,5 @@
   },
   "browserslist": [
     "last 4 version"
-  ],
-  "sideEffects": false
+  ]
 }

--- a/fixtures/tutorial/package.json
+++ b/fixtures/tutorial/package.json
@@ -26,6 +26,5 @@
     "@types/react-dom": "^17.0.0",
     "fs-extra": "^10.0.0",
     "pm2": "^4.5.1"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -132,7 +132,7 @@ export async function watch(
       try {
         [browserBuild, serverBuild] = await buildEverything(config, options);
         if (onRebuildFinish) onRebuildFinish();
-      } catch (err) {
+      } catch (err: any) {
         onBuildFailure(err);
       }
       return;
@@ -456,7 +456,11 @@ function browserRouteModulesPlugin(
       );
 
       build.onResolve({ filter: suffixMatcher }, args => {
-        return { path: args.path, namespace: "browser-route-module" };
+        return {
+          path: args.path,
+          namespace: "browser-route-module",
+          sideEffects: false
+        };
       });
 
       build.onLoad(
@@ -471,7 +475,7 @@ function browserRouteModulesPlugin(
             exports = (
               await getRouteModuleExportsCached(config, route.id)
             ).filter(ex => !!browserSafeRouteExports[ex]);
-          } catch (error) {
+          } catch (error: any) {
             return {
               errors: [
                 {

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "cacache": "^15.0.5",
     "chokidar": "^3.5.1",
-    "esbuild": "0.11.16",
+    "esbuild": "0.12.25",
     "fs-extra": "^10.0.0",
     "lodash.debounce": "^4.0.8",
     "meow": "^7.1.1",

--- a/packages/remix-init/templates/_shared_js/package.json
+++ b/packages/remix-init/templates/_shared_js/package.json
@@ -20,6 +20,5 @@
   },
   "engines": {
     "node": ">=14"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/remix-init/templates/_shared_ts/package.json
+++ b/packages/remix-init/templates/_shared_ts/package.json
@@ -23,6 +23,5 @@
   },
   "engines": {
     "node": ">=14"
-  },
-  "sideEffects": false
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3548,10 +3548,10 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild@0.11.16:
-  version "0.11.16"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.11.16.tgz#435f00474fb21e70f59a545b85e4cfc7ba106485"
-  integrity sha512-34ZWjo4ouvM5cDe7uRoM9GFuMyEmpH9fnVYmomvS1cq9ED9d/0ZG1r+p4P2VbX7ihjv36zA2SWTmP8Zmt/EANA==
+esbuild@0.12.25:
+  version "0.12.25"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.12.25.tgz#c2131cef022cf9fe94aaa5e00110b27fc976221a"
+  integrity sha512-woie0PosbRSoN8gQytrdCzUbS2ByKgO8nD1xCZkEup3D9q92miCze4PqEI9TZDYAuwn6CruEnQpJxgTRWdooAg==
 
 escalade@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Up to this point we've required all Remix apps to use `{ sideEffects: false }` in their package.json to get esbuild's tree-shaking to remove any loader/action-specific code from the route modules when bundling them for the browser. But with this change we should be able to eliminate this requirement and specify it ourselves for all client app modules.