### PR TITLE
chore: add local debugging logs for transition manager

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -114,7 +114,7 @@ REMIX_DEBUG=true yarn watch
 
 **`REMIX_LOCAL_DEV_OUTPUT_DIRECTORY`**
 
-When developing Remix locally, you often need to go beyond unit/integration tests and test your changes in a local Remix application. The easiest way to do this is to run your local Remix build and use this environment variable to direct `rollup` to write the output files directly into the local remix application's `node_modules` folder. Then you just need to restart your local Remix application serve to pick up the changes.
+When developing Remix locally, you often need to go beyond unit/integration tests and test your changes in a local Remix application. The easiest way to do this is to run your local Remix build and use this environment variable to direct `rollup` to write the output files directly into the local Remix application's `node_modules` folder. Then you just need to restart your local Remix application server to pick up the changes.
 
 ```sh
 # Tab 1 - create an run a local remix application
@@ -126,4 +126,4 @@ npm run dev
 REMIX_LOCAL_DEV_OUTPUT_DIRECTORY=../my-remix-app yarn watch
 ```
 
-Now - any time you make changes in the Remix repository, they'll write out to the appropriate locations in `my-remix-app/node_modules` and you can restart the `npm run dev` command to pick them up 🎉.
+Now - any time you make changes in the Remix repository, the they will be written out to the appropriate locations in `../my-remix-app/node_modules` and you can restart the `npm run dev` command to pick them up 🎉.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -97,3 +97,33 @@ git commit -m "fix: squashed a super gnarly bug"
 yarn run version patch
 yarn run publish
 ```
+
+## Local Development Tips and Tricks
+
+### Environment Variables
+
+This repository supports handful of environment variables to streamline the local development/testing process.
+
+**`REMIX_DEBUG`**
+
+By default, the Remix `rollup` build will strip any `console.debug` calls to avoid cluttering up the console during application usage. These `console.debug` statements can be preserved by setting `REMIX_DEBUG=true` during your local build.
+
+```sh
+REMIX_DEBUG=true yarn watch
+```
+
+**`REMIX_LOCAL_DEV_OUTPUT_DIRECTORY`**
+
+When developing Remix locally, you often need to go beyond unit/integration tests and test your changes in a local Remix application. The easiest way to do this is to run your local Remix build and use this environment variable to direct `rollup` to write the output files directly into the local remix application's `node_modules` folder. Then you just need to restart your local Remix application serve to pick up the changes.
+
+```sh
+# Tab 1 - create an run a local remix application
+npx create-remix
+cd my-remix-app
+npm run dev
+
+# Tab 2 - remix repository
+REMIX_LOCAL_DEV_OUTPUT_DIRECTORY=../my-remix-app yarn watch
+```
+
+Now - any time you make changes in the Remix repository, they'll write out to the appropriate locations in `my-remix-app/node_modules` and you can restart the `npm run dev` command to pick them up 🎉.

--- a/babel.config.js
+++ b/babel.config.js
@@ -14,5 +14,14 @@ module.exports = {
   plugins: [
     "@babel/plugin-proposal-export-namespace-from",
     "@babel/plugin-proposal-optional-chaining",
+    // Strip console.debug calls unless REMIX_DEBUG=true
+    ...(process.env.REMIX_DEBUG === "true"
+      ? []
+      : [
+          [
+            "transform-remove-console",
+            { exclude: ["error", "warn", "log", "info"] },
+          ],
+        ]),
   ],
 };

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "abort-controller": "^3.0.0",
     "abortcontroller-polyfill": "^1.7.3",
     "aws-sdk": "^2.1055.0",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "chalk": "^4.1.0",
     "cheerio": "^1.0.0-rc.3",
     "concurrently": "^7.0.0",

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -9,6 +9,10 @@ import type { ClientRoute } from "./routes";
 import { matchClientRoutes } from "./routeMatching";
 import invariant from "./invariant";
 
+////////////////////////////////////////////////////////////////////////////////
+//#region Types and Utils
+////////////////////////////////////////////////////////////////////////////////
+
 export interface CatchData<T = any> {
   status: number;
   statusText: string;
@@ -280,7 +284,6 @@ export type FetcherEvent = {
 
 export type DataEvent = NavigationEvent | FetcherEvent;
 
-////////////////////////////////////////////////////////////////////////////////
 function isActionSubmission(
   submission: Submission
 ): submission is ActionSubmission {
@@ -390,7 +393,11 @@ export const IDLE_FETCHER: FetcherStates["Idle"] = {
   data: undefined,
   submission: undefined,
 };
+//#endregion
 
+////////////////////////////////////////////////////////////////////////////////
+//#region createTransitionManager
+////////////////////////////////////////////////////////////////////////////////
 export function createTransitionManager(init: TransitionManagerInit) {
   let { routes } = init;
 
@@ -1236,7 +1243,10 @@ export function createTransitionManager(init: TransitionManagerInit) {
     },
   };
 }
+//#endregion
 
+////////////////////////////////////////////////////////////////////////////////
+//#region createTransitionManager sub-functions
 ////////////////////////////////////////////////////////////////////////////////
 function isIndexRequestAction(action: string) {
   let indexRequest = false;
@@ -1574,3 +1584,4 @@ function isErrorResult(result: DataResult) {
 function createUrl(href: string) {
   return new URL(href, window.location.origin);
 }
+//#endregion

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -440,6 +440,9 @@ export function createTransitionManager(init: TransitionManagerInit) {
       console.debug(
         `[transition] transition set to ${updates.transition.state}/${updates.transition.type}`
       );
+      if (updates.transition === IDLE_TRANSITION) {
+        pendingNavigationController = undefined;
+      }
     }
 
     state = Object.assign({}, state, updates);
@@ -1285,10 +1288,6 @@ export function createTransitionManager(init: TransitionManagerInit) {
     if (pendingNavigationController) {
       console.debug(`[transition] aborting pending navigation`);
       pendingNavigationController.abort();
-      // TODO: Should this be cleared now so it doesn't stick around for
-      // subsequent navigations and make logs look weird?
-      // Or just remove this log?
-      // pendingNavigationController = undefined;
     }
   }
 

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -436,6 +436,12 @@ export function createTransitionManager(init: TransitionManagerInit) {
   };
 
   function update(updates: Partial<TransitionManagerState>) {
+    if (updates.transition) {
+      console.debug(
+        `[transition] transition set to ${updates.transition.state}/${updates.transition.type}`
+      );
+    }
+
     state = Object.assign({}, state, updates);
     init.onChange(state);
   }
@@ -446,6 +452,13 @@ export function createTransitionManager(init: TransitionManagerInit) {
 
   function getFetcher<TData = any>(key: string): Fetcher<TData> {
     return state.fetchers.get(key) || IDLE_FETCHER;
+  }
+
+  function setFetcher(key: string, fetcher: Fetcher): void {
+    console.debug(
+      `[transition] fetcher set to ${fetcher.state}/${fetcher.type} (key: ${key})`
+    );
+    state.fetchers.set(key, fetcher);
   }
 
   function deleteFetcher(key: string): void {
@@ -557,7 +570,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
       submission,
       data: currentFetcher?.data || undefined,
     };
-    state.fetchers.set(key, fetcher);
+    setFetcher(key, fetcher);
 
     update({ fetchers: new Map(state.fetchers) });
 
@@ -581,7 +594,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
         data: result.value,
         submission: undefined,
       };
-      state.fetchers.set(key, doneFetcher);
+      setFetcher(key, doneFetcher);
       update({ fetchers: new Map(state.fetchers) });
       return;
     }
@@ -600,7 +613,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
       data: result.value,
       submission,
     };
-    state.fetchers.set(key, loadFetcher);
+    setFetcher(key, loadFetcher);
 
     update({ fetchers: new Map(state.fetchers) });
 
@@ -660,7 +673,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
       data: result.value,
       submission: undefined,
     };
-    state.fetchers.set(key, doneFetcher);
+    setFetcher(key, doneFetcher);
 
     let abortedKeys = abortStaleFetchLoads(loadId);
     if (abortedKeys) {
@@ -718,7 +731,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
         data: fetcher.data,
         submission: undefined,
       };
-      state.fetchers.set(key, doneFetcher);
+      setFetcher(key, doneFetcher);
     }
   }
 
@@ -752,7 +765,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
       data: currentFetcher?.data || undefined,
     };
 
-    state.fetchers.set(key, fetcher);
+    setFetcher(key, fetcher);
     update({ fetchers: new Map(state.fetchers) });
 
     let controller = new AbortController();
@@ -787,7 +800,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
       data: result.value,
       submission: undefined,
     };
-    state.fetchers.set(key, doneFetcher);
+    setFetcher(key, doneFetcher);
 
     update({ fetchers: new Map(state.fetchers) });
   }
@@ -813,7 +826,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
       data: currentFetcher?.data || undefined,
     };
 
-    state.fetchers.set(key, fetcher);
+    setFetcher(key, fetcher);
     update({ fetchers: new Map(state.fetchers) });
 
     let controller = new AbortController();
@@ -846,7 +859,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
       data: result.value,
       submission: undefined,
     };
-    state.fetchers.set(key, doneFetcher);
+    setFetcher(key, doneFetcher);
 
     update({ fetchers: new Map(state.fetchers) });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3215,6 +3215,11 @@ babel-plugin-polyfill-regenerator@^0.3.0:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.1"
 
+babel-plugin-transform-remove-console@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz#b980360c067384e24b357a588d807d3c83527780"
+  integrity sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=
+
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz"


### PR DESCRIPTION
This adds a bunch of helpful `console.debug` statements to the transition manager to help debug the heavily async nature of it.  To avoid cluttering the console in normal application usage, I added https://babeljs.io/docs/en/babel-plugin-transform-remove-console/ to strip all `console.debug` statements during the build.  For local development, setting `REMIX_DEBUG=true` will leave them in for debugging.

<img width="454" alt="Screen Shot 2022-03-03 at 9 31 53 AM" src="https://user-images.githubusercontent.com/1609022/156585272-b6ebc2db-60e5-4410-b596-dad025e14865.png">


- [x] Docs - [preview](https://github.com/remix-run/remix/blob/matt/transition-debug/DEVELOPMENT.md#local-development-tips-and-tricks)
- [x] Tests - n/a
