### PR TITLE
feat: implement debug flag to attach debugger (#337, #795)

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -139,6 +139,7 @@
 - ryanflorence
 - sdavids
 - sean-roberts
+- selfish
 - sergiodxa
 - shumuu
 - sidkh

--- a/packages/remix-dev/__tests__/cli-test.ts
+++ b/packages/remix-dev/__tests__/cli-test.ts
@@ -34,16 +34,22 @@ describe("remix cli", () => {
             --version, -v       Print the CLI version and exit
 
             --json              Print the routes as JSON (remix routes only)
-            --sourcemap         Generate source maps (remix build only)
+            --sourcemap         Generate source maps for production (remix build only)
+            --debug             Attach Node.js inspector (remix dev only)
 
           Values
             [remixPlatform]     Can be one of: node, cloudflare-pages, cloudflare-workers, or deno
 
           Examples
+            $ remix build
+            $ remix build --sourcemap
             $ remix build my-website
+            $ remix dev
+            $ remix dev --debug
             $ remix dev my-website
             $ remix setup node
             $ remix routes my-website
+            $ remix routes my-website --json
 
         "
       `);

--- a/packages/remix-dev/cli.ts
+++ b/packages/remix-dev/cli.ts
@@ -22,10 +22,15 @@ Values
   [remixPlatform]     Can be one of: node, cloudflare-pages, cloudflare-workers, or deno
 
 Examples
+  $ remix build
+  $ remix build --sourcemap
   $ remix build my-website
+  $ remix dev
+  $ remix dev --debug
   $ remix dev my-website
   $ remix setup node
   $ remix routes my-website
+  $ remix routes my-website --json
 `;
 
 const cli = meow(helpText, {

--- a/packages/remix-dev/cli.ts
+++ b/packages/remix-dev/cli.ts
@@ -1,4 +1,5 @@
 import meow from "meow";
+import inspector from "inspector";
 
 import * as commands from "./cli/commands";
 
@@ -14,7 +15,8 @@ Options
   --version, -v       Print the CLI version and exit
 
   --json              Print the routes as JSON (remix routes only)
-  --sourcemap         Generate source maps (remix build only)
+  --sourcemap         Generate source maps for production (remix build only)
+  --debug             Attach Node.js inspector (remix dev only)
 
 Values
   [remixPlatform]     Can be one of: node, cloudflare-pages, cloudflare-workers, or deno
@@ -39,6 +41,9 @@ const cli = meow(helpText, {
       type: "boolean"
     },
     sourcemap: {
+      type: "boolean"
+    },
+    debug: {
       type: "boolean"
     }
   }
@@ -74,6 +79,7 @@ switch (cli.input[0]) {
     break;
   case "dev":
     if (!process.env.NODE_ENV) process.env.NODE_ENV = "development";
+    if (cli.flags.debug) inspector.open();
     commands.dev(cli.input[1], process.env.NODE_ENV).catch(handleError);
     break;
   default:


### PR DESCRIPTION
### Changes:
Added new flag for remix CLI `--debug`.
This allows CLI commands to be started with Node's debug port open and attach a debugger to the backend process.

This resolves #337
And provides a working solution and resolves #795

example:
```
> remix --debug dev
```
Will print:
```
Debugger listening on ws://127.0.0.1:9229/039d309a...0be9c662c954
...
Watching Remix app in development mode...
💿 Built in 100ms
```
