### PR TITLE
Add `react-router-dom` dependency to gists fixture

### DIFF
--- a/fixtures/gists-app/package.json
+++ b/fixtures/gists-app/package.json
@@ -23,7 +23,8 @@
     "morgan": "^1.10.0",
     "postcss-nested": "^5.0.3",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "react-router-dom": "^6.0.2"
   },
   "devDependencies": {
     "@types/react": "^17.0.24",


### PR DESCRIPTION
This *technically* shouldn't be necessary, but since we don't actually install Remix in the gists fixture we don't get its dependencies, which means React Router was missing and all of our tests were failing. Tragic!