### PR TITLE
[@remix-run/remix-eslint-config] Include jest-testing-library.js

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -182,6 +182,7 @@
 - medayz
 - meetbryce
 - mehulmpt
+- mennopruijssers
 - michaeldeboey
 - michaelfriedman
 - michaseel

--- a/packages/remix-eslint-config/package.json
+++ b/packages/remix-eslint-config/package.json
@@ -17,6 +17,7 @@
     "index.js",
     "internal.js",
     "jest.js",
+    "jest-testing-library.js",
     "node.js",
     "rules",
     "settings"


### PR DESCRIPTION
Right now `jest-testing-library.js` isn't included when publishing to NPM while this should be the case.
This PR fixes it by adding it to the `files` array in `package.json`