### PR TITLE
feat(remix-react): support Open Graph "verticals" in `meta` function

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -672,6 +672,10 @@ export function Meta() {
     parentsData[routeId] = data;
   }
 
+  let [ogVertical] = (
+    typeof meta["og:type"] === "string" ? meta["og:type"] : ""
+  ).split(".");
+
   return (
     <>
       {Object.entries(meta).map(([name, value]) => {
@@ -689,7 +693,9 @@ export function Meta() {
 
         // Open Graph tags use the `property` attribute, while other meta tags
         // use `name`. See https://ogp.me/
-        let isOpenGraphTag = name.startsWith("og:");
+        let isOpenGraphTag =
+          name.startsWith("og:") ||
+          (ogVertical && name.startsWith(`${ogVertical}:`));
         return [value].flat().map((content) => {
           if (isOpenGraphTag) {
             return (


### PR DESCRIPTION
According to the [Open Graph spec](https://ogp.me/#types) you can have "verticals" that have a prefix other than `og:`. These verticals have a prefix that matches the value specified in `og:type` up until the first period.

For example, there is a vertical of "music". Within "music" you can have an `og:type` of "music.song".

When you specify `og:type` of "music.song" you can now have additional meta elements that are prefixed with `music:` (not `og:`) that must also use "property" instead of "name".

For example, this is valid:

```html
<title>Baby's Got Back</title>
<meta property="og:type" content="music.song" />
<meta property="music:musician" content="Sir Mix-a-Lot" />
<meta property="music:album" content="Mack Daddy" />
```

But currently, Remix renders the two "music" metas as `name`.

```html
<meta name="music:musician" content="Sir Mix-a-Lot" />
<meta name="music:album" content="Mack Daddy" />
```

This PR will fix this.

## Production issue

I have a real-life example of this bug. My blogging engine uses an `og:type` of "article" and erroneously renders this in production. (see https://donavon.com/blog/remix-locale)

NOTE: I've patched `components.js` so I no longer have this issue in prod.

```html
<meta property="og:type" content="article">
<meta name="article:published_time" content="2022-03-25T00:00:00.000Z">
```

With this PR, it will render correctly as:

```html
<meta property="og:type" content="article">
<meta property="article:published_time" content="2022-03-25T00:00:00.000Z">
```
