### PR TITLE
feat(remix-dev): improve types for imported MD & MDX files

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -191,6 +191,7 @@
 - luk-str
 - lukahartwig
 - lukasgerm
+- lukeshiru
 - m0nica
 - m5r
 - machour

--- a/packages/remix-dev/modules.ts
+++ b/packages/remix-dev/modules.ts
@@ -27,17 +27,29 @@ declare module "*.jpg" {
   export default asset;
 }
 declare module "*.md" {
-  import type { ComponentType as MdComponentType } from "react";
+  import type { ComponentType, ReactHTML } from "react";
   export let attributes: any;
   export let filename: string;
-  let Component: MdComponentType;
+  let Component: ComponentType<
+    Readonly<Record<string, unknown>> & {
+      components?: Readonly<
+        Record<keyof ReactHTML | "wrapper", keyof ReactHTML | ComponentType>
+      >;
+    }
+  >;
   export default Component;
 }
 declare module "*.mdx" {
-  import type { ComponentType as MdxComponentType } from "react";
+  import type { ComponentType, ReactHTML } from "react";
   export let attributes: any;
   export let filename: string;
-  let Component: MdxComponentType;
+  let Component: ComponentType<
+    Readonly<Record<string, unknown>> & {
+      components?: Readonly<
+        Record<keyof ReactHTML | "wrapper", keyof ReactHTML | ComponentType>
+      >;
+    }
+  >;
   export default Component;
 }
 declare module "*.mp3" {

--- a/packages/remix-dev/modules.ts
+++ b/packages/remix-dev/modules.ts
@@ -33,7 +33,9 @@ declare module "*.md" {
   let Component: ComponentType<
     Readonly<Record<string, unknown>> & {
       components?: Readonly<
-        Record<keyof ReactHTML | "wrapper", keyof ReactHTML | ComponentType>
+        Partial<
+          Record<keyof ReactHTML | "wrapper", keyof ReactHTML | ComponentType>
+        >
       >;
     }
   >;
@@ -46,7 +48,9 @@ declare module "*.mdx" {
   let Component: ComponentType<
     Readonly<Record<string, unknown>> & {
       components?: Readonly<
-        Record<keyof ReactHTML | "wrapper", keyof ReactHTML | ComponentType>
+        Partial<
+          Record<keyof ReactHTML | "wrapper", keyof ReactHTML | ComponentType>
+        >
       >;
     }
   >;


### PR DESCRIPTION
This MR changes the type of imported Markdown or MDX files so we get type check and auto-completion for the `components` property of [@mdx-js/mdx](https://npm.im/@mdx-js/mdx). This way if users want to customize classNames or whatever in their imported Markdown or MDX, they can:

```tsx
import Example from "./example.md";
import { Link } from "remix";

// ...

<Example components={{ a: Link }}/>
```

You can also pass a `wrapper` component to wrap the entire imported Markdown or MDX, and also pass extra properties that will be passed to said wrapper:

```tsx
import Example from "./example.md";
import { Link } from "remix";
import { FancyWrapper } from "../components/FancyWrapper";

// ...

<Example components={{ a: Link, wrapper: FancyWrapper }} theme="dark" />
```

Currently both snippets above give an error in TS of `components` not being a property of `Example`, when in reality it is. 

IDK if this is a "significant" change, so let me know if it is and I can move it to "ideas" first and then move this further.