### PR TITLE
docs(examples): fix `build` script of Tailwind example

### DIFF
--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -430,7 +430,7 @@ Update the package scripts to generate the Tailwind file during dev and for the 
 {
   // ...
   "scripts": {
-    "build": "run-p build:*",
+    "build": "run-s build:*",
     "build:css": "npm run generate:css -- --minify",
     "build:remix": "cross-env NODE_ENV=production remix build",
     "dev": "run-p dev:*",
@@ -475,7 +475,7 @@ Then alter how Tailwind is generating your css:
 {
   // ...
   "scripts": {
-    "build": "run-p build:*",
+    "build": "run-s build:*",
     "build:css": "npm run generate:css -- --minify",
     "build:remix": "cross-env NODE_ENV=production remix build",
     "dev": "run-p dev:*",

--- a/examples/tailwindcss/package.json
+++ b/examples/tailwindcss/package.json
@@ -5,7 +5,7 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "build": "run-p build:*",
+    "build": "run-s build:*",
     "build:css": "npm run generate:css -- --minify",
     "build:remix": "remix build",
     "dev": "run-p dev:*",


### PR DESCRIPTION
> The following 2 commands are the same.
> The `run-s` command is shorter.
> 
> ```
> $ run-s clean lint build
> $ npm run clean && npm run lint && npm run build
> ```
https://github.com/mysticatea/npm-run-all/blob/master/docs/run-s.md