### PR TITLE
Fix #625

### DIFF
--- a/examples/basic/app/routes/demos/params/$id.tsx
+++ b/examples/basic/app/routes/demos/params/$id.tsx
@@ -61,10 +61,12 @@ export function CatchBoundary() {
           Maybe ask the webmaster ({caught.data.webmasterEmail}) for access.
         </p>
       );
+      break;
     case 404:
       message = (
         <p>Looks like you tried to visit a page that does not exist.</p>
       );
+      break;
     default:
       message = (
         <p>
@@ -73,6 +75,7 @@ export function CatchBoundary() {
           {caught.status} {caught.statusText}
         </p>
       );
+      break;
   }
 
   return (


### PR DESCRIPTION
Add missing `break` statements. Without this, the `switch` always used the `default` error message.