### PR TITLE
Use wrangler@beta in Cloudflare Pages template

### DIFF
--- a/packages/create-remix/templates/cloudflare-pages/package.json
+++ b/packages/create-remix/templates/cloudflare-pages/package.json
@@ -4,7 +4,7 @@
     "postinstall": "remix setup cloudflare-pages",
     "build": "cross-env NODE_ENV=production remix build",
     "dev:remix": "remix watch",
-    "dev:wrangler": "wrangler pages dev ./public --watch ./build",
+    "dev:wrangler": "wrangler pages dev ./public",
     "dev": "cross-env NODE_ENV=development run-p dev:*",
     "start": "npm run dev:wrangler"
   },
@@ -16,6 +16,6 @@
     "cross-env": "^7.0.3",
     "esbuild": "0.13.14",
     "npm-run-all": "^4.1.5",
-    "wrangler": "alpha"
+    "wrangler": "beta"
   }
 }


### PR DESCRIPTION
We've managed to [automatically watch dependencies outside of just the `functions` folder](https://github.com/cloudflare/wrangler2/issues/49), and that has now been added to the `beta` tag as we gear up for an official release.