### PR TITLE
Fix PrefetchBehavior comment

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,4 +1,5 @@
 - abereghici
+- andrelandgraf
 - BasixKOR
 - chaance
 - goncy

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -364,9 +364,9 @@ export function RemixRoute({ id }: { id: string }) {
 /**
  * Defines the prefetching behavior of the link:
  *
- * - "intent": Default, fetched when the user focuses or hovers the link
+ * - "intent": Fetched when the user focuses or hovers the link
  * - "render": Fetched when the link is rendered
- * - "none": Never fetched
+ * - "none": Default, never fetched until the user clicks the link
  */
 type PrefetchBehavior = "intent" | "render" | "none";
 


### PR DESCRIPTION
@ryanflorence: "In the spirit of “you own the network tab” we don’t prefetch by default"

Fixes code comment at type PrefetchBehavior to correctly describe the default behavior of the Remix Link and NavLink components.