### PR TITLE
Remove REMIX_TOKEN from fly.io template

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,3 +1,4 @@
+- BasixKOR
 - chaance
 - jacob-ebey
 - kentcdodds

--- a/packages/create-remix/templates/fly/package.json
+++ b/packages/create-remix/templates/fly/package.json
@@ -3,7 +3,7 @@
     "postinstall": "remix setup node",
     "build": "remix build",
     "dev": "remix dev",
-    "deploy": "flyctl deploy --build-arg REMIX_TOKEN=${REMIX_TOKEN}",
+    "deploy": "flyctl deploy",
     "start": "remix-serve build"
   },
   "dependencies": {


### PR DESCRIPTION
I'm guessing this doesn't do anything since we moved on to open-source.