### PR TITLE
chore: Update TypeScript dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "start-server-and-test": "^1.14.0",
     "strip-ansi": "^6.0.1",
     "type-fest": "^2.11.1",
-    "typescript": "^4.2.3",
+    "typescript": "^4.5.5",
     "unified": "^9.2.0"
   },
   "engines": {

--- a/packages/create-remix/templates/_shared_ts/package.json
+++ b/packages/create-remix/templates/_shared_ts/package.json
@@ -13,7 +13,7 @@
     "@remix-run/dev": "*",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",
-    "typescript": "^4.1.2"
+    "typescript": "^4.5.5"
   },
   "engines": {
     "node": ">=14"

--- a/packages/create-remix/templates/arc-stack/package.json
+++ b/packages/create-remix/templates/arc-stack/package.json
@@ -32,7 +32,7 @@
     "mock-aws-s3": "^4.0.2",
     "nock": "^13.2.2",
     "npm-run-all": "^4.1.5",
-    "typescript": "^4.5.4"
+    "typescript": "^4.5.5"
   },
   "engines": {
     "node": ">=14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10936,10 +10936,10 @@ typescript@4.3.4:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz"
   integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
-typescript@^4.2.3:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz"
-  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+typescript@^4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 uid-safe@2.1.5, uid-safe@^2.1.5:
   version "2.1.5"


### PR DESCRIPTION
This PR updates the internal TypeScript dependency to 4.5.5. We are using some newer utility types (i.e. `Awaited`) that only work with newer releases, so the internal dependency should reflect that.

This also updates the dependency in `create-remix` templates to get new projects on the latest version.