### PR TITLE
Update fetcher load/submit error message

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1094,6 +1094,13 @@ export function useSubmitImpl(key?: string): SubmitFunction {
         }
       }
 
+      if (typeof window === "undefined") {
+        throw new Error(
+          "You are calling submit during the server render. " +
+            "Try calling submit within a `useEffect` or callback instead."
+        );
+      }
+
       let { protocol, host } = window.location;
       let url = new URL(action, `${protocol}//${host}`);
 

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -780,6 +780,13 @@ export function createTransitionManager(init: TransitionManagerInit) {
     key: string,
     match: ClientMatch
   ) {
+    if (typeof AbortController === "undefined") {
+      throw new Error(
+        "handleLoaderFetch was called during the server render, but it shouldn't be. " +
+          "You are likely calling useFetcher.load() in the body of your component. " +
+          "Try moving it to a useEffect or a callback."
+      );
+    }
     let currentFetcher = state.fetchers.get(key);
 
     let fetcher: FetcherStates["Loading"] = {


### PR DESCRIPTION
Fixes https://github.com/remix-run/remix/issues/1148

The error messages shown in the console when `useFetcher().load` or `useFetcher.submit` are called incorrectly wasn't very helpful. This PR throws new error messages explaining what went wrong.