### PR TITLE
Adjust HtmlMetaDescriptor title's type

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -97,6 +97,7 @@
 - luistorres
 - m0nica
 - m5r
+- manzano78
 - manzoorwanijk
 - matchai
 - matthew-burfield

--- a/packages/remix-react/routeModules.ts
+++ b/packages/remix-react/routeModules.ts
@@ -1,5 +1,5 @@
 import type { Location } from "history";
-import type { ComponentType } from "react";
+import type { ComponentType, ReactNode } from "react";
 import type { Params } from "react-router"; // TODO: import/export from react-router-dom
 
 import type { AppData } from "./data";
@@ -60,7 +60,9 @@ export interface MetaFunction {
  * tag, or an array of strings that will render multiple tags with the same
  * `name` attribute.
  */
-export interface HtmlMetaDescriptor {
+export type HtmlMetaDescriptor = {
+  title: ReactNode;
+} | {
   [name: string]: string | string[];
 }
 

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -1,5 +1,5 @@
 import type { Location } from "history";
-import type { ComponentType } from "react";
+import type { ComponentType, ReactNode } from "react";
 import type { Params } from "react-router-dom";
 
 import type { AppLoadContext, AppData } from "./data";
@@ -91,7 +91,9 @@ export interface MetaFunction {
  * tag, or an array of strings that will render multiple tags with the same
  * `name` attribute.
  */
-export interface HtmlMetaDescriptor {
+export type HtmlMetaDescriptor = {
+  title: ReactNode;
+} | {
   [name: string]: string | string[];
 }
 


### PR DESCRIPTION
Currently, in typescript mode, we can expose a document `title` as a string in the route `meta`'s export. This is ideal to satisfy most cases but some may need it to be typed as `ReactNode` for a larger flexibility.

A very common use case (that we face in my company) addresses messaging webapps that displays the number of new unread messages every 2 or 3 seconds, alternatively with the default page title.

The good news is remix already permits the document's title to be any `ReactNode`:

https://github.com/remix-run/remix/blob/50540dc73cd6c0983c389041348bdeafa9b72f73/packages/remix-react/components.tsx#L641

and if we don't use typescript, `title: <MyCustomTitle defaultValue={data.defaultTitle} />` works perfectly (as long as the component renders just a string in the end, of course)! So this PR only adjusts the `HtmlMetaDescriptor` type, and allows the developer to have finer grain in his component, if needed.

