### PR TITLE
chore: add repository directory for all packages.json

### DIFF
--- a/packages/create-remix/package.json
+++ b/packages/create-remix/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.4",
   "description": "Create a new Remix app",
   "homepage": "https://remix.run",
-  "repository": "https://github.com/remix-run/packages",
+  "repository": {
+    "url": "https://github.com/remix-run/remix.git",
+    "type": "git",
+    "directory": "packages/create-remix"
+  },
   "bin": {
     "create-remix": "cli.js"
   },

--- a/packages/remix-architect/package.json
+++ b/packages/remix-architect/package.json
@@ -2,7 +2,12 @@
   "name": "@remix-run/architect",
   "description": "Architect server request handler for Remix",
   "version": "1.0.4",
-  "repository": "https://github.com/remix-run/packages",
+  "homepage": "https://remix.run",
+  "repository": {
+    "url": "https://github.com/remix-run/remix.git",
+    "type": "git",
+    "directory": "packages/remix-architect"
+  },
   "dependencies": {
     "@types/aws-lambda": "^8.10.82",
     "@remix-run/node": "1.0.4"

--- a/packages/remix-cloudflare-workers/package.json
+++ b/packages/remix-cloudflare-workers/package.json
@@ -2,7 +2,12 @@
   "name": "@remix-run/cloudflare-workers",
   "description": "Cloudflare worker request handler for Remix",
   "version": "1.0.4",
-  "repository": "https://github.com/remix-run/packages",
+  "homepage": "https://remix.run",
+  "repository": {
+    "url": "https://github.com/remix-run/remix.git",
+    "type": "git",
+    "directory": "packages/remix-cloudflare-workers"
+  },
   "dependencies": {
     "@cloudflare/kv-asset-handler": "^0.1.3",
     "@remix-run/server-runtime": "1.0.4"

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -2,7 +2,12 @@
   "name": "@remix-run/dev",
   "description": "Dev tools and CLI for Remix",
   "version": "1.0.4",
-  "repository": "https://github.com/remix-run/packages",
+  "homepage": "https://remix.run",
+  "repository": {
+    "url": "https://github.com/remix-run/remix.git",
+    "type": "git",
+    "directory": "packages/remix-dev"
+  },
   "bin": {
     "remix": "cli.js"
   },

--- a/packages/remix-express/package.json
+++ b/packages/remix-express/package.json
@@ -2,7 +2,12 @@
   "name": "@remix-run/express",
   "description": "Express server request handler for Remix",
   "version": "1.0.4",
-  "repository": "https://github.com/remix-run/packages",
+  "homepage": "https://remix.run",
+  "repository": {
+    "url": "https://github.com/remix-run/remix.git",
+    "type": "git",
+    "directory": "packages/remix-express"
+  },
   "dependencies": {
     "@remix-run/node": "1.0.4"
   },

--- a/packages/remix-netlify/package.json
+++ b/packages/remix-netlify/package.json
@@ -2,7 +2,12 @@
   "name": "@remix-run/netlify",
   "description": "Netlify server request handler for Remix",
   "version": "1.0.4",
-  "repository": "https://github.com/remix-run/packages",
+  "homepage": "https://remix.run",
+  "repository": {
+    "url": "https://github.com/remix-run/remix.git",
+    "type": "git",
+    "directory": "packages/remix-netlify"
+  },
   "dependencies": {
     "@remix-run/node": "1.0.4"
   },

--- a/packages/remix-node/package.json
+++ b/packages/remix-node/package.json
@@ -2,7 +2,12 @@
   "name": "@remix-run/node",
   "description": "Node.js platform abstractions for Remix",
   "version": "1.0.4",
-  "repository": "https://github.com/remix-run/packages",
+  "homepage": "https://remix.run",
+  "repository": {
+    "url": "https://github.com/remix-run/remix.git",
+    "type": "git",
+    "directory": "packages/remix-node"
+  },
   "dependencies": {
     "@remix-run/server-runtime": "1.0.4",
     "@types/node-fetch": "^2.5.12",

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -2,7 +2,12 @@
   "name": "@remix-run/react",
   "description": "React DOM bindings for Remix",
   "version": "1.0.4",
-  "repository": "https://github.com/remix-run/packages",
+  "homepage": "https://remix.run",
+  "repository": {
+    "url": "https://github.com/remix-run/remix.git",
+    "type": "git",
+    "directory": "packages/remix-react"
+  },
   "main": "index.js",
   "browser": "browser/index.js",
   "dependencies": {

--- a/packages/remix-serve/package.json
+++ b/packages/remix-serve/package.json
@@ -2,7 +2,12 @@
   "name": "@remix-run/serve",
   "description": "Production application server for Remix",
   "version": "1.0.4",
-  "repository": "https://github.com/remix-run/packages",
+  "homepage": "https://remix.run",
+  "repository": {
+    "url": "https://github.com/remix-run/remix.git",
+    "type": "git",
+    "directory": "packages/remix-serve"
+  },
   "bin": {
     "remix-serve": "cli.js"
   },

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -2,7 +2,12 @@
   "name": "@remix-run/server-runtime",
   "description": "Server runtime for Remix",
   "version": "1.0.4",
-  "repository": "https://github.com/remix-run/packages",
+  "homepage": "https://remix.run",
+  "repository": {
+    "url": "https://github.com/remix-run/remix.git",
+    "type": "git",
+    "directory": "packages/remix-server-runtime"
+  },
   "dependencies": {
     "@types/cookie": "^0.4.0",
     "cookie": "^0.4.1",

--- a/packages/remix-vercel/package.json
+++ b/packages/remix-vercel/package.json
@@ -2,7 +2,12 @@
   "name": "@remix-run/vercel",
   "description": "Vercel server request handler for Remix",
   "version": "1.0.4",
-  "repository": "https://github.com/remix-run/packages",
+  "homepage": "https://remix.run",
+  "repository": {
+    "url": "https://github.com/remix-run/remix.git",
+    "type": "git",
+    "directory": "packages/remix-vercel"
+  },
   "dependencies": {
     "@remix-run/node": "1.0.4"
   },

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -8,5 +8,10 @@
   "sideEffects": false,
   "dependencies": {
     "fs-extra": "^10.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remix-run/remix.git",
+    "directory": "packages/remix"
   }
 }


### PR DESCRIPTION
> If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
> ```json
> "repository": {
>   "type" : "git",
>   "url" : "https://github.com/facebook/react.git",
>   "directory": "packages/react-dom"
> }
> ```
> — https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository

I use a lot https://njt.vercel.app/ to jump to different packages information,
and with this PR we can know exactly what package in what folder lives

Made the changes with a script to make it easier 🙂

https://gist.github.com/iamandrewluca/5cc85b56a595056f0099d04ed6dd8a79