### PR TITLE
Better websocket support

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -116,6 +116,7 @@
 - mcansh
 - medayz
 - meetbryce
+- mehulmpt
 - michaeldeboey
 - michaelfriedman
 - mjackson

--- a/contributors.yml
+++ b/contributors.yml
@@ -75,6 +75,7 @@
 - IshanKBG
 - jacob-ebey
 - jakewtaylor
+- jamiebuilds
 - jaydiablo
 - jenseng
 - jeremyjfleming

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -18,6 +18,7 @@ module.exports = {
   devServerPort: 8002,
   publicPath: "/build/",
   serverBuildDirectory: "build",
+  ignoredRouteFiles: [".*"],
   routes(defineRoutes) {
     return defineRoutes(route => {
       route("/somewhere/cool/*", "catchall.tsx");
@@ -75,6 +76,10 @@ The URL prefix of the browser build with a trailing slash. Defaults to "/build/"
 ### serverBuildDirectory
 
 The path to the server build, relative to remix.config.js. Defaults to "build". This needs to be deployed to your server.
+
+### ignoredRouteFiles
+
+This is an array of globs (via [minimatch][minimatch]) that Remix will match to files while reading your `app/routes` directory. If a file matches, it will be ignored rather that treated like a route module. This is useful for ignoring dotfiles (like `.DS_Store` files) or CSS/test files you wish to colocate.
 
 ### devServerPort
 
@@ -1256,3 +1261,4 @@ export default function Page() {
 [form]: ./remix#form
 [form action]: ./remix#form-action
 [link tag]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
+[minimatch]: https://www.npmjs.com/package/minimatch

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -869,6 +869,35 @@ export function headers({ loaderHeaders, parentHeaders }) {
 
 All that said, you can avoid this entire problem by _not defining headers in parent routes_ and only in leaf routes. Every layout that can be visited directly will likely have an "index route". If you only define headers on your leaf routes, not your parent routes, you will never have to worry about merging headers.
 
+Note that you can also add headers in your `entry.server` file for things that should be global, for example:
+
+```tsx lines=[16]
+import { renderToString } from "react-dom/server";
+import { RemixServer } from "remix";
+import type { EntryContext } from "remix";
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  remixContext: EntryContext
+) {
+  const markup = renderToString(
+    <RemixServer context={remixContext} url={request.url} />
+  );
+
+  responseHeaders.set("Content-Type", "text/html");
+  responseHeaders.set("X-Powered-By", "Hugs");
+
+  return new Response("<!DOCTYPE html>" + markup, {
+    status: responseStatusCode,
+    headers: responseHeaders
+  });
+}
+```
+
+Just keep in mind that doing this will apply to _all_ document requests, but does not apply to `data` requests (for client-side transitions for example). For those, use [`handleDataRequest`][handledatarequest].
+
 ### `meta`
 
 The meta export will set meta tags for your html document. We highly recommend setting the title and description on every route besides layout routes (their index route will set the meta).
@@ -1262,3 +1291,4 @@ export default function Page() {
 [form action]: ./remix#form-action
 [link tag]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
 [minimatch]: https://www.npmjs.com/package/minimatch
+[handledatarequest]: #entryservertsx

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -461,6 +461,8 @@ export default function SomeRouteComponent() {
 
 ### `loader`
 
+<docs-success>Watch the <a href="https://www.youtube.com/playlist?list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">📼 Remix Single</a>: <a href="https://www.youtube.com/watch?v=NXqEP_PsPNc&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Loading data into components</a></docs-success>
+
 Each route can define a "loader" function that will be called on the server before rendering to provide data to the route.
 
 ```tsx
@@ -736,6 +738,8 @@ export function CatchBoundary() {
 ```
 
 ### `action`
+
+<docs-success>Watch the <a href="https://www.youtube.com/playlist?list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">📼 Remix Singles</a>: <a href="https://www.youtube.com/watch?v=Iv25HAHaFDs&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Data Mutations with Form + action</a> and <a href="https://www.youtube.com/watch?v=w2i-9cYxSdc&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Multiple Forms and Single Button Mutations</a></docs-success>
 
 Like `loader`, action is a server only function to handle data mutations and other actions. If a non-GET request is made to your route (POST, PUT, PATCH, DELETE) then the action is called before the loaders.
 

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -142,6 +142,8 @@ function NavList() {
 
 ### `<Form>`
 
+<docs-success>Watch the <a href="https://www.youtube.com/playlist?list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">📼 Remix Singles</a>: <a href="https://www.youtube.com/watch?v=Iv25HAHaFDs&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Data Mutations with Form + action</a>, <a href="https://www.youtube.com/watch?v=w2i-9cYxSdc&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Multiple Forms and Single Button Mutations</a> and <a href="https://www.youtube.com/watch?v=bMLej7bg5Zo&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Clearing Inputs After Form Submissions</a></docs-success>
+
 The `<Form>` component is a declarative way to perform data mutations: creating, updating, and deleting data. While it might be a mind-shift to think about these tasks as "navigation", it's how the web has handled mutations since before JavaScript was created!
 
 ```js
@@ -249,6 +251,8 @@ It must be the last element on the page, right before the `<Scripts/>` tag:
 In order to avoid (usually) the client-side routing "scroll flash" on refresh or clicking back into the app from a different domain, this component attempts to restore scroll _before React hydration_. If you render the script anywhere other than the bottom of the document the window will not be tall enough to restore to the correct position.
 
 ### `useLoaderData`
+
+<docs-success>Watch the <a href="https://www.youtube.com/playlist?list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">📼 Remix Single</a>: <a href="https://www.youtube.com/watch?v=NXqEP_PsPNc&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Loading data into components</a></docs-success>
 
 This hook returns the JSON parsed data from your route loader function.
 
@@ -496,6 +500,8 @@ function useSessionTimeout() {
 
 ### `useTransition`
 
+<docs-success>Watch the <a href="https://www.youtube.com/playlist?list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">📼 Remix Singles</a>: <a href="https://www.youtube.com/watch?v=y4VLIFjFq8k&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Pending UI</a>, <a href="https://www.youtube.com/watch?v=bMLej7bg5Zo&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Clearing Inputs After Form Submissions</a>, and <a href="https://www.youtube.com/watch?v=EdB_nj01C80&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Optimistic UI</a></docs-success>
+
 This hook tells you everything you need to know about a page transition to build pending navigation indicators and optimistic UI on data mutations. Things like:
 
 - Global loading spinners
@@ -643,6 +649,8 @@ Note that this link will not appear "pending" if a form is being submitted to th
 
 <docs-error>This hook is for advanced cases that most features of your app don't need. It does not work with server rendering, usually requires JavaScript in the browser, and requires you to deal with pending states.</docs-error>
 
+<docs-success>Watch the <a href="https://www.youtube.com/playlist?list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">📼 Remix Singles</a>: <a href="https://www.youtube.com/watch?v=vTzNpiOk668&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Concurrent Mutations w/ useFetcher</a> and <a href="https://www.youtube.com/watch?v=EdB_nj01C80&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Optimistic UI</a></docs-success>
+
 It is common for Remix newcomers to see this hook and think it is the primary way to interact with the server for data loading and updates, but it is not! Remix was specifically designed to avoid this type of interaction with the server and has better ways of handling typical data loading and updating workflows, you probably want one of these:
 
 - [`useLoaderData`][useloaderdata]
@@ -762,6 +770,8 @@ fetcher.data; // the data from the loader
 ```
 
 #### Examples
+
+<docs-success>Watch the <a href="https://www.youtube.com/playlist?list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">📼 Remix Single</a>: <a href="https://www.youtube.com/watch?v=jd_bin5HPrw&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Remix Newsletter Signup Form</a></docs-success>
 
 **Newsletter Signup Form**
 

--- a/docs/guides/not-found.md
+++ b/docs/guides/not-found.md
@@ -18,7 +18,7 @@ The first case is already handled by Remix, you don't have to do anything. It kn
 As soon as you know you don't have what the user is looking for you should _throw a response_.
 
 ```tsx filename=routes/page/$slug.js
-export function loader({ params }) {
+export async function loader({ params }) {
   const page = await db.page.findOne({
     where: { slug: params.slug }
   });
@@ -71,7 +71,7 @@ Just like [errors], nested routes can export their own catch boundary to handle 
 ```tsx filename=app/routes/pages/$pageId.tsx
 import { Form, useLoaderData, useParams } from "remix";
 
-export function loader({ params }) {
+export async function loader({ params }) {
   const page = await db.page.findOne({
     where: { slug: params.slug }
   });

--- a/docs/pages/faq.md
+++ b/docs/pages/faq.md
@@ -1,0 +1,145 @@
+---
+title: FAQs
+description: Frequently Asked Questions about Remix
+---
+
+# Frequently Asked Questions
+
+## How can I have a parent route loader validate the user and protect all child routes?
+
+You can't 😅. During a client side transition, to make your app as speedy as possible, Remix will call all of your loaders _in parallel_, in separate fetch requests. Each one of them needs to have it's own authentication check.
+
+This is probably not different than what you were doing before Remix, it might just be more obvious now. Outside of Remix, when you make multiple fetches to your "API Routes", each of those endpoints needs to validate the user session. In other words, Remix route loaders are their own "API Route" and must be treated as such.
+
+We recommend you create a function that validates the user session that can be added to any routes that require it.
+
+```tsx filename=app/session.js lines=[9-22]
+import {
+  createCookieSessionStorage,
+  redirect
+} from "remix";
+
+// somewhere you've got a session storage
+const { getSession } = createCookieSessionStorage();
+
+export async function requireUserSession(request) {
+  // get the session
+  const cookie = request.headers.get("cookie");
+  const session = await getSession(cookie);
+
+  // validate the session, `userId` is just an example, use whatever value you
+  // put in the session when the user authenticated
+  if (!session.has("userId")) {
+    // if there is no user session, redirect to login
+    throw new redirect("/login");
+  }
+
+  return session;
+}
+```
+
+And now in any loader or action that requires a user session, you can call the function.
+
+```tsx filename=app/routes/projects.jsx lines=[3]
+export function loader({ request }) {
+  // if the user isn't authenticated, this will redirect to login
+  const session = await requireUserSession(request);
+
+  // otherwise the code continues to execute
+  const projects = await fakeDb.projects.scan({
+    userId: session.get("userId")
+  });
+  return projects;
+}
+```
+
+Even if you don't need the session information, the function will still protect the route:
+
+```js
+export async function loader({ request }) {
+  await requireUserSession(request);
+  // continue
+}
+```
+
+## How do I handle multiple forms in one route?
+
+[Watch on YouTube](https://www.youtube.com/watch?v=w2i-9cYxSdc&ab_channel=Remix)
+
+In HTML, forms can post to any URL with the action prop and the app will navigate there:
+
+```jsx
+<Form action="/some/where" />
+```
+
+In Remix the action defaults to the route that the form is rendered in, making it easy to co-locate the UI and the server code that handles it. Developers often wonder how you can handle multiple actions in this scenario. You have two choices:
+
+1. Send a form field to determine the action you want to take
+2. Post to a different route and redirect back to the original
+
+We find option (1) to be the simplest because you don't have to mess around with sessions to get validation errors back to the UI.
+
+HTML buttons can send a value, so it's the easiest way to implement this:
+
+```jsx filename=app/routes/projects/$id.jsx lines=[3-4,33,39]
+export function action({ request }) {
+  let formData = await request.formData();
+  let action = formData.get("_action");
+  switch (action) {
+    case "update": {
+      // do your update
+      return updateProjectName(formData.get("name"));
+    }
+    case "delete": {
+      // do your delete
+      return deleteStuff(formData);
+    }
+    default: {
+      throw new Error("Unexpected action");
+    }
+  }
+}
+
+export default function Projects() {
+  let project = useLoaderData();
+  return (
+    <>
+      <h2>Update Project</h2>
+      <Form method="post">
+        <label>
+          Project name:{" "}
+          <input
+            type="text"
+            name="name"
+            defaultValue={project.name}
+          />
+        </label>
+        <button type="submit" name="_action" value="create">
+          Update
+        </button>
+      </Form>
+
+      <Form method="post">
+        <button type="submit" name="_action" value="delete">
+          Delete
+        </button>
+      </Form>
+    </>
+  );
+}
+```
+
+You can also use a hidden input field:
+
+```jsx lines=[2]
+<Form method="post">
+  <input type="hidden" name="_action" value="create" />
+  <button type="submit">Create</button>
+</Form>
+```
+
+<docs-error>Do not use `action` as your field name!</docs-error>
+
+You may wonder why we used `<button name="_action">` instead of `<button name="action">`. You can use whatever you want, but just not `"action"`!
+
+Without getting into browser decisions decades ago, form elements have the `form.action` property in the DOM to know where to post to, as well as a property for every one of it's input element descendants by name. In our case: `form._action`. If you use `action`, there's a conflict and the submission will fail.

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1350,7 +1350,11 @@ export const LiveReload =
           <script
             dangerouslySetInnerHTML={{
               __html: `
-let ws = new WebSocket("ws://localhost:${port}/socket");
+let protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+let host = location.hostname;
+let socketPath = protocol + '//' + host + ':${port}/socket';
+
+let ws = new WebSocket(socketPath);
 ws.onmessage = message => {
   let event = JSON.parse(message.data);
   if (event.type === "LOG") {


### PR DESCRIPTION
The current remix implementation hardcodes the hostname and protocol of websocket, making it unusable over reverse tunnelling proxies like ngrok.

I ran into this issue while trying to deploy a Remix playground on codedamn (https://codedamn.com/playgrounds)
It fails to connect because codedamn playground websocket is listening on the same host but port 8002.

(Next addition should be running the development WebSocket server on the same HTTP port over which remix serves the app to save resources)

In the screenshot below, Remix should ideally connect to `wss://dawn-gravity.webx.sh:8002`

<img width="919" alt="Screenshot 2022-01-28 at 6 27 50 AM" src="https://user-images.githubusercontent.com/10388889/151468426-6e8519cb-61f0-4fef-889d-cc368a8b60d3.png">
