### PR TITLE
Remove reference to REMIX_TOKEN from fly.io readme

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,3 +1,4 @@
+- juhanakristian
 - BasixKOR
 - chaance
 - jacob-ebey

--- a/packages/create-remix/templates/fly/README.md
+++ b/packages/create-remix/templates/fly/README.md
@@ -30,7 +30,7 @@ This starts your app in development mode, rebuilding assets on file changes.
 
 ## Deployment
 
-If you've followed the setup instructions already, especially the REMIX_TOKEN environment variable step, all you need to do is run this:
+If you've followed the setup instructions already, all you need to do is run this:
 
 ```sh
 npm run deploy


### PR DESCRIPTION
REMIX_TOKEN was removed from the package.json deploy script in #519 but the README.md still referenced it. 