### PR TITLE
fix(remix-server-runtime): add `X-Remix-Catch` to immutable headers

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -285,6 +285,7 @@
 - raulrpearson
 - real34
 - reggie3
+- rkusa
 - rlfarman
 - roachjc
 - robindrost

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -43,7 +43,13 @@ export async function callRouteAction({
     }
 
     if (!isRedirectResponse(error)) {
-      error.headers.set("X-Remix-Catch", "yes");
+      let headers = new Headers(error.headers);
+      headers.set("X-Remix-Catch", "yes");
+      return new Response(error.body, {
+        status: error.status,
+        statusText: error.statusText,
+        headers,
+      });
     }
     result = error;
   }
@@ -90,7 +96,13 @@ export async function callRouteLoader({
     }
 
     if (!isRedirectResponse(error)) {
-      error.headers.set("X-Remix-Catch", "yes");
+      let headers = new Headers(error.headers);
+      headers.set("X-Remix-Catch", "yes");
+      return new Response(error.body, {
+        status: error.status,
+        statusText: error.statusText,
+        headers,
+      });
     }
     result = error;
   }


### PR DESCRIPTION
I am running Remix on Cloudflare Workers where I am receiving:

```
Can't modify immutable headers.
```

when throwing an error response in a loader. I've tracked the error down to the code setting a `X-Remix-Catch` header. This PR updates the code to create a new `Headers` and `Response` instance instead of trying to modify the existing `headers` instance which seems to be immutable on Cloudflare.