### PR TITLE
docs(tutorials/jokes) - Fix delete files instructions 

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -208,6 +208,7 @@
 - nurul3101
 - nwalters512
 - omamazainab
+- octokatherine
 - oott123
 - orballo
 - phishy

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -183,10 +183,9 @@ Remix App Server started at http://localhost:3000
 
 Open up that URL and you should be presented with a minimal page pointing to some docs.
 
-💿 Now stop the server and delete all this stuff:
+💿 Now stop the server and delete this directory:
 
 - `app/routes`
-- `app/styles`
 
 We're going to trim this down the bare bones and introduce things incrementally.
 


### PR DESCRIPTION

- [x] Docs
- [ ] Tests

The jokes tutorial instructed to delete `app/styles`, which did not exist at this point.
