### PR TITLE
fix: runnable node bundle without setup command

### DIFF
--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -369,6 +369,12 @@ async function createServerBuild(
         // browser build and it's not there yet.
         if (id === "./assets.json" && importer === "<stdin>") return true;
 
+        // Include direct imports to `remix` in the bundle to remove `require("remix")` in the
+        // bundle. These will be mapped to their underlying package such as `@remix-run/react`.
+        if (id === "remix") {
+          return false;
+        }
+
         // Mark all bare imports as external. They will be require()'d at
         // runtime from node_modules.
         if (isBareModuleId(id)) {


### PR DESCRIPTION
This removes direct `import abc from "remix"` and delegates to the underlying package that owns the import. So instead of `let { json } = require("remix")` in the server bundle, it would be `let { json } = require("@remix-run/server-runtime")`.