### PR TITLE
Added .DS_STORE to template .gitignores

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -32,3 +32,4 @@
 - tylerbrostrom
 - ascorbic
 - IAmLuisJ
+- nialldbarber

--- a/packages/create-remix/templates/_shared_js/gitignore
+++ b/packages/create-remix/templates/_shared_js/gitignore
@@ -1,4 +1,5 @@
 node_modules
+.DS_Store
 
 /.cache
 /server/build

--- a/packages/create-remix/templates/_shared_ts/gitignore
+++ b/packages/create-remix/templates/_shared_ts/gitignore
@@ -1,4 +1,5 @@
 node_modules
+.DS_Store
 
 /.cache
 /server/build

--- a/packages/create-remix/templates/arc/gitignore
+++ b/packages/create-remix/templates/arc/gitignore
@@ -1,4 +1,5 @@
 node_modules
+.DS_Store
 
 /.cache
 /server/build

--- a/packages/create-remix/templates/cloudflare-workers/gitignore
+++ b/packages/create-remix/templates/cloudflare-workers/gitignore
@@ -1,4 +1,5 @@
 node_modules
+.DS_Store
 
 /.cache
 /build

--- a/packages/create-remix/templates/netlify/gitignore
+++ b/packages/create-remix/templates/netlify/gitignore
@@ -1,4 +1,6 @@
 node_modules
+.DS_Store
+
 /.cache
 /netlify/functions/server/build
 /public/build

--- a/packages/create-remix/templates/remix/gitignore
+++ b/packages/create-remix/templates/remix/gitignore
@@ -1,4 +1,5 @@
 node_modules
+.DS_Store
 
 /.cache
 /build

--- a/packages/create-remix/templates/vercel/gitignore
+++ b/packages/create-remix/templates/vercel/gitignore
@@ -1,4 +1,5 @@
 node_modules
+.DS_Store
 
 .cache
 .vercel


### PR DESCRIPTION
Added `.DS_STORE` to all the relevant templates' `.gitignore`. This might need to changed to `**/.DS_Store` if they pop up in deeper directories, but hopefully not! 

This came about when I tried using the Vercel template and found quite a few `.DS_STORE`(s): https://github.com/nialldbarber/ndb-remix