### PR TITLE
fix: use document over window for browser check

### DIFF
--- a/docs/other-api/constraints.md
+++ b/docs/other-api/constraints.md
@@ -248,13 +248,13 @@ The most common scenario is intitializing a third party API when your module is 
 
 #### Window Guard
 
-This ensures the library is only initialized if there is a `window`, meaning you're in the browser.
+This ensures the library is only initialized if there is a `document`, meaning you're in the browser. We recomend `document` over `window` because server runtimes like Deno have a global `window` available.
 
 ```js [3]
 import firebase from "firebase/app";
 
-if (typeof window !== "undefined") {
-  firebase.initializeApp(window.ENV.firebase);
+if (typeof document !== "undefined") {
+  firebase.initializeApp(document.ENV.firebase);
 }
 
 export { firebase };

--- a/docs/other-api/constraints.md
+++ b/docs/other-api/constraints.md
@@ -246,9 +246,9 @@ export async function redirectToStripeCheckout(sessionId) {
 
 The most common scenario is intitializing a third party API when your module is imported. There are a couple ways to easily deal with this.
 
-#### Window Guard
+#### Document Guard
 
-This ensures the library is only initialized if there is a `document`, meaning you're in the browser. We recomend `document` over `window` because server runtimes like Deno have a global `window` available.
+This ensures the library is only initialized if there is a `document`, meaning you're in the browser. We recomend `document` over `window` because server runtimes like Deno has a global `window` available.
 
 ```js [3]
 import firebase from "firebase/app";

--- a/packages/remix-react/scroll-restoration.tsx
+++ b/packages/remix-react/scroll-restoration.tsx
@@ -7,7 +7,7 @@ let STORAGE_KEY = "positions";
 
 let positions: { [key: string]: number } = {};
 
-if (typeof window !== "undefined") {
+if (typeof document !== "undefined") {
   let sessionPositions = sessionStorage.getItem(STORAGE_KEY);
   if (sessionPositions) {
     positions = JSON.parse(sessionPositions);
@@ -79,7 +79,7 @@ function useScrollRestoration() {
     }, [])
   );
 
-  if (typeof window !== "undefined") {
+  if (typeof document !== "undefined") {
     // eslint-disable-next-line
     React.useLayoutEffect(() => {
       // don't do anything on hydration, the component already did this with an


### PR DESCRIPTION
Runtimes such as Deno have a window defined making this check not work.