### PR TITLE
Added `externals` option for esbuild

### DIFF
--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -123,7 +123,8 @@ export async function watch(
     },
     onFileDeleted(file) {
       log(`File deleted: ${path.relative(process.cwd(), file)}`);
-    }
+    },
+    externals: config.externals,
   });
 
   console.log(`💿 Built in ${prettyMs(Date.now() - start)}`);

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -379,8 +379,6 @@ export async function readConfig(
 
   let externals = appConfig.externals || [];
 
-  console.log('EXTERNALS', externals)
-
   return {
     appDirectory,
     cacheDirectory,

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -128,6 +128,11 @@ export interface AppConfig {
    * routes.
    */
   ignoredRouteFiles?: string[];
+
+  /** 
+   * A list of modules to skip when bundling.
+   */
+  externals?: string[];
 }
 
 /**
@@ -224,6 +229,11 @@ export interface RemixConfig {
    * A server entrypoint relative to the root directory that becomes your server's main module.
    */
   serverEntryPoint?: string;
+
+  /** 
+   * A list of modules to skip when bundling.
+   */
+  externals?: string[];
 }
 
 /**
@@ -367,6 +377,10 @@ export async function readConfig(
     serverBuildVirtualModule.id
   )};`;
 
+  let externals = appConfig.externals || [];
+
+  console.log('EXTERNALS', externals)
+
   return {
     appDirectory,
     cacheDirectory,
@@ -385,7 +399,8 @@ export async function readConfig(
     serverBuildTarget,
     serverBuildTargetEntryModule,
     serverEntryPoint: customServerEntryPoint,
-    mdx
+    mdx,
+    externals,
   };
 }
 


### PR DESCRIPTION
I am using MikroORM and esbuild does static analysis of the source files and throws errors on the pakages of the connectors of the databases I am not using. For this reason, I added the option. This would fix https://github.com/remix-run/remix/issues/1823

Example: https://github.com/Industrial/test-remix-vercel/blob/main/remix.config.js#L10