### PR TITLE
chore: add `prettier-plugin-tailwindcss`

### DIFF
--- a/examples/basic/app/root.tsx
+++ b/examples/basic/app/root.tsx
@@ -82,7 +82,7 @@ function Layout({ children }: React.PropsWithChildren<{}>) {
   return (
     <div className="remix-app">
       <header className="remix-app__header">
-        <div className="container remix-app__header-content">
+        <div className="remix-app__header-content container">
           <Link to="/" title="Remix" className="remix-app__header-home-link">
             <RemixLogo />
           </Link>
@@ -102,10 +102,10 @@ function Layout({ children }: React.PropsWithChildren<{}>) {
         </div>
       </header>
       <div className="remix-app__main">
-        <div className="container remix-app__main-content">{children}</div>
+        <div className="remix-app__main-content container">{children}</div>
       </div>
       <footer className="remix-app__footer">
-        <div className="container remix-app__footer-content">
+        <div className="remix-app__footer-content container">
           <p>&copy; You!</p>
         </div>
       </footer>

--- a/examples/blog-tutorial/app/root.tsx
+++ b/examples/blog-tutorial/app/root.tsx
@@ -79,7 +79,7 @@ function Layout({ children }: React.PropsWithChildren<{}>) {
   return (
     <div className="remix-app">
       <header className="remix-app__header">
-        <div className="container remix-app__header-content">
+        <div className="remix-app__header-content container">
           <Link to="/" title="Remix" className="remix-app__header-home-link">
             <RemixLogo />
           </Link>
@@ -102,10 +102,10 @@ function Layout({ children }: React.PropsWithChildren<{}>) {
         </div>
       </header>
       <main className="remix-app__main">
-        <div className="container remix-app__main-content">{children}</div>
+        <div className="remix-app__main-content container">{children}</div>
       </main>
       <footer className="remix-app__footer">
-        <div className="container remix-app__footer-content">
+        <div className="remix-app__footer-content container">
           <p>&copy; You!</p>
         </div>
       </footer>

--- a/examples/pm-app/app/ui/icon-box.tsx
+++ b/examples/pm-app/app/ui/icon-box.tsx
@@ -12,7 +12,7 @@ function IconBox({
     <div
       className={cx(
         className,
-        "flex items-center justify-center flex-grow-0 flex-shrink-0",
+        "flex flex-shrink-0 flex-grow-0 items-center justify-center",
         {
           "w-12": !(className && /\bw-[\d]/g.test(className)),
           "h-12": !(className && /\bh-[\d]/g.test(className)),

--- a/examples/pm-app/app/ui/link.tsx
+++ b/examples/pm-app/app/ui/link.tsx
@@ -60,7 +60,7 @@ const ArrowLink = React.forwardRef<HTMLAnchorElement, LinkProps>(
       >
         <span className="mr-3">{children}</span>
         <IconArrowRight
-          className="transform translate-x-0 group-hover:translate-x-1 transition-transform duration-300"
+          className="translate-x-0 transform transition-transform duration-300 group-hover:translate-x-1"
           aria-hidden
         />
       </CustomLink>

--- a/examples/tailwindcss/app/routes/index.tsx
+++ b/examples/tailwindcss/app/routes/index.tsx
@@ -1,3 +1,3 @@
 export default function Index() {
-  return <h1 className="text-6xl text-red-700 font-bold">Hello World!</h1>;
+  return <h1 className="text-6xl font-bold text-red-700">Hello World!</h1>;
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "meow": "^7.1.1",
     "netlify": "10.1.1",
     "prettier": "^2.1.2",
+    "prettier-plugin-tailwindcss": "^0.1.4",
     "prompt-confirm": "^2.0.4",
     "puppeteer": "^9.1.1",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8386,6 +8386,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier-plugin-tailwindcss@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.4.tgz#b09e826a57a0f69b0662eededd659b3d5a5551e7"
+  integrity sha512-kt3YFWqxcG9+bilBI0hPF7RjQZNtgBRvjJZGw6B2MNAjPqlfcYIiZnNaIEnq4XimKLTzZYxz6jQnUXmSQ/5njg==
+
 prettier@^2.1.2:
   version "2.4.1"
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz"


### PR DESCRIPTION
This will order Tailwind classes according to the official recommended way

https://tailwindcss.com/blog/automatic-class-sorting-with-prettier