### PR TITLE
docs: move 'HtmlMetaDescriptor' to be under 'meta' instead of 'links'

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -641,6 +641,30 @@ There are a few special cases like `title` renders a `<title>` tag, `og:style` t
 
 In the case of nested routes, the meta tags are merged automatically, so parent routes can add meta tags without the child routes needing to copy them.
 
+#### `HtmlMetaDescriptor`
+
+This is an object representation and abstraction of a `<meta {...props} />` element and its attributes. [View the MDN docs for the meta API](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta).
+
+The `meta` export from a route should return a single `HtmlMetaDescriptor` object.
+
+Almost every `meta` element takes a `name` and `content` attribute, with the exception of [OpenGraph tags](https://ogp.me/) which use `property` instead of `name`. In either case, the attributes represent a key/value pair for each tag. Each pair in the `HtmlMetaDescriptor` object represents a separate `meta` element, and Remix maps each to the correct attributes for that tag.
+
+The `meta` object can also hold a `title` reference which maps to the [HTML `<title>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title)
+
+Examples:
+
+```tsx
+import type { MetaFunction } from "remix";
+
+export const meta: MetaFunction = () => {
+  return {
+    title: "Josie's Shake Shack", // <title>Josie's Shake Shack</title>
+    description: "Delicious shakes", // <meta name="description" content="Delicious shakes">
+    "og:image": "https://josiesshakeshack.com/logo.jpg" // <meta property="og:image" content="https://josiesshakeshack.com/logo.jpg">
+  };
+};
+```
+
 ### `links`
 
 The links function defines which `<link>` elements to add to the page when the user visits a route.
@@ -720,30 +744,6 @@ export const links: LinksFunction = () => {
       media: "(min-width: 1000px)"
     }
   ];
-};
-```
-
-#### `HtmlMetaDescriptor`
-
-This is an object representation and abstraction of a `<meta {...props} />` element and its attributes. [View the MDN docs for the meta API](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta).
-
-The `meta` export from a route should return a single `HtmlMetaDescriptor` object.
-
-Almost every `meta` element takes a `name` and `content` attribute, with the exception of [OpenGraph tags](https://ogp.me/) which use `property` instead of `name`. In either case, the attributes represent a key/value pair for each tag. Each pair in the `HtmlMetaDescriptor` object represents a separate `meta` element, and Remix maps each to the correct attributes for that tag.
-
-The `meta` object can also hold a `title` reference which maps to the [HTML `<title>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title)
-
-Examples:
-
-```tsx
-import type { MetaFunction } from "remix";
-
-export const meta: MetaFunction = () => {
-  return {
-    title: "Josie's Shake Shack", // <title>Josie's Shake Shack</title>
-    description: "Delicious shakes", // <meta name="description" content="Delicious shakes">
-    "og:image": "https://josiesshakeshack.com/logo.jpg" // <meta property="og:image" content="https://josiesshakeshack.com/logo.jpg">
-  };
 };
 ```
 


### PR DESCRIPTION
I'm pretty sure the section about `HtmlMetaDescriptor`  is meant to be under `meta` instead of under `links`.