### PR TITLE
fix: suppress hydration warning

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1360,8 +1360,11 @@ export const LiveReload =
       }) {
         return (
           <script
+            suppressHydrationWarning
             dangerouslySetInnerHTML={{
-              __html: `
+              __html:
+                typeof document === "undefined"
+                  ? `
 let protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
 let host = location.hostname;
 let socketPath = protocol + '//' + host + ':${port}/socket';
@@ -1382,6 +1385,7 @@ ws.onerror = error => {
   console.error(error);
 };
               `.trim()
+                  : " "
             }}
           />
         );


### PR DESCRIPTION
IDK why we aren't suppressing this already, but there are seemingly random mismatches showing up for me in development mode.