### PR TITLE
fix(components): use typeof document

### DIFF
--- a/docs/pages/gotchas.md
+++ b/docs/pages/gotchas.md
@@ -92,4 +92,28 @@ You may ask why we don't just bundle everything for the server. We could, but th
 
 With major deployment platforms now supporting ESM server side, we're confident the future is brighter than the past here. We're still working on a solid dev experience for ESM server builds, our current approach relies on some things that you can't do in ESM. We'll get there.
 
+## `typeof window` checks
+
+Because the same JavaScript code can run in the browser as well as the server, sometimes you need to have a part of your code that only runs in one context or the other:
+
+```ts bad
+if (typeof window === "undefined") {
+  // running in a server environment
+} else {
+  // running in a browser environment
+}
+```
+
+This works fine in a Node.js environment, however, Deno actually supports `window`! So if you really want to check whether you're running in the browser, it's better to check for `document` instead:
+
+```ts good
+if (typeof document === "undefined") {
+  // running in a server environment
+} else {
+  // running in a browser environment
+}
+```
+
+This will work for all JS environments (Node.js, Deno, Workers, etc.).
+
 [esbuild]: https://esbuild.github.io/

--- a/examples/pm-app/app/utils/index.ts
+++ b/examples/pm-app/app/utils/index.ts
@@ -14,15 +14,14 @@ export function getUserFromDisplayName<
 }
 
 export const canUseDOM: boolean = !!(
-  typeof window !== "undefined" &&
-  typeof window.document !== "undefined" &&
-  typeof window.document.createElement !== "undefined"
+  typeof document !== "undefined" &&
+  typeof document.createElement !== "undefined"
 );
 
 export function getClientSafeEnvVariable<
   K extends keyof RemoveIndex<Exclude<Window["ENV"], undefined>>
 >(key: K): Exclude<Window["ENV"], undefined>[K] {
-  if (typeof window !== "undefined") {
+  if (typeof document !== "undefined") {
     try {
       const ENV = window.ENV;
       if (!ENV) {

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1132,7 +1132,7 @@ export function useSubmitImpl(key?: string): SubmitFunction {
         }
       }
 
-      if (typeof window === "undefined") {
+      if (typeof document === "undefined") {
         throw new Error(
           "You are calling submit during the server render. " +
             "Try calling submit within a `useEffect` or callback instead."


### PR DESCRIPTION
`typeof window` isn't a good way to determine whether you're running on the server thanks to Deno supporting a global `window`. So this updates all our code/examples to use `typeof document` instead. This PR also adds a note about this in the gotchas page.

I've added support for "good" in our code blocks on the website repo as well so you can now have "bad" and "good" code blocks :)

![image](https://user-images.githubusercontent.com/1500684/154725341-ee4a688e-17a0-4f1a-991f-8be89a86b4f0.png)

![image](https://user-images.githubusercontent.com/1500684/154725344-9b6bd7ac-75f1-4ea6-b071-b4aa9c138829.png)


- [x] Docs
