### PR TITLE
refactor(remix-server-runtime): simplify `isIndexRequestUrl`

### DIFF
--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -574,18 +574,12 @@ async function errorBoundaryError(error: Error, status: number) {
 }
 
 function isIndexRequestUrl(url: URL) {
-  for (let param of url.searchParams.getAll("index")) {
-    // only use bare `?index` params without a value
-    // ✅ /foo?index
-    // ✅ /foo?index&index=123
-    // ✅ /foo?index=123&index
-    // ❌ /foo?index=123
-    if (param === "") {
-      return true;
-    }
-  }
-
-  return false;
+  // only use bare `?index` params without a value
+  // ✅ /foo?index
+  // ✅ /foo?index&index=123
+  // ✅ /foo?index=123&index
+  // ❌ /foo?index=123
+  return url.searchParams.getAll("index").some((param) => param === "");
 }
 
 function getRequestMatch(url: URL, matches: RouteMatch<ServerRoute>[]) {


### PR DESCRIPTION
Use `some` vs. an explicit loop with an early return. This is a classic example of why `some` was added to the language. :)