### PR TITLE
types(remix-server-runtime): make `AppLoadContext` an empty interface instead of `any`

### DIFF
--- a/.changeset/great-pumas-act.md
+++ b/.changeset/great-pumas-act.md
@@ -1,0 +1,18 @@
+---
+"@remix-run/netlify": minor
+"@remix-run/server-runtime": minor
+---
+
+Type safety for load context.
+
+Change `AppLoadContext` to be an interface mapping `string` to `unknown`, allowing users to extend it via:
+
+```ts
+
+
+declare module "@remix-run/server-runtime" {
+  interface AppLoadContext {
+    // add custom properties here!
+  }
+}
+```

--- a/contributors.yml
+++ b/contributors.yml
@@ -80,6 +80,7 @@
 - cysp
 - damiensedgwick
 - dan-gamble
+- danielfgray
 - danielweinmann
 - davecalnan
 - davecranwell-vocovo

--- a/packages/remix-netlify/server.ts
+++ b/packages/remix-netlify/server.ts
@@ -39,7 +39,7 @@ export function createRequestHandler({
   mode = process.env.NODE_ENV,
 }: {
   build: ServerBuild;
-  getLoadContext?: AppLoadContext;
+  getLoadContext?: GetLoadContextFunction;
   mode?: string;
 }): RequestHandler {
   let handleRequest = createRemixRequestHandler(build, mode);

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -6,7 +6,9 @@ import { json, isResponse, isRedirectResponse } from "./responses";
  * An object of arbitrary for route loaders and actions provided by the
  * server's `getLoadContext()` function.
  */
-export interface AppLoadContext {};
+export interface AppLoadContext {
+  [key: string]: unknown;
+};
 
 /**
  * Data for a route that was returned from a `loader()`.

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -3,7 +3,7 @@ import type { ServerRoute } from "./routes";
 import { json, isResponse, isRedirectResponse } from "./responses";
 
 /**
- * An object of arbitrary for route loaders and actions provided by the
+ * An object of unknown type for route loaders and actions provided by the
  * server's `getLoadContext()` function.
  */
 export interface AppLoadContext {
@@ -20,7 +20,7 @@ export async function callRouteAction({
   match,
   request,
 }: {
-  loadContext: unknown;
+  loadContext: AppLoadContext;
   match: RouteMatch<ServerRoute>;
   request: Request;
 }) {
@@ -67,7 +67,7 @@ export async function callRouteLoader({
 }: {
   request: Request;
   match: RouteMatch<ServerRoute>;
-  loadContext: unknown;
+  loadContext: AppLoadContext;
 }) {
   let loader = match.route.module.loader;
 

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -6,7 +6,7 @@ import { json, isResponse, isRedirectResponse } from "./responses";
  * An object of arbitrary for route loaders and actions provided by the
  * server's `getLoadContext()` function.
  */
-export type AppLoadContext = any;
+export interface AppLoadContext {};
 
 /**
  * Data for a route that was returned from a `loader()`.

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -8,7 +8,7 @@ import { json, isResponse, isRedirectResponse } from "./responses";
  */
 export interface AppLoadContext {
   [key: string]: unknown;
-};
+}
 
 /**
  * Data for a route that was returned from a `loader()`.
@@ -20,7 +20,7 @@ export async function callRouteAction({
   match,
   request,
 }: {
-  loadContext: AppLoadContext;
+  loadContext?: AppLoadContext;
   match: RouteMatch<ServerRoute>;
   request: Request;
 }) {
@@ -67,7 +67,7 @@ export async function callRouteLoader({
 }: {
   request: Request;
   match: RouteMatch<ServerRoute>;
-  loadContext: AppLoadContext;
+  loadContext?: AppLoadContext;
 }) {
   let loader = match.route.module.loader;
 

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -15,7 +15,7 @@ export interface RouteModules<RouteModule> {
  */
 export interface DataFunctionArgs {
   request: Request;
-  context: AppLoadContext;
+  context?: AppLoadContext;
   params: Params;
 }
 

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -16,7 +16,7 @@ import { createServerHandoffString } from "./serverHandoff";
 
 export type RequestHandler = (
   request: Request,
-  loadContext: AppLoadContext
+  loadContext?: AppLoadContext
 ) => Promise<Response>;
 
 export type CreateRequestHandlerFunction = (
@@ -82,7 +82,7 @@ async function handleDataRequest({
   serverMode,
 }: {
   handleDataRequest?: HandleDataRequestFunction;
-  loadContext: AppLoadContext;
+  loadContext?: AppLoadContext;
   matches: RouteMatch<ServerRoute>[];
   request: Request;
   serverMode: ServerMode;
@@ -180,7 +180,7 @@ async function handleDocumentRequest({
   serverMode,
 }: {
   build: ServerBuild;
-  loadContext: AppLoadContext;
+  loadContext?: AppLoadContext;
   matches: RouteMatch<ServerRoute>[] | null;
   request: Request;
   routes: ServerRoute[];
@@ -516,7 +516,7 @@ async function handleResourceRequest({
   serverMode,
 }: {
   request: Request;
-  loadContext: AppLoadContext;
+  loadContext?: AppLoadContext;
   matches: RouteMatch<ServerRoute>[];
   serverMode: ServerMode;
 }): Promise<Response> {

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -16,7 +16,7 @@ import { createServerHandoffString } from "./serverHandoff";
 
 export type RequestHandler = (
   request: Request,
-  loadContext?: AppLoadContext
+  loadContext: AppLoadContext
 ) => Promise<Response>;
 
 export type CreateRequestHandlerFunction = (
@@ -82,7 +82,7 @@ async function handleDataRequest({
   serverMode,
 }: {
   handleDataRequest?: HandleDataRequestFunction;
-  loadContext: unknown;
+  loadContext: AppLoadContext;
   matches: RouteMatch<ServerRoute>[];
   request: Request;
   serverMode: ServerMode;
@@ -180,7 +180,7 @@ async function handleDocumentRequest({
   serverMode,
 }: {
   build: ServerBuild;
-  loadContext: unknown;
+  loadContext: AppLoadContext;
   matches: RouteMatch<ServerRoute>[] | null;
   request: Request;
   routes: ServerRoute[];
@@ -516,7 +516,7 @@ async function handleResourceRequest({
   serverMode,
 }: {
   request: Request;
-  loadContext: unknown;
+  loadContext: AppLoadContext;
   matches: RouteMatch<ServerRoute>[];
   serverMode: ServerMode;
 }): Promise<Response> {


### PR DESCRIPTION
this allows users to override the `context` with their own definitions using ambient modules.

as an example:
```js
declare module "remix" {
  interface AppLoadContext {
    graphql: <Result, Variables>(operation: {
      query: TypedDocumentNode<Result, Variables>
      variables: Variables
    }) => Promise<ExecutionResult<Result>>
  }
}
```