### PR TITLE
Cloudflare Pages tweaks

### DIFF
--- a/packages/create-remix/templates/cloudflare-pages/README.md
+++ b/packages/create-remix/templates/cloudflare-pages/README.md
@@ -17,4 +17,6 @@ Open up [http://127.0.0.1:8788](http://127.0.0.1:8788) and you should be ready t
 
 Cloudflare Pages are currently only deployable through their Git provider integrations.
 
-If you don't already have an account, then [create a cloudflare account here](https://dash.cloudflare.com/sign-up) and after verifying your email address with Cloudflare, go to your dashboard and follow the [CF Pages deployment guide](https://developers.cloudflare.com/pages/framework-guides/deploy-anything).
+If you don't already have an account, then [create a Cloudflare account here](https://dash.cloudflare.com/sign-up/pages) and after verifying your email address with Cloudflare, go to your dashboard and follow the [Cloudflare Pages deployment guide](https://developers.cloudflare.com/pages/framework-guides/deploy-anything).
+
+Configure the "Build command" should be set to `npm run build`, and the "Build output directory" should be set to `public`.

--- a/packages/create-remix/templates/cloudflare-pages/functions/[[path]].js
+++ b/packages/create-remix/templates/cloudflare-pages/functions/[[path]].js
@@ -1,9 +1,9 @@
-import { createFetchHandler } from "@remix-run/cloudflare-pages";
+import { createPagesFunctionHandler } from "@remix-run/cloudflare-pages";
 
 // @ts-ignore
 import * as build from "../build";
 
-const handleFetch = createFetchHandler({
+const handleFetch = createPagesFunctionHandler({
   build
 });
 

--- a/packages/create-remix/templates/cloudflare-pages/functions/[[path]].js
+++ b/packages/create-remix/templates/cloudflare-pages/functions/[[path]].js
@@ -3,10 +3,10 @@ import { createPagesFunctionHandler } from "@remix-run/cloudflare-pages";
 // @ts-ignore
 import * as build from "../build";
 
-const handleFetch = createPagesFunctionHandler({
+const handleRequest = createPagesFunctionHandler({
   build
 });
 
 export function onRequest(context) {
-  return handleFetch(context);
+  return handleRequest(context);
 }

--- a/packages/remix-cloudflare-pages/index.ts
+++ b/packages/remix-cloudflare-pages/index.ts
@@ -2,7 +2,7 @@ import { installGlobals } from "./globals";
 
 export { createCloudflareKVSessionStorage } from "./sessions/cloudflareKVSessionStorage";
 
-export type { CreateFetchHandlerParams } from "./worker";
-export { createFetchHandler, createRequestHandler } from "./worker";
+export type { createPagesFunctionHandlerParams } from "./worker";
+export { createPagesFunctionHandler, createRequestHandler } from "./worker";
 
 installGlobals();

--- a/packages/remix-cloudflare-pages/package.json
+++ b/packages/remix-cloudflare-pages/package.json
@@ -14,8 +14,7 @@
     "url": "https://github.com/remix-run/remix/issues"
   },
   "dependencies": {
-    "@remix-run/server-runtime": "1.0.6",
-    "mime": "^3.0.0"
+    "@remix-run/server-runtime": "1.0.6"
   },
   "peerDependencies": {
     "@cloudflare/workers-types": "^3.2.0"

--- a/packages/remix-cloudflare-pages/worker.ts
+++ b/packages/remix-cloudflare-pages/worker.ts
@@ -1,4 +1,3 @@
-import { getType } from "mime";
 import type { ServerBuild, AppLoadContext } from "@remix-run/server-runtime";
 import { createRequestHandler as createRemixRequestHandler } from "@remix-run/server-runtime";
 
@@ -44,9 +43,8 @@ export function createPagesFunctionHandler<Env = any>({
     // https://github.com/cloudflare/wrangler2/issues/117
     context.request.headers.delete("If-None-Match");
 
-    let url = new URL(context.request.url);
     try {
-      response = await context.env.ASSETS.fetch(
+      response = await (context.env as any).ASSETS.fetch(
         context.request.url,
         context.request
       );
@@ -54,13 +52,6 @@ export function createPagesFunctionHandler<Env = any>({
         ? new Response(response.body, response)
         : undefined;
     } catch {}
-    // This is a known CF bug in the Pages runtime
-    if (response) {
-      let contentType = getType(url.pathname);
-      if (contentType) {
-        response.headers.set("Content-Type", contentType);
-      }
-    }
 
     if (!response) {
       response = await handleRequest(context);

--- a/packages/remix-cloudflare-pages/worker.ts
+++ b/packages/remix-cloudflare-pages/worker.ts
@@ -41,15 +41,18 @@ export function createFetchHandler<Env = any>({
   const handleFetch = async (context: EventContext<Env, any, any>) => {
     let response: Response | undefined;
 
-    const request = new Request(context.request);
     // https://github.com/cloudflare/wrangler2/issues/117
-    request.headers.delete("If-None-Match");
-    context.request = request;
+    context.request.headers.delete("If-None-Match");
 
     let url = new URL(context.request.url);
     try {
-      response = await context.next();
-      response = response.ok ? response : undefined;
+      response = await context.env.ASSETS.fetch(
+        context.request.url,
+        context.request
+      );
+      response = response?.ok
+        ? new Response(response.body, response)
+        : undefined;
     } catch {}
     // This is a known CF bug in the Pages runtime
     if (response) {

--- a/packages/remix-cloudflare-pages/worker.ts
+++ b/packages/remix-cloudflare-pages/worker.ts
@@ -2,7 +2,7 @@ import { getType } from "mime";
 import type { ServerBuild, AppLoadContext } from "@remix-run/server-runtime";
 import { createRequestHandler as createRemixRequestHandler } from "@remix-run/server-runtime";
 
-export interface CreateFetchHandlerParams<Env = any> {
+export interface createPagesFunctionHandlerParams<Env = any> {
   build: ServerBuild;
   getLoadContext?: (context: EventContext<Env, any, any>) => AppLoadContext;
   mode?: string;
@@ -12,7 +12,7 @@ export function createRequestHandler<Env = any>({
   build,
   getLoadContext,
   mode
-}: CreateFetchHandlerParams<Env>): PagesFunction<Env> {
+}: createPagesFunctionHandlerParams<Env>): PagesFunction<Env> {
   let platform = {};
   let handleRequest = createRemixRequestHandler(build, platform, mode);
 
@@ -27,11 +27,11 @@ export function createRequestHandler<Env = any>({
 
 declare const process: any;
 
-export function createFetchHandler<Env = any>({
+export function createPagesFunctionHandler<Env = any>({
   build,
   getLoadContext,
   mode
-}: CreateFetchHandlerParams<Env>) {
+}: createPagesFunctionHandlerParams<Env>) {
   const handleRequest = createRequestHandler<Env>({
     build,
     getLoadContext,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6824,11 +6824,6 @@ mime@^2.4.6, mime@^2.5.2:
   resolved "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
   integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
 
-mime@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
-  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
-
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"


### PR DESCRIPTION
- Band-aid solution for [the `If-None-Match` caching bug in Pages](https://github.com/cloudflare/wrangler2/issues/117).
- Rename `createFetchHandler` to `createPagesFunctionHandler`
- Couple of tweaks to the create-remix README for Pages.