### PR TITLE
feat(remix-react): add support for `charset` in `meta` function

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -668,6 +668,8 @@ export function Meta() {
         let isOpenGraphTag = name.startsWith("og:");
         return name === "title" ? (
           <title key="title">{value}</title>
+        ) : ["charset", "charSet"].includes(name) ? (
+          <meta key="charset" charSet={value as string} />
         ) : Array.isArray(value) ? (
           value.map((content) =>
             isOpenGraphTag ? (

--- a/templates/arc-ts/app/root.tsx
+++ b/templates/arc-ts/app/root.tsx
@@ -8,16 +8,16 @@ import {
 } from "remix";
 import type { MetaFunction } from "remix";
 
-export const meta: MetaFunction = () => {
-  return { title: "New Remix App" };
-};
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/arc/app/root.jsx
+++ b/templates/arc/app/root.jsx
@@ -8,15 +8,17 @@ import {
 } from "remix";
 
 export function meta() {
-  return { title: "New Remix App" };
+  return {
+    charset: "utf-8",
+    title: "New Remix App",
+    viewport: "width=device-width,initial-scale=1",
+  };
 }
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/cloudflare-pages-ts/app/root.tsx
+++ b/templates/cloudflare-pages-ts/app/root.tsx
@@ -8,16 +8,16 @@ import {
 } from "remix";
 import type { MetaFunction } from "remix";
 
-export const meta: MetaFunction = () => {
-  return { title: "New Remix App" };
-};
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/cloudflare-pages/app/root.jsx
+++ b/templates/cloudflare-pages/app/root.jsx
@@ -8,15 +8,17 @@ import {
 } from "remix";
 
 export function meta() {
-  return { title: "New Remix App" };
+  return {
+    charset: "utf-8",
+    title: "New Remix App",
+    viewport: "width=device-width,initial-scale=1",
+  };
 }
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/cloudflare-workers-ts/app/root.tsx
+++ b/templates/cloudflare-workers-ts/app/root.tsx
@@ -8,16 +8,16 @@ import {
 } from "remix";
 import type { MetaFunction } from "remix";
 
-export const meta: MetaFunction = () => {
-  return { title: "New Remix App" };
-};
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/cloudflare-workers/app/root.jsx
+++ b/templates/cloudflare-workers/app/root.jsx
@@ -8,15 +8,17 @@ import {
 } from "remix";
 
 export function meta() {
-  return { title: "New Remix App" };
+  return {
+    charset: "utf-8",
+    title: "New Remix App",
+    viewport: "width=device-width,initial-scale=1",
+  };
 }
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/deno-ts/app/root.tsx
+++ b/templates/deno-ts/app/root.tsx
@@ -9,16 +9,16 @@ import {
 } from "./deps/@remix-run/react.ts";
 import type { MetaFunction } from "./deps/@remix-run/server-runtime.ts";
 
-export const meta: MetaFunction = () => {
-  return { title: "New Remix App" };
-};
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/express-ts/app/root.tsx
+++ b/templates/express-ts/app/root.tsx
@@ -8,16 +8,16 @@ import {
 } from "remix";
 import type { MetaFunction } from "remix";
 
-export const meta: MetaFunction = () => {
-  return { title: "New Remix App" };
-};
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/express/app/root.jsx
+++ b/templates/express/app/root.jsx
@@ -8,15 +8,17 @@ import {
 } from "remix";
 
 export function meta() {
-  return { title: "New Remix App" };
+  return {
+    charset: "utf-8",
+    title: "New Remix App",
+    viewport: "width=device-width,initial-scale=1",
+  };
 }
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/fly-ts/app/root.tsx
+++ b/templates/fly-ts/app/root.tsx
@@ -8,16 +8,16 @@ import {
 } from "remix";
 import type { MetaFunction } from "remix";
 
-export const meta: MetaFunction = () => {
-  return { title: "New Remix App" };
-};
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/fly/app/root.jsx
+++ b/templates/fly/app/root.jsx
@@ -8,15 +8,17 @@ import {
 } from "remix";
 
 export function meta() {
-  return { title: "New Remix App" };
+  return {
+    charset: "utf-8",
+    title: "New Remix App",
+    viewport: "width=device-width,initial-scale=1",
+  };
 }
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/netlify-ts/app/root.tsx
+++ b/templates/netlify-ts/app/root.tsx
@@ -8,16 +8,16 @@ import {
 } from "remix";
 import type { MetaFunction } from "remix";
 
-export const meta: MetaFunction = () => {
-  return { title: "New Remix App" };
-};
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/netlify/app/root.jsx
+++ b/templates/netlify/app/root.jsx
@@ -8,15 +8,17 @@ import {
 } from "remix";
 
 export function meta() {
-  return { title: "New Remix App" };
+  return {
+    charset: "utf-8",
+    title: "New Remix App",
+    viewport: "width=device-width,initial-scale=1",
+  };
 }
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/remix-ts/app/root.tsx
+++ b/templates/remix-ts/app/root.tsx
@@ -8,16 +8,16 @@ import {
 } from "remix";
 import type { MetaFunction } from "remix";
 
-export const meta: MetaFunction = () => {
-  return { title: "New Remix App" };
-};
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/remix/app/root.jsx
+++ b/templates/remix/app/root.jsx
@@ -8,15 +8,17 @@ import {
 } from "remix";
 
 export function meta() {
-  return { title: "New Remix App" };
+  return {
+    charset: "utf-8",
+    title: "New Remix App",
+    viewport: "width=device-width,initial-scale=1",
+  };
 }
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/vercel-ts/app/root.tsx
+++ b/templates/vercel-ts/app/root.tsx
@@ -8,16 +8,16 @@ import {
 } from "remix";
 import type { MetaFunction } from "remix";
 
-export const meta: MetaFunction = () => {
-  return { title: "New Remix App" };
-};
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>

--- a/templates/vercel/app/root.jsx
+++ b/templates/vercel/app/root.jsx
@@ -8,15 +8,17 @@ import {
 } from "remix";
 
 export function meta() {
-  return { title: "New Remix App" };
+  return {
+    charset: "utf-8",
+    title: "New Remix App",
+    viewport: "width=device-width,initial-scale=1",
+  };
 }
 
 export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>


### PR DESCRIPTION
@kentcdodds mentioned this a couple of times in his streams that he wanted to have this, so all `meta` tags are arranged by the `<Meta />` component