### PR TITLE
Added json back to import list in blog example.

### DIFF
--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -695,7 +695,7 @@ If you refresh you're not going to see it yet. Every route inside of `app/routes
 💿 Add an outlet to the admin page
 
 ```tsx filename=app/routes/admin.tsx lines=[1,21]
-import { Outlet, Link, useLoaderData } from "remix";
+import { json, Outlet, Link, useLoaderData } from "remix";
 
 //...
 export default function Admin() {


### PR DESCRIPTION
At this step in the process, the `loader` method in `app/routes/admin.tsx` still requires `json` when returning `getPosts()`.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

- [ ✅ ] Docs
- [ ] Tests
