### PR TITLE
fix(remix-react): fix circular dependency

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -49,8 +49,6 @@ import type { RouteModules, HtmlMetaDescriptor } from "./routeModules";
 import { createTransitionManager } from "./transition";
 import type { Transition, Fetcher, Submission } from "./transition";
 
-export { ScrollRestoration } from "./scroll-restoration";
-
 ////////////////////////////////////////////////////////////////////////////////
 // RemixEntry
 

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -26,7 +26,6 @@ export {
   NavLink,
   Form,
   PrefetchPageLinks,
-  ScrollRestoration,
   LiveReload,
   useFormAction,
   useSubmit,
@@ -48,6 +47,8 @@ export { useCatch } from "./errorBoundaries";
 
 export type { HtmlLinkDescriptor } from "./links";
 export type { ShouldReloadFunction, HtmlMetaDescriptor } from "./routeModules";
+
+export { ScrollRestoration } from "./scroll-restoration";
 
 export type { RemixServerProps } from "./server";
 export { RemixServer } from "./server";


### PR DESCRIPTION
When running `yarn build`, you get the following warning:

```sh
(!) Circular dependency
packages/remix-react/components.tsx -> packages/remix-react/scroll-restoration.tsx -> packages/remix-react/components.tsx
```

This PR fixes the circular dependency