### PR TITLE
fix(create-remix:express): Fix nodemon unnecessarily watches public/build

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -186,6 +186,7 @@
 - mskoroglu
 - msutkowski
 - mtt87
+- na2hiro
 - nareshbhatia
 - navid-kalaei
 - niconiahi

--- a/packages/create-remix/templates/express/package.json
+++ b/packages/create-remix/templates/express/package.json
@@ -4,7 +4,7 @@
     "build": "cross-env NODE_ENV=production remix build",
     "dev": "cross-env NODE_ENV=development remix build && run-p dev:*",
     "dev:remix": "cross-env NODE_ENV=development remix watch",
-    "dev:node": "cross-env NODE_ENV=development nodemon ./build/index.js",
+    "dev:node": "cross-env NODE_ENV=development nodemon ./build/index.js --watch ./build/index.js",
     "start": "cross-env NODE_ENV=production node ./build/index.js"
   },
   "dependencies": {


### PR DESCRIPTION
The Express template has an issue that takes a lot longer time than necessary to restart the server, whenever the code is updated. Restarting is triggered so many times after I **updated a single file**: 

```
[nodemon] restarting due to changes...
[nodemon] starting `node ./build/index.js`
💿 File changed: server.js
💿 Rebuilding...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
💿 Rebuilt in 1s
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
[nodemon] restarting due to changes...
(...abbreviated...)
```

This happens because `nodemon` watches the entire repository, including `/public/build/` where there could be bunch of changed files, and that causes `nodemon` to repetitively trigger restart of the server. This is the screenshot with `nodemon --verbose` specified:

<img width="641" alt="nodemon-watches-public-build-unnecessarily" src="https://user-images.githubusercontent.com/736244/155289182-1516cad7-c490-4e32-a9f1-67d953cec1a1.png">

The fix is to change command line option for `nodemon` to only watch `/build/index.js`, which I believe is the only necessary code to check, built by Remix.

- [ ] Docs
- [ ] Tests
