### PR TITLE
Remove extra whitespace in shebang for compatibility

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -19,6 +19,7 @@
 - goncy
 - goncy
 - graham42
+- GregBrimble
 - HenryVogt
 - Hopsken
 - ianduvall

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ function isBareModuleId(id) {
   return !id.startsWith(".") && !path.isAbsolute(id);
 }
 
-let executableBanner = "#!/usr/bin/env node \n";
+let executableBanner = "#!/usr/bin/env node\n";
 
 function createBanner(libraryName, version) {
   return `/**


### PR DESCRIPTION
Some machines apparently don't like the extra space after node, so we'd see errors like this:

```
> my-remix-app@1.0.0 postinstall /opt/buildhome/repo
> remix setup cloudflare-workers

/usr/bin/env: ‘node ’: No such file or directory
npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! my-remix-app@1.0.0 postinstall: `remix setup cloudflare-workers`
```

when trying to postinstall and `remix setup cloudflare-workers`. Never seen that before. Wild.