### PR TITLE
chore(docs): typo in internal link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,4 +1,5 @@
 - abereghici
+- abotsi
 - ahbruns
 - ahmedeldessouki
 - airjp73

--- a/docs/guides/data-loading.md
+++ b/docs/guides/data-loading.md
@@ -666,4 +666,4 @@ export default function RouteComp() {
 [url-search-params]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
 [url]: https://developer.mozilla.org/en-US/docs/Web/API/URL
 [use-submit]: ../api/remix#usesubmit
-[useloaderdata]: ../api/remix#userloaderdata
+[useloaderdata]: ../api/remix#useloaderdata


### PR DESCRIPTION
Hello, just a really small typo fix here (my way to kinda thank you for this exciting project)