### PR TITLE
fix(remix-dev): omit Resource Routes from client build

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -146,6 +146,7 @@
 - pyr0gan
 - real34
 - reggie3
+- rossipedia
 - RossJHagan
 - RossMcMillan92
 - rphlmr

--- a/integration/compiler-test.ts
+++ b/integration/compiler-test.ts
@@ -5,6 +5,8 @@ describe("compiler", () => {
   let fixture: Fixture;
   let app: AppFixture;
 
+  const RESOURCE_ROUTE = "routes/resource/route";
+
   beforeAll(async () => {
     fixture = await createFixture({
       files: {
@@ -19,6 +21,7 @@ describe("compiler", () => {
             return <div id="index">{Object.keys(fake).length}</div>
           }
         `,
+
         "app/routes/built-ins.jsx": js`
           import { useLoaderData } from "remix";
           import * as path from "path";
@@ -31,12 +34,23 @@ describe("compiler", () => {
             return <div id="built-ins">{useLoaderData()}</div>
           }
         `,
+
         "app/routes/built-ins-polyfill.jsx": js`
           import { useLoaderData } from "remix";
           import * as path from "path";
 
           export default function BuiltIns() {
             return <div id="built-ins-polyfill">{path.join("test", "file.txt")}</div>
+          }
+        `,
+
+        [`app/${RESOURCE_ROUTE}.js`]: js`
+          export function loader() {
+            return "loader";
+          }
+
+          export function action() {
+            return "action";
           }
         `
       }
@@ -47,6 +61,10 @@ describe("compiler", () => {
 
   afterAll(async () => {
     await app.close();
+  });
+
+  it("does not bundle resource routes", async () => {
+    expect(fixture.build.assets.routes[RESOURCE_ROUTE]).toBeUndefined();
   });
 
   it("removes server code with `*.server` files", async () => {

--- a/packages/remix-dev/compiler/assets.ts
+++ b/packages/remix-dev/compiler/assets.ts
@@ -29,6 +29,7 @@ export interface AssetsManifest {
       hasLoader: boolean;
       hasCatchBoundary: boolean;
       hasErrorBoundary: boolean;
+      resourceOnly?: boolean;
     };
   };
 }

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -25,6 +25,7 @@ interface Route {
   id: string;
   path?: string;
   index?: boolean;
+  resourceOnly?: boolean;
 }
 
 // NOTE: make sure to change the EntryRoute in server-runtime if you change this
@@ -36,6 +37,7 @@ export interface EntryRoute extends Route {
   imports?: string[];
   module: string;
   parentId?: string;
+  resourceOnly?: boolean;
 }
 
 export type RouteDataFunction = {
@@ -94,7 +96,8 @@ export function createClientRoute(
     shouldReload: createShouldReload(entryRoute, routeModulesCache),
     ErrorBoundary: entryRoute.hasErrorBoundary,
     CatchBoundary: entryRoute.hasCatchBoundary,
-    hasLoader: entryRoute.hasLoader
+    hasLoader: entryRoute.hasLoader,
+    resourceOnly: entryRoute.resourceOnly,
   };
 }
 

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -1,6 +1,6 @@
 // TODO: We eventually might not want to import anything directly from `history`
 // and leverage `react-router` here instead
-import { Action } from "history";
+import { Action, createPath } from "history";
 import type { Location } from "history";
 
 import type { RouteData } from "./routeData";
@@ -454,6 +454,18 @@ export function createTransitionManager(init: TransitionManagerInit) {
 
         let matches = matchClientRoutes(routes, location);
 
+        if (process.env.NODE_ENV === "development") {
+          // we include resource only routes in the manifest in dev mode
+          // so we can notify the developer about using <Link /> to a
+          // resource-only route.
+
+          // However, we still need to treat resource-only routes as if they
+          // didn't match to get proper behavior.
+          if (matches?.[matches.length - 1].route.resourceOnly) {
+            matches = null;
+          }
+        }
+
         if (!matches) {
           matches = [
             {
@@ -903,19 +915,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
     // complicated without the pending state, maybe we can figure something else
     // out later, but this works great.)
     await Promise.resolve();
-
-    let catchBoundaryId = findNearestCatchBoundary(matches[0], matches);
-    update({
-      location,
-      matches,
-      catch: {
-        data: null,
-        status: 404,
-        statusText: "Not Found"
-      },
-      catchBoundaryId,
-      transition: IDLE_TRANSITION
-    });
+    window.location.reload();
   }
 
   async function handleActionSubmissionNavigation(

--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -23,6 +23,7 @@ export interface EntryRoute extends Route {
   hasErrorBoundary: boolean;
   imports?: string[];
   module: string;
+  resourceOnly?: boolean;
 }
 
 export interface ServerRoute extends Route {


### PR DESCRIPTION
If resource routes don't have any client-safe exports, the entire thing gets included as a browser entry point (`export * from ${file}`). This can expose sensitive information.

Fix is to only include routes as entry points that have at least one browser safe export.

Fixes #1828