### PR TITLE
fix(dev/compiler): mark imports using node protocol as external

### DIFF
--- a/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
@@ -113,5 +113,10 @@ function getNpmPackageName(id: string): string {
 }
 
 function isBareModuleId(id: string): boolean {
-  return !id.startsWith(".") && !id.startsWith("~") && !isAbsolute(id);
+  return (
+    !id.startsWith("node:") &&
+    !id.startsWith(".") &&
+    !id.startsWith("~") &&
+    !isAbsolute(id)
+  );
 }


### PR DESCRIPTION
https://nodejs.org/api/esm.html#node-imports

closes #1229

Signed-off-by: Logan McAnsh <logan@mcan.sh>