### PR TITLE
chore(remix-react): remove `SubmissionTransition` type

### DIFF
--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -168,13 +168,6 @@ export type TransitionStates = {
   };
 };
 
-export type SubmissionTransition =
-  | TransitionStates["SubmittingAction"]
-  | TransitionStates["LoadingAction"]
-  | TransitionStates["LoadingActionRedirect"]
-  | TransitionStates["SubmittingLoader"]
-  | TransitionStates["LoadingLoaderSubmissionRedirect"];
-
 export type Transition = TransitionStates[keyof TransitionStates];
 
 export type Redirects = {


### PR DESCRIPTION
It's never used & also not exported as a public API