### PR TITLE
feat(remix-react): add support for `http-equiv` in `meta` function

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -1018,7 +1018,7 @@ There are a few special cases (read about those below). In the case of nested ro
 
 #### `HtmlMetaDescriptor`
 
-This is an object representation and abstraction of a `<meta {...props} />` element and its attributes. [View the MDN docs for the meta API](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta).
+This is an object representation and abstraction of a `<meta {...props}>` element and its attributes. [View the MDN docs for the meta API](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta).
 
 The `meta` export from a route should return a single `HtmlMetaDescriptor` object.
 
@@ -1026,22 +1026,31 @@ Almost every `meta` element takes a `name` and `content` attribute, with the exc
 
 The `meta` object can also hold a `title` reference which maps to the [HTML `<title>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title).
 
-As a convenience, `charSet: "utf-8"` will render a `<meta charSet="utf-8" />`.
+As a convenience, `charset: "utf-8"` will render a `<meta charset="utf-8">`.
+
+As a last option, you can also pass an object of attribute/value pairs as the value. This can be used as an escape-hetch for meta tags like the [`http-equiv` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-http-equiv) which uses `http-equiv` instead of `name`.
 
 Examples:
 
 ```tsx
 import type { MetaFunction } from "remix";
 
-export const meta: MetaFunction = () => {
-  return {
-    title: "Josie's Shake Shack", // <title>Josie's Shake Shack</title>
-    charSet: "utf-8", // <meta charSet="utf-8" />
-    description: "Delicious shakes", // <meta name="description" content="Delicious shakes">
-    "og:image": "https://josiesshakeshack.com/logo.jpg", // <meta property="og:image" content="https://josiesshakeshack.com/logo.jpg">
-    viewport: "width=device-width,initial-scale=1", // <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  };
-};
+export const meta: MetaFunction = () => ({
+  // Special cases
+  charset: "utf-8", // <meta charset="utf-8">
+  "og:image": "https://josiesshakeshack.com/logo.jpg", // <meta property="og:image" content="https://josiesshakeshack.com/logo.jpg">
+  title: "Josie's Shake Shack", // <title>Josie's Shake Shack</title>
+
+  // content => name
+  description: "Delicious shakes", // <meta name="description" content="Delicious shakes">
+  viewport: "width=device-width,initial-scale=1", // <meta name="viewport" content="width=device-width,initial-scale=1">
+
+  // <meta {...value}>
+  refresh: {
+    httpEquiv: "refresh",
+    content: "3;url=https://www.mozilla.org",
+  }, // <meta http-equiv="refresh" content="3;url=https://www.mozilla.org">
+});
 ```
 
 #### Page context in `meta` function
@@ -1055,18 +1064,18 @@ export const meta: MetaFunction = () => {
 
 ```tsx
 export const meta: MetaFunction = ({ data, params }) => {
-  if (data) {
-    const { shake } = data as LoaderData;
-    return {
-      title: `${shake.name} milkshake`,
-      description: shake.summary,
-    };
-  } else {
+  if (!data) {
     return {
       title: "Missing Shake",
       description: `There is no shake with the ID of ${params.shakeId}. 😢`,
     };
   }
+
+  const { shake } = data as LoaderData;
+  return {
+    title: `${shake.name} milkshake`,
+    description: shake.summary,
+  };
 };
 ```
 

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -9,18 +9,18 @@ This package provides all the components, hooks, and [Web Fetch API](https://dev
 
 ## Components and Hooks
 
-### `<Meta>`, `<Links>`, `<Scripts>`, `<LiveReload>`, `<ScrollRestoration>`
+### `<Links>`, `<LiveReload>`, `<Meta>`, `<Scripts>`, `<ScrollRestoration>`
 
 These components are to be used once inside of your root route (`root.tsx`). They include everything Remix figured out or built in order for your page to render properly.
 
 ```tsx
-import type { MetaFunction, LinksFunction } from "remix";
+import type { LinksFunction, MetaFunction } from "remix";
 import {
-  Meta,
   Links,
-  Scripts,
-  Outlet,
   LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
   ScrollRestoration,
 } from "remix";
 
@@ -30,13 +30,11 @@ export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: globalStylesheetUrl }];
 };
 
-export const meta: MetaFunction = () => {
-  return {
-    title: "My Amazing App",
-    viewport: "width=device-width,initial-scale=1",
-    charSet: "utf-8",
-  };
-};
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "My Amazing App",
+  viewport: "width=device-width,initial-scale=1",
+});
 
 export default function App() {
   return (
@@ -95,7 +93,7 @@ In our effort to remove all loading states from your UI, `Link` can automaticall
 
 ```tsx
 <>
-  <Link /> // defaults to "none"
+  <Link /> {/* defaults to "none" */}
   <Link prefetch="none" />
   <Link prefetch="intent" />
   <Link prefetch="render" />
@@ -194,7 +192,7 @@ If the `end` prop is used, it will ensure this component isn't matched as "activ
 
 The `<Form>` component is a declarative way to perform data mutations: creating, updating, and deleting data. While it might be a mind-shift to think about these tasks as "navigation", it's how the web has handled mutations since before JavaScript was created!
 
-```js
+```tsx
 import { Form } from "remix";
 
 function NewEvent() {
@@ -218,7 +216,7 @@ Most of the time you can omit this prop. Forms without an action prop (`<Form me
 
 If you need to post to a different route, then add an action prop:
 
-```jsx
+```tsx
 <Form action="/projects/new" method="post" />
 ```
 
@@ -235,7 +233,7 @@ If you want to post to an index route use `?index` in the action: `<Form action=
 
 This determines the [HTTP verb](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) to be used: get, post, put, patch, delete. The default is "get".
 
-```jsx
+```tsx
 <Form method="post" />
 ```
 
@@ -286,7 +284,7 @@ This component will emulate the browser's scroll restoration on location changes
 
 It must be the last element on the page, right before the `<Scripts/>` tag:
 
-```tsx [4,5]
+```tsx lines=[4,5]
 <html>
   <body>
     {/* ... */}
@@ -348,7 +346,7 @@ export default function Invoices() {
 
 The most common use-case for this hook is form validation errors. If the form isn't right, you can simply return the errors and let the user try again (instead of pushing all the errors into sessions and back out of the loader).
 
-```tsx [21, 30, 38-40, 44-46]
+```tsx lines=[21, 30, 38-40, 44-46]
 import { redirect, json, Form, useActionData } from "remix";
 
 export async function action({ request }) {

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -10,20 +10,24 @@ describe("meta", () => {
       files: {
         "app/root.jsx": js`
           import { json, Meta, Links, Outlet, Scripts } from "remix";
-          
+
           export const loader = async () =>
             json({
               description: "This is a meta page",
               title: "Meta Page",
             });
-          
+
           export const meta = ({ data }) => ({
+            charset: "utf-8",
             description: data.description,
             "og:image": "https://picsum.photos/200/200",
             "og:type": data.contentType, // undefined
+            refresh: {
+              httpEquiv: "refresh",
+              content: "3;url=https://www.mozilla.org",
+            },
             title: data.title,
           });
-
 
           export default function Root() {
             return (
@@ -52,8 +56,26 @@ describe("meta", () => {
     app = await createAppFixture(fixture);
   });
 
-  afterAll(async () => {
-    await app.close();
+  afterAll(async () => await app.close());
+
+  test("empty meta does not render a tag", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    await expect(app.getHtml('meta[property="og:type"]')).rejects.toThrowError(
+      'No element matches selector "meta[property="og:type"]"'
+    );
+    await enableJavaScript();
+  });
+
+  test("meta { charset } adds a <meta charset='utf-8' />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    expect(await app.getHtml('meta[charset="utf-8"]')).toBeTruthy();
+    await enableJavaScript();
   });
 
   test("meta { title } adds a <title />", async () => {
@@ -61,20 +83,7 @@ describe("meta", () => {
 
     await app.goto("/");
 
-    expect(await app.getHtml("title")).toEqual(
-      expect.stringMatching(/<title>/s)
-    );
-    await enableJavaScript();
-  });
-
-  test("meta { description } adds a <meta name='description' />", async () => {
-    let enableJavaScript = await app.disableJavaScript();
-
-    await app.goto("/");
-
-    expect(await app.getHtml("meta")).toEqual(
-      expect.stringMatching(/<meta\s+name="description"/s)
-    );
+    expect(await app.getHtml("title")).toBeTruthy();
     await enableJavaScript();
   });
 
@@ -83,20 +92,29 @@ describe("meta", () => {
 
     await app.goto("/");
 
-    expect(await app.getHtml("meta")).toEqual(
-      expect.stringMatching(/<meta\s+property="og:*/s)
-    );
+    expect(await app.getHtml('meta[property="og:image"]')).toBeTruthy();
     await enableJavaScript();
   });
 
-  test("empty meta does not render a tag", async () => {
+  test("meta { description } adds a <meta name='description' />", async () => {
     let enableJavaScript = await app.disableJavaScript();
 
     await app.goto("/");
 
-    expect(await app.getHtml("meta")).not.toEqual(
-      expect.stringMatching(/<meta\s+property="og:type/s)
-    );
+    expect(await app.getHtml('meta[name="description"]')).toBeTruthy();
+    await enableJavaScript();
+  });
+
+  test("meta { refresh } adds a <meta http-equiv='refresh' content='3;url=https://www.mozilla.org' />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    expect(
+      await app.getHtml(
+        'meta[http-equiv="refresh"][content="3;url=https://www.mozilla.org"]'
+      )
+    ).toBeTruthy();
     await enableJavaScript();
   });
 });

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -663,28 +663,38 @@ export function Meta() {
   return (
     <>
       {Object.entries(meta).map(([name, value]) => {
-        if (!value) return null;
+        if (!value) {
+          return null;
+        }
+
+        if (["charset", "charSet"].includes(name)) {
+          return <meta key="charset" charSet={value as string} />;
+        }
+
+        if (name === "title") {
+          return <title key="title">{value}</title>;
+        }
 
         // Open Graph tags use the `property` attribute, while other meta tags
         // use `name`. See https://ogp.me/
         let isOpenGraphTag = name.startsWith("og:");
-        return name === "title" ? (
-          <title key="title">{value}</title>
-        ) : ["charset", "charSet"].includes(name) ? (
-          <meta key="charset" charSet={value as string} />
-        ) : Array.isArray(value) ? (
-          value.map((content) =>
-            isOpenGraphTag ? (
-              <meta key={name + content} property={name} content={content} />
-            ) : (
-              <meta key={name + content} name={name} content={content} />
-            )
-          )
-        ) : isOpenGraphTag ? (
-          <meta key={name} property={name} content={value} />
-        ) : (
-          <meta key={name} name={name} content={value} />
-        );
+        return [value].flatMap((content) => {
+          if (isOpenGraphTag) {
+            return (
+              <meta
+                content={content as string}
+                key={name + content}
+                property={name}
+              />
+            );
+          }
+
+          if (typeof content === "string") {
+            return <meta content={content} name={name} key={name + content} />;
+          }
+
+          return <meta key={name + JSON.stringify(content)} {...content} />;
+        });
       })}
     </>
   );

--- a/packages/remix-react/routeModules.ts
+++ b/packages/remix-react/routeModules.ts
@@ -71,7 +71,16 @@ export interface MetaFunction {
  * `name` attribute.
  */
 export interface HtmlMetaDescriptor {
-  [name: string]: string | string[] | null | undefined;
+  charset?: "utf-8";
+  charSet?: "utf-8";
+  title?: string;
+  [name: string]:
+    | null
+    | string
+    | string[]
+    | undefined
+    | Record<string, string>
+    | Record<string, string>[];
 }
 
 /**

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -92,7 +92,16 @@ export interface MetaFunction {
  * `name` attribute.
  */
 export interface HtmlMetaDescriptor {
-  [name: string]: string | string[] | null | undefined;
+  charset?: "utf-8";
+  charSet?: "utf-8";
+  title?: string;
+  [name: string]:
+    | null
+    | string
+    | string[]
+    | undefined
+    | Record<string, string>
+    | Record<string, string>[];
 }
 
 export type MetaDescriptor = HtmlMetaDescriptor;


### PR DESCRIPTION
Took inspiration of the OG tags: if people want to use the `http-equiv` tag, they'll have to do

```ts
export const meta: MetaFunction = () => ({
  'http-equiv:refresh': '3;url=https://www.mozilla.org',
});
```

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-http-equiv

@kentcdodds Not sure how this would best fit in the docs, so I'll leave that up to you if you don't mind.

---

Closes #941