### PR TITLE
fix: button delegation going to wrong action

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -900,10 +900,11 @@ export let FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
                 if (event.defaultPrevented) return;
                 event.preventDefault();
 
-                submit(clickedButtonRef.current || event.currentTarget, {
+                submit(event.currentTarget, {
                   method,
-                  replace
-                });
+                  replace,
+                  submissionTrigger: clickedButtonRef.current
+                } as any);
                 clickedButtonRef.current = null;
               }
         }
@@ -1023,10 +1024,18 @@ export function useSubmitImpl(key?: string): SubmitFunction {
       let formData: FormData;
 
       if (isFormElement(target)) {
+        let submissionTrigger: HTMLButtonElement | HTMLInputElement = (
+          options as any
+        ).submissionTrigger;
+
         method = options.method || target.method;
         action = options.action || target.action;
         encType = options.encType || target.enctype;
         formData = new FormData(target);
+
+        if (submissionTrigger && submissionTrigger.name) {
+          formData.append(submissionTrigger.name, submissionTrigger.value);
+        }
       } else if (
         isButtonElement(target) ||
         (isInputElement(target) &&

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -870,11 +870,13 @@ export function createTransitionManager(init: TransitionManagerInit) {
     let controller = new AbortController();
     pendingNavigationController = controller;
 
+    let isIndexRequest = isIndexRequestAction(submission.action);
+    console.log({ location, matches, isIndexRequest });
     if (
-      !isIndexRequestSearch(location.search) &&
+      !isIndexRequestAction(submission.action) &&
       matches[matches.length - 1].route.id.endsWith("/index")
     ) {
-      matches.pop();
+      matches = matches.slice(0, -1);
     }
 
     let leafMatch = matches.slice(-1)[0];
@@ -1163,10 +1165,11 @@ export function createTransitionManager(init: TransitionManagerInit) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-function isIndexRequestSearch(search: string) {
+function isIndexRequestAction(action: string) {
+  console.log({ action });
   let indexRequest = false;
 
-  let searchParams = new URLSearchParams(search);
+  let searchParams = new URLSearchParams(action.split("?", 2)[1] || "");
   for (let param of searchParams.getAll("index")) {
     if (!param) {
       indexRequest = true;


### PR DESCRIPTION
A submit button has a default formAction of the current URL. This was always being picked due to the button always being the target of the submit.