### PR TITLE
feat(remix-cloudflare-workers): add caching

### DIFF
--- a/packages/remix-cloudflare-workers/worker.ts
+++ b/packages/remix-cloudflare-workers/worker.ts
@@ -69,10 +69,19 @@ export async function handleAsset(
     let requestpath = url.pathname.split("/").slice(0, -1).join("/");
 
     if (requestpath.startsWith(assetpath)) {
+      // Assets are hashed by Remix so are safe to cache in the browser
+      // And they're also hashed in KV storage, so are safe to cache on the edge
       cacheControl = {
         bypassCache: false,
         edgeTTL: 31536000,
         browserTTL: 31536000
+      };
+    } else {
+      // Assets are not necessarily hashed in the request URL, so we cannot cache in the browser
+      // But they are hashed in KV storage, so we can cache on the edge
+      cacheControl = {
+        bypassCache: false,
+        edgeTTL: 31536000
       };
     }
 


### PR DESCRIPTION
This PR makes two changes:

1. It gets more aggressive in caching assets in production (second commit). Workers Sites already hashes assets, and each deployment gets its own manifest, so it should be safe to cache them on the edge, even if they haven't been hashed by Remix.

1. The remaining piece here will also cache generated responses from Remix. This can significantly improve loading time if the page has loaders which fetch from other services or do any moderate amount of work.

    [Responses with a `Set-Cookie` header are never cached (without manually overriding this behavior)](https://developers.cloudflare.com/workers/runtime-apis/cache#headers), and its ultimately within the control of developers how aggressively they want to cache these pages (if at all). I'd expect people to commonly do something like this:
    
    ```ts
    import { json } from "remix"

    export const loader = async () => {
      return await fetch('https://api.github.com/') // which contains some Cache-Control headers

      // or

      const results = await db.getAll()
      return json(results, { headers: { "Cache-Control": "max-age=3600" } })
    }

    export const headers = ({ loaderHeaders }) => ({ ...loaderHeaders })

    export default function() {
      const data = useLoaderData()
    }
    ```

    These `Cache-Control` headers will be respected both the browser, and the Cloudflare point-of-presence where this worker is executing. If no headers are set, the response won't be cached.

Deploying a new version of this Worker won't purge this cache, so it will continue to serve stale responses until empty. The cache can be [manually purged on a custom domain](https://developers.cloudflare.com/cache/how-to/purge-cache), but not on a workers.dev domain.

If there is some unique identifier for a Remix deployment we could use for the cache, we could `caches.open(identifier)` rather than `caches.default`, which would be amazing and eliminate the problem of a stale cache entirely. Ordinarily, I personally do something like `esbuild --define:VERSION=\\\"$(git rev-parse HEAD)\\\"`, but I understand that Remix projects will already be set up without this.

Is there something in the Remix manifest that could act as a unique identifier for a deployment?