### PR TITLE
docs(tutorials/blog): add `json` import to `Actions` section

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -55,6 +55,7 @@
 - danielweinmann
 - davecalnan
 - DavidHollins6
+- davidjudilla
 - davongit
 - denissb
 - derekr

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -798,7 +798,7 @@ export async function createPost(post) {
 💿 Call `createPost` from the new post route's action
 
 ```tsx filename=app/routes/admin/new.tsx lines=[1,3,5-15]
-import { redirect, Form } from "remix";
+import { redirect, Form, json } from "remix";
 
 import { createPost } from "~/post";
 
@@ -848,7 +848,7 @@ export async function createPost(post: NewPost) {
 ```
 
 ```tsx filename=app/routes/admin/new.tsx lines=[2,6]
-import { Form, redirect } from "remix";
+import { Form, redirect, json } from "remix";
 import type { ActionFunction } from "remix";
 
 import { createPost } from "~/post";


### PR DESCRIPTION
## What is the Change?
Add `json` to imports in the Action section of the blog tutorial for a smoother dev experience
