### PR TITLE
Mention in the Jokes tutorial how to stop the process

### DIFF
--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1588,6 +1588,12 @@ if (process.env.NODE_ENV === "production") {
   db = global.__db;
 }
 
+// this is needed to correctly close the process when you try to
+// stop the process of your Remix application
+db.$on("beforeExit", () => {
+  process.exit(0);
+});
+
 export { db };
 ```
 


### PR DESCRIPTION
When using Prisma and you stop the Remix server, it left the port 8002 open and you had to manually close it, this is because of Prisma, adding this to the `utils/db.server.ts` file before the export close the process correctly.