### PR TITLE
docs: fix Property 'title' does not exist on type '{}'

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -10,3 +10,4 @@
 - morinokami
 - meetbryce
 - ryanflorence
+- sunadoi

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -834,7 +834,7 @@ export let action: ActionFunction = async ({ request }) => {
   let slug = formData.get("slug");
   let markdown = formData.get("markdown");
 
-  let errors = {};
+  let errors: Record<string, boolean> = {};
   if (!title) errors.title = true;
   if (!slug) errors.slug = true;
   if (!markdown) errors.markdown = true;


### PR DESCRIPTION
TypeScript is mad, so let's add  Record type to make it happy.

```
let errors = {};
if (!title) errors.title = true; // Property 'title' does not exist on type '{}'
```

fixed
```
let errors: Record<string, boolean> = {};
if (!title) errors.title = true;
```