### PR TITLE
feat(dev-server): add auto change dev server port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ yarn-error.log
 /fixtures/my-remix-app
 
 .eslintcache
+/.idea/

--- a/contributors.yml
+++ b/contributors.yml
@@ -33,3 +33,4 @@
 - silvenon
 - stephanerangaya
 - zachdtaylor
+- chenc041

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -172,6 +172,16 @@ export async function dev(remixRoot: string, modeArg?: string) {
         server = app.listen(port, () => {
           console.log(`Remix App Server started at http://localhost:${port}`);
         });
+        // handle app start error
+        const onError = (e: Error & { code?: string }) => {
+          if (e.code && e.code === "EADDRINUSE") {
+            console.log(`Port ${port} is inuse, trying another one..`);
+            server!?.listen(++(port as number));
+          } else {
+            server!?.off("error", onError);
+          }
+        };
+        server!?.on("error", onError);
       }
     });
   } finally {


### PR DESCRIPTION
## Change file or folder
1. .gitignore
2. remix-dev

## What is the current behavior?
1. The .idea folder will submit
2. An error is thrown when the default port is occupied,


## What is the new behavior?
1. Ad idea folder to .gitignore
2. I modified the startup logic to increment the port number automatically when the default port is occupied to avoid throwing an error