### PR TITLE
docs(tutorial): link label with its field in blog tutorial, to enhance accessibility

### DIFF
--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -946,7 +946,7 @@ export default function NewPost() {
           <em>Markdown is required</em>
         ) : null}
         <br />
-        <textarea rows={20} name="markdown" />
+        <textarea id="markdown" rows={20} name="markdown" />
       </p>
       <p>
         <button type="submit">Create Post</button>


### PR DESCRIPTION
I just realized the blog example was also a tutorial. So this PR is following #1821 to make one of the labels in the tutorial match the code in the examples folder.