### PR TITLE
fix: update wrangler to watch just build/index.js

### DIFF
--- a/packages/remix-init/templates/cloudflare-workers/wrangler.toml
+++ b/packages/remix-init/templates/cloudflare-workers/wrangler.toml
@@ -12,7 +12,7 @@ entry-point = "."
 
 [build]
 command = "npm run build:worker"
-watch_dir = "build"
+watch_dir = "build/index.js"
 
 [build.upload]
 format="service-worker"


### PR DESCRIPTION
I know it says "watch_dir", but a single file works as well and stops miniflare from reloading a bunch of times.