### PR TITLE
Change < and > in Acessibility guide to their html escaped versions

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -132,6 +132,7 @@
 - RossJHagan
 - RossMcMillan92
 - rphlmr
+- Runner-dev
 - ryanflorence
 - sean-roberts
 - sergiodxa

--- a/docs/guides/accessibility.md
+++ b/docs/guides/accessibility.md
@@ -12,7 +12,7 @@ Remix makes certain accessibility practices the default where possible and provi
 
 The [`<Link>` component][link] renders a standard anchor tag, meaning that you get its accessibility behaviors from the browser for free!
 
-Remix also provides the [<NavLink>][navlink] which behaves the same as `<Link>`, but it also provides context for assistive technology when the link points to the current page. This is useful for building navigation menus or breadcrumbs.
+Remix also provides the [&lt;NavLink&gt;][navlink] which behaves the same as `<Link>`, but it also provides context for assistive technology when the link points to the current page. This is useful for building navigation menus or breadcrumbs.
 
 ## Routing
 


### PR DESCRIPTION
This is important because in the current [guide](https://remix.run/docs/en/v1.1.3/guides/accessibility#links) the navlink component is getting rendered as an empty html element rendering the text "Remix also provides the which behaves..." while it should have been "Remix also provides the <NavLink> which behaves...."