### PR TITLE
chore(init): add jsdoc type to remix config for auto complete

### DIFF
--- a/packages/remix-init/templates/_shared_js/remix.config.js
+++ b/packages/remix-init/templates/_shared_js/remix.config.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('@remix-run/dev/config').AppConfig}
+ */
 module.exports = {
   appDirectory: "app",
   browserBuildDirectory: "public/build",

--- a/packages/remix-init/templates/_shared_ts/remix.config.js
+++ b/packages/remix-init/templates/_shared_ts/remix.config.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('@remix-run/dev/config').AppConfig}
+ */
 module.exports = {
   appDirectory: "app",
   browserBuildDirectory: "public/build",

--- a/packages/remix-init/templates/arc/remix.config.js
+++ b/packages/remix-init/templates/arc/remix.config.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('@remix-run/dev/config').AppConfig}
+ */
 module.exports = {
   appDirectory: "app",
   browserBuildDirectory: "public/build",

--- a/packages/remix-init/templates/express/remix.config.js
+++ b/packages/remix-init/templates/express/remix.config.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('@remix-run/dev/config').AppConfig}
+ */
 module.exports = {
   appDirectory: "app",
   browserBuildDirectory: "public/build",

--- a/packages/remix-init/templates/fly/remix.config.js
+++ b/packages/remix-init/templates/fly/remix.config.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('@remix-run/dev/config').AppConfig}
+ */
 module.exports = {
   appDirectory: "app",
   browserBuildDirectory: "public/build",

--- a/packages/remix-init/templates/netlify/remix.config.js
+++ b/packages/remix-init/templates/netlify/remix.config.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('@remix-run/dev/config').AppConfig}
+ */
 module.exports = {
   appDirectory: "app",
   browserBuildDirectory: "public/build",

--- a/packages/remix-init/templates/remix/remix.config.js
+++ b/packages/remix-init/templates/remix/remix.config.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('@remix-run/dev/config').AppConfig}
+ */
 module.exports = {
   appDirectory: "app",
   browserBuildDirectory: "public/build",


### PR DESCRIPTION
This PR adds a jsdoc comment to the remix init templates so we can provide type definitions as well as autocomplete. however jsdoc does not show errors when using incorrect types (e.g. using a number for appDirectory) ![image](https://user-images.githubusercontent.com/11698668/133942238-dd9553c7-9f12-4088-a8fd-a2f01cfa3db5.png)