### PR TITLE
feat: add support for pnpm

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -13,6 +13,7 @@
 - gon250
 - goncy
 - graham42
+- iamsahebgiri
 - ianduvall
 - jacob-ebey
 - jesseflorig

--- a/packages/create-remix/__tests__/cli-test.ts
+++ b/packages/create-remix/__tests__/cli-test.ts
@@ -181,8 +181,9 @@ function cleanPrompt<T extends { toString(): string }>(data: T): string {
 }
 
 function getPromptChoices(prompt: string) {
+  let pointer = process.platform === 'win32' ? ">" : "❯";
   return prompt
-    .slice(prompt.indexOf("❯") + 2)
+    .slice(prompt.indexOf(pointer) + 2)
     .split("\n")
     .map(s => s.trim());
 }

--- a/packages/create-remix/cli.ts
+++ b/packages/create-remix/cli.ts
@@ -52,16 +52,23 @@ async function run() {
     input.length > 0
       ? input[0]
       : (
-          await inquirer.prompt<{ dir: string }>([
-            {
-              type: "input",
-              name: "dir",
-              message: "Where would you like to create your app?",
-              default: "./my-remix-app"
-            }
-          ])
-        ).dir
+        await inquirer.prompt<{ dir: string }>([
+          {
+            type: "input",
+            name: "dir",
+            message: "Where would you like to create your app?",
+            default: "./my-remix-app"
+          }
+        ])
+      ).dir
   );
+
+  let packageManager = function () {
+    let currDir = path.resolve(__dirname);
+    if (currDir.includes(".npm")) return "npm";
+    else if (currDir.includes(".pnpm")) return "pnpm";
+    return "npm";
+  }();
 
   let answers = await inquirer.prompt<{
     server: Server;
@@ -96,7 +103,7 @@ async function run() {
     {
       name: "install",
       type: "confirm",
-      message: "Do you want me to run `npm install`?",
+      message: `Do you want me to run \`${packageManager} install\`?`,
       default: true
     }
   ]);
@@ -169,7 +176,7 @@ async function run() {
   );
 
   if (answers.install) {
-    execSync("npm install", { stdio: "inherit", cwd: projectDir });
+    execSync(`${packageManager} install`, { stdio: "inherit", cwd: projectDir });
   }
 
   if (projectDirIsCurrentDir) {


### PR DESCRIPTION
Now when `pnpx create-remix@latest` is called `pnpm install` is shown instead of `npm install`.