### PR TITLE
fix: strip ".client" files from server bundle

### DIFF
--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -399,7 +399,7 @@ async function createServerBuild(
 
   let plugins: esbuild.Plugin[] = [
     mdxPlugin(config),
-    emptyModulesPlugin(config, /\.client\.[tj]sx?$/),
+    emptyModulesPlugin(config, /\.client(\.[jt]sx?)?$/),
     serverRouteModulesPlugin(config),
     serverEntryModulePlugin(config),
     serverAssetsManifestPlugin(assetsManifestPromiseRef),


### PR DESCRIPTION
The regex is wrong? Not sure how this got changed or stopped working between release 🤷‍♀️

Closes: #

- [ ] Docs
- [x] Tests
