### PR TITLE
Fix(jokes tutorials): fix typo remove utils.server.ts

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -16,4 +16,4 @@
 - msutkowski
 - ryanflorence
 - ascorbic
-- Judicael
+- judicaelandria

--- a/contributors.yml
+++ b/contributors.yml
@@ -16,3 +16,4 @@
 - msutkowski
 - ryanflorence
 - ascorbic
+- Judicael

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -148,7 +148,6 @@ remix-jokes
 │   │   │   ├── about.css
 │   │   │   └── remix.css
 │   │   └── global.css
-│   └── utils.server.tsx
 ├── package-lock.json
 ├── package.json
 ├── public
@@ -205,7 +204,6 @@ Feel free to read a bit of what's in there and explore the code if you like. I'l
 
 - `app/routes`
 - `app/styles`
-- `app/utils.server.tsx`
 
 💿 Replace the contents of `app/root.tsx` with this:
 


### PR DESCRIPTION
When creating a new remix project there is no file called utils.server.ts, however the jokes tutorials still have it
So this PR delete the utils.server.ts from the tutorials