### PR TITLE
fix(remix-node): do not change empty string to null when using get method on FormData

### DIFF
--- a/packages/remix-node/__tests__/formData-test.ts
+++ b/packages/remix-node/__tests__/formData-test.ts
@@ -18,6 +18,12 @@ describe("FormData", () => {
     ]);
   });
 
+  it("restores correctly empty string values with get method", () => {
+    let formData = new NodeFormData();
+    formData.set("single", "");
+    expect(formData.get("single")).toBe("");
+  });
+
   it("allows for mix of set and append with blobs and files", () => {
     let formData = new NodeFormData();
     formData.set("single", new Blob([]));

--- a/packages/remix-node/formData.ts
+++ b/packages/remix-node/formData.ts
@@ -58,7 +58,7 @@ class NodeFormData implements FormData {
 
   get(name: string): FormDataEntryValue | null {
     let arr = this._fields[name];
-    return arr?.slice(-1)[0] || null;
+    return arr?.slice(-1)[0] ?? null;
   }
 
   getAll(name: string): FormDataEntryValue[] {


### PR DESCRIPTION
closes #1852 

[According to MDN](https://developer.mozilla.org/en-US/docs/Web/API/FormData/get#return_value), `FormData.get()` returns a `string` for `File`, and returns `null` only when the key does not exist.
Currently it returns `null` also for `""` value.