### PR TITLE
fix: Keep empty meta from rendering a tag

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐛 Bug Report
 description: Something is wrong with Remix.
 labels:
-  - bug
+  - "bug:unverified"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐛 Bug Report
 description: Something is wrong with Remix.
 labels:
-  - "bug:unverified"
+  - bug
 body:
   - type: markdown
     attributes:

--- a/fixtures/gists-app/app/routes/meta.tsx
+++ b/fixtures/gists-app/app/routes/meta.tsx
@@ -1,0 +1,28 @@
+import { LoaderFunction, MetaFunction } from "remix";
+import { json, useLoaderData } from "remix";
+
+export let loader: LoaderFunction = async () => {
+  return json({
+    title: "Meta Page",
+    description: "This is a meta page",
+  });
+};
+
+export let meta: MetaFunction = ({ data }) => {
+  return {
+    title: data.title,
+    description: data.description,
+    "og:image": "https://picsum.photos/200/200",
+    "og:type": data.contentType, // undefined
+  };
+};
+
+export default function MetaPage() {
+  let { title } = useLoaderData();
+  return (
+    <div data-test-id="/links">
+      <h2>{title}</h2>
+      <hr />
+    </div>
+  );
+}

--- a/fixtures/gists-app/tests/meta-test.ts
+++ b/fixtures/gists-app/tests/meta-test.ts
@@ -1,0 +1,52 @@
+import type { Browser, Page } from "puppeteer";
+import puppeteer from "puppeteer";
+
+import { disableJavaScript, getHtml } from "./utils";
+
+const testPort = 3000;
+const testServer = `http://localhost:${testPort}`;
+
+describe("route module meta export", () => {
+  let browser: Browser;
+  let page: Page;
+  beforeEach(async () => {
+    browser = await puppeteer.launch();
+    page = await browser.newPage();
+  });
+
+  afterEach(() => browser.close());
+
+  describe("route meta export", () => {
+    test("meta { title } adds a <title />", async () => {
+      await disableJavaScript(page);
+      await page.goto(`${testServer}/meta`);
+      let title = await getHtml(page, "title");
+      expect(title).toEqual(expect.stringMatching(/<title>/s));
+    });
+
+    test("meta { description } adds a <meta name='description' />", async () => {
+      await disableJavaScript(page);
+      await page.goto(`${testServer}/meta`);
+      let meta = await getHtml(page, "meta");
+      expect(meta).toEqual(
+        expect.stringMatching(/<meta\s+name="description"/s)
+      );
+    });
+
+    test("meta { 'og:*' } adds a <meta property='og:*' />", async () => {
+      await disableJavaScript(page);
+      await page.goto(`${testServer}/meta`);
+      let meta = await getHtml(page, "meta");
+      expect(meta).toEqual(expect.stringMatching(/<meta\s+property="og:*/s));
+    });
+
+    test("empty meta does not render a tag", async () => {
+      await disableJavaScript(page);
+      await page.goto(`${testServer}/meta`);
+      let meta = await getHtml(page, "meta");
+      expect(meta).not.toEqual(
+        expect.stringMatching(/<meta\s+property="og:type/s)
+      );
+    });
+  });
+});

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -663,6 +663,8 @@ export function Meta() {
   return (
     <>
       {Object.entries(meta).map(([name, value]) => {
+        if (!value) return null;
+
         // Open Graph tags use the `property` attribute, while other meta tags
         // use `name`. See https://ogp.me/
         let isOpenGraphTag = name.startsWith("og:");

--- a/packages/remix-react/routeModules.ts
+++ b/packages/remix-react/routeModules.ts
@@ -71,7 +71,7 @@ export interface MetaFunction {
  * `name` attribute.
  */
 export interface HtmlMetaDescriptor {
-  [name: string]: string | string[];
+  [name: string]: string | string[] | null | undefined;
 }
 
 /**

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -92,7 +92,7 @@ export interface MetaFunction {
  * `name` attribute.
  */
 export interface HtmlMetaDescriptor {
-  [name: string]: string | string[];
+  [name: string]: string | string[] | null | undefined;
 }
 
 export type MetaDescriptor = HtmlMetaDescriptor;


### PR DESCRIPTION
Currently, if a meta key is `null` or `undefined`, we will render an empty tag. Our types also don't support an empty meta key, which is a bit annoying if you're working with optional data.

```js
export function meta({ data }) {
  return {
    title: data.title, // always there, cool
    description: data.description // optional, don't bother with a tag but please don't yell at me!
  };
}
```