### PR TITLE
docs: fix typo

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -126,7 +126,7 @@ npm run dev
 REMIX_LOCAL_DEV_OUTPUT_DIRECTORY=../my-remix-app yarn watch
 ```
 
-Now - any time you make changes in the Remix repository, the they will be written out to the appropriate locations in `../my-remix-app/node_modules` and you can restart the `npm run dev` command to pick them up 🎉.
+Now - any time you make changes in the Remix repository, they will be written out to the appropriate locations in `../my-remix-app/node_modules` and you can restart the `npm run dev` command to pick them up 🎉.
 
 ### Transition Manager Flows
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -297,3 +297,4 @@
 - youngvform
 - zachdtaylor
 - zainfathoni
+- TheRealAstoo


### PR DESCRIPTION
Hello 👋

This PR fixes a small typo in the `DEVELOPMENT.md` doc I went by. 😃 

It's following #2433 , to make it on the main branch instead of dev.

- [x] Docs
- [x] Tests
