### PR TITLE
refactor(types): remove superfluous union types

### DIFF
--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -26,23 +26,11 @@ export interface HtmlLinkDescriptor {
   crossOrigin?: "anonymous" | "use-credentials";
 
   /**
-   * Relationship between the document containing the hyperlink and the destination resource
+   * Relationship between the document containing the hyperlink and the destination resource.
+   * Common values are: "alternate", "dns-prefetch", "icon", "manifest", "modulepreload", "next",
+   * "pingback", "preconnect", "prefetch", "preload", "prerender", "search", and "stylesheet".
    */
-  rel:
-    | "alternate"
-    | "dns-prefetch"
-    | "icon"
-    | "manifest"
-    | "modulepreload"
-    | "next"
-    | "pingback"
-    | "preconnect"
-    | "prefetch"
-    | "preload"
-    | "prerender"
-    | "search"
-    | "stylesheet"
-    | string;
+  rel: string;
 
   /**
    * Applicable media: "screen", "print", "(max-width: 764px)"
@@ -95,30 +83,11 @@ export interface HtmlLinkDescriptor {
 
   /**
    * Potential destination for a preload request (for rel="preload" and rel="modulepreload")
+   * Common values are: "audio", "audioworklet", "document", "embed", "fetch", "font", "frame",
+   * "iframe", "image", "manifest", "object", "paintworklet", "report", "script", "serviceworker",
+   * "sharedworker", "style", "track", "video", "worker", and "xslt"
    */
-  as?:
-    | "audio"
-    | "audioworklet"
-    | "document"
-    | "embed"
-    | "fetch"
-    | "font"
-    | "frame"
-    | "iframe"
-    | "image"
-    | "manifest"
-    | "object"
-    | "paintworklet"
-    | "report"
-    | "script"
-    | "serviceworker"
-    | "sharedworker"
-    | "style"
-    | "track"
-    | "video"
-    | "worker"
-    | "xslt"
-    | string;
+  as?: string;
 
   /**
    * Color to use when customizing a site's icon (for rel="mask-icon")


### PR DESCRIPTION
Once you add "string" to a union type, any string literal values are ignored. 

Here you see autocomplete of type `Foo` with "bar" and "foo". Cool.

![image](https://user-images.githubusercontent.com/887639/146525049-7a4cfdb5-fc89-4718-bbec-7383a2921b48.png)


But once you add `| string`, we no longer get autocomplete.

![image](https://user-images.githubusercontent.com/887639/146525823-d439b9a4-b614-41dc-80d8-dd06889301d7.png)

I moved the literal values into a JSDoc comment as I felt they still had merit, but removed them from the union type itself.