### PR TITLE
fix: support submit buttons outside of the form

### DIFF
--- a/fixtures/gists-app/app/routes/methods.tsx
+++ b/fixtures/gists-app/app/routes/methods.tsx
@@ -59,7 +59,12 @@ export default function Methods() {
 
   return (
     <div data-test-id="/methods">
-      <Form action="/methods" method={method} encType={enctype}>
+      <Form
+        action="/methods"
+        method={method}
+        encType={enctype}
+        id="methods-form"
+      >
         <p>
           <label>
             Method:{" "}
@@ -135,6 +140,15 @@ export default function Methods() {
           </button>
         </p>
       </Form>
+      <button
+        type="submit"
+        id="submit-with-data-outside-form"
+        name="data"
+        value="d"
+        form="methods-form"
+      >
+        {method} (with data)
+      </button>
       <div
         id="results"
         style={{

--- a/fixtures/gists-app/tests/form-test.ts
+++ b/fixtures/gists-app/tests/form-test.ts
@@ -148,6 +148,52 @@ describe("form", () => {
     `);
   });
 
+  it("posts to a loader with button data even when the button is outside the form", async () => {
+    await page.goto(`${testServer}/methods`);
+    await reactIsHydrated(page);
+
+    expect(await getHtml(page, "#results")).toMatchInlineSnapshot(`
+      "<div
+        id=\\"results\\"
+        style=\\"opacity: 1; transition: opacity 300ms; transition-delay: 50ms\\"
+      >
+        <p>null</p>
+      </div>
+      "
+    `);
+
+    await page.click("button#submit-with-data-outside-form");
+    await page.waitForSelector("[data-test-id='post']");
+
+    expect(await getHtml(page, "#results")).toMatchInlineSnapshot(`
+      "<div id=\\"results\\" style=\\"opacity: 1; transition: opacity 300ms ease 50ms\\">
+        <dl data-test-id=\\"post\\">
+          <div>
+            <dt>selectedMethod</dt>
+            <dd>\\"post\\"</dd>
+          </div>
+          <div>
+            <dt>selectedEnctype</dt>
+            <dd>\\"application/x-www-form-urlencoded\\"</dd>
+          </div>
+          <div>
+            <dt>userInput</dt>
+            <dd>\\"whatever\\"</dd>
+          </div>
+          <div>
+            <dt>multiple[]</dt>
+            <dd>[\\"a\\",\\"b\\"]</dd>
+          </div>
+          <div>
+            <dt>data</dt>
+            <dd>\\"d\\"</dd>
+          </div>
+        </dl>
+      </div>
+      "
+    `);
+  });
+
   it("posts with the correct checkbox data", async () => {
     await page.goto(`${testServer}/methods`);
     await reactIsHydrated(page);

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -880,14 +880,18 @@ export let FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
           HTMLButtonElement | HTMLInputElement
         >("button,input[type=submit]");
 
-        if (submitButton && submitButton.type === "submit") {
+        if (
+          submitButton &&
+          submitButton.form === form &&
+          submitButton.type === "submit"
+        ) {
           clickedButtonRef.current = submitButton;
         }
       }
 
-      form.addEventListener("click", handleClick);
+      window.addEventListener("click", handleClick);
       return () => {
-        form && form.removeEventListener("click", handleClick);
+        window.removeEventListener("click", handleClick);
       };
     }, []);
 


### PR DESCRIPTION
Fixes #1720.

This wasn't working because the `onClick` handler used to detect the submit button is placed on the `form` element itself. By adding the listener to the entire window and checking the form associated with the button, we can catch any submit button.