### PR TITLE
Fix small typo in Jokes tutorial

### DIFF
--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1612,7 +1612,7 @@ import { db } from "~/utils/db.server";
 type LoaderData = { users: Array<User> };
 export let loader: LoaderFunction = async () => {
   let data: LoaderData = {
-    users: await prisma.user.findMany()
+    users: await db.user.findMany()
   };
   return { data };
 };


### PR DESCRIPTION
Apologies for the tiny PR but I was attempting to figure out the Jokes loader function based on this example and I was initially confused at where `prisma` was being defined 😅 Love the tutorial so far though! 