### PR TITLE
fix: await handlers in server runtime

### DIFF
--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -518,9 +518,9 @@ async function handleDocumentRequest(
     serverHandoffString: createServerHandoffString(serverHandoff)
   };
 
-  let response: Response | Promise<Response>;
+  let response: Response;
   try {
-    response = serverEntryModule.default(
+    response = await serverEntryModule.default(
       request,
       statusCode,
       headers,
@@ -545,7 +545,7 @@ async function handleDocumentRequest(
     entryContext.serverHandoffString = createServerHandoffString(serverHandoff);
 
     try {
-      response = serverEntryModule.default(
+      response = await serverEntryModule.default(
         request,
         statusCode,
         headers,


### PR DESCRIPTION
otherwise we never hit the catch in time to handle error boundaries in case of async user code.