### PR TITLE
ci: only run test workflow on main/dev/release branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,9 @@ name: test
 on:
   push:
     branches:
-      - "**"
+      - main
+      - dev
+      - release/*
     tags-ignore:
       - v*
     paths-ignore:


### PR DESCRIPTION
Avoid duplicate runs of the `test` workflow on PRs by limiting the `push` trigger to only run for `dev`/`main`/`release/*` branches.  Pushes to open PR branches will be run via the `pull_request` trigger