### PR TITLE
let -> const (for external-facing code)

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -166,7 +166,7 @@ export default function handleRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  let markup = ReactDOMServer.renderToString(
+  const markup = ReactDOMServer.renderToString(
     <RemixServer context={remixContext} url={request.url} />
   );
 
@@ -179,14 +179,15 @@ export default function handleRequest(
 }
 
 // this is an optional export
-export let handleDataRequest: HandleDataRequestFunction = (
-  response: Response,
-  // same args that get passed to the action or loader that was called
-  { request, params, context }
-) => {
-  response.headers.set("x-custom", "yay!");
-  return response;
-};
+export const handleDataRequest: HandleDataRequestFunction =
+  (
+    response: Response,
+    // same args that get passed to the action or loader that was called
+    { request, params, context }
+  ) => {
+    response.headers.set("x-custom", "yay!");
+    return response;
+  };
 ```
 
 ## Route Module API
@@ -215,13 +216,13 @@ export default function SomeRouteComponent() {
 Each route can define a "loader" function that will be called on the server before rendering to provide data to the route.
 
 ```tsx
-export let loader = async () => {
+export const loader = async () => {
   return { ok: true };
 };
 
 // Typescript
 import type { LoaderFunction } from "remix";
-export let loader: LoaderFunction = async () => {
+export const loader: LoaderFunction = async () => {
   return { ok: true };
 };
 ```
@@ -234,12 +235,12 @@ Using the database ORM Prisma as an example:
 import { useLoaderData } from "remix";
 import { prisma } from "../db";
 
-export let loader = async () => {
+export const loader = async () => {
   return prisma.user.findMany();
 };
 
 export default function Users() {
-  let data = useLoaderData();
+  const data = useLoaderData();
   return (
     <ul>
       {data.map(user => (
@@ -260,7 +261,7 @@ Route params are passed to your loader. If you have a loader at `data/invoices/$
 
 ```js
 // if the user visits /invoices/123
-export let loader: LoaderFunction = ({ params }) => {
+export const loader: LoaderFunction = ({ params }) => {
   params.invoiceId; // "123"
 };
 ```
@@ -272,13 +273,13 @@ This is a [Fetch Request][request] instance with information about the request. 
 Most common cases are reading headers or the URL. You can also use this to read URL [URLSearchParams][urlsearchparams] from the request like so:
 
 ```tsx
-export let loader: LoaderFunction = ({ request }) => {
+export const loader: LoaderFunction = ({ request }) => {
   // read a cookie
-  let cookie = request.headers.get("Cookie");
+  const cookie = request.headers.get("Cookie");
 
   // parse the search params
-  let url = new URL(request.url);
-  let search = url.searchParams.get("search");
+  const url = new URL(request.url);
+  const search = url.searchParams.get("search");
 };
 ```
 
@@ -309,8 +310,8 @@ app.all(
 And then your loader can access it.
 
 ```ts filename=routes/some-route.tsx
-export let loader: LoaderFunction = ({ context }) => {
-  let { expressUser } = context;
+export const loader: LoaderFunction = ({ context }) => {
+  const { expressUser } = context;
   // ...
 };
 ```
@@ -320,7 +321,7 @@ export let loader: LoaderFunction = ({ context }) => {
 You can return plain JavaScript objects from your loaders that will be made available to your [route modules]("../route-module").
 
 ```ts
-export let loader = async () => {
+export const loader = async () => {
   return { whatever: "you want" };
 };
 ```
@@ -330,9 +331,9 @@ export let loader = async () => {
 When you return a plain object, Remix turns it into a [Fetch Response][response]. This means you can return them yourself, too.
 
 ```js
-export let loader: LoaderFunction = async () => {
-  let users = await db.users.findMany();
-  let body = JSON.stringify(users);
+export const loader: LoaderFunction = async () => {
+  const users = await db.users.findMany();
+  const body = JSON.stringify(users);
   return new Response(body, {
     headers: {
       "Content-Type": "application/json"
@@ -346,8 +347,8 @@ Remix provides helpers, like `json`, so you don't have to construct them yoursel
 ```tsx
 import { json } from "remix";
 
-export let loader: LoaderFunction = async () => {
-  let users = await fakeDb.users.findMany();
+export const loader: LoaderFunction = async () => {
+  const users = await fakeDb.users.findMany();
   return json(users);
 };
 ```
@@ -357,8 +358,10 @@ Between these two examples you can see how `json` just does a little of work to 
 ```tsx
 import { json } from "remix";
 
-export let loader: LoaderFunction = async ({ params }) => {
-  let user = await fakeDb.project.findOne({
+export const loader: LoaderFunction = async ({
+  params
+}) => {
+  const user = await fakeDb.project.findOne({
     where: { id: params.id }
   });
 
@@ -391,7 +394,7 @@ export type InvoiceNotFoundResponse = ThrownResponse<
 >;
 
 export function getInvoice(id, user) {
-  let invoice = db.invoice.find({ where: { id } });
+  const invoice = db.invoice.find({ where: { id } });
   if (invoice === null) {
     throw json("Not Found", { status: 404 });
   }
@@ -404,7 +407,7 @@ import { redirect } from "remix";
 import { getSession } from "./session";
 
 function requireUserSession(request) {
-  let session = await getSession(
+  const session = await getSession(
     request.headers.get("cookie")
   );
   if (!session) {
@@ -435,12 +438,12 @@ type ThrownResponses =
   | InvoiceNotFoundResponse
   | ThrownResponse<401, InvoiceCatchData>;
 
-export let loader = async ({ request, params }) => {
-  let user = await requireUserSession(request);
-  let invoice: Invoice = getInvoice(params.invoiceId);
+export const loader = async ({ request, params }) => {
+  const user = await requireUserSession(request);
+  const invoice: Invoice = getInvoice(params.invoiceId);
 
   if (!invoice.userIds.includes(user.id)) {
-    let data: InvoiceCatchData = {
+    const data: InvoiceCatchData = {
       invoiceOwnerEmail: invoice.owner.email
     };
     throw new json(data, { status: 401 });
@@ -450,13 +453,13 @@ export let loader = async ({ request, params }) => {
 };
 
 export default function InvoiceRoute() {
-  let invoice = useLoaderData<Invoice>();
+  const invoice = useLoaderData<Invoice>();
   return <InvoiceView invoice={invoice} />;
 }
 
 export function CatchBoundary() {
   // this returns { status, statusText, data }
-  let caught = useCatch<ThrownResponses>();
+  const caught = useCatch<ThrownResponses>();
 
   switch (caught.status) {
     case 401:
@@ -502,15 +505,15 @@ export async function loader() {
 }
 
 export async function action({ request }) {
-  let body = await request.formData();
-  let todo = await fakeCreateTodo({
+  const body = await request.formData();
+  const todo = await fakeCreateTodo({
     title: body.get("title")
   });
   return redirect(`/todos/${todo.id}`);
 }
 
 export default function Todos() {
-  let data = useLoaderData();
+  const data = useLoaderData();
   return (
     <div>
       <TodoList todos={data} />
@@ -596,16 +599,16 @@ That is all to say that Remix has given you a very large gun with which to shoot
 import parseCacheControl from "parse-cache-control";
 
 export function headers({ loaderHeaders, parentHeaders }) {
-  let loaderCache = parseCacheControl(
+  const loaderCache = parseCacheControl(
     loaderHeaders.get("Cache-Control")
   );
-  let parentCache = parseCacheControl(
+  const parentCache = parseCacheControl(
     parentHeaders.get("Cache-Control")
   );
 
   // take the most conservative between the parent and loader, otherwise
   // we'll be too aggressive for one of them.
-  let maxAge = Math.min(
+  const maxAge = Math.min(
     loaderCache["max-age"],
     parentCache["max-age"]
   );
@@ -625,7 +628,7 @@ The meta export will set meta tags for your html document. We highly recommend s
 ```tsx
 import type { MetaFunction } from "remix";
 
-export let meta: MetaFunction = () => {
+export const meta: MetaFunction = () => {
   return {
     title: "Something cool",
     description:
@@ -645,7 +648,7 @@ The links function defines which `<link>` elements to add to the page when the u
 ```tsx
 import type { LinksFunction } from "remix";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     {
       rel: "icon",
@@ -680,7 +683,7 @@ Examples:
 import type { LinksFunction } from "remix";
 import stylesHref from "../styles/something.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     // add a favicon
     {
@@ -735,7 +738,7 @@ Examples:
 ```tsx
 import type { MetaFunction } from "remix";
 
-export let meta: MetaFunction = () => {
+export const meta: MetaFunction = () => {
   return {
     title: "Josie's Shake Shack", // <title>Josie's Shake Shack</title>
     description: "Delicious shakes", // <meta name="description" content="Delicious shakes">
@@ -772,7 +775,7 @@ A `CatchBoundary` component has access to the status code and thrown response da
 import { useCatch } from "remix";
 
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   return (
     <div>
@@ -814,7 +817,7 @@ export function ErrorBoundary({ error }) {
 Exporting a handle allows you to create application conventions with the `useMatches()` hook. You can put whatever values you want on it:
 
 ```js
-export let handle = {
+export const handle = {
   its: "all yours"
 };
 ```
@@ -832,19 +835,20 @@ This function lets apps optimize which routes should be reloaded on some client-
 ```ts
 import type { ShouldReloadFunction } from "remix";
 
-export let unstable_shouldReload: ShouldReloadFunction = ({
-  // same params that go to `loader` and `action`
-  params,
+export const unstable_shouldReload: ShouldReloadFunction =
+  ({
+    // same params that go to `loader` and `action`
+    params,
 
-  // a possible form submission that caused this to be reloaded
-  submission,
+    // a possible form submission that caused this to be reloaded
+    submission,
 
-  // the next URL being used to render this page
-  url,
+    // the next URL being used to render this page
+    url,
 
-  // the previous URL used to render this page
-  prevUrl
-}) => false; // or `true`;
+    // the previous URL used to render this page
+    prevUrl
+  }) => false; // or `true`;
 ```
 
 During client-side transitions, Remix will optimize reloading of routes that are already rendering, like not reloading layout routes that aren't changing. In other cases, like form submissions or search param changes, Remix doesn't know which routes need to be reloaded so it reloads them all to be safe. This ensures data mutations from the submission or changes in the search params are reflected across the entire page.
@@ -867,7 +871,7 @@ Here are a couple of common use-cases:
 It's common for root loaders to return data that never changes, like environment variables to be sent to the client app. In these cases you never need the root loader to be called again. For this case, you can simply `return false`.
 
 ```js [10]
-export let loader = () => {
+export const loader = () => {
   return {
     ENV: {
       CLOUDINARY_ACCT: process.env.CLOUDINARY_ACCT,
@@ -876,7 +880,7 @@ export let loader = () => {
   };
 };
 
-export let unstable_shouldReload = () => false;
+export const unstable_shouldReload = () => false;
 ```
 
 With this in place, Remix will no longer make a request to your root loader for any reason, not after form submissions, not after search param changes, etc.
@@ -913,7 +917,7 @@ The `$activity.tsx` loader can use the search params to filter the list, so visi
 
 ```js [2,7]
 export function loader({ request, params }) {
-  let url = new URLSearchParams(request.url);
+  const url = new URLSearchParams(request.url);
   return exampleDb.activity.findAll({
     where: {
       projectId: params.projectId,
@@ -979,7 +983,7 @@ import type { LinksFunction } from "remix";
 import styles from "./styles/app.css";
 import banner from "./images/banner.jpg";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: styles }];
 };
 

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -198,7 +198,7 @@ export function loader() {
 }
 
 export default function Invoices() {
-  let invoices = useLoaderData();
+  const invoices = useLoaderData();
   // ...
 }
 ```
@@ -212,13 +212,13 @@ import React from "react";
 import { useActionData } from "remix";
 
 export async function action({ request }) {
-  let body = await request.formData();
-  let name = body.get("visitorsName");
+  const body = await request.formData();
+  const name = body.get("visitorsName");
   return { message: `Hello, ${name}` };
 }
 
 export default function Invoices() {
-  let data = useActionData();
+  const data = useActionData();
   return (
     <Form method="post">
       <p>
@@ -239,10 +239,10 @@ The most common use-case for this hook is form validation errors. If the form is
 import { redirect, json, Form, useActionData } from "remix";
 
 export async function action({ request }) {
-  let form = await request.formData();
-  let email = form.get("email");
-  let password = form.get("password");
-  let errors = {};
+  const form = await request.formData();
+  const email = form.get("email");
+  const password = form.get("password");
+  const errors = {};
 
   // validate the fields
   if (typeof email !== "string" || !email.includes("@")) {
@@ -265,7 +265,7 @@ export async function action({ request }) {
 }
 
 export default function Signup() {
-  let errors = useActionData();
+  const errors = useActionData();
 
   return (
     <>
@@ -388,8 +388,8 @@ export async function action() {
 }
 
 function UserPreferences() {
-  let submit = useSubmit();
-  let transition = useTransition();
+  const submit = useSubmit();
+  const transition = useTransition();
 
   function handleChange(event) {
     submit(event.currentTarget, { replace: true });
@@ -421,11 +421,11 @@ function AdminPage() {
 }
 
 function useSessionTimeout() {
-  let submit = useSubmit();
-  let transition = useTransition();
+  const submit = useSubmit();
+  const transition = useTransition();
 
   useEffect(() => {
-    let id = setTimeout(() => {
+    const id = setTimeout(() => {
       submit(null, { method: "post", action: "/logout" });
     }, 5 * 60_000);
     return () => clearTimeout(timer);
@@ -448,7 +448,7 @@ This hook tells you everything you need to know about a page transition to build
 import { useTransition } from "remix";
 
 function SomeComponent() {
-  let transition = useTransition();
+  const transition = useTransition();
   transition.state;
   transition.type;
   transition.submission;
@@ -484,9 +484,9 @@ idle → submitting → loading → idle
 
 ```tsx
 function SubmitButton() {
-  let transition = useTransition();
+  const transition = useTransition();
 
-  let text =
+  const text =
     : transition.state === "submitting"
     ? "Saving..."
     : transition.state === "loading"
@@ -525,14 +525,14 @@ Depending on the transition state, the types can be the following:
 
 ```tsx
 function SubmitButton() {
-  let transition = useTransition();
+  const transition = useTransition();
 
-  let loadTexts = {
+  const loadTexts = {
     actionRedirect: "Data saved, redirecting...",
     actionReload: "Data saved, reloading fresh data..."
   };
 
-  let text =
+  const text =
     transition.state === "submitting"
       ? "Saving..."
       : transition.state === "loading"
@@ -559,10 +559,10 @@ For example, this `Link` knows when it's page is loading and it's about to becom
 import { Link, useResolvedPath } from "remix";
 
 function PendingLink({ to, children }) {
-  let transition = useTransition();
-  let path = useResolvedPath(to);
+  const transition = useTransition();
+  const path = useResolvedPath(to);
 
-  let isPending =
+  const isPending =
     transition.state === "loading" &&
     transition.location.pathname === path.pathname;
 
@@ -595,7 +595,7 @@ This hook will call loaders and actions without navigating. It's similar to `use
 import { useFetcher } from "remix";
 
 function SomeComponent() {
-  let fetcher = useFetcher();
+  const fetcher = useFetcher();
 
   // trigger the fetch with these
   <fetcher.Form {..formOptions} />;
@@ -674,7 +674,7 @@ Just like `<Form>` except it doesn't cause a navigation. (You'll get over the do
 
 ```tsx
 function SomeComp() {
-  let fetcher = useFetcher();
+  const fetcher = useFetcher();
   return (
     <fetcher.Form method="post" action="/some/route">
       <input type="text" />
@@ -688,7 +688,7 @@ function SomeComp() {
 Just like `useSubmit` except it doesn't cause a navigation.
 
 ```tsx
-let fetcher = useFetcher();
+const fetcher = useFetcher();
 fetcher.submit({ some: "values" }, { method: "post" });
 ```
 
@@ -697,7 +697,7 @@ fetcher.submit({ some: "values" }, { method: "post" });
 Loads data from a route loader.
 
 ```tsx
-let fetcher = useFetcher();
+const fetcher = useFetcher();
 fetcher.load("/some/route");
 fetcher.data; // the data from the loader
 ```
@@ -711,7 +711,7 @@ Perhaps you have a persistent newsletter signup at the bottom of every page on y
 ```tsx
 // routes/newsletter/subscribe.js
 export async function action({ request }) {
-  let email = (await request.formData()).get("email");
+  const email = (await request.formData()).get("email");
   try {
     await subscribe(email);
     return json({ ok: true });
@@ -724,8 +724,8 @@ export async function action({ request }) {
 ```tsx
 // NewsletterSignup.js
 function NewsletterSignup() {
-  let newsletter = useFetcher();
-  let ref = useRef();
+  const newsletter = useFetcher();
+  const ref = useRef();
 
   useEffect(() => {
     if (newsletter.type === "done" && newsletter.data.ok) {
@@ -774,7 +774,7 @@ export function action({ request }) {
 }
 
 export default function NewsletterSignupRoute() {
-  let data = useActionData();
+  const data = useActionData();
   return (
     <Form method="post" action="/newsletter/subscribe">
       <p>
@@ -803,7 +803,7 @@ import { Form, useFetcher } from "remix";
 
 // used in the footer
 export function NewsletterSignup() {
-  let newsletter = useFetcher();
+  const newsletter = useFetcher();
   return (
     <NewsletterForm
       Form={newsletter.Form}
@@ -833,7 +833,7 @@ import { NewsletterForm } from "~/NewsletterSignup";
 import { Form } from "remix";
 
 export default function NewsletterSignupRoute() {
-  let data = useActionData();
+  const data = useActionData();
   return (
     <NewsletterForm
       Form={Form}
@@ -851,7 +851,7 @@ Imagine you want to mark an article has been read by the current user after they
 
 ```tsx
 function useMarkAsRead({ articleId, userId }) {
-  let marker = useFetcher();
+  const marker = useFetcher();
 
   useSpentSomeTimeHereAndScrolledToTheBottom(() => {
     marker.submit(
@@ -879,8 +879,8 @@ export function loader({ params }) {
 ```tsx
 // UserAvatar.js
 function UserAvatar({ partialUser }) {
-  let userDetails = useFetcher();
-  let [showDetails, setShowDetails] = useState(false);
+  const userDetails = useFetcher();
+  const [showDetails, setShowDetails] = useState(false);
 
   useEffect(() => {
     if (showDetails && userDetails.type === "init") {
@@ -912,14 +912,14 @@ If the user needs to select a city, you could have a loader that returns a list 
 ```tsx
 // routes/city-search.tsx
 export function loader({ request }) {
-  let url = new URL(request.url);
+  const url = new URL(request.url);
   return searchCities(url.searchParams.get("city-query"));
 }
 ```
 
 ```tsx
 function CitySearchCombobox() {
-  let cities = useFetcher();
+  const cities = useFetcher();
 
   return (
     <cities.Form method="get" action="/city-search">
@@ -986,14 +986,14 @@ When the user clicks a checkbox, the submission goes to the action to change the
 
 ```tsx
 function Task({ task }) {
-  let toggle = useFetcher();
-  let checked = toggle.submission
+  const toggle = useFetcher();
+  const checked = toggle.submission
     ? // use the optimistic version
       Boolean(toggle.submission.formData.get("complete"))
     : // use the normal version
       task.complete;
 
-  let { projectId, id } = task;
+  const { projectId, id } = task;
   return (
     <toggle.Form
       method="put"
@@ -1043,19 +1043,19 @@ Here's some sample code:
 
 ```js
 function ProjectTaskCount({ project }) {
-  let fetchers = useFetchers();
-  let completedTasks = 0;
+  const fetchers = useFetchers();
+  const completedTasks = 0;
 
   // 1) Find my task's submissions
-  let myFetchers = new Map();
-  for (let f of fetchers) {
+  const myFetchers = new Map();
+  for (const f of fetchers) {
     if (
       f.submission &&
       f.submission.action.startsWith(
         `/projects/${project.id}/task`
       )
     ) {
-      let taskId = f.submission.formData.get("id");
+      const taskId = f.submission.formData.get("id");
       myFetchers.set(
         parseInt(taskId),
         f.submission.formData.get("complete") === "on"
@@ -1063,7 +1063,7 @@ function ProjectTaskCount({ project }) {
     }
   }
 
-  for (let task of project.tasks) {
+  for (const task of project.tasks) {
     // 2) use the optimistic version
     if (myFetchers.has(task.id)) {
       if (myFetchers.get(task.id)) {
@@ -1089,7 +1089,7 @@ function ProjectTaskCount({ project }) {
 Returns the current route matches on the page. This is useful for creating layout abstractions with your current routes.
 
 ```js
-let matches = useMatches();
+const matches = useMatches();
 ```
 
 `matches` has the following shape:
@@ -1119,7 +1119,7 @@ You can put whatever you want on a route `handle`, here we'll use `breadcrumb`, 
 
    ```tsx
    // routes/parent.tsx
-   export let handle = {
+   export const handle = {
      breadcrumb: () => <Link to="/parent">Some Route</Link>
    };
    ```
@@ -1128,7 +1128,7 @@ You can put whatever you want on a route `handle`, here we'll use `breadcrumb`, 
 
    ```tsx
    // routes/parent/child.tsx
-   export let handle = {
+   export const handle = {
      breadcrumb: () => (
        <Link to="/parent/child">Child Route</Link>
      )
@@ -1147,7 +1147,7 @@ You can put whatever you want on a route `handle`, here we'll use `breadcrumb`, 
    } from "remix";
 
    export default function Root() {
-     let matches = useMatches();
+     const matches = useMatches();
 
      return (
        <html lang="en">
@@ -1200,7 +1200,7 @@ Remix or not, this is just good practice to do. The user can change the url, acc
 import { useBeforeUnload } from "remix";
 
 function SomeForm() {
-  let [state, setState] = React.useState(null);
+  const [state, setState] = React.useState(null);
 
   // save it off before the automatic page reload
   useBeforeUnload(
@@ -1232,7 +1232,7 @@ This is a shortcut for creating `application/json` responses. It assumes you are
 import type { LoaderFunction } from "remix";
 import { json } from "remix";
 
-export let loader: LoaderFunction = () => {
+export const loader: LoaderFunction = () => {
   // So you can write this:
   return json({ any: "thing" });
 
@@ -1248,7 +1248,7 @@ export let loader: LoaderFunction = () => {
 You can also pass a status code and headers:
 
 ```ts [4-9]
-export let loader: LoaderFunction = () => {
+export const loader: LoaderFunction = () => {
   return json(
     { not: "coffee" },
     {
@@ -1269,8 +1269,8 @@ This is shortcut for sending 30x responses.
 import type { ActionFunction } from "remix";
 import { redirect } from "remix";
 
-export let action: ActionFunction = async () => {
-  let userSession = await getUserSessionOrWhatever();
+export const action: ActionFunction = async () => {
+  const userSession = await getUserSessionOrWhatever();
 
   if (!userSession) {
     return redirect("/login");
@@ -1338,7 +1338,7 @@ First, create a cookie:
 ```js filename=app/cookies.js
 import { createCookie } from "remix";
 
-export let userPrefs = createCookie("user-prefs", {
+export const userPrefs = createCookie("user-prefs", {
   maxAge: 604_800 // one week
 });
 ```
@@ -1352,15 +1352,17 @@ import { useLoaderData, json, redirect } from "remix";
 import { userPrefs } from "~/cookies";
 
 export async function loader({ request }) {
-  let cookieHeader = request.headers.get("Cookie");
-  let cookie = (await userPrefs.parse(cookieHeader)) || {};
+  const cookieHeader = request.headers.get("Cookie");
+  const cookie =
+    (await userPrefs.parse(cookieHeader)) || {};
   return { showBanner: value.showBanner };
 }
 
 export async function action({ request }) {
-  let cookieHeader = request.headers.get("Cookie");
-  let cookie = (await userPrefs.parse(cookieHeader)) || {};
-  let bodyParams = await request.formData();
+  const cookieHeader = request.headers.get("Cookie");
+  const cookie =
+    (await userPrefs.parse(cookieHeader)) || {};
+  const bodyParams = await request.formData();
 
   if (bodyParams.get("banner") === "hidden") {
     cookie.showBanner = false;
@@ -1374,7 +1376,7 @@ export async function action({ request }) {
 }
 
 export default function Home() {
-  let { showBanner } = useLoaderData();
+  const { showBanner } = useLoaderData();
 
   return (
     <div>
@@ -1402,7 +1404,7 @@ export default function Home() {
 Cookies have [several attributes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes) that control when they expire, how they are accessed, and where they are sent. Any of these attributes may be specified either in `createCookie(name, options)`, or during `serialize()` when the `Set-Cookie` header is generated.
 
 ```js
-let cookie = createCookie("user-prefs", {
+const cookie = createCookie("user-prefs", {
   // These are defaults for this cookie.
   domain: "remix.run",
   path: "/",
@@ -1429,7 +1431,7 @@ It is possible to sign a cookie to automatically verify its contents when it is 
 To sign a cookie, provide one or more `secrets` when you first create the cookie:
 
 ```js
-let cookie = createCookie("user-prefs", {
+const cookie = createCookie("user-prefs", {
   secrets: ["s3cret1"]
 });
 ```
@@ -1440,15 +1442,15 @@ Secrets may be rotated by adding new secrets to the front of the `secrets` array
 
 ```js
 // app/cookies.js
-let cookie = createCookie("user-prefs", {
+const cookie = createCookie("user-prefs", {
   secrets: ["n3wsecr3t", "olds3cret"]
 });
 
 // in your route module...
 export async function loader({ request }) {
-  let oldCookie = request.headers.get("Cookie");
+  const oldCookie = request.headers.get("Cookie");
   // oldCookie may have been signed with "olds3cret", but still parses ok
-  let value = await cookie.parse(oldCookie);
+  const value = await cookie.parse(oldCookie);
 
   new Response("...", {
     headers: {
@@ -1466,7 +1468,7 @@ Creates a logical container for managing a browser cookie from there server.
 ```ts
 import { createCookie } from "remix";
 
-let cookie = createCookie("cookie-name", {
+const cookie = createCookie("cookie-name", {
   // all of these are optional defaults that can be overridden at runtime
   domain: "remix.run",
   expires: new Date(Date.now() + 60),
@@ -1487,7 +1489,7 @@ Returns `true` if an object is a Remix cookie container.
 
 ```ts
 import { isCookie } from "remix";
-let cookie = createCookie("user-prefs");
+const cookie = createCookie("user-prefs");
 console.log(isCookie(cookie));
 // true
 ```
@@ -1497,7 +1499,7 @@ console.log(isCookie(cookie));
 A cookie container is returned from `createCookie` and has handful of properties and methods.
 
 ```ts
-let cookie = createCookie(name);
+const cookie = createCookie(name);
 cookie.name;
 cookie.parse();
 // etc.
@@ -1512,7 +1514,7 @@ The name of the cookie, used in `Cookie` and `Set-Cookie` HTTP headers.
 Extracts and returns the value of this cookie in a given `Cookie` header.
 
 ```js
-let value = await cookie.parse(
+const value = await cookie.parse(
   request.headers.get("Cookie")
 );
 ```
@@ -1536,7 +1538,7 @@ new Response("...", {
 Will be `true` if the cookie uses any `secrets`, `false` otherwise.
 
 ```js
-let cookie = createCookie("user-prefs");
+const cookie = createCookie("user-prefs");
 console.log(cookie.isSigned); // false
 
 cookie = createCookie("user-prefs", {
@@ -1550,7 +1552,7 @@ console.log(cookie.isSigned); // true
 The `Date` on which this cookie expires. Note that if a cookie has both `maxAge` and `expires`, this value will the date at the current time plus the `maxAge` value since `Max-Age` takes precedence over `Expires`.
 
 ```js
-let cookie = createCookie("user-prefs", {
+const cookie = createCookie("user-prefs", {
   expires: new Date("2021-01-01")
 });
 
@@ -1579,7 +1581,7 @@ This is an example of a cookie session storage:
 // app/sessions.js
 import { createCookieSessionStorage } from "remix";
 
-let { getSession, commitSession, destroySession } =
+const { getSession, commitSession, destroySession } =
   createCookieSessionStorage({
     // a Cookie from `createCookie` or the CookieOptions to create one
     cookie: {
@@ -1613,7 +1615,7 @@ import { json, redirect } from "remix";
 import { getSession, commitSession } from "../sessions";
 
 export async function loader({ request }) {
-  let session = await getSession(
+  const session = await getSession(
     request.headers.get("Cookie")
   );
 
@@ -1622,7 +1624,7 @@ export async function loader({ request }) {
     return redirect("/");
   }
 
-  let data = { error: session.get("error") };
+  const data = { error: session.get("error") };
 
   return json(data, {
     headers: {
@@ -1632,14 +1634,14 @@ export async function loader({ request }) {
 }
 
 export async function action({ request }) {
-  let session = await getSession(
+  const session = await getSession(
     request.headers.get("Cookie")
   );
-  let form = await request.formData();
-  let username = form.get("username");
-  let password = form.get("password");
+  const form = await request.formData();
+  const username = form.get("username");
+  const password = form.get("password");
 
-  let userId = await validateCredentials(
+  const userId = await validateCredentials(
     username,
     password
   );
@@ -1666,7 +1668,7 @@ export async function action({ request }) {
 }
 
 export default function Login() {
-  let { currentUser, error } = useLoaderData();
+  const { currentUser, error } = useLoaderData();
 
   return (
     <div>
@@ -1693,8 +1695,10 @@ And then a logout form might look something like this:
 ```tsx
 import { getSession, destroySession } from "../sessions";
 
-export let action: ActionFunction = async ({ request }) => {
-  let session = await getSession(
+export const action: ActionFunction = async ({
+  request
+}) => {
+  const session = await getSession(
     request.headers.get("Cookie")
   );
   return redirect("/login", {
@@ -1744,7 +1748,7 @@ function createDatabaseSessionStorage({
   port
 }) {
   // Configure your database client...
-  let db = createDatabaseClient(host, port);
+  const db = createDatabaseClient(host, port);
 
   return createSessionStorage({
     cookie,
@@ -1752,7 +1756,7 @@ function createDatabaseSessionStorage({
       // `expires` is a Date after which the data should be considered
       // invalid. You could use it to invalidate the data somehow or
       // automatically purge this record from your database.
-      let id = await db.insert(data);
+      const id = await db.insert(data);
       return id;
     },
     async readData(id) {
@@ -1771,7 +1775,7 @@ function createDatabaseSessionStorage({
 And then you can use it like this:
 
 ```js
-let { getSession, commitSession, destroySession } =
+const { getSession, commitSession, destroySession } =
   createDatabaseSessionStorage({
     host: "localhost",
     port: 1234,
@@ -1795,7 +1799,7 @@ The downside is that you have to `commitSession` in almost every loader and acti
 ```js
 import { createCookieSessionStorage } from "remix";
 
-let { getSession, commitSession, destroySession } =
+const { getSession, commitSession, destroySession } =
   createCookieSessionStorage({
     // a Cookie from `createCookie` or the same CookieOptions to create one
     cookie: {
@@ -1820,12 +1824,12 @@ import {
 } from "remix";
 
 // In this example the Cookie is created separately.
-let sessionCookie = createCookie("__session", {
+const sessionCookie = createCookie("__session", {
   secrets: ["r3m1xr0ck5"],
   sameSite: true
 });
 
-let { getSession, commitSession, destroySession } =
+const { getSession, commitSession, destroySession } =
   createFileSessionStorage({
     // The root directory where you want to store the files.
     // Make sure it's writable!
@@ -1852,12 +1856,12 @@ import {
 } from "remix";
 
 // In this example the Cookie is created separately.
-let sessionCookie = createCookie("__session", {
+const sessionCookie = createCookie("__session", {
   secrets: ["r3m1xr0ck5"],
   sameSite: true
 });
 
-let { getSession, commitSession, destroySession } =
+const { getSession, commitSession, destroySession } =
   createFileSessionStorage({
     // The root directory where you want to store the files.
     // Make sure it's writable!
@@ -1882,12 +1886,12 @@ import {
 } from "remix";
 
 // In this example the Cookie is created separately.
-let sessionCookie = createCookie("__session", {
+const sessionCookie = createCookie("__session", {
   secrets: ["r3m1xr0ck5"],
   sameSite: true
 });
 
-let { getSession, commitSession, destroySession } =
+const { getSession, commitSession, destroySession } =
   createCloudflareKVSessionStorage({
     // The KV Namespace where you want to store sessions
     kv: YOUR_NAMESPACE,
@@ -1903,7 +1907,7 @@ After retrieving a session with `getSession`, the session object returned has a 
 
 ```js
 export async function action({ request }) {
-  let session = await getSession(
+  const session = await getSession(
     request.headers.get("Cookie")
   );
   session.get("foo");
@@ -1936,10 +1940,10 @@ Sets a session value that will be unset the first time it is read. After that, i
 import { getSession, commitSession } from "../sessions";
 
 export async function action({ request, params }) {
-  let session = await getSession(
+  const session = await getSession(
     request.headers.get("Cookie")
   );
-  let deletedProject = await archiveProject(
+  const deletedProject = await archiveProject(
     params.projectId
   );
 
@@ -1967,10 +1971,10 @@ import { Meta, Links, Scripts, Outlet, json } from "remix";
 import { getSession, commitSession } from "./sessions";
 
 export async function loader({ request }) {
-  let session = await getSession(
+  const session = await getSession(
     request.headers.get("Cookie")
   );
-  let message = session.get("globalMessage") || null;
+  const message = session.get("globalMessage") || null;
 
   return json(
     { message },
@@ -1984,7 +1988,7 @@ export async function loader({ request }) {
 }
 
 export default function App() {
-  let { message } = useLoaderData();
+  const { message } = useLoaderData();
 
   return (
     <html>

--- a/docs/guides/api-routes.md
+++ b/docs/guides/api-routes.md
@@ -34,7 +34,7 @@ For example, you could have a route to handle the search:
 
 ```tsx filename=routes/city-search.tsx
 export function loader({ request }) {
-  let url = new URL(request.url);
+  const url = new URL(request.url);
   return searchCities(url.searchParams.get("q"));
 }
 ```
@@ -43,7 +43,7 @@ And then `useFetcher` along with Reach UI's combobox input:
 
 ```tsx [2]
 function CitySearchCombobox() {
-  let cities = useFetcher();
+  const cities = useFetcher();
 
   return (
     <cities.Form method="get" action="/city-search">
@@ -90,8 +90,8 @@ In other cases, you may need routes that are part of your application, but aren'
 
 ```tsx
 export function loader({ params }) {
-  let report = await getReport(params.id);
-  let pdf = await generateReportPDF(report);
+  const report = await getReport(params.id);
+  const pdf = await generateReportPDF(report);
   return new Response(pdf, {
     status: 200,
     headers: {

--- a/docs/guides/data-writes.md
+++ b/docs/guides/data-writes.md
@@ -108,8 +108,8 @@ The data is made available to the server's request handler so you can create the
 
 ```js filename=app/routes/projects
 export function action({ request }) {
-  let body = await request.formData();
-  let project = await createProject(body);
+  const body = await request.formData();
+  const project = await createProject(body);
   redirect(`/projects/${project.id}`);
 }
 ```
@@ -180,9 +180,11 @@ import type { ActionFunction } from "remix";
 import { redirect } from "remix";
 
 // Note the "action" export name, this will handle our form POST
-export let action: ActionFunction = async ({ request }) => {
-  let formData = await request.formData();
-  let project = await createProject(formData);
+export const action: ActionFunction = async ({
+  request
+}) => {
+  const formData = await request.formData();
+  const project = await createProject(formData);
   return redirect(`/projects/${project.id}`);
 };
 
@@ -204,18 +206,20 @@ We know, we know, you want to animate in nice validation errors and stuff. We'll
 Back in our action, maybe we have an API that returns validation errors like this.
 
 ```tsx
-let [errors, project] = await createProject(newProject);
+const [errors, project] = await createProject(newProject);
 ```
 
 If there are validation errors, we want to go back to the form and display them.
 
 ```tsx [3,5-8]
-export let action: ActionFunction = async ({ request }) => {
-  let formData = await request.formData();
-  let [errors, project] = await createProject(formData);
+export const action: ActionFunction = async ({
+  request
+}) => {
+  const formData = await request.formData();
+  const [errors, project] = await createProject(formData);
 
   if (errors) {
-    let values = Object.fromEntries(newProject);
+    const values = Object.fromEntries(newProject);
     return { errors, values };
   }
 
@@ -228,12 +232,14 @@ Just like `useLoaderData` returns the values from the `loader`, `useActionData` 
 ```tsx [1,8,18,23-27,35,40-44]
 import { redirect, useActionData } from "remix";
 
-export let action: ActionFunction = async ({ request }) => {
+export const action: ActionFunction = async ({
+  request
+}) => {
   // ...
 };
 
 export default function NewProject() {
-  let actionData = useActionData();
+  const actionData = useActionData();
 
   return (
     <form method="post" action="/projects/new">
@@ -293,7 +299,7 @@ import { redirect, useActionData, Form } from "remix";
 // ...
 
 export default function NewProject() {
-  let actionData = useActionData();
+  const actionData = useActionData();
 
   return (
     // note the capital "F" <Form> now
@@ -323,8 +329,8 @@ import {
 export default function NewProject() {
   // when the form is being processed on the server, this returns different
   // transition states to help us build pending and optimistic UI.
-  let transition = useTransition();
-  let actionData = useActionData();
+  const transition = useTransition();
+  const actionData = useActionData();
 
   return (
     <Form method="post">
@@ -396,11 +402,11 @@ Now that we're using JavaScript to submit this page, our validation errors can b
 
 ```tsx
 function ValidationMessage({ error, isSubmitting }) {
-  let [show, setShow] = useState(!!error);
+  const [show, setShow] = useState(!!error);
 
   useEffect(() => {
-    let id = setTimeout(() => {
-      let hasError = !!error;
+    const id = setTimeout(() => {
+      const hasError = !!error;
       setShow(hasError && !isSubmitting);
     });
     return () => clearTimeout(id);
@@ -425,8 +431,8 @@ Now we can wrap our old error messages in this new fancy component, and even tur
 
 ```tsx [21-24, 31-34, 48-51, 57-60]
 export default function NewProject() {
-  let transition = useTransition();
-  let actionData = useActionData();
+  const transition = useTransition();
+  const actionData = useActionData();
 
   return (
     <Form method="post">

--- a/docs/guides/disabling-javascript.md
+++ b/docs/guides/disabling-javascript.md
@@ -12,7 +12,7 @@ Here's how we like to do it:
 Open up each route module you want to include JavaScript for and add a "handle". This is way for you to provide any kind of meta information about a route to the parent route (as you'll see in a moment).
 
 ```js
-export let handle = { hydrate: true };
+export const handle = { hydrate: true };
 ```
 
 Now open `root.tsx`, bring in `useMatches` and add this:
@@ -28,10 +28,10 @@ import {
 } from "remix";
 
 export default function App() {
-  let matches = useMatches();
+  const matches = useMatches();
 
   // If at least one route wants to hydrate, this will return true
-  let includeScripts = matches.some(
+  const includeScripts = matches.some(
     match => match.handle?.hydrate
   );
 

--- a/docs/guides/envvars.md
+++ b/docs/guides/envvars.md
@@ -111,7 +111,7 @@ Instead we recommend keeping all of your environment variables on the server (al
    }
 
    export function Root() {
-     let data = useLoaderData();
+     const data = useLoaderData();
      return (
        <html lang="en">
          <head>
@@ -142,7 +142,7 @@ Instead we recommend keeping all of your environment variables on the server (al
    export async function redirectToStripeCheckout(
      sessionId
    ) {
-     let stripe = await loadStripe(window.ENV.stripe);
+     const stripe = await loadStripe(window.ENV.stripe);
      return stripe.redirectToCheckout({ sessionId });
    }
    ```

--- a/docs/guides/mdx.md
+++ b/docs/guides/mdx.md
@@ -116,7 +116,7 @@ export function loader() {
 }
 
 export default function Index() {
-  let posts = useLoaderData();
+  const posts = useLoaderData();
 
   return (
     <ul>

--- a/docs/guides/not-found.md
+++ b/docs/guides/not-found.md
@@ -19,7 +19,7 @@ As soon as you know you don't have what the user is looking for you should _thro
 
 ```tsx filename=routes/page/$slug.js
 export function loader({ params }) {
-  let page = await db.page.findOne({
+  const page = await db.page.findOne({
     where: { slug: params.slug }
   });
 
@@ -45,7 +45,7 @@ You probably already have one at the root of your app. This will handle all thro
 
 ```tsx
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
   return (
     <html>
       <head>
@@ -72,7 +72,7 @@ Just like [errors], nested routes can export their own catch boundary to handle 
 import { Form, useLoaderData, useParams } from "remix";
 
 export function loader({ params }) {
-  let page = await db.page.findOne({
+  const page = await db.page.findOne({
     where: { slug: params.slug }
   });
 
@@ -86,7 +86,7 @@ export function loader({ params }) {
 }
 
 export function CatchBoundary() {
-  let params = useParams();
+  const params = useParams();
   return (
     <div>
       <h2>We couldn't find that page!</h2>

--- a/docs/guides/optimistic-ui.md
+++ b/docs/guides/optimistic-ui.md
@@ -31,7 +31,7 @@ export function loader({ params }) {
 }
 
 export default function ProjectRoute() {
-  let project = useLoaderData();
+  const project = useLoaderData();
   return <ProjectView project={project} />;
 }
 ```
@@ -60,10 +60,12 @@ Now we can get to the fun part. Here's what a "new project" route might look lik
 import { Form, redirect } from "remix";
 import { createProject } from "~/utils";
 
-export let action: ActionFunction = async ({ request }) => {
-  let body = await request.formData();
-  let newProject = Object.fromEntries(body);
-  let project = await createProject(newProject);
+export const action: ActionFunction = async ({
+  request
+}) => {
+  const body = await request.formData();
+  const newProject = Object.fromEntries(body);
+  const project = await createProject(newProject);
   return redirect(`/projects/${project.id}`);
 };
 
@@ -90,15 +92,17 @@ At this point, typically you'd render a busy spinner on the page while the user 
 import { Form, redirect, useTransition } from "remix";
 import { createProject } from "~/utils";
 
-export let action: ActionFunction = async ({ request }) => {
-  let body = await request.formData();
-  let newProject = Object.fromEntries(body);
-  let project = await createProject(newProject);
+export const action: ActionFunction = async ({
+  request
+}) => {
+  const body = await request.formData();
+  const newProject = Object.fromEntries(body);
+  const project = await createProject(newProject);
   return redirect(`/projects/${project.id}`);
 };
 
 export default function NewProject() {
-  let transition = useTransition();
+  const transition = useTransition();
   return (
     <>
       <h2>New Project</h2>
@@ -129,15 +133,17 @@ import { Form, redirect, useTransition } from "remix";
 import { createProject } from "~/utils";
 import { ProjectView } from "~/components/project";
 
-export let action: ActionFunction = async ({ request }) => {
-  let body = await request.formData();
-  let newProject = Object.fromEntries(body);
-  let project = await createProject(newProject);
+export const action: ActionFunction = async ({
+  request
+}) => {
+  const body = await request.formData();
+  const newProject = Object.fromEntries(body);
+  const project = await createProject(newProject);
   return redirect(`/projects/${project.id}`);
 };
 
 export default function NewProject() {
-  let transition = useTransition();
+  const transition = useTransition();
   return transition.submission ? (
     <ProjectView
       project={Object.fromEntries(
@@ -179,11 +185,13 @@ import {
 import { createProject } from "~/utils";
 import { ProjectView } from "~/components/project";
 
-export let action: ActionFunction = async ({ request }) => {
-  let body = await request.formData();
-  let newProject = Object.fromEntries(body);
+export const action: ActionFunction = async ({
+  request
+}) => {
+  const body = await request.formData();
+  const newProject = Object.fromEntries(body);
   try {
-    let project = await createProject(newProject);
+    const project = await createProject(newProject);
     return redirect(`/projects/${project.id}`);
   } catch (e) {
     console.error(e);
@@ -194,8 +202,8 @@ export let action: ActionFunction = async ({ request }) => {
 };
 
 export default function NewProject() {
-  let transition = useTransition();
-  let error = useActionData();
+  const transition = useTransition();
+  const error = useActionData();
 
   return transition.submission ? (
     <ProjectView

--- a/docs/guides/philosophy.md
+++ b/docs/guides/philosophy.md
@@ -27,7 +27,7 @@ Consider [the Github Gist API](https://api.github.com/gists). This payload is 75
 
 ```js
 export default function Gists() {
-  let gists = useSomeFetchWrapper(
+  const gists = useSomeFetchWrapper(
     "https://api.github.com/gists"
   );
   if (!gists) {
@@ -56,8 +56,8 @@ With Remix, you can filter down the data _on the server_ before sending it to th
 
 ```js [1-11]
 export async function loader() {
-  let res = await fetch("https://api.github.com/gists");
-  let json = await res.json();
+  const res = await fetch("https://api.github.com/gists");
+  const json = await res.json();
   return json.map(gist => {
     return {
       url: gist.html_url,
@@ -68,7 +68,7 @@ export async function loader() {
 }
 
 export default function Gists() {
-  let gists = useLoaderData();
+  const gists = useLoaderData();
   return (
     <ul>
       {gists.map(gist => (

--- a/docs/guides/resource-routes.md
+++ b/docs/guides/resource-routes.md
@@ -26,7 +26,7 @@ export function loader({ params }) {
 }
 
 export default function Report() {
-  let report = useLoaderData();
+  const report = useLoaderData();
   return (
     <div>
       <h1>{report.name}</h1>
@@ -43,8 +43,8 @@ It's linking to a PDF version of the page. To make this work we can create a Res
 
 ```tsx filename=app/routes/reports/$id/pdf.ts
 export function loader({ params }) {
-  let report = await getReport(params.id);
-  let pdf = await generateReportPDF(report);
+  const report = await getReport(params.id);
+  const pdf = await generateReportPDF(report);
   return new Response(pdf, {
     status: 200,
     headers: {

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -11,8 +11,7 @@ export function links() {
   return [
     {
       rel: "stylesheet",
-      href:
-        "https://unpkg.com/modern-css-reset@1.4.0/dist/reset.min.css"
+      href: "https://unpkg.com/modern-css-reset@1.4.0/dist/reset.min.css"
     }
   ];
 }
@@ -189,11 +188,11 @@ Note that these are not routes, but they export `links` functions as if they wer
 ```tsx filename=app/components/button/index.js lines=[1,3-5]
 import styles from "./styles.css";
 
-export let links = () => [
+export const links = () => [
   { rel: "stylesheet", href: styles }
 ];
 
-export let Button = React.forwardRef(
+export const Button = React.forwardRef(
   ({ children, ...props }, ref) => {
     return <button {...props} ref={ref} data-button />;
   }
@@ -213,12 +212,12 @@ And then a `<PrimaryButton>` that extends it:
 import { Button, links as buttonLinks } from "../button";
 import styles from "./styles.css";
 
-export let links = () => [
+export const links = () => [
   ...buttonLinks(),
   { rel: "stylesheet", href: styles }
 ];
 
-export let PrimaryButton = React.forwardRef(
+export const PrimaryButton = React.forwardRef(
   ({ children, ...props }, ref) => {
     return (
       <Button {...props} ref={ref} data-primary-button />
@@ -269,7 +268,7 @@ export function loader({ params }) {
 }
 
 export default function Category() {
-  let products = useLoaderData();
+  const products = useLoaderData();
   return (
     <TileGrid>
       {products.map(product => (
@@ -341,7 +340,7 @@ Since these are just `<link>` tags, you can do more than stylesheet links, like 
 ```tsx filename=app/components/copy-to-clipboard.jsx lines=[4-9]
 import styles from "./styles.css";
 
-export let links = () => [
+export const links = () => [
   {
     rel: "preload",
     href: "/icons/clipboard.svg",
@@ -351,7 +350,7 @@ export let links = () => [
   { rel: "stylesheet", href: styles }
 ];
 
-export let CopyToClipboard = React.forwardRef(
+export const CopyToClipboard = React.forwardRef(
   ({ children, ...props }, ref) => {
     return (
       <Button {...props} ref={ref} data-copy-to-clipboard />
@@ -464,12 +463,11 @@ You can load stylesheets from any server, here's an example of loading a modern 
 ```ts filename=app/root.tsx
 import type { LinksFunction } from "remix";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     {
       rel: "stylesheet",
-      href:
-        "https://unpkg.com/modern-css-reset@1.4.0/dist/reset.min.css"
+      href: "https://unpkg.com/modern-css-reset@1.4.0/dist/reset.min.css"
     }
   ];
 };
@@ -554,7 +552,7 @@ Here's how to set it up:
    import type { LinksFunction } from "remix";
    import styles from "./styles/app.css";
 
-   export let links: LinksFunction = () => {
+   export const links: LinksFunction = () => {
      return [{ rel: "stylesheet", href: styles }];
    };
    ```
@@ -621,12 +619,12 @@ Here's some sample code to show how you might use Styled Components with Remix:
      );
 
      // Now that we've rendered, we get the styles out of the sheet
-     let styles = sheet.getStyleTags();
+     const styles = sheet.getStyleTags();
      sheet.seal();
 
      // Finally, we render a second time, but this time we have styles to apply,
      // make sure to pass them to `<StylesContext.Provider value>`
-     let markup = ReactDOMServer.renderToString(
+     const markup = ReactDOMServer.renderToString(
        <StylesContext.Provider value={styles}>
          <RemixServer
            context={remixContext}
@@ -653,7 +651,7 @@ Here's some sample code to show how you might use Styled Components with Remix:
    import StylesContext from "./StylesContext";
 
    export default function Root() {
-     let styles = useContext(StylesContext);
+     const styles = useContext(StylesContext);
 
      return (
        <html>

--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -40,7 +40,7 @@ const {
   createRequestHandler
 } = require("@remix-run/express");
 
-let app = express();
+const app = express();
 
 // needs to handle all verbs (GET, POST, etc.)
 app.all(
@@ -98,7 +98,7 @@ function purgeRequireCache() {
   // netlify typically does this for you, but we've found it to be hit or
   // miss and some times requires you to refresh the page after it auto reloads
   // or even have to restart your server
-  for (let key in require.cache) {
+  for (const key in require.cache) {
     if (key.startsWith(BUILD_DIR)) {
       delete require.cache[key];
     }
@@ -139,7 +139,7 @@ import * as build from "../build";
 const handleRequest = createRequestHandler({ build });
 
 const handleEvent = async (event: FetchEvent) => {
-  let response = await handleAsset(event, build);
+  const response = await handleAsset(event, build);
 
   if (!response) {
     response = await handleRequest(event);

--- a/docs/other-api/constraints.md
+++ b/docs/other-api/constraints.md
@@ -32,7 +32,7 @@ export function meta() {
 }
 
 export default function Posts() {
-  let posts = useLoaderData();
+  const posts = useLoaderData();
   return <PostsView posts={posts} />;
 }
 ```
@@ -56,7 +56,7 @@ export function meta() {
 }
 
 export default function Posts() {
-  let posts = useLoaderData();
+  const posts = useLoaderData();
   return <PostsView posts={posts} />;
 }
 ```
@@ -89,7 +89,7 @@ export function meta() {
 }
 
 export default function Posts() {
-  let posts = useLoaderData();
+  const posts = useLoaderData();
   return <PostsView posts={posts} />;
 }
 ```
@@ -108,7 +108,7 @@ export function meta() {
 }
 
 export default function Posts() {
-  let posts = useLoaderData();
+  const posts = useLoaderData();
   return <PostsView posts={posts} />;
 }
 ```
@@ -132,7 +132,7 @@ export function meta() {
 }
 
 export default function Posts() {
-  let posts = useLoaderData();
+  const posts = useLoaderData();
   return <PostsView posts={posts} />;
 }
 ```
@@ -148,8 +148,8 @@ import { redirect } from "remix";
 
 export function removeTrailingSlash(loader) {
   return function (arg) {
-    let { request } = arg;
-    let url = new URL(request.url);
+    const { request } = arg;
+    const url = new URL(request.url);
     if (url.pathname.endsWith("/")) {
       return redirect(request.url.slice(0, -1), {
         status: 308
@@ -165,7 +165,7 @@ And then try to use it like this:
 ```js bad filename=app/root.js
 import { removeTrailingSlash } from "~/http";
 
-export let loader = removeTrailingSlash(({ request }) => {
+export const loader = removeTrailingSlash(({ request }) => {
   return { some: "data" };
 });
 ```
@@ -191,7 +191,7 @@ And then use it like this:
 ```js bad filename=app/root.js
 import { removeTrailingSlash } from "~/http";
 
-export let loader = ({ request }) => {
+export const loader = ({ request }) => {
   removeTrailingSlash(request.url);
   return { some: "data" };
 };
@@ -201,7 +201,7 @@ It reads much nicer as well when you've got a lot of these:
 
 ```ts
 // this
-export let loader = ({ request }) => {
+export const loader = ({ request }) => {
   return removeTrailingSlash(request.url, () => {
     return withSession(request, session => {
       return requireUser(session, user => {
@@ -212,10 +212,10 @@ export let loader = ({ request }) => {
 };
 
 // vs. this
-export let loader = ({ request }) => {
+export const loader = ({ request }) => {
   removeTrailingSlash(request.url);
-  let session = await getSession(request);
-  let user = await requireUser(session);
+  const session = await getSession(request);
+  const user = await requireUser(session);
   return json(user);
 };
 ```
@@ -231,7 +231,7 @@ Unlike the browser bundles, Remix doesn't try to remove _browser only code_ from
 ```js bad lines=3
 import { loadStripe } from "@stripe/stripe-js";
 
-let stripe = await loadStripe(window.ENV.stripe);
+const stripe = await loadStripe(window.ENV.stripe);
 
 export async function redirectToStripeCheckout(sessionId) {
   return stripe.redirectToCheckout({ sessionId });
@@ -266,7 +266,7 @@ This strategy defers initialization until the library is actually used:
 import { loadStripe } from "@stripe/stripe-js";
 
 export async function redirectToStripeCheckout(sessionId) {
-  let stripe = await loadStripe(window.ENV.stripe);
+  const stripe = await loadStripe(window.ENV.stripe);
   return stripe.redirectToCheckout({ sessionId });
 }
 ```
@@ -285,7 +285,7 @@ async function getStripe() {
 }
 
 export async function redirectToStripeCheckout(sessionId) {
-  let stripe = await getStripe();
+  const stripe = await getStripe();
   return stripe.redirectToCheckout({ sessionId });
 }
 ```
@@ -300,11 +300,11 @@ Another common case is code that calls browser-only APIs while rendering. When s
 
 ```js bad lines=2
 function useLocalStorage(key) {
-  let [state, setState] = useState(
+  const [state, setState] = useState(
     localStorage.getItem(key)
   );
 
-  let setWithLocalStorage = nextState => {
+  const setWithLocalStorage = nextState => {
     setState(nextState);
   };
 
@@ -316,13 +316,13 @@ You can fix this by moving the code into `useEffect`, which only runs in the bro
 
 ```js [2,4-6]
 function useLocalStorage(key) {
-  let [state, setState] = useState(null);
+  const [state, setState] = useState(null);
 
   useEffect(() => {
     setState(localStorage.getItem(key));
   }, []);
 
-  let setWithLocalStorage = nextState => {
+  const setWithLocalStorage = nextState => {
     setState(nextState);
   };
 

--- a/docs/other-api/fetch.md
+++ b/docs/other-api/fetch.md
@@ -9,14 +9,16 @@ When browsers added `window.fetch`, they also add three other objects: `Headers`
 When you do this:
 
 ```js
-let res = await fetch(url);
+const res = await fetch(url);
 ```
 
 That `res` is an instance of `Response`. And you can make a response yourself:
 
 ```js
-let res = new Response(JSON.stringify({ hello: "there" }));
-let json = await res.json();
+const res = new Response(
+  JSON.stringify({ hello: "there" })
+);
+const json = await res.json();
 console.log(json);
 // { hello: "there" }
 ```

--- a/docs/other-api/serve.md
+++ b/docs/other-api/serve.md
@@ -24,14 +24,14 @@ In development, `remix-serve` will ensure the latest code is run on each request
   ```ts [1-3]
   // this will be reset whenever any files change because the module cache was
   // cleared and this will be required brand new
-  let cache = new Map();
+  const cache = new Map();
 
   export async function loader({ params }) {
     if (cache.has(params.foo)) {
       return json(cache.get(params.foo));
     }
 
-    let record = await fakeDb.stuff.find(params.foo);
+    const record = await fakeDb.stuff.find(params.foo);
     cache.set(params.foo, res);
     return json(record);
   }

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -88,7 +88,7 @@ So let's get to it and provide some data to our component.
 ```tsx filename=app/routes/posts/index.tsx lines=[1,3-14,17-18]
 import { useLoaderData } from "remix";
 
-export let loader = () => {
+export const loader = () => {
   return [
     {
       slug: "my-first-post",
@@ -102,7 +102,7 @@ export let loader = () => {
 };
 
 export default function Posts() {
-  let posts = useLoaderData();
+  const posts = useLoaderData();
   console.log(posts);
   return (
     <div>
@@ -123,7 +123,7 @@ import { Link, useLoaderData } from "remix";
 
 // ...
 export default function Posts() {
-  let posts = useLoaderData();
+  const posts = useLoaderData();
   return (
     <div>
       <h1>Posts</h1>
@@ -151,8 +151,8 @@ type Post = {
   title: string;
 };
 
-export let loader = () => {
-  let posts: Post[] = [
+export const loader = () => {
+  const posts: Post[] = [
     {
       slug: "my-first-post",
       title: "My First Post"
@@ -166,7 +166,7 @@ export let loader = () => {
 };
 
 export default function Posts() {
-  let posts = useLoaderData<Post[]>();
+  const posts = useLoaderData<Post[]>();
   return (
     <div>
       <h1>Posts</h1>
@@ -203,7 +203,7 @@ export type Post = {
 };
 
 export function getPosts() {
-  let posts: Post[] = [
+  const posts: Post[] = [
     {
       slug: "my-first-post",
       title: "My First Post"
@@ -224,7 +224,7 @@ import { Link, useLoaderData } from "remix";
 import { getPosts } from "~/post";
 import type { Post } from "~/post";
 
-export let loader = () => {
+export const loader = () => {
   return getPosts();
 };
 
@@ -307,16 +307,16 @@ export type Post = {
 };
 
 // relative to the server output not the source!
-let postsPath = path.join(__dirname, "..", "posts");
+const postsPath = path.join(__dirname, "..", "posts");
 
 export async function getPosts() {
-  let dir = await fs.readdir(postsPath);
+  const dir = await fs.readdir(postsPath);
   return Promise.all(
     dir.map(async filename => {
-      let file = await fs.readFile(
+      const file = await fs.readFile(
         path.join(postsPath, filename)
       );
-      let { attributes } = parseFrontMatter(
+      const { attributes } = parseFrontMatter(
         file.toString()
       );
       return {
@@ -357,7 +357,7 @@ export type PostMarkdownAttributes = {
   title: string;
 };
 
-let postsPath = path.join(__dirname, "..", "posts");
+const postsPath = path.join(__dirname, "..", "posts");
 
 function isValidPostAttributes(
   attributes: any
@@ -366,13 +366,13 @@ function isValidPostAttributes(
 }
 
 export async function getPosts() {
-  let dir = await fs.readdir(postsPath);
+  const dir = await fs.readdir(postsPath);
   return Promise.all(
     dir.map(async filename => {
-      let file = await fs.readFile(
+      const file = await fs.readFile(
         path.join(postsPath, filename)
       );
-      let { attributes } = parseFrontMatter(
+      const { attributes } = parseFrontMatter(
         file.toString()
       );
       invariant(
@@ -426,12 +426,12 @@ You can click one of your posts and should see the new page.
 ```tsx filename=app/routes/posts/$slug.tsx lines=[1,3-5,8,11]
 import { useLoaderData } from "remix";
 
-export let loader = async ({ params }) => {
+export const loader = async ({ params }) => {
   return params.slug;
 };
 
 export default function PostSlug() {
-  let slug = useLoaderData();
+  const slug = useLoaderData();
   return (
     <div>
       <h1>Some Post: {slug}</h1>
@@ -448,7 +448,9 @@ The part of the filename attached to the `$` becomes a named key on the `params`
 import { useLoaderData } from "remix";
 import type { LoaderFunction } from "remix";
 
-export let loader: LoaderFunction = async ({ params }) => {
+export const loader: LoaderFunction = async ({
+  params
+}) => {
   return params.slug;
 };
 ```
@@ -462,9 +464,9 @@ Put this function anywhere in the `app/post.ts` module:
 ```tsx filename=app/post.ts lines=[2,4]
 // ...
 export async function getPost(slug: string) {
-  let filepath = path.join(postsPath, slug + ".md");
-  let file = await fs.readFile(filepath);
-  let { attributes } = parseFrontMatter(file.toString());
+  const filepath = path.join(postsPath, slug + ".md");
+  const file = await fs.readFile(filepath);
+  const { attributes } = parseFrontMatter(file.toString());
   invariant(
     isValidPostAttributes(attributes),
     `Post ${filepath} is missing attributes`
@@ -481,13 +483,15 @@ import type { LoaderFunction } from "remix";
 import { getPost } from "~/post";
 import invariant from "tiny-invariant";
 
-export let loader: LoaderFunction = async ({ params }) => {
+export const loader: LoaderFunction = async ({
+  params
+}) => {
   invariant(params.slug, "expected params.slug");
   return getPost(params.slug);
 };
 
 export default function PostSlug() {
-  let post = useLoaderData();
+  const post = useLoaderData();
   return (
     <div>
       <h1>{post.title}</h1>
@@ -519,16 +523,16 @@ import { marked } from "marked";
 
 //...
 export async function getPost(slug: string) {
-  let filepath = path.join(postsPath, slug + ".md");
-  let file = await fs.readFile(filepath);
-  let { attributes, body } = parseFrontMatter(
+  const filepath = path.join(postsPath, slug + ".md");
+  const file = await fs.readFile(filepath);
+  const { attributes, body } = parseFrontMatter(
     file.toString()
   );
   invariant(
     isValidPostAttributes(attributes),
     `Post ${filepath} is missing attributes`
   );
-  let html = marked(body);
+  const html = marked(body);
   return { slug, html, title: attributes.title };
 }
 ```
@@ -538,7 +542,7 @@ export async function getPost(slug: string) {
 ```tsx filename=app/routes/posts/$slug.tsx lines=[5]
 // ...
 export default function PostSlug() {
-  let post = useLoaderData();
+  const post = useLoaderData();
   return (
     <div dangerouslySetInnerHTML={{ __html: post.html }} />
   );
@@ -564,12 +568,12 @@ import { Link, useLoaderData } from "remix";
 import { getPosts } from "~/post";
 import type { Post } from "~/post";
 
-export let loader = () => {
+export const loader = () => {
   return getPosts();
 };
 
 export default function Admin() {
-  let posts = useLoaderData<Post[]>();
+  const posts = useLoaderData<Post[]>();
   return (
     <div className="admin">
       <nav>
@@ -624,7 +628,7 @@ import { getPosts } from "~/post";
 import type { Post } from "~/post";
 import adminStyles from "~/styles/admin.css";
 
-export let links = () => {
+export const links = () => {
   return [{ rel: "stylesheet", href: adminStyles }];
 };
 
@@ -667,7 +671,7 @@ import { Outlet, Link, useLoaderData } from "remix";
 
 //...
 export default function Admin() {
-  let posts = useLoaderData<Post[]>();
+  const posts = useLoaderData<Post[]>();
   return (
     <div className="admin">
       <nav>
@@ -752,7 +756,7 @@ Let's create the essential code that knows how to save a post first in our `post
 ```tsx filename=app/post.ts
 // ...
 export async function createPost(post) {
-  let md = `---\ntitle: ${post.title}\n---\n\n${post.markdown}`;
+  const md = `---\ntitle: ${post.title}\n---\n\n${post.markdown}`;
   await fs.writeFile(
     path.join(postsPath, post.slug + ".md"),
     md
@@ -767,12 +771,12 @@ export async function createPost(post) {
 import { redirect, Form } from "remix";
 import { createPost } from "~/post";
 
-export let action = async ({ request }) => {
-  let formData = await request.formData();
+export const action = async ({ request }) => {
+  const formData = await request.formData();
 
-  let title = formData.get("title");
-  let slug = formData.get("slug");
-  let markdown = formData.get("markdown");
+  const title = formData.get("title");
+  const slug = formData.get("slug");
+  const markdown = formData.get("markdown");
 
   await createPost({ title, slug, markdown });
 
@@ -801,7 +805,7 @@ type NewPost = {
 };
 
 export async function createPost(post: NewPost) {
-  let md = `---\ntitle: ${post.title}\n---\n\n${post.markdown}`;
+  const md = `---\ntitle: ${post.title}\n---\n\n${post.markdown}`;
   await fs.writeFile(
     path.join(postsPath, post.slug + ".md"),
     md
@@ -817,12 +821,14 @@ import { Form, redirect } from "remix";
 import type { ActionFunction } from "remix";
 import { createPost } from "~/post";
 
-export let action: ActionFunction = async ({ request }) => {
-  let formData = await request.formData();
+export const action: ActionFunction = async ({
+  request
+}) => {
+  const formData = await request.formData();
 
-  let title = formData.get("title");
-  let slug = formData.get("slug");
-  let markdown = formData.get("markdown");
+  const title = formData.get("title");
+  const slug = formData.get("slug");
+  const markdown = formData.get("markdown");
 
   await createPost({ title, slug, markdown });
 
@@ -838,14 +844,16 @@ Let's add some validation before we create the post.
 
 ```tsx filename=app/routes/admin/new.tsx lines=[9-12,14-16]
 //...
-export let action: ActionFunction = async ({ request }) => {
-  let formData = await request.formData();
+export const action: ActionFunction = async ({
+  request
+}) => {
+  const formData = await request.formData();
 
-  let title = formData.get("title");
-  let slug = formData.get("slug");
-  let markdown = formData.get("markdown");
+  const title = formData.get("title");
+  const slug = formData.get("slug");
+  const markdown = formData.get("markdown");
 
-  let errors = {};
+  const errors = {};
   if (!title) errors.title = true;
   if (!slug) errors.slug = true;
   if (!markdown) errors.markdown = true;
@@ -870,7 +878,7 @@ import { useActionData, Form, redirect } from "remix";
 // ...
 
 export default function NewPost() {
-  let errors = useActionData();
+  const errors = useActionData();
 
   return (
     <Form method="post">
@@ -912,7 +920,9 @@ TypeScript is still mad, so let's add some invariants to make it happy.
 //...
 import invariant from "tiny-invariant";
 
-export let action: ActionFunction = async ({ request }) => {
+export const action: ActionFunction = async ({
+  request
+}) => {
   // ...
 
   if (Object.keys(errors).length) {
@@ -934,12 +944,14 @@ For some real fun, disable JavaScript in your dev tools and try it out. Because 
 
 ```tsx filename=app/routes/admin/new.tsx lines=[3]
 // ...
-export let action: ActionFunction = async ({ request }) => {
+export const action: ActionFunction = async ({
+  request
+}) => {
   await new Promise(res => setTimeout(res, 1000));
-  let formData = await request.formData();
-  let title = formData.get("title");
-  let slug = formData.get("slug");
-  let markdown = formData.get("markdown");
+  const formData = await request.formData();
+  const title = formData.get("title");
+  const slug = formData.get("slug");
+  const markdown = formData.get("markdown");
   // ...
 };
 //...
@@ -958,8 +970,8 @@ import {
 // ...
 
 export default function NewPost() {
-  let errors = useActionData();
-  let transition = useTransition();
+  const errors = useActionData();
+  const transition = useTransition();
 
   return (
     <Form method="post">

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -487,7 +487,7 @@ body {
 import type { LinksFunction } from "remix";
 import stylesUrl from "../styles/index.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: stylesUrl }];
 };
 
@@ -1201,7 +1201,7 @@ import globalStylesUrl from "./styles/global.css";
 import globalMediumStylesUrl from "./styles/global-medium.css";
 import globalLargeStylesUrl from "./styles/global-large.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     {
       rel: "stylesheet",
@@ -1250,7 +1250,7 @@ import type { LinksFunction } from "remix";
 import { Outlet, Link } from "remix";
 import stylesUrl from "../styles/jokes.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     {
       rel: "stylesheet",
@@ -1315,7 +1315,7 @@ import type { LinksFunction } from "remix";
 import { Link } from "remix";
 import stylesUrl from "../styles/index.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     {
       rel: "stylesheet",
@@ -1465,7 +1465,7 @@ Next, we're going to write a little file that will "seed" our database with test
 
 ```ts filename=prisma/seed.ts
 import { PrismaClient } from "@prisma/client";
-let db = new PrismaClient();
+const db = new PrismaClient();
 
 async function seed() {
   await Promise.all(
@@ -1552,7 +1552,7 @@ Ok, one last thing we need to do is connect to the database in our app. We do th
 
 ```ts nocopy
 import { PrismaClient } from "@prisma/client";
-let db = new PrismaClient();
+const db = new PrismaClient();
 ```
 
 This works just fine, but the problem is, during development, we don't want to close down and completely restart our server every time we make a server-side change. So `@remix-run/serve` actually rebuilds our code and requires it brand new. The problem here is that every time we make a code change, we'll make a new connection to the database and eventually run out of connections! This is such a common problem with database-accessing apps that Prisma has a warning for it:
@@ -1610,15 +1610,15 @@ import type { User } from "@prisma/client";
 import { db } from "~/utils/db.server";
 
 type LoaderData = { users: Array<User> };
-export let loader: LoaderFunction = async () => {
-  let data: LoaderData = {
+export const loader: LoaderFunction = async () => {
+  const data: LoaderData = {
     users: await prisma.user.findMany()
   };
   return { data };
 };
 
 export default function Users() {
-  let data = useLoaderData<LoaderData>();
+  const data = useLoaderData<LoaderData>();
   return (
     <ul>
       {data.map(user => (
@@ -1649,7 +1649,7 @@ import { Link, Outlet, useLoaderData } from "remix";
 import { db } from "~/utils/db.server";
 import stylesUrl from "../styles/jokes.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     {
       rel: "stylesheet",
@@ -1662,15 +1662,15 @@ type LoaderData = {
   jokeListItems: Array<{ id: string; name: string }>;
 };
 
-export let loader: LoaderFunction = async () => {
-  let data: LoaderData = {
+export const loader: LoaderFunction = async () => {
+  const data: LoaderData = {
     jokeListItems: await db.joke.findMany()
   };
   return data;
 };
 
 export default function JokesRoute() {
-  let data = useLoaderData<LoaderData>();
+  const data = useLoaderData<LoaderData>();
 
   return (
     <div className="jokes-layout">
@@ -1729,8 +1729,8 @@ type LoaderData = {
   jokeListItems: Array<{ id: string; name: string }>;
 };
 
-export let loader: LoaderFunction = async () => {
-  let data: LoaderData = {
+export const loader: LoaderFunction = async () => {
+  const data: LoaderData = {
     jokeListItems: await db.joke.findMany({
       take: 5,
       select: { id: true, name: true },
@@ -1758,7 +1758,9 @@ So the only way to really be 100% positive that your data is correct, you should
 Before we get to the `/jokes/:jokeId` route, here's a quick example of how you can access params (like `:jokeId`) in your loader.
 
 ```tsx nocopy
-export let loader: LoaderFunction = async ({ params }) => {
+export const loader: LoaderFunction = async ({
+  params
+}) => {
   console.log(params); // <-- {jokeId: "123"}
 };
 ```
@@ -1766,7 +1768,7 @@ export let loader: LoaderFunction = async ({ params }) => {
 And here's how you get the joke from prisma:
 
 ```tsx nocopy
-let joke = await db.joke.findUnique({
+const joke = await db.joke.findUnique({
   where: { id: jokeId }
 });
 ```
@@ -1787,17 +1789,19 @@ import { db } from "~/utils/db.server";
 
 type LoaderData = { joke: Joke };
 
-export let loader: LoaderFunction = async ({ params }) => {
-  let joke = await db.joke.findUnique({
+export const loader: LoaderFunction = async ({
+  params
+}) => {
+  const joke = await db.joke.findUnique({
     where: { id: params.jokeId }
   });
   if (!joke) throw new Error("Joke not found");
-  let data: LoaderData = { joke };
+  const data: LoaderData = { joke };
   return data;
 };
 
 export default function JokeRoute() {
-  let data = useLoaderData<LoaderData>();
+  const data = useLoaderData<LoaderData>();
 
   return (
     <div>
@@ -1822,9 +1826,9 @@ Next, let's handle the `/jokes` index route in `app/routes/jokes/index.tsx` that
 Here's how you get a random joke from prisma:
 
 ```tsx
-let count = await db.joke.count();
-let randomRowNumber = Math.floor(Math.random() * count);
-let [randomJoke] = await db.joke.findMany({
+const count = await db.joke.count();
+const randomRowNumber = Math.floor(Math.random() * count);
+const [randomJoke] = await db.joke.findMany({
   take: 1,
   skip: randomRowNumber
 });
@@ -1844,19 +1848,19 @@ import { db } from "~/utils/db.server";
 
 type LoaderData = { randomJoke: Joke };
 
-export let loader: LoaderFunction = async () => {
-  let count = await db.joke.count();
-  let randomRowNumber = Math.floor(Math.random() * count);
-  let [randomJoke] = await db.joke.findMany({
+export const loader: LoaderFunction = async () => {
+  const count = await db.joke.count();
+  const randomRowNumber = Math.floor(Math.random() * count);
+  const [randomJoke] = await db.joke.findMany({
     take: 1,
     skip: randomRowNumber
   });
-  let data: LoaderData = { randomJoke };
+  const data: LoaderData = { randomJoke };
   return data;
 };
 
 export default function JokesIndexRoute() {
-  let data = useLoaderData<LoaderData>();
+  const data = useLoaderData<LoaderData>();
 
   return (
     <div>
@@ -1912,7 +1916,7 @@ Not much there. Just a form. What if I told you that you could make that form wo
 Here's the prisma code you'll need:
 
 ```tsx
-let joke = await db.joke.create({
+const joke = await db.joke.create({
   data: { name, content }
 });
 ```
@@ -1928,10 +1932,12 @@ import type { ActionFunction } from "remix";
 import { redirect } from "remix";
 import { db } from "~/utils/db.server";
 
-export let action: ActionFunction = async ({ request }) => {
-  let form = await request.formData();
-  let name = form.get("name");
-  let content = form.get("content");
+export const action: ActionFunction = async ({
+  request
+}) => {
+  const form = await request.formData();
+  const name = form.get("name");
+  const content = form.get("content");
   // we do this type check to be extra sure and to make TypeScript happy
   // we'll explore validation next!
   if (
@@ -1941,9 +1947,9 @@ export let action: ActionFunction = async ({ request }) => {
     throw new Error(`Form not submitted correctly.`);
   }
 
-  let fields = { name, content };
+  const fields = { name, content };
 
-  let joke = await db.joke.create({ data: fields });
+  const joke = await db.joke.create({ data: fields });
   return redirect(`/jokes/${joke.id}`);
 };
 
@@ -2034,12 +2040,12 @@ type ActionData = {
   };
 };
 
-export let action: ActionFunction = async ({
+export const action: ActionFunction = async ({
   request
 }): Promise<Response | ActionData> => {
-  let form = await request.formData();
-  let name = form.get("name");
-  let content = form.get("content");
+  const form = await request.formData();
+  const name = form.get("name");
+  const content = form.get("content");
   if (
     typeof name !== "string" ||
     typeof content !== "string"
@@ -2047,21 +2053,23 @@ export let action: ActionFunction = async ({
     return { formError: `Form not submitted correctly.` };
   }
 
-  let fieldErrors = {
+  const fieldErrors = {
     name: validateJokeName(name),
     content: validateJokeContent(content)
   };
-  let fields = { name, content };
+  const fields = { name, content };
   if (Object.values(fieldErrors).some(Boolean)) {
     return { fieldErrors, fields };
   }
 
-  let joke = await db.joke.create({ data: fields });
+  const joke = await db.joke.create({ data: fields });
   return redirect(`/jokes/${joke.id}`);
 };
 
 export default function NewJokeRoute() {
-  let actionData = useActionData<ActionData | undefined>();
+  const actionData = useActionData<
+    ActionData | undefined
+  >();
 
   return (
     <div>
@@ -2234,10 +2242,10 @@ With this change, we're going to start experiencing some TypeScript errors in ou
 
 ```ts filename=prisma/seed.ts lines=[5-12,15-16]
 import { PrismaClient } from "@prisma/client";
-let prisma = new PrismaClient();
+const prisma = new PrismaClient();
 
 async function seed() {
-  let kody = await prisma.user.create({
+  const kody = await prisma.user.create({
     data: {
       username: "kody",
       // this is a hashed version of "twixrox"
@@ -2247,7 +2255,7 @@ async function seed() {
   });
   await Promise.all(
     getJokes().map(joke => {
-      let data = { jokesterId: kody.id, ...joke };
+      const data = { jokesterId: kody.id, ...joke };
       return prisma.joke.create({ data });
     })
   );
@@ -2437,12 +2445,12 @@ import type { LinksFunction } from "remix";
 import { Link, useSearchParams } from "remix";
 import stylesUrl from "../styles/login.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: stylesUrl }];
 };
 
 export default function Login() {
-  let [searchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   return (
     <div className="container">
       <div className="content" data-light="">
@@ -2539,7 +2547,7 @@ import {
 import { db } from "~/utils/db.server";
 import stylesUrl from "../styles/login.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: stylesUrl }];
 };
 
@@ -2568,14 +2576,14 @@ type ActionData = {
   };
 };
 
-export let action: ActionFunction = async ({
+export const action: ActionFunction = async ({
   request
 }): Promise<Response | ActionData> => {
-  let form = await request.formData();
-  let loginType = form.get("loginType");
-  let username = form.get("username");
-  let password = form.get("password");
-  let redirectTo = form.get("redirectTo");
+  const form = await request.formData();
+  const loginType = form.get("loginType");
+  const username = form.get("username");
+  const password = form.get("password");
+  const redirectTo = form.get("redirectTo");
   if (
     typeof loginType !== "string" ||
     typeof username !== "string" ||
@@ -2585,8 +2593,8 @@ export let action: ActionFunction = async ({
     return { formError: `Form not submitted correctly.` };
   }
 
-  let fields = { loginType, username, password };
-  let fieldErrors = {
+  const fields = { loginType, username, password };
+  const fieldErrors = {
     username: validateUsername(username),
     password: validatePassword(password)
   };
@@ -2601,7 +2609,7 @@ export let action: ActionFunction = async ({
       return { fields, formError: "Not implemented" };
     }
     case "register": {
-      let userExists = await db.user.findFirst({
+      const userExists = await db.user.findFirst({
         where: { username }
       });
       if (userExists) {
@@ -2621,8 +2629,10 @@ export let action: ActionFunction = async ({
 };
 
 export default function Login() {
-  let actionData = useActionData<ActionData | undefined>();
-  let [searchParams] = useSearchParams();
+  const actionData = useActionData<
+    ActionData | undefined
+  >();
+  const [searchParams] = useSearchParams();
   return (
     <div className="container">
       <div className="content" data-light="">
@@ -2791,12 +2801,12 @@ export async function login({
   username,
   password
 }: LoginForm) {
-  let user = await db.user.findUnique({
+  const user = await db.user.findUnique({
     where: { username }
   });
   if (!user) return null;
 
-  let isCorrectPassword = await bcrypt.compare(
+  const isCorrectPassword = await bcrypt.compare(
     password,
     user.passwordHash
   );
@@ -2823,13 +2833,13 @@ import stylesUrl from "../styles/login.css";
 
 // ...
 
-export let action: ActionFunction = async ({
+export const action: ActionFunction = async ({
   request
 }): Promise<Response | ActionData> => {
   // ...
   switch (loginType) {
     case "login": {
-      let user = await login({ username, password });
+      const user = await login({ username, password });
       console.log({ user });
       if (!user) {
         return {
@@ -2902,11 +2912,11 @@ export async function login({
   username,
   password
 }: LoginForm) {
-  let user = await db.user.findUnique({
+  const user = await db.user.findUnique({
     where: { username }
   });
   if (!user) return null;
-  let isCorrectPassword = await bcrypt.compare(
+  const isCorrectPassword = await bcrypt.compare(
     password,
     user.passwordHash
   );
@@ -2914,12 +2924,12 @@ export async function login({
   return user;
 }
 
-let sessionSecret = process.env.SESSION_SECRET;
+const sessionSecret = process.env.SESSION_SECRET;
 if (!sessionSecret) {
   throw new Error("SESSION_SECRET must be set");
 }
 
-let storage = createCookieSessionStorage({
+const storage = createCookieSessionStorage({
   cookie: {
     name: "RJ_session",
     // normally you want this to be `secure: true`
@@ -2938,7 +2948,7 @@ export async function createUserSession(
   userId: string,
   redirectTo: string
 ) {
-  let session = await storage.getSession();
+  const session = await storage.getSession();
   session.set("userId", userId);
   return redirect(redirectTo, {
     headers: {
@@ -2957,7 +2967,7 @@ export async function createUserSession(
 ```tsx filename=app/routes/login.tsx nocopy
 // ...
 case "login": {
-  let user = await login({ username, password });
+  const user = await login({ username, password });
   if (!user) {
     return {
       fields,
@@ -2972,7 +2982,7 @@ case "login": {
 </details>
 
 I want to call out the `SESSION_SECRET` environment variable I'm using really quick. The value of the `secrets` option is not the sort of thing you want in your code because the badies could use it for their nefarious purposes. So instead we are going to read the value from the environment. This means you'll need to set the environment variable in your `.env` file. Incidentally, prisma loads that file for us automatically so all we need to do is make sure we set that value when we deploy to production (alternatively, during development we could use [dotenv](https://npm.im/dotenv) to load that when our app boots up).
-  
+
 💿 Update .env file with SESSION_SECRET (with any value you like).
 
 With that, pop open your [Network tab](https://developer.chrome.com/docs/devtools/network/reference/), go to [`/login`](http://localhost:3000/login) and enter `kody` and `twixrox` and check the response headers in the network tab. Should look something like this:
@@ -3014,11 +3024,11 @@ export async function login({
   username,
   password
 }: LoginForm) {
-  let user = await db.user.findUnique({
+  const user = await db.user.findUnique({
     where: { username }
   });
   if (!user) return null;
-  let isCorrectPassword = await bcrypt.compare(
+  const isCorrectPassword = await bcrypt.compare(
     password,
     user.passwordHash
   );
@@ -3026,12 +3036,12 @@ export async function login({
   return user;
 }
 
-let sessionSecret = process.env.SESSION_SECRET;
+const sessionSecret = process.env.SESSION_SECRET;
 if (!sessionSecret) {
   throw new Error("SESSION_SECRET must be set");
 }
 
-let storage = createCookieSessionStorage({
+const storage = createCookieSessionStorage({
   cookie: {
     name: "RJ_session",
     // normally you want this to be `secure: true`
@@ -3051,8 +3061,8 @@ export function getUserSession(request: Request) {
 }
 
 export async function getUserId(request: Request) {
-  let session = await getUserSession(request);
-  let userId = session.get("userId");
+  const session = await getUserSession(request);
+  const userId = session.get("userId");
   if (!userId || typeof userId !== "string") return null;
   return userId;
 }
@@ -3061,10 +3071,10 @@ export async function requireUserId(
   request: Request,
   redirectTo: string = new URL(request.url).pathname
 ) {
-  let session = await getUserSession(request);
-  let userId = session.get("userId");
+  const session = await getUserSession(request);
+  const userId = session.get("userId");
   if (!userId || typeof userId !== "string") {
-    let searchParams = new URLSearchParams([
+    const searchParams = new URLSearchParams([
       ["redirectTo", redirectTo]
     ]);
     throw redirect(`/login?${searchParams}`);
@@ -3076,7 +3086,7 @@ export async function createUserSession(
   userId: string,
   redirectTo: string
 ) {
-  let session = await storage.getSession();
+  const session = await storage.getSession();
   session.set("userId", userId);
   return redirect(redirectTo, {
     headers: {
@@ -3132,13 +3142,13 @@ type ActionData = {
   };
 };
 
-export let action: ActionFunction = async ({
+export const action: ActionFunction = async ({
   request
 }): Promise<Response | ActionData> => {
-  let userId = await requireUserId(request);
-  let form = await request.formData();
-  let name = form.get("name");
-  let content = form.get("content");
+  const userId = await requireUserId(request);
+  const form = await request.formData();
+  const name = form.get("name");
+  const content = form.get("content");
   if (
     typeof name !== "string" ||
     typeof content !== "string"
@@ -3146,23 +3156,25 @@ export let action: ActionFunction = async ({
     return { formError: `Form not submitted correctly.` };
   }
 
-  let fieldErrors = {
+  const fieldErrors = {
     name: validateJokeName(name),
     content: validateJokeContent(content)
   };
-  let fields = { name, content };
+  const fields = { name, content };
   if (Object.values(fieldErrors).some(Boolean)) {
     return { fieldErrors, fields };
   }
 
-  let joke = await db.joke.create({
+  const joke = await db.joke.create({
     data: { ...fields, jokesterId: userId }
   });
   return redirect(`/jokes/${joke.id}`);
 };
 
 export default function NewJokeRoute() {
-  let actionData = useActionData<ActionData | undefined>();
+  const actionData = useActionData<
+    ActionData | undefined
+  >();
 
   return (
     <div>
@@ -3265,11 +3277,11 @@ export async function login({
   username,
   password
 }: LoginForm) {
-  let user = await db.user.findUnique({
+  const user = await db.user.findUnique({
     where: { username }
   });
   if (!user) return null;
-  let isCorrectPassword = await bcrypt.compare(
+  const isCorrectPassword = await bcrypt.compare(
     password,
     user.passwordHash
   );
@@ -3277,12 +3289,12 @@ export async function login({
   return user;
 }
 
-let sessionSecret = process.env.SESSION_SECRET;
+const sessionSecret = process.env.SESSION_SECRET;
 if (!sessionSecret) {
   throw new Error("SESSION_SECRET must be set");
 }
 
-let storage = createCookieSessionStorage({
+const storage = createCookieSessionStorage({
   cookie: {
     name: "RJ_session",
     // normally you want this to be `secure: true`
@@ -3302,8 +3314,8 @@ export function getUserSession(request: Request) {
 }
 
 export async function getUserId(request: Request) {
-  let session = await getUserSession(request);
-  let userId = session.get("userId");
+  const session = await getUserSession(request);
+  const userId = session.get("userId");
   if (!userId || typeof userId !== "string") return null;
   return userId;
 }
@@ -3312,10 +3324,10 @@ export async function requireUserId(
   request: Request,
   redirectTo: string = new URL(request.url).pathname
 ) {
-  let session = await getUserSession(request);
-  let userId = session.get("userId");
+  const session = await getUserSession(request);
+  const userId = session.get("userId");
   if (!userId || typeof userId !== "string") {
-    let searchParams = new URLSearchParams([
+    const searchParams = new URLSearchParams([
       ["redirectTo", redirectTo]
     ]);
     throw redirect(`/login?${searchParams}`);
@@ -3324,13 +3336,13 @@ export async function requireUserId(
 }
 
 export async function getUser(request: Request) {
-  let userId = await getUserId(request);
+  const userId = await getUserId(request);
   if (typeof userId !== "string") {
     return null;
   }
 
   try {
-    let user = await db.user.findUnique({
+    const user = await db.user.findUnique({
       where: { id: userId }
     });
     return user;
@@ -3340,7 +3352,7 @@ export async function getUser(request: Request) {
 }
 
 export async function logout(request: Request) {
-  let session = await storage.getSession(
+  const session = await storage.getSession(
     request.headers.get("Cookie")
   );
   return redirect("/login", {
@@ -3354,7 +3366,7 @@ export async function createUserSession(
   userId: string,
   redirectTo: string
 ) {
-  let session = await storage.getSession();
+  const session = await storage.getSession();
   session.set("userId", userId);
   return redirect(redirectTo, {
     headers: {
@@ -3385,7 +3397,7 @@ import { db } from "~/utils/db.server";
 import { getUser } from "~/utils/session.server";
 import stylesUrl from "../styles/jokes.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     {
       rel: "stylesheet",
@@ -3399,15 +3411,17 @@ type LoaderData = {
   jokeListItems: Array<{ id: string; name: string }>;
 };
 
-export let loader: LoaderFunction = async ({ request }) => {
-  let jokeListItems = await db.joke.findMany({
+export const loader: LoaderFunction = async ({
+  request
+}) => {
+  const jokeListItems = await db.joke.findMany({
     take: 5,
     orderBy: { createdAt: "desc" },
     select: { id: true, name: true }
   });
-  let user = await getUser(request);
+  const user = await getUser(request);
 
-  let data: LoaderData = {
+  const data: LoaderData = {
     jokeListItems,
     user
   };
@@ -3415,7 +3429,7 @@ export let loader: LoaderFunction = async ({ request }) => {
 };
 
 export default function JokesRoute() {
-  let data = useLoaderData<LoaderData>();
+  const data = useLoaderData<LoaderData>();
 
   return (
     <div className="jokes-layout">
@@ -3482,11 +3496,13 @@ import type { ActionFunction, LoaderFunction } from "remix";
 import { redirect } from "remix";
 import { logout } from "~/utils/session.server";
 
-export let action: ActionFunction = async ({ request }) => {
+export const action: ActionFunction = async ({
+  request
+}) => {
   return logout(request);
 };
 
-export let loader: LoaderFunction = async () => {
+export const loader: LoaderFunction = async () => {
   return redirect("/");
 };
 ```
@@ -3540,7 +3556,7 @@ export async function register({
   username,
   password
 }: LoginForm) {
-  let passwordHash = await bcrypt.hash(password, 10);
+  const passwordHash = await bcrypt.hash(password, 10);
   return db.user.create({
     data: { username, passwordHash }
   });
@@ -3550,11 +3566,11 @@ export async function login({
   username,
   password
 }: LoginForm) {
-  let user = await db.user.findUnique({
+  const user = await db.user.findUnique({
     where: { username }
   });
   if (!user) return null;
-  let isCorrectPassword = await bcrypt.compare(
+  const isCorrectPassword = await bcrypt.compare(
     password,
     user.passwordHash
   );
@@ -3562,12 +3578,12 @@ export async function login({
   return user;
 }
 
-let sessionSecret = process.env.SESSION_SECRET;
+const sessionSecret = process.env.SESSION_SECRET;
 if (!sessionSecret) {
   throw new Error("SESSION_SECRET must be set");
 }
 
-let storage = createCookieSessionStorage({
+const storage = createCookieSessionStorage({
   cookie: {
     name: "RJ_session",
     // normally you want this to be `secure: true`
@@ -3587,8 +3603,8 @@ export function getUserSession(request: Request) {
 }
 
 export async function getUserId(request: Request) {
-  let session = await getUserSession(request);
-  let userId = session.get("userId");
+  const session = await getUserSession(request);
+  const userId = session.get("userId");
   if (!userId || typeof userId !== "string") return null;
   return userId;
 }
@@ -3597,10 +3613,10 @@ export async function requireUserId(
   request: Request,
   redirectTo: string = new URL(request.url).pathname
 ) {
-  let session = await getUserSession(request);
-  let userId = session.get("userId");
+  const session = await getUserSession(request);
+  const userId = session.get("userId");
   if (!userId || typeof userId !== "string") {
-    let searchParams = new URLSearchParams([
+    const searchParams = new URLSearchParams([
       ["redirectTo", redirectTo]
     ]);
     throw redirect(`/login?${searchParams}`);
@@ -3609,13 +3625,13 @@ export async function requireUserId(
 }
 
 export async function getUser(request: Request) {
-  let userId = await getUserId(request);
+  const userId = await getUserId(request);
   if (typeof userId !== "string") {
     return null;
   }
 
   try {
-    let user = await db.user.findUnique({
+    const user = await db.user.findUnique({
       where: { id: userId }
     });
     return user;
@@ -3625,7 +3641,7 @@ export async function getUser(request: Request) {
 }
 
 export async function logout(request: Request) {
-  let session = await storage.getSession(
+  const session = await storage.getSession(
     request.headers.get("Cookie")
   );
   return redirect("/login", {
@@ -3639,7 +3655,7 @@ export async function createUserSession(
   userId: string,
   redirectTo: string
 ) {
-  let session = await storage.getSession();
+  const session = await storage.getSession();
   session.set("userId", userId);
   return redirect(redirectTo, {
     headers: {
@@ -3657,7 +3673,11 @@ export async function createUserSession(
 
 ```tsx filename=app/routes/login.tsx lines=[2,7,86-93]
 import type { ActionFunction, LinksFunction } from "remix";
-import { useActionData, useSearchParams, Link } from "remix";
+import {
+  useActionData,
+  useSearchParams,
+  Link
+} from "remix";
 import { db } from "~/utils/db.server";
 import {
   createUserSession,
@@ -3666,7 +3686,7 @@ import {
 } from "~/utils/session.server";
 import stylesUrl from "../styles/login.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: stylesUrl }];
 };
 
@@ -3695,14 +3715,14 @@ type ActionData = {
   };
 };
 
-export let action: ActionFunction = async ({
+export const action: ActionFunction = async ({
   request
 }): Promise<Response | ActionData> => {
-  let form = await request.formData();
-  let loginType = form.get("loginType");
-  let username = form.get("username");
-  let password = form.get("password");
-  let redirectTo = form.get("redirectTo") || "/jokes";
+  const form = await request.formData();
+  const loginType = form.get("loginType");
+  const username = form.get("username");
+  const password = form.get("password");
+  const redirectTo = form.get("redirectTo") || "/jokes";
   if (
     typeof loginType !== "string" ||
     typeof username !== "string" ||
@@ -3712,8 +3732,8 @@ export let action: ActionFunction = async ({
     return { formError: `Form not submitted correctly.` };
   }
 
-  let fields = { loginType, username, password };
-  let fieldErrors = {
+  const fields = { loginType, username, password };
+  const fieldErrors = {
     username: validateUsername(username),
     password: validatePassword(password)
   };
@@ -3722,7 +3742,7 @@ export let action: ActionFunction = async ({
 
   switch (loginType) {
     case "login": {
-      let user = await login({ username, password });
+      const user = await login({ username, password });
       if (!user) {
         return {
           fields,
@@ -3732,7 +3752,7 @@ export let action: ActionFunction = async ({
       return createUserSession(user.id, redirectTo);
     }
     case "register": {
-      let userExists = await db.user.findFirst({
+      const userExists = await db.user.findFirst({
         where: { username }
       });
       if (userExists) {
@@ -3757,8 +3777,10 @@ export let action: ActionFunction = async ({
 };
 
 export default function Login() {
-  let actionData = useActionData<ActionData | undefined>();
-  let [searchParams] = useSearchParams();
+  const actionData = useActionData<
+    ActionData | undefined
+  >();
+  const [searchParams] = useSearchParams();
   return (
     <div className="container">
       <div className="content" data-light="">
@@ -3921,7 +3943,7 @@ import globalStylesUrl from "./styles/global.css";
 import globalMediumStylesUrl from "./styles/global-medium.css";
 import globalLargeStylesUrl from "./styles/global-large.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     {
       rel: "stylesheet",
@@ -3998,7 +4020,7 @@ import { Link, useLoaderData, useParams } from "remix";
 // ...
 
 export function ErrorBoundary() {
-  let { jokeId } = useParams();
+  const { jokeId } = useParams();
   return (
     <div className="error-container">{`There was an error loading joke by the id ${jokeId}. Sorry.`}</div>
   );
@@ -4088,7 +4110,7 @@ import globalStylesUrl from "./styles/global.css";
 import globalMediumStylesUrl from "./styles/global-medium.css";
 import globalLargeStylesUrl from "./styles/global-large.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     {
       rel: "stylesheet",
@@ -4140,7 +4162,7 @@ export default function App() {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   return (
     <Document
@@ -4186,8 +4208,10 @@ import { db } from "~/utils/db.server";
 
 type LoaderData = { joke: Joke };
 
-export let loader: LoaderFunction = async ({ params }) => {
-  let joke = await db.joke.findUnique({
+export const loader: LoaderFunction = async ({
+  params
+}) => {
+  const joke = await db.joke.findUnique({
     where: { id: params.jokeId }
   });
   if (!joke) {
@@ -4195,12 +4219,12 @@ export let loader: LoaderFunction = async ({ params }) => {
       status: 404
     });
   }
-  let data: LoaderData = { joke };
+  const data: LoaderData = { joke };
   return data;
 };
 
 export default function JokeRoute() {
-  let data = useLoaderData<LoaderData>();
+  const data = useLoaderData<LoaderData>();
 
   return (
     <div>
@@ -4212,8 +4236,8 @@ export default function JokeRoute() {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
-  let params = useParams();
+  const caught = useCatch();
+  const params = useParams();
   if (caught.status === 404) {
     return (
       <div className="error-container">
@@ -4225,7 +4249,7 @@ export function CatchBoundary() {
 }
 
 export function ErrorBoundary() {
-  let { jokeId } = useParams();
+  const { jokeId } = useParams();
   return (
     <div className="error-container">{`There was an error loading joke by the id ${jokeId}. Sorry.`}</div>
   );
@@ -4246,10 +4270,10 @@ import { db } from "~/utils/db.server";
 
 type LoaderData = { randomJoke: Joke };
 
-export let loader: LoaderFunction = async () => {
-  let count = await db.joke.count();
-  let randomRowNumber = Math.floor(Math.random() * count);
-  let [randomJoke] = await db.joke.findMany({
+export const loader: LoaderFunction = async () => {
+  const count = await db.joke.count();
+  const randomRowNumber = Math.floor(Math.random() * count);
+  const [randomJoke] = await db.joke.findMany({
     take: 1,
     skip: randomRowNumber
   });
@@ -4258,12 +4282,12 @@ export let loader: LoaderFunction = async () => {
       status: 404
     });
   }
-  let data: LoaderData = { randomJoke };
+  const data: LoaderData = { randomJoke };
   return data;
 };
 
 export default function JokesIndexRoute() {
-  let data = useLoaderData<LoaderData>();
+  const data = useLoaderData<LoaderData>();
 
   return (
     <div>
@@ -4277,7 +4301,7 @@ export default function JokesIndexRoute() {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   if (caught.status === 404) {
     return (
@@ -4320,8 +4344,10 @@ import {
   getUserId
 } from "~/utils/session.server";
 
-export let loader: LoaderFunction = async ({ request }) => {
-  let userId = await getUserId(request);
+export const loader: LoaderFunction = async ({
+  request
+}) => {
+  const userId = await getUserId(request);
   if (!userId) {
     throw new Response("Unauthorized", { status: 401 });
   }
@@ -4352,13 +4378,13 @@ type ActionData = {
   };
 };
 
-export let action: ActionFunction = async ({
+export const action: ActionFunction = async ({
   request
 }): Promise<Response | ActionData> => {
-  let userId = await requireUserId(request);
-  let form = await request.formData();
-  let name = form.get("name");
-  let content = form.get("content");
+  const userId = await requireUserId(request);
+  const form = await request.formData();
+  const name = form.get("name");
+  const content = form.get("content");
   if (
     typeof name !== "string" ||
     typeof content !== "string"
@@ -4366,23 +4392,25 @@ export let action: ActionFunction = async ({
     return { formError: `Form not submitted correctly.` };
   }
 
-  let fieldErrors = {
+  const fieldErrors = {
     name: validateJokeName(name),
     content: validateJokeContent(content)
   };
-  let fields = { name, content };
+  const fields = { name, content };
   if (Object.values(fieldErrors).some(Boolean)) {
     return { fieldErrors, fields };
   }
 
-  let joke = await db.joke.create({
+  const joke = await db.joke.create({
     data: { ...fields, jokesterId: userId }
   });
   return redirect(`/jokes/${joke.id}`);
 };
 
 export default function NewJokeRoute() {
-  let actionData = useActionData<ActionData | undefined>();
+  const actionData = useActionData<
+    ActionData | undefined
+  >();
 
   return (
     <div>
@@ -4454,7 +4482,7 @@ export default function NewJokeRoute() {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   if (caught.status === 401) {
     return (
@@ -4525,8 +4553,10 @@ import { requireUserId } from "~/utils/session.server";
 
 type LoaderData = { joke: Joke };
 
-export let loader: LoaderFunction = async ({ params }) => {
-  let joke = await db.joke.findUnique({
+export const loader: LoaderFunction = async ({
+  params
+}) => {
+  const joke = await db.joke.findUnique({
     where: { id: params.jokeId }
   });
   if (!joke) {
@@ -4534,18 +4564,18 @@ export let loader: LoaderFunction = async ({ params }) => {
       status: 404
     });
   }
-  let data: LoaderData = { joke };
+  const data: LoaderData = { joke };
   return data;
 };
 
-export let action: ActionFunction = async ({
+export const action: ActionFunction = async ({
   request,
   params
 }) => {
-  let form = await request.formData();
+  const form = await request.formData();
   if (form.get("_method") === "delete") {
-    let userId = await requireUserId(request);
-    let joke = await db.joke.findUnique({
+    const userId = await requireUserId(request);
+    const joke = await db.joke.findUnique({
       where: { id: params.jokeId }
     });
     if (!joke) {
@@ -4568,7 +4598,7 @@ export let action: ActionFunction = async ({
 };
 
 export default function JokeRoute() {
-  let data = useLoaderData<LoaderData>();
+  const data = useLoaderData<LoaderData>();
 
   return (
     <div>
@@ -4590,8 +4620,8 @@ export default function JokeRoute() {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
-  let params = useParams();
+  const caught = useCatch();
+  const params = useParams();
   switch (caught.status) {
     case 404: {
       return (
@@ -4615,7 +4645,7 @@ export function CatchBoundary() {
 
 export function ErrorBoundary({ error }: { error: Error }) {
   console.error(error);
-  let { jokeId } = useParams();
+  const { jokeId } = useParams();
   return (
     <div className="error-container">{`There was an error loading joke by the id ${jokeId}. Sorry.`}</div>
   );
@@ -4648,12 +4678,12 @@ import {
 
 type LoaderData = { joke: Joke; isOwner: boolean };
 
-export let loader: LoaderFunction = async ({
+export const loader: LoaderFunction = async ({
   request,
   params
 }) => {
-  let userId = await getUserId(request);
-  let joke = await db.joke.findUnique({
+  const userId = await getUserId(request);
+  const joke = await db.joke.findUnique({
     where: { id: params.jokeId }
   });
   if (!joke) {
@@ -4661,21 +4691,21 @@ export let loader: LoaderFunction = async ({
       status: 404
     });
   }
-  let data: LoaderData = {
+  const data: LoaderData = {
     joke,
     isOwner: userId === joke.jokesterId
   };
   return data;
 };
 
-export let action: ActionFunction = async ({
+export const action: ActionFunction = async ({
   request,
   params
 }) => {
-  let form = await request.formData();
+  const form = await request.formData();
   if (form.get("_method") === "delete") {
-    let userId = await requireUserId(request);
-    let joke = await db.joke.findUnique({
+    const userId = await requireUserId(request);
+    const joke = await db.joke.findUnique({
       where: { id: params.jokeId }
     });
     if (!joke) {
@@ -4698,7 +4728,7 @@ export let action: ActionFunction = async ({
 };
 
 export default function JokeRoute() {
-  let data = useLoaderData<LoaderData>();
+  const data = useLoaderData<LoaderData>();
 
   return (
     <div>
@@ -4722,8 +4752,8 @@ export default function JokeRoute() {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
-  let params = useParams();
+  const caught = useCatch();
+  const params = useParams();
   switch (caught.status) {
     case 404: {
       return (
@@ -4748,7 +4778,7 @@ export function CatchBoundary() {
 export function ErrorBoundary({ error }: { error: Error }) {
   console.error(error);
 
-  let { jokeId } = useParams();
+  const { jokeId } = useParams();
   return (
     <div className="error-container">{`There was an error loading joke by the id ${jokeId}. Sorry.`}</div>
   );
@@ -4789,7 +4819,7 @@ import globalStylesUrl from "./styles/global.css";
 import globalMediumStylesUrl from "./styles/global-medium.css";
 import globalLargeStylesUrl from "./styles/global-large.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     {
       rel: "stylesheet",
@@ -4808,8 +4838,8 @@ export let links: LinksFunction = () => {
   ];
 };
 
-export let meta: MetaFunction = () => {
-  let description = `Learn Remix and laugh at the same time!`;
+export const meta: MetaFunction = () => {
+  const description = `Learn Remix and laugh at the same time!`;
   return {
     description,
     keywords: "Remix,jokes",
@@ -4856,7 +4886,7 @@ export default function App() {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   return (
     <Document
@@ -4894,7 +4924,7 @@ import type { LinksFunction, MetaFunction } from "remix";
 import { Link } from "remix";
 import stylesUrl from "../styles/index.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     {
       rel: "stylesheet",
@@ -4903,7 +4933,7 @@ export let links: LinksFunction = () => {
   ];
 };
 
-export let meta: MetaFunction = () => {
+export const meta: MetaFunction = () => {
   return {
     title: "Remix: So great, it's funny!",
     description:
@@ -4956,11 +4986,11 @@ import {
 } from "~/utils/session.server";
 import stylesUrl from "../styles/login.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: stylesUrl }];
 };
 
-export let meta: MetaFunction = () => {
+export const meta: MetaFunction = () => {
   return {
     title: "Remix Jokes | Login",
     description:
@@ -4993,14 +5023,14 @@ type ActionData = {
   };
 };
 
-export let action: ActionFunction = async ({
+export const action: ActionFunction = async ({
   request
 }): Promise<Response | ActionData> => {
-  let form = await request.formData();
-  let loginType = form.get("loginType");
-  let username = form.get("username");
-  let password = form.get("password");
-  let redirectTo = form.get("redirectTo") || "/jokes";
+  const form = await request.formData();
+  const loginType = form.get("loginType");
+  const username = form.get("username");
+  const password = form.get("password");
+  const redirectTo = form.get("redirectTo") || "/jokes";
   if (
     typeof loginType !== "string" ||
     typeof username !== "string" ||
@@ -5010,8 +5040,8 @@ export let action: ActionFunction = async ({
     return { formError: `Form not submitted correctly.` };
   }
 
-  let fields = { loginType, username, password };
-  let fieldErrors = {
+  const fields = { loginType, username, password };
+  const fieldErrors = {
     username: validateUsername(username),
     password: validatePassword(password)
   };
@@ -5020,7 +5050,7 @@ export let action: ActionFunction = async ({
 
   switch (loginType) {
     case "login": {
-      let user = await login({ username, password });
+      const user = await login({ username, password });
       if (!user) {
         return {
           fields,
@@ -5030,7 +5060,7 @@ export let action: ActionFunction = async ({
       return createUserSession(user.id, redirectTo);
     }
     case "register": {
-      let userExists = await db.user.findFirst({
+      const userExists = await db.user.findFirst({
         where: { username }
       });
       if (userExists) {
@@ -5055,8 +5085,10 @@ export let action: ActionFunction = async ({
 };
 
 export default function Login() {
-  let actionData = useActionData<ActionData | undefined>();
-  let [searchParams] = useSearchParams();
+  const actionData = useActionData<
+    ActionData | undefined
+  >();
+  const [searchParams] = useSearchParams();
   return (
     <div className="container">
       <div className="content" data-light="">
@@ -5212,7 +5244,7 @@ import type { Joke } from "@prisma/client";
 import { db } from "~/utils/db.server";
 import { requireUserId } from "~/utils/session.server";
 
-export let meta: MetaFunction = ({
+export const meta: MetaFunction = ({
   data
 }: {
   data: LoaderData | undefined;
@@ -5231,8 +5263,10 @@ export let meta: MetaFunction = ({
 
 type LoaderData = { joke: Joke };
 
-export let loader: LoaderFunction = async ({ params }) => {
-  let joke = await db.joke.findUnique({
+export const loader: LoaderFunction = async ({
+  params
+}) => {
+  const joke = await db.joke.findUnique({
     where: { id: params.jokeId }
   });
   if (!joke) {
@@ -5240,18 +5274,18 @@ export let loader: LoaderFunction = async ({ params }) => {
       status: 404
     });
   }
-  let data: LoaderData = { joke };
+  const data: LoaderData = { joke };
   return data;
 };
 
-export let action: ActionFunction = async ({
+export const action: ActionFunction = async ({
   request,
   params
 }) => {
-  let form = await request.formData();
+  const form = await request.formData();
   if (form.get("_method") === "delete") {
-    let userId = await requireUserId(request);
-    let joke = await db.joke.findUnique({
+    const userId = await requireUserId(request);
+    const joke = await db.joke.findUnique({
       where: { id: params.jokeId }
     });
     if (!joke) {
@@ -5274,7 +5308,7 @@ export let action: ActionFunction = async ({
 };
 
 export default function JokeRoute() {
-  let data = useLoaderData<LoaderData>();
+  const data = useLoaderData<LoaderData>();
 
   return (
     <div>
@@ -5296,8 +5330,8 @@ export default function JokeRoute() {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
-  let params = useParams();
+  const caught = useCatch();
+  const params = useParams();
   switch (caught.status) {
     case 404: {
       return (
@@ -5320,7 +5354,7 @@ export function CatchBoundary() {
 }
 
 export function ErrorBoundary() {
-  let { jokeId } = useParams();
+  const { jokeId } = useParams();
   return (
     <div className="error-container">{`There was an error loading joke by the id ${jokeId}. Sorry.`}</div>
   );
@@ -5349,26 +5383,28 @@ For this one, you'll probably want to at least peak at the example unless you wa
 import type { LoaderFunction } from "remix";
 import { db } from "~/utils/db.server";
 
-export let loader: LoaderFunction = async ({ request }) => {
-  let jokes = await db.joke.findMany({
+export const loader: LoaderFunction = async ({
+  request
+}) => {
+  const jokes = await db.joke.findMany({
     take: 100,
     orderBy: { createdAt: "desc" },
     include: { jokester: { select: { username: true } } }
   });
 
-  let host =
+  const host =
     request.headers.get("X-Forwarded-Host") ??
     request.headers.get("host");
   if (!host) {
     throw new Error("Could not determine domain URL.");
   }
-  let protocol = host.includes("localhost")
+  const protocol = host.includes("localhost")
     ? "http"
     : "https";
-  let domain = `${protocol}://${host}`;
-  let jokesUrl = `${domain}/jokes`;
+  const domain = `${protocol}://${host}`;
+  const jokesUrl = `${domain}/jokes`;
 
-  let rssString = `
+  const rssString = `
     <rss xmlns:blogChannel="${jokesUrl}" version="2.0">
       <channel>
         <title>Remix Jokes</title>
@@ -5454,7 +5490,7 @@ import globalStylesUrl from "./styles/global.css";
 import globalMediumStylesUrl from "./styles/global-medium.css";
 import globalLargeStylesUrl from "./styles/global-large.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     {
       rel: "stylesheet",
@@ -5473,8 +5509,8 @@ export let links: LinksFunction = () => {
   ];
 };
 
-export let meta: MetaFunction = () => {
-  let description = `Learn Remix and laugh at the same time!`;
+export const meta: MetaFunction = () => {
+  const description = `Learn Remix and laugh at the same time!`;
   return {
     description,
     keywords: "Remix,jokes",
@@ -5522,7 +5558,7 @@ export default function App() {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   return (
     <Document
@@ -5657,7 +5693,7 @@ import {
 } from "~/utils/session.server";
 import { JokeDisplay } from "~/components/joke";
 
-export let meta: MetaFunction = ({
+export const meta: MetaFunction = ({
   data
 }: {
   data: LoaderData | undefined;
@@ -5676,13 +5712,13 @@ export let meta: MetaFunction = ({
 
 type LoaderData = { joke: Joke; isOwner: boolean };
 
-export let loader: LoaderFunction = async ({
+export const loader: LoaderFunction = async ({
   request,
   params
 }) => {
-  let userId = await getUserId(request);
+  const userId = await getUserId(request);
 
-  let joke = await db.joke.findUnique({
+  const joke = await db.joke.findUnique({
     where: { id: params.jokeId }
   });
   if (!joke) {
@@ -5690,21 +5726,21 @@ export let loader: LoaderFunction = async ({
       status: 404
     });
   }
-  let data: LoaderData = {
+  const data: LoaderData = {
     joke,
     isOwner: userId === joke.jokesterId
   };
   return data;
 };
 
-export let action: ActionFunction = async ({
+export const action: ActionFunction = async ({
   request,
   params
 }) => {
-  let form = await request.formData();
+  const form = await request.formData();
   if (form.get("_method") === "delete") {
-    let userId = await requireUserId(request);
-    let joke = await db.joke.findUnique({
+    const userId = await requireUserId(request);
+    const joke = await db.joke.findUnique({
       where: { id: params.jokeId }
     });
     if (!joke) {
@@ -5727,7 +5763,7 @@ export let action: ActionFunction = async ({
 };
 
 export default function JokeRoute() {
-  let data = useLoaderData<LoaderData>();
+  const data = useLoaderData<LoaderData>();
 
   return (
     <JokeDisplay joke={data.joke} isOwner={data.isOwner} />
@@ -5735,8 +5771,8 @@ export default function JokeRoute() {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
-  let params = useParams();
+  const caught = useCatch();
+  const params = useParams();
   switch (caught.status) {
     case 404: {
       return (
@@ -5761,7 +5797,7 @@ export function CatchBoundary() {
 export function ErrorBoundary({ error }: { error: Error }) {
   console.error(error);
 
-  let { jokeId } = useParams();
+  const { jokeId } = useParams();
   return (
     <div className="error-container">{`There was an error loading joke by the id ${jokeId}. Sorry.`}</div>
   );
@@ -5791,8 +5827,10 @@ import {
   getUserId
 } from "~/utils/session.server";
 
-export let loader: LoaderFunction = async ({ request }) => {
-  let userId = await getUserId(request);
+export const loader: LoaderFunction = async ({
+  request
+}) => {
+  const userId = await getUserId(request);
   if (!userId) {
     throw new Response("Unauthorized", { status: 401 });
   }
@@ -5823,13 +5861,13 @@ type ActionData = {
   };
 };
 
-export let action: ActionFunction = async ({
+export const action: ActionFunction = async ({
   request
 }): Promise<Response | ActionData> => {
-  let userId = await requireUserId(request);
-  let form = await request.formData();
-  let name = form.get("name");
-  let content = form.get("content");
+  const userId = await requireUserId(request);
+  const form = await request.formData();
+  const name = form.get("name");
+  const content = form.get("content");
   if (
     typeof name !== "string" ||
     typeof content !== "string"
@@ -5837,28 +5875,30 @@ export let action: ActionFunction = async ({
     return { formError: `Form not submitted correctly.` };
   }
 
-  let fieldErrors = {
+  const fieldErrors = {
     name: validateJokeName(name),
     content: validateJokeContent(content)
   };
-  let fields = { name, content };
+  const fields = { name, content };
   if (Object.values(fieldErrors).some(Boolean)) {
     return { fieldErrors, fields };
   }
 
-  let joke = await db.joke.create({
+  const joke = await db.joke.create({
     data: { ...fields, jokesterId: userId }
   });
   return redirect(`/jokes/${joke.id}`);
 };
 
 export default function NewJokeRoute() {
-  let actionData = useActionData<ActionData | undefined>();
-  let transition = useTransition();
+  const actionData = useActionData<
+    ActionData | undefined
+  >();
+  const transition = useTransition();
 
   if (transition.submission) {
-    let name = transition.submission.formData.get("name");
-    let content =
+    const name = transition.submission.formData.get("name");
+    const content =
       transition.submission.formData.get("content");
     if (
       typeof name === "string" &&
@@ -5946,7 +5986,7 @@ export default function NewJokeRoute() {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   if (caught.status === 401) {
     return (

--- a/examples/.eslintrc.js
+++ b/examples/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  rules: {
+    "prefer-const": "warn",
+
+    // because in our examples we shouldn't care
+    "import/order": "off"
+  }
+};

--- a/examples/basic/app/entry.server.tsx
+++ b/examples/basic/app/entry.server.tsx
@@ -8,7 +8,7 @@ export default function handleRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  let markup = renderToString(
+  const markup = renderToString(
     <RemixServer context={remixContext} url={request.url} />
   );
 

--- a/examples/basic/app/root.tsx
+++ b/examples/basic/app/root.tsx
@@ -24,7 +24,7 @@ import darkStylesUrl from "~/styles/dark.css";
  *
  * https://remix.run/api/app#links
  */
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     { rel: "stylesheet", href: globalStylesUrl },
     {
@@ -114,7 +114,7 @@ function Layout({ children }: React.PropsWithChildren<{}>) {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   let message;
   switch (caught.status) {
@@ -195,15 +195,15 @@ function RemixLogo(props: React.ComponentPropsWithoutRef<"svg">) {
  * Provides an alert for screen reader users when the route changes.
  */
 const RouteChangeAnnouncement = React.memo(() => {
-  let [hydrated, setHydrated] = React.useState(false);
-  let [innerHtml, setInnerHtml] = React.useState("");
-  let location = useLocation();
+  const [hydrated, setHydrated] = React.useState(false);
+  const [innerHtml, setInnerHtml] = React.useState("");
+  const location = useLocation();
 
   React.useEffect(() => {
     setHydrated(true);
   }, []);
 
-  let firstRenderRef = React.useRef(true);
+  const firstRenderRef = React.useRef(true);
   React.useEffect(() => {
     // Skip the first render because we don't want an announcement on the
     // initial page load.
@@ -212,7 +212,7 @@ const RouteChangeAnnouncement = React.memo(() => {
       return;
     }
 
-    let pageTitle =
+    const pageTitle =
       location.pathname === "/" ? "Remix demo home page" : document.title;
     setInnerHtml(`Navigated to ${pageTitle}`);
   }, [location.pathname]);

--- a/examples/basic/app/routes/demos/about.tsx
+++ b/examples/basic/app/routes/demos/about.tsx
@@ -3,13 +3,13 @@ import type { MetaFunction, LinksFunction } from "remix";
 
 import stylesUrl from "~/styles/demos/about.css";
 
-export let meta: MetaFunction = () => {
+export const meta: MetaFunction = () => {
   return {
     title: "About Remix"
   };
 };
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: stylesUrl }];
 };
 

--- a/examples/basic/app/routes/demos/actions.tsx
+++ b/examples/basic/app/routes/demos/actions.tsx
@@ -9,9 +9,9 @@ export function meta() {
 // When your form sends a POST, the action is called on the server.
 // - https://remix.run/api/conventions#action
 // - https://remix.run/guides/data-updates
-export let action: ActionFunction = async ({ request }) => {
-  let formData = await request.formData();
-  let answer = formData.get("answer");
+export const action: ActionFunction = async ({ request }) => {
+  const formData = await request.formData();
+  const answer = formData.get("answer");
 
   // Typical action workflows start with validating the form data that just came
   // over the network. Clientside validation is fine, but you definitely need it
@@ -34,8 +34,8 @@ export let action: ActionFunction = async ({ request }) => {
 
 export default function ActionsDemo() {
   // https://remix.run/api/remix#useactiondata
-  let actionMessage = useActionData<string>();
-  let answerRef = useRef<HTMLInputElement>(null);
+  const actionMessage = useActionData<string>();
+  const answerRef = useRef<HTMLInputElement>(null);
 
   // This form works without JavaScript, but when we have JavaScript we can make
   // the experience better by selecting the input on wrong answers! Go ahead, disable

--- a/examples/basic/app/routes/demos/params/$id.tsx
+++ b/examples/basic/app/routes/demos/params/$id.tsx
@@ -4,7 +4,7 @@ import type { LoaderFunction, MetaFunction } from "remix";
 // The `$` in route filenames becomes a pattern that's parsed from the URL and
 // passed to your loaders so you can look up data.
 // - https://remix.run/api/conventions#loader-params
-export let loader: LoaderFunction = async ({ params }) => {
+export const loader: LoaderFunction = async ({ params }) => {
   // pretend like we're using params.id to look something up in the db
 
   if (params.id === "this-record-does-not-exist") {
@@ -38,7 +38,7 @@ export let loader: LoaderFunction = async ({ params }) => {
 };
 
 export default function ParamDemo() {
-  let data = useLoaderData();
+  const data = useLoaderData();
   return (
     <h1>
       The param is <i style={{ color: "red" }}>{data.param}</i>
@@ -50,7 +50,7 @@ export default function ParamDemo() {
 // https://remix.run/api/remix#usecatch
 // https://remix.run/api/guides/not-found
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   let message: React.ReactNode;
   switch (caught.status) {
@@ -105,7 +105,7 @@ export function ErrorBoundary({ error }: { error: Error }) {
   );
 }
 
-export let meta: MetaFunction = ({ data }) => {
+export const meta: MetaFunction = ({ data }) => {
   return {
     title: data ? `Param: ${data.param}` : "Oops..."
   };

--- a/examples/basic/app/routes/index.tsx
+++ b/examples/basic/app/routes/index.tsx
@@ -10,8 +10,8 @@ type IndexData = {
 // you can connect to a database or run any server side code you want right next
 // to the component that renders it.
 // https://remix.run/api/conventions#loader
-export let loader: LoaderFunction = () => {
-  let data: IndexData = {
+export const loader: LoaderFunction = () => {
+  const data: IndexData = {
     resources: [
       {
         name: "Remix Docs",
@@ -47,7 +47,7 @@ export let loader: LoaderFunction = () => {
 };
 
 // https://remix.run/api/conventions#meta
-export let meta: MetaFunction = () => {
+export const meta: MetaFunction = () => {
   return {
     title: "Remix Starter",
     description: "Welcome to remix!"
@@ -56,7 +56,7 @@ export let meta: MetaFunction = () => {
 
 // https://remix.run/guides/routing#index-routes
 export default function Index() {
-  let data = useLoaderData<IndexData>();
+  const data = useLoaderData<IndexData>();
 
   return (
     <div className="remix__page">

--- a/examples/blog-tutorial/app/entry.server.tsx
+++ b/examples/blog-tutorial/app/entry.server.tsx
@@ -8,7 +8,7 @@ export default function handleRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  let markup = renderToString(
+  const markup = renderToString(
     <RemixServer context={remixContext} url={request.url} />
   );
 

--- a/examples/blog-tutorial/app/post.ts
+++ b/examples/blog-tutorial/app/post.ts
@@ -13,7 +13,7 @@ export type PostMarkdownAttributes = {
   title: string;
 };
 
-let postsPath = path.join(__dirname, "../posts");
+const postsPath = path.join(__dirname, "../posts");
 
 function isValidPostAttributes(
   attributes: any
@@ -28,29 +28,29 @@ type NewPost = {
 };
 
 export async function createPost(post: NewPost) {
-  let md = `---\ntitle: ${post.title}\n---\n\n${post.markdown}`;
+  const md = `---\ntitle: ${post.title}\n---\n\n${post.markdown}`;
   await fs.writeFile(path.join(postsPath, post.slug + ".md"), md);
   return getPost(post.slug);
 }
 
 export async function getPost(slug: string) {
-  let filepath = path.join(postsPath, slug + ".md");
-  let file = await fs.readFile(filepath);
-  let { attributes, body } = parseFrontMatter(file.toString());
+  const filepath = path.join(postsPath, slug + ".md");
+  const file = await fs.readFile(filepath);
+  const { attributes, body } = parseFrontMatter(file.toString());
   invariant(
     isValidPostAttributes(attributes),
     `Post ${filepath} is missing attributes`
   );
-  let html = marked(body);
+  const html = marked(body);
   return { slug, html, title: attributes.title };
 }
 
 export async function getPosts() {
-  let dir = await fs.readdir(postsPath);
+  const dir = await fs.readdir(postsPath);
   return Promise.all(
     dir.map(async filename => {
-      let file = await fs.readFile(path.join(postsPath, filename));
-      let { attributes } = parseFrontMatter(file.toString());
+      const file = await fs.readFile(path.join(postsPath, filename));
+      const { attributes } = parseFrontMatter(file.toString());
       invariant(isValidPostAttributes(attributes));
       return {
         slug: filename.replace(/\.md$/, ""),

--- a/examples/blog-tutorial/app/root.tsx
+++ b/examples/blog-tutorial/app/root.tsx
@@ -23,7 +23,7 @@ import darkStylesUrl from "~/styles/dark.css";
  *
  * https://remix.run/api/conventions#links
  */
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     { rel: "stylesheet", href: globalStylesUrl },
     {
@@ -114,7 +114,7 @@ function Layout({ children }: React.PropsWithChildren<{}>) {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   let message;
   switch (caught.status) {

--- a/examples/blog-tutorial/app/routes/admin.tsx
+++ b/examples/blog-tutorial/app/routes/admin.tsx
@@ -4,16 +4,16 @@ import { getPosts } from "~/post";
 import type { Post } from "~/post";
 import adminStyles from "~/styles/admin.css";
 
-export let links = () => {
+export const links = () => {
   return [{ rel: "stylesheet", href: adminStyles }];
 };
 
-export let loader = () => {
+export const loader = () => {
   return getPosts();
 };
 
 export default function Admin() {
-  let posts = useLoaderData<Post[]>();
+  const posts = useLoaderData<Post[]>();
   return (
     <div className="admin">
       <nav>

--- a/examples/blog-tutorial/app/routes/admin/new.tsx
+++ b/examples/blog-tutorial/app/routes/admin/new.tsx
@@ -4,14 +4,14 @@ import invariant from "tiny-invariant";
 
 import { createPost } from "~/post";
 
-export let action: ActionFunction = async ({ request }) => {
+export const action: ActionFunction = async ({ request }) => {
   await new Promise(res => setTimeout(res, 1000));
-  let formData = await request.formData();
-  let title = formData.get("title");
-  let slug = formData.get("slug");
-  let markdown = formData.get("markdown");
+  const formData = await request.formData();
+  const title = formData.get("title");
+  const slug = formData.get("slug");
+  const markdown = formData.get("markdown");
 
-  let errors: Record<string, boolean> = {};
+  const errors: Record<string, boolean> = {};
   if (!title) errors.title = true;
   if (!slug) errors.slug = true;
   if (!markdown) errors.markdown = true;
@@ -29,8 +29,8 @@ export let action: ActionFunction = async ({ request }) => {
 };
 
 export default function NewPost() {
-  let errors = useActionData();
-  let transition = useTransition();
+  const errors = useActionData();
+  const transition = useTransition();
 
   return (
     <Form method="post">

--- a/examples/blog-tutorial/app/routes/demos/about.tsx
+++ b/examples/blog-tutorial/app/routes/demos/about.tsx
@@ -3,13 +3,13 @@ import type { MetaFunction, LinksFunction } from "remix";
 
 import stylesUrl from "~/styles/demos/about.css";
 
-export let meta: MetaFunction = () => {
+export const meta: MetaFunction = () => {
   return {
     title: "About Remix"
   };
 };
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: stylesUrl }];
 };
 

--- a/examples/blog-tutorial/app/routes/demos/actions.tsx
+++ b/examples/blog-tutorial/app/routes/demos/actions.tsx
@@ -11,9 +11,9 @@ export function meta() {
 // When your form sends a POST, the action is called on the server.
 // - https://remix.run/api/conventions#action
 // - https://remix.run/guides/data-updates
-export let action: ActionFunction = async ({ request }) => {
-  let formData = await request.formData();
-  let answer = formData.get("answer");
+export const action: ActionFunction = async ({ request }) => {
+  const formData = await request.formData();
+  const answer = formData.get("answer");
 
   // Typical action workflows start with validating the form data that just came
   // over the network. Clientside validation is fine, but you definitely need it
@@ -23,13 +23,13 @@ export let action: ActionFunction = async ({ request }) => {
     return json("Come on, at least try!", { status: 400 });
   }
 
-  let rightAnswers = [
+  const rightAnswers = [
     "4fa6024f12494d3a99d8bda9b7a55f7d140f328a",
     "ce3659ad235ca6d1e12dec21465aff3f9a62bb8c",
     "bd111dcb4b343de4ec0a79d2d5ec55a3919c79c4"
   ];
 
-  let encrypted = hash(answer);
+  const encrypted = hash(answer);
 
   if (!rightAnswers.includes(encrypted)) {
     return json(`Sorry, ${answer} is not right.`, { status: 400 });
@@ -44,8 +44,8 @@ export let action: ActionFunction = async ({ request }) => {
 
 export default function ActionsDemo() {
   // https://remix.run/api/remix#useactiondata
-  let actionMessage = useActionData<string>();
-  let answerRef = useRef<HTMLInputElement>(null);
+  const actionMessage = useActionData<string>();
+  const answerRef = useRef<HTMLInputElement>(null);
 
   // This form works without JavaScript, but when we have JavaScript we can make
   // the experience better by selecting the input on wrong answers! Go ahead, disable

--- a/examples/blog-tutorial/app/routes/demos/params/$id.tsx
+++ b/examples/blog-tutorial/app/routes/demos/params/$id.tsx
@@ -4,7 +4,7 @@ import type { LoaderFunction, MetaFunction } from "remix";
 // The `$` in route filenames becomes a pattern that's parsed from the URL and
 // passed to your loaders so you can look up data.
 // - https://remix.run/api/conventions#loader-params
-export let loader: LoaderFunction = async ({ params }) => {
+export const loader: LoaderFunction = async ({ params }) => {
   // pretend like we're using params.id to look something up in the db
 
   if (params.id === "this-record-does-not-exist") {
@@ -38,7 +38,7 @@ export let loader: LoaderFunction = async ({ params }) => {
 };
 
 export default function ParamDemo() {
-  let data = useLoaderData();
+  const data = useLoaderData();
   return (
     <h1>
       The param is <i style={{ color: "red" }}>{data.param}</i>
@@ -50,7 +50,7 @@ export default function ParamDemo() {
 // https://remix.run/api/remix#usecatch
 // https://remix.run/api/guides/not-found
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   let message: React.ReactNode;
   switch (caught.status) {
@@ -105,7 +105,7 @@ export function ErrorBoundary({ error }: { error: Error }) {
   );
 }
 
-export let meta: MetaFunction = ({ data }) => {
+export const meta: MetaFunction = ({ data }) => {
   return {
     title: data ? `Param: ${data.param}` : "Oops..."
   };

--- a/examples/blog-tutorial/app/routes/index.tsx
+++ b/examples/blog-tutorial/app/routes/index.tsx
@@ -10,8 +10,8 @@ type IndexData = {
 // you can connect to a database or run any server side code you want right next
 // to the component that renders it.
 // https://remix.run/api/conventions#loader
-export let loader: LoaderFunction = () => {
-  let data: IndexData = {
+export const loader: LoaderFunction = () => {
+  const data: IndexData = {
     resources: [
       {
         name: "Remix Docs",
@@ -47,7 +47,7 @@ export let loader: LoaderFunction = () => {
 };
 
 // https://remix.run/api/conventions#meta
-export let meta: MetaFunction = () => {
+export const meta: MetaFunction = () => {
   return {
     title: "Remix Starter",
     description: "Welcome to remix!"
@@ -56,7 +56,7 @@ export let meta: MetaFunction = () => {
 
 // https://remix.run/guides/routing#index-routes
 export default function Index() {
-  let data = useLoaderData<IndexData>();
+  const data = useLoaderData<IndexData>();
 
   return (
     <div className="remix__page">

--- a/examples/blog-tutorial/app/routes/posts/$slug.tsx
+++ b/examples/blog-tutorial/app/routes/posts/$slug.tsx
@@ -4,12 +4,12 @@ import invariant from "tiny-invariant";
 
 import { getPost } from "~/post";
 
-export let loader: LoaderFunction = async ({ params }) => {
+export const loader: LoaderFunction = async ({ params }) => {
   invariant(params.slug, "expected params.slug");
   return getPost(params.slug);
 };
 
 export default function PostSlug() {
-  let post = useLoaderData();
+  const post = useLoaderData();
   return <div dangerouslySetInnerHTML={{ __html: post.html }} />;
 }

--- a/examples/blog-tutorial/app/routes/posts/index.tsx
+++ b/examples/blog-tutorial/app/routes/posts/index.tsx
@@ -3,12 +3,12 @@ import { Link, useLoaderData } from "remix";
 import { getPosts } from "~/post";
 import type { Post } from "~/post";
 
-export let loader = () => {
+export const loader = () => {
   return getPosts();
 };
 
 export default function Posts() {
-  let posts = useLoaderData<Post[]>();
+  const posts = useLoaderData<Post[]>();
   return (
     <div>
       <h1>Posts</h1>

--- a/examples/jokes/.eslintrc
+++ b/examples/jokes/.eslintrc
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "import/order": "off"
-  }
-}

--- a/examples/jokes/app/entry.server.tsx
+++ b/examples/jokes/app/entry.server.tsx
@@ -8,7 +8,7 @@ export default function handleRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  let markup = ReactDOMServer.renderToString(
+  const markup = ReactDOMServer.renderToString(
     <RemixServer context={remixContext} url={request.url} />
   );
 

--- a/examples/jokes/app/root.tsx
+++ b/examples/jokes/app/root.tsx
@@ -5,7 +5,7 @@ import globalStylesUrl from "./styles/global.css";
 import globalMediumStylesUrl from "./styles/global-medium.css";
 import globalLargeStylesUrl from "./styles/global-large.css";
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     { rel: "stylesheet", href: globalStylesUrl },
     {
@@ -21,8 +21,8 @@ export let links: LinksFunction = () => {
   ];
 };
 
-export let meta: MetaFunction = () => {
-  let description = `Learn Remix and laugh at the same time!`;
+export const meta: MetaFunction = () => {
+  const description = `Learn Remix and laugh at the same time!`;
   return {
     description,
     keywords: "Remix,jokes",
@@ -69,7 +69,7 @@ export default function App() {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   return (
     <Document title={`${caught.status} ${caught.statusText}`}>

--- a/examples/jokes/app/routes/index.tsx
+++ b/examples/jokes/app/routes/index.tsx
@@ -2,14 +2,14 @@ import { Link } from "remix";
 import type { MetaFunction, LinksFunction } from "remix";
 import stylesUrl from "../styles/index.css";
 
-export let meta: MetaFunction = () => {
+export const meta: MetaFunction = () => {
   return {
     title: "Remix: It's funny!",
     description: "Remix jokes app. Learn Remix and laugh at the same time!",
   };
 };
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: stylesUrl }];
 };
 

--- a/examples/jokes/app/routes/jokes.tsx
+++ b/examples/jokes/app/routes/jokes.tsx
@@ -11,15 +11,15 @@ type LoaderData = {
   jokeListItems: Array<{ id: string; name: string }>;
 };
 
-export let loader: LoaderFunction = async ({ request }) => {
-  let jokeListItems = await db.joke.findMany({
+export const loader: LoaderFunction = async ({ request }) => {
+  const jokeListItems = await db.joke.findMany({
     take: 5,
     select: { id: true, name: true },
     orderBy: { createdAt: "desc" },
   });
-  let user = await getUser(request);
+  const user = await getUser(request);
 
-  let data: LoaderData = {
+  const data: LoaderData = {
     jokeListItems,
     user,
   };
@@ -27,12 +27,12 @@ export let loader: LoaderFunction = async ({ request }) => {
   return data;
 };
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: stylesUrl }];
 };
 
 export default function JokesScreen() {
-  let data = useLoaderData<LoaderData>();
+  const data = useLoaderData<LoaderData>();
 
   return (
     <div className="jokes-layout">

--- a/examples/jokes/app/routes/jokes/$jokeId.tsx
+++ b/examples/jokes/app/routes/jokes/$jokeId.tsx
@@ -5,7 +5,7 @@ import { db } from "~/utils/db.server";
 import { getUserId, requireUserId } from "~/utils/session.server";
 import { JokeDisplay } from "~/components/joke";
 
-export let meta: MetaFunction = ({
+export const meta: MetaFunction = ({
   data,
 }: {
   data: LoaderData | undefined;
@@ -24,21 +24,21 @@ export let meta: MetaFunction = ({
 
 type LoaderData = { joke: Joke; isOwner: boolean };
 
-export let loader: LoaderFunction = async ({ request, params }) => {
-  let userId = await getUserId(request);
-  let joke = await db.joke.findUnique({ where: { id: params.jokeId } });
+export const loader: LoaderFunction = async ({ request, params }) => {
+  const userId = await getUserId(request);
+  const joke = await db.joke.findUnique({ where: { id: params.jokeId } });
   if (!joke) {
     throw new Response("What a joke! Not found.", { status: 404 });
   }
-  let data: LoaderData = { joke, isOwner: userId === joke.jokesterId };
+  const data: LoaderData = { joke, isOwner: userId === joke.jokesterId };
   return data;
 };
 
-export let action: ActionFunction = async ({ request, params }) => {
-  let form = await request.formData();
+export const action: ActionFunction = async ({ request, params }) => {
+  const form = await request.formData();
   if (form.get("_method") === "delete") {
-    let userId = await requireUserId(request);
-    let joke = await db.joke.findUnique({ where: { id: params.jokeId } });
+    const userId = await requireUserId(request);
+    const joke = await db.joke.findUnique({ where: { id: params.jokeId } });
     if (!joke) {
       throw new Response("Can't delete what does not exist", { status: 404 });
     }
@@ -53,14 +53,14 @@ export let action: ActionFunction = async ({ request, params }) => {
 };
 
 export default function JokeRoute() {
-  let data = useLoaderData<LoaderData>();
+  const data = useLoaderData<LoaderData>();
 
   return <JokeDisplay joke={data.joke} isOwner={data.isOwner} />;
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
-  let params = useParams();
+  const caught = useCatch();
+  const params = useParams();
   switch (caught.status) {
     case 404: {
       return (
@@ -84,7 +84,7 @@ export function CatchBoundary() {
 
 export function ErrorBoundary({ error }: { error: Error }) {
   console.error(error);
-  let { jokeId } = useParams();
+  const { jokeId } = useParams();
   return (
     <div>{`There was an error loading joke by the id ${jokeId}. Sorry.`}</div>
   );

--- a/examples/jokes/app/routes/jokes/index.tsx
+++ b/examples/jokes/app/routes/jokes/index.tsx
@@ -5,19 +5,22 @@ import { db } from "~/utils/db.server";
 
 type LoaderData = { randomJoke: Joke };
 
-export let loader = async () => {
+export const loader = async () => {
   const count = await db.joke.count();
   const randomRowNumber = Math.floor(Math.random() * count);
-  let [randomJoke] = await db.joke.findMany({ take: 1, skip: randomRowNumber });
+  const [randomJoke] = await db.joke.findMany({
+    take: 1,
+    skip: randomRowNumber,
+  });
   if (!randomJoke) {
     throw new Response("No jokes to be found!", { status: 404 });
   }
-  let data: LoaderData = { randomJoke };
+  const data: LoaderData = { randomJoke };
   return data;
 };
 
 export default function JokesIndexRoute() {
-  let data = useLoaderData<LoaderData>();
+  const data = useLoaderData<LoaderData>();
 
   return (
     <div>
@@ -29,7 +32,7 @@ export default function JokesIndexRoute() {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   if (caught.status === 404) {
     return (

--- a/examples/jokes/app/routes/jokes/new.tsx
+++ b/examples/jokes/app/routes/jokes/new.tsx
@@ -11,8 +11,8 @@ import { JokeDisplay } from "~/components/joke";
 import { db } from "~/utils/db.server";
 import { getUserId, requireUserId } from "~/utils/session.server";
 
-export let loader: LoaderFunction = async ({ request }) => {
-  let userId = await getUserId(request);
+export const loader: LoaderFunction = async ({ request }) => {
+  const userId = await getUserId(request);
   if (!userId) {
     throw new Response("Unauthorized", { status: 401 });
   }
@@ -40,36 +40,38 @@ type ActionData = {
   };
 };
 
-export let action: ActionFunction = async ({
+export const action: ActionFunction = async ({
   request,
 }): Promise<Response | ActionData> => {
   const userId = await requireUserId(request);
 
-  let form = await request.formData();
-  let name = form.get("name");
-  let content = form.get("content");
+  const form = await request.formData();
+  const name = form.get("name");
+  const content = form.get("content");
   if (typeof name !== "string" || typeof content !== "string") {
     return { formError: `Form not submitted correctly.` };
   }
 
-  let fieldErrors = {
+  const fieldErrors = {
     name: validateJokeName(name),
     content: validateJokeContent(content),
   };
-  let fields = { name, content };
+  const fields = { name, content };
   if (Object.values(fieldErrors).some(Boolean)) return { fieldErrors, fields };
 
-  let joke = await db.joke.create({ data: { ...fields, jokesterId: userId } });
+  const joke = await db.joke.create({
+    data: { ...fields, jokesterId: userId },
+  });
   return redirect(`/jokes/${joke.id}?redirectTo=/jokes/new`);
 };
 
 export default function NewJokeRoute() {
-  let actionData = useActionData<ActionData | undefined>();
-  let transition = useTransition();
+  const actionData = useActionData<ActionData | undefined>();
+  const transition = useTransition();
 
   if (transition.submission) {
-    let name = transition.submission.formData.get("name");
-    let content = transition.submission.formData.get("content");
+    const name = transition.submission.formData.get("name");
+    const content = transition.submission.formData.get("content");
     if (
       typeof name === "string" &&
       typeof content === "string" &&
@@ -142,7 +144,7 @@ export default function NewJokeRoute() {
 }
 
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   if (caught.status === 401) {
     return (

--- a/examples/jokes/app/routes/jokes[.]rss.tsx
+++ b/examples/jokes/app/routes/jokes[.]rss.tsx
@@ -1,8 +1,8 @@
 import type { LoaderFunction } from "remix";
 import { db } from "~/utils/db.server";
 
-export let loader: LoaderFunction = async ({ request }) => {
-  let jokes = await db.joke.findMany({
+export const loader: LoaderFunction = async ({ request }) => {
+  const jokes = await db.joke.findMany({
     take: 100,
     orderBy: { createdAt: "desc" },
     include: { jokester: { select: { username: true } } },
@@ -14,10 +14,10 @@ export let loader: LoaderFunction = async ({ request }) => {
     throw new Error("Could not determine domain URL.");
   }
   const protocol = host.includes("localhost") ? "http" : "https";
-  let domain = `${protocol}://${host}`;
+  const domain = `${protocol}://${host}`;
   const jokesUrl = `${domain}/jokes`;
 
-  let rssString = `
+  const rssString = `
     <rss xmlns:blogChannel="${jokesUrl}" version="2.0">
       <channel>
         <title>Remix Jokes</title>

--- a/examples/jokes/app/routes/login.tsx
+++ b/examples/jokes/app/routes/login.tsx
@@ -4,14 +4,14 @@ import { login, createUserSession, register } from "~/utils/session.server";
 import { db } from "~/utils/db.server";
 import stylesUrl from "../styles/login.css";
 
-export let meta: MetaFunction = () => {
+export const meta: MetaFunction = () => {
   return {
     title: "Remix Jokes | Login",
     description: "Login to submit your own jokes to Remix Jokes!",
   };
 };
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: stylesUrl }];
 };
 
@@ -33,14 +33,14 @@ type ActionData = {
   fields?: { loginType: string; username: string; password: string };
 };
 
-export let action: ActionFunction = async ({
+export const action: ActionFunction = async ({
   request,
 }): Promise<Response | ActionData> => {
-  let form = await request.formData();
-  let loginType = form.get("loginType");
-  let username = form.get("username");
-  let password = form.get("password");
-  let redirectTo = form.get("redirectTo") || "/jokes";
+  const form = await request.formData();
+  const loginType = form.get("loginType");
+  const username = form.get("username");
+  const password = form.get("password");
+  const redirectTo = form.get("redirectTo") || "/jokes";
   if (
     typeof loginType !== "string" ||
     typeof username !== "string" ||
@@ -50,8 +50,8 @@ export let action: ActionFunction = async ({
     return { formError: `Form not submitted correctly.` };
   }
 
-  let fields = { loginType, username, password };
-  let fieldErrors = {
+  const fields = { loginType, username, password };
+  const fieldErrors = {
     username: validateUsername(username),
     password: validatePassword(password),
   };
@@ -71,7 +71,7 @@ export let action: ActionFunction = async ({
       return createUserSession(user.id, redirectTo);
     }
     case "register": {
-      let userExists = await db.user.findFirst({ where: { username } });
+      const userExists = await db.user.findFirst({ where: { username } });
       if (userExists) {
         return {
           fields,
@@ -94,8 +94,8 @@ export let action: ActionFunction = async ({
 };
 
 export default function Login() {
-  let actionData = useActionData<ActionData | undefined>();
-  let [searchParams] = useSearchParams();
+  const actionData = useActionData<ActionData | undefined>();
+  const [searchParams] = useSearchParams();
   return (
     <div className="container">
       <div className="content" data-light="">

--- a/examples/jokes/app/routes/logout.tsx
+++ b/examples/jokes/app/routes/logout.tsx
@@ -2,10 +2,10 @@ import type { ActionFunction, LoaderFunction } from "remix";
 import { redirect } from "remix";
 import { logout } from "~/utils/session.server";
 
-export let action: ActionFunction = async ({ request }) => {
+export const action: ActionFunction = async ({ request }) => {
   return logout(request);
 };
 
-export let loader: LoaderFunction = async () => {
+export const loader: LoaderFunction = async () => {
   return redirect("/");
 };

--- a/examples/jokes/app/utils/session.server.ts
+++ b/examples/jokes/app/utils/session.server.ts
@@ -8,26 +8,26 @@ type LoginForm = {
 };
 
 export async function register({ username, password }: LoginForm) {
-  let passwordHash = await bcrypt.hash(password, 10);
+  const passwordHash = await bcrypt.hash(password, 10);
   return db.user.create({
     data: { username, passwordHash },
   });
 }
 
 export async function login({ username, password }: LoginForm) {
-  let user = await db.user.findUnique({ where: { username } });
+  const user = await db.user.findUnique({ where: { username } });
   if (!user) return null;
-  let isCorrectPassword = await bcrypt.compare(password, user.passwordHash);
+  const isCorrectPassword = await bcrypt.compare(password, user.passwordHash);
   if (!isCorrectPassword) return null;
   return user;
 }
 
-let sessionSecret = process.env.SESSION_SECRET;
+const sessionSecret = process.env.SESSION_SECRET;
 if (!sessionSecret) {
   throw new Error("SESSION_SECRET must be set");
 }
 
-let storage = createCookieSessionStorage({
+const storage = createCookieSessionStorage({
   cookie: {
     name: "RJ_session",
     // secure doesn't work on localhost for Safari
@@ -46,8 +46,8 @@ export function getUserSession(request: Request) {
 }
 
 export async function getUserId(request: Request) {
-  let session = await getUserSession(request);
-  let userId = session.get("userId");
+  const session = await getUserSession(request);
+  const userId = session.get("userId");
   if (!userId || typeof userId !== "string") return null;
   return userId;
 }
@@ -56,23 +56,23 @@ export async function requireUserId(
   request: Request,
   redirectTo: string = new URL(request.url).pathname
 ) {
-  let session = await getUserSession(request);
-  let userId = session.get("userId");
+  const session = await getUserSession(request);
+  const userId = session.get("userId");
   if (!userId || typeof userId !== "string") {
-    let searchParams = new URLSearchParams([["redirectTo", redirectTo]]);
+    const searchParams = new URLSearchParams([["redirectTo", redirectTo]]);
     throw redirect(`/login?${searchParams}`);
   }
   return userId;
 }
 
 export async function getUser(request: Request) {
-  let userId = await getUserId(request);
+  const userId = await getUserId(request);
   if (typeof userId !== "string") {
     return null;
   }
 
   try {
-    let user = await db.user.findUnique({ where: { id: userId } });
+    const user = await db.user.findUnique({ where: { id: userId } });
     return user;
   } catch {
     throw logout(request);
@@ -80,7 +80,7 @@ export async function getUser(request: Request) {
 }
 
 export async function logout(request: Request) {
-  let session = await storage.getSession(request.headers.get("Cookie"));
+  const session = await storage.getSession(request.headers.get("Cookie"));
   return redirect("/login", {
     headers: {
       "Set-Cookie": await storage.destroySession(session),
@@ -89,7 +89,7 @@ export async function logout(request: Request) {
 }
 
 export async function createUserSession(userId: string, redirectTo: string) {
-  let session = await storage.getSession();
+  const session = await storage.getSession();
   session.set("userId", userId);
   return redirect(redirectTo, {
     headers: {

--- a/examples/jokes/prisma/seed.ts
+++ b/examples/jokes/prisma/seed.ts
@@ -1,8 +1,8 @@
 import { PrismaClient } from "@prisma/client";
-let prisma = new PrismaClient();
+const prisma = new PrismaClient();
 
 async function seed() {
-  let kody = await prisma.user.create({
+  const kody = await prisma.user.create({
     data: {
       username: "kody",
       passwordHash:
@@ -11,7 +11,7 @@ async function seed() {
   });
   await Promise.all(
     getJokes().map((joke) => {
-      let data = { jokesterId: kody.id, ...joke };
+      const data = { jokesterId: kody.id, ...joke };
       return prisma.joke.create({ data });
     })
   );

--- a/packages/create-remix/templates/.eslintrc.js
+++ b/packages/create-remix/templates/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  rules: {
+    "prefer-const": "warn",
+
+    // because in our templates we shouldn't care
+    "import/order": "off"
+  }
+};

--- a/packages/create-remix/templates/_shared_ts/app/entry.server.tsx
+++ b/packages/create-remix/templates/_shared_ts/app/entry.server.tsx
@@ -8,7 +8,7 @@ export default function handleRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  let markup = renderToString(
+  const markup = renderToString(
     <RemixServer context={remixContext} url={request.url} />
   );
 

--- a/packages/create-remix/templates/_shared_ts/app/root.tsx
+++ b/packages/create-remix/templates/_shared_ts/app/root.tsx
@@ -14,7 +14,7 @@ import globalStylesUrl from "~/styles/global.css";
 import darkStylesUrl from "~/styles/dark.css";
 
 // https://remix.run/api/app#links
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [
     { rel: "stylesheet", href: globalStylesUrl },
     {
@@ -59,7 +59,7 @@ export function ErrorBoundary({ error }: { error: Error }) {
 
 // https://remix.run/api/conventions#catchboundary
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   let message;
   switch (caught.status) {

--- a/packages/create-remix/templates/_shared_ts/app/routes/demos/about.tsx
+++ b/packages/create-remix/templates/_shared_ts/app/routes/demos/about.tsx
@@ -3,13 +3,13 @@ import type { MetaFunction, LinksFunction } from "remix";
 
 import stylesUrl from "~/styles/demos/about.css";
 
-export let meta: MetaFunction = () => {
+export const meta: MetaFunction = () => {
   return {
     title: "About Remix"
   };
 };
 
-export let links: LinksFunction = () => {
+export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: stylesUrl }];
 };
 

--- a/packages/create-remix/templates/_shared_ts/app/routes/demos/actions.tsx
+++ b/packages/create-remix/templates/_shared_ts/app/routes/demos/actions.tsx
@@ -9,9 +9,9 @@ export function meta() {
 // When your form sends a POST, the action is called on the server.
 // - https://remix.run/api/conventions#action
 // - https://remix.run/guides/data-updates
-export let action: ActionFunction = async ({ request }) => {
-  let formData = await request.formData();
-  let answer = formData.get("answer");
+export const action: ActionFunction = async ({ request }) => {
+  const formData = await request.formData();
+  const answer = formData.get("answer");
 
   // Typical action workflows start with validating the form data that just came
   // over the network. Clientside validation is fine, but you definitely need it
@@ -34,8 +34,8 @@ export let action: ActionFunction = async ({ request }) => {
 
 export default function ActionsDemo() {
   // https://remix.run/api/remix#useactiondata
-  let actionMessage = useActionData<string>();
-  let answerRef = useRef<HTMLInputElement>(null);
+  const actionMessage = useActionData<string>();
+  const answerRef = useRef<HTMLInputElement>(null);
 
   // This form works without JavaScript, but when we have JavaScript we can make
   // the experience better by selecting the input on wrong answers! Go ahead, disable

--- a/packages/create-remix/templates/_shared_ts/app/routes/demos/params/$id.tsx
+++ b/packages/create-remix/templates/_shared_ts/app/routes/demos/params/$id.tsx
@@ -4,7 +4,7 @@ import type { LoaderFunction, MetaFunction } from "remix";
 // The `$` in route filenames becomes a pattern that's parsed from the URL and
 // passed to your loaders so you can look up data.
 // - https://remix.run/api/conventions#loader-params
-export let loader: LoaderFunction = async ({ params }) => {
+export const loader: LoaderFunction = async ({ params }) => {
   // pretend like we're using params.id to look something up in the db
 
   if (params.id === "this-record-does-not-exist") {
@@ -38,7 +38,7 @@ export let loader: LoaderFunction = async ({ params }) => {
 };
 
 export default function ParamDemo() {
-  let data = useLoaderData();
+  const data = useLoaderData();
   return (
     <h1>
       The param is <i style={{ color: "red" }}>{data.param}</i>
@@ -50,7 +50,7 @@ export default function ParamDemo() {
 // https://remix.run/api/remix#usecatch
 // https://remix.run/api/guides/not-found
 export function CatchBoundary() {
-  let caught = useCatch();
+  const caught = useCatch();
 
   let message: React.ReactNode;
   switch (caught.status) {
@@ -105,7 +105,7 @@ export function ErrorBoundary({ error }: { error: Error }) {
   );
 }
 
-export let meta: MetaFunction = ({ data }) => {
+export const meta: MetaFunction = ({ data }) => {
   return {
     title: data ? `Param: ${data.param}` : "Oops..."
   };

--- a/packages/create-remix/templates/_shared_ts/app/routes/index.tsx
+++ b/packages/create-remix/templates/_shared_ts/app/routes/index.tsx
@@ -10,8 +10,8 @@ type IndexData = {
 // you can connect to a database or run any server side code you want right next
 // to the component that renders it.
 // https://remix.run/api/conventions#loader
-export let loader: LoaderFunction = () => {
-  let data: IndexData = {
+export const loader: LoaderFunction = () => {
+  const data: IndexData = {
     resources: [
       {
         name: "Remix Docs",
@@ -47,7 +47,7 @@ export let loader: LoaderFunction = () => {
 };
 
 // https://remix.run/api/conventions#meta
-export let meta: MetaFunction = () => {
+export const meta: MetaFunction = () => {
   return {
     title: "Remix Starter",
     description: "Welcome to remix!"
@@ -56,7 +56,7 @@ export let meta: MetaFunction = () => {
 
 // https://remix.run/guides/routing#index-routes
 export default function Index() {
-  let data = useLoaderData<IndexData>();
+  const data = useLoaderData<IndexData>();
 
   return (
     <div className="remix__page">

--- a/packages/create-remix/templates/express/server/index.js
+++ b/packages/create-remix/templates/express/server/index.js
@@ -7,7 +7,7 @@ const { createRequestHandler } = require("@remix-run/express");
 const MODE = process.env.NODE_ENV;
 const BUILD_DIR = path.join(process.cwd(), "server/build");
 
-let app = express();
+const app = express();
 app.use(compression());
 
 // You may want to be more aggressive with this caching
@@ -23,12 +23,12 @@ app.all(
     ? createRequestHandler({ build: require("./build") })
     : (req, res, next) => {
         purgeRequireCache();
-        let build = require("./build");
+        const build = require("./build");
         return createRequestHandler({ build, mode: MODE })(req, res, next);
       }
 );
 
-let port = process.env.PORT || 3000;
+const port = process.env.PORT || 3000;
 app.listen(port, () => {
   console.log(`Express server listening on port ${port}`);
 });
@@ -40,7 +40,7 @@ function purgeRequireCache() {
   // alternatively you can set up nodemon/pm2-dev to restart the server on
   // file changes, we prefer the DX of this though, so we've included it
   // for you by default
-  for (let key in require.cache) {
+  for (const key in require.cache) {
     if (key.startsWith(BUILD_DIR)) {
       delete require.cache[key];
     }

--- a/packages/create-remix/templates/netlify/netlify/functions/server/index.js
+++ b/packages/create-remix/templates/netlify/netlify/functions/server/index.js
@@ -9,7 +9,7 @@ function purgeRequireCache() {
   // netlify typically does this for you, but we've found it to be hit or
   // miss and some times requires you to refresh the page after it auto reloads
   // or even have to restart your server
-  for (let key in require.cache) {
+  for (const key in require.cache) {
     if (key.startsWith(BUILD_DIR)) {
       delete require.cache[key];
     }

--- a/packages/remix-dev/config/routesConvention.ts
+++ b/packages/remix-dev/config/routesConvention.ts
@@ -209,3 +209,8 @@ function visitFiles(
     }
   }
 }
+
+/*
+eslint
+  no-loop-func: "off",
+*/


### PR DESCRIPTION
Let it go...

This PR (to the `dev` branch) is separated into a few commits:

1. Fix eslint warnings
2. Add eslint `prefer-const` to the examples (and `eslint --fix`)
3. Replace `let` with `const` in docs
4. Add eslint `prefer-const` to the templates (and `eslint --fix`)

Keep in mind, we aren't pushing an eslint config to the templates at all still. And we're also not including an eslint config in the individual examples either. So anyone using our examples on stackblitz/codesandbox and generating projects with the CLI will not have an eslint configuration that tells them to prefer const. This just helps us avoid distracting conversations like let vs const.

I don't care if we go against the grain of the community within our own code, but distracting conversations don't help anyone build better websites.