### PR TITLE
chore(examples): add `.eslintrc` again in `basic` example

### DIFF
--- a/examples/basic/.eslintrc.js
+++ b/examples/basic/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ["@remix-run/eslint-config", "@remix-run/eslint-config/node"],
+};


### PR DESCRIPTION
It was deleted on accident in #2502