### PR TITLE
fix: compiler should allow unstable_shouldReload

### DIFF
--- a/fixtures/gists-app/app/root.jsx
+++ b/fixtures/gists-app/app/root.jsx
@@ -33,7 +33,7 @@ export let handle = {
   breadcrumb: () => <Link to="/">Home</Link>
 };
 
-export let shouldReload = () => false;
+export let unstable_shouldReload = () => false;
 
 export default function Root() {
   useEffect(() => {

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -458,7 +458,7 @@ const browserSafeRouteExports: { [name: string]: boolean } = {
   handle: true,
   links: true,
   meta: true,
-  shouldReload: true
+  unstable_shouldReload: true
 };
 
 /**


### PR DESCRIPTION
fixes issue where compiler was stripping away the unstable_shouldReload method of route modules on client builds.