### PR TITLE
chore: remove `$` from command lines

### DIFF
--- a/packages/create-remix/README.md
+++ b/packages/create-remix/README.md
@@ -5,7 +5,7 @@
 To get started, open a new shell and run:
 
 ```sh
-$ npx create-remix@latest
+npx create-remix@latest
 ```
 
 Then follow the prompts you see in your terminal.

--- a/packages/remix-architect/README.md
+++ b/packages/remix-architect/README.md
@@ -5,7 +5,7 @@
 To get started, open a new shell and run:
 
 ```sh
-$ npx create-remix@latest
+npx create-remix@latest
 ```
 
 Then follow the prompts you see in your terminal.

--- a/packages/remix-cloudflare-pages/README.md
+++ b/packages/remix-cloudflare-pages/README.md
@@ -5,7 +5,7 @@
 To get started, open a new shell and run:
 
 ```sh
-$ npx create-remix@latest
+npx create-remix@latest
 ```
 
 Then follow the prompts you see in your terminal.

--- a/packages/remix-cloudflare-workers/README.md
+++ b/packages/remix-cloudflare-workers/README.md
@@ -5,7 +5,7 @@
 To get started, open a new shell and run:
 
 ```sh
-$ npx create-remix@latest
+npx create-remix@latest
 ```
 
 Then follow the prompts you see in your terminal.

--- a/packages/remix-dev/README.md
+++ b/packages/remix-dev/README.md
@@ -5,7 +5,7 @@
 To get started, open a new shell and run:
 
 ```sh
-$ npx create-remix@latest
+npx create-remix@latest
 ```
 
 Then follow the prompts you see in your terminal.

--- a/packages/remix-express/README.md
+++ b/packages/remix-express/README.md
@@ -5,7 +5,7 @@
 To get started, open a new shell and run:
 
 ```sh
-$ npx create-remix@latest
+npx create-remix@latest
 ```
 
 Then follow the prompts you see in your terminal.

--- a/packages/remix-netlify/README.md
+++ b/packages/remix-netlify/README.md
@@ -5,7 +5,7 @@
 To get started, open a new shell and run:
 
 ```sh
-$ npx create-remix@latest
+npx create-remix@latest
 ```
 
 Then follow the prompts you see in your terminal.

--- a/packages/remix-node/README.md
+++ b/packages/remix-node/README.md
@@ -5,7 +5,7 @@
 To get started, open a new shell and run:
 
 ```sh
-$ npx create-remix@latest
+npx create-remix@latest
 ```
 
 Then follow the prompts you see in your terminal.

--- a/packages/remix-react/README.md
+++ b/packages/remix-react/README.md
@@ -5,7 +5,7 @@
 To get started, open a new shell and run:
 
 ```sh
-$ npx create-remix@latest
+npx create-remix@latest
 ```
 
 Then follow the prompts you see in your terminal.

--- a/packages/remix-serve/README.md
+++ b/packages/remix-serve/README.md
@@ -5,7 +5,7 @@
 To get started, open a new shell and run:
 
 ```sh
-$ npx create-remix@latest
+npx create-remix@latest
 ```
 
 Then follow the prompts you see in your terminal.

--- a/packages/remix-server-runtime/README.md
+++ b/packages/remix-server-runtime/README.md
@@ -5,7 +5,7 @@
 To get started, open a new shell and run:
 
 ```sh
-$ npx create-remix@latest
+npx create-remix@latest
 ```
 
 Then follow the prompts you see in your terminal.

--- a/packages/remix-vercel/README.md
+++ b/packages/remix-vercel/README.md
@@ -5,7 +5,7 @@
 To get started, open a new shell and run:
 
 ```sh
-$ npx create-remix@latest
+npx create-remix@latest
 ```
 
 Then follow the prompts you see in your terminal.

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -5,7 +5,7 @@
 To get started, open a new shell and run:
 
 ```sh
-$ npx create-remix@latest
+npx create-remix@latest
 ```
 
 Then follow the prompts you see in your terminal.


### PR DESCRIPTION
Just like in #2204, this makes the commands easier to copy/paste in your own terminal

If wanted, I can also remove them from CLI helper texts
https://github.com/remix-run/remix/blob/0c8318a3fb00991a5dfde62514d9e1ffb0ee03f2/packages/remix-dev/cli.ts#L8-L11
https://github.com/remix-run/remix/blob/0c8318a3fb00991a5dfde62514d9e1ffb0ee03f2/packages/remix-dev/cli.ts#L24-L33