### PR TITLE
[Docs] – Add `useLoaderData` import to "Using Sessions" example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -160,6 +160,7 @@
 - shumuu
 - sidkh
 - silvenon
+- simonswiss
 - sinhalite
 - sitek94
 - skube

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -1886,7 +1886,7 @@ You'll use methods to get access to sessions in your `loader` and `action` funct
 A login form might look something like this:
 
 ```tsx filename=app/routes/login.js lines=2,5-7,9,14,18,24-26,37,42,47,52
-import { json, redirect } from "remix";
+import { json, redirect, useLoaderData } from "remix";
 import { getSession, commitSession } from "../sessions";
 
 export async function loader({ request }) {


### PR DESCRIPTION
Line 58 of the code example uses `useLoaderData()`, but it's not imported at the top of that example.