### PR TITLE
Fix tiny-invariant import and highlight in new.tsx

### DIFF
--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -823,10 +823,8 @@ Let's add some validation before we create the post.
 
 💿 Validate if the form data contains what we need, and return the errors if not
 
-```tsx filename=app/routes/admin/new.tsx lines=[11-14,16-18]
+```tsx filename=app/routes/admin/new.tsx lines=[9-12,14-16]
 //...
-import invariant from "tiny-invariant";
-
 export let action: ActionFunction = async ({ request }) => {
   let formData = await request.formData();
 
@@ -893,7 +891,7 @@ export default function NewPost() {
 
 TypeScript is still mad, so let's add some invariants to make it happy.
 
-```tsx filename=app/routes/admin/new.tsx lines=[11-14,16-18]
+```tsx filename=app/routes/admin/new.tsx lines=[2,11-14,16-18]
 //...
 import invariant from "tiny-invariant";
 


### PR DESCRIPTION
tiny-invariant was imported at line 828 in blog.md but not used actually, so I removed the unnecessary import.  Additionally I added highlight for its first use in new.tsx.