### PR TITLE
chore: use get-port in gists app

### DIFF
--- a/fixtures/gists-app/package.json
+++ b/fixtures/gists-app/package.json
@@ -29,6 +29,7 @@
     "autoprefixer": "^10.2.4",
     "cssnano": "^4.1.10",
     "fs-extra": "^10.0.0",
+    "get-port": "^5.1.1",
     "pm2": "^4.5.1",
     "postcss": "^8.2.6",
     "postcss-cli": "^8.3.1",

--- a/fixtures/gists-app/server.js
+++ b/fixtures/gists-app/server.js
@@ -2,69 +2,74 @@ const express = require("express");
 const morgan = require("morgan");
 const compression = require("compression");
 const { createRequestHandler } = require("@remix-run/express");
+const getPort = require("get-port");
 
-const port = process.env.PORT || 3000;
-
-if (process.env.NODE_ENV === "test") {
-  class MockConsole {
-    assert() {}
-    clear() {}
-    count() {}
-    countReset() {}
-    debug() {}
-    dir() {}
-    dirxml() {}
-    error() {}
-    group() {}
-    groupCollapsed() {}
-    groupEnd() {}
-    info() {}
-    log() {}
-    table() {}
-    time() {}
-    timeEnd() {}
-    timeLog() {}
-    timeStamp() {}
-    trace() {}
-    warn() {}
+getPort({ port: process.env.PORT || 3000 }).then((port) => {
+  if (process.env.NODE_ENV === "test") {
+    class MockConsole {
+      assert() {}
+      clear() {}
+      count() {}
+      countReset() {}
+      debug() {}
+      dir() {}
+      dirxml() {}
+      error() {}
+      group() {}
+      groupCollapsed() {}
+      groupEnd() {}
+      info() {}
+      log() {}
+      table() {}
+      time() {}
+      timeEnd() {}
+      timeLog() {}
+      timeStamp() {}
+      trace() {}
+      warn() {}
+    }
+    global.console = new MockConsole();
   }
-  global.console = new MockConsole();
-}
 
-let app = express();
+  let app = express();
 
-app.use(compression());
+  app.use(compression());
 
-app.use(
-  express.static("public", {
-    // maxAge: process.env.NODE_ENV === "production" ? "1y" : undefined
-    maxAge: "1y",
-  })
-);
+  app.use(
+    express.static("public", {
+      // maxAge: process.env.NODE_ENV === "production" ? "1y" : undefined
+      maxAge: "1y",
+    })
+  );
 
-app.get("/fails.css", (req, res) => {
-  res.status(500).send("Boom! No CSS here!");
-});
+  app.get("/fails.css", (req, res) => {
+    res.status(500).send("Boom! No CSS here!");
+  });
 
-// server-side redirect
-app.get("/user-gists/:username", (req, res) => {
-  res.redirect(301, `/gists/${req.params.username}`);
-});
+  // server-side redirect
+  app.get("/user-gists/:username", (req, res) => {
+    res.redirect(301, `/gists/${req.params.username}`);
+  });
 
-if (process.env.NODE_ENV !== "production" && process.env.NODE_ENV !== "test") {
-  app.use(morgan("dev"));
-}
+  if (
+    process.env.NODE_ENV !== "production" &&
+    process.env.NODE_ENV !== "test"
+  ) {
+    app.use(morgan("dev"));
+  }
 
-app.all(
-  "*",
-  createRequestHandler({
-    build: require("@remix-run/dev/server-build"),
-    getLoadContext() {
-      return { userId: 4 };
-    },
-  })
-);
+  app.all(
+    "*",
+    createRequestHandler({
+      build: require("@remix-run/dev/server-build"),
+      getLoadContext() {
+        return { userId: 4 };
+      },
+    })
+  );
 
-app.listen(port, () => {
-  console.log(`Gists app running on port ${port}`);
+  app.listen(port, () => {
+    console.log(`Gists app running on port ${port}`);
+    console.log(`http://localhost:${port}`);
+  });
 });


### PR DESCRIPTION
Got irritated with the server crashing with `yarn dev` when I have another app running on port `3000`, so this should fix it.

Unfortunately top-level `await` isn't supported in esbuild with our target, and we're building our server in the gists app. That's a task for another day.