### PR TITLE
fix(remix-eslint-config): add missing `files` item to `package.json`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -49,6 +49,7 @@
 - crismali
 - cysp
 - damiensedgwick
+- danecando
 - danielweinmann
 - davecalnan
 - DavidHollins6

--- a/packages/remix-eslint-config/package.json
+++ b/packages/remix-eslint-config/package.json
@@ -10,7 +10,8 @@
     "rules",
     "settings",
     "index.js",
-    "jest.js"
+    "jest.js",
+    "jest-testing-library.js"
   ],
   "dependencies": {
     "@babel/core": "^7.17.5",


### PR DESCRIPTION
Adds jest-testing-library.js to package.json files