### PR TITLE
fix: add status text to express & vercel packages

### DIFF
--- a/packages/remix-express/server.ts
+++ b/packages/remix-express/server.ts
@@ -120,6 +120,7 @@ function sendRemixResponse(
   response: NodeResponse,
   abortController: AbortController
 ): void {
+  res.statusMessage = response.statusText;
   res.status(response.status);
 
   for (let [key, values] of Object.entries(response.headers.raw())) {

--- a/packages/remix-vercel/server.ts
+++ b/packages/remix-vercel/server.ts
@@ -122,6 +122,7 @@ function sendRemixResponse(res: VercelResponse, response: NodeResponse): void {
     }
   }
 
+  res.statusMessage = response.statusText;
   res.writeHead(response.status, response.headers.raw());
 
   if (Buffer.isBuffer(response.body)) {


### PR DESCRIPTION
cloudflare handles this for us via native use of fetch Response, note there doesn't seem to be a way to send status text in the other adapters.