### PR TITLE
fix: `useLoaderData` in parent route without boundary handlers should return data when child throws an error

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -15,3 +15,4 @@
 - morinokami
 - msutkowski
 - ryanflorence
+- andmayorov

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -363,25 +363,13 @@ async function handleDocumentRequest(
   // If we did not match a route, there is no need to call any loaders
   let matchesToLoad = requestState !== "ok" ? [] : matches;
   switch (responseState) {
+    // get rid of the action, we don't want to call it's loader either
+    // because we'll be rendering the catch/error boundary, if you can get access
+    // to the loader data in the catch boundary then how the heck is it
+    // supposed to deal with thrown responses?
     case "caught":
-      matchesToLoad = getMatchesUpToDeepestBoundary(
-        // get rid of the action, we don't want to call it's loader either
-        // because we'll be rendering the catch boundary, if you can get access
-        // to the loader data in the catch boundary then how the heck is it
-        // supposed to deal with thrown responses?
-        matches.slice(0, -1),
-        "CatchBoundary"
-      );
-      break;
     case "error":
-      matchesToLoad = getMatchesUpToDeepestBoundary(
-        // get rid of the action, we don't want to call it's loader either
-        // because we'll be rendering the error boundary, if you can get access
-        // to the loader data in the error boundary then how the heck is it
-        // supposed to deal with errors in the loader, too?
-        matches.slice(0, -1),
-        "ErrorBoundary"
-      );
+      matchesToLoad = matches.slice(0, -1);
       break;
   }
 


### PR DESCRIPTION
Currently there is a bug which easier to explain by this example:

1. We have 3 nested routes
```ts
let matches = ["root", "/jokes", "/jokes/$jokeId"];
```
2. `root` and `/jokes/$jokeId` modules export `CatchBoundary` function while `/jokes` doesn't
3. Now we throw an error inside action in `/jokes/$jokeId` module and expect  `CatchBoundary` to handle it.
4. But instead we get some different kind of error because `useLoaderData` inside `/jokes` returns `undefined`. And error is handles by `ErrorBoundary` inside `root` module instead.

The reason why it happens is that at the moment we use `getMatchesUpToDeepestBoundary` to filter out `matchesToLoad`. We expect `matchesToLoad` to contain `["root", "/jokes"]` but instead it contains `["root"]`.

Since `/jokes` doesn't have `CatchBoundary` `getMatchesUpToDeepestBoundary` ignores it. Therefore it doesn't initialise `/jokes`'s `loader` even though it didn't throw any errors and Remix still tries to render it.

Related issue: https://github.com/remix-run/remix/issues/599