### PR TITLE
Setup new devServerAdditionalDirectories config option

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -39,6 +39,7 @@
 - jacob-ebey
 - jaydiablo
 - jesseflorig
+- jfranciscosousa
 - johannesbraeunig
 - juhanakristian
 - kentcdodds

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -16,6 +16,7 @@ module.exports = {
   appDirectory: "app",
   assetsBuildDirectory: "public/build",
   devServerPort: 8002,
+  devServerAdditionalDirectories: [],
   publicPath: "/build/",
   serverBuildDirectory: "build",
   routes(defineRoutes) {
@@ -80,6 +81,10 @@ The path to the server build, relative to remix.config.js. Defaults to "build". 
 ### devServerPort
 
 The port number to use for the dev server. Defaults to 8002.
+
+### devServerAdditionalDirectories
+
+An optional list of absolute paths that will trigger dev server recompiles.
 
 ## File Name Conventions
 

--- a/fixtures/gists-app/app/routes/dev-server-additional-dirs.jsx
+++ b/fixtures/gists-app/app/routes/dev-server-additional-dirs.jsx
@@ -1,0 +1,5 @@
+import SuperExternalComponent from "../../extra/SuperExternalComponent";
+
+export default function DevServerAdditionalDirs() {
+  return <SuperExternalComponent />;
+}

--- a/fixtures/gists-app/app/routes/index.jsx
+++ b/fixtures/gists-app/app/routes/index.jsx
@@ -131,6 +131,11 @@ export default function Index() {
           <li>
             <Link to="/resources">Resource routes</Link>
           </li>
+          <li>
+            <Link to="/dev-server-additional-dirs">
+              Additional watched dirs
+            </Link>
+          </li>
         </ul>
       </nav>
       <Shared />

--- a/fixtures/gists-app/extra/SuperExternalComponent.jsx
+++ b/fixtures/gists-app/extra/SuperExternalComponent.jsx
@@ -1,0 +1,3 @@
+export default function SuperExternalComponent() {
+  return <div>When I change, the dev server should handle me!</div>;
+}

--- a/fixtures/gists-app/remix.config.js
+++ b/fixtures/gists-app/remix.config.js
@@ -10,6 +10,7 @@ module.exports = {
   publicPath: "/build/",
   serverBuildDirectory: "./build",
   devServerPort: 8002,
+  devServerAdditionalDirectories: ["./extra"],
   ignoredRouteFiles: [".*", "blargh.ts"],
 
   mdx: async filename => {

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -179,7 +179,7 @@ export async function watch(
   }, 100);
 
   let watcher = chokidar
-    .watch(config.appDirectory, {
+    .watch([...config.devServerAdditionalDirectories, config.appDirectory], {
       persistent: true,
       ignoreInitial: true,
       awaitWriteFinish: {

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -69,10 +69,16 @@ export interface AppConfig {
    * The port number to use for the dev server. Defaults to 8002.
    */
   devServerPort?: number;
+
   /**
    * The delay before the dev server broadcasts a reload event.
    */
   devServerBroadcastDelay?: number;
+
+  /**
+   * A list of absolute paths that Remix will include on it's file watcher.
+   */
+  devServerAdditionalDirectories?: string[];
 
   /**
    * Additional MDX remark / rehype plugins.
@@ -162,6 +168,11 @@ export interface RemixConfig {
   devServerBroadcastDelay: number;
 
   /**
+   * A list of absolute paths that Remix will include on it's file watcher.
+   */
+  devServerAdditionalDirectories: string[];
+
+  /**
    * Additional MDX remark / rehype plugins.
    */
   mdx?: RemixMdxConfig | RemixMdxConfigFunction;
@@ -241,6 +252,8 @@ export async function readConfig(
 
   let devServerPort = appConfig.devServerPort || 8002;
   let devServerBroadcastDelay = appConfig.devServerBroadcastDelay || 0;
+  let devServerAdditionalDirectories =
+    appConfig.devServerAdditionalDirectories || [];
 
   let publicPath = addTrailingSlash(appConfig.publicPath || "/build/");
 
@@ -277,6 +290,7 @@ export async function readConfig(
     entryServerFile,
     devServerPort,
     devServerBroadcastDelay,
+    devServerAdditionalDirectories,
     assetsBuildDirectory,
     publicPath,
     rootDirectory,


### PR DESCRIPTION
As per this [discord interaction](https://discord.com/channels/770287896669978684/778004202282287104/926070217904386068), Jacob suggested me to add a new config option to Remix to allow extra directories to be watched by its file watcher.

The problem arose during some experiments with Turborepo. A company I'm working with wants to setup a monorepo with all of the frontend-based repos and while trying out their examples I noticed that updates to a package were not triggering any rebuild on Remix, which makes a subpar dev experience. Imagine you are working on a design system, you would have to reboot the dev-server with every change to the design system package.

This PR adds a `devServerAdditionalDirectories` option to the Remix config. You can add absolute paths to directories you want to watch for changes. You can add `node_modules` for example, or any folder outside the `app` that traditional Remix projects have.

I then updated the part of the docs where we talk about the config, and added an example to the `gists-app`.