### PR TITLE
docs: fix missing property serialization

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -68,6 +68,7 @@
 - fx109138
 - gabimor
 - gavriguy
+- ghaagsma
 - Gideon28
 - Girish21
 - gkueny

--- a/docs/pages/philosophy.md
+++ b/docs/pages/philosophy.md
@@ -60,6 +60,7 @@ export async function loader() {
   const json = await res.json();
   return json.map(gist => {
     return {
+      description: gist.description,
       url: gist.html_url,
       files: Object.keys(gist.files),
       owner: gist.owner.login


### PR DESCRIPTION
It appears the server-filtered gist example omits the `description` field from the response payload, but the field is still referenced client-side in the `Gists` function/component. This proposed change is meant to render the gist description rather than referencing an undefined property, but I'm unsure if this will result in inaccurate statistics pertaining to response payload size in the following paragraph. Should the response payload be re-evaluated with the `description` property serialized?