### PR TITLE
ci: add retry logic to fly and cf pages deployments

### DIFF
--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -1,0 +1,264 @@
+name: Deployment Test
+
+on: workflow_dispatch
+
+jobs:
+  arc_deploy:
+    name: Architect Deploy
+    needs: [build]
+    if: github.repository == 'remix-run/remix'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: echo "::set-output name=version::$(cat .nvmrc)"
+        id: nvmrc
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "${{ steps.nvmrc.outputs.version }}"
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - run: mkdir -p deployment-test
+
+      - name: Install latest version of npm
+        run: npm install -g npm@latest
+
+      - name: Deploy to Arc
+        run: node ./scripts/deployment-test/arc.mjs
+        env:
+          CI: true
+          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
+
+  cf_pages_deploy:
+    name: "CF Pages Deploy"
+    needs: [build]
+    if: github.repository == 'remix-run/remix'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: echo "::set-output name=version::$(cat .nvmrc)"
+        id: nvmrc
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.nvmrc.outputs.version }}"
+
+      - run: echo "::set-output name=dir::$(yarn cache dir)"
+        id: yarn-cache
+
+      - name: Restore dependency cache
+        uses: actions/cache@v2
+        with:
+          path: "${{ steps.yarn-cache.outputs.dir }}"
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-cache-
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - run: mkdir -p deployment-test
+
+      - name: Install latest version of npm
+        run: npm install -g npm@latest
+
+      - name: Deploy to Cloudflare Pages
+        run: node ./scripts/deployment-test/cf-pages.mjs
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.TEST_CF_ACCOUNT_ID }}
+          CF_GLOBAL_API_KEY: ${{ secrets.TEST_CF_GLOBAL_API_KEY }}
+          CF_EMAIL: ${{ secrets.TEST_CF_EMAIL }}
+          GITHUB_TOKEN: ${{ secrets.TEST_CF_GITHUB_TOKEN }}
+
+  cf_workers_deploy:
+    name: "CF Workers Deploy"
+    needs: [build]
+    if: github.repository == 'remix-run/remix'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: echo "::set-output name=version::$(cat .nvmrc)"
+        id: nvmrc
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.nvmrc.outputs.version }}"
+
+      - run: echo "::set-output name=dir::$(yarn cache dir)"
+        id: yarn-cache
+
+      - name: Restore dependency cache
+        uses: actions/cache@v2
+        with:
+          path: "${{ steps.yarn-cache.outputs.dir }}"
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-cache-
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - run: mkdir -p deployment-test
+
+      - name: Install latest version of npm
+        run: npm install -g npm@latest
+
+      - name: Install Wrangler
+        run: npm install -g @cloudflare/wrangler
+
+      - name: Deploy to Cloudflare Workers
+        run: node ./scripts/deployment-test/cf-workers.mjs
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.TEST_CF_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.TEST_CF_API_TOKEN }}
+
+  fly_deploy:
+    name: "Fly Deploy"
+    needs: [build]
+    if: github.repository == 'remix-run/remix'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: echo "::set-output name=version::$(cat .nvmrc)"
+        id: nvmrc
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.nvmrc.outputs.version }}"
+
+      - run: echo "::set-output name=dir::$(yarn cache dir)"
+        id: yarn-cache
+
+      - name: Restore dependency cache
+        uses: actions/cache@v2
+        with:
+          path: "${{ steps.yarn-cache.outputs.dir }}"
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-cache-
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - run: mkdir -p deployment-test
+
+      - name: Install latest version of npm
+        run: npm install -g npm@latest
+
+      - name: Install the Fly CLI
+        run: curl -L https://fly.io/install.sh | FLYCTL_INSTALL=/usr/local sh
+
+      - name: Deploy to Fly
+        run: node ./scripts/deployment-test/fly.mjs
+        env:
+          FLY_API_TOKEN: ${{ secrets.TEST_FLY_TOKEN }}
+
+  netlify_deploy:
+    name: "Netlify Deploy"
+    needs: [build]
+    if: github.repository == 'remix-run/remix'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: echo "::set-output name=version::$(cat .nvmrc)"
+        id: nvmrc
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.nvmrc.outputs.version }}"
+
+      - run: echo "::set-output name=dir::$(yarn cache dir)"
+        id: yarn-cache
+
+      - name: Restore dependency cache
+        uses: actions/cache@v2
+        with:
+          path: "${{ steps.yarn-cache.outputs.dir }}"
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-cache-
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - run: mkdir -p deployment-test
+
+      - name: Install latest version of npm
+        run: npm install -g npm@latest
+
+      - name: Deploy to Netlify
+        run: node ./scripts/deployment-test/netlify.mjs
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.TEST_NETLIFY_TOKEN }}
+
+  vercel_deploy:
+    name: "Vercel Deploy"
+    needs: [build]
+    if: github.repository == 'remix-run/remix'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: echo "::set-output name=version::$(cat .nvmrc)"
+        id: nvmrc
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.nvmrc.outputs.version }}"
+
+      - run: echo "::set-output name=dir::$(yarn cache dir)"
+        id: yarn-cache
+
+      - name: Restore dependency cache
+        uses: actions/cache@v2
+        with:
+          path: "${{ steps.yarn-cache.outputs.dir }}"
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-cache-
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - run: mkdir -p deployment-test
+
+      - name: Install latest version of npm
+        run: npm install -g npm@latest
+
+      - name: Deploy to Vercel
+        run: node ./scripts/deployment-test/vercel.mjs
+        env:
+          VERCEL_TOKEN: ${{ secrets.TEST_VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.TEST_VERCEL_USER_ID }}

--- a/scripts/deployment-test/_shared.mjs
+++ b/scripts/deployment-test/_shared.mjs
@@ -71,28 +71,32 @@ function runCypress(dir, dev, url) {
 }
 
 async function checkUp(url) {
-  let retriesLeft = 10;
+  return new Promise(async (resolve, reject) => {
+    let retriesLeft = 10;
 
-  async function check() {
-    try {
-      console.log(`Checking ${url}`);
-      await dns.lookup(url);
-      clearInterval(checker);
-      console.log(`${url} is up`);
-    } catch (error) {
-      retriesLeft -= 1;
-      if (retriesLeft === 0) {
+    async function check() {
+      try {
+        console.log(`Checking ${url}`);
+        await dns.lookup(url);
         clearInterval(checker);
-        throw new Error(`Could not connect to ${url}`);
+        console.log(`${url} is up`);
+        resolve();
+      } catch (error) {
+        retriesLeft -= 1;
+        if (retriesLeft === 0) {
+          clearInterval(checker);
+          reject(`Could not connect to ${url}`);
+        }
+
+        console.log(
+          `${url} is down, trying again in 10 seconds, ${retriesLeft} retries left`
+        );
       }
-
-      console.log(`${url} is down, trying again, ${retriesLeft} retries left`);
-      return false;
     }
-  }
 
-  await check();
-  let checker = setInterval(() => check(), 60_000);
+    await check();
+    let checker = setInterval(() => check(), 10_000);
+  });
 }
 
 function getAppName(target) {

--- a/scripts/deployment-test/_shared.mjs
+++ b/scripts/deployment-test/_shared.mjs
@@ -89,12 +89,17 @@ export async function checkUp(url) {
   let checker = setInterval(check, 60_000);
 }
 
+function getAppName(target) {
+  let unique = crypto.randomBytes(2).toString("hex");
+  return `remix-${target}-${sha}-${unique}`;
+}
+
 export {
-  sha,
   updatePackageConfig,
   getSpawnOpts,
   runCypress,
   addCypress,
   getRootPackageJson,
-  checkUp
+  checkUp,
+  getAppName
 };

--- a/scripts/deployment-test/_shared.mjs
+++ b/scripts/deployment-test/_shared.mjs
@@ -72,13 +72,17 @@ function runCypress(dir, dev, url) {
 
 async function checkUp(url) {
   let retriesLeft = 10;
+
   async function check() {
     try {
+      console.log(`Checking ${url}`);
       await dns.lookup(url);
       clearInterval(checker);
+      console.log(`${url} is up`);
     } catch (error) {
       retriesLeft -= 1;
       if (retriesLeft === 0) {
+        clearInterval(checker);
         throw new Error(`Could not connect to ${url}`);
       }
 
@@ -87,7 +91,8 @@ async function checkUp(url) {
     }
   }
 
-  let checker = setInterval(check, 60_000);
+  await check();
+  let checker = setInterval(() => check(), 60_000);
 }
 
 function getAppName(target) {

--- a/scripts/deployment-test/_shared.mjs
+++ b/scripts/deployment-test/_shared.mjs
@@ -1,3 +1,4 @@
+import dns from "dns/promises";
 import path from "path";
 import { execSync, spawnSync } from "child_process";
 import jsonfile from "jsonfile";
@@ -68,11 +69,32 @@ function runCypress(dir, dev, url) {
   }
 }
 
+export async function checkUp(url) {
+  let retriesLeft = 10;
+  function check() {
+    try {
+      await dns.lookup(url);
+      clearInterval(checker);
+    } catch (error) {
+      retriesLeft -= 1;
+      if (retriesLeft === 0) {
+        throw new Error(`Could not connect to ${url}`);
+      }
+
+      console.log(`${url} is down, trying again, ${retriesLeft} retries left`);
+      return false;
+    }
+  }
+
+  let checker = setInterval(check, 60_000);
+}
+
 export {
   sha,
   updatePackageConfig,
   getSpawnOpts,
   runCypress,
   addCypress,
-  getRootPackageJson
+  getRootPackageJson,
+  checkUp
 };

--- a/scripts/deployment-test/_shared.mjs
+++ b/scripts/deployment-test/_shared.mjs
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import dns from "dns/promises";
 import path from "path";
 import { execSync, spawnSync } from "child_process";
@@ -69,9 +70,9 @@ function runCypress(dir, dev, url) {
   }
 }
 
-export async function checkUp(url) {
+async function checkUp(url) {
   let retriesLeft = 10;
-  function check() {
+  async function check() {
     try {
       await dns.lookup(url);
       clearInterval(checker);

--- a/scripts/deployment-test/_shared.mjs
+++ b/scripts/deployment-test/_shared.mjs
@@ -6,7 +6,7 @@ import { execSync, spawnSync } from "child_process";
 import jsonfile from "jsonfile";
 import fetch from "node-fetch";
 
-let sha = execSync("git rev-parse HEAD").toString().trim().slice(0, 7) + "-new";
+let sha = execSync("git rev-parse HEAD").toString().trim().slice(0, 7);
 
 function getAppName(target) {
   let unique = crypto.randomBytes(2).toString("hex");

--- a/scripts/deployment-test/arc.mjs
+++ b/scripts/deployment-test/arc.mjs
@@ -6,15 +6,15 @@ import arcParser from "@architect/parser";
 import { toLogicalID } from "@architect/utils";
 
 import {
-  sha,
-  updatePackageConfig,
+  addCypress,
+  getAppName,
   getSpawnOpts,
   runCypress,
-  addCypress
+  updatePackageConfig
 } from "./_shared.mjs";
 import { createApp } from "../../build/node_modules/create-remix/index.js";
 
-let APP_NAME = `remix-arc-${sha}`;
+let APP_NAME = getAppName("arc");
 let AWS_STACK_NAME = toLogicalID(APP_NAME) + "Staging";
 let PROJECT_DIR = path.join(process.cwd(), "deployment-test", APP_NAME);
 let ARC_CONFIG_PATH = path.join(PROJECT_DIR, "app.arc");

--- a/scripts/deployment-test/arc.mjs
+++ b/scripts/deployment-test/arc.mjs
@@ -10,7 +10,8 @@ import {
   getAppName,
   getSpawnOpts,
   runCypress,
-  updatePackageConfig
+  updatePackageConfig,
+  validatePackageVersions
 } from "./_shared.mjs";
 import { createApp } from "../../build/node_modules/create-remix/index.js";
 
@@ -25,7 +26,8 @@ async function createNewApp() {
     install: false,
     lang: "ts",
     server: "arc",
-    projectDir: PROJECT_DIR
+    projectDir: PROJECT_DIR,
+    quiet: true
   });
 }
 
@@ -45,6 +47,9 @@ async function getArcDeployment() {
 
 try {
   await createNewApp();
+
+  // validate dependencies are available
+  await validatePackageVersions(PROJECT_DIR);
 
   await Promise.all([
     fse.copy(

--- a/scripts/deployment-test/cf-pages.mjs
+++ b/scripts/deployment-test/cf-pages.mjs
@@ -171,11 +171,6 @@ try {
   // run cypress against the cloudflare pages server
   runCypress(PROJECT_DIR, false, appUrl);
 
-  process.exit(0);
-} catch (error) {
-  console.error(error);
-  process.exit(1);
-} finally {
   if (currentGitUser.email && currentGitUser.name) {
     spawnSync(
       "git",
@@ -188,4 +183,22 @@ try {
       spawnOpts
     );
   }
+
+  process.exit(0);
+} catch (error) {
+  if (currentGitUser.email && currentGitUser.name) {
+    spawnSync(
+      "git",
+      ["config", "--global", "user.email", currentGitUser.email],
+      spawnOpts
+    );
+    spawnSync(
+      "git",
+      ["config", "--global", "user.name", currentGitUser.name],
+      spawnOpts
+    );
+  }
+
+  console.error(error);
+  process.exit(1);
 }

--- a/scripts/deployment-test/cf-pages.mjs
+++ b/scripts/deployment-test/cf-pages.mjs
@@ -6,6 +6,7 @@ import fetch from "node-fetch";
 
 import { addCypress, runCypress, sha, getSpawnOpts } from "./_shared.mjs";
 import { createApp } from "../../build/node_modules/create-remix/index.js";
+import { checkUp } from "./_shared.mjs";
 
 let APP_NAME = `remix-cf-pages-${sha}`;
 let PROJECT_DIR = path.join(process.cwd(), "deployment-test", APP_NAME);
@@ -150,11 +151,15 @@ try {
     "we'll sleep for 5 minutes to give it time to build"
   );
 
-  // sleep for 5 minutes to be safe...
-  await new Promise(resolve => setTimeout(resolve, 60_000 * 5));
+  // builds typically take between 2 and 3 minutes
+  await new Promise(resolve => setTimeout(resolve, 60_000 * 3));
+
+  let appUrl = new URL(`https://${APP_NAME}.pages.dev`);
+
+  await checkUp(appUrl.origin);
 
   // run cypress against the cloudflare pages server
-  runCypress(PROJECT_DIR, false, `https://${APP_NAME}.pages.dev`);
+  runCypress(PROJECT_DIR, false, appUrl.toString());
 
   process.exit(0);
 } catch (error) {

--- a/scripts/deployment-test/cf-pages.mjs
+++ b/scripts/deployment-test/cf-pages.mjs
@@ -164,12 +164,12 @@ try {
   // builds typically take between 2 and 3 minutes
   await new Promise(resolve => setTimeout(resolve, 60_000 * 3));
 
-  let appUrl = new URL(`https://${APP_NAME}.pages.dev`);
+  let appUrl = `https://${APP_NAME}.pages.dev`;
 
-  await checkUp(appUrl.hostname);
+  await checkUp(appUrl);
 
   // run cypress against the cloudflare pages server
-  runCypress(PROJECT_DIR, false, appUrl.toString());
+  runCypress(PROJECT_DIR, false, appUrl);
 
   process.exit(0);
 } catch (error) {

--- a/scripts/deployment-test/cf-pages.mjs
+++ b/scripts/deployment-test/cf-pages.mjs
@@ -1,5 +1,5 @@
 import path from "path";
-import { spawnSync } from "child_process";
+import { execSync, spawnSync } from "child_process";
 import { Octokit } from "@octokit/rest";
 import fse from "fs-extra";
 import fetch from "node-fetch";
@@ -92,6 +92,11 @@ async function createRepoIfNeeded() {
   return repo.data;
 }
 
+let currentGitUser = {
+  email: execSync("git config --get user.email").toString().trim(),
+  name: execSync("git config --get user.name").toString().trim()
+};
+
 try {
   // create a new remix app
   await createNewApp();
@@ -170,4 +175,17 @@ try {
 } catch (error) {
   console.error(error);
   process.exit(1);
+} finally {
+  if (currentGitUser.email && currentGitUser.name) {
+    spawnSync(
+      "git",
+      ["config", "--global", "user.email", currentGitUser.email],
+      spawnOpts
+    );
+    spawnSync(
+      "git",
+      ["config", "--global", "user.name", currentGitUser.name],
+      spawnOpts
+    );
+  }
 }

--- a/scripts/deployment-test/cf-pages.mjs
+++ b/scripts/deployment-test/cf-pages.mjs
@@ -4,11 +4,16 @@ import { Octokit } from "@octokit/rest";
 import fse from "fs-extra";
 import fetch from "node-fetch";
 
-import { addCypress, runCypress, sha, getSpawnOpts } from "./_shared.mjs";
+import {
+  addCypress,
+  checkUp,
+  getAppName,
+  getSpawnOpts,
+  runCypress
+} from "./_shared.mjs";
 import { createApp } from "../../build/node_modules/create-remix/index.js";
-import { checkUp } from "./_shared.mjs";
 
-let APP_NAME = `remix-cf-pages-${sha}`;
+let APP_NAME = getAppName("cf-pages");
 let PROJECT_DIR = path.join(process.cwd(), "deployment-test", APP_NAME);
 let CYPRESS_DEV_URL = "http://localhost:8788";
 

--- a/scripts/deployment-test/cf-pages.mjs
+++ b/scripts/deployment-test/cf-pages.mjs
@@ -161,7 +161,7 @@ try {
 
   let appUrl = new URL(`https://${APP_NAME}.pages.dev`);
 
-  await checkUp(appUrl.origin);
+  await checkUp(appUrl.hostname);
 
   // run cypress against the cloudflare pages server
   runCypress(PROJECT_DIR, false, appUrl.toString());

--- a/scripts/deployment-test/cf-pages.mjs
+++ b/scripts/deployment-test/cf-pages.mjs
@@ -9,7 +9,8 @@ import {
   checkUp,
   getAppName,
   getSpawnOpts,
-  runCypress
+  runCypress,
+  validatePackageVersions
 } from "./_shared.mjs";
 import { createApp } from "../../build/node_modules/create-remix/index.js";
 
@@ -22,7 +23,8 @@ async function createNewApp() {
     install: false,
     lang: "ts",
     server: "cloudflare-pages",
-    projectDir: PROJECT_DIR
+    projectDir: PROJECT_DIR,
+    quiet: true
   });
 }
 
@@ -97,9 +99,14 @@ let currentGitUser = {
   name: execSync("git config --get user.name").toString().trim()
 };
 
+let spawnOpts = getSpawnOpts(PROJECT_DIR);
+
 try {
   // create a new remix app
   await createNewApp();
+
+  // validate dependencies are available
+  await validatePackageVersions(PROJECT_DIR);
 
   // create a new github repo
   let repo = await createRepoIfNeeded(APP_NAME);
@@ -118,8 +125,6 @@ try {
 
     addCypress(PROJECT_DIR, CYPRESS_DEV_URL)
   ]);
-
-  let spawnOpts = getSpawnOpts(PROJECT_DIR);
 
   // install deps
   spawnSync("npm", ["install"], spawnOpts);

--- a/scripts/deployment-test/cf-workers.mjs
+++ b/scripts/deployment-test/cf-workers.mjs
@@ -3,10 +3,15 @@ import { spawnSync } from "child_process";
 import fse from "fs-extra";
 import toml from "@iarna/toml";
 
-import { sha, getSpawnOpts, runCypress, addCypress } from "./_shared.mjs";
+import {
+  addCypress
+  getAppName,
+  getSpawnOpts,
+  runCypress,
+} from "./_shared.mjs";
 import { createApp } from "../../build/node_modules/create-remix/index.js";
 
-let APP_NAME = `remix-cf-workers-${sha}`;
+let APP_NAME = getAppName("cf-workers");
 let PROJECT_DIR = path.join(process.cwd(), "deployment-test", APP_NAME);
 let CYPRESS_DEV_URL = "http://localhost:8787";
 

--- a/scripts/deployment-test/cf-workers.mjs
+++ b/scripts/deployment-test/cf-workers.mjs
@@ -4,10 +4,11 @@ import fse from "fs-extra";
 import toml from "@iarna/toml";
 
 import {
-  addCypress
+  addCypress,
   getAppName,
   getSpawnOpts,
   runCypress,
+  validatePackageVersions
 } from "./_shared.mjs";
 import { createApp } from "../../build/node_modules/create-remix/index.js";
 
@@ -20,13 +21,17 @@ async function createNewApp() {
     install: false,
     lang: "ts",
     server: "cloudflare-workers",
-    projectDir: PROJECT_DIR
+    projectDir: PROJECT_DIR,
+    quiet: true
   });
 }
 
 try {
   // create a new remix app
   await createNewApp();
+
+  // validate dependencies are available
+  await validatePackageVersions(PROJECT_DIR);
 
   // add cypress to the project
   await Promise.all([

--- a/scripts/deployment-test/fly.mjs
+++ b/scripts/deployment-test/fly.mjs
@@ -3,11 +3,11 @@ import { spawnSync } from "child_process";
 import fse from "fs-extra";
 import toml from "@iarna/toml";
 
-import { sha, getSpawnOpts, runCypress, addCypress } from "./_shared.mjs";
+import { addCypress, checkUp, getSpawnOpts, runCypress } from "./_shared.mjs";
 import { createApp } from "../../build/node_modules/create-remix/index.js";
-import { checkUp } from "./_shared.mjs";
+import { getAppName } from "./_shared.mjs";
 
-let APP_NAME = `remix-fly-${sha}`;
+let APP_NAME = getAppName("fly");
 let PROJECT_DIR = path.join(process.cwd(), "deployment-test", APP_NAME);
 let CYPRESS_DEV_URL = "http://localhost:3000";
 

--- a/scripts/deployment-test/fly.mjs
+++ b/scripts/deployment-test/fly.mjs
@@ -93,7 +93,7 @@ try {
   // ... or a minute...
   // ... or a few minutes...
   console.log(`Fly app deployed, waiting for dns...`);
-  await checkUp(flyUrl.origin);
+  await checkUp(flyUrl.hostname);
 
   // run cypress against the deployed server
   runCypress(PROJECT_DIR, false, flyUrl.toString());

--- a/scripts/deployment-test/fly.mjs
+++ b/scripts/deployment-test/fly.mjs
@@ -70,8 +70,8 @@ try {
   flyToml.services[0].internal_port = "8080";
 
   await fse.writeFile(flyTomlPath, toml.stringify(flyToml));
-  let flyUrl = new URL(`https://${flyToml.app}.fly.dev`);
-  console.log(`Fly app url: ${flyUrl.toString()}`);
+  let flyUrl = `https://${flyToml.app}.fly.dev`;
+  console.log(`Fly app url: ${flyUrl}`);
 
   // install deps
   spawnSync("npm", ["install"], spawnOpts);
@@ -93,10 +93,10 @@ try {
   // ... or a minute...
   // ... or a few minutes...
   console.log(`Fly app deployed, waiting for dns...`);
-  await checkUp(flyUrl.hostname);
+  await checkUp(flyUrl);
 
   // run cypress against the deployed server
-  runCypress(PROJECT_DIR, false, flyUrl.toString());
+  runCypress(PROJECT_DIR, false, flyUrl);
 
   process.exit(0);
 } catch (error) {

--- a/scripts/deployment-test/netlify.mjs
+++ b/scripts/deployment-test/netlify.mjs
@@ -3,10 +3,15 @@ import { spawnSync } from "child_process";
 import { NetlifyAPI } from "netlify";
 import fse from "fs-extra";
 
-import { sha, getSpawnOpts, runCypress, addCypress } from "./_shared.mjs";
+import {
+  addCypress,
+  getAppName,
+  getSpawnOpts,
+  runCypress
+} from "./_shared.mjs";
 import { createApp } from "../../build/node_modules/create-remix/index.js";
 
-let APP_NAME = `remix-netlify-${sha}`;
+let APP_NAME = getAppName("netlify");
 let PROJECT_DIR = path.join(process.cwd(), "deployment-test", APP_NAME);
 let CYPRESS_DEV_URL = "http://localhost:3000";
 

--- a/scripts/deployment-test/netlify.mjs
+++ b/scripts/deployment-test/netlify.mjs
@@ -7,7 +7,8 @@ import {
   addCypress,
   getAppName,
   getSpawnOpts,
-  runCypress
+  runCypress,
+  validatePackageVersions
 } from "./_shared.mjs";
 import { createApp } from "../../build/node_modules/create-remix/index.js";
 
@@ -20,7 +21,8 @@ async function createNewApp() {
     install: false,
     lang: "ts",
     server: "netlify",
-    projectDir: PROJECT_DIR
+    projectDir: PROJECT_DIR,
+    quiet: true
   });
 }
 
@@ -36,6 +38,9 @@ function createNetlifySite() {
 
 try {
   await createNewApp();
+
+  // validate dependencies are available
+  await validatePackageVersions(PROJECT_DIR);
 
   await Promise.all([
     fse.copy(

--- a/scripts/deployment-test/vercel.mjs
+++ b/scripts/deployment-test/vercel.mjs
@@ -3,10 +3,15 @@ import { spawnSync } from "child_process";
 import fse from "fs-extra";
 import fetch from "node-fetch";
 
-import { sha, getSpawnOpts, runCypress, addCypress } from "./_shared.mjs";
+import {
+  addCypress,
+  getAppName,
+  getSpawnOpts,
+  runCypress
+} from "./_shared.mjs";
 import { createApp } from "../../build/node_modules/create-remix/index.js";
 
-let APP_NAME = `remix-vercel-${sha}`;
+let APP_NAME = getAppName("vercel");
 let PROJECT_DIR = path.join(process.cwd(), "deployment-test", APP_NAME);
 let CYPRESS_DEV_URL = "http://localhost:3000";
 

--- a/scripts/deployment-test/vercel.mjs
+++ b/scripts/deployment-test/vercel.mjs
@@ -7,7 +7,8 @@ import {
   addCypress,
   getAppName,
   getSpawnOpts,
-  runCypress
+  runCypress,
+  validatePackageVersions
 } from "./_shared.mjs";
 import { createApp } from "../../build/node_modules/create-remix/index.js";
 
@@ -20,7 +21,8 @@ async function createNewApp() {
     install: false,
     lang: "ts",
     server: "vercel",
-    projectDir: PROJECT_DIR
+    projectDir: PROJECT_DIR,
+    quiet: true
   });
 }
 
@@ -69,6 +71,9 @@ async function getVercelDeploymentUrl(projectId) {
 
 try {
   await createNewApp();
+
+  // validate dependencies are available
+  await validatePackageVersions(PROJECT_DIR);
 
   await Promise.all([
     fse.copy(


### PR DESCRIPTION
This PR improves the reliability of our deployment tests for CF Pages and Fly by running a check to make sure the DNS resolves as well as returns a 200 status code before attempting to run cypress, it will run each check every 10 seconds, with a max of 10 times before giving up and failing

It also adds a new GitHub Action workflow to allow manually running the deployment tests

and finally this PR also adds some `npm publish` verification to make sure packages are published and readily available to be installed by `npm`

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

- [ ] Docs
- [x] Tests
