### PR TITLE
Add cache-control header to cloudflare pages template

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -25,8 +25,8 @@
 - christophgockel
 - clarkmitchell
 - codymjarrett
-- coryhouse
 - confix
+- coryhouse
 - craigglennie
 - crismali
 - danielweinmann
@@ -137,6 +137,7 @@
 - RossMcMillan92
 - rphlmr
 - ryanflorence
+- schpet
 - sdavids
 - sean-roberts
 - sergiodxa

--- a/packages/create-remix/templates/cloudflare-pages/public/_headers
+++ b/packages/create-remix/templates/cloudflare-pages/public/_headers
@@ -1,0 +1,2 @@
+/build/*
+  Cache-Control: public, max-age=31536000, s-maxage=31536000


### PR DESCRIPTION
this PR adds the _header file described here:
https://developers.cloudflare.com/pages/platform/headers

and sets the same Cache-Control value as the netlify template:

https://github.com/remix-run/remix/blob/712ca2b5b08eb3200b5cb1bbf29e8faa77f556d1/packages/create-remix/templates/netlify/netlify.toml#L18

Todo

- [x] figure out how to run this template to test it out 🤔