### PR TITLE
chore: Allow for faster Builds on Vercel

### DIFF
--- a/packages/create-remix/templates/vercel/api/index.js
+++ b/packages/create-remix/templates/vercel/api/index.js
@@ -1,5 +1,5 @@
 const { createRequestHandler } = require("@remix-run/vercel");
 
 module.exports = createRequestHandler({
-  build: require("./build")
+  build: require("./_build")
 });

--- a/packages/create-remix/templates/vercel/gitignore
+++ b/packages/create-remix/templates/vercel/gitignore
@@ -5,4 +5,4 @@ node_modules
 .output
 
 public/build
-api/build
+api/_build

--- a/packages/create-remix/templates/vercel/remix.config.js
+++ b/packages/create-remix/templates/vercel/remix.config.js
@@ -5,5 +5,5 @@ module.exports = {
   appDirectory: "app",
   browserBuildDirectory: "public/build",
   publicPath: "/build/",
-  serverBuildDirectory: "api/build"
+  serverBuildDirectory: "api/_build"
 };


### PR DESCRIPTION
This change will prevent the `_build` directory within `api` from receiving its own dedicated Serverless Function, which will speed up the build because it prevents unnecessary transformations.