### PR TITLE
Skip script rendering after hydration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,5 @@ yarn-error.log
 /fixtures/test
 /fixtures/my-remix-app
 /fixtures/deno-app
-/fixtures/my-remix-app
 
 .eslintcache

--- a/contributors.yml
+++ b/contributors.yml
@@ -12,6 +12,7 @@
 - coryhouse
 - davecalnan
 - derekr
+- developit
 - dunglas
 - dwt47
 - edgesoft

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -658,6 +658,12 @@ export function Meta() {
   );
 }
 
+/**
+ * Tracks whether Remix has finished hydrating or not,
+ * so scripts can be skipped during client-side updates.
+ */
+let isHydrated = false;
+
 type ScriptProps = Omit<
   React.HTMLProps<HTMLScriptElement>,
   | "children"
@@ -669,12 +675,6 @@ type ScriptProps = Omit<
   | "dangerouslySetInnerHTML"
   | "suppressHydrationWarning"
 >;
-
-declare global {
-  interface Window {
-    remixIsHydrated: boolean;
-  }
-}
 
 /**
  * Renders the `<script>` tags needed for the initial render. Bundles for
@@ -693,10 +693,8 @@ export function Scripts(props: ScriptProps) {
     serverHandoffString
   } = useRemixEntryContext();
 
-  let hydratedRef = React.useRef(false);
-
   React.useEffect(() => {
-    window.remixIsHydrated = true;
+    isHydrated = true;
   }, []);
 
   let initialScripts = React.useMemo(() => {
@@ -760,8 +758,6 @@ window.__remixRouteModules = {${matches
 
   let preloads = manifest.entry.imports.concat(routePreloads);
 
-  let alreadyHydrated = typeof window !== "undefined" && window.remixIsHydrated;
-
   return (
     <>
       {dedupe(preloads).map(path => (
@@ -772,7 +768,7 @@ window.__remixRouteModules = {${matches
           crossOrigin={props.crossOrigin}
         />
       ))}
-      {alreadyHydrated ? null : initialScripts}
+      {isHydrated ? null : initialScripts}
     </>
   );
 }

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -659,8 +659,8 @@ export function Meta() {
 }
 
 /**
- * Tracks whether Remix has finished hydrating or not,
- * so scripts can be skipped during client-side updates.
+ * Tracks whether Remix has finished hydrating or not, so scripts can be skipped
+ * during client-side updates.
  */
 let isHydrated = false;
 

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -670,6 +670,12 @@ type ScriptProps = Omit<
   | "suppressHydrationWarning"
 >;
 
+declare global {
+  interface Window {
+    remixIsHydrated: boolean;
+  }
+}
+
 /**
  * Renders the `<script>` tags needed for the initial render. Bundles for
  * additional routes are loaded later as needed.
@@ -686,6 +692,12 @@ export function Scripts(props: ScriptProps) {
     clientRoutes,
     serverHandoffString
   } = useRemixEntryContext();
+
+  let hydratedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    window.remixIsHydrated = true;
+  }, []);
 
   let initialScripts = React.useMemo(() => {
     let contextScript = serverHandoffString
@@ -748,6 +760,8 @@ window.__remixRouteModules = {${matches
 
   let preloads = manifest.entry.imports.concat(routePreloads);
 
+  let alreadyHydrated = typeof window !== "undefined" && window.remixIsHydrated;
+
   return (
     <>
       {dedupe(preloads).map(path => (
@@ -758,7 +772,7 @@ window.__remixRouteModules = {${matches
           crossOrigin={props.crossOrigin}
         />
       ))}
-      {initialScripts}
+      {alreadyHydrated ? null : initialScripts}
     </>
   );
 }


### PR DESCRIPTION
This is a small tweak to @jacob-ebey's #403 that removes the window property. It achieves the same result as #390 but with minimal changes to Remix and no hydration mismatch concerns. Remix's `components` module is only instantiated once, so a module variable is sufficient for tracking `isHydrated` state.