### PR TITLE
bug: NavLink applies custom styles and class names (specified with a function) to all NavLinks regardless of the current route

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -188,3 +188,4 @@
 - guerra08
 - wladiston
 - supachaidev
+- ariofrio

--- a/integration/navlink-test.ts
+++ b/integration/navlink-test.ts
@@ -1,0 +1,122 @@
+import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
+import type { Fixture, AppFixture } from "./helpers/create-fixture";
+
+describe("NavLink", () => {
+  let fixture: Fixture;
+  let app: AppFixture;
+
+  beforeAll(async () => {
+    fixture = await createFixture({
+      files: {
+        "app/root.jsx": js`
+          import {
+            NavLink,
+            Outlet,
+            Scripts
+          } from "remix";
+
+          export default function App() {
+            return (
+              <html>
+                <head />
+                <body>
+                  <header>
+                    <nav>
+                      <NavLink
+                        to="/"
+                        end
+                        style={isActive => isActive ? {fontWeight: 'bold'} : {}}
+                        className={isActive => isActive ? "custom-active" : undefined}
+                      >
+                        Home
+                      </NavLink>
+                      
+                      <NavLink
+                        to="/one"
+                        style={isActive => isActive ? {fontWeight: 'bold'} : {}}
+                        className={isActive => isActive ? "custom-active" : undefined}
+                      >
+                        One
+                      </NavLink>
+
+                      <NavLink
+                        to="/two"
+                        style={isActive => isActive ? {fontWeight: 'bold'} : {}}
+                        className={isActive => isActive ? "custom-active" : undefined}
+                      >
+                        Two
+                      </NavLink>
+                    </nav>
+                  </header>
+                  <main>
+                    <Outlet />
+                  </main>
+                  <Scripts />
+                </body>
+              </html>
+            );
+          }
+        `,
+
+        "app/routes/index.jsx": js`
+          export default function Index() {
+            return <div>Home</div>
+          }
+        `,
+        "app/routes/one.jsx": js`
+          export default function One() {
+            return <div>One</div>
+          }
+        `,
+        "app/routes/two.jsx": js`
+          export default function Two() {
+            return <div>Two</div>
+          }
+        `
+      }
+    });
+
+    app = await createAppFixture(fixture);
+  });
+
+  afterAll(async () => await app.close());
+
+  it("applies custom style and class name only to active", async () => {
+    async function fontWeightForNavLinkTo(route: string): Promise<string> {
+      return await app.page.$eval(
+        `a[href='${route}']`,
+        el => (el as HTMLElement).style.fontWeight
+      );
+    }
+    async function classNameForNavLinkTo(route: string): Promise<string> {
+      return await app.page.$eval(
+        `a[href='${route}']`,
+        el => (el as HTMLElement).className
+      );
+    }
+
+    await app.goto("/");
+    expect(await fontWeightForNavLinkTo("/")).toEqual("bold");
+    expect(await fontWeightForNavLinkTo("/one")).toEqual("");
+    expect(await fontWeightForNavLinkTo("/two")).toEqual("");
+    expect(await classNameForNavLinkTo("/")).toEqual("custom-active");
+    expect(await classNameForNavLinkTo("/one")).toEqual("");
+    expect(await classNameForNavLinkTo("/two")).toEqual("");
+
+    await app.goto("/one");
+    expect(await fontWeightForNavLinkTo("/")).toEqual("");
+    expect(await fontWeightForNavLinkTo("/one")).toEqual("bold");
+    expect(await fontWeightForNavLinkTo("/two")).toEqual("");
+    expect(await classNameForNavLinkTo("/")).toEqual("");
+    expect(await classNameForNavLinkTo("/one")).toEqual("custom-active");
+    expect(await classNameForNavLinkTo("/two")).toEqual("");
+
+    await app.goto("/two");
+    expect(await fontWeightForNavLinkTo("/")).toEqual("");
+    expect(await fontWeightForNavLinkTo("/one")).toEqual("");
+    expect(await fontWeightForNavLinkTo("/two")).toEqual("bold");
+    expect(await classNameForNavLinkTo("/")).toEqual("");
+    expect(await classNameForNavLinkTo("/one")).toEqual("");
+    expect(await classNameForNavLinkTo("/two")).toEqual("custom-active");
+  });
+});


### PR DESCRIPTION
This is a bug report with an integration test as requested [in the docs](https://remix.run/docs/en/v1/pages/contributing#think-you-found-a-bug).

This seems to affect every usage of `NavLink` that requires a custom class name or styles. This is particularly a problem when using Tailwind, which is [recommended by the docs](https://remix.run/docs/en/v1/guides/styling#tailwind) as the most popular solution. The most straightforward way of using Tailwind is like this:

```
<NavLink to="/somewhere" className={(isActive) => isActive ? "underline" : ""}>Somewhere</NavLink>
```

But this bug causes all navigation links to appear active when this is done.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

-->
