### PR TITLE
Propose alternative way to load dotenv

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -130,3 +130,4 @@
 - yomeshgupta
 - zachdtaylor
 - zainfathoni
+- lkostrowski

--- a/docs/guides/envvars.md
+++ b/docs/guides/envvars.md
@@ -43,13 +43,12 @@ Edit your `.env` file.
 SOME_SECRET=super-secret
 ```
 
-Then update your package.json dev script to this:
+Then update your entry.server.tsx and add these lines before your imports
 
-```json lines=[2] filename=package.json
-{
-  "dev": "node -r dotenv/config node_modules/.bin/remix dev",
-  "start": "remix-serve build"
-}
+```js filename=entry.server.tsx
+  if(process.env.NODE_ENV) {
+	  require('dotenv').config()
+  }
 ```
 
 Now you can access those values in your loaders/actions:

--- a/docs/guides/envvars.md
+++ b/docs/guides/envvars.md
@@ -46,8 +46,8 @@ SOME_SECRET=super-secret
 Then update your entry.server.tsx and add these lines before your imports
 
 ```js filename=entry.server.tsx
-  if(process.env.NODE_ENV = 'development') {
-    require('dotenv').config()
+  if(process.env.NODE_ENV === "development") {
+    require("dotenv").config()
   }
 ```
 

--- a/docs/guides/envvars.md
+++ b/docs/guides/envvars.md
@@ -46,8 +46,8 @@ SOME_SECRET=super-secret
 Then update your entry.server.tsx and add these lines before your imports
 
 ```js filename=entry.server.tsx
-  if(process.env.NODE_ENV) {
-	  require('dotenv').config()
+  if(process.env.NODE_ENV = 'development') {
+    require('dotenv').config()
   }
 ```
 


### PR DESCRIPTION
Hey

So I figured that conditional loading dotenv in development in entry might be better than preloading in package.json script, what do you think?