### PR TITLE
fix(cli): stop CLI from logging full stack trace on known errors

### DIFF
--- a/packages/create-remix/cli.ts
+++ b/packages/create-remix/cli.ts
@@ -1,11 +1,11 @@
 import { cli } from "@remix-run/dev";
 
-cli.run(["create", ...process.argv.slice(2)]).then(
-  () => {
+cli
+  .run(["create", ...process.argv.slice(2)])
+  .then(() => {
     process.exit(0);
-  },
-  (error: Error) => {
-    console.error(error);
+  })
+  .catch((error: Error) => {
+    console.error(error.message || error);
     process.exit(1);
-  }
-);
+  });

--- a/packages/create-remix/cli.ts
+++ b/packages/create-remix/cli.ts
@@ -1,11 +1,13 @@
 import { cli } from "@remix-run/dev";
 
+let args = process.argv.slice(2);
+
 cli
-  .run(["create", ...process.argv.slice(2)])
+  .run(["create", ...args])
   .then(() => {
     process.exit(0);
   })
   .catch((error: Error) => {
-    console.error(error.message || error);
+    console.error(args.includes("--debug") ? error : error.message);
     process.exit(1);
   });


### PR DESCRIPTION
Per @mcansh's comment in #2500, this PR simply changes the error handling behavior of the CLI to prevent spitting out the full stack trace on errors. We should be handling those errors internally unless the `--debug` flag is provided.

I'd like to hold on #2500 until we have an opportunity to make the tests more robust, but this is a simple change we can easily merge before the next release.