### PR TITLE
fix #496

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -6,3 +6,4 @@
 - michaeldeboey
 - msutkowski
 - ryanflorence
+- arpitdalal

--- a/examples/basic/app/routes/demos/about.tsx
+++ b/examples/basic/app/routes/demos/about.tsx
@@ -31,7 +31,7 @@ export default function Index() {
         <p>
           Wait a sec...<em>its children</em>? To understand what we mean by
           this,{" "}
-          <a href="https://remix.run/tutorial/4-nested-routes-params">
+          <a href="https://remix.run/docs/en/dev/guides/routing#what-are-nested-routes">
             read all about nested routes in the docs
           </a>
           .

--- a/examples/blog-tutorial/app/routes/demos/about.tsx
+++ b/examples/blog-tutorial/app/routes/demos/about.tsx
@@ -31,7 +31,7 @@ export default function Index() {
         <p>
           Wait a sec...<em>its children</em>? To understand what we mean by
           this,{" "}
-          <a href="https://remix.run/tutorial/4-nested-routes-params">
+          <a href="https://remix.run/docs/en/dev/guides/routing#what-are-nested-routes">
             read all about nested routes in the docs
           </a>
           .


### PR DESCRIPTION
Fix #496.

### Fix:
Replace the [broken link](https://remix.run/tutorial/4-nested-routes-params) with [this link](https://remix.run/docs/en/dev/guides/routing#what-are-nested-routes) in `examples/basic/app/routes/demos/about.tsx` and `examples/blog-tutorial/app/routes/demos/about.tsx` examples.