### PR TITLE
feat(remix-server-runtime): allow generic types for `SessionData`

### DIFF
--- a/docs/utils/sessions.md
+++ b/docs/utils/sessions.md
@@ -21,12 +21,17 @@ Remix comes with several pre-built session storage options for common scenarios,
 
 This is an example of a cookie session storage:
 
-```js filename=app/sessions.js
-// app/sessions.js
+```ts filename=app/sessions.ts
+// app/sessions.ts
 import { createCookieSessionStorage } from "@remix-run/node"; // or cloudflare/deno
 
+type SessionData = {
+  userId: string;
+  error: string;
+}
+
 const { getSession, commitSession, destroySession } =
-  createCookieSessionStorage({
+  createCookieSessionStorage<SessionData>({
     // a Cookie from `createCookie` or the CookieOptions to create one
     cookie: {
       name: "__session",
@@ -49,7 +54,7 @@ const { getSession, commitSession, destroySession } =
 export { getSession, commitSession, destroySession };
 ```
 
-We recommend setting up your session storage object in `app/sessions.js` so all routes that need to access session data can import from the same spot (also, see our [Route Module Constraints][constraints]).
+We recommend setting up your session storage object in `app/sessions.ts` so all routes that need to access session data can import from the same spot (also, see our [Route Module Constraints][constraints]).
 
 The input/output to a session storage object are HTTP cookies. `getSession()` retrieves the current session from the incoming request's `Cookie` header, and `commitSession()`/`destroySession()` provide the `Set-Cookie` header for the outgoing response.
 

--- a/docs/utils/sessions.md
+++ b/docs/utils/sessions.md
@@ -27,11 +27,14 @@ import { createCookieSessionStorage } from "@remix-run/node"; // or cloudflare/d
 
 type SessionData = {
   userId: string;
+};
+
+type SessionFlashData = {
   error: string;
-}
+};
 
 const { getSession, commitSession, destroySession } =
-  createCookieSessionStorage<SessionData>({
+  createCookieSessionStorage<SessionData, SessionFlashData>({
     // a Cookie from `createCookie` or the CookieOptions to create one
     cookie: {
       name: "__session",

--- a/packages/remix-architect/sessions/arcTableSessionStorage.ts
+++ b/packages/remix-architect/sessions/arcTableSessionStorage.ts
@@ -44,10 +44,13 @@ interface ArcTableSessionStorageOptions {
  *     _idx *String
  *     _ttl TTL
  */
-export function createArcTableSessionStorage<Data = SessionData>({
+export function createArcTableSessionStorage<
+  Data = SessionData,
+  FlashData = Data
+>({
   cookie,
   ...props
-}: ArcTableSessionStorageOptions): SessionStorage<Data> {
+}: ArcTableSessionStorageOptions): SessionStorage<Data, FlashData> {
   async function getTable() {
     if (typeof props.table === "string") {
       let tables = await arc.tables();

--- a/packages/remix-architect/sessions/arcTableSessionStorage.ts
+++ b/packages/remix-architect/sessions/arcTableSessionStorage.ts
@@ -44,10 +44,10 @@ interface ArcTableSessionStorageOptions {
  *     _idx *String
  *     _ttl TTL
  */
-export function createArcTableSessionStorage({
+export function createArcTableSessionStorage<Data = SessionData>({
   cookie,
   ...props
-}: ArcTableSessionStorageOptions): SessionStorage {
+}: ArcTableSessionStorageOptions): SessionStorage<Data> {
   async function getTable() {
     if (typeof props.table === "string") {
       let tables = await arc.tables();
@@ -74,7 +74,7 @@ export function createArcTableSessionStorage({
           continue;
         }
 
-        let params = {
+        let params: Record<string, unknown> = {
           [props.idx]: id,
           ...data,
         };
@@ -99,7 +99,7 @@ export function createArcTableSessionStorage({
     },
     async updateData(id, data, expires) {
       let table = await getTable();
-      let params = {
+      let params: Record<string, unknown> = {
         [props.idx]: id,
         ...data,
       };

--- a/packages/remix-cloudflare/sessions/workersKVStorage.ts
+++ b/packages/remix-cloudflare/sessions/workersKVStorage.ts
@@ -25,10 +25,13 @@ interface WorkersKVSessionStorageOptions {
  * The advantage of using this instead of cookie session storage is that
  * KV Store may contain much more data than cookies.
  */
-export function createWorkersKVSessionStorage<Data = SessionData>({
+export function createWorkersKVSessionStorage<
+  Data = SessionData,
+  FlashData = Data
+>({
   cookie,
   kv,
-}: WorkersKVSessionStorageOptions): SessionStorage<Data> {
+}: WorkersKVSessionStorageOptions): SessionStorage<Data, FlashData> {
   return createSessionStorage({
     cookie,
     async createData(data, expires) {

--- a/packages/remix-cloudflare/sessions/workersKVStorage.ts
+++ b/packages/remix-cloudflare/sessions/workersKVStorage.ts
@@ -1,6 +1,7 @@
 import type {
   SessionStorage,
   SessionIdStorageStrategy,
+  SessionData,
 } from "@remix-run/server-runtime";
 
 import { createSessionStorage } from "../implementations";
@@ -24,10 +25,10 @@ interface WorkersKVSessionStorageOptions {
  * The advantage of using this instead of cookie session storage is that
  * KV Store may contain much more data than cookies.
  */
-export function createWorkersKVSessionStorage({
+export function createWorkersKVSessionStorage<Data = SessionData>({
   cookie,
   kv,
-}: WorkersKVSessionStorageOptions): SessionStorage {
+}: WorkersKVSessionStorageOptions): SessionStorage<Data> {
   return createSessionStorage({
     cookie,
     async createData(data, expires) {

--- a/packages/remix-deno/sessions/fileStorage.ts
+++ b/packages/remix-deno/sessions/fileStorage.ts
@@ -1,6 +1,7 @@
 import * as path from "https://deno.land/std@0.128.0/path/mod.ts";
 
 import type {
+  SessionData,
   SessionIdStorageStrategy,
   SessionStorage,
 } from "@remix-run/server-runtime";
@@ -25,10 +26,10 @@ interface FileSessionStorageOptions {
  * The advantage of using this instead of cookie session storage is that
  * files may contain much more data than cookies.
  */
-export function createFileSessionStorage({
+export function createFileSessionStorage<Data = SessionData>({
   cookie,
   dir,
-}: FileSessionStorageOptions): SessionStorage {
+}: FileSessionStorageOptions): SessionStorage<Data> {
   return createSessionStorage({
     cookie,
     async createData(data, expires) {

--- a/packages/remix-deno/sessions/fileStorage.ts
+++ b/packages/remix-deno/sessions/fileStorage.ts
@@ -26,10 +26,10 @@ interface FileSessionStorageOptions {
  * The advantage of using this instead of cookie session storage is that
  * files may contain much more data than cookies.
  */
-export function createFileSessionStorage<Data = SessionData>({
+export function createFileSessionStorage<Data = SessionData, FlashData = Data>({
   cookie,
   dir,
-}: FileSessionStorageOptions): SessionStorage<Data> {
+}: FileSessionStorageOptions): SessionStorage<Data, FlashData> {
   return createSessionStorage({
     cookie,
     async createData(data, expires) {

--- a/packages/remix-node/sessions/fileStorage.ts
+++ b/packages/remix-node/sessions/fileStorage.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import type {
   SessionStorage,
   SessionIdStorageStrategy,
+  SessionData,
 } from "@remix-run/server-runtime";
 
 import { createSessionStorage } from "../implementations";
@@ -29,10 +30,10 @@ interface FileSessionStorageOptions {
  *
  * @see https://remix.run/utils/sessions#createfilesessionstorage-node
  */
-export function createFileSessionStorage({
+export function createFileSessionStorage<Data = SessionData>({
   cookie,
   dir,
-}: FileSessionStorageOptions): SessionStorage {
+}: FileSessionStorageOptions): SessionStorage<Data> {
   return createSessionStorage({
     cookie,
     async createData(data, expires) {

--- a/packages/remix-node/sessions/fileStorage.ts
+++ b/packages/remix-node/sessions/fileStorage.ts
@@ -30,10 +30,10 @@ interface FileSessionStorageOptions {
  *
  * @see https://remix.run/utils/sessions#createfilesessionstorage-node
  */
-export function createFileSessionStorage<Data = SessionData>({
+export function createFileSessionStorage<Data = SessionData, FlashData = Data>({
   cookie,
   dir,
-}: FileSessionStorageOptions): SessionStorage<Data> {
+}: FileSessionStorageOptions): SessionStorage<Data, FlashData> {
   return createSessionStorage({
     cookie,
     async createData(data, expires) {

--- a/packages/remix-server-runtime/index.ts
+++ b/packages/remix-server-runtime/index.ts
@@ -44,6 +44,7 @@ export type {
   DataFunctionArgs,
   EntryContext,
   ErrorBoundaryComponent,
+  FlashSessionData,
   HandleDataRequestFunction,
   HandleDocumentRequestFunction,
   HeadersFunction,

--- a/packages/remix-server-runtime/reexport.ts
+++ b/packages/remix-server-runtime/reexport.ts
@@ -60,4 +60,5 @@ export type {
   SessionData,
   SessionIdStorageStrategy,
   SessionStorage,
+  FlashSessionData,
 } from "./sessions";

--- a/packages/remix-server-runtime/sessions/cookieStorage.ts
+++ b/packages/remix-server-runtime/sessions/cookieStorage.ts
@@ -15,9 +15,12 @@ interface CookieSessionStorageOptions {
   cookie?: SessionIdStorageStrategy["cookie"];
 }
 
-export type CreateCookieSessionStorageFunction = <Data = SessionData>(
+export type CreateCookieSessionStorageFunction = <
+  Data = SessionData,
+  FlashData = Data
+>(
   options?: CookieSessionStorageOptions
-) => SessionStorage<Data>;
+) => SessionStorage<Data, FlashData>;
 
 /**
  * Creates and returns a SessionStorage object that stores all session data

--- a/packages/remix-server-runtime/sessions/cookieStorage.ts
+++ b/packages/remix-server-runtime/sessions/cookieStorage.ts
@@ -1,6 +1,10 @@
 import type { CreateCookieFunction } from "../cookies";
 import { isCookie } from "../cookies";
-import type { SessionStorage, SessionIdStorageStrategy } from "../sessions";
+import type {
+  SessionStorage,
+  SessionIdStorageStrategy,
+  SessionData,
+} from "../sessions";
 import { warnOnceAboutSigningSessionCookie, createSession } from "../sessions";
 
 interface CookieSessionStorageOptions {
@@ -11,9 +15,9 @@ interface CookieSessionStorageOptions {
   cookie?: SessionIdStorageStrategy["cookie"];
 }
 
-export type CreateCookieSessionStorageFunction = (
+export type CreateCookieSessionStorageFunction = <Data = SessionData>(
   options?: CookieSessionStorageOptions
-) => SessionStorage;
+) => SessionStorage<Data>;
 
 /**
  * Creates and returns a SessionStorage object that stores all session data

--- a/packages/remix-server-runtime/sessions/memoryStorage.ts
+++ b/packages/remix-server-runtime/sessions/memoryStorage.ts
@@ -3,6 +3,7 @@ import type {
   SessionStorage,
   SessionIdStorageStrategy,
   CreateSessionStorageFunction,
+  FlashSessionData,
 } from "../sessions";
 
 interface MemorySessionStorageOptions {
@@ -13,9 +14,9 @@ interface MemorySessionStorageOptions {
   cookie?: SessionIdStorageStrategy["cookie"];
 }
 
-export type CreateMemorySessionStorageFunction = (
+export type CreateMemorySessionStorageFunction = <Data = SessionData>(
   options?: MemorySessionStorageOptions
-) => SessionStorage;
+) => SessionStorage<Data>;
 
 /**
  * Creates and returns a simple in-memory SessionStorage object, mostly useful
@@ -30,9 +31,14 @@ export const createMemorySessionStorageFactory =
   (
     createSessionStorage: CreateSessionStorageFunction
   ): CreateMemorySessionStorageFunction =>
-  ({ cookie } = {}) => {
+  <Data = SessionData>({
+    cookie,
+  }: MemorySessionStorageOptions = {}): SessionStorage<Data> => {
     let uniqueId = 0;
-    let map = new Map<string, { data: SessionData; expires?: Date }>();
+    let map = new Map<
+      string,
+      { data: FlashSessionData<Data>; expires?: Date }
+    >();
 
     return createSessionStorage({
       cookie,

--- a/packages/remix-server-runtime/sessions/memoryStorage.ts
+++ b/packages/remix-server-runtime/sessions/memoryStorage.ts
@@ -14,9 +14,12 @@ interface MemorySessionStorageOptions {
   cookie?: SessionIdStorageStrategy["cookie"];
 }
 
-export type CreateMemorySessionStorageFunction = <Data = SessionData>(
+export type CreateMemorySessionStorageFunction = <
+  Data = SessionData,
+  FlashData = Data
+>(
   options?: MemorySessionStorageOptions
-) => SessionStorage<Data>;
+) => SessionStorage<Data, FlashData>;
 
 /**
  * Creates and returns a simple in-memory SessionStorage object, mostly useful
@@ -31,13 +34,13 @@ export const createMemorySessionStorageFactory =
   (
     createSessionStorage: CreateSessionStorageFunction
   ): CreateMemorySessionStorageFunction =>
-  <Data = SessionData>({
+  <Data = SessionData, FlashData = Data>({
     cookie,
-  }: MemorySessionStorageOptions = {}): SessionStorage<Data> => {
+  }: MemorySessionStorageOptions = {}): SessionStorage<Data, FlashData> => {
     let uniqueId = 0;
     let map = new Map<
       string,
-      { data: FlashSessionData<Data>; expires?: Date }
+      { data: FlashSessionData<Data, FlashData>; expires?: Date }
     >();
 
     return createSessionStorage({


### PR DESCRIPTION
Currently, all session-related functions use the default `SessionData` interface that is defined as `{ [key: string]: any }`.
This works fine, but doesn't provide any type information for TypeScript when using e.g. `session.get(...)`.

This PR adds generic types to
- the `Session` interface
- the `createSession(...)` function
- all built-in session stores

You can now create a session storage like this:
```ts
// app/sessions.ts
interface CustomSessionData {
  userId: number;
  error: string;
}

export const {
  getSession,
  commitSession,
  destroySession
} = createCookieSessionStorage<CustomSessionData>();
```
and use it like usual, but you will now get type information and auto-completion when using any of the `session.(has|get|set|flash|unset)` functions.

Using the generic session data type is optional and it defaults to the build-in `SessionData` interface, making this change fully backwards-compatible.
