### PR TITLE
fix(create-remix): express template docs and move npm-run-all to devDependencies

### DIFF
--- a/packages/create-remix/templates/express/README.md
+++ b/packages/create-remix/templates/express/README.md
@@ -12,12 +12,6 @@ Start the Remix development asset server
 npm run dev
 ```
 
-In a new tab start your express app:
-
-```sh
-npm run start:dev
-```
-
 This starts your app in development mode, which will purge the server require cache when Remix rebuilds assets so you don't need a process manager restarting the express server.
 
 ## Deployment

--- a/packages/create-remix/templates/express/package.json
+++ b/packages/create-remix/templates/express/package.json
@@ -12,10 +12,10 @@
     "compression": "^1.7.4",
     "cross-env": "^7.0.3",
     "express": "^4.17.1",
-    "morgan": "^1.10.0",
-    "npm-run-all": "^4.1.5"
+    "morgan": "^1.10.0"
   },
   "devDependencies": {
-    "nodemon": "^2.0.15"
+    "nodemon": "^2.0.15",
+    "npm-run-all": "^4.1.5"
   }
 }


### PR DESCRIPTION
The `start:dev` script no longer exists in the express template

the `npm-run-all` dependency is only required for the `dev` script so can safely be made into a devDependency.
