### PR TITLE
fix(templates/vercel): fix dependencies

### DIFF
--- a/templates/vercel/package.json
+++ b/templates/vercel/package.json
@@ -12,6 +12,7 @@
     "@remix-run/node": "*",
     "@remix-run/react": "*",
     "@remix-run/vercel": "*",
+    "@vercel/node": "^1.14.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },


### PR DESCRIPTION
`@vercel/node` is in `@remix-run/vercel`'s `peerDependencies`

https://github.com/remix-run/remix/blob/22a618f93556d7cf57f3630273d8ae6c689656fc/packages/remix-vercel/package.json#L17-L19