### PR TITLE
chore(examples): run `replace-remix-imports` migration

### DIFF
--- a/examples/basic/app/entry.client.tsx
+++ b/examples/basic/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/basic/app/entry.server.tsx
+++ b/examples/basic/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/basic/app/root.tsx
+++ b/examples/basic/app/root.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import type { LinksFunction, MetaFunction } from "remix";
+import type { LinksFunction, MetaFunction } from "@remix-run/node";
 import {
   Link,
   Links,
@@ -10,7 +9,8 @@ import {
   ScrollRestoration,
   useCatch,
   useLocation,
-} from "remix";
+} from "@remix-run/react";
+import * as React from "react";
 
 import deleteMeRemixStyles from "~/styles/demos/remix.css";
 import globalStylesUrl from "~/styles/global.css";

--- a/examples/basic/app/routes/demos/about.tsx
+++ b/examples/basic/app/routes/demos/about.tsx
@@ -1,5 +1,5 @@
-import { Outlet } from "remix";
-import type { MetaFunction, LinksFunction } from "remix";
+import type { LinksFunction, MetaFunction } from "@remix-run/node";
+import { Outlet } from "@remix-run/react";
 
 import stylesUrl from "~/styles/demos/about.css";
 

--- a/examples/basic/app/routes/demos/about/index.tsx
+++ b/examples/basic/app/routes/demos/about/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from "remix";
+import { Link } from "@remix-run/react";
 
 export default function AboutIndex() {
   return (

--- a/examples/basic/app/routes/demos/about/whoa.tsx
+++ b/examples/basic/app/routes/demos/about/whoa.tsx
@@ -1,4 +1,4 @@
-import { Link } from "remix";
+import { Link } from "@remix-run/react";
 
 export default function Whoa() {
   return (

--- a/examples/basic/app/routes/demos/actions.tsx
+++ b/examples/basic/app/routes/demos/actions.tsx
@@ -1,6 +1,7 @@
+import type { ActionFunction, MetaFunction } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { Form, useActionData } from "@remix-run/react";
 import { useEffect, useRef } from "react";
-import type { ActionFunction, MetaFunction } from "remix";
-import { Form, json, useActionData, redirect } from "remix";
 
 export const meta: MetaFunction = () => ({
   title: "Actions Demo",

--- a/examples/basic/app/routes/demos/params.tsx
+++ b/examples/basic/app/routes/demos/params.tsx
@@ -1,5 +1,5 @@
-import type { MetaFunction } from "remix";
-import { Link, Outlet } from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Link, Outlet } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   title: "Boundaries Demo",

--- a/examples/basic/app/routes/demos/params/$id.tsx
+++ b/examples/basic/app/routes/demos/params/$id.tsx
@@ -1,5 +1,6 @@
-import { json, useCatch, useLoaderData } from "remix";
-import type { LoaderFunction, MetaFunction } from "remix";
+import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useCatch, useLoaderData } from "@remix-run/react";
 
 // The `$` in route filenames becomes a pattern that's parsed from the URL and
 // passed to your loaders so you can look up data.

--- a/examples/basic/app/routes/index.tsx
+++ b/examples/basic/app/routes/index.tsx
@@ -1,5 +1,6 @@
-import type { MetaFunction, LoaderFunction } from "remix";
-import { useLoaderData, json, Link } from "remix";
+import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
 
 type IndexData = {
   resources: Array<{ name: string; url: string }>;

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/blog-tutorial/app/entry.client.tsx
+++ b/examples/blog-tutorial/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/blog-tutorial/app/entry.server.tsx
+++ b/examples/blog-tutorial/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/blog-tutorial/app/root.tsx
+++ b/examples/blog-tutorial/app/root.tsx
@@ -1,13 +1,6 @@
-import {
-  json,
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
-import type { LinksFunction, MetaFunction, LoaderFunction } from "remix";
+import type { LinksFunction, LoaderFunction, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 import tailwindStylesheetUrl from "./styles/tailwind.css";
 import { getUser } from "./session.server";

--- a/examples/blog-tutorial/app/routes/healthcheck.tsx
+++ b/examples/blog-tutorial/app/routes/healthcheck.tsx
@@ -1,5 +1,6 @@
 // learn more: https://fly.io/docs/reference/configuration/#services-http_checks
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+
 import { prisma } from "~/db.server";
 
 export const loader: LoaderFunction = async ({ request }) => {

--- a/examples/blog-tutorial/app/routes/index.tsx
+++ b/examples/blog-tutorial/app/routes/index.tsx
@@ -1,4 +1,5 @@
-import { Link } from "remix";
+import { Link } from "@remix-run/react";
+
 import { useOptionalUser } from "~/utils";
 
 export default function Index() {

--- a/examples/blog-tutorial/app/routes/join.tsx
+++ b/examples/blog-tutorial/app/routes/join.tsx
@@ -1,13 +1,11 @@
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { Form, Link, useActionData, useSearchParams } from "@remix-run/react";
 import * as React from "react";
-import type { ActionFunction, LoaderFunction, MetaFunction } from "remix";
-import {
-  Form,
-  Link,
-  redirect,
-  useSearchParams,
-  json,
-  useActionData,
-} from "remix";
 
 import { getUserId, createUserSession } from "~/session.server";
 

--- a/examples/blog-tutorial/app/routes/login.tsx
+++ b/examples/blog-tutorial/app/routes/login.tsx
@@ -1,13 +1,11 @@
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { Form, Link, useActionData, useSearchParams } from "@remix-run/react";
 import * as React from "react";
-import type { ActionFunction, LoaderFunction, MetaFunction } from "remix";
-import {
-  Form,
-  json,
-  Link,
-  useActionData,
-  redirect,
-  useSearchParams,
-} from "remix";
 
 import { createUserSession, getUserId } from "~/session.server";
 import { verifyLogin } from "~/models/user.server";

--- a/examples/blog-tutorial/app/routes/logout.tsx
+++ b/examples/blog-tutorial/app/routes/logout.tsx
@@ -1,5 +1,6 @@
-import type { ActionFunction, LoaderFunction } from "remix";
-import { redirect } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+
 import { logout } from "~/session.server";
 
 export const action: ActionFunction = async ({ request }) => {

--- a/examples/blog-tutorial/app/routes/notes.tsx
+++ b/examples/blog-tutorial/app/routes/notes.tsx
@@ -1,5 +1,6 @@
-import { Form, json, useLoaderData, Outlet, Link, NavLink } from "remix";
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, Link, NavLink, Outlet, useLoaderData } from "@remix-run/react";
 
 import { requireUserId } from "~/session.server";
 import { useUser } from "~/utils";

--- a/examples/blog-tutorial/app/routes/notes/$noteId.tsx
+++ b/examples/blog-tutorial/app/routes/notes/$noteId.tsx
@@ -1,7 +1,8 @@
-import type { LoaderFunction, ActionFunction } from "remix";
-import { redirect } from "remix";
-import { json, useLoaderData, useCatch, Form } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { Form, useCatch, useLoaderData } from "@remix-run/react";
 import invariant from "tiny-invariant";
+
 import type { Note } from "~/models/note.server";
 import { deleteNote } from "~/models/note.server";
 import { getNote } from "~/models/note.server";

--- a/examples/blog-tutorial/app/routes/notes/index.tsx
+++ b/examples/blog-tutorial/app/routes/notes/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from "remix";
+import { Link } from "@remix-run/react";
 
 export default function NoteIndexPage() {
   return (

--- a/examples/blog-tutorial/app/routes/notes/new.tsx
+++ b/examples/blog-tutorial/app/routes/notes/new.tsx
@@ -1,7 +1,8 @@
-import * as React from "react";
-import { Form, json, redirect, useActionData } from "remix";
-import type { ActionFunction } from "remix";
 import Alert from "@reach/alert";
+import type { ActionFunction } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { Form, useActionData } from "@remix-run/react";
+import * as React from "react";
 
 import { createNote } from "~/models/note.server";
 import { requireUserId } from "~/session.server";

--- a/examples/blog-tutorial/app/routes/posts/$slug.tsx
+++ b/examples/blog-tutorial/app/routes/posts/$slug.tsx
@@ -1,9 +1,11 @@
-import type { LoaderFunction } from "remix";
-import { useLoaderData, json } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { marked } from "marked";
+import invariant from "tiny-invariant";
+
 import { getPost } from "~/models/post.server";
 import type { Post } from "~/models/post.server";
-import invariant from "tiny-invariant";
-import { marked } from "marked";
 
 type LoaderData = { post: Post; html: string };
 

--- a/examples/blog-tutorial/app/routes/posts/admin.tsx
+++ b/examples/blog-tutorial/app/routes/posts/admin.tsx
@@ -1,5 +1,6 @@
-import type { LoaderFunction } from "remix";
-import { Link, Outlet, useLoaderData, json } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link, Outlet, useLoaderData } from "@remix-run/react";
 
 import { getPosts } from "~/models/post.server";
 

--- a/examples/blog-tutorial/app/routes/posts/admin/index.tsx
+++ b/examples/blog-tutorial/app/routes/posts/admin/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from "remix";
+import { Link } from "@remix-run/react";
 
 export default function AdminIndex() {
   return (

--- a/examples/blog-tutorial/app/routes/posts/admin/new.tsx
+++ b/examples/blog-tutorial/app/routes/posts/admin/new.tsx
@@ -1,6 +1,8 @@
-import type { ActionFunction } from "remix";
-import { Form, redirect, json, useActionData, useTransition } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { Form, useActionData, useTransition } from "@remix-run/react";
 import invariant from "tiny-invariant";
+
 import { createPost } from "~/models/post.server";
 
 type ActionData =

--- a/examples/blog-tutorial/app/routes/posts/index.tsx
+++ b/examples/blog-tutorial/app/routes/posts/index.tsx
@@ -1,4 +1,6 @@
-import { Link, json, useLoaderData } from "remix";
+import { json } from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
+
 import { getPosts } from "~/models/post.server";
 
 type LoaderData = {

--- a/examples/blog-tutorial/app/session.server.ts
+++ b/examples/blog-tutorial/app/session.server.ts
@@ -1,4 +1,4 @@
-import { createCookieSessionStorage, redirect } from "remix";
+import { createCookieSessionStorage, redirect } from "@remix-run/node";
 import invariant from "tiny-invariant";
 
 import type { User } from "~/models/user.server";

--- a/examples/blog-tutorial/app/utils.ts
+++ b/examples/blog-tutorial/app/utils.ts
@@ -1,5 +1,5 @@
+import { useMatches } from "@remix-run/react";
 import { useMemo } from "react";
-import { useMatches } from "remix";
 
 import type { User } from "~/models/user.server";
 

--- a/examples/blog-tutorial/package.json
+++ b/examples/blog-tutorial/package.json
@@ -13,7 +13,6 @@
     "dev:remix": "node --require ./mocks ./node_modules/.bin/remix dev",
     "format": "prettier --write .",
     "generate:css": "tailwindcss -o ./app/styles/tailwind.css",
-    "postinstall": "remix setup node",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "setup": "prisma migrate dev",
     "start": "remix-serve build",
@@ -35,12 +34,12 @@
     "@node-rs/bcrypt": "^1.6.0",
     "@prisma/client": "^3.11.0",
     "@reach/alert": "^0.16.0",
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "marked": "^4.0.12",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.3.4",
     "tiny-invariant": "^1.2.0"
   },
   "devDependencies": {

--- a/examples/bullmq-task-queue/app/entry.client.tsx
+++ b/examples/bullmq-task-queue/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/bullmq-task-queue/app/entry.server.tsx
+++ b/examples/bullmq-task-queue/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/bullmq-task-queue/app/root.tsx
+++ b/examples/bullmq-task-queue/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/bullmq-task-queue/app/routes/index.tsx
+++ b/examples/bullmq-task-queue/app/routes/index.tsx
@@ -1,5 +1,6 @@
-import type { ActionFunction } from "remix";
-import { Form, json, useActionData, useTransition } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useActionData, useTransition } from "@remix-run/react";
 
 import { queue } from "~/queues/notifier.server";
 

--- a/examples/bullmq-task-queue/package.json
+++ b/examples/bullmq-task-queue/package.json
@@ -7,17 +7,16 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "bullmq": "^1.76.0",
     "ioredis": "^4.28.5",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/catch-boundary/app/entry.client.tsx
+++ b/examples/catch-boundary/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/catch-boundary/app/entry.server.tsx
+++ b/examples/catch-boundary/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/catch-boundary/app/root.tsx
+++ b/examples/catch-boundary/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/catch-boundary/app/routes/index.tsx
+++ b/examples/catch-boundary/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import type { LoaderFunction } from "remix";
-import { redirect } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
 
 export const loader: LoaderFunction = async () => redirect("/users");

--- a/examples/catch-boundary/app/routes/users.tsx
+++ b/examples/catch-boundary/app/routes/users.tsx
@@ -1,6 +1,7 @@
-import type { LoaderFunction, MetaFunction } from "remix";
-import { Link, Outlet, json } from "remix";
-import { useLoaderData } from "remix";
+import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link, Outlet, useLoaderData } from "@remix-run/react";
+
 import type { User } from "~/data.server";
 import { getUsers } from "~/data.server";
 

--- a/examples/catch-boundary/app/routes/users/$userId.tsx
+++ b/examples/catch-boundary/app/routes/users/$userId.tsx
@@ -1,5 +1,7 @@
-import type { LoaderFunction, MetaFunction } from "remix";
-import { json, useCatch, useLoaderData, useParams } from "remix";
+import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useCatch, useLoaderData, useParams } from "@remix-run/react";
+
 import type { User as UserType } from "~/data.server";
 import { getUsers } from "~/data.server";
 

--- a/examples/catch-boundary/package.json
+++ b/examples/catch-boundary/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/chakra-ui/app/entry.client.tsx
+++ b/examples/chakra-ui/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/chakra-ui/app/entry.server.tsx
+++ b/examples/chakra-ui/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/chakra-ui/app/root.tsx
+++ b/examples/chakra-ui/app/root.tsx
@@ -1,14 +1,6 @@
 import { ChakraProvider, Box, Heading } from "@chakra-ui/react";
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-  useCatch,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration, useCatch } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/chakra-ui/package.json
+++ b/examples/chakra-ui/package.json
@@ -7,19 +7,18 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
     "@chakra-ui/react": "^1.8.6",
     "@emotion/react": "^11.8.1",
     "@emotion/styled": "^11.8.1",
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "framer-motion": "^5.6.0",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/client-only-components/app/entry.client.tsx
+++ b/examples/client-only-components/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/client-only-components/app/entry.server.tsx
+++ b/examples/client-only-components/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/client-only-components/app/root.tsx
+++ b/examples/client-only-components/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/client-only-components/package.json
+++ b/examples/client-only-components/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.3.4",
     "remix-utils": "^2.7.0"
   },
   "devDependencies": {

--- a/examples/client-side-validation/app/entry.client.tsx
+++ b/examples/client-side-validation/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/client-side-validation/app/entry.server.tsx
+++ b/examples/client-side-validation/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/client-side-validation/app/root.tsx
+++ b/examples/client-side-validation/app/root.tsx
@@ -3,9 +3,9 @@ import type {
   LinksFunction,
   LoaderFunction,
   MetaFunction,
-} from "remix";
+} from "@remix-run/node";
+import { json } from "@remix-run/node";
 import {
-  json,
   Links,
   LiveReload,
   Meta,
@@ -13,7 +13,7 @@ import {
   ScrollRestoration,
   useActionData,
   useLoaderData,
-} from "remix";
+} from "@remix-run/react";
 
 import stylesUrl from "./index.css";
 

--- a/examples/client-side-validation/package.json
+++ b/examples/client-side-validation/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/collected-notes/app/entry.client.tsx
+++ b/examples/collected-notes/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/collected-notes/app/entry.server.tsx
+++ b/examples/collected-notes/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import type { EntryContext } from "remix";
-import { RemixServer } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/collected-notes/app/root.tsx
+++ b/examples/collected-notes/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/collected-notes/app/routes/$slug.tsx
+++ b/examples/collected-notes/app/routes/$slug.tsx
@@ -1,6 +1,8 @@
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 import type { HTML } from "collected-notes";
-import type { LoaderFunction } from "remix";
-import { json, useLoaderData } from "remix";
+
 import { cn, sitePath } from "~/cn.server";
 
 type LoaderData = {

--- a/examples/collected-notes/app/routes/index.tsx
+++ b/examples/collected-notes/app/routes/index.tsx
@@ -1,6 +1,8 @@
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, Link, useLoaderData, useSearchParams } from "@remix-run/react";
 import type { Note, Site } from "collected-notes";
-import type { LoaderFunction } from "remix";
-import { Form, json, Link, useLoaderData, useSearchParams } from "remix";
+
 import { cn, sitePath } from "~/cn.server";
 
 type LoaderData = {

--- a/examples/collected-notes/package.json
+++ b/examples/collected-notes/package.json
@@ -7,16 +7,15 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "collected-notes": "^2.3.0",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/combobox-resource-route/app/entry.client.tsx
+++ b/examples/combobox-resource-route/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/combobox-resource-route/app/entry.server.tsx
+++ b/examples/combobox-resource-route/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/combobox-resource-route/app/root.tsx
+++ b/examples/combobox-resource-route/app/root.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -6,7 +6,8 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-} from "remix";
+} from "@remix-run/react";
+
 import styles from "./app.css";
 
 export const meta: MetaFunction = () => ({

--- a/examples/combobox-resource-route/app/routes/index.tsx
+++ b/examples/combobox-resource-route/app/routes/index.tsx
@@ -5,7 +5,7 @@ import {
   ComboboxOption,
   ComboboxPopover,
 } from "@reach/combobox";
-import { Form, useFetcher, useSearchParams } from "remix";
+import { Form, useFetcher, useSearchParams } from "@remix-run/react";
 
 import type { Lang } from "~/models/langs";
 

--- a/examples/combobox-resource-route/app/routes/lang-search.tsx
+++ b/examples/combobox-resource-route/app/routes/lang-search.tsx
@@ -1,5 +1,6 @@
-import type { LoaderFunction } from "remix";
-import { json } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+
 import { searchLangs } from "~/models/langs";
 
 /**

--- a/examples/combobox-resource-route/package.json
+++ b/examples/combobox-resource-route/package.json
@@ -7,17 +7,16 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
     "@reach/combobox": "^0.16.5",
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "match-sorter": "^6.3.1",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/dark-mode/app/entry.client.tsx
+++ b/examples/dark-mode/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/dark-mode/app/entry.server.tsx
+++ b/examples/dark-mode/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/dark-mode/app/root.tsx
+++ b/examples/dark-mode/app/root.tsx
@@ -1,13 +1,5 @@
-import type { LoaderFunction, MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-  useLoaderData,
-} from "remix";
+import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData } from "@remix-run/react";
 
 import {
   ThemeBody,

--- a/examples/dark-mode/app/routes/action/set-theme.tsx
+++ b/examples/dark-mode/app/routes/action/set-theme.tsx
@@ -1,5 +1,5 @@
-import { json, redirect } from "remix";
-import type { ActionFunction, LoaderFunction } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
 
 import { getThemeSession } from "~/utils/theme.server";
 import { isTheme } from "~/utils/theme-provider";

--- a/examples/dark-mode/app/routes/index.tsx
+++ b/examples/dark-mode/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction } from "remix";
+import type { LinksFunction } from "@remix-run/node";
 
 import styles from "~/styles/styles.css";
 import { Theme, Themed, useTheme } from "~/utils/theme-provider";

--- a/examples/dark-mode/app/utils/theme-provider.tsx
+++ b/examples/dark-mode/app/utils/theme-provider.tsx
@@ -1,3 +1,5 @@
+import { useFetcher } from "@remix-run/react";
+import type { Dispatch, ReactNode, SetStateAction } from "react";
 import {
   createContext,
   createElement,
@@ -6,8 +8,6 @@ import {
   useRef,
   useState,
 } from "react";
-import type { Dispatch, ReactNode, SetStateAction } from "react";
-import { useFetcher } from "remix";
 
 enum Theme {
   DARK = "dark",

--- a/examples/dark-mode/app/utils/theme.server.ts
+++ b/examples/dark-mode/app/utils/theme.server.ts
@@ -1,4 +1,4 @@
-import { createCookieSessionStorage } from "remix";
+import { createCookieSessionStorage } from "@remix-run/node";
 
 import { isTheme } from "./theme-provider";
 import type { Theme } from "./theme-provider";

--- a/examples/dark-mode/package.json
+++ b/examples/dark-mode/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/dataloader/app/entry.client.tsx
+++ b/examples/dataloader/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/dataloader/app/entry.server.tsx
+++ b/examples/dataloader/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/dataloader/app/root.tsx
+++ b/examples/dataloader/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/dataloader/app/routes/index.tsx
+++ b/examples/dataloader/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import type { LoaderFunction } from "remix";
-import { redirect } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
 
 export const loader: LoaderFunction = async () => redirect("/users");

--- a/examples/dataloader/app/routes/users.tsx
+++ b/examples/dataloader/app/routes/users.tsx
@@ -1,5 +1,7 @@
-import type { LoaderFunction } from "remix";
-import { json, Outlet, useLoaderData } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Outlet, useLoaderData } from "@remix-run/react";
+
 import type { User } from "~/data.server";
 
 interface LoaderData {

--- a/examples/dataloader/app/routes/users/index.tsx
+++ b/examples/dataloader/app/routes/users/index.tsx
@@ -1,5 +1,7 @@
-import type { LoaderFunction } from "remix";
-import { json, useLoaderData } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+
 import type { User } from "~/data.server";
 
 interface LoaderData {

--- a/examples/dataloader/package.json
+++ b/examples/dataloader/package.json
@@ -7,12 +7,12 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix watch",
-    "postinstall": "remix setup node",
     "start": "cross-env NODE_ENV=production node -r esbuild-register server/index.ts",
     "start:dev": "cross-env NODE_ENV=development node -r esbuild-register server/index.ts"
   },
   "dependencies": {
     "@remix-run/express": "1.3.4",
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "compression": "^1.7.4",
     "cross-env": "^7.0.3",
@@ -20,8 +20,7 @@
     "express": "^4.17.3",
     "morgan": "^1.10.0",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/emotion/app/entry.client.tsx
+++ b/examples/emotion/app/entry.client.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 import { CacheProvider } from "@emotion/react";
 import createEmotionCache from "./styles/createEmotionCache";
 import ClientStyleContext from "./styles/client.context";

--- a/examples/emotion/app/entry.server.tsx
+++ b/examples/emotion/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 import createEmotionServer from "@emotion/server/create-instance";
 import { CacheProvider } from "@emotion/react";

--- a/examples/emotion/app/root.tsx
+++ b/examples/emotion/app/root.tsx
@@ -1,4 +1,6 @@
-import type { MetaFunction } from "remix";
+import { withEmotionCache } from "@emotion/react";
+import styled from "@emotion/styled";
+import type { MetaFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -7,13 +9,11 @@ import {
   Scripts,
   ScrollRestoration,
   useCatch,
-} from "remix";
+} from "@remix-run/react";
 import { useContext, useEffect } from "react";
-import { withEmotionCache } from "@emotion/react";
+
 import ServerStyleContext from "./styles/server.context";
 import ClientStyleContext from "./styles/client.context";
-
-import styled from "@emotion/styled";
 
 const Container = styled("div")`
   background-color: #ff0000;

--- a/examples/emotion/app/routes/index.tsx
+++ b/examples/emotion/app/routes/index.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Link } from "remix";
+import { Link } from "@remix-run/react";
 
 const Container = styled("div")`
   font-family: "system-ui, sans-serif";

--- a/examples/emotion/app/routes/jokes.tsx
+++ b/examples/emotion/app/routes/jokes.tsx
@@ -1,5 +1,5 @@
-import { Link } from "remix";
 import styled from "@emotion/styled";
+import { Link } from "@remix-run/react";
 
 const Container = styled("div")`
   background-color: #d6d6d6;

--- a/examples/emotion/package.json
+++ b/examples/emotion/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
@@ -15,11 +14,11 @@
     "@emotion/react": "^11.8.1",
     "@emotion/server": "^11.4.0",
     "@emotion/styled": "^11.8.1",
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/file-and-cloudinary-upload/app/entry.client.tsx
+++ b/examples/file-and-cloudinary-upload/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/file-and-cloudinary-upload/app/entry.server.tsx
+++ b/examples/file-and-cloudinary-upload/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/file-and-cloudinary-upload/app/root.tsx
+++ b/examples/file-and-cloudinary-upload/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/file-and-cloudinary-upload/app/routes/cloudinary-upload.tsx
+++ b/examples/file-and-cloudinary-upload/app/routes/cloudinary-upload.tsx
@@ -1,10 +1,6 @@
-import {
-  Form,
-  unstable_parseMultipartFormData,
-  useActionData,
-  json,
-} from "remix";
-import type { ActionFunction, UploadHandler } from "remix";
+import type { ActionFunction, UploadHandler } from "@remix-run/node";
+import { json, unstable_parseMultipartFormData } from "@remix-run/node";
+import { Form, useActionData } from "@remix-run/react";
 
 import { uploadImage } from "~/utils/utils.server";
 

--- a/examples/file-and-cloudinary-upload/app/routes/local-upload.tsx
+++ b/examples/file-and-cloudinary-upload/app/routes/local-upload.tsx
@@ -1,11 +1,6 @@
-import {
-  Form,
-  unstable_createFileUploadHandler,
-  unstable_parseMultipartFormData,
-  useActionData,
-  json,
-} from "remix";
-import type { ActionFunction } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { json, unstable_createFileUploadHandler, unstable_parseMultipartFormData } from "@remix-run/node";
+import { Form, useActionData } from "@remix-run/react";
 
 type ActionData = {
   errorMsg?: string;

--- a/examples/file-and-cloudinary-upload/package.json
+++ b/examples/file-and-cloudinary-upload/package.json
@@ -7,16 +7,15 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "cloudinary": "^1.28.1",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/firebase-auth-firestore/app/entry.client.tsx
+++ b/examples/firebase-auth-firestore/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/firebase-auth-firestore/app/entry.server.tsx
+++ b/examples/firebase-auth-firestore/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/firebase-auth-firestore/app/root.tsx
+++ b/examples/firebase-auth-firestore/app/root.tsx
@@ -1,12 +1,5 @@
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/firebase-auth-firestore/app/routes/index.tsx
+++ b/examples/firebase-auth-firestore/app/routes/index.tsx
@@ -1,14 +1,14 @@
-import { useEffect, useRef } from "react";
-import type { ActionFunction, LoaderFunction } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
 import {
   Form,
-  json,
   Link,
-  redirect,
   useActionData,
   useFetcher,
   useLoaderData,
-} from "remix";
+} from "@remix-run/react";
+import { useEffect, useRef } from "react";
+
 import { requireAuth } from "~/server/auth.server";
 import type { Todo } from "~/server/db.server";
 import { addTodo, getUserTodos, removeTodo } from "~/server/db.server";

--- a/examples/firebase-auth-firestore/app/routes/join.tsx
+++ b/examples/firebase-auth-firestore/app/routes/join.tsx
@@ -1,5 +1,7 @@
-import type { ActionFunction, LoaderFunction } from "remix";
-import { Form, json, Link, redirect, useActionData } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { Form, Link, useActionData } from "@remix-run/react";
+
 import { checkSessionCookie, signUp } from "~/server/auth.server";
 import { commitSession, getSession } from "~/sessions";
 

--- a/examples/firebase-auth-firestore/app/routes/login.tsx
+++ b/examples/firebase-auth-firestore/app/routes/login.tsx
@@ -1,5 +1,7 @@
-import type { ActionFunction, LoaderFunction } from "remix";
-import { json, Link, redirect, useActionData } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { Link, useActionData } from "@remix-run/react";
+
 import { checkSessionCookie, signIn } from "~/server/auth.server";
 import { commitSession, getSession } from "~/sessions";
 

--- a/examples/firebase-auth-firestore/app/routes/logout.tsx
+++ b/examples/firebase-auth-firestore/app/routes/logout.tsx
@@ -1,5 +1,7 @@
-import type { LoaderFunction } from "remix";
-import { Form, redirect } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import { Form } from "@remix-run/react";
+
 import { destroySession, getSession } from "~/sessions";
 
 export const action: LoaderFunction = async ({ request }) => {

--- a/examples/firebase-auth-firestore/app/server/auth.server.ts
+++ b/examples/firebase-auth-firestore/app/server/auth.server.ts
@@ -1,8 +1,9 @@
-import type { UserRecord } from "firebase-admin/auth";
+import type { Session } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
 import { signInWithEmailAndPassword } from "firebase/auth";
+import type { UserRecord } from "firebase-admin/auth";
+
 import { destroySession, getSession } from "~/sessions";
-import type { Session } from "remix";
-import { redirect } from "remix";
 import { auth } from "./firebase.server";
 
 export const checkSessionCookie = async (session: Session) => {

--- a/examples/firebase-auth-firestore/app/sessions.ts
+++ b/examples/firebase-auth-firestore/app/sessions.ts
@@ -1,4 +1,4 @@
-import { createCookieSessionStorage } from "remix";
+import { createCookieSessionStorage } from "@remix-run/node";
 
 export const { getSession, commitSession, destroySession } =
   createCookieSessionStorage({

--- a/examples/firebase-auth-firestore/package.json
+++ b/examples/firebase-auth-firestore/package.json
@@ -7,17 +7,16 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "firebase": "^9.6.10",
     "firebase-admin": "^10.0.2",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/form-to-notion-db/app/entry.client.tsx
+++ b/examples/form-to-notion-db/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/form-to-notion-db/app/entry.server.tsx
+++ b/examples/form-to-notion-db/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/form-to-notion-db/app/root.tsx
+++ b/examples/form-to-notion-db/app/root.tsx
@@ -1,12 +1,13 @@
-import type { ActionFunction, MetaFunction } from "remix";
+import type { ActionFunction, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
 import {
   Links,
   LiveReload,
   Meta,
   Scripts,
   ScrollRestoration,
-  json,
-} from "remix";
+} from "@remix-run/react";
+
 import notion from "./notion.server";
 
 export const action: ActionFunction = async ({ request }) => {

--- a/examples/form-to-notion-db/package.json
+++ b/examples/form-to-notion-db/package.json
@@ -7,16 +7,15 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
     "@notionhq/client": "^0.4.13",
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/framer-motion/app/entry.client.tsx
+++ b/examples/framer-motion/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/framer-motion/app/entry.server.tsx
+++ b/examples/framer-motion/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/framer-motion/app/root.tsx
+++ b/examples/framer-motion/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/framer-motion/package.json
+++ b/examples/framer-motion/package.json
@@ -7,16 +7,15 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "framer-motion": "^5.6.0",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/framer-route-animation/app/entry.client.tsx
+++ b/examples/framer-route-animation/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/framer-route-animation/app/entry.server.tsx
+++ b/examples/framer-route-animation/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/framer-route-animation/app/root.tsx
+++ b/examples/framer-route-animation/app/root.tsx
@@ -1,5 +1,4 @@
-import { AnimatePresence, motion } from "framer-motion";
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -7,7 +6,8 @@ import {
   NavLink,
   Scripts,
   ScrollRestoration,
-} from "remix";
+} from "@remix-run/react";
+import { AnimatePresence, motion } from "framer-motion";
 import { useLocation, useOutlet } from "react-router-dom";
 
 export const meta: MetaFunction = () => ({

--- a/examples/framer-route-animation/package.json
+++ b/examples/framer-route-animation/package.json
@@ -7,16 +7,15 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "framer-motion": "^6.2.8",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/gdpr-cookie-consent/app/cookies.ts
+++ b/examples/gdpr-cookie-consent/app/cookies.ts
@@ -1,4 +1,4 @@
-import { createCookie } from "remix";
+import { createCookie } from "@remix-run/node";
 
 export const gdprConsent = createCookie("gdpr-consent", {
   maxAge: 31536000, // One Year

--- a/examples/gdpr-cookie-consent/app/entry.client.tsx
+++ b/examples/gdpr-cookie-consent/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/gdpr-cookie-consent/app/entry.server.tsx
+++ b/examples/gdpr-cookie-consent/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/gdpr-cookie-consent/app/root.tsx
+++ b/examples/gdpr-cookie-consent/app/root.tsx
@@ -1,16 +1,17 @@
-import * as React from "react";
-import type { LoaderFunction, MetaFunction } from "remix";
+import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
 import {
-  json,
   Links,
   LiveReload,
   Meta,
   Outlet,
   Scripts,
   ScrollRestoration,
-  useLoaderData,
   useFetcher,
-} from "remix";
+  useLoaderData,
+} from "@remix-run/react";
+import * as React from "react";
+
 import { gdprConsent } from "./cookies";
 
 export const loader: LoaderFunction = async ({ request }) => {

--- a/examples/gdpr-cookie-consent/app/routes/enable-analytics.tsx
+++ b/examples/gdpr-cookie-consent/app/routes/enable-analytics.tsx
@@ -1,5 +1,6 @@
-import type { ActionFunction } from "remix";
-import { json } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+
 import { gdprConsent } from "~/cookies";
 
 export const action: ActionFunction = async ({ request }) => {

--- a/examples/gdpr-cookie-consent/package.json
+++ b/examples/gdpr-cookie-consent/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/google-analytics/app/entry.client.tsx
+++ b/examples/google-analytics/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/google-analytics/app/entry.server.tsx
+++ b/examples/google-analytics/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/google-analytics/app/root.tsx
+++ b/examples/google-analytics/app/root.tsx
@@ -1,7 +1,6 @@
-import { useEffect } from "remix";
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
+// import { json } from "@remix-run/node";
 import {
-  // json,
   Link,
   Links,
   LiveReload,
@@ -10,7 +9,9 @@ import {
   Scripts,
   ScrollRestoration,
   useLocation,
-} from "remix";
+} from "@remix-run/react";
+import { useEffect } from "react";
+
 import * as gtag from "~/utils/gtags.client";
 
 /**

--- a/examples/google-analytics/app/routes/contact.tsx
+++ b/examples/google-analytics/app/routes/contact.tsx
@@ -1,6 +1,7 @@
+import type { ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form } from "@remix-run/react";
 import type { SyntheticEvent } from "react";
-import type { ActionFunction } from "remix";
-import { Form, json } from "remix";
 
 import * as gtag from "~/utils/gtags.client";
 

--- a/examples/google-analytics/app/routes/dashboard.tsx
+++ b/examples/google-analytics/app/routes/dashboard.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
 
 export const meta: MetaFunction = () => ({
   title: "Dashboard",

--- a/examples/google-analytics/app/routes/index.tsx
+++ b/examples/google-analytics/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
 
 export const meta: MetaFunction = () => ({
   title: "Home",

--- a/examples/google-analytics/app/routes/profile.tsx
+++ b/examples/google-analytics/app/routes/profile.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
 
 export const meta: MetaFunction = () => ({
   title: "Profile",

--- a/examples/google-analytics/package.json
+++ b/examples/google-analytics/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/graphql-api/app/entry.client.tsx
+++ b/examples/graphql-api/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/graphql-api/app/entry.server.tsx
+++ b/examples/graphql-api/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/graphql-api/app/root.tsx
+++ b/examples/graphql-api/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/graphql-api/app/routes/api/character.tsx
+++ b/examples/graphql-api/app/routes/api/character.tsx
@@ -1,6 +1,6 @@
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
 import type { ApolloError } from "apollo-server-errors";
-import type { LoaderFunction } from "remix";
-import { json } from "remix";
 
 import { fetchFromGraphQL, gql } from "~/utils";
 import type { Character } from "~/generated/types";

--- a/examples/graphql-api/app/routes/api/characters.tsx
+++ b/examples/graphql-api/app/routes/api/characters.tsx
@@ -1,6 +1,6 @@
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
 import type { ApolloError } from "apollo-server-errors";
-import type { LoaderFunction } from "remix";
-import { json } from "remix";
 
 import { fetchFromGraphQL, gql } from "~/utils";
 import type { Characters } from "~/generated/types";

--- a/examples/graphql-api/app/routes/character/$id.tsx
+++ b/examples/graphql-api/app/routes/character/$id.tsx
@@ -1,5 +1,6 @@
-import type { LoaderFunction } from "remix";
-import { json, Link, useLoaderData } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
 
 import { Code } from "~/components/Code";
 import type { LoaderData } from "~/routes/api/character";

--- a/examples/graphql-api/app/routes/character/error.tsx
+++ b/examples/graphql-api/app/routes/character/error.tsx
@@ -1,6 +1,7 @@
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
 import type { ApolloError } from "apollo-server-errors";
-import type { LoaderFunction } from "remix";
-import { json, Link, useLoaderData } from "remix";
 
 import { Code } from "~/components/Code";
 import { fetchFromGraphQL, gql } from "~/utils/index";

--- a/examples/graphql-api/app/routes/index.tsx
+++ b/examples/graphql-api/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import { Link, useLoaderData } from "remix";
+import { Link, useLoaderData } from "@remix-run/react";
 
 import { Code } from "~/components/Code";
 import type { LoaderData } from "~/routes/api/characters";

--- a/examples/graphql-api/package.json
+++ b/examples/graphql-api/package.json
@@ -10,16 +10,15 @@
     "predev": "npm run generate:types",
     "dev": "remix dev",
     "generate:types": "graphql-codegen",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "apollo-server-errors": "^3.3.1",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "2.6.2",

--- a/examples/image-resize/app/entry.client.tsx
+++ b/examples/image-resize/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/image-resize/app/entry.server.tsx
+++ b/examples/image-resize/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/image-resize/app/root.tsx
+++ b/examples/image-resize/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/image-resize/app/routes/assets/resize/$.ts
+++ b/examples/image-resize/app/routes/assets/resize/$.ts
@@ -12,7 +12,8 @@
  * Further improvements could be done by implementing ETags, but that is out of scope for this demo.
  */
 
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+
 import type { Params } from "react-router";
 
 import path from "path";

--- a/examples/image-resize/package.json
+++ b/examples/image-resize/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.3.4",
     "sharp": "^0.30.2"
   },
   "devDependencies": {

--- a/examples/infinite-scrolling/app/entry.client.tsx
+++ b/examples/infinite-scrolling/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/infinite-scrolling/app/entry.server.tsx
+++ b/examples/infinite-scrolling/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/infinite-scrolling/app/root.tsx
+++ b/examples/infinite-scrolling/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/infinite-scrolling/app/routes/index.tsx
+++ b/examples/infinite-scrolling/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from "remix";
+import { Link } from "@remix-run/react";
 
 export default function IndexRoute() {
   return (

--- a/examples/infinite-scrolling/app/routes/offset/advanced.tsx
+++ b/examples/infinite-scrolling/app/routes/offset/advanced.tsx
@@ -1,3 +1,11 @@
+import type { LinksFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import {
+  useBeforeUnload,
+  useLoaderData,
+  useSearchParams,
+  useTransition,
+} from "@remix-run/react";
 import {
   useCallback,
   useEffect,
@@ -5,16 +13,7 @@ import {
   useRef,
   useState,
 } from "react";
-
 import { useVirtual } from "react-virtual";
-import type { LoaderFunction, LinksFunction } from "remix";
-import {
-  json,
-  useLoaderData,
-  useSearchParams,
-  useTransition,
-  useBeforeUnload,
-} from "remix";
 
 import { countItems, getItems } from "~/utils/backend.server";
 

--- a/examples/infinite-scrolling/app/routes/offset/simple.tsx
+++ b/examples/infinite-scrolling/app/routes/offset/simple.tsx
@@ -1,7 +1,8 @@
+import type { LinksFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useFetcher, useLoaderData, useTransition } from "@remix-run/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useVirtual } from "react-virtual";
-import type { LoaderFunction, LinksFunction } from "remix";
-import { json, useLoaderData, useTransition, useFetcher } from "remix";
 
 import { countItems, getItems } from "~/utils/backend.server";
 

--- a/examples/infinite-scrolling/app/routes/page/advanced.tsx
+++ b/examples/infinite-scrolling/app/routes/page/advanced.tsx
@@ -1,3 +1,11 @@
+import type { LinksFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import {
+  useBeforeUnload,
+  useLoaderData,
+  useSearchParams,
+  useTransition,
+} from "@remix-run/react";
 import {
   useCallback,
   useEffect,
@@ -6,14 +14,6 @@ import {
   useState,
 } from "react";
 import { useVirtual } from "react-virtual";
-import type { LoaderFunction, LinksFunction } from "remix";
-import {
-  json,
-  useLoaderData,
-  useSearchParams,
-  useTransition,
-  useBeforeUnload,
-} from "remix";
 
 import { countItems, getItemsPaginated } from "~/utils/backend.server";
 

--- a/examples/infinite-scrolling/app/routes/page/alternative.tsx
+++ b/examples/infinite-scrolling/app/routes/page/alternative.tsx
@@ -1,7 +1,8 @@
+import type { LinksFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useFetcher, useLoaderData } from "@remix-run/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useVirtual } from "react-virtual";
-import type { LoaderFunction, LinksFunction } from "remix";
-import { json, useLoaderData, useFetcher } from "remix";
 
 import { countItems, getItemsPaginated } from "~/utils/backend.server";
 

--- a/examples/infinite-scrolling/app/routes/page/simple.tsx
+++ b/examples/infinite-scrolling/app/routes/page/simple.tsx
@@ -1,7 +1,8 @@
+import type { LinksFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useFetcher, useLoaderData, useTransition } from "@remix-run/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useVirtual } from "react-virtual";
-import type { LoaderFunction, LinksFunction } from "remix";
-import { json, useLoaderData, useTransition, useFetcher } from "remix";
 
 import { countItems, getItemsPaginated } from "~/utils/backend.server";
 

--- a/examples/infinite-scrolling/package.json
+++ b/examples/infinite-scrolling/package.json
@@ -7,16 +7,15 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-virtual": "^2.10.4",
-    "remix": "1.3.4"
+    "react-virtual": "^2.10.4"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/io-ts-formdata-decoding/app/entry.client.tsx
+++ b/examples/io-ts-formdata-decoding/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/io-ts-formdata-decoding/app/entry.server.tsx
+++ b/examples/io-ts-formdata-decoding/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/io-ts-formdata-decoding/app/root.tsx
+++ b/examples/io-ts-formdata-decoding/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/io-ts-formdata-decoding/app/routes/index.tsx
+++ b/examples/io-ts-formdata-decoding/app/routes/index.tsx
@@ -1,5 +1,6 @@
-import type { ActionFunction } from "remix";
-import { Form, json, useCatch, useActionData } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useActionData, useCatch } from "@remix-run/react";
 import * as t from "io-ts";
 
 import { decodeFormData } from "../formData";

--- a/examples/io-ts-formdata-decoding/package.json
+++ b/examples/io-ts-formdata-decoding/package.json
@@ -7,17 +7,16 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "fp-ts": "^2.11.8",
     "io-ts": "^2.2.16",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/ioredis/app/entry.client.tsx
+++ b/examples/ioredis/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/ioredis/app/entry.server.tsx
+++ b/examples/ioredis/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/ioredis/app/root.tsx
+++ b/examples/ioredis/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/ioredis/app/routes/index.tsx
+++ b/examples/ioredis/app/routes/index.tsx
@@ -1,12 +1,12 @@
-import type { ActionFunction, LoaderFunction } from "remix";
-import { redirect } from "remix";
-import { useActionData } from "remix";
-import { Form, json, useLoaderData } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { Form, useActionData, useLoaderData } from "@remix-run/react";
+
 import { redis } from "~/utils/redis.server";
 
-export const loader: LoaderFunction = async ({ request }) => {
+export const loader: LoaderFunction = async () => {
   const message = await redis.get("message");
-  return { message };
+  return json({ message });
 };
 
 export const action: ActionFunction = async ({ request }) => {

--- a/examples/ioredis/package.json
+++ b/examples/ioredis/package.json
@@ -7,16 +7,15 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "ioredis": "^4.28.5",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/jokes/app/components/joke.tsx
+++ b/examples/jokes/app/components/joke.tsx
@@ -1,5 +1,5 @@
-import { Link, Form } from "remix";
 import type { Joke } from "@prisma/client";
+import { Form, Link } from "@remix-run/react";
 
 export function JokeDisplay({
   joke,

--- a/examples/jokes/app/entry.client.tsx
+++ b/examples/jokes/app/entry.client.tsx
@@ -1,4 +1,4 @@
 import ReactDOM from "react-dom";
-import { RemixBrowser } from "remix";
+import { RemixBrowser } from "@remix-run/react";
 
 ReactDOM.hydrate(<RemixBrowser />, document);

--- a/examples/jokes/app/entry.server.tsx
+++ b/examples/jokes/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import type { EntryContext } from "remix";
-import { RemixServer } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/jokes/app/root.tsx
+++ b/examples/jokes/app/root.tsx
@@ -1,5 +1,5 @@
-import type { LinksFunction, MetaFunction } from "remix";
-import { Links, LiveReload, Meta, Outlet, Scripts, useCatch } from "remix";
+import type { LinksFunction, MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, useCatch } from "@remix-run/react";
 
 import globalStylesUrl from "./styles/global.css";
 import globalMediumStylesUrl from "./styles/global-medium.css";

--- a/examples/jokes/app/routes/index.tsx
+++ b/examples/jokes/app/routes/index.tsx
@@ -1,5 +1,6 @@
-import { Link } from "remix";
-import type { MetaFunction, LinksFunction } from "remix";
+import type { LinksFunction, MetaFunction } from "@remix-run/node";
+import { Link } from "@remix-run/react";
+
 import stylesUrl from "../styles/index.css";
 
 export const meta: MetaFunction = () => {

--- a/examples/jokes/app/routes/jokes.tsx
+++ b/examples/jokes/app/routes/jokes.tsx
@@ -1,6 +1,7 @@
-import type { LoaderFunction, LinksFunction } from "remix";
-import { json, Form } from "remix";
-import { Outlet, useLoaderData, Link } from "remix";
+import type { LinksFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, Link, Outlet, useLoaderData } from "@remix-run/react";
+
 import { db } from "~/utils/db.server";
 import { getUser } from "~/utils/session.server";
 import stylesUrl from "../styles/jokes.css";

--- a/examples/jokes/app/routes/jokes/$jokeId.tsx
+++ b/examples/jokes/app/routes/jokes/$jokeId.tsx
@@ -1,6 +1,12 @@
-import type { LoaderFunction, ActionFunction, MetaFunction } from "remix";
-import { json, useLoaderData, useCatch, redirect, useParams } from "remix";
 import type { Joke } from "@prisma/client";
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { useCatch, useLoaderData, useParams } from "@remix-run/react";
+
 import { db } from "~/utils/db.server";
 import { getUserId, requireUserId } from "~/utils/session.server";
 import { JokeDisplay } from "~/components/joke";

--- a/examples/jokes/app/routes/jokes/index.tsx
+++ b/examples/jokes/app/routes/jokes/index.tsx
@@ -1,6 +1,7 @@
-import type { LoaderFunction } from "remix";
-import { json, useLoaderData, Link, useCatch } from "remix";
 import type { Joke } from "@prisma/client";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link, useCatch, useLoaderData } from "@remix-run/react";
 
 import { db } from "~/utils/db.server";
 import { getUserId } from "~/utils/session.server";

--- a/examples/jokes/app/routes/jokes/new.tsx
+++ b/examples/jokes/app/routes/jokes/new.tsx
@@ -1,13 +1,13 @@
-import type { ActionFunction, LoaderFunction } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
 import {
-  Link,
-  useCatch,
-  useActionData,
   Form,
-  redirect,
+  Link,
+  useActionData,
+  useCatch,
   useTransition,
-  json,
-} from "remix";
+} from "@remix-run/react";
+
 import { JokeDisplay } from "~/components/joke";
 import { db } from "~/utils/db.server";
 import { getUserId, requireUserId } from "~/utils/session.server";

--- a/examples/jokes/app/routes/jokes[.]rss.tsx
+++ b/examples/jokes/app/routes/jokes[.]rss.tsx
@@ -1,4 +1,5 @@
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+
 import { db } from "~/utils/db.server";
 
 export const loader: LoaderFunction = async ({ request }) => {

--- a/examples/jokes/app/routes/login.tsx
+++ b/examples/jokes/app/routes/login.tsx
@@ -1,5 +1,11 @@
-import type { ActionFunction, LinksFunction, MetaFunction } from "remix";
-import { useActionData, Form, Link, useSearchParams, json } from "remix";
+import type {
+  ActionFunction,
+  LinksFunction,
+  MetaFunction,
+} from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, Link, useActionData, useSearchParams } from "@remix-run/react";
+
 import { login, createUserSession, register } from "~/utils/session.server";
 import { db } from "~/utils/db.server";
 import stylesUrl from "../styles/login.css";

--- a/examples/jokes/app/routes/logout.tsx
+++ b/examples/jokes/app/routes/logout.tsx
@@ -1,5 +1,6 @@
-import type { ActionFunction, LoaderFunction } from "remix";
-import { redirect } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+
 import { logout } from "~/utils/session.server";
 
 export const action: ActionFunction = async ({ request }) => {

--- a/examples/jokes/app/utils/session.server.ts
+++ b/examples/jokes/app/utils/session.server.ts
@@ -1,5 +1,6 @@
+import { createCookieSessionStorage, redirect } from "@remix-run/node";
 import bcrypt from "bcryptjs";
-import { createCookieSessionStorage, redirect } from "remix";
+
 import { db } from "./db.server";
 
 type LoginForm = {

--- a/examples/jokes/package.json
+++ b/examples/jokes/package.json
@@ -7,17 +7,16 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
     "@prisma/client": "^3.10.0",
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "bcryptjs": "^2.4.3",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/mantine/app/entry.client.tsx
+++ b/examples/mantine/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/mantine/app/entry.server.tsx
+++ b/examples/mantine/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 import { injectStylesIntoStaticMarkup } from "@mantine/ssr";
 
 export default function handleRequest(

--- a/examples/mantine/app/root.tsx
+++ b/examples/mantine/app/root.tsx
@@ -1,7 +1,6 @@
 import type { ColorScheme } from "@mantine/core";
 import { MantineProvider, ColorSchemeProvider } from "@mantine/core";
-import { useState } from "react";
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -9,7 +8,8 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-} from "remix";
+} from "@remix-run/react";
+import { useState } from "react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/mantine/package.json
+++ b/examples/mantine/package.json
@@ -7,18 +7,17 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
     "@mantine/core": "^3.6.14",
     "@mantine/hooks": "^3.6.14",
     "@mantine/ssr": "^3.6.14",
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/msw/app/entry.client.tsx
+++ b/examples/msw/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/msw/app/entry.server.tsx
+++ b/examples/msw/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/msw/app/root.tsx
+++ b/examples/msw/app/root.tsx
@@ -1,13 +1,6 @@
-import type { LoaderFunction, MetaFunction } from "remix";
-import {
-  json,
-  Links,
-  LiveReload,
-  Meta,
-  Scripts,
-  ScrollRestoration,
-  useLoaderData,
-} from "remix";
+import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Links, LiveReload, Meta, Scripts, ScrollRestoration, useLoaderData } from "@remix-run/react";
 
 type LoaderData = { message: string };
 

--- a/examples/msw/package.json
+++ b/examples/msw/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/multiple-forms/app/entry.client.tsx
+++ b/examples/multiple-forms/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/multiple-forms/app/entry.server.tsx
+++ b/examples/multiple-forms/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/multiple-forms/app/root.tsx
+++ b/examples/multiple-forms/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/multiple-forms/app/routes/index.tsx
+++ b/examples/multiple-forms/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import type { LoaderFunction } from "remix";
-import { redirect } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
 
 export const loader: LoaderFunction = async () => redirect("/invitations");

--- a/examples/multiple-forms/app/routes/invitations.tsx
+++ b/examples/multiple-forms/app/routes/invitations.tsx
@@ -1,5 +1,7 @@
-import { Form, json, useLoaderData, redirect } from "remix";
-import type { LoaderFunction, ActionFunction } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
+
 import type { Invitation } from "~/data.server";
 import { sendInvitation } from "~/data.server";
 import {

--- a/examples/multiple-forms/package.json
+++ b/examples/multiple-forms/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/multiple-params/app/entry.client.tsx
+++ b/examples/multiple-params/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/multiple-params/app/entry.server.tsx
+++ b/examples/multiple-params/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/multiple-params/app/root.tsx
+++ b/examples/multiple-params/app/root.tsx
@@ -1,13 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Link,
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Link, Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/multiple-params/app/routes/clients.tsx
+++ b/examples/multiple-params/app/routes/clients.tsx
@@ -1,6 +1,7 @@
-import type { LoaderFunction } from "remix";
-import { Link, useLoaderData } from "remix";
-import { json, Outlet } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link, Outlet, useLoaderData } from "@remix-run/react";
+
 import type { Client } from "~/db";
 import { getClients } from "~/db";
 

--- a/examples/multiple-params/app/routes/clients/$clientId.tsx
+++ b/examples/multiple-params/app/routes/clients/$clientId.tsx
@@ -1,5 +1,13 @@
-import { json, Link, Outlet, useCatch, useLoaderData, useParams } from "remix";
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import {
+  Link,
+  Outlet,
+  useCatch,
+  useLoaderData,
+  useParams,
+} from "@remix-run/react";
+
 import type { Client } from "~/db";
 import { getClient } from "~/db";
 

--- a/examples/multiple-params/app/routes/clients/$clientId/index.tsx
+++ b/examples/multiple-params/app/routes/clients/$clientId/index.tsx
@@ -1,5 +1,7 @@
-import { json, useLoaderData } from "remix";
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+
 import type { Client } from "~/db";
 import { getClient } from "~/db";
 

--- a/examples/multiple-params/app/routes/clients/$clientId/invoices.tsx
+++ b/examples/multiple-params/app/routes/clients/$clientId/invoices.tsx
@@ -1,6 +1,7 @@
-import type { LoaderFunction } from "remix";
-import { Link, useLoaderData } from "remix";
-import { json, Outlet } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link, Outlet, useLoaderData } from "@remix-run/react";
+
 import type { Invoice } from "~/db";
 import { getClient } from "~/db";
 

--- a/examples/multiple-params/app/routes/clients/$clientId/invoices/$invoiceId.tsx
+++ b/examples/multiple-params/app/routes/clients/$clientId/invoices/$invoiceId.tsx
@@ -1,7 +1,7 @@
-import type { LoaderFunction } from "remix";
-import { useParams, useCatch } from "remix";
-import { useLoaderData } from "remix";
-import { json } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useCatch, useLoaderData, useParams } from "@remix-run/react";
+
 import type { Invoice } from "~/db";
 import { getClient } from "~/db";
 

--- a/examples/multiple-params/package.json
+++ b/examples/multiple-params/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/newsletter-signup/app/entry.client.tsx
+++ b/examples/newsletter-signup/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/newsletter-signup/app/entry.server.tsx
+++ b/examples/newsletter-signup/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/newsletter-signup/app/root.tsx
+++ b/examples/newsletter-signup/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 import styles from "./styles.css";
 

--- a/examples/newsletter-signup/app/routes/newsletter.tsx
+++ b/examples/newsletter-signup/app/routes/newsletter.tsx
@@ -1,6 +1,7 @@
+import type { ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, Link, useActionData, useTransition } from "@remix-run/react";
 import { useEffect, useRef } from "react";
-import type { ActionFunction } from "remix";
-import { Form, json, Link, useActionData, useTransition } from "remix";
 
 export const action: ActionFunction = async ({ request }) => {
   await new Promise((res) => setTimeout(res, 1000));

--- a/examples/newsletter-signup/package.json
+++ b/examples/newsletter-signup/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/nprogress/app/entry.client.tsx
+++ b/examples/nprogress/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/nprogress/app/entry.server.tsx
+++ b/examples/nprogress/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/nprogress/app/root.tsx
+++ b/examples/nprogress/app/root.tsx
@@ -1,7 +1,4 @@
-import NProgress from "nprogress";
-import nProgressStyles from "nprogress/nprogress.css";
-import { useEffect } from "react";
-import type { LinksFunction, MetaFunction } from "remix";
+import type { LinksFunction, MetaFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -10,7 +7,10 @@ import {
   Scripts,
   ScrollRestoration,
   useTransition,
-} from "remix";
+} from "@remix-run/react";
+import NProgress from "nprogress";
+import nProgressStyles from "nprogress/nprogress.css";
+import { useEffect } from "react";
 
 export const links: LinksFunction = () => {
   // if you already have one only add this stylesheet to your list of links

--- a/examples/nprogress/app/routes/index.tsx
+++ b/examples/nprogress/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from "remix";
+import { Link } from "@remix-run/react";
 
 export default function Screen() {
   return <Link to="/slow-page">Slow Page</Link>;

--- a/examples/nprogress/app/routes/slow-page.tsx
+++ b/examples/nprogress/app/routes/slow-page.tsx
@@ -1,5 +1,6 @@
-import type { LoaderFunction } from "remix";
-import { json, Link } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link } from "@remix-run/react";
 
 export const loader: LoaderFunction = async () => {
   await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/examples/nprogress/package.json
+++ b/examples/nprogress/package.json
@@ -7,16 +7,15 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "nprogress": "^0.2.0",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/on-demand-hydration/app/entry.client.tsx
+++ b/examples/on-demand-hydration/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/on-demand-hydration/app/entry.server.tsx
+++ b/examples/on-demand-hydration/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/on-demand-hydration/app/root.tsx
+++ b/examples/on-demand-hydration/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 import { useShouldHydrate } from "remix-utils";
 
 export const meta: MetaFunction = () => ({

--- a/examples/on-demand-hydration/app/routes/index.tsx
+++ b/examples/on-demand-hydration/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from "remix";
+import { Link } from "@remix-run/react";
 
 export default function Screen() {
   return (

--- a/examples/on-demand-hydration/app/routes/on-demand-js.tsx
+++ b/examples/on-demand-hydration/app/routes/on-demand-js.tsx
@@ -1,5 +1,6 @@
-import type { LoaderFunction } from "remix";
-import { json, useLoaderData } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 type LoaderData = { withJS: boolean };
 

--- a/examples/on-demand-hydration/package.json
+++ b/examples/on-demand-hydration/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.3.4",
     "remix-utils": "^2.7.0"
   },
   "devDependencies": {

--- a/examples/outlet-form-rerender/app/entry.client.tsx
+++ b/examples/outlet-form-rerender/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/outlet-form-rerender/app/entry.server.tsx
+++ b/examples/outlet-form-rerender/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/outlet-form-rerender/app/root.tsx
+++ b/examples/outlet-form-rerender/app/root.tsx
@@ -1,13 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-  useCatch,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration, useCatch } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/outlet-form-rerender/app/routes/index.tsx
+++ b/examples/outlet-form-rerender/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import type { LoaderFunction } from "remix";
-import { redirect } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
 
 export const loader: LoaderFunction = async () => redirect("/users");

--- a/examples/outlet-form-rerender/app/routes/users.tsx
+++ b/examples/outlet-form-rerender/app/routes/users.tsx
@@ -1,6 +1,7 @@
-import type { LoaderFunction, MetaFunction } from "remix";
-import { Link, Outlet, json } from "remix";
-import { useLoaderData } from "remix";
+import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link, Outlet, useLoaderData } from "@remix-run/react";
+
 import type { User } from "~/data.server";
 import { users } from "~/data.server";
 

--- a/examples/outlet-form-rerender/app/routes/users/$userId.tsx
+++ b/examples/outlet-form-rerender/app/routes/users/$userId.tsx
@@ -1,5 +1,7 @@
-import type { LoaderFunction, MetaFunction } from "remix";
-import { Form, json, useCatch, useLoaderData, useLocation } from "remix";
+import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useCatch, useLoaderData, useLocation } from "@remix-run/react";
+
 import type { User as UserType } from "~/data.server";
 import { users } from "~/data.server";
 

--- a/examples/outlet-form-rerender/package.json
+++ b/examples/outlet-form-rerender/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/pathless-routes/app/entry.client.tsx
+++ b/examples/pathless-routes/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/pathless-routes/app/entry.server.tsx
+++ b/examples/pathless-routes/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/pathless-routes/app/root.tsx
+++ b/examples/pathless-routes/app/root.tsx
@@ -1,13 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  NavLink,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, NavLink, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/pathless-routes/app/routes/articles.tsx
+++ b/examples/pathless-routes/app/routes/articles.tsx
@@ -1,5 +1,6 @@
-import { Link, Outlet } from "remix";
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Link, Outlet } from "@remix-run/react";
+
 import { attributes } from "./articles/__layout/hello.md";
 
 export const meta: MetaFunction = () => {

--- a/examples/pathless-routes/app/routes/articles/__layout.tsx
+++ b/examples/pathless-routes/app/routes/articles/__layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "remix";
+import { Outlet } from "@remix-run/react";
 
 export default function ArticleLayoutRoute() {
   return (

--- a/examples/pathless-routes/app/routes/index.tsx
+++ b/examples/pathless-routes/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
 
 export const meta: MetaFunction = () => {
   return { title: "Home" };

--- a/examples/pathless-routes/package.json
+++ b/examples/pathless-routes/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/pm-app/app/auth.server.ts
+++ b/examples/pm-app/app/auth.server.ts
@@ -1,5 +1,6 @@
-import { json, redirect } from "remix";
-import type { Session } from "remix";
+import type { Session } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+
 import { sessionStorage, sessionKey, getUserSession } from "~/session.server";
 import type { User } from "~/models";
 

--- a/examples/pm-app/app/entry.client.tsx
+++ b/examples/pm-app/app/entry.client.tsx
@@ -1,4 +1,4 @@
 import ReactDOM from "react-dom";
-import { RemixBrowser } from "remix";
+import { RemixBrowser } from "@remix-run/react";
 
 ReactDOM.hydrate(<RemixBrowser />, document);

--- a/examples/pm-app/app/entry.server.tsx
+++ b/examples/pm-app/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import type { EntryContext } from "remix";
-import { RemixServer } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/pm-app/app/root.tsx
+++ b/examples/pm-app/app/root.tsx
@@ -1,6 +1,10 @@
-import type { LinksFunction, LoaderFunction, MetaFunction } from "remix";
+import type {
+  LinksFunction,
+  LoaderFunction,
+  MetaFunction,
+} from "@remix-run/node";
+import { json } from "@remix-run/node";
 import {
-  json,
   Links,
   LiveReload,
   Meta,
@@ -9,7 +13,7 @@ import {
   ScrollRestoration,
   useCatch,
   useLoaderData,
-} from "remix";
+} from "@remix-run/react";
 
 import global from "~/dist/styles/global.css";
 import type { User } from "./models";

--- a/examples/pm-app/app/routes/dashboard.tsx
+++ b/examples/pm-app/app/routes/dashboard.tsx
@@ -1,6 +1,11 @@
+import type {
+  LinksFunction,
+  LoaderFunction,
+  MetaFunction,
+} from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Outlet, useCatch } from "@remix-run/react";
 import * as React from "react";
-import type { LoaderFunction, LinksFunction, MetaFunction } from "remix";
-import { json, Outlet, useCatch } from "remix";
 
 import stylesUrl from "~/dist/styles/routes/dashboard.css";
 import { NavLink } from "~/ui/link";

--- a/examples/pm-app/app/routes/dashboard/index.tsx
+++ b/examples/pm-app/app/routes/dashboard/index.tsx
@@ -1,6 +1,8 @@
+import type { LinksFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useCatch, useFetcher, useLoaderData } from "@remix-run/react";
 import * as React from "react";
-import type { LoaderFunction, LinksFunction } from "remix";
-import { json, useCatch, useFetcher, useLoaderData } from "remix";
+
 import type { UserSecure, Project } from "~/models";
 import { Heading, Section } from "~/ui/section-heading";
 import { MaxContainer } from "~/ui/max-container";

--- a/examples/pm-app/app/routes/dashboard/projects/$projectId.tsx
+++ b/examples/pm-app/app/routes/dashboard/projects/$projectId.tsx
@@ -1,15 +1,19 @@
-import * as React from "react";
+import type {
+  LinksFunction,
+  LoaderFunction,
+  MetaFunction,
+} from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
 import {
   Form,
-  json,
   Outlet,
-  redirect,
   useActionData,
   useFetcher,
   useLoaderData,
   useTransition,
-} from "remix";
-import type { LoaderFunction, LinksFunction, MetaFunction } from "remix";
+} from "@remix-run/react";
+import * as React from "react";
+
 import { Heading, Section } from "~/ui/section-heading";
 import { MaxContainer } from "~/ui/max-container";
 

--- a/examples/pm-app/app/routes/dashboard/projects/$projectId/delete.tsx
+++ b/examples/pm-app/app/routes/dashboard/projects/$projectId/delete.tsx
@@ -1,7 +1,8 @@
-import type { ActionFunction } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+
 import { deleteProject } from "~/db.server";
 import { requireUser } from "~/session.server";
-import { redirect } from "remix";
 
 export const action: ActionFunction = async ({ request, params }) => {
   await requireUser(request, {

--- a/examples/pm-app/app/routes/dashboard/projects/$projectId/list/$listId.tsx
+++ b/examples/pm-app/app/routes/dashboard/projects/$projectId/list/$listId.tsx
@@ -1,11 +1,13 @@
-import * as React from "react";
-import { useLoaderData, json, redirect, useFetcher, useFetchers } from "remix";
 import type {
-  LoaderFunction,
-  LinksFunction,
   ActionFunction,
+  LinksFunction,
+  LoaderFunction,
   MetaFunction,
-} from "remix";
+} from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { useFetcher, useFetchers, useLoaderData } from "@remix-run/react";
+import * as React from "react";
+
 import { Heading, Section } from "~/ui/section-heading";
 
 import stylesUrl from "~/dist/styles/routes/dashboard/todo-lists/$listId/index.css";

--- a/examples/pm-app/app/routes/dashboard/projects/new.tsx
+++ b/examples/pm-app/app/routes/dashboard/projects/new.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
-import {
-  Form,
-  json,
-  redirect,
-  useActionData,
-  useLoaderData,
-  useCatch,
-} from "remix";
-import type { ActionFunction, LoaderFunction, LinksFunction } from "remix";
+import type {
+  ActionFunction,
+  LinksFunction,
+  LoaderFunction,
+} from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { Form, useActionData, useCatch, useLoaderData } from "@remix-run/react";
+
 import type { UserSecure } from "~/models";
 import { Heading } from "~/ui/section-heading";
 import { MaxContainer } from "~/ui/max-container";

--- a/examples/pm-app/app/routes/dashboard/todo-lists/$listId/delete.tsx
+++ b/examples/pm-app/app/routes/dashboard/todo-lists/$listId/delete.tsx
@@ -1,7 +1,8 @@
-import type { ActionFunction, LoaderFunction } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+
 import { deleteTodoList } from "~/db.server";
 import { requireUser } from "~/session.server";
-import { redirect } from "remix";
 
 export const action: ActionFunction = async ({ request, params }) => {
   await requireUser(request, {

--- a/examples/pm-app/app/routes/dashboard/todo-lists/$listId/index.tsx
+++ b/examples/pm-app/app/routes/dashboard/todo-lists/$listId/index.tsx
@@ -1,11 +1,13 @@
-import * as React from "react";
-import { useLoaderData, json, redirect, useFetcher, useFetchers } from "remix";
 import type {
-  LoaderFunction,
-  LinksFunction,
   ActionFunction,
+  LinksFunction,
+  LoaderFunction,
   MetaFunction,
-} from "remix";
+} from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { useFetcher, useFetchers, useLoaderData } from "@remix-run/react";
+import * as React from "react";
+
 import { Heading, Section } from "~/ui/section-heading";
 import { MaxContainer } from "~/ui/max-container";
 

--- a/examples/pm-app/app/routes/dashboard/todo-lists/index.tsx
+++ b/examples/pm-app/app/routes/dashboard/todo-lists/index.tsx
@@ -1,6 +1,8 @@
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
 import * as React from "react";
-import type { LoaderFunction } from "remix";
-import { json, Link, useLoaderData } from "remix";
+
 import { getAllTodoLists } from "~/db.server";
 import type { TodoList } from "~/models";
 import { requireUser } from "~/session.server";

--- a/examples/pm-app/app/routes/dashboard/todo-lists/new.tsx
+++ b/examples/pm-app/app/routes/dashboard/todo-lists/new.tsx
@@ -1,19 +1,19 @@
 import * as React from "react";
-import {
-  Form,
-  json,
-  redirect,
-  useActionData,
-  useSearchParams,
-  useLoaderData,
-  useCatch,
-} from "remix";
 import type {
   ActionFunction,
-  RouteComponent,
-  LoaderFunction,
   LinksFunction,
-} from "remix";
+  LoaderFunction,
+  RouteComponent,
+} from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import {
+  Form,
+  useActionData,
+  useCatch,
+  useLoaderData,
+  useSearchParams,
+} from "@remix-run/react";
+
 import type { UserSecure, TodoDataUnordered, Project } from "~/models";
 import { Heading } from "~/ui/section-heading";
 import { MaxContainer } from "~/ui/max-container";

--- a/examples/pm-app/app/routes/dashboard/todos/$todoId/delete.tsx
+++ b/examples/pm-app/app/routes/dashboard/todos/$todoId/delete.tsx
@@ -1,5 +1,6 @@
-import { json } from "remix";
-import type { ActionFunction } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+
 import { requireUser } from "~/session.server";
 import { deleteTodo } from "~/db.server";
 import type { Todo } from "~/models";

--- a/examples/pm-app/app/routes/dashboard/todos/$todoId/edit.tsx
+++ b/examples/pm-app/app/routes/dashboard/todos/$todoId/edit.tsx
@@ -1,5 +1,6 @@
-import { json } from "remix";
-import type { ActionFunction } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+
 import { requireUser } from "~/session.server";
 import { updateTodo } from "~/db.server";
 import type { Todo } from "~/models";

--- a/examples/pm-app/app/routes/dashboard/todos/$todoId/index.tsx
+++ b/examples/pm-app/app/routes/dashboard/todos/$todoId/index.tsx
@@ -1,5 +1,6 @@
-import { json } from "remix";
-import type { LoaderFunction, ActionFunction } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+
 import { requireUser } from "~/session.server";
 import { getTodo, updateTodo } from "~/db.server";
 import type { Todo } from "~/models";

--- a/examples/pm-app/app/routes/dashboard/todos/$todoId/set.tsx
+++ b/examples/pm-app/app/routes/dashboard/todos/$todoId/set.tsx
@@ -1,5 +1,6 @@
-import { json } from "remix";
-import type { ActionFunction } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+
 import { requireUser } from "~/session.server";
 import { updateTodo } from "~/db.server";
 import type { Todo } from "~/models";

--- a/examples/pm-app/app/routes/dashboard/todos/index.tsx
+++ b/examples/pm-app/app/routes/dashboard/todos/index.tsx
@@ -1,7 +1,14 @@
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import {
+  Form,
+  useActionData,
+  useLoaderData,
+  useTransition,
+} from "@remix-run/react";
 import * as React from "react";
+
 import { getAllTodos, getTodo, updateTodo } from "~/db.server";
-import type { ActionFunction, LoaderFunction } from "remix";
-import { Form, json, useActionData, useLoaderData, useTransition } from "remix";
 import type { Todo } from "~/models";
 
 export const loader: LoaderFunction = async () => {

--- a/examples/pm-app/app/routes/dashboard/todos/new.tsx
+++ b/examples/pm-app/app/routes/dashboard/todos/new.tsx
@@ -1,5 +1,6 @@
-import { json } from "remix";
-import type { ActionFunction } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+
 import { requireUser } from "~/session.server";
 import { createTodo, getTodosFromList } from "~/db.server";
 import type { Todo } from "~/models";

--- a/examples/pm-app/app/routes/dashboard/todos/toggle.tsx
+++ b/examples/pm-app/app/routes/dashboard/todos/toggle.tsx
@@ -1,7 +1,8 @@
-import type { ActionFunction } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+
 import { getTodo, updateTodo } from "~/db.server";
 import { requireUser } from "~/session.server";
-import { json } from "remix";
 
 export const action: ActionFunction = async ({ request }) => {
   await requireUser(request, {

--- a/examples/pm-app/app/routes/index.tsx
+++ b/examples/pm-app/app/routes/index.tsx
@@ -1,5 +1,6 @@
-import type { LoaderFunction } from "remix";
-import { redirect } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+
 import { getUser } from "~/session.server";
 
 export const loader: LoaderFunction = async ({ request }) => {

--- a/examples/pm-app/app/routes/register.tsx
+++ b/examples/pm-app/app/routes/register.tsx
@@ -1,11 +1,13 @@
-import * as React from "react";
 import type {
   ActionFunction,
-  MetaFunction,
   LinksFunction,
   LoaderFunction,
-} from "remix";
-import { Form, json, useActionData, useSearchParams } from "remix";
+  MetaFunction,
+} from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useActionData, useSearchParams } from "@remix-run/react";
+import * as React from "react";
+
 import { Button } from "~/ui/button";
 import { Link } from "~/ui/link";
 import { ShadowBox } from "~/ui/shadow-box";

--- a/examples/pm-app/app/routes/sign-in.tsx
+++ b/examples/pm-app/app/routes/sign-in.tsx
@@ -1,11 +1,13 @@
-import * as React from "react";
 import type {
   ActionFunction,
-  MetaFunction,
   LinksFunction,
   LoaderFunction,
-} from "remix";
-import { Form, json, useActionData, useSearchParams } from "remix";
+  MetaFunction,
+} from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useActionData, useSearchParams } from "@remix-run/react";
+import * as React from "react";
+
 import { Button } from "~/ui/button";
 import { Link } from "~/ui/link";
 import { ShadowBox } from "~/ui/shadow-box";

--- a/examples/pm-app/app/routes/sign-out.tsx
+++ b/examples/pm-app/app/routes/sign-out.tsx
@@ -1,4 +1,5 @@
-import type { LoaderFunction, ActionFunction } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+
 import { logout } from "~/session.server";
 
 export const action: ActionFunction = async ({ request }) => {

--- a/examples/pm-app/app/session.server.ts
+++ b/examples/pm-app/app/session.server.ts
@@ -1,4 +1,5 @@
-import { createCookieSessionStorage, redirect } from "remix";
+import { createCookieSessionStorage, redirect } from "@remix-run/node";
+
 import { createUser, verifyLogin, getUser as getDbUser } from "./db.server";
 import { getServerSafeEnvVariable } from "~/utils";
 import type { User } from "~/models";

--- a/examples/pm-app/app/ui/link.tsx
+++ b/examples/pm-app/app/ui/link.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable jsx-a11y/anchor-has-content */
-import * as React from "react";
+import type { LinkProps, NavLinkProps } from "@remix-run/react";
+import { Link, NavLink } from "@remix-run/react";
 import cx from "clsx";
-import { NavLink, Link } from "remix";
+import * as React from "react";
+
 import { isFunction, isExternalUrl } from "~/utils";
 import { IconArrowRight } from "~/ui/icons";
-import type { LinkProps, NavLinkProps } from "remix";
 
 const CustomNavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
   ({ to, ...props }, ref) => {

--- a/examples/pm-app/app/ui/todo-list.tsx
+++ b/examples/pm-app/app/ui/todo-list.tsx
@@ -1,7 +1,8 @@
-import * as React from "react";
-import { useFetcher, useFetchers } from "remix";
-import type { Todo } from "~/models";
+import { useFetcher, useFetchers } from "@remix-run/react";
 import cx from "clsx";
+import * as React from "react";
+
+import type { Todo } from "~/models";
 import { Token } from "~/ui/token";
 
 export function TodoList({

--- a/examples/pm-app/package.json
+++ b/examples/pm-app/package.json
@@ -17,7 +17,6 @@
     "build:css": "postcss app/styles --base app/styles --dir app/dist/styles --env production",
     "build:remix": "remix build",
     "build": "run-s build:*",
-    "postinstall": "remix setup node",
     "typecheck": "tsc -b",
     "deploy": "flyctl deploy",
     "start": "node server/index.js"
@@ -27,6 +26,7 @@
     "@reach/combobox": "^0.16.5",
     "@reach/dialog": "^0.16.2",
     "@reach/menu-button": "^0.16.2",
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "bcrypt": "^5.0.1",
@@ -35,7 +35,6 @@
     "prisma": "^3.10.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.3.4",
     "validator": "^13.7.0"
   },
   "devDependencies": {

--- a/examples/quirrel/app/entry.client.tsx
+++ b/examples/quirrel/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/quirrel/app/entry.server.tsx
+++ b/examples/quirrel/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/quirrel/app/root.tsx
+++ b/examples/quirrel/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/quirrel/app/routes/index.tsx
+++ b/examples/quirrel/app/routes/index.tsx
@@ -1,5 +1,5 @@
-import type { LoaderFunction } from "remix";
-import { json } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
 
 import greetingsQueue from "~/queues/greetings.server";
 

--- a/examples/quirrel/package.json
+++ b/examples/quirrel/package.json
@@ -9,16 +9,15 @@
     "dev": "run-p dev:*",
     "dev:quirrel": "quirrel",
     "dev:remix": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "quirrel": "^1.8.1",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/react-spring/app/entry.client.tsx
+++ b/examples/react-spring/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/react-spring/app/entry.server.tsx
+++ b/examples/react-spring/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/react-spring/app/root.tsx
+++ b/examples/react-spring/app/root.tsx
@@ -1,12 +1,5 @@
-import type { LinksFunction, MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { LinksFunction, MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 import styles from "~/styles.css";
 import noScriptStyles from "~/no-script.css";

--- a/examples/react-spring/package.json
+++ b/examples/react-spring/package.json
@@ -7,16 +7,15 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-spring": "^9.4.3",
-    "remix": "1.3.4"
+    "react-spring": "^9.4.3"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/redis-upstash-session/app/entry.client.tsx
+++ b/examples/redis-upstash-session/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/redis-upstash-session/app/entry.server.tsx
+++ b/examples/redis-upstash-session/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/redis-upstash-session/app/root.tsx
+++ b/examples/redis-upstash-session/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/redis-upstash-session/app/routes/index.tsx
+++ b/examples/redis-upstash-session/app/routes/index.tsx
@@ -1,5 +1,7 @@
-import type { LoaderFunction } from "remix";
-import { json, useLoaderData } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+
 import { commitSession, getSession } from "~/sessions.server";
 
 export const loader: LoaderFunction = async ({ request }) => {

--- a/examples/redis-upstash-session/app/sessions.server.ts
+++ b/examples/redis-upstash-session/app/sessions.server.ts
@@ -1,4 +1,5 @@
-import { createCookie } from "remix";
+import { createCookie } from "@remix-run/node";
+
 import { createUpstashSessionStorage } from "~/sessions/upstash.server";
 
 // This will set the length of the session.

--- a/examples/redis-upstash-session/app/sessions/upstash.server.ts
+++ b/examples/redis-upstash-session/app/sessions/upstash.server.ts
@@ -1,6 +1,5 @@
+import { createSessionStorage } from "@remix-run/node";
 import * as crypto from "crypto";
-
-import { createSessionStorage } from "remix";
 
 const upstashRedisRestUrl = process.env.UPSTASH_REDIS_REST_URL;
 

--- a/examples/redis-upstash-session/package.json
+++ b/examples/redis-upstash-session/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/remix-auth-auth0/app/entry.client.tsx
+++ b/examples/remix-auth-auth0/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/remix-auth-auth0/app/entry.server.tsx
+++ b/examples/remix-auth-auth0/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/remix-auth-auth0/app/root.tsx
+++ b/examples/remix-auth-auth0/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/remix-auth-auth0/app/routes/auth0.tsx
+++ b/examples/remix-auth-auth0/app/routes/auth0.tsx
@@ -1,5 +1,5 @@
-import type { ActionFunction, LoaderFunction } from "remix";
-import { redirect } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
 
 import { auth } from "~/utils/auth.server";
 

--- a/examples/remix-auth-auth0/app/routes/callback.tsx
+++ b/examples/remix-auth-auth0/app/routes/callback.tsx
@@ -1,4 +1,4 @@
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
 
 import { auth } from "~/utils/auth.server";
 

--- a/examples/remix-auth-auth0/app/routes/index.tsx
+++ b/examples/remix-auth-auth0/app/routes/index.tsx
@@ -1,5 +1,7 @@
-import type { LoaderFunction } from "remix";
-import { Form, json, useLoaderData } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
+
 import { auth, getSession } from "~/utils/auth.server";
 
 type LoaderData = {

--- a/examples/remix-auth-auth0/app/routes/logout.tsx
+++ b/examples/remix-auth-auth0/app/routes/logout.tsx
@@ -1,5 +1,6 @@
-import type { ActionFunction } from "remix";
-import { redirect } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+
 import { destroySession, getSession } from "~/utils/auth.server";
 import {
   AUTH0_CLIENT_ID,

--- a/examples/remix-auth-auth0/app/routes/private.tsx
+++ b/examples/remix-auth-auth0/app/routes/private.tsx
@@ -1,6 +1,8 @@
-import type { LoaderFunction } from "remix";
-import { Form, json, useLoaderData } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
 import type { Auth0Profile } from "remix-auth-auth0";
+
 import { auth } from "~/utils/auth.server";
 
 type LoaderData = { profile: Auth0Profile };

--- a/examples/remix-auth-auth0/app/utils/auth.server.ts
+++ b/examples/remix-auth-auth0/app/utils/auth.server.ts
@@ -1,7 +1,8 @@
+import { createCookieSessionStorage } from "@remix-run/node";
 import { Authenticator } from "remix-auth";
-import { Auth0Strategy } from "remix-auth-auth0";
-import { createCookieSessionStorage } from "remix";
 import type { Auth0Profile } from "remix-auth-auth0";
+import { Auth0Strategy } from "remix-auth-auth0";
+
 import {
   AUTH0_CALLBACK_URL,
   AUTH0_CLIENT_ID,

--- a/examples/remix-auth-auth0/package.json
+++ b/examples/remix-auth-auth0/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.3.4",
     "remix-auth": "^3.2.1",
     "remix-auth-auth0": "^1.3.2"
   },

--- a/examples/remix-auth-form/app/auth.server.ts
+++ b/examples/remix-auth-form/app/auth.server.ts
@@ -1,4 +1,4 @@
-import { createCookieSessionStorage } from "remix";
+import { createCookieSessionStorage } from "@remix-run/node";
 import { Authenticator, AuthorizationError } from "remix-auth";
 import { FormStrategy } from "remix-auth-form";
 

--- a/examples/remix-auth-form/app/entry.client.tsx
+++ b/examples/remix-auth-form/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/remix-auth-form/app/entry.server.tsx
+++ b/examples/remix-auth-form/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/remix-auth-form/app/root.tsx
+++ b/examples/remix-auth-form/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/remix-auth-form/app/routes/login.tsx
+++ b/examples/remix-auth-form/app/routes/login.tsx
@@ -1,5 +1,7 @@
-import type { ActionFunction, LoaderFunction } from "remix";
-import { Form, json, useLoaderData } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
+
 import { auth, sessionStorage } from "~/auth.server";
 
 type LoaderData = {

--- a/examples/remix-auth-form/app/routes/private.tsx
+++ b/examples/remix-auth-form/app/routes/private.tsx
@@ -1,5 +1,7 @@
-import type { ActionFunction, LoaderFunction } from "remix";
-import { Form, json, useLoaderData } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
+
 import { auth } from "~/auth.server";
 
 type LoaderData = { email: string };

--- a/examples/remix-auth-form/package.json
+++ b/examples/remix-auth-form/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.3.4",
     "remix-auth": "^3.2.1",
     "remix-auth-form": "^1.1.1"
   },

--- a/examples/remix-auth-github/app/auth.server.ts
+++ b/examples/remix-auth-github/app/auth.server.ts
@@ -1,4 +1,4 @@
-import { createCookieSessionStorage } from "remix";
+import { createCookieSessionStorage } from "@remix-run/node";
 import { Authenticator } from "remix-auth";
 import type { GitHubExtraParams, GitHubProfile } from "remix-auth-github";
 import { GitHubStrategy } from "remix-auth-github";

--- a/examples/remix-auth-github/app/entry.client.tsx
+++ b/examples/remix-auth-github/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/remix-auth-github/app/entry.server.tsx
+++ b/examples/remix-auth-github/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import type { EntryContext } from "remix";
-import { RemixServer } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/remix-auth-github/app/root.tsx
+++ b/examples/remix-auth-github/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/remix-auth-github/app/routes/auth.github.callback.tsx
+++ b/examples/remix-auth-github/app/routes/auth.github.callback.tsx
@@ -1,7 +1,8 @@
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+
 import { auth } from "~/auth.server";
 
-export const loader: LoaderFunction = async ({ request, params }) => {
+export const loader: LoaderFunction = async ({ request }) => {
   return auth.authenticate("github", request, {
     successRedirect: "/private",
     failureRedirect: "/",

--- a/examples/remix-auth-github/app/routes/auth.github.tsx
+++ b/examples/remix-auth-github/app/routes/auth.github.tsx
@@ -1,4 +1,5 @@
-import type { ActionFunction } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+
 import { auth } from "~/auth.server";
 
 export const action: ActionFunction = async ({ request }) => {

--- a/examples/remix-auth-github/app/routes/index.tsx
+++ b/examples/remix-auth-github/app/routes/index.tsx
@@ -1,5 +1,7 @@
-import type { LoaderFunction } from "remix";
-import { Form, json, useLoaderData } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
+
 import { auth, sessionStorage } from "~/auth.server";
 
 type LoaderData = {

--- a/examples/remix-auth-github/app/routes/private.tsx
+++ b/examples/remix-auth-github/app/routes/private.tsx
@@ -1,6 +1,8 @@
-import type { ActionFunction, LoaderFunction } from "remix";
-import { Form, json, useLoaderData } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
 import type { GitHubProfile } from "remix-auth-github";
+
 import { auth } from "~/auth.server";
 
 type LoaderData = { profile: GitHubProfile };

--- a/examples/remix-auth-github/package.json
+++ b/examples/remix-auth-github/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.3.4",
     "remix-auth": "^3.2.1",
     "remix-auth-github": "^1.0.0"
   },

--- a/examples/remix-auth-supabase-github/app/auth.server.ts
+++ b/examples/remix-auth-supabase-github/app/auth.server.ts
@@ -1,6 +1,7 @@
-import { createCookieSessionStorage } from "remix";
+import { createCookieSessionStorage } from "@remix-run/node";
 import { Authenticator, AuthorizationError } from "remix-auth";
 import { SupabaseStrategy } from "remix-auth-supabase";
+
 import { supabaseAdmin } from "~/supabase.server";
 import type { Session } from "~/supabase.server";
 

--- a/examples/remix-auth-supabase-github/app/entry.client.tsx
+++ b/examples/remix-auth-supabase-github/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/remix-auth-supabase-github/app/entry.server.tsx
+++ b/examples/remix-auth-supabase-github/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/remix-auth-supabase-github/app/root.tsx
+++ b/examples/remix-auth-supabase-github/app/root.tsx
@@ -1,14 +1,6 @@
-import type { LoaderFunction, MetaFunction } from "remix";
-import {
-  json,
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-  useLoaderData,
-} from "remix";
+import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData } from "@remix-run/react";
 
 export const loader: LoaderFunction = () => {
   return json({

--- a/examples/remix-auth-supabase-github/app/routes/index.tsx
+++ b/examples/remix-auth-supabase-github/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from "remix";
+import { Link } from "@remix-run/react";
 
 export default function Index() {
   return (

--- a/examples/remix-auth-supabase-github/app/routes/login.tsx
+++ b/examples/remix-auth-supabase-github/app/routes/login.tsx
@@ -1,5 +1,7 @@
-import type { ActionFunction, LoaderFunction } from "remix";
-import { Form, json, useLoaderData } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
+
 import { authenticator, sessionStorage, supabaseStrategy } from "~/auth.server";
 import { signInWithGithub } from "~/supabase.client";
 

--- a/examples/remix-auth-supabase-github/app/routes/oauth.callback.tsx
+++ b/examples/remix-auth-supabase-github/app/routes/oauth.callback.tsx
@@ -1,6 +1,7 @@
+import type { ActionFunction } from "@remix-run/node";
+import { useSubmit } from "@remix-run/react";
 import { useEffect } from "react";
-import type { ActionFunction } from "remix";
-import { useSubmit } from "remix";
+
 import { authenticator } from "~/auth.server";
 import { supabaseClient } from "~/supabase.client";
 

--- a/examples/remix-auth-supabase-github/app/routes/private.tsx
+++ b/examples/remix-auth-supabase-github/app/routes/private.tsx
@@ -1,5 +1,7 @@
-import type { ActionFunction, LoaderFunction } from "remix";
-import { Form, json, useLoaderData } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
+
 import { authenticator, supabaseStrategy } from "~/auth.server";
 
 type LoaderData = { email?: string };

--- a/examples/remix-auth-supabase-github/package.json
+++ b/examples/remix-auth-supabase-github/package.json
@@ -7,16 +7,15 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "@supabase/supabase-js": "^1.30.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.3.4",
     "remix-auth": "^3.2.1",
     "remix-auth-supabase": "^3.1.0"
   },

--- a/examples/remix-auth-supabase/app/auth.server.ts
+++ b/examples/remix-auth-supabase/app/auth.server.ts
@@ -1,6 +1,7 @@
-import { createCookieSessionStorage } from "remix";
+import { createCookieSessionStorage } from "@remix-run/node";
 import { Authenticator, AuthorizationError } from "remix-auth";
 import { SupabaseStrategy } from "remix-auth-supabase";
+
 import { supabaseClient } from "~/supabase";
 import type { Session } from "~/supabase";
 

--- a/examples/remix-auth-supabase/app/entry.client.tsx
+++ b/examples/remix-auth-supabase/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/remix-auth-supabase/app/entry.server.tsx
+++ b/examples/remix-auth-supabase/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/remix-auth-supabase/app/root.tsx
+++ b/examples/remix-auth-supabase/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/remix-auth-supabase/app/routes/index.tsx
+++ b/examples/remix-auth-supabase/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from "remix";
+import { Link } from "@remix-run/react";
 
 export default function Index() {
   return (

--- a/examples/remix-auth-supabase/app/routes/login.tsx
+++ b/examples/remix-auth-supabase/app/routes/login.tsx
@@ -1,5 +1,7 @@
-import type { ActionFunction, LoaderFunction } from "remix";
-import { Form, json, useLoaderData } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
+
 import { authenticator, sessionStorage, supabaseStrategy } from "~/auth.server";
 
 type LoaderData = {

--- a/examples/remix-auth-supabase/app/routes/private.tsx
+++ b/examples/remix-auth-supabase/app/routes/private.tsx
@@ -1,5 +1,7 @@
-import type { ActionFunction, LoaderFunction } from "remix";
-import { Form, json, useLoaderData } from "remix";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
+
 import { authenticator, supabaseStrategy } from "~/auth.server";
 
 type LoaderData = { email?: string };

--- a/examples/remix-auth-supabase/package.json
+++ b/examples/remix-auth-supabase/package.json
@@ -7,16 +7,15 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "@supabase/supabase-js": "^1.30.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.3.4",
     "remix-auth": "^3.2.1",
     "remix-auth-supabase": "^3.1.0"
   },

--- a/examples/route-modal/app/entry.client.tsx
+++ b/examples/route-modal/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/route-modal/app/entry.server.tsx
+++ b/examples/route-modal/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/route-modal/app/root.tsx
+++ b/examples/route-modal/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/route-modal/app/routes/invoices.tsx
+++ b/examples/route-modal/app/routes/invoices.tsx
@@ -1,5 +1,6 @@
-import type { LoaderFunction } from "remix";
-import { json, Link, Outlet, useLoaderData } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link, Outlet, useLoaderData } from "@remix-run/react";
 
 export const loader: LoaderFunction = async ({ params }) => {
   const invoices = [

--- a/examples/route-modal/app/routes/invoices/$id/edit.tsx
+++ b/examples/route-modal/app/routes/invoices/$id/edit.tsx
@@ -1,12 +1,13 @@
-import * as React from "react";
 import Dialog from "@reach/dialog";
-import type { ActionFunction, LinksFunction, LoaderFunction } from "remix";
-import { redirect } from "remix";
-import { useLoaderData } from "remix";
-import { json } from "remix";
-import { Form } from "remix";
-import { useNavigate } from "remix";
 import styles from "@reach/dialog/styles.css";
+import type {
+  ActionFunction,
+  LinksFunction,
+  LoaderFunction,
+} from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { Form, useLoaderData, useNavigate } from "@remix-run/react";
+import * as React from "react";
 
 export const links: LinksFunction = () => {
   return [

--- a/examples/route-modal/app/routes/invoices/add.tsx
+++ b/examples/route-modal/app/routes/invoices/add.tsx
@@ -1,11 +1,13 @@
 import Dialog from "@reach/dialog";
-import type { ActionFunction, LinksFunction } from "remix";
-import { useTransition } from "remix";
-import { redirect, useActionData } from "remix";
-import { Form } from "remix";
-import { useNavigate } from "remix";
-
 import styles from "@reach/dialog/styles.css";
+import type { ActionFunction, LinksFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import {
+  Form,
+  useActionData,
+  useNavigate,
+  useTransition,
+} from "@remix-run/react";
 
 export const links: LinksFunction = () => {
   return [

--- a/examples/route-modal/package.json
+++ b/examples/route-modal/package.json
@@ -7,16 +7,15 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
     "@reach/dialog": "^0.16.2",
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/routes-gen/app/entry.client.tsx
+++ b/examples/routes-gen/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/routes-gen/app/entry.server.tsx
+++ b/examples/routes-gen/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/routes-gen/app/root.tsx
+++ b/examples/routes-gen/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/routes-gen/app/routes/products/index.tsx
+++ b/examples/routes-gen/app/routes/products/index.tsx
@@ -1,6 +1,7 @@
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 import { Link } from "react-router-dom";
-import type { LoaderFunction } from "remix";
-import { json, useLoaderData } from "remix";
 import { route } from "routes-gen";
 
 type Post = {

--- a/examples/routes-gen/package.json
+++ b/examples/routes-gen/package.json
@@ -7,16 +7,15 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "routes-gen": "routes-gen -d @routes-gen/remix",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.3.4",
     "routes-gen": "^0.3.0"
   },
   "devDependencies": {

--- a/examples/rust/app/entry.client.tsx
+++ b/examples/rust/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/rust/app/entry.server.tsx
+++ b/examples/rust/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/rust/app/root.tsx
+++ b/examples/rust/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 import globalStylesUrl from "~/styles/global.css";
 

--- a/examples/rust/app/routes/index.tsx
+++ b/examples/rust/app/routes/index.tsx
@@ -1,5 +1,7 @@
-import type { ActionFunction } from "remix";
-import { Form, json, useActionData } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useActionData } from "@remix-run/react";
+
 import { add } from "~/rust.server";
 import indexStylesUrl from "~/styles/index.css";
 

--- a/examples/rust/package.json
+++ b/examples/rust/package.json
@@ -8,15 +8,14 @@
     "build": "remix build",
     "predev": "wasm-pack build rust-functions --target nodejs --out-name rust-functions",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.3.4",
     "rust-functions": "file:rust-functions/pkg"
   },
   "devDependencies": {

--- a/examples/sanity/app/entry.client.jsx
+++ b/examples/sanity/app/entry.client.jsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import ReactDOM from "react-dom";
-import { RemixBrowser } from "remix";
 
 ReactDOM.hydrate(<RemixBrowser />, document);

--- a/examples/sanity/app/entry.server.jsx
+++ b/examples/sanity/app/entry.server.jsx
@@ -1,5 +1,5 @@
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
 
 export default function handleRequest(
   request,

--- a/examples/sanity/app/root.jsx
+++ b/examples/sanity/app/root.jsx
@@ -1,4 +1,4 @@
-import { Links, LiveReload, Meta, Outlet, Scripts, useCatch } from "remix";
+import { Links, LiveReload, Meta, Outlet, Scripts, useCatch } from "@remix-run/react";
 
 import stylesUrl from "./styles/global.css";
 

--- a/examples/sanity/app/routes/$slug.jsx
+++ b/examples/sanity/app/routes/$slug.jsx
@@ -1,5 +1,6 @@
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 import { useState } from "react";
-import { json, useLoaderData } from "remix";
 
 import { getClient } from "~/lib/sanity/getClient";
 import { filterDataToSingleItem } from "~/lib/sanity/filterDataToSingleItem";

--- a/examples/sanity/app/routes/index.jsx
+++ b/examples/sanity/app/routes/index.jsx
@@ -1,4 +1,5 @@
-import { json, Link, useLoaderData } from "remix";
+import { json } from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
 
 import { getClient } from "~/lib/sanity/getClient";
 

--- a/examples/sanity/package.json
+++ b/examples/sanity/package.json
@@ -7,10 +7,10 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "@sanity/block-content-to-react": "^3.0.0",
@@ -18,8 +18,7 @@
     "@sanity/image-url": "^1.0.1",
     "picosanity": "^3.0.3",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/sass/app/entry.client.tsx
+++ b/examples/sass/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/sass/app/entry.server.tsx
+++ b/examples/sass/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/sass/app/root.tsx
+++ b/examples/sass/app/root.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, MetaFunction } from "remix";
+import type { LinksFunction, MetaFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -6,7 +6,7 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-} from "remix";
+} from "@remix-run/react";
 
 import globalStyles from "./styles/global.css";
 

--- a/examples/sass/package.json
+++ b/examples/sass/package.json
@@ -11,15 +11,14 @@
     "dev": "run-p dev:*",
     "dev:css": "sass styles/:app/styles/ --watch ",
     "dev:remix": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/search-input/app/entry.client.tsx
+++ b/examples/search-input/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/search-input/app/entry.server.tsx
+++ b/examples/search-input/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/search-input/app/root.tsx
+++ b/examples/search-input/app/root.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import type { LinksFunction, MetaFunction } from "remix";
+import type { LinksFunction, MetaFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -8,7 +7,8 @@ import {
   Scripts,
   ScrollRestoration,
   useCatch,
-} from "remix";
+} from "@remix-run/react";
+import * as React from "react";
 
 import globalStylesUrl from "~/styles/global.css";
 

--- a/examples/search-input/app/routes/index.tsx
+++ b/examples/search-input/app/routes/index.tsx
@@ -1,5 +1,11 @@
-import { Form, json, useLoaderData, useTransition } from "remix";
-import type { MetaFunction, LinksFunction, LoaderFunction } from "remix";
+import type {
+  LinksFunction,
+  LoaderFunction,
+  MetaFunction,
+} from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useLoaderData, useTransition } from "@remix-run/react";
+
 import stylesUrl from "../styles/index.css";
 
 export const meta: MetaFunction = () => {

--- a/examples/search-input/package.json
+++ b/examples/search-input/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/sharing-loader-data/app/entry.client.tsx
+++ b/examples/sharing-loader-data/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/sharing-loader-data/app/entry.server.tsx
+++ b/examples/sharing-loader-data/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/sharing-loader-data/app/root.tsx
+++ b/examples/sharing-loader-data/app/root.tsx
@@ -1,13 +1,6 @@
-import type { LoaderFunction, MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-  json,
-} from "remix";
+import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 import type { User } from "~/data.server";
 import { getUser } from "~/data.server";

--- a/examples/sharing-loader-data/app/routes/index.tsx
+++ b/examples/sharing-loader-data/app/routes/index.tsx
@@ -1,4 +1,5 @@
-import { useMatches, Link } from "remix";
+import { Link, useMatches } from "@remix-run/react";
+
 import type { User } from "~/data.server";
 
 export default function Index() {

--- a/examples/sharing-loader-data/app/routes/workshops.tsx
+++ b/examples/sharing-loader-data/app/routes/workshops.tsx
@@ -1,5 +1,7 @@
-import { Link, Outlet, json, useLoaderData } from "remix";
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link, Outlet, useLoaderData } from "@remix-run/react";
+
 import type { Workshop } from "~/data.server";
 import { getWorkshops } from "~/data.server";
 

--- a/examples/sharing-loader-data/app/routes/workshops/$workshopId.tsx
+++ b/examples/sharing-loader-data/app/routes/workshops/$workshopId.tsx
@@ -1,5 +1,7 @@
-import type { LoaderFunction } from "remix";
-import { json, useCatch, useMatches, useParams } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useCatch, useMatches, useParams } from "@remix-run/react";
+
 import type { Workshop } from "~/data.server";
 import { getWorkshops } from "~/data.server";
 

--- a/examples/sharing-loader-data/package.json
+++ b/examples/sharing-loader-data/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/socket.io/app/entry.client.tsx
+++ b/examples/socket.io/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/socket.io/app/entry.server.tsx
+++ b/examples/socket.io/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/socket.io/app/root.tsx
+++ b/examples/socket.io/app/root.tsx
@@ -1,13 +1,6 @@
 import { useEffect, useState } from "react";
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 import type { Socket } from "socket.io-client";
 import io from "socket.io-client";
 import { SocketProvider } from "./context";

--- a/examples/socket.io/package.json
+++ b/examples/socket.io/package.json
@@ -7,12 +7,12 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "cross-env NODE_ENV=production node server/index.js",
     "start:dev": "cross-env NODE_ENV=development node server/index.js"
   },
   "dependencies": {
     "@remix-run/express": "1.3.4",
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "compression": "^1.7.4",
     "cross-env": "^7.0.3",
@@ -20,7 +20,6 @@
     "morgan": "^1.10.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.3.4",
     "socket.io": "^4.4.1",
     "socket.io-client": "^4.4.1"
   },

--- a/examples/stitches/app/entry.client.tsx
+++ b/examples/stitches/app/entry.client.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 import { getCssText } from "./styles/stitches.config";
 import ClientStyleContext from "./styles/client.context";
 

--- a/examples/stitches/app/entry.server.tsx
+++ b/examples/stitches/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 import { getCssText } from "./styles/stitches.config";
 

--- a/examples/stitches/app/root.tsx
+++ b/examples/stitches/app/root.tsx
@@ -1,5 +1,4 @@
-import { useContext, useEffect } from "react";
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -8,7 +7,8 @@ import {
   Scripts,
   ScrollRestoration,
   useCatch,
-} from "remix";
+} from "@remix-run/react";
+import { useContext, useEffect } from "react";
 
 import ClientStyleContext from "./styles/client.context";
 import { styled } from "./styles/stitches.config";

--- a/examples/stitches/app/routes/index.tsx
+++ b/examples/stitches/app/routes/index.tsx
@@ -1,4 +1,5 @@
-import { Link } from "remix";
+import { Link } from "@remix-run/react";
+
 import { styled } from "../styles/stitches.config";
 
 const Container = styled("div", {

--- a/examples/stitches/app/routes/jokes.tsx
+++ b/examples/stitches/app/routes/jokes.tsx
@@ -1,4 +1,5 @@
-import { Link } from "remix";
+import { Link } from "@remix-run/react";
+
 import { styled } from "../styles/stitches.config";
 
 const Container = styled("div", {

--- a/examples/stitches/package.json
+++ b/examples/stitches/package.json
@@ -7,16 +7,15 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "@stitches/react": "^1.2.7",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/strapi/app/entry.client.tsx
+++ b/examples/strapi/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/strapi/app/entry.server.tsx
+++ b/examples/strapi/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/strapi/app/root.tsx
+++ b/examples/strapi/app/root.tsx
@@ -1,6 +1,6 @@
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet } from "@remix-run/react";
 import * as React from "react";
-import type { MetaFunction } from "remix";
-import { Links, LiveReload, Meta, Outlet } from "remix";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/strapi/app/routes/index.tsx
+++ b/examples/strapi/app/routes/index.tsx
@@ -1,7 +1,8 @@
-import * as React from "react";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 import { marked } from "marked";
-import type { LoaderFunction } from "remix";
-import { json, useLoaderData } from "remix";
+import * as React from "react";
 
 type Post = {
   title: string;

--- a/examples/strapi/package.json
+++ b/examples/strapi/package.json
@@ -8,17 +8,16 @@
     "build": "remix build",
     "dev": "run-p dev:*",
     "dev:remix": "remix dev",
-    "postinstall": "remix setup node",
     "dev:strapi": "cd strapi && npm run develop",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "marked": "^4.0.12",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/stripe-integration/app/entry.client.tsx
+++ b/examples/stripe-integration/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/stripe-integration/app/entry.server.tsx
+++ b/examples/stripe-integration/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/stripe-integration/app/root.tsx
+++ b/examples/stripe-integration/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/stripe-integration/app/routes/api/stripe-web-hook.tsx
+++ b/examples/stripe-integration/app/routes/api/stripe-web-hook.tsx
@@ -1,5 +1,5 @@
-import type { ActionFunction } from "remix";
-import { json } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
 import stripe from "stripe";
 
 //[credit @kiliman to get this webhook working](https://github.com/remix-run/remix/discussions/1978)

--- a/examples/stripe-integration/app/routes/buy.tsx
+++ b/examples/stripe-integration/app/routes/buy.tsx
@@ -1,5 +1,6 @@
-import type { ActionFunction } from "remix";
-import { Form, redirect } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import { Form } from "@remix-run/react";
 
 import { getStripeSession, getDomainUrl } from "~/utils/stripe.server";
 

--- a/examples/stripe-integration/package.json
+++ b/examples/stripe-integration/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.3.4",
     "stripe": "^8.209.0"
   },
   "devDependencies": {

--- a/examples/styled-components/app/entry.client.tsx
+++ b/examples/styled-components/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/styled-components/app/entry.server.tsx
+++ b/examples/styled-components/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 import { ServerStyleSheet } from "styled-components";
 
 export default function handleRequest(

--- a/examples/styled-components/app/root.tsx
+++ b/examples/styled-components/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.3.4",
     "styled-components": "^5.3.3"
   },
   "devDependencies": {

--- a/examples/supabase-subscription/app/entry.client.tsx
+++ b/examples/supabase-subscription/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/supabase-subscription/app/entry.server.tsx
+++ b/examples/supabase-subscription/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/supabase-subscription/app/root.tsx
+++ b/examples/supabase-subscription/app/root.tsx
@@ -1,8 +1,6 @@
-import { createClient } from "@supabase/supabase-js";
-import { Provider } from "react-supabase";
-import type { MetaFunction, LoaderFunction } from "remix";
+import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
 import {
-  json,
   Links,
   LiveReload,
   Meta,
@@ -10,7 +8,9 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
-} from "remix";
+} from "@remix-run/react";
+import { createClient } from "@supabase/supabase-js";
+import { Provider } from "react-supabase";
 
 type LoaderData = {
   ENV: {

--- a/examples/supabase-subscription/app/routes/realtime.tsx
+++ b/examples/supabase-subscription/app/routes/realtime.tsx
@@ -1,6 +1,8 @@
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useFetcher, useLoaderData } from "@remix-run/react";
 import { useSubscription } from "react-supabase";
-import type { ActionFunction, LoaderFunction } from "remix";
-import { Form, json, useFetcher, useLoaderData } from "remix";
+
 import { client } from "~/utils/supabaseClient.server";
 
 export const loader: LoaderFunction = async () => {

--- a/examples/supabase-subscription/package.json
+++ b/examples/supabase-subscription/package.json
@@ -7,17 +7,16 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "@supabase/supabase-js": "^1.31.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-supabase": "^0.2.0",
-    "remix": "1.3.4"
+    "react-supabase": "^0.2.0"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/tailwindcss/app/entry.client.tsx
+++ b/examples/tailwindcss/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/tailwindcss/app/entry.server.tsx
+++ b/examples/tailwindcss/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import type { EntryContext } from "remix";
-import { RemixServer } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/tailwindcss/app/root.tsx
+++ b/examples/tailwindcss/app/root.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, MetaFunction } from "remix";
+import type { LinksFunction, MetaFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -6,7 +6,7 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-} from "remix";
+} from "@remix-run/react";
 
 import tailwind from "./tailwind.css";
 

--- a/examples/tailwindcss/package.json
+++ b/examples/tailwindcss/package.json
@@ -12,15 +12,14 @@
     "dev:css": "npm run generate:css -- --watch",
     "dev:remix": "remix dev",
     "generate:css": "npx tailwindcss -o ./app/tailwind.css",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/template/app/entry.client.tsx
+++ b/examples/template/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/template/app/entry.server.tsx
+++ b/examples/template/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/template/app/root.tsx
+++ b/examples/template/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/template/package.json
+++ b/examples/template/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/toast-message/app/entry.client.tsx
+++ b/examples/toast-message/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/toast-message/app/entry.server.tsx
+++ b/examples/toast-message/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/toast-message/app/message.server.ts
+++ b/examples/toast-message/app/message.server.ts
@@ -1,5 +1,5 @@
-import { createCookieSessionStorage } from "remix";
-import type { Session } from "remix";
+import type { Session } from "@remix-run/node";
+import { createCookieSessionStorage } from "@remix-run/node";
 
 export type ToastMessage = { message: string; type: "success" | "error" };
 

--- a/examples/toast-message/app/root.tsx
+++ b/examples/toast-message/app/root.tsx
@@ -1,8 +1,6 @@
-import * as React from "react";
-import { Toaster, toast } from "react-hot-toast";
-import type { LoaderFunction, MetaFunction } from "remix";
+import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
 import {
-  json,
   Links,
   LiveReload,
   Meta,
@@ -10,7 +8,9 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
-} from "remix";
+} from "@remix-run/react";
+import * as React from "react";
+import { Toaster, toast } from "react-hot-toast";
 
 import type { ToastMessage } from "./message.server";
 import { commitSession, getSession } from "./message.server";

--- a/examples/toast-message/app/routes/index.tsx
+++ b/examples/toast-message/app/routes/index.tsx
@@ -1,5 +1,7 @@
-import { Form, redirect, useFetcher } from "remix";
-import type { ActionFunction } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import { Form, useFetcher } from "@remix-run/react";
+
 import {
   commitSession,
   getSession,

--- a/examples/toast-message/app/routes/submit-secret.ts
+++ b/examples/toast-message/app/routes/submit-secret.ts
@@ -1,5 +1,6 @@
-import type { ActionFunction } from "remix";
-import { json } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+
 import {
   commitSession,
   getSession,

--- a/examples/toast-message/package.json
+++ b/examples/toast-message/package.json
@@ -7,16 +7,15 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-hot-toast": "^2.2.0",
-    "remix": "1.3.4"
+    "react-hot-toast": "^2.2.0"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/examples/turborepo-vercel/apps/remix-app/app/entry.client.tsx
+++ b/examples/turborepo-vercel/apps/remix-app/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/turborepo-vercel/apps/remix-app/app/entry.server.tsx
+++ b/examples/turborepo-vercel/apps/remix-app/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/turborepo-vercel/apps/remix-app/app/root.tsx
+++ b/examples/turborepo-vercel/apps/remix-app/app/root.tsx
@@ -1,12 +1,5 @@
-import type { MetaFunction } from "remix";
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-} from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/examples/turborepo-vercel/package.json
+++ b/examples/turborepo-vercel/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write .",
     "lint": "turbo run lint"
   },
+  "dependencies": {},
   "devDependencies": {
     "prettier": "^2.5.1",
     "turbo": "latest"

--- a/examples/usematches-loader-data/app/entry.client.tsx
+++ b/examples/usematches-loader-data/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/examples/usematches-loader-data/app/entry.server.tsx
+++ b/examples/usematches-loader-data/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/examples/usematches-loader-data/app/root.tsx
+++ b/examples/usematches-loader-data/app/root.tsx
@@ -1,13 +1,14 @@
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
 import {
-  json,
   Links,
   LiveReload,
   Meta,
   Outlet,
   Scripts,
   ScrollRestoration,
-} from "remix";
+} from "@remix-run/react";
+
 import { getCurrentUser } from "./db.server";
 
 /*

--- a/examples/usematches-loader-data/app/useMatchesData.ts
+++ b/examples/usematches-loader-data/app/useMatchesData.ts
@@ -1,5 +1,5 @@
+import { useMatches } from "@remix-run/react";
 import { useMemo } from "react";
-import { useMatches } from "remix";
 
 /**
  * This base hook is used in other hooks to quickly search for specific data

--- a/examples/usematches-loader-data/package.json
+++ b/examples/usematches-loader-data/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "postinstall": "remix setup node",
     "start": "remix-serve build"
   },
   "dependencies": {
+    "@remix-run/node": "1.3.4",
     "@remix-run/react": "1.3.4",
     "@remix-run/serve": "1.3.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "remix": "1.3.4"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.3.4",

--- a/scripts/run-migration-on-examples.js
+++ b/scripts/run-migration-on-examples.js
@@ -1,0 +1,31 @@
+const { execSync } = require("child_process");
+const { readdir, stat } = require("fs/promises");
+const { join } = require("path");
+
+const main = async (migration) => {
+  if (!migration) {
+    console.error("Please specify a migration to run");
+    process.exit(1);
+  }
+
+  let buildPath = join(__dirname, "../", "build");
+  let cliPath = join(buildPath, "node_modules", "@remix-run/dev", "cli.js");
+  let examplesPath = join(process.cwd(), "examples");
+  let examples = await readdir(examplesPath);
+
+  examples.forEach(async (example) => {
+    let examplePath = join(examplesPath, example);
+    let stats = await stat(examplePath);
+
+    if (!stats.isDirectory()) {
+      return;
+    }
+
+    execSync(
+      `node ${cliPath} migrate --migration ${migration} --force ${examplePath}`,
+      { stdio: "inherit" }
+    );
+  });
+};
+
+main(process.argv[2]);


### PR DESCRIPTION
Follow-up of #2430