### PR TITLE
fix: allow import of node builtins in routes

### DIFF
--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -370,6 +370,7 @@ async function createBrowserBuild(
       )
     },
     plugins: [
+      NodeModulesPolyfillPlugin(),
       mdxPlugin(config),
       browserRouteModulesPlugin(config, /\?browser$/),
       emptyModulesPlugin(config, /\.server(\.[jt]sx?)?$/)


### PR DESCRIPTION
this adds polyfills for native node modules for the browser. These don't end up being shipped in the bundle if you don't use them outside your loaders / actions, but it prevents nasty failures at runtime caused by esbuild not knowing it can tree shake out those imports.