### PR TITLE
added .env to gitignore

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -16,3 +16,4 @@
 - msutkowski
 - ryanflorence
 - ascorbic
+- IAmLuisJ

--- a/packages/create-remix/templates/_shared_js/gitignore
+++ b/packages/create-remix/templates/_shared_js/gitignore
@@ -3,3 +3,4 @@ node_modules
 /.cache
 /server/build
 /public/build
+.env

--- a/packages/create-remix/templates/_shared_ts/gitignore
+++ b/packages/create-remix/templates/_shared_ts/gitignore
@@ -3,3 +3,4 @@ node_modules
 /.cache
 /server/build
 /public/build
+.env

--- a/packages/create-remix/templates/remix/gitignore
+++ b/packages/create-remix/templates/remix/gitignore
@@ -3,3 +3,4 @@ node_modules
 /.cache
 /build
 /public/build
+.env


### PR DESCRIPTION
Updated gitignore template files to include .env files by default so they are not committed to a repo. Adds feature request #760 