### PR TITLE
Rename CLI commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # History of Changes
 
+## Unreleased
+
+### Breaking Changes
+
+- Several users felt that the `remix dev` command did not behave as expected. The CLI command `remix dev` has been changed to `remix watch`, and `remix run` has been changed to `remix dev` to hopefully make the CLI a bit more intuitive. Please note that `remix dev` requires that `@remix-run/serve` is installed as a dependency, just as `remix run` did before.
+
 ## 0.19.0 - Fri Oct 08 2021
 
 ### Improvements

--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -26,7 +26,9 @@ Each adapter has the same API. In the future we may have helpers specific to the
 Creates a request handler for your server to serve the app. This is the ultimate entry point of your Remix application.
 
 ```ts
-const { createRequestHandler } = require("@remix-run/{adapter}");
+const {
+  createRequestHandler,
+} = require("@remix-run/{adapter}");
 createRequestHandler({ build, getLoadContext });
 ```
 
@@ -34,7 +36,9 @@ Here's a full example with express:
 
 ```ts [2, 9-20]
 const express = require("express");
-const { createRequestHandler } = require("@remix-run/express");
+const {
+  createRequestHandler,
+} = require("@remix-run/express");
 
 let app = express();
 
@@ -42,7 +46,7 @@ let app = express();
 app.all(
   "*",
   createRequestHandler({
-    // `remix build` and `remix run` output files to a build directory, you need
+    // `remix build` and `remix dev` output files to a build directory, you need
     // to pass that build to the request handler
     build: require("./build"),
 
@@ -51,7 +55,7 @@ app.all(
     // and your server
     getLoadContext(req, res) {
       return {};
-    }
+    },
   })
 );
 ```
@@ -59,8 +63,12 @@ app.all(
 Here's an example with Architect (AWS).
 
 ```ts
-const { createRequestHandler } = require("@remix-run/architect");
-exports.handler = createRequestHandler({ build: require("./build") });
+const {
+  createRequestHandler,
+} = require("@remix-run/architect");
+exports.handler = createRequestHandler({
+  build: require("./build"),
+});
 ```
 
 ## Starter Templates

--- a/docs/other-api/dev.md
+++ b/docs/other-api/dev.md
@@ -28,18 +28,18 @@ Builds your app for production with our new [esbuild](https://esbuild.github.io)
 $ remix build
 ```
 
-### `remix dev`
+### `remix watch`
 
 Watches your application files and builds your app for development when files change with our new esbuild-based compiler.
 
 ```sh
-$ remix dev
+$ remix watch
 ```
 
-## `remix run`
+## `remix dev`
 
-Same as `dev` but also boots the [Remix app server](../serve/) in development mode.
+Same as `watch` but also boots the [Remix app server](../serve/) in development mode.
 
 ```sh
-$ remix run
+$ remix dev
 ```

--- a/docs/tutorial/1-installation.md
+++ b/docs/tutorial/1-installation.md
@@ -29,7 +29,7 @@ Enough chat, let's go!
 
 ```sh
 cd my-remix-app
-remix run
+remix dev
 ```
 
 Your new website should be up at [http://localhost:3000](http://localhost:3000).

--- a/packages/remix-dev/__tests__/cli-test.ts
+++ b/packages/remix-dev/__tests__/cli-test.ts
@@ -25,7 +25,7 @@ describe("remix cli", () => {
         "
           Usage
             $ remix build [remixRoot]
-            $ remix run [remixRoot]
+            $ remix dev [remixRoot]
             $ remix setup [remixPlatform]
 
           Options
@@ -37,7 +37,7 @@ describe("remix cli", () => {
 
           Examples
             $ remix build my-website
-            $ remix run my-website
+            $ remix dev my-website
             $ remix setup node
 
         "

--- a/packages/remix-dev/cli.ts
+++ b/packages/remix-dev/cli.ts
@@ -6,7 +6,7 @@ import * as commands from "./cli/commands";
 const helpText = `
 Usage
   $ remix build [remixRoot]
-  $ remix run [remixRoot]
+  $ remix dev [remixRoot]
   $ remix setup [remixPlatform]
 
 Options
@@ -18,7 +18,7 @@ Values
 
 Examples
   $ remix build my-website
-  $ remix run my-website
+  $ remix dev my-website
   $ remix setup node
 `;
 
@@ -44,19 +44,18 @@ switch (cli.input[0]) {
   case "build":
     commands.build(cli.input[1], process.env.NODE_ENV);
     break;
-  case "dev": // `remix dev` is alias for `remix watch`
   case "watch":
     commands.watch(cli.input[1], process.env.NODE_ENV);
     break;
   case "setup":
     commands.setup(cli.input[1]);
     break;
-  case "run":
+  case "dev":
     if (!process.env.NODE_ENV) process.env.NODE_ENV = "development";
-    commands.run(cli.input[1], process.env.NODE_ENV);
+    commands.dev(cli.input[1], process.env.NODE_ENV);
     break;
   default:
-    // `remix ./my-project` is shorthand for `remix run ./my-project`
+    // `remix ./my-project` is shorthand for `remix dev ./my-project`
     if (!process.env.NODE_ENV) process.env.NODE_ENV = "development";
-    commands.run(cli.input[0], process.env.NODE_ENV);
+    commands.dev(cli.input[0], process.env.NODE_ENV);
 }

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -98,7 +98,7 @@ export async function watch(
   console.log(`💿 Built in ${prettyMs(Date.now() - start)}`);
 }
 
-export async function run(remixRoot: string, modeArg?: string) {
+export async function dev(remixRoot: string, modeArg?: string) {
   // TODO: Warn about the need to install @remix-run/serve if it isn't there?
   let { createApp } = require("@remix-run/serve");
 

--- a/packages/remix-init/templates/_shared_js/package.json
+++ b/packages/remix-init/templates/_shared_js/package.json
@@ -5,7 +5,7 @@
   "license": "",
   "scripts": {
     "build": "remix build",
-    "dev": "remix dev"
+    "dev": "remix watch"
   },
   "dependencies": {
     "@remix-run/react": "*",

--- a/packages/remix-init/templates/_shared_ts/package.json
+++ b/packages/remix-init/templates/_shared_ts/package.json
@@ -5,7 +5,7 @@
   "license": "",
   "scripts": {
     "build": "remix build",
-    "dev": "remix dev"
+    "dev": "remix watch"
   },
   "dependencies": {
     "@remix-run/react": "*",

--- a/packages/remix-init/templates/arc/package.json
+++ b/packages/remix-init/templates/arc/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "postinstall": "remix setup node",
     "build": "remix build",
-    "dev": "remix dev",
+    "dev": "remix watch",
     "start": "arc sandbox"
   },
   "dependencies": {

--- a/packages/remix-init/templates/express/package.json
+++ b/packages/remix-init/templates/express/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "postinstall": "remix setup node",
-    "dev": "remix dev",
+    "dev": "remix watch",
     "start": "cross-env NODE_ENV=production node server/index.js",
     "start:dev": "cross-env NODE_ENV=development node server/index.js"
   },

--- a/packages/remix-init/templates/fly/package.json
+++ b/packages/remix-init/templates/fly/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "postinstall": "remix setup node",
     "build": "remix build",
-    "dev": "remix run",
+    "dev": "remix dev",
     "deploy": "flyctl deploy --build-arg REMIX_TOKEN=${REMIX_TOKEN}",
     "start": "remix-serve build"
   },

--- a/packages/remix-init/templates/netlify/package.json
+++ b/packages/remix-init/templates/netlify/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "postinstall": "remix setup node",
     "build": "remix build",
-    "dev": "remix dev",
+    "dev": "remix watch",
     "dev:netlify": "cross-env NODE_ENV=development netlify dev"
   },
   "dependencies": {

--- a/packages/remix-init/templates/remix/package.json
+++ b/packages/remix-init/templates/remix/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "postinstall": "remix setup node",
-    "dev": "remix run",
+    "dev": "remix dev",
     "start": "remix-serve build"
   },
   "dependencies": {

--- a/packages/remix-init/templates/vercel/package.json
+++ b/packages/remix-init/templates/vercel/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "postinstall": "remix setup node",
-    "dev": "remix dev",
+    "dev": "remix watch",
     "start": "vercel dev"
   },
   "dependencies": {


### PR DESCRIPTION
This PR makes the following changes to our CLI:

```
remix dev  -->  remix watch
remix run  -->  remix dev
```

Just as `remix run` did before, `remix dev` now requires `@remix-run/serve`.
