### PR TITLE
feat(remix-dev): add `devServerRebuildingIndicator` config option

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -136,6 +136,7 @@
 - hzhu
 - IAmLuisJ
 - ianduvall
+- ikhattab
 - illright
 - imzshh
 - isaacrmoreno

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -62,6 +62,10 @@ There is no delay by default.
 
 The port number to use for the dev websocket server. Defaults to 8002.
 
+### devServerRebuildingIndicator
+
+Whether to show loading spinner 💿 to indicate rebuilding is in progress. Defaults to `true`.
+
 ### ignoredRouteFiles
 
 This is an array of globs (via [minimatch][minimatch]) that Remix will match to

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -28,6 +28,7 @@ describe("readConfig", () => {
         "cacheDirectory": Any<String>,
         "devServerBroadcastDelay": 0,
         "devServerPort": Any<Number>,
+        "devServerRebuildingIndicator": true,
         "entryClientFile": "entry.client.tsx",
         "entryServerFile": "entry.server.tsx",
         "mdx": undefined,

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -202,6 +202,9 @@ export async function watch(
       start = Date.now();
       onRebuildStart?.();
       log("Rebuilding...");
+      if (config.devServerRebuildingIndicator) {
+        broadcast({ type: "REBUILDING" });
+      }
     },
     onRebuildFinish() {
       log(`Rebuilt in ${prettyMs(Date.now() - start)}`);

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -103,6 +103,11 @@ export interface AppConfig {
   devServerBroadcastDelay?: number;
 
   /**
+   * Whether to show loading spinner 💿 to indicate rebuilding is in progress. Defaults to `true`.
+   */
+  devServerRebuildingIndicator?: boolean;
+
+  /**
    * Additional MDX remark / rehype plugins.
    */
   mdx?: RemixMdxConfig | RemixMdxConfigFunction;
@@ -213,6 +218,11 @@ export interface RemixConfig {
    * The delay before the dev (asset) server broadcasts a reload event.
    */
   devServerBroadcastDelay: number;
+
+  /**
+   * Whether to show loading spinner 💿 to indicate rebuilding is in progress. Defaults to `true`.
+   */
+  devServerRebuildingIndicator?: boolean;
 
   /**
    * Additional MDX remark / rehype plugins.
@@ -359,6 +369,10 @@ export async function readConfig(
   // set env variable so un-bundled servers can use it
   process.env.REMIX_DEV_SERVER_WS_PORT = `${devServerPort}`;
   let devServerBroadcastDelay = appConfig.devServerBroadcastDelay || 0;
+  let devServerRebuildingIndicator =
+    typeof appConfig.devServerRebuildingIndicator === "boolean"
+      ? appConfig.devServerRebuildingIndicator
+      : true;
 
   let defaultPublicPath = "/build/";
   switch (serverBuildTarget) {
@@ -408,6 +422,7 @@ export async function readConfig(
     entryServerFile,
     devServerPort,
     devServerBroadcastDelay,
+    devServerRebuildingIndicator,
     assetsBuildDirectory,
     publicPath,
     rootDirectory,

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1437,36 +1437,70 @@ export const LiveReload =
       }) {
         let js = String.raw;
         return (
-          <script
-            nonce={nonce}
-            suppressHydrationWarning
-            dangerouslySetInnerHTML={{
-              __html: js`
-                (() => {
-                  let protocol = location.protocol === "https:" ? "wss:" : "ws:";
-                  let host = location.hostname;
-                  let socketPath = protocol + "//" + host + ":" + ${String(
-                    port
-                  )} + "/socket";
+          <>
+            <span
+              id="__remix-livereload-spinner"
+              aria-label="loading..."
+              role="img"
+            >
+              💿
+            </span>
+            <script
+              nonce={nonce}
+              suppressHydrationWarning
+              dangerouslySetInnerHTML={{
+                __html: js`
+                  (() => {
+                    let protocol = location.protocol === "https:" ? "wss:" : "ws:";
+                    let host = location.hostname;
+                    let socketPath = protocol + "//" + host + ":" + ${String(
+                      port
+                    )} + "/socket";
 
-                  let ws = new WebSocket(socketPath);
-                  ws.onmessage = (message) => {
-                    let event = JSON.parse(message.data);
-                    if (event.type === "LOG") {
-                      console.log(event.message);
-                    }
-                    if (event.type === "RELOAD") {
-                      console.log("💿 Reloading window ...");
-                      window.location.reload();
-                    }
-                  };
-                  ws.onerror = (error) => {
-                    console.log("Remix dev asset server web socket error:");
-                    console.error(error);
-                  };
-                })();
+                    let ws = new WebSocket(socketPath);
+                    let spinner = document.getElementById('__remix-livereload-spinner');
+                    ws.onmessage = (message) => {
+                      let event = JSON.parse(message.data);
+                      if (event.type === "LOG") {
+                        console.log(event.message);
+                      }
+                      if(event.type === "REBUILDING") {
+                        spinner.classList.add("loading");
+                      }
+                      if (event.type === "RELOAD") {
+                        console.log("💿 Reloading window ...");
+                        window.location.reload();
+                      }
+                    };
+                    ws.onerror = (error) => {
+                      console.log("Remix dev asset server web socket error:");
+                      console.error(error);
+                    };
+                  })();
+                `,
+              }}
+            />
+            <style
+              dangerouslySetInnerHTML={{
+                __html: `
+              #__remix-livereload-spinner {
+                visibility: hidden;
+                position: fixed;
+                bottom: 10px;
+                right: 10px;
+                font-size: 20px;
+                user-select: none;
+              }
+              #__remix-livereload-spinner.loading {
+                visibility: visible;
+                animation: __remix-livereload-spin 1s linear infinite;
+              }
+              @keyframes __remix-livereload-spin {
+                to { transform: rotate(360deg); }
+              }
               `,
-            }}
-          />
+              }}
+            />
+          </>
         );
       };


### PR DESCRIPTION
add spinner in LiveReload component to show spinning 💿 when any change that require live reload happens


https://user-images.githubusercontent.com/401304/143497677-80f48d9e-c9eb-44e8-bfbe-8a729ad44d87.mov

**UPDATE 1:**

I made a few updates in [cc8b0d2](https://github.com/remix-run/remix/pull/664/commits/cc8b0d2a21b7b78f2cab6561cc516e0661d46b86) to allow adding `devServer` key to `remix.config` that can configure a few options for now. e.g:

```
devServer:  {
  broadcastDelay: 0,
  port: 8002,
  rebuildingIndicator: true,
}
```

I took the same approach as deprecating browserBuildDirectory added `@deprecated` flag and still alow `devServerPort` and `devServerBroadcastDelay` to be used.

**UPDATE 2:**

I created a separate PR for refactoring devServer options in https://github.com/remix-run/remix/pull/923