### PR TITLE
fix(remix-dev/cli): Remove excess fetching and improve error handling

### DIFF
--- a/packages/create-remix/cli.ts
+++ b/packages/create-remix/cli.ts
@@ -1,11 +1,11 @@
 import { cli } from "@remix-run/dev";
 
-cli.run(["create", ...process.argv.slice(2)]).then(
-  () => {
+cli
+  .run(["create", ...process.argv.slice(2)])
+  .then(() => {
     process.exit(0);
-  },
-  (error: Error) => {
+  })
+  .catch((error) => {
     console.error(error);
     process.exit(1);
-  }
-);
+  });

--- a/packages/create-remix/cli.ts
+++ b/packages/create-remix/cli.ts
@@ -1,11 +1,13 @@
 import { cli } from "@remix-run/dev";
 
+let args = process.argv.slice(2);
+
 cli
-  .run(["create", ...process.argv.slice(2)])
+  .run(["create", ...args])
   .then(() => {
     process.exit(0);
   })
-  .catch((error) => {
-    console.error(error);
+  .catch((error: Error) => {
+    console.error(args.includes("--debug") ? error : error.message);
     process.exit(1);
   });

--- a/packages/remix-dev/__tests__/cli-test.ts
+++ b/packages/remix-dev/__tests__/cli-test.ts
@@ -70,14 +70,13 @@ describe("remix cli", () => {
 
             - a file path to a directory of files
             - a file path to a tarball
-            - the name of a repo in the remix-run GitHub org
-            - the name of a username/repo on GitHub
+            - the name of a :username/:repo on GitHub
             - the URL of a tarball
 
             $ remix create my-app --template /path/to/remix-template
             $ remix create my-app --template /path/to/remix-template.tar.gz
-            $ remix create my-app --template [remix-run/]grunge-stack
-            $ remix create my-app --template github-username/repo-name
+            $ remix create my-app --template remix-run/grunge-stack
+            $ remix create my-app --template :username/:repo
             $ remix create my-app --template https://github.com/:username/:repo
             $ remix create my-app --template https://github.com/:username/:repo/tree/:branch
             $ remix create my-app --template https://github.com/:username/:repo/archive/refs/tags/:tag.tar.gz
@@ -178,7 +177,7 @@ describe("remix cli", () => {
         "create",
         projectDir,
         "--template",
-        "basic",
+        "examples/basic",
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
@@ -199,7 +198,7 @@ describe("remix cli", () => {
         "create",
         projectDir,
         "--template",
-        "grunge-stack",
+        "remix-run/grunge-stack",
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
@@ -328,7 +327,7 @@ describe("remix cli", () => {
         "create",
         projectDir,
         "--template",
-        "blues-stack",
+        "remix-run/blues-stack",
         "--no-install",
         "--no-typescript",
       ]);

--- a/packages/remix-dev/__tests__/cli-test.ts
+++ b/packages/remix-dev/__tests__/cli-test.ts
@@ -181,8 +181,7 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into ${projectDir} and check the
-   README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -203,12 +202,9 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 You've opted out of installing dependencies so we won't run the
-   remix.init/index.js script for you just yet. Once you've installed
-   dependencies, you can run it manually with \`npx remix init\`
+        `💿 You've opted out of installing dependencies so we won't run the remix.init/index.js script for you just yet. Once you've installed dependencies, you can run it manually with \`npx remix init\`
 
-💿 That's it! \`cd\` into ${projectDir} and check the
-   README for development and deploy instructions!`
+💿 That's it! \`cd\` into ${projectDir} and check the README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -229,8 +225,7 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into ${projectDir} and check the
-   README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -251,8 +246,7 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into ${projectDir} and check the
-   README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -273,8 +267,7 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into ${projectDir} and check the
-   README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -295,8 +288,7 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into ${projectDir} and check the
-   README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -319,8 +311,7 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into ${projectDir} and check the
-   README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -342,12 +333,9 @@ describe("remix cli", () => {
         "--no-typescript",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 You've opted out of installing dependencies so we won't run the
-   remix.init/index.js script for you just yet. Once you've installed
-   dependencies, you can run it manually with \`npx remix init\`
+        `💿 You've opted out of installing dependencies so we won't run the remix.init/index.js script for you just yet. Once you've installed dependencies, you can run it manually with \`npx remix init\`
 
-💿 That's it! \`cd\` into ${projectDir} and check the
-   README for development and deploy instructions!`
+💿 That's it! \`cd\` into ${projectDir} and check the README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -383,8 +371,7 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into ${projectDir} and check the
-   README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -405,8 +392,7 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into ${projectDir} and check the
-   README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -427,8 +413,7 @@ describe("remix cli", () => {
         "--install",
       ]);
       expect(stdout.trim()).toContain(
-        `💿 That's it! \`cd\` into ${projectDir} and check the
-   README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the README for development and deploy instructions!`
       );
       expect(stdout.trim()).toContain(`💿 Running remix.init script`);
       expect(
@@ -453,8 +438,7 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toContain(
-        `💿 That's it! \`cd\` into ${projectDir} and check the
-   README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the README for development and deploy instructions!`
       );
 
       let initResult = await execFile("node", [remix, "init"], {
@@ -510,8 +494,7 @@ describe("remix cli", () => {
       ]);
 
       expect(stdout.trim()).toContain(
-        `💿 That's it! \`cd\` into ${projectDir} and check the
-   README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the README for development and deploy instructions!`
       );
 
       await expect(

--- a/packages/remix-dev/__tests__/cli-test.ts
+++ b/packages/remix-dev/__tests__/cli-test.ts
@@ -181,7 +181,8 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into "${projectDir}" and check the README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the
+   README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -202,8 +203,12 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 You've opted out of installing dependencies so we won't run the remix.init/index.js script for you just yet. Once you've installed dependencies, you can run it manually with \`npx remix init\`
-💿 That's it! \`cd\` into "${projectDir}" and check the README for development and deploy instructions!`
+        `💿 You've opted out of installing dependencies so we won't run the
+   remix.init/index.js script for you just yet. Once you've installed
+   dependencies, you can run it manually with \`npx remix init\`
+
+💿 That's it! \`cd\` into ${projectDir} and check the
+   README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -224,7 +229,8 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into "${projectDir}" and check the README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the
+   README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -245,7 +251,8 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into "${projectDir}" and check the README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the
+   README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -266,7 +273,8 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into "${projectDir}" and check the README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the
+   README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -287,7 +295,8 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into "${projectDir}" and check the README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the
+   README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -310,7 +319,8 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into "${projectDir}" and check the README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the
+   README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -332,8 +342,12 @@ describe("remix cli", () => {
         "--no-typescript",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 You've opted out of installing dependencies so we won't run the remix.init/index.js script for you just yet. Once you've installed dependencies, you can run it manually with \`npx remix init\`
-💿 That's it! \`cd\` into "${projectDir}" and check the README for development and deploy instructions!`
+        `💿 You've opted out of installing dependencies so we won't run the
+   remix.init/index.js script for you just yet. Once you've installed
+   dependencies, you can run it manually with \`npx remix init\`
+
+💿 That's it! \`cd\` into ${projectDir} and check the
+   README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -369,7 +383,8 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into "${projectDir}" and check the README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the
+   README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -390,7 +405,8 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toBe(
-        `💿 That's it! \`cd\` into "${projectDir}" and check the README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the
+   README for development and deploy instructions!`
       );
       expect(
         fse.existsSync(path.join(projectDir, "package.json"))
@@ -411,7 +427,8 @@ describe("remix cli", () => {
         "--install",
       ]);
       expect(stdout.trim()).toContain(
-        `💿 That's it! \`cd\` into "${projectDir}" and check the README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the
+   README for development and deploy instructions!`
       );
       expect(stdout.trim()).toContain(`💿 Running remix.init script`);
       expect(
@@ -436,7 +453,8 @@ describe("remix cli", () => {
         "--no-install",
       ]);
       expect(stdout.trim()).toContain(
-        `💿 That's it! \`cd\` into "${projectDir}" and check the README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the
+   README for development and deploy instructions!`
       );
 
       let initResult = await execFile("node", [remix, "init"], {
@@ -492,7 +510,8 @@ describe("remix cli", () => {
       ]);
 
       expect(stdout.trim()).toContain(
-        `💿 That's it! \`cd\` into "${projectDir}" and check the README for development and deploy instructions!`
+        `💿 That's it! \`cd\` into ${projectDir} and check the
+   README for development and deploy instructions!`
       );
 
       await expect(

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -52,19 +52,23 @@ export async function create({
 
   let initScriptDir = path.join(projectDir, "remix.init");
   let hasInitScript = await fse.pathExists(initScriptDir);
+
+  spinner.stop();
+  spinner.clear();
+
   if (hasInitScript) {
     if (installDeps) {
-      spinner.text = "Running remix.init script…";
+      console.log("💿 Running remix.init script");
       await init(projectDir);
       await fse.remove(initScriptDir);
-      spinner.stop();
     } else {
-      spinner.stop();
       console.log();
       console.log(
-        "💿 You've opted out of installing dependencies so we won't run the " +
-          "remix.init/index.js script for you just yet. Once you've installed " +
-          "dependencies, you can run it manually with `npx remix init`"
+        colors.warning(
+          "💿 You've opted out of installing dependencies so we won't run the\n" +
+            "   remix.init/index.js script for you just yet. Once you've installed\n" +
+            "   dependencies, you can run it manually with `npx remix init`"
+        )
       );
       console.log();
     }
@@ -72,9 +76,6 @@ export async function create({
 
   let relProjectDir = path.relative(process.cwd(), projectDir);
   let projectDirIsCurrentDir = relProjectDir === "";
-
-  spinner.stop();
-  spinner.clear();
 
   if (projectDirIsCurrentDir) {
     console.log(
@@ -101,7 +102,9 @@ export async function init(projectDir: string) {
     try {
       await initFn({ rootDirectory: projectDir });
     } catch (error) {
-      console.error(`🚨 Oops, remix.init failed`);
+      if (error instanceof Error) {
+        error.message = colors.error(`🚨 Oops, remix.init failed`);
+      }
       throw error;
     }
   }

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -65,9 +65,9 @@ export async function create({
       console.log();
       console.log(
         colors.warning(
-          "💿 You've opted out of installing dependencies so we won't run the\n" +
-            "   remix.init/index.js script for you just yet. Once you've installed\n" +
-            "   dependencies, you can run it manually with `npx remix init`"
+          "💿 You've opted out of installing dependencies so we won't run the" +
+            "remix.init/index.js script for you just yet. Once you've installed" +
+            "dependencies, you can run it manually with `npx remix init`"
         )
       );
       console.log();
@@ -85,8 +85,7 @@ export async function create({
     console.log(
       "💿 That's it! `cd` into " +
         colors.logoGreen(path.resolve(process.cwd(), projectDir)) +
-        " and check the\n" +
-        "   README for development and deploy instructions!"
+        " and check the README for development and deploy instructions!"
     );
   }
 }
@@ -103,7 +102,7 @@ export async function init(projectDir: string) {
       await initFn({ rootDirectory: projectDir });
     } catch (error) {
       if (error instanceof Error) {
-        error.message = colors.error(`🚨 Oops, remix.init failed`);
+        error.message = colors.error("🚨 Oops, remix.init failed");
       }
       throw error;
     }
@@ -117,7 +116,8 @@ export async function setup(platformArg?: string) {
     platformArg === "cloudflare-pages"
   ) {
     console.warn(
-      `Using '${platformArg}' as a platform value is deprecated. Use 'cloudflare' instead.`
+      `Using '${platformArg}' as a platform value is deprecated. Use ` +
+        "'cloudflare' instead."
     );
     console.log("HINT: check the `postinstall` script in `package.json`");
     platform = SetupPlatform.Cloudflare;
@@ -155,7 +155,10 @@ export async function build(
       "\n⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️"
     );
     console.warn(
-      "You have enabled source maps in production. This will make your server side code visible to the public and is highly discouraged! If you insist, please ensure you are using environment variables for secrets and not hard-coding them into your source!"
+      "You have enabled source maps in production. This will make your " +
+        "server-side code visible to the public and is highly discouraged! If " +
+        "you insist, please ensure you are using environment variables for " +
+        "secrets and not hard-coding them into your source!"
     );
     console.warn(
       "⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️\n"
@@ -255,7 +258,8 @@ export async function dev(remixRoot: string, modeArg?: string) {
     express = require("express");
   } catch (err) {
     throw new Error(
-      "Could not locate @remix-run/serve. Please verify you have it installed to use the dev command."
+      "Could not locate @remix-run/serve. Please verify you have it installed " +
+        "to use the dev command."
     );
   }
 

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -65,8 +65,8 @@ export async function create({
       console.log();
       console.log(
         colors.warning(
-          "💿 You've opted out of installing dependencies so we won't run the" +
-            "remix.init/index.js script for you just yet. Once you've installed" +
+          "💿 You've opted out of installing dependencies so we won't run the " +
+            "remix.init/index.js script for you just yet. Once you've installed " +
             "dependencies, you can run it manually with `npx remix init`"
         )
       );

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -12,6 +12,7 @@ import type { createApp as createAppType } from "@remix-run/serve";
 import getPort from "get-port";
 
 import { BuildMode, isBuildMode } from "../build";
+import * as colors from "./colors";
 import * as compiler from "../compiler";
 import type { RemixConfig } from "../config";
 import { readConfig } from "../config";
@@ -47,7 +48,6 @@ export async function create({
     installDeps,
     useTypeScript,
     githubToken,
-    templateType,
   });
 
   let initScriptDir = path.join(projectDir, "remix.init");
@@ -60,14 +60,21 @@ export async function create({
       spinner.stop();
     } else {
       spinner.stop();
+      console.log();
       console.log(
-        "💿 You've opted out of installing dependencies so we won't run the remix.init/index.js script for you just yet. Once you've installed dependencies, you can run it manually with `npx remix init`"
+        "💿 You've opted out of installing dependencies so we won't run the " +
+          "remix.init/index.js script for you just yet. Once you've installed " +
+          "dependencies, you can run it manually with `npx remix init`"
       );
+      console.log();
     }
   }
 
   let relProjectDir = path.relative(process.cwd(), projectDir);
   let projectDirIsCurrentDir = relProjectDir === "";
+
+  spinner.stop();
+  spinner.clear();
 
   if (projectDirIsCurrentDir) {
     console.log(
@@ -75,10 +82,10 @@ export async function create({
     );
   } else {
     console.log(
-      `💿 That's it! \`cd\` into "${path.resolve(
-        process.cwd(),
-        projectDir
-      )}" and check the README for development and deploy instructions!`
+      "💿 That's it! `cd` into " +
+        colors.logoGreen(path.resolve(process.cwd(), projectDir)) +
+        " and check the\n" +
+        "   README for development and deploy instructions!"
     );
   }
 }

--- a/packages/remix-dev/cli/create.ts
+++ b/packages/remix-dev/cli/create.ts
@@ -472,8 +472,6 @@ export async function validateTemplate(input: string): Promise<TemplateType> {
 
   let templateType = detectTemplateType(input);
   switch (templateType) {
-    case "validatedLocal":
-      return "local";
     case "local": {
       if (input.startsWith("file://")) {
         input = fileURLToPath(input);
@@ -588,9 +586,7 @@ export type TemplateType =
   // local directory
   | "local";
 
-export function detectTemplateType(
-  template: string
-): TemplateType | "validatedLocal" | null {
+export function detectTemplateType(template: string): TemplateType | null {
   // 1. Check if the user passed a local file. If they hand us an explicit file
   //    URL, we'll validate it first. Otherwise we just ping the filesystem to
   //    see if the string references a filepath and, if not, move on.
@@ -606,8 +602,7 @@ export function detectTemplateType(
           : path.resolve(process.cwd(), template)
       )
     ) {
-      // We know this exists, so no need to validate again
-      return "validatedLocal";
+      return "local";
     }
   } catch (_) {
     // ignore FS errors and move on

--- a/packages/remix-dev/cli/create.ts
+++ b/packages/remix-dev/cli/create.ts
@@ -137,13 +137,14 @@ ${HELP_TEXT}
       break;
     }
     default:
-      throw new Error(
+      console.error(
         `🚨 Unable to determine template type for "${appTemplate}"
 
 Valid template flags may look like one of the following:${VALID_TEMPLATE_EXAMPLES}
 ${HELP_TEXT}
 `
       );
+      process.exit(1);
   }
 
   // Update remix deps
@@ -585,7 +586,7 @@ function detectTemplateType(template: string): TemplateType {
     return "template";
   }
 
-  // 4. Handle GitHub repos (URLs or :org/:repo shorthand)
+  // 3. Handle GitHub repos (URLs or :org/:repo shorthand)
   if (isValidGithubUrl(template) || isGithubRepoShorthand(template)) {
     return "repo";
   }

--- a/packages/remix-dev/cli/create.ts
+++ b/packages/remix-dev/cli/create.ts
@@ -43,7 +43,8 @@ export async function createApp({
   let versions = process.versions;
   if (versions?.node && semver.major(versions.node) < 14) {
     throw new Error(
-      `️🚨 Oops, Node v${versions.node} detected. Remix requires a Node version greater than 14.`
+      `️🚨 Oops, Node v${versions.node} detected. Remix requires a Node version ` +
+        `greater than 14.`
     );
   }
 
@@ -136,7 +137,9 @@ export async function createApp({
     });
     if (npmConfig?.startsWith("https://npm.remix.run")) {
       throw Error(
-        "🚨 Oops! You still have the private Remix registry configured. Please run `npm config delete @remix-run:registry` or edit your .npmrc file to remove it."
+        "🚨 Oops! You still have the private Remix registry configured. Please " +
+          "run `npm config delete @remix-run:registry` or edit your .npmrc file " +
+          "to remove it."
       );
     }
     execSync("npm install", { stdio: "inherit", cwd: projectDir });
@@ -158,7 +161,7 @@ async function extractLocalTarball(
     );
   } catch (err) {
     throw Error(
-      `🚨 There was a problem extracting the file from the provided template.\n\n` +
+      "🚨 There was a problem extracting the file from the provided template.\n\n" +
         `  Template filepath: \`${filePath}\`\n` +
         `  Destination directory: \`${projectDir}\``
     );
@@ -188,8 +191,8 @@ async function downloadAndExtractTemplateOrExample(
 
   if (response.status !== 200) {
     throw Error(
-      "🚨 There was a problem fetching the file from GitHub. The request responded " +
-        `with a ${response.status} status. Please try again later.`
+      "🚨 There was a problem fetching the file from GitHub. The request " +
+        `responded with a ${response.status} status. Please try again later.`
     );
   }
 
@@ -283,8 +286,8 @@ async function downloadAndExtractTarball(
 
   if (response.status !== 200) {
     throw Error(
-      "🚨 There was a problem fetching the file from GitHub. The request responded " +
-        `with a ${response.status} status. Please try again later.`
+      "🚨 There was a problem fetching the file from GitHub. The request " +
+        `responded with a ${response.status} status. Please try again later.`
     );
   }
 
@@ -411,7 +414,8 @@ function getRepoInfo(validatedGithubUrl: string): RepoInfo {
     url: validatedGithubUrl,
     owner,
     name,
-    // If we've validated the GitHub URL and there is a tree, there will also be a branch
+    // If we've validated the GitHub URL and there is a tree, there will also be
+    // a branch
     branch: branch!,
     filePath: filePath === "" || filePath === "/" ? null : filePath,
   };
@@ -427,7 +431,8 @@ export async function validateNewProjectPath(input: string): Promise<void> {
     let contents = await fse.readdir(projectDir);
     if (contents.length > 0) {
       throw Error(
-        `🚨 The current directory must be empty to create a new project. Please clear the contents of the directory or choose a different path.`
+        "🚨 The current directory must be empty to create a new project. Please " +
+          "clear the contents of the directory or choose a different path."
       );
     }
     return;
@@ -438,7 +443,8 @@ export async function validateNewProjectPath(input: string): Promise<void> {
     (await fse.stat(projectDir)).isDirectory()
   ) {
     throw Error(
-      `🚨 The directory provided already exists. Please try again with a different directory.`
+      "🚨 The directory provided already exists. Please try again with a " +
+        "different directory."
     );
   }
 }
@@ -491,17 +497,21 @@ export async function validateTemplate(input: string): Promise<TemplateType> {
             return "remoteTarball";
           case 404:
             throw Error(
-              `🚨 The template file could not be verified. Please double check the URL and try again.`
+              "🚨 The template file could not be verified. Please double check " +
+                "the URL and try again."
             );
           default:
             throw Error(
-              `🚨 The template file could not be verified. The server returned a response with a ${response.status} status. Please double check the URL and try again.`
+              "🚨 The template file could not be verified. The server returned " +
+                `a response with a ${response.status} status. Please double ` +
+                "check the URL and try again."
             );
         }
       } catch (err) {
         spinner.stop();
         throw Error(
-          `🚨 There was a problem verifying the template file. Please ensure you are connected to the internet and try again later.`
+          "🚨 There was a problem verifying the template file. Please ensure " +
+            "you are connected to the internet and try again later."
         );
       }
     }
@@ -516,25 +526,31 @@ export async function validateTemplate(input: string): Promise<TemplateType> {
             return "repo";
           case 403:
             throw Error(
-              `🚨 The template could not be verified because you do not have access to the repository. Please double check the access rights of this repo and try again.`
+              "🚨 The template could not be verified because you do not have " +
+                "access to the repository. Please double check the access " +
+                "rights of this repo and try again."
             );
           case 404:
             throw Error(
-              `🚨 The template could not be verified. Please double check that the template is a valid GitHub repository${
-                filePath && filePath !== "/"
+              "🚨 The template could not be verified. Please double check that " +
+                "the template is a valid GitHub repository" +
+                (filePath && filePath !== "/"
                   ? " and that the filepath points to a directory in the repo"
-                  : ""
-              } and try again.`
+                  : "") +
+                " and try again."
             );
           default:
             throw Error(
-              `🚨 The template could not be verified. The server returned a response with a ${response.status} status. Please double check that the template is a valid GitHub repository  and try again.`
+              "🚨 The template could not be verified. The server returned a " +
+                `response with a ${response.status} status. Please double check ` +
+                "that the template is a valid GitHub repository  and try again."
             );
         }
       } catch (_) {
         spinner.stop();
         throw Error(
-          `🚨 There was a problem verifying the template. Please ensure you are connected to the internet and try again later.`
+          "🚨 There was a problem verifying the template. Please ensure you " +
+            "are connected to the internet and try again later."
         );
       }
     }
@@ -555,17 +571,25 @@ export async function validateTemplate(input: string): Promise<TemplateType> {
             return templateType;
           case 404:
             throw Error(
-              `🚨 The template could not be verified. Please double check that the template is a valid project directory in https://github.com/remix-run/remix/tree/main/${typeDir} and try again.`
+              "🚨 The template could not be verified. Please double check that " +
+                "the template is a valid project directory in " +
+                `https://github.com/remix-run/remix/tree/main/${typeDir} and ` +
+                "try again."
             );
           default:
             throw Error(
-              `🚨 The template could not be verified. The server returned a response with a ${response.status} status. Please double check that the template is a valid project directory in https://github.com/remix-run/remix/tree/main/${typeDir} and try again.`
+              "🚨 The template could not be verified. The server returned a " +
+                `response with a ${response.status} status. Please double ` +
+                "check that the template is a valid project directory in " +
+                `https://github.com/remix-run/remix/tree/main/${typeDir} and ` +
+                "try again."
             );
         }
       } catch (_) {
         spinner.stop();
         throw Error(
-          `🚨 There was a problem verifying the template. Please ensure you are connected to the internet and try again later.`
+          "🚨 There was a problem verifying the template. Please ensure you are " +
+            "connected to the internet and try again later."
         );
       }
     }

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -144,9 +144,10 @@ export async function run(argv: string[] = process.argv.slice(2)) {
       let templateType: TemplateType;
 
       // Flags will validate early and stop the process if invalid flags are
-      // provided. Input provided in the interactive CLI is validated by inquirer
-      // step-by-step. This not only allows us to catch issues as early as possible,
-      // but inquirer will allow users to retry input rather than stop the process.
+      // provided. Input provided in the interactive CLI is validated by
+      // inquirer step-by-step. This not only allows us to catch issues as early
+      // as possible, but inquirer will allow users to retry input rather than
+      // stop the process.
       if (flags.template) {
         templateType = await validateTemplate(flags.template);
       }
@@ -247,7 +248,9 @@ export async function run(argv: string[] = process.argv.slice(2)) {
             when(answers) {
               return answers.appType === "template";
             },
-            message: `Where do you want to deploy? Choose Remix if you're unsure; it's easy to change deployment targets.`,
+            message:
+              "Where do you want to deploy? Choose Remix if you're unsure; " +
+              "it's easy to change deployment targets.",
             loop: false,
             choices: templateChoices,
           },
@@ -279,9 +282,11 @@ export async function run(argv: string[] = process.argv.slice(2)) {
           if (error.isTtyError) {
             console.warn(
               colors.warning(
-                "🚨 Your terminal doesn't support interactivity; using default configuration.\n\n" +
-                  "If you'd like to use different settings, try passing them as arguments. Run " +
-                  "`npx create-remix@latest --help` to see available options."
+                "🚨 Your terminal doesn't support interactivity; using default " +
+                  "configuration.\n\n" +
+                  "If you'd like to use different settings, try passing them " +
+                  "as arguments. Run `npx create-remix@latest --help` to see " +
+                  "available options."
               )
             );
             return {

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -305,7 +305,8 @@ export async function run(argv: string[] = process.argv.slice(2)) {
           templateType! || (answers.appType === "stack" ? "repo" : "template"),
         projectDir,
         remixVersion: flags.remixVersion,
-        installDeps: flags.install ?? answers.install,
+        installDeps: flags.install || answers.install,
+        useTypeScript: flags.typescript || answers.useTypeScript,
         useTypeScript: flags.typescript ?? answers.useTypeScript,
         githubToken: process.env.GITHUB_TOKEN,
       });

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -49,14 +49,13 @@ ${colors.heading("Creating a new project")}:
 
   - a file path to a directory of files
   - a file path to a tarball
-  - the name of a repo in the remix-run GitHub org
-  - the name of a username/repo on GitHub
+  - the name of a :username/:repo on GitHub
   - the URL of a tarball
 
   $ remix create my-app --template /path/to/remix-template
   $ remix create my-app --template /path/to/remix-template.tar.gz
-  $ remix create my-app --template [remix-run/]grunge-stack
-  $ remix create my-app --template github-username/repo-name
+  $ remix create my-app --template remix-run/grunge-stack
+  $ remix create my-app --template :username/:repo
   $ remix create my-app --template https://github.com/:username/:repo
   $ remix create my-app --template https://github.com/:username/:repo/tree/:branch
   $ remix create my-app --template https://github.com/:username/:repo/archive/refs/tags/:tag.tar.gz

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -202,15 +202,15 @@ export async function run(argv: string[] = process.argv.slice(2)) {
             choices: [
               {
                 name: "Blues",
-                value: "blues-stack",
+                value: "remix-run/blues-stack",
               },
               {
                 name: "Indie",
-                value: "indie-stack",
+                value: "remix-run/indie-stack",
               },
               {
                 name: "Grunge",
-                value: "grunge-stack",
+                value: "remix-run/grunge-stack",
               },
             ],
           },

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -1,11 +1,16 @@
 import * as path from "path";
-import meow from "meow";
+import fs from "fs";
+import { fileURLToPath } from "url";
 import inspector from "inspector";
+import fse from "fs-extra";
+import meow from "meow";
 import inquirer from "inquirer";
-// import chalkAnimation from "chalk-animation";
+import ora from "ora";
+import fetch from "node-fetch";
 
 import * as colors from "./colors";
 import * as commands from "./commands";
+import type { TemplateType } from "./create";
 
 const helpText = `
 ${colors.logoBlue("R")} ${colors.logoGreen("E")} ${colors.logoYellow(
@@ -93,6 +98,32 @@ ${colors.heading("Show all routes in your app")}:
   $ remix routes --json
 `;
 
+const stackChoices = [
+  {
+    name: "Blues",
+    value: "remix-run/blues-stack",
+  },
+  {
+    name: "Indie",
+    value: "remix-run/indie-stack",
+  },
+  {
+    name: "Grunge",
+    value: "remix-run/grunge-stack",
+  },
+];
+
+const templateChoices = [
+  { name: "Remix App Server", value: "remix" },
+  { name: "Express Server", value: "express" },
+  { name: "Architect (AWS Lambda)", value: "arc" },
+  { name: "Fly.io", value: "fly" },
+  { name: "Netlify", value: "netlify" },
+  { name: "Vercel", value: "vercel" },
+  { name: "Cloudflare Pages", value: "cloudflare-pages" },
+  { name: "Cloudflare Workers", value: "cloudflare-workers" },
+];
+
 /**
  * Programmatic interface for running the Remix CLI with the given command line
  * arguments.
@@ -121,49 +152,64 @@ export async function run(argv: string[] = process.argv.slice(2)) {
     flags.template = "remix-ts";
   }
 
-  //   if (!flags.template) {
-  //     if (colors.supportsColor && process.env.NODE_ENV !== "test") {
-  //       let anim = chalkAnimation.rainbow(
-  //         `\nR E M I X - v${remixDevPackageVersion}\n`
-  //       );
-  //       await new Promise((res) => setTimeout(res, 1500));
-  //       anim.stop();
-  //     }
-  //   }
+  let command = input[0];
 
   // Note: Keep each case in this switch statement small.
-  switch (input[0]) {
+  switch (command) {
     case "create":
     // `remix new` is an alias for `remix create`
     case "new": {
-      let projectPath =
-        input.length > 1
-          ? input[1]
-          : (
-              await inquirer
-                .prompt<{ dir: string }>([
-                  {
-                    type: "input",
-                    name: "dir",
-                    message: "Where would you like to create your app?",
-                    default: "./my-remix-app",
-                  },
-                ])
-                .catch((error) => {
-                  if (error.isTtyError) {
-                    showHelp();
-                    return;
-                  }
-                  throw error;
-                })
-            )?.dir;
+      let projectPath = input[1];
+      let templateType: string;
 
-      if (!projectPath) {
+      // Flags will validate early and stop the process if invalid flags are
+      // provided. Input provided in the interactive CLI is validated by inquirer
+      // step-by-step. This not only allows us to catch issues as early as possible,
+      // but inquirer will allow users to retry input rather than stop the process.
+      if (flags.template) {
+        templateType = await validateTemplate(flags.template);
+      }
+      if (projectPath) {
+        await validateNewProjectPath(projectPath);
+      }
+
+      let projectDir = projectPath
+        ? path.resolve(process.cwd(), projectPath)
+        : await inquirer
+            .prompt<{ dir: string }>([
+              {
+                type: "input",
+                name: "dir",
+                message: "Where would you like to create your app?",
+                default: "./my-remix-app",
+                async validate(input) {
+                  try {
+                    await validateNewProjectPath(String(input));
+                    return true;
+                  } catch (error) {
+                    if (error instanceof Error && error.message) {
+                      return error.message;
+                    }
+                    throw error;
+                  }
+                },
+              },
+            ])
+            .then(async (input) => {
+              return path.resolve(process.cwd(), input.dir);
+            })
+            .catch((error) => {
+              if (error.isTtyError) {
+                showHelp();
+                return;
+              }
+              throw error;
+            });
+
+      if (!projectDir) {
         showHelp();
         return;
       }
-
-      let projectDir = path.resolve(process.cwd(), projectPath);
 
       let answers = await inquirer
         .prompt<{
@@ -199,20 +245,7 @@ export async function run(argv: string[] = process.argv.slice(2)) {
             message: "Which Stack do you want? ",
             loop: false,
             suffix: "(Learn more about these stacks: https://remix.run/stacks)",
-            choices: [
-              {
-                name: "Blues",
-                value: "remix-run/blues-stack",
-              },
-              {
-                name: "Indie",
-                value: "remix-run/indie-stack",
-              },
-              {
-                name: "Grunge",
-                value: "remix-run/grunge-stack",
-              },
-            ],
+            choices: stackChoices,
           },
           {
             name: "appTemplate",
@@ -220,18 +253,9 @@ export async function run(argv: string[] = process.argv.slice(2)) {
             when(answers) {
               return answers.appType === "template";
             },
-            message: `Where do you want to deploy? Choose Remix if you're unsure, it's easy to change deployment targets.`,
+            message: `Where do you want to deploy? Choose Remix if you're unsure; it's easy to change deployment targets.`,
             loop: false,
-            choices: [
-              { name: "Remix App Server", value: "remix" },
-              { name: "Express Server", value: "express" },
-              { name: "Architect (AWS Lambda)", value: "arc" },
-              { name: "Fly.io", value: "fly" },
-              { name: "Netlify", value: "netlify" },
-              { name: "Vercel", value: "vercel" },
-              { name: "Cloudflare Pages", value: "cloudflare-pages" },
-              { name: "Cloudflare Workers", value: "cloudflare-workers" },
-            ],
+            choices: templateChoices,
           },
           {
             name: "useTypeScript",
@@ -267,6 +291,7 @@ export async function run(argv: string[] = process.argv.slice(2)) {
               )
             );
             return {
+              appType: "template",
               appTemplate: "remix",
               useTypeScript: true,
               install: true,
@@ -277,6 +302,8 @@ export async function run(argv: string[] = process.argv.slice(2)) {
 
       await commands.create({
         appTemplate: flags.template ?? answers.appTemplate,
+        templateType:
+          templateType! || answers.appType === "stack" ? "repo" : "template",
         projectDir,
         remixVersion: flags.remixVersion,
         installDeps: flags.install ?? answers.install,
@@ -312,4 +339,303 @@ export async function run(argv: string[] = process.argv.slice(2)) {
       if (!process.env.NODE_ENV) process.env.NODE_ENV = "development";
       await commands.dev(input[0], process.env.NODE_ENV);
   }
+}
+
+async function validateNewProjectPath(input: string): Promise<void> {
+  let cwd = process.cwd();
+  let projectDir = path.resolve(cwd, input);
+  if (cwd === projectDir) {
+    let contents = await fse.readdir(projectDir);
+    if (contents.length > 0) {
+      throw Error(
+        `🚨 The current directory must be empty to create a new project. Please clear the contents of the directory or choose a different path.`
+      );
+    }
+    return;
+  }
+
+  if (
+    (await fse.pathExists(projectDir)) &&
+    (await fse.stat(projectDir)).isDirectory()
+  ) {
+    throw Error(
+      `🚨 The directory provided already exists. Please try again with a different directory.`
+    );
+  }
+}
+
+async function validateTemplate(input: string): Promise<TemplateType> {
+  // If a template string matches one of the choices in our interactive
+  // prompt, we can skip fetching and manual validation
+  if (stackChoices.find((choice) => choice.value === input)) {
+    return "repo";
+  }
+  if (templateChoices.find((choice) => choice.value === input)) {
+    return "template";
+  }
+
+  let templateType = detectTemplateType(input);
+  switch (templateType) {
+    case "validatedLocal":
+      return "local";
+    case "local": {
+      if (input.startsWith("file://")) {
+        input = fileURLToPath(input);
+      }
+      if (!(await fse.pathExists(input))) {
+        throw Error(`🚨 Oops, the file \`${input}\` does not exist.`);
+      }
+      return "local";
+    }
+    case "remoteTarball": {
+      let spinner = ora("Validating the template file…").start();
+      try {
+        let response = await fetch(input, { method: "HEAD" });
+        spinner.stop();
+        switch (response.status) {
+          case 200:
+            return "remoteTarball";
+          case 404:
+            throw Error(
+              `🚨 The template file could not be verified. Please double check the URL and try again.`
+            );
+          default:
+            throw Error(
+              `🚨 The template file could not be verified. The server returned a response with a ${response.status} status. Please double check the URL and try again.`
+            );
+        }
+      } catch (err) {
+        spinner.stop();
+        throw Error(
+          `🚨 There was a problem verifying the template file. Please ensure you are connected to the internet and try again later.`
+        );
+      }
+    }
+    case "repo": {
+      let spinner = ora("Validating the template repo…").start();
+      let { url, filePath } = getRepoInfo(input);
+      try {
+        let response = await fetch(url, { method: "HEAD" });
+        spinner.stop();
+        switch (response.status) {
+          case 200:
+            return "repo";
+          case 403:
+            throw Error(
+              `🚨 The template could not be verified because you do not have access to the repository. Please double check the access rights of this repo and try again.`
+            );
+          case 404:
+            throw Error(
+              `🚨 The template could not be verified. Please double check that the template is a valid GitHub repository${
+                filePath && filePath !== "/"
+                  ? " and that the filepath points to a directory in the repo"
+                  : ""
+              } and try again.`
+            );
+          default:
+            throw Error(
+              `🚨 The template could not be verified. The server returned a response with a ${response.status} status. Please double check that the template is a valid GitHub repository  and try again.`
+            );
+        }
+      } catch (_) {
+        spinner.stop();
+        throw Error(
+          `🚨 There was a problem verifying the template. Please ensure you are connected to the internet and try again later.`
+        );
+      }
+    }
+    case "example":
+    case "template": {
+      let spinner = ora("Validating the template…").start();
+      let name = input;
+      if (templateType === "example") {
+        name = name.split("/")[1];
+      }
+      let typeDir = templateType + "s";
+      let templateUrl = `https://github.com/remix-run/remix/tree/main/${typeDir}/${name}`;
+      try {
+        let response = await fetch(templateUrl, { method: "HEAD" });
+        spinner.stop();
+        switch (response.status) {
+          case 200:
+            return templateType;
+          case 404:
+            throw Error(
+              `🚨 The template could not be verified. Please double check that the template is a valid project directory in https://github.com/remix-run/remix/tree/main/${typeDir} and try again.`
+            );
+          default:
+            throw Error(
+              `🚨 The template could not be verified. The server returned a response with a ${response.status} status. Please double check that the template is a valid project directory in https://github.com/remix-run/remix/tree/main/${typeDir} and try again.`
+            );
+        }
+      } catch (_) {
+        spinner.stop();
+        throw Error(
+          `🚨 There was a problem verifying the template. Please ensure you are connected to the internet and try again later.`
+        );
+      }
+    }
+  }
+
+  throw Error("🚨 Invalid template selected. Please try again.");
+}
+
+function detectTemplateType(
+  template: string
+): TemplateType | "validatedLocal" | null {
+  // 1. Check if the user passed a local file. If they hand us an explicit file
+  //    URL, we'll validate it first. Otherwise we just ping the filesystem to
+  //    see if the string references a filepath and, if not, move on.
+  if (template.startsWith("file://")) {
+    return "local";
+  }
+
+  try {
+    if (
+      fs.existsSync(
+        path.isAbsolute(template)
+          ? template
+          : path.resolve(process.cwd(), template)
+      )
+    ) {
+      // We know this exists, so no need to validate again
+      return "validatedLocal";
+    }
+  } catch (_) {
+    // ignore FS errors and move on
+  }
+
+  // 3. examples/<template> will use an example folder in the Remix repo
+  if (/^examples?\/[\w-]+$/.test(template)) {
+    return "example";
+  }
+
+  // 2. If the string contains no slashes, spaces, or special chars, we assume
+  //    it is one of our templates.
+  if (/^[\w-]+$/.test(template)) {
+    return "template";
+  }
+
+  // 3. Handle GitHub repos (URLs or :org/:repo shorthand)
+  if (isValidGithubUrl(template) || isGithubRepoShorthand(template)) {
+    return "repo";
+  }
+
+  // 4. Any other valid URL should be treated as a tarball.
+  if (isUrl(template)) {
+    return "remoteTarball";
+  }
+
+  return null;
+}
+
+function isUrl(value: string) {
+  try {
+    new URL(value);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+type GithubUrlString =
+  | `https://github.com/${string}/${string}`
+  | `https://www.github.com/${string}/${string}`;
+
+function isValidGithubUrl(value: string | URL): value is URL | GithubUrlString {
+  try {
+    let url = typeof value === "string" ? new URL(value) : value;
+    let pathSegments = url.pathname.slice(1).split("/");
+
+    return (
+      url.protocol === "https:" &&
+      url.hostname === "github.com" &&
+      // The pathname must have at least 2 segments. If it has more than 2, the
+      // third must be "tree" and it must have at least 4 segments.
+      // https://github.com/remix-run/remix
+      // https://github.com/remix-run/remix/tree/dev
+      pathSegments.length >= 2 &&
+      (pathSegments.length > 2
+        ? pathSegments[2] === "tree" && pathSegments.length >= 4
+        : true)
+    );
+  } catch (_) {
+    return false;
+  }
+}
+
+function isGithubRepoShorthand(value: string) {
+  return /^[\w-]+\/[\w-]+$/.test(value);
+}
+
+function getGithubUrl(info: Omit<RepoInfo, "url">) {
+  let url = `https://github.com/${info.owner}/${info.name}`;
+  if (info.branch) {
+    url += `/${info.branch}`;
+    if (info.filePath && info.filePath !== "/") {
+      url += `/${info.filePath}`;
+    }
+  }
+  return url;
+}
+
+function getRepoInfo(validatedGithubUrl: string): RepoInfo {
+  if (isGithubRepoShorthand(validatedGithubUrl)) {
+    let [owner, name] = validatedGithubUrl.split("/");
+    return {
+      url: getGithubUrl({ owner, name, branch: null, filePath: null }),
+      owner,
+      name,
+      branch: null,
+      filePath: null,
+    };
+  }
+
+  let url = new URL(validatedGithubUrl);
+  let [, owner, name, tree, branch, ...file] = url.pathname.split("/") as [
+    _: string,
+    Owner: string,
+    Name: string,
+    Tree: string | undefined,
+    Branch: string | undefined,
+    FileInfo: string | undefined
+  ];
+  let filePath = file.join(path.sep);
+
+  if (tree === undefined) {
+    return {
+      url: validatedGithubUrl,
+      owner,
+      name,
+      branch: null,
+      filePath: null,
+    };
+  }
+
+  return {
+    url: validatedGithubUrl,
+    owner,
+    name,
+    // If we've validated the GitHub URL and there is a tree, there will also be a branch
+    branch: branch!,
+    filePath: filePath === "" || filePath === "/" ? null : filePath,
+  };
+}
+
+type RepoInfo = RepoInfoWithBranch | RepoInfoWithoutBranch;
+
+interface RepoInfoWithBranch {
+  url: string;
+  owner: string;
+  name: string;
+  branch: string;
+  filePath: string | null;
+}
+
+interface RepoInfoWithoutBranch {
+  url: string;
+  owner: string;
+  name: string;
+  branch: null;
+  filePath: null;
 }

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -40,6 +40,7 @@
     "meow": "^7.1.1",
     "minimatch": "^3.0.4",
     "node-fetch": "^2.6.7",
+    "ora": "^5.4.1",
     "prettier": "2.6.1",
     "pretty-ms": "^7.0.1",
     "remark-frontmatter": "^4.0.0",


### PR DESCRIPTION
Instead of fetching early to detect template types in the CLI, we can simplify the code and speed up the setup process with a few heuristics:

1. Check if the user passed a local file. If they hand us an explicit file URL, we'll validate it first. Otherwise we just ping the filesystem to see if the string references a filepath and, if not, move on.
2. If the provided template contains no slashes, spaces, or special chars, we assume it is one of our templates and attempt to fetch it.
3. If the template is a GitHub URL or shorthand :org/:repo, we fetch the repo.
4. Any other URLs are assumed to be direct tarball URLs, so we try to fetch them.

Worth noting that there are probably more opportunities to improve error handling. We'll want to iterate here.

- [ ] Docs
- [x] Tests 
