### PR TITLE
docs: fix typo in /api/remix

### DIFF
--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -1426,7 +1426,7 @@ return new Response(null, {
 });
 ```
 
-## `parseMultipartFormData` (node)
+## `unstable_parseMultipartFormData` (node)
 
 Allows you to handle multipart forms (file uploads) for your app.
 
@@ -1436,14 +1436,14 @@ It's to be used in place of `request.formData()`.
 
 ```diff
 - let formData = await request.formData();
-+ let formData = await parseMultipartFormData(request, uploadHandler);
++ let formData = await unstable_parseMultipartFormData(request, uploadHandler);
 ```
 
 For example:
 
 ```tsx lines=[2-5,7,23]
 export let action: ActionFunction = async ({ request }) => {
-  let formData = await parseMultipartFormData(
+  let formData = await unstable_parseMultipartFormData(
     request,
     uploadHandler // <-- we'll look at this deeper next
   );
@@ -1493,7 +1493,7 @@ let uploadHandler = unstable_createFileUploadHandler({
 });
 
 export let action: ActionFunction = async ({ request }) => {
-  let formData = await parseMultipartFormData(
+  let formData = await unstable_parseMultipartFormData(
     request,
     uploadHandler
   );
@@ -1577,7 +1577,7 @@ export let action: ActionFunction = async ({ request }) => {
     return uploadedImage.secure_url;
   };
 
-  let formData = await parseMultipartFormData(
+  let formData = await unstable_parseMultipartFormData(
     request,
     uploadHandler
   );

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -1462,7 +1462,7 @@ export let action: ActionFunction = async ({ request }) => {
 
 export default function AvatarUploadRoute() {
   return (
-    <Form method="post">
+    <Form method="post" encType="multipart/form-data">
       <label htmlFor="avatar-input">Avatar</label>
       <input id="avatar-input" type="file" name="avatar" />
       <button>Upload</button>


### PR DESCRIPTION
I'm on `v1.1.3` and it's still `unstable_parseMultipartFormData` and not (yet) `parseMultipartFormData`
unless I'm missing something?