### PR TITLE
chore: Create `release` script

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,19 +29,59 @@ yarn test
 yarn test react
 # run the tests in watch mode
 yarn test react --watch
-
-# cut a release
-yarn run version major|minor|patch|prerelease [prereleaseId]
-yarn run publish
-# or, to automatically publish from GitHub Actions
-git push origin --follow-tags
 ```
 
+## Releases
+
+New releases should be created from release branches originating from the `dev`
+branch. To simplify this process, use the `release.js` Node script.
+
+```bash
+# Ensure you are on the dev branch
+git checkout dev
+
+# This command will create a new release branch, merge all changes from main, and
+# create a prerelease tag.
+yarn release start patch|minor|major
+
+# Once you create the pre-release, you can run tests and even publish a pre-release
+# directly to ensure everything works as expected. If there are any issues, you can
+# iterate with a new pre-release with the following command:
+yarn release bump
+
+# Once all tests have passed and the release is ready to be made stable, the following
+# command will create a new stable release tag, merge changes back into the dev branch,
+# and prompt you to push the changes and tags to GitHub
+yarn release finish
+git push origin/release-<version> --follow-tags
+
+# Now you can create the release from GitHub from the new tag and write release notes!
+```
+
+### `create-remix`
+
 All packages are published together except for `create-remix`, which is
-versioned and published separately. To publish `create-remix`, just run the
-build and publish it manually.
+versioned and published separately. To publish `create-remix`, run the build and
+publish it manually.
 
 ```bash
 yarn build
 npm publish build/node_modules/create-remix
+```
+
+### Experimental releases
+
+Experimental releases do not need to be branched off of `dev` or `main` but can
+be branched from anywhere as they are not intended for general use. The release
+process here is a bit simpler:
+
+```bash
+git checkout -b release/experimental
+yarn run version experimental
+yarn run publish
+
+# clean up
+git checkout <previous-branch>
+git branch -d release/experimental
+git push origin --delete release/experimental
 ```

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "license": "node ./scripts/license.js",
     "publish": "node ./scripts/publish.js",
     "publish:private": "node ./scripts/publish-private.js",
+    "release": "node ./scripts/release.js",
     "test": "jest",
     "version": "node ./scripts/version.js",
     "watch": "rollup -c -w",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "semver": "^7.3.4",
     "start-server-and-test": "^1.14.0",
     "strip-ansi": "^6.0.1",
+    "type-fest": "^2.11.1",
     "typescript": "^4.2.3",
     "unified": "^9.2.0"
   },

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -8,6 +8,8 @@ const {
   prompt
 } = require("./utils");
 
+const releaseTypes = ["patch", "minor", "major"];
+
 run(process.argv.slice(2)).then(
   () => {
     process.exit(0);
@@ -18,55 +20,143 @@ run(process.argv.slice(2)).then(
   }
 );
 
+/**
+ * @param {string[]} args
+ */
 async function run(args) {
-  let givenVersion = args[0];
-  let prereleaseId = args[1];
-
   ensureCleanWorkingDirectory();
 
-  // 1. Get the next version number
-  let currentVersion = await getPackageVersion("remix");
-  let nextVersion = semver.valid(givenVersion);
-  if (nextVersion == null) {
-    nextVersion = getNextVersion(currentVersion, givenVersion, prereleaseId);
+  /** @type {string | undefined} */
+  let phase;
+  /** @type {string | undefined} */
+  let givenVersion;
+  /** @type {string | undefined} */
+  let nextVersion;
+
+  // Validate args and get the next version number
+  if (
+    args.length === 1 &&
+    (releaseTypes.includes(args[0]) || semver.valid(args[0]))
+  ) {
+    phase = "start";
+    givenVersion = args[0];
+  } else {
+    phase = args[0];
+    givenVersion = args[1];
   }
-  let versionTag = "v" + nextVersion;
-  let releaseBranch = `release/${versionTag}`;
 
-  let initialBranch = getCurrentBranch();
+  let allTags = getAllTags();
+  let currentBranch = getCurrentBranch();
+  let gitArgs = { tags: allTags, initialBranch: currentBranch };
 
-  // 2. Confirm the next version number
+  switch (phase) {
+    case "start": {
+      nextVersion = await initStart(givenVersion, gitArgs);
+      break;
+    }
+    case "bump": {
+      nextVersion = await initBump(gitArgs);
+      break;
+    }
+    case "finish": {
+      nextVersion = await initFinish(gitArgs);
+      break;
+    }
+    default:
+      throw Error(`Invalid argument. Usage:
+
+  $ yarn release [start | bump | finish] [patch | minor | major]`);
+  }
+
+  if (versionExists(allTags, nextVersion)) {
+    throw Error(`Version ${nextVersion} has already been released.`);
+  }
+
   let answer = await prompt(
     `Are you sure you want to release version ${chalk.bold(nextVersion)}? [Yn] `
   );
   if (answer === false) return 0;
 
-  // 3. Ensure that non-experimental releases are created from the dev branch
-  if (!isExperimentalRelease(nextVersion)) {
-    if (initialBranch !== "dev") {
-      throw Error("Releases should be created from the dev branch.");
+  switch (phase) {
+    case "start": {
+      await execStart(nextVersion);
+      break;
     }
-
-    // 3a. Pull from the origin/dev and rebase commits as needed
-    try {
-      let resp = execSync(`git pull --rebase origin dev`).toString();
-      if (hasMergeConflicts(resp)) {
-        let answer = await prompt(
-          `Merge conflicts detected. Resolve all conflicts and commit the changes before resuming the process.
-        ${chalk.bold("Press Y to continue or N to cancel the release.")}`
-        );
-        if (answer === false) return 0;
-      } else if (mergeFailed(resp)) {
-        console.error(chalk.red("Merge failed.\n"));
-        throw Error(resp);
-      }
-    } catch (e) {
-      console.error(chalk.red("Error rebasing to origin/dev"));
-      throw e;
+    case "bump": {
+      await execBump(nextVersion, gitArgs);
+      break;
+    }
+    case "finish": {
+      await execFinish(nextVersion, gitArgs);
+      break;
     }
   }
 
-  // 4. Checkout new release branch
+  let versionTag = getVersionTag(nextVersion);
+
+  console.log(
+    chalk.green(
+      `Remix version ${nextVersion} is now ready to release. To trigger the release process, create a new release in GitHub from the ${versionTag} tag:
+  - Navigate to https://github.com/remix-run/remix/releases/new
+  - Select ${chalk.bold(versionTag)} from the "Choose a tag" menu
+  - Draft the release notes
+  - If this is a pre-release, be sure to select the ${chalk.bold(
+    "This is a pre-release"
+  )} checkbox
+  - Click ${chalk.bold("Publish release")}
+  Once the CI is complete, the new release will be published to npm. 🥳`
+    )
+  );
+}
+
+/**
+ * @param {string} givenVersion
+ * @param {{ tags: string[]; initialBranch: string }} git
+ * @returns {Promise<string>}
+ */
+async function initStart(givenVersion, git) {
+  ensureDevBranch(git.initialBranch);
+  let nextVersion = semver.valid(givenVersion);
+  if (nextVersion == null) {
+    nextVersion = getNextVersion(
+      await getPackageVersion("remix"),
+      givenVersion
+    );
+  }
+  return nextVersion;
+}
+
+/**
+ * @param {{ tags: string[]; initialBranch: string }} git
+ * @returns {Promise<string>}
+ */
+async function initBump(git) {
+  ensureReleaseBranch(git.initialBranch);
+  let versionFromBranch = getVersionFromReleaseBranch(git.initialBranch);
+  let currentVersion = git.tags
+    .filter(tag => tag.startsWith("v" + versionFromBranch))
+    .sort((a, b) => (a > b ? -1 : a < b ? 1 : 0))[0];
+  let nextVersion = semver.inc(currentVersion, "prerelease");
+  return nextVersion;
+}
+
+/**
+ * @param {{ tags: string[]; initialBranch: string }} git
+ * @returns {Promise<string>}
+ */
+async function initFinish(git) {
+  ensureReleaseBranch(git.initialBranch);
+  let nextVersion = getVersionFromReleaseBranch(git.initialBranch);
+  return nextVersion;
+}
+
+/**
+ * @param {string} nextVersion
+ */
+async function execStart(nextVersion) {
+  let releaseBranch = getReleaseBranch(nextVersion);
+
+  await gitPull("dev");
   try {
     checkoutNewBranch(releaseBranch);
   } catch (e) {
@@ -77,147 +167,110 @@ async function run(args) {
     );
   }
 
-  // 5. Merge updates from the main branch for stable releases
-  if (!isPreRelease(nextVersion)) {
-    execSync(`git checkout main`);
-    try {
-      let resp = execSync(`git pull --rebase origin main`).toString();
-      if (hasMergeConflicts(resp)) {
-        let answer = await prompt(
-          `Merge conflicts detected. Resolve all conflicts and commit the changes before resuming the process.
-    ${chalk.bold("Press Y to continue or N to cancel the release.")}`
-        );
-        if (answer === false) return 0;
-      } else if (mergeFailed(resp)) {
-        console.error(chalk.red("Merge failed.\n"));
-        throw Error(resp);
-      }
-    } catch (e) {
-      console.error(chalk.red("Rebasing error when pulling from origin/main"));
-      throw e;
-    }
+  await gitMerge("main", releaseBranch, { pullFirst: true });
+  incrementVersion(nextVersion);
+  execSync(`git push origin ${releaseBranch} --follow-tags`);
+}
 
-    // 5a. Return to the release branch and merge changes from main
-    execSync(`git checkout ${releaseBranch}`);
-    let resp = execSync(`git merge main`).toString();
+/**
+ * @param {string} nextVersion
+ * @param {{ tags: string[]; initialBranch: string }} git
+ */
+async function execBump(nextVersion, git) {
+  ensureReleaseBranch(git.initialBranch);
+  await gitMerge("main", git.initialBranch, { pullFirst: true });
+  incrementVersion(nextVersion);
+  execSync(`git push origin ${git.initialBranch} --follow-tags`);
+}
+
+/**
+ * @param {string} nextVersion
+ * @param {{ tags: string[]; initialBranch: string }} git
+ */
+async function execFinish(nextVersion, git) {
+  ensureReleaseBranch(git.initialBranch);
+  await gitMerge(git.initialBranch, "main");
+  incrementVersion(nextVersion);
+  await gitMerge(git.initialBranch, "dev");
+}
+
+/**
+ * @param {string} version
+ */
+function incrementVersion(version) {
+  return execSync(`yarn run version ${version}`);
+}
+
+/**
+ * @param {string} from
+ * @param {string} to
+ * @param {{ pullFirst?: boolean }} [opts]
+ */
+async function gitMerge(from, to, opts = {}) {
+  execSync(`git checkout ${from}`);
+  if (opts.pullFirst) {
+    await gitPull(from);
+  }
+  execSync(`git checkout ${to}`);
+  let resp = execSync(`git merge ${from}`).toString();
+  if (hasMergeConflicts(resp)) {
+    let answer = await prompt(
+      `Merge conflicts detected. Resolve all conflicts and commit the changes before resuming the process.
+          ${chalk.bold("Press Y to continue or N to cancel the release.")}`
+    );
+    if (answer === false) return 0;
+  } else if (mergeFailed(resp)) {
+    console.error(chalk.red("Merge failed.\n"));
+    throw Error(resp);
+  }
+}
+
+/**
+ * @param {string} branch
+ * @returns
+ */
+async function gitPull(branch) {
+  try {
+    let resp = execSync(`git pull --rebase origin ${branch}`).toString();
     if (hasMergeConflicts(resp)) {
       let answer = await prompt(
         `Merge conflicts detected. Resolve all conflicts and commit the changes before resuming the process.
-        ${chalk.bold("Press Y to continue or N to cancel the release.")}`
+
+    ${chalk.bold("Press Y to continue or N to cancel the release.")}`
       );
       if (answer === false) return 0;
     } else if (mergeFailed(resp)) {
       console.error(chalk.red("Merge failed.\n"));
       throw Error(resp);
     }
+  } catch (e) {
+    console.error(chalk.red(`Error rebasing to origin/${branch}`));
+    throw e;
   }
-
-  // 6. Run the version script to update all package versions and create tag
-  execSync(`yarn run version ${nextVersion} ${prereleaseId ?? ""}`);
-
-  // 7. Push the release branch and tags to GitHub. All releases will be
-  //    triggered from there.
-  execSync(`git push origin ${releaseBranch} --follow-tags`);
-
-  console.log(
-    chalk.green(
-      `Remix version ${nextVersion} is now ready to release. To trigger the release process, create a new release in GitHub from the ${versionTag} tag:
-
-  - Navigate to https://github.com/remix-run/remix/releases/new
-  - Select ${chalk.bold(versionTag)} from the "Choose a tag" menu
-  - Draft the release notes
-  - If this is a pre-release, be sure to select the ${chalk.bold(
-    "This is a pre-release"
-  )} checkbox
-  - Click ${chalk.bold("Publish release")}
-
-Once the CI is complete, the new release will be published to npm. 🥳`
-    )
-  );
-
-  // 8. Optionally, merge new release branch back into dev. This should usually
-  //    be done but may be skipped in some cases (hotfixes, etc.)
-  let mergeToDev = await prompt(
-    `Do you want to merge ${releaseBranch} into ${chalk.bold("dev")}? [Yn]`
-  );
-  if (mergeToDev) {
-    execSync(`git checkout dev`);
-    execSync(`git merge ${releaseBranch}`);
-
-    // For simplicity, do not push back to origin/dev automatically. If the
-    // remote dev branch has changed since we started the release process we
-    // should handle this manually.
-    console.log(
-      `Successfully merged ${releaseBranch} into dev. Be sure to push changes to origin/dev`
-    );
-  }
-
-  // 9. Optionally, merge new release branch back into main. Only offered for
-  //    stable releases, as main should reflect the latest stable version.
-  if (!isPreRelease(nextVersion)) {
-    let mergeToMain = await prompt(
-      `Do you want to merge ${releaseBranch} into ${chalk.bold("main")}? [Yn]`
-    );
-    if (mergeToMain) {
-      execSync(`git checkout main`);
-      execSync(`git merge ${releaseBranch}`);
-
-      // For simplicity, do not push back to origin/main automatically. If the
-      // remote main branch has changed since we started the release process we
-      // should handle this manually.
-      console.log(
-        `Successfully merged ${releaseBranch} into main. Be sure to push changes to origin/main`
-      );
-    }
-  }
-
-  // 10. Return to the initial branch before exit
-  execSync(`git checkout ${initialBranch}`);
 }
 
+/**
+ * @param {string} currentVersion
+ * @param {string} givenVersion
+ * @param {string | undefined} [prereleaseId]
+ */
 function getNextVersion(currentVersion, givenVersion, prereleaseId = "pre") {
   if (givenVersion == null) {
-    throw Error("Missing next version. Usage: node release.js [nextVersion]");
+    throw Error(
+      "Missing next version. Usage: node scripts/release.js start [nextVersion]"
+    );
   }
-
-  let nextVersion;
-  if (givenVersion === "experimental") {
-    let hash = execSync(`git rev-parse --short HEAD`).toString().trim();
-    nextVersion = `0.0.0-experimental-${hash}`;
-  } else {
-    nextVersion = semver.inc(currentVersion, givenVersion, prereleaseId);
-  }
-
+  // @ts-ignore
+  let nextVersion = semver.inc(currentVersion, givenVersion, prereleaseId);
   if (nextVersion == null) {
     throw Error(`Invalid version specifier: ${givenVersion}`);
   }
-
   return nextVersion;
 }
 
 function getCurrentBranch() {
   let output = execSync("git rev-parse --abbrev-ref HEAD").toString().trim();
   return output;
-}
-
-/**
- * @param {string} version
- * @returns {boolean}
- */
-function isExperimentalRelease(version) {
-  return version.includes("experimental");
-}
-
-/**
- * @param {string} version
- * @returns {boolean}
- */
-function isPreRelease(version) {
-  return (
-    isExperimentalRelease(version) ||
-    version.includes("alpha") ||
-    version.includes("beta")
-  );
 }
 
 /**
@@ -247,3 +300,55 @@ function checkoutNewBranch(branch) {
     throw Error(`Branch ${chalk.bold(output)} already exists.`);
   }
 }
+
+function getAllTags() {
+  return execSync("git tag --list").toString().trim().split("\n");
+}
+
+/**
+ * @param {string} branch
+ * @returns {"dev"}
+ */
+function ensureDevBranch(branch) {
+  if (branch !== "dev") {
+    throw Error("Releases should be created from the dev branch.");
+  }
+  return branch;
+}
+
+/**
+ * @param {string} branch
+ */
+function ensureReleaseBranch(branch) {
+  let version = getVersionFromReleaseBranch(branch);
+  if (version == null || !semver.valid(version)) {
+    throw Error(
+      "You must be on a valid release branch when continuing the release process."
+    );
+  }
+}
+
+/**
+ * @param {string} branch
+ * @returns {string | undefined}
+ */
+const getVersionFromReleaseBranch = branch => branch.split("/")[1]?.slice(1);
+
+/**
+ * @param {string} version
+ */
+const getVersionTag = version => (version.startsWith("v") ? "" : "v") + version;
+
+/**
+ * @param {string} version
+ */
+const getReleaseBranch = version =>
+  `release/${getVersionTag(
+    version.includes("-") ? version.slice(0, version.indexOf("-")) : version
+  )}`;
+
+/**
+ * @param {string[]} tags
+ * @param {string} version
+ */
+const versionExists = (tags, version) => tags.includes(getVersionTag(version));

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -131,7 +131,7 @@ async function initStart(givenVersion, git) {
  * @returns {Promise<string>}
  */
 async function initBump(git) {
-  ensureReleaseBranch(git.initialBranch);
+  ensureLatestReleaseBranch(git.initialBranch);
   let versionFromBranch = getVersionFromReleaseBranch(git.initialBranch);
   let currentVersion = git.tags
     .filter(tag => tag.startsWith("v" + versionFromBranch))
@@ -145,7 +145,7 @@ async function initBump(git) {
  * @returns {Promise<string>}
  */
 async function initFinish(git) {
-  ensureReleaseBranch(git.initialBranch);
+  ensureLatestReleaseBranch(git.initialBranch);
   let nextVersion = getVersionFromReleaseBranch(git.initialBranch);
   return nextVersion;
 }
@@ -169,7 +169,16 @@ async function execStart(nextVersion) {
 
   await gitMerge("main", releaseBranch, { pullFirst: true });
   incrementVersion(nextVersion);
-  execSync(`git push origin ${releaseBranch} --follow-tags`);
+  // TODO: After testing a few times, execute git push as a part of the flow and
+  // remove the silly message
+  console.log(
+    chalk.green(`Version ${nextVersion} is ready to roll.`) +
+      "\n" +
+      chalk.yellow(`Ryan says since I'm just a 👶 script you probably shouldn't trust me *too* much just yet (he's right, I know!)
+
+Run ${chalk.bold(`git push origin ${releaseBranch} --follow-tags`)}`)
+  );
+  // execSync(`git push origin ${releaseBranch} --follow-tags`);
 }
 
 /**
@@ -180,7 +189,16 @@ async function execBump(nextVersion, git) {
   ensureReleaseBranch(git.initialBranch);
   await gitMerge("main", git.initialBranch, { pullFirst: true });
   incrementVersion(nextVersion);
-  execSync(`git push origin ${git.initialBranch} --follow-tags`);
+  // TODO: After testing a few times, execute git push as a part of the flow and
+  // remove the silly message
+  console.log(
+    chalk.green(`Version ${nextVersion} is ready to roll.`) +
+      "\n" +
+      chalk.yellow(`Ryan says since I'm just a 👶 script you probably shouldn't trust me *too* much just yet (he's right, I know!)
+
+Run ${chalk.bold(`git push origin ${git.initialBranch} --follow-tags`)}`)
+  );
+  // execSync(`git push origin ${git.initialBranch} --follow-tags`);
 }
 
 /**
@@ -327,6 +345,23 @@ function ensureReleaseBranch(branch) {
   if (version == null || !semver.valid(version)) {
     throw Error(
       "You must be on a valid release branch when continuing the release process."
+    );
+  }
+  return version;
+}
+
+/**
+ * @param {string} branch
+ */
+function ensureLatestReleaseBranch(branch, git) {
+  let versionFromBranch = ensureReleaseBranch(branch);
+  let taggedVersions = git.tags
+    .filter(tag => /^v\d/.test(tag))
+    .sort(semver.compare)[0];
+  let latestTaggedVersion = taggedVersions[taggedVersions.length - 1];
+  if (semver.compare(latestTaggedVersion, versionFromBranch) > 0) {
+    throw Error(
+      "You must be on the latest release branch when continuing the release process."
     );
   }
 }

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,0 +1,249 @@
+const { execSync } = require("child_process");
+const chalk = require("chalk");
+const semver = require("semver");
+
+const {
+  ensureCleanWorkingDirectory,
+  getPackageVersion,
+  prompt
+} = require("./utils");
+
+run(process.argv.slice(2)).then(
+  () => {
+    process.exit(0);
+  },
+  error => {
+    console.error(chalk.red(error));
+    process.exit(1);
+  }
+);
+
+async function run(args) {
+  let givenVersion = args[0];
+  let prereleaseId = args[1];
+
+  ensureCleanWorkingDirectory();
+
+  // 1. Get the next version number
+  let currentVersion = await getPackageVersion("remix");
+  let nextVersion = semver.valid(givenVersion);
+  if (nextVersion == null) {
+    nextVersion = getNextVersion(currentVersion, givenVersion, prereleaseId);
+  }
+  let versionTag = "v" + nextVersion;
+  let releaseBranch = `release/${versionTag}`;
+
+  let initialBranch = getCurrentBranch();
+
+  // 2. Confirm the next version number
+  let answer = await prompt(
+    `Are you sure you want to release version ${chalk.bold(nextVersion)}? [Yn] `
+  );
+  if (answer === false) return 0;
+
+  // 3. Ensure that non-experimental releases are created from the dev branch
+  if (!isExperimentalRelease(nextVersion)) {
+    if (initialBranch !== "dev") {
+      throw Error("Releases should be created from the dev branch.");
+    }
+
+    // 3a. Pull from the origin/dev and rebase commits as needed
+    try {
+      let resp = execSync(`git pull --rebase origin dev`).toString();
+      if (hasMergeConflicts(resp)) {
+        let answer = await prompt(
+          `Merge conflicts detected. Resolve all conflicts and commit the changes before resuming the process.
+        ${chalk.bold("Press Y to continue or N to cancel the release.")}`
+        );
+        if (answer === false) return 0;
+      } else if (mergeFailed(resp)) {
+        console.error(chalk.red("Merge failed.\n"));
+        throw Error(resp);
+      }
+    } catch (e) {
+      console.error(chalk.red("Error rebasing to origin/dev"));
+      throw e;
+    }
+  }
+
+  // 4. Checkout new release branch
+  try {
+    checkoutNewBranch(releaseBranch);
+  } catch (e) {
+    throw Error(
+      `Branch ${chalk.bold(
+        releaseBranch
+      )} already exists. Delete the branch if you wish to create a new release from the same version, or use a different version number.`
+    );
+  }
+
+  // 5. Merge updates from the main branch for stable releases
+  if (!isPreRelease(nextVersion)) {
+    execSync(`git checkout main`);
+    try {
+      let resp = execSync(`git pull --rebase origin main`).toString();
+      if (hasMergeConflicts(resp)) {
+        let answer = await prompt(
+          `Merge conflicts detected. Resolve all conflicts and commit the changes before resuming the process.
+    ${chalk.bold("Press Y to continue or N to cancel the release.")}`
+        );
+        if (answer === false) return 0;
+      } else if (mergeFailed(resp)) {
+        console.error(chalk.red("Merge failed.\n"));
+        throw Error(resp);
+      }
+    } catch (e) {
+      console.error(chalk.red("Rebasing error when pulling from origin/main"));
+      throw e;
+    }
+
+    // 5a. Return to the release branch and merge changes from main
+    execSync(`git checkout ${releaseBranch}`);
+    let resp = execSync(`git merge main`).toString();
+    if (hasMergeConflicts(resp)) {
+      let answer = await prompt(
+        `Merge conflicts detected. Resolve all conflicts and commit the changes before resuming the process.
+        ${chalk.bold("Press Y to continue or N to cancel the release.")}`
+      );
+      if (answer === false) return 0;
+    } else if (mergeFailed(resp)) {
+      console.error(chalk.red("Merge failed.\n"));
+      throw Error(resp);
+    }
+  }
+
+  // 6. Run the version script to update all package versions and create tag
+  execSync(`yarn run version ${nextVersion} ${prereleaseId ?? ""}`);
+
+  // 7. Push the release branch and tags to GitHub. All releases will be
+  //    triggered from there.
+  execSync(`git push origin ${releaseBranch} --follow-tags`);
+
+  console.log(
+    chalk.green(
+      `Remix version ${nextVersion} is now ready to release. To trigger the release process, create a new release in GitHub from the ${versionTag} tag:
+
+  - Navigate to https://github.com/remix-run/remix/releases/new
+  - Select ${chalk.bold(versionTag)} from the "Choose a tag" menu
+  - Draft the release notes
+  - If this is a pre-release, be sure to select the ${chalk.bold(
+    "This is a pre-release"
+  )} checkbox
+  - Click ${chalk.bold("Publish release")}
+
+Once the CI is complete, the new release will be published to npm. 🥳`
+    )
+  );
+
+  // 8. Optionally, merge new release branch back into dev. This should usually
+  //    be done but may be skipped in some cases (hotfixes, etc.)
+  let mergeToDev = await prompt(
+    `Do you want to merge ${releaseBranch} into ${chalk.bold("dev")}? [Yn]`
+  );
+  if (mergeToDev) {
+    execSync(`git checkout dev`);
+    execSync(`git merge ${releaseBranch}`);
+
+    // For simplicity, do not push back to origin/dev automatically. If the
+    // remote dev branch has changed since we started the release process we
+    // should handle this manually.
+    console.log(
+      `Successfully merged ${releaseBranch} into dev. Be sure to push changes to origin/dev`
+    );
+  }
+
+  // 9. Optionally, merge new release branch back into main. Only offered for
+  //    stable releases, as main should reflect the latest stable version.
+  if (!isPreRelease(nextVersion)) {
+    let mergeToMain = await prompt(
+      `Do you want to merge ${releaseBranch} into ${chalk.bold("main")}? [Yn]`
+    );
+    if (mergeToMain) {
+      execSync(`git checkout main`);
+      execSync(`git merge ${releaseBranch}`);
+
+      // For simplicity, do not push back to origin/main automatically. If the
+      // remote main branch has changed since we started the release process we
+      // should handle this manually.
+      console.log(
+        `Successfully merged ${releaseBranch} into main. Be sure to push changes to origin/main`
+      );
+    }
+  }
+
+  // 10. Return to the initial branch before exit
+  execSync(`git checkout ${initialBranch}`);
+}
+
+function getNextVersion(currentVersion, givenVersion, prereleaseId = "pre") {
+  if (givenVersion == null) {
+    throw Error("Missing next version. Usage: node release.js [nextVersion]");
+  }
+
+  let nextVersion;
+  if (givenVersion === "experimental") {
+    let hash = execSync(`git rev-parse --short HEAD`).toString().trim();
+    nextVersion = `0.0.0-experimental-${hash}`;
+  } else {
+    nextVersion = semver.inc(currentVersion, givenVersion, prereleaseId);
+  }
+
+  if (nextVersion == null) {
+    throw Error(`Invalid version specifier: ${givenVersion}`);
+  }
+
+  return nextVersion;
+}
+
+function getCurrentBranch() {
+  let output = execSync("git rev-parse --abbrev-ref HEAD").toString().trim();
+  return output;
+}
+
+/**
+ * @param {string} version
+ * @returns {boolean}
+ */
+function isExperimentalRelease(version) {
+  return version.includes("experimental");
+}
+
+/**
+ * @param {string} version
+ * @returns {boolean}
+ */
+function isPreRelease(version) {
+  return (
+    isExperimentalRelease(version) ||
+    version.includes("alpha") ||
+    version.includes("beta")
+  );
+}
+
+/**
+ * @param {string} output
+ * @returns {boolean}
+ */
+function hasMergeConflicts(output) {
+  let lines = output.trim().split("\n");
+  return lines.some(line => /^CONFLICT\s/.test(line));
+}
+
+/**
+ * @param {string} output
+ * @returns {boolean}
+ */
+function mergeFailed(output) {
+  let lines = output.trim().split("\n");
+  return lines.some(line => /^Automatic merge failed;\s/.test(line));
+}
+
+/**
+ * @param {string} branch
+ */
+function checkoutNewBranch(branch) {
+  let output = execSync(`git checkout -b ${branch}`).toString().trim();
+  if (/^fatal:/.test(output)) {
+    throw Error(`Branch ${chalk.bold(output)} already exists.`);
+  }
+}

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -207,6 +207,7 @@ function incrementVersion(version) {
  * @param {{ pullFirst?: boolean }} [opts]
  */
 async function gitMerge(from, to, opts = {}) {
+  let initialBranch = getCurrentBranch();
   execSync(`git checkout ${from}`);
   if (opts.pullFirst) {
     await gitPull(from);
@@ -223,6 +224,8 @@ async function gitMerge(from, to, opts = {}) {
     console.error(chalk.red("Merge failed.\n"));
     throw Error(resp);
   }
+
+  execSync(`git checkout ${initialBranch}`);
 }
 
 /**

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -111,7 +111,7 @@ async function run(args) {
 
 /**
  * @param {string} givenVersion
- * @param {{ tags: string[]; initialBranch: string }} git
+ * @param {GitAttributes} git
  * @returns {Promise<string>}
  */
 async function initStart(givenVersion, git) {
@@ -127,11 +127,11 @@ async function initStart(givenVersion, git) {
 }
 
 /**
- * @param {{ tags: string[]; initialBranch: string }} git
+ * @param {GitAttributes} git
  * @returns {Promise<string>}
  */
 async function initBump(git) {
-  ensureLatestReleaseBranch(git.initialBranch);
+  ensureLatestReleaseBranch(git.initialBranch, git);
   let versionFromBranch = getVersionFromReleaseBranch(git.initialBranch);
   let currentVersion = git.tags
     .filter(tag => tag.startsWith("v" + versionFromBranch))
@@ -141,11 +141,11 @@ async function initBump(git) {
 }
 
 /**
- * @param {{ tags: string[]; initialBranch: string }} git
+ * @param {GitAttributes} git
  * @returns {Promise<string>}
  */
 async function initFinish(git) {
-  ensureLatestReleaseBranch(git.initialBranch);
+  ensureLatestReleaseBranch(git.initialBranch, git);
   let nextVersion = getVersionFromReleaseBranch(git.initialBranch);
   return nextVersion;
 }
@@ -183,7 +183,7 @@ Run ${chalk.bold(`git push origin ${releaseBranch} --follow-tags`)}`)
 
 /**
  * @param {string} nextVersion
- * @param {{ tags: string[]; initialBranch: string }} git
+ * @param {GitAttributes} git
  */
 async function execBump(nextVersion, git) {
   ensureReleaseBranch(git.initialBranch);
@@ -203,7 +203,7 @@ Run ${chalk.bold(`git push origin ${git.initialBranch} --follow-tags`)}`)
 
 /**
  * @param {string} nextVersion
- * @param {{ tags: string[]; initialBranch: string }} git
+ * @param {GitAttributes} git
  */
 async function execFinish(nextVersion, git) {
   ensureReleaseBranch(git.initialBranch);
@@ -352,6 +352,7 @@ function ensureReleaseBranch(branch) {
 
 /**
  * @param {string} branch
+ * @param {GitAttributes} git
  */
 function ensureLatestReleaseBranch(branch, git) {
   let versionFromBranch = ensureReleaseBranch(branch);
@@ -390,3 +391,7 @@ const getReleaseBranch = version =>
  * @param {string} version
  */
 const versionExists = (tags, version) => tags.includes(getVersionTag(version));
+
+/**
+ * @typedef {{ tags: string[]; initialBranch: string }} GitAttributes
+ */

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["."],
+  "exclude": ["./deployment-test"],
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true
+  }
+}

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,55 @@
+const path = require("path");
+const { execSync } = require("child_process");
+const jsonfile = require("jsonfile");
+const Confirm = require("prompt-confirm");
+
+let rootDir = path.resolve(__dirname, "..");
+
+/**
+ * @param {string} packageName
+ * @param {string} [directory]
+ * @returns {string}
+ */
+function packageJson(packageName, directory) {
+  return path.join(rootDir, directory, packageName, "package.json");
+}
+
+/**
+ * @param {string} packageName
+ * @returns {Promise<string | undefined>}
+ */
+async function getPackageVersion(packageName) {
+  let file = packageJson(packageName, "packages");
+  let json = await jsonfile.readFile(file);
+  return json.version;
+}
+
+/**
+ * @returns {void}
+ */
+function ensureCleanWorkingDirectory() {
+  let status = execSync(`git status --porcelain`).toString().trim();
+  let lines = status.split("\n");
+  if (!lines.every(line => line === "" || line.startsWith("?"))) {
+    console.error(
+      "Working directory is not clean. Please commit or stash your changes."
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * @param {string} question
+ * @returns {Promise<string | boolean>}
+ */
+async function prompt(question) {
+  let confirm = new Confirm(question);
+  let answer = await confirm.run();
+  return answer;
+}
+
+exports.rootDir = rootDir;
+exports.packageJson = packageJson;
+exports.getPackageVersion = getPackageVersion;
+exports.ensureCleanWorkingDirectory = ensureCleanWorkingDirectory;
+exports.prompt = prompt;

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -2,37 +2,23 @@ const fsp = require("fs").promises;
 const path = require("path");
 const { execSync } = require("child_process");
 const chalk = require("chalk");
-const Confirm = require("prompt-confirm");
 const jsonfile = require("jsonfile");
 const semver = require("semver");
 
-let rootDir = path.resolve(__dirname, "..");
+const {
+  ensureCleanWorkingDirectory,
+  getPackageVersion,
+  packageJson,
+  prompt,
+  rootDir
+} = require("./utils");
+
 let examplesDir = path.resolve(rootDir, "examples");
 
 let adapters = ["architect", "express", "netlify", "vercel"];
 let runtimes = ["cloudflare-workers", "cloudflare-pages", "deno", "node"];
 let core = ["dev", "server-runtime", "react", "eslint-config"];
 let allPackages = [...adapters, ...runtimes, ...core, "serve"];
-
-/**
- * @param {string} packageName
- * @param {string} [directory]
- * @returns {string}
- */
-function packageJson(packageName, directory) {
-  return path.join(rootDir, directory, packageName, "package.json");
-}
-
-function ensureCleanWorkingDirectory() {
-  let status = execSync(`git status --porcelain`).toString().trim();
-  let lines = status.split("\n");
-  if (!lines.every(line => line === "" || line.startsWith("?"))) {
-    console.error(
-      "Working directory is not clean. Please commit or stash your changes."
-    );
-    process.exit(1);
-  }
-}
 
 function getNextVersion(currentVersion, givenVersion, prereleaseId = "pre") {
   if (givenVersion == null) {
@@ -54,18 +40,6 @@ function getNextVersion(currentVersion, givenVersion, prereleaseId = "pre") {
   }
 
   return nextVersion;
-}
-
-async function prompt(question) {
-  let confirm = new Confirm(question);
-  let answer = await confirm.run();
-  return answer;
-}
-
-async function getPackageVersion(packageName) {
-  let file = packageJson(packageName, "packages");
-  let json = await jsonfile.readFile(file);
-  return json.version;
 }
 
 async function updatePackageConfig(packageName, transform) {

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -20,6 +20,12 @@ let runtimes = ["cloudflare-workers", "cloudflare-pages", "deno", "node"];
 let core = ["dev", "server-runtime", "react", "eslint-config"];
 let allPackages = [...adapters, ...runtimes, ...core, "serve"];
 
+/**
+ * @param {string} currentVersion
+ * @param {string} givenVersion
+ * @param {string} [prereleaseId]
+ * @returns
+ */
 function getNextVersion(currentVersion, givenVersion, prereleaseId = "pre") {
   if (givenVersion == null) {
     console.error("Missing next version. Usage: node version.js [nextVersion]");
@@ -31,6 +37,7 @@ function getNextVersion(currentVersion, givenVersion, prereleaseId = "pre") {
     let hash = execSync(`git rev-parse --short HEAD`).toString().trim();
     nextVersion = `0.0.0-experimental-${hash}`;
   } else {
+    // @ts-ignore
     nextVersion = semver.inc(currentVersion, givenVersion, prereleaseId);
   }
 
@@ -42,6 +49,10 @@ function getNextVersion(currentVersion, givenVersion, prereleaseId = "pre") {
   return nextVersion;
 }
 
+/**
+ * @param {string} packageName
+ * @param {(json: import('type-fest').PackageJson) => any} transform
+ */
 async function updatePackageConfig(packageName, transform) {
   let file = packageJson(packageName, "packages");
   let json = await jsonfile.readFile(file);
@@ -51,7 +62,7 @@ async function updatePackageConfig(packageName, transform) {
 
 /**
  * @param {string} example
- * @param {(json: string) => any} transform
+ * @param {(json: import('type-fest').PackageJson) => any} transform
  */
 async function updateExamplesPackageConfig(example, transform) {
   let file = packageJson(example, "examples");
@@ -62,6 +73,9 @@ async function updateExamplesPackageConfig(example, transform) {
   await jsonfile.writeFile(file, json, { spaces: 2 });
 }
 
+/**
+ * @param {string[]} args
+ */
 async function run(args) {
   let givenVersion = args[0];
   let prereleaseId = args[1];
@@ -161,8 +175,8 @@ run(process.argv.slice(2)).then(
  */
 async function fileExists(filePath) {
   try {
-    let stat = await fsp.stat(filePath);
-    return stat.code !== "ENOENT";
+    await fsp.stat(filePath);
+    return true;
   } catch (_) {
     return false;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10647,6 +10647,11 @@ type-fest@^0.8.1:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^2.11.1:
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.11.2.tgz#5534a919858bc517492cd3a53a673835a76d2e71"
+  integrity sha512-reW2Y2Mpn0QNA/5fvtm5doROLwDPu2zOm5RtY7xQQS05Q7xgC8MOZ3yPNaP9m/s/sNjjFQtHo7VCNqYW2iI+Ig==
+
 type-is@^1.6.16, type-is@^1.6.18, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz"


### PR DESCRIPTION
This PR introduces a `release` script to simplify the release process based on our branching strategy. I will need to stress test a few of the processes during the next release process, but I first want to make sure the flow is correct and accounts for the various types of releases we work with.