### PR TITLE
ci: use cloudflare api to determine if deployment is done

### DIFF
--- a/scripts/deployment-test/_shared.mjs
+++ b/scripts/deployment-test/_shared.mjs
@@ -80,7 +80,7 @@ export function runCypress(dir, dev, url) {
   }
 }
 
-export async function checkUrl(url) {
+export function checkUrl(url) {
   let operation = retry.operation({ retries: 10 });
 
   return new Promise((resolve, reject) => {
@@ -88,11 +88,12 @@ export async function checkUrl(url) {
       try {
         let response = await fetch(url);
         if (response.status >= 200 && response.status < 400) {
-          resolve("App server is up");
+          resolve("URL responded with status " + response.status);
         } else {
-          throw new Error(`App server is not up: ${response.status}`);
+          throw new Error(`URL responded with status ${response.status}`);
         }
       } catch (error) {
+        console.error(error);
         reject(operation.retry(error));
       }
     });

--- a/scripts/deployment-test/cf-pages.mjs
+++ b/scripts/deployment-test/cf-pages.mjs
@@ -57,6 +57,7 @@ async function createCloudflareProject() {
           build_command: "npm run build",
           destination_dir: "public",
           root_dir: "",
+          fast_builds: true,
         },
       }),
     }

--- a/scripts/deployment-test/cf-pages.mjs
+++ b/scripts/deployment-test/cf-pages.mjs
@@ -4,6 +4,7 @@ import { Octokit } from "@octokit/rest";
 import fse from "fs-extra";
 import fetch from "node-fetch";
 import { createApp } from "create-remix";
+import retry from "retry";
 
 import {
   addCypress,
@@ -67,7 +68,7 @@ async function createCloudflareProject() {
     if (promise.headers.get("Content-Type").includes("application/json")) {
       console.error(await promise.json());
     }
-    throw new Error(`Failed to create cloudflare pages project`);
+    throw new Error(`Failed to create Cloudflare Pages project`);
   }
 }
 
@@ -87,8 +88,46 @@ async function createCloudflareDeployment() {
     if (promise.headers.get("Content-Type").includes("application/json")) {
       console.error(await promise.json());
     }
-    throw new Error(`Failed to create cloudflare pages project`);
+    throw new Error(`Failed to create Cloudflare Pages project`);
   }
+
+  let deployment = await promise.json();
+
+  return deployment.result.id;
+}
+
+function checkDeploymentStatus() {
+  let operation = retry.operation({ retries: 20 });
+  let url = `https://api.cloudflare.com/client/v4/accounts/${process.env.CF_ACCOUNT_ID}/pages/projects/${APP_NAME}/deployments`;
+
+  return new Promise((resolve, reject) => {
+    operation.attempt(async (currentAttempt) => {
+      console.log(`Checking deployment status; attempt ${currentAttempt}`);
+      let response = await fetch(url, {
+        headers: {
+          "X-Auth-Email": process.env.CF_EMAIL,
+          "X-Auth-Key": process.env.CF_GLOBAL_API_KEY,
+        },
+      });
+
+      if (response.status >= 200 && response.status < 400) {
+        let data = await response.json();
+        let deployment = data.result[0];
+        let latest = deployment.latest_stage;
+        if (latest.name === "deploy" && latest.status === "success") {
+          resolve("Pages deployed successfully");
+        } else {
+          let message = `Deployment not complete; latest stage: ${latest.name}/${latest.status}`;
+          console.error(message);
+          operation.retry(new Error(message));
+        }
+      } else {
+        let message = `URL responded with status ${response.status}`;
+        console.error(message);
+        operation.retry(new Error(message));
+      }
+    });
+  });
 }
 
 let octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
@@ -118,9 +157,6 @@ try {
   // validate dependencies are available
   await validatePackageVersions(PROJECT_DIR);
 
-  // create a new github repo
-  let repo = await createRepoIfNeeded(APP_NAME);
-
   // add cypress to the project
   await Promise.all([
     fse.copy(CYPRESS_SOURCE_DIR, path.join(PROJECT_DIR, "cypress")),
@@ -136,6 +172,9 @@ try {
 
   // run cypress against the dev server
   runCypress(PROJECT_DIR, true, CYPRESS_DEV_URL);
+
+  // create a new github repo
+  let repo = await createRepoIfNeeded(APP_NAME);
 
   spawnSync("git", ["init"], spawnOpts);
   spawnSync(
@@ -165,19 +204,16 @@ try {
 
   await createCloudflareProject();
   await createCloudflareDeployment();
-  console.log(
-    "Successfully created cloudflare pages project, the build is in progress, but will take a bit before it's ready to run cypress against it",
-    "we'll sleep for 5 minutes to give it time to build"
-  );
+  console.log("Successfully created Cloudflare Pages project");
 
-  // builds typically take between 2 and 3 minutes
-  await new Promise((resolve) => setTimeout(resolve, 60_000 * 3));
+  // wait for deployment to complete
+  await checkDeploymentStatus();
 
   let appUrl = `https://${APP_NAME}.pages.dev`;
 
   await checkUrl(appUrl);
 
-  // run cypress against the cloudflare pages server
+  // run cypress against the Cloudflare Pages server
   runCypress(PROJECT_DIR, false, appUrl);
 
   if (currentGitUser.email && currentGitUser.name) {


### PR DESCRIPTION
This PR changes how we wait for deployments for Cloudflare Pages but pinging the api instead of a setTimeout, it also adds support for "fast builds" once they enable it to be configured via the API - if they don't, it'll be enabled by default on April 1st.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [x] Tests
