### PR TITLE
fix(arc): aws-sdk should be a global install

### DIFF
--- a/packages/create-remix/templates/arc/package.json
+++ b/packages/create-remix/templates/arc/package.json
@@ -6,7 +6,6 @@
     "start": "arc sandbox"
   },
   "dependencies": {
-    "@remix-run/architect": "*",
-    "aws-sdk": "2.796.0"
+    "@remix-run/architect": "*"
   }
 }


### PR DESCRIPTION
The Arc team says that the aws-sdk dep is huge and delays cold boot times by 2-3 seconds, so it shouldn't be a regular dep. Instead, continue to suggest that people install it as a global dep like the README says.