### PR TITLE
docs: fix CONTRIBUTING link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The documentation is automatically generated on each release from the files in
 
 ## Contributing
 
-If you're interested in contributing code and/or documentation, please see [our guide to contributing](docs/contributing.md).
+If you're interested in contributing code and/or documentation, please see [our guide to contributing](/CONTRIBUTING.md).
 
 ## Code of Conduct
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -114,6 +114,7 @@
 - jgarrow
 - jkup
 - jmasson
+- joannaotmianowska
 - joaosamouco
 - johannesbraeunig
 - johnson444


### PR DESCRIPTION
I noticed that Contributing link in README is not working, file is not in docs directory but in the main folder. This PR fixes it 
