### PR TITLE
docs(conventions): update 'Returning objects' docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -128,6 +128,7 @@
 - jesse-deboer
 - jesseflorig
 - jgarrow
+- jinglesthula
 - jkup
 - jmasson
 - jo-ninja

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -658,9 +658,9 @@ export const loader: LoaderFunction = async ({
 };
 ```
 
-#### Returning objects
+#### Returning JSON
 
-You can return plain JavaScript objects from your loaders that will be made available to your component by the [`useLoaderData`](./remix#useloaderdata) hook.
+You can return JSON from your loaders that will be made available to your component as a deserialized JavaScript object by the [`useLoaderData`](./remix#useloaderdata) hook.
 
 ```ts
 import { json } from "remix";
@@ -672,7 +672,7 @@ export const loader = async () => {
 
 #### Returning Response Instances
 
-When you return a plain object, Remix turns it into a [Fetch Response][response]. This means you can return them yourself, too.
+The `json` helper turns a plain JavaScript object into a [Fetch Response][response]. This means you can return them yourself, too.
 
 ```ts
 export const loader: LoaderFunction = async () => {
@@ -686,18 +686,9 @@ export const loader: LoaderFunction = async () => {
 };
 ```
 
-Using the `json` helper simplifies this so you don't have to construct them yourself, but these two examples are effectively the same!
+Using the `json` helper simplifies this so you don't have to construct them yourself, but the above two examples are effectively the same!
 
-```tsx
-import { json } from "remix";
-
-export const loader: LoaderFunction = async () => {
-  const users = await fakeDb.users.findMany();
-  return json(users);
-};
-```
-
-You can see how `json` just does a little of the work to make your loader a lot cleaner. You can also use the `json` helper to add headers or a status code to your response:
+You can also use the `json` helper to add headers or a status code to your response:
 
 ```tsx
 import { json } from "remix";


### PR DESCRIPTION
Requested by Kent in discord > contributing.  This is part of the removal of references to returning plain objects.  Rather than simply removing the paragraph though, I updated it to indicate how to get objects from loader to default view component, as that's very useful to know and feeds into the "by hand" response example that follows it.

I also removed what was essentially a duplicate example, as it didn't seem to add anything (i.e., the object could be a literal or something returned from Prisma, or... anything; a single simple example probably suffices).