### PR TITLE
Enhancement: Implemented a node minimum version check

### DIFF
--- a/packages/create-remix/index.ts
+++ b/packages/create-remix/index.ts
@@ -24,6 +24,17 @@ interface CreateAppArgs {
 }
 
 async function createApp({ projectDir, lang, server, install }: CreateAppArgs) {
+  // Check the host's node version
+  const versions = process.versions;
+  if (versions && versions.node) {
+    if (parseInt(versions.node) < 14) {
+      console.log(
+        `️🚨 Oops, Node  v"${versions.node}" Remix requires a Node version greater than 14.`
+      );
+      process.exit(1);
+    }
+  }
+
   // Create the app directory
   let relativeProjectDir = path.relative(process.cwd(), projectDir);
   let projectDirIsCurrentDir = relativeProjectDir === "";

--- a/packages/create-remix/index.ts
+++ b/packages/create-remix/index.ts
@@ -29,7 +29,7 @@ async function createApp({ projectDir, lang, server, install }: CreateAppArgs) {
   if (versions && versions.node) {
     if (parseInt(versions.node) < 14) {
       console.log(
-        `️🚨 Oops, Node  v"${versions.node}" Remix requires a Node version greater than 14.`
+        `️🚨 Oops, Node v${versions.node} detected. Remix requires a Node version greater than 14.`
       );
       process.exit(1);
     }


### PR DESCRIPTION
## Overview

### What is the feature?
This prevents users from running the create-remix command when they do not have the minimum version of Node required for Remix.

### What is the solution?
At the top of `createApp`, I added a  simple check to grab the users node version and if it is below v14, it will log to the console and prevent further execution of the script.

I have attached a screen shot of a failed attempt and a succeeding attempt using 2 different node versions.

<img width="1920" alt="Screenshot 2022-01-20 at 19 32 11" src="https://user-images.githubusercontent.com/42817702/150409260-3bdb7349-c424-4174-984f-043ba944e601.png">