### PR TITLE
docs(tutorial): refer to the right file to add a link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -127,6 +127,7 @@
 - RossMcMillan92
 - rphlmr
 - ryanflorence
+- saharbit
 - sean-roberts
 - sergiodxa
 - shumuu

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -40,7 +40,7 @@ This might happen if you've added `ignore-scripts = true` to your `npm` configur
 
 We're going to make a new route to render at the "/posts" URL. Before we do that, let's link to it.
 
-💿 Add a link to posts in `app/root.tsx`
+💿 Add a link to posts in `app/routes/index.tsx`
 
 ```tsx
 <Link to="/posts">Posts</Link>


### PR DESCRIPTION
I think the docs are somewhat misleading, because they tell you to go to `root.tsx` and then 

_"You can put it anywhere you like, you might want to just delete everything that's there."_

Obviously we don't want people removing everything in `root.tsx` (Scripts, LiveReload etc.) so it's better to edit `routes/index.tsx`