### PR TITLE
chore: updated contributing guide link to include pages directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see [our guide to contributing](docs/contributing.md).
+Please see [our guide to contributing](docs/pages/contributing.md).

--- a/contributors.yml
+++ b/contributors.yml
@@ -25,6 +25,7 @@
 - graham42
 - HenryVogt
 - Hopsken
+- iAmLuisJ
 - ianduvall
 - jacob-ebey
 - jaydiablo


### PR DESCRIPTION
contributing guide has moved under pages directory, updating link in contributing.md to reflect changes. Closes #1010 