### PR TITLE
fix(remix-server-runtime): don't automatically cast `error` without check

### DIFF
--- a/.changeset/lazy-lions-invent.md
+++ b/.changeset/lazy-lions-invent.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+fix: Don't automatically cast `error` without check

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -163,8 +163,8 @@ async function handleDataRequest({
       console.error(error);
     }
 
-    if (serverMode === ServerMode.Development) {
-      return errorBoundaryError(error as Error, 500);
+    if (serverMode === ServerMode.Development && error instanceof Error) {
+      return errorBoundaryError(error, 500);
     }
 
     return errorBoundaryError(new Error("Unexpected Server Error"), 500);


### PR DESCRIPTION
Don’t lie to TypeScript or it will lie to you