### PR TITLE
docs: replace remix dev with remix watch

### DIFF
--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -422,7 +422,7 @@ Update the package scripts to generate the tailwind file during dev and for the 
   "scripts": {
     "build": "npm run build:css && remix build",
     "build:css": "tailwindcss -o ./app/tailwind.css",
-    "dev": "concurrently \"npm run dev:css\" \"remix dev\"",
+    "dev": "concurrently \"npm run dev:css\" \"remix watch\"",
     "dev:css": "tailwindcss -o ./app/tailwind.css --watch",
     "postinstall": "remix setup node",
     "start": "remix-serve build"
@@ -464,7 +464,7 @@ Then alter how tailwind is generating css:
   "scripts": {
     "build": "npm run build:css && remix build",
     "build:css": "tailwindcss -i ./styles/tailwind.css -o ./app/tailwind.css --minify",
-    "dev": "concurrently \"npm run dev:css\" \"remix dev\"",
+    "dev": "concurrently \"npm run dev:css\" \"remix watch\"",
     "dev:css": "tailwindcss -i ./styles/tailwind.css -o ./app/tailwind.css --watch",
     "postinstall": "remix setup node",
     "start": "remix-serve build"


### PR DESCRIPTION
I get the error `Could not locate @remix-run/serve. Please verify you have it installed to use the dev command.` when using `remix dev`. This should be replaced with `remix watch`.