### PR TITLE
fix: include createArcTableSessionStorage in remix exports

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import path from "path";
 import babel from "@rollup/plugin-babel";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import copy from "rollup-plugin-copy";
+import fse from "fs-extra";
 
 function isBareModuleId(id) {
   return !id.startsWith(".") && !path.isAbsolute(id);
@@ -568,52 +569,97 @@ function remixDeno() {
   ];
 }
 
-/** @return {import("rollup").RollupOptions} */
+/** @return {import("rollup").RollupOptions[]} */
 function getServerConfig(name) {
   let LIBRARY_NAME = `@remix-run/${name}`;
   let SOURCE_DIR = `packages/remix-${name}`;
   let OUTPUT_DIR = `build/node_modules/${LIBRARY_NAME}`;
+  let HAS_MAGIC_EXPORTS = fse.existsSync(
+    `${SOURCE_DIR}/magicExports/platform.ts`
+  );
   let version = getVersion(SOURCE_DIR);
 
-  return {
-    external(id) {
-      return isBareModuleId(id);
+  return [
+    {
+      external(id) {
+        return isBareModuleId(id);
+      },
+      input: `${SOURCE_DIR}/index.ts`,
+      output: {
+        banner: createBanner(LIBRARY_NAME, version),
+        dir: OUTPUT_DIR,
+        format: "cjs",
+        preserveModules: true,
+        exports: "auto",
+      },
+      plugins: [
+        babel({
+          babelHelpers: "bundled",
+          exclude: /node_modules/,
+          extensions: [".ts", ".tsx"],
+        }),
+        nodeResolve({ extensions: [".ts", ".tsx"] }),
+        copy({
+          targets: [
+            { src: `LICENSE.md`, dest: OUTPUT_DIR },
+            { src: `${SOURCE_DIR}/package.json`, dest: OUTPUT_DIR },
+            { src: `${SOURCE_DIR}/README.md`, dest: OUTPUT_DIR },
+          ],
+        }),
+      ],
     },
-    input: `${SOURCE_DIR}/index.ts`,
-    output: {
-      banner: createBanner(LIBRARY_NAME, version),
-      dir: OUTPUT_DIR,
-      format: "cjs",
-      preserveModules: true,
-      exports: "auto",
-    },
-    plugins: [
-      babel({
-        babelHelpers: "bundled",
-        exclude: /node_modules/,
-        extensions: [".ts", ".tsx"],
-      }),
-      nodeResolve({ extensions: [".ts", ".tsx"] }),
-      copy({
-        targets: [
-          { src: `LICENSE.md`, dest: OUTPUT_DIR },
-          { src: `${SOURCE_DIR}/package.json`, dest: OUTPUT_DIR },
-          { src: `${SOURCE_DIR}/README.md`, dest: OUTPUT_DIR },
-        ],
-      }),
-    ],
-  };
+    ...(HAS_MAGIC_EXPORTS
+      ? [
+          {
+            external() {
+              return true;
+            },
+            input: `${SOURCE_DIR}/magicExports/platform.ts`,
+            output: {
+              banner: createBanner(LIBRARY_NAME, version),
+              dir: `${OUTPUT_DIR}/magicExports`,
+              format: "cjs",
+            },
+            plugins: [
+              babel({
+                babelHelpers: "bundled",
+                exclude: /node_modules/,
+                extensions: [".ts", ".tsx"],
+              }),
+            ],
+          },
+          {
+            external() {
+              return true;
+            },
+            input: `${SOURCE_DIR}/magicExports/platform.ts`,
+            output: {
+              banner: createBanner(LIBRARY_NAME, version),
+              dir: `${OUTPUT_DIR}/magicExports/esm`,
+              format: "esm",
+            },
+            plugins: [
+              babel({
+                babelHelpers: "bundled",
+                exclude: /node_modules/,
+                extensions: [".ts", ".tsx"],
+              }),
+            ],
+          },
+        ]
+      : []),
+  ];
 }
 
 /** @returns {import("rollup").RollupOptions[]} */
 function remixServerAdapters() {
   return [
-    getServerConfig("architect"),
-    getServerConfig("cloudflare-pages"),
-    getServerConfig("cloudflare-workers"),
-    getServerConfig("express"),
-    getServerConfig("vercel"),
-    getServerConfig("netlify"),
+    ...getServerConfig("architect"),
+    ...getServerConfig("cloudflare-pages"),
+    ...getServerConfig("cloudflare-workers"),
+    ...getServerConfig("express"),
+    ...getServerConfig("vercel"),
+    ...getServerConfig("netlify"),
   ];
 }
 


### PR DESCRIPTION
This PR adds magicExports for any "server" adapter that uses the "getServerConfig" function to generate it's rollup build config

Signed-off-by: Logan McAnsh <logan@mcan.sh>
(cherry picked from commit 187970c94130645fd551e6fb1c05a713a5d43e78)

<!--

👋 Hey, thanks for your interest in contributing to Remix!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

-->
