### PR TITLE
feat(cloudflare+cloudflare-pages+cloudflare-workers+templates): add support for `@cloudflare/workers-types` v3

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -3,6 +3,7 @@
 - chaance
 - goncy
 - ianduvall
+- edmundhung
 - jacob-ebey
 - jesseflorig
 - juhanakristian

--- a/packages/create-remix/templates/cloudflare-workers/package.json
+++ b/packages/create-remix/templates/cloudflare-workers/package.json
@@ -13,7 +13,7 @@
     "@remix-run/cloudflare-workers": "*"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^2.2.2",
+    "@cloudflare/workers-types": "^3.0.0",
     "esbuild": "0.13.14",
     "miniflare": "2.0.0-next.3"
   }

--- a/packages/remix-cloudflare-workers/package.json
+++ b/packages/remix-cloudflare-workers/package.json
@@ -15,9 +15,9 @@
     "@remix-run/server-runtime": "1.0.5"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^2.2.2"
+    "@cloudflare/workers-types": "^2.2.2 || ^3.0.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^2.2.2"
+    "@cloudflare/workers-types": "^3.2.0"
   }
 }

--- a/packages/remix-cloudflare-workers/tsconfig.json
+++ b/packages/remix-cloudflare-workers/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": ["**/*.ts"],
   "compilerOptions": {
-    "lib": ["ES2019", "WebWorker"],
+    "lib": ["ES2019"],
     "target": "ES2019",
     "types": ["@cloudflare/workers-types"],
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,10 +986,10 @@
   dependencies:
     mime "^2.5.2"
 
-"@cloudflare/workers-types@^2.2.2":
-  version "2.2.2"
-  resolved "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-2.2.2.tgz#1bced16bba801d7af987da835467545bb5cc7ac6"
-  integrity sha512-kaMn2rueJ0PL1TYVGknTCh0X0x0d9G+FNXAFep7/4uqecEZoQb/63o6rOmMuiqI09zLuHV6xhKRXinokV/MY9A==
+"@cloudflare/workers-types@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.2.0.tgz#df300466f5f8a03b205bdd533990017b0538496e"
+  integrity sha512-y0+f7QeB5/fMMdU0wSwvBB18yE9kAD2s7Wben8a4uI4f/EJyE+eJrai5QO52Pq8EmWP0vRpKqZh0qU857WhY2A==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"


### PR DESCRIPTION
Cloudflare released an [update](https://github.com/cloudflare/workers-types/releases/tag/v3.0.0) for `@cloudflare/workers-types` last month. It is now automatically generated from the source as announced [here](https://blog.cloudflare.com/automatically-generated-types/) and this ensures typing to be always up-to-dated with the latest runtime.

However, the current CF adapter has a peerDependency of v2 only. It would be nice if we could add support of v3 as well.
This will also makes experimenting with new ESM worker easier (as all new types are only defined on v3) before official support is ready. 

Thanks for all the great work!