### PR TITLE
fix: PNPM does some weird hardlinking so attempting to write to index.d.ts fails

### DIFF
--- a/packages/remix/tsconfig.json
+++ b/packages/remix/tsconfig.json
@@ -9,8 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
 
-    "declaration": true,
-    "emitDeclarationOnly": true,
+    "noEmit": true,
 
     "outDir": "../../build/node_modules/remix",
     "rootDir": "."


### PR DESCRIPTION
fix: PNPM does some weird hardlinking so attempting to write to index.d.ts of the remix package causes completely unrelated packages to break?

Anyways, this stops shipping type definitions with the remix package as we generate them based on the setup command.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests
