### PR TITLE
fix(remix-server-runtime): keep memory storage data across cache clears

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -182,6 +182,7 @@
 - sbernheim4
 - sean-roberts
 - sergiodxa
+- sheepsteak
 - shumuu
 - sidkh
 - silvenon


### PR DESCRIPTION
Fixes #1832 

Using an object stored on global the memory session storage will now keep data when the require cache is purged.

I started adding tests for this but I wasn't sure if they were useful. I can add them if needed.