### PR TITLE
docs(examples): fix broken link in blog app

### DIFF
--- a/examples/blog-tutorial/app/routes/index.tsx
+++ b/examples/blog-tutorial/app/routes/index.tsx
@@ -19,7 +19,7 @@ export const loader: LoaderFunction = async () => {
       },
       {
         name: "React Router Docs",
-        url: "reactrouter.com/docs",
+        url: "https://reactrouter.com/docs",
       },
       {
         name: "Remix Discord",


### PR DESCRIPTION
Currently this link is targetting `http://localhost:3000/reactrouter.com/docs`.
