### PR TITLE
docs(examples): run `replace-remix-imports` migration on `turborepo-vercel` example

### DIFF
--- a/examples/turborepo-vercel/apps/remix-app/package.json
+++ b/examples/turborepo-vercel/apps/remix-app/package.json
@@ -6,16 +6,15 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build && rollup -c",
-    "dev": "remix dev",
-    "postinstall": "remix setup node"
+    "dev": "remix dev"
   },
   "dependencies": {
+    "@remix-run/node": "1.2.3",
     "@remix-run/react": "1.2.3",
     "@remix-run/serve": "1.2.3",
     "@remix-run/vercel": "1.2.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "1.2.3",
     "ui": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
Seems like this was missed in #2585 🙈