### PR TITLE
chore(docs): Explicitly return `Response` in loader/action examples

### DIFF
--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -269,10 +269,10 @@ In order to avoid (usually) the client-side routing "scroll flash" on refresh or
 This hook returns the JSON parsed data from your route loader function.
 
 ```tsx lines=[1,8]
-import { useLoaderData } from "remix";
+import { json, useLoaderData } from "remix";
 
 export async function loader() {
-  return fakeDb.invoices.findAll();
+  return json(await fakeDb.invoices.findAll());
 }
 
 export default function Invoices() {
@@ -286,12 +286,12 @@ export default function Invoices() {
 This hook returns the JSON parsed data from your route action. It returns `undefined` if there hasn't been a submission at the current location yet.
 
 ```tsx lines=[1,10,19]
-import { useActionData, Form } from "remix";
+import { json, useActionData, Form } from "remix";
 
 export async function action({ request }) {
   const body = await request.formData();
   const name = body.get("visitorsName");
-  return { message: `Hello, ${name}` };
+  return json({ message: `Hello, ${name}` });
 }
 
 export default function Invoices() {
@@ -457,10 +457,10 @@ Returns the function that may be used to submit a `<form>` (or some raw `FormDat
 This is useful whenever you need to programmatically submit a form. For example, you may wish to save a user preferences form whenever any field changes.
 
 ```tsx filename=app/routes/prefs.tsx lines=[1,13,17]
-import { useSubmit, useTransition } from "remix";
+import { json, useSubmit, useTransition } from "remix";
 
 export async function loader() {
-  await getUserPreferences();
+  return json(await getUserPreferences());
 }
 
 export async function action({ request }) {
@@ -978,7 +978,9 @@ Anytime you show the user avatar, you could put a hover effect that fetches data
 
 ```tsx filename=routes/user/$id/details.tsx
 export async function loader({ params }) {
-  return fakeDb.user.find({ where: { id: params.id } });
+  return json(
+    await fakeDb.user.find({ where: { id: params.id } })
+  );
 }
 
 function UserAvatar({ partialUser }) {
@@ -1016,7 +1018,9 @@ If the user needs to select a city, you could have a loader that returns a list 
 ```tsx filename=routes/city-search.tsx
 export async function loader({ request }) {
   const url = new URL(request.url);
-  return searchCities(url.searchParams.get("city-query"));
+  return json(
+    await searchCities(url.searchParams.get("city-query"))
+  );
 }
 
 function CitySearchCombobox() {
@@ -1706,7 +1710,7 @@ export async function loader({ request }) {
   const cookieHeader = request.headers.get("Cookie");
   const cookie =
     (await userPrefs.parse(cookieHeader)) || {};
-  return { showBanner: cookie.showBanner };
+  return json({ showBanner: cookie.showBanner });
 }
 
 export async function action({ request }) {

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -98,10 +98,10 @@ import { NavLink } from "remix";
 function NavList() {
   // This styling will be applied to a <NavLink> when the
   // route that it links to is currently selected.
-  let activeStyle = {
+  const activeStyle = {
     textDecoration: "underline",
   };
-  let activeClassName = "underline";
+  const activeClassName = "underline";
   return (
     <nav>
       <ul>
@@ -1435,15 +1435,17 @@ Would be useful to understand [the Browser File API](https://developer.mozilla.o
 It's to be used in place of `request.formData()`.
 
 ```diff
-- let formData = await request.formData();
-+ let formData = await unstable_parseMultipartFormData(request, uploadHandler);
+- const formData = await request.formData();
++ const formData = await unstable_parseMultipartFormData(request, uploadHandler);
 ```
 
 For example:
 
 ```tsx lines=[2-5,7,23]
-export let action: ActionFunction = async ({ request }) => {
-  let formData = await unstable_parseMultipartFormData(
+export const action: ActionFunction = async ({
+  request,
+}) => {
+  const formData = await unstable_parseMultipartFormData(
     request,
     uploadHandler // <-- we'll look at this deeper next
   );
@@ -1451,7 +1453,7 @@ export let action: ActionFunction = async ({ request }) => {
   // the returned value for the file field is whatever our uploadHandler returns.
   // Let's imagine we're uploading the avatar to s3,
   // so our uploadHandler returns the URL.
-  let avatarUrl = formData.get("avatar");
+  const avatarUrl = formData.get("avatar");
 
   // update the currently logged in user's avatar in our database
   await updateUserAvatar(request, avatarUrl);
@@ -1487,18 +1489,20 @@ These are fully featured utilities for handling fairly simple use cases. It's no
 **Example:**
 
 ```tsx
-let uploadHandler = unstable_createFileUploadHandler({
+const uploadHandler = unstable_createFileUploadHandler({
   maxFileSize: 5_000_000,
   file: ({ filename }) => filename,
 });
 
-export let action: ActionFunction = async ({ request }) => {
-  let formData = await unstable_parseMultipartFormData(
+export const action: ActionFunction = async ({
+  request,
+}) => {
+  const formData = await unstable_parseMultipartFormData(
     request,
     uploadHandler
   );
 
-  let file = formData.get("avatar");
+  const file = formData.get("avatar");
 
   // file is a "NodeFile" which has a similar API to "File"
   // ... etc
@@ -1524,17 +1528,19 @@ The `filter` function accepts an `object` and returns a `boolean` (or a promise 
 **Example:**
 
 ```tsx
-let uploadHandler = unstable_createMemoryUploadHandler({
+const uploadHandler = unstable_createMemoryUploadHandler({
   maxFileSize: 500_000,
 });
 
-export let action: ActionFunction = async ({ request }) => {
-  let formData = await unstable_parseMultipartFormData(
+export const action: ActionFunction = async ({
+  request,
+}) => {
+  const formData = await unstable_parseMultipartFormData(
     request,
     uploadHandler
   );
 
-  let file = formData.get("avatar");
+  const file = formData.get("avatar");
 
   // file is a "File" (https://mdn.io/File) polyfilled for node
   // ... etc
@@ -1559,7 +1565,9 @@ import type {
 } from "cloudinary";
 import cloudinary from "cloudinary";
 
-export let action: ActionFunction = async ({ request }) => {
+export const action: ActionFunction = async ({
+  request,
+}) => {
   const userId = getUserId(request);
 
   function uploadStreamToCloudinary(
@@ -1582,7 +1590,7 @@ export let action: ActionFunction = async ({ request }) => {
     });
   }
 
-  let uploadHandler: UploadHandler = async ({
+  const uploadHandler: UploadHandler = async ({
     name,
     stream,
   }) => {
@@ -1607,12 +1615,12 @@ export let action: ActionFunction = async ({ request }) => {
     return uploadedImage.secure_url;
   };
 
-  let formData = await unstable_parseMultipartFormData(
+  const formData = await unstable_parseMultipartFormData(
     request,
     uploadHandler
   );
 
-  let imageUrl = formData.get("avatar");
+  const imageUrl = formData.get("avatar");
 
   // because our uploadHandler returns a string, that's what the imageUrl will be.
   // ... etc
@@ -1640,17 +1648,17 @@ import type { UploadHandler } from "remix";
 import { unstable_createFileUploadHandler } from "remix";
 import { createCloudinaryUploadHandler } from "some-handy-remix-util";
 
-export let fileUploadHandler =
+export const fileUploadHandler =
   unstable_createFileUploadHandler({
     directory: "public/calendar-events",
   });
 
-export let cloudinaryUploadHandler =
+export const cloudinaryUploadHandler =
   createCloudinaryUploadHandler({
     folder: "/my-site/avatars",
   });
 
-export let multHandler: UploadHandler = (args) => {
+export const multHandler: UploadHandler = (args) => {
   if (args.name === "calendarEvent") {
     return fileUploadHandler(args);
   } else if (args.name === "eventBanner") {
@@ -1895,7 +1903,7 @@ console.log(cookie.isSigned); // true
 The `Date` on which this cookie expires. Note that if a cookie has both `maxAge` and `expires`, this value will be the date at the current time plus the `maxAge` value since `Max-Age` takes precedence over `Expires`.
 
 ```js
-let cookie = createCookie("user-prefs", {
+const cookie = createCookie("user-prefs", {
   expires: new Date("2021-01-01"),
 });
 
@@ -2083,8 +2091,8 @@ Returns `true` if an object is a Remix session.
 ```js
 import { isSession } from "remix";
 
-let sessionData = { foo: "bar" };
-let session = createSession(sessionData, "remix-session");
+const sessionData = { foo: "bar" };
+const session = createSession(sessionData, "remix-session");
 console.log(isSession(session));
 // true
 ```

--- a/docs/guides/api-routes.md
+++ b/docs/guides/api-routes.md
@@ -14,7 +14,7 @@ Consider this route:
 
 ```tsx filename=routes/teams.tsx
 export async function loader() {
-  return getTeams();
+  return json(await getTeams());
 }
 
 export default function Teams() {
@@ -35,7 +35,9 @@ For example, you could have a route to handle the search:
 ```tsx filename=routes/city-search.tsx
 export async function loader({ request }) {
   const url = new URL(request.url);
-  return searchCities(url.searchParams.get("q"));
+  return json(
+    await searchCities(url.searchParams.get("q"))
+  );
 }
 ```
 

--- a/docs/guides/constraints.md
+++ b/docs/guides/constraints.md
@@ -19,13 +19,13 @@ The Remix compiler will automatically remove server code from the browser bundle
 Consider a route module that exports `loader`, `meta`, and a component:
 
 ```tsx
-import { useLoaderData } from "remix";
+import { json, useLoaderData } from "remix";
 
 import PostsView from "../PostsView";
 import { prisma } from "../db";
 
 export async function loader() {
-  return prisma.post.findMany();
+  return json(await prisma.post.findMany());
 }
 
 export function meta() {
@@ -76,7 +76,7 @@ Simply put, a **side effect** is any code that might _do something_. A **module 
 Taking our code from earlier, we saw how the compiler can remove the exports and their imports that aren't used. But if we add this seemingly harmless line of code your app will break!
 
 ```tsx bad lines=[6]
-import { useLoaderData } from "remix";
+import { json, useLoaderData } from "remix";
 
 import PostsView from "../PostsView";
 import { prisma } from "../db";
@@ -84,7 +84,7 @@ import { prisma } from "../db";
 console.log(prisma);
 
 export async function loader() {
-  return prisma.post.findMany();
+  return json(await prisma.post.findMany());
 }
 
 export function meta() {
@@ -122,14 +122,14 @@ The loader is gone but the prisma dependency stayed! Had we logged something har
 To fix this, remove the side effect by simply moving the code _into the loader_.
 
 ```tsx lines=[7]
-import { useLoaderData } from "remix";
+import { json, useLoaderData } from "remix";
 
 import PostsView from "../PostsView";
 import { prisma } from "../db";
 
 export async function loader() {
   console.log(prisma);
-  return prisma.post.findMany();
+  return json(await prisma.post.findMany());
 }
 
 export function meta() {
@@ -196,11 +196,13 @@ export function removeTrailingSlash(url) {
 And then use it like this:
 
 ```js bad filename=app/root.js
+import { json } from "remix";
+
 import { removeTrailingSlash } from "~/http";
 
 export const loader = async ({ request }) => {
   removeTrailingSlash(request.url);
-  return { some: "data" };
+  return json({ some: "data" });
 };
 ```
 

--- a/docs/guides/data-loading.md
+++ b/docs/guides/data-loading.md
@@ -25,7 +25,7 @@ Each [route module][route-module] can export a component and a [`loader`][loader
 import { useLoaderData } from "remix";
 import type { LoaderFunction } from "remix";
 
-export let loader: LoaderFunction = async () => {
+export const loader: LoaderFunction = async () => {
   return [
     { id: "1", name: "Pants" },
     { id: "2", name: "Jacket" },
@@ -33,7 +33,7 @@ export let loader: LoaderFunction = async () => {
 };
 
 export default function Products() {
-  let products = useLoaderData();
+  const products = useLoaderData();
   return (
     <div>
       <h1>Products</h1>
@@ -56,7 +56,9 @@ When you name a file with `$` like `routes/users/$userId.tsx` and `routes/users/
 ```tsx filename=routes/users/$userId/projects/$projectId.tsx
 import type { LoaderFunction } from "remix";
 
-export let loader: LoaderFunction = async ({ params }) => {
+export const loader: LoaderFunction = async ({
+  params,
+}) => {
   console.log(params.userId);
   console.log(params.projectId);
 };
@@ -74,7 +76,9 @@ These params are most useful for looking up data:
 ```tsx filename=routes/users/$userId/projects/$projectId.tsx lines=[6,7]
 import type { LoaderFunction } from "remix";
 
-export let loader: LoaderFunction = async ({ params }) => {
+export const loader: LoaderFunction = async ({
+  params,
+}) => {
   return fakeDb.project.findMany({
     where: {
       userId: params.userId,
@@ -92,7 +96,9 @@ Because these params come from the URL and not your source code, you can't know 
 import invariant from "tiny-invariant";
 import type { LoaderFunction } from "remix";
 
-export let loader: LoaderFunction = async ({ params }) => {
+export const loader: LoaderFunction = async ({
+  params,
+}) => {
   invariant(params.userId, "Expected params.userId");
   invariant(params.projectId, "Expected params.projectId");
 
@@ -108,12 +114,12 @@ Remix polyfills the `fetch` API on your server so it's very easy to fetch data f
 
 ```tsx filename=app/routes/gists.jsx lines=[2]
 export async function loader() {
-  let res = await fetch("https://api.github.com/gists");
+  const res = await fetch("https://api.github.com/gists");
   return res.json();
 }
 
 export default function GistsRoute() {
-  let gists = useLoaderData();
+  const gists = useLoaderData();
   return (
     <ul>
       {gists.map((gist) => (
@@ -134,7 +140,7 @@ Since Remix runs on your server, you can connect directly to a database in your 
 
 ```tsx filename=app/db.server.ts
 import { PrismaClient } from "@prisma/client";
-let db = new PrismaClient();
+const db = new PrismaClient();
 export { db };
 ```
 
@@ -146,7 +152,9 @@ import type { LoaderFunction } from "remix";
 
 import { db } from "~/db.server";
 
-export let loader: LoaderFunction = async ({ params }) => {
+export const loader: LoaderFunction = async ({
+  params,
+}) => {
   return db.product.findMany({
     where: {
       categoryId: params.categoryId,
@@ -155,7 +163,7 @@ export let loader: LoaderFunction = async ({ params }) => {
 };
 
 export default function ProductCategory() {
-  let products = useLoaderData();
+  const products = useLoaderData();
   return (
     <div>
       <p>{products.length} Products</p>
@@ -185,12 +193,12 @@ async function getLoaderData() {
   return { products };
 }
 
-export let loader = async () => {
+export const loader = async () => {
   return json<LoaderData>(await getLoaderData());
 };
 
 export default function Product() {
-  let product = useLoaderData<LoaderData>();
+  const product = useLoaderData<LoaderData>();
   return (
     <div>
       <p>Product {product.id}</p>
@@ -208,14 +216,16 @@ If you picked Cloudflare Workers as your environment, [Cloudflare Key Value][clo
 import { useLoaderData } from "remix";
 import type { LoaderFunction } from "remix";
 
-export let loader: LoaderFunction = async ({ params }) => {
+export const loader: LoaderFunction = async ({
+  params,
+}) => {
   return PRODUCTS_KV.get(`product-${params.productId}`, {
     type: "json",
   });
 };
 
 export default function Product() {
-  let product = useLoaderData();
+  const product = useLoaderData();
   return (
     <div>
       <p>{} Products</p>
@@ -230,11 +240,11 @@ export default function Product() {
 While loading data it's common for a record to be "not found". As soon as you know you can't render the component as expected, `throw` a response and Remix will stop executing code in the current loader and switch over to the nearest [catch boundary][catch-boundary].
 
 ```tsx lines=[10-13]
-export let loader: LoaderFunction = async ({
+export const loader: LoaderFunction = async ({
   params,
   request,
 }) => {
-  let product = await db.product.findOne({
+  const product = await db.product.findOne({
     where: { id: params.productId },
   });
 
@@ -245,7 +255,7 @@ export let loader: LoaderFunction = async ({
     throw new Response("Not Found", { status: 404 });
   }
 
-  let cart = await getCart(request);
+  const cart = await getCart(request);
   return { product, inCart: cart.includes(product.id) };
 };
 ```
@@ -257,9 +267,11 @@ URL Search Params are the portion of the URL after a `?`. Other names for this a
 ```tsx filename=routes/products.tsx lines=[1,4,5]
 import type { LoaderFunction } from "remix";
 
-export let loader: LoaderFunction = async ({ request }) => {
-  let url = new URL(request.url);
-  let term = url.searchParams.get("term");
+export const loader: LoaderFunction = async ({
+  request,
+}) => {
+  const url = new URL(request.url);
+  const term = url.searchParams.get("term");
   return fakeProductSearch(term);
 };
 ```
@@ -334,8 +346,8 @@ Note that `brand` is repeated in the URL search string since both checkboxes wer
 
 ```tsx lines=[3]
 export async function loader({ request }) {
-  let url = new URL(request.url);
-  let brands = url.searchParams.getAll("brand");
+  const url = new URL(request.url);
+  const brands = url.searchParams.getAll("brand");
   return getProducts({ brands });
 }
 ```
@@ -356,8 +368,8 @@ In addition to reading search params in loaders, you often need access to them i
 import { useSearchParams } from "remix";
 
 export default function ProductFilters() {
-  let [searchParams] = useSearchParams();
-  let brands = searchParams.getAll("brand");
+  const [searchParams] = useSearchParams();
+  const brands = searchParams.getAll("brand");
 
   return (
     <Form method="get">
@@ -391,9 +403,9 @@ You might want to auto submit the form on any field change, for that there is [`
 import { useSubmit, useSearchParams } from "remix";
 
 export default function ProductFilters() {
-  let submit = useSubmit();
-  let [searchParams] = useSearchParams();
-  let brands = searchParams.getAll("brand");
+  const submit = useSubmit();
+  const [searchParams] = useSearchParams();
+  const brands = searchParams.getAll("brand");
 
   return (
     <Form
@@ -414,10 +426,10 @@ While uncommon, you can also set searchParams imperatively at any time for any r
 import { useSearchParams } from "remix";
 
 export default function ProductFilters() {
-  let [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   useEffect(() => {
-    let id = setInterval(() => {
+    const id = setInterval(() => {
       setSearchParams({ now: Date.now() });
     }, 1000);
     return () => clearInterval(id);
@@ -437,8 +449,8 @@ This is only needed if the search params can be set in two ways and we want the 
 import { useSearchParams } from "remix";
 
 export default function ProductFilters() {
-  let [searchParams] = useSearchParams();
-  let brands = searchParams.getAll("brand");
+  const [searchParams] = useSearchParams();
+  const brands = searchParams.getAll("brand");
 
   return (
     <Form method="get">
@@ -484,9 +496,9 @@ You have two choices, and what you pick depends on the user experience you want.
 import { useSubmit, useSearchParams } from "remix";
 
 export default function ProductFilters() {
-  let submit = useSubmit();
-  let [searchParams] = useSearchParams();
-  let brands = searchParams.getAll("brand");
+  const submit = useSubmit();
+  const [searchParams] = useSearchParams();
+  const brands = searchParams.getAll("brand");
 
   return (
     <Form method="get">
@@ -521,11 +533,11 @@ export default function ProductFilters() {
 import { useSubmit, useSearchParams } from "remix";
 
 export default function ProductFilters() {
-  let submit = useSubmit();
-  let [searchParams] = useSearchParams();
-  let brands = searchParams.getAll("brand");
+  const submit = useSubmit();
+  const [searchParams] = useSearchParams();
+  const brands = searchParams.getAll("brand");
 
-  let [nikeChecked, setNikeChecked] = React.useState(
+  const [nikeChecked, setNikeChecked] = React.useState(
     // initialize from the URL
     brands.includes("nike")
   );
@@ -570,9 +582,9 @@ You might want to make an abstraction for checkboxes like this:
 </div>;
 
 function SearchCheckbox({ name, value }) {
-  let [searchParams] = useSearchParams();
-  let all = searchParams.getAll(name);
-  let [checked, setChecked] = React.useState(
+  const [searchParams] = useSearchParams();
+  const all = searchParams.getAll(name);
+  const [checked, setChecked] = React.useState(
     all.includes(value)
   );
 
@@ -664,7 +676,7 @@ export async function loader() {
 }
 
 export default function RouteComp() {
-  let data = useLoaderData();
+  const data = useLoaderData();
   console.log(data);
   // '{"date":"2021-11-27T23:54:26.384Z"}'
 }
@@ -679,12 +691,12 @@ Additionally, Remix will call your loaders for you, in no case should you ever t
 <docs-error>This will not work</docs-error>
 
 ```tsx bad nocopy
-export let loader = async () => {
+export const loader = async () => {
   return fakeDb.products.findMany();
 };
 
 export default function RouteComp() {
-  let data = loader();
+  const data = loader();
   // ...
 }
 ```

--- a/docs/guides/data-writes.md
+++ b/docs/guides/data-writes.md
@@ -220,7 +220,7 @@ export const action: ActionFunction = async ({
 
   if (errors) {
     const values = Object.fromEntries(formData);
-    return { errors, values };
+    return json({ errors, values });
   }
 
   return redirect(`/projects/${project.id}`);

--- a/docs/guides/envvars.md
+++ b/docs/guides/envvars.md
@@ -68,12 +68,12 @@ Instead we recommend keeping all of your environment variables on the server (al
 
    ```tsx [3-6]
    export async function loader() {
-     return {
+     return json({
        ENV: {
          STRIPE_PUBLIC_KEY: process.env.STRIPE_PUBLIC_KEY,
          FAUNA_DB_URL: process.env.FAUNA_DB_URL,
        },
-     };
+     });
    }
 
    export function Root() {
@@ -96,11 +96,11 @@ Instead we recommend keeping all of your environment variables on the server (al
 
    ```tsx [10, 19-25]
    export async function loader() {
-     return {
+     return json({
        ENV: {
          STRIPE_PUBLIC_KEY: process.env.STRIPE_PUBLIC_KEY,
        },
-     };
+     });
    }
 
    export function Root() {

--- a/docs/guides/mdx.md
+++ b/docs/guides/mdx.md
@@ -87,7 +87,7 @@ The following example demonstrates how you might build a simple blog with MDX, i
 In `app/routes/index.jsx`:
 
 ```tsx
-import { Link, useLoaderData } from "remix";
+import { json, Link, useLoaderData } from "remix";
 
 // Import all your posts from the app/routes/posts directory. Since these are
 // regular route modules, they will all be available for individual viewing
@@ -108,11 +108,11 @@ export async function loader() {
   // Referencing the posts here instead of in the Index component down below
   // lets us avoid bundling the actual posts themselves in the bundle for the
   // index page.
-  return [
+  return json([
     postFromModule(postA),
     postFromModule(postB),
     postFromModule(postC),
-  ];
+  ]);
 }
 
 export default function Index() {

--- a/docs/guides/not-found.md
+++ b/docs/guides/not-found.md
@@ -29,7 +29,7 @@ export async function loader({ params }) {
     });
   }
 
-  return page;
+  return json(page);
 }
 ```
 
@@ -82,7 +82,7 @@ export async function loader({ params }) {
     });
   }
 
-  return page;
+  return json(page);
 }
 
 export function CatchBoundary() {

--- a/docs/guides/optimistic-ui.md
+++ b/docs/guides/optimistic-ui.md
@@ -23,12 +23,12 @@ Remix can help you build optimistic UI with [`useTransition`][use-transition] an
 Consider the workflow for viewing and creating a new project. The project route loads the project and renders it.
 
 ```tsx filename=app/routes/project/$id.tsx
-import { useLoaderData } from "remix";
+import { json, useLoaderData } from "remix";
 
 import { ProjectView } from "~/components/project";
 
 export async function loader({ params }) {
-  return findProject(params.id);
+  return json(await findProject(params.id));
 }
 
 export default function ProjectRoute() {

--- a/docs/guides/resource-routes.md
+++ b/docs/guides/resource-routes.md
@@ -22,7 +22,7 @@ For example, consider a UI Route that renders a report, note the link:
 
 ```tsx lines=[10-12] filename=app/routes/reports/$id.js
 export async function loader({ params }) {
-  return getReport(params.id);
+  return json(await getReport(params.id));
 }
 
 export default function Report() {

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -253,7 +253,9 @@ Now Remix can prefetch, load, and unload the styles for `button.css`, `primary-b
 
 An initial reaction to this is that routes have to know more than you want them to. Keep in mind each component must be imported already, so it's not introducing a new dependency, just some boilerplate to get the assets. For example, consider a product category page like this:
 
-```tsx filename=app/routes/$category.js lines=[1-4,19-26]
+```tsx filename=app/routes/$category.js lines=[3-6,23-30]
+import { json, useLoaderData } from "remix";
+
 import { TileGrid } from "~/components/tile-grid";
 import { ProductTile } from "~/components/product-tile";
 import { ProductDetails } from "~/components/product-details";
@@ -265,7 +267,9 @@ export function links() {
 }
 
 export async function loader({ params }) {
-  return getProductsForCategory(params.category);
+  return json(
+    await getProductsForCategory(params.category)
+  );
 }
 
 export default function Category() {

--- a/docs/pages/faq.md
+++ b/docs/pages/faq.md
@@ -49,7 +49,7 @@ export async function loader({ request }) {
   const projects = await fakeDb.projects.scan({
     userId: session.get("userId"),
   });
-  return projects;
+  return json(projects);
 }
 ```
 

--- a/docs/pages/gotchas.md
+++ b/docs/pages/gotchas.md
@@ -18,11 +18,12 @@ TypeError: Cannot read properties of undefined (reading 'root')
 
 For example, you can't import "fs-extra" directly into a route module:
 
-```js lines=[1] filename=app/routes/index.jsx bad
+```js lines=[2] filename=app/routes/index.jsx bad
+import { json } from "remix";
 import fs from "fs-extra";
 
-export function loader() {
-  return fs.pathExists("../some/path");
+export async function loader() {
+  return json(await fs.pathExists("../some/path"));
 }
 
 export default function SomeRoute() {
@@ -38,11 +39,13 @@ export * from "fs-extra";
 
 And then change our import in the route to the new "wrapper" module:
 
-```js lines=[1] filename=app/routes/index.jsx
+```js lines=[3] filename=app/routes/index.jsx
+import { json } from "remix";
+
 import fs from "../utils/fs-extra.server";
 
-export function loader() {
-  return fs.pathExists("../some/path");
+export async function loader() {
+  return json(await fs.pathExists("../some/path"));
 }
 
 export default function SomeRoute() {

--- a/docs/pages/philosophy.md
+++ b/docs/pages/philosophy.md
@@ -54,18 +54,22 @@ export default function Gists() {
 
 With Remix, you can filter down the data _on the server_ before sending it to the user:
 
-```js [1-11]
+```js [3-16]
+import { json } from "remix";
+
 export async function loader() {
   const res = await fetch("https://api.github.com/gists");
-  const json = await res.json();
-  return json.map((gist) => {
-    return {
-      description: gist.description,
-      url: gist.html_url,
-      files: Object.keys(gist.files),
-      owner: gist.owner.login,
-    };
-  });
+  const gists = await res.json();
+  return json(
+    gists.map((gist) => {
+      return {
+        description: gist.description,
+        url: gist.html_url,
+        files: Object.keys(gist.files),
+        owner: gist.owner.login,
+      };
+    })
+  );
 }
 
 export default function Gists() {

--- a/docs/pages/technical-explanation.md
+++ b/docs/pages/technical-explanation.md
@@ -88,7 +88,7 @@ Route modules have three primary exports: `loader`, `action`, and `default` (com
 // Loaders only run on the server and provide data
 // to your component on GET requests
 export async function loader() {
-  return db.projects.findAll();
+  return json(await db.projects.findAll());
 }
 
 // Actions only run on the server and handle POST
@@ -98,10 +98,10 @@ export async function action({ request }) {
   const form = await request.formData();
   const errors = validate(form);
   if (errors) {
-    return { errors };
+    return json({ errors });
   }
   await createProject({ title: form.get("title") });
-  return { ok: true };
+  return json({ ok: true });
 }
 
 // The default export is the component that will be

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -108,10 +108,10 @@ So let's get to it and provide some data to our component.
 💿 Make the posts route "loader"
 
 ```tsx filename=app/routes/posts/index.tsx lines=[1,3-14,17-18]
-import { useLoaderData } from "remix";
+import { json, useLoaderData } from "remix";
 
 export const loader = async () => {
-  return [
+  return json([
     {
       slug: "my-first-post",
       title: "My First Post",
@@ -120,7 +120,7 @@ export const loader = async () => {
       slug: "90s-mixtape",
       title: "A Mixtape I Made Just For You",
     },
-  ];
+  ]);
 };
 
 export default function Posts() {
@@ -164,7 +164,7 @@ TypeScript is mad, so let's help it out:
 💿 Add the Post type and generic for `useLoaderData`
 
 ```tsx filename=app/routes/posts/index.tsx lines=[3-6,9,19,23]
-import { Link, useLoaderData } from "remix";
+import { json, Link, useLoaderData } from "remix";
 
 export type Post = {
   slug: string;
@@ -182,7 +182,7 @@ export const loader = async () => {
       title: "A Mixtape I Made Just For You",
     },
   ];
-  return posts;
+  return json(posts);
 };
 
 export default function Posts() {
@@ -240,13 +240,13 @@ export function getPosts() {
 💿 Update the posts route to use our new posts module
 
 ```tsx filename=app/routes/posts/index.tsx
-import { Link, useLoaderData } from "remix";
+import { json, Link, useLoaderData } from "remix";
 
 import { getPosts } from "~/post";
 import type { Post } from "~/post";
 
 export const loader = async () => {
-  return getPosts();
+  return json(await getPosts());
 };
 
 // ...
@@ -445,10 +445,10 @@ You can click one of your posts and should see the new page.
 💿 Add a loader to access the params
 
 ```tsx filename=app/routes/posts/$slug.tsx lines=[1,3-5,8,11]
-import { useLoaderData } from "remix";
+import { json, useLoaderData } from "remix";
 
 export const loader = async ({ params }) => {
-  return params.slug;
+  return json(params.slug);
 };
 
 export default function PostSlug() {
@@ -466,13 +466,13 @@ The part of the filename attached to the `$` becomes a named key on the `params`
 💿 Let's get some help from TypeScript for the loader function signature.
 
 ```tsx filename=app/routes/posts/$slug.tsx lines=[2,4]
-import { useLoaderData } from "remix";
+import { json, useLoaderData } from "remix";
 import type { LoaderFunction } from "remix";
 
 export const loader: LoaderFunction = async ({
   params,
 }) => {
-  return params.slug;
+  return json(params.slug);
 };
 ```
 
@@ -499,7 +499,7 @@ export async function getPost(slug: string) {
 💿 Use the new `getPost` function in the route
 
 ```tsx filename=app/routes/posts/$slug.tsx lines=[3,5,10-11,15,18]
-import { useLoaderData } from "remix";
+import { json, useLoaderData } from "remix";
 import type { LoaderFunction } from "remix";
 import invariant from "tiny-invariant";
 
@@ -509,7 +509,7 @@ export const loader: LoaderFunction = async ({
   params,
 }) => {
   invariant(params.slug, "expected params.slug");
-  return getPost(params.slug);
+  return json(await getPost(params.slug));
 };
 
 export default function PostSlug() {
@@ -586,13 +586,13 @@ touch app/routes/admin.tsx
 ```
 
 ```tsx filename=app/routes/admin.tsx
-import { Link, useLoaderData } from "remix";
+import { json, Link, useLoaderData } from "remix";
 
 import { getPosts } from "~/post";
 import type { Post } from "~/post";
 
 export const loader = async () => {
-  return getPosts();
+  return json(await getPosts());
 };
 
 export default function Admin() {
@@ -791,7 +791,7 @@ export async function createPost(post) {
     path.join(postsPath, post.slug + ".md"),
     md
   );
-  return getPost(post.slug);
+  return json(await getPost(post.slug));
 }
 ```
 
@@ -841,7 +841,7 @@ export async function createPost(post: NewPost) {
     path.join(postsPath, post.slug + ".md"),
     md
   );
-  return getPost(post.slug);
+  return json(await getPost(post.slug));
 }
 
 //...
@@ -891,7 +891,7 @@ export const action: ActionFunction = async ({
   if (!markdown) errors.markdown = true;
 
   if (Object.keys(errors).length) {
-    return errors;
+    return json(errors);
   }
 
   await createPost({ title, slug, markdown });
@@ -970,7 +970,7 @@ export const action: ActionFunction = async ({
   if (!markdown) errors.markdown = true;
 
   if (Object.keys(errors).length) {
-    return errors;
+    return json(errors);
   }
 
   invariant(typeof title === "string");

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1583,7 +1583,7 @@ import type { User } from "@prisma/client";
 import { db } from "~/utils/db.server";
 
 type LoaderData = { users: Array<User> };
-export let loader: LoaderFunction = async () => {
+export const loader: LoaderFunction = async () => {
   const data: LoaderData = {
     users: await db.user.findMany(),
   };

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1577,6 +1577,7 @@ To _load_ data in a Remix route module, you use a [`loader`](../api/conventions#
 
 ```tsx nocopy
 // this is just an example. No need to copy/paste this 😄
+import { json } from "remix";
 import type { LoaderFunction } from "remix";
 import type { User } from "@prisma/client";
 
@@ -1587,7 +1588,7 @@ export const loader: LoaderFunction = async () => {
   const data: LoaderData = {
     users: await db.user.findMany(),
   };
-  return data;
+  return json(data);
 };
 
 export default function Users() {
@@ -1618,7 +1619,7 @@ Remix and the `tsconfig.json` you get from the starter template are configured t
 
 ```tsx filename=app/routes/jokes.tsx lines=[1-2,4,11-13,15-20,23,47-51]
 import type { LinksFunction, LoaderFunction } from "remix";
-import { Link, Outlet, useLoaderData } from "remix";
+import { json, Link, Outlet, useLoaderData } from "remix";
 
 import { db } from "~/utils/db.server";
 import stylesUrl from "~/styles/jokes.css";
@@ -1635,7 +1636,7 @@ export const loader: LoaderFunction = async () => {
   const data: LoaderData = {
     jokeListItems: await db.joke.findMany(),
   };
-  return data;
+  return json(data);
 };
 
 export default function JokesRoute() {
@@ -1706,7 +1707,7 @@ export const loader: LoaderFunction = async () => {
       orderBy: { createdAt: "desc" },
     }),
   };
-  return data;
+  return json(data);
 };
 ```
 
@@ -1752,7 +1753,7 @@ const joke = await db.joke.findUnique({
 
 ```tsx filename=app/routes/jokes/$jokeId.tsx lines=[3,5,7,9-18,21]
 import type { LoaderFunction } from "remix";
-import { Link, useLoaderData } from "remix";
+import { json, Link, useLoaderData } from "remix";
 import type { Joke } from "@prisma/client";
 
 import { db } from "~/utils/db.server";
@@ -1767,7 +1768,7 @@ export const loader: LoaderFunction = async ({
   });
   if (!joke) throw new Error("Joke not found");
   const data: LoaderData = { joke };
-  return data;
+  return json(data);
 };
 
 export default function JokeRoute() {
@@ -1812,7 +1813,7 @@ const [randomJoke] = await db.joke.findMany({
 
 ```tsx filename=app/routes/jokes/index.tsx lines=[3,5,7,9-18,21]
 import type { LoaderFunction } from "remix";
-import { useLoaderData, Link } from "remix";
+import { json, useLoaderData, Link } from "remix";
 import type { Joke } from "@prisma/client";
 
 import { db } from "~/utils/db.server";
@@ -1827,7 +1828,7 @@ export const loader: LoaderFunction = async () => {
     skip: randomRowNumber,
   });
   const data: LoaderData = { randomJoke };
-  return data;
+  return json(data);
 };
 
 export default function JokesIndexRoute() {
@@ -3409,7 +3410,7 @@ export async function createUserSession(
 ```tsx filename=app/routes/jokes.tsx lines=[6,14,30,52-63]
 import type { User } from "@prisma/client";
 import type { LinksFunction, LoaderFunction } from "remix";
-import { Link, Outlet, useLoaderData } from "remix";
+import { json, Link, Outlet, useLoaderData } from "remix";
 
 import { db } from "~/utils/db.server";
 import { getUser } from "~/utils/session.server";
@@ -3438,7 +3439,7 @@ export const loader: LoaderFunction = async ({
     jokeListItems,
     user,
   };
-  return data;
+  return json(data);
 };
 
 export default function JokesRoute() {
@@ -4213,9 +4214,10 @@ export function ErrorBoundary({ error }: { error: Error }) {
 
 <summary>app/routes/jokes/$jokeId.tsx</summary>
 
-```tsx filename=app/routes/jokes/$jokeId.tsx lines=[5,20-24,41-52]
+```tsx filename=app/routes/jokes/$jokeId.tsx lines=[6,21-25,42-53]
 import type { LoaderFunction } from "remix";
 import {
+  json,
   Link,
   useLoaderData,
   useCatch,
@@ -4239,7 +4241,7 @@ export const loader: LoaderFunction = async ({
     });
   }
   const data: LoaderData = { joke };
-  return data;
+  return json(data);
 };
 
 export default function JokeRoute() {
@@ -4283,7 +4285,7 @@ export function ErrorBoundary() {
 
 ```tsx filename=app/routes/jokes/index.tsx lines=[2,16-20,39-52]
 import type { LoaderFunction } from "remix";
-import { useLoaderData, Link, useCatch } from "remix";
+import { json, useLoaderData, Link, useCatch } from "remix";
 import type { Joke } from "@prisma/client";
 
 import { db } from "~/utils/db.server";
@@ -4303,7 +4305,7 @@ export const loader: LoaderFunction = async () => {
     });
   }
   const data: LoaderData = { randomJoke };
-  return data;
+  return json(data);
 };
 
 export default function JokesIndexRoute() {
@@ -4373,7 +4375,7 @@ export const loader: LoaderFunction = async ({
   if (!userId) {
     throw new Response("Unauthorized", { status: 401 });
   }
-  return {};
+  return json({});
 };
 
 function validateJokeContent(content: string) {
@@ -4571,10 +4573,11 @@ And then the `action` can determine whether the intention is to delete based on 
 
 <summary>app/routes/jokes/$jokeId.tsx</summary>
 
-```tsx filename=app/routes/jokes/$jokeId.tsx lines=[2,7,12,31-61,71-80,89-95,103-109]
+```tsx filename=app/routes/jokes/$jokeId.tsx lines=[3,8,13,32-62,72-81,90-96,104-110]
 import type { Joke } from "@prisma/client";
 import type { ActionFunction, LoaderFunction } from "remix";
 import {
+  json,
   Link,
   useLoaderData,
   useCatch,
@@ -4599,7 +4602,7 @@ export const loader: LoaderFunction = async ({
     });
   }
   const data: LoaderData = { joke };
-  return data;
+  return json(data);
 };
 
 export const action: ActionFunction = async ({
@@ -4704,10 +4707,11 @@ Now that people will get a proper error message if they try to delete a joke tha
 
 <summary>app/routes/jokes/$jokeId.tsx</summary>
 
-```tsx filename=app/routes/jokes/$jokeId.tsx lines=[13,17,23,34,79-90]
+```tsx filename=app/routes/jokes/$jokeId.tsx lines=[14,18,24,35,80-91]
 import type { Joke } from "@prisma/client";
 import type { ActionFunction, LoaderFunction } from "remix";
 import {
+  json,
   Link,
   useLoaderData,
   useCatch,
@@ -4740,7 +4744,7 @@ export const loader: LoaderFunction = async ({
     joke,
     isOwner: userId === joke.jokesterId,
   };
-  return data;
+  return json(data);
 };
 
 export const action: ActionFunction = async ({
@@ -5275,13 +5279,14 @@ export default function Login() {
 
 <summary>app/routes/jokes/$jokeId.tsx</summary>
 
-```tsx filename=app/routes/jokes/$jokeId.tsx lines=[4,21-36]
+```tsx filename=app/routes/jokes/$jokeId.tsx lines=[5,22-37]
 import type {
   ActionFunction,
   LoaderFunction,
   MetaFunction,
 } from "remix";
 import {
+  json,
   Link,
   useLoaderData,
   useCatch,
@@ -5332,7 +5337,7 @@ export const loader: LoaderFunction = async ({
     joke,
     isOwner: userId === joke.jokesterId,
   };
-  return data;
+  return json(data);
 };
 
 export const action: ActionFunction = async ({
@@ -5763,13 +5768,14 @@ export function JokeDisplay({
 
 <summary>app/routes/jokes/$jokeId.tsx</summary>
 
-```tsx filename=app/routes/jokes/$jokeId.tsx lines=[19,97]
+```tsx filename=app/routes/jokes/$jokeId.tsx lines=[20,98]
 import type {
   LoaderFunction,
   ActionFunction,
   MetaFunction,
 } from "remix";
 import {
+  json,
   useLoaderData,
   useCatch,
   redirect,
@@ -5821,7 +5827,7 @@ export const loader: LoaderFunction = async ({
     joke,
     isOwner: userId === joke.jokesterId,
   };
-  return data;
+  return json(data);
 };
 
 export const action: ActionFunction = async ({
@@ -5937,7 +5943,7 @@ export const loader: LoaderFunction = async ({
   if (!userId) {
     throw new Response("Unauthorized", { status: 401 });
   }
-  return {};
+  return json({});
 };
 
 function validateJokeContent(content: string) {

--- a/examples/jokes/app/routes/jokes.tsx
+++ b/examples/jokes/app/routes/jokes.tsx
@@ -1,5 +1,5 @@
 import type { LoaderFunction, LinksFunction } from "remix";
-import { Form } from "remix";
+import { json, Form } from "remix";
 import { Outlet, useLoaderData, Link } from "remix";
 import { db } from "~/utils/db.server";
 import { getUser } from "~/utils/session.server";
@@ -29,7 +29,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     user,
   };
 
-  return data;
+  return json(data);
 };
 
 export const links: LinksFunction = () => {

--- a/examples/jokes/app/routes/jokes/$jokeId.tsx
+++ b/examples/jokes/app/routes/jokes/$jokeId.tsx
@@ -1,5 +1,5 @@
 import type { LoaderFunction, ActionFunction, MetaFunction } from "remix";
-import { useLoaderData, useCatch, redirect, useParams } from "remix";
+import { json, useLoaderData, useCatch, redirect, useParams } from "remix";
 import type { Joke } from "@prisma/client";
 import { db } from "~/utils/db.server";
 import { getUserId, requireUserId } from "~/utils/session.server";
@@ -31,7 +31,7 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     throw new Response("What a joke! Not found.", { status: 404 });
   }
   const data: LoaderData = { joke, isOwner: userId === joke.jokesterId };
-  return data;
+  return json(data);
 };
 
 export const action: ActionFunction = async ({ request, params }) => {

--- a/examples/jokes/app/routes/jokes/index.tsx
+++ b/examples/jokes/app/routes/jokes/index.tsx
@@ -1,5 +1,5 @@
 import type { LoaderFunction } from "remix";
-import { useLoaderData, Link, useCatch } from "remix";
+import { json, useLoaderData, Link, useCatch } from "remix";
 import type { Joke } from "@prisma/client";
 
 import { db } from "~/utils/db.server";
@@ -27,7 +27,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     throw new Response("No jokes to be found!", { status: 404 });
   }
   const data: LoaderData = { randomJoke };
-  return data;
+  return json(data);
 };
 
 export default function JokesIndexRoute() {

--- a/examples/jokes/app/routes/jokes/new.tsx
+++ b/examples/jokes/app/routes/jokes/new.tsx
@@ -17,7 +17,7 @@ export const loader: LoaderFunction = async ({ request }) => {
   if (!userId) {
     throw new Response("Unauthorized", { status: 401 });
   }
-  return {};
+  return json({});
 };
 
 function validateJokeContent(content: string) {


### PR DESCRIPTION
This PR updates our docs and some examples to explicitly return a response for all loaders/actions. (internal team: see REM-779 in Linear for context)