### PR TITLE
fix: button delegation going to wrong action

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -900,11 +900,10 @@ export let FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
                 if (event.defaultPrevented) return;
                 event.preventDefault();
 
-                submit(event.currentTarget, {
+                submit(clickedButtonRef.current || event.currentTarget, {
                   method,
-                  replace,
-                  submissionTrigger: clickedButtonRef.current
-                } as any);
+                  replace
+                });
                 clickedButtonRef.current = null;
               }
         }
@@ -1048,9 +1047,13 @@ export function useSubmitImpl(key?: string): SubmitFunction {
         }
 
         // <button>/<input type="submit"> may override attributes of <form>
-        method = options.method || target.formMethod || form.method;
-        action = options.action || target.formAction || form.action;
-        encType = options.encType || target.formEnctype || form.enctype;
+
+        method =
+          options.method || target.getAttribute("formmethod") || form.method;
+        action =
+          options.action || target.getAttribute("formaction") || form.action;
+        encType =
+          options.encType || target.getAttribute("formenctype") || form.enctype;
         formData = new FormData(form);
 
         // Include name + value from a <button>

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -1164,7 +1164,6 @@ export function createTransitionManager(init: TransitionManagerInit) {
 
 ////////////////////////////////////////////////////////////////////////////////
 function isIndexRequestAction(action: string) {
-  console.log({ action });
   let indexRequest = false;
 
   let searchParams = new URLSearchParams(action.split("?", 2)[1] || "");


### PR DESCRIPTION
A submit button has a default formAction of the current URL. This was always being picked due to the button always being the target of the submit.