### PR TITLE
docs(examples/templates): remove `$` from command lines

### DIFF
--- a/docs/other-api/dev.md
+++ b/docs/other-api/dev.md
@@ -34,7 +34,7 @@ import {} from "remix";
 Builds your app for production. No need to add `NODE_ENV=production` to the command.
 
 ```sh
-$ remix build
+remix build
 ```
 
 ### `remix watch`
@@ -42,7 +42,7 @@ $ remix build
 Watches your application files and builds your app for development when files change.
 
 ```sh
-$ remix watch
+remix watch
 ```
 
 ### `remix dev`
@@ -50,5 +50,5 @@ $ remix watch
 Same as `watch` but also boots the [Remix app server](serve.md) in development mode if it's installed.
 
 ```sh
-$ remix dev
+remix dev
 ```

--- a/examples/bullmq-task-queue/README.md
+++ b/examples/bullmq-task-queue/README.md
@@ -11,9 +11,9 @@ Open this example on [CodeSandbox](https://codesandbox.com):
 ## Usages
 
 - Use your existing redis server or [install new redis server](https://redis.io/topics/quickstart) or [start redis server with docker](https://hub.docker.com/_/redis).
-- Duplicate the local `.env.example` file to `.env` and change the REDIS_URL environment variable to your redis server URL.
-- Run `$ npm install`
-- Run `$ npm run dev`
+- Duplicate the local `.env.example` file to `.env` and change the `REDIS_URL` environment variable to your redis server URL.
+- Run `npm install`
+- Run `npm run dev`
 
 ## Relevant files:
 

--- a/examples/graphql-api/README.md
+++ b/examples/graphql-api/README.md
@@ -6,8 +6,8 @@ This example demonstrates using the [Fetch API][link-fetch] to query a [GraphQL]
 
 - Setup the `GRAPHQL_API` environment variable
   - See the [Remix docs](/docs/guides/envvars) for some suggested patterns
-- Run `$ npm install`
-- And start the example with `$ npm run dev`
+- Run `npm install`
+- And start the example with `npm run dev`
 - Visit [http://localhost:3000](http://localhost:3000) in your browser.
 
 ## Preview

--- a/examples/ioredis/README.md
+++ b/examples/ioredis/README.md
@@ -11,9 +11,9 @@ Open this example on [CodeSandbox](https://codesandbox.com):
 ## Usages
 
 - Use your existing redis server or [install new redis server](https://redis.io/topics/quickstart) or [start redis server with docker](https://hub.docker.com/_/redis).
-- Duplicate the local `.env.example` file to `.env` and change the REDIS_URL environment variable to your redis server URL.
-- Run `$ npm install`
-- Run `$ npm run dev`
+- Duplicate the local `.env.example` file to `.env` and change the `REDIS_URL` environment variable to your redis server URL.
+- Run `npm install`
+- Run `npm run dev`
 
 ## Relevant files:
 

--- a/examples/redis-upstash-session/README.md
+++ b/examples/redis-upstash-session/README.md
@@ -18,8 +18,8 @@ Sorry no preview as you'll need an account on Upstash for it
 - Create a new Redis database
 - Duplicate the local `.env.example` file to `.env` and change the URL & Token environment variables
   with your database info.
-- Run `$ npm install`
-- Run `$ npm run dev`
+- Run `npm install`
+- Run `npm run dev`
 
 ## Usage
 

--- a/templates/arc-ts/README.md
+++ b/templates/arc-ts/README.md
@@ -12,7 +12,7 @@ When deploying to AWS Lambda with Architect, you'll need:
 Architect recommends installing these globally:
 
 ```sh
-$ npm i -g @architect/architect aws-sdk
+npm i -g @architect/architect aws-sdk
 ```
 
 ## Development
@@ -24,10 +24,10 @@ You will be running two processes during development when using Architect as you
 
 ```sh
 # in one tab
-$ arc sandbox
+arc sandbox
 
 # in another
-$ npm run dev
+npm run dev
 ```
 
 Open up [http://localhost:3333](http://localhost:3333) and you should be ready to go!
@@ -46,13 +46,13 @@ If you make it through all of that, you're ready to deploy!
 1. build the app for production:
 
    ```sh
-   $ npm run build
+   npm run build
    ```
 
 2. Deploy with `arc`
 
    ```sh
-   $ arc deploy production
+   arc deploy production
    ```
 
 You're in business!

--- a/templates/arc/README.md
+++ b/templates/arc/README.md
@@ -12,7 +12,7 @@ When deploying to AWS Lambda with Architect, you'll need:
 Architect recommends installing these globally:
 
 ```sh
-$ npm i -g @architect/architect aws-sdk
+npm i -g @architect/architect aws-sdk
 ```
 
 ## Development
@@ -24,10 +24,10 @@ You will be running two processes during development when using Architect as you
 
 ```sh
 # in one tab
-$ arc sandbox
+arc sandbox
 
 # in another
-$ npm run dev
+npm run dev
 ```
 
 Open up [http://localhost:3333](http://localhost:3333) and you should be ready to go!
@@ -46,13 +46,13 @@ If you make it through all of that, you're ready to deploy!
 1. build the app for production:
 
    ```sh
-   $ npm run build
+   npm run build
    ```
 
 2. Deploy with `arc`
 
    ```sh
-   $ arc deploy production
+   arc deploy production
    ```
 
 You're in business!

--- a/templates/cloudflare-pages-ts/README.md
+++ b/templates/cloudflare-pages-ts/README.md
@@ -8,7 +8,7 @@ You will be utilizing Wrangler for local development to emulate the Cloudflare r
 
 ```sh
 # start the remix dev server and wrangler
-$ npm run dev
+npm run dev
 ```
 
 Open up [http://127.0.0.1:8788](http://127.0.0.1:8788) and you should be ready to go!

--- a/templates/cloudflare-pages/README.md
+++ b/templates/cloudflare-pages/README.md
@@ -8,7 +8,7 @@ You will be utilizing Wrangler for local development to emulate the Cloudflare r
 
 ```sh
 # start the remix dev server and wrangler
-$ npm run dev
+npm run dev
 ```
 
 Open up [http://127.0.0.1:8788](http://127.0.0.1:8788) and you should be ready to go!

--- a/templates/cloudflare-workers-ts/README.md
+++ b/templates/cloudflare-workers-ts/README.md
@@ -12,7 +12,7 @@ You will be running two processes during development:
 Both are started with one command:
 
 ```sh
-$ npm run dev
+npm run dev
 ```
 
 Open up [http://127.0.0.1:8787](http://127.0.0.1:8787) and you should be ready to go!
@@ -20,8 +20,8 @@ Open up [http://127.0.0.1:8787](http://127.0.0.1:8787) and you should be ready t
 If you want to check the production build, you can stop the dev server and run following commands:
 
 ```sh
-$ npm run build
-$ npm start
+npm run build
+npm start
 ```
 
 Then refresh the same URL in your browser (no live reload for production builds).

--- a/templates/cloudflare-workers/README.md
+++ b/templates/cloudflare-workers/README.md
@@ -12,7 +12,7 @@ You will be running two processes during development:
 Both are started with one command:
 
 ```sh
-$ npm run dev
+npm run dev
 ```
 
 Open up [http://127.0.0.1:8787](http://127.0.0.1:8787) and you should be ready to go!
@@ -20,8 +20,8 @@ Open up [http://127.0.0.1:8787](http://127.0.0.1:8787) and you should be ready t
 If you want to check the production build, you can stop the dev server and run following commands:
 
 ```sh
-$ npm run build
-$ npm start
+npm run build
+npm start
 ```
 
 Then refresh the same URL in your browser (no live reload for production builds).

--- a/templates/netlify-ts/README.md
+++ b/templates/netlify-ts/README.md
@@ -43,10 +43,10 @@ Open up [http://localhost:3000](http://localhost:3000), and you should be ready 
 There are two ways to deploy your app to Netlify, you can either link your app to your git repo and have it auto deploy changes to Netlify, or you can deploy your app manually. If you've followed the setup instructions already, all you need to do is run this:
 
 ```sh
-$ npm run build
+npm run build
 # preview deployment
-$ netlify deploy
+netlify deploy
 
 # production deployment
-$ netlify deploy --prod
+netlify deploy --prod
 ```

--- a/templates/netlify/README.md
+++ b/templates/netlify/README.md
@@ -43,10 +43,10 @@ Open up [http://localhost:3000](http://localhost:3000), and you should be ready 
 There are two ways to deploy your app to Netlify, you can either link your app to your git repo and have it auto deploy changes to Netlify, or you can deploy your app manually. If you've followed the setup instructions already, all you need to do is run this:
 
 ```sh
-$ npm run build
+npm run build
 # preview deployment
-$ netlify deploy
+netlify deploy
 
 # production deployment
-$ netlify deploy --prod
+netlify deploy --prod
 ```


### PR DESCRIPTION
This makes the commands easier to copy/paste in your own terminal