### PR TITLE
Correct post path in blog tutorial. Closes #644

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -15,3 +15,4 @@
 - morinokami
 - msutkowski
 - ryanflorence
+- RKRohk

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -575,7 +575,7 @@ export default function Admin() {
         <ul>
           {posts.map(post => (
             <li key={post.slug}>
-              <Link to={post.slug}>{post.title}</Link>
+              <Link to={`/posts/${post.slug}`}>{post.title}</Link>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
While following the current tutorial, if a user goes to the admin screen and clicks on a slug, the website gives a 404 error. 
This is because the slug redirects the user to `/admin/<slug>` path instead of `/posts/<slug>` path.

This change fixes the above mentioned issue