### PR TITLE
docs(faq): Embed multiple forms video in docs/faq.md

### DIFF
--- a/docs/pages/faq.md
+++ b/docs/pages/faq.md
@@ -64,7 +64,9 @@ export async function loader({ request }) {
 
 ## How do I handle multiple forms in one route?
 
-[Watch on YouTube](https://www.youtube.com/watch?v=w2i-9cYxSdc&ab_channel=Remix)
+| [![YouTube: Multiple Forms and Single Button Mutations](https://img.youtube.com/vi/9cYxSdc/0.jpg)](https://www.youtube.com/watch?v=w2i-9cYxSdc&ab_channel=Remix) |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+|                                         [Watch on YouTube](https://www.youtube.com/watch?v=w2i-9cYxSdc&ab_channel=Remix)                                         |
 
 In HTML, forms can post to any URL with the action prop and the app will navigate there:
 


### PR DESCRIPTION
The Remix Single video series is very cool! It deserves to be in the spotlight more prominently.

This makes the YouTube video on multiple forms appear more prominent in the FAQs, which I think is both beneficial for the docs itself and the promotion of the YouTube channel in general.

If you like this PR, @ryanflorence should probably add some nice thumbnails on YouTube (which would be a nice touch regardless) before merging it, otherwise it renders as something like this:

![Rendered preview of the proposed changes](https://user-images.githubusercontent.com/20690465/151344966-08f9b10b-4f6a-4cb0-9cff-983de1e6428d.png)