### PR TITLE
refactor(remix-server-runtime): use `Object.entries` instead of `Object.keys` in `createRoutes`

### DIFF
--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -34,10 +34,10 @@ export function createRoutes(
   manifest: ServerRouteManifest,
   parentId?: string
 ): ServerRoute[] {
-  return Object.keys(manifest)
-    .filter((key) => manifest[key].parentId === parentId)
-    .map((id) => ({
-      ...manifest[id],
+  return Object.entries(manifest)
+    .filter(([, route]) => route.parentId === parentId)
+    .map(([id, route]) => ({
+      ...route,
       children: createRoutes(manifest, id),
     }));
 }


### PR DESCRIPTION
why? self documenting (i.e. `route` vs `manifest[key]`)

also, the old code used `key` in one loop and `id` in another. very confusing