### PR TITLE
fix(create-remix): check if .gitignore exisits and prompt user

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,4 +1,5 @@
 - abereghici
+- abhinavrobinson
 - ahbruns
 - ahmedeldessouki
 - Alarid

--- a/packages/create-remix/cli.ts
+++ b/packages/create-remix/cli.ts
@@ -140,10 +140,31 @@ async function run() {
   }
 
   // rename dotfiles
-  await fse.move(
-    path.join(projectDir, "gitignore"),
-    path.join(projectDir, ".gitignore")
-  );
+  if (fse.existsSync(path.resolve(projectDir, ".gitignore"))) {
+    console.log(
+      `️🚨 Oops, "${relativeProjectDir}/.gitignore" already exists. Do you want to replace this file?`
+    );
+    let gitignore = await inquirer.prompt<{ replace: boolean }>([
+      {
+        type: "confirm",
+        name: "replace",
+        message: "Replace existing .gitignore?",
+        default: true
+      }
+    ]);
+    if (gitignore.replace) {
+      await fse.copy(
+        path.join(projectDir, "gitignore"),
+        path.join(projectDir, ".gitignore"),
+        { overwrite: true }
+      );
+    }
+  } else {
+    await fse.move(
+      path.join(projectDir, "gitignore"),
+      path.join(projectDir, ".gitignore")
+    );
+  }
 
   // merge package.jsons
   let appPkg = require(path.join(sharedTemplate, "package.json"));


### PR DESCRIPTION
I had noticed that in a preinitialised git repository, the create-remix app fails to run. After going through the `create-remix/cli.ts` I had not seen a check for if `.gitignore` exists. For this I have added a check as well as a user prompt to ask to replace the existing `.gitignore` with the one that remix ships with.