### PR TITLE
docs(styling): fix broken link in CSS preprocessor section

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -153,6 +153,7 @@
 - kubaprzetakiewicz
 - kumard3
 - lachlanjc
+- laughnan
 - lawrencecchen
 - leo
 - leon

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -624,7 +624,7 @@ npm add -D concurrently
 
 You can use CSS preprocessors like LESS and SASS. Doing so requires running an additional build process to convert these files to CSS files. This can be done via the command line tools provided by the preprocessor or any equivalent tool.
 
-Once converted to CSS by the preprocessor, the generated CSS files can be imported into your components via the [Route Module `links` export]([route-module-links]) function, just like any other CSS file in Remix.
+Once converted to CSS by the preprocessor, the generated CSS files can be imported into your components via the [Route Module `links` export][route-module-links] function, just like any other CSS file in Remix.
 
 To ease development with CSS preprocessors you can add npm scripts to your `package.json` that generate CSS files from your SASS or LESS files. These scripts can be run in parallel alongside any other npm scripts that you run for developing a Remix application.
 


### PR DESCRIPTION
Closes: #2407

- [x] Docs
- [ ] Tests
