### PR TITLE
fix(remix-architect): set request URL scheme to `http` when running arc sandbox

### DIFF
--- a/packages/remix-architect/server.ts
+++ b/packages/remix-architect/server.ts
@@ -68,7 +68,8 @@ export function createRemixRequest(
 ): NodeRequest {
   let host = event.headers["x-forwarded-host"] || event.headers.host;
   let search = event.rawQueryString.length ? `?${event.rawQueryString}` : "";
-  let url = new URL(event.rawPath + search, `https://${host}`);
+  let scheme = (process.env.ARC_SANDBOX ? 'http' : 'https');
+  let url = new URL(event.rawPath + search, `${scheme}://${host}`);
 
   return new NodeRequest(url.href, {
     method: event.requestContext.http.method,


### PR DESCRIPTION
Fixes #1536.