### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see [our guide to contributing](docs/contributing.md).
+Please see [our guide to contributing](docs/pages/contributing.md).

--- a/contributors.yml
+++ b/contributors.yml
@@ -96,3 +96,4 @@
 - VictorPeralta
 - zachdtaylor
 - zainfathoni
+- unhackit


### PR DESCRIPTION
The CONTRIBUTING.md has a wrong link to view the documentation for contributors. I have just updated it to point towards the right file.