### PR TITLE
chore: remove all `React` default imports

### DIFF
--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -13,8 +13,7 @@ This package provides all the components, hooks, and [Web Fetch API](https://dev
 
 These components are to be used once inside of your root route (`root.tsx`). They include everything Remix figured out or built in order for your page to render properly.
 
-```tsx [2,10,11,15]
-import React from "react";
+```tsx lines=[1,9-10,14]
 import { Meta, Links, Scripts, Outlet } from "remix";
 
 export default function App() {
@@ -189,8 +188,7 @@ In order to avoid (usually) the client-side routing "scroll flash" on refresh or
 
 This hook returns the JSON parsed data from your route loader function.
 
-```tsx [2,9]
-import React from "react";
+```tsx lines=[1,8]
 import { useLoaderData } from "remix";
 
 export function loader() {
@@ -207,8 +205,7 @@ export default function Invoices() {
 
 This hook returns the JSON parsed data from your route action. It returns `undefined` if there hasn't been a submission at the current location yet.
 
-```tsx [2,11,20]
-import React from "react";
+```tsx lines=[1,10,19]
 import { useActionData } from "remix";
 
 export async function action({ request }) {
@@ -2174,7 +2171,6 @@ Now we can read the message in a loader.
 <docs-info>You must commit the session whenever you read a `flash`. This is different than you might be used to where some type of middleware automatically sets the cookie header for you.</docs-info>
 
 ```js
-import React from "react";
 import { Meta, Links, Scripts, Outlet, json } from "remix";
 
 import { getSession, commitSession } from "./sessions";

--- a/docs/guides/disabling-javascript.md
+++ b/docs/guides/disabling-javascript.md
@@ -17,8 +17,7 @@ export const handle = { hydrate: true };
 
 Now open `root.tsx`, bring in `useMatches` and add this:
 
-```tsx [7,11,14-16,29]
-import React from "react";
+```tsx [6,10,13-15,28]
 import {
   Meta,
   Links,

--- a/fixtures/gists-app/app/pages/one.mdx
+++ b/fixtures/gists-app/app/pages/one.mdx
@@ -19,8 +19,6 @@ This is stateful:
 Here's a code block.
 
 ```jsx
-import React from "react";
-
 export default function PageOne() {
   return <div>Page One</div>;
 }

--- a/fixtures/gists-app/app/pages/two.mdx
+++ b/fixtures/gists-app/app/pages/two.mdx
@@ -3,8 +3,6 @@
 I am page two.
 
 ```jsx
-import React from "react";
-
 export default function PageTwo() {
   return <div>Page Two</div>;
 }

--- a/fixtures/gists-app/app/routes/blog/hello-world.mdx
+++ b/fixtures/gists-app/app/routes/blog/hello-world.mdx
@@ -27,8 +27,6 @@ This is stateful:
 Here's a code block.
 
 ```js
-import React from "react";
-
 export default function PageOne() {
   return <div>Page One</div>;
 }

--- a/fixtures/gists-app/app/routes/blog/second.md
+++ b/fixtures/gists-app/app/routes/blog/second.md
@@ -13,8 +13,6 @@ I am a Markdown page.
 Here's a code block.
 
 ```jsx
-import React from "react";
-
 export default function PageOne() {
   return <div>Page One</div>;
 }

--- a/fixtures/gists-app/app/routes/blog/third.md
+++ b/fixtures/gists-app/app/routes/blog/third.md
@@ -13,8 +13,6 @@ I am a Markdown page.
 Here's a code block.
 
 ```jsx
-import React from "react";
-
 export default function PageOne() {
   return <div>Page One</div>;
 }

--- a/fixtures/gists-app/app/routes/one.mdx
+++ b/fixtures/gists-app/app/routes/one.mdx
@@ -21,8 +21,6 @@ This is stateful:
 Here's a code block.
 
 ```jsx
-import React from "react";
-
 export default function PageOne() {
   return <div>Page One</div>;
 }

--- a/fixtures/gists-app/app/routes/two.md
+++ b/fixtures/gists-app/app/routes/two.md
@@ -11,8 +11,6 @@ I am a page.
 Here's a code block.
 
 ```jsx
-import React from "react";
-
 export default function PageOne() {
   return <div>Page One</div>;
 }

--- a/packages/remix-react/browser.tsx
+++ b/packages/remix-react/browser.tsx
@@ -1,7 +1,7 @@
 import type { BrowserHistory, Update } from "history";
 import { createBrowserHistory } from "history";
 import type { ReactElement } from "react";
-import React from "react";
+import * as React from "react";
 
 import { RemixEntry } from "./components";
 import type { EntryContext } from "./entry";

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -5,7 +5,7 @@ import type {
   MouseEventHandler,
   TouchEventHandler
 } from "react";
-import React from "react";
+import * as React from "react";
 import type { Navigator } from "react-router";
 import {
   Router,

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType, ReactNode } from "react";
-import React from "react";
+import * as React from "react";
 import type { Params } from "react-router";
 
 import type { RouteModules, ShouldReloadFunction } from "./routeModules";

--- a/packages/remix-react/server.tsx
+++ b/packages/remix-react/server.tsx
@@ -1,7 +1,7 @@
 import type { Location, To } from "history";
 import { Action, createPath } from "history";
 import type { ReactElement } from "react";
-import React from "react";
+import * as React from "react";
 
 import { RemixEntry } from "./components";
 import type { EntryContext } from "./entry";


### PR DESCRIPTION
We're pushing `react-jsx` in our templates

https://github.com/remix-run/remix/blob/f5a551ee139484f8d821220986a0515f95a69ce2/packages/create-remix/templates/_shared_ts/tsconfig.json#L6