### PR TITLE
Missed Dependency

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -15,3 +15,4 @@
 - morinokami
 - msutkowski
 - ryanflorence
+- AdvTechnoKing

--- a/examples/blog-tutorial/package.json
+++ b/examples/blog-tutorial/package.json
@@ -17,6 +17,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remix": "1.0.6",
+    "react-router-dom": "^6.0.2",
     "tiny-invariant": "^1.2.0"
   },
   "devDependencies": {

--- a/examples/jokes/package.json
+++ b/examples/jokes/package.json
@@ -19,7 +19,8 @@
     "bcrypt": "^5.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.0.6"
+    "remix": "1.0.6",
+    "react-router-dom": "^6.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.0.6",


### PR DESCRIPTION
When installing via [PNPM](https://pnpm.io/), you also need to install react-router-dom too.

![image](https://user-images.githubusercontent.com/17812651/143656756-5ea39384-531d-4fe2-ae67-141fdff0c17c.png)
