### PR TITLE
chore: cleanup `.eslintrc` & fix ESLint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,18 +7,24 @@ module.exports = {
   ],
   overrides: [
     {
-      // all ```jsx & ```tsx code blocks in .md files
+      // all code blocks in .md files
       files: ["**/*.md/*.js", "**/*.md/*.jsx", "**/*.md/*.ts", "**/*.md/*.tsx"],
       rules: {
         "no-unreachable": "off",
+      },
+    },
+    {
+      // all React (.jsx & .tsx) code blocks in .md files
+      files: ["**/*.md/*.jsx", "**/*.md/*.tsx"],
+      rules: {
         "jsx-a11y/alt-text": "off",
         "jsx-a11y/anchor-has-content": "off",
-        "react/jsx-no-comment-textnodes": "off",
+
         "react/jsx-no-undef": "off",
       },
     },
     {
-      // all ```ts & ```tsx code blocks in .md files
+      // all TypeScript (.ts & .tsx) code blocks in .md files
       files: ["**/*.md/*.ts", "**/*.md/*.tsx"],
       rules: {
         "@typescript-eslint/no-unused-expressions": "off",
@@ -26,12 +32,10 @@ module.exports = {
       },
     },
     {
-      files: [
-        "packages/create-remix/templates/cloudflare-workers/**/*.js",
-        "packages/remix-cloudflare-workers/**/*.ts",
-      ],
+      // all test files
+      files: ["**/__tests__/**/*.ts", "**/__tests__/**/*.tsx"],
       rules: {
-        "no-restricted-globals": "off",
+        "jest/no-disabled-tests": "off",
       },
     },
     {
@@ -40,21 +44,10 @@ module.exports = {
         "jest/globals": true,
       },
     },
-    {
-      files: ["examples/**/*.js", "examples/**/*.jsx"],
-      rules: {
-        "no-unused-vars": "off",
-      },
-    },
-    {
-      files: ["examples/**/*.ts", "examples/**/*.tsx"],
-      rules: {
-        "@typescript-eslint/no-unused-vars": "off",
-      },
-    },
   ],
   rules: {
     "@typescript-eslint/consistent-type-imports": "error",
+
     "import/order": [
       "error",
       {
@@ -65,6 +58,5 @@ module.exports = {
         ],
       },
     ],
-    "jest/no-disabled-tests": "off",
   },
 };

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -59,7 +59,7 @@ In our effort to remove all loading states from your UI, `Link` can automaticall
 
 ```tsx
 <>
-  <Link /> // defaults to "none"
+  <Link /> {/* defaults to "none" */}
   <Link prefetch="none" />
   <Link prefetch="intent" />
   <Link prefetch="render" />

--- a/docs/pages/faq.md
+++ b/docs/pages/faq.md
@@ -187,10 +187,10 @@ If you still want to submit nested structures as well, you can use non-standard 
 
 ```tsx
 <>
-  // arrays with []
+  {/* arrays with [] */}
   <input name="category[]" value="comedy" />
   <input name="category[]" value="comedy" />
-  // nested structures parentKey[childKey]
+  {/* nested structures parentKey[childKey] */}
   <input name="user[name]" value="Ryan" />
 </>
 ```

--- a/examples/bullmq-task-queue/app/queues/notifier.server.ts
+++ b/examples/bullmq-task-queue/app/queues/notifier.server.ts
@@ -25,7 +25,7 @@ export const queue: Queue =
 // They reach out to our redis connection and pull jobs off the queue
 // in an order determined by factors such as job priority, delay, etc.
 // The scheduler plays an important role in helping workers stay busy.
-const worker: Worker =
+export const worker: Worker =
   global.__notifierWorker ||
   (global.__notifierWorker = new Worker<QueueData>(
     QUEUE_NAME,
@@ -45,7 +45,7 @@ const worker: Worker =
 // Schedulers are used to move tasks between states within the queue.
 // Jobs may be queued in a delayed or waiting state, but the scheduler's
 // job is to eventually move them to an active state.
-const scheduler: QueueScheduler =
+export const scheduler: QueueScheduler =
   global.__notifierScheduler ||
   (global.__notifierScheduler = new QueueScheduler(QUEUE_NAME, {
     connection: redis,

--- a/examples/emotion/app/root.tsx
+++ b/examples/emotion/app/root.tsx
@@ -48,7 +48,7 @@ const Document = withEmotionCache(
 
       // reset cache to re-apply global styles
       clientStyleData.reset();
-    }, []);
+    }, [clientStyleData, emotionCache.sheet]);
 
     return (
       <html lang="en">

--- a/examples/graphql-api/app/routes/character/$id.tsx
+++ b/examples/graphql-api/app/routes/character/$id.tsx
@@ -22,14 +22,16 @@ export const loader: LoaderFunction = async (args) => {
  * @description This route fetches the details of a single character using
  * the Remix loader & route params.
  */
-export default function () {
+export default function Character() {
   const loader = useLoaderData<LoaderData>();
   const { data } = loader;
 
   const character = data.character;
 
   const renderCharacter = () => {
-    if (!character) return null;
+    if (!character) {
+      return null;
+    }
 
     return (
       <div style={{ display: "flex", gap: 16 }}>

--- a/examples/graphql-api/app/routes/character/error.tsx
+++ b/examples/graphql-api/app/routes/character/error.tsx
@@ -49,7 +49,7 @@ export const loader: LoaderFunction = async (_args) => {
  * @description This route triggers an error of type "ApolloError" which is
  * an array of errors coming back from the GraphQL API.
  */
-export default function () {
+export default function CharacterError() {
   const loader = useLoaderData<LoaderData>();
 
   return (

--- a/examples/graphql-api/app/routes/index.tsx
+++ b/examples/graphql-api/app/routes/index.tsx
@@ -13,7 +13,7 @@ export { loader } from "~/routes/api/characters";
  * @description This route demonstrates fetching a list of characters from
  * a GraphQL API.
  */
-export default function () {
+export default function Index() {
   const loader = useLoaderData<LoaderData>();
   const { data } = loader;
 

--- a/examples/sanity/app/root.jsx
+++ b/examples/sanity/app/root.jsx
@@ -1,21 +1,9 @@
-import {
-  Meta,
-  Links,
-  Scripts,
-  useLoaderData,
-  LiveReload,
-  useCatch,
-} from "remix";
-import { Outlet } from "react-router-dom";
+import { Links, LiveReload, Meta, Outlet, Scripts, useCatch } from "remix";
 
 import stylesUrl from "./styles/global.css";
 
 export function links() {
   return [{ rel: "stylesheet", href: stylesUrl }];
-}
-
-export async function loader() {
-  return { date: new Date() };
 }
 
 function Document({ children, title }) {
@@ -38,8 +26,6 @@ function Document({ children, title }) {
 }
 
 export default function App() {
-  const data = useLoaderData();
-
   return (
     <Document>
       <Outlet />

--- a/examples/toast-message/app/routes/index.tsx
+++ b/examples/toast-message/app/routes/index.tsx
@@ -33,7 +33,7 @@ export const action: ActionFunction = async ({ request }) => {
   }
 };
 
-export default function () {
+export default function Index() {
   const fetcher = useFetcher();
 
   return (


### PR DESCRIPTION
Just as in #2226, this makes the `.eslintrc` file clearer + removes unnecessary rules (as they were already fixed)

---

This PR is for `dev` branch