### PR TITLE
add example for <NavLink> taken from react router

### DIFF
--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -77,6 +77,58 @@ Remix uses the browser's cache for prefetching with HTML `<link rel="prefetch"/>
 
 A `<NavLink>` is a special kind of `<Link>` that knows whether or not it is "active". This is useful when building a navigation menu, such as a breadcrumb or a set of tabs where you'd like to show which of them is currently selected. It also provides useful context for assistive technology like screen readers.
 
+By default, an `active` class is added to a `<NavLink>` component when it is active. You can also pass a function as children to customize the content of the `<NavLink>` component based on their active state, specially useful to change styles on internal elements.
+
+```tsx
+import { NavLink } from "remix";
+
+function NavList() {
+  // This styling will be applied to a <NavLink> when the
+  // route that it links to is currently selected.
+  let activeStyle = {
+    textDecoration: "underline"
+  };
+  let activeClassName = "underline"
+  return (
+    <nav>
+      <ul>
+        <li>
+          <NavLink
+            to="messages"
+            style={({ isActive }) =>
+              isActive ? activeStyle : undefined
+            }
+          >
+            Messages
+          </NavLink>
+        </li>
+        <li>
+          <NavLink
+            to="tasks"
+            className={({ isActive }) =>
+              isActive ? activeClassName : undefined
+            }
+          >
+            Tasks
+          </NavLink>
+        </li>
+        <li>
+          <NavLink
+            to="tasks"
+          >
+            {({ isActive }) => (
+              <span className={isActive ? activeClassName : undefined}>
+                Tasks
+              </span>
+            ))}
+          </NavLink>
+        </li>
+      </ul>
+    </nav>
+  );
+}
+```
+
 ### `<Form>`
 
 The `<Form>` component is a declarative way to perform data mutations: creating, updating, and deleting data. While it might be a mind-shift to think about these tasks as "navigation", it's how the web has handled mutations since before JavaScript was created!


### PR DESCRIPTION
Expanded description and added example for NavLink component, with an example taken from react-router docs, as this component is taken from react-router.