### PR TITLE
feat: define process.env.NODE_ENV for server build

### DIFF
--- a/packages/remix-cloudflare-workers/globals.ts
+++ b/packages/remix-cloudflare-workers/globals.ts
@@ -1,9 +1,14 @@
 import { sign, unsign } from "./cookieSigning";
 
 declare global {
+  interface ProcessEnv {
+    NODE_ENV: "development" | "production" | "test";
+  }
+
   interface WorkerGlobalScope {
     sign: typeof sign;
     unsign: typeof unsign;
+    process: { env: ProcessEnv };
   }
 }
 

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -357,6 +357,9 @@ async function createServerBuild(
     // of CSS and other files.
     assetNames: "_assets/[name]-[hash]",
     publicPath: config.publicPath,
+    define: {
+      "process.env.NODE_ENV": JSON.stringify(options.mode)
+    },
     plugins: [
       mdxPlugin(config),
       serverRouteModulesPlugin(config),

--- a/packages/remix-node/globals.ts
+++ b/packages/remix-node/globals.ts
@@ -16,6 +16,10 @@ import { FormData as NodeFormData } from "./formData";
 
 declare global {
   namespace NodeJS {
+    interface ProcessEnv {
+      NODE_ENV: "development" | "production" | "test";
+    }
+
     interface Global {
       atob: typeof atob;
       btoa: typeof btoa;


### PR DESCRIPTION
This will help avoid descrepancies at runtime between it being defined for the browser and a different runtime value for the server. This has been a source of issues for many regarding surfacing `<LiveReload>` in production.