### PR TITLE
chore(docs,examples,templates): quote glob run params in `build` command

### DIFF
--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -430,10 +430,10 @@ Update the package scripts to generate the Tailwind file during dev and for the 
 {
   // ...
   "scripts": {
-    "build": "run-s build:*",
+    "build": "run-s 'build:*'",
     "build:css": "npm run generate:css -- --minify",
     "build:remix": "cross-env NODE_ENV=production remix build",
-    "dev": "run-p dev:*",
+    "dev": "run-p 'dev:*'",
     "dev:css": "npm run generate:css -- --watch",
     "dev:remix": "cross-env NODE_ENV=development remix dev",
     "generate:css": "npx tailwindcss -o ./app/tailwind.css",
@@ -475,10 +475,10 @@ Then alter how Tailwind is generating your css:
 {
   // ...
   "scripts": {
-    "build": "run-s build:*",
+    "build": "run-s 'build:*'",
     "build:css": "npm run generate:css -- --minify",
     "build:remix": "cross-env NODE_ENV=production remix build",
-    "dev": "run-p dev:*",
+    "dev": "run-p 'dev:*'",
     "dev:css": "npm run generate:css -- --watch",
     "dev:remix": "cross-env NODE_ENV=development remix dev",
     "generate:css": "npx tailwindcss -i ./styles/tailwind.css -o ./app/tailwind.css",

--- a/examples/pm-app/package.json
+++ b/examples/pm-app/package.json
@@ -16,7 +16,7 @@
     "db:check": "docker ps",
     "build:css": "postcss app/styles --base app/styles --dir app/dist/styles --env production",
     "build:remix": "remix build",
-    "build": "run-s build:*",
+    "build": "run-s 'build:*'",
     "postinstall": "remix setup node",
     "typecheck": "tsc -b",
     "deploy": "flyctl deploy",

--- a/examples/quirrel/package.json
+++ b/examples/quirrel/package.json
@@ -6,7 +6,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
-    "dev": "run-p dev:*",
+    "dev": "run-p 'dev:*'",
     "dev:quirrel": "quirrel",
     "dev:remix": "remix dev",
     "postinstall": "remix setup node",

--- a/examples/sass/package.json
+++ b/examples/sass/package.json
@@ -5,10 +5,10 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "build": "run-s build:*",
+    "build": "run-s 'build:*'",
     "build:css": "sass styles/:app/styles/ --style=compressed",
     "build:remix": "remix build",
-    "dev": "run-p dev:*",
+    "dev": "run-p 'dev:*'",
     "dev:css": "sass styles/:app/styles/ --watch ",
     "dev:remix": "remix dev",
     "postinstall": "remix setup node",

--- a/examples/strapi/package.json
+++ b/examples/strapi/package.json
@@ -6,7 +6,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
-    "dev": "run-p dev:*",
+    "dev": "run-p 'dev:*'",
     "dev:remix": "remix dev",
     "postinstall": "remix setup node",
     "dev:strapi": "cd strapi && npm run develop",

--- a/examples/tailwindcss/package.json
+++ b/examples/tailwindcss/package.json
@@ -5,10 +5,10 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "build": "run-s build:*",
+    "build": "run-s 'build:*'",
     "build:css": "npm run generate:css -- --minify",
     "build:remix": "remix build",
-    "dev": "run-p dev:*",
+    "dev": "run-p 'dev:*'",
     "dev:css": "npm run generate:css -- --watch",
     "dev:remix": "remix dev",
     "generate:css": "npx tailwindcss -o ./app/tailwind.css",

--- a/templates/arc-ts/package.json
+++ b/templates/arc-ts/package.json
@@ -8,7 +8,7 @@
     "build": "remix build",
     "dev:remix": "remix watch",
     "dev:arc": "cross-env NODE_ENV=development arc sandbox",
-    "dev": "remix build && run-p dev:*",
+    "dev": "remix build && run-p 'dev:*'",
     "postinstall": "remix setup node",
     "start": "cross-env NODE_ENV=production arc sandbox"
   },

--- a/templates/arc/package.json
+++ b/templates/arc/package.json
@@ -8,7 +8,7 @@
     "build": "remix build",
     "dev:remix": "remix watch",
     "dev:arc": "cross-env NODE_ENV=development arc sandbox",
-    "dev": "remix build && run-p dev:*",
+    "dev": "remix build && run-p 'dev:*'",
     "postinstall": "remix setup node",
     "start": "cross-env NODE_ENV=production arc sandbox"
   },

--- a/templates/cloudflare-pages-ts/package.json
+++ b/templates/cloudflare-pages-ts/package.json
@@ -8,7 +8,7 @@
     "build": "remix build",
     "dev:remix": "remix watch",
     "dev:wrangler": "cross-env NODE_ENV=development wrangler pages dev ./public",
-    "dev": "remix build && run-p dev:*",
+    "dev": "remix build && run-p 'dev:*'",
     "postinstall": "remix setup cloudflare-pages",
     "start": "cross-env NODE_ENV=production npm run dev:wrangler"
   },

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -8,7 +8,7 @@
     "build": "remix build",
     "dev:remix": "remix watch",
     "dev:wrangler": "cross-env NODE_ENV=development wrangler pages dev ./public",
-    "dev": "remix build && run-p dev:*",
+    "dev": "remix build && run-p 'dev:*'",
     "postinstall": "remix setup cloudflare-pages",
     "start": "cross-env NODE_ENV=production npm run dev:wrangler"
   },

--- a/templates/cloudflare-workers-ts/package.json
+++ b/templates/cloudflare-workers-ts/package.json
@@ -10,7 +10,7 @@
     "deploy": "npm run build && wrangler publish",
     "dev:remix": "remix watch",
     "dev:miniflare": "cross-env NODE_ENV=development miniflare ./build/index.js --watch",
-    "dev": "remix build && run-p dev:*",
+    "dev": "remix build && run-p 'dev:*'",
     "postinstall": "remix setup cloudflare-workers",
     "start": "cross-env NODE_ENV=production miniflare ./build/index.js"
   },

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -10,7 +10,7 @@
     "deploy": "npm run build && wrangler publish",
     "dev:remix": "remix watch",
     "dev:miniflare": "cross-env NODE_ENV=development miniflare ./build/index.js --watch",
-    "dev": "remix build && run-p dev:*",
+    "dev": "remix build && run-p 'dev:*'",
     "postinstall": "remix setup cloudflare-workers",
     "start": "cross-env NODE_ENV=production miniflare ./build/index.js"
   },

--- a/templates/deno-ts/package.json
+++ b/templates/deno-ts/package.json
@@ -4,7 +4,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
-    "dev": "remix build && run-p dev:*",
+    "dev": "remix build && run-p 'dev:*'",
     "dev:remix": "remix watch",
     "dev:deno": "cross-env NODE_ENV=development deno run --watch --allow-net --allow-read --allow-env ./build/index.js",
     "start": "cross-env NODE_ENV=production deno run --allow-net --allow-read --allow-env ./build/index.js"

--- a/templates/express-ts/package.json
+++ b/templates/express-ts/package.json
@@ -6,7 +6,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
-    "dev": "remix build && run-p dev:*",
+    "dev": "remix build && run-p 'dev:*'",
     "dev:node": "cross-env NODE_ENV=development nodemon ./build/index.js --watch ./build/index.js",
     "dev:remix": "remix watch",
     "postinstall": "remix setup node",

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -6,7 +6,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
-    "dev": "remix build && run-p dev:*",
+    "dev": "remix build && run-p 'dev:*'",
     "dev:node": "cross-env NODE_ENV=development nodemon ./build/index.js --watch ./build/index.js",
     "dev:remix": "remix watch",
     "postinstall": "remix setup node",


### PR DESCRIPTION
Just ran into https://github.com/mysticatea/npm-run-all/issues/200 using Yarn 3

Quoting it "dev": "run-p 'dev:*'", like mentioned in the linked issue fixed it for me with Yarn 3 and also tested Yarn 1.22.10 and npm 8.1.0, just to make sure.

So I figured as it shouldn't break anything why not always quote it?

Ref https://github.com/mysticatea/npm-run-all/issues/200

---
As @machour  requested that I fix the conflicts in https://github.com/remix-run/remix/pull/2033 but I felt it was to much mental overhead right now to get my head around fixing the other PR 🤯  I created a new one, renaming my branch and PR and also realized that I missed `run-s` commands containing globs as well 🤦🏻‍♂️
