### PR TITLE
fix(remix-dev): fix compiler for Cloudflare runtime

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -4,6 +4,7 @@
 - abotsi
 - ahbruns
 - ahmedeldessouki
+- aiji42
 - airjp73
 - airondumael
 - Alarid

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -440,7 +440,12 @@ function createServerBuild(
           config.serverBuildTarget
         ),
       mainFields:
-        config.serverModuleFormat === "esm"
+        !!config.serverBuildTarget &&
+        ["cloudflare-workers", "cloudflare-pages"].includes(
+          config.serverBuildTarget
+        )
+          ? ["browser", "module", "main"]
+          : config.serverModuleFormat === "esm"
           ? ["module", "main"]
           : ["main", "module"],
       target: options.target,

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -423,6 +423,11 @@ function createServerBuild(
     plugins.unshift(NodeModulesPolyfillPlugin());
   }
 
+  const isCloudflareRuntime = [
+    "cloudflare-workers",
+    "cloudflare-pages"
+  ].includes(config.serverBuildTarget ?? "");
+
   return esbuild
     .build({
       absWorkingDir: config.rootDirectory,
@@ -433,21 +438,12 @@ function createServerBuild(
       platform: config.serverPlatform,
       format: config.serverModuleFormat,
       treeShaking: true,
-      minify:
-        options.mode === BuildMode.Production &&
-        !!config.serverBuildTarget &&
-        ["cloudflare-workers", "cloudflare-pages"].includes(
-          config.serverBuildTarget
-        ),
-      mainFields:
-        !!config.serverBuildTarget &&
-        ["cloudflare-workers", "cloudflare-pages"].includes(
-          config.serverBuildTarget
-        )
-          ? ["browser", "module", "main"]
-          : config.serverModuleFormat === "esm"
-          ? ["module", "main"]
-          : ["main", "module"],
+      minify: options.mode === BuildMode.Production && isCloudflareRuntime,
+      mainFields: isCloudflareRuntime
+        ? ["browser", "module", "main"]
+        : config.serverModuleFormat === "esm"
+        ? ["module", "main"]
+        : ["main", "module"],
       target: options.target,
       inject: config.serverBuildTarget === "deno" ? [] : [reactShim],
       loader: loaders,


### PR DESCRIPTION
Closes: #2075

If the runtime is Cloudflare Worlers (or pages), then the browser module must be resolved first.
Currently I have found the problem in `@supabase/supabase-js`, but similar problems must be occurring in other packages. An update to this pull request should resolve them.

I used this esbuild configuration as a reference.
https://github.com/gmencz/cloudflare-workers-typescript-esbuild-esm/blob/main/build.mjs
