### PR TITLE
fix(components): fix prefetch for routes without a loader (#1091)

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -186,6 +186,7 @@
 - mskoroglu
 - msutkowski
 - mtt87
+- na2hiro
 - nareshbhatia
 - navid-kalaei
 - niconiahi

--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -333,10 +333,7 @@ export function getNewMatchesForLinks(
           return true;
         })
       : nextMatches.filter((match, index) => {
-          return (
-            match.route.hasLoader &&
-            (isNew(match, index) || matchPathChanged(match, index))
-          );
+          return isNew(match, index) || matchPathChanged(match, index);
         });
 
   return newMatches;


### PR DESCRIPTION
Closes: #1091

Fixed a bug that prefetch doesn't happen if the route doesn't have a loader.

Current behavior:
* ✅ prefetch links to routes with loader: Remix adds `<link>`s for bundle file and loader data
* 🐛 prefetch links to routes without loader: **Remix doesn't add `<link>` tag**

Expected behavior:
* ✅ prefetch links to routes with loader: Remix adds `<link>`s for bundle file and loader data
* ✅ prefetch links to routes without loader: **Remix adds `<link>` for bundle file**

I made a fix which is suggested by @kentcdodds in the issue. Also I added and improved unit tests around elements when prefetch happens.

- [x] Tests
  - [x] I added test cases which reproduces the issue. The unit tests passed.
  - [x] However, entire testing with `yarn test` results in bunch of failures even for `dev` branch in my local, including flaky tests with timeouts, and it's difficult to see if my change affects other tests. ~I'd like to run branch testing and revisit if something is broken~
    - Update: I ran the branch testing in my forked repo, and I confirmed it passed all the test cases. https://github.com/na2hiro/remix/runs/5257542886?check_suite_focus=true