### PR TITLE
docs: Fixed formatting to correctly surface the NavLink component in markdown

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -158,3 +158,4 @@
 - yomeshgupta
 - zachdtaylor
 - zainfathoni
+- mitchdotdeveloper

--- a/docs/guides/accessibility.md
+++ b/docs/guides/accessibility.md
@@ -12,7 +12,7 @@ Remix makes certain accessibility practices the default where possible and provi
 
 The [`<Link>` component][link] renders a standard anchor tag, meaning that you get its accessibility behaviors from the browser for free!
 
-Remix also provides the [<NavLink>][navlink] which behaves the same as `<Link>`, but it also provides context for assistive technology when the link points to the current page. This is useful for building navigation menus or breadcrumbs.
+Remix also provides the [`<NavLink>` component][navlink] which behaves the same as `<Link>`, but it also provides context for assistive technology when the link points to the current page. This is useful for building navigation menus or breadcrumbs.
 
 ## Routing
 


### PR DESCRIPTION
### Before
<img width="845" alt="Screen Shot 2022-01-26 at 11 15 02 AM" src="https://user-images.githubusercontent.com/23520530/151230906-bc45409e-f516-43e5-a8a2-6e82a6ee9892.png">

### After
<img width="947" alt="Screen Shot 2022-01-26 at 11 24 18 AM" src="https://user-images.githubusercontent.com/23520530/151232275-d7473daf-25c0-4dba-90a3-c9c99200dfa9.png">

