### PR TITLE
chore(templates/arc): prevent port error on first run

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -269,6 +269,7 @@
 - vimutti77
 - visormatt
 - weavdale
+- wickdninja 
 - wladiston
 - xstevenyung
 - yauri-io

--- a/packages/create-remix/templates/arc/README.md
+++ b/packages/create-remix/templates/arc/README.md
@@ -19,14 +19,11 @@ $ npm i -g @architect/architect aws-sdk
 
 You will be running two processes during development when using Architect as your server.
 
-- Your Architect server sandbox in one
-- The Remix development server in another
+- Your Architect server sandbox 
+- The Remix development server
 
 ```sh
-# in one tab
-$ arc sandbox
-
-# in another
+# run both arcitect server sandbox & remix development server with run-p
 $ npm run dev
 ```
 


### PR DESCRIPTION
otherwise docs result it port error

```
npm run dev

> dev
> cross-env NODE_ENV=development remix build && run-p dev:*

Building Remix app in development mode...
Built in 386ms

> dev:arc
> cross-env NODE_ENV=development arc sandbox


> dev:remix
> cross-env NODE_ENV=development remix watch

Watching Remix app in development mode...
         App ⌁ remix-architect-app
      Region ⌁ us-east-1
     Profile ⌁ default
     Version ⌁ Architect 10.0.5
         cwd ⌁ /Users/nate/src/apn/tmp/apn-test-aws

💿 Built in 408ms
✓ Sandbox Found Architect project manifest: app.arc
✓ Sandbox No custom testing environment variables found
Error: Port 3333 (http) is already in use, please select another with prefs.arc
    at Server.<anonymous> (/usr/local/lib/node_modules/@architect/architect/node_modules/@architect/sandbox/src/sandbox/ports.js:85:27)
    at Object.onceWrapper (node:events:640:26)
    at Server.emit (node:events:520:28)
    at Server.emit (node:domain:475:12)
    at emitErrorNT (node:net:1357:8)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
ERROR: "dev:arc" exited with 1.
```

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ x] Docs
- [ ] Tests
