### PR TITLE
chore: add support for native .node modules to remix-dev (making tailwind integration pain free)

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -46,3 +46,4 @@
 - ascorbic
 - IAmLuisJ
 - weavdale
+- sync

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -14,6 +14,7 @@ import { createAssetsManifest } from "./compiler/assets";
 import { getAppDependencies } from "./compiler/dependencies";
 import { loaders, getLoaderForFile } from "./compiler/loaders";
 import { mdxPlugin } from "./compiler/plugins/mdx";
+import { nativeNodeModulesPlugin } from "./compiler/plugins/nativeNodeModules";
 import { getRouteModuleExportsCached } from "./compiler/routes";
 import { writeFileSafe } from "./compiler/utils/fs";
 
@@ -326,6 +327,7 @@ async function createBrowserBuild(
     },
     plugins: [
       mdxPlugin(config),
+      nativeNodeModulesPlugin(),
       browserRouteModulesPlugin(config, /\?browser$/),
       emptyModulesPlugin(config, /\.server(\.[jt]sx?)?$/)
     ]
@@ -359,6 +361,7 @@ async function createServerBuild(
     publicPath: config.publicPath,
     plugins: [
       mdxPlugin(config),
+      nativeNodeModulesPlugin(),
       serverRouteModulesPlugin(config),
       emptyModulesPlugin(config, /\.client(\.[jt]sx?)?$/),
       manualExternalsPlugin((id, importer) => {

--- a/packages/remix-dev/compiler/plugins/nativeNodeModules.ts
+++ b/packages/remix-dev/compiler/plugins/nativeNodeModules.ts
@@ -1,0 +1,41 @@
+import type { Plugin } from "esbuild";
+
+export function nativeNodeModulesPlugin(): Plugin {
+  return {
+    name: "native-node-modules",
+    setup(build) {
+      // If a ".node" file is imported within a module in the "file" namespace, resolve
+      // it to an absolute path and put it into the "node-file" virtual namespace.
+      build.onResolve({ filter: /\.node$/, namespace: "file" }, args => ({
+        path: require.resolve(args.path, { paths: [args.resolveDir] }),
+        namespace: "node-file"
+      }));
+
+      // Files in the "node-file" virtual namespace call "require()" on the
+      // path from esbuild of the ".node" file in the output directory.
+      build.onLoad({ filter: /.*/, namespace: "node-file" }, args => ({
+        contents: `
+        import path from ${JSON.stringify(args.path)}
+        try { module.exports = require(path) }
+        catch {}
+      `
+      }));
+
+      // If a ".node" file is imported within a module in the "node-file" namespace, put
+      // it in the "file" namespace where esbuild's default loading behavior will handle
+      // it. It is already an absolute path since we resolved it to one above.
+      build.onResolve({ filter: /\.node$/, namespace: "node-file" }, args => ({
+        path: args.path,
+        namespace: "file"
+      }));
+
+      // Tell esbuild's default loading behavior to use the "file" loader for
+      // these ".node" files.
+      let opts = build.initialOptions;
+      opts.loader = opts.loader || {};
+      opts.loader[".node"] = "file";
+    }
+  };
+}
+
+exports.nativeNodeModulesPlugin = nativeNodeModulesPlugin;

--- a/packages/remix-dev/compiler/routes.ts
+++ b/packages/remix-dev/compiler/routes.ts
@@ -4,6 +4,7 @@ import * as esbuild from "esbuild";
 import * as cache from "../cache";
 import type { RemixConfig } from "../config";
 import { mdxPlugin } from "./plugins/mdx";
+import { nativeNodeModulesPlugin } from "./plugins/nativeNodeModules";
 import { getFileHash } from "./utils/crypto";
 
 type CachedRouteExports = { hash: string; exports: string[] };
@@ -54,7 +55,7 @@ export async function getRouteModuleExports(
     metafile: true,
     write: false,
     logLevel: "silent",
-    plugins: [mdxPlugin(config)]
+    plugins: [mdxPlugin(config), nativeNodeModulesPlugin()]
   });
   let metafile = result.metafile!;
 


### PR DESCRIPTION
Was checking out remix-tailwind and it had issues on OSX due to fsevents use of .node modules in OSX. I think remix-tailwind is a super nice way to do tailwind in remix, pain free and it would be nice if our OSX users could also use it.

Here you can find more details about the issue:
https://github.com/itsMapleLeaf/remix-tailwind/issues/1

This code was originated from here and written by Evan:
https://github.com/evanw/esbuild/issues/1051

For anyone interested trying this fix, feel free to:
- install [patch-package](https://github.com/ds300/patch-package#readme)
- create a patches folder in the root
- unzip and drop the patched files into the patches folder

[@remix-run+dev+1.0.6.patch.zip](https://github.com/remix-run/remix/files/7612991/%40remix-run%2Bdev%2B1.0.6.patch.zip)