### PR TITLE
chore(docs): fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -37,3 +37,4 @@
 - VictorPeralta
 - zachdtaylor
 - zainfathoni
+- francisudeji

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -1353,7 +1353,7 @@ export async function loader({ request }) {
   const cookieHeader = request.headers.get("Cookie");
   const cookie =
     (await userPrefs.parse(cookieHeader)) || {};
-  return { showBanner: value.showBanner };
+  return { showBanner: cookie.showBanner };
 }
 
 export async function action({ request }) {


### PR DESCRIPTION
Kent tweeted [this](https://twitter.com/kentcdodds/status/1466409430694576128?t=DiZ4XoBq09mr1I2KDScNaw&s=19) in response to a tweet this evening and while reading I noticed a reference to `value.showBanner` rather than `cookie.showBanner` in the loader function of an example, so I fixed it!