### PR TITLE
fix(doc): remove trailing slash from anchored links

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -72,6 +72,7 @@
 - reggie3
 - RossJHagan
 - RossMcMillan92
+- real34
 - ryanflorence
 - sean-roberts
 - shumuu

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -1091,7 +1091,7 @@ export const handle = {
 };
 ```
 
-This is almost always used on conjunction with `useMatches`. To see what kinds of things you can do with it, refer to [`useMatches`](./remix/#usematches) for more information.
+This is almost always used on conjunction with `useMatches`. To see what kinds of things you can do with it, refer to [`useMatches`](./remix#usematches) for more information.
 
 ### unstable_shouldReload
 
@@ -1270,6 +1270,6 @@ export default function Page() {
 [response]: https://developer.mozilla.org/en-US/docs/Web/API/Response
 [headers]: https://developer.mozilla.org/en-US/docs/Web/API/Headers
 [urlsearchparams]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
-[form]: ./remix/#form
-[form action]: ./remix/#form-action
+[form]: ./remix#form
+[form action]: ./remix#form-action
 [link tag]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link


### PR DESCRIPTION
because it leads to client side navigation errors: the canonical URL has no trailing slash

--- 

I noticed that on https://remix.run/docs/en/v1/api/conventions#handle, the `﻿useMatches﻿` link redirects to https://remix.run/docs/en/v1.0.6/api/remix/#usematches

When SSR'd (e.g: open in new tab) it renders properly because of a 302 to https://remix.run/docs/en/v1.0.6/api/remix#usematches (trailing URL slash removed).
On client side navigation it leads to a 404.


https://user-images.githubusercontent.com/75968/145932105-126839c6-3b0e-4b4e-96d7-88a1e9ff560c.mp4



## Next

I've only searched for occurrences in this documentation page. The doc may contain other ones.
It may also be considered as a bug with Remix itself and may need a fix in the client-side navigation default patterns? (not sure what does the 302 on the deployed instance - if it comes from fly.io or remix server)