### PR TITLE
append to formData/searchParams

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1079,11 +1079,11 @@ export function useSubmitImpl(key?: string): SubmitFunction {
 
           if (target instanceof URLSearchParams) {
             for (let [name, value] of target) {
-              formData.set(name, value);
+              formData.append(name, value);
             }
           } else if (target != null) {
             for (let name of Object.keys(target)) {
-              formData.set(name, target[name]);
+              formData.append(name, target[name]);
             }
           }
         }
@@ -1095,7 +1095,7 @@ export function useSubmitImpl(key?: string): SubmitFunction {
       if (method.toLowerCase() === "get") {
         for (let [name, value] of formData) {
           if (typeof value === "string") {
-            url.searchParams.set(name, value);
+            url.searchParams.append(name, value);
           } else {
             throw new Error(`Cannot submit binary form data using GET`);
           }


### PR DESCRIPTION
```tsx
export default function ProductFilters() {
  return (
    <Form method="get">
      <label htmlFor="nike">Nike</label>
      <input
        type="checkbox"
        id="nike"
        name="brand"
        value="nike"
      />

      <label htmlFor="adidas">Adidas</label>
      <input
        type="checkbox"
        id="adidas"
        name="brand"
        value="adidas"
      />

      <button type="submit">Update</button>
    </Form>
  );
}
```

Serializing that should end up with `brand=nike&brand=adidas` but it only keeps the last one since it was using `set`