### PR TITLE
(fix:docs) small typo fix in jokes app tutorial

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -105,6 +105,7 @@
 - RossJHagan
 - RossMcMillan92
 - ryanflorence
+- schalkneethling
 - sean-roberts
 - sergiodxa
 - shumuu

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -4254,7 +4254,7 @@ export function CatchBoundary() {
   if (caught.status === 404) {
     return (
       <div className="error-container">
-        Huh? What the heck is "{params.jokeId}"?
+        {`Huh? What the heck is "${params.jokeId}"?`}
       </div>
     );
   }


### PR DESCRIPTION
I believe lines 4256-4258 should be as follows:

```jsx
<div className="error-container">
    {`Huh? What the heck is "${params.jokeId}"?`}
</div>
```