### PR TITLE
fix: Highlight correct lines on Data Writes guide

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -120,6 +120,7 @@
 - nielsdb97
 - nobeeakon
 - nurul3101
+- nwalters512
 - orballo
 - phishy
 - plastic041

--- a/docs/guides/data-writes.md
+++ b/docs/guides/data-writes.md
@@ -175,7 +175,7 @@ export default function NewProject() {
 
 Now add the route action. Any form submissions that are "post" will call your data "action". Any "get" submissions (`<Form method="get">`) will be handled by your "loader".
 
-```tsx [5-9]
+```tsx [5-11]
 import type { ActionFunction } from "remix";
 import { redirect } from "remix";
 
@@ -211,7 +211,7 @@ const [errors, project] = await createProject(formData);
 
 If there are validation errors, we want to go back to the form and display them.
 
-```tsx [3,5-8]
+```tsx [5,7-10]
 export const action: ActionFunction = async ({
   request
 }) => {
@@ -229,7 +229,7 @@ export const action: ActionFunction = async ({
 
 Just like `useLoaderData` returns the values from the `loader`, `useActionData` will return the data from the action. It will only be there if the navigation was a form submission, so you always have to check if you've got it or not.
 
-```tsx [1,8,18,23-27,35,40-44]
+```tsx [1,10,20,25-29,37,42-46]
 import { redirect, useActionData } from "remix";
 
 export const action: ActionFunction = async ({
@@ -429,7 +429,7 @@ function ValidationMessage({ error, isSubmitting }) {
 
 Now we can wrap our old error messages in this new fancy component, and even turn the borders of our fields red that have errors:
 
-```tsx [21-24, 31-34, 48-51, 57-60]
+```tsx [21-24, 31-34, 44-47, 53-56]
 export default function NewProject() {
   const transition = useTransition();
   const actionData = useActionData();


### PR DESCRIPTION
I noticed that the wrong lines were highlighted on some of the code samples on the "Data Writes" guide. This should fix that! That said, I couldn't find a way to actually preview the documentation site locally to triple check the highlighting - is there any way to do that?