### PR TITLE
fix: button value not submitted if form is inside a container that calls `stopPropagation` on the click event

### DIFF
--- a/integration/button-value-test.ts
+++ b/integration/button-value-test.ts
@@ -1,0 +1,53 @@
+import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
+import type { Fixture, AppFixture } from "./helpers/create-fixture";
+
+let fixture: Fixture;
+let app: AppFixture;
+
+beforeAll(async () => {
+  fixture = await createFixture({
+    files: {
+      "app/routes/index.jsx": js`
+        import { Form } from 'remix';
+
+        export default function Index() {
+          return (
+            <div onClick={e => e.stopPropagation()}>
+              <Form method="post" action="/action">
+                <button type="submit" name="buttonValue" value="Hello">Submit</button>
+              </Form>
+            </div>
+          )
+        }
+      `,
+
+      "app/routes/action.jsx": js`
+        import { json, useActionData } from "remix";
+
+        export async function action({ request }) {
+          const formData = await request.formData();
+          return json({ buttonValue: formData.get('buttonValue') });
+        }
+
+        export default function Index() {
+          const data = useActionData();
+          return (
+            <p>
+              Button value is: {data.buttonValue}
+            </p>
+          );
+        }
+      `
+    }
+  });
+
+  app = await createAppFixture(fixture);
+});
+
+afterAll(async () => app.close());
+
+it("should submit the value of the button correctly even when inside a container calling stopPropagation", async () => {
+  await app.goto("/");
+  await app.clickSubmitButton("/action");
+  expect(await app.getHtml()).toMatch("Button value is: Hello");
+});

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -919,9 +919,9 @@ export let FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
         }
       }
 
-      window.addEventListener("click", handleClick);
+      window.addEventListener("click", handleClick, { capture: true });
       return () => {
-        window.removeEventListener("click", handleClick);
+        window.removeEventListener("click", handleClick, { capture: true });
       };
     }, []);
 


### PR DESCRIPTION
I ran into a bug while fixing [this issue](https://github.com/airjp73/remix-validated-form/issues/64) in `remix-validated form`.

In the following situation:
* The `Form` is inside an element where `stopPropagation` is being called on a click event
* The submit button of the form has a `name` and `value`

The value on the button will not be submitted. Here's an example:

```tsx
<div onClick={e => e.stopPropagation()}>
  <Form method="post">
    <button type="submit" name="buttonValue" value="Hello">Submit</button>
  </Form>
</div>
```

This situation commonly arises when putting a form inside a headlessui Dialog.

# The fix

By catching the click event in the capture phase, we can catch it before anything has had a chance to stop propagation.

### Possible alternate fix

By using `event.nativeEvent.submitter` ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/SubmitEvent/submitter))([caniuse](https://caniuse.com/?search=submitter)), we can reliably identify the submit button without having to catch it with a click event. Not sure if the browser support is sufficient to use it though?