### PR TITLE
fix: empty gists app remix node modules before copying new ones

### DIFF
--- a/fixtures/gists-app/scripts/install_remix.js
+++ b/fixtures/gists-app/scripts/install_remix.js
@@ -9,6 +9,9 @@ let installDir = path.resolve(__dirname, "../node_modules");
 async function run() {
   // Install all remix packages
   await fs.ensureDir(installDir);
+  await fs.emptyDir(path.resolve(installDir, "@remix-run"));
+  await fs.emptyDir(path.resolve(installDir, "remix"));
+  await fs.emptyDir(path.resolve(installDir, "create-remix"));
   await fs.copy(buildDir, installDir);
 }
 


### PR DESCRIPTION
we changed platform.ts to remix.ts but if you didnt nuke your node_modules we would combine them in remix setup

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests
