### PR TITLE
Fix some code highlights in blog tutorial

### DIFF
--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -880,7 +880,7 @@ Notice we don't return a redirect this time, we actually return the errors. Thes
 
 💿 Add validation messages to the UI
 
-```tsx filename=app/routes/admin/new.tsx lines=[2,17-18,24-25,30-31]
+```tsx filename=app/routes/admin/new.tsx lines=[2,11,17-18,24-25,30-31]
 import {
   useActionData,
   Form,

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -485,7 +485,7 @@ export async function getPost(slug: string) {
 
 💿 Use the new `getPost` function in the route
 
-```tsx filename=app/routes/posts/$slug.tsx lines=[3,4,9,10,17]
+```tsx filename=app/routes/posts/$slug.tsx lines=[3,4,9,10,14,17]
 import { useLoaderData } from "remix";
 import type { LoaderFunction } from "remix";
 import { getPost } from "~/post";


### PR DESCRIPTION
For the code highlight for `useActionData` the import statement is highlighted, but the highlight is missing where the new hook is used.

For the the code for the dynamic post route (`routes/post/$slug`), in the previous sample code for the `PostSlug` component, line 14 was `const slug = //...` and changes in this snippet to `const post = //...` but was missing the highlight.