### PR TITLE
wip: Add Support for Yarn 3 PnP

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -41,6 +41,7 @@
 - christianhg
 - christophgockel
 - clarkmitchell
+- cmd-johnson
 - codymjarrett
 - confix
 - coryhouse

--- a/packages/create-remix/package.json
+++ b/packages/create-remix/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@types/chalk-animation": "^1.6.0",
-    "@types/inquirer": "^7.3.1"
+    "@types/inquirer": "^7.3.1",
+    "strip-ansi": "^6.0.0"
   }
 }

--- a/packages/create-remix/templates/fly/package.json
+++ b/packages/create-remix/templates/fly/package.json
@@ -9,5 +9,8 @@
   "dependencies": {
     "@remix-run/serve": "*",
     "cross-env": "^7.0.3"
+  },
+  "devDependencies": {
+    "express": "^4.17.1"
   }
 }

--- a/packages/create-remix/templates/remix/package.json
+++ b/packages/create-remix/templates/remix/package.json
@@ -8,5 +8,8 @@
   "dependencies": {
     "@remix-run/serve": "*",
     "cross-env": "^7.0.3"
+  },
+  "devDependencies": {
+    "express": "^4.17.1"
   }
 }

--- a/packages/create-remix/templates/vercel/package.json
+++ b/packages/create-remix/templates/vercel/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@remix-run/serve": "*",
-    "cross-env": "^7.0.3"
+    "cross-env": "^7.0.3",
+    "express": "^4.17.1"
   }
 }

--- a/packages/create-remix/templates/yarn-pnp/gitignore
+++ b/packages/create-remix/templates/yarn-pnp/gitignore
@@ -1,0 +1,14 @@
+node_modules
+
+/.cache
+/server/build
+/public/build
+.env
+
+.yarn/*
+!.yarn/cache
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions

--- a/packages/create-remix/templates/yarn-pnp_js/app/entry.client.jsx
+++ b/packages/create-remix/templates/yarn-pnp_js/app/entry.client.jsx
@@ -1,0 +1,4 @@
+import { hydrate } from "react-dom";
+import { RemixBrowser } from "@remix-run/react";
+
+hydrate(<RemixBrowser />, document);

--- a/packages/create-remix/templates/yarn-pnp_js/app/entry.server.jsx
+++ b/packages/create-remix/templates/yarn-pnp_js/app/entry.server.jsx
@@ -1,0 +1,20 @@
+import { renderToString } from "react-dom/server";
+import { RemixServer } from "@remix-run/react";
+
+export default function handleRequest(
+  request,
+  responseStatusCode,
+  responseHeaders,
+  remixContext
+) {
+  const markup = renderToString(
+    <RemixServer context={remixContext} url={request.url} />
+  );
+
+  responseHeaders.set("Content-Type", "text/html");
+
+  return new Response("<!DOCTYPE html>" + markup, {
+    status: responseStatusCode,
+    headers: responseHeaders
+  });
+}

--- a/packages/create-remix/templates/yarn-pnp_js/app/root.jsx
+++ b/packages/create-remix/templates/yarn-pnp_js/app/root.jsx
@@ -1,0 +1,31 @@
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration
+} from "@remix-run/react";
+
+export function meta() {
+  return { title: "New Remix App" };
+}
+
+export default function App() {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        {process.env.NODE_ENV === "development" && <LiveReload />}
+      </body>
+    </html>
+  );
+}

--- a/packages/create-remix/templates/yarn-pnp_js/package.json
+++ b/packages/create-remix/templates/yarn-pnp_js/package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "@remix-run/serve": "*",
+    "@remix-run/server-runtime": "*"
+  },
+  "devDependencies": {
+    "esbuild": ">=0.10.0",
+    "@yarnpkg/esbuild-plugin-pnp": "^2.0.0"
+  }
+}

--- a/packages/create-remix/templates/yarn-pnp_ts/app/entry.client.tsx
+++ b/packages/create-remix/templates/yarn-pnp_ts/app/entry.client.tsx
@@ -1,0 +1,4 @@
+import { hydrate } from "react-dom";
+import { RemixBrowser } from "@remix-run/react";
+
+hydrate(<RemixBrowser />, document);

--- a/packages/create-remix/templates/yarn-pnp_ts/app/entry.server.tsx
+++ b/packages/create-remix/templates/yarn-pnp_ts/app/entry.server.tsx
@@ -1,0 +1,21 @@
+import { renderToString } from "react-dom/server";
+import { RemixServer } from "@remix-run/react";
+import type { EntryContext } from "@remix-run/server-runtime";
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  remixContext: EntryContext
+) {
+  const markup = renderToString(
+    <RemixServer context={remixContext} url={request.url} />
+  );
+
+  responseHeaders.set("Content-Type", "text/html");
+
+  return new Response("<!DOCTYPE html>" + markup, {
+    status: responseStatusCode,
+    headers: responseHeaders
+  });
+}

--- a/packages/create-remix/templates/yarn-pnp_ts/app/root.tsx
+++ b/packages/create-remix/templates/yarn-pnp_ts/app/root.tsx
@@ -1,0 +1,32 @@
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration
+} from "@remix-run/react";
+import type { MetaFunction } from "@remix-run/server-runtime";
+
+export const meta: MetaFunction = () => {
+  return { title: "New Remix App" };
+};
+
+export default function App() {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        {process.env.NODE_ENV === "development" && <LiveReload />}
+      </body>
+    </html>
+  );
+}

--- a/packages/create-remix/templates/yarn-pnp_ts/package.json
+++ b/packages/create-remix/templates/yarn-pnp_ts/package.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "@remix-run/serve": "*",
+    "@remix-run/server-runtime": "*"
+  },
+  "devDependencies": {
+    "esbuild": ">=0.10.0",
+    "@types/node": "^17.0.8",
+    "@yarnpkg/esbuild-plugin-pnp": "^2.0.0"
+  }
+}

--- a/packages/remix-architect/package.json
+++ b/packages/remix-architect/package.json
@@ -18,7 +18,9 @@
     "@remix-run/server-runtime": "1.2.2"
   },
   "peerDependencies": {
-    "@architect/architect": "^8.3.7"
+    "@architect/architect": "^8.3.7",
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "devDependencies": {
     "@types/architect__functions": "^3.13.6",

--- a/packages/remix-cloudflare-pages/package.json
+++ b/packages/remix-cloudflare-pages/package.json
@@ -17,7 +17,9 @@
     "@remix-run/server-runtime": "1.2.2"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^3.2.0"
+    "@cloudflare/workers-types": "^3.2.0",
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^3.2.0",

--- a/packages/remix-cloudflare-workers/package.json
+++ b/packages/remix-cloudflare-workers/package.json
@@ -18,7 +18,9 @@
     "@remix-run/server-runtime": "1.2.2"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^2.2.2"
+    "@cloudflare/workers-types": "^2.2.2",
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^2.2.2"

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -145,14 +145,20 @@ export async function watch(
 export async function dev(remixRoot: string, modeArg?: string) {
   // TODO: Warn about the need to install @remix-run/serve if it isn't there?
   let createApp: typeof createAppType;
-  let express: typeof Express;
   try {
     let serve = require("@remix-run/serve");
     createApp = serve.createApp;
-    express = require("express");
   } catch (err) {
     throw new Error(
       "Could not locate @remix-run/serve. Please verify you have it installed to use the dev command."
+    );
+  }
+  let express: typeof Express;
+  try {
+    express = require("express");
+  } catch (err) {
+    throw new Error(
+      "Could not locate express. Please verify you have it installed to use the dev command."
     );
   }
 

--- a/packages/remix-dev/compiler/assets.ts
+++ b/packages/remix-dev/compiler/assets.ts
@@ -73,7 +73,7 @@ export async function createAssetsManifest(
     if (!output.entryPoint) continue;
 
     let entryPointFile = path.resolve(
-      output.entryPoint.replace(/(^browser-route-module:|\?browser$)/g, "")
+      output.entryPoint.replace(/(^browser-route-module:|^pnp:|\?browser$)/g, "")
     );
     if (entryPointFile === entryClientFile) {
       entry = {

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -37,6 +37,15 @@
     "@types/cacache": "^15.0.0",
     "@types/lodash.debounce": "^4.0.6",
     "@types/ws": "^7.4.1",
+    "@yarnpkg/esbuild-plugin-pnp": "^2.0.0",
     "semver": "^7.3.4"
+  },
+  "peerDependencies": {
+    "@yarnpkg/esbuild-plugin-pnp": "^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@yarnpkg/esbuild-plugin-pnp": {
+      "optional": true
+    }
   }
 }

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -23,6 +23,7 @@
     "exit-hook": "2.2.1",
     "fs-extra": "^10.0.0",
     "get-port": "^5.1.1",
+    "jsesc": "^3.0.1",
     "lodash.debounce": "^4.0.8",
     "meow": "^7.1.1",
     "minimatch": "^3.0.4",
@@ -35,17 +36,23 @@
   },
   "devDependencies": {
     "@types/cacache": "^15.0.0",
+    "@types/jsesc": "^2.5.1",
     "@types/lodash.debounce": "^4.0.6",
     "@types/ws": "^7.4.1",
     "@yarnpkg/esbuild-plugin-pnp": "^2.0.0",
+    "rollup": "^2.36.1",
     "semver": "^7.3.4"
   },
   "peerDependencies": {
-    "@yarnpkg/esbuild-plugin-pnp": "^2.0.0"
+    "@remix-run/serve": "*",
+    "@yarnpkg/esbuild-plugin-pnp": "^2.0.0",
+    "express": "^4.17.1",
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "peerDependenciesMeta": {
-    "@yarnpkg/esbuild-plugin-pnp": {
-      "optional": true
-    }
+    "@remix-run/serve": { "optional": true },
+    "@yarnpkg/esbuild-plugin-pnp": { "optional": true },
+    "express": { "optional": true }
   }
 }

--- a/packages/remix-express/package.json
+++ b/packages/remix-express/package.json
@@ -16,7 +16,9 @@
     "@remix-run/server-runtime": "1.2.2"
   },
   "peerDependencies": {
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "devDependencies": {
     "@types/express": "^4.17.9",

--- a/packages/remix-netlify/package.json
+++ b/packages/remix-netlify/package.json
@@ -16,9 +16,12 @@
     "@remix-run/server-runtime": "1.2.2"
   },
   "peerDependencies": {
-    "@netlify/functions": "^0.10.0"
+    "@netlify/functions": "^0.10.0",
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "devDependencies": {
-    "@netlify/functions": "^0.10.0"
+    "@netlify/functions": "^0.10.0",
+    "lambda-tester": "^4.0.1"
   }
 }

--- a/packages/remix-node/package.json
+++ b/packages/remix-node/package.json
@@ -27,7 +27,13 @@
   "devDependencies": {
     "@types/blob-stream": "^0.1.30",
     "@types/cookie-signature": "^1.0.3",
-    "@types/source-map-support": "^0.5.4"
+    "@types/prettier": "^2.1.2",
+    "@types/source-map-support": "^0.5.4",
+    "prettier": "^2.1.2"
+  },
+  "peerDependencies": {
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "sideEffects": false
 }

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -14,14 +14,16 @@
   "main": "index.js",
   "module": "esm/index.js",
   "dependencies": {
-    "history": "^5.2.0",
-    "react-router-dom": "^6.2.1"
+    "react-router-dom": "^6.2.1",
+    "react-router": "^6.2.1",
+    "history": "^5.2.0"
   },
   "peerDependencies": {
     "react": ">=16.8",
     "react-dom": ">=16.8"
   },
   "devDependencies": {
+    "@remix-run/node": "1.2.2",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "abort-controller": "^3.0.0"

--- a/packages/remix-serve/package.json
+++ b/packages/remix-serve/package.json
@@ -24,5 +24,9 @@
     "@types/compression": "^1.7.0",
     "@types/express": "^4.17.9",
     "@types/morgan": "^1.9.2"
+  },
+  "peerDependencies": {
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   }
 }

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -16,8 +16,10 @@
   "dependencies": {
     "@types/cookie": "^0.4.0",
     "cookie": "^0.4.1",
+    "history": "^5.2.0",
     "jsesc": "^3.0.1",
     "react-router-dom": "^6.2.1",
+    "react-router": "^6.2.1",
     "set-cookie-parser": "^2.4.8",
     "source-map": "^0.7.3"
   },
@@ -26,8 +28,11 @@
     "react-dom": ">=16.8"
   },
   "devDependencies": {
+    "@remix-run/node": "1.2.2",
     "@types/jsesc": "^2.5.1",
-    "@types/set-cookie-parser": "^2.4.1"
+    "@types/prettier": "^2.1.2",
+    "@types/set-cookie-parser": "^2.4.1",
+    "prettier": "^2.1.2"
   },
   "sideEffects": false
 }

--- a/packages/remix-vercel/package.json
+++ b/packages/remix-vercel/package.json
@@ -16,7 +16,9 @@
     "@remix-run/server-runtime": "1.2.2"
   },
   "peerDependencies": {
-    "@vercel/node": "^1.8.3"
+    "@vercel/node": "^1.8.3",
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "devDependencies": {
     "@types/supertest": "^2.0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2798,6 +2798,13 @@
   dependencies:
     web-streams-polyfill "^3.1.1"
 
+"@yarnpkg/esbuild-plugin-pnp@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/esbuild-plugin-pnp/-/esbuild-plugin-pnp-2.0.0.tgz#cfbaa94c89758f89fa5ac754b9d5fd82cc09c2e4"
+  integrity sha512-lF8jk1IwL6fJeAhJEZaqn1pe00EMK7VzZOJdArqjuITJnTrv82cPPLcixiG8/3P70SYEiTbUItR6HqcMjv4rwg==
+  dependencies:
+    tslib "^1.13.0"
+
 "@zxing/text-encoding@0.9.0":
   version "0.9.0"
   resolved "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz"
@@ -10987,7 +10994,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2482,6 +2482,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.2.tgz#4c62fae93eb479660c3bd93f9d24d561597a8281"
   integrity sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==
 
+"@types/prettier@^2.1.2":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.4.tgz#5d9b63132df54d8909fce1c3f8ca260fdd693e17"
+  integrity sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==
+
 "@types/prop-types@*":
   version "15.7.4"
   resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz"
@@ -9572,7 +9577,7 @@ react-router-dom@^6.2.1:
     history "^5.2.0"
     react-router "6.2.1"
 
-react-router@6.2.1:
+react-router@6.2.1, react-router@^6.2.1:
   version "6.2.1"
   resolved "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz"
   integrity sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==


### PR DESCRIPTION
Yarn 3 has a feature called [Plug'n'Play (or PnP)](https://yarnpkg.com/features/pnp), which, among other things, gets rid of the `node_modules` directory.
Unfortunately, the way Remix modifies the `remix` package when running `remix setup node` is not compatible with PnP, because it tries to add/edit files in the `node_modules` directory.
PnP also enforces that all dependencies by a package are included in their respective `package.json` file, even when the package already indirectly depends on them. Additionally, `esbuild` doesn't work with PnP out of the box.

I have made a few changes that should enable Remix to work with projects that are using PnP, which I have outlined in #683.
Builds using yarn 3.2.0 (which is currently in the canary stage) now work without having to disable the PnP feature.

What _doesn't_ work though, is using the `remix` package. As far as I can tell, there's no easy way to change this.
For now, you can work around this by importing from the `@remix-run/node`, `@remix-run/server-runtime`,`@remix-run/react`, ... packages directly.

What _could_ work, is to include everything the `remix` package does into the project directory. This could also be automated by e.g. adding a flag to the `remix setup` command. That way, you would only have to change the `import {} from "remix";` imports to `import {} from "./remix";`. In TypeScript projects, the auto-generated files could also be added to the `paths` property in the `tsconfig.json`, which means you wouldn't have to change the imports at all.

I'm open for suggestions regarding the `remix` package issues with PnP and happy to implement them, if that will get PnP support added to Remix.