### PR TITLE
feat(config): add API to modify esbuild config before it is used

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -16,3 +16,4 @@
 - msutkowski
 - ryanflorence
 - ascorbic
+- nicksrandall

--- a/contributors.yml
+++ b/contributors.yml
@@ -15,3 +15,4 @@
 - morinokami
 - msutkowski
 - ryanflorence
+- ascorbic

--- a/packages/create-remix/templates/netlify/README.md
+++ b/packages/create-remix/templates/netlify/README.md
@@ -10,42 +10,39 @@
 npm i -g netlify-cli
 ```
 
+If you have previously installed the Netlify CLI, you should update it to the latest version:
+
+```sh
+npm i -g netlify-cli@latest
+```
+
 2. Sign up and log in to Netlify:
 
 ```sh
-  netlify login
+netlify login
 ```
 
 3. Create a new site:
 
 ```sh
-  netlify init
+netlify init
 ```
 
 4. You'll need to tell Netlify to use Node 14, as at the time of writing Netlify uses Node 12 by [default](https://docs.netlify.com/functions/build-with-javascript/#runtime-settings)
 
 ```sh
-  netlify env:set AWS_LAMBDA_JS_RUNTIME nodejs14.x
+netlify env:set AWS_LAMBDA_JS_RUNTIME nodejs14.x
 ```
 
 ## Development
 
-You will be running two processes during development when using Netlify as your server.
-
-- Your Netlify server in one
-- The Remix development server in another
+The Netlify CLI starts your app in development mode, rebuilding assets on file changes.
 
 ```sh
-# in one tab
-$ npm run dev:netlify
-
-# in another
-$ npm run dev
+npm run dev
 ```
 
 Open up [http://localhost:3000](http://localhost:3000), and you should be ready to go!
-
-If you'd rather run everything in a single tab, you can look at [concurrently](https://npm.im/concurrently) or similar tools to run both processes in one tab.
 
 ## Deployment
 

--- a/packages/create-remix/templates/netlify/netlify.toml
+++ b/packages/create-remix/templates/netlify/netlify.toml
@@ -1,10 +1,10 @@
 [build]
+  command = "remix build"
   functions = "netlify/functions"
   publish = "public"
 
 [dev]
-  functions = "netlify/functions"
-  publish = "public"
+  command = "remix watch"
   port = 3000
 
 [[redirects]]

--- a/packages/create-remix/templates/netlify/package.json
+++ b/packages/create-remix/templates/netlify/package.json
@@ -2,11 +2,10 @@
   "scripts": {
     "postinstall": "remix setup node",
     "build": "remix build",
-    "dev": "remix watch",
-    "dev:netlify": "cross-env NODE_ENV=development netlify dev"
+    "dev": "cross-env NODE_ENV=development netlify dev"
   },
   "dependencies": {
-    "@netlify/functions": "^0.7.2",
+    "@netlify/functions": "^0.10.0",
     "@remix-run/netlify": "*"
   },
   "devDependencies": {

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -331,7 +331,7 @@ async function createBrowserBuild(
     ]
   };
   if (typeof config.esbuild === "function") {
-    esbuildConfig = await config.esbuild(esbuildConfig, BuildTarget.Browser);
+    esbuildConfig = await config.esbuild(esbuildConfig, { target: BuildTarget.Browser });
   }
   return esbuild.build(esbuildConfig);
 }
@@ -399,7 +399,7 @@ async function createServerBuild(
     ]
   };
   if (typeof config.esbuild === "function") {
-    esbuildConfig = await config.esbuild(esbuildConfig, BuildTarget.Server);
+    esbuildConfig = await config.esbuild(esbuildConfig, { target: BuildTarget.Server });
   }
   return esbuild.build(esbuildConfig);
 }

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -83,7 +83,7 @@ export interface AppConfig {
    */
   esbuild?: (
     options: BuildOptions,
-    target: BuildTarget
+    context: { target: BuildTarget }
   ) => BuildOptions | Promise<BuildOptions>;
 }
 
@@ -158,7 +158,7 @@ export interface RemixConfig {
    */
   esbuild?: (
     options: BuildOptions,
-    target: BuildTarget
+    context: { target: BuildTarget }
   ) => BuildOptions | Promise<BuildOptions>;
 }
 

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -1,6 +1,8 @@
 import * as fs from "fs";
 import * as path from "path";
+import type { BuildOptions } from "esbuild";
 
+import type { BuildTarget } from "./build";
 import type { RouteManifest, DefineRoutesFunction } from "./config/routes";
 import { defineRoutes } from "./config/routes";
 import { defineConventionalRoutes } from "./config/routesConvention";
@@ -75,6 +77,14 @@ export interface AppConfig {
   devServerBroadcastDelay?: number;
 
   mdx?: RemixMdxConfig | RemixMdxConfigFunction;
+
+  /**
+   * A hook to modify the esbuild config before it is used.
+   */
+  esbuild?: (
+    options: BuildOptions,
+    target: BuildTarget
+  ) => BuildOptions | Promise<BuildOptions>;
 }
 
 /**
@@ -142,6 +152,14 @@ export interface RemixConfig {
   devServerBroadcastDelay: number;
 
   mdx?: RemixMdxConfig | RemixMdxConfigFunction;
+
+  /**
+   * A hook to modify the esbuild config before it is used.
+   */
+  esbuild?: (
+    options: BuildOptions,
+    target: BuildTarget
+  ) => BuildOptions | Promise<BuildOptions>;
 }
 
 /**
@@ -243,7 +261,8 @@ export async function readConfig(
     routes,
     serverBuildDirectory,
     serverMode,
-    mdx: appConfig.mdx
+    mdx: appConfig.mdx,
+    esbuild: appConfig.esbuild
   };
 }
 


### PR DESCRIPTION
This API borrows inspiration from the Next.js config api allowing users to modify the esbuild config for the various targets before they are used to build the application. 