### PR TITLE
docs(tutorials): fix link in your-first-route step

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -24,6 +24,7 @@
 - christianhg
 - christophgockel
 - clarkmitchell
+- cam31007
 - codymjarrett
 - coryhouse
 - craigglennie

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -40,7 +40,7 @@ This might happen if you've added `ignore-scripts = true` to your `npm` configur
 
 We're going to make a new route to render at the "/posts" URL. Before we do that, let's link to it.
 
-💿 Add a link to posts in `app/root.tsx`
+💿 Add a link to posts in `app/routes/index.tsx`
 
 ```tsx
 <Link to="/posts">Posts</Link>


### PR DESCRIPTION
The Developer Blog tutorial mentions to add a `<Link />`  inside `app/root.tsx` and that could also delete the entire content of that file. I believe that is incorrect since modifying that file incorrectly could "break" the app. My best guess is the intention probably was to add the `<Link />`  inside `app/routes/index.tsx` instead.