### PR TITLE
fix(remix): export a type so that remix/index.d.ts is not empty

### DIFF
--- a/packages/remix/index.ts
+++ b/packages/remix/index.ts
@@ -1,1 +1,8 @@
-throw new Error("Did you forget to run `remix setup` for your platform?");
+// This class exists to prevent https://github.com/remix-run/remix/issues/2031 from occuring
+export class RemixNotSetupError extends Error {
+    constructor() {
+        super("Did you forget to run `remix setup` for your platform?")
+    }
+}
+
+throw new RemixNotSetupError();


### PR DESCRIPTION
This shows one way to fairly straightforwardly fix this issue with pnpm https://github.com/remix-run/remix/issues/2031

Closes: #2031 

- [ ] Docs
- [ ] Tests
