### PR TITLE
DOC: changed application/x-www-urlencoded to application/x-www-form-urlencoded

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -159,3 +159,4 @@
 - yomeshgupta
 - zachdtaylor
 - zainfathoni
+- gabimor

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -199,7 +199,7 @@ Without JavaScript, Remix will turn non-get requests into "post", but you'll sti
 
 #### `<Form encType>`
 
-Defaults to `application/x-www-urlencoded`, which is also the only supported value right now.
+Defaults to `application/x-www-form-urlencoded`, which is also the only supported value right now.
 
 #### `<Form replace>`
 


### PR DESCRIPTION
fixed a small misnaming of `application/x-www-form-urlencoded` in the docs