### PR TITLE
docs: add jit compiler to tailwind config

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -15,3 +15,4 @@
 - morinokami
 - msutkowski
 - ryanflorence
+- mnlfischer

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -86,6 +86,7 @@ Here's a quick guide to getting it set up. We encourage you to read the official
 
     ```js filename=tailwind.config.js
     module.exports = {
+      mode: 'jit', // enables just-in-time compiler
       purge: [
         "./app/**/*.tsx",
         "./app/**/*.jsx",


### PR DESCRIPTION
The JIT compiler generates styles on-demand and increases the browser performance in development.

Reference:
[Tailwind JIT](https://tailwindcss.com/docs/just-in-time-mode)

fixes #581 