### PR TITLE
docs: fix typo -- remove erroneous apostrophe

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -82,6 +82,7 @@
 - jdeniau
 - jeremyjfleming
 - jesseflorig
+- jgarrow
 - jkup
 - jmasson
 - joaosamouco

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -441,7 +441,7 @@ Great! We've got our primary routes all set up!
 
 ## Styling
 
-From the beginning of styling on the web, to get CSS on the page, we've used `<link rel="stylesheet" href="/path-to-file.css" />`. This is how you style your Remix applications as well, but Remix makes it much easier than just throwing `link` tags all over the place. Remix brings the power of it's Nested Routing support to CSS and allows you to associate `link`s to routes. When the route is active, the `link` is on the page and the CSS applies. When the route is not active (the user navigates away), the `link` tag is removed and the CSS no longer applies.
+From the beginning of styling on the web, to get CSS on the page, we've used `<link rel="stylesheet" href="/path-to-file.css" />`. This is how you style your Remix applications as well, but Remix makes it much easier than just throwing `link` tags all over the place. Remix brings the power of its Nested Routing support to CSS and allows you to associate `link`s to routes. When the route is active, the `link` is on the page and the CSS applies. When the route is not active (the user navigates away), the `link` tag is removed and the CSS no longer applies.
 
 You do this by exporting a [`links`](../api/conventions#links) function in your route module. Let's get the homepage styled. You can put your CSS files anywhere you like within the `app` directory. We'll put ours in `app/styles/`.
 


### PR DESCRIPTION
Just a grammar nit to change `it's` to the possessive `its`. Thanks for the great tutorial, loving it so far! 😊