### PR TITLE
feat: Add PR Checks to GitHub Actions Workflows

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,33 @@
+name: PR Compliance
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+# Action should have write permission to make updates to PR
+permissions:
+  pull-requests: write
+
+jobs:
+  pr-compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mtfoley/pr-compliance-action@main
+        with:
+          body-auto-close: false
+          protected-branch-auto-close: false
+          body-comment: >
+            ## Issue Reference
+
+            In order to be considered for merging, the pull request description must refer to a 
+            specific issue number. This is described in our Contributing Guide. 
+
+            The check is looking for a phrase similar to: "Fixes #XYZ" or "Resolves #XYZ" where XYZ is the issue
+            number that this PR is meant to address.
+          protected-branch-comment: >
+            ## Protected Branch
+      
+            In order to be considered for merging, the pull request changes must 
+            not be implemented on the "%branch%" branch. This is described in our Contributing Guide. 
+          watch-files: |
+            package.json

--- a/contributors.yml
+++ b/contributors.yml
@@ -63,6 +63,7 @@
 - morinokami
 - mskoroglu
 - msutkowski
+- mtfoley
 - nareshbhatia
 - niconiahi
 - nobeeakon


### PR DESCRIPTION
This PR add's the Github Action [mtfoley/pr-compliance-action](https://github.com/mtfoley/pr-compliance-action) to this repo, to validate PR titles, linked issues, and head branches. It can also be used to highlight when key files are modified (e.g. package.json).

See also discussion: 
https://github.com/remix-run/remix/discussions/857

We've been using it in https://github.com/open-sauced to improve new contributors' experience, and to make sure PRs are suitable for merging.

cc @bdougie @MichaelDeBoey @mcansh 