### PR TITLE
feat: use `assetsBuildDirectory` instead of deprecated `browserBuildDirectory` config option

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -14,7 +14,7 @@ This file has a few build and development configuration options, but does not ac
 ```tsx filename=remix.config.js
 module.exports = {
   appDirectory: "app",
-  browserBuildDirectory: "public/build",
+  assetsBuildDirectory: "public/build",
   devServerPort: 8002,
   publicPath: "/build/",
   serverBuildDirectory: "build",
@@ -65,7 +65,7 @@ exports.routes = async (defineRoutes) => {
 }
 ```
 
-### browserBuildDirectory
+### assetsBuildDirectory
 
 The path to the browser build, relative to remix.config.js. Defaults to "public/build". Should be deployed to static hosting.
 

--- a/examples/basic/remix.config.js
+++ b/examples/basic/remix.config.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
   appDirectory: "app",
-  browserBuildDirectory: "public/build",
+  assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "build",
   devServerPort: 8002

--- a/examples/blog-tutorial/remix.config.js
+++ b/examples/blog-tutorial/remix.config.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
   appDirectory: "app",
-  browserBuildDirectory: "public/build",
+  assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "build",
   devServerPort: 8002

--- a/examples/jokes/remix.config.js
+++ b/examples/jokes/remix.config.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
   appDirectory: "app",
-  browserBuildDirectory: "public/build",
+  assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "build",
   devServerPort: 8003,

--- a/packages/create-remix/templates/_shared_js/remix.config.js
+++ b/packages/create-remix/templates/_shared_js/remix.config.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
   appDirectory: "app",
-  browserBuildDirectory: "public/build",
+  assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "server/build"
 };

--- a/packages/create-remix/templates/_shared_ts/remix.config.js
+++ b/packages/create-remix/templates/_shared_ts/remix.config.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
   appDirectory: "app",
-  browserBuildDirectory: "public/build",
+  assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "server/build"
 };

--- a/packages/create-remix/templates/arc/remix.config.js
+++ b/packages/create-remix/templates/arc/remix.config.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
   appDirectory: "app",
-  browserBuildDirectory: "public/build",
+  assetsBuildDirectory: "public/build",
   publicPath: "/_static/build/",
   serverBuildDirectory: "server/build",
   devServerPort: 8002

--- a/packages/create-remix/templates/cloudflare-workers/remix.config.js
+++ b/packages/create-remix/templates/cloudflare-workers/remix.config.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
   appDirectory: "app",
-  browserBuildDirectory: "public/build",
+  assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "build",
   devServerBroadcastDelay: 1000

--- a/packages/create-remix/templates/express/remix.config.js
+++ b/packages/create-remix/templates/express/remix.config.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
   appDirectory: "app",
-  browserBuildDirectory: "public/build",
+  assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "server/build",
   devServerPort: 8002

--- a/packages/create-remix/templates/fly/remix.config.js
+++ b/packages/create-remix/templates/fly/remix.config.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
   appDirectory: "app",
-  browserBuildDirectory: "public/build",
+  assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "build",
   devServerPort: 8002

--- a/packages/create-remix/templates/netlify/remix.config.js
+++ b/packages/create-remix/templates/netlify/remix.config.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
   appDirectory: "app",
-  browserBuildDirectory: "public/build",
+  assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "netlify/functions/server/build",
   devServerPort: 8002

--- a/packages/create-remix/templates/remix/remix.config.js
+++ b/packages/create-remix/templates/remix/remix.config.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
   appDirectory: "app",
-  browserBuildDirectory: "public/build",
+  assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "build",
   devServerPort: 8002

--- a/packages/create-remix/templates/vercel/remix.config.js
+++ b/packages/create-remix/templates/vercel/remix.config.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
   appDirectory: "app",
-  browserBuildDirectory: "public/build",
+  assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "api/_build"
 };


### PR DESCRIPTION
`browserBuildDirectory` is deprecated and `assetsBuildDirectory` should be used instead