### PR TITLE
fix: `HtmlMetaDescriptor` types

### DIFF
--- a/packages/remix-react/routeModules.ts
+++ b/packages/remix-react/routeModules.ts
@@ -77,10 +77,9 @@ export interface HtmlMetaDescriptor {
   [name: string]:
     | null
     | string
-    | string[]
     | undefined
     | Record<string, string>
-    | Record<string, string>[];
+    | Array<Record<string, string> | string>;
 }
 
 /**

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -98,10 +98,9 @@ export interface HtmlMetaDescriptor {
   [name: string]:
     | null
     | string
-    | string[]
     | undefined
     | Record<string, string>
-    | Record<string, string>[];
+    | Array<Record<string, string> | string>;
 }
 
 export type MetaDescriptor = HtmlMetaDescriptor;


### PR DESCRIPTION
The `HtmlMetaDescriptor` is typed incorrectly since we added support for object values. 

Given the existing type:

```ts
export interface HtmlMetaDescriptor {
  charset?: "utf-8";
  charSet?: "utf-8";
  title?: string;
  [name: string]:
    | null
    | string
    | string[]
    | undefined
    | Record<string, string>
    | Record<string, string>[];
}
```

A meta object can either have an array of strings or an array of objects, but not an array of both. However our implementation allows for that:

```ts
export function meta() {
  return {
    "og:type": [
      // this is totally fine
      "og:locale:alternate",
      {
        "property": "og:locale:alternate",
        "content": "es_ES",
      },
    ];
  };
}
```

Most users won't do this, of course, but I noticed that it breaks my `remix-seo` package, as I'm trying to push a value into an array that can either be an object or a string, but the value is always a string and `Array.prototype.push` expects an intersection of the possible types:

![screenshot of the TS error: Argument of type 'string' is not assignable to parameter of type 'string & Record<string, string>'](https://user-images.githubusercontent.com/3082153/161115729-730c8729-c2d1-4b57-9240-9ec68953ec0e.png)
