### PR TITLE
chore(scripts/publish-private): skip publishing `remix` and `create-r…

### DIFF
--- a/.github/workflows/release-private.yml
+++ b/.github/workflows/release-private.yml
@@ -41,8 +41,6 @@ jobs:
 
       - name: Setup npm auth
         run: |
-          echo "registry=https://registry.npmjs.org" >> ~/.npmrc
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
           echo "@remix-run:registry=https://npm.pkg.github.com" >> ~/.npmrc
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_PUBLISH_TOKEN }}" >> ~/.npmrc
 

--- a/scripts/publish-private.js
+++ b/scripts/publish-private.js
@@ -39,12 +39,6 @@ async function run() {
   ]) {
     publish(path.join(buildDir, "@remix-run", name), tag);
   }
-
-  // Publish create-remix
-  publish(path.join(buildDir, "create-remix"), tag);
-
-  // Publish remix package
-  publish(path.join(buildDir, "remix"), tag);
 }
 
 run().then(


### PR DESCRIPTION
- chore(scripts/publish-private): skip publishing remix and `create-remix` packages as they'll be published by the regular publish script

Signed-off-by: Logan McAnsh <logan@mcan.sh>