### PR TITLE
chore(remix-architect): bump @architect/functions to v5

### DIFF
--- a/packages/remix-architect/package.json
+++ b/packages/remix-architect/package.json
@@ -12,13 +12,10 @@
     "url": "https://github.com/remix-run/remix/issues"
   },
   "dependencies": {
-    "@architect/functions": "^4.1.1",
+    "@architect/functions": "^5.0.2",
     "@types/aws-lambda": "^8.10.82",
     "@remix-run/node": "1.2.2",
     "@remix-run/server-runtime": "1.2.2"
-  },
-  "peerDependencies": {
-    "@architect/architect": "^8.3.7"
   },
   "devDependencies": {
     "@types/architect__functions": "^3.13.6",


### PR DESCRIPTION
@architect/architect v10 came out on Monday and requires @architect/functions v5

we could also update docs to say to use arc 9, but that seems less than ideal

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests
