### PR TITLE
chore(create-remix/arc): set NODE_ENV in arc

### DIFF
--- a/packages/create-remix/templates/arc/README.md
+++ b/packages/create-remix/templates/arc/README.md
@@ -12,7 +12,7 @@ When deploying to AWS Lambda with Architect, you'll need:
 Architect recommends installing these globally:
 
 ```sh
-$ npm i -g @architect/architect aws-sdk
+$ npm i -g @architect/architect@RC aws-sdk
 ```
 
 ## Development

--- a/packages/create-remix/templates/arc/preferences.arc
+++ b/packages/create-remix/templates/arc/preferences.arc
@@ -6,8 +6,8 @@ testing
 
 staging
   REMIX_ENV production
-  NODE_ENV development
+  NODE_ENV production
 
 production
   REMIX_ENV production
-  NODE_ENV development
+  NODE_ENV production

--- a/packages/create-remix/templates/arc/preferences.arc
+++ b/packages/create-remix/templates/arc/preferences.arc
@@ -1,13 +1,10 @@
 # The @env pragma is synced (and overwritten) by running arc env
 @env
 testing
-  REMIX_ENV development
   NODE_ENV development
 
 staging
-  REMIX_ENV production
   NODE_ENV production
 
 production
-  REMIX_ENV production
   NODE_ENV production

--- a/packages/create-remix/templates/arc/preferences.arc
+++ b/packages/create-remix/templates/arc/preferences.arc
@@ -2,9 +2,12 @@
 @env
 testing
   REMIX_ENV development
+  NODE_ENV development
 
 staging
   REMIX_ENV production
+  NODE_ENV development
 
 production
   REMIX_ENV production
+  NODE_ENV development


### PR DESCRIPTION
this requires [arc v10](https://github.com/architect/architect/pull/1302) which is in the RC stage as they stopped changing `NODE_ENV` to "testing" https://github.com/architect/architect/pull/1302/commits/be8be096dffc4773b7d11d42015ba3d8f86f9bf0