### PR TITLE
chore(examples): add `sandbox.config.json` again to `blog` example

### DIFF
--- a/examples/blog-tutorial/sandbox.config.json
+++ b/examples/blog-tutorial/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+  "hardReloadOnChange": true,
+  "container": {
+    "port": 3000
+  }
+}


### PR DESCRIPTION
It was deleted on accident in #2502