### PR TITLE
docs(examples/framer-motion): Fix wrong codesandbox link on README.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -54,6 +54,7 @@
 - danielweinmann
 - davecalnan
 - DavidHollins6
+- davongit
 - denissb
 - derekr
 - developit

--- a/examples/framer-motion/README.md
+++ b/examples/framer-motion/README.md
@@ -33,4 +33,4 @@ npm start
 
 Open this example on [CodeSandbox](https://codesandbox.com):
 
-[![Open in codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/basic)
+[![Open in codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/remix-run/remix/tree/main/examples/framer-motion)


### PR DESCRIPTION
The link now is pointing to the basic example, with this change it will open the 'framer-motion' example.
_(This is a docs change)_
