### PR TITLE
Fix the Remix Jokes App tutorial docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -9,6 +9,7 @@
 - kentcdodds
 - kgregory
 - leo
+- maxzitron
 - mcansh
 - meetbryce
 - michaeldeboey

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -3644,7 +3644,7 @@ export async function createUserSession(
 
 ```tsx filename=app/routes/login.tsx lines=[7,86-93]
 import type { ActionFunction, LinksFunction } from "remix";
-import { useActionData, useSearchParams } from "remix";
+import { useActionData, Link, useSearchParams } from "remix";
 import { db } from "~/utils/db.server";
 import {
   createUserSession,

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -2987,13 +2987,13 @@ So we can now check whether the user is authenticated on the server by reading t
 
 <docs-info>Remember to check [the docs](../api/remix#sessions) to learn how to get the session from the request</docs-info>
 
-💿 Update `app/utils/session.ts` to get the `userId` from the session. In my solution I create three functions: `getUserSession(request: Request)`, `getUserId(request: Request)` and `requireUserId(userId: string)`.
+💿 Update `app/utils/session.server.ts` to get the `userId` from the session. In my solution I create three functions: `getUserSession(request: Request)`, `getUserId(request: Request)` and `requireUserId(userId: string)`.
 
 <details>
 
-<summary>app/utils/session.ts</summary>
+<summary>app/utils/session.server.ts</summary>
 
-```ts filename=app/utils/session.ts lines=[46-48,50-55,57-70]
+```ts filename=app/utils/session.server.ts lines=[46-48,50-55,57-70]
 import bcrypt from "bcrypt";
 import {
   createCookieSessionStorage,
@@ -3239,9 +3239,9 @@ We should probably give people the ability to see that they're logged in and a w
 
 <details>
 
-<summary>app/utils/session.ts</summary>
+<summary>app/utils/session.server.ts</summary>
 
-```ts filename=app/utils/session.ts lines=[72-86,88-97]
+```ts filename=app/utils/session.server.ts lines=[72-86,88-97]
 import bcrypt from "bcrypt";
 import {
   createCookieSessionStorage,


### PR DESCRIPTION
While following the [Remix Jokes App tutorial](https://remix.run/docs/en/v1/tutorials/jokes), I have spotted some filename mistakes that arise my confusion. The following filename issues have been addressed by this PR

<img width="818" alt="Screen Shot 2564-11-28 at 16 44 26" src="https://user-images.githubusercontent.com/1258062/143765690-f70c8620-0a4e-4176-acbb-0d2012627594.png">

<img width="899" alt="Screen Shot 2564-11-28 at 16 44 34" src="https://user-images.githubusercontent.com/1258062/143765699-a9b579da-8ae5-4639-9cd6-1a78f606155e.png">

Also, in one of the code snippets, one of the dependencies has not been imported properly causing error when pasting into a code editor without adding the missing dependency.
<img width="892" alt="Screen Shot 2564-11-28 at 18 25 23" src="https://user-images.githubusercontent.com/1258062/143765821-552aca16-5c3f-41e7-9084-7ba4d14ebebc.png">


