### PR TITLE
fix: check for private registry config

### DIFF
--- a/packages/remix-dev/create.ts
+++ b/packages/remix-dev/create.ts
@@ -148,6 +148,16 @@ export async function createApp({
 
   if (installDeps) {
     // TODO: use yarn/pnpm/npm
+    const npmConfig = execSync("npm config get @remix-run:registry", {
+      encoding: "utf8",
+    });
+    if (npmConfig?.startsWith("https://npm.remix.run")) {
+      console.log(
+        "🚨 Oops! You still have the private Remix registry configured. Please run `npm config delete @remix-run:registry` or edit your .npmrc file to remove it."
+      );
+      process.exit(1);
+    }
+
     execSync("npm install", { stdio: "inherit", cwd: projectDir });
   }
 }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

This PR adds a check for the old private registry config. If it's still configured, it causes errors such as those reported in #2202 and #2215 and others I've seen in Discord.

I can't find any docs on migrating from the private beta, but there could be a link to these if they exist.