### PR TITLE
docs: fix wrong new code line marking in blog tutorial

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -209,3 +209,4 @@
 - yomeshgupta
 - zachdtaylor
 - zainfathoni
+- luk-str

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -657,7 +657,7 @@ em {
 
 💿 Link to the stylesheet in the admin route
 
-```tsx filename=app/routes/admin.tsx lines=[4,6-8]
+```tsx filename=app/routes/admin.tsx lines=[5,7-9]
 import { Link, useLoaderData } from "remix";
 
 import { getPosts } from "~/post";


### PR DESCRIPTION
This PR fixes faulty line numbers for new code lines in one of the code blocks in the blog tutorial