### PR TITLE
docs(tutorials): mention stacks to avoid confusing new comers

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -63,6 +63,7 @@
 - donavon
 - Dueen
 - dunglas
+- dwightwatson
 - dwt47
 - eastlondoner
 - edgesoft

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -29,7 +29,7 @@ Make sure you are running at least Node v14 or greater
 
 ```sh
 npx create-remix@latest
-# IMPORTANT: Choose "Remix App Server" when prompted
+# IMPORTANT: Choose "Just the basics", and then "Remix App Server" when prompted
 cd [whatever you named the project]
 npm run dev
 ```

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -94,7 +94,7 @@ This may ask you whether you want to install `create-remix` to run the command. 
 
 </docs-info>
 
-When the fun Remix animation is finished, it'll ask you a few questions. We'll call our app "remix-jokes", choose the "Remix App Server" deploy target, use TypeScript, and have it run the installation for us:
+When the fun Remix animation is finished, it'll ask you a few questions. We'll call our app "remix-jokes", choose "Just the basics", then the "Remix App Server" deploy target, use TypeScript, and have it run the installation for us:
 
 ```
 R E M I X


### PR DESCRIPTION
When going through the tutorials I was thrown off by the introduction of stacks - being asked to choose which type of app I want. This guides the user to select "Just the basics" so they can continue with the tutorials as they work now.