### PR TITLE
Fix highlighting error in blog tutorial and typo in contributing page

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -100,6 +100,7 @@
 - thomasrettig
 - tjefferson08
 - tombyrer
+- tvanantwerp
 - twhitbeck
 - unhackit
 - veritem

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -42,7 +42,7 @@ git checkout dev
 
 ## Think You Found a Bug?
 
-Please conform to the issue template and provide a clear path to reproduction with a code example. Best is a pull request with a failing test. Next best is a link to [ [Remix Stackblitz](https://remix.new/) or repository that illustrates the bug.
+Please conform to the issue template and provide a clear path to reproduction with a code example. Best is a pull request with a failing test. Next best is a link to [Remix Stackblitz](https://remix.new/) or repository that illustrates the bug.
 
 ## Proposing New or Changed API?
 

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -890,7 +890,7 @@ Notice we don't return a redirect this time, we actually return the errors. Thes
 
 💿 Add validation messages to the UI
 
-```tsx filename=app/routes/admin/new.tsx lines=[2,11-12,17-18,24-25,30-31]
+```tsx filename=app/routes/admin/new.tsx lines=[1,6-7,13-15,20-22,26-28]
 import { useActionData, Form, redirect } from "remix";
 import type { ActionFunction } from "remix";
 

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -890,7 +890,7 @@ Notice we don't return a redirect this time, we actually return the errors. Thes
 
 💿 Add validation messages to the UI
 
-```tsx filename=app/routes/admin/new.tsx lines=[1,6-7,13-15,20-22,26-28]
+```tsx filename=app/routes/admin/new.tsx lines=[1,7,13-15,20-22,26-28]
 import { useActionData, Form, redirect } from "remix";
 import type { ActionFunction } from "remix";
 


### PR DESCRIPTION
I noticed an error with the blog tutorial. In the section titled "💿 Add validation messages to the UI", exactly the opposite lines as what actually changed in the file are highlighted. This PR changes the line highlights to show the correct changes from the file's previous state.

While reading the contributing page, I also saw a `[` that appears to have accidentally been left in the text when a link to CodeSandbox was swapped for a link to StackBlitz. This PR also removes that bracket.