### PR TITLE
docs(errorBoundary): correct component name on comment

### DIFF
--- a/packages/remix-react/errorBoundaries.tsx
+++ b/packages/remix-react/errorBoundaries.tsx
@@ -154,7 +154,7 @@ export function RemixCatchBoundary({
 }
 
 /**
- * When app's don't provide a root level ErrorBoundary, we default to this.
+ * When app's don't provide a root level CatchBoundary, we default to this.
  */
 export function RemixRootDefaultCatchBoundary() {
   return (


### PR DESCRIPTION
just a minor naming thing on an informative comment