### PR TITLE
Enhancement: Added docs-warning to quickstart guide

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -158,3 +158,4 @@
 - yomeshgupta
 - zachdtaylor
 - zainfathoni
+- damiensedgwick

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -15,6 +15,10 @@ This uses TypeScript, but we always pepper the types on after we write the code.
 
 💿 Initialize a new Remix project
 
+<docs-warning>
+Make sure you are running at least Node v14 or greater
+</docs-warning>
+
 ```sh
 npx create-remix@latest
 # choose Remix App Server


### PR DESCRIPTION
I mistakenly tried going through the quick-start guide on Node v12 which lead me to encounter an error where `@remix/server` was not found, even after trying to install it manually.

I thought maybe i'd done something wrong so I repeated the process and hit the same issue.

A simple fix is to just add a docs-warning to the top of the remix-quickstart guide.