### PR TITLE
feat(compiler): CSS modules support

### DIFF
--- a/integration/css-modules-test.ts
+++ b/integration/css-modules-test.ts
@@ -1,0 +1,58 @@
+import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
+import type { Fixture, AppFixture } from "./helpers/create-fixture";
+
+describe("CSS modules", () => {
+  let fixture: Fixture;
+  let app: AppFixture;
+
+  beforeAll(async () => {
+    fixture = await createFixture({
+      files: {
+        "remix.config.js": js`
+          module.exports = {
+            unstable_cssModules: true
+          };
+        `,
+        "app/button.jsx": js`
+          import styles from "~/button.module.css";
+          export function Button(props) {
+            return <button {...props} className={styles.button}>;
+          }
+        `,
+        "app/button.module.css": js`
+          .button {
+            color: red;
+          }
+        `,
+        "app/routes/one.jsx": js`
+          import { Button } from "~/button";
+          export default function() {
+            return (
+              <div>
+                <h1>One</h1>
+                <Button>Click Me</Button>
+              </div>
+            )
+          }
+        `,
+      },
+    });
+
+    app = await createAppFixture(fixture);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it.todo(
+    "uses the hashed classname"
+    /* async () => {
+    //let enableJavaScript = await app.disableJavaScript();
+    await app.goto("/one");
+    await app.page.waitForNavigation();
+    // TODO:
+    expect(true).toBe(true);
+  } */
+  );
+});

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -19,6 +19,8 @@ describe("readConfig", () => {
         cacheDirectory: expect.any(String),
         serverBuildPath: expect.any(String),
         assetsBuildDirectory: expect.any(String),
+        assetsBuildDirectory: expect.any(String),
+        unstable_cssModules: expect.any(Boolean),
       },
       `
       Object {
@@ -415,6 +417,7 @@ describe("readConfig", () => {
         "serverMode": "production",
         "serverModuleFormat": "cjs",
         "serverPlatform": "node",
+        "unstable_cssModules": Any<Boolean>,
       }
     `
     );

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -19,7 +19,6 @@ describe("readConfig", () => {
         cacheDirectory: expect.any(String),
         serverBuildPath: expect.any(String),
         assetsBuildDirectory: expect.any(String),
-        assetsBuildDirectory: expect.any(String),
         unstable_cssModules: expect.any(Boolean),
       },
       `

--- a/packages/remix-dev/compiler/assets.ts
+++ b/packages/remix-dev/compiler/assets.ts
@@ -31,6 +31,7 @@ export interface AssetsManifest {
       hasErrorBoundary: boolean;
     };
   };
+  rootAssets: RootAssets;
 }
 
 export async function createAssetsManifest(

--- a/packages/remix-dev/compiler/assets.ts
+++ b/packages/remix-dev/compiler/assets.ts
@@ -34,9 +34,13 @@ export interface AssetsManifest {
   rootAssets: RootAssets;
 }
 
+type RootAssetType = "cssModules";
+export type RootAssets = Partial<Record<RootAssetType, string>>;
+
 export async function createAssetsManifest(
   config: RemixConfig,
-  metafile: esbuild.Metafile
+  metafile: esbuild.Metafile,
+  rootAssets?: RootAssets
 ): Promise<AssetsManifest> {
   function resolveUrl(outputPath: string): string {
     return createUrl(
@@ -107,7 +111,19 @@ export async function createAssetsManifest(
   optimizeRoutes(routes, entry.imports);
   let version = getHash(JSON.stringify({ entry, routes })).slice(0, 8);
 
-  return { version, entry, routes };
+  let cssModules =
+    config.unstable_cssModules === true && rootAssets?.cssModules
+      ? resolveUrl(rootAssets.cssModules)
+      : undefined;
+
+  return {
+    version,
+    entry,
+    routes,
+    rootAssets: {
+      cssModules,
+    },
+  };
 }
 
 type ImportsCache = { [routeId: string]: string[] };

--- a/packages/remix-dev/compiler/plugins/css-modules.ts
+++ b/packages/remix-dev/compiler/plugins/css-modules.ts
@@ -1,0 +1,153 @@
+import postcss from "postcss";
+import type { Result as PostCSSResult } from "postcss";
+import cssModules from "postcss-modules";
+import path from "path";
+import * as fse from "fs-extra";
+import type * as esbuild from "esbuild";
+
+import { getFileHash } from "../utils/crypto";
+import * as cache from "../../cache";
+import type { RemixConfig } from "../../config";
+
+type CSSModuleClassMap = { [key: string]: string };
+interface CachedCSSResult {
+  hash: string;
+  result: PostCSSResult;
+  json: CSSModuleClassMap;
+}
+
+const suffixMatcher = /\.module\.css?$/;
+
+export function cssModulesServerPlugin(config: RemixConfig): esbuild.Plugin {
+  return {
+    name: "css-modules-imports-server",
+    async setup(build) {
+      build.onResolve({ filter: suffixMatcher }, (args) => {
+        return {
+          path: getResolvedFilePath(config, args),
+          namespace: "css-modules-import-server",
+        };
+      });
+
+      build.onLoad({ filter: suffixMatcher }, async (args) => {
+        try {
+          if (config.unstable_cssModules !== true) {
+            throw Error(
+              "CSS Module imports are an experimental feature and not supported by " +
+                "default. To enable support for CSS Modules, set `unstable_cssModules` " +
+                "to `true` in `remix.config.js`."
+            );
+          }
+          let { json } = await processCss(config, args.path);
+          return {
+            contents: JSON.stringify(json),
+            loader: "json",
+          };
+        } catch (err: any) {
+          return {
+            errors: [{ text: err.message }],
+          };
+        }
+      });
+    },
+  };
+}
+
+export function cssModulesClientPlugin(
+  config: RemixConfig,
+  handleProcessedCss: (args: { css: string; hash: string }) => void
+): esbuild.Plugin {
+  return {
+    name: "css-modules-imports-client",
+    async setup(build) {
+      build.onResolve({ filter: suffixMatcher }, (args) => {
+        return {
+          path: getResolvedFilePath(config, args),
+          namespace: "css-modules-import-client",
+          sideEffects: false,
+        };
+      });
+
+      build.onLoad({ filter: suffixMatcher }, async (args) => {
+        try {
+          if (config.unstable_cssModules !== true) {
+            throw Error(
+              "CSS Module imports are an experimental feature and not supported by " +
+                "default. To enable support for CSS Modules, set `unstable_cssModules` " +
+                "to `true` in `remix.config.js`."
+            );
+          }
+          let { json, result, hash } = await processCss(config, args.path);
+          handleProcessedCss({ css: result.css, hash });
+          return {
+            contents: JSON.stringify(json),
+            loader: "json",
+          };
+        } catch (err: any) {
+          return {
+            errors: [{ text: err.message }],
+          };
+        }
+      });
+    },
+  };
+}
+
+let cssPromiseCache = new Map<string, Promise<any>>();
+
+async function processCss(
+  config: RemixConfig,
+  filePath: string
+): Promise<CachedCSSResult> {
+  let hash = (await getFileHash(filePath)).slice(0, 8).toUpperCase();
+  if (cssPromiseCache.has(hash)) {
+    return cssPromiseCache.get(hash);
+  }
+
+  let cssPromise = (async function () {
+    let cached: CachedCSSResult | null = null;
+    let key = getCacheKey(config, filePath);
+    let json: CSSModuleClassMap = {};
+    try {
+      cached = await cache.getJson(config.cacheDirectory, key);
+    } catch (error) {}
+
+    if (!cached || cached.hash !== hash) {
+      let css = await fse.readFile(filePath, "utf-8");
+      let result = await postcss([
+        cssModules({
+          localsConvention: "camelCase",
+          generateScopedName: "[name]__[local]___[hash:base64:8]",
+          hashPrefix: "remix",
+          getJSON(_, data) {
+            json = { ...data };
+            return json;
+          },
+        }),
+      ]).process(css, { from: undefined, map: false });
+      cached = { hash, json, result };
+
+      try {
+        await cache.putJson(config.cacheDirectory, key, cached);
+      } catch (error) {}
+    }
+    return cached;
+  })();
+  cssPromiseCache.set(hash, cssPromise);
+  return cssPromise;
+}
+
+function getCacheKey(config: RemixConfig, filePath: string) {
+  return "css-module:" + path.relative(config.appDirectory, filePath);
+}
+
+function getResolvedFilePath(
+  config: RemixConfig,
+  args: { path: string; resolveDir: string }
+) {
+  // TODO: Ideally we should deal with the "~/" higher up in the build process
+  // if possible.
+  return args.path.startsWith("~/")
+    ? path.resolve(config.appDirectory, args.path.replace(/^~\//, ""))
+    : path.resolve(args.resolveDir, args.path);
+}

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -147,6 +147,14 @@ export interface AppConfig {
    * in a CJS build.
    */
   serverDependenciesToBundle?: Array<string | RegExp>;
+
+  /**
+   * Adds experimental support for CSS module imports.
+   *
+   * **Warning:** The API and implementation of experimental features may change
+   * between minor and patch versions.
+   */
+  unstable_cssModules?: boolean;
 }
 
 /**
@@ -250,6 +258,14 @@ export interface RemixConfig {
    * in a CJS build.
    */
   serverDependenciesToBundle: Array<string | RegExp>;
+
+  /**
+   * Adds experimental support for CSS module imports.
+   *
+   * **Warning:** The API and implementation of experimental features may change
+   * between minor and patch versions.
+   */
+  unstable_cssModules?: boolean;
 }
 
 /**
@@ -395,6 +411,8 @@ export async function readConfig(
 
   let serverDependenciesToBundle = appConfig.serverDependenciesToBundle || [];
 
+  let unstable_cssModules = appConfig.unstable_cssModules || false;
+
   return {
     appDirectory,
     cacheDirectory,
@@ -415,6 +433,7 @@ export async function readConfig(
     serverEntryPoint: customServerEntryPoint,
     serverDependenciesToBundle,
     mdx,
+    unstable_cssModules,
   };
 }
 

--- a/packages/remix-dev/modules.ts
+++ b/packages/remix-dev/modules.ts
@@ -6,6 +6,10 @@ declare module "*.css" {
   const asset: string;
   export default asset;
 }
+declare module "*.module.css" {
+  const asset: { [key: string]: string };
+  export default asset;
+}
 declare module "*.eot" {
   const asset: string;
   export default asset;

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -26,6 +26,8 @@
     "lodash.debounce": "^4.0.8",
     "meow": "^7.1.1",
     "minimatch": "^3.0.4",
+    "postcss": "^8.4.6",
+    "postcss-modules": "^4.3.0",
     "pretty-ms": "^7.0.1",
     "read-package-json-fast": "^2.0.2",
     "remark-frontmatter": "^4.0.0",

--- a/packages/remix-react/entry.ts
+++ b/packages/remix-react/entry.ts
@@ -21,5 +21,8 @@ export interface AssetsManifest {
   };
   routes: RouteManifest<EntryRoute>;
   url: string;
-  version: string;
+  rootAssets: RootAssets;
 }
+
+type RootAssetType = "cssModules";
+type RootAssets = Partial<Record<RootAssetType, string>>;

--- a/packages/remix-server-runtime/entry.ts
+++ b/packages/remix-server-runtime/entry.ts
@@ -27,7 +27,11 @@ export interface AssetsManifest {
   routes: RouteManifest<EntryRoute>;
   url: string;
   version: string;
+  rootAssets: RootAssets;
 }
+
+type RootAssetType = "cssModules";
+type RootAssets = Partial<Record<RootAssetType, string>>;
 
 export function createEntryMatches(
   matches: RouteMatch<ServerRoute>[],

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,14 +9,13 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@architect/functions@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@architect/functions/-/functions-4.1.1.tgz#4520f6070858f8731c1da403e40591f3909fcfec"
-  integrity sha512-x0+B/V9Jo5onksOce6iYdYeLh5F91dOp5fTnGJdkgOFCS+N0YN9zlI2asdPIs1Rb6xxCwoH1nuzs/jnNkupQWA==
+"@architect/functions@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@architect/functions/-/functions-5.0.2.tgz#748dcb71376cc0794bfd7ad4dcf85ab6f825cd74"
+  integrity sha512-bph1tyJpKTdKuyX32imWKy2hbHOzKGs9aHS6UhZYNirj9cuX/O0RWgHks/PKaJ/Hx4qewFaCmF2UL08knWpSeA==
   dependencies:
-    aws-serverless-express "^3.4.0"
-    cookie "^0.4.1"
-    cookie-signature "^1.1.0"
+    cookie "^0.4.2"
+    cookie-signature "^1.2.0"
     csrf "^3.1.0"
     node-webtokens "^1.0.4"
     run-parallel "^1.2.0"
@@ -2567,14 +2566,6 @@
     "@typescript-eslint/types" "5.12.1"
     eslint-visitor-keys "^3.0.0"
 
-"@vendia/serverless-express@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@vendia/serverless-express/-/serverless-express-3.4.0.tgz#156f47d364b067ae6fa678a914c51887f494321a"
-  integrity sha512-/UAAbi9qRjUtjRISt5MJ1sfhtrHb26hqQ0nvE5qhMLsAdR5H7ErBwPD8Q/v2OENKm0iWsGwErIZEg7ebUeFDjQ==
-  dependencies:
-    binary-case "^1.0.0"
-    type-is "^1.6.16"
-
 "@vercel/node@^1.8.3":
   version "1.12.1"
   resolved "https://registry.npmjs.org/@vercel/node/-/node-1.12.1.tgz"
@@ -3148,15 +3139,6 @@ aws-sdk@^2.820.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
-aws-serverless-express@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/aws-serverless-express/-/aws-serverless-express-3.4.0.tgz#74153b8cc80dbd2c6a32a51e6d353a325c2710d7"
-  integrity sha512-YG9ZjAOI9OpwqDDWzkRc3kKJYJuR7gTMjLa3kAWopO17myoprxskCUyCEee+RKe34tcR4UNrVtgAwW5yDe74bw==
-  dependencies:
-    "@vendia/serverless-express" "^3.4.0"
-    binary-case "^1.0.0"
-    type-is "^1.6.16"
-
 axe-core@^4.3.5:
   version "4.3.5"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz"
@@ -3303,11 +3285,6 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
-
-binary-case@^1.0.0:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/binary-case/-/binary-case-1.1.4.tgz#d687104d59e38f2b9e658d3a58936963c59ab931"
-  integrity sha512-9Kq8m6NZTAgy05Ryuh7U3Qc4/ujLQU1AZ5vMw4cr3igTdi5itZC6kCNrRr2X8NzPiDn2oUIFTfa71DKMnue/Zg==
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -3980,6 +3957,11 @@ cookie-signature@^1.1.0:
   resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.1.0.tgz"
   integrity sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A==
 
+cookie-signature@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.2.0.tgz#4deed303f5f095e7a02c979e3fcb19157f5eaeea"
+  integrity sha512-R0BOPfLGTitaKhgKROKZQN6iyq2iDQcH1DOF8nJoaWapguX5bC2w+Q/I9NmmM5lfcvEarnLZr+cCvmEYYSXvYA==
+
 cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz"
@@ -3989,6 +3971,11 @@ cookie@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
+cookie@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 cookiejar@^2.1.2:
   version "2.1.2"
@@ -4071,6 +4058,11 @@ css@^3.0.0:
     inherits "^2.0.4"
     source-map "^0.6.1"
     source-map-resolve "^0.6.0"
+
+cssesc@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 cssom@^0.4.4:
   version "0.4.4"
@@ -5427,6 +5419,13 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+generic-names@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/generic-names/-/generic-names-4.0.0.tgz#0bd8a2fd23fe8ea16cbd0a279acd69c06933d9a3"
+  integrity sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==
+  dependencies:
+    loader-utils "^3.2.0"
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
@@ -5793,6 +5792,16 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+icss-replace-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
+  integrity sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=
+
+icss-utils@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
+  integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
 ieee754@1.1.13:
   version "1.1.13"
@@ -7129,6 +7138,11 @@ loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
+loader-utils@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-3.2.0.tgz#bcecc51a7898bee7473d4bc6b845b23af8304d4f"
+  integrity sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz"
@@ -7143,6 +7157,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -7980,6 +7999,11 @@ nanocolors@^0.1.0, nanocolors@^0.1.5:
   resolved "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz"
   integrity sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==
 
+nanoid@^3.2.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
+  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -8520,6 +8544,70 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+
+postcss-modules-extract-imports@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz#cda1f047c0ae80c97dbe28c3e76a43b88025741d"
+  integrity sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==
+
+postcss-modules-local-by-default@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz#ebbb54fae1598eecfdf691a02b3ff3b390a5a51c"
+  integrity sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==
+  dependencies:
+    icss-utils "^5.0.0"
+    postcss-selector-parser "^6.0.2"
+    postcss-value-parser "^4.1.0"
+
+postcss-modules-scope@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz#9ef3151456d3bbfa120ca44898dfca6f2fa01f06"
+  integrity sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==
+  dependencies:
+    postcss-selector-parser "^6.0.4"
+
+postcss-modules-values@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz#d7c5e7e68c3bb3c9b27cbf48ca0bb3ffb4602c9c"
+  integrity sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==
+  dependencies:
+    icss-utils "^5.0.0"
+
+postcss-modules@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/postcss-modules/-/postcss-modules-4.3.1.tgz#517c06c09eab07d133ae0effca2c510abba18048"
+  integrity sha512-ItUhSUxBBdNamkT3KzIZwYNNRFKmkJrofvC2nWab3CPKhYBQ1f27XXh1PAPE27Psx58jeelPsxWB/+og+KEH0Q==
+  dependencies:
+    generic-names "^4.0.0"
+    icss-replace-symbols "^1.1.0"
+    lodash.camelcase "^4.3.0"
+    postcss-modules-extract-imports "^3.0.0"
+    postcss-modules-local-by-default "^4.0.0"
+    postcss-modules-scope "^3.0.0"
+    postcss-modules-values "^4.0.0"
+    string-hash "^1.1.1"
+
+postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz#ee71c3b9ff63d9cd130838876c13a2ec1a992b2f"
+  integrity sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
+postcss-value-parser@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
+
+postcss@^8.4.6:
+  version "8.4.6"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.6.tgz#c5ff3c3c457a23864f32cb45ac9b741498a09ae1"
+  integrity sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==
+  dependencies:
+    nanoid "^3.2.0"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -9553,6 +9641,11 @@ sort-package-json@^1.54.0:
     is-plain-obj "2.1.0"
     sort-object-keys "^1.1.3"
 
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+
 source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
@@ -9692,6 +9785,11 @@ streamsearch@0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz"
   integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
+
+string-hash@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
+  integrity sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -10206,7 +10304,7 @@ type-fest@^2.11.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.11.2.tgz#5534a919858bc517492cd3a53a673835a76d2e71"
   integrity sha512-reW2Y2Mpn0QNA/5fvtm5doROLwDPu2zOm5RtY7xQQS05Q7xgC8MOZ3yPNaP9m/s/sNjjFQtHo7VCNqYW2iI+Ig==
 
-type-is@^1.6.16, type-is@^1.6.18, type-is@~1.6.17, type-is@~1.6.18:
+type-is@^1.6.18, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz"
   integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
@@ -10483,7 +10581,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-util-deprecate@^1.0.1:
+util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=


### PR DESCRIPTION
⚠️ **NOTE:** This is a draft WIP, not ready for review or merging ⚠️

In its current state, CSS modules are compiled into a stylesheet that gets loaded via `<Links />` before all other links. This is enabled with `unstable_cssModules` in the Remix config.

This is currently working in the gists app, but there is an issue in dev mode with the watch script so the asset gets lost in the manifest after a rebuild.