### PR TITLE
feat(dev): get available port if not available

### DIFF
--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -7,6 +7,7 @@ import WebSocket from "ws";
 import type { Server } from "http";
 import type * as Express from "express";
 import type { createApp as createAppType } from "@remix-run/serve";
+import getPort from "get-port";
 
 import { BuildMode, isBuildMode } from "../build";
 import * as compiler from "../compiler";
@@ -156,7 +157,9 @@ export async function dev(remixRoot: string, modeArg?: string) {
 
   let config = await readConfig(remixRoot);
   let mode = isBuildMode(modeArg) ? modeArg : BuildMode.Development;
-  let port = process.env.PORT || 3000;
+  let port = await getPort({
+    port: process.env.PORT ? Number(process.env.PORT) : 3000
+  });
 
   if (config.serverEntryPoint) {
     throw new Error("remix dev is not supported for custom servers.");

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import * as fse from "fs-extra";
+import getPort from "get-port";
 
 import type { RouteManifest, DefineRoutesFunction } from "./config/routes";
 import { defineRoutes } from "./config/routes";
@@ -322,7 +323,7 @@ export async function readConfig(
       path.join("public", "build")
   );
 
-  let devServerPort = appConfig.devServerPort || 8002;
+  let devServerPort = await getPort({ port: appConfig.devServerPort || 8002 });
   let devServerBroadcastDelay = appConfig.devServerBroadcastDelay || 0;
 
   let defaultPublicPath = "/build/";

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -22,6 +22,7 @@
     "esbuild": "0.13.14",
     "exit-hook": "2.2.1",
     "fs-extra": "^10.0.0",
+    "get-port": "^5.1.1",
     "lodash.debounce": "^4.0.8",
     "meow": "^7.1.1",
     "minimatch": "^3.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5299,6 +5299,11 @@ get-package-type@^0.1.0:
   resolved "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
+get-port@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
+  integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
+
 get-stream@^4.0.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz"


### PR DESCRIPTION
uses [get-port](https://github.com/sindresorhus/get-port) instead of incrementing by 1 like #844 and #746

also applies the port checking to the `devServerPort`

closes #863, #844, and #746

Signed-off-by: Logan McAnsh <logan@mcan.sh>