### PR TITLE
chore: fix params demo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -6,6 +6,7 @@
 - BasixKOR
 - chaance
 - coryhouse
+- dynamite-bud
 - eps1lon
 - evanwinter
 - francisudeji

--- a/examples/basic/app/routes/demos/params/$id.tsx
+++ b/examples/basic/app/routes/demos/params/$id.tsx
@@ -78,7 +78,7 @@ export function CatchBoundary() {
   return (
     <>
       <h2>Oops!</h2>
-      <p>{message}</p>
+      {message}
       <p>
         (Isn't it cool that the user gets to stay in context and try a different
         link in the parts of the UI that didn't blow up?)


### PR DESCRIPTION
The basic example had issue with switch case and in the render method had a `<p>` tag inside a `<p>` tag.