### PR TITLE
fix(remix-dev/compiler): make `getDependenciesToBundle` more resilient to misconfigured `packages.json`s

### DIFF
--- a/integration/compiler-test.ts
+++ b/integration/compiler-test.ts
@@ -55,9 +55,20 @@ describe("compiler", () => {
             return <div id="esm-only-pkg">{esmOnlyPkg}</div>;
           }
         `,
+        "app/routes/esm-only-exports-pkg.jsx": js`
+          import esmOnlyPkg from "esm-only-exports-pkg";
+
+          export default function EsmOnlyPkg() {
+            return <div id="esm-only-exports-pkg">{esmOnlyPkg}</div>;
+          }
+        `,
         "remix.config.js": js`
+          let { getDependenciesToBundle } = require("@remix-run/dev");
           module.exports = {
-            serverDependenciesToBundle: ["esm-only-pkg"],
+            serverDependenciesToBundle: [
+              "esm-only-pkg",
+              ...getDependenciesToBundle("esm-only-exports-pkg")
+            ],
           };
         `,
         "node_modules/esm-only-pkg/package.json": `{
@@ -68,6 +79,17 @@ describe("compiler", () => {
         }`,
         "node_modules/esm-only-pkg/esm-only-pkg.js": js`
           export default "esm-only-pkg";
+        `,
+        "node_modules/esm-only-exports-pkg/package.json": `{
+          "name": "esm-only-exports-pkg",
+          "version": "1.0.0",
+          "type": "module",
+          "exports": {
+            ".": "./esm-only-exports-pkg.js"
+          }
+        }`,
+        "node_modules/esm-only-exports-pkg/esm-only-exports-pkg.js": js`
+          export default "esm-only-exports-pkg";
         `,
       },
     });
@@ -137,6 +159,15 @@ describe("compiler", () => {
     // rendered the page instead of the error boundary
     expect(await app.getHtml("#esm-only-pkg")).toMatchInlineSnapshot(
       `"<div id=\\"esm-only-pkg\\">esm-only-pkg</div>"`
+    );
+  });
+
+  it("allows consumption of ESM modules with exports in CJS builds with `serverDependenciesToBundle` and `getDependenciesToBundle`", async () => {
+    let res = await app.goto("/esm-only-exports-pkg", true);
+    expect(res.status()).toBe(200); // server rendered fine
+    // rendered the page instead of the error boundary
+    expect(await app.getHtml("#esm-only-exports-pkg")).toMatchInlineSnapshot(
+      `"<div id=\\"esm-only-exports-pkg\\">esm-only-exports-pkg</div>"`
     );
   });
 });

--- a/packages/remix-dev/compiler/dependencies.ts
+++ b/packages/remix-dev/compiler/dependencies.ts
@@ -36,7 +36,12 @@ function getPackageDependenciesRecursive(
 ): void {
   visitedPackages.add(pkg);
 
-  let pkgJson = require.resolve(`${pkg}/package.json`);
+  let pkgPath = require.resolve(pkg);
+  let lastIndexOfPackageName = pkgPath.lastIndexOf(pkg);
+  if (lastIndexOfPackageName !== -1) {
+    pkgPath = pkgPath.substring(0, lastIndexOfPackageName);
+  }
+  let pkgJson = path.join(pkgPath, "package.json");
   if (!fs.existsSync(pkgJson)) {
     console.log(pkgJson, `does not exist`);
     return;

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -275,7 +275,9 @@ export async function readConfig(
   try {
     appConfig = require(configFile);
   } catch (error) {
-    throw new Error(`Error loading Remix config in ${configFile}`);
+    throw new Error(
+      `Error loading Remix config in ${configFile}\n${String(error)}`
+    );
   }
 
   let customServerEntryPoint = appConfig.server;


### PR DESCRIPTION
feat: surface error message if remix.config fails to load

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [x] Tests
