### PR TITLE
transpileModules config

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -25,6 +25,7 @@
 - chenc041
 - christianhg
 - christophgockel
+- cj
 - clarkmitchell
 - codymjarrett
 - coryhouse

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -296,7 +296,7 @@ async function createBrowserBuild(
   };
   for (let id of Object.keys(config.routes)) {
     // All route entry points are virtual modules that will be loaded by the
-    // browserEntryPointsPlugin. This allows us to tree-shake server-only code
+    // browserEntryPointsPlugin. This devcompilallows us to tree-shake server-only code
     // that we don't want to run in the browser (i.e. action & loader).
     entryPoints[id] =
       path.resolve(config.appDirectory, config.routes[id].file) + "?browser";
@@ -391,6 +391,8 @@ async function createServerBuild(
             );
           }
 
+          // Include files added by transpileModules config
+          if (config.transpileModules.includes(id)) return false;
           // Include .css files from node_modules in the build so we can get a
           // hashed file name to put into the HTML.
           if (id.endsWith(".css")) return false;

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -270,6 +270,8 @@ export async function readConfig(
     }
   }
 
+  if (config.transpileModules.includes(id)) return false;
+
   return {
     appDirectory,
     cacheDirectory,
@@ -285,7 +287,8 @@ export async function readConfig(
     serverMode,
     serverModuleFormat,
     serverPlatform,
-    mdx
+    mdx,
+    transpileModules
   };
 }
 


### PR DESCRIPTION
This will allow transpiled modules just like https://www.npmjs.com/package/next-transpile-modules you can now just add transpileModules to your remix.config.js.

```javascript
/**
 * @type {import('@remix-run/dev/config').AppConfig}
 */
module.exports = {
  appDirectory: 'app',
  browserBuildDirectory: './public/build',
  publicPath: '/build/',
  serverBuildDirectory: './server/build',
  devServerPort: 8002,
  transpileModules: ['ui', 'lib', 'env'],
}
```