### PR TITLE
wip: re-work server runtime

### DIFF
--- a/fixtures/gists-app/tests/error-handling-test.ts
+++ b/fixtures/gists-app/tests/error-handling-test.ts
@@ -54,7 +54,7 @@ describe("uncaught exceptions", () => {
         expect(html).toMatchInlineSnapshot(`
           "<div data-test-id=\\"action-error-boundary\\">
             <h1>Action Error Boundary</h1>
-            <pre>I am an action error!</pre>
+            <pre>Unexpected Server Error</pre>
           </div>
           "
         `);
@@ -98,7 +98,7 @@ describe("uncaught exceptions", () => {
         expect(html).toMatchInlineSnapshot(`
           "<div data-test-id=\\"app-error-boundary\\">
             <h1>App Error Boundary</h1>
-            <pre>I am an action error!</pre>
+            <pre>Unexpected Server Error</pre>
           </div>
           "
         `);
@@ -229,7 +229,7 @@ describe("uncaught exceptions", () => {
           .toMatchInlineSnapshot(`
           "<div data-test-id=\\"app-error-boundary\\">
             <h1>App Error Boundary</h1>
-            <pre>I am a loader error!</pre>
+            <pre>Unexpected Server Error</pre>
           </div>
           "
         `);
@@ -289,7 +289,7 @@ describe("uncaught exceptions", () => {
                 There was an error at this specific route. The parent still renders cause
                 it was fine, but this one blew up.
               </p>
-              <pre>I am a loader error!</pre>
+              <pre>Unexpected Server Error</pre>
             </div>
           </div>
           "

--- a/packages/remix-react/browser.tsx
+++ b/packages/remix-react/browser.tsx
@@ -43,8 +43,8 @@ export function RemixBrowser(_props: RemixBrowserProps): ReactElement {
   // In the browser, we don't need this because a) in the case of loader
   // errors we already know the order and b) in the case of render errors
   // React knows the order and handles error boundaries normally.
-  entryContext.componentDidCatchEmulator.trackBoundaries = false;
-  entryContext.componentDidCatchEmulator.trackCatchBoundaries = false;
+  entryContext.appState.trackBoundaries = false;
+  entryContext.appState.trackCatchBoundaries = false;
 
   return (
     <RemixEntry

--- a/packages/remix-react/entry.ts
+++ b/packages/remix-react/entry.ts
@@ -1,11 +1,11 @@
-import type { ComponentDidCatchEmulator } from "./errors";
+import type { AppState } from "./errors";
 import type { RouteManifest, EntryRoute } from "./routes";
 import type { RouteData } from "./routeData";
 import type { RouteMatch } from "./routeMatching";
 import type { RouteModules } from "./routeModules";
 
 export interface EntryContext {
-  componentDidCatchEmulator: ComponentDidCatchEmulator;
+  appState: AppState;
   manifest: AssetsManifest;
   matches: RouteMatch<EntryRoute>[];
   routeData: RouteData;

--- a/packages/remix-react/errors.ts
+++ b/packages/remix-react/errors.ts
@@ -1,6 +1,6 @@
 import type { AppData } from "./data";
 
-export interface ComponentDidCatchEmulator {
+export interface AppState {
   error?: SerializedError;
   catch?: ThrownResponse;
   catchBoundaryRouteId: string | null;

--- a/packages/remix-server-runtime/__tests__/server-test.ts
+++ b/packages/remix-server-runtime/__tests__/server-test.ts
@@ -103,1272 +103,1582 @@ describe("shared server runtime", () => {
 
   let baseUrl = "http://test.com";
 
-  test("calls resource route loader", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let resourceLoader = jest.fn(() => {
-      return "resource";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader
-      },
-      "routes/resource": {
-        loader: resourceLoader,
-        path: "resource"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/resource`, { method: "get" });
-
-    let result = await handler(request);
-    expect(result.status).toBe(200);
-    expect(await result.json()).toBe("resource");
-    expect(rootLoader.mock.calls.length).toBe(0);
-    expect(resourceLoader.mock.calls.length).toBe(1);
-  });
-
-  test("calls sub resource route loader", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let resourceLoader = jest.fn(() => {
-      return "resource";
-    });
-    let subResourceLoader = jest.fn(() => {
-      return "sub";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader
-      },
-      "routes/resource": {
-        loader: resourceLoader,
-        path: "resource"
-      },
-      "routes/resource.sub": {
-        loader: subResourceLoader,
-        path: "resource/sub"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/resource/sub`, { method: "get" });
-
-    let result = await handler(request);
-    expect(result.status).toBe(200);
-    expect(await result.json()).toBe("sub");
-    expect(rootLoader.mock.calls.length).toBe(0);
-    expect(resourceLoader.mock.calls.length).toBe(0);
-    expect(subResourceLoader.mock.calls.length).toBe(1);
-  });
-
-  test("resource route loader allows thrown responses", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let resourceLoader = jest.fn(() => {
-      throw new Response("resource");
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader
-      },
-      "routes/resource": {
-        loader: resourceLoader,
-        path: "resource"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/resource`, { method: "get" });
-
-    let result = await handler(request);
-    expect(result.status).toBe(200);
-    expect(await result.text()).toBe("resource");
-    expect(rootLoader.mock.calls.length).toBe(0);
-    expect(resourceLoader.mock.calls.length).toBe(1);
-  });
-
-  test("resource route loader responds with generic error when thrown", async () => {
-    let error = new Error("should be logged when resource loader throws");
-    let loader = jest.fn(() => {
-      throw error;
-    });
-    let build = mockServerBuild({
-      "routes/resource": {
-        loader,
-        path: "resource"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/resource`, { method: "get" });
-
-    let result = await handler(request);
-    expect(await result.text()).toBe("Unexpected Server Error");
-  });
-
-  test("resource route loader responds with detailed error when thrown in development", async () => {
-    let error = new Error("should be logged when resource loader throws");
-    let loader = jest.fn(() => {
-      throw error;
-    });
-    let build = mockServerBuild({
-      "routes/resource": {
-        loader,
-        path: "resource"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Development);
-
-    let request = new Request(`${baseUrl}/resource`, { method: "get" });
-
-    let result = await handler(request);
-    expect((await result.text()).includes(error.message)).toBe(true);
-    expect(spy.console.mock.calls.length).toBe(1);
-  });
-
-  test("calls resource route action", async () => {
-    let rootAction = jest.fn(() => {
-      return "root";
-    });
-    let resourceAction = jest.fn(() => {
-      return "resource";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        action: rootAction
-      },
-      "routes/resource": {
-        action: resourceAction,
-        path: "resource"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/resource`, { method: "post" });
-
-    let result = await handler(request);
-    expect(result.status).toBe(200);
-    expect(await result.json()).toBe("resource");
-    expect(rootAction.mock.calls.length).toBe(0);
-    expect(resourceAction.mock.calls.length).toBe(1);
-  });
-
-  test("calls sub resource route action", async () => {
-    let rootAction = jest.fn(() => {
-      return "root";
-    });
-    let resourceAction = jest.fn(() => {
-      return "resource";
-    });
-    let subResourceAction = jest.fn(() => {
-      return "sub";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        action: rootAction
-      },
-      "routes/resource": {
-        action: resourceAction,
-        path: "resource"
-      },
-      "routes/resource.sub": {
-        action: subResourceAction,
-        path: "resource/sub"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/resource/sub`, { method: "post" });
-
-    let result = await handler(request);
-    expect(result.status).toBe(200);
-    expect(await result.json()).toBe("sub");
-    expect(rootAction.mock.calls.length).toBe(0);
-    expect(resourceAction.mock.calls.length).toBe(0);
-    expect(subResourceAction.mock.calls.length).toBe(1);
-  });
-
-  test("resource route action allows thrown responses", async () => {
-    let rootAction = jest.fn(() => {
-      return "root";
-    });
-    let resourceAction = jest.fn(() => {
-      throw new Response("resource");
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        action: rootAction
-      },
-      "routes/resource": {
-        action: resourceAction,
-        path: "resource"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/resource`, { method: "post" });
-
-    let result = await handler(request);
-    expect(result.status).toBe(200);
-    expect(await result.text()).toBe("resource");
-    expect(rootAction.mock.calls.length).toBe(0);
-    expect(resourceAction.mock.calls.length).toBe(1);
-  });
-
-  test("resource route action responds with generic error when thrown", async () => {
-    let error = new Error("should be logged when resource loader throws");
-    let action = jest.fn(() => {
-      throw error;
-    });
-    let build = mockServerBuild({
-      "routes/resource": {
-        action,
-        path: "resource"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/resource`, { method: "post" });
-
-    let result = await handler(request);
-    expect(await result.text()).toBe("Unexpected Server Error");
-  });
-
-  test("resource route action responds with detailed error when thrown in development", async () => {
-    let message = "should be logged when resource loader throws";
-    let action = jest.fn(() => {
-      throw new Error(message);
-    });
-    let build = mockServerBuild({
-      "routes/resource": {
-        action,
-        path: "resource"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Development);
-
-    let request = new Request(`${baseUrl}/resource`, { method: "post" });
-
-    let result = await handler(request);
-    expect((await result.text()).includes(message)).toBe(true);
-    expect(spy.console.mock.calls.length).toBe(1);
-  });
-
-  test("data request that does not match loader surfaces error for boundary", async () => {
-    let build = mockServerBuild({
-      root: {
-        default: {}
-      },
-      "routes/index": {
-        parentId: "root",
-        index: true
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/?_data=routes/index`, {
-      method: "get"
-    });
-
-    let result = await handler(request);
-    expect(result.status).toBe(500);
-    expect(result.headers.get("X-Remix-Error")).toBe("yes");
-    expect((await result.json()).message).toBeTruthy();
-  });
-
-  test("data request calls loader", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let indexLoader = jest.fn(() => {
-      return "index";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader
-      },
-      "routes/index": {
-        parentId: "root",
-        loader: indexLoader,
-        index: true
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/?_data=routes/index`, {
-      method: "get"
-    });
-
-    let result = await handler(request);
-    expect(result.status).toBe(200);
-    expect(await result.json()).toBe("index");
-    expect(rootLoader.mock.calls.length).toBe(0);
-    expect(indexLoader.mock.calls.length).toBe(1);
-  });
-
-  test("data request calls loader and responds with generic message and error header", async () => {
-    let rootLoader = jest.fn(() => {
-      throw new Error("test");
-    });
-    let testAction = jest.fn(() => {
-      return "root";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader
-      },
-      "routes/test": {
-        parentId: "root",
-        action: testAction,
-        path: "test"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/test?_data=root`, {
-      method: "get"
-    });
-
-    let result = await handler(request);
-    expect(result.status).toBe(500);
-    expect((await result.json()).message).toBe("Unexpected Server Error");
-    expect(result.headers.get("X-Remix-Error")).toBe("yes");
-    expect(rootLoader.mock.calls.length).toBe(1);
-    expect(testAction.mock.calls.length).toBe(0);
-  });
-
-  test("data request calls loader and responds with detailed info and error header in development mode", async () => {
-    let message =
-      "data request loader error logged to console once in dev mode";
-    let rootLoader = jest.fn(() => {
-      throw new Error(message);
-    });
-    let testAction = jest.fn(() => {
-      return "root";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader
-      },
-      "routes/test": {
-        parentId: "root",
-        action: testAction,
-        path: "test"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Development);
-
-    let request = new Request(`${baseUrl}/test?_data=root`, {
-      method: "get"
-    });
-
-    let result = await handler(request);
-    expect(result.status).toBe(500);
-    expect((await result.json()).message).toBe(message);
-    expect(result.headers.get("X-Remix-Error")).toBe("yes");
-    expect(rootLoader.mock.calls.length).toBe(1);
-    expect(testAction.mock.calls.length).toBe(0);
-    expect(spy.console.mock.calls.length).toBe(1);
-  });
-
-  test("data request calls loader and responds with catch header", async () => {
-    let rootLoader = jest.fn(() => {
-      throw new Response("test", { status: 400 });
-    });
-    let testAction = jest.fn(() => {
-      return "root";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader
-      },
-      "routes/test": {
-        parentId: "root",
-        action: testAction,
-        path: "test"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/test?_data=root`, {
-      method: "get"
-    });
-
-    let result = await handler(request);
-    expect(result.status).toBe(400);
-    expect(await result.text()).toBe("test");
-    expect(result.headers.get("X-Remix-Catch")).toBe("yes");
-    expect(rootLoader.mock.calls.length).toBe(1);
-    expect(testAction.mock.calls.length).toBe(0);
-  });
-
-  test("data request that does not match action surfaces error for boundary", async () => {
-    let build = mockServerBuild({
-      root: {
-        default: {}
-      },
-      "routes/index": {
-        parentId: "root",
-        index: true
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/?index&_data=routes/index`, {
-      method: "post"
-    });
-
-    let result = await handler(request);
-    expect(result.status).toBe(500);
-    expect(result.headers.get("X-Remix-Error")).toBe("yes");
-    expect((await result.json()).message).toBeTruthy();
-  });
-
-  test("data request calls action", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let testAction = jest.fn(() => {
-      return "test";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader
-      },
-      "routes/test": {
-        parentId: "root",
-        action: testAction,
-        path: "test"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/test?_data=routes/test`, {
-      method: "post"
-    });
-
-    let result = await handler(request);
-    expect(result.status).toBe(200);
-    expect(await result.json()).toBe("test");
-    expect(rootLoader.mock.calls.length).toBe(0);
-    expect(testAction.mock.calls.length).toBe(1);
-  });
-
-  test("data request calls action and responds with generic message and error header", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let testAction = jest.fn(() => {
-      throw new Error("test");
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader
-      },
-      "routes/test": {
-        parentId: "root",
-        action: testAction,
-        path: "test"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/test?_data=routes/test`, {
-      method: "post"
-    });
-
-    let result = await handler(request);
-    expect(result.status).toBe(500);
-    expect((await result.json()).message).toBe("Unexpected Server Error");
-    expect(result.headers.get("X-Remix-Error")).toBe("yes");
-    expect(rootLoader.mock.calls.length).toBe(0);
-    expect(testAction.mock.calls.length).toBe(1);
-  });
-
-  test("data request calls action and responds with detailed info and error header in development mode", async () => {
-    let message =
-      "data request action error logged to console once in dev mode";
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let testAction = jest.fn(() => {
-      throw new Error(message);
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader
-      },
-      "routes/test": {
-        parentId: "root",
-        action: testAction,
-        path: "test"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Development);
-
-    let request = new Request(`${baseUrl}/test?_data=routes/test`, {
-      method: "post"
-    });
-
-    let result = await handler(request);
-    expect(result.status).toBe(500);
-    expect((await result.json()).message).toBe(message);
-    expect(result.headers.get("X-Remix-Error")).toBe("yes");
-    expect(rootLoader.mock.calls.length).toBe(0);
-    expect(testAction.mock.calls.length).toBe(1);
-    expect(spy.console.mock.calls.length).toBe(1);
-  });
-
-  test("data request calls action and responds with catch header", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let testAction = jest.fn(() => {
-      throw new Response("test", { status: 400 });
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader
-      },
-      "routes/test": {
-        parentId: "root",
-        action: testAction,
-        path: "test"
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/test?_data=routes/test`, {
-      method: "post"
-    });
-
-    let result = await handler(request);
-    expect(result.status).toBe(400);
-    expect(await result.text()).toBe("test");
-    expect(result.headers.get("X-Remix-Catch")).toBe("yes");
-    expect(rootLoader.mock.calls.length).toBe(0);
-    expect(testAction.mock.calls.length).toBe(1);
-  });
-
-  test("data request calls layout action", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let rootAction = jest.fn(() => {
-      return "root";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader,
-        action: rootAction
-      },
-      "routes/index": {
-        parentId: "root",
-        index: true
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/?_data=root`, { method: "post" });
-
-    let result = await handler(request);
-    expect(result.status).toBe(200);
-    expect(await result.json()).toBe("root");
-    expect(rootLoader.mock.calls.length).toBe(0);
-    expect(rootAction.mock.calls.length).toBe(1);
-  });
-
-  test("data request calls index action", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let indexAction = jest.fn(() => {
-      return "index";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader
-      },
-      "routes/index": {
-        parentId: "root",
-        action: indexAction,
-        index: true
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/?index&_data=routes/index`, {
-      method: "post"
-    });
-
-    let result = await handler(request);
-    expect(result.status).toBe(200);
-    expect(await result.json()).toBe("index");
-    expect(rootLoader.mock.calls.length).toBe(0);
-    expect(indexAction.mock.calls.length).toBe(1);
-  });
-
-  test("not found document request for no matches and no CatchBoundary", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/`, { method: "get" });
-
-    let result = await handler(request);
-    expect(result.status).toBe(404);
-    expect(rootLoader.mock.calls.length).toBe(0);
-    expect(build.entry.module.default.mock.calls.length).toBe(1);
-
-    let calls = build.entry.module.default.mock.calls;
-    expect(calls.length).toBe(1);
-    let entryContext = calls[0][3];
-    expect(entryContext.appState.catch).toBeTruthy();
-    expect(entryContext.appState.catch!.status).toBe(404);
-    expect(entryContext.appState.catchBoundaryRouteId).toBe(null);
-  });
-
-  test("sets root as catch boundary for not found document request", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader,
-        CatchBoundary: {}
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/`, { method: "get" });
-
-    let result = await handler(request);
-    expect(result.status).toBe(404);
-    expect(rootLoader.mock.calls.length).toBe(0);
-    expect(build.entry.module.default.mock.calls.length).toBe(1);
-
-    let calls = build.entry.module.default.mock.calls;
-    expect(calls.length).toBe(1);
-    let entryContext = calls[0][3];
-    expect(entryContext.appState.catch).toBeTruthy();
-    expect(entryContext.appState.catch!.status).toBe(404);
-    expect(entryContext.appState.catchBoundaryRouteId).toBe("root");
-    expect(entryContext.routeData).toEqual({});
-  });
-
-  test("thrown loader responses bubble up", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let indexLoader = jest.fn(() => {
-      throw new Response(null, { status: 400 });
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader,
-        CatchBoundary: {}
-      },
-      "routes/index": {
-        parentId: "root",
-        index: true,
-        default: {},
-        loader: indexLoader
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-    let request = new Request(`${baseUrl}/`, { method: "get" });
-
-    let result = await handler(request);
-    expect(result.status).toBe(400);
-    expect(rootLoader.mock.calls.length).toBe(1);
-    expect(indexLoader.mock.calls.length).toBe(1);
-    expect(build.entry.module.default.mock.calls.length).toBe(1);
-
-    let calls = build.entry.module.default.mock.calls;
-    expect(calls.length).toBe(1);
-    let entryContext = calls[0][3];
-    expect(entryContext.appState.catch).toBeTruthy();
-    expect(entryContext.appState.catch!.status).toBe(400);
-    expect(entryContext.appState.catchBoundaryRouteId).toBe("root");
-    expect(entryContext.routeData).toEqual({
-      root: "root"
+  describe("resource routes", () => {
+    test("calls resource route loader", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let resourceLoader = jest.fn(() => {
+        return "resource";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader
+        },
+        "routes/resource": {
+          loader: resourceLoader,
+          path: "resource"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/resource`, { method: "get" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(200);
+      expect(await result.json()).toBe("resource");
+      expect(rootLoader.mock.calls.length).toBe(0);
+      expect(resourceLoader.mock.calls.length).toBe(1);
+    });
+
+    test("calls sub resource route loader", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let resourceLoader = jest.fn(() => {
+        return "resource";
+      });
+      let subResourceLoader = jest.fn(() => {
+        return "sub";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader
+        },
+        "routes/resource": {
+          loader: resourceLoader,
+          path: "resource"
+        },
+        "routes/resource.sub": {
+          loader: subResourceLoader,
+          path: "resource/sub"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/resource/sub`, { method: "get" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(200);
+      expect(await result.json()).toBe("sub");
+      expect(rootLoader.mock.calls.length).toBe(0);
+      expect(resourceLoader.mock.calls.length).toBe(0);
+      expect(subResourceLoader.mock.calls.length).toBe(1);
+    });
+
+    test("resource route loader allows thrown responses", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let resourceLoader = jest.fn(() => {
+        throw new Response("resource");
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader
+        },
+        "routes/resource": {
+          loader: resourceLoader,
+          path: "resource"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/resource`, { method: "get" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(200);
+      expect(await result.text()).toBe("resource");
+      expect(rootLoader.mock.calls.length).toBe(0);
+      expect(resourceLoader.mock.calls.length).toBe(1);
+    });
+
+    test("resource route loader responds with generic error when thrown", async () => {
+      let error = new Error("should be logged when resource loader throws");
+      let loader = jest.fn(() => {
+        throw error;
+      });
+      let build = mockServerBuild({
+        "routes/resource": {
+          loader,
+          path: "resource"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/resource`, { method: "get" });
+
+      let result = await handler(request);
+      expect(await result.text()).toBe("Unexpected Server Error");
+    });
+
+    test("resource route loader responds with detailed error when thrown in development", async () => {
+      let error = new Error("should be logged when resource loader throws");
+      let loader = jest.fn(() => {
+        throw error;
+      });
+      let build = mockServerBuild({
+        "routes/resource": {
+          loader,
+          path: "resource"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Development);
+
+      let request = new Request(`${baseUrl}/resource`, { method: "get" });
+
+      let result = await handler(request);
+      expect((await result.text()).includes(error.message)).toBe(true);
+      expect(spy.console.mock.calls.length).toBe(1);
+    });
+
+    test("calls resource route action", async () => {
+      let rootAction = jest.fn(() => {
+        return "root";
+      });
+      let resourceAction = jest.fn(() => {
+        return "resource";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          action: rootAction
+        },
+        "routes/resource": {
+          action: resourceAction,
+          path: "resource"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/resource`, { method: "post" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(200);
+      expect(await result.json()).toBe("resource");
+      expect(rootAction.mock.calls.length).toBe(0);
+      expect(resourceAction.mock.calls.length).toBe(1);
+    });
+
+    test("calls sub resource route action", async () => {
+      let rootAction = jest.fn(() => {
+        return "root";
+      });
+      let resourceAction = jest.fn(() => {
+        return "resource";
+      });
+      let subResourceAction = jest.fn(() => {
+        return "sub";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          action: rootAction
+        },
+        "routes/resource": {
+          action: resourceAction,
+          path: "resource"
+        },
+        "routes/resource.sub": {
+          action: subResourceAction,
+          path: "resource/sub"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/resource/sub`, { method: "post" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(200);
+      expect(await result.json()).toBe("sub");
+      expect(rootAction.mock.calls.length).toBe(0);
+      expect(resourceAction.mock.calls.length).toBe(0);
+      expect(subResourceAction.mock.calls.length).toBe(1);
+    });
+
+    test("resource route action allows thrown responses", async () => {
+      let rootAction = jest.fn(() => {
+        return "root";
+      });
+      let resourceAction = jest.fn(() => {
+        throw new Response("resource");
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          action: rootAction
+        },
+        "routes/resource": {
+          action: resourceAction,
+          path: "resource"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/resource`, { method: "post" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(200);
+      expect(await result.text()).toBe("resource");
+      expect(rootAction.mock.calls.length).toBe(0);
+      expect(resourceAction.mock.calls.length).toBe(1);
+    });
+
+    test("resource route action responds with generic error when thrown", async () => {
+      let error = new Error("should be logged when resource loader throws");
+      let action = jest.fn(() => {
+        throw error;
+      });
+      let build = mockServerBuild({
+        "routes/resource": {
+          action,
+          path: "resource"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/resource`, { method: "post" });
+
+      let result = await handler(request);
+      expect(await result.text()).toBe("Unexpected Server Error");
+    });
+
+    test("resource route action responds with detailed error when thrown in development", async () => {
+      let message = "should be logged when resource loader throws";
+      let action = jest.fn(() => {
+        throw new Error(message);
+      });
+      let build = mockServerBuild({
+        "routes/resource": {
+          action,
+          path: "resource"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Development);
+
+      let request = new Request(`${baseUrl}/resource`, { method: "post" });
+
+      let result = await handler(request);
+      expect((await result.text()).includes(message)).toBe(true);
+      expect(spy.console.mock.calls.length).toBe(1);
     });
   });
 
-  test("thrown loader responses catch deep", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let indexLoader = jest.fn(() => {
-      throw new Response(null, { status: 400 });
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader,
-        CatchBoundary: {}
-      },
-      "routes/index": {
-        parentId: "root",
-        index: true,
-        default: {},
-        loader: indexLoader,
-        CatchBoundary: {}
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
+  describe("data requests", () => {
+    test("data request that does not match loader surfaces error for boundary", async () => {
+      let build = mockServerBuild({
+        root: {
+          default: {}
+        },
+        "routes/index": {
+          parentId: "root",
+          index: true
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
 
-    let request = new Request(`${baseUrl}/`, { method: "get" });
+      let request = new Request(`${baseUrl}/?_data=routes/index`, {
+        method: "get"
+      });
 
-    let result = await handler(request);
-    expect(result.status).toBe(400);
-    expect(rootLoader.mock.calls.length).toBe(1);
-    expect(indexLoader.mock.calls.length).toBe(1);
-    expect(build.entry.module.default.mock.calls.length).toBe(1);
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect(result.headers.get("X-Remix-Error")).toBe("yes");
+      expect((await result.json()).message).toBeTruthy();
+    });
 
-    let calls = build.entry.module.default.mock.calls;
-    expect(calls.length).toBe(1);
-    let entryContext = calls[0][3];
-    expect(entryContext.appState.catch).toBeTruthy();
-    expect(entryContext.appState.catch!.status).toBe(400);
-    expect(entryContext.appState.catchBoundaryRouteId).toBe("routes/index");
-    expect(entryContext.routeData).toEqual({
-      root: "root"
+    test("data request calls loader", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let indexLoader = jest.fn(() => {
+        return "index";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader
+        },
+        "routes/index": {
+          parentId: "root",
+          loader: indexLoader,
+          index: true
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/?_data=routes/index`, {
+        method: "get"
+      });
+
+      let result = await handler(request);
+      expect(result.status).toBe(200);
+      expect(await result.json()).toBe("index");
+      expect(rootLoader.mock.calls.length).toBe(0);
+      expect(indexLoader.mock.calls.length).toBe(1);
+    });
+
+    test("data request calls loader and responds with generic message and error header", async () => {
+      let rootLoader = jest.fn(() => {
+        throw new Error("test");
+      });
+      let testAction = jest.fn(() => {
+        return "root";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader
+        },
+        "routes/test": {
+          parentId: "root",
+          action: testAction,
+          path: "test"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/test?_data=root`, {
+        method: "get"
+      });
+
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect((await result.json()).message).toBe("Unexpected Server Error");
+      expect(result.headers.get("X-Remix-Error")).toBe("yes");
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(testAction.mock.calls.length).toBe(0);
+    });
+
+    test("data request calls loader and responds with detailed info and error header in development mode", async () => {
+      let message =
+        "data request loader error logged to console once in dev mode";
+      let rootLoader = jest.fn(() => {
+        throw new Error(message);
+      });
+      let testAction = jest.fn(() => {
+        return "root";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader
+        },
+        "routes/test": {
+          parentId: "root",
+          action: testAction,
+          path: "test"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Development);
+
+      let request = new Request(`${baseUrl}/test?_data=root`, {
+        method: "get"
+      });
+
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect((await result.json()).message).toBe(message);
+      expect(result.headers.get("X-Remix-Error")).toBe("yes");
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(testAction.mock.calls.length).toBe(0);
+      expect(spy.console.mock.calls.length).toBe(1);
+    });
+
+    test("data request calls loader and responds with catch header", async () => {
+      let rootLoader = jest.fn(() => {
+        throw new Response("test", { status: 400 });
+      });
+      let testAction = jest.fn(() => {
+        return "root";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader
+        },
+        "routes/test": {
+          parentId: "root",
+          action: testAction,
+          path: "test"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/test?_data=root`, {
+        method: "get"
+      });
+
+      let result = await handler(request);
+      expect(result.status).toBe(400);
+      expect(await result.text()).toBe("test");
+      expect(result.headers.get("X-Remix-Catch")).toBe("yes");
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(testAction.mock.calls.length).toBe(0);
+    });
+
+    test("data request that does not match action surfaces error for boundary", async () => {
+      let build = mockServerBuild({
+        root: {
+          default: {}
+        },
+        "routes/index": {
+          parentId: "root",
+          index: true
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/?index&_data=routes/index`, {
+        method: "post"
+      });
+
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect(result.headers.get("X-Remix-Error")).toBe("yes");
+      expect((await result.json()).message).toBeTruthy();
+    });
+
+    test("data request calls action", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let testAction = jest.fn(() => {
+        return "test";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader
+        },
+        "routes/test": {
+          parentId: "root",
+          action: testAction,
+          path: "test"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/test?_data=routes/test`, {
+        method: "post"
+      });
+
+      let result = await handler(request);
+      expect(result.status).toBe(200);
+      expect(await result.json()).toBe("test");
+      expect(rootLoader.mock.calls.length).toBe(0);
+      expect(testAction.mock.calls.length).toBe(1);
+    });
+
+    test("data request calls action and responds with generic message and error header", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let testAction = jest.fn(() => {
+        throw new Error("test");
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader
+        },
+        "routes/test": {
+          parentId: "root",
+          action: testAction,
+          path: "test"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/test?_data=routes/test`, {
+        method: "post"
+      });
+
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect((await result.json()).message).toBe("Unexpected Server Error");
+      expect(result.headers.get("X-Remix-Error")).toBe("yes");
+      expect(rootLoader.mock.calls.length).toBe(0);
+      expect(testAction.mock.calls.length).toBe(1);
+    });
+
+    test("data request calls action and responds with detailed info and error header in development mode", async () => {
+      let message =
+        "data request action error logged to console once in dev mode";
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let testAction = jest.fn(() => {
+        throw new Error(message);
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader
+        },
+        "routes/test": {
+          parentId: "root",
+          action: testAction,
+          path: "test"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Development);
+
+      let request = new Request(`${baseUrl}/test?_data=routes/test`, {
+        method: "post"
+      });
+
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect((await result.json()).message).toBe(message);
+      expect(result.headers.get("X-Remix-Error")).toBe("yes");
+      expect(rootLoader.mock.calls.length).toBe(0);
+      expect(testAction.mock.calls.length).toBe(1);
+      expect(spy.console.mock.calls.length).toBe(1);
+    });
+
+    test("data request calls action and responds with catch header", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let testAction = jest.fn(() => {
+        throw new Response("test", { status: 400 });
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader
+        },
+        "routes/test": {
+          parentId: "root",
+          action: testAction,
+          path: "test"
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/test?_data=routes/test`, {
+        method: "post"
+      });
+
+      let result = await handler(request);
+      expect(result.status).toBe(400);
+      expect(await result.text()).toBe("test");
+      expect(result.headers.get("X-Remix-Catch")).toBe("yes");
+      expect(rootLoader.mock.calls.length).toBe(0);
+      expect(testAction.mock.calls.length).toBe(1);
+    });
+
+    test("data request calls layout action", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let rootAction = jest.fn(() => {
+        return "root";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          action: rootAction
+        },
+        "routes/index": {
+          parentId: "root",
+          index: true
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/?_data=root`, { method: "post" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(200);
+      expect(await result.json()).toBe("root");
+      expect(rootLoader.mock.calls.length).toBe(0);
+      expect(rootAction.mock.calls.length).toBe(1);
+    });
+
+    test("data request calls index action", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let indexAction = jest.fn(() => {
+        return "index";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader
+        },
+        "routes/index": {
+          parentId: "root",
+          action: indexAction,
+          index: true
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/?index&_data=routes/index`, {
+        method: "post"
+      });
+
+      let result = await handler(request);
+      expect(result.status).toBe(200);
+      expect(await result.json()).toBe("index");
+      expect(rootLoader.mock.calls.length).toBe(0);
+      expect(indexAction.mock.calls.length).toBe(1);
     });
   });
 
-  test("thrown action responses bubble up", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let indexAction = jest.fn(() => {
-      throw new Response(null, { status: 400 });
-    });
-    let indexLoader = jest.fn(() => {
-      return "index";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader,
-        CatchBoundary: {}
-      },
-      "routes/index": {
-        parentId: "root",
-        index: true,
-        default: {},
-        loader: indexLoader,
-        action: indexAction
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
+  describe("document requests", () => {
+    test("not found document request for no matches and no CatchBoundary", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
 
-    let request = new Request(`${baseUrl}/?index`, { method: "post" });
+      let request = new Request(`${baseUrl}/`, { method: "get" });
 
-    let result = await handler(request);
-    expect(result.status).toBe(400);
-    expect(indexAction.mock.calls.length).toBe(1);
-    expect(rootLoader.mock.calls.length).toBe(1);
-    expect(indexLoader.mock.calls.length).toBe(0);
-    expect(build.entry.module.default.mock.calls.length).toBe(1);
+      let result = await handler(request);
+      expect(result.status).toBe(404);
+      expect(rootLoader.mock.calls.length).toBe(0);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
 
-    let calls = build.entry.module.default.mock.calls;
-    expect(calls.length).toBe(1);
-    let entryContext = calls[0][3];
-    expect(entryContext.appState.catch).toBeTruthy();
-    expect(entryContext.appState.catch!.status).toBe(400);
-    expect(entryContext.appState.catchBoundaryRouteId).toBe("root");
-    expect(entryContext.routeData).toEqual({
-      root: "root"
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.catch).toBeTruthy();
+      expect(entryContext.appState.catch!.status).toBe(404);
+      expect(entryContext.appState.catchBoundaryRouteId).toBe(null);
     });
-  });
 
-  test("thrown action responses catch deep", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let indexAction = jest.fn(() => {
-      throw new Response(null, { status: 400 });
-    });
-    let indexLoader = jest.fn(() => {
-      return "index";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader,
-        CatchBoundary: {}
-      },
-      "routes/index": {
-        parentId: "root",
-        index: true,
-        default: {},
-        loader: indexLoader,
-        action: indexAction,
-        CatchBoundary: {}
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
+    test("sets root as catch boundary for not found document request", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          CatchBoundary: {}
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
 
-    let request = new Request(`${baseUrl}/?index`, { method: "post" });
+      let request = new Request(`${baseUrl}/`, { method: "get" });
 
-    let result = await handler(request);
-    expect(result.status).toBe(400);
-    expect(indexAction.mock.calls.length).toBe(1);
-    expect(rootLoader.mock.calls.length).toBe(1);
-    expect(indexLoader.mock.calls.length).toBe(0);
-    expect(build.entry.module.default.mock.calls.length).toBe(1);
+      let result = await handler(request);
+      expect(result.status).toBe(404);
+      expect(rootLoader.mock.calls.length).toBe(0);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
 
-    let calls = build.entry.module.default.mock.calls;
-    expect(calls.length).toBe(1);
-    let entryContext = calls[0][3];
-    expect(entryContext.appState.catch).toBeTruthy();
-    expect(entryContext.appState.catch!.status).toBe(400);
-    expect(entryContext.appState.catchBoundaryRouteId).toBe("routes/index");
-    expect(entryContext.routeData).toEqual({
-      root: "root"
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.catch).toBeTruthy();
+      expect(entryContext.appState.catch!.status).toBe(404);
+      expect(entryContext.appState.catchBoundaryRouteId).toBe("root");
+      expect(entryContext.routeData).toEqual({});
     });
-  });
 
-  test("thrown loader response after thrown action response bubble up action throw to deepest loader boundary", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let layoutLoader = jest.fn(() => {
-      throw new Response("layout", { status: 401 });
-    });
-    let indexAction = jest.fn(() => {
-      throw new Response("action", { status: 400 });
-    });
-    let indexLoader = jest.fn(() => {
-      return "index";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader,
-        CatchBoundary: {}
-      },
-      "routes/__layout": {
-        parentId: "root",
-        default: {},
-        loader: layoutLoader,
-        CatchBoundary: {}
-      },
-      "routes/__layout/index": {
-        parentId: "routes/__layout",
-        index: true,
-        default: {},
-        loader: indexLoader,
-        action: indexAction
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
+    test("thrown loader responses bubble up", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let indexLoader = jest.fn(() => {
+        throw new Response(null, { status: 400 });
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          CatchBoundary: {}
+        },
+        "routes/index": {
+          parentId: "root",
+          index: true,
+          default: {},
+          loader: indexLoader
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
 
-    let request = new Request(`${baseUrl}/?index`, { method: "post" });
+      let request = new Request(`${baseUrl}/`, { method: "get" });
 
-    let result = await handler(request);
-    expect(result.status).toBe(400);
-    expect(indexAction.mock.calls.length).toBe(1);
-    expect(rootLoader.mock.calls.length).toBe(1);
-    expect(indexLoader.mock.calls.length).toBe(0);
-    expect(build.entry.module.default.mock.calls.length).toBe(1);
+      let result = await handler(request);
+      expect(result.status).toBe(400);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(indexLoader.mock.calls.length).toBe(1);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
 
-    let calls = build.entry.module.default.mock.calls;
-    expect(calls.length).toBe(1);
-    let entryContext = calls[0][3];
-    expect(entryContext.appState.catch).toBeTruthy();
-    expect(entryContext.appState.catch.data).toBe("action");
-    expect(entryContext.appState.catchBoundaryRouteId).toBe("routes/__layout");
-    expect(entryContext.routeData).toEqual({
-      root: "root"
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.catch).toBeTruthy();
+      expect(entryContext.appState.catch!.status).toBe(400);
+      expect(entryContext.appState.catchBoundaryRouteId).toBe("root");
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-  });
 
-  test("loader errors bubble up", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let indexLoader = jest.fn(() => {
-      throw new Error("index");
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader,
-        ErrorBoundary: {}
-      },
-      "routes/index": {
-        parentId: "root",
-        index: true,
-        default: {},
-        loader: indexLoader
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
+    test("thrown loader responses catch deep", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let indexLoader = jest.fn(() => {
+        throw new Response(null, { status: 400 });
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          CatchBoundary: {}
+        },
+        "routes/index": {
+          parentId: "root",
+          index: true,
+          default: {},
+          loader: indexLoader,
+          CatchBoundary: {}
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
 
-    let request = new Request(`${baseUrl}/`, { method: "get" });
+      let request = new Request(`${baseUrl}/`, { method: "get" });
 
-    let result = await handler(request);
-    expect(result.status).toBe(500);
-    expect(rootLoader.mock.calls.length).toBe(1);
-    expect(indexLoader.mock.calls.length).toBe(1);
-    expect(build.entry.module.default.mock.calls.length).toBe(1);
+      let result = await handler(request);
+      expect(result.status).toBe(400);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(indexLoader.mock.calls.length).toBe(1);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
 
-    let calls = build.entry.module.default.mock.calls;
-    expect(calls.length).toBe(1);
-    let entryContext = calls[0][3];
-    expect(entryContext.appState.error).toBeTruthy();
-    expect(entryContext.appState.error.message).toBe("index");
-    expect(entryContext.appState.loaderBoundaryRouteId).toBe("root");
-    expect(entryContext.routeData).toEqual({
-      root: "root"
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.catch).toBeTruthy();
+      expect(entryContext.appState.catch!.status).toBe(400);
+      expect(entryContext.appState.catchBoundaryRouteId).toBe("routes/index");
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-  });
 
-  test("loader errors catch deep", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let indexLoader = jest.fn(() => {
-      throw new Error("index");
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader,
-        ErrorBoundary: {}
-      },
-      "routes/index": {
-        parentId: "root",
-        index: true,
-        default: {},
-        loader: indexLoader,
-        ErrorBoundary: {}
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
+    test("thrown action responses bubble up", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let testAction = jest.fn(() => {
+        throw new Response(null, { status: 400 });
+      });
+      let testLoader = jest.fn(() => {
+        return "test";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          CatchBoundary: {}
+        },
+        "routes/test": {
+          parentId: "root",
+          path: "test",
+          default: {},
+          loader: testLoader,
+          action: testAction
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
 
-    let request = new Request(`${baseUrl}/`, { method: "get" });
+      let request = new Request(`${baseUrl}/test`, { method: "post" });
 
-    let result = await handler(request);
-    expect(result.status).toBe(500);
-    expect(rootLoader.mock.calls.length).toBe(1);
-    expect(indexLoader.mock.calls.length).toBe(1);
-    expect(build.entry.module.default.mock.calls.length).toBe(1);
+      let result = await handler(request);
+      expect(result.status).toBe(400);
+      expect(testAction.mock.calls.length).toBe(1);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(testLoader.mock.calls.length).toBe(0);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
 
-    let calls = build.entry.module.default.mock.calls;
-    expect(calls.length).toBe(1);
-    let entryContext = calls[0][3];
-    expect(entryContext.appState.error).toBeTruthy();
-    expect(entryContext.appState.error.message).toBe("index");
-    expect(entryContext.appState.loaderBoundaryRouteId).toBe("routes/index");
-    expect(entryContext.routeData).toEqual({
-      root: "root"
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.catch).toBeTruthy();
+      expect(entryContext.appState.catch!.status).toBe(400);
+      expect(entryContext.appState.catchBoundaryRouteId).toBe("root");
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-  });
 
-  test("action errors bubble up", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let indexAction = jest.fn(() => {
-      throw new Error("index");
-    });
-    let indexLoader = jest.fn(() => {
-      return "index";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader,
-        ErrorBoundary: {}
-      },
-      "routes/index": {
-        parentId: "root",
-        index: true,
-        default: {},
-        loader: indexLoader,
-        action: indexAction
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
+    test("thrown action responses bubble up for index routes", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let indexAction = jest.fn(() => {
+        throw new Response(null, { status: 400 });
+      });
+      let indexLoader = jest.fn(() => {
+        return "index";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          CatchBoundary: {}
+        },
+        "routes/index": {
+          parentId: "root",
+          index: true,
+          default: {},
+          loader: indexLoader,
+          action: indexAction
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
 
-    let request = new Request(`${baseUrl}/?index`, { method: "post" });
+      let request = new Request(`${baseUrl}/?index`, { method: "post" });
 
-    let result = await handler(request);
-    expect(result.status).toBe(500);
-    expect(indexAction.mock.calls.length).toBe(1);
-    expect(rootLoader.mock.calls.length).toBe(1);
-    expect(indexLoader.mock.calls.length).toBe(0);
-    expect(build.entry.module.default.mock.calls.length).toBe(1);
+      let result = await handler(request);
+      expect(result.status).toBe(400);
+      expect(indexAction.mock.calls.length).toBe(1);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(indexLoader.mock.calls.length).toBe(0);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
 
-    let calls = build.entry.module.default.mock.calls;
-    expect(calls.length).toBe(1);
-    let entryContext = calls[0][3];
-    expect(entryContext.appState.error).toBeTruthy();
-    expect(entryContext.appState.error.message).toBe("index");
-    expect(entryContext.appState.loaderBoundaryRouteId).toBe("root");
-    expect(entryContext.routeData).toEqual({
-      root: "root"
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.catch).toBeTruthy();
+      expect(entryContext.appState.catch!.status).toBe(400);
+      expect(entryContext.appState.catchBoundaryRouteId).toBe("root");
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-  });
 
-  test("action errors catch deep", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
-    });
-    let indexAction = jest.fn(() => {
-      throw new Error("index");
-    });
-    let indexLoader = jest.fn(() => {
-      return "index";
-    });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader,
-        ErrorBoundary: {}
-      },
-      "routes/index": {
-        parentId: "root",
-        index: true,
-        default: {},
-        loader: indexLoader,
-        action: indexAction,
-        ErrorBoundary: {}
-      }
-    });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
+    test("thrown action responses catch deep", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let testAction = jest.fn(() => {
+        throw new Response(null, { status: 400 });
+      });
+      let testLoader = jest.fn(() => {
+        return "test";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          CatchBoundary: {}
+        },
+        "routes/test": {
+          parentId: "root",
+          path: "test",
+          default: {},
+          loader: testLoader,
+          action: testAction,
+          CatchBoundary: {}
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
 
-    let request = new Request(`${baseUrl}/?index`, { method: "post" });
+      let request = new Request(`${baseUrl}/test`, { method: "post" });
 
-    let result = await handler(request);
-    expect(result.status).toBe(500);
-    expect(indexAction.mock.calls.length).toBe(1);
-    expect(rootLoader.mock.calls.length).toBe(1);
-    expect(indexLoader.mock.calls.length).toBe(0);
-    expect(build.entry.module.default.mock.calls.length).toBe(1);
+      let result = await handler(request);
+      expect(result.status).toBe(400);
+      expect(testAction.mock.calls.length).toBe(1);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(testLoader.mock.calls.length).toBe(0);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
 
-    let calls = build.entry.module.default.mock.calls;
-    expect(calls.length).toBe(1);
-    let entryContext = calls[0][3];
-    expect(entryContext.appState.error).toBeTruthy();
-    expect(entryContext.appState.error.message).toBe("index");
-    expect(entryContext.appState.loaderBoundaryRouteId).toBe("routes/index");
-    expect(entryContext.routeData).toEqual({
-      root: "root"
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.catch).toBeTruthy();
+      expect(entryContext.appState.catch!.status).toBe(400);
+      expect(entryContext.appState.catchBoundaryRouteId).toBe("routes/test");
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-  });
 
-  test("loader errors after action error bubble up action error to deepest loader boundary", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
+    test("thrown action responses catch deep for index routes", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let indexAction = jest.fn(() => {
+        throw new Response(null, { status: 400 });
+      });
+      let indexLoader = jest.fn(() => {
+        return "index";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          CatchBoundary: {}
+        },
+        "routes/index": {
+          parentId: "root",
+          index: true,
+          default: {},
+          loader: indexLoader,
+          action: indexAction,
+          CatchBoundary: {}
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/?index`, { method: "post" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(400);
+      expect(indexAction.mock.calls.length).toBe(1);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(indexLoader.mock.calls.length).toBe(0);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.catch).toBeTruthy();
+      expect(entryContext.appState.catch!.status).toBe(400);
+      expect(entryContext.appState.catchBoundaryRouteId).toBe("routes/index");
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-    let layoutLoader = jest.fn(() => {
-      throw new Error("layout");
+
+    test("thrown loader response after thrown action response bubble up action throw to deepest loader boundary", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let layoutLoader = jest.fn(() => {
+        throw new Response("layout", { status: 401 });
+      });
+      let testAction = jest.fn(() => {
+        throw new Response("action", { status: 400 });
+      });
+      let testLoader = jest.fn(() => {
+        return "test";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          CatchBoundary: {}
+        },
+        "routes/__layout": {
+          parentId: "root",
+          default: {},
+          loader: layoutLoader,
+          CatchBoundary: {}
+        },
+        "routes/__layout/test": {
+          parentId: "routes/__layout",
+          path: "test",
+          default: {},
+          loader: testLoader,
+          action: testAction
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/test`, { method: "post" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(400);
+      expect(testAction.mock.calls.length).toBe(1);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(testLoader.mock.calls.length).toBe(0);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.catch).toBeTruthy();
+      expect(entryContext.appState.catch.data).toBe("action");
+      expect(entryContext.appState.catchBoundaryRouteId).toBe(
+        "routes/__layout"
+      );
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-    let indexAction = jest.fn(() => {
-      throw new Error("action");
+
+    test("thrown loader response after thrown index action response bubble up action throw to deepest loader boundary", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let layoutLoader = jest.fn(() => {
+        throw new Response("layout", { status: 401 });
+      });
+      let indexAction = jest.fn(() => {
+        throw new Response("action", { status: 400 });
+      });
+      let indexLoader = jest.fn(() => {
+        return "index";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          CatchBoundary: {}
+        },
+        "routes/__layout": {
+          parentId: "root",
+          default: {},
+          loader: layoutLoader,
+          CatchBoundary: {}
+        },
+        "routes/__layout/index": {
+          parentId: "routes/__layout",
+          index: true,
+          default: {},
+          loader: indexLoader,
+          action: indexAction
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/?index`, { method: "post" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(400);
+      expect(indexAction.mock.calls.length).toBe(1);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(indexLoader.mock.calls.length).toBe(0);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.catch).toBeTruthy();
+      expect(entryContext.appState.catch.data).toBe("action");
+      expect(entryContext.appState.catchBoundaryRouteId).toBe(
+        "routes/__layout"
+      );
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-    let indexLoader = jest.fn(() => {
-      return "index";
+
+    test("loader errors bubble up", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let indexLoader = jest.fn(() => {
+        throw new Error("index");
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          ErrorBoundary: {}
+        },
+        "routes/index": {
+          parentId: "root",
+          index: true,
+          default: {},
+          loader: indexLoader
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/`, { method: "get" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(indexLoader.mock.calls.length).toBe(1);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.error).toBeTruthy();
+      expect(entryContext.appState.error.message).toBe("index");
+      expect(entryContext.appState.loaderBoundaryRouteId).toBe("root");
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader,
-        ErrorBoundary: {}
-      },
-      "routes/__layout": {
-        parentId: "root",
-        default: {},
-        loader: layoutLoader,
-        ErrorBoundary: {}
-      },
-      "routes/__layout/index": {
-        parentId: "routes/__layout",
-        index: true,
-        default: {},
-        loader: indexLoader,
-        action: indexAction
-      }
+
+    test("loader errors catch deep", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let indexLoader = jest.fn(() => {
+        throw new Error("index");
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          ErrorBoundary: {}
+        },
+        "routes/index": {
+          parentId: "root",
+          index: true,
+          default: {},
+          loader: indexLoader,
+          ErrorBoundary: {}
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/`, { method: "get" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(indexLoader.mock.calls.length).toBe(1);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.error).toBeTruthy();
+      expect(entryContext.appState.error.message).toBe("index");
+      expect(entryContext.appState.loaderBoundaryRouteId).toBe("routes/index");
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
 
-    let request = new Request(`${baseUrl}/?index`, { method: "post" });
+    test("action errors bubble up", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let testAction = jest.fn(() => {
+        throw new Error("test");
+      });
+      let testLoader = jest.fn(() => {
+        return "test";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          ErrorBoundary: {}
+        },
+        "routes/test": {
+          parentId: "root",
+          path: "test",
+          default: {},
+          loader: testLoader,
+          action: testAction
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
 
-    let result = await handler(request);
-    expect(result.status).toBe(500);
-    expect(indexAction.mock.calls.length).toBe(1);
-    expect(rootLoader.mock.calls.length).toBe(1);
-    expect(indexLoader.mock.calls.length).toBe(0);
-    expect(build.entry.module.default.mock.calls.length).toBe(1);
+      let request = new Request(`${baseUrl}/test`, { method: "post" });
 
-    let calls = build.entry.module.default.mock.calls;
-    expect(calls.length).toBe(1);
-    let entryContext = calls[0][3];
-    expect(entryContext.appState.error).toBeTruthy();
-    expect(entryContext.appState.error.message).toBe("action");
-    expect(entryContext.appState.loaderBoundaryRouteId).toBe("routes/__layout");
-    expect(entryContext.routeData).toEqual({
-      root: "root"
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect(testAction.mock.calls.length).toBe(1);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(testLoader.mock.calls.length).toBe(0);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.error).toBeTruthy();
+      expect(entryContext.appState.error.message).toBe("test");
+      expect(entryContext.appState.loaderBoundaryRouteId).toBe("root");
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-  });
 
-  test("calls handleDocumentRequest again with new error when handleDocumentRequest throws", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
+    test("action errors bubble up for index routes", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let indexAction = jest.fn(() => {
+        throw new Error("index");
+      });
+      let indexLoader = jest.fn(() => {
+        return "index";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          ErrorBoundary: {}
+        },
+        "routes/index": {
+          parentId: "root",
+          index: true,
+          default: {},
+          loader: indexLoader,
+          action: indexAction
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/?index`, { method: "post" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect(indexAction.mock.calls.length).toBe(1);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(indexLoader.mock.calls.length).toBe(0);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.error).toBeTruthy();
+      expect(entryContext.appState.error.message).toBe("index");
+      expect(entryContext.appState.loaderBoundaryRouteId).toBe("root");
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-    let indexLoader = jest.fn(() => {
-      return "index";
+
+    test("action errors catch deep", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let testAction = jest.fn(() => {
+        throw new Error("test");
+      });
+      let testLoader = jest.fn(() => {
+        return "test";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          ErrorBoundary: {}
+        },
+        "routes/test": {
+          parentId: "root",
+          path: "test",
+          default: {},
+          loader: testLoader,
+          action: testAction,
+          ErrorBoundary: {}
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/test`, { method: "post" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect(testAction.mock.calls.length).toBe(1);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(testLoader.mock.calls.length).toBe(0);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.error).toBeTruthy();
+      expect(entryContext.appState.error.message).toBe("test");
+      expect(entryContext.appState.loaderBoundaryRouteId).toBe("routes/test");
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader,
-        ErrorBoundary: {}
-      },
-      "routes/index": {
-        parentId: "root",
-        default: {},
-        loader: indexLoader
-      }
+
+    test("action errors catch deep for index routes", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let indexAction = jest.fn(() => {
+        throw new Error("index");
+      });
+      let indexLoader = jest.fn(() => {
+        return "index";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          ErrorBoundary: {}
+        },
+        "routes/index": {
+          parentId: "root",
+          index: true,
+          default: {},
+          loader: indexLoader,
+          action: indexAction,
+          ErrorBoundary: {}
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/?index`, { method: "post" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect(indexAction.mock.calls.length).toBe(1);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(indexLoader.mock.calls.length).toBe(0);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.error).toBeTruthy();
+      expect(entryContext.appState.error.message).toBe("index");
+      expect(entryContext.appState.loaderBoundaryRouteId).toBe("routes/index");
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-    let calledBefore = false;
-    let ogHandleDocumentRequest = build.entry.module.default;
-    build.entry.module.default = jest.fn(function () {
-      if (!calledBefore) {
-        throw new Error("thrown");
-      }
-      calledBefore = true;
-      return ogHandleDocumentRequest.call(null, arguments);
-    }) as any;
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
 
-    let request = new Request(`${baseUrl}/`, { method: "get" });
+    test("loader errors after action error bubble up action error to deepest loader boundary", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let layoutLoader = jest.fn(() => {
+        throw new Error("layout");
+      });
+      let testAction = jest.fn(() => {
+        throw new Error("action");
+      });
+      let testLoader = jest.fn(() => {
+        return "test";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          ErrorBoundary: {}
+        },
+        "routes/__layout": {
+          parentId: "root",
+          default: {},
+          loader: layoutLoader,
+          ErrorBoundary: {}
+        },
+        "routes/__layout/test": {
+          parentId: "routes/__layout",
+          path: "test",
+          default: {},
+          loader: testLoader,
+          action: testAction
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
 
-    let result = await handler(request);
-    expect(result.status).toBe(500);
-    expect(rootLoader.mock.calls.length).toBe(0);
-    expect(indexLoader.mock.calls.length).toBe(0);
+      let request = new Request(`${baseUrl}/test`, { method: "post" });
 
-    let calls = build.entry.module.default.mock.calls;
-    expect(calls.length).toBe(2);
-    let entryContext = calls[1][3];
-    expect(entryContext.appState.error).toBeTruthy();
-    expect(entryContext.appState.error.message).toBe("thrown");
-    expect(entryContext.appState.trackBoundaries).toBe(false);
-    expect(entryContext.routeData).toEqual({});
-  });
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect(testAction.mock.calls.length).toBe(1);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(testLoader.mock.calls.length).toBe(0);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
 
-  test("returns generic message if handleDocumentRequest throws a second time", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.error).toBeTruthy();
+      expect(entryContext.appState.error.message).toBe("action");
+      expect(entryContext.appState.loaderBoundaryRouteId).toBe(
+        "routes/__layout"
+      );
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-    let indexLoader = jest.fn(() => {
-      return "index";
+
+    test("loader errors after index action error bubble up action error to deepest loader boundary", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let layoutLoader = jest.fn(() => {
+        throw new Error("layout");
+      });
+      let indexAction = jest.fn(() => {
+        throw new Error("action");
+      });
+      let indexLoader = jest.fn(() => {
+        return "index";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          ErrorBoundary: {}
+        },
+        "routes/__layout": {
+          parentId: "root",
+          default: {},
+          loader: layoutLoader,
+          ErrorBoundary: {}
+        },
+        "routes/__layout/index": {
+          parentId: "routes/__layout",
+          index: true,
+          default: {},
+          loader: indexLoader,
+          action: indexAction
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/?index`, { method: "post" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect(indexAction.mock.calls.length).toBe(1);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(indexLoader.mock.calls.length).toBe(0);
+      expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(1);
+      let entryContext = calls[0][3];
+      expect(entryContext.appState.error).toBeTruthy();
+      expect(entryContext.appState.error.message).toBe("action");
+      expect(entryContext.appState.loaderBoundaryRouteId).toBe(
+        "routes/__layout"
+      );
+      expect(entryContext.routeData).toEqual({
+        root: "root"
+      });
     });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader,
-        ErrorBoundary: {}
-      },
-      "routes/index": {
-        parentId: "root",
-        default: {},
-        loader: indexLoader
-      }
+
+    test("calls handleDocumentRequest again with new error when handleDocumentRequest throws", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let indexLoader = jest.fn(() => {
+        return "index";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          ErrorBoundary: {}
+        },
+        "routes/index": {
+          parentId: "root",
+          default: {},
+          loader: indexLoader
+        }
+      });
+      let calledBefore = false;
+      let ogHandleDocumentRequest = build.entry.module.default;
+      build.entry.module.default = jest.fn(function () {
+        if (!calledBefore) {
+          throw new Error("thrown");
+        }
+        calledBefore = true;
+        return ogHandleDocumentRequest.call(null, arguments);
+      }) as any;
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/`, { method: "get" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect(rootLoader.mock.calls.length).toBe(0);
+      expect(indexLoader.mock.calls.length).toBe(0);
+
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(2);
+      let entryContext = calls[1][3];
+      expect(entryContext.appState.error).toBeTruthy();
+      expect(entryContext.appState.error.message).toBe("thrown");
+      expect(entryContext.appState.trackBoundaries).toBe(false);
+      expect(entryContext.routeData).toEqual({});
     });
-    let lastThrownError;
-    build.entry.module.default = jest.fn(function () {
-      lastThrownError = new Error("rofl");
-      throw lastThrownError;
-    }) as any;
-    let handler = createRequestHandler(build, {}, ServerMode.Test);
 
-    let request = new Request(`${baseUrl}/`, { method: "get" });
+    test("returns generic message if handleDocumentRequest throws a second time", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let indexLoader = jest.fn(() => {
+        return "index";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          ErrorBoundary: {}
+        },
+        "routes/index": {
+          parentId: "root",
+          default: {},
+          loader: indexLoader
+        }
+      });
+      let lastThrownError;
+      build.entry.module.default = jest.fn(function () {
+        lastThrownError = new Error("rofl");
+        throw lastThrownError;
+      }) as any;
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
 
-    let result = await handler(request);
-    expect(result.status).toBe(500);
-    expect(await result.text()).toBe("Unexpected Server Error");
-    expect(rootLoader.mock.calls.length).toBe(0);
-    expect(indexLoader.mock.calls.length).toBe(0);
+      let request = new Request(`${baseUrl}/`, { method: "get" });
 
-    let calls = build.entry.module.default.mock.calls;
-    expect(calls.length).toBe(2);
-  });
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect(await result.text()).toBe("Unexpected Server Error");
+      expect(rootLoader.mock.calls.length).toBe(0);
+      expect(indexLoader.mock.calls.length).toBe(0);
 
-  test("returns more detailed message if handleDocumentRequest throws a second time in development mode", async () => {
-    let rootLoader = jest.fn(() => {
-      return "root";
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(2);
     });
-    let indexLoader = jest.fn(() => {
-      return "index";
+
+    test("returns more detailed message if handleDocumentRequest throws a second time in development mode", async () => {
+      let rootLoader = jest.fn(() => {
+        return "root";
+      });
+      let indexLoader = jest.fn(() => {
+        return "index";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          ErrorBoundary: {}
+        },
+        "routes/index": {
+          parentId: "root",
+          default: {},
+          loader: indexLoader
+        }
+      });
+      let errorMessage =
+        "thrown from handleDocumentRequest and expected to be logged in console only once";
+      let lastThrownError;
+      build.entry.module.default = jest.fn(function () {
+        lastThrownError = new Error(errorMessage);
+        throw lastThrownError;
+      }) as any;
+      let handler = createRequestHandler(build, {}, ServerMode.Development);
+
+      let request = new Request(`${baseUrl}/`, { method: "get" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(500);
+      expect((await result.text()).includes(errorMessage)).toBe(true);
+      expect(rootLoader.mock.calls.length).toBe(0);
+      expect(indexLoader.mock.calls.length).toBe(0);
+
+      let calls = build.entry.module.default.mock.calls;
+      expect(calls.length).toBe(2);
+      expect(spy.console.mock.calls.length).toBe(1);
     });
-    let build = mockServerBuild({
-      root: {
-        default: {},
-        loader: rootLoader,
-        ErrorBoundary: {}
-      },
-      "routes/index": {
-        parentId: "root",
-        default: {},
-        loader: indexLoader
-      }
-    });
-    let errorMessage =
-      "thrown from handleDocumentRequest and expected to be logged in console only once";
-    let lastThrownError;
-    build.entry.module.default = jest.fn(function () {
-      lastThrownError = new Error(errorMessage);
-      throw lastThrownError;
-    }) as any;
-    let handler = createRequestHandler(build, {}, ServerMode.Development);
-
-    let request = new Request(`${baseUrl}/`, { method: "get" });
-
-    let result = await handler(request);
-    expect(result.status).toBe(500);
-    expect((await result.text()).includes(errorMessage)).toBe(true);
-    expect(rootLoader.mock.calls.length).toBe(0);
-    expect(indexLoader.mock.calls.length).toBe(0);
-
-    let calls = build.entry.module.default.mock.calls;
-    expect(calls.length).toBe(2);
-    expect(spy.console.mock.calls.length).toBe(1);
   });
 });

--- a/packages/remix-server-runtime/__tests__/server-test.ts
+++ b/packages/remix-server-runtime/__tests__/server-test.ts
@@ -1,7 +1,26 @@
 import { createRequestHandler } from "..";
+import { ServerMode } from "../mode";
 import type { ServerBuild } from "../build";
+import { mockServerBuild } from "./utils";
+
+function spyConsole() {
+  // https://github.com/facebook/react/issues/7047
+  let spy: any = {};
+
+  beforeAll(() => {
+    spy.console = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    spy.console.mockRestore();
+  });
+
+  return spy;
+}
 
 describe("server", () => {
+  let spy = spyConsole();
+
   let routeId = "root";
   let build: ServerBuild = {
     entry: {
@@ -72,5 +91,1284 @@ describe("server", () => {
 
       expect(await response.text()).toBe("");
     });
+  });
+});
+
+describe("shared server runtime", () => {
+  const spy = spyConsole();
+
+  beforeEach(() => {
+    spy.console.mockClear();
+  });
+
+  let baseUrl = "http://test.com";
+
+  test("calls resource route loader", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let resourceLoader = jest.fn(() => {
+      return "resource";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader
+      },
+      "routes/resource": {
+        loader: resourceLoader,
+        path: "resource"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/resource`, { method: "get" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(200);
+    expect(await result.json()).toBe("resource");
+    expect(rootLoader.mock.calls.length).toBe(0);
+    expect(resourceLoader.mock.calls.length).toBe(1);
+  });
+
+  test("calls sub resource route loader", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let resourceLoader = jest.fn(() => {
+      return "resource";
+    });
+    let subResourceLoader = jest.fn(() => {
+      return "sub";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader
+      },
+      "routes/resource": {
+        loader: resourceLoader,
+        path: "resource"
+      },
+      "routes/resource.sub": {
+        loader: subResourceLoader,
+        path: "resource/sub"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/resource/sub`, { method: "get" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(200);
+    expect(await result.json()).toBe("sub");
+    expect(rootLoader.mock.calls.length).toBe(0);
+    expect(resourceLoader.mock.calls.length).toBe(0);
+    expect(subResourceLoader.mock.calls.length).toBe(1);
+  });
+
+  test("resource route loader allows thrown responses", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let resourceLoader = jest.fn(() => {
+      throw new Response("resource");
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader
+      },
+      "routes/resource": {
+        loader: resourceLoader,
+        path: "resource"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/resource`, { method: "get" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(200);
+    expect(await result.text()).toBe("resource");
+    expect(rootLoader.mock.calls.length).toBe(0);
+    expect(resourceLoader.mock.calls.length).toBe(1);
+  });
+
+  test("resource route loader responds with generic error when thrown", async () => {
+    let error = new Error("should be logged when resource loader throws");
+    let loader = jest.fn(() => {
+      throw error;
+    });
+    let build = mockServerBuild({
+      "routes/resource": {
+        loader,
+        path: "resource"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/resource`, { method: "get" });
+
+    let result = await handler(request);
+    expect(await result.text()).toBe("Unexpected Server Error");
+  });
+
+  test("resource route loader responds with detailed error when thrown in development", async () => {
+    let error = new Error("should be logged when resource loader throws");
+    let loader = jest.fn(() => {
+      throw error;
+    });
+    let build = mockServerBuild({
+      "routes/resource": {
+        loader,
+        path: "resource"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Development);
+
+    let request = new Request(`${baseUrl}/resource`, { method: "get" });
+
+    let result = await handler(request);
+    expect((await result.text()).includes(error.message)).toBe(true);
+    expect(spy.console.mock.calls.length).toBe(1);
+  });
+
+  test("calls resource route action", async () => {
+    let rootAction = jest.fn(() => {
+      return "root";
+    });
+    let resourceAction = jest.fn(() => {
+      return "resource";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        action: rootAction
+      },
+      "routes/resource": {
+        action: resourceAction,
+        path: "resource"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/resource`, { method: "post" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(200);
+    expect(await result.json()).toBe("resource");
+    expect(rootAction.mock.calls.length).toBe(0);
+    expect(resourceAction.mock.calls.length).toBe(1);
+  });
+
+  test("calls sub resource route action", async () => {
+    let rootAction = jest.fn(() => {
+      return "root";
+    });
+    let resourceAction = jest.fn(() => {
+      return "resource";
+    });
+    let subResourceAction = jest.fn(() => {
+      return "sub";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        action: rootAction
+      },
+      "routes/resource": {
+        action: resourceAction,
+        path: "resource"
+      },
+      "routes/resource.sub": {
+        action: subResourceAction,
+        path: "resource/sub"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/resource/sub`, { method: "post" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(200);
+    expect(await result.json()).toBe("sub");
+    expect(rootAction.mock.calls.length).toBe(0);
+    expect(resourceAction.mock.calls.length).toBe(0);
+    expect(subResourceAction.mock.calls.length).toBe(1);
+  });
+
+  test("resource route action allows thrown responses", async () => {
+    let rootAction = jest.fn(() => {
+      return "root";
+    });
+    let resourceAction = jest.fn(() => {
+      throw new Response("resource");
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        action: rootAction
+      },
+      "routes/resource": {
+        action: resourceAction,
+        path: "resource"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/resource`, { method: "post" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(200);
+    expect(await result.text()).toBe("resource");
+    expect(rootAction.mock.calls.length).toBe(0);
+    expect(resourceAction.mock.calls.length).toBe(1);
+  });
+
+  test("resource route action responds with generic error when thrown", async () => {
+    let error = new Error("should be logged when resource loader throws");
+    let action = jest.fn(() => {
+      throw error;
+    });
+    let build = mockServerBuild({
+      "routes/resource": {
+        action,
+        path: "resource"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/resource`, { method: "post" });
+
+    let result = await handler(request);
+    expect(await result.text()).toBe("Unexpected Server Error");
+  });
+
+  test("resource route action responds with detailed error when thrown in development", async () => {
+    let message = "should be logged when resource loader throws";
+    let action = jest.fn(() => {
+      throw new Error(message);
+    });
+    let build = mockServerBuild({
+      "routes/resource": {
+        action,
+        path: "resource"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Development);
+
+    let request = new Request(`${baseUrl}/resource`, { method: "post" });
+
+    let result = await handler(request);
+    expect((await result.text()).includes(message)).toBe(true);
+    expect(spy.console.mock.calls.length).toBe(1);
+  });
+
+  test("data request that does not match loader surfaces error for boundary", async () => {
+    let build = mockServerBuild({
+      root: {
+        default: {}
+      },
+      "routes/index": {
+        parentId: "root",
+        index: true
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/?_data=routes/index`, {
+      method: "get"
+    });
+
+    let result = await handler(request);
+    expect(result.status).toBe(500);
+    expect(result.headers.get("X-Remix-Error")).toBe("yes");
+    expect((await result.json()).message).toBeTruthy();
+  });
+
+  test("data request calls loader", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let indexLoader = jest.fn(() => {
+      return "index";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader
+      },
+      "routes/index": {
+        parentId: "root",
+        loader: indexLoader,
+        index: true
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/?_data=routes/index`, {
+      method: "get"
+    });
+
+    let result = await handler(request);
+    expect(result.status).toBe(200);
+    expect(await result.json()).toBe("index");
+    expect(rootLoader.mock.calls.length).toBe(0);
+    expect(indexLoader.mock.calls.length).toBe(1);
+  });
+
+  test("data request calls loader and responds with generic message and error header", async () => {
+    let rootLoader = jest.fn(() => {
+      throw new Error("test");
+    });
+    let testAction = jest.fn(() => {
+      return "root";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader
+      },
+      "routes/test": {
+        parentId: "root",
+        action: testAction,
+        path: "test"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/test?_data=root`, {
+      method: "get"
+    });
+
+    let result = await handler(request);
+    expect(result.status).toBe(500);
+    expect((await result.json()).message).toBe("Unexpected Server Error");
+    expect(result.headers.get("X-Remix-Error")).toBe("yes");
+    expect(rootLoader.mock.calls.length).toBe(1);
+    expect(testAction.mock.calls.length).toBe(0);
+  });
+
+  test("data request calls loader and responds with detailed info and error header in development mode", async () => {
+    let message =
+      "data request loader error logged to console once in dev mode";
+    let rootLoader = jest.fn(() => {
+      throw new Error(message);
+    });
+    let testAction = jest.fn(() => {
+      return "root";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader
+      },
+      "routes/test": {
+        parentId: "root",
+        action: testAction,
+        path: "test"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Development);
+
+    let request = new Request(`${baseUrl}/test?_data=root`, {
+      method: "get"
+    });
+
+    let result = await handler(request);
+    expect(result.status).toBe(500);
+    expect((await result.json()).message).toBe(message);
+    expect(result.headers.get("X-Remix-Error")).toBe("yes");
+    expect(rootLoader.mock.calls.length).toBe(1);
+    expect(testAction.mock.calls.length).toBe(0);
+    expect(spy.console.mock.calls.length).toBe(1);
+  });
+
+  test("data request calls loader and responds with catch header", async () => {
+    let rootLoader = jest.fn(() => {
+      throw new Response("test", { status: 400 });
+    });
+    let testAction = jest.fn(() => {
+      return "root";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader
+      },
+      "routes/test": {
+        parentId: "root",
+        action: testAction,
+        path: "test"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/test?_data=root`, {
+      method: "get"
+    });
+
+    let result = await handler(request);
+    expect(result.status).toBe(400);
+    expect(await result.text()).toBe("test");
+    expect(result.headers.get("X-Remix-Catch")).toBe("yes");
+    expect(rootLoader.mock.calls.length).toBe(1);
+    expect(testAction.mock.calls.length).toBe(0);
+  });
+
+  test("data request that does not match action surfaces error for boundary", async () => {
+    let build = mockServerBuild({
+      root: {
+        default: {}
+      },
+      "routes/index": {
+        parentId: "root",
+        index: true
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/?index&_data=routes/index`, {
+      method: "post"
+    });
+
+    let result = await handler(request);
+    expect(result.status).toBe(500);
+    expect(result.headers.get("X-Remix-Error")).toBe("yes");
+    expect((await result.json()).message).toBeTruthy();
+  });
+
+  test("data request calls action", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let testAction = jest.fn(() => {
+      return "test";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader
+      },
+      "routes/test": {
+        parentId: "root",
+        action: testAction,
+        path: "test"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/test?_data=routes/test`, {
+      method: "post"
+    });
+
+    let result = await handler(request);
+    expect(result.status).toBe(200);
+    expect(await result.json()).toBe("test");
+    expect(rootLoader.mock.calls.length).toBe(0);
+    expect(testAction.mock.calls.length).toBe(1);
+  });
+
+  test("data request calls action and responds with generic message and error header", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let testAction = jest.fn(() => {
+      throw new Error("test");
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader
+      },
+      "routes/test": {
+        parentId: "root",
+        action: testAction,
+        path: "test"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/test?_data=routes/test`, {
+      method: "post"
+    });
+
+    let result = await handler(request);
+    expect(result.status).toBe(500);
+    expect((await result.json()).message).toBe("Unexpected Server Error");
+    expect(result.headers.get("X-Remix-Error")).toBe("yes");
+    expect(rootLoader.mock.calls.length).toBe(0);
+    expect(testAction.mock.calls.length).toBe(1);
+  });
+
+  test("data request calls action and responds with detailed info and error header in development mode", async () => {
+    let message =
+      "data request action error logged to console once in dev mode";
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let testAction = jest.fn(() => {
+      throw new Error(message);
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader
+      },
+      "routes/test": {
+        parentId: "root",
+        action: testAction,
+        path: "test"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Development);
+
+    let request = new Request(`${baseUrl}/test?_data=routes/test`, {
+      method: "post"
+    });
+
+    let result = await handler(request);
+    expect(result.status).toBe(500);
+    expect((await result.json()).message).toBe(message);
+    expect(result.headers.get("X-Remix-Error")).toBe("yes");
+    expect(rootLoader.mock.calls.length).toBe(0);
+    expect(testAction.mock.calls.length).toBe(1);
+    expect(spy.console.mock.calls.length).toBe(1);
+  });
+
+  test("data request calls action and responds with catch header", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let testAction = jest.fn(() => {
+      throw new Response("test", { status: 400 });
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader
+      },
+      "routes/test": {
+        parentId: "root",
+        action: testAction,
+        path: "test"
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/test?_data=routes/test`, {
+      method: "post"
+    });
+
+    let result = await handler(request);
+    expect(result.status).toBe(400);
+    expect(await result.text()).toBe("test");
+    expect(result.headers.get("X-Remix-Catch")).toBe("yes");
+    expect(rootLoader.mock.calls.length).toBe(0);
+    expect(testAction.mock.calls.length).toBe(1);
+  });
+
+  test("data request calls layout action", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let rootAction = jest.fn(() => {
+      return "root";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader,
+        action: rootAction
+      },
+      "routes/index": {
+        parentId: "root",
+        index: true
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/?_data=root`, { method: "post" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(200);
+    expect(await result.json()).toBe("root");
+    expect(rootLoader.mock.calls.length).toBe(0);
+    expect(rootAction.mock.calls.length).toBe(1);
+  });
+
+  test("data request calls index action", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let indexAction = jest.fn(() => {
+      return "index";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader
+      },
+      "routes/index": {
+        parentId: "root",
+        action: indexAction,
+        index: true
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/?index&_data=routes/index`, {
+      method: "post"
+    });
+
+    let result = await handler(request);
+    expect(result.status).toBe(200);
+    expect(await result.json()).toBe("index");
+    expect(rootLoader.mock.calls.length).toBe(0);
+    expect(indexAction.mock.calls.length).toBe(1);
+  });
+
+  test("not found document request for no matches and no CatchBoundary", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/`, { method: "get" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(404);
+    expect(rootLoader.mock.calls.length).toBe(0);
+    expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+    let calls = build.entry.module.default.mock.calls;
+    expect(calls.length).toBe(1);
+    let entryContext = calls[0][3];
+    expect(entryContext.appState.catch).toBeTruthy();
+    expect(entryContext.appState.catch!.status).toBe(404);
+    expect(entryContext.appState.catchBoundaryRouteId).toBe(null);
+  });
+
+  test("sets root as catch boundary for not found document request", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader,
+        CatchBoundary: {}
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/`, { method: "get" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(404);
+    expect(rootLoader.mock.calls.length).toBe(0);
+    expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+    let calls = build.entry.module.default.mock.calls;
+    expect(calls.length).toBe(1);
+    let entryContext = calls[0][3];
+    expect(entryContext.appState.catch).toBeTruthy();
+    expect(entryContext.appState.catch!.status).toBe(404);
+    expect(entryContext.appState.catchBoundaryRouteId).toBe("root");
+    expect(entryContext.routeData).toEqual({});
+  });
+
+  test("thrown loader responses bubble up", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let indexLoader = jest.fn(() => {
+      throw new Response(null, { status: 400 });
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader,
+        CatchBoundary: {}
+      },
+      "routes/index": {
+        parentId: "root",
+        index: true,
+        default: {},
+        loader: indexLoader
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/`, { method: "get" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(400);
+    expect(rootLoader.mock.calls.length).toBe(1);
+    expect(indexLoader.mock.calls.length).toBe(1);
+    expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+    let calls = build.entry.module.default.mock.calls;
+    expect(calls.length).toBe(1);
+    let entryContext = calls[0][3];
+    expect(entryContext.appState.catch).toBeTruthy();
+    expect(entryContext.appState.catch!.status).toBe(400);
+    expect(entryContext.appState.catchBoundaryRouteId).toBe("root");
+    expect(entryContext.routeData).toEqual({
+      root: "root"
+    });
+  });
+
+  test("thrown loader responses catch deep", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let indexLoader = jest.fn(() => {
+      throw new Response(null, { status: 400 });
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader,
+        CatchBoundary: {}
+      },
+      "routes/index": {
+        parentId: "root",
+        index: true,
+        default: {},
+        loader: indexLoader,
+        CatchBoundary: {}
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/`, { method: "get" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(400);
+    expect(rootLoader.mock.calls.length).toBe(1);
+    expect(indexLoader.mock.calls.length).toBe(1);
+    expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+    let calls = build.entry.module.default.mock.calls;
+    expect(calls.length).toBe(1);
+    let entryContext = calls[0][3];
+    expect(entryContext.appState.catch).toBeTruthy();
+    expect(entryContext.appState.catch!.status).toBe(400);
+    expect(entryContext.appState.catchBoundaryRouteId).toBe("routes/index");
+    expect(entryContext.routeData).toEqual({
+      root: "root"
+    });
+  });
+
+  test("thrown action responses bubble up", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let indexAction = jest.fn(() => {
+      throw new Response(null, { status: 400 });
+    });
+    let indexLoader = jest.fn(() => {
+      return "index";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader,
+        CatchBoundary: {}
+      },
+      "routes/index": {
+        parentId: "root",
+        index: true,
+        default: {},
+        loader: indexLoader,
+        action: indexAction
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/?index`, { method: "post" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(400);
+    expect(indexAction.mock.calls.length).toBe(1);
+    expect(rootLoader.mock.calls.length).toBe(1);
+    expect(indexLoader.mock.calls.length).toBe(0);
+    expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+    let calls = build.entry.module.default.mock.calls;
+    expect(calls.length).toBe(1);
+    let entryContext = calls[0][3];
+    expect(entryContext.appState.catch).toBeTruthy();
+    expect(entryContext.appState.catch!.status).toBe(400);
+    expect(entryContext.appState.catchBoundaryRouteId).toBe("root");
+    expect(entryContext.routeData).toEqual({
+      root: "root"
+    });
+  });
+
+  test("thrown action responses catch deep", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let indexAction = jest.fn(() => {
+      throw new Response(null, { status: 400 });
+    });
+    let indexLoader = jest.fn(() => {
+      return "index";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader,
+        CatchBoundary: {}
+      },
+      "routes/index": {
+        parentId: "root",
+        index: true,
+        default: {},
+        loader: indexLoader,
+        action: indexAction,
+        CatchBoundary: {}
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/?index`, { method: "post" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(400);
+    expect(indexAction.mock.calls.length).toBe(1);
+    expect(rootLoader.mock.calls.length).toBe(1);
+    expect(indexLoader.mock.calls.length).toBe(0);
+    expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+    let calls = build.entry.module.default.mock.calls;
+    expect(calls.length).toBe(1);
+    let entryContext = calls[0][3];
+    expect(entryContext.appState.catch).toBeTruthy();
+    expect(entryContext.appState.catch!.status).toBe(400);
+    expect(entryContext.appState.catchBoundaryRouteId).toBe("routes/index");
+    expect(entryContext.routeData).toEqual({
+      root: "root"
+    });
+  });
+
+  test("thrown loader response after thrown action response bubble up action throw to deepest loader boundary", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let layoutLoader = jest.fn(() => {
+      throw new Response("layout", { status: 401 });
+    });
+    let indexAction = jest.fn(() => {
+      throw new Response("action", { status: 400 });
+    });
+    let indexLoader = jest.fn(() => {
+      return "index";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader,
+        CatchBoundary: {}
+      },
+      "routes/__layout": {
+        parentId: "root",
+        default: {},
+        loader: layoutLoader,
+        CatchBoundary: {}
+      },
+      "routes/__layout/index": {
+        parentId: "routes/__layout",
+        index: true,
+        default: {},
+        loader: indexLoader,
+        action: indexAction
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/?index`, { method: "post" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(400);
+    expect(indexAction.mock.calls.length).toBe(1);
+    expect(rootLoader.mock.calls.length).toBe(1);
+    expect(indexLoader.mock.calls.length).toBe(0);
+    expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+    let calls = build.entry.module.default.mock.calls;
+    expect(calls.length).toBe(1);
+    let entryContext = calls[0][3];
+    expect(entryContext.appState.catch).toBeTruthy();
+    expect(entryContext.appState.catch.data).toBe("action");
+    expect(entryContext.appState.catchBoundaryRouteId).toBe("routes/__layout");
+    expect(entryContext.routeData).toEqual({
+      root: "root"
+    });
+  });
+
+  test("loader errors bubble up", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let indexLoader = jest.fn(() => {
+      throw new Error("index");
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader,
+        ErrorBoundary: {}
+      },
+      "routes/index": {
+        parentId: "root",
+        index: true,
+        default: {},
+        loader: indexLoader
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/`, { method: "get" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(500);
+    expect(rootLoader.mock.calls.length).toBe(1);
+    expect(indexLoader.mock.calls.length).toBe(1);
+    expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+    let calls = build.entry.module.default.mock.calls;
+    expect(calls.length).toBe(1);
+    let entryContext = calls[0][3];
+    expect(entryContext.appState.error).toBeTruthy();
+    expect(entryContext.appState.error.message).toBe("index");
+    expect(entryContext.appState.loaderBoundaryRouteId).toBe("root");
+    expect(entryContext.routeData).toEqual({
+      root: "root"
+    });
+  });
+
+  test("loader errors catch deep", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let indexLoader = jest.fn(() => {
+      throw new Error("index");
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader,
+        ErrorBoundary: {}
+      },
+      "routes/index": {
+        parentId: "root",
+        index: true,
+        default: {},
+        loader: indexLoader,
+        ErrorBoundary: {}
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/`, { method: "get" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(500);
+    expect(rootLoader.mock.calls.length).toBe(1);
+    expect(indexLoader.mock.calls.length).toBe(1);
+    expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+    let calls = build.entry.module.default.mock.calls;
+    expect(calls.length).toBe(1);
+    let entryContext = calls[0][3];
+    expect(entryContext.appState.error).toBeTruthy();
+    expect(entryContext.appState.error.message).toBe("index");
+    expect(entryContext.appState.loaderBoundaryRouteId).toBe("routes/index");
+    expect(entryContext.routeData).toEqual({
+      root: "root"
+    });
+  });
+
+  test("action errors bubble up", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let indexAction = jest.fn(() => {
+      throw new Error("index");
+    });
+    let indexLoader = jest.fn(() => {
+      return "index";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader,
+        ErrorBoundary: {}
+      },
+      "routes/index": {
+        parentId: "root",
+        index: true,
+        default: {},
+        loader: indexLoader,
+        action: indexAction
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/?index`, { method: "post" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(500);
+    expect(indexAction.mock.calls.length).toBe(1);
+    expect(rootLoader.mock.calls.length).toBe(1);
+    expect(indexLoader.mock.calls.length).toBe(0);
+    expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+    let calls = build.entry.module.default.mock.calls;
+    expect(calls.length).toBe(1);
+    let entryContext = calls[0][3];
+    expect(entryContext.appState.error).toBeTruthy();
+    expect(entryContext.appState.error.message).toBe("index");
+    expect(entryContext.appState.loaderBoundaryRouteId).toBe("root");
+    expect(entryContext.routeData).toEqual({
+      root: "root"
+    });
+  });
+
+  test("action errors catch deep", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let indexAction = jest.fn(() => {
+      throw new Error("index");
+    });
+    let indexLoader = jest.fn(() => {
+      return "index";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader,
+        ErrorBoundary: {}
+      },
+      "routes/index": {
+        parentId: "root",
+        index: true,
+        default: {},
+        loader: indexLoader,
+        action: indexAction,
+        ErrorBoundary: {}
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/?index`, { method: "post" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(500);
+    expect(indexAction.mock.calls.length).toBe(1);
+    expect(rootLoader.mock.calls.length).toBe(1);
+    expect(indexLoader.mock.calls.length).toBe(0);
+    expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+    let calls = build.entry.module.default.mock.calls;
+    expect(calls.length).toBe(1);
+    let entryContext = calls[0][3];
+    expect(entryContext.appState.error).toBeTruthy();
+    expect(entryContext.appState.error.message).toBe("index");
+    expect(entryContext.appState.loaderBoundaryRouteId).toBe("routes/index");
+    expect(entryContext.routeData).toEqual({
+      root: "root"
+    });
+  });
+
+  test("loader errors after action error bubble up action error to deepest loader boundary", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let layoutLoader = jest.fn(() => {
+      throw new Error("layout");
+    });
+    let indexAction = jest.fn(() => {
+      throw new Error("action");
+    });
+    let indexLoader = jest.fn(() => {
+      return "index";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader,
+        ErrorBoundary: {}
+      },
+      "routes/__layout": {
+        parentId: "root",
+        default: {},
+        loader: layoutLoader,
+        ErrorBoundary: {}
+      },
+      "routes/__layout/index": {
+        parentId: "routes/__layout",
+        index: true,
+        default: {},
+        loader: indexLoader,
+        action: indexAction
+      }
+    });
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/?index`, { method: "post" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(500);
+    expect(indexAction.mock.calls.length).toBe(1);
+    expect(rootLoader.mock.calls.length).toBe(1);
+    expect(indexLoader.mock.calls.length).toBe(0);
+    expect(build.entry.module.default.mock.calls.length).toBe(1);
+
+    let calls = build.entry.module.default.mock.calls;
+    expect(calls.length).toBe(1);
+    let entryContext = calls[0][3];
+    expect(entryContext.appState.error).toBeTruthy();
+    expect(entryContext.appState.error.message).toBe("action");
+    expect(entryContext.appState.loaderBoundaryRouteId).toBe("routes/__layout");
+    expect(entryContext.routeData).toEqual({
+      root: "root"
+    });
+  });
+
+  test("calls handleDocumentRequest again with new error when handleDocumentRequest throws", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let indexLoader = jest.fn(() => {
+      return "index";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader,
+        ErrorBoundary: {}
+      },
+      "routes/index": {
+        parentId: "root",
+        default: {},
+        loader: indexLoader
+      }
+    });
+    let calledBefore = false;
+    let ogHandleDocumentRequest = build.entry.module.default;
+    build.entry.module.default = jest.fn(function () {
+      if (!calledBefore) {
+        throw new Error("thrown");
+      }
+      calledBefore = true;
+      return ogHandleDocumentRequest.call(null, arguments);
+    }) as any;
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/`, { method: "get" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(500);
+    expect(rootLoader.mock.calls.length).toBe(0);
+    expect(indexLoader.mock.calls.length).toBe(0);
+
+    let calls = build.entry.module.default.mock.calls;
+    expect(calls.length).toBe(2);
+    let entryContext = calls[1][3];
+    expect(entryContext.appState.error).toBeTruthy();
+    expect(entryContext.appState.error.message).toBe("thrown");
+    expect(entryContext.appState.trackBoundaries).toBe(false);
+    expect(entryContext.routeData).toEqual({});
+  });
+
+  test("returns generic message if handleDocumentRequest throws a second time", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let indexLoader = jest.fn(() => {
+      return "index";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader,
+        ErrorBoundary: {}
+      },
+      "routes/index": {
+        parentId: "root",
+        default: {},
+        loader: indexLoader
+      }
+    });
+    let lastThrownError;
+    build.entry.module.default = jest.fn(function () {
+      lastThrownError = new Error("rofl");
+      throw lastThrownError;
+    }) as any;
+    let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+    let request = new Request(`${baseUrl}/`, { method: "get" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(500);
+    expect(await result.text()).toBe("Unexpected Server Error");
+    expect(rootLoader.mock.calls.length).toBe(0);
+    expect(indexLoader.mock.calls.length).toBe(0);
+
+    let calls = build.entry.module.default.mock.calls;
+    expect(calls.length).toBe(2);
+  });
+
+  test("returns more detailed message if handleDocumentRequest throws a second time in development mode", async () => {
+    let rootLoader = jest.fn(() => {
+      return "root";
+    });
+    let indexLoader = jest.fn(() => {
+      return "index";
+    });
+    let build = mockServerBuild({
+      root: {
+        default: {},
+        loader: rootLoader,
+        ErrorBoundary: {}
+      },
+      "routes/index": {
+        parentId: "root",
+        default: {},
+        loader: indexLoader
+      }
+    });
+    let errorMessage =
+      "thrown from handleDocumentRequest and expected to be logged in console only once";
+    let lastThrownError;
+    build.entry.module.default = jest.fn(function () {
+      lastThrownError = new Error(errorMessage);
+      throw lastThrownError;
+    }) as any;
+    let handler = createRequestHandler(build, {}, ServerMode.Development);
+
+    let request = new Request(`${baseUrl}/`, { method: "get" });
+
+    let result = await handler(request);
+    expect(result.status).toBe(500);
+    expect((await result.text()).includes(errorMessage)).toBe(true);
+    expect(rootLoader.mock.calls.length).toBe(0);
+    expect(indexLoader.mock.calls.length).toBe(0);
+
+    let calls = build.entry.module.default.mock.calls;
+    expect(calls.length).toBe(2);
+    expect(spy.console.mock.calls.length).toBe(1);
   });
 });

--- a/packages/remix-server-runtime/__tests__/utils.ts
+++ b/packages/remix-server-runtime/__tests__/utils.ts
@@ -1,5 +1,94 @@
 import prettier from "prettier";
 
+import type {
+  ActionFunction,
+  HandleDataRequestFunction,
+  HandleDocumentRequestFunction,
+  HeadersFunction,
+  LoaderFunction
+} from "../";
+import type { EntryRoute, ServerRoute, ServerRouteManifest } from "../routes";
+
+export function mockServerBuild(
+  routes: Record<
+    string,
+    {
+      parentId?: string;
+      index?: true;
+      path?: string;
+      default?: any;
+      CatchBoundary?: any;
+      ErrorBoundary?: any;
+      action?: ActionFunction;
+      headers?: HeadersFunction;
+      loader?: LoaderFunction;
+    }
+  >
+) {
+  return {
+    assets: {
+      entry: {
+        imports: [""],
+        module: ""
+      },
+      routes: Object.entries(routes).reduce((p, [id, config]) => {
+        let route: EntryRoute = {
+          hasAction: !!config.action,
+          hasCatchBoundary: !!config.CatchBoundary,
+          hasErrorBoundary: !!config.ErrorBoundary,
+          hasLoader: !!config.loader,
+          id,
+          module: "",
+          index: config.index,
+          path: config.path,
+          parentId: config.parentId
+        };
+        return {
+          ...p,
+          [id]: route
+        };
+      }, {}),
+      url: "",
+      version: ""
+    },
+    entry: {
+      module: {
+        default: jest.fn(
+          async (request, responseStatusCode, responseHeaders, entryContext) =>
+            new Response(null, {
+              status: responseStatusCode,
+              headers: responseHeaders
+            })
+        ),
+        handleDataRequest: jest.fn(async response => response)
+      }
+    },
+    routes: Object.entries(routes).reduce<ServerRouteManifest>(
+      (p, [id, config]) => {
+        let route: Omit<ServerRoute, "children"> = {
+          id,
+          index: config.index,
+          path: config.path,
+          parentId: config.parentId,
+          module: {
+            default: config.default,
+            CatchBoundary: config.CatchBoundary,
+            ErrorBoundary: config.ErrorBoundary,
+            action: config.action,
+            headers: config.headers,
+            loader: config.loader
+          }
+        };
+        return {
+          ...p,
+          [id]: route
+        };
+      },
+      {}
+    )
+  };
+}
+
 export function prettyHtml(source: string): string {
   return prettier.format(source, { parser: "html" });
 }

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -1,7 +1,6 @@
-import type { Params } from "react-router";
-
-import type { ServerBuild } from "./build";
-import { json } from "./responses";
+import type { RouteMatch } from "./routeMatching";
+import type { ServerRoute } from "./routes";
+import { json, isResponse, isRedirectResponse } from "./responses";
 
 /**
  * An object of arbitrary for route loaders and actions provided by the
@@ -14,65 +13,33 @@ export type AppLoadContext = any;
  */
 export type AppData = any;
 
-export async function loadRouteData(
-  build: ServerBuild,
-  routeId: string,
-  request: Request,
-  context: AppLoadContext,
-  params: Params
-): Promise<Response> {
-  let routeModule = build.routes[routeId].module;
+export async function callRouteAction({
+  loadContext,
+  match,
+  request
+}: {
+  loadContext: unknown;
+  match: RouteMatch<ServerRoute>;
+  request: Request;
+}) {
+  let action = match.route.module.action;
 
-  if (!routeModule.loader) {
-    return Promise.resolve(json(null));
-  }
-
-  let result;
-
-  try {
-    result = await routeModule.loader({ request, context, params });
-  } catch (error) {
-    if (!isResponse(error)) {
-      throw error;
-    }
-
-    if (!isRedirectResponse(error)) {
-      error.headers.set("X-Remix-Catch", "yes");
-    }
-    result = error;
-  }
-
-  if (result === undefined) {
-    throw new Error(
-      `You defined a loader for route "${routeId}" but didn't return ` +
-        `anything from your \`loader\` function. Please return a value or \`null\`.`
-    );
-  }
-
-  return isResponse(result) ? result : json(result);
-}
-
-export async function callRouteAction(
-  build: ServerBuild,
-  routeId: string,
-  request: Request,
-  context: AppLoadContext,
-  params: Params
-): Promise<Response> {
-  let routeModule = build.routes[routeId].module;
-
-  if (!routeModule.action) {
+  if (!action) {
     throw new Error(
       `You made a ${request.method} request to ${request.url} but did not provide ` +
-        `an \`action\` for route "${routeId}", so there is no way to handle the ` +
+        `an \`action\` for route "${match.route.id}", so there is no way to handle the ` +
         `request.`
     );
   }
 
   let result;
   try {
-    result = await routeModule.action({ request, context, params });
-  } catch (error) {
+    result = await action({
+      request: stripDataParam(stripIndexParam(request.clone())),
+      context: loadContext,
+      params: match.params
+    });
+  } catch (error: unknown) {
     if (!isResponse(error)) {
       throw error;
     }
@@ -85,7 +52,7 @@ export async function callRouteAction(
 
   if (result === undefined) {
     throw new Error(
-      `You defined an action for route "${routeId}" but didn't return ` +
+      `You defined an action for route "${match.route.id}" but didn't return ` +
         `anything from your \`action\` function. Please return a value or \`null\`.`
     );
   }
@@ -93,27 +60,77 @@ export async function callRouteAction(
   return isResponse(result) ? result : json(result);
 }
 
-export function isCatchResponse(value: any) {
-  return isResponse(value) && value.headers.get("X-Remix-Catch") != null;
+export async function callRouteLoader({
+  loadContext,
+  match,
+  request
+}: {
+  request: Request;
+  match: RouteMatch<ServerRoute>;
+  loadContext: unknown;
+}) {
+  let loader = match.route.module.loader;
+
+  if (!loader) {
+    throw new Error(
+      `You made a ${request.method} request to ${request.url} but did not provide ` +
+        `a \`loader\` for route "${match.route.id}", so there is no way to handle the ` +
+        `request.`
+    );
+  }
+
+  let result;
+  try {
+    result = await loader({
+      request: stripDataParam(stripIndexParam(request.clone())),
+      context: loadContext,
+      params: match.params
+    });
+  } catch (error: unknown) {
+    if (!isResponse(error)) {
+      throw error;
+    }
+
+    if (!isRedirectResponse(error)) {
+      error.headers.set("X-Remix-Catch", "yes");
+    }
+    result = error;
+  }
+
+  if (result === undefined) {
+    throw new Error(
+      `You defined an action for route "${match.route.id}" but didn't return ` +
+        `anything from your \`action\` function. Please return a value or \`null\`.`
+    );
+  }
+
+  return isResponse(result) ? result : json(result);
 }
 
-function isResponse(value: any): value is Response {
-  return (
-    value != null &&
-    typeof value.status === "number" &&
-    typeof value.statusText === "string" &&
-    typeof value.headers === "object" &&
-    typeof value.body !== "undefined"
-  );
+function stripIndexParam(request: Request) {
+  let url = new URL(request.url);
+  let indexValues = url.searchParams.getAll("index");
+  url.searchParams.delete("index");
+  let indexValuesToKeep = [];
+  for (let indexValue of indexValues) {
+    if (indexValue) {
+      indexValuesToKeep.push(indexValue);
+    }
+  }
+  for (let toKeep of indexValuesToKeep) {
+    url.searchParams.append("index", toKeep);
+  }
+
+  return new Request(url.toString(), request);
 }
 
-const redirectStatusCodes = new Set([301, 302, 303, 307, 308]);
-
-export function isRedirectResponse(response: Response): boolean {
-  return redirectStatusCodes.has(response.status);
+function stripDataParam(request: Request) {
+  let url = new URL(request.url);
+  url.searchParams.delete("_data");
+  return new Request(url.toString(), request);
 }
 
-export function extractData(response: Response): Promise<AppData> {
+export function extractData(response: Response): Promise<unknown> {
   let contentType = response.headers.get("Content-Type");
 
   if (contentType && /\bapplication\/json\b/.test(contentType)) {

--- a/packages/remix-server-runtime/entry.ts
+++ b/packages/remix-server-runtime/entry.ts
@@ -1,4 +1,4 @@
-import type { ComponentDidCatchEmulator } from "./errors";
+import type { AppState } from "./errors";
 import type {
   RouteManifest,
   ServerRouteManifest,
@@ -10,7 +10,7 @@ import type { RouteMatch } from "./routeMatching";
 import type { RouteModules, EntryRouteModule } from "./routeModules";
 
 export interface EntryContext {
-  componentDidCatchEmulator: ComponentDidCatchEmulator;
+  appState: AppState;
   manifest: AssetsManifest;
   matches: RouteMatch<EntryRoute>[];
   routeData: RouteData;

--- a/packages/remix-server-runtime/errors.ts
+++ b/packages/remix-server-runtime/errors.ts
@@ -40,7 +40,7 @@
  * line.
  */
 
-export interface ComponentDidCatchEmulator {
+export interface AppState {
   error?: SerializedError;
   catch?: ThrownResponse;
   catchBoundaryRouteId: string | null;

--- a/packages/remix-server-runtime/responses.ts
+++ b/packages/remix-server-runtime/responses.ts
@@ -1,7 +1,10 @@
 /**
  * A JSON response. Converts `data` to JSON and sets the `Content-Type` header.
  */
-export function json<Data>(data: Data, init: number | ResponseInit = {}): Response {
+export function json<Data>(
+  data: Data,
+  init: number | ResponseInit = {}
+): Response {
   let responseInit: any = init;
   if (typeof init === "number") {
     responseInit = { status: init };
@@ -26,9 +29,9 @@ export function redirect(
   url: string,
   init: number | ResponseInit = 302
 ): Response {
-  let responseInit: any = init;
-  if (typeof init === "number") {
-    responseInit = { status: init };
+  let responseInit = init;
+  if (typeof responseInit === "number") {
+    responseInit = { status: responseInit };
   } else if (typeof responseInit.status === "undefined") {
     responseInit.status = 302;
   }
@@ -40,4 +43,39 @@ export function redirect(
     ...responseInit,
     headers
   });
+}
+
+export function isResponse(value: any): value is Response {
+  return (
+    value != null &&
+    typeof value.status === "number" &&
+    typeof value.statusText === "string" &&
+    typeof value.headers === "object" &&
+    typeof value.body !== "undefined"
+  );
+}
+
+const redirectStatusCodes = new Set([301, 302, 303, 307, 308]);
+export function isRedirectResponse(response: Response): boolean {
+  return redirectStatusCodes.has(response.status);
+}
+
+export function isCatchResponse(response: Response) {
+  return response.headers.get("X-Remix-Catch") != null;
+}
+
+export function extractData(response: Response): Promise<unknown> {
+  let contentType = response.headers.get("Content-Type");
+
+  if (contentType && /\bapplication\/json\b/.test(contentType)) {
+    return response.json();
+  }
+
+  // What other data types do we need to handle here? What other kinds of
+  // responses are people going to be returning from their loaders?
+  // - application/x-www-form-urlencoded ?
+  // - multipart/form-data ?
+  // - binary (audio/video) ?
+
+  return response.text();
 }

--- a/packages/remix-server-runtime/routeData.ts
+++ b/packages/remix-server-runtime/routeData.ts
@@ -1,24 +1,5 @@
 import type { AppData } from "./data";
-import { extractData } from "./data";
-import type { ServerRoute } from "./routes";
-import type { RouteMatch } from "./routeMatching";
 
 export interface RouteData {
   [routeId: string]: AppData;
-}
-
-export async function createRouteData(
-  matches: RouteMatch<ServerRoute>[],
-  responses: Response[]
-): Promise<RouteData> {
-  let data = await Promise.all(responses.map(extractData));
-
-  return matches.reduce((memo, match, index) => {
-    memo[match.route.id] = data[index];
-    return memo;
-  }, {} as RouteData);
-}
-
-export async function createActionData(response: Response): Promise<RouteData> {
-  return extractData(response);
 }

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -1,8 +1,8 @@
 import type { AppLoadContext } from "./data";
-import { extractData, isCatchResponse } from "./data";
-import { loadRouteData, callRouteAction, isRedirectResponse } from "./data";
+import { extractData } from "./data";
+import { callRouteAction, callRouteLoader } from "./data";
 import type { ComponentDidCatchEmulator } from "./errors";
-import type { ServerBuild } from "./build";
+import type { HandleDataRequestFunction, ServerBuild } from "./build";
 import type { EntryContext } from "./entry";
 import { createEntryMatches, createEntryRouteModules } from "./entry";
 import { serializeError } from "./errors";
@@ -13,8 +13,7 @@ import { matchServerRoutes } from "./routeMatching";
 import { ServerMode, isServerMode } from "./mode";
 import type { ServerRoute } from "./routes";
 import { createRoutes } from "./routes";
-import { createActionData, createRouteData } from "./routeData";
-import { json } from "./responses";
+import { json, isRedirectResponse, isCatchResponse } from "./responses";
 import { createServerHandoffString } from "./serverHandoff";
 
 /**
@@ -26,13 +25,504 @@ export interface RequestHandler {
   (request: Request, loadContext?: AppLoadContext): Promise<Response>;
 }
 
+/**
+ * Creates a function that serves HTTP requests.
+ */
+export function createRequestHandler(
+  build: ServerBuild,
+  platform: ServerPlatform,
+  mode?: string
+): RequestHandler {
+  let routes = createRoutes(build.routes);
+  let serverMode = isServerMode(mode) ? mode : ServerMode.Production;
+
+  return async function requestHandler(request, loadContext) {
+    let url = new URL(request.url);
+    let matches = matchServerRoutes(routes, url.pathname);
+    let requestType = getRequestType(url, matches);
+
+    let response: Response;
+    switch (requestType) {
+      case "data":
+        response = await handleDataRequest({
+          request,
+          loadContext,
+          matches: matches!,
+          handleDataRequest: build.entry.module.handleDataRequest
+        });
+        break;
+      case "document":
+        response = await renderDocumentRequest({
+          build,
+          loadContext,
+          matches,
+          request,
+          routes,
+          serverMode
+        });
+        break;
+      case "resource":
+        response = await handleResourceRequest({
+          request,
+          loadContext,
+          matches: matches!
+        });
+        break;
+    }
+
+    if (request.method.toLowerCase() === "head") {
+      return new Response(null, {
+        headers: response.headers,
+        status: response.status,
+        statusText: response.statusText
+      });
+    }
+
+    return response;
+  };
+}
+async function handleDataRequest({
+  handleDataRequest,
+  loadContext,
+  matches,
+  request
+}: {
+  handleDataRequest?: HandleDataRequestFunction;
+  loadContext: unknown;
+  matches: RouteMatch<ServerRoute>[];
+  request: Request;
+}): Promise<Response> {
+  if (!isValidRequestMethod(request)) {
+    return errorBoundaryError(
+      new Error(`Invalid request method "${request.method}"`),
+      405
+    );
+  }
+
+  let url = new URL(request.url);
+
+  if (!matches) {
+    return errorBoundaryError(
+      new Error(`No route matches URL "${url.pathname}"`),
+      404
+    );
+  }
+
+  let response: Response;
+  let match: RouteMatch<ServerRoute>;
+  try {
+    if (isActionRequest(request)) {
+      match = getActionRequestMatch(url, matches);
+
+      response = await callRouteAction({
+        loadContext,
+        match,
+        request: request
+      });
+    } else {
+      let routeId = url.searchParams.get("_data");
+      if (!routeId) {
+        return errorBoundaryError(new Error(`Missing route id in ?_data`), 403);
+      }
+
+      let tempMatch = matches.find(match => match.route.id === routeId);
+      if (!tempMatch) {
+        return errorBoundaryError(
+          new Error(`Route "${routeId}" does not match URL "${url.pathname}"`),
+          403
+        );
+      }
+      match = tempMatch;
+
+      response = await callRouteLoader({ loadContext, match, request });
+    }
+
+    if (isRedirectResponse(response)) {
+      // We don't have any way to prevent a fetch request from following
+      // redirects. So we use the `X-Remix-Redirect` header to indicate the
+      // next URL, and then "follow" the redirect manually on the client.
+      let headers = new Headers(response.headers);
+      headers.set("X-Remix-Redirect", headers.get("Location")!);
+      headers.delete("Location");
+
+      return new Response(null, {
+        status: 204,
+        headers
+      });
+    }
+
+    if (handleDataRequest) {
+      response = await handleDataRequest(response.clone(), {
+        context: loadContext,
+        params: match.params,
+        request: request.clone()
+      });
+    }
+
+    return response;
+  } catch (error: unknown) {
+    return errorBoundaryError(error as Error, 500);
+  }
+}
+
+async function renderDocumentRequest({
+  build,
+  loadContext,
+  matches,
+  request,
+  routes,
+  serverMode
+}: {
+  build: ServerBuild;
+  loadContext: unknown;
+  matches: RouteMatch<ServerRoute>[] | null;
+  request: Request;
+  routes: ServerRoute[];
+  serverMode?: ServerMode;
+}): Promise<Response> {
+  let url = new URL(request.url);
+
+  let appState: ComponentDidCatchEmulator = {
+    trackBoundaries: true,
+    trackCatchBoundaries: true,
+    catchBoundaryRouteId: null,
+    renderBoundaryRouteId: null,
+    loaderBoundaryRouteId: null,
+    error: undefined,
+    catch: undefined
+  };
+
+  if (!isValidRequestMethod(request)) {
+    matches = null;
+    appState.trackCatchBoundaries = false;
+    appState.catch = {
+      data: null,
+      status: 405,
+      statusText: "Method Not Allowed"
+    };
+  } else if (!matches) {
+    appState.trackCatchBoundaries = false;
+    appState.catch = {
+      data: null,
+      status: 404,
+      statusText: "Not Found"
+    };
+  }
+
+  let actionStatus: { status: number; statusText: string } | undefined;
+  let actionData: Record<string, unknown> | undefined;
+  let actionMatch: RouteMatch<ServerRoute> | undefined;
+  let actionResponse: Response | undefined;
+
+  if (matches && isActionRequest(request)) {
+    actionMatch = getActionRequestMatch(url, matches);
+
+    try {
+      actionResponse = await callRouteAction({
+        loadContext,
+        match: actionMatch,
+        request: request
+      });
+
+      if (isRedirectResponse(actionResponse)) {
+        return actionResponse;
+      }
+
+      actionStatus = {
+        status: actionResponse.status,
+        statusText: actionResponse.statusText
+      };
+
+      if (isCatchResponse(actionResponse)) {
+        appState.catchBoundaryRouteId = getDeepestRouteIdWithBoundary(
+          matches,
+          "CatchBoundary"
+        );
+        appState.trackCatchBoundaries = false;
+        appState.catch = {
+          ...actionStatus,
+          data: await extractData(actionResponse)
+        };
+      } else {
+        actionData = {
+          [actionMatch.route.id]: await extractData(actionResponse)
+        };
+      }
+    } catch (error: any) {
+      appState.loaderBoundaryRouteId = getDeepestRouteIdWithBoundary(
+        matches,
+        "ErrorBoundary"
+      );
+      appState.trackBoundaries = false;
+      appState.error = await serializeError(error);
+
+      if (serverMode !== ServerMode.Test) {
+        console.error(
+          `There was an error running the action for route ${actionMatch.route.id}`
+        );
+      }
+    }
+  }
+
+  let routeModules = createEntryRouteModules(build.routes);
+
+  let matchesToLoad = matches || [];
+  if (appState.catch) {
+    matchesToLoad = getMatchesUpToDeepestBoundary(
+      // get rid of the action, we don't want to call it's loader either
+      // because we'll be rendering the catch boundary, if you can get access
+      // to the loader data in the catch boundary then how the heck is it
+      // supposed to deal with thrown responses?
+      matchesToLoad.slice(0, -1),
+      "CatchBoundary"
+    );
+  } else if (appState.error) {
+    matchesToLoad = getMatchesUpToDeepestBoundary(
+      // get rid of the action, we don't want to call it's loader either
+      // because we'll be rendering the error boundary, if you can get access
+      // to the loader data in the error boundary then how the heck is it
+      // supposed to deal with errors in the loader, too?
+      matchesToLoad.slice(0, -1),
+      "ErrorBoundary"
+    );
+  }
+
+  let routeLoaderResults = await Promise.allSettled(
+    matchesToLoad.map(match =>
+      match.route.module.loader
+        ? callRouteLoader({
+            loadContext,
+            match,
+            request
+          })
+        : Promise.resolve(undefined)
+    )
+  );
+
+  // Store the state of the action. We will use this to determine later
+  // what catch or error boundary should be rendered under cases where
+  // actions don't throw but loaders do, actions throw and parent loaders
+  // also throw, etc.
+  let actionCatch = appState.catch;
+  let actionError = appState.error;
+  let actionCatchBoundaryRouteId = appState.catchBoundaryRouteId;
+  let actionLoaderBoundaryRouteId = appState.loaderBoundaryRouteId;
+  // Reset the app error and catch state to propogate the loader states
+  // from the results into the app state.
+  appState.catch = undefined;
+  appState.error = undefined;
+
+  let headerMatches: RouteMatch<ServerRoute>[] = [];
+  let routeLoaderResponses: Response[] = [];
+  let loaderStatusCodes: number[] = [];
+  let routeData: Record<string, unknown> = {};
+  for (let index = 0; index < matchesToLoad.length; index++) {
+    let match = matchesToLoad[index];
+    let result = routeLoaderResults[index];
+
+    let error = result.status === "rejected" ? result.reason : undefined;
+    let response = result.status === "fulfilled" ? result.value : undefined;
+    let isRedirect = response ? isRedirectResponse(response) : false;
+    let isCatch = response ? isCatchResponse(response) : false;
+
+    // If a parent loader has already caught or error'd, bail because
+    // we don't need any more child data.
+    if (appState.catch || appState.error) {
+      break;
+    }
+
+    // If there is a response and it's a redirect, do it unless there
+    // is an action error or catch state, those action boundary states
+    // take precedence over loader sates, this means if a loader redirects
+    // after an action catches or errors we won't follow it, and instead
+    // render the boundary caused by the action.
+    if (!actionCatch && !actionError && response && isRedirect) {
+      return response;
+    }
+
+    // Track the boundary ID's for the loaders
+    if (match.route.module.CatchBoundary) {
+      appState.catchBoundaryRouteId = match.route.id;
+    }
+    if (match.route.module.ErrorBoundary) {
+      appState.loaderBoundaryRouteId = match.route.id;
+    }
+
+    if (error) {
+      loaderStatusCodes.push(500);
+      appState.trackBoundaries = false;
+      appState.error = await serializeError(error);
+
+      if (serverMode !== ServerMode.Test) {
+        console.error(
+          `There was an error running the data loader for route ${match.route.id}`
+        );
+      }
+      break;
+    } else if (response) {
+      headerMatches.push(match);
+      routeLoaderResponses.push(response);
+      loaderStatusCodes.push(response.status);
+
+      if (isCatch) {
+        // If it's a catch response, store it in app state, and bail
+        appState.trackCatchBoundaries = false;
+        appState.catch = {
+          data: await extractData(response),
+          status: response.status,
+          statusText: response.statusText
+        };
+        break;
+      } else {
+        // Extract and store the loader data
+        routeData[match.route.id] = await extractData(response);
+      }
+    }
+  }
+
+  // If there was not a loader catch or error state triggered reset the
+  // boundaries as they are probably deeper in the tree if the action
+  // initially triggered a boundary as that match would not exist in the
+  // matches to load.
+  if (!appState.catch) {
+    appState.catchBoundaryRouteId = actionCatchBoundaryRouteId;
+  }
+  if (!appState.error) {
+    appState.loaderBoundaryRouteId = actionLoaderBoundaryRouteId;
+  }
+  // If there was an action error or catch, we will reset the state to the
+  // initial values, otherwise we will use whatever came out of the loaders.
+  appState.catch = actionCatch || appState.catch;
+  appState.error = actionError || appState.error;
+
+  let renderableMatches = getRenderableMatches(matches, appState);
+  if (!renderableMatches) {
+    renderableMatches = [];
+
+    let root = routes[0];
+    if (root && root.module.CatchBoundary) {
+      appState.catchBoundaryRouteId = "root";
+      renderableMatches.push({
+        params: {},
+        pathname: "",
+        route: routes[0]
+      });
+    }
+  }
+
+  // Handle responses with a non-200 status code. The first loader with a
+  // non-200 status code determines the status code for the whole response.
+  let notOkResponse =
+    actionStatus && actionStatus.status !== 200
+      ? actionStatus.status
+      : loaderStatusCodes.find(status => status !== 200);
+
+  let responseStatusCode = appState.error
+    ? 500
+    : typeof notOkResponse === "number"
+    ? notOkResponse
+    : appState.catch
+    ? appState.catch.status
+    : 200;
+
+  let responseHeaders = getDocumentHeaders(
+    build,
+    renderableMatches,
+    routeLoaderResponses,
+    actionResponse
+  );
+
+  let entryMatches = createEntryMatches(renderableMatches, build.assets.routes);
+
+  let serverHandoff = {
+    actionData,
+    componentDidCatchEmulator: appState,
+    matches: entryMatches,
+    routeData
+  };
+
+  let entryContext: EntryContext = {
+    ...serverHandoff,
+    manifest: build.assets,
+    routeModules,
+    serverHandoffString: createServerHandoffString(serverHandoff)
+  };
+
+  let handleDocumentRequest = build.entry.module.default;
+  try {
+    return await handleDocumentRequest(
+      request.clone(),
+      responseStatusCode,
+      responseHeaders,
+      entryContext
+    );
+  } catch (error: any) {
+    responseStatusCode = 500;
+
+    // Go again, this time with the componentDidCatch emulation. As it rendered
+    // last time we mutated `componentDidCatch.routeId` for the last rendered
+    // route, now we know where to render the error boundary (feels a little
+    // hacky but that's how hooks work). This tells the emulator to stop
+    // tracking the `routeId` as we render because we already have an error to
+    // render.
+    appState.trackBoundaries = false;
+    appState.error = await serializeError(error);
+    entryContext.serverHandoffString = createServerHandoffString(serverHandoff);
+
+    try {
+      return await handleDocumentRequest(
+        request.clone(),
+        responseStatusCode,
+        responseHeaders,
+        entryContext
+      );
+    } catch (error: any) {
+      if (serverMode !== ServerMode.Test) {
+        console.error(error);
+      }
+
+      let message = "Unexpected Server Error";
+
+      if (serverMode === ServerMode.Development) {
+        message += `\n\n${String(error)}`;
+      }
+
+      // Good grief folks, get your act together 😂!
+      return new Response(message, {
+        status: 500,
+        headers: {
+          "Content-Type": "text/plain"
+        }
+      });
+    }
+  }
+}
+
+async function handleResourceRequest({
+  loadContext,
+  matches,
+  request
+}: {
+  request: Request;
+  loadContext: unknown;
+  matches: RouteMatch<ServerRoute>[];
+}): Promise<Response> {
+  let match = matches.slice(-1)[0];
+
+  if (isActionRequest(request)) {
+    return callRouteAction({ match, loadContext, request });
+  } else {
+    return callRouteLoader({ match, loadContext, request });
+  }
+}
+
 type RequestType = "data" | "document" | "resource";
 
 function getRequestType(
-  request: Request,
+  url: URL,
   matches: RouteMatch<ServerRoute>[] | null
 ): RequestType {
-  if (isDataRequest(request)) {
+  if (url.searchParams.has("_data")) {
     return "data";
   }
 
@@ -48,530 +538,6 @@ function getRequestType(
   return "document";
 }
 
-/**
- * Creates a function that serves HTTP requests.
- */
-export function createRequestHandler(
-  build: ServerBuild,
-  platform: ServerPlatform,
-  mode?: string
-): RequestHandler {
-  let routes = createRoutes(build.routes);
-  let serverMode = isServerMode(mode) ? mode : ServerMode.Production;
-
-  return async (request, loadContext = {}) => {
-    let url = new URL(request.url);
-    let matches = matchServerRoutes(routes, url.pathname);
-
-    let requestType = getRequestType(request, matches);
-
-    let response: Response;
-
-    switch (requestType) {
-      // has _data
-      case "data":
-        response = await handleDataRequest(
-          request,
-          loadContext,
-          build,
-          platform,
-          matches
-        );
-        break;
-      // no _data & default export
-      case "document":
-        response = await handleDocumentRequest(
-          request,
-          loadContext,
-          build,
-          platform,
-          routes,
-          serverMode
-        );
-        break;
-      // no _data  or default export
-      case "resource":
-        response = await handleResourceRequest(
-          request,
-          loadContext,
-          build,
-          platform,
-          matches
-        );
-        break;
-    }
-
-    if (isHeadRequest(request)) {
-      return new Response(null, {
-        headers: response.headers,
-        status: response.status,
-        statusText: response.statusText
-      });
-    }
-
-    return response;
-  };
-}
-
-async function handleResourceRequest(
-  request: Request,
-  loadContext: AppLoadContext,
-  build: ServerBuild,
-  platform: ServerPlatform,
-  matches: RouteMatch<ServerRoute>[] | null
-): Promise<Response> {
-  let url = new URL(request.url);
-
-  if (!matches) {
-    return jsonError(`No route matches URL "${url.pathname}"`, 404);
-  }
-
-  let routeMatch: RouteMatch<ServerRoute> = matches.slice(-1)[0];
-  try {
-    return isActionRequest(request)
-      ? await callRouteAction(
-          build,
-          routeMatch.route.id,
-          request,
-          loadContext,
-          routeMatch.params
-        )
-      : await loadRouteData(
-          build,
-          routeMatch.route.id,
-          request,
-          loadContext,
-          routeMatch.params
-        );
-  } catch (error: any) {
-    let formattedError = (await platform.formatServerError?.(error)) || error;
-    throw formattedError;
-  }
-}
-
-async function handleDataRequest(
-  request: Request,
-  loadContext: AppLoadContext,
-  build: ServerBuild,
-  platform: ServerPlatform,
-  matches: RouteMatch<ServerRoute>[] | null
-): Promise<Response> {
-  if (!isValidRequestMethod(request)) {
-    return jsonError(`Invalid request method "${request.method}"`, 405);
-  }
-
-  let url = new URL(request.url);
-
-  if (!matches) {
-    return jsonError(`No route matches URL "${url.pathname}"`, 404);
-  }
-
-  let routeMatch: RouteMatch<ServerRoute>;
-  if (isActionRequest(request)) {
-    routeMatch = matches[matches.length - 1];
-
-    if (
-      !isIndexRequestUrl(url) &&
-      matches[matches.length - 1].route.id.endsWith("/index")
-    ) {
-      routeMatch = matches[matches.length - 2];
-    }
-  } else {
-    let routeId = url.searchParams.get("_data");
-    if (!routeId) {
-      return jsonError(`Missing route id in ?_data`, 403);
-    }
-
-    let match = matches.find(match => match.route.id === routeId);
-    if (!match) {
-      return jsonError(
-        `Route "${routeId}" does not match URL "${url.pathname}"`,
-        403
-      );
-    }
-
-    routeMatch = match;
-  }
-
-  let response: Response;
-  try {
-    response = isActionRequest(request)
-      ? await callRouteAction(
-          build,
-          routeMatch.route.id,
-          stripIndexParam(stripDataParam(request.clone())),
-          loadContext,
-          routeMatch.params
-        )
-      : await loadRouteData(
-          build,
-          routeMatch.route.id,
-          stripIndexParam(stripDataParam(request.clone())),
-          loadContext,
-          routeMatch.params
-        );
-  } catch (error: any) {
-    let formattedError = (await platform.formatServerError?.(error)) || error;
-    response = json(await serializeError(formattedError), {
-      status: 500,
-      headers: {
-        "X-Remix-Error": "unfortunately, yes"
-      }
-    });
-  }
-
-  if (isRedirectResponse(response)) {
-    // We don't have any way to prevent a fetch request from following
-    // redirects. So we use the `X-Remix-Redirect` header to indicate the
-    // next URL, and then "follow" the redirect manually on the client.
-    let headers = new Headers(response.headers);
-    headers.set("X-Remix-Redirect", headers.get("Location")!);
-    headers.delete("Location");
-
-    return new Response(null, {
-      status: 204,
-      headers
-    });
-  }
-
-  if (build.entry.module.handleDataRequest) {
-    return build.entry.module.handleDataRequest(response, {
-      request: request.clone(),
-      context: loadContext,
-      params: routeMatch.params
-    });
-  }
-
-  return response;
-}
-
-async function handleDocumentRequest(
-  request: Request,
-  loadContext: AppLoadContext,
-  build: ServerBuild,
-  platform: ServerPlatform,
-  routes: ServerRoute[],
-  serverMode: ServerMode
-): Promise<Response> {
-  let url = new URL(request.url);
-
-  let requestState: "ok" | "no-match" | "invalid-request" =
-    isValidRequestMethod(request) ? "ok" : "invalid-request";
-  let matches =
-    requestState === "ok" ? matchServerRoutes(routes, url.pathname) : null;
-
-  if (!matches) {
-    // If we do not match a user-provided-route, fall back to the root
-    // to allow the CatchBoundary to take over while maintining invalid
-    // request state if already set
-    if (requestState === "ok") {
-      requestState = "no-match";
-    }
-
-    matches = [
-      {
-        params: {},
-        pathname: "",
-        route: routes[0]
-      }
-    ];
-  }
-
-  let componentDidCatchEmulator: ComponentDidCatchEmulator = {
-    trackBoundaries: true,
-    trackCatchBoundaries: true,
-    catchBoundaryRouteId: null,
-    renderBoundaryRouteId: null,
-    loaderBoundaryRouteId: null,
-    error: undefined,
-    catch: undefined
-  };
-
-  let responseState: "ok" | "caught" | "error" = "ok";
-  let actionResponse: Response | undefined;
-  let actionRouteId: string | undefined;
-
-  if (requestState !== "ok") {
-    responseState = "caught";
-    componentDidCatchEmulator.trackCatchBoundaries = false;
-    let withBoundaries = getMatchesUpToDeepestBoundary(
-      matches,
-      "CatchBoundary"
-    );
-    componentDidCatchEmulator.catchBoundaryRouteId =
-      withBoundaries.length > 0
-        ? withBoundaries[withBoundaries.length - 1].route.id
-        : null;
-    componentDidCatchEmulator.catch = {
-      status: requestState === "no-match" ? 404 : 405,
-      statusText:
-        requestState === "no-match" ? "Not Found" : "Method Not Allowed",
-      data: null
-    };
-  } else if (isActionRequest(request)) {
-    let actionMatch = matches[matches.length - 1];
-    if (!isIndexRequestUrl(url) && actionMatch.route.id.endsWith("/index")) {
-      actionMatch = matches[matches.length - 2];
-    }
-    actionRouteId = actionMatch.route.id;
-
-    try {
-      actionResponse = await callRouteAction(
-        build,
-        actionMatch.route.id,
-        stripIndexParam(stripDataParam(request.clone())),
-        loadContext,
-        actionMatch.params
-      );
-      if (isRedirectResponse(actionResponse)) {
-        return actionResponse;
-      }
-    } catch (error: any) {
-      let formattedError = (await platform.formatServerError?.(error)) || error;
-      responseState = "error";
-      let withBoundaries = getMatchesUpToDeepestBoundary(
-        matches,
-        "ErrorBoundary"
-      );
-      componentDidCatchEmulator.loaderBoundaryRouteId =
-        withBoundaries[withBoundaries.length - 1].route.id;
-      componentDidCatchEmulator.error = await serializeError(formattedError);
-    }
-  }
-
-  if (actionResponse && isCatchResponse(actionResponse)) {
-    responseState = "caught";
-    let withBoundaries = getMatchesUpToDeepestBoundary(
-      matches,
-      "CatchBoundary"
-    );
-    componentDidCatchEmulator.trackCatchBoundaries = false;
-    componentDidCatchEmulator.catchBoundaryRouteId =
-      withBoundaries[withBoundaries.length - 1].route.id;
-    componentDidCatchEmulator.catch = {
-      status: actionResponse.status,
-      statusText: actionResponse.statusText,
-      data: await extractData(actionResponse.clone())
-    };
-  }
-
-  // If we did not match a route, there is no need to call any loaders
-  let matchesToLoad = requestState !== "ok" ? [] : matches;
-  switch (responseState) {
-    case "caught":
-      matchesToLoad = getMatchesUpToDeepestBoundary(
-        // get rid of the action, we don't want to call it's loader either
-        // because we'll be rendering the catch boundary, if you can get access
-        // to the loader data in the catch boundary then how the heck is it
-        // supposed to deal with thrown responses?
-        matches.slice(0, -1),
-        "CatchBoundary"
-      );
-      break;
-    case "error":
-      matchesToLoad = getMatchesUpToDeepestBoundary(
-        // get rid of the action, we don't want to call it's loader either
-        // because we'll be rendering the error boundary, if you can get access
-        // to the loader data in the error boundary then how the heck is it
-        // supposed to deal with errors in the loader, too?
-        matches.slice(0, -1),
-        "ErrorBoundary"
-      );
-      break;
-  }
-
-  // Run all data loaders in parallel. Await them in series below.  Note: This
-  // code is a little weird due to the way unhandled promise rejections are
-  // handled in node. We use a .catch() handler on each promise to avoid the
-  // warning, then handle errors manually afterwards.
-  let routeLoaderPromises: Promise<Response | Error>[] = matchesToLoad.map(
-    match =>
-      loadRouteData(
-        build,
-        match.route.id,
-        stripIndexParam(stripDataParam(request.clone())),
-        loadContext,
-        match.params
-      ).catch(error => error)
-  );
-
-  let routeLoaderResults = await Promise.all(routeLoaderPromises);
-  for (let [index, response] of routeLoaderResults.entries()) {
-    let route = matches[index].route;
-    let routeModule = build.routes[route.id].module;
-
-    // Rare case where an action throws an error, and then when we try to render
-    // the action's page to tell the user about the the error, a loader above
-    // the action route *also* threw an error or tried to redirect!
-    //
-    // Instead of rendering the loader error or redirecting like usual, we
-    // ignore the loader error or redirect because the action error was first
-    // and is higher priority to surface.  Perhaps the action error is the
-    // reason the loader blows up now! It happened first and is more important
-    // to address.
-    //
-    // We just give up and move on with rendering the error as deeply as we can,
-    // which is the previous iteration of this loop
-    if (
-      (responseState === "error" &&
-        (response instanceof Error || isRedirectResponse(response))) ||
-      (responseState === "caught" && isCatchResponse(response))
-    ) {
-      break;
-    }
-
-    if (componentDidCatchEmulator.catch || componentDidCatchEmulator.error) {
-      continue;
-    }
-
-    if (routeModule.CatchBoundary) {
-      componentDidCatchEmulator.catchBoundaryRouteId = route.id;
-    }
-
-    if (routeModule.ErrorBoundary) {
-      componentDidCatchEmulator.loaderBoundaryRouteId = route.id;
-    }
-
-    if (response instanceof Error) {
-      if (serverMode !== ServerMode.Test) {
-        console.error(
-          `There was an error running the data loader for route ${route.id}`
-        );
-      }
-
-      let formattedError =
-        (await platform.formatServerError?.(response)) || response;
-
-      componentDidCatchEmulator.error = await serializeError(formattedError);
-      routeLoaderResults[index] = json(null, { status: 500 });
-    } else if (isRedirectResponse(response)) {
-      return response;
-    } else if (isCatchResponse(response)) {
-      componentDidCatchEmulator.trackCatchBoundaries = false;
-      componentDidCatchEmulator.catch = {
-        status: response.status,
-        statusText: response.statusText,
-        data: await extractData(response.clone())
-      };
-      routeLoaderResults[index] = json(null, { status: response.status });
-    }
-  }
-
-  // We already filtered out all Errors, so these are all Responses.
-  let routeLoaderResponses: Response[] = routeLoaderResults as Response[];
-
-  // Handle responses with a non-200 status code. The first loader with a
-  // non-200 status code determines the status code for the whole response.
-  let notOkResponse = [actionResponse, ...routeLoaderResponses].find(
-    response => response && response.status !== 200
-  );
-
-  let statusCode =
-    requestState === "no-match"
-      ? 404
-      : requestState === "invalid-request"
-      ? 405
-      : responseState === "error"
-      ? 500
-      : notOkResponse
-      ? notOkResponse.status
-      : 200;
-
-  let renderableMatches = getRenderableMatches(
-    matches,
-    componentDidCatchEmulator
-  );
-  let serverEntryModule = build.entry.module;
-  let headers = getDocumentHeaders(
-    build,
-    renderableMatches,
-    routeLoaderResponses,
-    actionResponse
-  );
-  let entryMatches = createEntryMatches(renderableMatches, build.assets.routes);
-  let routeData = await createRouteData(
-    renderableMatches,
-    routeLoaderResponses
-  );
-  let actionData =
-    actionResponse && actionRouteId
-      ? {
-          [actionRouteId]: await createActionData(actionResponse.clone())
-        }
-      : undefined;
-  let routeModules = createEntryRouteModules(build.routes);
-  let serverHandoff = {
-    matches: entryMatches,
-    componentDidCatchEmulator,
-    routeData,
-    actionData
-  };
-  let entryContext: EntryContext = {
-    ...serverHandoff,
-    manifest: build.assets,
-    routeModules,
-    serverHandoffString: createServerHandoffString(serverHandoff)
-  };
-
-  let response: Response;
-  try {
-    response = await serverEntryModule.default(
-      request,
-      statusCode,
-      headers,
-      entryContext
-    );
-  } catch (error: any) {
-    let formattedError = (await platform.formatServerError?.(error)) || error;
-    if (serverMode !== ServerMode.Test) {
-      console.error(formattedError);
-    }
-
-    statusCode = 500;
-
-    // Go again, this time with the componentDidCatch emulation. As it rendered
-    // last time we mutated `componentDidCatch.routeId` for the last rendered
-    // route, now we know where to render the error boundary (feels a little
-    // hacky but that's how hooks work). This tells the emulator to stop
-    // tracking the `routeId` as we render because we already have an error to
-    // render.
-    componentDidCatchEmulator.trackBoundaries = false;
-    componentDidCatchEmulator.error = await serializeError(formattedError);
-    entryContext.serverHandoffString = createServerHandoffString(serverHandoff);
-
-    try {
-      response = await serverEntryModule.default(
-        request,
-        statusCode,
-        headers,
-        entryContext
-      );
-    } catch (error: any) {
-      let formattedError = (await platform.formatServerError?.(error)) || error;
-      if (serverMode !== ServerMode.Test) {
-        console.error(formattedError);
-      }
-
-      // Good grief folks, get your act together 😂!
-      response = new Response(
-        `Unexpected Server Error\n\n${formattedError.message}`,
-        {
-          status: 500,
-          headers: {
-            "Content-Type": "text/plain"
-          }
-        }
-      );
-    }
-  }
-
-  return response;
-}
-
-function jsonError(error: string, status = 403): Response {
-  return json({ error }, { status });
-}
-
 function isActionRequest(request: Request): boolean {
   let method = request.method.toLowerCase();
   return (
@@ -582,6 +548,10 @@ function isActionRequest(request: Request): boolean {
   );
 }
 
+function isHeadRequest(request: Request): boolean {
+  return request.method.toLowerCase() === "head";
+}
+
 function isValidRequestMethod(request: Request): boolean {
   return (
     request.method.toLowerCase() === "get" ||
@@ -590,12 +560,13 @@ function isValidRequestMethod(request: Request): boolean {
   );
 }
 
-function isHeadRequest(request: Request): boolean {
-  return request.method.toLowerCase() === "head";
-}
-
-function isDataRequest(request: Request): boolean {
-  return new URL(request.url).searchParams.has("_data");
+async function errorBoundaryError(error: Error, status: number) {
+  return json(await serializeError(error), {
+    status,
+    headers: {
+      "X-Remix-Error": "yes"
+    }
+  });
 }
 
 function isIndexRequestUrl(url: URL) {
@@ -610,30 +581,24 @@ function isIndexRequestUrl(url: URL) {
   return indexRequest;
 }
 
-function stripIndexParam(request: Request) {
-  let url = new URL(request.url);
-  let indexValues = url.searchParams.getAll("index");
-  url.searchParams.delete("index");
-  let indexValuesToKeep = [];
-  for (let indexValue of indexValues) {
-    if (indexValue) {
-      indexValuesToKeep.push(indexValue);
-    }
-  }
-  for (let toKeep of indexValuesToKeep) {
-    url.searchParams.append("index", toKeep);
+function getActionRequestMatch(url: URL, matches: RouteMatch<ServerRoute>[]) {
+  let match = matches.slice(-1)[0];
+
+  if (!isIndexRequestUrl(url) && match.route.id.endsWith("/index")) {
+    return matches.slice(-2)[0];
   }
 
-  return new Request(url.toString(), request);
+  return match;
 }
 
-function stripDataParam(request: Request) {
-  let url = new URL(request.url);
-  url.searchParams.delete("_data");
-  return new Request(url.toString(), request);
+function getDeepestRouteIdWithBoundary(
+  matches: RouteMatch<ServerRoute>[],
+  key: "CatchBoundary" | "ErrorBoundary"
+) {
+  let matched = getMatchesUpToDeepestBoundary(matches, key).slice(-1)[0];
+  return matched ? matched.route.id : null;
 }
 
-// TODO: update to use key for lookup
 function getMatchesUpToDeepestBoundary(
   matches: RouteMatch<ServerRoute>[],
   key: "CatchBoundary" | "ErrorBoundary"
@@ -657,9 +622,13 @@ function getMatchesUpToDeepestBoundary(
 // This prevents `<Outlet/>` from rendering anything below where the error threw
 // TODO: maybe do this in <RemixErrorBoundary + context>
 function getRenderableMatches(
-  matches: RouteMatch<ServerRoute>[],
+  matches: RouteMatch<ServerRoute>[] | null,
   componentDidCatchEmulator: ComponentDidCatchEmulator
 ) {
+  if (!matches) {
+    return null;
+  }
+
   // no error, no worries
   if (!componentDidCatchEmulator.catch && !componentDidCatchEmulator.error) {
     return matches;


### PR DESCRIPTION
goals:
- simplify shared server runtime
- simplify loop that tracks boundaries
- simplify how actions / loaders are called
- make sure all boundary cases are surfaced properly

addresses https://github.com/remix-run/remix/issues/599 (todo: add tests)