### PR TITLE
feat(remix-cloudflare-workers): support ES Module

### DIFF
--- a/.changeset/dull-kings-hide.md
+++ b/.changeset/dull-kings-hide.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/cloudflare-workers": minor
+---
+
+Allow for ESM based Cloudflare Workers

--- a/contributors.yml
+++ b/contributors.yml
@@ -114,6 +114,7 @@
 - edgesoft
 - edmundhung
 - efkann
+- ekosz
 - eldarshamukhamedov
 - emzoumpo
 - eps1lon

--- a/packages/remix-cloudflare-workers/package.json
+++ b/packages/remix-cloudflare-workers/package.json
@@ -15,7 +15,7 @@
   "typings": "dist/index.d.ts",
   "module": "dist/esm/index.js",
   "dependencies": {
-    "@cloudflare/kv-asset-handler": "^0.1.3",
+    "@cloudflare/kv-asset-handler": "^0.2.0",
     "@remix-run/cloudflare": "1.7.2"
   },
   "devDependencies": {

--- a/templates/cloudflare-workers/README.md
+++ b/templates/cloudflare-workers/README.md
@@ -35,3 +35,29 @@ Once that's done, you should be able to deploy your app:
 ```sh
 npm run deploy
 ```
+
+## Using [ES Module workers](https://blog.cloudflare.com/workers-javascript-modules/)
+
+If you would like to use features like [Durable
+Objects](https://developers.cloudflare.com/workers/learning/using-durable-objects)
+you will need to slightly change the [`worker/index.js`](./worker/index.js)
+file. In ES Module workers we no longer have a `FetchEvent` object and will
+need to generate something similar ourselves instead.
+
+```js
+import { createEventHandler } from "@remix-run/cloudflare-workers";
+
+import * as build from "../build";
+
+const handler = createEventHandler({ build })
+
+export default {
+  fetch(request, env, context) {
+    const event = { request, env, waitUntil: context.waitUntil.bind(waitUntil) };
+    return handler(event);
+  }
+}
+```
+
+**Note**: This will now be the new object passed to you if you add
+a `getLoadContext` function to the `createEventHandler`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1845,6 +1845,13 @@
   dependencies:
     mime "^2.5.2"
 
+"@cloudflare/kv-asset-handler@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.2.0.tgz#c9959bbd7a1c40bd7c674adae98aa8c8d0e5ca68"
+  integrity sha512-MVbXLbTcAotOPUj0pAMhVtJ+3/kFkwJqc5qNOleOZTv6QkZZABDMS21dSrSlVswEHwrpWC03e4fWytjqKvuE2A==
+  dependencies:
+    mime "^3.0.0"
+
 "@cloudflare/workers-types@^3.4.0":
   version "3.4.0"
   resolved "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.4.0.tgz"
@@ -9644,7 +9651,7 @@ mime@3.0.0, mime@^3.0.0:
   resolved "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz"
   integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
 
-mime@^2.4.6, mime@^2.5.2:
+mime@^2.4.6:
   version "2.5.2"
   resolved "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz"
   integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==


### PR DESCRIPTION
Hi there,

This is my first contribution to the Remix project so please let me know what additions you would like to see from this PR 😄 . 

I've very interested in using features like [Durable Objects](https://developers.cloudflare.com/workers/learning/using-durable-objects) in my Cloudflare workers, but to use them we need the ability to publish ESM versions of our workers. Remix has already(?) shipped the ability to generate native ESM, but we still need to update the `@remix/cloudflare-workers` package. 

This change adds three commits to help us get there. Each commit explains what it does, but happy to further explain here as well.

Cheers!

P.S. This also fixes a bug where if the result of the handler is a `Promise<Response>` that rejects, it wouldn't have been caught by the try catch block due to the promise not being awaited.

Closes #764 