### PR TITLE
feat(remix-server-runtime): add loader context generic types

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -253,6 +253,7 @@
 - rvlewerissa
 - ryanflorence
 - ryankshaw
+- rwu823
 - sandulat
 - sbernheim4
 - schpet

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -3,6 +3,7 @@ import type { ServerRoute } from "./routes";
 import { json, isResponse, isRedirectResponse } from "./responses";
 
 /**
+ * @deprecated Please switch to use Generics type
  * An object of arbitrary for route loaders and actions provided by the
  * server's `getLoadContext()` function.
  */

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -2,7 +2,7 @@ import type { Location } from "history";
 import type { ComponentType } from "react";
 import type { Params } from "react-router-dom";
 
-import type { AppLoadContext, AppData } from "./data";
+import type { AppData } from "./data";
 import type { LinkDescriptor } from "./links";
 import type { RouteData } from "./routeData";
 
@@ -13,9 +13,9 @@ export interface RouteModules<RouteModule> {
 /**
  * The arguments passed to ActionFunction and LoaderFunction.
  */
-export interface DataFunctionArgs {
+export interface DataFunctionArgs<Context = unknown> {
   request: Request;
-  context: AppLoadContext;
+  context: Context;
   params: Params;
 }
 
@@ -63,8 +63,8 @@ export interface LinksFunction {
 /**
  * A function that loads data for a route.
  */
-export interface LoaderFunction {
-  (args: DataFunctionArgs):
+export interface LoaderFunction<Context = any> {
+  (args: DataFunctionArgs<Context>):
     | Promise<Response>
     | Response
     | Promise<AppData>

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -1,4 +1,3 @@
-import type { AppLoadContext } from "./data";
 import { callRouteAction, callRouteLoader, extractData } from "./data";
 import type { AppState } from "./errors";
 import type { HandleDataRequestFunction, ServerBuild } from "./build";
@@ -14,9 +13,9 @@ import { createRoutes } from "./routes";
 import { json, isRedirectResponse, isCatchResponse } from "./responses";
 import { createServerHandoffString } from "./serverHandoff";
 
-export type RequestHandler = (
+export type RequestHandler<Context = unknown> = (
   request: Request,
-  loadContext?: AppLoadContext
+  loadContext?: Context
 ) => Promise<Response>;
 
 export type CreateRequestHandlerFunction = (


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Because the context does not change too often, users can easily customize it without having to use the type to correspond to it every time.

for example:

```ts
import { LoaderFunction } from 'remix';

type MyContext  = {
  user: string
}

type LoaderFunctionWithContext = LoaderFunction<MyContext>

export const loader: LoaderFunctionWithContext = () => {}
```