### PR TITLE
docs(examples): remove `devServerPort` from `remix.config.js`

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -18,7 +18,6 @@ This file has a few build and development configuration options, but does not ac
 module.exports = {
   appDirectory: "app",
   assetsBuildDirectory: "public/build",
-  devServerPort: 8002,
   ignoredRouteFiles: [".*"],
   publicPath: "/build/",
   routes(defineRoutes) {
@@ -153,7 +152,6 @@ module.exports = {
   assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "build",
-  devServerPort: 8002,
   ignoredRouteFiles: [".*"],
   serverDependenciesToBundle: [
     /^rehype.*/,

--- a/examples/gdpr-cookie-consent/remix.config.js
+++ b/examples/gdpr-cookie-consent/remix.config.js
@@ -6,5 +6,4 @@ module.exports = {
   browserBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "build",
-  devServerPort: 8002,
 };

--- a/examples/graphql-api/remix.config.js
+++ b/examples/graphql-api/remix.config.js
@@ -6,5 +6,4 @@ module.exports = {
   browserBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "build",
-  devServerPort: 8002,
 };

--- a/examples/jokes/remix.config.js
+++ b/examples/jokes/remix.config.js
@@ -6,6 +6,5 @@ module.exports = {
   assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "build",
-  devServerPort: 8003,
   ignoredRouteFiles: [".*"],
 };

--- a/examples/remix-auth-supabase-github/remix.config.js
+++ b/examples/remix-auth-supabase-github/remix.config.js
@@ -6,5 +6,4 @@ module.exports = {
   browserBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "build",
-  devServerPort: 8002,
 };

--- a/examples/stitches/remix.config.js
+++ b/examples/stitches/remix.config.js
@@ -6,6 +6,5 @@ module.exports = {
   assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "build",
-  devServerPort: 8002,
   ignoredRouteFiles: [".*"],
 };

--- a/fixtures/gists-app/remix.config.js
+++ b/fixtures/gists-app/remix.config.js
@@ -9,7 +9,6 @@ module.exports = {
   publicBuildDirectory: "./public/build",
   publicPath: "/build/",
   serverBuildDirectory: "./build",
-  devServerPort: 8002,
   ignoredRouteFiles: [".*", "blargh.ts"],
   server: "./server.js",
 


### PR DESCRIPTION
As suggested by @kentcdodds in https://github.com/remix-run/remix/pull/2158#discussion_r818948749