### PR TITLE
Fix: Ignore Dotfiles when Defining Routes

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,5 +1,6 @@
 - abereghici
 - BasixKOR
+- bsharrow
 - chaance
 - goncy
 - ianduvall

--- a/packages/remix-dev/config/routesConvention.ts
+++ b/packages/remix-dev/config/routesConvention.ts
@@ -26,6 +26,11 @@ export function defineConventionalRoutes(appDir: string): RouteManifest {
 
   // First, find all route modules in app/routes
   visitFiles(path.join(appDir, "routes"), file => {
+    // Ignore dotfiles (e.g. ".DS_Store")
+    if (file.startsWith(".")) {
+      return;
+    }
+
     let routeId = createRouteId(path.join("routes", file));
 
     if (isRouteModuleFile(file)) {


### PR DESCRIPTION
Addresses #391. 

If a `.DS_Store` file or other dotfile is generated in the `app/routes/` directory, Remix will not start successfully with the message:

```
Invalid route module file: /path/to/my-remix-app/app/routes/.DS_Store
```