### PR TITLE
feat: add generics to `Cookie` interface

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -97,6 +97,7 @@
 - hollandThomas
 - hollandThomas
 - Hopsken
+- htunnicliff
 - hzhu
 - IAmLuisJ
 - ianduvall


### PR DESCRIPTION
This PR adds an optional generic to the `Cookie` interface and related functions. By having an optional generic available when a cookie is created, stronger types can be expected.

Here is an example:

```ts
import { createCookie } from "remix";

type Data = {
  userId: string;
  favoriteColor: string;
};

export const sessionCookie = createCookie<Data>("session");

// Enforce types when serializing
await sessionCookie.serialize({
  userId: "user-123",
  favoriteColor: false // <-- Error: Type 'boolean' is not assignable to type 'string'
});

// Receive types when parsing
const data = await sessionCookie.parse("... Cookie headers");

data.userId // <-- string
data.favoriteColor // <-- string