### PR TITLE
chore(useMatches): memoize matches

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -107,6 +107,7 @@
 - luistorres
 - m0nica
 - m5r
+- manzano78
 - manzoorwanijk
 - matchai
 - matthew-burfield

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1232,18 +1232,22 @@ export function useBeforeUnload(callback: () => any): void {
  */
 export function useMatches() {
   let { matches, routeData, routeModules } = useRemixEntryContext();
-  return matches.map(match => {
-    let { pathname, params } = match;
-    return {
-      id: match.route.id,
-      pathname,
-      params,
-      data: routeData[match.route.id],
-      // if the module fails to load or an error/response is thrown, the module
-      // won't be defined.
-      handle: routeModules[match.route.id]?.handle
-    };
-  });
+
+  return React.useMemo(
+    () => matches.map(match => {
+      let { pathname, params } = match;
+      return {
+        id: match.route.id,
+        pathname,
+        params,
+        data: routeData[match.route.id],
+        // if the module fails to load or an error/response is thrown, the module
+        // won't be defined.
+        handle: routeModules[match.route.id]?.handle
+      };
+    }),
+    [matches, routeData, routeModules]
+  );
 }
 
 /**


### PR DESCRIPTION
Memoize the matches returned by `useMatches()` in order to not have a new reference of the array (and of all its items) at every re-rendering. As these matches are made to be looped over, I think it's more performant to memoize them.