### PR TITLE
docs(examples/jokes): add validation to prevent open redirect on login

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -302,3 +302,4 @@
 - youngvform
 - zachdtaylor
 - zainfathoni
+- LewisArdern

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -3730,7 +3730,6 @@ function validatePassword(password: unknown) {
 }
 
 function validateUrl(url: any) {
-  console.log(url)
   let urls = ['/jokes','/','https://remix.run']
   if (urls.includes(url)) {
     return url

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -5079,7 +5079,6 @@ function validatePassword(password: unknown) {
 }
 
 function validateUrl(url: any) {
-  console.log(url)
   let urls = ['/jokes','/','https://remix.run']
   if (urls.includes(url)) {
     return url

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -2553,6 +2553,15 @@ function validatePassword(password: unknown) {
   }
 }
 
+function validateUrl(url: any) {
+  console.log(url)
+  let urls = ['/jokes','/','https://remix.run']
+  if (urls.includes(url)) {
+    return url
+  }
+  return '/jokes'
+}
+
 type ActionData = {
   formError?: string;
   fieldErrors?: {
@@ -2576,7 +2585,7 @@ export const action: ActionFunction = async ({
   const loginType = form.get("loginType");
   const username = form.get("username");
   const password = form.get("password");
-  const redirectTo = form.get("redirectTo") || "/jokes";
+  const redirectTo = validateUrl(form.get("redirectTo") || '/jokes');
   if (
     typeof loginType !== "string" ||
     typeof username !== "string" ||
@@ -3720,6 +3729,15 @@ function validatePassword(password: unknown) {
   }
 }
 
+function validateUrl(url: any) {
+  console.log(url)
+  let urls = ['/jokes','/','https://remix.run']
+  if (urls.includes(url)) {
+    return url
+  }
+  return '/jokes'
+}
+
 type ActionData = {
   formError?: string;
   fieldErrors?: {
@@ -3743,7 +3761,7 @@ export const action: ActionFunction = async ({
   const loginType = form.get("loginType");
   const username = form.get("username");
   const password = form.get("password");
-  const redirectTo = form.get("redirectTo") || "/jokes";
+  const redirectTo = validateUrl(form.get("redirectTo") || '/jokes');
   if (
     typeof loginType !== "string" ||
     typeof username !== "string" ||
@@ -5060,6 +5078,15 @@ function validatePassword(password: unknown) {
   }
 }
 
+function validateUrl(url: any) {
+  console.log(url)
+  let urls = ['/jokes','/','https://remix.run']
+  if (urls.includes(url)) {
+    return url
+  }
+  return '/jokes'
+}
+
 type ActionData = {
   formError?: string;
   fieldErrors?: {
@@ -5083,7 +5110,7 @@ export const action: ActionFunction = async ({
   const loginType = form.get("loginType");
   const username = form.get("username");
   const password = form.get("password");
-  const redirectTo = form.get("redirectTo") || "/jokes";
+  const redirectTo = validateUrl(form.get("redirectTo") || '/jokes');
   if (
     typeof loginType !== "string" ||
     typeof username !== "string" ||

--- a/examples/jokes/app/routes/login.tsx
+++ b/examples/jokes/app/routes/login.tsx
@@ -27,6 +27,15 @@ function validatePassword(password: unknown) {
   }
 }
 
+function validateUrl(url: any) {
+  console.log(url)
+  let urls = ['/jokes','/','https://remix.run']
+  if (urls.includes(url)) {
+    return url
+  }
+  return '/jokes'
+}
+
 type ActionData = {
   formError?: string;
   fieldErrors?: { username: string | undefined; password: string | undefined };
@@ -45,7 +54,7 @@ export const action: ActionFunction = async ({ request }) => {
   const loginType = form.get("loginType");
   const username = form.get("username");
   const password = form.get("password");
-  const redirectTo = form.get("redirectTo") || "/jokes";
+  const redirectTo = validateUrl(form.get("redirectTo") || '/jokes');
   if (
     typeof loginType !== "string" ||
     typeof username !== "string" ||

--- a/examples/jokes/app/routes/login.tsx
+++ b/examples/jokes/app/routes/login.tsx
@@ -28,7 +28,6 @@ function validatePassword(password: unknown) {
 }
 
 function validateUrl(url: any) {
-  console.log(url)
   let urls = ['/jokes','/','https://remix.run']
   if (urls.includes(url)) {
     return url


### PR DESCRIPTION
Re-opening https://github.com/remix-run/remix/pull/2473 (as I think I messed up the rebase)

This change validates the URL based on /jokes, /, and https://remix.run to prevent the open redirect vulnerability that exists in the jokes tutorial.

https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html

