### PR TITLE
Fix deploying to fly.io from local terminal

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -46,3 +46,4 @@
 - ascorbic
 - IAmLuisJ
 - weavdale
+- p10ns11y

--- a/packages/create-remix/templates/fly/package.json
+++ b/packages/create-remix/templates/fly/package.json
@@ -1,9 +1,9 @@
 {
   "scripts": {
     "postinstall": "remix setup node",
-    "build": "rm -rf build && remix build",
+    "build": "remix build",
     "dev": "remix dev",
-    "deploy": "flyctl deploy",
+    "deploy": "rm -rf build && flyctl deploy",
     "start": "remix-serve build"
   },
   "dependencies": {

--- a/packages/create-remix/templates/fly/package.json
+++ b/packages/create-remix/templates/fly/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "postinstall": "remix setup node",
-    "build": "remix build",
+    "build": "rm -rf build && remix build",
     "dev": "remix dev",
     "deploy": "flyctl deploy",
     "start": "remix-serve build"


### PR DESCRIPTION
When there is an existing `build` folder (generated during development)
`npm run build` (`remix build`) in the fly generated `Dockerfile`
 Ignores generating new folder and looses environment context (production).