### PR TITLE
chore(docs): Use fragment of remix page.

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -8,6 +8,7 @@
 - bruno-oliveira
 - chaance
 - christophgockel
+- clarkmitchell
 - codymjarrett
 - coryhouse
 - crismali

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -1091,7 +1091,7 @@ export const handle = {
 };
 ```
 
-This is almost always used on conjunction with `useMatches`. To see what kinds of things you can do with it, refer to [`useMatches`](./remix/#usematches) for more information.
+This is almost always used on conjunction with `useMatches`. To see what kinds of things you can do with it, refer to [`useMatches`](./remix#usematches) for more information.
 
 ### unstable_shouldReload
 


### PR DESCRIPTION
Navigating to https://remix.run/docs/en/v1.0.6/api/remix/#usematches directly will strip the last slash and correctly resolve to https://remix.run/docs/en/v1.0.6/api/remix#usematches, but using this link [here](https://remix.run/docs/en/v1/api/conventions#handle) directs to a 404.