### PR TITLE
fix: Clone the request body to better handle POSTs

### DIFF
--- a/packages/remix-cloudflare-pages/worker.ts
+++ b/packages/remix-cloudflare-pages/worker.ts
@@ -46,7 +46,7 @@ export function createPagesFunctionHandler<Env = any>({
     try {
       response = await (context.env as any).ASSETS.fetch(
         context.request.url,
-        context.request
+        context.request.clone()
       );
       response = response?.ok
         ? new Response(response.body, response)


### PR DESCRIPTION
We're accessing the request twice (once with the `env.ASSETS.fetch` and once by Remix). This clones it in the first case so the body can still be accessed by Remix.