### PR TITLE
docs: fix type annotation in jokes tutorial

### DIFF
--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -2062,7 +2062,7 @@ export let action: ActionFunction = async ({
 };
 
 export default function NewJokeRoute() {
-  let actionData = useActionData<ActionData | undefined>();
+  let actionData = useActionData<ActionData>();
 
   return (
     <div>


### PR DESCRIPTION
The `useActionData` takes a type parameter `T` and returns something of type `T | undefined`, so we don't need to specify `ActionData | undefined` in the type parameter.