### PR TITLE
docs(examples): add instructions for prisma migration to the example 'jokes' app README

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -62,6 +62,7 @@
 - Dueen
 - dunglas
 - dwt47
+- eastlondoner
 - edgesoft
 - edmundhung
 - efkann

--- a/examples/jokes/README.md
+++ b/examples/jokes/README.md
@@ -32,10 +32,11 @@ From your terminal:
 
 ```sh
 npm install
+npx prisma migrate dev
 npm run dev
 ```
 
-This starts your app in development mode, rebuilding assets on file changes.
+This prepares the local dev database and starts your app in development mode, rebuilding assets on file changes.
 
 ## Deployment
 
@@ -43,6 +44,12 @@ First, build your app for production:
 
 ```sh
 npm run build
+```
+
+Then apply any database changes:
+
+```sh
+npx prisma migrate deploy
 ```
 
 Then run the app in production mode:


### PR DESCRIPTION
This is a docs improvement in the example jokes app.

Without these additional instructions trying to use the app results in errors:

```
PrismaClientKnownRequestError: 
Invalid `prisma.joke.count()` invocation:


  The table `main.Joke` does not exist in the current database.
    at Object.request (/workspaces/remix/examples/jokes/node_modules/@prisma/client/runtime/index.js:39809:15)
    at PrismaClient._request (/workspaces/remix/examples/jokes/node_modules/@prisma/client/runtime/index.js:40637:18)
    at loader5 (/workspaces/remix/examples/jokes/build/route:/workspaces/remix/examples/jokes/app/routes/jokes/index.tsx:12:17)
    at Object.callRouteLoader (/workspaces/remix/examples/jokes/node_modules/@remix-run/server-runtime/data.js:73:14)
    at handleDataRequest (/workspaces/remix/examples/jokes/node_modules/@remix-run/server-runtime/server.js:129:18)
    at requestHandler (/workspaces/remix/examples/jokes/node_modules/@remix-run/server-runtime/server.js:45:20)
    at /workspaces/remix/examples/jokes/node_modules/@remix-run/express/server.js:43:22 {
  code: 'P2021',
  clientVersion: '3.10.0',
  meta: { table: 'main.Joke' }
}
```