### PR TITLE
Fix routing guide link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -53,6 +53,7 @@
 - princerajroy
 - RossJHagan
 - RossMcMillan92
+- robinclowers
 - ryanflorence
 - sean-roberts
 - shumuu

--- a/examples/basic/app/routes/demos/about.tsx
+++ b/examples/basic/app/routes/demos/about.tsx
@@ -31,7 +31,7 @@ export default function Index() {
         <p>
           Wait a sec...<em>its children</em>? To understand what we mean by
           this,{" "}
-          <a href="https://remix.run/tutorial/4-nested-routes-params">
+          <a href="https://remix.run/guides/routing">
             read all about nested routes in the docs
           </a>
           .

--- a/examples/blog-tutorial/app/routes/demos/about.tsx
+++ b/examples/blog-tutorial/app/routes/demos/about.tsx
@@ -31,7 +31,7 @@ export default function Index() {
         <p>
           Wait a sec...<em>its children</em>? To understand what we mean by
           this,{" "}
-          <a href="https://remix.run/tutorial/4-nested-routes-params">
+          <a href="https://remix.run/guides/routing">
             read all about nested routes in the docs
           </a>
           .

--- a/packages/create-remix/templates/_shared_js/app/routes/demos/about.jsx
+++ b/packages/create-remix/templates/_shared_js/app/routes/demos/about.jsx
@@ -30,7 +30,7 @@ export default function Index() {
         <p>
           Wait a sec...<em>its children</em>? To understand what we mean by
           this,{" "}
-          <a href="https://remix.run/tutorial/4-nested-routes-params">
+          <a href="https://remix.run/guides/routing">
             read all about nested routes in the docs
           </a>
           .

--- a/packages/create-remix/templates/_shared_ts/app/routes/demos/about.tsx
+++ b/packages/create-remix/templates/_shared_ts/app/routes/demos/about.tsx
@@ -31,7 +31,7 @@ export default function Index() {
         <p>
           Wait a sec...<em>its children</em>? To understand what we mean by
           this,{" "}
-          <a href="https://remix.run/tutorial/4-nested-routes-params">
+          <a href="https://remix.run/guides/routing">
             read all about nested routes in the docs
           </a>
           .


### PR DESCRIPTION
I noticed the link to the guide on nested routes was broken, so I fixed it. Loving remix so far, thanks for open sourcing it!