### PR TITLE
docs: Jokes Tutorial: Incorrect terminal output example in jokes tutorial for login

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -135,6 +135,7 @@
 - knowler
 - kubaprzetakiewicz
 - kumard3
+- kylemckell
 - lachlanjc
 - lawrencecchen
 - leo

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -2868,7 +2868,7 @@ To check our work, I added a `console.log` to `app/routes/login.tsx` after the `
 {
   user: {
     id: '1dc45f54-4061-4d9e-8a6d-28d6df6a8d7f',
-    username: 'kody',
+    username: 'kody'
   }
 }
 ```

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -2868,10 +2868,7 @@ To check our work, I added a `console.log` to `app/routes/login.tsx` after the `
 {
   user: {
     id: '1dc45f54-4061-4d9e-8a6d-28d6df6a8d7f',
-    createdAt: 2021-11-21T00:28:52.560Z,
-    updatedAt: 2021-11-21T00:28:52.560Z,
     username: 'kody',
-    passwordHash: '$2b$10$K7L1OJ45/4Y2nIvhRVpCe.FSmhDdWoXehVzJptJ/op0lSsvqNu/1u'
   }
 }
 ```


### PR DESCRIPTION
Currently in the jokes tutorial the example terminal output for the console.log for what is returned from our `login()` function is incorrect, as it assumes that `login()` is returning the full user, not just parts of the user (namely the id and username). See below code for what login currently looks like:

```ts
// current login
export async function login({
  username,
  password
}: LoginForm) {
  // do nifty login stuff
  return { id: user.id, username };
}
```

Currently the example terminal output looks as follows:
```ts
{
  user: {
    id: '1dc45f54-4061-4d9e-8a6d-28d6df6a8d7f',
    createdAt: 2021-11-21T00:28:52.560Z,
    updatedAt: 2021-11-21T00:28:52.560Z,
    username: 'kody',
    passwordHash: '$2b$10$K7L1OJ45/4Y2nIvhRVpCe.FSmhDdWoXehVzJptJ/op0lSsvqNu/1u'
  }
}
```

But since we're not returning the full user, we need it to only show the following, which is what is reflected in the terminal:
```js
{
  user: {
    id: '1dc45f54-4061-4d9e-8a6d-28d6df6a8d7f',
    username: 'kody'
  }
}
```
