### PR TITLE
deprecated: Warn if returning non-`Response` from loader/action

### DIFF
--- a/fixtures/gists-app/app/root.jsx
+++ b/fixtures/gists-app/app/root.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import {
+  json,
   Link,
   Links,
   Meta,
@@ -28,9 +29,9 @@ export function links() {
 }
 
 export async function loader({ request }) {
-  return {
+  return json({
     enableScripts: new URL(request.url).searchParams.get("disableJs") == null,
-  };
+  });
 }
 
 export let handle = {

--- a/fixtures/gists-app/app/routes/action-catches-from-loader-self-boundary.jsx
+++ b/fixtures/gists-app/app/routes/action-catches-from-loader-self-boundary.jsx
@@ -14,7 +14,7 @@ export async function loader({ request }) {
     throw json("loader catch data!", { status: 401 });
   }
 
-  return null;
+  return json(null);
 }
 
 export default function ActionCatches() {

--- a/fixtures/gists-app/app/routes/action-catches-from-loader.jsx
+++ b/fixtures/gists-app/app/routes/action-catches-from-loader.jsx
@@ -9,7 +9,7 @@ export async function loader({ request }) {
     throw json("loader catch data!", { status: 401 });
   }
 
-  return null;
+  return json(null);
 }
 
 export default function ActionCatches() {

--- a/fixtures/gists-app/app/routes/action-errors-self-boundary.jsx
+++ b/fixtures/gists-app/app/routes/action-errors-self-boundary.jsx
@@ -1,11 +1,11 @@
-import { Form, useLoaderData } from "remix";
+import { Form, json, useLoaderData } from "remix";
 
 export async function action() {
   throw new Error("I am an action error!");
 }
 
 export async function loader() {
-  return "nope";
+  return json("nope");
 }
 
 export default function ActionErrors() {

--- a/fixtures/gists-app/app/routes/actions.tsx
+++ b/fixtures/gists-app/app/routes/actions.tsx
@@ -10,7 +10,7 @@ import type { HeadersFunction, ActionFunction } from "remix";
 import { uploadHandler } from "../uploadHandler.server";
 
 export async function loader() {
-  return "ay! data from the loader!";
+  return json("ay! data from the loader!");
 }
 
 export let action: ActionFunction = async ({ request }) => {

--- a/fixtures/gists-app/app/routes/fetchers.tsx
+++ b/fixtures/gists-app/app/routes/fetchers.tsx
@@ -49,8 +49,10 @@ export let loader: LoaderFunction = async ({ request }) => {
 
   if (searchParams.has("q")) {
     // await new Promise(res => setTimeout(res, 1000));
-    return tasks.filter((task) =>
-      task.name.toLowerCase().includes(searchParams.get("q")!.toLowerCase())
+    return json(
+      tasks.filter((task) =>
+        task.name.toLowerCase().includes(searchParams.get("q")!.toLowerCase())
+      )
     );
   }
 

--- a/fixtures/gists-app/app/routes/gists/index.jsx
+++ b/fixtures/gists-app/app/routes/gists/index.jsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from "remix";
+import { json, useLoaderData } from "remix";
 
 let fakeGists = [
   {
@@ -19,11 +19,11 @@ let fakeGists = [
 
 export async function loader() {
   if (process.env.NODE_ENV !== "development") {
-    return Promise.resolve(fakeGists);
+    return json(fakeGists);
   }
 
   let res = await fetch(`https://api.github.com/gists`);
-  return res.json();
+  return json(await res.json());
 }
 
 export function headers() {

--- a/fixtures/gists-app/app/routes/index.jsx
+++ b/fixtures/gists-app/app/routes/index.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { Link } from "remix";
+import { json, Link } from "remix";
 
 import Shared from "../components/Shared";
 // import Guitar from "../components/Guitar";
@@ -18,7 +18,7 @@ export async function loader() {
     console.log(serverMessage);
   }
 
-  return null;
+  return json(null);
 }
 
 export function headers() {

--- a/fixtures/gists-app/app/routes/links.tsx
+++ b/fixtures/gists-app/app/routes/links.tsx
@@ -1,6 +1,5 @@
 import type { LinksFunction, LoaderFunction } from "remix";
-import { useLoaderData, Link } from "remix";
-
+import { json, useLoaderData, Link } from "remix";
 import redTextHref from "~/styles/redText.css";
 import blueTextHref from "~/styles/blueText.css";
 import guitar from "~/components/guitar.jpg";
@@ -10,11 +9,11 @@ interface User {
   id: string;
 }
 
-export let loader: LoaderFunction = async (): User[] => {
-  return [
+export let loader: LoaderFunction = async () => {
+  return json<User[]>([
     { name: "Michael Jackson", id: "mjackson" },
     { name: "Ryan Florence", id: "ryanflorence" },
-  ];
+  ]);
 };
 
 export let links: LinksFunction = () => {

--- a/fixtures/gists-app/app/routes/loader-errors.jsx
+++ b/fixtures/gists-app/app/routes/loader-errors.jsx
@@ -8,7 +8,7 @@ export async function loader({ request }) {
   if (params.has("catch")) {
     throw json("catch data!", { status: 401 });
   }
-  return null;
+  return json(null);
 }
 
 export default function LoaderErrors() {

--- a/fixtures/gists-app/app/routes/loader-errors/nested-catch.jsx
+++ b/fixtures/gists-app/app/routes/loader-errors/nested-catch.jsx
@@ -3,7 +3,7 @@ import { Link, json, useCatch, useLocation } from "remix";
 export async function loader({ request }) {
   let url = new URL(request.url);
   if (url.searchParams.get("authed")) {
-    return {};
+    return json({});
   }
 
   throw json("catch data!", { status: 401 });

--- a/fixtures/gists-app/app/routes/prefs.tsx
+++ b/fixtures/gists-app/app/routes/prefs.tsx
@@ -1,5 +1,5 @@
 import type { MetaFunction, LoaderFunction, ActionFunction } from "remix";
-import { useLoaderData, useSubmit, Form, Link, redirect } from "remix";
+import { json, useLoaderData, useSubmit, Form, Link, redirect } from "remix";
 
 import { userPrefsCookie } from "../cookies";
 
@@ -21,7 +21,7 @@ export let meta: MetaFunction = () => {
 };
 
 export let loader: LoaderFunction = async ({ request }) => {
-  return getUserPrefs(request.headers.get("Cookie"));
+  return json(await getUserPrefs(request.headers.get("Cookie")));
 };
 
 export let action: ActionFunction = async ({ request }) => {

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -57,7 +57,7 @@ export async function callRouteAction({
 
   if (!isResponse(result)) {
     console.warn(
-      `You returned a values other than a \`Response\` object from the action for route "${match.route.id}". This is deprecated and will result in a server error in a future version of Remix.
+      `You returned a value other than a \`Response\` object from the action for route "${match.route.id}". This is deprecated and will result in a server error in a future version of Remix.
 
 To fix this and remove the warning, you can return the same value passed into our \`json\` helper function which will construct a \`Response\` instance:
 

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -74,7 +74,7 @@ To fix this and remove the warning, you can return the same value passed into ou
       return json(someData);
     }
 
-    // You can also return an \`Response\` directly:
+    // You can also return a \`Response\` directly:
     export async function action() {
       return new Response(someData, {
         headers: {

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -55,7 +55,38 @@ export async function callRouteAction({
     );
   }
 
-  return isResponse(result) ? result : json(result);
+  if (!isResponse(result)) {
+    console.warn(
+      `You returned a values other than a \`Response\` object from the action for route "${match.route.id}". This is deprecated and will result in a server error in a future version of Remix.
+
+To fix this and remove the warning, you can return the same value passed into our \`json\` helper function which will construct a \`Response\` instance:
+
+
+    // before
+    export async function action() {
+      return someData;
+    }
+
+    // after
+    import { json } from "remix";
+
+    export async function action() {
+      return json(someData);
+    }
+
+    // You can also return an \`Response\` directly:
+    export async function action() {
+      return new Response(someData, {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    }
+`
+    );
+    return json(result);
+  }
+  return result;
 }
 
 export async function callRouteLoader({
@@ -102,7 +133,38 @@ export async function callRouteLoader({
     );
   }
 
-  return isResponse(result) ? result : json(result);
+  if (!isResponse(result)) {
+    console.warn(
+      `You returned a values other than a \`Response\` object from the loader for route "${match.route.id}". This is deprecated and will result in a server error in a future version of Remix.
+
+  To fix this and remove the warning, you can return the same value passed into our \`json\` helper function which will construct a \`Response\` instance:
+
+
+      // before
+      export async function loader() {
+        return someData;
+      }
+
+      // after
+      import { json } from "remix";
+
+      export async function loader() {
+        return json(someData);
+      }
+
+      // You can also return an \`Response\` directly:
+      export async function loader() {
+        return new Response(someData, {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+      }
+  `
+    );
+    return json(result);
+  }
+  return result;
 }
 
 function stripIndexParam(request: Request) {


### PR DESCRIPTION
This PR will result in warnings for users if they return a value other than a `Response` from either a loader or action function. This will deprecate the behavior and set us up to remove support for it in a later release.

Docs and examples were updated in https://github.com/remix-run/remix/pull/2250 and merged into `main` without explicitly mentioning deprecation at this point. I will make a notice in the docs about this once this is merged and again PR that change  to `main`.