### PR TITLE
Change ?? to || in ScrollRestoration inlined code

### DIFF
--- a/packages/remix-react/scroll-restoration.tsx
+++ b/packages/remix-react/scroll-restoration.tsx
@@ -44,7 +44,7 @@ export function ScrollRestoration() {
             window.history.replaceState({ key: Math.random().toString(32).slice(2) }, null);
           }
           try {
-            let positions = JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? '{}')
+            let positions = JSON.parse(sessionStorage.getItem(STORAGE_KEY) || '{}')
             let storedY = positions[window.history.state.key];
             if (typeof storedY === 'number') {
               window.scrollTo(0, storedY)


### PR DESCRIPTION
ScrollRestoration is rendering a inlined script that is not being parsed by esbuild to support older browser when possible.

The tsconfig.json generated by the CLI is configured to target ES2019 but that inlined script is using `??` which is a ES2020 feature, this is breaking support for iOS 13 (based on a Discord discussion, see https://discord.com/channels/770287896669978684/771068344320786452/941472115163537499).

The PR changes `??` to `||`, it should work similar, just adding the scenario where the value from localStorage is `""` so it will use `"{}"` which I don't think it's a problem anyway.