### PR TITLE
feat(remix-react): Add array-syntax for `meta` export

### DIFF
--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -130,113 +130,113 @@ describe("meta array syntax", () => {
         "app/root.jsx": js`
           import { json, Meta, Links, Outlet, Scripts } from "remix";
 
-          export const loader = async () =>
-            json({
-              description: "This is a meta page",
-              title: "Meta Page",
-            });
+//           export const loader = async () =>
+//             json({
+//               description: "This is a meta page",
+//               title: "Meta Page",
+//             });
 
-          export const meta = ({ data }) => ({
-            charset: "utf-8",
-            description: data.description,
-            "og:image": "https://picsum.photos/200/200",
-            "og:type": data.contentType, // undefined
-            refresh: {
-              httpEquiv: "refresh",
-              content: "3;url=https://www.mozilla.org",
-            },
-            title: data.title,
-          });
+//           export const meta = ({ data }) => ({
+//             charset: "utf-8",
+//             description: data.description,
+//             "og:image": "https://picsum.photos/200/200",
+//             "og:type": data.contentType, // undefined
+//             refresh: {
+//               httpEquiv: "refresh",
+//               content: "3;url=https://www.mozilla.org",
+//             },
+//             title: data.title,
+//           });
 
-          export default function Root() {
-            return (
-              <html lang="en">
-                <head>
-                  <Meta />
-                  <Links />
-                </head>
-                <body>
-                  <Outlet />
-                  <Scripts />
-                </body>
-              </html>
-            );
-          }
-        `,
+//           export default function Root() {
+//             return (
+//               <html lang="en">
+//                 <head>
+//                   <Meta />
+//                   <Links />
+//                 </head>
+//                 <body>
+//                   <Outlet />
+//                   <Scripts />
+//                 </body>
+//               </html>
+//             );
+//           }
+//         `,
 
-        "app/routes/index.jsx": js`
-          export default function Index() {
-            return <div>This is the index file</div>;
-          }
-        `,
-      },
-    });
+//         "app/routes/index.jsx": js`
+//           export default function Index() {
+//             return <div>This is the index file</div>;
+//           }
+//         `,
+//       },
+//     });
 
-    app = await createAppFixture(fixture);
-  });
+//     app = await createAppFixture(fixture);
+//   });
 
-  afterAll(async () => await app.close());
+//   afterAll(async () => await app.close());
 
-  test("empty meta does not render a tag", async () => {
-    let enableJavaScript = await app.disableJavaScript();
+//   test("empty meta does not render a tag", async () => {
+//     let enableJavaScript = await app.disableJavaScript();
 
-    await app.goto("/");
+//     await app.goto("/");
 
-    await expect(app.getHtml('meta[property="og:type"]')).rejects.toThrowError(
-      'No element matches selector "meta[property="og:type"]"'
-    );
-    await enableJavaScript();
-  });
+//     await expect(app.getHtml('meta[property="og:type"]')).rejects.toThrowError(
+//       'No element matches selector "meta[property="og:type"]"'
+//     );
+//     await enableJavaScript();
+//   });
 
-  test("meta { charset } adds a <meta charset='utf-8' />", async () => {
-    let enableJavaScript = await app.disableJavaScript();
+//   test("meta { charset } adds a <meta charset='utf-8' />", async () => {
+//     let enableJavaScript = await app.disableJavaScript();
 
-    await app.goto("/");
+//     await app.goto("/");
 
-    expect(await app.getHtml('meta[charset="utf-8"]')).toBeTruthy();
-    await enableJavaScript();
-  });
+//     expect(await app.getHtml('meta[charset="utf-8"]')).toBeTruthy();
+//     await enableJavaScript();
+//   });
 
-  test("meta { title } adds a <title />", async () => {
-    let enableJavaScript = await app.disableJavaScript();
+//   test("meta { title } adds a <title />", async () => {
+//     let enableJavaScript = await app.disableJavaScript();
 
-    await app.goto("/");
+//     await app.goto("/");
 
-    expect(await app.getHtml("title")).toBeTruthy();
-    await enableJavaScript();
-  });
+//     expect(await app.getHtml("title")).toBeTruthy();
+//     await enableJavaScript();
+//   });
 
-  test("meta { 'og:*' } adds a <meta property='og:*' />", async () => {
-    let enableJavaScript = await app.disableJavaScript();
+//   test("meta { 'og:*' } adds a <meta property='og:*' />", async () => {
+//     let enableJavaScript = await app.disableJavaScript();
 
-    await app.goto("/");
+//     await app.goto("/");
 
-    expect(await app.getHtml('meta[property="og:image"]')).toBeTruthy();
-    await enableJavaScript();
-  });
+//     expect(await app.getHtml('meta[property="og:image"]')).toBeTruthy();
+//     await enableJavaScript();
+//   });
 
-  test("meta { description } adds a <meta name='description' />", async () => {
-    let enableJavaScript = await app.disableJavaScript();
+//   test("meta { description } adds a <meta name='description' />", async () => {
+//     let enableJavaScript = await app.disableJavaScript();
 
-    await app.goto("/");
+//     await app.goto("/");
 
-    expect(await app.getHtml('meta[name="description"]')).toBeTruthy();
-    await enableJavaScript();
-  });
+//     expect(await app.getHtml('meta[name="description"]')).toBeTruthy();
+//     await enableJavaScript();
+//   });
 
-  test("meta { refresh } adds a <meta http-equiv='refresh' content='3;url=https://www.mozilla.org' />", async () => {
-    let enableJavaScript = await app.disableJavaScript();
+//   test("meta { refresh } adds a <meta http-equiv='refresh' content='3;url=https://www.mozilla.org' />", async () => {
+//     let enableJavaScript = await app.disableJavaScript();
 
-    await app.goto("/");
+//     await app.goto("/");
 
-    expect(
-      await app.getHtml(
-        'meta[http-equiv="refresh"][content="3;url=https://www.mozilla.org"]'
-      )
-    ).toBeTruthy();
-    await enableJavaScript();
-  });
-});
+//     expect(
+//       await app.getHtml(
+//         'meta[http-equiv="refresh"][content="3;url=https://www.mozilla.org"]'
+//       )
+//     ).toBeTruthy();
+//     await enableJavaScript();
+//   });
+// });
 
 describe("meta array-syntax", () => {
   let fixture: Fixture;

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -136,14 +136,17 @@ describe("meta array syntax", () => {
               title: "Meta Page",
             });
 
-          export const meta = ({ data }) => [
-            { charset: "utf-8" },
-            { description: data.description },
-            { "og:image": "https://picsum.photos/200/200" },
-            { "og:type": data.contentType }, // undefined
-            { httpEquiv: "refresh", content: "3;url=https://www.mozilla.org" },
-            { title: data.title },
-          ];
+          export const meta = ({ data }) => ({
+            charset: "utf-8",
+            description: data.description,
+            "og:image": "https://picsum.photos/200/200",
+            "og:type": data.contentType, // undefined
+            refresh: {
+              httpEquiv: "refresh",
+              content: "3;url=https://www.mozilla.org",
+            },
+            title: data.title,
+          });
 
           export default function Root() {
             return (

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -256,9 +256,9 @@ describe("meta array-syntax", () => {
 
           export const meta = ({ data }) => [
             { charset: "utf-8" },
-            { description: data.description },
-            { "og:image": "https://picsum.photos/200/200" },
-            { "og:type": data.contentType }, // undefined
+            { name: "description", content: "data.description" },
+            { property: "og:image", content: "https://picsum.photos/200/200" },
+            { property: "og:type", content: data.contentType }, // undefined
             { httpEquiv: "refresh", content: "3;url=https://www.mozilla.org" },
             { title: data.title },
           ];

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -237,3 +237,118 @@ describe("meta array syntax", () => {
     await enableJavaScript();
   });
 });
+
+describe("meta array-syntax", () => {
+  let fixture: Fixture;
+  let app: AppFixture;
+
+  beforeAll(async () => {
+    fixture = await createFixture({
+      files: {
+        "app/root.jsx": js`
+          import { json, Meta, Links, Outlet, Scripts } from "remix";
+
+          export const loader = async () =>
+            json({
+              description: "This is a meta page",
+              title: "Meta Page",
+            });
+
+          export const meta = ({ data }) => [
+            { charset: "utf-8" },
+            { description: data.description },
+            { "og:image": "https://picsum.photos/200/200" },
+            { "og:type": data.contentType }, // undefined
+            { httpEquiv: "refresh", content: "3;url=https://www.mozilla.org" },
+            { title: data.title },
+          ];
+
+          export default function Root() {
+            return (
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
+                <body>
+                  <Outlet />
+                  <Scripts />
+                </body>
+              </html>
+            );
+          }
+        `,
+
+        "app/routes/index.jsx": js`
+          export default function Index() {
+            return <div>This is the index file</div>;
+          }
+        `,
+      },
+    });
+
+    app = await createAppFixture(fixture);
+  });
+
+  afterAll(async () => await app.close());
+
+  test("empty meta does not render a tag", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    await expect(app.getHtml('meta[property="og:type"]')).rejects.toThrowError(
+      'No element matches selector "meta[property="og:type"]"'
+    );
+    await enableJavaScript();
+  });
+
+  test("meta { charset } adds a <meta charset='utf-8' />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    expect(await app.getHtml('meta[charset="utf-8"]')).toBeTruthy();
+    await enableJavaScript();
+  });
+
+  test("meta { title } adds a <title />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    expect(await app.getHtml("title")).toBeTruthy();
+    await enableJavaScript();
+  });
+
+  test("meta { 'og:*' } adds a <meta property='og:*' />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    expect(await app.getHtml('meta[property="og:image"]')).toBeTruthy();
+    await enableJavaScript();
+  });
+
+  test("meta { description } adds a <meta name='description' />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    expect(await app.getHtml('meta[name="description"]')).toBeTruthy();
+    await enableJavaScript();
+  });
+
+  test("meta { refresh } adds a <meta http-equiv='refresh' content='3;url=https://www.mozilla.org' />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    expect(
+      await app.getHtml(
+        'meta[http-equiv="refresh"][content="3;url=https://www.mozilla.org"]'
+      )
+    ).toBeTruthy();
+    await enableJavaScript();
+  });
+});

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -119,3 +119,118 @@ test.describe("meta", () => {
     ).toBeTruthy();
   });
 });
+
+describe("meta array syntax", () => {
+  let fixture: Fixture;
+  let app: AppFixture;
+
+  beforeAll(async () => {
+    fixture = await createFixture({
+      files: {
+        "app/root.jsx": js`
+          import { json, Meta, Links, Outlet, Scripts } from "remix";
+
+          export const loader = async () =>
+            json({
+              description: "This is a meta page",
+              title: "Meta Page",
+            });
+
+          export const meta = ({ data }) => [
+            { charset: "utf-8" },
+            { description: data.description },
+            { "og:image": "https://picsum.photos/200/200" },
+            { "og:type": data.contentType }, // undefined
+            { httpEquiv: "refresh", content: "3;url=https://www.mozilla.org" },
+            { title: data.title },
+          ];
+
+          export default function Root() {
+            return (
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
+                <body>
+                  <Outlet />
+                  <Scripts />
+                </body>
+              </html>
+            );
+          }
+        `,
+
+        "app/routes/index.jsx": js`
+          export default function Index() {
+            return <div>This is the index file</div>;
+          }
+        `,
+      },
+    });
+
+    app = await createAppFixture(fixture);
+  });
+
+  afterAll(async () => await app.close());
+
+  test("empty meta does not render a tag", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    await expect(app.getHtml('meta[property="og:type"]')).rejects.toThrowError(
+      'No element matches selector "meta[property="og:type"]"'
+    );
+    await enableJavaScript();
+  });
+
+  test("meta { charset } adds a <meta charset='utf-8' />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    expect(await app.getHtml('meta[charset="utf-8"]')).toBeTruthy();
+    await enableJavaScript();
+  });
+
+  test("meta { title } adds a <title />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    expect(await app.getHtml("title")).toBeTruthy();
+    await enableJavaScript();
+  });
+
+  test("meta { 'og:*' } adds a <meta property='og:*' />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    expect(await app.getHtml('meta[property="og:image"]')).toBeTruthy();
+    await enableJavaScript();
+  });
+
+  test("meta { description } adds a <meta name='description' />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    expect(await app.getHtml('meta[name="description"]')).toBeTruthy();
+    await enableJavaScript();
+  });
+
+  test("meta { refresh } adds a <meta http-equiv='refresh' content='3;url=https://www.mozilla.org' />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    expect(
+      await app.getHtml(
+        'meta[http-equiv="refresh"][content="3;url=https://www.mozilla.org"]'
+      )
+    ).toBeTruthy();
+    await enableJavaScript();
+  });
+});

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -266,14 +266,7 @@ describe("meta array-syntax", () => {
           export default function Root() {
             return (
               <html lang="en">
-                <head>
-                  <Meta />
-                  <Links />
-                </head>
-                <body>
-                  <Outlet />
-                  <Scripts />
-                </body>
+              <Meta />
               </html>
             );
           }
@@ -296,59 +289,60 @@ describe("meta array-syntax", () => {
     let enableJavaScript = await app.disableJavaScript();
 
     await app.goto("/");
-
+    let html = await app.getHtml("html");
+    console.log(html);
     await expect(app.getHtml('meta[property="og:type"]')).rejects.toThrowError(
       'No element matches selector "meta[property="og:type"]"'
     );
     await enableJavaScript();
   });
 
-  test("meta { charset } adds a <meta charset='utf-8' />", async () => {
-    let enableJavaScript = await app.disableJavaScript();
+  // test("meta { charset } adds a <meta charset='utf-8' />", async () => {
+  //   let enableJavaScript = await app.disableJavaScript();
 
-    await app.goto("/");
+  //   await app.goto("/");
 
-    expect(await app.getHtml('meta[charset="utf-8"]')).toBeTruthy();
-    await enableJavaScript();
-  });
+  //   expect(await app.getHtml('meta[charset="utf-8"]')).toBeTruthy();
+  //   await enableJavaScript();
+  // });
 
-  test("meta { title } adds a <title />", async () => {
-    let enableJavaScript = await app.disableJavaScript();
+  // test("meta { title } adds a <title />", async () => {
+  //   let enableJavaScript = await app.disableJavaScript();
 
-    await app.goto("/");
+  //   await app.goto("/");
 
-    expect(await app.getHtml("title")).toBeTruthy();
-    await enableJavaScript();
-  });
+  //   expect(await app.getHtml("title")).toBeTruthy();
+  //   await enableJavaScript();
+  // });
 
-  test("meta { 'og:*' } adds a <meta property='og:*' />", async () => {
-    let enableJavaScript = await app.disableJavaScript();
+  // test("meta { 'og:*' } adds a <meta property='og:*' />", async () => {
+  //   let enableJavaScript = await app.disableJavaScript();
 
-    await app.goto("/");
+  //   await app.goto("/");
 
-    expect(await app.getHtml('meta[property="og:image"]')).toBeTruthy();
-    await enableJavaScript();
-  });
+  //   expect(await app.getHtml('meta[property="og:image"]')).toBeTruthy();
+  //   await enableJavaScript();
+  // });
 
-  test("meta { description } adds a <meta name='description' />", async () => {
-    let enableJavaScript = await app.disableJavaScript();
+  // test("meta { description } adds a <meta name='description' />", async () => {
+  //   let enableJavaScript = await app.disableJavaScript();
 
-    await app.goto("/");
+  //   await app.goto("/");
 
-    expect(await app.getHtml('meta[name="description"]')).toBeTruthy();
-    await enableJavaScript();
-  });
+  //   expect(await app.getHtml('meta[name="description"]')).toBeTruthy();
+  //   await enableJavaScript();
+  // });
 
-  test("meta { refresh } adds a <meta http-equiv='refresh' content='3;url=https://www.mozilla.org' />", async () => {
-    let enableJavaScript = await app.disableJavaScript();
+  // test("meta { refresh } adds a <meta http-equiv='refresh' content='3;url=https://www.mozilla.org' />", async () => {
+  //   let enableJavaScript = await app.disableJavaScript();
 
-    await app.goto("/");
+  //   await app.goto("/");
 
-    expect(
-      await app.getHtml(
-        'meta[http-equiv="refresh"][content="3;url=https://www.mozilla.org"]'
-      )
-    ).toBeTruthy();
-    await enableJavaScript();
-  });
+  //   expect(
+  //     await app.getHtml(
+  //       'meta[http-equiv="refresh"][content="3;url=https://www.mozilla.org"]'
+  //     )
+  //   ).toBeTruthy();
+  //   await enableJavaScript();
+  // });
 });

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -266,7 +266,9 @@ describe("meta array-syntax", () => {
           export default function Root() {
             return (
               <html lang="en">
+              <head>
               <Meta />
+              </head>
               </html>
             );
           }
@@ -289,8 +291,8 @@ describe("meta array-syntax", () => {
     let enableJavaScript = await app.disableJavaScript();
 
     await app.goto("/");
-    let html = await app.getHtml("html");
-    console.log(html);
+    let head = await app.getHtml("head");
+    console.log(head);
     await expect(app.getHtml('meta[property="og:type"]')).rejects.toThrowError(
       'No element matches selector "meta[property="og:type"]"'
     );

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -18,7 +18,7 @@ test.describe("meta", () => {
       files: {
         "app/root.jsx": js`
           import { json } from "@remix-run/node";
-          import { Meta, Links, Outlet, Scripts } from "@remix-run/react";
+          import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
 
           export const loader = async () =>
             json({
@@ -31,10 +31,6 @@ test.describe("meta", () => {
             description: data.description,
             "og:image": "https://picsum.photos/200/200",
             "og:type": data.contentType, // undefined
-            refresh: {
-              httpEquiv: "refresh",
-              content: "3;url=https://www.mozilla.org",
-            },
             title: data.title,
           });
 
@@ -128,125 +124,8 @@ describe("meta array syntax", () => {
     fixture = await createFixture({
       files: {
         "app/root.jsx": js`
-          import { json, Meta, Links, Outlet, Scripts } from "remix";
-
-//           export const loader = async () =>
-//             json({
-//               description: "This is a meta page",
-//               title: "Meta Page",
-//             });
-
-//           export const meta = ({ data }) => ({
-//             charset: "utf-8",
-//             description: data.description,
-//             "og:image": "https://picsum.photos/200/200",
-//             "og:type": data.contentType, // undefined
-//             refresh: {
-//               httpEquiv: "refresh",
-//               content: "3;url=https://www.mozilla.org",
-//             },
-//             title: data.title,
-//           });
-
-//           export default function Root() {
-//             return (
-//               <html lang="en">
-//                 <head>
-//                   <Meta />
-//                   <Links />
-//                 </head>
-//                 <body>
-//                   <Outlet />
-//                   <Scripts />
-//                 </body>
-//               </html>
-//             );
-//           }
-//         `,
-
-//         "app/routes/index.jsx": js`
-//           export default function Index() {
-//             return <div>This is the index file</div>;
-//           }
-//         `,
-//       },
-//     });
-
-//     app = await createAppFixture(fixture);
-//   });
-
-//   afterAll(async () => await app.close());
-
-//   test("empty meta does not render a tag", async () => {
-//     let enableJavaScript = await app.disableJavaScript();
-
-//     await app.goto("/");
-
-//     await expect(app.getHtml('meta[property="og:type"]')).rejects.toThrowError(
-//       'No element matches selector "meta[property="og:type"]"'
-//     );
-//     await enableJavaScript();
-//   });
-
-//   test("meta { charset } adds a <meta charset='utf-8' />", async () => {
-//     let enableJavaScript = await app.disableJavaScript();
-
-//     await app.goto("/");
-
-//     expect(await app.getHtml('meta[charset="utf-8"]')).toBeTruthy();
-//     await enableJavaScript();
-//   });
-
-//   test("meta { title } adds a <title />", async () => {
-//     let enableJavaScript = await app.disableJavaScript();
-
-//     await app.goto("/");
-
-//     expect(await app.getHtml("title")).toBeTruthy();
-//     await enableJavaScript();
-//   });
-
-//   test("meta { 'og:*' } adds a <meta property='og:*' />", async () => {
-//     let enableJavaScript = await app.disableJavaScript();
-
-//     await app.goto("/");
-
-//     expect(await app.getHtml('meta[property="og:image"]')).toBeTruthy();
-//     await enableJavaScript();
-//   });
-
-//   test("meta { description } adds a <meta name='description' />", async () => {
-//     let enableJavaScript = await app.disableJavaScript();
-
-//     await app.goto("/");
-
-//     expect(await app.getHtml('meta[name="description"]')).toBeTruthy();
-//     await enableJavaScript();
-//   });
-
-//   test("meta { refresh } adds a <meta http-equiv='refresh' content='3;url=https://www.mozilla.org' />", async () => {
-//     let enableJavaScript = await app.disableJavaScript();
-
-//     await app.goto("/");
-
-//     expect(
-//       await app.getHtml(
-//         'meta[http-equiv="refresh"][content="3;url=https://www.mozilla.org"]'
-//       )
-//     ).toBeTruthy();
-//     await enableJavaScript();
-//   });
-// });
-
-describe("meta array-syntax", () => {
-  let fixture: Fixture;
-  let app: AppFixture;
-
-  beforeAll(async () => {
-    fixture = await createFixture({
-      files: {
-        "app/root.jsx": js`
-          import { json, Meta, Links, Outlet, Scripts } from "remix";
+          import { json } from "@remix-run/node";
+          import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
 
           export const loader = async () =>
             json({
@@ -259,22 +138,32 @@ describe("meta array-syntax", () => {
             { name: "description", content: data.description },
             { property: "og:image", content: "https://picsum.photos/200/200" },
             { property: "og:type", content: data.contentType }, // undefined
-            { key: "http-equiv:refresh", httpEquiv: "refresh", content: "3;url=https://www.mozilla.org" },
-            { key: "title", content: data.title },
+            { key: "httpEquiv:refresh", httpEquiv: "refresh", content: "3;url=https://www.mozilla.org" },
+            { title: data.title },
+            { name: "viewport", content: "width=device-width, initial-scale=1" },
           ];
 
           export default function Root() {
             return (
               <html lang="en">
-              <head>
-              <Meta />
-              </head>
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
+                <body>
+                  <Outlet />
+                  <Scripts />
+                </body>
               </html>
             );
           }
         `,
 
         "app/routes/index.jsx": js`
+          export const meta = ({ data }) => [
+            { title: 'Override Title' },
+          ];
+
           export default function Index() {
             return <div>This is the index file</div>;
           }
@@ -291,60 +180,68 @@ describe("meta array-syntax", () => {
     let enableJavaScript = await app.disableJavaScript();
 
     await app.goto("/");
-    let head = await app.getHtml("head");
-    console.log(head);
+
     await expect(app.getHtml('meta[property="og:type"]')).rejects.toThrowError(
       'No element matches selector "meta[property="og:type"]"'
     );
     await enableJavaScript();
   });
 
-  // test("meta { charset } adds a <meta charset='utf-8' />", async () => {
-  //   let enableJavaScript = await app.disableJavaScript();
+  test("meta { charset } adds a <meta charset='utf-8' />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
 
-  //   await app.goto("/");
+    await app.goto("/");
 
-  //   expect(await app.getHtml('meta[charset="utf-8"]')).toBeTruthy();
-  //   await enableJavaScript();
-  // });
+    expect(await app.getHtml('meta[charset="utf-8"]')).toBeTruthy();
+    await enableJavaScript();
+  });
 
-  // test("meta { title } adds a <title />", async () => {
-  //   let enableJavaScript = await app.disableJavaScript();
+  test("meta { title } adds a <title />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
 
-  //   await app.goto("/");
+    await app.goto("/");
 
-  //   expect(await app.getHtml("title")).toBeTruthy();
-  //   await enableJavaScript();
-  // });
+    expect(await app.getHtml("title")).toBeTruthy();
+    await enableJavaScript();
+  });
 
-  // test("meta { 'og:*' } adds a <meta property='og:*' />", async () => {
-  //   let enableJavaScript = await app.disableJavaScript();
+  test("meta { title } overrides a <title />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
 
-  //   await app.goto("/");
+    await app.goto("/");
 
-  //   expect(await app.getHtml('meta[property="og:image"]')).toBeTruthy();
-  //   await enableJavaScript();
-  // });
+    expect(await app.getHtml("title")).toBe("<title>Override Title</title>");
+    await enableJavaScript();
+  });
 
-  // test("meta { description } adds a <meta name='description' />", async () => {
-  //   let enableJavaScript = await app.disableJavaScript();
+  test("meta { 'og:*' } adds a <meta property='og:*' />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
 
-  //   await app.goto("/");
+    await app.goto("/");
 
-  //   expect(await app.getHtml('meta[name="description"]')).toBeTruthy();
-  //   await enableJavaScript();
-  // });
+    expect(await app.getHtml('meta[property="og:image"]')).toBeTruthy();
+    await enableJavaScript();
+  });
 
-  // test("meta { refresh } adds a <meta http-equiv='refresh' content='3;url=https://www.mozilla.org' />", async () => {
-  //   let enableJavaScript = await app.disableJavaScript();
+  test("meta { description } adds a <meta name='description' />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
 
-  //   await app.goto("/");
+    await app.goto("/");
 
-  //   expect(
-  //     await app.getHtml(
-  //       'meta[http-equiv="refresh"][content="3;url=https://www.mozilla.org"]'
-  //     )
-  //   ).toBeTruthy();
-  //   await enableJavaScript();
-  // });
+    expect(await app.getHtml('meta[name="description"]')).toBeTruthy();
+    await enableJavaScript();
+  });
+
+  test("meta { refresh } adds a <meta http-equiv='refresh' content='3;url=https://www.mozilla.org' />", async () => {
+    let enableJavaScript = await app.disableJavaScript();
+
+    await app.goto("/");
+
+    expect(
+      await app.getHtml(
+        'meta[http-equiv="refresh"][content="3;url=https://www.mozilla.org"]'
+      )
+    ).toBeTruthy();
+    await enableJavaScript();
+  });
 });

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -3,7 +3,6 @@ import { test, expect } from "@playwright/test";
 import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
 import type { Fixture, AppFixture } from "./helpers/create-fixture";
 import { PlaywrightFixture } from "./helpers/playwright-fixture";
-import { compareDocumentPosition } from "domutils";
 
 test.describe("meta", () => {
   let fixture: Fixture;

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -255,12 +255,12 @@ describe("meta array-syntax", () => {
             });
 
           export const meta = ({ data }) => [
-            { charset: "utf-8" },
-            { name: "description", content: "data.description" },
+            { key: "charset", content: "utf-8" },
+            { name: "description", content: data.description },
             { property: "og:image", content: "https://picsum.photos/200/200" },
             { property: "og:type", content: data.contentType }, // undefined
-            { httpEquiv: "refresh", content: "3;url=https://www.mozilla.org" },
-            { title: data.title },
+            { key: "http-equiv:refresh", httpEquiv: "refresh", content: "3;url=https://www.mozilla.org" },
+            { key: "title", content: data.title },
           ];
 
           export default function Root() {

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -141,12 +141,18 @@ test.describe("meta array syntax", () => {
             json({
               description: "This is a meta page",
               title: "Meta Page",
+              contentType: undefined,
             });
 
           export const meta = ({ data }) => [
             { key: "charset", content: "utf-8" },
             { name: "description", content: data.description },
+            { property: "og:image", content: "https://picsum.photos/300/300" },
+            { property: "og:image:width", content: "300" },
+            { property: "og:image:height", content: "300" },
             { property: "og:image", content: "https://picsum.photos/200/200" },
+            { property: "og:image", content: "https://picsum.photos/500/1000" },
+            { property: "og:image:height", content: "1000" },
             { property: "og:type", content: data.contentType }, // undefined
             { key: "httpEquiv:refresh", httpEquiv: "refresh", content: "3;url=https://www.mozilla.org" },
             { title: data.title },

--- a/packages/remix-react/__tests__/meta-test.tsx
+++ b/packages/remix-react/__tests__/meta-test.tsx
@@ -1,8 +1,10 @@
 import React from "react";
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { renderToString } from "react-dom/server";
 import "@testing-library/jest-dom/extend-expect";
+
 import { processMeta } from "../components";
 import type { HtmlMetaDescriptor, MetaFunction } from "../routeModules";
-import { renderToString } from "react-dom/server";
 
 describe("meta", () => {
   it(`renders proper <meta> tags`, () => {

--- a/packages/remix-react/__tests__/meta-test.tsx
+++ b/packages/remix-react/__tests__/meta-test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/extend-expect";
 import { processMeta } from "../components";
-import { HtmlMetaDescriptor, MetaFunction } from "../routeModules";
+import type { HtmlMetaDescriptor, MetaFunction } from "../routeModules";
 
 describe("meta", () => {
   it(`renders proper <meta> tags`, () => {
@@ -31,7 +31,7 @@ describe("meta", () => {
       ];
     }
 
-    const result = getMeta(
+    let result = getMeta(
       {
         title: "test title",
         description: "test description",
@@ -65,6 +65,7 @@ function getMeta(data: any, metaFunctions: MetaFunction[]) {
   return meta;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function renderMeta(meta: HtmlMetaDescriptor[]) {
   return meta.map((metaDescriptor) => {
     return `<meta ${Object.keys(metaDescriptor)

--- a/packages/remix-react/__tests__/meta-test.tsx
+++ b/packages/remix-react/__tests__/meta-test.tsx
@@ -46,9 +46,9 @@ describe("meta", () => {
     // console.log(html);
 
     // title should override the title from the first meta function
-    expect(map.get("title").content).toBe("Updated title");
+    expect(map.get("title")!.content).toBe("Updated title");
     // viewport should be added
-    expect(map.get("viewport").content).toBe(
+    expect(map.get("viewport")!.content).toBe(
       "width=device-width, initial-scale=1"
     );
   });
@@ -63,11 +63,11 @@ function getMeta(data: any, metaFunctions: MetaFunction[]) {
       data,
       parentsData: {},
       params: {},
+      // @ts-expect-error
       location: null,
     });
     if (routeMeta) {
       processMeta(meta, routeMeta);
-      //console.log(meta, routeMeta);
     }
   });
 

--- a/packages/remix-react/__tests__/meta-test.tsx
+++ b/packages/remix-react/__tests__/meta-test.tsx
@@ -3,7 +3,7 @@ import { processMeta } from "../components";
 import { HtmlMetaDescriptor, MetaFunction } from "../routeModules";
 
 describe("meta", () => {
-  it.only(`renders proper <meta> tags`, () => {
+  it(`renders proper <meta> tags`, () => {
     function meta({ data }): HtmlMetaDescriptor {
       return {
         charset: "utf-8",

--- a/packages/remix-react/__tests__/meta-test.tsx
+++ b/packages/remix-react/__tests__/meta-test.tsx
@@ -1,0 +1,74 @@
+import "@testing-library/jest-dom/extend-expect";
+import { processMeta } from "../components";
+import { HtmlMetaDescriptor, MetaFunction } from "../routeModules";
+
+describe("meta", () => {
+  it.only(`renders proper <meta> tags`, () => {
+    function meta({ data }): HtmlMetaDescriptor {
+      return {
+        charset: "utf-8",
+        description: data.description,
+        "og:image": "https://picsum.photos/200/200",
+        "og:type": data.contentType, // undefined
+        refresh: {
+          httpEquiv: "refresh",
+          content: "3;url=https://www.mozilla.org",
+        },
+        title: data.title,
+      };
+    }
+    function meta2({ data }): HtmlMetaDescriptor[] {
+      return [
+        { name: "description", content: "override description" },
+        { property: "og:image", content: "https://remix.run/logo.png" },
+        { property: "og:type", content: "image/png" },
+        {
+          httpEquiv: "refresh",
+          content: "5;url=https://google.com",
+        },
+        { title: "Updated title" },
+        { name: "viewport", content: "width=device-width, initial-scale=1" },
+      ];
+    }
+
+    const result = getMeta(
+      {
+        title: "test title",
+        description: "test description",
+      },
+      [meta, meta2]
+    );
+
+    // title should override the title from the first meta function
+    let titleMeta = result.find((meta) => meta.hasOwnProperty("title"));
+    expect(titleMeta["title"]).toBe("Updated title");
+    // viewport should be added
+    let viewportMeta = result.find((meta) => meta["name"] === "viewport");
+    expect(viewportMeta["content"]).toBe("width=device-width, initial-scale=1");
+  });
+});
+
+function getMeta(data: any, metaFunctions: MetaFunction[]) {
+  let meta: HtmlMetaDescriptor[] = [];
+  metaFunctions.forEach((metaFunction) => {
+    let routeMeta = metaFunction({
+      data,
+      parentsData: {},
+      params: {},
+      location: null,
+    });
+    if (routeMeta) {
+      meta = processMeta(meta, routeMeta);
+    }
+  });
+
+  return meta;
+}
+
+function renderMeta(meta: HtmlMetaDescriptor[]) {
+  return meta.map((metaDescriptor) => {
+    return `<meta ${Object.keys(metaDescriptor)
+      .map((key) => `${key}="${metaDescriptor[key]}"`)
+      .join(" ")} />`;
+  });
+}

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -56,7 +56,6 @@ import type {
   Fetcher,
   Submission,
 } from "./transition";
-import { keyBy } from "lodash";
 
 ////////////////////////////////////////////////////////////////////////////////
 // RemixEntry

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -713,7 +713,7 @@ export function Meta() {
           ? routeModule.meta({ data, parentsData, params, location })
           : routeModule.meta;
       if (routeMeta) {
-        processMeta(meta, routeMeta);
+        meta = processMeta(meta, routeMeta);
       }
     }
 

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -56,6 +56,7 @@ import type {
   Fetcher,
   Submission,
 } from "./transition";
+import { keyBy } from "lodash";
 
 ////////////////////////////////////////////////////////////////////////////////
 // RemixEntry

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -770,7 +770,9 @@ export function processMeta(
   routeMeta: HtmlMetaDescriptor | HtmlMetaDescriptor[]
 ) {
   let items: HtmlMetaDescriptor[] = Array.isArray(routeMeta)
-    ? routeMeta
+    ? routeMeta.map((item) =>
+        item.title ? { key: "title", content: item.title } : item
+      )
     : Object.entries(routeMeta)
         .map(([key, value]) => {
           if (!value) return [];

--- a/packages/remix-react/routeModules.ts
+++ b/packages/remix-react/routeModules.ts
@@ -70,17 +70,13 @@ export interface MetaFunction {
  * tag, or an array of strings that will render multiple tags with the same
  * `name` attribute.
  */
-export interface HtmlMetaDescriptor {
-  charset?: "utf-8";
-  charSet?: "utf-8";
+export type HtmlMetaDescriptor = {
+  key?: string;
+  name?: string;
+  property?: string;
   title?: string;
-  [name: string]:
-    | null
-    | string
-    | undefined
-    | Record<string, string>
-    | Array<Record<string, string> | string>;
-}
+  content?: string;
+} & Record<string, string | string[] | null | undefined>;
 
 /**
  * During client side transitions Remix will optimize reloading of routes that

--- a/packages/remix-react/routeModules.ts
+++ b/packages/remix-react/routeModules.ts
@@ -61,7 +61,7 @@ export interface MetaFunction {
     parentsData: RouteData;
     params: Params;
     location: Location;
-  }): HtmlMetaDescriptor | undefined;
+  }): HtmlMetaDescriptor | HtmlMetaDescriptor[] | undefined;
 }
 
 /**

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -142,7 +142,7 @@ export interface MetaFunction<
     } & RouteData;
     params: Params;
     location: Location;
-  }): HtmlMetaDescriptor;
+  }): HtmlMetaDescriptor | HtmlMetaDescriptor[];
 }
 
 /**


### PR DESCRIPTION
This PR adds array-syntax to the `meta` export.

```ts
export const meta: MetaFunction = ({data}) => [
  { name: "description", content: data.description },
  { property: "og:image", content: "https://remix.run/logo.png" },
  { property: "og:type", content: "image/png" },
  { key: "http-equiv:refresh", httpEquiv: "refresh", content: "5;url=https://google.com" },
  { title: data.title },
  { name: "viewport", content: "width=device-width, initial-scale=1" },
];
```
