### PR TITLE
refactor: use url.href vs url.toString()

### DIFF
--- a/packages/remix-architect/server.ts
+++ b/packages/remix-architect/server.ts
@@ -115,7 +115,7 @@ export function createRemixRequest(
   let search = event.rawQueryString.length ? `?${event.rawQueryString}` : "";
   let url = new URL(event.rawPath + search, `https://${host}`);
 
-  return new NodeRequest(url.toString(), {
+  return new NodeRequest(url.href, {
     method: event.requestContext.http.method,
     headers: createRemixHeaders(event.headers, event.cookies),
     body:

--- a/packages/remix-express/server.ts
+++ b/packages/remix-express/server.ts
@@ -111,7 +111,7 @@ export function createRemixRequest(
     init.body = req; //req.pipe(new PassThrough({ highWaterMark: 16384 }));
   }
 
-  return new NodeRequest(url.toString(), init);
+  return new NodeRequest(url.href, init);
 }
 
 function sendRemixResponse(

--- a/packages/remix-netlify/server.ts
+++ b/packages/remix-netlify/server.ts
@@ -94,7 +94,7 @@ export function createRemixRequest(
       : event.body;
   }
 
-  return new NodeRequest(url.toString(), init);
+  return new NodeRequest(url.href, init);
 }
 
 export function createRemixHeaders(

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -121,13 +121,13 @@ function stripIndexParam(request: Request) {
     url.searchParams.append("index", toKeep);
   }
 
-  return new Request(url.toString(), request);
+  return new Request(url.href, request);
 }
 
 function stripDataParam(request: Request) {
   let url = new URL(request.url);
   url.searchParams.delete("_data");
-  return new Request(url.toString(), request);
+  return new Request(url.href, request);
 }
 
 export function extractData(response: Response): Promise<unknown> {

--- a/packages/remix-vercel/server.ts
+++ b/packages/remix-vercel/server.ts
@@ -106,7 +106,7 @@ export function createRemixRequest(
     init.body = req;
   }
 
-  return new NodeRequest(url.toString(), init);
+  return new NodeRequest(url.href, init);
 }
 
 function sendRemixResponse(res: VercelResponse, response: NodeResponse): void {


### PR DESCRIPTION
The code used `url.href` in places and `url.toString()` in others. Be consistant throughout and use the more concise `url.href`.