### PR TITLE
Add missing step for typescript declarations

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -131,3 +131,4 @@
 - yomeshgupta
 - zachdtaylor
 - zainfathoni
+- BogdanDevBst

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -624,6 +624,21 @@ em {
 }
 ```
 
+💿 Create a declarations file
+
+```sh
+touch declarations.d.ts
+```
+
+```ts filename=declarations.d.ts
+declare module '*.css' {
+  const content: { [className: string]: string };
+  export default content;
+}
+```
+
+Before we can link the stylesheet in the admin route we need to create a declarations file which tells typescript to allow importing CSS files as modules.
+
 💿 Link to the stylesheet in the admin route
 
 ```tsx filename=app/routes/admin.tsx lines=[4,6-8]


### PR DESCRIPTION
The tutorial step telling the developer to link the admin.css file in the route doesn't work as typescript does not recognise CSS files. The change fixes this by adding an extra step of creating a declarations file to support CSS files.