### PR TITLE
fix(remix-react): use `.flat().map()` instead of `flatMap` in `Meta` component

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -678,7 +678,7 @@ export function Meta() {
         // Open Graph tags use the `property` attribute, while other meta tags
         // use `name`. See https://ogp.me/
         let isOpenGraphTag = name.startsWith("og:");
-        return [value].flatMap((content) => {
+        return [value].flat().map((content) => {
           if (isOpenGraphTag) {
             return (
               <meta


### PR DESCRIPTION
Follow-up of #2331.

This implementation is created with thinking that `flatMap` is the same as `flat().map()`, but instead it's `map().flat()`

> The `flatMap()` method returns a new array formed by applying a given callback function to each element of the array, and then flattening the result by one level. It is identical to a [`map()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) followed by a [`flat()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) of depth 1, but slightly more efficient than calling those two methods separately.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap

Since we have our `if`-statements in the callback, this doesn't really matter, but I wanted to make it more correct to be sure.