### PR TITLE
Docs (Example): codesandbox fix - added "@mantine/hooks" package

### DIFF
--- a/examples/mantine/package.json
+++ b/examples/mantine/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@mantine/core": "^3.5.0",
+    "@mantine/hooks": "^3.5.0",
     "@mantine/ssr": "^3.5.0",
     "@remix-run/react": "^1.1.1",
     "@remix-run/serve": "^1.1.1",


### PR DESCRIPTION
codesandbox can't resolve the hooks package and throws an error; so we have to add it manually. I will check again when server container is out of beta.