### PR TITLE
docs(jokes): update highlighted lines

### DIFF
--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -4352,7 +4352,7 @@ export function ErrorBoundary() {
 
 <summary>app/routes/jokes/new.tsx</summary>
 
-```tsx filename=app/routes/jokes/new.tsx lines=[6,16-24,156-167]
+```tsx filename=app/routes/jokes/new.tsx lines=[6,16-24,164-175]
 import type { ActionFunction, LoaderFunction } from "remix";
 import {
   useActionData,


### PR DESCRIPTION
I corrected this wrong highlighted lines in **app/routes/jokes/new.tsx** of [expected-errors](https://remix.run/docs/en/v1/tutorials/jokes#expected-errors)