### PR TITLE
docs(examples): Fix expire bug in redis-upstash-session example

### DIFF
--- a/examples/redis-upstash-session/app/sessions.server.ts
+++ b/examples/redis-upstash-session/app/sessions.server.ts
@@ -5,13 +5,10 @@ import { createUpstashSessionStorage } from "~/sessions/upstash.server";
 // For the example we use very short duration to easily demonstrate its functionally.
 const EXPIRATION_DURATION_IN_SECONDS = 10;
 
-const expires = new Date();
-expires.setSeconds(expires.getSeconds() + EXPIRATION_DURATION_IN_SECONDS);
-
 const sessionCookie = createCookie("__session", {
   secrets: ["r3m1xr0ck1"],
   sameSite: true,
-  expires,
+  expires: new Date(Date.now() + EXPIRATION_DURATION_IN_SECONDS * 1000),
 });
 
 const { getSession, commitSession, destroySession } =


### PR DESCRIPTION
The previous implementation didn't really added correctly the EXPIRATION_DURATION_IN_SECONDS
