### PR TITLE
Fix Variable Used in Conventions.md Code Example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -15,3 +15,4 @@
 - morinokami
 - msutkowski
 - ryanflorence
+- mpetrus001

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -464,7 +464,7 @@ export function CatchBoundary() {
         <div>
           <p>You don't have access to this invoice.</p>
           <p>
-            Contact {invoiceCatch.data.invoiceOwnerEmail} to
+            Contact {caught.data.invoiceOwnerEmail} to
             get access
           </p>
         </div>
@@ -477,8 +477,8 @@ export function CatchBoundary() {
   // This will be caught by the closest `ErrorBoundary`.
   return (
     <div>
-      Something went wrong: {invoiceCatch.status}{" "}
-      {invoiceCatch.statusText}
+      Something went wrong: {caught.status}{" "}
+      {caught.statusText}
     </div>
   );
 }


### PR DESCRIPTION
The "Throwing Responses in Loaders" code example appears to use an undefined variable in the CatchBoundary function. The return value of useCatch() is defined as "let caught", but the JSX returned by the boundary tries to use "invoiceCatch" as the variable; "invoiceCatch" does not appear to be defined in the code example. The commit replaces "invoiceCatch" with "caught".

I've also added myself to the Contributors.yml as has been requested by others.