### PR TITLE
Correct code example in Remix Package docs for transition.type

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -98,6 +98,7 @@
 - kevinrambaud
 - kgregory
 - kimdontdoit
+- knowler
 - kubaprzetakiewicz
 - kumard3
 - lachlanjc

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -606,7 +606,7 @@ function SubmitButton() {
       ? loadTexts[transition.type] || "Loading..."
       : "Go";
 
-  return <button type="submit"></button>;
+  return <button type="submit">{text}</button>;
 }
 ```
 


### PR DESCRIPTION
Just noticed that in this example, `text` is not used in the render.