### PR TITLE
docs: fixed wrong type import

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -135,6 +135,7 @@
 - ryanflorence
 - sean-roberts
 - sergiodxa
+- ShafSpecs
 - shumuu
 - sidkh
 - silvenon

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -1509,7 +1509,7 @@ Most of the time, you'll probably want to proxy the file stream to a file host.
 **Example:**
 
 ```tsx
-import type { UploadHandler } from "remix";
+import type { UploadHandler } from "@remix-run/node/formData";
 
 export let action: ActionFunction = async ({ request }) => {
   const userId = getUserId(request);
@@ -1565,7 +1565,7 @@ Your job is to do whatever you need with the `stream` and return a value that's 
 We have the built-in `unstable_createFileUploadHandler` and `unstable_createMemoryUploadHandler` and we also expect more upload handler utilities to be developed in the future. If you have a form that needs to use different upload handlers, you can compose them together with a custom handler, here's a theoretical example:
 
 ```tsx
-import type { UploadHandler } from "remix";
+import type { UploadHandler } from "@remix-run/node/formData";
 import { unstable_createFileUploadHandler } from "remix";
 import { createCloudinaryUploadHandler } from "some-handy-remix-util";
 


### PR DESCRIPTION
_docs: Fixed wrong import of `UploadHandler` type from `remix` to `@remix-run/node/formData`