### PR TITLE
fix: remove process.env check for LiveReload from docs, examples and templates

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -16,3 +16,4 @@
 - msutkowski
 - ryanflorence
 - ascorbic
+- ZiiMakc

--- a/contributors.yml
+++ b/contributors.yml
@@ -15,3 +15,4 @@
 - morinokami
 - msutkowski
 - ryanflorence
+- ascorbic

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -221,9 +221,7 @@ export default function App() {
       </head>
       <body>
         Hello world
-        {process.env.NODE_ENV === "development" ? (
-          <LiveReload />
-        ) : null}
+        <LiveReload />
       </body>
     </html>
   );
@@ -307,9 +305,7 @@ export default function App() {
       </head>
       <body>
         <Outlet />
-        {process.env.NODE_ENV === "development" ? (
-          <LiveReload />
-        ) : null}
+        <LiveReload />
       </body>
     </html>
   );
@@ -522,9 +518,7 @@ export default function App() {
       </head>
       <body>
         <Outlet />
-        {process.env.NODE_ENV === "development" ? (
-          <LiveReload />
-        ) : null}
+        <LiveReload />
       </body>
     </html>
   );
@@ -1231,9 +1225,7 @@ export default function App() {
       </head>
       <body>
         <Outlet />
-        {process.env.NODE_ENV === "development" ? (
-          <LiveReload />
-        ) : null}
+        <LiveReload />
       </body>
     </html>
   );
@@ -3943,9 +3935,7 @@ function Document({
       </head>
       <body>
         {children}
-        {process.env.NODE_ENV === "development" ? (
-          <LiveReload />
-        ) : null}
+        <LiveReload />
       </body>
     </html>
   );
@@ -4110,9 +4100,7 @@ function Document({
       </head>
       <body>
         {children}
-        {process.env.NODE_ENV === "development" ? (
-          <LiveReload />
-        ) : null}
+        <LiveReload />
       </body>
     </html>
   );
@@ -4826,9 +4814,7 @@ function Document({
       </head>
       <body>
         {children}
-        {process.env.NODE_ENV === "development" ? (
-          <LiveReload />
-        ) : null}
+        <LiveReload />
       </body>
     </html>
   );
@@ -5492,9 +5478,7 @@ function Document({
       <body>
         {children}
         <Scripts />
-        {process.env.NODE_ENV === "development" ? (
-          <LiveReload />
-        ) : null}
+        <LiveReload />
       </body>
     </html>
   );

--- a/examples/basic/app/root.tsx
+++ b/examples/basic/app/root.tsx
@@ -72,7 +72,7 @@ function Document({
         <RouteChangeAnnouncement />
         <ScrollRestoration />
         <Scripts />
-        {process.env.NODE_ENV === "development" && <LiveReload />}
+        <LiveReload />
       </body>
     </html>
   );

--- a/examples/blog-tutorial/app/root.tsx
+++ b/examples/blog-tutorial/app/root.tsx
@@ -70,7 +70,7 @@ function Document({
         {children}
         <ScrollRestoration />
         <Scripts />
-        {process.env.NODE_ENV === "development" && <LiveReload />}
+        <LiveReload />
       </body>
     </html>
   );

--- a/examples/jokes/app/root.tsx
+++ b/examples/jokes/app/root.tsx
@@ -54,7 +54,7 @@ function Document({
       <body>
         {children}
         <Scripts />
-        {process.env.NODE_ENV === "development" && <LiveReload />}
+        <LiveReload />
       </body>
     </html>
   );

--- a/packages/create-remix/templates/_shared_js/app/root.jsx
+++ b/packages/create-remix/templates/_shared_js/app/root.jsx
@@ -106,7 +106,7 @@ function Document({ children, title }) {
         {children}
         <ScrollRestoration />
         <Scripts />
-        {process.env.NODE_ENV === "development" && <LiveReload />}
+        <LiveReload />
       </body>
     </html>
   );

--- a/packages/create-remix/templates/_shared_ts/app/root.tsx
+++ b/packages/create-remix/templates/_shared_ts/app/root.tsx
@@ -113,7 +113,7 @@ function Document({
         {children}
         <ScrollRestoration />
         <Scripts />
-        {process.env.NODE_ENV === "development" && <LiveReload />}
+        <LiveReload />
       </body>
     </html>
   );

--- a/packages/create-remix/templates/netlify/README.md
+++ b/packages/create-remix/templates/netlify/README.md
@@ -10,42 +10,39 @@
 npm i -g netlify-cli
 ```
 
+If you have previously installed the Netlify CLI, you should update it to the latest version:
+
+```sh
+npm i -g netlify-cli@latest
+```
+
 2. Sign up and log in to Netlify:
 
 ```sh
-  netlify login
+netlify login
 ```
 
 3. Create a new site:
 
 ```sh
-  netlify init
+netlify init
 ```
 
 4. You'll need to tell Netlify to use Node 14, as at the time of writing Netlify uses Node 12 by [default](https://docs.netlify.com/functions/build-with-javascript/#runtime-settings)
 
 ```sh
-  netlify env:set AWS_LAMBDA_JS_RUNTIME nodejs14.x
+netlify env:set AWS_LAMBDA_JS_RUNTIME nodejs14.x
 ```
 
 ## Development
 
-You will be running two processes during development when using Netlify as your server.
-
-- Your Netlify server in one
-- The Remix development server in another
+The Netlify CLI starts your app in development mode, rebuilding assets on file changes.
 
 ```sh
-# in one tab
-$ npm run dev:netlify
-
-# in another
-$ npm run dev
+npm run dev
 ```
 
 Open up [http://localhost:3000](http://localhost:3000), and you should be ready to go!
-
-If you'd rather run everything in a single tab, you can look at [concurrently](https://npm.im/concurrently) or similar tools to run both processes in one tab.
 
 ## Deployment
 

--- a/packages/create-remix/templates/netlify/netlify.toml
+++ b/packages/create-remix/templates/netlify/netlify.toml
@@ -1,10 +1,10 @@
 [build]
+  command = "remix build"
   functions = "netlify/functions"
   publish = "public"
 
 [dev]
-  functions = "netlify/functions"
-  publish = "public"
+  command = "remix watch"
   port = 3000
 
 [[redirects]]

--- a/packages/create-remix/templates/netlify/package.json
+++ b/packages/create-remix/templates/netlify/package.json
@@ -2,11 +2,10 @@
   "scripts": {
     "postinstall": "remix setup node",
     "build": "remix build",
-    "dev": "remix watch",
-    "dev:netlify": "cross-env NODE_ENV=development netlify dev"
+    "dev": "cross-env NODE_ENV=development netlify dev"
   },
   "dependencies": {
-    "@netlify/functions": "^0.7.2",
+    "@netlify/functions": "^0.10.0",
     "@remix-run/netlify": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
When using:
```
{process.env.NODE_ENV === "development" ? (
   <LiveReload />
) : null}
```
in `root` component as stated in docs or by using express default example, browser will show multiple `Uncaught ReferenceError: process is not defined` errors caught by `ErrorBoundary`.

This check is already included in `LiveReload` [component](https://github.com/remix-run/remix/blob/c56761e09d1aeb27c4d3d5374759fd1bb5f79dcf/packages/remix-react/components.tsx) itself `if (process.env.NODE_ENV !== "development") return null;` so it's not necessary to duplicate it. Removing `process...` ckeck will remove this errors from appearing. 

Only thing I'm unsure of, is why there is no errors from `process...` usage inside `LiveReload` component.

![chrome_7SlCkQVedg](https://user-images.githubusercontent.com/22568762/143723940-7e20b169-7972-4abc-9193-7173e6a13b40.png)
