### PR TITLE
chore: run workflows on main repo only (`dev` branch)

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   format:
+    if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This was causing failures on my fork

https://github.com/MichaelDeBoey/remix/actions/runs/1814598064