### PR TITLE
docs: update cloudflare KV example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -88,6 +88,7 @@
 - morinokami
 - mskoroglu
 - msutkowski
+- mtt87
 - nareshbhatia
 - niconiahi
 - nielsdb97

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -2141,7 +2141,7 @@ For [Cloudflare KV](https://developers.cloudflare.com/workers/learning/how-kv-wo
 The advantage of KV backed sessions is that only the session ID is stored in the cookie while the rest of the data is stored in a globally replicated, low-latency data store with exceptionally high read volumes with low-latency.
 
 ```js
-// app/sessions.js
+// app/sessions.server.js
 import {
   createCookie,
   createCloudflareKVSessionStorage


### PR DESCRIPTION
When using Cloudflare KV storage to store a session it's important to use file name `sessions.server.ts` with the `.server` keyword in order for Remix to only bundle this code on the server bundle.
Spent a couple of hours trying to figure out why a route that has a `loader` and a `default` export with the UI would throw an error although the session is only handled on the loader (server side) and this was the solution.