### PR TITLE
fix(docs): fixing highlight lines Close remix-run#1683

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -159,3 +159,4 @@
 - yomeshgupta
 - zachdtaylor
 - zainfathoni
+- hadizz

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -13,7 +13,7 @@ This package provides all the components, hooks, and [Web Fetch API](https://dev
 
 These components are to be used once inside of your root route (`root.tsx`). They include everything Remix figured out or built in order for your page to render properly.
 
-```tsx lines=[1,9-10,14]
+```tsx lines=[1,8-9,13]
 import { Meta, Links, Scripts, Outlet } from "remix";
 
 export default function App() {


### PR DESCRIPTION
Hi. Just a little fix on the highlight lines in the documentation site. see #1683 for more details.

URL: https://remix.run/docs/en/v1/api/remix

<img width="710" alt="Screen Shot 2022-01-28 at 03 51 12" src="https://user-images.githubusercontent.com/60828165/151465160-e77845c1-0f84-4a70-9ee1-186139fb13dd.png">

