### PR TITLE
fix(remix-dev): update `serverModuleFormat` deprecation notice

### DIFF
--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -102,7 +102,7 @@ export interface AppConfig {
 
   /**
    * The output format of the server build. Defaults to "cjs".
-   * * @deprecated Use {@link ServerConfig.serverBuildTarget} instead.
+   * @deprecated Use {@link ServerConfig.serverBuildTarget} instead.
    */
   serverModuleFormat?: ServerModuleFormat;
 


### PR DESCRIPTION
before: 
<img width="607" alt="image" src="https://user-images.githubusercontent.com/11698668/154383975-c21f08fe-e4c5-4532-a349-2fb9b68190c3.png">

after: 
<img width="597" alt="image" src="https://user-images.githubusercontent.com/11698668/154384023-7b795176-7801-4fd0-b6a3-18c92374e91b.png">



<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests
