### PR TITLE
chore(remix-react): use `document` instead of `AbortController` to check for bad `fetcher.load` call

### DIFF
--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -904,7 +904,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
     key: string,
     match: ClientMatch
   ) {
-    if (typeof AbortController === "undefined") {
+    if (typeof window === "undefined") {
       throw new Error(
         "handleLoaderFetch was called during the server render, but it shouldn't be. " +
           "You are likely calling useFetcher.load() in the body of your component. " +

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -904,7 +904,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
     key: string,
     match: ClientMatch
   ) {
-    if (typeof window === "undefined") {
+    if (typeof document === "undefined") {
       throw new Error(
         "handleLoaderFetch was called during the server render, but it shouldn't be. " +
           "You are likely calling useFetcher.load() in the body of your component. " +


### PR DESCRIPTION
This is a fix for a PR I made a while back, #1416. I created that PR while on node 14, which doesn't have `AbortController` defined as a global object. In later versions of node, however, `AbortController` is defined and thus the check I created doesn't work. This PR replaces `AbortController` with `window`, which is a more reliable way of determining if we are in node or in the browser.