### PR TITLE
Add dynamic websocket host

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -94,3 +94,4 @@
 - anishpras
 - kumard3
 - mattmazzola
+- warmpigman

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1279,7 +1279,7 @@ export function LiveReload({ port = 8002 }: { port?: number }) {
     <script
       dangerouslySetInnerHTML={{
         __html: `
-          let ws = new WebSocket("ws://localhost:${port}/socket");
+          let ws = new WebSocket("ws://${window.location.host.split(':')[0]}:${port}/socket");
           ws.onmessage = message => {
             let event = JSON.parse(message.data);
             if (event.type === "LOG") {


### PR DESCRIPTION
Changes static localhost websocket host url to dynamic, fetches the host and applies that + port. #1264 Proposes a suggestion via specifying the host but that means static and you would have to type it in if you were to change/the first time.