### PR TITLE
fixed links to posts from admin

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,3 +1,4 @@
+- wdj82
 - chaance
 - mcansh
 - jacob-ebey

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -557,7 +557,7 @@ export default function Admin() {
         <ul>
           {posts.map(post => (
             <li key={post.slug}>
-              <Link to={post.slug}>{post.title}</Link>
+              <Link to={`/posts/${post.slug}`}>{post.title}</Link>
             </li>
           ))}
         </ul>

--- a/examples/blog-tutorial/app/routes/admin.tsx
+++ b/examples/blog-tutorial/app/routes/admin.tsx
@@ -20,7 +20,7 @@ export default function Admin() {
         <ul>
           {posts.map((post) => (
             <li key={post.slug}>
-              <Link to={post.slug}>{post.title}</Link>
+              <Link to={`/posts/${post.slug}`}>{post.title}</Link>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
In the blog tutorial the post links in admin go to "admin/post-slugs" which are 404'd. 

They should link to "posts/post-slugs".  It seems by default the link goes for the admin route?

Change fixes the links to the correct location in the project. I don't know if there's a better way of doing that but the template literal seemed to work.

Updated both the blog.md and code.