### PR TITLE
doc: Updated to support tailwind css v3

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -70,3 +70,4 @@
 - VictorPeralta
 - zachdtaylor
 - zainfathoni
+- mochi-sann

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -405,9 +405,7 @@ Initialize a tailwind config so we can tell it which files to generate classes f
 
 ```js filename=tailwind.config.js lines=[2,3]
 module.exports = {
-  mode: "jit",
-  purge: ["./app/**/*.{ts,tsx}"],
-  darkMode: "media", // or 'media' or 'class'
+  content: ["./app/**/*.{ts,tsx}"],
   theme: {
     extend: {}
   },


### PR DESCRIPTION
Since Tailwindcss has been updated to v3, the document page of install tailwindcss has been updated

about tailwindcss v3 https://tailwindcss.com/blog/tailwindcss-v3
Tailwindcss upgrade guide https://tailwindcss.com/docs/upgrade-guide 