### PR TITLE
fix: allow build/start as esm module [ready for review]

### DIFF
--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -167,7 +167,9 @@ export async function dev(remixRoot: string, modeArg?: string) {
     purgeAppRequireCache(config.serverBuildPath);
     next();
   });
-  app.use(createApp(config.serverBuildPath, mode));
+
+  const createAppHandler = await createApp(config.serverBuildPath, mode);
+  app.use(createAppHandler);
 
   let server: Server | null = null;
 

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -245,7 +245,11 @@ export async function readConfig(
 
   let appConfig: AppConfig;
   try {
-    appConfig = require(configFile);
+    appConfig = await import(configFile);
+
+    if('default' in appConfig) {
+      appConfig = appConfig.default;
+    }
   } catch (error) {
     throw new Error(`Error loading Remix config in ${configFile}`);
   }

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -18,6 +18,7 @@ export type RemixMdxConfigFunction = (
 
 export type ServerBuildTarget =
   | "node-cjs"
+  | "node-esm"
   | "arc"
   | "netlify"
   | "vercel"
@@ -236,6 +237,10 @@ export async function readConfig(
     remixRoot = process.env.REMIX_ROOT || process.cwd();
   }
 
+  let packageJson = await import(`${remixRoot}/package.json`);
+  let moduleFormat: ServerModuleFormat =
+    packageJson.type === "module" ? "esm" : "cjs";
+
   if (!isValidServerMode(serverMode)) {
     throw new Error(`Invalid server mode "${serverMode}"`);
   }
@@ -259,7 +264,7 @@ export async function readConfig(
   let serverBuildTarget: ServerBuildTarget | undefined =
     appConfig.serverBuildTarget;
   let serverModuleFormat: ServerModuleFormat =
-    appConfig.serverModuleFormat || "cjs";
+    appConfig.serverModuleFormat || moduleFormat;
   let serverPlatform: ServerPlatform = appConfig.serverPlatform || "node";
   switch (appConfig.serverBuildTarget) {
     case "cloudflare-pages":
@@ -267,6 +272,8 @@ export async function readConfig(
       serverModuleFormat = "esm";
       serverPlatform = "neutral";
       break;
+    case "node-esm":
+      serverModuleFormat = "esm";
   }
 
   let mdx = appConfig.mdx;

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -243,7 +243,8 @@ export async function readConfig(
   let rootDirectory = path.resolve(remixRoot);
   let configFile = path.resolve(rootDirectory, "remix.config.js");
 
-  let appConfig: AppConfig;
+  let appConfig: AppConfig | { default: AppConfig };
+  
   try {
     appConfig = await import(configFile);
 

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -244,11 +244,11 @@ export async function readConfig(
   let configFile = path.resolve(rootDirectory, "remix.config.js");
 
   let appConfig: AppConfig | { default: AppConfig };
-  
+
   try {
     appConfig = await import(configFile);
 
-    if('default' in appConfig) {
+    if ("default" in appConfig) {
       appConfig = appConfig.default;
     }
   } catch (error) {

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -26,4 +26,5 @@ createApp(buildPath).then(server => {
     }
 
     console.log(`Remix App Server started at http://${address}:${port}`);
-})});
+  });
+});

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -15,14 +15,15 @@ if (!buildPathArg) {
 
 let buildPath = path.resolve(process.cwd(), buildPathArg);
 
-createApp(buildPath).listen(port, () => {
-  let address = Object.values(os.networkInterfaces())
-    .flat()
-    .find(ip => ip?.family == "IPv4" && !ip.internal)?.address;
+createApp(buildPath).then(server => {
+  server.listen(port, () => {
+    let address = Object.values(os.networkInterfaces())
+      .flat()
+      .find(ip => ip?.family == "IPv4" && !ip.internal)?.address;
 
-  if (!address) {
-    throw new Error("Could not find an IPv4 address.");
-  }
+    if (!address) {
+      throw new Error("Could not find an IPv4 address.");
+    }
 
-  console.log(`Remix App Server started at http://${address}:${port}`);
-});
+    console.log(`Remix App Server started at http://${address}:${port}`);
+})});

--- a/packages/remix-serve/index.ts
+++ b/packages/remix-serve/index.ts
@@ -3,7 +3,7 @@ import compression from "compression";
 import morgan from "morgan";
 import { createRequestHandler } from "@remix-run/express";
 
-export function createApp(buildPath: string, mode = "production") {
+export async function createApp(buildPath: string, mode = "production") {
   let app = express();
 
   app.use(compression());
@@ -13,10 +13,10 @@ export function createApp(buildPath: string, mode = "production") {
   app.all(
     "*",
     mode === "production"
-      ? createRequestHandler({ build: require(buildPath), mode })
-      : (req, res, next) => {
+      ? createRequestHandler({ build: await import(buildPath), mode })
+      : async (req, res, next) => {
           // require cache is purged in @remix-run/dev where the file watcher is
-          let build = require(buildPath);
+          let build = await import(buildPath);
           return createRequestHandler({ build, mode })(req, res, next);
         }
   );

--- a/packages/remix-serve/tsconfig.json
+++ b/packages/remix-serve/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
+    "module": "es2020",
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
ATM, if you set `{"type": "module"}` in `package.json` you lost ability to build remix app because `require()` is not in module context.

With this change we will use `import()` statement that works with CommonJS and ESM. [More info in v14.x docs](https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_interoperability_with_commonjs)

Other changes:
— remix-dev createServer now async function, it can break code that relies on @remix-run/dev
— appConfig.serverModuleFormat inherits value from package.json type field. if type === undefined, then 'cjs' else 'esm'.

ATM serverModuleFormat is undocumented feature. I am not native speaker and i cannot update documentation :-(

Commonjs `remix.config.js`
```JS
module.exports = {
	appDirectory: "app",
	assetsBuildDirectory: "public/build",
	publicPath: "/build/",
	serverBuildDirectory: "build",
	devServerPort: 8002,
	ignoredRouteFiles: [".*"],
	serverModuleFormat: "esm"
};
```

ESM `remix.config.js`
```JS
export default {
	appDirectory: "app",
	assetsBuildDirectory: "public/build",
	publicPath: "/build/",
	serverBuildDirectory: "build",
	devServerPort: 8002,
	ignoredRouteFiles: [".*"],
	serverModuleFormat: "esm"
};
```
Related issue and PR:
https://github.com/remix-run/remix/issues/1283
https://github.com/remix-run/remix/pull/976
https://github.com/remix-run/remix/issues/1279


**P.S.**: Also looks like all build tests are skipped now =\, but trust me, it works! :D
https://github.com/remix-run/remix/blob/dev/packages/remix-dev/__tests__/build-test.ts#L20