### PR TITLE
docs(tutorial): Sanitize parsing of markdown in blog tutorial to remove potential XSS vulnerability

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -147,6 +147,7 @@
 - UsamaHameed
 - veritem
 - VictorPeralta
+- wdoug
 - weavdale
 - yauri-io
 - yesmeck

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -540,7 +540,7 @@ export async function getPost(slug: string) {
     isValidPostAttributes(attributes),
     `Post ${filepath} is missing attributes`
   );
-  const html = marked(body);
+  const html = marked(body, { sanitize: true });
   return { slug, html, title: attributes.title };
 }
 ```


### PR DESCRIPTION
Obviously, the blog tutorial is an introductory example of some of the capabilities of Remix and not a secure website. That said, I think we should try to reduce the risks of people having security vulnerabilities in their code by copying documentation. I believe that we should encourage people to pass that `sanitize` parameter by default. If someone fully trusts the markdown source and also wants HTML capabilities beyond what markdown offers directly, it is easy enough for them to remove, but at least that way they would be more inclined to understand the ramifications.