### PR TITLE
fix(remix-react): prevent `CatchValue` & `Error` results to be passed into `MetaFunction`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -273,6 +273,7 @@
 - stephanerangaya
 - SufianBabri
 - supachaidev
+- swwind
 - tascord
 - TheRealAstoo
 - therealflyingcoder

--- a/packages/remix-react/__tests__/transition-test.tsx
+++ b/packages/remix-react/__tests__/transition-test.tsx
@@ -566,7 +566,6 @@ describe("errors on navigation", () => {
       Object {
         "a": "LOADER A",
         "b": "LOADER B",
-        "c": [Error: Kaboom!],
       }
     `);
   });

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -1693,8 +1693,10 @@ function makeLoaderData(
   matches: ClientMatch[]
 ) {
   let newData: RouteData = {};
-  for (let { match, value } of results) {
-    newData[match.route.id] = value;
+  for (let result of results) {
+    if (!isCatchResult(result) && !isErrorResult(result)) {
+      newData[result.match.route.id] = result.value;
+    }
   }
 
   let loaderData: RouteData = {};


### PR DESCRIPTION
Prevented CatchValue and Error to be put into routeData, which maybe passed into data field in MetaFunction in clients when navigating.

It seems to work on my machine very well.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #1054

- [ ] Docs
- [ ] Tests
