### PR TITLE
docs: fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,6 +1,7 @@
 - abereghici
 - BasixKOR
 - chaance
+- drazik
 - goncy
 - ianduvall
 - jacob-ebey

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1613,7 +1613,7 @@ import { db } from "~/utils/db.server";
 type LoaderData = { users: Array<User> };
 export let loader: LoaderFunction = async () => {
   let data: LoaderData = {
-    users: await prisma.user.findMany()
+    users: await db.user.findMany()
   };
   return { data };
 };


### PR DESCRIPTION
Example code was relying on a non existing `prisma` variable. It was actually intended to reference the `db` variable.