### PR TITLE
fix(dev,serve): remove trailing space in executableBanner in cli

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -39,3 +39,4 @@
 - tylerbrostrom
 - ascorbic
 - IAmLuisJ
+- weavdale

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ function isBareModuleId(id) {
   return !id.startsWith(".") && !path.isAbsolute(id);
 }
 
-let executableBanner = "#!/usr/bin/env node \n";
+let executableBanner = "#!/usr/bin/env node\n";
 
 function createBanner(libraryName, version) {
   return `/**


### PR DESCRIPTION
Remove the trailing space after `#!/usr/bin/env node` when inserting the executable banner in

- @remix-run/dev/cli.js
- @remix-run/serve/cli.js

The trailing space causes builds to fail when deploying to Digital Ocean's Apps Platform with error
`/usr/bin/env: 'node ': No such file or directory`