### PR TITLE
Provide type for return type of both LoaderFunction and ActionFunction

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -164,3 +164,4 @@
 - yomeshgupta
 - zachdtaylor
 - zainfathoni
+- MarkusWendorf

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -20,14 +20,15 @@ export interface DataFunctionArgs {
 }
 
 /**
+ * Return type of both LoaderFunction and ActionFunction
+ */
+export type DataFunctionResponse = Promise<Response> | Response | Promise<AppData> | AppData;
+
+/**
  * A function that handles data mutations for a route.
  */
 export interface ActionFunction {
-  (args: DataFunctionArgs):
-    | Promise<Response>
-    | Response
-    | Promise<AppData>
-    | AppData;
+  (args: DataFunctionArgs): DataFunctionResponse;
 }
 
 /**
@@ -64,11 +65,7 @@ export interface LinksFunction {
  * A function that loads data for a route.
  */
 export interface LoaderFunction {
-  (args: DataFunctionArgs):
-    | Promise<Response>
-    | Response
-    | Promise<AppData>
-    | AppData;
+  (args: DataFunctionArgs): DataFunctionResponse;
 }
 
 /**


### PR DESCRIPTION
This PR adds a new type `DataFunctionResponse` as a type alias for: `Promise<Response> | Response | Promise<AppData> | AppData`.

I've come across the following code, where I want to make my code a little more typesafe by typing my custom functions to the return type of my `ActionFunction`. But I can't use the `ActionFunction` interface because my functions do have other arguments.

So this PR exports the response type of `ActionFunction` (and `LoaderFunction`)

```tsx
export const action: ActionFunction = async ({ request, params }) => {
  const id = params["id"];
  const { values } = await formData(request);
  const action = values["_action"];

  switch (action) {
    case Action.Save:
      return save(id, values);
    case Action.Delete:
      return del(id);
    default:
      return new Response("Not found", { status: 404 });
  }
};

// I don't want to type out this rather long return type
export function save(id: number | undefined, values: Record<string, string): Promise<Response> | Response | Promise<AppData> | AppData;

// Better but not much better
export function del(id: number | undefined, values: Record<string, string): Promise<ReturnType<ActionFunction>>;

// Ideally the type would be exported
import { ActionResponse } from "@remix-run/server-runtime";
export function del(id: number | undefined, values: Record<string, string): ActionResponse;

```

I've settled with the name `DataFunctionResponse` because there's already `DataFunctionArgs` being used by both `ActionFunction` and `LoaderFunction` and they both share this new response type.