### PR TITLE
docs: import from @remix-run/node instead of remix

### DIFF
--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -1726,7 +1726,7 @@ Let's say you have a banner on your e-commerce site that prompts users to check 
 First, create a cookie:
 
 ```js filename=app/cookies.js
-import { createCookie } from "remix";
+import { createCookie } from "@remix-run/node";
 
 export const userPrefs = createCookie("user-prefs", {
   maxAge: 604_800, // one week
@@ -1857,7 +1857,7 @@ export async function loader({ request }) {
 Creates a logical container for managing a browser cookie from the server.
 
 ```ts
-import { createCookie } from "remix";
+import { createCookie } from "@remix-run/node";
 
 const cookie = createCookie("cookie-name", {
   // all of these are optional defaults that can be overridden at runtime
@@ -1879,7 +1879,7 @@ To learn more about each attribute, please see the [MDN Set-Cookie docs](https:/
 Returns `true` if an object is a Remix cookie container.
 
 ```ts
-import { isCookie } from "remix";
+import { isCookie } from "@remix-run/node";
 const cookie = createCookie("user-prefs");
 console.log(isCookie(cookie));
 // true
@@ -1971,7 +1971,7 @@ This is an example of a cookie session storage:
 
 ```js filename=app/sessions.js
 // app/sessions.js
-import { createCookieSessionStorage } from "remix";
+import { createCookieSessionStorage } from "@remix-run/node";
 
 const { getSession, commitSession, destroySession } =
   createCookieSessionStorage({
@@ -2201,7 +2201,7 @@ The main advantage of cookie session storage is that you don't need any addition
 The downside is that you have to `commitSession` in almost every loader and action. If your loader or action changes the session at all, it must be committed. That means if you `session.flash` in an action, and then `session.get` in another, you must commit it for that flashed message to go away. With other session storage strategies you only have to commit it when it's created (the browser cookie doesn't need to change because it doesn't store the session data, just the key to find it elsewhere).
 
 ```js
-import { createCookieSessionStorage } from "remix";
+import { createCookieSessionStorage } from "@remix-run/node";
 
 const { getSession, commitSession, destroySession } =
   createCookieSessionStorage({

--- a/docs/pages/faq.md
+++ b/docs/pages/faq.md
@@ -17,7 +17,7 @@ We recommend you create a function that validates the user session that can be a
 import {
   createCookieSessionStorage,
   redirect,
-} from "remix";
+} from "@remix-run/node";
 
 // somewhere you've got a session storage
 const { getSession } = createCookieSessionStorage();

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -2905,7 +2905,7 @@ import bcrypt from "bcryptjs";
 import {
   createCookieSessionStorage,
   redirect,
-} from "remix";
+} from "@remix-run/node";
 
 import { db } from "./db.server";
 
@@ -3031,7 +3031,7 @@ import bcrypt from "bcryptjs";
 import {
   createCookieSessionStorage,
   redirect,
-} from "remix";
+} from "@remix-run/node";
 
 import { db } from "./db.server";
 
@@ -3297,7 +3297,7 @@ import bcrypt from "bcryptjs";
 import {
   createCookieSessionStorage,
   redirect,
-} from "remix";
+} from "@remix-run/node";
 
 import { db } from "./db.server";
 
@@ -3568,7 +3568,7 @@ import bcrypt from "bcryptjs";
 import {
   createCookieSessionStorage,
   redirect,
-} from "remix";
+} from "@remix-run/node";
 
 import { db } from "./db.server";
 


### PR DESCRIPTION
Got a `createCookie() is not a function` today after upgrading my app to 1.3.3

According to https://github.com/remix-run/remix/issues/2503#issuecomment-1079963155, we should not import from `remix` or `@remix-run/server-runtime` anymore.