### PR TITLE
fix(ScrollRestoration): errors with invalid selector

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -11,6 +11,7 @@
 - bsharrow
 - chaance
 - christophgockel
+- Commandtechno
 - coryhouse
 - donavon
 - davecalnan

--- a/packages/remix-react/scroll-restoration.tsx
+++ b/packages/remix-react/scroll-restoration.tsx
@@ -99,7 +99,11 @@ function useScrollRestoration() {
 
       // try to scroll to the hash
       if (location.hash) {
-        let el = document.querySelector(location.hash);
+        let el;
+        try {
+          el = document.querySelector(location.hash);
+        } catch {}
+
         if (el) {
           el.scrollIntoView();
           return;


### PR DESCRIPTION
With an invalid selector `document.querySelector` throws a `SyntaxError` which crashes the website
Example of an invalid selector that throws a `SyntaxError` is an ID that starts with a number (#1)

Stackoverflow Reference: https://stackoverflow.com/a/34777644
MDN Docs:
https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector#parameters

To reproduce go to https://remix.run/ and then change the URL to https://remix.run/#1 for ScrollRestoration to activate
I'm guessing the remix website just trys to re-render on an error so it leads to an error loop in the console

![image](https://user-images.githubusercontent.com/68407783/150204086-e49ab7e2-c65a-407e-9edb-1174bc98730d.png)