### PR TITLE
fix: avoid `export *` in magic files for shaking

### DIFF
--- a/fixtures/gists-app/package.json
+++ b/fixtures/gists-app/package.json
@@ -7,7 +7,7 @@
     "prebuild": "yarn run install_remix",
     "build": "node node_modules/@remix-run/dev/cli.js build",
     "predev": "yarn run install_remix",
-    "dev": "pm2-dev pm2.config.js",
+    "dev": "node node_modules/@remix-run/dev/cli.js build && pm2-dev pm2.config.js",
     "prestart": "yarn run install_remix",
     "start": "node ./build",
     "preroutes": "yarn run install_remix",

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -356,7 +356,7 @@ async function createBrowserBuild(
     sourcemap: options.sourcemap,
     metafile: true,
     incremental: options.incremental,
-    mainFields: ["module", "browser", "main"],
+    mainFields: ["browser", "module", "main"],
     treeShaking: true,
     minify: options.mode === BuildMode.Production,
     entryNames: "[dir]/[name]-[hash]",

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -356,6 +356,7 @@ async function createBrowserBuild(
     sourcemap: options.sourcemap,
     metafile: true,
     incremental: options.incremental,
+    mainFields: ["module", "browser", "main"],
     treeShaking: true,
     minify: options.mode === BuildMode.Production,
     entryNames: "[dir]/[name]-[hash]",

--- a/packages/remix-dev/compiler/plugins/browserRouteModulesPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/browserRouteModulesPlugin.ts
@@ -38,7 +38,11 @@ export function browserRouteModulesPlugin(
       );
 
       build.onResolve({ filter: suffixMatcher }, args => {
-        return { path: args.path, namespace: "browser-route-module" };
+        return {
+          path: args.path,
+          namespace: "browser-route-module",
+          sideEffects: false
+        };
       });
 
       build.onLoad(

--- a/packages/remix-dev/compiler/plugins/browserRouteModulesPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/browserRouteModulesPlugin.ts
@@ -40,8 +40,7 @@ export function browserRouteModulesPlugin(
       build.onResolve({ filter: suffixMatcher }, args => {
         return {
           path: args.path,
-          namespace: "browser-route-module",
-          sideEffects: false
+          namespace: "browser-route-module"
         };
       });
 

--- a/packages/remix/index.ts
+++ b/packages/remix/index.ts
@@ -1,6 +1,1 @@
-// @ts-ignore
-export * from "./client";
-// @ts-ignore
-export * from "./server";
-// @ts-ignore
-export * from "./platform";
+throw new Error("Did you forget to run `remix setup` for your platform?");


### PR DESCRIPTION
fix: add mainFields to client build to resolve ESM
fix: force sideEffects false for browser route modules