### PR TITLE
feat(remix-dev): support nested pathless layout routes

### DIFF
--- a/integration/pathless-routes-test.ts
+++ b/integration/pathless-routes-test.ts
@@ -12,17 +12,22 @@ describe("rendering", () => {
     fixture = await createFixture({
       files: {
         "app/root.jsx": js`
-          import { Outlet, Scripts } from "remix";
+          import { Links, Meta, Outlet, Scripts } from "remix";
           export default function Root() {
             return (
-              <html>
-                <head />
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
                 <body>
-                  <Outlet />
+                  <main>
+                    <Outlet />
+                  </main>
                   <Scripts />
                 </body>
               </html>
-            )
+            );
           }
         `,
 

--- a/integration/pathless-routes-test.ts
+++ b/integration/pathless-routes-test.ts
@@ -1,0 +1,66 @@
+import type { Fixture } from "./helpers/create-fixture";
+import { createFixture, js } from "./helpers/create-fixture";
+
+describe("rendering", () => {
+  let fixture: Fixture;
+
+  let PARENT_LAYOUT = "PARENT_LAYOUT";
+  let CHILD_LAYOUT = "CHILD_LAYOUT";
+  let CHILD = "CHILD";
+
+  beforeAll(async () => {
+    fixture = await createFixture({
+      files: {
+        "app/root.jsx": js`
+          import { Outlet, Scripts } from "remix";
+          export default function Root() {
+            return (
+              <html>
+                <head />
+                <body>
+                  <Outlet />
+                  <Scripts />
+                </body>
+              </html>
+            )
+          }
+        `,
+
+        "app/routes/__layout.jsx": js`
+          import { Outlet } from "remix";
+          export default function() {
+            return (
+              <div>
+                <h2>${PARENT_LAYOUT}</h2>
+                <Outlet/>
+              </div>
+            )
+          }
+        `,
+
+        "app/routes/__layout/__layout.jsx": js`
+          import { Outlet } from "remix";
+          export default function() {
+            return (
+              <div>
+                <h3>${CHILD_LAYOUT}</h3>
+                <Outlet/>
+              </div>
+            )
+          }
+        `,
+
+        "app/routes/__layout/__layout/test.jsx": js`
+          export default function() {
+            return <h4>${CHILD}</h4>;
+          }
+        `,
+      },
+    });
+  });
+
+  test("child exact match", async () => {
+    let res = await fixture.requestDocument("/test");
+    expect(await res.text()).toMatch(CHILD);
+  });
+});

--- a/packages/remix-dev/config/routesConvention.ts
+++ b/packages/remix-dev/config/routesConvention.ts
@@ -67,8 +67,11 @@ export function defineConventionalRoutes(
       );
 
       let isIndexRoute = routeId.endsWith("/index");
+      let routeIdBySegment = routeId.split("/");
+      let lastSegment = routeIdBySegment[routeIdBySegment.length - 1];
+      let isLayoutRoute = lastSegment.startsWith("__");
       let fullPath = createRoutePath(routeId.slice("routes".length + 1));
-      let uniqueRouteId = (fullPath || "") + (isIndexRoute ? "?index" : "");
+      let uniqueRouteId = (fullPath || "") + (isIndexRoute ? "?index" : "") + (isLayoutRoute ? routeId : "");
 
       if (uniqueRouteId) {
         if (uniqueRoutes.has(uniqueRouteId)) {


### PR DESCRIPTION
Because pathless layouts has a uniqueRouteId being `""` this adds the whole routeId, this way nested layouts will be use the actual routeId.

Closes: #

- [ ] Docs
- [x] Tests (pending)
