### PR TITLE
fix: fix invalid checking of layout route id

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -153,3 +153,4 @@
 - yomeshgupta
 - zachdtaylor
 - zainfathoni
+- ehesp

--- a/packages/remix-dev/config/routesConvention.ts
+++ b/packages/remix-dev/config/routesConvention.ts
@@ -70,7 +70,7 @@ export function defineConventionalRoutes(
       let fullPath = createRoutePath(routeId.slice("routes".length + 1));
       let uniqueRouteId = (fullPath || "") + (isIndexRoute ? "?index" : "");
 
-      if (typeof uniqueRouteId !== "undefined") {
+      if (uniqueRouteId) {
         if (uniqueRoutes.has(uniqueRouteId)) {
           throw new Error(
             `Path ${JSON.stringify(fullPath)} defined by route ${JSON.stringify(


### PR DESCRIPTION
Fixes https://github.com/remix-run/remix/issues/1549

Layout routes (e.g. `__foo.tsx`) are getting treated as a route because the typeof check will never be undefined (since strings are concatenated). This changes the logic to only check for path uniqueness if there is a route id with a string length greater than 0.