### PR TITLE
docs: fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -114,6 +114,7 @@
 - jgarrow
 - jkup
 - jmasson
+- jo-ninja
 - joaosamouco
 - johannesbraeunig
 - johnson444

--- a/docs/guides/data-loading.md
+++ b/docs/guides/data-loading.md
@@ -162,7 +162,7 @@ export default function ProductCategory() {
 }
 ```
 
-If you are using TypeScript, you can use type inference to use Primsa Client generated types on when calling `useLoaderData`. This allowes better type safety and intellisense when writing your code that uses the loaded data.
+If you are using TypeScript, you can use type inference to use Prisma Client generated types on when calling `useLoaderData`. This allowes better type safety and intellisense when writing your code that uses the loaded data.
 
 ```tsx filename=tsx filename=app/routes/products/$productId.tsx
 import { useLoaderData, json } from "remix";


### PR DESCRIPTION
Minor typo: `Primsa` => `Prisma`