### PR TITLE
fix(docs/tutorials): fix highlighted code lines in Jokes tutorial

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -154,6 +154,7 @@
 - klauspaiva
 - knowler
 - kubaprzetakiewicz
+- kuldar
 - kumard3
 - lachlanjc
 - laughnan

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -3696,7 +3696,7 @@ export async function createUserSession(
 
 <summary>app/routes/login.tsx</summary>
 
-```tsx filename=app/routes/login.tsx lines=[13,97-103]
+```tsx filename=app/routes/login.tsx lines=[13,105-112]
 import type { ActionFunction, LinksFunction } from "remix";
 import {
   useActionData,


### PR DESCRIPTION
In the User Registration section of the Jokes tutorial, there are incorrect lines of code highlighted in `routes/login.tsx`
https://remix.run/docs/en/v1/tutorials/jokes#user-registration