### PR TITLE
fix: use browser polyfills for deno node builtins

### DIFF
--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -407,7 +407,7 @@ async function createServerBuild(
   ];
 
   if (config.serverPlatform !== "node") {
-    plugins.push(NodeModulesPolyfillPlugin());
+    plugins.unshift(NodeModulesPolyfillPlugin());
   }
 
   return esbuild

--- a/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
@@ -71,15 +71,6 @@ export function serverBareModulesPlugin(
           case "cloudflare-pages":
           case "cloudflare-workers":
             return undefined;
-          // Map node externals to deno std libs and bundle everything else.
-          case "deno":
-            if (isNodeBuiltIn(packageName)) {
-              return {
-                path: `https://deno.land/std/node/${packageName}/mod.ts`,
-                external: true
-              };
-            }
-            return undefined;
         }
 
         for (let pattern of remixConfig.serverDependenciesToBundle) {


### PR DESCRIPTION
Esbuild can't hoist `require("xyz")` calls to `import "xyz"`, this leads to an issue every time you try to re-map a require'd version in external code to a URL.

Closes: #1993

- [ ] Docs
- [ ] Tests
