### PR TITLE
fix: add missing break statements for CatchBoundary

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -66,3 +66,4 @@
 - VictorPeralta
 - zachdtaylor
 - zainfathoni
+- stevenspads

--- a/examples/basic/app/routes/demos/params/$id.tsx
+++ b/examples/basic/app/routes/demos/params/$id.tsx
@@ -61,10 +61,12 @@ export function CatchBoundary() {
           Maybe ask the webmaster ({caught.data.webmasterEmail}) for access.
         </p>
       );
+      break;
     case 404:
       message = (
         <p>Looks like you tried to visit a page that does not exist.</p>
       );
+      break;
     default:
       message = (
         <p>


### PR DESCRIPTION
Without adding the missing `break` statements, the `default` case is executed for all the cases in the switch statement. The 401 and 404 links on page `http://localhost:3000/demos/params` display the `message` of the `default` case rather than that of the `401` and `404` cases.