### PR TITLE
chore(scripts/publish-private): publish eslint config to remix registry

### DIFF
--- a/scripts/publish-private.js
+++ b/scripts/publish-private.js
@@ -24,6 +24,9 @@ async function run() {
 
   let prerelease = semver.prerelease(taggedVersion);
   let tag = prerelease ? prerelease[0] : "latest";
+  
+  // Publish eslint config directly from the package directory
+   publish(path.join(packageDir, "remix-eslint-config"), tag);
 
   // Publish all @remix-run/* packages
   for (let name of [


### PR DESCRIPTION
This PR adds the `@remix-run/eslint-config` package to `scripts/publish-private.js`, some ~users~ supporters still have a `.npmrc` file pointed to our registry which causes them to not be able to install dependencies.

https://canary.discord.com/channels/770287896669978684/771068344320786452/950398837460189234

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests
