### PR TITLE
Docs: Explain how to handle different request methods with resource routes

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -6,6 +6,7 @@
 - BasixKOR
 - chaance
 - coryhouse
+- davecalnan
 - eps1lon
 - evanwinter
 - francisudeji

--- a/docs/guides/resource-routes.md
+++ b/docs/guides/resource-routes.md
@@ -88,7 +88,7 @@ To handle `GET` requests export a loader function:
 ```ts
 import type { LoaderFunction } from "remix";
 
-export const loader: LoaderFunction = async ({ request }) => {
+export const loader: LoaderFunction = ({ request }) => {
   // handle "GET" request
 
   return json({ success: true }, 200);
@@ -100,7 +100,7 @@ To handle `POST`, `PUT`, `PATCH` or `DELETE` requests export an action function:
 ```ts
 import type { ActionFunction } from "remix";
 
-export const action: ActionFunction = async ({ request }) => {
+export const action: ActionFunction = ({ request }) => {
   switch (request.method) {
     case 'POST': { /* handle "POST" */ }
     case 'PUT': { /* handle "PUT" */ }

--- a/docs/guides/resource-routes.md
+++ b/docs/guides/resource-routes.md
@@ -80,3 +80,32 @@ app/routes/reports/$id/[.pdf].ts
 # or like this, the resulting URL is the same
 app/routes/reports/$id.[.pdf].ts
 ```
+
+## Handling different request methods
+
+To handle `GET` requests export a loader function:
+
+```ts
+import type { LoaderFunction } from "remix";
+
+export const loader: LoaderFunction = async ({ request }) => {
+  // handle "GET" request
+
+  return json({ success: true }, 200);
+};
+```
+
+To handle `POST`, `PUT`, `PATCH` or `DELETE` requests export an action function:
+
+```ts
+import type { ActionFunction } from "remix";
+
+export const action: ActionFunction = async ({ request }) => {
+  switch (request.method) {
+    case 'POST': { /* handle "POST" */ }
+    case 'PUT': { /* handle "PUT" */ }
+    case 'PATCH': { /* handle "PATCH" */ }
+    case 'DELETE': { /* handle "DELETE" */ }
+  }
+};
+```


### PR DESCRIPTION
This PR:
- Adds an explanation to the resource routes doc explaining to use `loader` for `GET` requests and `action` for `POST`, `PUT`, `PATCH` and `DELETE` requests.

I was a bit confused and asked in the Discord and ran my own test. Hopefully this will short-circuit that for future people.