### PR TITLE
getLoadContext param for arc's createRequestHandler optional

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -92,6 +92,7 @@
 - leo
 - leon
 - levippaul
+- lpsinger
 - lswest
 - luispagarcia
 - luistorres

--- a/packages/remix-architect/server.ts
+++ b/packages/remix-architect/server.ts
@@ -41,7 +41,7 @@ export function createRequestHandler({
   mode = process.env.NODE_ENV
 }: {
   build: ServerBuild;
-  getLoadContext: GetLoadContextFunction;
+  getLoadContext?: GetLoadContextFunction;
   mode?: string;
 }): APIGatewayProxyHandlerV2 {
   let platform: ServerPlatform = { formatServerError };


### PR DESCRIPTION
The `getLoadContext` parameter for remix-architect's `createRequestHandler` function should be optional.

According to https://remix.run/docs/en/v1/api/conventions#loader-context:

> This API is an escape hatch, it’s uncommon to need it

And indeed other Remix hosting targets (`remix-cloudflare-pages`, `remix-cloudflare-workers`, `remix-express`, `remix-netlify`, `remix-vercel` declare this parameter as optional.