### PR TITLE
fix: Fix error when defining multiple layout routes

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -76,6 +76,7 @@
 - tjefferson08
 - twhitbeck
 - tylerbrostrom
+- universse
 - UsamaHameed
 - veritem
 - VictorPeralta

--- a/packages/remix-dev/config/routesConvention.ts
+++ b/packages/remix-dev/config/routesConvention.ts
@@ -65,7 +65,7 @@ export function defineConventionalRoutes(appDir: string): RouteManifest {
       let fullPath = createRoutePath(routeId.slice("routes".length + 1));
       let uniqueRouteId = (fullPath || "") + (isIndexRoute ? "?index" : "");
 
-      if (typeof uniqueRouteId !== "undefined") {
+      if (uniqueRouteId !== "") {
         if (uniqueRoutes.has(uniqueRouteId)) {
           throw new Error(
             `Path ${JSON.stringify(fullPath)} defined by route ${JSON.stringify(


### PR DESCRIPTION
`uniqueRouteId` is an empty string instead of `undefined` for layout routes.
Fix https://github.com/remix-run/remix/issues/769