### PR TITLE
feat: revalidate on redirect if cookies were set

### DIFF
--- a/integration/set-cookie-revalidation-test.ts
+++ b/integration/set-cookie-revalidation-test.ts
@@ -1,0 +1,110 @@
+import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
+import type { Fixture, AppFixture } from "./helpers/create-fixture";
+
+let fixture: Fixture;
+let app: AppFixture;
+
+let BANNER_MESSAGE = "you do not have permission to view /protected";
+
+beforeAll(async () => {
+  fixture = await createFixture({
+    files: {
+      "app/session.server.js": js`
+        import { createCookieSessionStorage } from "remix";
+
+        export let MESSAGE_KEY = "message";
+
+        export let sessionStorage = createCookieSessionStorage({
+          cookie: {
+            httpOnly: true,
+            path: "/",
+            sameSite: "lax",
+            secrets: ["cookie-secret"],
+          }
+        })
+      `,
+
+      "app/root.jsx": js`
+        import { json, Outlet, Scripts, useLoaderData } from "remix";
+
+        import { sessionStorage, MESSAGE_KEY } from "~/session.server";
+
+        export let loader = async ({ request }) => {
+          let session = await sessionStorage.getSession(request.headers.get("Cookie"));
+          let message = session.get(MESSAGE_KEY) || null;
+
+          return json(message, {
+            headers: {
+              "Set-Cookie": await sessionStorage.commitSession(session),
+            },
+          });
+        };
+
+        export default function Root() {
+          let message = useLoaderData();
+
+          return (
+            <html>
+              <body>
+                {!!message && <p id="message">{message}</p>}
+                <Outlet />
+                <Scripts />
+              </body>
+            </html>
+          );
+        }
+      `,
+
+      "app/routes/index.jsx": js`
+        import { Link } from "remix";
+
+        export default function Index() {
+          return (
+            <p>
+              <Link to="/protected">protected</Link>
+            </p>
+          );
+        }
+      `,
+
+      "app/routes/login.jsx": js`
+        export default function Login() {
+          return <p>login</p>;
+        }
+      `,
+
+      "app/routes/protected.jsx": js`
+        import { redirect } from "remix";
+
+        import { sessionStorage, MESSAGE_KEY } from "~/session.server";
+
+        export let loader = async ({ request }) => {
+          let session = await sessionStorage.getSession(request.headers.get("Cookie"));
+
+          session.flash(MESSAGE_KEY, "${BANNER_MESSAGE}");
+
+          return redirect("/login", {
+            headers: {
+              "Set-Cookie": await sessionStorage.commitSession(session),
+            },
+          });
+        };
+
+        export default function Protected() {
+          return <p>protected</p>;
+        }
+      `,
+    },
+  });
+
+  // This creates an interactive app using puppeteer.
+  app = await createAppFixture(fixture);
+});
+
+afterAll(async () => app.close());
+
+it("should revalidate when cookie is set on redirect from loader", async () => {
+  await app.goto("/");
+  await app.clickLink("/protected");
+  expect(await app.getHtml()).toMatch(BANNER_MESSAGE);
+});

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -216,7 +216,10 @@ async function checkRedirect(
         window.location.replace(url.href);
       });
     } else {
-      return new TransitionRedirect(url.pathname + url.search);
+      return new TransitionRedirect(
+        url.pathname + url.search,
+        response.headers.get("X-Remix-Set-Cookie") !== null
+      );
     }
   }
 

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -218,7 +218,7 @@ async function checkRedirect(
     } else {
       return new TransitionRedirect(
         url.pathname + url.search,
-        response.headers.get("X-Remix-Set-Cookie") !== null
+        response.headers.get("X-Remix-Revalidate") !== null
       );
     }
   }

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -180,18 +180,22 @@ export type Redirects = {
   Loader: {
     isRedirect: true;
     type: "loader";
+    setCookie: boolean;
   };
   Action: {
     isRedirect: true;
     type: "action";
+    setCookie: boolean;
   };
   LoaderSubmission: {
     isRedirect: true;
     type: "loaderSubmission";
+    setCookie: boolean;
   };
   FetchAction: {
     isRedirect: true;
     type: "fetchAction";
+    setCookie: boolean;
   };
 };
 
@@ -313,6 +317,7 @@ interface RedirectLocation extends _Location {
   state: {
     isRedirect: true;
     type: string;
+    setCookie: boolean;
   };
 }
 
@@ -326,6 +331,7 @@ interface LoaderRedirectLocation extends RedirectLocation {
   state: {
     isRedirect: true;
     type: "loader";
+    setCookie: boolean;
   };
 }
 
@@ -339,6 +345,7 @@ interface ActionRedirectLocation extends RedirectLocation {
   state: {
     isRedirect: true;
     type: "action";
+    setCookie: boolean;
   };
 }
 
@@ -352,6 +359,7 @@ interface FetchActionRedirectLocation extends RedirectLocation {
   state: {
     isRedirect: true;
     type: "fetchAction";
+    setCookie: boolean;
   };
 }
 
@@ -365,6 +373,7 @@ interface LoaderSubmissionRedirectLocation extends RedirectLocation {
   state: {
     isRedirect: true;
     type: "loaderSubmission";
+    setCookie: boolean;
   };
 }
 
@@ -378,7 +387,7 @@ function isLoaderSubmissionRedirectLocation(
 
 export class TransitionRedirect {
   location: string;
-  constructor(location: Location | string) {
+  constructor(location: Location | string, public setCookie: boolean) {
     this.location =
       typeof location === "string"
         ? location
@@ -658,6 +667,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
       let locationState: Redirects["FetchAction"] = {
         isRedirect: true,
         type: "fetchAction",
+        setCookie: result.value.setCookie,
       };
       fetchRedirectIds.add(key);
       init.onRedirect(result.value.location, locationState);
@@ -697,12 +707,11 @@ export function createTransitionManager(init: TransitionManagerInit) {
     fetchReloadIds.set(key, loadId);
 
     let matchesToLoad = state.nextMatches || state.matches;
-    let hrefToLoad = createHref(state.transition.location || state.location);
 
     console.debug(`[transition] fetcher calling loaders (key: ${key})`);
     let results = await callLoaders(
       state,
-      createUrl(hrefToLoad),
+      state.transition.location || state.location,
       matchesToLoad,
       controller.signal,
       maybeActionErrorResult,
@@ -725,6 +734,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
       let locationState: Redirects["Loader"] = {
         isRedirect: true,
         type: "loader",
+        setCookie: redirect.setCookie,
       };
       init.onRedirect(redirect.location, locationState);
       return;
@@ -863,6 +873,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
       let locationState: Redirects["Loader"] = {
         isRedirect: true,
         type: "loader",
+        setCookie: result.value.setCookie,
       };
       init.onRedirect(result.value.location, locationState);
       return;
@@ -922,6 +933,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
       let locationState: Redirects["Loader"] = {
         isRedirect: true,
         type: "loader",
+        setCookie: result.value.setCookie,
       };
       init.onRedirect(result.value.location, locationState);
       return;
@@ -1057,6 +1069,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
       let locationState: Redirects["Action"] = {
         isRedirect: true,
         type: "action",
+        setCookie: result.value.setCookie,
       };
       init.onRedirect(result.value.location, locationState);
       return;
@@ -1245,7 +1258,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
     console.debug("[transition] calling loaders for loadPageData");
     let results = await callLoaders(
       state,
-      createUrl(createHref(location)),
+      location,
       matches,
       controller.signal,
       maybeActionErrorResult,
@@ -1271,18 +1284,21 @@ export function createTransitionManager(init: TransitionManagerInit) {
         let locationState: Redirects["Action"] = {
           isRedirect: true,
           type: "action",
+          setCookie: redirect.setCookie,
         };
         init.onRedirect(redirect.location, locationState);
       } else if (state.transition.type === "loaderSubmission") {
         let locationState: Redirects["LoaderSubmission"] = {
           isRedirect: true,
           type: "loaderSubmission",
+          setCookie: redirect.setCookie,
         };
         init.onRedirect(redirect.location, locationState);
       } else {
         let locationState: Redirects["Loader"] = {
           isRedirect: true,
           type: "loader",
+          setCookie: redirect.setCookie,
         };
         init.onRedirect(redirect.location, locationState);
       }
@@ -1385,7 +1401,7 @@ function isIndexRequestAction(action: string) {
 
 async function callLoaders(
   state: TransitionManagerState,
-  url: URL,
+  location: Location,
   matches: ClientMatch[],
   signal: AbortSignal,
   actionErrorResult?: DataErrorResult,
@@ -1394,9 +1410,10 @@ async function callLoaders(
   submissionRouteId?: string,
   fetcher?: Fetcher
 ): Promise<DataResult[]> {
+  let url = createUrl(createHref(location));
   let matchesToLoad = filterMatchesToLoad(
     state,
-    url,
+    location,
     matches,
     actionErrorResult,
     actionCatchResult,
@@ -1448,7 +1465,7 @@ async function callAction(
 
 function filterMatchesToLoad(
   state: TransitionManagerState,
-  url: URL,
+  location: Location,
   matches: ClientMatch[],
   actionErrorResult?: DataErrorResult,
   actionCatchResult?: DataCatchResult,
@@ -1491,6 +1508,8 @@ function filterMatchesToLoad(
     );
   };
 
+  let url = createUrl(createHref(location));
+
   let filterByRouteProps = (match: ClientMatch, index: number) => {
     if (!match.route.loader) {
       return false;
@@ -1527,7 +1546,9 @@ function filterMatchesToLoad(
     // clicked the same link, resubmitted a GET form
     createHref(url) === createHref(state.location) ||
     // search affects all loaders
-    url.searchParams.toString() !== state.location.search.substring(1)
+    url.searchParams.toString() !== state.location.search.substring(1) ||
+    // a cookie was set
+    (location.state as any)?.setCookie
   ) {
     return matches.filter(filterByRouteProps);
   }
@@ -1540,7 +1561,9 @@ function filterMatchesToLoad(
 
     return (
       match.route.loader &&
-      (isNew(match, index) || matchPathChanged(match, index))
+      (isNew(match, index) ||
+        matchPathChanged(match, index) ||
+        (location.state as any)?.setCookie)
     );
   });
 }

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -148,7 +148,7 @@ async function handleDataRequest({
       headers.set("X-Remix-Redirect", headers.get("Location")!);
       headers.delete("Location");
       if (response.headers.get("Set-Cookie") !== null) {
-        headers.set("X-Remix-Set-Cookie", "yes");
+        headers.set("X-Remix-Revalidate", "yes");
       }
 
       return new Response(null, {

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -147,6 +147,9 @@ async function handleDataRequest({
       let headers = new Headers(response.headers);
       headers.set("X-Remix-Redirect", headers.get("Location")!);
       headers.delete("Location");
+      if (response.headers.get("Set-Cookie") !== null) {
+        headers.set("X-Remix-Set-Cookie", "yes");
+      }
 
       return new Response(null, {
         status: 204,


### PR DESCRIPTION
Consider this use case:

- Root loader reads the cookie to flash messages in one location
- User signs up, but need to verify their email address before they can create new projects
- User is logged in, and visits /projects/new but have not yet verified their email
- The projects/new loader redirects them to /account and sets a cookie with a flash message why they were redirected `session.flash("You need to add an email address and verify it")
- The root loader will not get called and therefore no flash message happens because Remix's optimizations didn't call the root loader.

Today we revalidate for three reasons:

- After an action (POST/PUT/PATCH/DELETE) because loaders usually read from the database and this will capture it
- If the url search params change because any loader can use them to return data
- If the exact same URL was clicked because the user probably wants fresh data (and that's what the browser does)

We're missing a fourth:

- If a redirect sets a cookie.

Just like (2) with url search params, any loader can use cookies to return data.

Additionally, this workflow works today for document transitions, but not script transitions. As a Remix principle, script and document transitions should result in the same UI.

Closes: #

- [ ] Docs
- [x] Tests
