### PR TITLE
Add baseUrl to tsconfig.json for VSCode autocomplete

### DIFF
--- a/packages/create-remix/templates/_shared_ts/tsconfig.json
+++ b/packages/create-remix/templates/_shared_ts/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
   "compilerOptions": {
+    "baseUrl": "./",
     "lib": ["DOM", "DOM.Iterable", "ES2019"],
     "isolatedModules": true,
     "esModuleInterop": true,
@@ -11,7 +12,7 @@
     "strict": true,
     "baseUrl": ".",
     "paths": {
-      "~/*": ["./app/*"]
+      "~/*": ["app/*"]
     },
 
     // Remix takes care of building everything in `remix build`.


### PR DESCRIPTION
Add `"baseUrl": "./"` to tsconfig.json so VSCode will autocomplete `~` path alias.