### PR TITLE
fix: DOMException in scroll restoration

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -64,6 +64,7 @@
 - morinokami
 - mskoroglu
 - msutkowski
+- n1ck
 - nareshbhatia
 - niconiahi
 - nobeeakon

--- a/packages/remix-react/scroll-restoration.tsx
+++ b/packages/remix-react/scroll-restoration.tsx
@@ -99,10 +99,14 @@ function useScrollRestoration() {
 
       // try to scroll to the hash
       if (location.hash) {
-        let el = document.querySelector(location.hash);
-        if (el) {
-          el.scrollIntoView();
-          return;
+        try {
+          let el = document.querySelector(location.hash);
+          if (el) {
+            el.scrollIntoView();
+            return;
+          }
+        } catch (e) {
+          console.error(e);
         }
       }
 


### PR DESCRIPTION
## Issue

When trying to scroll to a hash, if the provided hash is not a valid selector it currently throws a DOMException.

I noticed this when viewing the blog https://remix.run/blog/remix-vs-next and clicking on a header with an emoji: "Remix ❤️ the Web"  as it has a `href` of `#remix-%EF%B8%8F-the-web`


https://user-images.githubusercontent.com/1018141/150040187-5ada8897-e37b-4b84-bc18-476ec3cc5e0d.mov

## Fix

I've attempted to fix this by wrapping the call to `document.querySelector` with a try/catch block to avoid the exception and log the error. If there is a different, preferred approach to resolve this let me know.