### PR TITLE
feat(cloudflare-workers): edge cache static assets

### DIFF
--- a/packages/remix-cloudflare-workers/worker.ts
+++ b/packages/remix-cloudflare-workers/worker.ts
@@ -69,6 +69,8 @@ export async function handleAsset(
     let requestpath = url.pathname.split("/").slice(0, -1).join("/");
 
     if (requestpath.startsWith(assetpath)) {
+      // Assets are hashed by Remix so are safe to cache in the browser
+      // And they're also hashed in KV storage, so are safe to cache on the edge
       cacheControl = {
         bypassCache: false,
         edgeTTL: 31536000,

--- a/packages/remix-cloudflare-workers/worker.ts
+++ b/packages/remix-cloudflare-workers/worker.ts
@@ -74,6 +74,13 @@ export async function handleAsset(
         edgeTTL: 31536000,
         browserTTL: 31536000
       };
+    } else {
+      // Assets are not necessarily hashed in the request URL, so we cannot cache in the browser
+      // But they are hashed in KV storage, so we can cache on the edge
+      cacheControl = {
+        bypassCache: false,
+        edgeTTL: 31536000
+      };
     }
 
     return await getAssetFromKV(event, {


### PR DESCRIPTION
Part 1 from PR https://github.com/remix-run/remix/pull/924 by @GregBrimble.

~~This was pulled into its own PR because I don't think we can do part 2 because unless I misunderstand CF's edge cache, they operate on the `max-age` header and not `s-maxage`. This would land you in cases where you want to `max-age=5` or some small value for a piece of user-specific content in just their browser and have it end up cached at the edge and served to other visitors.~~ I forgot about the `private` directive 🤦‍♀️

Still good to pull it into its own PR to give it a good test run and make sure CF isn't caching things we don't expect them to be.