### PR TITLE
Remove comment from tsconfig file

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -59,6 +59,7 @@
 - jesseflorig
 - joaosamouco
 - johannesbraeunig
+- jnicklas
 - juhanakristian
 - kalch
 - KenanYusuf

--- a/packages/create-remix/templates/_shared_ts/tsconfig.json
+++ b/packages/create-remix/templates/_shared_ts/tsconfig.json
@@ -13,8 +13,6 @@
     "paths": {
       "~/*": ["./app/*"]
     },
-
-    // Remix takes care of building everything in `remix build`.
     "noEmit": true
   }
 }


### PR DESCRIPTION
Closes #823

Comments are not valid in JSON files according to the spec, and while some parsers do support comments, others don't and so Remix should not add any comments in the JSON files it generates.