### PR TITLE
Add native _redirects support for Cloudflare Pages

### DIFF
--- a/packages/remix-cloudflare-pages/worker.ts
+++ b/packages/remix-cloudflare-pages/worker.ts
@@ -48,9 +48,10 @@ export function createPagesFunctionHandler<Env = any>({
         context.request.url,
         context.request.clone()
       );
-      response = response?.ok
-        ? new Response(response.body, response)
-        : undefined;
+      response =
+        response && response.status >= 200 && response.status < 400
+          ? new Response(response.body, response)
+          : undefined;
     } catch {}
 
     if (!response) {


### PR DESCRIPTION
[`Response.ok` is true only when returning a 2XX status](https://developer.mozilla.org/en-US/docs/Web/API/Response/ok).

[Cloudflare Pages can return a 3XX if the developer creates a `_redirects` file](https://developers.cloudflare.com/pages/platform/redirects) in their `public` folder.

This PR checks that the status code is between 200–399 inclusive and if so, returns that response directly from Pages.

Replaces a dud #1236.