### PR TITLE
fix(netlify): use Netlify internal functions dir

### DIFF
--- a/packages/create-remix/templates/netlify/gitignore
+++ b/packages/create-remix/templates/netlify/gitignore
@@ -1,5 +1,4 @@
 node_modules
 /.cache
-/netlify/functions/server/index.js
 /public/build
 /.netlify

--- a/packages/create-remix/templates/netlify/netlify.toml
+++ b/packages/create-remix/templates/netlify/netlify.toml
@@ -1,6 +1,5 @@
 [build]
   command = "remix build"
-  functions = "netlify/functions"
   publish = "public"
 
 [dev]

--- a/packages/create-remix/templates/netlify/remix.config.js
+++ b/packages/create-remix/templates/netlify/remix.config.js
@@ -7,6 +7,6 @@ module.exports = {
   ignoredRouteFiles: [".*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
-  // serverBuildPath: "netlify/functions/server/index.js",
+  // serverBuildPath: ".netlify/functions-internal/server.js",
   // publicPath: "/build/",
 };

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -324,7 +324,7 @@ export async function readConfig(
       serverBuildPath = "functions/[[path]].js";
       break;
     case "netlify":
-      serverBuildPath = "netlify/functions/server/index.js";
+      serverBuildPath = ".netlify/functions-internal/server.js";
       break;
     case "vercel":
       serverBuildPath = "api/index.js";


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

This PR changes the Netlify template, and the default `serverBuildPath` to use the internal functions directory. This is preferred for frameworks because it is in a directory that is already gitignored, and does not interfere with the user's own functions. The redirects do not need changing, because the URL is unchanged.