### PR TITLE
Cloudflare pages wrangler build fix

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -94,3 +94,4 @@
 - anishpras
 - kumard3
 - mattmazzola
+- jerryharrison

--- a/packages/create-remix/templates/cloudflare-pages/package.json
+++ b/packages/create-remix/templates/cloudflare-pages/package.json
@@ -16,6 +16,6 @@
     "cross-env": "^7.0.3",
     "esbuild": "0.13.14",
     "npm-run-all": "^4.1.5",
-    "wrangler": "alpha"
+    "wrangler": "beta"
   }
 }


### PR DESCRIPTION
Fixes for #1426

I've noticed that the correct version for cloudflare pages builds is `beta` not `alpha`. I've been able to confirm this with two projects and with several successful builds.