### PR TITLE
docs: fix 404 on conventions page

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -162,6 +162,7 @@
 - manzano78
 - manzoorwanijk
 - marcomafessolli
+- marr
 - marshallwalker
 - martensonbj
 - marvinwu

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -521,7 +521,7 @@ export const handleDataRequest: HandleDataRequestFunction =
 
 A route in Remix can be used for many things. Usually they’re used for the user interface of your app, like a React component with server-side lifecycle hooks. But they can also serve as generic routes for any kind of resource (like dynamic CSS or social images).
 
-It's important to read [Route Module Constraints](../other-api/constraints/).
+It's important to read [Module Constraints](../guides/constraints/).
 
 ### `default` export
 


### PR DESCRIPTION
Fix incorrect link on conventions page. Also rename link title _Route Module Constraints_ => _Module Constraints_ to match the destination of the link.