### PR TITLE
Use replace instead of replaceAll in jokes tutorial

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -128,3 +128,4 @@
 - yesmeck
 - zachdtaylor
 - zainfathoni
+- gkueny

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -5408,16 +5408,16 @@ import type { LoaderFunction } from "remix";
 import { db } from "~/utils/db.server";
 
 function escapeCdata(s: string) {
-  return s.replaceAll("]]>", "]]]]><![CDATA[>");
+  return s.replace(/\]\]>/g, "]]]]><![CDATA[>");
 }
 
 function escapeHtml(s: string) {
   return s
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#039;");
+    .replace(/\&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
 }
 
 export const loader: LoaderFunction = async ({


### PR DESCRIPTION
`replaceAll` is not supported in  node **v14.***, see https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V15.md#v8-86---35415

should fix https://github.com/remix-run/remix/issues/1156
