### PR TITLE
chore: DRY up shared logic between links/transitions

### DIFF
--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -291,30 +291,28 @@ export function getNewMatchesForLinks(
 ): ClientMatch[] {
   let path = parsePathPatch(page);
 
-  let prevUrl = new URL(
-    location.pathname + location.search + location.hash,
-    window.origin
-  );
-  let url = new URL(page, window.origin);
-  let filterByRouteProps = filterByRoutePropsFactory(
-    currentMatches,
-    prevUrl,
-    url
-  );
-
   // NOTE: keep this mostly up-to-date w/ the transition data diff, but this
   // version doesn't care about submissions
-  let newMatches =
-    mode === "data" && location.search !== path.search
-      ? nextMatches.filter(filterByRouteProps)
-      : nextMatches.filter((match, index) => {
-          return (
-            (mode === "assets" || match.route.hasLoader) &&
-            shouldReloadForMatch(currentMatches, match, index)
-          );
-        });
+  if (mode === "data" && location.search !== path.search) {
+    let prevUrl = new URL(
+      location.pathname + location.search + location.hash,
+      window.origin
+    );
+    let url = new URL(page, window.origin);
+    let filterByRouteProps = filterByRoutePropsFactory(
+      currentMatches,
+      prevUrl,
+      url
+    );
+    return nextMatches.filter(filterByRouteProps);
+  }
 
-  return newMatches;
+  return nextMatches.filter((match, index) => {
+    return (
+      (mode === "assets" || match.route.hasLoader) &&
+      shouldReloadForMatch(currentMatches, match, index)
+    );
+  });
 }
 
 export function getDataLinkHrefs(

--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -302,6 +302,8 @@ export function getNewMatchesForLinks(
     url
   );
 
+  // NOTE: keep this mostly up-to-date w/ the transition data diff, but this
+  // version doesn't care about submissions
   let newMatches =
     mode === "data" && location.search !== path.search
       ? nextMatches.filter(filterByRouteProps)

--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -9,7 +9,6 @@ import {
   filterByRoutePropsFactory,
   shouldReloadForMatch,
 } from "./routeMatching";
-// import { matchClientRoutes } from "./routeMatching";
 import type { RouteModules, RouteModule } from "./routeModules";
 import { loadRouteModule } from "./routeModules";
 

--- a/packages/remix-react/routeMatching.ts
+++ b/packages/remix-react/routeMatching.ts
@@ -5,12 +5,15 @@ import type { Params, RouteObject } from "react-router"; // TODO: export/import 
 import { matchRoutes } from "react-router-dom";
 
 import type { ClientRoute } from "./routes";
+import type { Submission } from "./transition";
 
 export interface RouteMatch<Route> {
   params: Params;
   pathname: string;
   route: Route;
 }
+
+export type ClientMatch = RouteMatch<ClientRoute>;
 
 export function matchClientRoutes(
   routes: ClientRoute[],
@@ -24,4 +27,67 @@ export function matchClientRoutes(
     pathname: match.pathname,
     route: match.route as unknown as ClientRoute,
   }));
+}
+
+function isNewMatch(
+  currentMatches: ClientMatch[],
+  match: ClientMatch,
+  index: number
+) {
+  if (!currentMatches[index]) return true;
+  return match.route.id !== currentMatches[index].route.id;
+}
+
+function didMatchPathChange(
+  currentMatches: ClientMatch[],
+  match: ClientMatch,
+  index: number
+) {
+  return (
+    // param change, /users/123 -> /users/456
+    currentMatches[index].pathname !== match.pathname ||
+    // splat param changed, which is not present in match.path
+    // e.g. /files/images/avatar.jpg -> files/finances.xls
+    (currentMatches[index].route.path?.endsWith("*") &&
+      currentMatches[index].params["*"] !== match.params["*"])
+  );
+}
+
+export function shouldReloadForMatch(
+  currentMatches: ClientMatch[],
+  match: ClientMatch,
+  index: number
+) {
+  return (
+    isNewMatch(currentMatches, match, index) ||
+    didMatchPathChange(currentMatches, match, index)
+  );
+}
+
+export function filterByRoutePropsFactory(
+  currentMatches: ClientMatch[],
+  prevUrl: URL,
+  url: URL,
+  submission?: Submission
+) {
+  return (match: ClientMatch, index: number) => {
+    if (!match.route.loader) {
+      return false;
+    }
+
+    if (shouldReloadForMatch(currentMatches, match, index)) {
+      return true;
+    }
+
+    if (match.route.shouldReload) {
+      return match.route.shouldReload({
+        prevUrl,
+        url,
+        submission,
+        params: match.params,
+      });
+    }
+
+    return true;
+  };
 }

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -1343,7 +1343,7 @@ function filterMatchesToLoad(
   }
 
   let prevUrl = createUrl(createHref(state.location));
-  let filterByRouteProps2 = filterByRoutePropsFactory(
+  let filterByRouteProps = filterByRoutePropsFactory(
     state.matches,
     prevUrl,
     url,
@@ -1356,7 +1356,7 @@ function filterMatchesToLoad(
   }
 
   if (fetcher?.type === "actionReload") {
-    return matches.filter(filterByRouteProps2);
+    return matches.filter(filterByRouteProps);
   } else if (
     // mutation, reload for fresh data
     state.transition.type === "actionReload" ||
@@ -1366,7 +1366,7 @@ function filterMatchesToLoad(
     // search affects all loaders
     url.searchParams.toString() !== state.location.search.substring(1)
   ) {
-    return matches.filter(filterByRouteProps2);
+    return matches.filter(filterByRouteProps);
   }
 
   return matches.filter((match, index, arr) => {


### PR DESCRIPTION
DRY up route matching/filtering logic between links/transitions

- [x] Docs - n/a
- [x] Tests - internal refactor should leverage current tests
