### PR TITLE
Docs: replace `remix` imports (#2596)

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -5,7 +5,7 @@ order: 1
 
 # Conventions
 
-A lot of Remix APIs aren't imported from the `"remix"` package, but are instead conventions and exports from _your_ application modules. When you `import from "remix"`, _you are calling Remix_, but these APIs are when _Remix calls your code_.
+A lot of Remix APIs aren't imported from the `"@remix-run/*"` packages, but are instead conventions and exports from _your_ application modules. When you `import from "@remix-run/*"`, _you are calling Remix_, but these APIs are when _Remix calls your code_.
 
 ## remix.config.js
 
@@ -259,8 +259,11 @@ For example: `app/routes/blog/$postId.tsx` will match the following URLs:
 On each of these pages, the dynamic segment of the URL path is the value of the parameter. There can be multiple parameters active at any time (as in `/dashboard/:client/invoices/:invoiceId` [view example app](https://github.com/remix-run/remix/tree/main/examples/multiple-params)) and all parameters can be accessed within components via [`useParams`](https://reactrouter.com/docs/en/v6/api#useparams) and within loaders/actions via the argument's [`params`](#loader-params) property:
 
 ```tsx filename=app/routes/blog/$postId.tsx
-import { useParams } from "remix";
-import type { LoaderFunction, ActionFunction } from "remix";
+import { useParams } from "@remix-run/react";
+import type {
+  LoaderFunction,
+  ActionFunction,
+} from "@remix-run/node";
 
 export const loader: LoaderFunction = async ({
   params,
@@ -419,8 +422,11 @@ Files that are named `$.tsx` are called "splat" (or "catch-all") routes. These r
 Similar to dynamic route parameters, you can access the value of the matched path on the splat route's `params` with the `"*"` key.
 
 ```tsx filename=app/routes/$.tsx
-import { useParams } from "remix";
-import type { LoaderFunction, ActionFunction } from "remix";
+import { useParams } from "@remix-run/react";
+import type {
+  LoaderFunction,
+  ActionFunction,
+} from "@remix-run/node";
 
 export const loader: LoaderFunction = async ({
   params,
@@ -460,7 +466,7 @@ Here's a basic example:
 
 ```tsx
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
+import { RemixBrowser } from "@remix-run/react";
 
 hydrate(<RemixBrowser />, document);
 ```
@@ -482,8 +488,8 @@ import { renderToString } from "react-dom/server";
 import type {
   EntryContext,
   HandleDataRequestFunction,
-} from "remix";
-import { RemixServer } from "remix";
+} from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 
 export default function handleRequest(
   request: Request,
@@ -543,7 +549,7 @@ export default function SomeRouteComponent() {
 Each route can define a "loader" function that will be called on the server before rendering to provide data to the route.
 
 ```js
-import { json } from "remix";
+import { json } from "@remix-run/node";
 
 export const loader = async () => {
   // The `json` function converts a serializable object into a JSON response
@@ -554,8 +560,8 @@ export const loader = async () => {
 
 ```ts
 // Typescript
-import { json } from "remix";
-import type { LoaderFunction } from "remix";
+import { json } from "@remix-run/node";
+import type { LoaderFunction } from "@remix-run/node";
 
 export const loader: LoaderFunction = async () => {
   return json({ ok: true });
@@ -566,8 +572,9 @@ This function is only ever run on the server. On the initial server render it wi
 
 Using the database ORM Prisma as an example:
 
-```tsx lines=[1,5-7,10]
-import { json, useLoaderData } from "remix";
+```tsx lines=[1-2,6-8,11]
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 import { prisma } from "../db";
 
@@ -677,7 +684,7 @@ export const loader: LoaderFunction = async () => {
 Using the `json` helper simplifies this so you don't have to construct them yourself, but these two examples are effectively the same!
 
 ```tsx
-import { json } from "remix";
+import { json } from "@remix-run/node";
 
 export const loader: LoaderFunction = async () => {
   const users = await fakeDb.users.findMany();
@@ -688,7 +695,7 @@ export const loader: LoaderFunction = async () => {
 You can see how `json` just does a little of the work to make your loader a lot cleaner. You can also use the `json` helper to add headers or a status code to your response:
 
 ```tsx
-import { json } from "remix";
+import { json } from "@remix-run/node";
 
 export const loader: LoaderFunction = async ({
   params,
@@ -717,8 +724,8 @@ Along with returning responses, you can also throw Response objects from your lo
 Here is a full example showing how you can create utility functions that throw responses to stop code execution in the loader and move over to an alternative UI.
 
 ```ts filename=app/db.ts
-import { json } from "remix";
-import type { ThrownResponse } from "remix";
+import { json } from "@remix-run/node";
+import type { ThrownResponse } from "@remix-run/react";
 
 export type InvoiceNotFoundResponse = ThrownResponse<
   404,
@@ -735,7 +742,7 @@ export function getInvoice(id, user) {
 ```
 
 ```ts filename=app/http.ts
-import { redirect } from "remix";
+import { redirect } from "@remix-run/node";
 
 import { getSession } from "./session";
 
@@ -753,8 +760,8 @@ export async function requireUserSession(request) {
 ```
 
 ```tsx filename=app/routes/invoice/$invoiceId.tsx
-import { useCatch, useLoaderData } from "remix";
-import type { ThrownResponse } from "remix";
+import { useCatch, useLoaderData } from "@remix-run/react";
+import type { ThrownResponse } from "@remix-run/react";
 
 import { requireUserSession } from "~/http";
 import { getInvoice } from "~/db";
@@ -831,7 +838,8 @@ Actions have the same API as loaders, the only difference is when they are calle
 This enables you to co-locate everything about a data set in a single route module: the data read, the component that renders the data, and the data writes:
 
 ```tsx
-import { json, redirect, Form } from "remix";
+import { json, redirect } from "@remix-run/node";
+import { Form } from "@remix-run/react";
 
 import { fakeGetTodos, fakeCreateTodo } from "~/utils/db";
 import { TodoList } from "~/components/TodoList";
@@ -961,8 +969,8 @@ Note that you can also add headers in your `entry.server` file for things that s
 
 ```tsx lines=[16]
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
+import { RemixServer } from "@remix-run/react";
+import type { EntryContext } from "@remix-run/node";
 
 export default function handleRequest(
   request: Request,
@@ -991,7 +999,7 @@ Just keep in mind that doing this will apply to _all_ document requests, but doe
 The meta export will set meta tags for your html document. We highly recommend setting the title and description on every route besides layout routes (their index route will set the meta).
 
 ```tsx
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
 
 export const meta: MetaFunction = () => {
   return {
@@ -1021,7 +1029,7 @@ As a last option, you can also pass an object of attribute/value pairs as the va
 Examples:
 
 ```tsx
-import type { MetaFunction } from "remix";
+import type { MetaFunction } from "@remix-run/node";
 
 export const meta: MetaFunction = () => ({
   // Special cases
@@ -1072,7 +1080,7 @@ export const meta: MetaFunction = ({ data, params }) => {
 The links function defines which `<link>` elements to add to the page when the user visits a route.
 
 ```tsx
-import type { LinksFunction } from "remix";
+import type { LinksFunction } from "@remix-run/node";
 
 export const links: LinksFunction = () => {
   return [
@@ -1106,7 +1114,7 @@ The `links` export from a route should return an array of `HtmlLinkDescriptor` o
 Examples:
 
 ```tsx
-import type { LinksFunction } from "remix";
+import type { LinksFunction } from "@remix-run/node";
 
 import stylesHref from "../styles/something.css";
 
@@ -1175,7 +1183,7 @@ A Remix `CatchBoundary` component works just like a route component, but instead
 A `CatchBoundary` component has access to the status code and thrown response data through `useCatch`.
 
 ```tsx
-import { useCatch } from "remix";
+import { useCatch } from "@remix-run/react";
 
 export function CatchBoundary() {
   const caught = useCatch();
@@ -1236,7 +1244,7 @@ This is almost always used on conjunction with `useMatches`. To see what kinds o
 This function lets apps optimize which routes should be reloaded on some client-side transitions.
 
 ```ts
-import type { ShouldReloadFunction } from "remix";
+import type { ShouldReloadFunction } from "@remix-run/react";
 
 export const unstable_shouldReload: ShouldReloadFunction =
   ({
@@ -1383,7 +1391,7 @@ Any files inside the `app` folder can be imported into your modules. Remix will:
 It's most common for stylesheets, but can used for anything.
 
 ```tsx filename=app/routes/root.tsx
-import type { LinksFunction } from "remix";
+import type { LinksFunction } from "@remix-run/node";
 
 import styles from "./styles/app.css";
 import banner from "./images/banner.jpg";

--- a/docs/guides/constraints.md
+++ b/docs/guides/constraints.md
@@ -19,7 +19,8 @@ The Remix compiler will automatically remove server code from the browser bundle
 Consider a route module that exports `loader`, `meta`, and a component:
 
 ```tsx
-import { json, useLoaderData } from "remix";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 import PostsView from "../PostsView";
 import { prisma } from "../db";
@@ -49,7 +50,7 @@ export { meta, default } from "./routes/posts.tsx";
 The compiler will now analyze the code in `routes/posts.tsx` and only keep code that's inside of `meta` and the component. The result is something like this:
 
 ```tsx
-import { useLoaderData } from "remix";
+import { useLoaderData } from "@remix-run/react";
 
 import PostsView from "../PostsView";
 
@@ -75,8 +76,9 @@ Simply put, a **side effect** is any code that might _do something_. A **module 
 
 Taking our code from earlier, we saw how the compiler can remove the exports and their imports that aren't used. But if we add this seemingly harmless line of code your app will break!
 
-```tsx bad lines=[6]
-import { json, useLoaderData } from "remix";
+```tsx bad lines=[7]
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 import PostsView from "../PostsView";
 import { prisma } from "../db";
@@ -100,7 +102,7 @@ export default function Posts() {
 That `console.log` _does something_. The module is imported and then immediately logs to the console. The compiler won't remove it because it has to run when the module is imported. It will bundle something like this:
 
 ```tsx bad lines=[4,6]
-import { useLoaderData } from "remix";
+import { useLoaderData } from "@remix-run/react";
 
 import PostsView from "../PostsView";
 import { prisma } from "../db"; //😬
@@ -121,8 +123,9 @@ The loader is gone but the prisma dependency stayed! Had we logged something har
 
 To fix this, remove the side effect by simply moving the code _into the loader_.
 
-```tsx lines=[7]
-import { json, useLoaderData } from "remix";
+```tsx lines=[8]
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 import PostsView from "../PostsView";
 import { prisma } from "../db";
@@ -151,7 +154,7 @@ Occasionally, the build may have trouble tree-shaking code that should only run 
 Some Remix newcomers try to abstract their loaders with "higher order functions". Something like this:
 
 ```js bad filename=app/http.js
-import { redirect } from "remix";
+import { redirect } from "@remix-run/node";
 
 export function removeTrailingSlash(loader) {
   return function (arg) {
@@ -182,7 +185,7 @@ You can probably now see that this is a module side effect so the compiler can't
 This type of abstraction is introduced to try to return a response early. Since you can throw a Response in a loader, we can make this simpler and remove the module side effect at the same time so that the server code can be pruned:
 
 ```js filename=app/http.js
-import { redirect } from "remix";
+import { redirect } from "@remix-run/node";
 
 export function removeTrailingSlash(url) {
   if (url.pathname.endsWith("/")) {
@@ -196,7 +199,7 @@ export function removeTrailingSlash(url) {
 And then use it like this:
 
 ```js bad filename=app/root.js
-import { json } from "remix";
+import { json } from "@remix-run/node";
 
 import { removeTrailingSlash } from "~/http";
 

--- a/docs/guides/data-loading.md
+++ b/docs/guides/data-loading.md
@@ -21,9 +21,10 @@ One of the primary features of Remix is simplifying interactions with the server
 
 Each [route module][route-module] can export a component and a [`loader`][loader]. [`useLoaderData`][useloaderdata] will provide the loader's data to your component:
 
-```tsx filename=app/routes/products.tsx lines=[1,2,4-6,9]
-import { json, useLoaderData } from "remix";
-import type { LoaderFunction } from "remix";
+```tsx filename=app/routes/products.tsx lines=[1-3,5-10,13]
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 export const loader: LoaderFunction = async () => {
   return json([
@@ -54,7 +55,7 @@ If your server side modules end up in client bundles, move the imports for those
 When you name a file with `$` like `routes/users/$userId.tsx` and `routes/users/$userId/projects/$projectId.tsx` the dynamic segments (the ones starting with `$`) will be parsed from the URL and passed to your loader on a `params` object.
 
 ```tsx filename=routes/users/$userId/projects/$projectId.tsx
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
 
 export const loader: LoaderFunction = async ({
   params,
@@ -74,8 +75,8 @@ Given the following URLs, the params would be parsed as follows:
 These params are most useful for looking up data:
 
 ```tsx filename=routes/users/$userId/projects/$projectId.tsx lines=[8,9]
-import { json } from "remix";
-import type { LoaderFunction } from "remix";
+import { json } from "@remix-run/node";
+import type { LoaderFunction } from "@remix-run/node";
 
 export const loader: LoaderFunction = async ({
   params,
@@ -95,9 +96,9 @@ export const loader: LoaderFunction = async ({
 
 Because these params come from the URL and not your source code, you can't know for sure if they will be defined. That's why the types on the param's keys are `string | undefined`. It's good practice to validate before using them, especially in TypeScript to get type safety. Using `invariant` makes it easy.
 
-```tsx filename=routes/users/$userId/projects/$projectId.tsx lines=[1,5-6]
+```tsx filename=routes/users/$userId/projects/$projectId.tsx lines=[1,7-8]
 import invariant from "tiny-invariant";
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
 
 export const loader: LoaderFunction = async ({
   params,
@@ -115,8 +116,9 @@ While you may be uncomfortable throwing errors like this with `invariant` when i
 
 Remix polyfills the `fetch` API on your server so it's very easy to fetch data from existing JSON APIs. Instead of managing state, errors, race conditions, and more yourself, you can do the fetch from your loader (on the server) and let Remix handle the rest.
 
-```tsx filename=app/routes/gists.jsx lines=[4]
-import { json, useLoaderData } from "remix";
+```tsx filename=app/routes/gists.jsx lines=[5]
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 export async function loader() {
   const res = await fetch("https://api.github.com/gists");
@@ -152,8 +154,9 @@ export { db };
 And then your routes can import it and make queries against it:
 
 ```tsx filename=app/routes/products/$categoryId.tsx
-import { json, useLoaderData } from "remix";
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 import { db } from "~/db.server";
 
@@ -183,7 +186,8 @@ export default function ProductCategory() {
 If you are using TypeScript, you can use type inference to use Prisma Client generated types on when calling `useLoaderData`. This allowes better type safety and intellisense when writing your code that uses the loaded data.
 
 ```tsx filename=tsx filename=app/routes/products/$productId.tsx
-import { useLoaderData, json } from "remix";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 import { db } from "~/db.server";
 
@@ -220,8 +224,9 @@ export default function Product() {
 If you picked Cloudflare Workers as your environment, [Cloudflare Key Value][cloudflare-kv] storage allows you to persist data at the edge as if it were a static resource. You'll need to [do some configuration][cloudflare-kv-setup] but then you can access the data from your loaders:
 
 ```tsx filename=app/routes/products/$productId.tsx
-import { json, useLoaderData } from "remix";
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 export const loader: LoaderFunction = async ({
   params,
@@ -277,8 +282,8 @@ export const loader: LoaderFunction = async ({
 URL Search Params are the portion of the URL after a `?`. Other names for this are "query string", "search string", or "location search". You can access the values by creating a URL out of the `request.url`:
 
 ```tsx filename=routes/products.tsx lines=[7,8]
-import { json } from "remix";
-import type { LoaderFunction } from "remix";
+import { json } from "@remix-run/node";
+import type { LoaderFunction } from "@remix-run/node";
 
 export const loader: LoaderFunction = async ({
   request,
@@ -358,7 +363,7 @@ Then the url will be: `/products/shoes?brand=nike&brand=adidas`
 Note that `brand` is repeated in the URL search string since both checkboxes were named `"brand"`. In your loader you can get access to all of those values with [`searchParams.getAll`][search-params-getall]
 
 ```tsx lines=[5]
-import { json } from "remix";
+import { json } from "@remix-run/node";
 
 export async function loader({ request }) {
   const url = new URL(request.url);
@@ -379,8 +384,8 @@ As the developer, you can control the search params by linking to URLs with sear
 
 In addition to reading search params in loaders, you often need access to them in components, too:
 
-```tsx lines=[1,4,5,15,24]
-import { useSearchParams } from "remix";
+```tsx lines=[1,4-5,15,24]
+import { useSearchParams } from "@remix-run/react";
 
 export default function ProductFilters() {
   const [searchParams] = useSearchParams();
@@ -414,8 +419,11 @@ export default function ProductFilters() {
 
 You might want to auto submit the form on any field change, for that there is [`useSubmit`][use-submit]:
 
-```tsx lines=[1,4,11]
-import { useSubmit, useSearchParams } from "remix";
+```tsx lines=[2,7,14]
+import {
+  useSubmit,
+  useSearchParams,
+} from "@remix-run/react";
 
 export default function ProductFilters() {
   const submit = useSubmit();
@@ -438,7 +446,7 @@ export default function ProductFilters() {
 While uncommon, you can also set searchParams imperatively at any time for any reason. The use cases here are slim, so slim we couldn't even come up with a good one, but here's a silly example:
 
 ```tsx
-import { useSearchParams } from "remix";
+import { useSearchParams } from "@remix-run/react";
 
 export default function ProductFilters() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -461,7 +469,7 @@ Often you want to keep some inputs, like checkboxes, in sync with the search par
 This is only needed if the search params can be set in two ways and we want the inputs to stay in sync with the search params. For example, both the `<input type="checkbox">` and the `Link` can change the brand in this component:
 
 ```tsx bad lines=[11-18]
-import { useSearchParams } from "remix";
+import { useSearchParams } from "@remix-run/react";
 
 export default function ProductFilters() {
   const [searchParams] = useSearchParams();
@@ -507,8 +515,11 @@ You have two choices, and what you pick depends on the user experience you want.
 
 **First Choice**: The simplest thing is to auto-submit the form when the user clicks the checkbox:
 
-```tsx lines=[1,4,17]
-import { useSubmit, useSearchParams } from "remix";
+```tsx lines=[2,7,20]
+import {
+  useSubmit,
+  useSearchParams,
+} from "@remix-run/react";
 
 export default function ProductFilters() {
   const submit = useSubmit();
@@ -544,8 +555,11 @@ export default function ProductFilters() {
 - Update the state when the user clicks the checkbox so the box changes to "checked"
 - Update the state when the search params change (the user submitted the form or clicked the link) to reflect what's in the url search params
 
-```tsx lines=[8-11,13-17,28-32]
-import { useSubmit, useSearchParams } from "remix";
+```tsx lines=[11-14,16-20,31-35]
+import {
+  useSubmit,
+  useSearchParams,
+} from "@remix-run/react";
 
 export default function ProductFilters() {
   const submit = useSubmit();

--- a/docs/guides/data-writes.md
+++ b/docs/guides/data-writes.md
@@ -176,8 +176,8 @@ export default function NewProject() {
 Now add the route action. Any form submissions that are "post" will call your data "action". Any "get" submissions (`<Form method="get">`) will be handled by your "loader".
 
 ```tsx [5-11]
-import type { ActionFunction } from "remix";
-import { redirect } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
 
 // Note the "action" export name, this will handle our form POST
 export const action: ActionFunction = async ({
@@ -229,8 +229,9 @@ export const action: ActionFunction = async ({
 
 Just like `useLoaderData` returns the values from the `loader`, `useActionData` will return the data from the action. It will only be there if the navigation was a form submission, so you always have to check if you've got it or not.
 
-```tsx [1,10,20,25-29,37,42-46]
-import { redirect, useActionData } from "remix";
+```tsx [2,11,21,26-30,38,43-47]
+import { redirect } from "@remix-run/node";
+import { useActionData } from "@remix-run/react";
 
 export const action: ActionFunction = async ({
   request,
@@ -293,8 +294,9 @@ You can ship this code as-is. The browser will handle the pending UI and interru
 
 Let's use progressive enhancement to make this UX a bit more fancy. By changing it from `<Form reloadDocument>` to `<Form>`, Remix will emulate the browser behavior with `fetch`. It will also give you access to the pending form data so you can build pending UI.
 
-```tsx [1, 10]
-import { redirect, useActionData, Form } from "remix";
+```tsx [2, 11]
+import { redirect } from "@remix-run/node";
+import { useActionData, Form } from "@remix-run/react";
 
 // ...
 
@@ -317,12 +319,12 @@ If you don't have the time or drive to do the rest of the job here, use `<Form r
 Now let's add some pending UI so the user has a clue something happened when they submit. There's a hook called `useTransition`. When there is a pending form submission, Remix will give you the serialized version of the form as a <a href="https://developer.mozilla.org/en-US/docs/Web/API/FormData">`FormData`</a> object. You'll be most interested in the <a href="https://developer.mozilla.org/en-US/docs/Web/API/FormData/get">`formData.get()`</a> method..
 
 ```tsx [5, 13, 19, 65-67]
+import { redirect } from "@remix-run/node";
 import {
-  redirect,
   useActionData,
   Form,
   useTransition,
-} from "remix";
+} from "@remix-run/react";
 
 // ...
 

--- a/docs/guides/disabling-javascript.md
+++ b/docs/guides/disabling-javascript.md
@@ -24,7 +24,7 @@ import {
   Scripts,
   Outlet,
   useMatches,
-} from "remix";
+} from "@remix-run/react";
 
 export default function App() {
   const matches = useMatches();

--- a/docs/guides/mdx.md
+++ b/docs/guides/mdx.md
@@ -87,7 +87,8 @@ The following example demonstrates how you might build a simple blog with MDX, i
 In `app/routes/index.jsx`:
 
 ```tsx
-import { json, Link, useLoaderData } from "remix";
+import { json } from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
 
 // Import all your posts from the app/routes/posts directory. Since these are
 // regular route modules, they will all be available for individual viewing

--- a/docs/guides/not-found.md
+++ b/docs/guides/not-found.md
@@ -69,7 +69,11 @@ export function CatchBoundary() {
 Just like [errors], nested routes can export their own catch boundary to handle the 404 UI without taking down all of the parent layouts around it, and add some nice UX touches right in context. Bots are happy, SEO is happy, CDNs are happy, users are happy, and your code stays in context, so it seems like everybody involved is happy with this.
 
 ```tsx filename=app/routes/pages/$pageId.tsx
-import { Form, useLoaderData, useParams } from "remix";
+import {
+  Form,
+  useLoaderData,
+  useParams,
+} from "@remix-run/react";
 
 export async function loader({ params }) {
   const page = await db.page.findOne({

--- a/docs/guides/optimistic-ui.md
+++ b/docs/guides/optimistic-ui.md
@@ -23,7 +23,8 @@ Remix can help you build optimistic UI with [`useTransition`][use-transition] an
 Consider the workflow for viewing and creating a new project. The project route loads the project and renders it.
 
 ```tsx filename=app/routes/project/$id.tsx
-import { json, useLoaderData } from "remix";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 import { ProjectView } from "~/components/project";
 
@@ -58,7 +59,8 @@ export function ProjectView({ project }) {
 Now we can get to the fun part. Here's what a "new project" route might look like:
 
 ```tsx filename=app/routes/projects/new.tsx
-import { Form, redirect } from "remix";
+import { redirect } from "@remix-run/node";
+import { Form } from "@remix-run/react";
 
 import { createProject } from "~/utils";
 
@@ -90,8 +92,9 @@ export default function NewProject() {
 
 At this point, typically you'd render a busy spinner on the page while the user waits for the project to be sent to the server, added to the database, and sent back to the browser and then redirected to the project. Remix makes that pretty easy:
 
-```tsx filename=app/routes/projects/new.tsx lines=[1,15,27,29-31]
-import { Form, redirect, useTransition } from "remix";
+```tsx filename=app/routes/projects/new.tsx lines=[2,16,28,30-32]
+import { redirect } from "@remix-run/node";
+import { Form, useTransition } from "@remix-run/react";
 
 import { createProject } from "~/utils";
 
@@ -131,8 +134,9 @@ export default function NewProject() {
 
 Since we know that almost every time this form is submitted it's going to succeed, we can just skip the busy spinners and show the UI as we know it's going to be: the `<ProjectView>`.
 
-```tsx filename=app/routes/projects/new.tsx lines=[4,16-22]
-import { Form, redirect, useTransition } from "remix";
+```tsx filename=app/routes/projects/new.tsx lines=[5,17-23]
+import { redirect } from "@remix-run/node";
+import { Form, useTransition } from "@remix-run/react";
 
 import { createProject } from "~/utils";
 import { ProjectView } from "~/components/project";
@@ -178,14 +182,13 @@ One of the hardest parts about implementing optimistic UI is how to handle failu
 
 If you want to have more control over the UI when an error occurs and put the user right back where they were without losing any state, you can catch your own error and send it down through action data.
 
-```tsx filename=app/routes/projects/new.tsx lines=[5,6,17-25,30,49]
+```tsx filename=app/routes/projects/new.tsx lines=[4-5,16-24,29,48]
+import { json, redirect } from "@remix-run/node";
 import {
   Form,
-  redirect,
   useTransition,
   useActionData,
-  json,
-} from "remix";
+} from "@remix-run/react";
 
 import { createProject } from "~/utils";
 import { ProjectView } from "~/components/project";

--- a/docs/guides/resource-routes.md
+++ b/docs/guides/resource-routes.md
@@ -86,8 +86,8 @@ app/routes/reports/$id[.]pdf.ts
 To handle `GET` requests export a loader function:
 
 ```ts
-import { json } from "remix";
-import type { LoaderFunction } from "remix";
+import { json } from "@remix-run/node";
+import type { LoaderFunction } from "@remix-run/node";
 
 export const loader: LoaderFunction = async ({
   request,
@@ -101,7 +101,7 @@ export const loader: LoaderFunction = async ({
 To handle `POST`, `PUT`, `PATCH` or `DELETE` requests export an action function:
 
 ```ts
-import type { ActionFunction } from "remix";
+import type { ActionFunction } from "@remix-run/node";
 
 export const action: ActionFunction = async ({
   request,
@@ -128,8 +128,8 @@ export const action: ActionFunction = async ({
 Resource routes can be used to handle webhooks. For example, you can create a webhook that receives notifications from GitHub when a new commit is pushed to a repository:
 
 ```ts
-import type { ActionFunction } from "remix";
-import { json } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
 import crypto from "crypto";
 
 export const action: ActionFunction = async ({

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -20,7 +20,7 @@ export function links() {
 Each nested route's `links` are merged (parents first) and rendered as `<link>` tags by the `<Links/>` you rendered in `app/root.js` in the head of the document.
 
 ```tsx filename=app/root.js lines=[1,7]
-import { Links } from "remix";
+import { Links } from "@remix-run/react";
 // ...
 export default function Root() {
   return (
@@ -253,8 +253,9 @@ Now Remix can prefetch, load, and unload the styles for `button.css`, `primary-b
 
 An initial reaction to this is that routes have to know more than you want them to. Keep in mind each component must be imported already, so it's not introducing a new dependency, just some boilerplate to get the assets. For example, consider a product category page like this:
 
-```tsx filename=app/routes/$category.js lines=[3-6,23-30]
-import { json, useLoaderData } from "remix";
+```tsx filename=app/routes/$category.js lines=[4-8,24-31]
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 import { TileGrid } from "~/components/tile-grid";
 import { ProductTile } from "~/components/product-tile";
@@ -509,7 +510,7 @@ If you're using VS Code, it's recommended you install the [Tailwind IntelliSense
 You can load stylesheets from any server, here's an example of loading a modern css reset from unpkg.
 
 ```ts filename=app/root.tsx
-import type { LinksFunction } from "remix";
+import type { LinksFunction } from "@remix-run/node";
 
 export const links: LinksFunction = () => {
   return [
@@ -597,7 +598,7 @@ Here's how to set it up:
    Then import like any other css file:
 
    ```tsx filename=root.tsx
-   import type { LinksFunction } from "remix";
+   import type { LinksFunction } from "@remix-run/node";
 
    import styles from "./styles/app.css";
 
@@ -686,7 +687,7 @@ Here's some sample code to show how you might use Styled Components with Remix (
 1. First you'll need to put a placeholder in your root component to control where the styles are inserted.
 
    ```tsx filename=app/root.tsx lines=[22-24]
-   import type { MetaFunction } from "remix";
+   import type { MetaFunction } from "@remix-run/node";
    import {
      Links,
      LiveReload,
@@ -694,7 +695,7 @@ Here's some sample code to show how you might use Styled Components with Remix (
      Outlet,
      Scripts,
      ScrollRestoration,
-   } from "remix";
+   } from "@remix-run/react";
 
    export const meta: MetaFunction = () => ({
      charset: "utf-8",
@@ -726,8 +727,8 @@ Here's some sample code to show how you might use Styled Components with Remix (
 
    ```tsx filename=entry.server.tsx lines=[4,12,15-20,22-23]
    import { renderToString } from "react-dom/server";
-   import { RemixServer } from "remix";
-   import type { EntryContext } from "remix";
+   import { RemixServer } from "@remix-run/react";
+   import type { EntryContext } from "@remix-run/node";
    import { ServerStyleSheet } from "styled-components";
 
    export default function handleRequest(

--- a/docs/other-api/dev.md
+++ b/docs/other-api/dev.md
@@ -9,26 +9,6 @@ The Remix CLI comes from the `@remix-run/dev` package. It also includes the comp
 
 ## Commands
 
-### `remix setup`
-
-Remix is architected in a way that is not locked to a specific runtime, but this introduces a few challenges in getting your environment setup properly. To make life as easy as possible, we have included the `remix setup` command that will prepare your `node_modules/remix` folder; simply include this command in your packages postinstall command (the starter templates already do this):
-
-```json
-{
-  "scripts": {
-    "postinstall": "remix setup"
-  }
-}
-```
-
-Now, no matter which platform you're deploying to, you can import everything you need from `"remix"`.
-
-```js
-// whether you're on cloudflare workers, node.js, or something
-// else everything you need will come from this package.
-import {} from "remix";
-```
-
 ### `remix build`
 
 Builds your app for production. No need to add `NODE_ENV=production` to the command.

--- a/docs/other-api/serve.md
+++ b/docs/other-api/serve.md
@@ -42,7 +42,7 @@ In development, `remix-serve` will ensure the latest code is run on each request
 - Any **module side effects** will remain in place! This may cause problems, but should probably be avoided anyway.
 
   ```ts [3-6]
-  import { json } from "remix";
+  import { json } from "@remix-run/node";
 
   // this starts running the moment the module is imported
   setInterval(() => {

--- a/docs/pages/faq.md
+++ b/docs/pages/faq.md
@@ -17,7 +17,7 @@ We recommend you create a function that validates the user session that can be a
 import {
   createCookieSessionStorage,
   redirect,
-} from "remix";
+} from "@remix-run/node";
 
 // somewhere you've got a session storage
 const { getSession } = createCookieSessionStorage();

--- a/docs/pages/gotchas.md
+++ b/docs/pages/gotchas.md
@@ -19,7 +19,7 @@ TypeError: Cannot read properties of undefined (reading 'root')
 For example, you can't import "fs-extra" directly into a route module:
 
 ```js lines=[2] filename=app/routes/index.jsx bad
-import { json } from "remix";
+import { json } from "@remix-run/node";
 import fs from "fs-extra";
 
 export async function loader() {
@@ -40,7 +40,7 @@ export * from "fs-extra";
 And then change our import in the route to the new "wrapper" module:
 
 ```js lines=[3] filename=app/routes/index.jsx
-import { json } from "remix";
+import { json } from "@remix-run/node";
 
 import fs from "../utils/fs-extra.server";
 

--- a/docs/pages/philosophy.md
+++ b/docs/pages/philosophy.md
@@ -56,7 +56,7 @@ export default function Gists() {
 With Remix, you can filter down the data _on the server_ before sending it to the user:
 
 ```js [3-16]
-import { json } from "remix";
+import { json } from "@remix-run/node";
 
 export async function loader() {
   const res = await fetch("https://api.github.com/gists");

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -132,8 +132,9 @@ So let's get to it and provide some data to our component.
 
 💿 Make the posts route "loader"
 
-```tsx filename=app/routes/posts/index.tsx lines=[1,3-16,19-20]
-import { json, useLoaderData } from "remix";
+```tsx filename=app/routes/posts/index.tsx lines=[1-2,4-17,20-21]
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 export const loader = async () => {
   return json({
@@ -165,8 +166,9 @@ Loaders are the backend "API" for their component and it's already wired up for 
 
 💿 Render links to our posts
 
-```tsx filename=app/routes/posts/index.tsx lines=[1,9-20] nocopy
-import { Link, json, useLoaderData } from "remix";
+```tsx filename=app/routes/posts/index.tsx lines=[2,10-21] nocopy
+import { json } from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
 
 // ...
 export default function Posts() {
@@ -195,8 +197,9 @@ TypeScript is mad, so let's help it out:
 
 💿 Add the Post type and generic for `useLoaderData`
 
-```tsx filename=app/routes/posts/index.tsx lines=[3-6,8-10,13,28]
-import { Link, json, useLoaderData } from "remix";
+```tsx filename=app/routes/posts/index.tsx lines=[4-7,9-11,14,29]
+import { json } from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
 
 type Post = {
   slug: string;
@@ -283,7 +286,8 @@ Note that we're making the `getPosts` function `async` because even though it's 
 💿 Update the posts route to use our new posts module:
 
 ```tsx filename=app/routes/posts/index.tsx nocopy
-import { json, Link, useLoaderData } from "remix";
+import { json } from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
 
 import { getPosts } from "~/models/post.server";
 
@@ -440,8 +444,9 @@ You can click one of your posts and should see the new page.
 
 💿 Add a loader to access the params
 
-```tsx filename=app/routes/posts/$slug.tsx lines=[1,3-5,8,12]
-import { useLoaderData, json } from "remix";
+```tsx filename=app/routes/posts/$slug.tsx lines=[1-2,4-6,9,13]
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 export const loader = async ({ params }) => {
   return json({ slug: params.slug });
@@ -463,9 +468,10 @@ The part of the filename attached to the `$` becomes a named key on the `params`
 
 💿 Let's get some help from TypeScript for the loader function signature.
 
-```tsx filename=app/routes/posts/$slug.tsx lines=[1,4]
-import type { LoaderFunction } from "remix";
-import { json, useLoaderData } from "remix";
+```tsx filename=app/routes/posts/$slug.tsx lines=[1,5]
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 export const loader: LoaderFunction = async ({
   params,
@@ -496,9 +502,10 @@ export async function getPost(slug: string) {
 
 💿 Use the new `getPost` function in the route
 
-```tsx filename=app/routes/posts/$slug.tsx lines=[4,9-10,14,18]
-import type { LoaderFunction } from "remix";
-import { json, useLoaderData } from "remix";
+```tsx filename=app/routes/posts/$slug.tsx lines=[5,10-11,15,19]
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 
 import { getPost } from "~/models/post.server";
 
@@ -525,9 +532,10 @@ Check that out! We're now pulling our posts from a data source instead of includ
 
 Let's make TypeScript happy with our code:
 
-```tsx filename=app/routes/posts/$slug.tsx lines=[3,5,8,13,16,18,22]
-import type { LoaderFunction } from "remix";
-import { json, useLoaderData } from "remix";
+```tsx filename=app/routes/posts/$slug.tsx lines=[4,6,9,14,17,19,23]
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 import invariant from "tiny-invariant";
 
 import type { Post } from "~/models/post.server";
@@ -572,10 +580,11 @@ npm add marked
 npm add @types/marked -D
 ```
 
-```tsx filename=app/routes/post/$slug.ts lines=[1,9,19-20,24,30]
+```tsx filename=app/routes/post/$slug.ts lines=[1,10,20-21,25,31]
 import { marked } from "marked";
-import type { LoaderFunction } from "remix";
-import { json, useLoaderData } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 import invariant from "tiny-invariant";
 
 import type { Post } from "~/models/post.server";
@@ -637,8 +646,9 @@ touch app/routes/posts/admin.tsx
 ```
 
 ```tsx filename=app/routes/posts/admin.tsx
-import type { LoaderFunction } from "remix";
-import { Link, useLoaderData, json } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
 
 import { getPosts } from "~/models/post.server";
 
@@ -696,7 +706,7 @@ touch app/routes/posts/admin/index.tsx
 ```
 
 ```tsx filename=app/routes/posts/admin/index.tsx
-import { Link } from "remix";
+import { Link } from "@remix-run/react";
 
 export default function AdminIndex() {
   return (
@@ -713,9 +723,14 @@ If you refresh you're not going to see it yet. Every route inside of `app/routes
 
 💿 Add an outlet to the admin page
 
-```tsx filename=app/routes/posts/admin.tsx lines=[2,37]
-import type { LoaderFunction } from "remix";
-import { Link, Outlet, useLoaderData, json } from "remix";
+```tsx filename=app/routes/posts/admin.tsx lines=[5,42]
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import {
+  Link,
+  Outlet,
+  useLoaderData,
+} from "@remix-run/react";
 
 import { getPosts } from "~/models/post.server";
 
@@ -783,7 +798,7 @@ We're gonna get serious now. Let's build a form to create a new post in our new 
 💿 Add a form to the new route
 
 ```tsx filename=app/routes/posts/admin/new.tsx
-import { Form } from "remix";
+import { Form } from "@remix-run/react";
 
 const inputClassName = `w-full rounded border border-gray-500 px-2 py-1 text-lg`;
 
@@ -851,7 +866,8 @@ export async function createPost(post) {
 💿 Call `createPost` from the new post route's action
 
 ```tsx filename=app/routes/posts/admin/new.tsx
-import { Form, redirect } from "remix";
+import { redirect } from "@remix-run/node";
+import { Form } from "@remix-run/react";
 
 import { createPost } from "~/models/post.server";
 
@@ -892,9 +908,10 @@ export async function createPost(
 }
 ```
 
-```tsx filename=app/routes/posts/admin/new.tsx lines=[1,6]
-import type { ActionFunction } from "remix";
-import { Form, redirect } from "remix";
+```tsx filename=app/routes/posts/admin/new.tsx lines=[1,7]
+import type { ActionFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import { Form } from "@remix-run/react";
 
 import { createPost } from "~/models/post.server";
 
@@ -964,9 +981,10 @@ Notice we don't return a redirect this time, we actually return the errors. Thes
 
 💿 Add validation messages to the UI
 
-```tsx filename=app/routes/posts/admin/new.tsx lines=[2,9,16-18,25-27,34-38]
-import type { ActionFunction } from "remix";
-import { Form, redirect, json, useActionData } from "remix";
+```tsx filename=app/routes/posts/admin/new.tsx lines=[3,10,17-19,26-28,35-39]
+import type { ActionFunction } from "@remix-run/node";
+import { redirect, json } from "@remix-run/node";
+import { Form, useActionData } from "@remix-run/react";
 
 // ...
 
@@ -1078,14 +1096,13 @@ export const action: ActionFunction = async ({
 
 💿 Add some pending UI with `useTransition`
 
-```tsx filename=app/routes/posts/admin/new.tsx lines=[6,14-15,24,26]
+```tsx filename=app/routes/posts/admin/new.tsx lines=[5,13-14,23,25]
+import { json, redirect } from "@remix-run/node";
 import {
   Form,
-  redirect,
-  json,
   useActionData,
   useTransition,
-} from "remix";
+} from "@remix-run/react";
 
 // ..
 

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -192,7 +192,7 @@ We're going to trim this down the bare bones and introduce things incrementally.
 💿 Replace the contents of `app/root.tsx` with this:
 
 ```tsx filename=app/root.tsx
-import { LiveReload } from "remix";
+import { LiveReload } from "@remix-run/react";
 
 export default function App() {
   return (
@@ -269,14 +269,14 @@ export default function IndexRoute() {
 
 React Router supports "nested routing" which means we have parent-child relationships in our routes. The `app/routes/index.tsx` is a child of the `app/root.tsx` route. In nested routing, parents are responsible for laying out their children.
 
-💿 Update the `app/root.tsx` to position children. You'll do this with the `<Outlet />` component from `remix`:
+💿 Update the `app/root.tsx` to position children. You'll do this with the `<Outlet />` component from `@remix-run/react`:
 
 <details>
 
 <summary>app/root.tsx</summary>
 
 ```tsx filename=app/root.tsx lines=[1,11]
-import { LiveReload, Outlet } from "remix";
+import { LiveReload, Outlet } from "@remix-run/react";
 
 export default function App() {
   return (
@@ -313,7 +313,7 @@ Great! Next let's handle the `/jokes` route.
 <summary>app/routes/jokes.tsx</summary>
 
 ```tsx filename=app/routes/jokes.tsx
-import { Outlet } from "remix";
+import { Outlet } from "@remix-run/react";
 
 export default function JokesRoute() {
   return (
@@ -463,7 +463,7 @@ body {
 <summary>app/routes/index.tsx</summary>
 
 ```tsx filename=app/routes/index.tsx lines=[1, 3, 5-7]
-import type { LinksFunction } from "remix";
+import type { LinksFunction } from "@remix-run/node";
 
 import stylesUrl from "~/styles/index.css";
 
@@ -488,8 +488,12 @@ So we need some way to get the `link` exports from all active routes and add `<l
 
 <summary>app/root.tsx</summary>
 
-```tsx filename=app/root.tsx lines=[1,9]
-import { Links, LiveReload, Outlet } from "remix";
+```tsx filename=app/root.tsx lines=[2,13]
+import {
+  Links,
+  LiveReload,
+  Outlet,
+} from "@remix-run/react";
 
 export default function App() {
   return (
@@ -1171,9 +1175,13 @@ The `global-large.css` and `global-medium.css` files are for media query-based C
 
 <summary>app/root.tsx</summary>
 
-```tsx filename=app/root.tsx lines=[1,4-6,8-25]
-import type { LinksFunction } from "remix";
-import { Links, LiveReload, Outlet } from "remix";
+```tsx filename=app/root.tsx lines=[1,8-10,12-29]
+import type { LinksFunction } from "@remix-run/node";
+import {
+  Links,
+  LiveReload,
+  Outlet,
+} from "@remix-run/react";
 
 import globalStylesUrl from "./styles/global.css";
 import globalMediumStylesUrl from "./styles/global-medium.css";
@@ -1222,8 +1230,8 @@ export default function App() {
 <summary>app/routes/jokes.tsx</summary>
 
 ```tsx filename=app/routes/jokes.tsx lines=[1,4,6-8]
-import type { LinksFunction } from "remix";
-import { Outlet, Link } from "remix";
+import type { LinksFunction } from "@remix-run/node";
+import { Outlet, Link } from "@remix-run/react";
 
 import stylesUrl from "~/styles/jokes.css";
 
@@ -1281,8 +1289,8 @@ export default function JokesRoute() {
 <summary>app/routes/index.tsx</summary>
 
 ```tsx filename=app/routes/index.tsx lines=[1,4,6-13]
-import type { LinksFunction } from "remix";
-import { Link } from "remix";
+import type { LinksFunction } from "@remix-run/node";
+import { Link } from "@remix-run/react";
 
 import stylesUrl from "~/styles/index.css";
 
@@ -1574,8 +1582,9 @@ To _load_ data in a Remix route module, you use a [`loader`](../api/conventions#
 
 ```tsx nocopy
 // this is just an example. No need to copy/paste this 😄
-import { json, useLoaderData } from "remix";
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
 import type { User } from "@prisma/client";
 
 import { db } from "~/utils/db.server";
@@ -1615,9 +1624,17 @@ Remix and the `tsconfig.json` you get from the starter template are configured t
 
 <summary>app/routes/jokes.tsx</summary>
 
-```tsx filename=app/routes/jokes.tsx lines=[1-2,4,11-13,15-20,23,47-51]
-import type { LinksFunction, LoaderFunction } from "remix";
-import { json, Link, Outlet, useLoaderData } from "remix";
+```tsx filename=app/routes/jokes.tsx lines=[3,5,12,19-21,23-28,31,55-59]
+import type {
+  LinksFunction,
+  LoaderFunction,
+} from "@remix-run/node";
+import { json } from "@remix-run/node";
+import {
+  Link,
+  Outlet,
+  useLoaderData,
+} from "@remix-run/react";
 
 import { db } from "~/utils/db.server";
 import stylesUrl from "~/styles/jokes.css";
@@ -1749,9 +1766,10 @@ const joke = await db.joke.findUnique({
 
 <summary>app/routes/jokes/$jokeId.tsx</summary>
 
-```tsx filename=app/routes/jokes/$jokeId.tsx lines=[3,5,7,9-18,21]
-import type { LoaderFunction } from "remix";
-import { json, Link, useLoaderData } from "remix";
+```tsx filename=app/routes/jokes/$jokeId.tsx lines=[4,6,8,10-19,22]
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
 import type { Joke } from "@prisma/client";
 
 import { db } from "~/utils/db.server";
@@ -1809,9 +1827,10 @@ const [randomJoke] = await db.joke.findMany({
 
 <summary>app/routes/jokes/index.tsx</summary>
 
-```tsx filename=app/routes/jokes/index.tsx lines=[3,5,7,9-18,21]
-import type { LoaderFunction } from "remix";
-import { json, useLoaderData, Link } from "remix";
+```tsx filename=app/routes/jokes/index.tsx lines=[4,6,8,10-19,22]
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData, Link } from "@remix-run/react";
 import type { Joke } from "@prisma/client";
 
 import { db } from "~/utils/db.server";
@@ -1898,8 +1917,8 @@ const joke = await db.joke.create({
 <summary>app/routes/jokes/new.tsx</summary>
 
 ```tsx filename=app/routes/jokes/new.tsx lines=[1-2,4,6-25]
-import type { ActionFunction } from "remix";
-import { redirect } from "remix";
+import type { ActionFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
 
 import { db } from "~/utils/db.server";
 
@@ -1982,9 +2001,10 @@ But if there's an error, you can return an object with the error messages and th
 
 <summary>app/routes/jokes/new.tsx</summary>
 
-```tsx filename=app/routes/jokes/new.tsx lines=[2,6-10,12-16,18-28,30-31,43-45,48-51,53-55,62,73,75-83,86-94,100,102-110,113-121,124-131]
-import type { ActionFunction } from "remix";
-import { useActionData, redirect, json } from "remix";
+```tsx filename=app/routes/jokes/new.tsx lines=[2-3,7-11,13-17,19-29,31-32,44-46,49-52,54-56,63,74,76-84,87-95,101,103-111,114-122,125-132]
+import type { ActionFunction } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { useActionData } from "@remix-run/react";
 
 import { db } from "~/utils/db.server";
 
@@ -2426,8 +2446,8 @@ fieldset > :not(:last-child) {
 <summary>app/routes/login.tsx</summary>
 
 ```tsx filename=app/routes/login.tsx
-import type { LinksFunction } from "remix";
-import { Link, useSearchParams } from "remix";
+import type { LinksFunction } from "@remix-run/node";
+import { Link, useSearchParams } from "@remix-run/react";
 
 import stylesUrl from "../styles/login.css";
 
@@ -2524,13 +2544,16 @@ Great, now that we've got the UI looking nice, let's add some logic. This will b
 <summary>app/routes/login.tsx</summary>
 
 ```tsx filename=app/routes/login.tsx
-import type { ActionFunction, LinksFunction } from "remix";
+import type {
+  ActionFunction,
+  LinksFunction,
+} from "@remix-run/node";
+import { json } from "@remix-run/node";
 import {
   useActionData,
-  json,
   Link,
   useSearchParams,
-} from "remix";
+} from "@remix-run/react";
 
 import { db } from "~/utils/db.server";
 import stylesUrl from "~/styles/login.css";
@@ -2905,7 +2928,7 @@ import bcrypt from "bcryptjs";
 import {
   createCookieSessionStorage,
   redirect,
-} from "remix";
+} from "@remix-run/node";
 
 import { db } from "./db.server";
 
@@ -3031,7 +3054,7 @@ import bcrypt from "bcryptjs";
 import {
   createCookieSessionStorage,
   redirect,
-} from "remix";
+} from "@remix-run/node";
 
 import { db } from "./db.server";
 
@@ -3132,9 +3155,10 @@ You may also notice that our solution makes use of the `login` route's `redirect
 
 <summary>app/routes/jokes/new.tsx</summary>
 
-```tsx filename=app/routes/jokes/new.tsx lines=[5,37,60]
-import type { ActionFunction } from "remix";
-import { useActionData, redirect, json } from "remix";
+```tsx filename=app/routes/jokes/new.tsx lines=[6,38,61]
+import type { ActionFunction } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { useActionData } from "@remix-run/react";
 
 import { db } from "~/utils/db.server";
 import { requireUserId } from "~/utils/session.server";
@@ -3297,7 +3321,7 @@ import bcrypt from "bcryptjs";
 import {
   createCookieSessionStorage,
   redirect,
-} from "remix";
+} from "@remix-run/node";
 
 import { db } from "./db.server";
 
@@ -3416,10 +3440,18 @@ export async function createUserSession(
 
 <summary>app/routes/jokes.tsx</summary>
 
-```tsx filename=app/routes/jokes.tsx lines=[6,14,18-20,26,30,52-63]
+```tsx filename=app/routes/jokes.tsx lines=[14,22,27,34,38,60-71]
 import type { User } from "@prisma/client";
-import type { LinksFunction, LoaderFunction } from "remix";
-import { json, Link, Outlet, useLoaderData } from "remix";
+import type {
+  LinksFunction,
+  LoaderFunction,
+} from "@remix-run/node";
+import { json } from "@remix-run/node";
+import {
+  Link,
+  Outlet,
+  useLoaderData,
+} from "@remix-run/react";
 
 import { db } from "~/utils/db.server";
 import { getUser } from "~/utils/session.server";
@@ -3515,8 +3547,11 @@ export default function JokesRoute() {
 <summary>app/routes/logout.tsx</summary>
 
 ```tsx filename=app/routes/logout.tsx
-import type { ActionFunction, LoaderFunction } from "remix";
-import { redirect } from "remix";
+import type {
+  ActionFunction,
+  LoaderFunction,
+} from "@remix-run/node";
+import { redirect } from "@remix-run/node";
 
 import { logout } from "~/utils/session.server";
 
@@ -3568,7 +3603,7 @@ import bcrypt from "bcryptjs";
 import {
   createCookieSessionStorage,
   redirect,
-} from "remix";
+} from "@remix-run/node";
 
 import { db } from "./db.server";
 
@@ -3696,14 +3731,17 @@ export async function createUserSession(
 
 <summary>app/routes/login.tsx</summary>
 
-```tsx filename=app/routes/login.tsx lines=[13,105-112]
-import type { ActionFunction, LinksFunction } from "remix";
+```tsx filename=app/routes/login.tsx lines=[16,100-117]
+import type {
+  ActionFunction,
+  LinksFunction,
+} from "@remix-run/node";
+import { json } from "@remix-run/node";
 import {
   useActionData,
-  json,
   useSearchParams,
   Link,
-} from "remix";
+} from "@remix-run/react";
 
 import { db } from "~/utils/db.server";
 import {
@@ -3971,9 +4009,13 @@ Remember that the `app/root.tsx` module is responsible for rendering our `<html>
 
 <summary>app/root.tsx</summary>
 
-```tsx filename=app/root.tsx lines=[27-47,49-55,57-67]
-import type { LinksFunction } from "remix";
-import { Links, LiveReload, Outlet } from "remix";
+```tsx filename=app/root.tsx lines=[31-51,53-59,61-70]
+import type { LinksFunction } from "@remix-run/node";
+import {
+  Links,
+  LiveReload,
+  Outlet,
+} from "@remix-run/react";
 
 import globalStylesUrl from "./styles/global.css";
 import globalMediumStylesUrl from "./styles/global-medium.css";
@@ -4027,7 +4069,7 @@ export default function App() {
     </Document>
   );
 }
-
+// 60
 export function ErrorBoundary({ error }: { error: Error }) {
   return (
     <Document title="Uh-oh!">
@@ -4049,7 +4091,11 @@ export function ErrorBoundary({ error }: { error: Error }) {
 ```tsx filename=app/routes/jokes/$jokeId.tsx nocopy
 // ...
 
-import { Link, useLoaderData, useParams } from "remix";
+import {
+  Link,
+  useLoaderData,
+  useParams,
+} from "@remix-run/react";
 
 // ...
 
@@ -4142,9 +4188,14 @@ With that understanding, we're going to add a `CatchBoundary` component to the f
 
 <summary>app/root.tsx</summary>
 
-```tsx filename=app/root.tsx lines=[2,57-71]
-import type { LinksFunction } from "remix";
-import { Links, LiveReload, Outlet, useCatch } from "remix";
+```tsx filename=app/root.tsx lines=[6,62-76]
+import type { LinksFunction } from "@remix-run/node";
+import {
+  Links,
+  LiveReload,
+  Outlet,
+  useCatch,
+} from "@remix-run/react";
 
 import globalStylesUrl from "./styles/global.css";
 import globalMediumStylesUrl from "./styles/global-medium.css";
@@ -4234,14 +4285,14 @@ export function ErrorBoundary({ error }: { error: Error }) {
 <summary>app/routes/jokes/$jokeId.tsx</summary>
 
 ```tsx filename=app/routes/jokes/$jokeId.tsx lines=[6,21-25,42-53]
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
 import {
-  json,
   Link,
   useLoaderData,
   useCatch,
   useParams,
-} from "remix";
+} from "@remix-run/react";
 import type { Joke } from "@prisma/client";
 
 import { db } from "~/utils/db.server";
@@ -4302,9 +4353,14 @@ export function ErrorBoundary() {
 
 <summary>app/routes/jokes/index.tsx</summary>
 
-```tsx filename=app/routes/jokes/index.tsx lines=[2,16-20,39-52]
-import type { LoaderFunction } from "remix";
-import { json, useLoaderData, Link, useCatch } from "remix";
+```tsx filename=app/routes/jokes/index.tsx lines=[6,21-25,44-57]
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import {
+  useLoaderData,
+  Link,
+  useCatch,
+} from "@remix-run/react";
 import type { Joke } from "@prisma/client";
 
 import { db } from "~/utils/db.server";
@@ -4371,15 +4427,17 @@ export function ErrorBoundary() {
 
 <summary>app/routes/jokes/new.tsx</summary>
 
-```tsx filename=app/routes/jokes/new.tsx lines=[6,16-24,164-175]
-import type { ActionFunction, LoaderFunction } from "remix";
+```tsx filename=app/routes/jokes/new.tsx lines=[8,18-26,166-177]
+import type {
+  ActionFunction,
+  LoaderFunction,
+} from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
 import {
   useActionData,
-  redirect,
-  json,
   useCatch,
   Link,
-} from "remix";
+} from "@remix-run/react";
 
 import { db } from "~/utils/db.server";
 import {
@@ -4592,17 +4650,19 @@ And then the `action` can determine whether the intention is to delete based on 
 
 <summary>app/routes/jokes/$jokeId.tsx</summary>
 
-```tsx filename=app/routes/jokes/$jokeId.tsx lines=[3,8,13,32-62,72-81,90-96,104-110]
+```tsx filename=app/routes/jokes/$jokeId.tsx lines=[6,15,34-64,74-83,92-98,106-112]
 import type { Joke } from "@prisma/client";
-import type { ActionFunction, LoaderFunction } from "remix";
+import type {
+  ActionFunction,
+  LoaderFunction,
+} from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
 import {
-  json,
   Link,
   useLoaderData,
   useCatch,
-  redirect,
   useParams,
-} from "remix";
+} from "@remix-run/react";
 
 import { db } from "~/utils/db.server";
 import { requireUserId } from "~/utils/session.server";
@@ -4726,17 +4786,19 @@ Now that people will get a proper error message if they try to delete a joke tha
 
 <summary>app/routes/jokes/$jokeId.tsx</summary>
 
-```tsx filename=app/routes/jokes/$jokeId.tsx lines=[14,18,24,35,80-91]
+```tsx filename=app/routes/jokes/$jokeId.tsx lines=[16,20,26,37,82-93]
 import type { Joke } from "@prisma/client";
-import type { ActionFunction, LoaderFunction } from "remix";
+import type {
+  ActionFunction,
+  LoaderFunction,
+} from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
 import {
-  json,
   Link,
   useLoaderData,
   useCatch,
-  redirect,
   useParams,
-} from "remix";
+} from "@remix-run/react";
 
 import { db } from "~/utils/db.server";
 import {
@@ -4883,15 +4945,18 @@ But before you get started, remember that we're in charge of rendering everythin
 
 <summary>app/root.tsx</summary>
 
-```tsx filename=app/root.tsx lines=[1,5,30-43,55]
-import type { LinksFunction, MetaFunction } from "remix";
+```tsx filename=app/root.tsx lines=[3,8,33-46,58]
+import type {
+  LinksFunction,
+  MetaFunction,
+} from "@remix-run/node";
 import {
   Links,
   LiveReload,
   Meta,
   Outlet,
   useCatch,
-} from "remix";
+} from "@remix-run/react";
 
 import globalStylesUrl from "./styles/global.css";
 import globalMediumStylesUrl from "./styles/global-medium.css";
@@ -4992,9 +5057,12 @@ export function ErrorBoundary({ error }: { error: Error }) {
 
 <summary>app/routes/index.tsx</summary>
 
-```tsx filename=app/routes/index.tsx lines=[1,10-14]
-import type { LinksFunction, MetaFunction } from "remix";
-import { Link } from "remix";
+```tsx filename=app/routes/index.tsx lines=[3,13-17]
+import type {
+  LinksFunction,
+  MetaFunction,
+} from "@remix-run/node";
+import { Link } from "@remix-run/react";
 
 import stylesUrl from "~/styles/index.css";
 
@@ -5039,13 +5107,13 @@ import type {
   ActionFunction,
   LinksFunction,
   MetaFunction,
-} from "remix";
+} from "@remix-run/node";
+import { json } from "@remix-run/node";
 import {
   useActionData,
-  json,
   useSearchParams,
   Link,
-} from "remix";
+} from "@remix-run/react";
 
 import { db } from "~/utils/db.server";
 import {
@@ -5305,20 +5373,19 @@ export default function Login() {
 
 <summary>app/routes/jokes/$jokeId.tsx</summary>
 
-```tsx filename=app/routes/jokes/$jokeId.tsx lines=[5,22-37]
+```tsx filename=app/routes/jokes/$jokeId.tsx lines=[4,21-36]
 import type {
   ActionFunction,
   LoaderFunction,
   MetaFunction,
-} from "remix";
+} from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
 import {
-  json,
   Link,
   useLoaderData,
   useCatch,
-  redirect,
   useParams,
-} from "remix";
+} from "@remix-run/react";
 import type { Joke } from "@prisma/client";
 
 import { db } from "~/utils/db.server";
@@ -5482,7 +5549,7 @@ For this one, you'll probably want to at least peek at the example unless you wa
 <summary>app/routes/jokes[.]rss.tsx</summary>
 
 ```tsx filename=app/routes/jokes[.]rss.tsx
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/node";
 
 import { db } from "~/utils/db.server";
 
@@ -5599,8 +5666,11 @@ Ok, so let's load JavaScript on this page now 😆
 
 <summary>app/root.tsx</summary>
 
-```tsx filename=app/root.tsx lines=[7,62,94]
-import type { LinksFunction, MetaFunction } from "remix";
+```tsx filename=app/root.tsx lines=[10,65,97]
+import type {
+  LinksFunction,
+  MetaFunction,
+} from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -5608,7 +5678,7 @@ import {
   Outlet,
   Scripts,
   useCatch,
-} from "remix";
+} from "@remix-run/react";
 
 import globalStylesUrl from "./styles/global.css";
 import globalMediumStylesUrl from "./styles/global-medium.css";
@@ -5747,7 +5817,7 @@ Note, you'll probably want to create a new file in `app/components/` called `jok
 <summary>app/components/joke.tsx</summary>
 
 ```tsx filename=app/components/joke.tsx
-import { Link, Form } from "remix";
+import { Link, Form } from "@remix-run/react";
 import type { Joke } from "@prisma/client";
 
 export function JokeDisplay({
@@ -5791,19 +5861,18 @@ export function JokeDisplay({
 
 <summary>app/routes/jokes/$jokeId.tsx</summary>
 
-```tsx filename=app/routes/jokes/$jokeId.tsx lines=[20,98]
+```tsx filename=app/routes/jokes/$jokeId.tsx lines=[19,97]
 import type {
   LoaderFunction,
   ActionFunction,
   MetaFunction,
-} from "remix";
+} from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
 import {
-  json,
   useLoaderData,
   useCatch,
-  redirect,
   useParams,
-} from "remix";
+} from "@remix-run/react";
 import type { Joke } from "@prisma/client";
 
 import { db } from "~/utils/db.server";
@@ -5940,17 +6009,19 @@ export function ErrorBoundary({ error }: { error: Error }) {
 
 <summary>app/routes/jokes/new.tsx</summary>
 
-```tsx filename=app/routes/jokes/new.tsx lines=[9,12,89-109]
-import type { ActionFunction, LoaderFunction } from "remix";
+```tsx filename=app/routes/jokes/new.tsx lines=[11,14,91-111]
+import type {
+  ActionFunction,
+  LoaderFunction,
+} from "@remix-run/node";
+import { redirect, json } from "@remix-run/node";
 import {
-  useActionData,
-  redirect,
-  json,
-  useCatch,
-  Link,
   Form,
+  Link,
+  useActionData,
+  useCatch,
   useTransition,
-} from "remix";
+} from "@remix-run/react";
 
 import { JokeDisplay } from "~/components/joke";
 import { db } from "~/utils/db.server";


### PR DESCRIPTION
* docs(jokes): replace `remix` imports

* docs(blog): replace `remix` imports

* docs(guides): replace `remix` imports

* docs(pages): replace `remix` imports

* docs(other-api): replace `remix` imports

* docs(dev): remove `remix setup` explanation

`remix setup` is no longer needed now that we don't rely on `remix` imports

* docs(conventions): replace `remix` imports

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests
