### PR TITLE
wip: proof of concept for request / response hooks

### DIFF
--- a/packages/remix-architect/server.ts
+++ b/packages/remix-architect/server.ts
@@ -12,7 +12,8 @@ import type {
 import type {
   AppLoadContext,
   ServerBuild,
-  ServerPlatform
+  ServerPlatform,
+  CreateRequestHandlerOptions
 } from "@remix-run/server-runtime";
 import { createRequestHandler as createRemixRequestHandler } from "@remix-run/server-runtime";
 import type { Response as NodeResponse } from "@remix-run/node";
@@ -35,16 +36,22 @@ export type RequestHandler = ReturnType<typeof createRequestHandler>;
  * Remix.
  */
 export function createRequestHandler({
+  beforeRequest,
+  beforeResponse,
   build,
   getLoadContext,
   mode = process.env.NODE_ENV
-}: {
-  build: ServerBuild;
+}: Omit<CreateRequestHandlerOptions, "platform"> & {
   getLoadContext: GetLoadContextFunction;
-  mode?: string;
 }): APIGatewayProxyHandlerV2 {
   let platform: ServerPlatform = { formatServerError };
-  let handleRequest = createRemixRequestHandler(build, platform, mode);
+  let handleRequest = createRemixRequestHandler({
+    beforeRequest,
+    beforeResponse,
+    build,
+    platform,
+    mode
+  });
 
   return async (event, _context) => {
     let request = createRemixRequest(event);

--- a/packages/remix-cloudflare-workers/worker.ts
+++ b/packages/remix-cloudflare-workers/worker.ts
@@ -7,7 +7,8 @@ import {
 import type {
   AppLoadContext,
   ServerBuild,
-  ServerPlatform
+  ServerPlatform,
+  CreateRequestHandlerOptions
 } from "@remix-run/server-runtime";
 import { createRequestHandler as createRemixRequestHandler } from "@remix-run/server-runtime";
 
@@ -29,16 +30,20 @@ export type RequestHandler = ReturnType<typeof createRequestHandler>;
  * Remix SSR response.
  */
 export function createRequestHandler({
+  beforeRequest,
+  beforeResponse,
   build,
   getLoadContext,
   mode
-}: {
-  build: ServerBuild;
+}: Omit<CreateRequestHandlerOptions, "platform"> & {
   getLoadContext?: GetLoadContextFunction;
-  mode?: string;
 }) {
-  let platform: ServerPlatform = {};
-  let handleRequest = createRemixRequestHandler(build, platform, mode);
+  let handleRequest = createRemixRequestHandler({
+    beforeRequest,
+    beforeResponse,
+    build,
+    mode
+  });
 
   return (event: FetchEvent) => {
     let loadContext =
@@ -93,15 +98,17 @@ export async function handleAsset(
 }
 
 export function createEventHandler({
+  beforeRequest,
+  beforeResponse,
   build,
   getLoadContext,
   mode
-}: {
-  build: ServerBuild;
+}: Omit<CreateRequestHandlerOptions, "platform"> & {
   getLoadContext?: GetLoadContextFunction;
-  mode?: string;
 }) {
   const handleRequest = createRequestHandler({
+    beforeRequest,
+    beforeResponse,
     build,
     getLoadContext,
     mode

--- a/packages/remix-express/server.ts
+++ b/packages/remix-express/server.ts
@@ -3,7 +3,8 @@ import type * as express from "express";
 import type {
   AppLoadContext,
   ServerBuild,
-  ServerPlatform
+  ServerPlatform,
+  CreateRequestHandlerOptions
 } from "@remix-run/server-runtime";
 import { createRequestHandler as createRemixRequestHandler } from "@remix-run/server-runtime";
 import type {
@@ -34,16 +35,22 @@ export type RequestHandler = ReturnType<typeof createRequestHandler>;
  * Returns a request handler for Express that serves the response using Remix.
  */
 export function createRequestHandler({
+  beforeRequest,
+  beforeResponse,
   build,
   getLoadContext,
   mode = process.env.NODE_ENV
-}: {
-  build: ServerBuild;
+}: Omit<CreateRequestHandlerOptions, "platform"> & {
   getLoadContext?: GetLoadContextFunction;
-  mode?: string;
 }) {
   let platform: ServerPlatform = { formatServerError };
-  let handleRequest = createRemixRequestHandler(build, platform, mode);
+  let handleRequest = createRemixRequestHandler({
+    beforeRequest,
+    beforeResponse,
+    build,
+    platform,
+    mode
+  });
 
   return async (
     req: express.Request,

--- a/packages/remix-netlify/server.ts
+++ b/packages/remix-netlify/server.ts
@@ -1,7 +1,8 @@
 import type {
   AppLoadContext,
   ServerBuild,
-  ServerPlatform
+  ServerPlatform,
+  CreateRequestHandlerOptions
 } from "@remix-run/server-runtime";
 import { createRequestHandler as createRemixRequestHandler } from "@remix-run/server-runtime";
 import type {
@@ -29,16 +30,22 @@ export interface GetLoadContextFunction {
 export type RequestHandler = ReturnType<typeof createRequestHandler>;
 
 export function createRequestHandler({
+  beforeRequest,
+  beforeResponse,
   build,
   getLoadContext,
   mode = process.env.NODE_ENV
-}: {
-  build: ServerBuild;
+}: Omit<CreateRequestHandlerOptions, "platform"> & {
   getLoadContext?: AppLoadContext;
-  mode?: string;
 }): Handler {
   let platform: ServerPlatform = { formatServerError };
-  let handleRequest = createRemixRequestHandler(build, platform, mode);
+  let handleRequest = createRemixRequestHandler({
+    beforeRequest,
+    beforeResponse,
+    build,
+    platform,
+    mode
+  });
 
   return async (event, context) => {
     let request = createRemixRequest(event);

--- a/packages/remix-server-runtime/__tests__/data-test.ts
+++ b/packages/remix-server-runtime/__tests__/data-test.ts
@@ -23,7 +23,7 @@ describe("loaders", () => {
       entry: { module: {} }
     } as unknown as ServerBuild;
 
-    let handler = createRequestHandler(build, {});
+    let handler = createRequestHandler({ build });
 
     let request = new Request(
       "http://example.com/random?_data=routes/random&foo=bar",
@@ -61,7 +61,7 @@ describe("loaders", () => {
       entry: { module: {} }
     } as unknown as ServerBuild;
 
-    let handler = createRequestHandler(build, {});
+    let handler = createRequestHandler({ build });
 
     let request = new Request(
       "http://example.com/random?_data=routes/random&foo=bar",
@@ -95,7 +95,7 @@ describe("loaders", () => {
       entry: { module: {} }
     } as unknown as ServerBuild;
 
-    let handler = createRequestHandler(build, {});
+    let handler = createRequestHandler({ build });
 
     let request = new Request(
       "http://example.com/random?_data=routes/random&index&foo=bar",
@@ -129,7 +129,7 @@ describe("loaders", () => {
       entry: { module: {} }
     } as unknown as ServerBuild;
 
-    let handler = createRequestHandler(build, {});
+    let handler = createRequestHandler({ build });
 
     let request = new Request(
       "http://example.com/random?_data=routes/random&index&foo=bar&index=test",

--- a/packages/remix-server-runtime/__tests__/server-test.ts
+++ b/packages/remix-server-runtime/__tests__/server-test.ts
@@ -51,7 +51,7 @@ describe("server", () => {
     ];
     for (let [method, to] of allowThrough) {
       it(`allows through ${method} request to ${to}`, async () => {
-        let handler = createRequestHandler(build, {});
+        let handler = createRequestHandler({ build });
         let response = await handler(
           new Request(`http://localhost:3000${to}`, {
             method
@@ -63,7 +63,7 @@ describe("server", () => {
     }
 
     it("strips body for HEAD requests", async () => {
-      let handler = createRequestHandler(build, {});
+      let handler = createRequestHandler({ build });
       let response = await handler(
         new Request("http://localhost:3000/", {
           method: "HEAD"

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -97,7 +97,7 @@ export function isCatchResponse(value: any) {
   return isResponse(value) && value.headers.get("X-Remix-Catch") != null;
 }
 
-function isResponse(value: any): value is Response {
+export function isResponse(value: any): value is Response {
   return (
     value != null &&
     typeof value.status === "number" &&

--- a/packages/remix-server-runtime/index.ts
+++ b/packages/remix-server-runtime/index.ts
@@ -41,7 +41,12 @@ export type {
 
 export { json, redirect } from "./responses";
 
-export type { RequestHandler } from "./server";
+export type {
+  BeforeRequestFunction,
+  BeforeResponseFunction,
+  CreateRequestHandlerOptions,
+  RequestHandler
+} from "./server";
 export { createRequestHandler } from "./server";
 
 export type {

--- a/packages/remix-vercel/server.ts
+++ b/packages/remix-vercel/server.ts
@@ -2,7 +2,8 @@ import type { VercelRequest, VercelResponse } from "@vercel/node";
 import type {
   AppLoadContext,
   ServerBuild,
-  ServerPlatform
+  ServerPlatform,
+  CreateRequestHandlerOptions
 } from "@remix-run/server-runtime";
 import { createRequestHandler as createRemixRequestHandler } from "@remix-run/server-runtime";
 import type {
@@ -33,16 +34,24 @@ export type RequestHandler = ReturnType<typeof createRequestHandler>;
  * response using Remix.
  */
 export function createRequestHandler({
+  beforeRequest,
+  beforeResponse,
   build,
   getLoadContext,
   mode = process.env.NODE_ENV
-}: {
+}: Omit<CreateRequestHandlerOptions, "platform"> & {
   build: ServerBuild;
   getLoadContext?: GetLoadContextFunction;
   mode?: string;
 }) {
   let platform: ServerPlatform = { formatServerError };
-  let handleRequest = createRemixRequestHandler(build, platform, mode);
+  let handleRequest = createRemixRequestHandler({
+    beforeRequest,
+    beforeResponse,
+    build,
+    platform,
+    mode
+  });
 
   return async (req: VercelRequest, res: VercelResponse) => {
     let request = createRemixRequest(req);


### PR DESCRIPTION
Adds `beforeRequest` and `beforeResponse` to createRequestHandler to allow a place to implement things like request rewrites, SWR caches, request / response logging, etc...

Questions:
- How composable should this be?
- Is the throw pattern in beforeRequest a good idea?

Current idea:

```tsx
let { createRequestHandler } = require("@remix-run/express");
let build = require("./build");

let swrCache = require("./swr-cache");

async function beforeRequest({ request }) {
  try {
    let cachedResponse = swrCache.get(request.clone());
    if (cachedResponse) {
      throw cachedResponse;
    }
  } catch (err) {
    console.error(err);
  }
  return request;
}

async function beforeResponse({ request, response }) {
  try {
    return await swrCache.write(request, response.clone());
  } catch (err) {
    console.error(err);
    return response;
  }
}

let handler = createRequestHandler({ build, beforeRequest, beforeResponse });

// etc.....
```