### PR TITLE
feat(remix-cloudflare-workers): add support for `@cloudflare/workers-types` v3

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -113,6 +113,7 @@
 - jeremyjfleming
 - jesse-deboer
 - jesseflorig
+- jfsiii
 - jgarrow
 - jkup
 - jmasson

--- a/packages/remix-cloudflare-workers/package.json
+++ b/packages/remix-cloudflare-workers/package.json
@@ -18,9 +18,9 @@
     "@remix-run/server-runtime": "1.2.2"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^2.2.2"
+    "@cloudflare/workers-types": "^2.2.2 || ^3.0.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^2.2.2"
+    "@cloudflare/workers-types": "^2.2.2 || ^3.0.0"
   }
 }


### PR DESCRIPTION
## Symptoms
I'm getting TS errors like `Property 'request' does not exist on type 'FetchEvent'.ts(2339)` when writing an event listener like

```
addEventListener('fetch', event => {
  console.log(event, event.request, event.eventPhase)
})
```
<img width="712" alt="Screen Shot 2022-02-25 at 10 47 21 AM" src="https://user-images.githubusercontent.com/57655/155747837-6cd84762-1e61-4442-8d72-20c80ab8d372.png">

## Root cause
The [type specified](https://github.com/cloudflare/workers-types/blob/v2.2.0/index.d.ts#L1-L3) is from version `2.2.2` but the current version is `3.4.0`.

The [v3 types](https://github.com/cloudflare/workers-types/blob/74c94f8f96fa427353acd60ebc00d910f8e7cdfe/index.d.ts#L570-L575
) have `request` and all the other properties that logging shows are available

## Proposed solution
Change package.json to allow users to use the current version. I wasn't sure if it was preferable to a) replace the v2 range with the v3 range b) extend the range to allow v2 or v3 

I chose the more permissive option b, but do not have a strong opinion so long as it's possible to use the current major version

- [ ] Docs
- [ ] Tests
