### PR TITLE
fix(docs/tutorials): fix typo in blog tutorial

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -142,6 +142,7 @@
 - juhanakristian
 - justinnoel
 - juwiragiye
+- jveldridge
 - jvnm-dev
 - kalch
 - kanermichael

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -465,7 +465,7 @@ export const loader: LoaderFunction = async ({
 };
 ```
 
-Now, let's actually get the post contents from the database by it's slug.
+Now, let's actually get the post contents from the database by its slug.
 
 💿 Add a `getPost` function to our post module
 


### PR DESCRIPTION
Changing an "it's" -> "its"