### PR TITLE
feat(cloudflare+cloudflare-pages+cloudflare-workers): update `@cloudflare/workers-types` dependency

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -123,6 +123,7 @@
 - jca41
 - jdeniau
 - jenseng
+- jensmeindertsma
 - jeremyjfleming
 - jesse-deboer
 - jesseflorig

--- a/packages/remix-cloudflare-pages/package.json
+++ b/packages/remix-cloudflare-pages/package.json
@@ -18,10 +18,10 @@
     "@remix-run/server-runtime": "1.3.3"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^3.2.0"
+    "@cloudflare/workers-types": "^3.4.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^3.2.0",
+    "@cloudflare/workers-types": "^3.4.0",
     "@types/mime": "^2.0.3"
   }
 }

--- a/packages/remix-cloudflare-workers/package.json
+++ b/packages/remix-cloudflare-workers/package.json
@@ -18,9 +18,9 @@
     "@remix-run/cloudflare": "1.3.3"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^2.2.2"
+    "@cloudflare/workers-types": "^3.4.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^2.2.2"
+    "@cloudflare/workers-types": "^3.4.0"
   }
 }

--- a/packages/remix-cloudflare/package.json
+++ b/packages/remix-cloudflare/package.json
@@ -16,9 +16,9 @@
     "@remix-run/server-runtime": "1.3.3"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^2.2.2"
+    "@cloudflare/workers-types": "^3.4.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^2.2.2"
+    "@cloudflare/workers-types": "^3.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,15 +1503,10 @@
   dependencies:
     mime "^2.5.2"
 
-"@cloudflare/workers-types@^2.2.2":
-  version "2.2.2"
-  resolved "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-2.2.2.tgz"
-  integrity sha512-kaMn2rueJ0PL1TYVGknTCh0X0x0d9G+FNXAFep7/4uqecEZoQb/63o6rOmMuiqI09zLuHV6xhKRXinokV/MY9A==
-
-"@cloudflare/workers-types@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.2.0.tgz"
-  integrity sha512-y0+f7QeB5/fMMdU0wSwvBB18yE9kAD2s7Wben8a4uI4f/EJyE+eJrai5QO52Pq8EmWP0vRpKqZh0qU857WhY2A==
+"@cloudflare/workers-types@3.4.0", "@cloudflare/workers-types@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.4.0.tgz#80311e14df2f7f8c2cfcdce945b4f4ad8f9b03b1"
+  integrity sha512-i/3czUrt6YqbOWl44OtIqd0cSZvEVXp/1oD/DZylC4PHZL3q/BhbamdEVeVhc/HPk4iD/7MZ2HGaIMO4Z4b12A==
 
 "@esbuild-plugins/node-modules-polyfill@^0.1.4":
   version "0.1.4"


### PR DESCRIPTION
This pull request updates `@cloudflare/workers-types` to the latest version so I don't get version conflicts anymore when installing these types myself in my Remix project. The different Remix packages were also requiring different versions of the same package, making that install impossible.