### PR TITLE
docs: Add allowUnsafe to parseFrontMatter calls in Quickstart Tutorial

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -53,6 +53,7 @@
 - DavidHollins6
 - denissb
 - derekr
+- derfl007
 - developit
 - dhargitai
 - dhmacs

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -338,7 +338,8 @@ export async function getPosts() {
         path.join(postsPath, filename)
       );
       const { attributes } = parseFrontMatter(
-        file.toString()
+        file.toString(),
+        { allowUnsafe: true }
       );
       return {
         slug: filename.replace(/\.md$/, ""),
@@ -394,7 +395,8 @@ export async function getPosts() {
         path.join(postsPath, filename)
       );
       const { attributes } = parseFrontMatter(
-        file.toString()
+        file.toString(),
+        { allowUnsafe: true }
       );
       invariant(
         isValidPostAttributes(attributes),
@@ -487,7 +489,10 @@ Put this function anywhere in the `app/post.ts` module:
 export async function getPost(slug: string) {
   const filepath = path.join(postsPath, slug + ".md");
   const file = await fs.readFile(filepath);
-  const { attributes } = parseFrontMatter(file.toString());
+  const { attributes } = parseFrontMatter(
+    file.toString(),
+    { allowUnsafe: true }
+  );
   invariant(
     isValidPostAttributes(attributes),
     `Post ${filepath} is missing attributes`
@@ -548,7 +553,8 @@ export async function getPost(slug: string) {
   const filepath = path.join(postsPath, slug + ".md");
   const file = await fs.readFile(filepath);
   const { attributes, body } = parseFrontMatter(
-    file.toString()
+    file.toString(),
+    { allowUnsafe: true }
   );
   invariant(
     isValidPostAttributes(attributes),


### PR DESCRIPTION
There's currently a bug where `front-matter` and `remark-mdx-frontmatter` use different versions of `js-yaml`. `js-yaml` 4 removes `yaml.safeload` which is used by front-matter if the `allowUnsafe` parameter is not `true`.
See: https://github.com/jxson/front-matter/issues/84 and https://github.com/remix-run/remix/issues/2067
To avoid this issue we have to add allowUnsafe to the parseFrontMatter calls which causes front-matter to use `yaml.load` instead of `yaml.safeload`

Fixes: #2067 