### PR TITLE
fix(remix-react): make `LiveReload` work for ports other than 8002

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1380,7 +1380,7 @@ export const LiveReload =
       }: {
         port?: number;
       }) {
-        let setupLiveReload = ((port: number) => {
+        let setupLiveReload = (() => {
           let protocol = location.protocol === "https:" ? "wss:" : "ws:";
           let host = location.hostname;
           let socketPath = `${protocol}//${host}:${port}/socket`;

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1406,7 +1406,7 @@ export const LiveReload =
           <script
             suppressHydrationWarning
             dangerouslySetInnerHTML={{
-              __html: `(${setupLiveReload})(${JSON.stringify(port)})`,
+              __html: `(${setupLiveReload})()`,
             }}
           />
         );


### PR DESCRIPTION
Prior to this change, if `config.devServerPort` was changed either manually or automatically (something already running on 8002), the port inlined to LiveReload was 8002 anyways. I went through some testing locally in `node_modules` and this was the solution. with our current testing infrastructure, I wasn't sure where to write a test for this, so if anyone has an idea, please let me know :)

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests
