### PR TITLE
fix: allow root route forms to hit actions on different pages and have that submission hit shouldReload

### DIFF
--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -1366,11 +1366,6 @@ function filterMatchesToLoad(
     return true;
   };
 
-  let isInRootCatchBoundary = state.matches.length === 1;
-  if (isInRootCatchBoundary) {
-    return matches.filter(match => !!match.route.loader);
-  }
-
   if (fetcher?.type === "actionReload") {
     return matches.filter(filterByRouteProps);
   } else if (


### PR DESCRIPTION
fixes an issue where `<Form>` in the root route hitting a different route's action wouldn't pass the submission to shouldReload

closes REM-693

writing a test now...

Signed-off-by: Logan McAnsh <logan@mcan.sh>