### PR TITLE
fix(create-remix): escape [ and ] in .gitignore

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -187,3 +187,4 @@
 - jssisodiya
 - guerra08
 - wladiston
+- supachaidev

--- a/packages/create-remix/templates/cloudflare-pages/gitignore
+++ b/packages/create-remix/templates/cloudflare-pages/gitignore
@@ -1,5 +1,5 @@
 node_modules
 
 /.cache
-/functions/[[path]].js
+/functions/\[\[path\]\].js
 /public/build


### PR DESCRIPTION
Make /functions/[[path]].js ignored by git in cloudflare-pages template project.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

-->
