### PR TITLE
fix: keep fetcher in loading state during action submission redirect

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -184,23 +184,26 @@ graph LR
   idle/init -->|"submit (post)"| submitting/actionSubmission
 
   subgraph "Normal Fetch"
-  loading/normalLoad -.->|loader redirected| T1{transition}
+  loading/normalLoad -.->|loader redirected| T1{{transition}}
   end
   loading/normalLoad -->|loader completed| idle/done
-  T1{transition} -.-> idle/done
+  T1{{transition}} -.-> idle/done
 
   subgraph "Loader Submission"
-  submitting/loaderSubmission -.->|"loader redirected"| T2{transition}
+  submitting/loaderSubmission -.->|"loader redirected"| T2{{transition}}
   end
   submitting/loaderSubmission -->|loader completed| idle/done
-  T2{transition} -.-> idle/done
+  T2{{transition}} -.-> idle/done
 
   subgraph "Action Submission"
   submitting/actionSubmission -->|action completed| loading/actionReload
   submitting/actionSubmission -->|action redirected| loading/actionSubmissionRedirect
-  loading/actionSubmissionRedirect -.-> T3{transition}
-  loading/actionReload -.-> |loaders redirected| T3{transition}
+  loading/actionSubmissionRedirect -.-> T3{{transition}}
+  loading/actionReload -.-> |loaders redirected| T3{{transition}}
   end
-  T3{transition} -.-> idle/done
+  T3{{transition}} -.-> idle/done
   loading/actionReload --> |loaders completed| idle/done
+
+  classDef transition fill:lightgreen;
+  class T1,T2,T3 transition;
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -136,29 +136,35 @@ The transition manager is a complex and heavily async bit of logic that is found
 graph LR
   %% <Link> transition
   idle -->|link clicked| loading/normalLoad
-  loading/normalLoad -->|loaders completed| idle
+  idle -->|form method=get| submitting/loaderSubmission
+  idle -->|form method=post| submitting/actionSubmission
+  idle -->|fetcher action redirects| loading/fetchActionRedirect
+
+  subgraph "&lt;Link&gt; transition"
   loading/normalLoad -->|loader redirected| loading/normalRedirect
   loading/normalRedirect --> loading/normalRedirect
+  end
+  loading/normalLoad -->|loaders completed| idle
   loading/normalRedirect -->|loaders completed| idle
 
-  %% <Form method=get>
-  idle -->|form method=get| submitting/loaderSubmission
-  submitting/loaderSubmission -->|loaders completed| idle
+  subgraph "&lt;Form method=get&gt;"
   submitting/loaderSubmission -->|loader redirected| loading/loaderSubmissionRedirect
   loading/loaderSubmissionRedirect --> loading/loaderSubmissionRedirect
+  end
+  submitting/loaderSubmission -->|loaders completed| idle
   loading/loaderSubmissionRedirect -->|loaders completed| idle
 
-  %% <Form method=post>
-  idle -->|form method=post| submitting/actionSubmission
+  subgraph "&lt;Form method=post&gt;"
   submitting/actionSubmission -->|action returned| loading/actionReload
   submitting/actionSubmission -->|action redirected| loading/actionRedirect
-  loading/actionReload -->|loaders completed| idle
   loading/actionReload -->|loader redirected| loading/actionRedirect
   loading/actionRedirect --> loading/actionRedirect
+  end
+  loading/actionReload -->|loaders completed| idle
   loading/actionRedirect -->|loaders completed| idle
 
-  %% fetcher action redirect
-  idle -->|fetcher action redirects| loading/fetchActionRedirect
+  subgraph "Fetcher action redirect"
   loading/fetchActionRedirect --> loading/fetchActionRedirect
+  end
   loading/fetchActionRedirect -->|loaders completed| idle
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -127,3 +127,38 @@ REMIX_LOCAL_DEV_OUTPUT_DIRECTORY=../my-remix-app yarn watch
 ```
 
 Now - any time you make changes in the Remix repository, the they will be written out to the appropriate locations in `../my-remix-app/node_modules` and you can restart the `npm run dev` command to pick them up 🎉.
+
+### Transition Manager Flows
+
+The transition manager is a complex and heavily async bit of logic that is foundational to Remix's ability to manage data loading, submission, error handling, and interruptions. Due to the user-driven nature of interruptions we don't quite believe it can be modeled as a finite state machine, however we have modeled some of the happy path flows below for clarity.
+
+```mermaid
+graph LR
+  %% <Link> transition
+  idle -->|link clicked| loading/normalLoad
+  loading/normalLoad -->|loaders completed| idle
+  loading/normalLoad -->|loader redirected| loading/normalRedirect
+  loading/normalRedirect --> loading/normalRedirect
+  loading/normalRedirect -->|loaders completed| idle
+
+  %% <Form method=get>
+  idle -->|form method=get| submitting/loaderSubmission
+  submitting/loaderSubmission -->|loaders completed| idle
+  submitting/loaderSubmission -->|loader redirected| loading/loaderSubmissionRedirect
+  loading/loaderSubmissionRedirect --> loading/loaderSubmissionRedirect
+  loading/loaderSubmissionRedirect -->|loaders completed| idle
+
+  %% <Form method=post>
+  idle -->|form method=post| submitting/actionSubmission
+  submitting/actionSubmission -->|action returned| loading/actionReload
+  submitting/actionSubmission -->|action redirected| loading/actionRedirect
+  loading/actionReload -->|loaders completed| idle
+  loading/actionReload -->|loader redirected| loading/actionRedirect
+  loading/actionRedirect --> loading/actionRedirect
+  loading/actionRedirect -->|loaders completed| idle
+
+  %% fetcher action redirect
+  idle -->|fetcher action redirects| loading/fetchActionRedirect
+  loading/fetchActionRedirect --> loading/fetchActionRedirect
+  loading/fetchActionRedirect -->|loaders completed| idle
+```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -197,8 +197,8 @@ graph LR
 
   subgraph "Action Submission"
   submitting/actionSubmission -->|action completed| loading/actionReload
-  submitting/actionSubmission -->|action redirected| loading/actionSubmissionRedirect
-  loading/actionSubmissionRedirect -.-> T3{{transition}}
+  submitting/actionSubmission -->|action redirected| loading/actionRedirect
+  loading/actionRedirect -.-> T3{{transition}}
   loading/actionReload -.-> |loaders redirected| T3{{transition}}
   end
   T3{{transition}} -.-> idle/done

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -747,6 +747,7 @@ This is the type of state the fetcher is in. It's like `fetcher.state`, but more
 - `state === "loading"`
 
   - **actionReload** - The action from an "actionSubmission" returned data and the loaders on the page are being reloaded.
+  - **actionSubmissionRedirect** - The action from an "actionSubmission" returned a redirect and the page is transitioning to the new location.
   - **load** - A route's loader is being called without a submission (`fetcher.load()`).
 
 #### `fetcher.submission`

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -747,7 +747,7 @@ This is the type of state the fetcher is in. It's like `fetcher.state`, but more
 - `state === "loading"`
 
   - **actionReload** - The action from an "actionSubmission" returned data and the loaders on the page are being reloaded.
-  - **actionSubmissionRedirect** - The action from an "actionSubmission" returned a redirect and the page is transitioning to the new location.
+  - **actionRedirect** - The action from an "actionSubmission" returned a redirect and the page is transitioning to the new location.
   - **load** - A route's loader is being called without a submission (`fetcher.load()`).
 
 #### `fetcher.submission`

--- a/packages/remix-react/__tests__/transition-test.tsx
+++ b/packages/remix-react/__tests__/transition-test.tsx
@@ -1331,20 +1331,23 @@ describe("fetcher redirects", () => {
   test("action fetch", async () => {
     let t = setup({ url: "/foo" });
     let A = t.fetch.post("/foo");
+    expect(t.getFetcher(A.key).state).toBe("submitting");
+    expect(t.getFetcher(A.key).type).toBe("actionSubmission");
     let AR = await A.action.redirect("/bar");
+    expect(t.getFetcher(A.key).state).toBe("loading");
+    expect(t.getFetcher(A.key).type).toBe("actionSubmissionRedirect");
+    let state = t.getState();
+    expect(state.transition.type).toBe("fetchActionRedirect");
+    expect(state.transition.location).toBe(AR.location);
+    await AR.loader.resolve("stuff");
     expect(t.getFetcher(A.key)).toMatchInlineSnapshot(`
       Object {
-        "data": TransitionRedirect {
-          "location": "/bar",
-        },
+        "data": undefined,
         "state": "idle",
         "submission": undefined,
         "type": "done",
       }
     `);
-    let state = t.getState();
-    expect(state.transition.type).toBe("fetchActionRedirect");
-    expect(state.transition.location).toBe(AR.location);
   });
 });
 

--- a/packages/remix-react/__tests__/transition-test.tsx
+++ b/packages/remix-react/__tests__/transition-test.tsx
@@ -1335,7 +1335,7 @@ describe("fetcher redirects", () => {
     expect(t.getFetcher(A.key).type).toBe("actionSubmission");
     let AR = await A.action.redirect("/bar");
     expect(t.getFetcher(A.key).state).toBe("loading");
-    expect(t.getFetcher(A.key).type).toBe("actionSubmissionRedirect");
+    expect(t.getFetcher(A.key).type).toBe("actionRedirect");
     let state = t.getState();
     expect(state.transition.type).toBe("fetchActionRedirect");
     expect(state.transition.location).toBe(AR.location);

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -221,6 +221,12 @@ type FetcherStates<TData = any> = {
     submission: ActionSubmission;
     data: TData;
   };
+  LoadingSubmissionActionRedirect: {
+    state: "loading";
+    type: "actionSubmissionRedirect";
+    submission: ActionSubmission;
+    data: undefined;
+  };
   Loading: {
     state: "loading";
     type: "normalLoad";
@@ -406,6 +412,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
   let incrementingLoadId = 0;
   let navigationLoadId = -1;
   let fetchReloadIds = new Map<string, number>();
+  let fetchRedirectIds = new Set<string>();
 
   let matches = matchClientRoutes(routes, init.location);
 
@@ -468,6 +475,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
     console.debug(`[transition] deleting fetcher (key: ${key})`);
     if (fetchControllers.has(key)) abortFetcher(key);
     fetchReloadIds.delete(key);
+    fetchRedirectIds.delete(key);
     state.fetchers.delete(key);
   }
 
@@ -620,14 +628,15 @@ export function createTransitionManager(init: TransitionManagerInit) {
         isRedirect: true,
         type: "fetchAction",
       };
+      fetchRedirectIds.add(key);
       init.onRedirect(result.value.location, locationState);
-      let doneFetcher: FetcherStates["Done"] = {
-        state: "idle",
-        type: "done",
-        data: result.value,
-        submission: undefined,
+      let loadingFetcher: FetcherStates["LoadingSubmissionActionRedirect"] = {
+        state: "loading",
+        type: "actionSubmissionRedirect",
+        submission,
+        data: undefined,
       };
-      setFetcher(key, doneFetcher);
+      setFetcher(key, loadingFetcher);
       update({ fetchers: new Map(state.fetchers) });
       return;
     }
@@ -1261,6 +1270,8 @@ export function createTransitionManager(init: TransitionManagerInit) {
       maybeActionErrorResult
     );
 
+    markFetchRedirectsDone();
+
     let abortedIds = abortStaleFetchLoads(navigationLoadId);
     if (abortedIds) {
       console.debug(
@@ -1297,6 +1308,19 @@ export function createTransitionManager(init: TransitionManagerInit) {
     invariant(controller, `Expected fetch controller: ${key}`);
     controller.abort();
     fetchControllers.delete(key);
+  }
+
+  function markFetchRedirectsDone(): void {
+    let doneKeys = [];
+    for (let key of fetchRedirectIds) {
+      let fetcher = state.fetchers.get(key);
+      invariant(fetcher, `Expected fetcher: ${key}`);
+      if (fetcher.type === "actionSubmissionRedirect") {
+        fetchRedirectIds.delete(key);
+        doneKeys.push(key);
+      }
+    }
+    markFetchersDone(doneKeys);
   }
 
   return {

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -221,9 +221,9 @@ type FetcherStates<TData = any> = {
     submission: ActionSubmission;
     data: TData;
   };
-  LoadingSubmissionActionRedirect: {
+  LoadingActionRedirect: {
     state: "loading";
-    type: "actionSubmissionRedirect";
+    type: "actionRedirect";
     submission: ActionSubmission;
     data: undefined;
   };
@@ -630,9 +630,9 @@ export function createTransitionManager(init: TransitionManagerInit) {
       };
       fetchRedirectIds.add(key);
       init.onRedirect(result.value.location, locationState);
-      let loadingFetcher: FetcherStates["LoadingSubmissionActionRedirect"] = {
+      let loadingFetcher: FetcherStates["LoadingActionRedirect"] = {
         state: "loading",
-        type: "actionSubmissionRedirect",
+        type: "actionRedirect",
         submission,
         data: undefined,
       };
@@ -1315,7 +1315,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
     for (let key of fetchRedirectIds) {
       let fetcher = state.fetchers.get(key);
       invariant(fetcher, `Expected fetcher: ${key}`);
-      if (fetcher.type === "actionSubmissionRedirect") {
+      if (fetcher.type === "actionRedirect") {
         fetchRedirectIds.delete(key);
         doneKeys.push(key);
       }


### PR DESCRIPTION
### ~~Dependent on #2194~~

- [x] Docs - [preview](https://github.com/remix-run/remix/blob/matt/fetcher-redirect/DEVELOPMENT.md#transition-manager-flows)
- [x] Tests
