### PR TITLE
docs: fix variable name in CatchBoundary example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -153,3 +153,4 @@
 - yomeshgupta
 - zachdtaylor
 - zainfathoni
+- bustamantedev

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -710,7 +710,7 @@ export function CatchBoundary() {
         <div>
           <p>You don't have access to this invoice.</p>
           <p>
-            Contact {invoiceCatch.data.invoiceOwnerEmail} to
+            Contact {caught.data.invoiceOwnerEmail} to
             get access
           </p>
         </div>
@@ -723,8 +723,8 @@ export function CatchBoundary() {
   // This will be caught by the closest `ErrorBoundary`.
   return (
     <div>
-      Something went wrong: {invoiceCatch.status}{" "}
-      {invoiceCatch.statusText}
+      Something went wrong: {caught.status}{" "}
+      {caught.statusText}
     </div>
   );
 }


### PR DESCRIPTION
I was reading through the page and saw `invoiceCatch` referenced in the template. I think you meant `caught`.