### PR TITLE
update remix to use react router 6.1.1

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -35,6 +35,7 @@
 - imzshh
 - jacob-ebey
 - jaydiablo
+- jeremyjfleming
 - jesseflorig
 - joaosamouco
 - johannesbraeunig

--- a/docs/other-api/react-router.md
+++ b/docs/other-api/react-router.md
@@ -12,5 +12,6 @@ Remix is built on top of React Router v6. Here are the most common that you'll u
 - [`useNavigate`](https://reactrouter.com/docs/api#usenavigate)
 - [`useParams`](https://reactrouter.com/docs/api#useparams)
 - [`useResolvedPath`](https://reactrouter.com/docs/api#useresolvedpath)
+- [`useOutletContext`](https://reactrouter.com/docs/en/v6/api#useoutletcontext)
 
 Most of the other APIs are either used internally by Remix or just aren't commonly needed in your app.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "puppeteer": "^9.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^6.0.2",
+    "react-router-dom": "^6.1.1",
     "rollup": "^2.36.1",
     "rollup-plugin-copy": "^3.3.0",
     "semver": "^7.3.4",

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -17,7 +17,7 @@ import {
   useHref,
   useResolvedPath
 } from "react-router-dom";
-import type { LinkProps, NavLinkPropsOutletProps } from "react-router-dom";
+import type { LinkProps, NavLinkProps } from "react-router-dom";
 
 import type { AppData } from "./data";
 import type { FormEncType, FormMethod } from "./data";

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -17,7 +17,7 @@ import {
   useHref,
   useResolvedPath
 } from "react-router-dom";
-import type { LinkProps, NavLinkProps, OutletProps } from "react-router-dom";
+import type { LinkProps, NavLinkPropsOutletProps } from "react-router-dom";
 
 import type { AppData } from "./data";
 import type { FormEncType, FormMethod } from "./data";

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -17,7 +17,7 @@ import {
   useHref,
   useResolvedPath
 } from "react-router-dom";
-import type { LinkProps, NavLinkProps } from "react-router-dom";
+import type { LinkProps, NavLinkProps, OutletProps } from "react-router-dom";
 
 import type { AppData } from "./data";
 import type { FormEncType, FormMethod } from "./data";

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -18,7 +18,8 @@ export type {
   SubmitOptions,
   SubmitFunction,
   RemixNavLinkProps as NavLinkProps,
-  RemixLinkProps as LinkProps
+  RemixLinkProps as LinkProps,
+  OutletProps
 } from "./components";
 export {
   Meta,

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -7,6 +7,7 @@ export {
   useNavigate,
   useNavigationType,
   useOutlet,
+  useOutletContext,
   useParams,
   useResolvedPath,
   useSearchParams

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -18,8 +18,7 @@ export type {
   SubmitOptions,
   SubmitFunction,
   RemixNavLinkProps as NavLinkProps,
-  RemixLinkProps as LinkProps,
-  OutletProps
+  RemixLinkProps as LinkProps
 } from "./components";
 export {
   Meta,

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -13,7 +13,7 @@
   "main": "index.js",
   "browser": "browser/index.js",
   "dependencies": {
-    "react-router-dom": "^6.0.2"
+    "react-router-dom": "^6.1.1"
   },
   "peerDependencies": {
     "react": ">=16.8",


### PR DESCRIPTION
Update remix to use react router version 6.1.1 which includes the useOutletContext functionality. 