### PR TITLE
Do not use Prisma instance, use db instance instead

### DIFF
--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1612,7 +1612,7 @@ import { db } from "~/utils/db.server";
 type LoaderData = { users: Array<User> };
 export let loader: LoaderFunction = async () => {
   let data: LoaderData = {
-    users: await prisma.user.findMany()
+    users: await db.user.findMany()
   };
   return { data };
 };


### PR DESCRIPTION
In this part of the J🤪kes example we're using a `prisma` instance instead of using the `db`. This is a bit weird in this place because we're not creating the Prisma instance anywhere in this code, if you take a look at the previous examples, we created the Prisma instance inside the `db.server.ts` file and is being exported there.