### PR TITLE
docs: fix incorrect method name

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -112,3 +112,4 @@
 - VictorPeralta
 - zachdtaylor
 - zainfathoni
+- ehesp

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -914,7 +914,7 @@ function useMarkAsRead({ articleId, userId }) {
     marker.submit(
       { userId },
       {
-        method: "POST",
+        method: "post",
         action: "/article/${articleID}/mark-as-read"
       }
     );


### PR DESCRIPTION
The `method` should be lowercase, currently it's uppercase so TS complains.

```ts
export declare type FormMethod = "get" | "post" | "put" | "patch" | "delete";
```