### PR TITLE
feat(remix-cloudflare-pages): add `GetLoadContextFunction` & `RequestHandler` types + remove `@remix-run/server-runtime` dependency

### DIFF
--- a/packages/remix-cloudflare-pages/index.ts
+++ b/packages/remix-cloudflare-pages/index.ts
@@ -1,2 +1,6 @@
-export type { createPagesFunctionHandlerParams } from "./worker";
+export type {
+  createPagesFunctionHandlerParams,
+  GetLoadContextFunction,
+  RequestHandler,
+} from "./worker";
 export { createPagesFunctionHandler, createRequestHandler } from "./worker";

--- a/packages/remix-cloudflare-pages/package.json
+++ b/packages/remix-cloudflare-pages/package.json
@@ -14,8 +14,7 @@
     "url": "https://github.com/remix-run/remix/issues"
   },
   "dependencies": {
-    "@remix-run/cloudflare": "1.3.4",
-    "@remix-run/server-runtime": "1.3.4"
+    "@remix-run/cloudflare": "1.3.4"
   },
   "peerDependencies": {
     "@cloudflare/workers-types": "^3.0.0"

--- a/packages/remix-cloudflare-pages/worker.ts
+++ b/packages/remix-cloudflare-pages/worker.ts
@@ -1,9 +1,22 @@
-import type { ServerBuild, AppLoadContext } from "@remix-run/server-runtime";
-import { createRequestHandler as createRemixRequestHandler } from "@remix-run/server-runtime";
+import type { AppLoadContext, ServerBuild } from "@remix-run/cloudflare";
+import { createRequestHandler as createRemixRequestHandler } from "@remix-run/cloudflare";
+
+/**
+ * A function that returns the value to use as `context` in route `loader` and
+ * `action` functions.
+ *
+ * You can think of this as an escape hatch that allows you to pass
+ * environment/platform-specific values through to your loader/action.
+ */
+export type GetLoadContextFunction<Env = any> = (
+  context: EventContext<Env, any, any>
+) => AppLoadContext;
+
+export type RequestHandler<Env = any> = PagesFunction<Env>;
 
 export interface createPagesFunctionHandlerParams<Env = any> {
   build: ServerBuild;
-  getLoadContext?: (context: EventContext<Env, any, any>) => AppLoadContext;
+  getLoadContext?: GetLoadContextFunction<Env>;
   mode?: string;
 }
 
@@ -11,7 +24,7 @@ export function createRequestHandler<Env = any>({
   build,
   getLoadContext,
   mode,
-}: createPagesFunctionHandlerParams<Env>): PagesFunction<Env> {
+}: createPagesFunctionHandlerParams<Env>): RequestHandler<Env> {
   let handleRequest = createRemixRequestHandler(build, mode);
 
   return (context) => {

--- a/packages/remix-dev/cli/migrate/migrations/replace-remix-imports/transform/map-normalized-imports/package-exports.ts
+++ b/packages/remix-dev/cli/migrate/migrations/replace-remix-imports/transform/map-normalized-imports/package-exports.ts
@@ -84,7 +84,7 @@ export const packageExports: Record<Package, Exports> = {
   },
   "cloudflare-pages": {
     value: [...defaultAdapterExports.value, "createPagesFunctionHandler"],
-    type: ["createPagesFunctionHandlerParams"],
+    type: [...defaultAdapterExports.type, "createPagesFunctionHandlerParams"],
   },
   "cloudflare-workers": {
     value: [


### PR DESCRIPTION
Seems like this was forgotten in #2359, so wanted to make `remix-cloudflare-pages` consistent with all other adapter packages.