### PR TITLE
fix: restore scroll position for hashed routes

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -184,3 +184,4 @@
 - zainfathoni
 - jssisodiya
 - guerra08
+- wladiston

--- a/packages/remix-react/scroll-restoration.tsx
+++ b/packages/remix-react/scroll-restoration.tsx
@@ -98,7 +98,7 @@ function useScrollRestoration() {
       let y = positions[location.key];
 
       // been here before, scroll to it
-      if (y) {
+      if (y != undefined) {
         window.scrollTo(0, y);
         return;
       }


### PR DESCRIPTION
There's currently a bug on scroll restoration when the route has a hash and user scrolls to very top of the page. Instead of the scroll be restored from there, it was restoring the scroll to the hash element when navigating back.