### PR TITLE
Add displayName to RouteChangeAnnouncement

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,3 +1,4 @@
+- andrelandgraf
 - BasixKOR
 - chaance
 - jacob-ebey

--- a/packages/create-remix/templates/_shared_js/app/root.jsx
+++ b/packages/create-remix/templates/_shared_js/app/root.jsx
@@ -238,3 +238,5 @@ const RouteChangeAnnouncement = React.memo(() => {
     </div>
   );
 });
+
+RouteChangeAnnouncement.displayName = 'RouteChangeAnnouncement';

--- a/packages/create-remix/templates/_shared_ts/app/root.tsx
+++ b/packages/create-remix/templates/_shared_ts/app/root.tsx
@@ -245,3 +245,5 @@ const RouteChangeAnnouncement = React.memo(() => {
     </div>
   );
 });
+
+RouteChangeAnnouncement.displayName = 'RouteChangeAnnouncement';


### PR DESCRIPTION
The displayName is used by React in debugging messages. Adding the display name satisfies the eslint rule [react/display-name](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md).