### PR TITLE
docs: access Cloudflare KV namespace via env

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -79,6 +79,7 @@
 - johannesbraeunig
 - johnson444
 - juhanakristian
+- justinnoel
 - juwiragiye
 - kalch
 - karimsan

--- a/docs/guides/data-loading.md
+++ b/docs/guides/data-loading.md
@@ -169,8 +169,8 @@ If you picked Cloudflare Workers as you environment, [Cloudflare Key Value][clou
 import { useLoaderData } from "remix";
 import type { LoaderFunction } from "remix";
 
-export let loader: LoaderFunction = async ({ params }) => {
-  return PRODUCTS_KV.get(`product-${params.productId}`, {
+export let loader: LoaderFunction = async ({ env, params }) => {
+  return env.PRODUCTS_KV.get(`product-${params.productId}`, {
     type: "json"
   });
 };

--- a/docs/guides/data-loading.md
+++ b/docs/guides/data-loading.md
@@ -169,8 +169,8 @@ If you picked Cloudflare Workers as you environment, [Cloudflare Key Value][clou
 import { useLoaderData } from "remix";
 import type { LoaderFunction } from "remix";
 
-export let loader: LoaderFunction = async ({ env, params }) => {
-  return env.PRODUCTS_KV.get(`product-${params.productId}`, {
+export let loader: LoaderFunction = async ({ context, params }) => {
+  return context.env.PRODUCTS_KV.get(`product-${params.productId}`, {
     type: "json"
   });
 };


### PR DESCRIPTION
According to the Cloudflare docs and in practice, the KV namespace is only available on the `env` and can't be accessed directly.

https://developers.cloudflare.com/pages/platform/functions#kv-namespace-locally