### PR TITLE
build: fix run-p glob matching for yarn > 2 ..

### DIFF
--- a/examples/sass/package.json
+++ b/examples/sass/package.json
@@ -10,7 +10,7 @@
     "build": "run-s build:*",
     "dev:remix": "remix dev",
     "dev:css": "sass styles/:app/styles/ --watch ",
-    "dev": "run-p dev:*",
+    "dev": "run-p 'dev:*'",
     "postinstall": "remix setup node",
     "start": "remix-serve build"
   },

--- a/packages/create-remix/templates/arc-stack/package.json
+++ b/packages/create-remix/templates/arc-stack/package.json
@@ -8,7 +8,7 @@
     "build": "remix build",
     "dev:remix": "remix watch",
     "dev:arc": "arc sandbox",
-    "dev": "cross-env ARC_LOCAL=1 ARC_TABLES_PORT=5555 run-p dev:*"
+    "dev": "cross-env ARC_LOCAL=1 ARC_TABLES_PORT=5555 run-p 'dev:*'"
   },
   "dependencies": {
     "@architect/functions": "^4.1.2",

--- a/packages/create-remix/templates/arc/package.json
+++ b/packages/create-remix/templates/arc/package.json
@@ -4,7 +4,7 @@
     "build": "cross-env NODE_ENV=production remix build",
     "dev:remix": "cross-env NODE_ENV=development remix watch",
     "dev:arc": "cross-env NODE_ENV=development arc sandbox",
-    "dev": "cross-env NODE_ENV=development remix build && run-p dev:*",
+    "dev": "cross-env NODE_ENV=development remix build && run-p 'dev:*'",
     "start": "cross-env NODE_ENV=production arc sandbox"
   },
   "dependencies": {

--- a/packages/create-remix/templates/cloudflare-pages/package.json
+++ b/packages/create-remix/templates/cloudflare-pages/package.json
@@ -4,7 +4,7 @@
     "build": "cross-env NODE_ENV=production remix build",
     "dev:remix": "cross-env NODE_ENV=development remix watch",
     "dev:wrangler": "cross-env NODE_ENV=development wrangler pages dev ./public",
-    "dev": "cross-env NODE_ENV=development remix build && run-p dev:*",
+    "dev": "cross-env NODE_ENV=development remix build && run-p 'dev:*'",
     "start": "cross-env NODE_ENV=production npm run dev:wrangler"
   },
   "dependencies": {

--- a/packages/create-remix/templates/cloudflare-workers/package.json
+++ b/packages/create-remix/templates/cloudflare-workers/package.json
@@ -5,7 +5,7 @@
     "build": "cross-env NODE_ENV=production remix build",
     "dev:remix": "cross-env NODE_ENV=development remix watch",
     "dev:miniflare": "cross-env NODE_ENV=development miniflare ./build/index.js --watch",
-    "dev": "cross-env NODE_ENV=development remix build && run-p dev:*",
+    "dev": "cross-env NODE_ENV=development remix build && run-p 'dev:*'",
     "start": "cross-env NODE_ENV=production miniflare ./build/index.js",
     "deploy": "npm run build && wrangler publish"
   },

--- a/packages/create-remix/templates/deno/package.json
+++ b/packages/create-remix/templates/deno/package.json
@@ -4,7 +4,7 @@
     "build": "cross-env NODE_ENV=production remix build",
     "dev:remix": "cross-env NODE_ENV=development remix watch",
     "dev:deno": "cross-env NODE_ENV=development deno run --watch --allow-net --allow-read --allow-env ./build/index.js",
-    "dev": "cross-env NODE_ENV=development remix build && run-p dev:*",
+    "dev": "cross-env NODE_ENV=development remix build && run-p 'dev:*'",
     "start": "cross-env NODE_ENV=production deno run --allow-net --allow-read --allow-env ./build/index.js"
   },
   "dependencies": {

--- a/packages/create-remix/templates/express/package.json
+++ b/packages/create-remix/templates/express/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "postinstall": "remix setup node",
     "build": "cross-env NODE_ENV=production remix build",
-    "dev": "cross-env NODE_ENV=development remix build && run-p dev:*",
+    "dev": "cross-env NODE_ENV=development remix build && run-p 'dev:*'",
     "dev:remix": "cross-env NODE_ENV=development remix watch",
     "dev:node": "cross-env NODE_ENV=development nodemon ./build/index.js",
     "start": "cross-env NODE_ENV=production node ./build/index.js"


### PR DESCRIPTION
Just ran into [`No matches found: "dev:*"`](https://github.com/mysticatea/npm-run-all/issues/200) using Yarn 3

Quoting it `"dev": "run-p 'dev:*'",` like mentioned in the linked issue fixed it for me with Yarn 3 and also tested Yarn 1.22.10 and npm 8.1.0, just to make sure.

So I figured as it shouldn't break anything why not always quote it?

Please correct me if I'm mistaken 🙏