### PR TITLE
feat: distinguish between index/layout routes

### DIFF
--- a/fixtures/gists-app/app/routes/nested-forms.tsx
+++ b/fixtures/gists-app/app/routes/nested-forms.tsx
@@ -1,0 +1,22 @@
+import type { ActionFunction } from "remix";
+import { Form, json, useActionData } from "remix";
+import { Outlet } from "react-router-dom";
+
+export let action: ActionFunction = ({ request }) => {
+  return json("layout action data");
+};
+
+export default function NestedFormsIndexLayout() {
+  let actionData = useActionData<string>();
+
+  return (
+    <div>
+      <Form method="post" action=".">
+        {actionData ? <p>{actionData}</p> : null}
+        <button type="submit">Submit Layout Form</button>
+      </Form>
+
+      <Outlet />
+    </div>
+  );
+}

--- a/fixtures/gists-app/app/routes/nested-forms/nested.tsx
+++ b/fixtures/gists-app/app/routes/nested-forms/nested.tsx
@@ -1,0 +1,21 @@
+import { Form, json, useActionData } from "remix";
+import { Outlet } from "react-router-dom";
+
+export function action() {
+  return json("nested layout action data");
+}
+
+export default function NestedFormsIndexLayout() {
+  let actionData = useActionData<string>();
+
+  return (
+    <div>
+      <Form method="post">
+        {actionData ? <p>{actionData}</p> : null}
+        <button type="submit">Submit Nested Form</button>
+      </Form>
+
+      <Outlet />
+    </div>
+  );
+}

--- a/fixtures/gists-app/app/routes/nested-forms/nested/index.tsx
+++ b/fixtures/gists-app/app/routes/nested-forms/nested/index.tsx
@@ -1,0 +1,21 @@
+import { Form, json, useActionData } from "remix";
+import { Outlet } from "react-router-dom";
+
+export function action() {
+  return json("nested index action data");
+}
+
+export default function NestedFormsIndexLayout() {
+  let actionData = useActionData<string>();
+
+  return (
+    <div>
+      <Form method="post">
+        {actionData ? <p>{actionData}</p> : null}
+        <button type="submit">Submit Nested Index Form</button>
+      </Form>
+
+      <Outlet />
+    </div>
+  );
+}

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -246,6 +246,27 @@ describe("readConfig", () => {
             "parentId": "root",
             "path": "multiple-set-cookies",
           },
+          "routes/nested-forms": Object {
+            "caseSensitive": false,
+            "file": "routes/nested-forms.tsx",
+            "id": "routes/nested-forms",
+            "parentId": "root",
+            "path": "nested-forms",
+          },
+          "routes/nested-forms/nested": Object {
+            "caseSensitive": false,
+            "file": "routes/nested-forms/nested.tsx",
+            "id": "routes/nested-forms/nested",
+            "parentId": "routes/nested-forms",
+            "path": "nested",
+          },
+          "routes/nested-forms/nested/index": Object {
+            "caseSensitive": false,
+            "file": "routes/nested-forms/nested/index.tsx",
+            "id": "routes/nested-forms/nested/index",
+            "parentId": "routes/nested-forms/nested",
+            "path": "/",
+          },
           "routes/one": Object {
             "caseSensitive": false,
             "file": "routes/one.mdx",

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -615,9 +615,17 @@ export let FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
  * Resolves a `<form action>` path relative to the current route.
  */
 export function useFormAction(action = "."): string {
+  let { id } = useRemixRouteContext();
   let path = useResolvedPath(action);
-  let location = useLocation();
-  return path.pathname + location.search;
+  let search = path.search;
+
+  let isIndexRoute = id.endsWith("/index");
+
+  if (isIndexRoute && action === ".") {
+    search = "?index";
+  }
+
+  return path.pathname + search;
 }
 
 export interface SubmitOptions {

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -865,6 +865,13 @@ export function createTransitionManager(init: TransitionManagerInit) {
     let controller = new AbortController();
     pendingNavigationController = controller;
 
+    if (
+      !isIndexRequestSearch(location.search) &&
+      matches[matches.length - 1].route.id.endsWith("/index")
+    ) {
+      matches.pop();
+    }
+
     let leafMatch = matches.slice(-1)[0];
     let result = await callAction(submission, leafMatch, controller.signal);
 
@@ -1140,6 +1147,19 @@ export function createTransitionManager(init: TransitionManagerInit) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+function isIndexRequestSearch(search: string) {
+  let indexRequest = false;
+
+  let searchParams = new URLSearchParams(search);
+  for (let param of searchParams.getAll("index")) {
+    if (!param) {
+      indexRequest = true;
+    }
+  }
+
+  return indexRequest;
+}
+
 async function callLoaders(
   state: TransitionManagerState,
   url: URL,

--- a/packages/remix-server-runtime/__tests__/data-test.ts
+++ b/packages/remix-server-runtime/__tests__/data-test.ts
@@ -73,4 +73,70 @@ describe("loaders", () => {
     let res = await handler(request);
     expect(await res.headers.get("X-Remix-Catch")).toBeTruthy();
   });
+
+   it("removes index from request.url", async () => {
+    let loader = async ({ request }) => {
+      return new URL(request.url).search;
+    };
+
+    let routeId = "routes/random";
+    let build = ({
+      routes: {
+        [routeId]: {
+          id: routeId,
+          path: "/random",
+          module: {
+            loader
+          }
+        }
+      }
+    } as unknown) as ServerBuild;
+
+    let handler = createRequestHandler(build, {});
+
+    let request = new Request(
+      "http://example.com/random?_data=routes/random&index&foo=bar",
+      {
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    );
+
+    let res = await handler(request);
+    expect(await res.json()).toMatchInlineSnapshot(`"?foo=bar"`);
+  });
+
+  it("removes index from request.url and keeps other values", async () => {
+    let loader = async ({ request }) => {
+      return new URL(request.url).search;
+    };
+
+    let routeId = "routes/random";
+    let build = ({
+      routes: {
+        [routeId]: {
+          id: routeId,
+          path: "/random",
+          module: {
+            loader
+          }
+        }
+      }
+    } as unknown) as ServerBuild;
+
+    let handler = createRequestHandler(build, {});
+
+    let request = new Request(
+      "http://example.com/random?_data=routes/random&index&foo=bar&index=test",
+      {
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    );
+
+    let res = await handler(request);
+    expect(await res.json()).toMatchInlineSnapshot(`"?foo=bar&index=test"`);
+  });
 });


### PR DESCRIPTION
## The problem:

You make a route at "/projects" with a form and and action:

```js
export function action() {
  // ...
}

export default function () {
  return <Form method="post" />;
}
```

Everything works great. Now you add child routes to "projects/" including "routes/projects/index.tsx". Now when you submit the form you get an error that the route doesn't have an action!

The problem is that on actions Remix matches the routes and assumes the leaf route is the route we want to call the action on. But in this case we still wanted the parent route, not the index route. By simply adding an index route, the behavior completely changed in unexpected ways!

In fact, in Remix right now it is impossible to call the parent route's action as soon as it has an index.

```js
<Form />  // oops, index
<Form path="/projects" /> // oops, index
```

## Behavior we want: 

We need to be able to call the parent loader or the index.

A cool thing about Remix actions/routes is that if you render a <Form> without an "action" prop, it will call the action of this route. It shouldn't matter if you're in a parent route with an index route.

```js
// projects.tsx
export function action() {
  // ...
}

export default function () {
  // this should call the action in this file
  return <Form method="post" />;
}
```

Today Remix will only call the index route, in order to not fix this in a way that just now makes it impossible to call the actions on index routes, we will add the ?index search param to a route's action:

```js
<Form action="/projects?index" /> // <-- new feature, call action in /routes/projects/index.tsx
<Form action="/projects" /> // <-- new behavior, call action in /routes/projects.tsx
                            // it used to call the index route
```

Apps can still use "?index=123" in their urls, we have only made a value-less "index" search param a special thing. This is fine because searchParams can have multiple values on a single key: "?index&index=123"

## Summary of changes

- CHANGE: The shared URL among parent/index routes should call the parent action, not the index
- NEW: Adding "?index" will call the index route's action (if there isn't one, error as usual)
- CHANGE: The default path for a form should be the route you're at

For the parent that's something like "/projects"

For the index it's something like "/projects?index"