### PR TITLE
feat(remix-react): add `useIsHydrated` hook & `ClientOnly` component

### DIFF
--- a/fixtures/gists-app/app/routes/client-only.tsx
+++ b/fixtures/gists-app/app/routes/client-only.tsx
@@ -1,0 +1,23 @@
+import { ClientOnly, useIsHydrated } from "remix";
+
+export default function ClientOnlyRoute() {
+  let isHydrated = useIsHydrated();
+
+  return (
+    <>
+      <ClientOnly
+        fallback={<h1 data-test-id="server-only-title">Server-Side</h1>}
+      >
+        <h1 data-test-id="client-only-title">Client Side</h1>
+      </ClientOnly>
+
+      <button
+        type="button"
+        disabled={!isHydrated}
+        data-test-id="client-only-button"
+      >
+        I only work client side
+      </button>
+    </>
+  );
+}

--- a/fixtures/gists-app/app/routes/client-only.tsx
+++ b/fixtures/gists-app/app/routes/client-only.tsx
@@ -6,7 +6,7 @@ export default function ClientOnlyRoute() {
   return (
     <>
       <ClientOnly
-        fallback={<h1 data-test-id="server-only-title">Server-Side</h1>}
+        placeholder={<h1 data-test-id="server-only-title">Server-Side</h1>}
       >
         <h1 data-test-id="client-only-title">Client Side</h1>
       </ClientOnly>

--- a/fixtures/gists-app/tests/client-only-test.ts
+++ b/fixtures/gists-app/tests/client-only-test.ts
@@ -1,0 +1,70 @@
+import type { Browser, Page } from "puppeteer";
+import puppeteer from "puppeteer";
+
+import { disableJavaScript, getHtml, reactIsHydrated } from "./utils";
+
+const testPort = 3000;
+const testServer = `http://localhost:${testPort}`;
+
+describe("ClientOnly and useIsHydrated", () => {
+  let browser: Browser;
+  let page: Page;
+  beforeEach(async () => {
+    browser = await puppeteer.launch();
+    page = await browser.newPage();
+  });
+
+  afterEach(() => browser.close());
+
+  describe("the h1 should change if JS loaded or not", () => {
+    it("with javascript enabled", async () => {
+      await page.goto(`${testServer}/client-only`);
+      await reactIsHydrated(page);
+
+      expect(await getHtml(page, '[data-test-id="client-only-title"]'))
+        .toMatchInlineSnapshot(`
+        "<h1 data-test-id=\\"client-only-title\\">Client Side</h1>
+        "
+      `);
+    });
+
+    it("with javascript disabled", async () => {
+      await disableJavaScript(page);
+      await page.goto(`${testServer}/client-only`);
+
+      expect(await getHtml(page, '[data-test-id="server-only-title"]'))
+        .toMatchInlineSnapshot(`
+        "<h1 data-test-id=\\"server-only-title\\">Server-Side</h1>
+        "
+      `);
+    });
+  });
+
+  describe("the button should be enabled only if JS loaded", () => {
+    it("with javascript enabled", async () => {
+      await page.goto(`${testServer}/client-only`);
+      await reactIsHydrated(page);
+
+      expect(await getHtml(page, '[data-test-id="client-only-button"]'))
+        .toMatchInlineSnapshot(`
+        "<button type=\\"button\\" data-test-id=\\"client-only-button\\">
+          I only work client side
+        </button>
+        "
+      `);
+    });
+
+    it("with javascript disabled", async () => {
+      await disableJavaScript(page);
+      await page.goto(`${testServer}/client-only`);
+
+      expect(await getHtml(page, '[data-test-id="client-only-button"]'))
+        .toMatchInlineSnapshot(`
+        "<button type=\\"button\\" disabled=\\"\\" data-test-id=\\"client-only-button\\">
+          I only work client side
+        </button>
+        "
+      `);
+    });
+  });
+});

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -222,6 +222,14 @@ describe("readConfig", () => {
             "parentId": "root",
             "path": "catchall/flat/*",
           },
+          "routes/client-only": Object {
+            "caseSensitive": undefined,
+            "file": "routes/client-only.tsx",
+            "id": "routes/client-only",
+            "index": undefined,
+            "parentId": "root",
+            "path": "client-only",
+          },
           "routes/empty": Object {
             "caseSensitive": undefined,
             "file": "routes/empty.jsx",

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -18,7 +18,6 @@ import {
   useResolvedPath,
   useRoutes
 } from "react-router-dom";
-
 import type { AppData, FormEncType, FormMethod } from "./data";
 import type { AssetsManifest, EntryContext } from "./entry";
 import {
@@ -47,6 +46,7 @@ import type { ClientRoute } from "./routes";
 import { createClientRoutes } from "./routes";
 import type { Fetcher, Submission, Transition } from "./transition";
 import { createTransitionManager } from "./transition";
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // RemixEntry
@@ -1333,7 +1333,7 @@ function useComposedRefs<RefValueType = any>(
 
 /**
  * Render the children only after the JS has loaded client-side.
- * Use an optional fallback component if the JS is not yet loaded.
+ * Use an optional placeholder component if the JS is not yet loaded.
  */
 export function ClientOnly({
   children,

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1337,10 +1337,10 @@ function useComposedRefs<RefValueType = any>(
  */
 export function ClientOnly({
   children,
-  fallback = null
+  placeholder = null
 }: {
   children: React.ReactNode;
-  fallback?: React.ReactNode;
+  placeholder?: React.ReactNode;
 }) {
-  return useIsHydrated() ? <>{children}</> : <>{fallback}</>;
+  return useIsHydrated() ? <>{children}</> : <>{placeholder}</>;
 }

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -29,6 +29,7 @@ export {
   Form,
   PrefetchPageLinks,
   LiveReload,
+  ClientOnly,
   useFormAction,
   useSubmit,
   useTransition,
@@ -37,7 +38,8 @@ export {
   useLoaderData,
   useActionData,
   useBeforeUnload,
-  useMatches
+  useMatches,
+  useIsHydrated
 } from "./components";
 
 export type { FormMethod, FormEncType } from "./data";

--- a/packages/remix-react/magicExports/client.ts
+++ b/packages/remix-react/magicExports/client.ts
@@ -27,6 +27,7 @@ export {
   PrefetchPageLinks,
   ScrollRestoration,
   LiveReload,
+  ClientOnly,
   useFormAction,
   useSubmit,
   useTransition,
@@ -37,6 +38,7 @@ export {
   useActionData,
   useBeforeUnload,
   useMatches,
+  useIsHydrated,
   RemixServer
 } from "@remix-run/react";
 


### PR DESCRIPTION
Right now Remix has an internal boolean called isHydrated, it use it to know when JS has already loaded and change the result of rendering the Scripts component.

This PRs adds two things:

## useIsHydrated

This hook expose the isHydrated boolean without being able to change it, it also runs a one-time only effect to change the boolean to `true` and update the internal state.

The way it works is:

1. On SSR the result is always `false`
2. On CSR, the first render is always `false`, then it's updated to `true`
3. Subsequent CSR will always return `true` and it will not cause a second render.

This hook is useful to implement the second change and to be able to change prop values once JS load, e.g. if you have `<button type="button" />` you can add `disable={!isHydrated}` so it's disabled until JS load, this way the button will not be interactive without JS. Other use cases are to disable a `<fieldset>` with `<input type="checkbox" />` that only works if JS is enabled with useFetcher or useSubmit.

## ClientOnly

Closes #139
Closes #180
Closes #2852

This component uses the `useIsHydrated` hook internally, it receives two props a `children` to be render only client-side (after JS loaded) and an optional `placeholder` to be rendered server-side useful to render something that uses the same space of the client only component so it doesn't cause a layout shift or to render a fallback.

Examples:
1. If you have an interactive Chart component that can't be rendered server-side wrap it with ClientOnly and use a placeholder of an empty box with the same size of the chart or render a static SVG that can still show the data while JS loads or in case it fails.
2. If you have a rich editor and you need to support non-JS users, render a textarea as the placeholder, that way the form is still usable (without rich editing features) and once JS load the textarea can be replaced.
3. If you have a third-party component that needs to be rendered only client-side because it access browser only APIs in the render (like localStorage to initialize a state or window or element), re-export it from a `.client.ts|js` file and wrap it in ClientOnly, that way you won't get an error because server-side the imported component will be `undefined`.
4. If you need to render a React Portal you will need to pass the DOM element used to attach the portal, wrap the `React.createPortal()` call in ClientOnly and use it safely.

---

This PR also deprecated https://github.com/sergiodxa/remix-utils#clientonly and https://github.com/sergiodxa/remix-utils#usehydrated from Remix Utils.

---

Docs are pending