### PR TITLE
fix(remix-node): base64 tool function does not support Chinese characters and emoji 

### DIFF
--- a/packages/remix-node/__tests__/base64-test.ts
+++ b/packages/remix-node/__tests__/base64-test.ts
@@ -1,0 +1,35 @@
+import { atob, btoa } from '../base64'
+describe('atob & btoa', () => {
+	it('atob and btoa with emoji', () => {
+		const smile = '😁'
+		const b = btoa(smile);
+		const a = atob(b);
+		expect(a).toEqual(smile);
+	})
+
+
+	it('atob and btoa with chinese characters', () => {
+		const animal = '熊猫'
+		const b = btoa(animal);
+		const a = atob(b);
+		expect(a).toEqual(animal);
+	})
+
+	it('atob and btoa with english characters', () => {
+		const animal = 'panda'
+		const b = btoa(animal);
+		const a = atob(b);
+		expect(a).toEqual(animal);
+	})
+
+	it('atob and btoa with object', () => {
+		const object = {
+			name: '熊猫',
+			type: 'animal',
+			age: 2
+		}
+		const b = btoa(JSON.stringify(object));
+		const a = JSON.parse(atob(b));
+		expect(a).toEqual(object);
+	})
+})

--- a/packages/remix-node/base64.ts
+++ b/packages/remix-node/base64.ts
@@ -1,7 +1,7 @@
 export function atob(a: string): string {
-  return Buffer.from(a, "base64").toString("binary");
+  return Buffer.from(a, "base64").toString();
 }
 
 export function btoa(b: string): string {
-  return Buffer.from(b, "binary").toString("base64");
+  return Buffer.from(b).toString("base64");
 }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: [#1962](https://github.com/remix-run/remix/issues/1962)

Fix the atob & bota does not support Chinese characters and emoji 
