### PR TITLE
fix(doc): remove the "we don't have CLA" notice

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -15,8 +15,6 @@ When it comes to open source, there are many different kinds of contributions th
 
 If you'd like to contribute something—whether it's a bug fix to scratch your own itch or a typo in the docs—we'd be happy to have your contribution. We need you to "sign" a contributor license agreement (CLA) first that assigns us ownership so we are able to include it in this software.
 
-**We don't yet have a CLA, but we are working on it and we will be able to accept your contributions as soon as we do.** Until then, please keep letting us know about our bugs and typos in Discord and we will do our best to address them.
-
 ## Setup
 
 Before you can contribute to the codebase, you will need to fork the repo. This will look a bit different depending on what type of contribution you are making:


### PR DESCRIPTION
We do have a CLA already, right? I can see "CLA signed" tag on many late PR's.