### PR TITLE
Specifying that the devServerPort is specifically for the websocket server

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -128,3 +128,4 @@
 - yesmeck
 - zachdtaylor
 - zainfathoni
+- DavidHollins6

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -79,7 +79,7 @@ The path to the server build, relative to remix.config.js. Defaults to "build". 
 
 ### devServerPort
 
-The port number to use for the dev server. Defaults to 8002.
+The port number to use for the dev websocket server. Defaults to 8002.
 
 ## File Name Conventions
 


### PR DESCRIPTION
I spent a lot of time wondering why I was getting a `426 Upgrade Required` response back from my local application when running `remix dev`. I had made the assumption that `devServerPort` was the port of my applications server, but it is in-fact the port of the websocket server. This PR specifies in the docs that for anyone in the future who might make the same assumption.