### PR TITLE
fix: Allow `process.env.NODE_ENV === "test"` in build

### DIFF
--- a/packages/remix-dev/build.ts
+++ b/packages/remix-dev/build.ts
@@ -1,10 +1,15 @@
 export enum BuildMode {
   Development = "development",
-  Production = "production"
+  Production = "production",
+  Test = "test"
 }
 
 export function isBuildMode(mode: any): mode is BuildMode {
-  return mode === BuildMode.Development || mode === BuildMode.Production;
+  return (
+    mode === BuildMode.Development ||
+    mode === BuildMode.Production ||
+    mode === BuildMode.Test
+  );
 }
 
 export enum BuildTarget {


### PR DESCRIPTION
We set `process.env.NODE_ENV` to `"test"` when running our test suite, but `yarn build` overrides anything other that `"development"` or `"production"` which makes env-based mocking more difficult. This PR allows `"test"` as a valid `NODE_ENV` value.