### PR TITLE
fix(remix-architect): fix forwarding of request cookie headers

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -26,6 +26,7 @@
 - clarkmitchell
 - codymjarrett
 - coryhouse
+- confix
 - craigglennie
 - crismali
 - danielweinmann

--- a/packages/remix-architect/__tests__/server-test.ts
+++ b/packages/remix-architect/__tests__/server-test.ts
@@ -212,16 +212,15 @@ describe("architect createRemixHeaders", () => {
 
     it("handles cookies", () => {
       expect(
-        createRemixHeaders({ "x-something-else": "true" }, [
-          "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
-          "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax"
-        ])
+          createRemixHeaders({ "x-something-else": "true" }, [
+            "__session=some_value",
+            "__other=some_other_value"
+          ])
       ).toMatchInlineSnapshot(`
         Headers {
           Symbol(map): Object {
             "Cookie": Array [
-              "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
-              "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
+              "__session=some_value; __other=some_other_value",
             ],
             "x-something-else": Array [
               "true",

--- a/packages/remix-architect/server.ts
+++ b/packages/remix-architect/server.ts
@@ -99,9 +99,7 @@ export function createRemixHeaders(
   }
 
   if (requestCookies) {
-    for (let cookie of requestCookies) {
-      headers.append("Cookie", cookie);
-    }
+    headers.append("Cookie", requestCookies.join("; "));
   }
 
   return headers;


### PR DESCRIPTION
Separate multiple request cookie header values by semi-colon instead of comma.

Closes #1663 