### PR TITLE
[Docs] SEO - Move the Meta component above title tag

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -15,3 +15,4 @@
 - morinokami
 - msutkowski
 - ryanflorence
+- Alarid

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -4756,7 +4756,7 @@ This is why Remix has the [`meta`](../api/conventions#meta) export. Why don't yo
 
 But before you get started, remember that we're in charge of rendering everything from the `<html>` to the `</html>` which means we need to make sure these `meta` tags are rendered in the `<head>` of the `<html>`. This is why Remix gives us a [`<Meta />` component](../api/remix#meta-links-scripts).
 
-💿 Add the `<Meta />` component to `app/root.tsx`, and add the `meta` export to the routes mentioned above.
+💿 Add the `<Meta />` component to `app/root.tsx`, and add the `meta` export to the routes mentioned above. The `<Meta />` component needs to be placed above the existing `<title>` tag to be able to overwrite it when provided.
 
 <details>
 
@@ -4820,8 +4820,8 @@ function Document({
     <html lang="en">
       <head>
         <meta charSet="utf-8" />
-        <title>{title}</title>
         <Meta />
+        <title>{title}</title>
         <Links />
       </head>
       <body>


### PR DESCRIPTION
As @kentcdodds mentioned in [yesterday's live stream](https://youtu.be/hsIWJpuxNj0?t=18158) while going through the Jokes App tutorial, the `<Meta />` component needs to be placed above the `<title>` tag in the root's `Document`. 

I just spent quite some time wondering why my titles weren't showing up, before finally checking the live stream replay to watch Kent figure it out. Apparently, browsers take the first `<title>` tag to name their tabs. 