### PR TITLE
docs: clarify newsletter useFetcher example in the docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -28,6 +28,7 @@
 - coryhouse
 - craigglennie
 - crismali
+- danielweinmann
 - davecalnan
 - DavidHollins6
 - derekr

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -765,7 +765,7 @@ fetcher.data; // the data from the loader
 
 **Newsletter Signup Form**
 
-Perhaps you have a persistent newsletter signup at the bottom of every page on your site. This is not a navigation event, so useFetcher is perfect for the job:
+Perhaps you have a persistent newsletter signup at the bottom of every page on your site. This is not a navigation event, so useFetcher is perfect for the job. First, you create an API-only route:
 
 ```tsx filename=routes/newsletter/subscribe.tsx
 export async function action({ request }) {
@@ -777,6 +777,12 @@ export async function action({ request }) {
     return json({ error: error.message });
   }
 }
+```
+
+Then, somewhere else in your app (your root layout in this example), you render the following component:
+
+```tsx filename=routes/root.tsx
+// ...
 
 function NewsletterSignup() {
   const newsletter = useFetcher();

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -765,7 +765,7 @@ fetcher.data; // the data from the loader
 
 **Newsletter Signup Form**
 
-Perhaps you have a persistent newsletter signup at the bottom of every page on your site. This is not a navigation event, so useFetcher is perfect for the job. First, you create an API-only route:
+Perhaps you have a persistent newsletter signup at the bottom of every page on your site. This is not a navigation event, so useFetcher is perfect for the job. First, you create a Resource Route:
 
 ```tsx filename=routes/newsletter/subscribe.tsx
 export async function action({ request }) {


### PR DESCRIPTION
It wasn't clear where the `NewsletterSignup` component was rendered at the beginning of the newsletter example for `useFetcher`. I hope this change makes it clearer.