### PR TITLE
docs(jokes): fix passwordHash included in body on /jokes/* response in

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -5,6 +5,7 @@
 - ahbruns
 - ahmedeldessouki
 - airjp73
+- airondumael
 - Alarid
 - alex-ketch
 - alexuxui

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -3290,7 +3290,7 @@ We should probably give people the ability to see that they're logged in and a w
 
 <summary>app/utils/session.server.ts</summary>
 
-```ts filename=app/utils/session.server.ts lines=[76-90,92-101]
+```ts filename=app/utils/session.server.ts lines=[76-91,93-102]
 import bcrypt from "bcryptjs";
 import {
   createCookieSessionStorage,
@@ -3374,7 +3374,8 @@ export async function getUser(request: Request) {
 
   try {
     const user = await db.user.findUnique({
-      where: { id: userId }
+      where: { id: userId },
+      select: { id: true, username: true }
     });
     return user;
   } catch {
@@ -3429,7 +3430,7 @@ export const links: LinksFunction = () => {
 };
 
 type LoaderData = {
-  user: User | null;
+  user: Awaited<ReturnType<typeof getUser>>;
   jokeListItems: Array<{ id: string; name: string }>;
 };
 
@@ -3656,7 +3657,8 @@ export async function getUser(request: Request) {
 
   try {
     const user = await db.user.findUnique({
-      where: { id: userId }
+      where: { id: userId },
+      select: { id: true, username: true }
     });
     return user;
   } catch {

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -2814,7 +2814,7 @@ export async function login({
   );
   if (!isCorrectPassword) return null;
 
-  return user;
+  return { id: user.id, username };
 }
 ```
 
@@ -2906,7 +2906,7 @@ Note: If you need a hand, there's a small example of how the whole basic flow go
 
 <summary>app/utils/session.server.ts</summary>
 
-```tsx filename=app/utils/session.server.ts lines=[3,20-33,35-48,50-61]
+```tsx filename=app/utils/session.server.ts lines=[3,29-32,34-47,49-60]
 import bcrypt from "bcryptjs";
 import {
   createCookieSessionStorage,
@@ -2933,7 +2933,7 @@ export async function login({
     user.passwordHash
   );
   if (!isCorrectPassword) return null;
-  return user;
+  return { id: user.id, username };
 }
 
 const sessionSecret = process.env.SESSION_SECRET;
@@ -3032,7 +3032,7 @@ So we can now check whether the user is authenticated on the server by reading t
 
 <summary>app/utils/session.server.ts</summary>
 
-```ts filename=app/utils/session.server.ts lines=[50-52,54-59,61-74]
+```ts filename=app/utils/session.server.ts lines=[49-51,53-58,60-73]
 import bcrypt from "bcryptjs";
 import {
   createCookieSessionStorage,
@@ -3059,7 +3059,7 @@ export async function login({
     user.passwordHash
   );
   if (!isCorrectPassword) return null;
-  return user;
+  return { id: user.id, username };
 }
 
 const sessionSecret = process.env.SESSION_SECRET;
@@ -3290,7 +3290,7 @@ We should probably give people the ability to see that they're logged in and a w
 
 <summary>app/utils/session.server.ts</summary>
 
-```ts filename=app/utils/session.server.ts lines=[76-91,93-102]
+```ts filename=app/utils/session.server.ts lines=[75-90,92-101]
 import bcrypt from "bcryptjs";
 import {
   createCookieSessionStorage,
@@ -3317,7 +3317,7 @@ export async function login({
     user.passwordHash
   );
   if (!isCorrectPassword) return null;
-  return user;
+  return { id: user.id, username };
 }
 
 const sessionSecret = process.env.SESSION_SECRET;
@@ -3563,7 +3563,7 @@ Luckily, all we need to do to support this is to update `app/utils/session.serve
 
 <summary>app/utils/session.server.ts</summary>
 
-```tsx filename=app/utils/session.server.ts lines=[14-22]
+```tsx filename=app/utils/session.server.ts lines=[14-23]
 import bcrypt from "bcryptjs";
 import {
   createCookieSessionStorage,
@@ -3582,9 +3582,10 @@ export async function register({
   password
 }: LoginForm) {
   const passwordHash = await bcrypt.hash(password, 10);
-  return db.user.create({
+  const user = await db.user.create({
     data: { username, passwordHash }
   });
+  return { id: user.id, username };
 }
 
 export async function login({
@@ -3600,7 +3601,7 @@ export async function login({
     user.passwordHash
   );
   if (!isCorrectPassword) return null;
-  return user;
+  return { id: user.id, username };
 }
 
 const sessionSecret = process.env.SESSION_SECRET;

--- a/examples/jokes/app/routes/jokes.tsx
+++ b/examples/jokes/app/routes/jokes.tsx
@@ -2,12 +2,11 @@ import type { LoaderFunction, LinksFunction } from "remix";
 import { Form } from "remix";
 import { Outlet, useLoaderData, Link } from "remix";
 import { db } from "~/utils/db.server";
-import type { User } from "@prisma/client";
 import { getUser } from "~/utils/session.server";
 import stylesUrl from "../styles/jokes.css";
 
 type LoaderData = {
-  user: User | null;
+  user: Awaited<ReturnType<typeof getUser>>;
   jokeListItems: Array<{ id: string; name: string }>;
 };
 
@@ -21,10 +20,7 @@ export const loader: LoaderFunction = async ({ request }) => {
 
   const data: LoaderData = {
     jokeListItems,
-    user: user && {
-      id: user.id,
-      username: user.username,
-    },
+    user,
   };
 
   return data;

--- a/examples/jokes/app/routes/jokes.tsx
+++ b/examples/jokes/app/routes/jokes.tsx
@@ -21,7 +21,10 @@ export const loader: LoaderFunction = async ({ request }) => {
 
   const data: LoaderData = {
     jokeListItems,
-    user,
+    user: user && {
+      id: user.id,
+      username: user.username,
+    },
   };
 
   return data;

--- a/examples/jokes/app/utils/session.server.ts
+++ b/examples/jokes/app/utils/session.server.ts
@@ -72,7 +72,10 @@ export async function getUser(request: Request) {
   }
 
   try {
-    const user = await db.user.findUnique({ where: { id: userId } });
+    const user = await db.user.findUnique({
+      where: { id: userId },
+      select: { id: true, username: true },
+    });
     return user;
   } catch {
     throw logout(request);

--- a/examples/jokes/app/utils/session.server.ts
+++ b/examples/jokes/app/utils/session.server.ts
@@ -9,17 +9,20 @@ type LoginForm = {
 
 export async function register({ username, password }: LoginForm) {
   const passwordHash = await bcrypt.hash(password, 10);
-  return db.user.create({
+  const user = await db.user.create({
     data: { username, passwordHash },
   });
+  return { id: user.id, username };
 }
 
 export async function login({ username, password }: LoginForm) {
-  const user = await db.user.findUnique({ where: { username } });
+  const user = await db.user.findUnique({
+    where: { username },
+  });
   if (!user) return null;
   const isCorrectPassword = await bcrypt.compare(password, user.passwordHash);
   if (!isCorrectPassword) return null;
-  return user;
+  return { id: user.id, username };
 }
 
 const sessionSecret = process.env.SESSION_SECRET;


### PR DESCRIPTION
resolves: #673

Jokes example returns `passwordHash` in body. 
this happens because the whole user data was returned in the loader function.

<img width="841" alt="image" src="https://user-images.githubusercontent.com/4447799/143591862-579b9f97-dd5c-493f-b755-5fbb83057073.png">
