### PR TITLE
feat: change devServer config structure to allow more options

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -28,8 +28,8 @@
 - christophgockel
 - clarkmitchell
 - codymjarrett
-- coryhouse
 - confix
+- coryhouse
 - craigglennie
 - crismali
 - damiensedgwick
@@ -73,6 +73,7 @@
 - hzhu
 - IAmLuisJ
 - ianduvall
+- ikhattab
 - imzshh
 - IshanKBG
 - jacob-ebey

--- a/packages/create-remix/templates/arc/remix.config.js
+++ b/packages/create-remix/templates/arc/remix.config.js
@@ -9,5 +9,5 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "server/index.js",
   // publicPath: "/_static/build/",
-  // devServerPort: 8002
+  // devServer: { port: 8002 }
 };

--- a/packages/create-remix/templates/cloudflare-pages/remix.config.js
+++ b/packages/create-remix/templates/cloudflare-pages/remix.config.js
@@ -4,11 +4,13 @@
 module.exports = {
   serverBuildTarget: "cloudflare-pages",
   server: "./server.js",
-  devServerBroadcastDelay: 1000,
+  devServer: {
+    broadcastDelay: 1000
+    // port: 8002
+  },
   ignoredRouteFiles: [".*"]
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "functions/[[path]].js",
   // publicPath: "/build/",
-  // devServerPort: 8002
 };

--- a/packages/create-remix/templates/cloudflare-workers/remix.config.js
+++ b/packages/create-remix/templates/cloudflare-workers/remix.config.js
@@ -4,11 +4,13 @@
 module.exports = {
   serverBuildTarget: "cloudflare-workers",
   server: "./server.js",
-  devServerBroadcastDelay: 1000,
+  devServer: {
+    broadcastDelay: 1000
+    // port: 8002
+  },
   ignoredRouteFiles: [".*"]
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
-  // devServerPort: 8002
 };

--- a/packages/create-remix/templates/deno/remix.config.js
+++ b/packages/create-remix/templates/deno/remix.config.js
@@ -4,11 +4,13 @@
 module.exports = {
   serverBuildTarget: "deno",
   server: "./server.js",
-  devServerBroadcastDelay: 1000,
+  devServer: {
+    broadcastDelay: 1000
+    // port: 8002
+  },
   ignoredRouteFiles: [".*"]
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
-  // devServerPort: 8002
 };

--- a/packages/create-remix/templates/express/remix.config.js
+++ b/packages/create-remix/templates/express/remix.config.js
@@ -4,10 +4,12 @@
 module.exports = {
   server: "./server.js",
   ignoredRouteFiles: [".*"],
-  devServerBroadcastDelay: 1000
+  devServer: {
+    broadcastDelay: 1000
+    // port: 8002
+  }
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
-  // devServerPort: 8002
 };

--- a/packages/create-remix/templates/fly-stack/remix.config.js
+++ b/packages/create-remix/templates/fly-stack/remix.config.js
@@ -6,6 +6,8 @@ module.exports = {
   assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "build",
-  devServerPort: 8002,
+  devServer: {
+    port: 8002
+  },
   ignoredRouteFiles: [".*"]
 };

--- a/packages/create-remix/templates/fly/remix.config.js
+++ b/packages/create-remix/templates/fly/remix.config.js
@@ -7,5 +7,7 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
-  // devServerPort: 8002
+  // devServer: {
+  //   port: 8002
+  // }
 };

--- a/packages/create-remix/templates/netlify/remix.config.js
+++ b/packages/create-remix/templates/netlify/remix.config.js
@@ -9,5 +9,7 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "netlify/functions/server/index.js",
   // publicPath: "/build/",
-  // devServerPort: 8002
+  // devServer: {
+  //   port: 8002
+  // }
 };

--- a/packages/create-remix/templates/remix/remix.config.js
+++ b/packages/create-remix/templates/remix/remix.config.js
@@ -7,5 +7,7 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
-  // devServerPort: 8002
+  // devServer: {
+  //   port: 8002
+  // }
 };

--- a/packages/create-remix/templates/vercel/remix.config.js
+++ b/packages/create-remix/templates/vercel/remix.config.js
@@ -12,5 +12,7 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "api/index.js",
   // publicPath: "/build/",
-  // devServerPort: 8002
+  // devServer: {
+  //   port: 8002
+  // }
 };

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -25,8 +25,10 @@ describe("readConfig", () => {
         "appDirectory": Any<String>,
         "assetsBuildDirectory": Any<String>,
         "cacheDirectory": Any<String>,
-        "devServerBroadcastDelay": 0,
-        "devServerPort": 8002,
+        "devServer": Object {
+          "broadcastDelay": 0,
+          "port": 8002,
+        },
         "entryClientFile": "entry.client.jsx",
         "entryServerFile": "entry.server.jsx",
         "mdx": [Function],

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -86,7 +86,7 @@ export async function watch(
       ? remixRootOrConfig
       : await readConfig(remixRootOrConfig);
 
-  let wss = new WebSocket.Server({ port: config.devServerPort });
+  let wss = new WebSocket.Server({ port: config.devServer.port });
   function broadcast(event: { type: string; [key: string]: any }) {
     setTimeout(() => {
       wss.clients.forEach(client => {
@@ -94,7 +94,7 @@ export async function watch(
           client.send(JSON.stringify(event));
         }
       });
-    }, config.devServerBroadcastDelay);
+    }, config.devServer.broadcastDelay);
   }
 
   function log(_message: string) {

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -365,7 +365,7 @@ async function createBrowserBuild(
     define: {
       "process.env.NODE_ENV": JSON.stringify(options.mode),
       "process.env.REMIX_DEV_SERVER_WS_PORT": JSON.stringify(
-        config.devServerPort
+        config.devServer.port
       )
     },
     plugins: [
@@ -444,7 +444,7 @@ async function createServerBuild(
       define: {
         "process.env.NODE_ENV": JSON.stringify(options.mode),
         "process.env.REMIX_DEV_SERVER_WS_PORT": JSON.stringify(
-          config.devServerPort
+          config.devServer.port
         )
       },
       plugins


### PR DESCRIPTION
# Background

following the discussion in https://github.com/remix-run/remix/pull/664 , this PR is to refactor options used in dev server to allow adding more options without adding root keys.

https://github.com/remix-run/remix/pull/664#discussion_r761500087

> Let's be careful about adding root keys to the config. Can we try to come up with a key name for development overlay configuration? We will probably need a few more keys in there in the future for surfacing uncaught errors and whatnot.

The proposed change in this PR is to pass dev server options as

```
devServer:  {
  broadcastDelay: 0,
  port: 8002,
}
```

instead of  using `devServerBroadcastDelay` and `devServerPort`

- [x] `devServerBroadcastDelay` or `devServerPort` will be used if passed.
- [x] `console.warn` with a deprecation note if `devServerBroadcastDelay` or `devServerPort`  are passed.