### PR TITLE
fix(remix-server-runtime): fix invalid character error in cookie serialize

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -89,3 +89,4 @@
 - weavdale
 - zachdtaylor
 - zainfathoni
+- nimaa77

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -86,14 +86,14 @@ Running `yarn build` from the root directory will run the build.
 
 ### Testing
 
-Before running the tests, you need to run a build. After you build, running `yarn test` from the root directory will run **every** package's tests. If you want to run tests for a specific package, use `yarn test --projects packages/<package-name>`:
+Before running the tests, you need to run a build. After you build, running `yarn test` from the root directory will run **every** package's tests. If you want to run tests for a specific package, use `yarn test --selectProjects <project-displayName>` (you can find project displayName from `jest.config.js` file):
 
 ```bash
 # Test all packages
 yarn test
 
 # Test only @remix-run/express
-yarn test --projects packages/remix-express
+yarn test --selectProjects express
 ```
 
 ## Repository Branching

--- a/packages/remix-server-runtime/__tests__/cookies-test.ts
+++ b/packages/remix-server-runtime/__tests__/cookies-test.ts
@@ -118,4 +118,36 @@ describe("cookies", () => {
     let setCookie2 = await cookie.serialize(value);
     expect(setCookie).not.toEqual(setCookie2);
   });
+
+  it("parses/serializes unsigned UTF8 string values", async () => {
+    let cookie = createCookie("my-cookie");
+    let setCookie = await cookie.serialize("سلام دنیا");
+    let value = await cookie.parse(getCookieFromSetCookie(setCookie));
+
+    expect(value).toEqual("سلام دنیا");
+  });
+
+  it("parses/serializes signed UTF8 string values", async () => {
+    let cookie = createCookie("my-cookie", {
+      secrets: ["secret1"]
+    });
+    let setCookie = await cookie.serialize("سلام ریمیکس");
+    let value = await cookie.parse(getCookieFromSetCookie(setCookie));
+
+    expect(value).toMatchInlineSnapshot(`"سلام ریمیکس"`);
+  });
+
+  it("parses/serializes signed object UTF8 values", async () => {
+    let cookie = createCookie("my-cookie", {
+      secrets: ["secret1"]
+    });
+    let setCookie = await cookie.serialize({ hello: "مایکل" });
+    let value = await cookie.parse(getCookieFromSetCookie(setCookie));
+
+    expect(value).toMatchInlineSnapshot(`
+      Object {
+        "hello": "مایکل",
+      }
+    `);
+  });
 });

--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -151,13 +151,43 @@ async function decodeCookieValue(
 }
 
 function encodeData(value: any): string {
-  return btoa(JSON.stringify(value));
+  let stringified = JSON.stringify(value);
+  let converted = toBinary(stringified);
+  return btoa(converted);
 }
 
 function decodeData(value: string): any {
   try {
-    return JSON.parse(atob(value));
+    let decodedData = atob(value);
+    let coverted = fromBinary(decodedData);
+    return JSON.parse(coverted);
   } catch (error) {
     return {};
   }
+}
+
+function toBinary(string: string): string {
+  let codeUnits = new Uint16Array(string.length);
+  for (let i = 0; i < codeUnits.length; i++) {
+    codeUnits[i] = string.charCodeAt(i);
+  }
+  let charCodes = new Uint8Array(codeUnits.buffer);
+  let result = "";
+  for (let i = 0; i < charCodes.byteLength; i++) {
+    result += String.fromCharCode(charCodes[i]);
+  }
+  return result;
+}
+
+function fromBinary(binary: string): string {
+  let bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  let charCodes = new Uint16Array(bytes.buffer);
+  let result = "";
+  for (let i = 0; i < charCodes.length; i++) {
+    result += String.fromCharCode(charCodes[i]);
+  }
+  return result;
 }


### PR DESCRIPTION
### Description

you save a cookie that contains utf-8 characters as it's value, you don't get the right content after reading the cookie.
this is because atob and btoa function that used inside cookie module and these functions don't support utf-8.

[as MDN suggested in their docs,](https://developer.mozilla.org/en-US/docs/Web/API/btoa#unicode_strings) you can convert the utf8 content into binary string and then pass it to `btoa` function and vice versa for ...

this is what this Pull Request is all about, fixing the issue with saving a cookie with utf8 text content


### How to reproduce

https://codesandbox.io/s/dazzling-monad-0wt38?file=/app/routes/index.jsx

closes: #1282