### PR TITLE
docs: fix typo in docs/guides/styling.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -128,3 +128,4 @@
 - yesmeck
 - zachdtaylor
 - zainfathoni
+- mantey-github

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -136,7 +136,7 @@ Websites large and small usually have a set of shared components used throughout
 
 #### Shared stylesheet
 
-The first is approach is very simple. Put them all in a `shared.css` file included in `app/root.tsx`. That makes it easy for the components themselves to share CSS code (and your editor to provide intellisense for things like [custom properties][custom-properties]), and each component already needs a unique module name in JavaScript anyway, so you can scope the styles to a unique class name or data attribute:
+The first approach is very simple. Put them all in a `shared.css` file included in `app/root.tsx`. That makes it easy for the components themselves to share CSS code (and your editor to provide intellisense for things like [custom properties][custom-properties]), and each component already needs a unique module name in JavaScript anyway, so you can scope the styles to a unique class name or data attribute:
 
 ```css filename=app/styles/shared.css
 /* scope with class names */


### PR DESCRIPTION
Fix a typo in guides docs [styling.md](https://github.com/remix-run/remix/blob/main/docs/guides/styling.md)