### PR TITLE
ci: update fly deployment test to use —-remote-only

### DIFF
--- a/scripts/deployment-test/fly.mjs
+++ b/scripts/deployment-test/fly.mjs
@@ -79,7 +79,7 @@ try {
   runCypress(PROJECT_DIR, true, CYPRESS_DEV_URL);
 
   // deploy to fly
-  let flyDeployCommand = spawnSync("fly", ["deploy"], spawnOpts);
+  let flyDeployCommand = spawnSync("fly", ["deploy", "--remote-only"], spawnOpts);
   if (flyDeployCommand.status !== 0) {
     throw new Error("Deployment failed");
   }


### PR DESCRIPTION
will use fly’s docker setup instead of github’s so we should get some better docker caching