### PR TITLE
Add responseBack response helper

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -3,3 +3,4 @@
 - jacob-ebey
 - ryanflorence
 - kentcdodds
+- sergiodxa

--- a/packages/remix-server-runtime/responses.ts
+++ b/packages/remix-server-runtime/responses.ts
@@ -41,3 +41,24 @@ export function redirect(
     headers
   });
 }
+
+/**
+ * Create a new Response with a redirect set to the URL the user was before.
+ * It uses the Referer header to detect the previous URL. It asks for a fallback
+ * URL in case the Referer couldn't be found, this fallback should be a URL you
+ * may be ok the user to land to after an action even if it's not the same.
+ * @example
+ * let action: ActionFunction = async ({ request }) => {
+ *   await doSomething(request);
+ *   // If the user was on `/search?query=something` we redirect to that URL
+ *   // but if we couldn't we redirect to `/search`, which is an good enough
+ *   // fallback
+ *   return redirectBack(request, { fallback: "/search" });
+ * }
+ */
+export function redirectBack(
+  request: Request,
+  { fallback, ...init }: ResponseInit & { fallback: string }
+): Response {
+  return redirect(request.headers.get("Referer") ?? fallback, init);
+}


### PR DESCRIPTION
While now you can return data from the action, if you need to return a redirect for some reason and want to ensure the user is on the exact same page (pathname and query params) there's a header Referer (the typo is correct) you can use to know from what URL the user came from.

This PR adds a response helper called `responseBack` which receives the Request object to get the header and ask for a fallback URL, because the Referer may not always be there based on user privacy settings (most of the time it's there), this fallback should be something you are ok if the user go there, for example if you are on a filtered list page, submit an action, the Referer will keep the same search params, the fallback can be just the pathname and remove the params, which is a nice fallback in case user has stricter privacy settings.

This is how you could use it:

```ts
export let action: ActionFunction = async ({ request }) => {
  // do something
  return redirectBack(request, { fallback: "/list" });
};
```

This makes https://github.com/sergiodxa/remix-utils#redirect-back useless. 🥳 