### PR TITLE
fix: deno template adjustments

### DIFF
--- a/templates/deno-ts/README.md
+++ b/templates/deno-ts/README.md
@@ -40,14 +40,6 @@ For now, we are inlining Remix's `@remix-run/deno` package into `remix-deno` to 
 In the future, this template would not include the `remix-deno` directory at all.
 Instead, users could import from `@remix-run/deno` (exact URL TBD).
 
-### Required `installGlobals` call
-
-Remix depends on specific globals (`sign`/`unsign`) for internal functionality (cookie signing).
-Right now, the values for those globals are defined in the local `remix-deno` package.
-The globals are _actually_ assigned these values in the `installGlobals` function that must be called in user code (i.e. `server.ts`).
-
-In the future, we plan to obviate these globals (`sign`/`unsign`), removing the `installGlobals` call (and even the import) from user code in `server.ts`.
-
 ## 🐞 Known issues 🐞
 
 ### `dev` does not live reload

--- a/templates/deno-ts/remix-deno/implementations.ts
+++ b/templates/deno-ts/remix-deno/implementations.ts
@@ -8,6 +8,8 @@ import {
 import { sign, unsign } from "./crypto.ts";
 
 export const createCookie = createCookieFactory({ sign, unsign });
-export const createCookieSessionStorage = createCookieSessionStorageFactory(createCookie);
+export const createCookieSessionStorage =
+  createCookieSessionStorageFactory(createCookie);
 export const createSessionStorage = createSessionStorageFactory(createCookie);
-export const createMemorySessionStorage = createMemorySessionStorageFactory(createSessionStorage);
+export const createMemorySessionStorage =
+  createMemorySessionStorageFactory(createSessionStorage);

--- a/templates/deno-ts/remix-deno/index.ts
+++ b/templates/deno-ts/remix-deno/index.ts
@@ -1,12 +1,16 @@
-export { createFileSessionStorage } from './sessions/fileStorage.ts'
-export { createRequestHandler, createRequestHandlerWithStaticFiles, serveStaticFiles } from './server.ts'
+export { createFileSessionStorage } from "./sessions/fileStorage.ts";
+export {
+  createRequestHandler,
+  createRequestHandlerWithStaticFiles,
+  serveStaticFiles,
+} from "./server.ts";
 
 export {
   createCookie,
   createCookieSessionStorage,
   createMemorySessionStorage,
   createSessionStorage,
-} from './implementations.ts';
+} from "./implementations.ts";
 
 export {
   createSession,

--- a/templates/deno-ts/remix-deno/server.ts
+++ b/templates/deno-ts/remix-deno/server.ts
@@ -1,5 +1,6 @@
 import * as path from "https://deno.land/std@0.128.0/path/mod.ts";
 import mime from "https://esm.sh/mime";
+
 import { createRequestHandler as createRemixRequestHandler } from "./deps/@remix-run/server-runtime.ts";
 import type { ServerBuild } from "./deps/@remix-run/server-runtime.ts";
 

--- a/templates/deno-ts/remix-deno/sessions/fileStorage.ts
+++ b/templates/deno-ts/remix-deno/sessions/fileStorage.ts
@@ -1,4 +1,5 @@
 import * as path from "https://deno.land/std@0.128.0/path/mod.ts";
+
 import type {
   SessionStorage,
   SessionIdStorageStrategy,

--- a/templates/deno-ts/server.ts
+++ b/templates/deno-ts/server.ts
@@ -1,17 +1,14 @@
 import { serve } from "https://deno.land/std@0.128.0/http/server.ts";
 // Temporary: in the future, import from `@remix-run/deno` at some URL
-import { createRequestHandlerWithStaticFiles, installGlobals } from "./remix-deno/index.ts";
+import { createRequestHandlerWithStaticFiles } from "./remix-deno/index.ts";
 // Import path interpreted by the Remix compiler
 import * as build from "@remix-run/dev/server-build";
-
-// Temporary: required by Remix; do not remove.
-installGlobals();
 
 const remixHandler = createRequestHandlerWithStaticFiles({
   build,
   // process.env.NODE_ENV is provided by Remix at compile time
   mode: process.env.NODE_ENV,
-  getLoadContext: () => ({})
+  getLoadContext: () => ({}),
 });
 
 const port = Number(Deno.env.get("PORT")) || 8000;


### PR DESCRIPTION
Removes the unneeded `installGlobals` call from the deno template.
