### PR TITLE
Docs: Fixes error in useSubmit example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -21,6 +21,7 @@
 - clarkmitchell
 - codymjarrett
 - coryhouse
+- craigglennie
 - crismali
 - davecalnan
 - derekr

--- a/docs/guides/data-loading.md
+++ b/docs/guides/data-loading.md
@@ -357,7 +357,7 @@ export default function ProductFilters() {
   let brands = searchParams.getAll("brand");
 
   return (
-    <Form method="get" onChange={e => submit(e.target)}>
+    <Form method="get" onChange={e => submit(e.currentTarget)}>
       {/* ... */}
     </Form>
   );


### PR DESCRIPTION
Was passing `e.target` to `useSubmit`, which is incorrect and won't type-check. The other example of `useSubmit` on this page uses `e.currentTarget`, as do the [docs for useSubmit](https://remix.run/docs/en/v1/api/remix#usesubmit)