### PR TITLE
feat(cloudflare+cloudflare-pages+cloudflare-workers+templates): add support for `@cloudflare/workers-types` v3

### DIFF
--- a/packages/remix-cloudflare-pages/package.json
+++ b/packages/remix-cloudflare-pages/package.json
@@ -21,7 +21,7 @@
     "@cloudflare/workers-types": "^3.2.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^3.2.0",
+    "@cloudflare/workers-types": "^3.4.0",
     "@types/mime": "^2.0.3"
   }
 }

--- a/packages/remix-cloudflare-pages/package.json
+++ b/packages/remix-cloudflare-pages/package.json
@@ -18,7 +18,7 @@
     "@remix-run/server-runtime": "1.3.4"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^3.2.0"
+    "@cloudflare/workers-types": "^3.0.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^3.4.0",

--- a/packages/remix-cloudflare-pages/tsconfig.json
+++ b/packages/remix-cloudflare-pages/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": ["**/*.ts"],
   "compilerOptions": {
-    "lib": ["ES2019", "WebWorker"],
+    "lib": ["ES2019"],
     "target": "ES2019",
     "types": ["@cloudflare/workers-types"],
 

--- a/packages/remix-cloudflare-workers/package.json
+++ b/packages/remix-cloudflare-workers/package.json
@@ -18,9 +18,9 @@
     "@remix-run/cloudflare": "1.3.4"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^2.2.2"
+    "@cloudflare/workers-types": "^2.2.2 || ^3.0.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^2.2.2"
+    "@cloudflare/workers-types": "^3.4.0"
   }
 }

--- a/packages/remix-cloudflare-workers/package.json
+++ b/packages/remix-cloudflare-workers/package.json
@@ -18,7 +18,7 @@
     "@remix-run/cloudflare": "1.3.4"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^2.2.2 || ^3.0.0"
+    "@cloudflare/workers-types": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^3.4.0"

--- a/packages/remix-cloudflare-workers/tsconfig.json
+++ b/packages/remix-cloudflare-workers/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": ["**/*.ts"],
   "compilerOptions": {
-    "lib": ["ES2019", "WebWorker"],
+    "lib": ["ES2019"],
     "target": "ES2019",
     "types": ["@cloudflare/workers-types"],
 

--- a/packages/remix-cloudflare/package.json
+++ b/packages/remix-cloudflare/package.json
@@ -16,7 +16,7 @@
     "@remix-run/server-runtime": "1.3.4"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^2.2.2 || ^3.0.0"
+    "@cloudflare/workers-types": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^3.4.0"

--- a/packages/remix-cloudflare/package.json
+++ b/packages/remix-cloudflare/package.json
@@ -16,9 +16,9 @@
     "@remix-run/server-runtime": "1.3.4"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^2.2.2"
+    "@cloudflare/workers-types": "^2.2.2 || ^3.0.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^2.2.2"
+    "@cloudflare/workers-types": "^3.4.0"
   }
 }

--- a/packages/remix-cloudflare/tsconfig.json
+++ b/packages/remix-cloudflare/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": ["**/*.ts"],
   "compilerOptions": {
-    "lib": ["ES2019", "WebWorker"],
+    "lib": ["ES2019"],
     "target": "ES2019",
     "types": ["@cloudflare/workers-types"],
 

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -21,7 +21,7 @@
     "remix": "*"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^3.2.0",
+    "@cloudflare/workers-types": "^3.4.0",
     "@remix-run/dev": "*",
     "@remix-run/eslint-config": "*",
     "@types/react": "^17.0.24",

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -23,7 +23,7 @@
     "remix": "*"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^2.2.2",
+    "@cloudflare/workers-types": "^3.4.0",
     "@remix-run/dev": "*",
     "@remix-run/eslint-config": "*",
     "@types/react": "^17.0.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,11 +1503,6 @@
   dependencies:
     mime "^2.5.2"
 
-"@cloudflare/workers-types@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.2.0.tgz"
-  integrity sha512-y0+f7QeB5/fMMdU0wSwvBB18yE9kAD2s7Wben8a4uI4f/EJyE+eJrai5QO52Pq8EmWP0vRpKqZh0qU857WhY2A==
-
 "@cloudflare/workers-types@^3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.4.0.tgz#80311e14df2f7f8c2cfcdce945b4f4ad8f9b03b1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,15 +1503,15 @@
   dependencies:
     mime "^2.5.2"
 
-"@cloudflare/workers-types@^2.2.2":
-  version "2.2.2"
-  resolved "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-2.2.2.tgz"
-  integrity sha512-kaMn2rueJ0PL1TYVGknTCh0X0x0d9G+FNXAFep7/4uqecEZoQb/63o6rOmMuiqI09zLuHV6xhKRXinokV/MY9A==
-
 "@cloudflare/workers-types@^3.2.0":
   version "3.2.0"
   resolved "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.2.0.tgz"
   integrity sha512-y0+f7QeB5/fMMdU0wSwvBB18yE9kAD2s7Wben8a4uI4f/EJyE+eJrai5QO52Pq8EmWP0vRpKqZh0qU857WhY2A==
+
+"@cloudflare/workers-types@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.4.0.tgz#80311e14df2f7f8c2cfcdce945b4f4ad8f9b03b1"
+  integrity sha512-i/3czUrt6YqbOWl44OtIqd0cSZvEVXp/1oD/DZylC4PHZL3q/BhbamdEVeVhc/HPk4iD/7MZ2HGaIMO4Z4b12A==
 
 "@esbuild-plugins/node-modules-polyfill@^0.1.4":
   version "0.1.4"


### PR DESCRIPTION
Follow up for #645 

I made a mistake and deleted the fork repository and now I cannot push any commit to the original PR. So I open a new one here:

> Cloudflare released an [update](https://github.com/cloudflare/workers-types/releases/tag/v3.0.0) for `@cloudflare/workers-types` last month. It is now automatically generated from the source as announced [here](https://blog.cloudflare.com/automatically-generated-types/) and this ensures typing to be always up-to-dated with the latest runtime.
>
> However, the current CF adapter has a peerDependency of v2 only. It would be nice if we could add support of v3 as well.
This will also makes experimenting with new ESM worker easier (as all new types are only defined on v3) before official support is ready. 
>
> Thanks for all the great work!

- This PR does not touch the `cloudflare-pages` adapter as it is already using `@cloudflare/workers-types` [v3](https://github.com/remix-run/remix/blob/dev/packages/remix-cloudflare-pages/package.json#L21).
- I have updated the `devDependencies` to v3 now so the tsconfig has to be updated as well as stated on the [release note](https://github.com/cloudflare/workers-types/releases/tag/v3.0.0) 


Closes #2504

- [ ] Docs
- [ ] Tests
