### PR TITLE
Fix header casing windows cloudflare pages

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -20,6 +20,7 @@
 - dunglas
 - dwt47
 - edgesoft
+- efkann
 - eps1lon
 - evanwinter
 - fergusmeiklejohn

--- a/packages/remix-cloudflare-pages/worker.ts
+++ b/packages/remix-cloudflare-pages/worker.ts
@@ -41,7 +41,7 @@ export function createPagesFunctionHandler<Env = any>({
     let response: Response | undefined;
 
     // https://github.com/cloudflare/wrangler2/issues/117
-    context.request.headers.delete("If-None-Match");
+    context.request.headers.delete("if-none-match");
 
     try {
       response = await (context.env as any).ASSETS.fetch(


### PR DESCRIPTION
On Windows, `If-None-Match` header causes an error, this PR changes the header to the lowercase version.