### PR TITLE
docs: update installation command for tailwindcss guide

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -153,6 +153,7 @@
 - veritem
 - VictorPeralta
 - weavdale
+- xstevenyung
 - yauri-io
 - yesmeck
 - yomeshgupta

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -398,7 +398,7 @@ Perhaps the most popular way to style a Remix application in the community is to
 First install a couple dev dependencies:
 
 ```sh
-npm add -D concurrently tailwindcss
+npm add -D concurrently tailwindcss postcss autoprefixer
 ```
 
 Initialize a tailwind config so we can tell it which files to generate classes from.


### PR DESCRIPTION
Since v3, Tailwind.css requires PostCSS to run the CLI and recommend `autoprefixer` as a `peerDependency`.

I updated the styling guide to include those update