### PR TITLE
fix(docs/tutorials): fix Post links on Admin page in blog tutorial

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -146,6 +146,7 @@
 - kalch
 - kanermichael
 - karimsan
+- kaspermroz
 - KenanYusuf
 - kentcdodds
 - kevinrambaud

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -726,7 +726,7 @@ export default function PostAdmin() {
         <nav className="col-span-4 md:col-span-1">
           <ul>
             {posts.map((post) => (
-              <li key={post.slug}>
+              <li key={`/posts/${post.slug}`}>
                 <Link
                   to={post.slug}
                   className="text-blue-600 underline"


### PR DESCRIPTION
Super-tiny change to the docs - I noticed that in the blog tutorial on Admin page there is an issue with URLs to the blog posts, resulting in a 404 error after clicking any of them (also newly created, which can create confusion and double check if creating posts actually works :) )
![Screenshot 2022-03-26 at 19 43 46](https://user-images.githubusercontent.com/29861461/160252954-de4d80db-53d6-403d-9bf3-030c0e475430.png)
