### PR TITLE
docs(jokes): add example code to test error boundaries

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -130,6 +130,7 @@
 - joshball
 - jssisodiya
 - juhanakristian
+- justinnoel
 - juwiragiye
 - jvnm-dev
 - kalch

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -4065,7 +4065,9 @@ export function ErrorBoundary() {
 
 Ok great, with those in place, let's check what happens when there's an error. Go ahead and just add this to the default component, loader, or action of each of the routes.
 
-`throw "Testing Error Boundary"`
+```ts
+throw new Error("Testing Error Boundary")
+```
 
 Here's what I get:
 

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -4063,7 +4063,11 @@ export function ErrorBoundary() {
 
 </details>
 
-Ok great, with those in place, let's check what happens when there's an error. Go ahead and just add this to the default component, loader, or action of each of the routes. Here's what I get:
+Ok great, with those in place, let's check what happens when there's an error. Go ahead and just add this to the default component, loader, or action of each of the routes.
+
+`throw "Testing Error Boundary"`
+
+Here's what I get:
 
 ![App error](/jokes-tutorial/img/app-level-error.png)
 


### PR DESCRIPTION
This fixes a minor issue in the Jokes tutorial. In the [error boundaries section](https://remix.run/docs/en/v1/tutorials/jokes#unexpected-errors), it says:

> Ok great, with those in place, let's check what happens when there's an error. Go ahead and just add this to the default component, loader, or action of each of the routes. Here's what I get:

This indicates there should be some code sample for the user to add to the code. However, none is provided.

This PR simply adds some.

See also: https://github.com/remix-run/remix/pull/530#issuecomment-976873148