### PR TITLE
docs: Adds example of Prisma generated type

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -158,3 +158,4 @@
 - yomeshgupta
 - zachdtaylor
 - zainfathoni
+- guerra08

--- a/docs/guides/data-loading.md
+++ b/docs/guides/data-loading.md
@@ -161,16 +161,17 @@ export default function ProductCategory() {
 }
 ```
 
-If you are using TypeScript, you can use Prisma Client generated types to get better type safety and intellisense when writing your code to load data.
+If you are using TypeScript, you can use type inference to use Primsa Client generated types on when calling `useLoaderData`. This allowes better type safety and intellisense when writing your code that uses the loaded data.
 
 ```tsx filename=tsx filename=app/routes/products/$productId.tsx
 import { useLoaderData } from "remix";
-import type { LoaderFunction } from "remix";
-import type { Product } from "@prisma/client";
+import { db } from "~/db.server";
 
-type LoaderData = Product;
+type LoaderData = Awaited<ReturnType<typeof loader>>
 
-// Loader function implementation...
+export let loader = async ({ params }) => {
+  return db.product.findMany({});
+};
 
 export default function Product() {
   let product = useLoaderData<LoaderData>();

--- a/docs/guides/data-loading.md
+++ b/docs/guides/data-loading.md
@@ -161,6 +161,29 @@ export default function ProductCategory() {
 }
 ```
 
+If you are using TypeScript, you can use Prisma Client generated types to get better type safety and intellisense when writing your code to load data.
+
+```tsx filename=tsx filename=app/routes/products/$productId.tsx
+import { useLoaderData } from "remix";
+import type { LoaderFunction } from "remix";
+import type { Product } from "@prisma/client";
+
+type LoaderData = Product;
+
+// Loader function implementation...
+
+export default function Product() {
+  let product = useLoaderData<LoaderData>();
+  return (
+    <div>
+      <p>Product {product.id}</p>
+      {/* ... */}
+    </div>
+  );
+}
+
+```
+
 ## Cloudflare KV
 
 If you picked Cloudflare Workers as you environment, [Cloudflare Key Value][cloudflare-kv] storage allows you to persist data at the edge as if it were a static resource. You'll need to [do some configuration][cloudflare-kv-setup] but then you can access the data from your loaders:

--- a/docs/guides/data-loading.md
+++ b/docs/guides/data-loading.md
@@ -164,13 +164,24 @@ export default function ProductCategory() {
 If you are using TypeScript, you can use type inference to use Primsa Client generated types on when calling `useLoaderData`. This allowes better type safety and intellisense when writing your code that uses the loaded data.
 
 ```tsx filename=tsx filename=app/routes/products/$productId.tsx
-import { useLoaderData } from "remix";
+import { useLoaderData, json } from "remix";
 import { db } from "~/db.server";
 
-type LoaderData = Awaited<ReturnType<typeof loader>>
+type LoaderData = Awaited<ReturnType<typeof getLoaderData>>
 
-export let loader = async ({ params }) => {
-  return db.product.findMany({});
+async function getLoaderData() {
+  const products = await db.product.findMany({
+    select: {
+      id: true,
+      name: true,
+      imgSrc: true,
+    }
+  })
+  return { products }
+}
+
+export let loader = async () => {
+  return json<LoaderData>(await getLoaderData());
 };
 
 export default function Product() {


### PR DESCRIPTION
This PR adds an example of **Prisma Client generated types** when using a **LoaderFunction**. This is similar to other samples found on the example projects and video guides on Remix YouTube channel.

![image](https://user-images.githubusercontent.com/29544679/150785695-d795bef6-5ff0-4410-9304-6796abd45c0f.png)
