### PR TITLE
fix(templates): remove `cross-env` references

### DIFF
--- a/templates/arc-ts/package.json
+++ b/templates/arc-ts/package.json
@@ -5,11 +5,11 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "postinstall": "remix setup node",
-    "build": "cross-env NODE_ENV=production remix build",
-    "dev:remix": "cross-env NODE_ENV=development remix watch",
+    "build": "remix build",
+    "dev:remix": "remix watch",
     "dev:arc": "cross-env NODE_ENV=development arc sandbox",
-    "dev": "cross-env NODE_ENV=development remix build && run-p dev:*",
+    "dev": "remix build && run-p dev:*",
+    "postinstall": "remix setup node",
     "start": "cross-env NODE_ENV=production arc sandbox"
   },
   "dependencies": {

--- a/templates/arc/package.json
+++ b/templates/arc/package.json
@@ -5,11 +5,11 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "postinstall": "remix setup node",
-    "build": "cross-env NODE_ENV=production remix build",
-    "dev:remix": "cross-env NODE_ENV=development remix watch",
+    "build": "remix build",
+    "dev:remix": "remix watch",
     "dev:arc": "cross-env NODE_ENV=development arc sandbox",
-    "dev": "cross-env NODE_ENV=development remix build && run-p dev:*",
+    "dev": "remix build && run-p dev:*",
+    "postinstall": "remix setup node",
     "start": "cross-env NODE_ENV=production arc sandbox"
   },
   "dependencies": {

--- a/templates/cloudflare-pages-ts/package.json
+++ b/templates/cloudflare-pages-ts/package.json
@@ -5,11 +5,11 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "postinstall": "remix setup cloudflare-pages",
-    "build": "cross-env NODE_ENV=production remix build",
-    "dev:remix": "cross-env NODE_ENV=development remix watch",
+    "build": "remix build",
+    "dev:remix": "remix watch",
     "dev:wrangler": "cross-env NODE_ENV=development wrangler pages dev ./public",
-    "dev": "cross-env NODE_ENV=development remix build && run-p dev:*",
+    "dev": "remix build && run-p dev:*",
+    "postinstall": "remix setup cloudflare-pages",
     "start": "cross-env NODE_ENV=production npm run dev:wrangler"
   },
   "dependencies": {

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -5,11 +5,11 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "postinstall": "remix setup cloudflare-pages",
-    "build": "cross-env NODE_ENV=production remix build",
-    "dev:remix": "cross-env NODE_ENV=development remix watch",
+    "build": "remix build",
+    "dev:remix": "remix watch",
     "dev:wrangler": "cross-env NODE_ENV=development wrangler pages dev ./public",
-    "dev": "cross-env NODE_ENV=development remix build && run-p dev:*",
+    "dev": "remix build && run-p dev:*",
+    "postinstall": "remix setup cloudflare-pages",
     "start": "cross-env NODE_ENV=production npm run dev:wrangler"
   },
   "dependencies": {

--- a/templates/cloudflare-workers-ts/package.json
+++ b/templates/cloudflare-workers-ts/package.json
@@ -6,13 +6,13 @@
   "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
-    "postinstall": "remix setup cloudflare-workers",
-    "build": "cross-env NODE_ENV=production remix build",
-    "dev:remix": "cross-env NODE_ENV=development remix watch",
+    "build": "remix build",
+    "deploy": "npm run build && wrangler publish",
+    "dev:remix": "remix watch",
     "dev:miniflare": "cross-env NODE_ENV=development miniflare ./build/index.js --watch",
-    "dev": "cross-env NODE_ENV=development remix build && run-p dev:*",
-    "start": "cross-env NODE_ENV=production miniflare ./build/index.js",
-    "deploy": "npm run build && wrangler publish"
+    "dev": "remix build && run-p dev:*",
+    "postinstall": "remix setup cloudflare-workers",
+    "start": "cross-env NODE_ENV=production miniflare ./build/index.js"
   },
   "dependencies": {
     "@remix-run/cloudflare-workers": "^1.2.3",

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -6,13 +6,13 @@
   "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
-    "postinstall": "remix setup cloudflare-workers",
-    "build": "cross-env NODE_ENV=production remix build",
-    "dev:remix": "cross-env NODE_ENV=development remix watch",
+    "build": "remix build",
+    "deploy": "npm run build && wrangler publish",
+    "dev:remix": "remix watch",
     "dev:miniflare": "cross-env NODE_ENV=development miniflare ./build/index.js --watch",
-    "dev": "cross-env NODE_ENV=development remix build && run-p dev:*",
-    "start": "cross-env NODE_ENV=production miniflare ./build/index.js",
-    "deploy": "npm run build && wrangler publish"
+    "dev": "remix build && run-p dev:*",
+    "postinstall": "remix setup cloudflare-workers",
+    "start": "cross-env NODE_ENV=production miniflare ./build/index.js"
   },
   "dependencies": {
     "@remix-run/cloudflare-workers": "^1.2.3",

--- a/templates/deno-ts/package.json
+++ b/templates/deno-ts/package.json
@@ -2,11 +2,11 @@
     "private": true,
     "sideEffects": false,
     "scripts": {
-      "build": "cross-env NODE_ENV=production remix build",
-      "start": "cross-env NODE_ENV=production deno run --allow-net --allow-read --allow-env ./build/index.js",
-      "dev": "cross-env NODE_ENV=development remix build && run-p dev:*",
-      "dev:remix": "cross-env NODE_ENV=development remix watch",
-      "dev:deno": "cross-env NODE_ENV=development deno run --watch --allow-net --allow-read --allow-env ./build/index.js"
+      "build": "remix build",
+      "dev": "remix build && run-p dev:*",
+      "dev:remix": "remix watch",
+      "dev:deno": "cross-env NODE_ENV=development deno run --watch --allow-net --allow-read --allow-env ./build/index.js",
+      "start": "cross-env NODE_ENV=production deno run --allow-net --allow-read --allow-env ./build/index.js"
     },
     "devDependencies": {
       "@remix-run/dev": "*",

--- a/templates/express-ts/package.json
+++ b/templates/express-ts/package.json
@@ -5,10 +5,10 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "build": "cross-env NODE_ENV=production remix build",
-    "dev": "cross-env NODE_ENV=development remix build && run-p dev:*",
+    "build": "remix build",
+    "dev": "remix build && run-p dev:*",
     "dev:node": "cross-env NODE_ENV=development nodemon ./build/index.js --watch ./build/index.js",
-    "dev:remix": "cross-env NODE_ENV=development remix watch",
+    "dev:remix": "remix watch",
     "postinstall": "remix setup node",
     "start": "cross-env NODE_ENV=production node ./build/index.js"
   },

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -5,10 +5,10 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "build": "cross-env NODE_ENV=production remix build",
-    "dev": "cross-env NODE_ENV=development remix build && run-p dev:*",
+    "build": "remix build",
+    "dev": "remix build && run-p dev:*",
     "dev:node": "cross-env NODE_ENV=development nodemon ./build/index.js --watch ./build/index.js",
-    "dev:remix": "cross-env NODE_ENV=development remix watch",
+    "dev:remix": "remix watch",
     "postinstall": "remix setup node",
     "start": "cross-env NODE_ENV=production node ./build/index.js"
   },

--- a/templates/fly-ts/package.json
+++ b/templates/fly-ts/package.json
@@ -5,16 +5,15 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "build": "cross-env NODE_ENV=production remix build",
+    "build": "remix build",
     "deploy": "fly deploy --remote-only",
-    "dev": "cross-env NODE_ENV=development remix dev",
+    "dev": "remix dev",
     "postinstall": "remix setup node",
-    "start": "cross-env NODE_ENV=production remix-serve build"
+    "start": "remix-serve build"
   },
   "dependencies": {
     "@remix-run/react": "^1.2.3",
     "@remix-run/serve": "^1.2.3",
-    "cross-env": "^7.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remix": "^1.2.3"

--- a/templates/fly/package.json
+++ b/templates/fly/package.json
@@ -5,16 +5,15 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "build": "cross-env NODE_ENV=production remix build",
+    "build": "remix build",
     "deploy": "fly deploy --remote-only",
-    "dev": "cross-env NODE_ENV=development remix dev",
+    "dev": "remix dev",
     "postinstall": "remix setup node",
-    "start": "cross-env NODE_ENV=production remix-serve build"
+    "start": "remix-serve build"
   },
   "dependencies": {
     "@remix-run/react": "^1.2.3",
     "@remix-run/serve": "^1.2.3",
-    "cross-env": "^7.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remix": "^1.2.3"

--- a/templates/remix-ts/package.json
+++ b/templates/remix-ts/package.json
@@ -5,15 +5,14 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "build": "cross-env NODE_ENV=production remix build",
-    "dev": "cross-env NODE_ENV=development remix dev",
+    "build": "remix build",
+    "dev": "remix dev",
     "postinstall": "remix setup node",
-    "start": "cross-env NODE_ENV=production remix-serve build"
+    "start": "remix-serve build"
   },
   "dependencies": {
     "@remix-run/react": "^1.2.3",
     "@remix-run/serve": "^1.2.3",
-    "cross-env": "^7.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remix": "^1.2.3"

--- a/templates/remix/package.json
+++ b/templates/remix/package.json
@@ -5,15 +5,14 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "build": "cross-env NODE_ENV=production remix build",
-    "dev": "cross-env NODE_ENV=development remix dev",
+    "build": "remix build",
+    "dev": "remix dev",
     "postinstall": "remix setup node",
-    "start": "cross-env NODE_ENV=production remix-serve build"
+    "start": "remix-serve build"
   },
   "dependencies": {
     "@remix-run/react": "^1.2.3",
     "@remix-run/serve": "^1.2.3",
-    "cross-env": "^7.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remix": "^1.2.3"

--- a/templates/vercel-ts/package.json
+++ b/templates/vercel-ts/package.json
@@ -5,14 +5,13 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "build": "cross-env NODE_ENV=production remix build",
-    "dev": "cross-env NODE_ENV=development remix dev",
+    "build": "remix build",
+    "dev": "remix dev",
     "postinstall": "remix setup node"
   },
   "dependencies": {
     "@remix-run/react": "^1.2.3",
     "@remix-run/vercel": "^1.2.3",
-    "cross-env": "^7.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remix": "^1.2.3"

--- a/templates/vercel/package.json
+++ b/templates/vercel/package.json
@@ -5,14 +5,13 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "build": "cross-env NODE_ENV=production remix build",
-    "dev": "cross-env NODE_ENV=development remix dev",
+    "build": "remix build",
+    "dev": "remix dev",
     "postinstall": "remix setup node"
   },
   "dependencies": {
     "@remix-run/react": "^1.2.3",
     "@remix-run/vercel": "^1.2.3",
-    "cross-env": "^7.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remix": "^1.2.3"


### PR DESCRIPTION
As discussed with @chaance, all `cross-env` references should be removed when calling Remix scripts

---

Follow-up of 9e3f164e