### PR TITLE
docs(blog): Add prerequisites to Developer Blog page

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -143,3 +143,4 @@
 - yomeshgupta
 - zachdtaylor
 - zainfathoni
+- rvlewerissa

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -11,6 +11,13 @@ We're going to be short on words and quick on code in this quickstart. If you're
 
 This uses TypeScript, but we always pepper the types on after we write the code. This isn't our normal workflow, but some of you aren't using TypeScript so we didn't want to clutter up the code for you. Normally we create the type as we write the code so that we get it right the first time (measure twice, cut once!).
 
+## Prerequisites
+
+If you want to follow this tutorial locally on your own computer, it is important for you to have these things installed:
+- [Node.js](https://nodejs.org) 14 or greater
+- [npm](https://www.npmjs.com) 7 or greater
+- A code editor
+
 ## Creating the project
 
 💿 Initialize a new Remix project


### PR DESCRIPTION
👋 Hi,

I'm new to this library and tried to follow along with the tutorial but results in an error. Then I discovered that we need Node v14 while digging through the issues page (and later in the [Jokes App](https://remix.run/docs/en/v1/tutorials/jokes#prerequisites) page).

I think it would be great to add prerequisites to the page directly or have it on its own page.

Thank you.