### PR TITLE
feat: Add support for returning arbitrary Responses directly from loader

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -25,8 +25,9 @@
 - christophgockel
 - clarkmitchell
 - codymjarrett
-- coryhouse
+- colinclerk
 - confix
+- coryhouse
 - craigglennie
 - crismali
 - danielweinmann

--- a/packages/remix-server-runtime/__tests__/server-test.ts
+++ b/packages/remix-server-runtime/__tests__/server-test.ts
@@ -788,6 +788,74 @@ describe("shared server runtime", () => {
       expect(entryContext.routeData).toEqual({});
     });
 
+    test("skip-render response returns from root loader", async () => {
+      let rootLoader = jest.fn(() => {
+        throw new Response(null, {
+          status: 400,
+          headers: { "X-Remix-Skip-Render": "yes" }
+        });
+      });
+      let indexLoader = jest.fn(() => {
+        return "route";
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          CatchBoundary: {}
+        },
+        "routes/index": {
+          parentId: "root",
+          index: true,
+          default: {},
+          loader: indexLoader
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/`, { method: "get" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(400);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(indexLoader.mock.calls.length).toBe(1);
+      expect(build.entry.module.default.mock.calls.length).toBe(0);
+    });
+
+    test("skip-render response returns from route loader", async () => {
+      let rootLoader = jest.fn(() => {
+        return "route";
+      });
+      let indexLoader = jest.fn(() => {
+        throw new Response(null, {
+          status: 400,
+          headers: { "X-Remix-Skip-Render": "yes" }
+        });
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {},
+          loader: rootLoader,
+          CatchBoundary: {}
+        },
+        "routes/index": {
+          parentId: "root",
+          index: true,
+          default: {},
+          loader: indexLoader
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/`, { method: "get" });
+
+      let result = await handler(request);
+      expect(result.status).toBe(400);
+      expect(rootLoader.mock.calls.length).toBe(1);
+      expect(indexLoader.mock.calls.length).toBe(1);
+      expect(build.entry.module.default.mock.calls.length).toBe(0);
+    });
+
     test("thrown loader responses bubble up", async () => {
       let rootLoader = jest.fn(() => {
         return "root";

--- a/packages/remix-server-runtime/responses.ts
+++ b/packages/remix-server-runtime/responses.ts
@@ -64,6 +64,10 @@ export function isCatchResponse(response: Response) {
   return response.headers.get("X-Remix-Catch") != null;
 }
 
+export function isSkipRenderResponse(response: Response) {
+  return response.headers.get("X-Remix-Skip-Render") != null;
+}
+
 export function extractData(response: Response): Promise<unknown> {
   let contentType = response.headers.get("Content-Type");
 


### PR DESCRIPTION
Adds support for https://github.com/remix-run/remix/issues/1753

This PR allows developers to return an arbitrary Response object directly from the loader during a "document" request. Developers can opt-in to the functionality by adding a `X-Remix-Skip-Render` header to their Response object, which was chosen to mimic the special behavior of the `X-Remix-Catch` header.

The special header can be added to any returned Response object (which would skip the default export render), or any thrown Response object (which would skip the boundary render).

This feature is purely additive.  If developers try to **return** a Response object from a loader today, Remix will error out unless that Response object is a redirect.  If developers try to **throw** a Response object from a loader today, the CatchBoundary will be rendered and the Response's body will be ignored.  This feature provides developers with a mechanism to skip the default or boundary render and return a Response object directly.