### PR TITLE
Add 304 to redirectStatusCodes to support throwing 304 responses from loaders

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -46,3 +46,4 @@
 - ascorbic
 - IAmLuisJ
 - weavdale
+- tshddx

--- a/packages/remix-server-runtime/__tests__/data-test.ts
+++ b/packages/remix-server-runtime/__tests__/data-test.ts
@@ -40,7 +40,7 @@ describe("loaders", () => {
 
   it("sets header for thrown responses", async () => {
     let loader = async ({ request }) => {
-      throw new Response("null", {
+      throw new Response(null, {
         headers: {
           "Content-type": "application/json"
         }
@@ -78,7 +78,7 @@ describe("loaders", () => {
 
   it("doesn't set header for thrown 304 responses", async () => {
     let loader = async ({ request }) => {
-      throw new Response("null", {
+      throw new Response(null, {
         status: 304,
         headers: {
           "Content-type": "application/json"

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -107,7 +107,7 @@ function isResponse(value: any): value is Response {
   );
 }
 
-const redirectStatusCodes = new Set([301, 302, 303, 307, 308]);
+const redirectStatusCodes = new Set([301, 302, 303, 304, 307, 308]);
 
 export function isRedirectResponse(response: Response): boolean {
   return redirectStatusCodes.has(response.status);


### PR DESCRIPTION
This adds 304 to the list of `redirectStatusCodes`, which means that throwing a 304 from a `loader` function will behave similarly to throwing 301 and 302 status codes. Namely, the thrown 304 response will not be caught by a CatchBoundary.

This makes it possible to create helper functions that check something in the request (e.g. an ETag header) and throw a 304 if appropriate, similar to the [`requireUserSession` example in the docs](https://remix.run/docs/en/v1/api/conventions#throwing-responses-in-loaders) which conditionally throws a 302 response.