### PR TITLE
Remove duplicate useEffect in useScrollRestoration

### DIFF
--- a/packages/remix-react/scroll-restoration.tsx
+++ b/packages/remix-react/scroll-restoration.tsx
@@ -116,10 +116,4 @@ function useScrollRestoration() {
       window.scrollTo(0, 0);
     }, [location]);
   }
-
-  React.useEffect(() => {
-    if (transition.submission) {
-      wasSubmissionRef.current = true;
-    }
-  }, [transition]);
 }


### PR DESCRIPTION
I noticed the same `useEffect` appeared twice in `useScrollRestoration`, so I removed the second one.