### PR TITLE
chore: update remix-dev and remix-serve start message

### DIFF
--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -183,7 +183,17 @@ export async function dev(remixRoot: string, modeArg?: string) {
     await watch(config, mode, {
       onInitialBuild: () => {
         server = app.listen(port, () => {
-          console.log(`Remix App Server started at http://localhost:${port}`);
+          let address = Object.values(os.networkInterfaces())
+            .flat()
+            .find((ip) => ip?.family === "IPv4" && !ip.internal)?.address;
+
+          if (!address) {
+            console.log(`Remix App Server started at http://localhost:${port}`);
+          } else {
+            console.log(
+              `Remix App Server started at http://localhost:${port} (http://${address}:${port})`
+            );
+          }
         });
       },
     });

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -182,16 +182,8 @@ export async function dev(remixRoot: string, modeArg?: string) {
   try {
     await watch(config, mode, {
       onInitialBuild: () => {
-        let address = Object.values(os.networkInterfaces())
-          .flat()
-          .find((ip) => ip?.family == "IPv4" && !ip.internal)?.address;
-
-        if (!address) {
-          address = "localhost";
-        }
-
         server = app.listen(port, () => {
-          console.log(`Remix App Server started at http://${address}:${port}`);
+          console.log(`Remix App Server started at http://localhost:${port}`);
         });
       },
     });

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -16,13 +16,5 @@ if (!buildPathArg) {
 let buildPath = path.resolve(process.cwd(), buildPathArg);
 
 createApp(buildPath).listen(port, () => {
-  let address = Object.values(os.networkInterfaces())
-    .flat()
-    .find((ip) => ip?.family == "IPv4" && !ip.internal)?.address;
-
-  if (!address) {
-    address = "localhost";
-  }
-
-  console.log(`Remix App Server started at http://${address}:${port}`);
+  console.log(`Remix App Server started at http://localhost:${port}`);
 });

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -16,5 +16,15 @@ if (!buildPathArg) {
 let buildPath = path.resolve(process.cwd(), buildPathArg);
 
 createApp(buildPath).listen(port, () => {
-  console.log(`Remix App Server started at http://localhost:${port}`);
+  let address = Object.values(os.networkInterfaces())
+    .flat()
+    .find((ip) => ip?.family === "IPv4" && !ip.internal)?.address;
+
+  if (!address) {
+    console.log(`Remix App Server started at http://localhost:${port}`);
+  } else {
+    console.log(
+      `Remix App Server started at http://localhost:${port} (http://${address}:${port})`
+    );
+  }
 });


### PR DESCRIPTION
there are pretty major differences in how `localhost:3000` and ip addresses work (besides 127.0.0.1) in browsers as localhost is deemed a ["secure" context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts#:~:text=Locally%2Ddelivered%20resources%20such%20as%20those%20with%20http%3A//127.0.0.1%20URLs%2C%20http%3A//localhost%20and%20http%3A//*.localhost%20URLs%20(e.g.%20http%3A//dev.whatever.localhost/)%2C%20and%20file%3A//%20URLs%20are%20also%20considered%20to%20have%20been%20delivered%20securely.), so [Client Hint](https://developer.mozilla.org/en-US/docs/Web/HTTP/Client_hints) HTTP headers aren't sent and secure cookies don't work 

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests
