### PR TITLE
refactor(remix-server-runtime): move away from deprecated `atob`/`btoa`

### DIFF
--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-nodejs-modules */
+import { Buffer } from "buffer";
 import type { CookieParseOptions, CookieSerializeOptions } from "cookie";
 import { parse, serialize } from "cookie";
 
@@ -177,13 +179,13 @@ async function decodeCookieValue(
 }
 
 function encodeData(value: any): string {
-  return btoa(JSON.stringify(value));
+  return Buffer.from(JSON.stringify(value)).toString("base64");
 }
 
 function decodeData(value: string): any {
   try {
-    return JSON.parse(atob(value));
-  } catch (error) {
+    return JSON.parse(Buffer.from(value, "base64").toString("ascii"));
+  } catch {
     return {};
   }
 }


### PR DESCRIPTION
`atob` and `btoa` are deprecated in Node, according to the docs, so this PR uses `Buffer.from` instead.

```
function atob(data: string): string;
/**
 * Decodes a string into bytes using Latin-1 (ISO-8859), and encodes those bytes
 * into a string using Base64.
 *
 * The `data` may be any JavaScript-value that can be coerced into a string.
 *
 * **This function is only provided for compatibility with legacy web platform APIs**
 * **and should never be used in new code, because they use strings to represent**
 * **binary data and predate the introduction of typed arrays in JavaScript.**
 * **For code running using Node.js APIs, converting between base64-encoded strings**
 * **and binary data should be performed using `Buffer.from(str, 'base64')` and`buf.toString('base64')`.**
 * @since v15.13.0
 * @deprecated Use `buf.toString('base64')` instead.
 * @param data An ASCII (Latin1) string.
 */
```

It also removes a needless [exception identifier](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#the_exception_identifier). i.e.:

```diff
-  } catch (error) {
+  } catch {
```