### PR TITLE
documentation: fixed some path finding issues that leads into 404

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,5 +1,6 @@
 - abereghici
 - chaance
+- chandelieraxel
 - goncy
 - ianduvall
 - jacob-ebey

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -129,7 +129,7 @@ Because some characters have special meaning, you must use our escaping syntax i
 
 Remix uses `app/entry.client.tsx` as the entry point for the browser bundle. This module gives you full control over the "hydrate" step after JavaScript loads into the document.
 
-Typically this module uses `ReactDOM.hydrate` to re-hydrate the markup that was already generated on the server in your [server entry module](../entry.server).
+Typically this module uses `ReactDOM.hydrate` to re-hydrate the markup that was already generated on the server in your [server entry module](../entry.server). // TODO Couldn't find this one
 
 Here's a basic example:
 
@@ -193,7 +193,7 @@ export let handleDataRequest: HandleDataRequestFunction = (
 
 A route in Remix is can used for many things. Usually they’re used for the user interface of your app, like a React component with server side lifecycle hooks. But they can also serve as generic routes for any kind of resource (like dynamic CSS or social images).
 
-It's important to read [Route Module Constraints](../constraints/).
+It's important to read [Route Module Constraints](../other-api/constraints).
 
 ### `default` export
 
@@ -819,7 +819,7 @@ export let handle = {
 };
 ```
 
-This is almost always used on conjunction with `useMatches`. To see what kinds of things you can do with it, refer to [`useMatches`](../remix/#usematches) for more information.
+This is almost always used on conjunction with `useMatches`. To see what kinds of things you can do with it, refer to [`useMatches`](./remix#usematches) for more information.
 
 ### unstable_shouldReload
 
@@ -998,6 +998,6 @@ export default function Page() {
 [response]: https://developer.mozilla.org/en-US/docs/Web/API/Response
 [headers]: https://developer.mozilla.org/en-US/docs/Web/API/Headers
 [urlsearchparams]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
-[form]: ../remix/#form
-[form action]: ../remix/#form-action
+[form]: ./remix#form
+[form action]: ./remix#form-action
 [link tag]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link


### PR DESCRIPTION
Some links within the documentation were leading to 404 pages, because the paths were wrong