### PR TITLE
chore: Use `remix setup cloudflare` for CF templates

### DIFF
--- a/templates/cloudflare-pages-ts/package.json
+++ b/templates/cloudflare-pages-ts/package.json
@@ -9,7 +9,7 @@
     "dev:remix": "remix watch",
     "dev:wrangler": "cross-env NODE_ENV=development wrangler pages dev ./public",
     "dev": "remix build && run-p dev:*",
-    "postinstall": "remix setup cloudflare-pages",
+    "postinstall": "remix setup cloudflare",
     "start": "cross-env NODE_ENV=production npm run dev:wrangler"
   },
   "dependencies": {

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -9,7 +9,7 @@
     "dev:remix": "remix watch",
     "dev:wrangler": "cross-env NODE_ENV=development wrangler pages dev ./public",
     "dev": "remix build && run-p dev:*",
-    "postinstall": "remix setup cloudflare-pages",
+    "postinstall": "remix setup cloudflare",
     "start": "cross-env NODE_ENV=production npm run dev:wrangler"
   },
   "dependencies": {

--- a/templates/cloudflare-workers-ts/package.json
+++ b/templates/cloudflare-workers-ts/package.json
@@ -11,7 +11,7 @@
     "dev:remix": "remix watch",
     "dev:miniflare": "cross-env NODE_ENV=development miniflare ./build/index.js --watch",
     "dev": "remix build && run-p dev:*",
-    "postinstall": "remix setup cloudflare-workers",
+    "postinstall": "remix setup cloudflare",
     "start": "cross-env NODE_ENV=production miniflare ./build/index.js"
   },
   "dependencies": {

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -11,7 +11,7 @@
     "dev:remix": "remix watch",
     "dev:miniflare": "cross-env NODE_ENV=development miniflare ./build/index.js --watch",
     "dev": "remix build && run-p dev:*",
-    "postinstall": "remix setup cloudflare-workers",
+    "postinstall": "remix setup cloudflare",
     "start": "cross-env NODE_ENV=production miniflare ./build/index.js"
   },
   "dependencies": {


### PR DESCRIPTION
cloudflare-workers and cloudflare-pages are no longer separate setup targets.

I believe we can merge directly into `main` since these are template changes that we should have shipped last week.

