### PR TITLE
feat(remix-cloudflare): rename `createCloudflareKVSessionStorage` to `createWorkersKVSessionStorage`

### DIFF
--- a/.changeset/breezy-dancers-lie.md
+++ b/.changeset/breezy-dancers-lie.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/cloudflare": minor
+---
+
+Rename `createCloudflareKVSessionStorage` to `createWorkersKVSessionStorage`

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -258,7 +258,7 @@ title: Remix Packages
 
 [Moved →][moved-59]
 
-### `createCloudflareKVSessionStorage` (cloudflare-workers)
+### `createWorkersKVSessionStorage` (Cloudflare Workers)
 
 [Moved →][moved-60]
 

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -354,7 +354,7 @@ title: Remix Packages
 [moved-57]: ../utils/sessions#createcookiesessionstorage
 [moved-58]: ../utils/sessions#creatememorysessionstorage
 [moved-59]: ../utils/sessions#createfilesessionstorage-node
-[moved-60]: ../utils/sessions#createcloudflarekvsessionstorage-cloudflare-workers
+[moved-60]: ../utils/sessions#createworkerskvsessionstorage-cloudflare-workers
 [moved-61]: ../utils/sessions#createarctablesessionstorage-architect-amazon-dynamodb
 [moved-62]: ../utils/sessions#session-api
 [moved-63]: ../utils/sessions#sessionhaskey

--- a/docs/utils/sessions.md
+++ b/docs/utils/sessions.md
@@ -13,7 +13,7 @@ Remix comes with several pre-built session storage options for common scenarios,
 - `createCookieSessionStorage`
 - `createMemorySessionStorage`
 - `createFileSessionStorage` (node)
-- `createCloudflareKVSessionStorage` (cloudflare-workers)
+- `createWorkersKVSessionStorage` (Cloudflare Workers)
 - `createArcTableSessionStorage` (architect, Amazon DynamoDB)
 - custom storage with `createSessionStorage`
 
@@ -330,16 +330,16 @@ const { getSession, commitSession, destroySession } =
 export { getSession, commitSession, destroySession };
 ```
 
-## `createCloudflareKVSessionStorage` (cloudflare-workers)
+## `createWorkersKVSessionStorage` (Cloudflare Workers)
 
-For [Cloudflare KV][cloudflare-kv] backed sessions, use `createCloudflareKVSessionStorage()`.
+For [Cloudflare Workers KV][cloudflare-kv] backed sessions, use `createWorkersKVSessionStorage()`.
 
 The advantage of KV backed sessions is that only the session ID is stored in the cookie while the rest of the data is stored in a globally replicated, low-latency data store with exceptionally high read volumes with low-latency.
 
 ```js filename=app/sessions.server.js
 import {
   createCookie,
-  createCloudflareKVSessionStorage,
+  createWorkersKVSessionStorage,
 } from "@remix-run/cloudflare";
 
 // In this example the Cookie is created separately.
@@ -349,7 +349,7 @@ const sessionCookie = createCookie("__session", {
 });
 
 const { getSession, commitSession, destroySession } =
-  createCloudflareKVSessionStorage({
+  createWorkersKVSessionStorage({
     // The KV Namespace where you want to store sessions
     kv: YOUR_NAMESPACE,
     cookie: sessionCookie,

--- a/integration/cf-compiler-test.ts
+++ b/integration/cf-compiler-test.ts
@@ -155,6 +155,7 @@ test.describe("cloudflare compiler", () => {
       "createMemorySessionStorage",
       "createSessionStorage",
       "createSession",
+      "createWorkersKVSessionStorage",
       "isCookie",
       "isSession",
       "json",

--- a/packages/remix-cloudflare/index.ts
+++ b/packages/remix-cloudflare/index.ts
@@ -1,10 +1,22 @@
 import "./globals";
 
-export {
+import {createWorkersKVSessionStorage} from './sessions/workersKVStorage';
+
+const warn = <T extends Function>(fn: T, message: string): T =>
+  ((...args: unknown[]) => {
+    console.warn(message);
+
+    return fn(...args);
+  }) as unknown as T;
+
+
+/** @deprecated Use `createWorkersKVSessionStorage` instead. */
+export const createCloudflareKVSessionStorage = warn(
   createWorkersKVSessionStorage,
-  // TODO: Deprecate createCloudflareKVSessionStorage
-  createWorkersKVSessionStorage as createCloudflareKVSessionStorage,
-} from "./sessions/workersKVStorage";
+  "`createCloudflareKVSessionStorage` is deprecated. Please use `createWorkersKVSessionStorage` instead.",
+);
+
+export { createWorkersKVSessionStorage } from "./sessions/workersKVStorage";
 
 export {
   createCookie,

--- a/packages/remix-cloudflare/index.ts
+++ b/packages/remix-cloudflare/index.ts
@@ -1,6 +1,10 @@
 import "./globals";
 
-export { createCloudflareKVSessionStorage } from "./sessions/cloudflareKVSessionStorage";
+export {
+  createWorkersKVSessionStorage,
+  // TODO: Deprecate createCloudflareKVSessionStorage
+  createWorkersKVSessionStorage as createCloudflareKVSessionStorage,
+} from "./sessions/workersKVStorage";
 
 export {
   createCookie,

--- a/packages/remix-cloudflare/sessions/workersKVStorage.ts
+++ b/packages/remix-cloudflare/sessions/workersKVStorage.ts
@@ -5,7 +5,7 @@ import type {
 
 import { createSessionStorage } from "../implementations";
 
-interface CloudflareKVSessionStorageOptions {
+interface WorkersKVSessionStorageOptions {
   /**
    * The Cookie used to store the session id on the client, or options used
    * to automatically create one.
@@ -24,10 +24,10 @@ interface CloudflareKVSessionStorageOptions {
  * The advantage of using this instead of cookie session storage is that
  * KV Store may contain much more data than cookies.
  */
-export function createCloudflareKVSessionStorage({
+export function createWorkersKVSessionStorage({
   cookie,
   kv,
-}: CloudflareKVSessionStorageOptions): SessionStorage {
+}: WorkersKVSessionStorageOptions): SessionStorage {
   return createSessionStorage({
     cookie,
     async createData(data, expires) {

--- a/packages/remix-dev/__tests__/transform-replaceRemixMagicImports-test.ts
+++ b/packages/remix-dev/__tests__/transform-replaceRemixMagicImports-test.ts
@@ -61,7 +61,7 @@ it("replaces multi-kind, multi-specifier imports", async () => {
 
 it("replaces runtime-specific and adapter-specific imports", async () => {
   let code = [
-    'import { json, createCloudflareKVSessionStorage, createRequestHandler, createPagesFunctionHandler, Form } from "remix"',
+    'import { json, createWorkersKVSessionStorage, createRequestHandler, createPagesFunctionHandler, Form } from "remix"',
     'import type { ActionFunction, GetLoadContextFunction, createPagesFunctionHandlerParams, LinkProps } from "remix"',
   ].join("\n");
   let transform = replaceRemixMagicImports({
@@ -71,7 +71,7 @@ it("replaces runtime-specific and adapter-specific imports", async () => {
   let result = eol.normalize(transform(code, "fake.tsx"));
   expect(result).toBe(
     [
-      'import { type ActionFunction, createCloudflareKVSessionStorage, json } from "@remix-run/cloudflare";',
+      'import { type ActionFunction, createWorkersKVSessionStorage, json } from "@remix-run/cloudflare";',
       "", // recast adds a newline here https://github.com/benjamn/recast/issues/39
       "import {",
       "  type GetLoadContextFunction,",

--- a/packages/remix-dev/codemod/replace-remix-magic-imports/utils/export.ts
+++ b/packages/remix-dev/codemod/replace-remix-magic-imports/utils/export.ts
@@ -100,7 +100,10 @@ const defaultRuntimeExports: ExportNames = {
 
 const exportNamesByRuntime: Record<Runtime, Partial<ExportNames>> = {
   cloudflare: {
-    value: ["createCloudflareKVSessionStorage"],
+    value: [
+      "createCloudflareKVSessionStorage",
+      "createWorkersKVSessionStorage",
+    ],
   },
   node: {
     type: ["HeadersInit", "RequestInfo", "RequestInit", "ResponseInit"],

--- a/packages/remix-eslint-config/rules/packageExports.js
+++ b/packages/remix-eslint-config/rules/packageExports.js
@@ -66,7 +66,7 @@ const architectSpecificExports = {
 };
 
 const cloudflareSpecificExports = {
-  value: ["createCloudflareKVSessionStorage"],
+  value: ["createCloudflareKVSessionStorage", "createWorkersKVSessionStorage"],
   type: [],
 };
 

--- a/rollup.utils.js
+++ b/rollup.utils.js
@@ -267,6 +267,7 @@ function getMagicExports(packageName) {
         "createCookieSessionStorage",
         "createMemorySessionStorage",
         "createSessionStorage",
+        "createWorkersKVSessionStorage",
       ],
     },
     "@remix-run/node": {


### PR DESCRIPTION
Rename to `createWorkersKVSessionStorage` for consistency with the "Workers KV" product name.