### PR TITLE
docs: update blog example step

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -49,6 +49,7 @@
 - hkan
 - Holben888
 - Hopsken
+- hzhu
 - IAmLuisJ
 - ianduvall
 - imzshh

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -601,6 +601,7 @@ You should recognize a lot of that code from the posts route. We set up some ext
 💿 Create an admin stylesheet
 
 ```sh
+mkdir app/styles
 touch app/styles/admin.css
 ```
 


### PR DESCRIPTION
There is an error that appears when users go through the _[Creating Blog Posts](https://remix.run/docs/en/v1/tutorials/blog#creating-blog-posts)_ tutorial steps. The error indicates the `app/styles` directory does not exist:

<img width="424" alt="Screen Shot 2021-12-22 at 12 20 33 AM" src="https://user-images.githubusercontent.com/1811365/147059641-c53dda91-2dcc-4a04-9516-9d7addcfa88a.png">

This directory [existed before](https://github.com/remix-run/remix/pull/1114/files#diff-d04ce6f8a6ca906b75f64b36cd1b9f156968ab7742c006555fcefefb7f3fa80aL149), but the starter template was recently changed. This PR adds a `mkdir` step so that users do not encounter the error seen above while going through the tutorial.
