### PR TITLE
fix: wrong server build path in express template

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -297,3 +297,4 @@
 - youngvform
 - zachdtaylor
 - zainfathoni
+- dogukanakkaya

--- a/templates/express-ts/.gitignore
+++ b/templates/express-ts/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 
 /.cache
-/server/build
+/build
 /public/build
 .env

--- a/templates/express-ts/README.md
+++ b/templates/express-ts/README.md
@@ -34,7 +34,7 @@ Now you'll need to pick a host to deploy it to.
 
 If you're familiar with deploying express applications you should be right at home just make sure to deploy the output of `remix build`
 
-- `server/build/`
+- `build/`
 - `public/build/`
 
 ### Using a Template

--- a/templates/express/.gitignore
+++ b/templates/express/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 
 /.cache
-/server/build
+/build
 /public/build
 .env

--- a/templates/express/README.md
+++ b/templates/express/README.md
@@ -40,7 +40,7 @@ Now you'll need to pick a host to deploy it to.
 
 If you're familiar with deploying express applications you should be right at home just make sure to deploy the output of `remix build`
 
-- `server/build/`
+- `build/`
 - `public/build/`
 
 ### Using a Template


### PR DESCRIPTION
Express server build is placed into the build directory in the root of the project, not to the server directory.