### PR TITLE
fix: allow remix dev and remix-serve to work offline

### DIFF
--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -182,7 +182,7 @@ export async function dev(remixRoot: string, modeArg?: string) {
           .find(ip => ip?.family == "IPv4" && !ip.internal)?.address;
 
         if (!address) {
-          throw new Error("Could not find an IPv4 address.");
+          address = "localhost";
         }
 
         server = app.listen(port, () => {

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -21,7 +21,7 @@ createApp(buildPath).listen(port, () => {
     .find(ip => ip?.family == "IPv4" && !ip.internal)?.address;
 
   if (!address) {
-    throw new Error("Could not find an IPv4 address.");
+    address = "localhost";
   }
 
   console.log(`Remix App Server started at http://${address}:${port}`);


### PR DESCRIPTION
fixes an issue discovered in discord https://canary.discord.com/channels/770287896669978684/771068344320786452/937765256879554711, and brought to my attention by @BenMcH

this used to work prior to #1328, but now that we log the ip address of the server, it no longer starts due to throwing an error about being offline


Signed-off-by: Logan McAnsh <logan@mcan.sh>