### PR TITLE
fix: stop sorting params on data fetch

### DIFF
--- a/packages/remix-react/data.ts
+++ b/packages/remix-react/data.ts
@@ -37,7 +37,6 @@ export async function fetchData(
   submission?: Submission
 ): Promise<Response | Error> {
   url.searchParams.set("_data", routeId);
-  url.searchParams.sort(); // Improves caching
 
   let init: RequestInit = submission
     ? getActionInit(submission, signal)

--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -346,7 +346,7 @@ export function getDataLinkHrefs(
       .map(match => {
         let { pathname, search } = path;
         let searchParams = new URLSearchParams(search);
-        searchParams.append("_data", match.route.id);
+        searchParams.set("_data", match.route.id);
         return `${pathname}?${searchParams}`;
       })
   );


### PR DESCRIPTION
The prefetch link tag and the actual data being fetched were not the same because the data fetching code sorted the params. I'm the dork that sorted it in the first place, it was a mistake.

Now the href's match up and prefetching is actually useful for link with search params:

```jsx
// given this anchor
<Link to="/page?same=thing" />

// prefetch link
<link rel="prefetch" href="/page?same=thing&_data={routeId}" as="fetch" />`

// data fetch
fetch(`/page?same=thing&_data={routeId}`)
```

Updated the prefetch search params to use `set` instead of `append` because `_data` is a remix-reserved param, apps don't get to use it.