### PR TITLE
fix(docs): Use correct dev URL in blog tutorial

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,4 +1,5 @@
 - abereghici
+- bramus
 - BasixKOR
 - chaance
 - goncy

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -26,7 +26,7 @@ npm run dev
 
 We're going to be doing some work with the file system and not all setups are compatible with the code in this tutorial.
 
-Open up [https://localhost:3000](https://localhost:3000), the app should be running. If you want, take a minute and poke around the starter template, there's a lot of information in there.
+Open up [http://localhost:3000](http://localhost:3000), the app should be running. If you want, take a minute and poke around the starter template, there's a lot of information in there.
 
 ## Your First Route
 


### PR DESCRIPTION
When starting the dev server it runs on `http://localhost:3000`, not `https://localhost:3000`