### PR TITLE
Add missing mkdir step to create the directory

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -131,3 +131,4 @@
 - yomeshgupta
 - zachdtaylor
 - zainfathoni
+- BogdanDevBst

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -601,6 +601,7 @@ You should recognize a lot of that code from the posts route. We set up some ext
 💿 Create an admin stylesheet
 
 ```sh
+mkdir app/styles
 touch app/styles/admin.css
 ```
 


### PR DESCRIPTION
On some operating systems touching a file without having a directory folder will fail. This extra step of explicitly creating the styles directory will ensure that this works for everyone.