### PR TITLE
Add config path to tailwind style documentation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -7,6 +7,7 @@
 - bruno-oliveira
 - chaance
 - coryhouse
+- csprle
 - davecalnan
 - derekr
 - dunglas

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -423,9 +423,9 @@ Update the package scripts to generate the tailwind file during dev and for the 
   // ...
   "scripts": {
     "build": "npm run build:css && remix build",
-    "build:css": "tailwindcss -o ./app/tailwind.css",
+    "build:css": "tailwindcss -o ./app/tailwind.css --c ./tailwind.config.js",
     "dev": "concurrently \"npm run dev:css\" \"remix dev\"",
-    "dev:css": "tailwindcss -o ./app/tailwind.css --watch",
+    "dev:css": "tailwindcss -o ./app/tailwind.css --c ./tailwind.config.js --watch",
     "postinstall": "remix setup node",
     "start": "remix-serve build"
   }
@@ -453,7 +453,7 @@ If you want to use Tailwind's `@apply` method to extract custom classes, create 
 
 @layer components {
   .custom-class {
-    @apply ...
+    @apply ...;
   }
 }
 ```


### PR DESCRIPTION
I didn't get tailwind to work with a custom config file until I added the path to the config within the scripts. 

Maybe I did something wrong because in the [tailwind docs](https://tailwindcss.com/docs/installation#customizing-your-configuration) it also says that a file named `tailwind.config.js` should be automatically be read.