### PR TITLE
chore: cleanup `.eslintrc` & fix ESLint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,18 +7,24 @@ module.exports = {
   ],
   overrides: [
     {
-      // all ```jsx & ```tsx code blocks in .md files
+      // all code blocks in .md files
       files: ["**/*.md/*.js", "**/*.md/*.jsx", "**/*.md/*.ts", "**/*.md/*.tsx"],
       rules: {
         "no-unreachable": "off",
+      },
+    },
+    {
+      // all React (.jsx & .tsx) code blocks in .md files
+      files: ["**/*.md/*.jsx", "**/*.md/*.tsx"],
+      rules: {
         "jsx-a11y/alt-text": "off",
         "jsx-a11y/anchor-has-content": "off",
-        "react/jsx-no-comment-textnodes": "off",
+
         "react/jsx-no-undef": "off",
       },
     },
     {
-      // all ```ts & ```tsx code blocks in .md files
+      // all TypeScript (.ts & .tsx) code blocks in .md files
       files: ["**/*.md/*.ts", "**/*.md/*.tsx"],
       rules: {
         "@typescript-eslint/no-unused-expressions": "off",
@@ -26,12 +32,10 @@ module.exports = {
       },
     },
     {
-      files: [
-        "packages/create-remix/templates/cloudflare-workers/**/*.js",
-        "packages/remix-cloudflare-workers/**/*.ts",
-      ],
+      // all test files
+      files: ["**/__tests__/**/*.ts", "**/__tests__/**/*.tsx"],
       rules: {
-        "no-restricted-globals": "off",
+        "jest/no-disabled-tests": "off",
       },
     },
     {
@@ -40,21 +44,10 @@ module.exports = {
         "jest/globals": true,
       },
     },
-    {
-      files: ["examples/**/*.js", "examples/**/*.jsx"],
-      rules: {
-        "no-unused-vars": "off",
-      },
-    },
-    {
-      files: ["examples/**/*.ts", "examples/**/*.tsx"],
-      rules: {
-        "@typescript-eslint/no-unused-vars": "off",
-      },
-    },
   ],
   rules: {
     "@typescript-eslint/consistent-type-imports": "error",
+
     "import/order": [
       "error",
       {
@@ -65,6 +58,5 @@ module.exports = {
         ],
       },
     ],
-    "jest/no-disabled-tests": "off",
   },
 };

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -59,7 +59,7 @@ In our effort to remove all loading states from your UI, `Link` can automaticall
 
 ```tsx
 <>
-  <Link /> // defaults to "none"
+  <Link /> {/* defaults to "none" */}
   <Link prefetch="none" />
   <Link prefetch="intent" />
   <Link prefetch="render" />

--- a/docs/pages/faq.md
+++ b/docs/pages/faq.md
@@ -181,10 +181,10 @@ If you still want to submit nested structures as well, you can use non-standard 
 
 ```tsx
 <>
-  // arrays with []
+  {/* arrays with [] */}
   <input name="category[]" value="comedy" />
   <input name="category[]" value="comedy" />
-  // nested structures parentKey[childKey]
+  {/* nested structures parentKey[childKey] */}
   <input name="user[name]" value="Ryan" />
 </>
 ```


### PR DESCRIPTION
This makes the `.eslintrc` file clearer + removes unnecessary rules (as they were already fixed)

---

This PR is for `main` branch