### PR TITLE
fix(ci): use built in cache strategy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         id: nvmrc
 
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: "${{ steps.nvmrc.outputs.version }}"
           cache: 'yarn'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,17 +24,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: "${{ steps.nvmrc.outputs.version }}"
-
-      - run: echo "::set-output name=dir::$(yarn cache dir)"
-        id: yarn-cache
-
-      - name: Restore dependency cache
-        uses: actions/cache@v2
-        with:
-          path: "${{ steps.yarn-cache.outputs.dir }}"
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-cache-
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn --frozen-lockfile

--- a/contributors.yml
+++ b/contributors.yml
@@ -19,6 +19,7 @@
 - bruno-oliveira
 - bsharrow
 - CanRau
+- c43721
 - chaance
 - chenc041
 - christianhg


### PR DESCRIPTION
CI will now use the built-in cache strategy from `setup-node` instead of manually setting the cache keys.

See:
https://github.com/actions/setup-node#caching-packages-dependencies
https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

Tested with my fork with https://github.com/c43721/remix/pull/1, this performs similar given margin of error while also being a bit more cleaner to read.

This bumps the action `setup-node` to version **2**. This should be a consideration before merging as it could become an issue. 