### PR TITLE
docs(create-remix): remove `devServerPort` from `remix.config.js` in templates

### DIFF
--- a/packages/create-remix/templates/arc-stack/remix.config.js
+++ b/packages/create-remix/templates/arc-stack/remix.config.js
@@ -6,6 +6,5 @@ module.exports = {
   assetsBuildDirectory: "public/build",
   publicPath: "/_static/build/",
   serverBuildDirectory: "server/build",
-  devServerPort: 8002,
   ignoredRouteFiles: [".*"],
 };

--- a/packages/create-remix/templates/arc/remix.config.js
+++ b/packages/create-remix/templates/arc/remix.config.js
@@ -9,5 +9,4 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "server/index.js",
   // publicPath: "/_static/build/",
-  // devServerPort: 8002
 };

--- a/packages/create-remix/templates/cloudflare-pages/remix.config.js
+++ b/packages/create-remix/templates/cloudflare-pages/remix.config.js
@@ -10,5 +10,4 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "functions/[[path]].js",
   // publicPath: "/build/",
-  // devServerPort: 8002
 };

--- a/packages/create-remix/templates/cloudflare-workers/remix.config.js
+++ b/packages/create-remix/templates/cloudflare-workers/remix.config.js
@@ -10,5 +10,4 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
-  // devServerPort: 8002
 };

--- a/packages/create-remix/templates/deno/remix.config.js
+++ b/packages/create-remix/templates/deno/remix.config.js
@@ -10,5 +10,4 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
-  // devServerPort: 8002
 };

--- a/packages/create-remix/templates/express/remix.config.js
+++ b/packages/create-remix/templates/express/remix.config.js
@@ -9,5 +9,4 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
-  // devServerPort: 8002
 };

--- a/packages/create-remix/templates/fly-stack/remix.config.js
+++ b/packages/create-remix/templates/fly-stack/remix.config.js
@@ -6,6 +6,5 @@ module.exports = {
   assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildDirectory: "build",
-  devServerPort: 8002,
   ignoredRouteFiles: [".*"],
 };

--- a/packages/create-remix/templates/fly/remix.config.js
+++ b/packages/create-remix/templates/fly/remix.config.js
@@ -7,5 +7,4 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
-  // devServerPort: 8002
 };

--- a/packages/create-remix/templates/netlify/remix.config.js
+++ b/packages/create-remix/templates/netlify/remix.config.js
@@ -9,5 +9,4 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "netlify/functions/server/index.js",
   // publicPath: "/build/",
-  // devServerPort: 8002
 };

--- a/packages/create-remix/templates/remix/remix.config.js
+++ b/packages/create-remix/templates/remix/remix.config.js
@@ -7,5 +7,4 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
-  // devServerPort: 8002
 };

--- a/packages/create-remix/templates/vercel/remix.config.js
+++ b/packages/create-remix/templates/vercel/remix.config.js
@@ -12,5 +12,4 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "api/index.js",
   // publicPath: "/build/",
-  // devServerPort: 8002
 };


### PR DESCRIPTION
As suggested by @kentcdodds in https://github.com/remix-run/remix/pull/2158#discussion_r818948749