### PR TITLE
docs(jokes): fix LiveReload import

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -154,6 +154,7 @@
 - kgregory
 - kimdontdoit
 - klauspaiva
+- kleinfreund
 - knowler
 - kubaprzetakiewicz
 - kuldar

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -192,7 +192,7 @@ We're going to trim this down the bare bones and introduce things incrementally.
 💿 Replace the contents of `app/root.tsx` with this:
 
 ```tsx filename=app/root.tsx
-import { LiveReload } from "remix";
+import { LiveReload } from "@remix-run/react";
 
 export default function App() {
   return (


### PR DESCRIPTION
Fixes the LiveReload import using the package `remix` instead of `@remix-run/react`. The former isn’t installed in the recommended `create-remix@latest` project and causes the subsequent `npm run dev` step to fail.