### PR TITLE
Split Newsletter example in two files to avoid missleading the reader

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -53,6 +53,7 @@
 - gonzoscript
 - graham42
 - GregBrimble
+- gustavoguichard
 - hardingmatt
 - HenryVogt
 - hkan

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -777,7 +777,9 @@ export async function action({ request }) {
     return json({ error: error.message });
   }
 }
+```
 
+```tsx filename=components/footer.tsx
 function NewsletterSignup() {
   const newsletter = useFetcher();
   const ref = useRef();


### PR DESCRIPTION
By reading the docs my colleague got confused about this bit of the docs so in a call we figured out it was talking about 2 different files.
I hope this change speaks for itself, let me know if I need to work further on this PR.