### PR TITLE
feat(remix-react,remix-server-runtime): make the `MetaFunction` interface accept a generic

### DIFF
--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -76,7 +76,7 @@ export interface LoaderFunction {
  * `<meta>` tags for a route. These tags will be merged with (and take
  * precedence over) tags from parent routes.
  */
-export interface MetaFunction<Data = AppData> {
+export interface MetaFunction<Data extends AppData = AppData> {
   (args: {
     data: Data | undefined;
     parentsData: RouteData;

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -76,9 +76,9 @@ export interface LoaderFunction {
  * `<meta>` tags for a route. These tags will be merged with (and take
  * precedence over) tags from parent routes.
  */
-export interface MetaFunction {
+export interface MetaFunction<Data = AppData> {
   (args: {
-    data: AppData;
+    data: Data | undefined;
     parentsData: RouteData;
     params: Params;
     location: Location;


### PR DESCRIPTION
# Why is this needed

Right now, if you export a meta function from a route with a loader, and you need to access the loader data inside the meta function, you will need to cast the `data` to be the type of your loader. Something like this:

```ts
export let meta: MetaFunction = ({ data }) => {
  let { title } = data as LoaderData
  return { title }
}
```

# What this change

This PR let MetaFunction accepts a generic called Data which defaults to AppData (current type of data), this way you can do `MetaFunction<LoaderData>` to type the value for the `data` property. And because `data` could be `undefined` in case the loader throw an error, this PR also make the `data` to be typed as `Data | undefined` forcing you to check data exists.

```ts
export let meta: MetaFunction<LoaderData> = ({ data }) => {
  if (!data) return { title: "Error!" }; // here data is undefined so there was an error
  // here data is the LoaderData type so you know it has a title
  return { title: data.title }
}
```

---

This closes #374