### PR TITLE
docs: correct `requireUserSession()` in conventions

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -649,7 +649,7 @@ export function getInvoice(id, user) {
 import { redirect } from "remix";
 import { getSession } from "./session";
 
-function requireUserSession(request) {
+export async function requireUserSession(request) {
   const session = await getSession(
     request.headers.get("cookie")
   );


### PR DESCRIPTION
The code is missing `export` and `async` .