### PR TITLE
add nonce prop to LiveReload and ScrollRestoration

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -62,6 +62,7 @@
 - donavon
 - Dueen
 - dunglas
+- dusty
 - dwt47
 - eastlondoner
 - edgesoft

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1382,8 +1382,10 @@ export const LiveReload =
     ? () => null
     : function LiveReload({
         port = Number(process.env.REMIX_DEV_SERVER_WS_PORT || 8002),
+        nonce = undefined,
       }: {
         port?: number;
+        nonce?: string;
       }) {
         let setupLiveReload = ((port: number) => {
           let protocol = location.protocol === "https:" ? "wss:" : "ws:";
@@ -1409,6 +1411,7 @@ export const LiveReload =
 
         return (
           <script
+            nonce={nonce}
             suppressHydrationWarning
             dangerouslySetInnerHTML={{
               __html: `(${setupLiveReload})(${JSON.stringify(port)})`,

--- a/packages/remix-react/scroll-restoration.tsx
+++ b/packages/remix-react/scroll-restoration.tsx
@@ -20,7 +20,7 @@ if (typeof document !== "undefined") {
  *
  * @see https://remix.run/api/remix#scrollrestoration
  */
-export function ScrollRestoration() {
+export function ScrollRestoration({ nonce = undefined }: { nonce?: string }) {
   useScrollRestoration();
 
   // wait for the browser to restore it on its own
@@ -54,6 +54,7 @@ export function ScrollRestoration() {
 
   return (
     <script
+      nonce={nonce}
       suppressHydrationWarning
       dangerouslySetInnerHTML={{
         __html: `(${restoreScroll})(${JSON.stringify(STORAGE_KEY)})`,


### PR DESCRIPTION
This is a duplicate of https://github.com/remix-run/remix/pull/2043, which had merge conflicts.

Adds the nonce prop to LiveReload and ScrollRestoration so one can use a Content Security Policy

