### PR TITLE
feat(remix-server-runtime): throw error when cookie limit is reached

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -189,6 +189,7 @@
 - matthew-burfield
 - Matthew-Mallimo
 - MatthewAlbrecht
+- matt-l-w
 - mattmazzola
 - mattstobbs
 - mbarto

--- a/packages/remix-server-runtime/__tests__/sessions-test.ts
+++ b/packages/remix-server-runtime/__tests__/sessions-test.ts
@@ -129,6 +129,16 @@ describe("Cookie session storage", () => {
     expect(setCookie).toContain("Path=/");
   });
 
+  it('throws an error when the cookie size exceeds 4096 bytes', async () => {
+    let { getSession, commitSession } = createCookieSessionStorage({
+      cookie: { secrets: ["secret1"] },
+    });
+    let session = await getSession();
+    const longString = new Array(4097).fill("a").join('');
+    session.set("over4096bytes", longString);
+    await expect(() => commitSession(session)).rejects.toThrow();
+  })
+
   describe("when a new secret shows up in the rotation", () => {
     it("unsigns old session cookies using the old secret and encodes new cookies using the new secret", async () => {
       let { getSession, commitSession } = createCookieSessionStorage({

--- a/packages/remix-server-runtime/__tests__/sessions-test.ts
+++ b/packages/remix-server-runtime/__tests__/sessions-test.ts
@@ -134,7 +134,7 @@ describe("Cookie session storage", () => {
       cookie: { secrets: ["secret1"] },
     });
     let session = await getSession();
-    const longString = new Array(4097).fill("a").join("");
+    let longString = new Array(4097).fill("a").join("");
     session.set("over4096bytes", longString);
     await expect(() => commitSession(session)).rejects.toThrow();
   });

--- a/packages/remix-server-runtime/__tests__/sessions-test.ts
+++ b/packages/remix-server-runtime/__tests__/sessions-test.ts
@@ -129,15 +129,15 @@ describe("Cookie session storage", () => {
     expect(setCookie).toContain("Path=/");
   });
 
-  it('throws an error when the cookie size exceeds 4096 bytes', async () => {
+  it("throws an error when the cookie size exceeds 4096 bytes", async () => {
     let { getSession, commitSession } = createCookieSessionStorage({
       cookie: { secrets: ["secret1"] },
     });
     let session = await getSession();
-    const longString = new Array(4097).fill("a").join('');
+    const longString = new Array(4097).fill("a").join("");
     session.set("over4096bytes", longString);
     await expect(() => commitSession(session)).rejects.toThrow();
-  })
+  });
 
   describe("when a new secret shows up in the rotation", () => {
     it("unsigns old session cookies using the old secret and encodes new cookies using the new secret", async () => {

--- a/packages/remix-server-runtime/sessions/cookieStorage.ts
+++ b/packages/remix-server-runtime/sessions/cookieStorage.ts
@@ -44,7 +44,10 @@ export const createCookieSessionStorageFactory =
     async commitSession(session, options) {
       const serializedCookie = await cookie.serialize(session.data, options);
       if (serializedCookie.length > 4096) {
-        throw new Error('Cookie length will exceed browser maximum. Length: ' + serializedCookie.length)
+        throw new Error(
+          "Cookie length will exceed browser maximum. Length: " +
+            serializedCookie.length
+        );
       }
       return serializedCookie;
     },

--- a/packages/remix-server-runtime/sessions/cookieStorage.ts
+++ b/packages/remix-server-runtime/sessions/cookieStorage.ts
@@ -58,3 +58,4 @@ export const createCookieSessionStorageFactory =
       });
     },
   };
+};

--- a/packages/remix-server-runtime/sessions/cookieStorage.ts
+++ b/packages/remix-server-runtime/sessions/cookieStorage.ts
@@ -43,9 +43,8 @@ export const createCookieSessionStorageFactory =
     },
     async commitSession(session, options) {
       const serializedCookie = await cookie.serialize(session.data, options);
-      const byteLength = Buffer.byteLength(serializedCookie);
-      if (byteLength > 4096) {
-        throw new Error('Cookie length will exceed browser maximum. Length: ' + byteLength)
+      if (serializedCookie.length > 4096) {
+        throw new Error('Cookie length will exceed browser maximum. Length: ' + serializedCookie.length)
       }
       return serializedCookie;
     },

--- a/packages/remix-server-runtime/sessions/cookieStorage.ts
+++ b/packages/remix-server-runtime/sessions/cookieStorage.ts
@@ -42,7 +42,7 @@ export const createCookieSessionStorageFactory =
       );
     },
     async commitSession(session, options) {
-      const serializedCookie = await cookie.serialize(session.data, options);
+      let serializedCookie = await cookie.serialize(session.data, options);
       if (serializedCookie.length > 4096) {
         throw new Error(
           "Cookie length will exceed browser maximum. Length: " +


### PR DESCRIPTION
Closes: N/A

- [ ] Docs
- [x] Tests

Session storage inside a cookie is great for smaller things and
normally "just works". For newer developers (and older forgetful ones
like myself), the storage limit can be a source of errors that is
easily missed.

This makes the commit action for cookie session storage throw an
error describing the problem if data is attempted to be persisted that
will exceed the browser max of 4096 bytes.
