### PR TITLE
docs(examples): remove not allowed and unneeded div in blog example

### DIFF
--- a/examples/blog-tutorial/app/routes/demos/actions.tsx
+++ b/examples/blog-tutorial/app/routes/demos/actions.tsx
@@ -71,7 +71,7 @@ export default function ActionsDemo() {
             <i>What is more useful when it is broken?</i>
           </p>
           <label>
-            <div>Answer:</div>
+            Answer:
             <input ref={answerRef} name="answer" type="text" />
           </label>
           <div>


### PR DESCRIPTION
This `<div>` is not allowed as child of `<label>` (cf. [div spec](https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element)).
And it's not needed here even for visual purposes because the `<input>` below is already set to `display: block; width: 100%;` [in the CSS](https://github.com/remix-run/remix/blob/9ea7d4ae37c59082cff9d8011f609268b42e15dd/examples/blog-tutorial/app/styles/global.css#L66).