### PR TITLE
docs(examples): fix expires calculation in redis session

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -76,6 +76,7 @@
 - juhanakristian
 - juwiragiye
 - kalch
+- karimsan
 - KenanYusuf
 - kentcdodds
 - kevinrambaud

--- a/examples/redis-upstash-session/app/sessions/upstash.server.ts
+++ b/examples/redis-upstash-session/app/sessions/upstash.server.ts
@@ -13,7 +13,9 @@ const headers = {
 const expiresToSeconds = expires => {
   const now = new Date();
   const expiresDate = new Date(expires);
-  const secondsDelta = expiresDate.getSeconds() - now.getSeconds();
+  const secondsDelta = Math.ceil(
+    (expiresDate.getTime() - now.getTime()) / 1000
+  );
   return secondsDelta < 0 ? 0 : secondsDelta;
 };
 


### PR DESCRIPTION
Method `getSeconds()` returns the seconds of the specified date (from 0 to 60) and it leads to incorrect expiration time calculation.

For correct total time difference calculation should be used method `getTime()` - it returns milliseconds since the Unix Epoch.   