### PR TITLE
chore(format): use github bot token to push

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -39,5 +39,5 @@ jobs:
             exit 0
           fi
           git commit -m "chore: format" -m "formatted $GITHUB_SHA"
-          git push
+          git push https://${{ secrets.GH_BOT_TOKEN }}@github.com/$GITHUB_REPOSITORY.git
           echo "💿 pushed formatting changes https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"


### PR DESCRIPTION
Pretty certain this should work to push the commits as the remix bot so it can get in without protections blocking it.