### PR TITLE
Refactor getStylesheetPrefetchLinks

### DIFF
--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -263,12 +263,11 @@ export async function getStylesheetPrefetchLinks(
     .flat(1)
     .filter(isHtmlLinkDescriptor)
     .filter(link => link.rel === "stylesheet" || link.rel === "preload")
-    .map(({ rel, ...attrs }) => {
-      if (rel === "preload") {
-        return { rel: "prefetch", ...attrs };
-      }
-      return { rel: "prefetch", as: "style", ...attrs };
-    });
+    .map(({ rel, ...attrs }) => ({
+      rel: "prefetch",
+      ...(rel !== "preload" && { as: "style" }),
+      ...attrs
+    }));
 }
 
 // This is ridiculously identical to transition.ts `filterMatchesToLoad`


### PR DESCRIPTION
DRY up the code by using a single return vs two returns and an `if` statement