### PR TITLE
feat: Remove x-powered-by header (#1710)

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -133,6 +133,7 @@
 - RossMcMillan92
 - rphlmr
 - ryanflorence
+- sdavids
 - sean-roberts
 - sergiodxa
 - shumuu

--- a/packages/create-remix/templates/express/server.js
+++ b/packages/create-remix/templates/express/server.js
@@ -8,6 +8,9 @@ import * as build from "@remix-run/dev/server-build";
 const app = express();
 app.use(compression());
 
+// http://expressjs.com/en/advanced/best-practice-security.html#at-a-minimum-disable-x-powered-by-header
+app.disable("x-powered-by");
+
 // You may want to be more aggressive with this caching
 app.use(express.static("public", { maxAge: "1h" }));
 

--- a/packages/remix-serve/index.ts
+++ b/packages/remix-serve/index.ts
@@ -6,6 +6,8 @@ import { createRequestHandler } from "@remix-run/express";
 export function createApp(buildPath: string, mode = "production") {
   let app = express();
 
+  app.disable("x-powered-by");
+
   app.use(compression());
   app.use(express.static("public", { immutable: true, maxAge: "1y" }));
 


### PR DESCRIPTION
I do not know how to write a test for it because I do not know what to set as `buildPath`:

packages/remix-serve/\_\_tests\_\_/index-test.ts
```typescript
import { createApp } from "../index";

describe("createApp", () => {
  it("x-powered-by header is disabled", async () => {

    const buildPath = "????";

    const app = createApp(buildPath);

    expect(app.disabled("x-powered-by")).toBe(true);
  });
});
```

jest.config.js
```javascript
module.exports = {
  projects: [
...
    {
      displayName: "serve",
      testEnvironment: "node",
      testMatch: [
        "<rootDir>/packages/remix-serve/**/*-test.[jt]s?(x)",
      ],
      setupFiles: ["<rootDir>/jest/setupNodeGlobals.ts"]
    },
...
  ],
...
}
```

I solved it for Express, but maybe it should be part of `ServerPlatform` to disable this header?

Resolves: #1710