### PR TITLE
chore: use external server for express template

### DIFF
--- a/templates/express/.gitignore
+++ b/templates/express/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 
 /.cache
-/server/build
+/build
 /public/build
 .env

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -7,10 +7,10 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix build && run-p dev:*",
-    "dev:node": "cross-env NODE_ENV=development nodemon ./build/index.js --watch ./build/index.js",
+    "dev:node": "cross-env NODE_ENV=development nodemon ./server.js --watch ./server.js",
     "dev:remix": "remix watch",
     "postinstall": "remix setup node",
-    "start": "cross-env NODE_ENV=production node ./build/index.js"
+    "start": "cross-env NODE_ENV=production node ./server.js"
   },
   "dependencies": {
     "@remix-run/express": "*",

--- a/templates/express/remix.config.js
+++ b/templates/express/remix.config.js
@@ -2,9 +2,7 @@
  * @type {import('@remix-run/dev').AppConfig}
  */
 module.exports = {
-  server: "./server.js",
   ignoredRouteFiles: [".*"],
-  devServerBroadcastDelay: 1000,
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -28,15 +28,15 @@ app.all(
   "*",
   process.env.NODE_ENV === "development"
     ? (req, res, next) => {
-        purgeRequireCache(buildPath);
+        purgeRequireCache();
 
         return createRequestHandler({
-          build: require(buildPath),
+          build: require(BUILD_DIR),
           mode: process.env.NODE_ENV,
         })(req, res, next);
       }
     : createRequestHandler({
-        build: require(buildPath),
+        build: require(BUILD_DIR),
         mode: process.env.NODE_ENV,
       })
 );

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -46,6 +46,15 @@ app.listen(port, () => {
   console.log(`Express server listening on port ${port}`);
 });
 
-function purgeRequireCache(path) {
-  delete require.cache[require.resolve(path)];
+function purgeRequireCache() {
+  // purge require cache on requests for "server side HMR" this won't let
+  // you have in-memory objects between requests in development,
+  // alternatively you can set up nodemon/pm2-dev to restart the server on
+  // file changes, but then you'll have to reconnect to databases/etc on each
+  // change. We prefer the DX of this, so we've included it for you by default
+  for (const key in require.cache) {
+    if (key.startsWith(BUILD_DIR)) {
+      delete require.cache[key];
+    }
+  }
 }

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -26,12 +26,8 @@ app.use(morgan("tiny"));
 
 app.all(
   "*",
-  process.env.NODE_ENV === "production"
-    ? createRequestHandler({
-        build: require(buildPath),
-        mode: process.env.NODE_ENV,
-      })
-    : (req, res, next) => {
+  process.env.NODE_ENV === "development"
+    ? (req, res, next) => {
         purgeRequireCache(buildPath);
 
         return createRequestHandler({
@@ -39,6 +35,10 @@ app.all(
           mode: process.env.NODE_ENV,
         })(req, res, next);
       }
+    : createRequestHandler({
+        build: require(buildPath),
+        mode: process.env.NODE_ENV,
+      })
 );
 const port = process.env.PORT || 3000;
 

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -3,7 +3,7 @@ const compression = require("compression");
 const morgan = require("morgan");
 const { createRequestHandler } = require("@remix-run/express");
 
-const buildPath = "./build";
+const BUILD_DIR = path.join(process.cwd(), "build");
 
 const app = express();
 


### PR DESCRIPTION
If Remix bundles your server entry point:
- you get to use server.ts
- you get to share bundled deps between your server and app folder code
- have to use virtual module id to get the server build
- have to use a process manager, like nodemon or pm2 in dev
- have to reconnect to your database each time you change a file in dev

If your server.js is separate:
- you get to avoid side effects because server.js only runs once (e.g. pass db connections through using getLoadContext)
- have to require('./build') to get the server build
- changes surface to the browser quicker

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests
