### PR TITLE
Add option to change routes directory

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -16,3 +16,4 @@
 - msutkowski
 - ryanflorence
 - ascorbic
+- mjr

--- a/contributors.yml
+++ b/contributors.yml
@@ -15,3 +15,4 @@
 - morinokami
 - msutkowski
 - ryanflorence
+- ascorbic

--- a/packages/create-remix/templates/netlify/README.md
+++ b/packages/create-remix/templates/netlify/README.md
@@ -10,42 +10,39 @@
 npm i -g netlify-cli
 ```
 
+If you have previously installed the Netlify CLI, you should update it to the latest version:
+
+```sh
+npm i -g netlify-cli@latest
+```
+
 2. Sign up and log in to Netlify:
 
 ```sh
-  netlify login
+netlify login
 ```
 
 3. Create a new site:
 
 ```sh
-  netlify init
+netlify init
 ```
 
 4. You'll need to tell Netlify to use Node 14, as at the time of writing Netlify uses Node 12 by [default](https://docs.netlify.com/functions/build-with-javascript/#runtime-settings)
 
 ```sh
-  netlify env:set AWS_LAMBDA_JS_RUNTIME nodejs14.x
+netlify env:set AWS_LAMBDA_JS_RUNTIME nodejs14.x
 ```
 
 ## Development
 
-You will be running two processes during development when using Netlify as your server.
-
-- Your Netlify server in one
-- The Remix development server in another
+The Netlify CLI starts your app in development mode, rebuilding assets on file changes.
 
 ```sh
-# in one tab
-$ npm run dev:netlify
-
-# in another
-$ npm run dev
+npm run dev
 ```
 
 Open up [http://localhost:3000](http://localhost:3000), and you should be ready to go!
-
-If you'd rather run everything in a single tab, you can look at [concurrently](https://npm.im/concurrently) or similar tools to run both processes in one tab.
 
 ## Deployment
 

--- a/packages/create-remix/templates/netlify/netlify.toml
+++ b/packages/create-remix/templates/netlify/netlify.toml
@@ -1,10 +1,10 @@
 [build]
+  command = "remix build"
   functions = "netlify/functions"
   publish = "public"
 
 [dev]
-  functions = "netlify/functions"
-  publish = "public"
+  command = "remix watch"
   port = 3000
 
 [[redirects]]

--- a/packages/create-remix/templates/netlify/package.json
+++ b/packages/create-remix/templates/netlify/package.json
@@ -2,11 +2,10 @@
   "scripts": {
     "postinstall": "remix setup node",
     "build": "remix build",
-    "dev": "remix watch",
-    "dev:netlify": "cross-env NODE_ENV=development netlify dev"
+    "dev": "cross-env NODE_ENV=development netlify dev"
   },
   "dependencies": {
-    "@netlify/functions": "^0.7.2",
+    "@netlify/functions": "^0.10.0",
     "@remix-run/netlify": "*"
   },
   "devDependencies": {

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -26,6 +26,12 @@ export interface AppConfig {
   appDirectory?: string;
 
   /**
+   * The path to the `routes` directory, relative to `remix.config.js`. Defaults
+   * to "routes".
+   */
+   routesDirectory?: string;
+
+  /**
    * The path to a directory Remix can use for caching things in development,
    * relative to `remix.config.js`. Defaults to ".cache".
    */
@@ -90,6 +96,11 @@ export interface RemixConfig {
    * The absolute path to the application source directory.
    */
   appDirectory: string;
+
+  /**
+   * The path to the routes directory, relative to `config.appDirectory`.
+   */
+   routesDirectory: string;
 
   /**
    * The absolute path to the cache directory.
@@ -180,6 +191,8 @@ export async function readConfig(
     appConfig.cacheDirectory || ".cache"
   );
 
+  let routesDirectory = appConfig.routesDirectory || "routes";
+
   let entryClientFile = findEntry(appDirectory, "entry.client");
   if (!entryClientFile) {
     throw new Error(`Missing "entry.client" file in ${appDirectory}`);
@@ -215,8 +228,8 @@ export async function readConfig(
   let routes: RouteManifest = {
     root: { path: "", id: "root", file: rootRouteFile }
   };
-  if (fs.existsSync(path.resolve(appDirectory, "routes"))) {
-    let conventionalRoutes = defineConventionalRoutes(appDirectory);
+  if (fs.existsSync(path.resolve(appDirectory, routesDirectory))) {
+    let conventionalRoutes = defineConventionalRoutes(appDirectory, routesDirectory);
     for (let key of Object.keys(conventionalRoutes)) {
       let route = conventionalRoutes[key];
       routes[route.id] = { ...route, parentId: route.parentId || "root" };
@@ -233,6 +246,7 @@ export async function readConfig(
   return {
     appDirectory,
     cacheDirectory,
+    routesDirectory,
     entryClientFile,
     entryServerFile,
     devServerPort,

--- a/packages/remix-dev/config/routesConvention.ts
+++ b/packages/remix-dev/config/routesConvention.ts
@@ -21,18 +21,18 @@ export function isRouteModuleFile(filename: string): boolean {
  * For example, a file named `app/routes/gists/$username.tsx` creates a route
  * with a path of `gists/:username`.
  */
-export function defineConventionalRoutes(appDir: string): RouteManifest {
+export function defineConventionalRoutes(appDir: string, routesDirectory: string): RouteManifest {
   let files: { [routeId: string]: string } = {};
 
   // First, find all route modules in app/routes
-  visitFiles(path.join(appDir, "routes"), file => {
-    let routeId = createRouteId(path.join("routes", file));
+  visitFiles(path.join(appDir, routesDirectory), file => {
+    let routeId = createRouteId(path.join(routesDirectory, file));
 
     if (isRouteModuleFile(file)) {
-      files[routeId] = path.join("routes", file);
+      files[routeId] = path.join(routesDirectory, file);
     } else {
       throw new Error(
-        `Invalid route module file: ${path.join(appDir, "routes", file)}`
+        `Invalid route module file: ${path.join(appDir, routesDirectory, file)}`
       );
     }
   });
@@ -52,11 +52,11 @@ export function defineConventionalRoutes(appDir: string): RouteManifest {
 
     for (let routeId of childRouteIds) {
       let routePath: string | undefined = createRoutePath(
-        routeId.slice((parentId || "routes").length + 1)
+        routeId.slice((parentId || routesDirectory).length + 1)
       );
 
       let isIndexRoute = routeId.endsWith("/index");
-      let fullPath = createRoutePath(routeId.slice("routes".length + 1));
+      let fullPath = createRoutePath(routeId.slice(routesDirectory.length + 1));
       let uniqueRouteId = (fullPath || "") + (isIndexRoute ? "?index" : "");
 
       if (typeof uniqueRouteId !== "undefined") {


### PR DESCRIPTION
Add property `routesDirectory` in `remix.config.js` to allow change routes directory.

```es6
module.exports = {
  appDirectory: 'src',
  routesDirectory: 'pages',
  browserBuildDirectory: 'public/build',
  publicPath: '/build/',
  serverBuildDirectory: 'build',
  devServerPort: 8002,
};
```