### PR TITLE
add: configurable live reload host

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1270,13 +1270,23 @@ export function useFetchers(): Fetcher[] {
   return [...fetchers.values()];
 }
 
-export function LiveReload({ port = 8002 }: { port?: number }) {
-  if (process.env.NODE_ENV !== "development") return null;
+type LiveReloadProps = {
+  host?: string;
+  port?: number;
+};
+
+export function LiveReload(props: LiveReloadProps) {
+  if (process.env.NODE_ENV !== "development") 
+    return null;
+  
+  const { host = 'localhost' } = props;
+  const { port = 8002 } = props;
+  
   return (
     <script
       dangerouslySetInnerHTML={{
         __html: `
-          let ws = new WebSocket("ws://localhost:${port}/socket");
+          let ws = new WebSocket("ws://${host}:${port}/socket");
           ws.onmessage = message => {
             let event = JSON.parse(message.data);
             if (event.type === "LOG") {


### PR DESCRIPTION
LiveReload seems to be limited to localhost only, because the host is hardcoded. I created a hotfix by adding an additional host parameter to the LiveReload component.