### PR TITLE
Add a tutorial for using SVGs as components.

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -23,6 +23,7 @@
 - mcansh
 - medayz
 - meetbryce
+- mikeybinnswebdesign
 - michaeldeboey
 - michaelfriedman
 - morinokami

--- a/docs/guides/svgs.md
+++ b/docs/guides/svgs.md
@@ -1,0 +1,59 @@
+---
+title: SVGs
+---
+# SVGs
+
+Adding SVGs as components can be achieved using the following steps:
+
+Create a file in your `app` folder called `svgs.{jsx,tsx}`
+
+Inside that file, create an exporting function for your SVG.
+
+```tsx filename=app/svgs.{jsx,tsx}
+export function YourSVG() {
+	return ();
+}
+```
+
+Optional: Run your SVG through an optimiser (like [SVGO](https://jakearchibald.github.io/svgomg/)) to optimise the file.
+
+Paste your SVG code into the function return:
+
+```tsx [3-5]
+export function YourSVG() {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+			...
+		</svg>
+	);
+}
+```
+
+Add props spread for allowing runtime customisation
+```tsx [1,3]
+export function YourSVG({ props }) {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...props}>
+			...
+		</svg>
+	);
+}
+```
+Or for Typescript:
+```tsx [1-2,4]
+import type { SVGProps } from "react";
+export function YourSVG({ props }: { props?: SVGProps<SVGSVGElement> }) {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...props}>
+			...
+		</svg>
+	);
+}
+```
+
+Then import your SVGs like so and use them as normal JSX components:
+```tsx
+import { YourSVG, AnotherSVG } from "~/svgs";
+```
+
+<docs-warning>After import, you may get some errors in the console depending on the content of your SVG. This is because SVGs use hyphenated attributes and JSX needs camelcase attributes. Use these errors to find the attributes you need to change. It will tell you what to change them to.</docs-warning>

--- a/docs/guides/svgs.md
+++ b/docs/guides/svgs.md
@@ -31,7 +31,7 @@ export function YourSVG() {
 
 Add props spread for allowing runtime customisation
 ```tsx [1,3]
-export function YourSVG({ props }) {
+export function YourSVG(props) {
 	return (
 		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...props}>
 			...
@@ -42,7 +42,7 @@ export function YourSVG({ props }) {
 Or for Typescript:
 ```tsx [1-2,4]
 import type { SVGProps } from "react";
-export function YourSVG({ props }: { props?: SVGProps<SVGSVGElement> }) {
+export function YourSVG(props: SVGProps<SVGSVGElement>) {
 	return (
 		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...props}>
 			...


### PR DESCRIPTION
I've played around with this concept a bunch and this is the best method I've found:

Pros:
- It reduces all SVG imports to a single line, so if you call multiple SVGs, your imports don't get messy
- It allows you to use SVGs as components, which lets you add props for customisation

Cons:
- No automatic conversion of SVGs to JSX, requires updating some SVG attributes manually.
- No automatic optimisation of SVGs, SVGs should be run through SVGO beforehand for performance reasons.

Things I've also considered:

- Having an SVGs folder and importing individual TSX files (makes importing really messy)
- Pasting SVG code directly (makes code messier, prevents reuse of SVG code)
- Adding a build step for automatic compilation similar to create-react-app (increases build complexity, requires all SVGs go through the same optimisation steps where different steps are needed)