### PR TITLE
fix(serve): Build not emitting env module

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -665,7 +665,7 @@ function remixServe() {
       external(id) {
         return isBareModuleId(id);
       },
-      input: `${SOURCE_DIR}/index.ts`,
+      input: [`${SOURCE_DIR}/index.ts`, `${SOURCE_DIR}/env.ts`],
       output: {
         banner: createBanner("@remix-run/serve", version),
         dir: OUTPUT_DIR,


### PR DESCRIPTION
The `@remix-run/serve` build is currently broken because it does not emit the `env` module. Unsure if this is the right long-term fix but I think it should be sufficient for a patch. Fixes https://github.com/remix-run/remix/issues/1128.