### PR TITLE
feat(remix-cloudflare-workers): add `createCloudflareDurableObjectSessionStorage`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -13,6 +13,7 @@
 - gon250
 - goncy
 - graham42
+- GregBrimble
 - ianduvall
 - jacob-ebey
 - jesseflorig

--- a/packages/remix-cloudflare-workers/index.ts
+++ b/packages/remix-cloudflare-workers/index.ts
@@ -1,6 +1,10 @@
 import { installGlobals } from "./globals";
 
 export { createCloudflareKVSessionStorage } from "./sessions/cloudflareKVSessionStorage";
+export {
+  createCloudflareDurableObjectSessionStorage,
+  SessionStorageDurableObject
+} from "./sessions/cloudflareDurableObjectSessionStorage";
 
 export type { GetLoadContextFunction, RequestHandler } from "./worker";
 export {

--- a/packages/remix-cloudflare-workers/index.ts
+++ b/packages/remix-cloudflare-workers/index.ts
@@ -5,6 +5,7 @@ export {
   createCloudflareDurableObjectSessionStorage,
   SessionStorageDurableObject
 } from "./sessions/cloudflareDurableObjectSessionStorage";
+export { createCloudflareSessionStorage } from "./sessions/cloudflareSessionStorage";
 
 export type { GetLoadContextFunction, RequestHandler } from "./worker";
 export {

--- a/packages/remix-cloudflare-workers/sessions/cloudflareDurableObjectSessionStorage.ts
+++ b/packages/remix-cloudflare-workers/sessions/cloudflareDurableObjectSessionStorage.ts
@@ -5,7 +5,7 @@ import type {
 } from "@remix-run/server-runtime";
 import { createSessionStorage } from "@remix-run/server-runtime";
 
-interface DurableObjectSessionStorageOptions {
+export interface DurableObjectSessionStorageOptions {
   /**
    * The Cookie used to store the session id on the client, or options used
    * to automatically create one.

--- a/packages/remix-cloudflare-workers/sessions/cloudflareDurableObjectSessionStorage.ts
+++ b/packages/remix-cloudflare-workers/sessions/cloudflareDurableObjectSessionStorage.ts
@@ -1,0 +1,123 @@
+import type {
+  SessionData,
+  SessionIdStorageStrategy,
+  SessionStorage
+} from "@remix-run/server-runtime";
+import { createSessionStorage } from "@remix-run/server-runtime";
+
+interface DurableObjectSessionStorageOptions {
+  /**
+   * The Cookie used to store the session id on the client, or options used
+   * to automatically create one.
+   */
+  cookie?: SessionIdStorageStrategy["cookie"];
+
+  /**
+   * The Durable Object Namespace used to store the sessions.
+   */
+  do: DurableObjectNamespace;
+}
+
+export const createCloudflareDurableObjectSessionStorage = ({
+  cookie,
+  do: durableObjectNamespace
+}: DurableObjectSessionStorageOptions) => {
+  return createSessionStorage({
+    cookie,
+    createData: async (data, expires) => {
+      const hexId = durableObjectNamespace.newUniqueId();
+      const durableObject = durableObjectNamespace.get(hexId);
+
+      await durableObject.fetch("http://fakehost/", {
+        method: "POST",
+        body: JSON.stringify({ data, expires })
+      });
+
+      return hexId.toString();
+    },
+    readData: async id => {
+      const hexId = durableObjectNamespace.idFromString(id);
+      const durableObject = durableObjectNamespace.get(hexId);
+
+      const response = await durableObject.fetch("http://fakehost/");
+      const data = (await response.json()) as SessionStorage | null;
+
+      return data;
+    },
+    updateData: async (id, data, expires) => {
+      const hexId = durableObjectNamespace.idFromString(id);
+      const durableObject = durableObjectNamespace.get(hexId);
+
+      await durableObject.fetch("http://fakehost/", {
+        method: "POST",
+        body: JSON.stringify({ data, expires })
+      });
+    },
+    deleteData: async id => {
+      const hexId = durableObjectNamespace.idFromString(id);
+      const durableObject = durableObjectNamespace.get(hexId);
+
+      await durableObject.fetch("http://fakehost/", {
+        method: "DELETE"
+      });
+    }
+  });
+};
+
+// This magical key stores the expiration Date instance, if given.
+const EXPIRES_KEY = "__expires";
+
+export class SessionStorageDurableObject implements DurableObject {
+  storage: DurableObjectStorage;
+
+  constructor(state: DurableObjectState) {
+    this.storage = state.storage;
+  }
+
+  async fetch(request: Request) {
+    switch (request.method.toLowerCase()) {
+      case "get": {
+        const dataMap = await this.storage.list();
+        const expires = dataMap.get(EXPIRES_KEY) as Date | undefined;
+
+        if (expires && expires < new Date()) {
+          await this.storage.deleteAll();
+          return new Response(JSON.stringify(null));
+        }
+
+        if (dataMap.size === 0 || (expires !== undefined && dataMap.size === 1))
+          return new Response(JSON.stringify(null));
+
+        const entries = [...dataMap.entries()].filter(
+          ([key]) => key !== EXPIRES_KEY
+        ) as [string, SessionData][];
+
+        return new Response(JSON.stringify(Object.fromEntries(entries)));
+      }
+      case "post": {
+        const { data, expires } = (await request.json()) as {
+          data: SessionData;
+          expires: Date | undefined;
+        };
+
+        if (EXPIRES_KEY in data) {
+          throw new Error(
+            `"${EXPIRES_KEY}" is a protected key and cannot be used directly in the session data. Set it using the "expires" option of commitSession().`
+          );
+        }
+
+        await this.storage.deleteAll();
+        if (expires !== undefined) await this.storage.put(EXPIRES_KEY, expires);
+        await this.storage.put(data);
+
+        return new Response();
+      }
+      case "delete": {
+        await this.storage.deleteAll();
+        return new Response();
+      }
+    }
+
+    return new Response(null, { status: 405 });
+  }
+}

--- a/packages/remix-cloudflare-workers/sessions/cloudflareKVSessionStorage.ts
+++ b/packages/remix-cloudflare-workers/sessions/cloudflareKVSessionStorage.ts
@@ -4,7 +4,7 @@ import type {
 } from "@remix-run/server-runtime";
 import { createSessionStorage } from "@remix-run/server-runtime";
 
-interface KVSessionStorageOptions {
+export interface KVSessionStorageOptions {
   /**
    * The Cookie used to store the session id on the client, or options used
    * to automatically create one.

--- a/packages/remix-cloudflare-workers/sessions/cloudflareSessionStorage.ts
+++ b/packages/remix-cloudflare-workers/sessions/cloudflareSessionStorage.ts
@@ -1,0 +1,22 @@
+import { createCloudflareKVSessionStorage } from "./cloudflareKVSessionStorage";
+import type { KVSessionStorageOptions } from "./cloudflareKVSessionStorage";
+import { createCloudflareDurableObjectSessionStorage } from "./cloudflareDurableObjectSessionStorage";
+import type { DurableObjectSessionStorageOptions } from "./cloudflareDurableObjectSessionStorage";
+
+export const createCloudflareSessionStorage = ({
+  cookie,
+  ...storage
+}: DurableObjectSessionStorageOptions | KVSessionStorageOptions) => {
+  if ("do" in storage) {
+    return createCloudflareDurableObjectSessionStorage({
+      cookie,
+      do: storage.do
+    });
+  } else if ("kv" in storage) {
+    return createCloudflareKVSessionStorage({ cookie, kv: storage.kv });
+  }
+
+  throw new Error(
+    "You must specify either a Durable Object namespace or a KV namespace when creating session storage."
+  );
+};


### PR DESCRIPTION
This PR adds a session storage implementation using Cloudflare's Durable Objects. It is only usable with ES Modules (PR for that coming shortly).

Things of note:

- `__expires` is a protected key that will throw an error if you try to set some session data to it.
- Every session created will belong to a new Durable Object instance. [It will be created as close as possible to the where the request came from, but note that might not be the same point-of-presence as where the request is being handled](https://developers.cloudflare.com/workers/learning/using-durable-objects#object-location). This will happen transparently, so no developer should have to worry about this implementation detail.
- Each piece of session data is created as an individual record, and so each is constrained to the following limits: [key size cannot exceed 2048 bytes, and value size cannot exceed 32 KiB](https://developers.cloudflare.com/workers/platform/limits#durable-objects-limits).
- Expired data is only deleted if it is attempted to be retrieved again. We might be able to be more proactive in the future as more functionality is added to Durable Objects.
- The developer must publish the `SessionStorageDurableObject` class provided.
- The second commit adds a convenience `createCloudflareSessionStorage` which takes either a `do` or `kv` namespace.

Questions for maintainers:

- Durable Objects instances have [the ability to be restricted to a jurisdiction](https://developers.cloudflare.com/workers/runtime-apis/durable-objects#restricting-objects-to-a-jurisdiction). This is a really powerful feature, particularly when dealing with user data (common for session data, I'd imagine), so I'd really love to include it somehow.

    Setting a jurisdiction has to happen when the instance is first created (it's encoded in as part of the instance ID), so has to be done in the `createData` method. Therefore, I see four options:
    
    - Extending `getSession`'s options to include `jurisdiction` which gets set on the session object and is picked up later when committing.
    - The developer sets a session data record (e.g. `session.set("__jurisdiction", "eu")`). This pollutes Remix's API the least, but is the most _magical_ which maybe isn't a good thing.
    - Extending `Session` include a `jurisdiction` property which developers could set to some value.
    - Extending `commitSession`'s options to include `jurisdiction`.

    I imagine most people will be determining whether or not to set a jurisdiction (and what it should be) based on the incoming request. They might be looking at `request.cf.continent` or get it specified by users directly in the request body.

    And given that jurisdiction should only be set at creation, I think the usage pattern should look something like this:
    
    ```ts
    export const loader: LoaderFunction = async ({ context, request }) => {
      const { getSession, commitSession } = context.sessionStorage
      
      const session = await getSession(request.headers.get('Cookie'))
      // session.id is "" when new, else it's the existing Durable Object instance ID

      const count = (session.get('count') || 0) + 1
      session.set('count', count)
      
      if (!session.id && request.cf.continent === "EU") {
        session.set("__jurisdiction", "eu")
        // or
        session.jurisdiction = 'eu'
      }
      
      return json({ count }, { headers: { "Set-Cookie": await commitSession(session) }})
    }
    ```

    or

    ```ts
    export const loader: LoaderFunction = async ({ context, request }) => {
      const { getSession, commitSession } = context.sessionStorage
      
      const session = await getSession(request.headers.get('Cookie'))
      // session.id is "" when new, else it's the existing Durable Object instance ID

      const count = (session.get('count') || 0) + 1
      session.set('count', count)
      
      let cookie

      if (!session.id && request.cf.continent === "EU") {
        cookie = await commitSession(session, { jurisdiction: "eu" })
      } else {
        cookie = await commitSession(session)
      }
      
      return json({ count }, { headers: { "Set-Cookie": cookie }})
    }
    ```

    We'd likely want to throw an exception when `commitSession` is called if the object already exists and jurisdiction has been set, but we can advise checking the `session.id` like as above.

What do y'all think?