### PR TITLE
fix(docs):#704 Invalid link to route-module-links

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,3 +1,4 @@
+- aaronpowell96
 - abereghici
 - ahbruns
 - ahmedeldessouki

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -4,7 +4,7 @@ title: Styling
 
 # Styling
 
-The primary way to style in Remix (and the web) is to add a `<link rel="stylesheet">` to the page. In Remix, you can add these links via the [Route Module `links` export]([route-module-links]) at route layout boundaries. When the route is active, the stylesheet is added to the page. When the route is no longer active, the stylesheet is removed.
+The primary way to style in Remix (and the web) is to add a `<link rel="stylesheet">` to the page. In Remix, you can add these links via the [Route Module `links` export][route-module-links] at route layout boundaries. When the route is active, the stylesheet is added to the page. When the route is no longer active, the stylesheet is removed.
 
 ```js
 export function links() {


### PR DESCRIPTION
Corrected the syntax for linking.

I stumbled across this issue in the docs and also found a bug report to have the same issue, I have linked it to this PR.

closes #704