### PR TITLE
ci: checkout repo using GH_BOT_TOKEN

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Checkout Repository
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_BOT_TOKEN }}
 
       - name: Use Node.js
         uses: actions/setup-node@v2
@@ -39,5 +41,5 @@ jobs:
             exit 0
           fi
           git commit -m "chore: format" -m "formatted $GITHUB_SHA"
-          git push https://${{ secrets.GH_BOT_TOKEN }}@github.com/$GITHUB_REPOSITORY.git
+          git push
           echo "💿 pushed formatting changes https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"


### PR DESCRIPTION
@kentcdodds was soooo close in #1454

this led me to resolving the issue https://www.paulmowat.co.uk/blog/resolve-github-action-gh006-protected-branch-update-failed

here's a quick example before i delete the repo https://github.com/remix-run/gh-action-push-to-protected-branch/commits/dev