### PR TITLE
docs: fix name validation rule in Mutations section

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -145,6 +145,7 @@
 - thomasrettig
 - tjefferson08
 - tombyrer
+- toyozaki
 - tvanantwerp
 - twhitbeck
 - tylerbrostrom

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1987,7 +1987,7 @@ Before I set you off on this one, there's one more thing you need to know about 
 
 But if there's an error, you can return an object with the error messages and then the component can get those values from [`useActionData`](../api/remix#useactiondata) and display them to the user.
 
-💿 Go ahead and validate that the `name` and `content` fields are long enough. I'd say the name should be at least 3 characters long and the content should be at least 10 characters long. Do this validation server-side.
+💿 Go ahead and validate that the `name` and `content` fields are long enough. I'd say the name should be at least 2 characters long and the content should be at least 10 characters long. Do this validation server-side.
 
 <details>
 


### PR DESCRIPTION
The `validateJokeName()` described as the sample code in this section is `name.length < 2`, so I fixed the description for the validation rule in docs.