### PR TITLE
Update package.json for eslint-config

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -182,6 +182,7 @@
 - medayz
 - meetbryce
 - mehulmpt
+- memark
 - michaeldeboey
 - michaelfriedman
 - michaseel

--- a/packages/remix-eslint-config/package.json
+++ b/packages/remix-eslint-config/package.json
@@ -2,7 +2,11 @@
   "name": "@remix-run/eslint-config",
   "description": "ESLint configuration for Remix projects",
   "version": "1.2.3",
-  "repository": "https://github.com/remix-run/packages",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remix-run/remix",
+    "directory": "packages/remix-eslint-config"
+  }
   "main": "index.js",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
The current link on npm to the repository is incorrect. Updated it.

As per the syntax here
https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository

