### PR TITLE
feat(remix-dev/compiler): support native `.node` files

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -359,6 +359,7 @@
 - nexxeln
 - ni554n
 - nicholaschiang
+- nicksrandall
 - nickytonline
 - niconiahi
 - nielsdb97

--- a/packages/remix-dev/compiler/loaders.ts
+++ b/packages/remix-dev/compiler/loaders.ts
@@ -28,6 +28,7 @@ export const loaders: { [ext: string]: esbuild.Loader } = {
   ".mov": "file",
   ".mp3": "file",
   ".mp4": "file",
+  ".node": "copy",
   ".ogg": "file",
   ".otf": "file",
   ".png": "file",


### PR DESCRIPTION
This PR enables support for users to include "native" (`.node`) modules into their server bundles (when using NodeJS). 

Libraries like `sharp` (awesome for for image processing) are written in a lower-level language than NodeJS and then are compiled as a "native" module to be used in a Node environment.

Discussion: #2560

- [ ] Docs
- [ ] Tests
