### PR TITLE
feat(create-remix): add support for custom server templates

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -14,6 +14,7 @@
 - graham42
 - ianduvall
 - jacob-ebey
+- jenseng
 - jesseflorig
 - juhanakristian
 - kentcdodds

--- a/packages/create-remix/__tests__/fixtures/custom-adapter/templates/shared/README.md
+++ b/packages/create-remix/__tests__/fixtures/custom-adapter/templates/shared/README.md
@@ -1,0 +1,1 @@
+# READ ME SEYMOUR


### PR DESCRIPTION
Give create-remix a "Custom..." deployment option, and a corresponding `--server-type` flag. If you select "Custom...", you can then provide a package id or path containing your custom server type's templates. The `--server-type` flag accepts package ids, paths, and built-ins (e.g. "remix" or "express"), and will bypass questions accordingly.

This makes it easier to use custom deployments/adapters for things that don't make the cut for first class support within remix (e.g. restify).

Also:
* Enhance the package.json merging to consider both the server and lang-specific ones
* Add a section to the docs around custom adapters/servers (both for authoring and around how the templating works)
* Expand cli tests and (hopefully) simplify test authoring

Points of Discussion:
1. Should we also move the built-in server templates into their respective adapter packages?
   1. 👍 Helps scope server/adapter-specific stuff to one place
   2. 👍 Makes the layout the same as custom server templates. Combined with 1), this makes it trivial to promote or demote server types
   3. 👍 Simplifies create-remix
   4. 👎 create-remix will need to install built-in adapters (and their deps) on demand just like custom server types, even though we really only need their templates. Alternatively we could bake those templates into create-remix at build time, but this somewhat negates 2 and 3.
   5. 👎 Not all server types have their own adapter packages (e.g. fly uses remix-serve)
2. Should we go further with the tests in this PR? The new functionality is generally covered, and we now test some basic file copying (package.json). But we still don't truly test end-to-end afaict (i.e. generate each server/deployment type, start it up, test a few routes). Would be great for catching regressions and ensuring all supported adapters work. Feels out of scope for this PR, but I could look at doing that as a separate PR.

Additional context:
* @ryanflorence "🔥'd" this idea on discord [here](https://discord.com/channels/770287896669978684/770287896669978687/914926217243803669)
* Pull request #615 (restify adapter PR, will be abandoned in favor of this)