### PR TITLE
feat(remix-server-runtime): log time taken in `action`s/`loader`s

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -137,6 +137,7 @@
 - RossMcMillan92
 - rphlmr
 - ryanflorence
+- ryankshaw
 - sdavids
 - sean-roberts
 - sergiodxa


### PR DESCRIPTION
This both logs the amount of time taken for each loader to the console
as well as sets a server timing header so you can see it in the browser

I just took a rough shot at a first draft of doing this. I don’t know
if this is something you guys would want to do. We’ll want to make a
way for people to opt out but I didn’t know what would be the best
way to check for that (I talk about it in my screencast)

To test, 
* go to a page that has a few loaders. 
* Go to the network panel
* hover over the waterfall for a request served by remix
* it should show the amount of time it spent in each loader

I made a little screencast to explain it more:
https://drive.google.com/file/d/1PSlg9kAstP42vGyIggNJ_TCBji0HbC5k/view