### PR TITLE
fix: allow remix-serve to run while off network

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -16,6 +16,7 @@
 - ashleyryan
 - ashocean
 - BasixKOR
+- BenMcH
 - bmontalvo
 - bogas04
 - bruno-oliveira

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -21,7 +21,9 @@ createApp(buildPath).listen(port, () => {
     .find(ip => ip?.family == "IPv4" && !ip.internal)?.address;
 
   if (!address) {
-    throw new Error("Could not find an IPv4 address.");
+    console.warn("Could not find an IPv4 address.");
+    
+    address = 'localhost'
   }
 
   console.log(`Remix App Server started at http://${address}:${port}`);


### PR DESCRIPTION
remix-run#1328 prevents us from running remix locally while off of a network (On a train or bus for example during a commute)

This PR should allow us to run apps locally and simply receive a warning otherwise.