### PR TITLE
docs(examples): explicitly return `Response` in `action`/`loader`

### DIFF
--- a/examples/basic/app/routes/demos/params/$id.tsx
+++ b/examples/basic/app/routes/demos/params/$id.tsx
@@ -34,7 +34,7 @@ export const loader: LoaderFunction = async ({ params }) => {
   // but otherwise the record was found, user has access, so we can do whatever
   // else we needed to in the loader and return the data. (This is boring, we're
   // just gonna return the params.id).
-  return { param: params.id };
+  return json({ param: params.id });
 };
 
 export default function ParamDemo() {

--- a/examples/blog-tutorial/app/routes/admin.tsx
+++ b/examples/blog-tutorial/app/routes/admin.tsx
@@ -1,4 +1,4 @@
-import { Outlet, Link, useLoaderData } from "remix";
+import { json, Link, Outlet, useLoaderData } from "remix";
 
 import { getPosts } from "~/post";
 import type { Post } from "~/post";
@@ -9,7 +9,7 @@ export const links = () => {
 };
 
 export const loader = async () => {
-  return getPosts();
+  return json(await getPosts());
 };
 
 export default function Admin() {

--- a/examples/blog-tutorial/app/routes/demos/params/$id.tsx
+++ b/examples/blog-tutorial/app/routes/demos/params/$id.tsx
@@ -34,7 +34,7 @@ export const loader: LoaderFunction = async ({ params }) => {
   // but otherwise the record was found, user has access, so we can do whatever
   // else we needed to in the loader and return the data. (This is boring, we're
   // just gonna return the params.id).
-  return { param: params.id };
+  return json({ param: params.id });
 };
 
 export default function ParamDemo() {

--- a/examples/blog-tutorial/app/routes/posts/$slug.tsx
+++ b/examples/blog-tutorial/app/routes/posts/$slug.tsx
@@ -1,12 +1,12 @@
-import { useLoaderData } from "remix";
 import type { LoaderFunction } from "remix";
+import { json, useLoaderData } from "remix";
 import invariant from "tiny-invariant";
 
 import { getPost } from "~/post";
 
 export const loader: LoaderFunction = async ({ params }) => {
   invariant(params.slug, "expected params.slug");
-  return getPost(params.slug);
+  return json(await getPost(params.slug));
 };
 
 export default function PostSlug() {

--- a/examples/blog-tutorial/app/routes/posts/index.tsx
+++ b/examples/blog-tutorial/app/routes/posts/index.tsx
@@ -1,10 +1,10 @@
-import { Link, useLoaderData } from "remix";
+import { json, Link, useLoaderData } from "remix";
 
 import { getPosts } from "~/post";
 import type { Post } from "~/post";
 
 export const loader = async () => {
-  return getPosts();
+  return json(await getPosts());
 };
 
 export default function Posts() {

--- a/examples/client-side-validation/app/root.tsx
+++ b/examples/client-side-validation/app/root.tsx
@@ -56,7 +56,7 @@ export const loader: LoaderFunction = async () => {
     (date.getMonth() + 1)
   ).slice(-2)}-${("00" + (date.getDate() + 1)).slice(-2)}`;
 
-  return { todayString, tomorrowString };
+  return json({ todayString, tomorrowString });
 };
 
 export default function App() {

--- a/examples/dataloader/app/routes/users.tsx
+++ b/examples/dataloader/app/routes/users.tsx
@@ -1,6 +1,6 @@
 import type { LoaderFunction } from "remix";
+import { json, Outlet, useLoaderData } from "remix";
 import type { User } from "~/data.server";
-import { Outlet, useLoaderData } from "remix";
 
 interface LoaderData {
   users: User[];
@@ -11,7 +11,7 @@ export const loader: LoaderFunction = async ({ context }) => {
     "ef3fcb93-0623-4d10-adbf-4dd865d6688c",
     "2cbad877-2da6-422d-baa6-c6a96a9e085f",
   ]);
-  return { users };
+  return json({ users });
 };
 
 export default function UserNames() {

--- a/examples/dataloader/app/routes/users/index.tsx
+++ b/examples/dataloader/app/routes/users/index.tsx
@@ -1,6 +1,6 @@
 import type { LoaderFunction } from "remix";
+import { json, useLoaderData } from "remix";
 import type { User } from "~/data.server";
-import { useLoaderData } from "remix";
 
 interface LoaderData {
   users: User[];
@@ -26,7 +26,7 @@ export const loader: LoaderFunction = async ({ context }) => {
   );
   const users = await Promise.all([user1, user2, user3]);
 
-  return { users };
+  return json({ users });
 };
 
 export default function UserEmails() {

--- a/examples/gdpr-cookie-consent/app/root.tsx
+++ b/examples/gdpr-cookie-consent/app/root.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import type { LoaderFunction } from "remix";
 import {
+  json,
   Links,
   LiveReload,
   Meta,
@@ -15,7 +16,7 @@ import { gdprConsent } from "./cookies";
 export const loader: LoaderFunction = async ({ request }) => {
   const cookieHeader = request.headers.get("Cookie");
   const cookie = (await gdprConsent.parse(cookieHeader)) || {};
-  return { track: cookie.gdprConsent };
+  return json({ track: cookie.gdprConsent });
 };
 
 export default function App() {

--- a/examples/graphql-api/app/routes/api/character.tsx
+++ b/examples/graphql-api/app/routes/api/character.tsx
@@ -1,5 +1,6 @@
 import type { ApolloError } from "apollo-server-errors";
 import type { LoaderFunction } from "remix";
+import { json } from "remix";
 
 import { fetchFromGraphQL, gql } from "~/utils";
 import type { Character } from "~/generated/types";
@@ -41,5 +42,5 @@ export const loader: LoaderFunction = async (args): Promise<LoaderData> => {
   const res = await fetchFromGraphQL(getCharacterQuery, { id });
   const data = await res.json();
 
-  return data;
+  return json(data);
 };

--- a/examples/graphql-api/app/routes/api/characters.tsx
+++ b/examples/graphql-api/app/routes/api/characters.tsx
@@ -1,5 +1,6 @@
 import type { ApolloError } from "apollo-server-errors";
 import type { LoaderFunction } from "remix";
+import { json } from "remix";
 
 import { fetchFromGraphQL, gql } from "~/utils";
 import type { Characters } from "~/generated/types";
@@ -44,5 +45,5 @@ export const loader: LoaderFunction = async (args): Promise<LoaderData> => {
 
   const res = await fetchFromGraphQL(getCharactersQuery, { page });
 
-  return res.json();
+  return json(await res.json());
 };

--- a/examples/graphql-api/app/routes/character/$id.tsx
+++ b/examples/graphql-api/app/routes/character/$id.tsx
@@ -1,5 +1,5 @@
-import { Link, useLoaderData } from "remix";
 import type { LoaderFunction } from "remix";
+import { json, Link, useLoaderData } from "remix";
 
 import { Code } from "~/components/Code";
 import type { LoaderData } from "~/routes/api/character";
@@ -15,7 +15,7 @@ export const loader: LoaderFunction = async (args) => {
     method: "GET",
   });
 
-  return res.json();
+  return json(await res.json());
 };
 
 /**

--- a/examples/graphql-api/app/routes/character/error.tsx
+++ b/examples/graphql-api/app/routes/character/error.tsx
@@ -1,9 +1,9 @@
-import { Link, useLoaderData } from "remix";
 import type { ApolloError } from "apollo-server-errors";
 import type { LoaderFunction } from "remix";
+import { json, Link, useLoaderData } from "remix";
 
 import { Code } from "~/components/Code";
-import { fetchFromGraphQL } from "~/utils/index";
+import { fetchFromGraphQL, gql } from "~/utils/index";
 import type { Character } from "~/generated/types";
 
 type LoaderData = {
@@ -15,7 +15,7 @@ type LoaderData = {
  * @description Here we query an external GraphQL API directly via "fetch".
  */
 export const loader: LoaderFunction = async (_args) => {
-  const getCharacterQuery = `
+  const getCharacterQuery = gql`
     fragment CharacterFields on Character {
       gender
       id
@@ -42,7 +42,7 @@ export const loader: LoaderFunction = async (_args) => {
   const invalidId = 8675309;
 
   const res = await fetchFromGraphQL(getCharacterQuery, { id: invalidId });
-  return res.json();
+  return json(await res.json());
 };
 
 /**

--- a/examples/newsletter-signup/app/routes/newsletter.tsx
+++ b/examples/newsletter-signup/app/routes/newsletter.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { ActionFunction } from "remix";
-import { Form, Link, useActionData, useTransition } from "remix";
+import { Form, json, Link, useActionData, useTransition } from "remix";
 
 export const action: ActionFunction = async ({ request }) => {
   await new Promise((res) => setTimeout(res, 1000));
@@ -19,7 +19,7 @@ export const action: ActionFunction = async ({ request }) => {
     },
   });
 
-  return res.json();
+  return json(await res.json());
 };
 
 export default function Newsletter() {

--- a/examples/nprogress/app/routes/slow-page.tsx
+++ b/examples/nprogress/app/routes/slow-page.tsx
@@ -1,9 +1,9 @@
 import type { LoaderFunction } from "remix";
-import { Link } from "remix";
+import { json, Link } from "remix";
 
 export const loader: LoaderFunction = async () => {
   await new Promise((resolve) => setTimeout(resolve, 1000));
-  return null;
+  return json({});
 };
 
 export default function Screen() {

--- a/examples/pm-app/app/root.tsx
+++ b/examples/pm-app/app/root.tsx
@@ -1,5 +1,6 @@
 import type { LinksFunction, LoaderFunction } from "remix";
 import {
+  json,
   Links,
   LiveReload,
   Meta,
@@ -28,7 +29,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     },
   };
 
-  return data;
+  return json(data);
 };
 
 function Document({

--- a/examples/pm-app/app/routes/dashboard.tsx
+++ b/examples/pm-app/app/routes/dashboard.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { Outlet, useCatch } from "remix";
 import type { LoaderFunction, LinksFunction, MetaFunction } from "remix";
+import { json, Outlet, useCatch } from "remix";
 
 import stylesUrl from "~/dist/styles/routes/dashboard.css";
 import { NavLink } from "~/ui/link";
@@ -12,9 +12,9 @@ export const loader: LoaderFunction = async ({ request }) => {
   const { passwordHash, ...secureUser } = await requireUser(request, {
     redirect: "/sign-in",
   });
-  return {
+  return json({
     user: secureUser,
-  };
+  });
 };
 
 export const links: LinksFunction = () => {

--- a/examples/pm-app/app/routes/dashboard/index.tsx
+++ b/examples/pm-app/app/routes/dashboard/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { useLoaderData, useCatch, useFetcher } from "remix";
 import type { LoaderFunction, LinksFunction } from "remix";
+import { json, useCatch, useFetcher, useLoaderData } from "remix";
 import type { UserSecure, Project } from "~/models";
 import { Heading, Section } from "~/ui/section-heading";
 import { MaxContainer } from "~/ui/max-container";
@@ -35,7 +35,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     projects,
   };
 
-  return data;
+  return json(data);
 };
 
 export default function DashboardIndex() {

--- a/examples/pm-app/app/routes/dashboard/projects/new.tsx
+++ b/examples/pm-app/app/routes/dashboard/projects/new.tsx
@@ -39,7 +39,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     allUsers: allUsers,
   };
 
-  return loaderData;
+  return json(loaderData);
 };
 
 export const action: ActionFunction = async ({ request }) => {

--- a/examples/pm-app/app/routes/dashboard/todo-lists/index.tsx
+++ b/examples/pm-app/app/routes/dashboard/todo-lists/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { getAllTodoLists } from "~/db.server";
-import { useLoaderData, Link } from "remix";
 import type { LoaderFunction } from "remix";
+import { json, Link, useLoaderData } from "remix";
+import { getAllTodoLists } from "~/db.server";
 import type { TodoList } from "~/models";
 import { requireUser } from "~/session.server";
 
@@ -11,9 +11,9 @@ export const loader: LoaderFunction = async ({ request }) => {
   });
 
   const lists = await getAllTodoLists();
-  return {
+  return json({
     lists,
-  };
+  });
 };
 
 export default function AllLists() {

--- a/examples/pm-app/app/routes/dashboard/todo-lists/new.tsx
+++ b/examples/pm-app/app/routes/dashboard/todo-lists/new.tsx
@@ -49,7 +49,7 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     projects,
   };
 
-  return loaderData;
+  return json(loaderData);
 };
 
 export const action: ActionFunction = async ({ request, context, params }) => {

--- a/examples/pm-app/app/routes/dashboard/todos/index.tsx
+++ b/examples/pm-app/app/routes/dashboard/todos/index.tsx
@@ -1,14 +1,14 @@
 import * as React from "react";
 import { getAllTodos, getTodo, updateTodo } from "~/db.server";
-import type { ActionFunction } from "remix";
-import { useLoaderData, useActionData, Form, useTransition } from "remix";
+import type { ActionFunction, LoaderFunction } from "remix";
+import { Form, json, useActionData, useLoaderData, useTransition } from "remix";
 import type { Todo } from "~/models";
 
-export const loader = async () => {
+export const loader: LoaderFunction = async () => {
   const todos = await getAllTodos();
-  return {
+  return json({
     todos,
-  };
+  });
 };
 
 export const action: ActionFunction = async ({ request }) => {
@@ -22,7 +22,7 @@ export const action: ActionFunction = async ({ request }) => {
       todo = await updateTodo(todoId, { order });
     }
   }
-  return { todo };
+  return json({ todo });
 };
 
 export default function Llllll() {

--- a/examples/pm-app/app/routes/register.tsx
+++ b/examples/pm-app/app/routes/register.tsx
@@ -34,7 +34,7 @@ export const loader: LoaderFunction = async ({ request }) => {
   //     successRedirect: "/done",
   //   });
 
-  return {};
+  return json({});
 };
 
 export const action: ActionFunction = async ({ request }) => {
@@ -102,19 +102,19 @@ export const action: ActionFunction = async ({ request }) => {
   // 3. Check for existing user
   const existingUser = await getUser("email", email);
   if (existingUser) {
-    return {
+    return json({
       fields,
       formError: `Sorry! That email is already taken.`,
-    };
+    });
   }
 
   // 4. Register a new user
   const user = await register({ email, password, nameFirst, nameLast });
   if (!user) {
-    return {
+    return json({
       fields,
       formError: `Something went wrong with registration. Please try again later!`,
-    };
+    });
   }
 
   // 5. Create a user session with the new user's ID

--- a/examples/pm-app/app/routes/sign-in.tsx
+++ b/examples/pm-app/app/routes/sign-in.tsx
@@ -117,7 +117,7 @@ export const loader: LoaderFunction = async ({ request }) => {
   await redirectUser(request, {
     redirect: "/dashboard",
   });
-  return {};
+  return json({});
 };
 
 export default function SignIn() {

--- a/examples/quirrel/app/routes/index.tsx
+++ b/examples/quirrel/app/routes/index.tsx
@@ -1,10 +1,11 @@
 import type { LoaderFunction } from "remix";
+import { json } from "remix";
 
 import greetingsQueue from "~/queues/greetings.server";
 
 export const loader: LoaderFunction = async () => {
   await greetingsQueue.enqueue("Groot");
-  return null;
+  return json({});
 };
 
 export default function Index() {

--- a/examples/remix-auth-supabase-github/app/root.tsx
+++ b/examples/remix-auth-supabase-github/app/root.tsx
@@ -1,5 +1,6 @@
 import type { LoaderFunction } from "remix";
 import {
+  json,
   Links,
   LiveReload,
   Meta,
@@ -10,12 +11,12 @@ import {
 } from "remix";
 
 export const loader: LoaderFunction = () => {
-  return {
+  return json({
     env: {
       SUPABASE_URL: process.env.SUPABASE_URL,
       PUBLIC_SUPABASE_ANON_KEY: process.env.PUBLIC_SUPABASE_ANON_KEY,
     },
-  };
+  });
 };
 
 export default function App() {

--- a/examples/routes-gen/app/routes/products/index.tsx
+++ b/examples/routes-gen/app/routes/products/index.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import type { LoaderFunction } from "remix";
-import { useLoaderData } from "remix";
+import { json, useLoaderData } from "remix";
 import { route } from "routes-gen";
 
 type Post = {
@@ -20,7 +20,7 @@ const posts: Post[] = [
 ];
 
 export const loader: LoaderFunction = async () => {
-  return posts;
+  return json(posts);
 };
 
 export default function Products() {

--- a/examples/rust/app/routes/index.tsx
+++ b/examples/rust/app/routes/index.tsx
@@ -1,8 +1,7 @@
-import { Form, useActionData } from "remix";
+import type { ActionFunction } from "remix";
+import { Form, json, useActionData } from "remix";
 import { add } from "~/rust.server";
 import indexStylesUrl from "~/styles/index.css";
-
-import type { ActionFunction } from "remix";
 
 export function links() {
   return [{ rel: "stylesheet", href: indexStylesUrl }];
@@ -17,14 +16,14 @@ export const action: ActionFunction = async ({ request }) => {
     case "+":
       const result = add(Number(left_operand), Number(right_operand));
       console.log("result", result);
-      return {
+      return json({
         result,
-      };
+      });
     default:
       // Implement other operators
-      return {
+      return json({
         result: "🤷🏾",
-      };
+      });
   }
 };
 

--- a/examples/sanity/app/routes/$slug.jsx
+++ b/examples/sanity/app/routes/$slug.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useLoaderData } from "remix";
+import { json, useLoaderData } from "remix";
 
 import { getClient } from "~/lib/sanity/getClient";
 import { filterDataToSingleItem } from "~/lib/sanity/filterDataToSingleItem";
@@ -18,13 +18,13 @@ export async function loader({ request, params }) {
   const queryParams = { slug: params.slug };
   const initialData = await getClient(preview).fetch(query, queryParams);
 
-  return {
+  return json({
     initialData,
     preview,
     // If `preview` mode is active, we'll need these for live updates
     query: preview ? query : null,
     queryParams: preview ? queryParams : null,
-  };
+  });
 }
 
 export default function Movie() {

--- a/examples/sanity/app/routes/index.jsx
+++ b/examples/sanity/app/routes/index.jsx
@@ -1,4 +1,4 @@
-import { Link, useLoaderData } from "remix";
+import { json, Link, useLoaderData } from "remix";
 
 import { getClient } from "~/lib/sanity/getClient";
 
@@ -20,7 +20,7 @@ export async function loader() {
     `*[_type == "movie"]{ _id, title, slug }`
   );
 
-  return { movies };
+  return json({ movies });
 }
 
 export default function Index() {

--- a/examples/sharing-loader-data/app/routes/workshops/$workshopId.tsx
+++ b/examples/sharing-loader-data/app/routes/workshops/$workshopId.tsx
@@ -1,5 +1,5 @@
 import type { LoaderFunction } from "remix";
-import { useParams, useMatches, useCatch } from "remix";
+import { json, useCatch, useMatches, useParams } from "remix";
 import type { Workshop } from "~/data.server";
 import { getWorkshops } from "~/data.server";
 
@@ -15,7 +15,7 @@ export const loader: LoaderFunction = async ({ params }) => {
   // to read into our database to handle the 404 case, we don't have to send
   // the client the workshop data in this route because we sent that to the client
   // in the parent route already and we can access that data via useMatches.
-  return null;
+  return json({});
 };
 
 export default function WorkshopRoute() {

--- a/examples/strapi/app/routes/index.tsx
+++ b/examples/strapi/app/routes/index.tsx
@@ -1,7 +1,7 @@
-import type { LoaderFunction } from "remix";
-import React from "react";
-import { useLoaderData } from "remix";
 import { marked } from "marked";
+import React from "react";
+import type { LoaderFunction } from "remix";
+import { json, useLoaderData } from "remix";
 
 type Post = {
   title: string;
@@ -30,13 +30,13 @@ export const loader: LoaderFunction = async () => {
   const response = await fetch("http://localhost:1337/api/posts");
   const postResponse = (await response.json()) as PostResponse;
 
-  return postResponse.data.map((post) => ({
+  return json(postResponse.data.map((post) => ({
     ...post,
     attributes: {
       ...post.attributes,
       article: marked(post.attributes.article),
     },
-  }));
+  })));
 };
 
 const Posts: React.FC = () => {

--- a/examples/usematches-loader-data/app/root.tsx
+++ b/examples/usematches-loader-data/app/root.tsx
@@ -1,4 +1,5 @@
 import {
+  json,
   Links,
   LiveReload,
   Meta,
@@ -15,7 +16,7 @@ import { getCurrentUser } from "./db.server";
  */
 export const loader = async () => {
   const user = await getCurrentUser();
-  return { user };
+  return json({ user });
 };
 
 export default function App() {


### PR DESCRIPTION
To build upon the amazing work @chaance already did in #2250

This will make sure the warnings introduced in #2252 won't be seen in the examples.