### PR TITLE
docs: fix type error `POST` to `post`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -129,3 +129,4 @@
 - yomeshgupta
 - zachdtaylor
 - zainfathoni
+- johnson444

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -909,7 +909,7 @@ function useMarkAsRead({ articleId, userId }) {
     marker.submit(
       { userId },
       {
-        method: "POST",
+        method: "post",
         action: "/article/${articleID}/mark-as-read"
       }
     );


### PR DESCRIPTION
Type '"POST"' is not assignable to type 'FormMethod | undefined'.ts(2322)