### PR TITLE
refactor: getStylesheetPrefetchLinks (one more time)

### DIFF
--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -263,12 +263,11 @@ export async function getStylesheetPrefetchLinks(
     .flat(1)
     .filter(isHtmlLinkDescriptor)
     .filter(link => link.rel === "stylesheet" || link.rel === "preload")
-    .map(({ rel, ...attrs }) => {
-      if (rel === "preload") {
-        return { rel: "prefetch", ...attrs };
-      }
-      return { rel: "prefetch", as: "style", ...attrs };
-    });
+    .map(({ rel, ...attrs }) =>
+      rel === "preload"
+        ? { rel: "prefetch", ...attrs }
+        : { rel: "prefetch", as: "style", ...attrs }
+    );
 }
 
 // This is ridiculously identical to transition.ts `filterMatchesToLoad`


### PR DESCRIPTION
It appears as though #1096 was a bridge too far with its optional object key. What about this?