### PR TITLE
Simpler asset caching strategy in Express template

### DIFF
--- a/packages/create-remix/templates/express/server.js
+++ b/packages/create-remix/templates/express/server.js
@@ -1,40 +1,39 @@
-import path from "path";
 import express from "express";
 import compression from "compression";
 import morgan from "morgan";
 import { createRequestHandler } from "@remix-run/express";
 
-import * as build from "@remix-run/dev/server-build";
-
-const PUBLIC_DIR = path.join(process.cwd(), "public");
-const BROWSER_BUILD_DIR = "/build/";
+import * as serverBuild from "@remix-run/dev/server-build";
 
 const app = express();
+
 app.use(compression());
 
 // http://expressjs.com/en/advanced/best-practice-security.html#at-a-minimum-disable-x-powered-by-header
 app.disable("x-powered-by");
 
+// Remix fingerprints its assets so we can cache forever.
 app.use(
-  express.static("public", {
-    setHeaders(res, pathname) {
-      const relativePath = pathname.replace(PUBLIC_DIR, "");
-      res.setHeader(
-        "Cache-Control",
-        relativePath.startsWith(BROWSER_BUILD_DIR)
-          ? // Remix fingerprints its assets so we can cache forever
-            "public, max-age=31536000, immutable"
-          : // You may want to be more aggressive with this caching
-            "public, max-age=3600"
-      );
-    }
+  "/build",
+  express.static("public/build", { immutable: true, maxAge: "1y" })
+);
+
+// Everything else (like favicon.ico) is cached for an hour. You may want to be
+// more aggressive with this caching.
+app.use(express.static("public/build", { maxAge: "1h" }));
+
+app.use(morgan("tiny"));
+
+app.all(
+  "*",
+  createRequestHandler({
+    build: serverBuild,
+    mode: process.env.NODE_ENV
   })
 );
 
-app.use(morgan("tiny"));
-app.all("*", createRequestHandler({ build, mode: process.env.NODE_ENV }));
-
 const port = process.env.PORT || 3000;
+
 app.listen(port, () => {
   console.log(`Express server listening on port ${port}`);
 });


### PR DESCRIPTION
Use multiple `app.use` calls instead of trying to combine into one and doing manual path manipulation.

Supersedes #1861

Also related to #977 