### PR TITLE
fix(remix-dev): Remove x-powered-by header from Express dev server

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -29,6 +29,7 @@
 - bmontalvo
 - bogas04
 - BogdanDevBst
+- brophdawg11
 - bruno-oliveira
 - bsharrow
 - bsides

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -167,6 +167,7 @@ export async function dev(remixRoot: string, modeArg?: string) {
   }
 
   let app = express();
+  app.disable("x-powered-by");
   app.use((_, __, next) => {
     purgeAppRequireCache(config.serverBuildPath);
     next();


### PR DESCRIPTION
Related to #1710 and #194 which are fixed in `remix serve` but this also removes the header from `remix dev`