### PR TITLE
fix(remix-server-runtime): fix headers function access to loaderHeaders when parent has no loader

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -159,6 +159,7 @@
 - veritem
 - VictorPeralta
 - weavdale
+- xstevenyung
 - yauri-io
 - yesmeck
 - yomeshgupta

--- a/integration/headers-test.ts
+++ b/integration/headers-test.ts
@@ -79,8 +79,7 @@ describe("headers export", () => {
     expect(response.headers.get(ROOT_HEADER_KEY)).toBe(ROOT_HEADER_VALUE);
   });
 
-  // FIXME: this test is busted
-  it.skip("can use the loader headers when parents don't have loaders", async () => {
+  it("can use the loader headers when parents don't have loaders", async () => {
     const HEADER_KEY = "X-Test";
     const HEADER_VALUE = "SUCCESS";
 

--- a/packages/remix-server-runtime/__tests__/server-test.ts
+++ b/packages/remix-server-runtime/__tests__/server-test.ts
@@ -1679,37 +1679,4 @@ describe("shared server runtime", () => {
       expect(spy.console.mock.calls.length).toBe(1);
     });
   });
-
-  describe("header requests", () => {
-    test("can access loader headers if parent doesn't have a loader itself", async () => {
-      let indexLoader = jest.fn(() => {
-        return new Response(null, { headers: { "X-Test": "SUCCESS" } });
-      });
-      let indexHeaders = jest.fn(({ loaderHeaders }) => {
-        return {
-          "X-Test": loaderHeaders.get("X-Test") || "FAILED"
-        };
-      });
-      let build = mockServerBuild({
-        root: {
-          default: {}
-        },
-        "routes/index": {
-          loader: indexLoader,
-          parentId: "root",
-          index: true,
-          headers: indexHeaders,
-          default: {}
-        }
-      });
-      let handler = createRequestHandler(build, {}, ServerMode.Test);
-
-      let request = new Request(`${baseUrl}/`, { method: "get" });
-
-      let result = await handler(request);
-
-      expect(result.headers.get("X-Test")).toBe("SUCCESS");
-      expect(indexHeaders.mock.calls.length).toBe(1);
-    });
-  });
 });

--- a/packages/remix-server-runtime/__tests__/server-test.ts
+++ b/packages/remix-server-runtime/__tests__/server-test.ts
@@ -1679,4 +1679,37 @@ describe("shared server runtime", () => {
       expect(spy.console.mock.calls.length).toBe(1);
     });
   });
+
+  describe("header requests", () => {
+    test("can access loader headers if parent doesn't have a loader itself", async () => {
+      let indexLoader = jest.fn(() => {
+        return new Response(null, { headers: { "X-Test": "SUCCESS" } });
+      });
+      let indexHeaders = jest.fn(({ loaderHeaders }) => {
+        return {
+          "X-Test": loaderHeaders.get("X-Test") || "FAILED"
+        };
+      });
+      let build = mockServerBuild({
+        root: {
+          default: {}
+        },
+        "routes/index": {
+          loader: indexLoader,
+          parentId: "root",
+          index: true,
+          headers: indexHeaders,
+          default: {}
+        }
+      });
+      let handler = createRequestHandler(build, {}, ServerMode.Test);
+
+      let request = new Request(`${baseUrl}/`, { method: "get" });
+
+      let result = await handler(request);
+
+      expect(result.headers.get("X-Test")).toBe("SUCCESS");
+      expect(indexHeaders.mock.calls.length).toBe(1);
+    });
+  });
 });

--- a/packages/remix-server-runtime/headers.ts
+++ b/packages/remix-server-runtime/headers.ts
@@ -7,13 +7,14 @@ import type { RouteMatch } from "./routeMatching";
 export function getDocumentHeaders(
   build: ServerBuild,
   matches: RouteMatch<ServerRoute>[],
-  routeLoaderResponses: Response[],
+  routeLoaderResponses: Record<string, Response>,
   actionResponse?: Response
 ): Headers {
   return matches.reduce((parentHeaders, match, index) => {
     let routeModule = build.routes[match.route.id].module;
-    let loaderHeaders = routeLoaderResponses[index]
-      ? routeLoaderResponses[index].headers
+    let routeLoaderResponse = routeLoaderResponses[match.route.id];
+    let loaderHeaders = routeLoaderResponse
+      ? routeLoaderResponse.headers
       : new Headers();
     let actionHeaders = actionResponse ? actionResponse.headers : new Headers();
     let headers = new Headers(

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -324,7 +324,7 @@ async function renderDocumentRequest({
   appState.error = undefined;
 
   let headerMatches: RouteMatch<ServerRoute>[] = [];
-  let routeLoaderResponses: Response[] = [];
+  let routeLoaderResponses: Record<string, Response> = {};
   let loaderStatusCodes: number[] = [];
   let routeData: Record<string, unknown> = {};
   for (let index = 0; index < matchesToLoad.length; index++) {
@@ -372,7 +372,7 @@ async function renderDocumentRequest({
       break;
     } else if (response) {
       headerMatches.push(match);
-      routeLoaderResponses.push(response);
+      routeLoaderResponses[match.route.id] = response;
       loaderStatusCodes.push(response.status);
 
       if (isCatch) {


### PR DESCRIPTION
This should fixes issue: https://github.com/remix-run/remix/issues/1140

The issue came from `routeLoaderResponses` not taking into account that some parent route might not have loaders hence no response. Because `getDocumentHeaders` matched the response to the `index` position in `routeLoaderResponses`, this could provoke a mismatch.

I replaced `routeLoaderResponses` from an array to a `Record<string, Response>` (matching the route's id instead of the index) which would solve the issue.

I also created a test but I think it might not be in the right place, feel free to move it if needed.

Thanks for your awesome work, I love Remix !