### PR TITLE
fix(remix-dev/create): always pull templates from dev

### DIFF
--- a/packages/remix-dev/create.ts
+++ b/packages/remix-dev/create.ts
@@ -176,9 +176,7 @@ async function downloadAndExtractTemplateOrExample(
   }
 ) {
   let response = await fetch(
-    type === "templates"
-      ? "https://codeload.github.com/remix-run/remix/tar.gz/logan/support-remote-repos-in-create-remix"
-      : "https://codeload.github.com/remix-run/remix/tar.gz/main",
+    "https://codeload.github.com/remix-run/remix/tar.gz/main",
     options.token
       ? { headers: { Authorization: `token ${options.token}` } }
       : {}

--- a/packages/remix-dev/create.ts
+++ b/packages/remix-dev/create.ts
@@ -176,7 +176,7 @@ async function downloadAndExtractTemplateOrExample(
   }
 ) {
   let response = await fetch(
-    "https://codeload.github.com/remix-run/remix/tar.gz/main",
+    "https://codeload.github.com/remix-run/remix/tar.gz/dev",
     options.token
       ? { headers: { Authorization: `token ${options.token}` } }
       : {}


### PR DESCRIPTION
left over TODO from the other day that i never marked as a TODO 😅

reason being is that's where the templates and examples will get updates

if `examples` might get PR for "main", we'll need to branch this a bit...

x-ref #2315
x-ref #2189

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests
