### PR TITLE
fix(remix-dev/create): move getRepoInfo check after example/template check

### DIFF
--- a/packages/remix-dev/create.ts
+++ b/packages/remix-dev/create.ts
@@ -406,14 +406,14 @@ async function detectTemplateType(
   if (template.startsWith("file://") || fse.existsSync(template)) {
     return "local";
   }
-  if (await getRepoInfo(template, token)) {
-    return "repo";
-  }
   if (await isRemixTemplate(template, useTypeScript, token)) {
     return "template";
   }
   if (await isRemixExample(template, token)) {
     return "example";
+  }
+  if (await getRepoInfo(template, token)) {
+    return "repo";
   }
   return "remoteTarball";
 }


### PR DESCRIPTION
broke it here https://github.com/remix-run/remix/commit/d7e2d535ff71cfd5fbbe1705924a4ed3b16374ea 🤦‍♂️

the other option would be to change the template name

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests
