### PR TITLE
docs: clarify instruction in blog tutorial

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -28,3 +28,4 @@
 - ryanflorence
 - stephanerangaya
 - zachdtaylor
+- graham42

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -34,7 +34,7 @@ If your application is not running properly at [https://localhost:3000](https://
 
 We're going to make a new route to render at the "/posts" URL. Before we do that, let's link to it.
 
-There's a bit going on in the file, find into the `Layout` component and right after the link to "Home", add a new link to "/posts"
+There's a bit going on in the file `app/root.tsx`. Find the `Layout` component, and right after the link to "Home", add a new link to "/posts"
 
 💿 Add a link to posts in `app/root.tsx`
 


### PR DESCRIPTION
"the file" didn't have any context yet, so it was not clear which file
was being referred to.

In the phrase "find into the Layout component" it appears "into" is an
extra word.

fixes: https://github.com/remix-run/remix/issues/793