### PR TITLE
test(integration): represent real app in `app/root.jsx`

### DIFF
--- a/integration/catch-boundary-data-test.ts
+++ b/integration/catch-boundary-data-test.ts
@@ -19,13 +19,19 @@ beforeAll(async () => {
   fixture = await createFixture({
     files: {
       "app/root.jsx": js`
-        import { Outlet, Scripts, useMatches, useLoaderData } from "remix";
-        export let loader = () => "${ROOT_DATA}";
+        import { json, Links, Meta, Outlet, Scripts, useLoaderData, useMatches } from "remix";
+
+        export const loader = () => json("${ROOT_DATA}");
+
         export default function Root() {
-          let data = useLoaderData();
+          const data = useLoaderData();
+
           return (
-            <html>
-              <head />
+            <html lang="en">
+              <head>
+                <Meta />
+                <Links />
+              </head>
               <body>
                 <div>{data}</div>
                 <Outlet />
@@ -34,6 +40,7 @@ beforeAll(async () => {
             </html>
           );
         }
+
         export function CatchBoundary() {
           let matches = useMatches();
           let { data } = matches.find(match => match.id === "root");

--- a/integration/catch-boundary-test.ts
+++ b/integration/catch-boundary-test.ts
@@ -21,18 +21,23 @@ describe("CatchBoundary", () => {
     fixture = await createFixture({
       files: {
         "app/root.jsx": js`
-          import { Outlet, Scripts } from "remix";
+          import { Links, Meta, Outlet, Scripts } from "remix";
+
           export default function Root() {
             return (
-              <html>
-                <head />
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
                 <body>
                   <Outlet />
                   <Scripts />
                 </body>
               </html>
-            )
+            );
           }
+
           export function CatchBoundary() {
             return (
               <html>

--- a/integration/error-boundary-test.ts
+++ b/integration/error-boundary-test.ts
@@ -28,12 +28,15 @@ describe("ErrorBoundary", () => {
     fixture = await createFixture({
       files: {
         "app/root.jsx": js`
-          import { Outlet, Scripts } from "remix";
+          import { Links, Meta, Outlet, Scripts } from "remix";
 
-          export default function () {
+          export default function Root() {
             return (
-              <html>
-                <head />
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
                 <body>
                   <main>
                     <Outlet />
@@ -41,7 +44,7 @@ describe("ErrorBoundary", () => {
                   <Scripts />
                 </body>
               </html>
-            )
+            );
           }
 
           export function ErrorBoundary() {
@@ -276,21 +279,22 @@ describe("ErrorBoundary", () => {
       fixture = await createFixture({
         files: {
           "app/root.jsx": js`
-            import { Outlet, Scripts } from "remix";
+            import { Links, Meta, Outlet, Scripts } from "remix";
 
-            export default function () {
-              return (
-                <html>
-                  <head />
-                  <body>
-                    <main>
-                      <Outlet />
-                    </main>
-                    <Scripts />
-                  </body>
-                </html>
-              )
-            }
+          export default function Root() {
+            return (
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
+                <body>
+                  <Outlet />
+                  <Scripts />
+                </body>
+              </html>
+            );
+          }
           `,
 
           "app/routes/index.jsx": js`

--- a/integration/headers-test.ts
+++ b/integration/headers-test.ts
@@ -13,14 +13,23 @@ describe("headers export", () => {
     fixture = await createFixture({
       files: {
         "app/root.jsx": js`
-          import { Outlet } from "remix";
+          import { json, Links, Meta, Outlet, Scripts } from "remix";
 
-          export function loader() {
-            return null
-          }
+          export const loader = () => json({});
 
-          export default function Index() {
-            return <html><body><Outlet/></body></html>
+          export default function Root() {
+            return (
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
+                <body>
+                  <Outlet />
+                  <Scripts />
+                </body>
+              </html>
+            );
           }
         `,
 
@@ -86,10 +95,21 @@ describe("headers export", () => {
     let fixture = await createFixture({
       files: {
         "app/root.jsx": js`
-          import { Outlet } from "remix";
+          import { Links, Meta, Outlet, Scripts } from "remix";
 
-          export default function Index() {
-            return <html><body><Outlet/></body></html>
+          export default function Root() {
+            return (
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
+                <body>
+                  <Outlet />
+                  <Scripts />
+                </body>
+              </html>
+            );
           }
         `,
 

--- a/integration/loader-test.ts
+++ b/integration/loader-test.ts
@@ -11,14 +11,23 @@ describe("loader", () => {
     fixture = await createFixture({
       files: {
         "app/root.jsx": js`
-          import { Outlet } from "remix";
+          import { json, Links, Meta, Outlet, Scripts } from "remix";
 
-          export function loader() {
-            return "${ROOT_DATA}"
-          }
+          export const loader = () => json("${ROOT_DATA}");
 
-          export default function Index() {
-            return <html><body><Outlet/></body></html>
+          export default function Root() {
+            return (
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
+                <body>
+                  <Outlet />
+                  <Scripts />
+                </body>
+              </html>
+            );
           }
         `,
 

--- a/integration/prefetch-test.ts
+++ b/integration/prefetch-test.ts
@@ -6,15 +6,19 @@ function fixtureFactory(mode) {
   return {
     files: {
       "app/root.jsx": js`
-        import { Outlet, Scripts, Link, useLoaderData } from "remix";
+        import { Link, Links, Meta, Outlet, Scripts, useLoaderData } from "remix";
+
         export default function Root() {
           const styles =
           'a:hover { color: red; } a:hover:after { content: " (hovered)"; }' +
           'a:focus { color: green; } a:focus:after { content: " (focused)"; }';
 
           return (
-            <html>
-              <head />
+            <html lang="en">
+              <head>
+                <Meta />
+                <Links />
+              </head>
               <body>
                 <style>{styles}</style>
                 <h1>Root</h1>
@@ -31,7 +35,7 @@ function fixtureFactory(mode) {
                 <Scripts />
               </body>
             </html>
-          )
+          );
         }
       `,
 

--- a/integration/rendering-test.ts
+++ b/integration/rendering-test.ts
@@ -14,11 +14,15 @@ describe("rendering", () => {
     fixture = await createFixture({
       files: {
         "app/root.jsx": js`
-          import { Outlet, Scripts } from "remix";
+          import { Links, Meta, Outlet, Scripts } from "remix";
+
           export default function Root() {
             return (
-              <html>
-                <head />
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
                 <body>
                   <div id="content">
                     <h1>Root</h1>
@@ -27,7 +31,7 @@ describe("rendering", () => {
                   <Scripts />
                 </body>
               </html>
-            )
+            );
           }
         `,
 

--- a/integration/set-cookie-revalidation-test.ts
+++ b/integration/set-cookie-revalidation-test.ts
@@ -25,11 +25,11 @@ beforeAll(async () => {
       `,
 
       "app/root.jsx": js`
-        import { json, Outlet, Scripts, useLoaderData } from "remix";
+        import { json, Links, Meta, Outlet, Scripts, useLoaderData } from "remix";
 
         import { sessionStorage, MESSAGE_KEY } from "~/session.server";
 
-        export let loader = async ({ request }) => {
+        export const loader = async ({ request }) => {
           let session = await sessionStorage.getSession(request.headers.get("Cookie"));
           let message = session.get(MESSAGE_KEY) || null;
 
@@ -41,10 +41,14 @@ beforeAll(async () => {
         };
 
         export default function Root() {
-          let message = useLoaderData();
+          const message = useLoaderData();
 
           return (
-            <html>
+            <html lang="en">
+              <head>
+                <Meta />
+                <Links />
+              </head>
               <body>
                 {!!message && <p id="message">{message}</p>}
                 <Outlet />

--- a/integration/splat-routes-test.ts
+++ b/integration/splat-routes-test.ts
@@ -16,17 +16,21 @@ describe("rendering", () => {
     fixture = await createFixture({
       files: {
         "app/root.jsx": js`
-          import { Outlet, Scripts } from "remix";
+          import { Links, Meta, Outlet, Scripts } from "remix";
+
           export default function Root() {
             return (
-              <html>
-                <head />
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
                 <body>
                   <Outlet />
                   <Scripts />
                 </body>
               </html>
-            )
+            );
           }
         `,
 

--- a/integration/transition-test.ts
+++ b/integration/transition-test.ts
@@ -17,11 +17,15 @@ describe("rendering", () => {
     fixture = await createFixture({
       files: {
         "app/root.jsx": js`
-          import { Outlet, Scripts } from "remix";
+          import { Links, Meta, Outlet, Scripts } from "remix";
+
           export default function Root() {
             return (
-              <html>
-                <head />
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
                 <body>
                   <main>
                     <Outlet />
@@ -29,10 +33,10 @@ describe("rendering", () => {
                   <Scripts />
                 </body>
               </html>
-            )
+            );
           }
-
         `,
+
         "app/routes/index.jsx": js`
           import { Link } from "remix";
           export default function() {


### PR DESCRIPTION
As @chaance suggested in https://github.com/remix-run/remix/pull/2451#discussion_r832642948, this will better represent a real app in our tests.