### PR TITLE
chore(templates): run `replace-remix-imports` migration

### DIFF
--- a/templates/arc/app/entry.client.tsx
+++ b/templates/arc/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/templates/arc/app/entry.server.tsx
+++ b/templates/arc/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/templates/arc/app/root.tsx
+++ b/templates/arc/app/root.tsx
@@ -1,12 +1,5 @@
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/templates/arc/package.json
+++ b/templates/arc/package.json
@@ -9,16 +9,15 @@
     "dev:remix": "remix watch",
     "dev:arc": "cross-env NODE_ENV=development arc sandbox",
     "dev": "remix build && run-p dev:*",
-    "postinstall": "remix setup node",
     "start": "cross-env NODE_ENV=production arc sandbox"
   },
   "dependencies": {
     "@remix-run/architect": "*",
+    "@remix-run/node": "*",
     "@remix-run/react": "*",
     "cross-env": "^7.0.3",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "*"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "*",

--- a/templates/cloudflare-pages/app/entry.client.tsx
+++ b/templates/cloudflare-pages/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/templates/cloudflare-pages/app/entry.server.tsx
+++ b/templates/cloudflare-pages/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/cloudflare";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/templates/cloudflare-pages/app/root.tsx
+++ b/templates/cloudflare-pages/app/root.tsx
@@ -1,12 +1,5 @@
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/cloudflare";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -9,16 +9,15 @@
     "dev:remix": "remix watch",
     "dev:wrangler": "cross-env NODE_ENV=development wrangler pages dev ./public",
     "dev": "remix build && run-p dev:*",
-    "postinstall": "remix setup cloudflare",
     "start": "cross-env NODE_ENV=production npm run dev:wrangler"
   },
   "dependencies": {
+    "@remix-run/cloudflare": "*",
     "@remix-run/cloudflare-pages": "*",
     "@remix-run/react": "*",
     "cross-env": "^7.0.3",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "*"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^3.2.0",

--- a/templates/cloudflare-workers/app/entry.client.tsx
+++ b/templates/cloudflare-workers/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/templates/cloudflare-workers/app/entry.server.tsx
+++ b/templates/cloudflare-workers/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/cloudflare";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/templates/cloudflare-workers/app/root.tsx
+++ b/templates/cloudflare-workers/app/root.tsx
@@ -1,12 +1,5 @@
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/cloudflare";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -11,16 +11,15 @@
     "dev:remix": "remix watch",
     "dev:miniflare": "cross-env NODE_ENV=development miniflare ./build/index.js --watch",
     "dev": "remix build && run-p dev:*",
-    "postinstall": "remix setup cloudflare",
     "start": "cross-env NODE_ENV=production miniflare ./build/index.js"
   },
   "dependencies": {
+    "@remix-run/cloudflare": "*",
     "@remix-run/cloudflare-workers": "*",
     "@remix-run/react": "*",
     "cross-env": "^7.0.3",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "*"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^2.2.2",

--- a/templates/express/app/entry.client.tsx
+++ b/templates/express/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/templates/express/app/entry.server.tsx
+++ b/templates/express/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/templates/express/app/root.tsx
+++ b/templates/express/app/root.tsx
@@ -1,12 +1,5 @@
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -9,19 +9,18 @@
     "dev": "remix build && run-p dev:*",
     "dev:node": "cross-env NODE_ENV=development nodemon ./build/index.js --watch ./build/index.js",
     "dev:remix": "remix watch",
-    "postinstall": "remix setup node",
     "start": "cross-env NODE_ENV=production node ./build/index.js"
   },
   "dependencies": {
     "@remix-run/express": "*",
+    "@remix-run/node": "*",
     "@remix-run/react": "*",
     "compression": "^1.7.4",
     "cross-env": "^7.0.3",
     "express": "^4.17.1",
     "morgan": "^1.10.0",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "*"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "*",

--- a/templates/fly/app/entry.client.tsx
+++ b/templates/fly/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/templates/fly/app/entry.server.tsx
+++ b/templates/fly/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/templates/fly/app/root.tsx
+++ b/templates/fly/app/root.tsx
@@ -1,12 +1,5 @@
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/templates/fly/package.json
+++ b/templates/fly/package.json
@@ -8,15 +8,14 @@
     "build": "remix build",
     "deploy": "fly deploy --remote-only",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "*",
     "@remix-run/react": "*",
     "@remix-run/serve": "*",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "*"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "*",

--- a/templates/netlify/app/entry.client.tsx
+++ b/templates/netlify/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/templates/netlify/app/entry.server.tsx
+++ b/templates/netlify/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/templates/netlify/app/root.tsx
+++ b/templates/netlify/app/root.tsx
@@ -1,12 +1,5 @@
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/templates/netlify/package.json
+++ b/templates/netlify/package.json
@@ -7,17 +7,16 @@
   "scripts": {
     "build": "remix build",
     "dev": "cross-env NODE_ENV=development netlify dev",
-    "postinstall": "remix setup node",
     "start": "cross-env NODE_ENV=production netlify dev"
   },
   "dependencies": {
     "@netlify/functions": "^0.10.0",
     "@remix-run/netlify": "*",
+    "@remix-run/node": "*",
     "@remix-run/react": "*",
     "cross-env": "^7.0.3",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "*"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "*",

--- a/templates/remix/app/entry.client.tsx
+++ b/templates/remix/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/templates/remix/app/entry.server.tsx
+++ b/templates/remix/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/templates/remix/app/root.tsx
+++ b/templates/remix/app/root.tsx
@@ -1,12 +1,5 @@
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/templates/remix/package.json
+++ b/templates/remix/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "*",
     "@remix-run/react": "*",
     "@remix-run/serve": "*",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "*"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "*",

--- a/templates/vercel/app/entry.client.tsx
+++ b/templates/vercel/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/templates/vercel/app/entry.server.tsx
+++ b/templates/vercel/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/templates/vercel/app/root.tsx
+++ b/templates/vercel/app/root.tsx
@@ -1,12 +1,5 @@
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/templates/vercel/package.json
+++ b/templates/vercel/package.json
@@ -6,15 +6,14 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
-    "dev": "remix dev",
-    "postinstall": "remix setup node"
+    "dev": "remix dev"
   },
   "dependencies": {
+    "@remix-run/node": "*",
     "@remix-run/react": "*",
     "@remix-run/vercel": "*",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "*"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "*",


### PR DESCRIPTION
Follow-up of #2430