### PR TITLE
fix(templates/cloudflare-workers): fix double build on deployment

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -5,6 +5,7 @@
 - adicuco
 - ahbruns
 - ahmedeldessouki
+- aiji42
 - airjp73
 - airondumael
 - Alarid

--- a/templates/cloudflare-workers-ts/wrangler.toml
+++ b/templates/cloudflare-workers-ts/wrangler.toml
@@ -11,7 +11,7 @@ bucket = "./public"
 entry-point = "."
 
 [build]
-command = "npm run build"
+command = ""
 
 [build.upload]
 format="service-worker"

--- a/templates/cloudflare-workers/wrangler.toml
+++ b/templates/cloudflare-workers/wrangler.toml
@@ -11,7 +11,7 @@ bucket = "./public"
 entry-point = "."
 
 [build]
-command = "npm run build"
+command = ""
 
 [build.upload]
 format="service-worker"


### PR DESCRIPTION
Closes: #2238

Solve the problem of double build runs during deployment when the runtime is selected Cloudflare Workers.