### PR TITLE
feat(remix-dev): allow `data` to be returned from the MDX loader

### DIFF
--- a/packages/remix-dev/compiler/plugins/mdx.ts
+++ b/packages/remix-dev/compiler/plugins/mdx.ts
@@ -82,7 +82,7 @@ export const filename = ${JSON.stringify(path.basename(args.path))};
 export const headers = typeof attributes !== "undefined" && attributes.headers;
 export const meta = typeof attributes !== "undefined" && attributes.meta;
 export const links = undefined;
-export const data = ${JSON.stringify(compiled.data)})};
+export const data = ${JSON.stringify(compiled.data)};
 `;
 
           let errors: esbuild.PartialMessage[] = [];

--- a/packages/remix-dev/compiler/plugins/mdx.ts
+++ b/packages/remix-dev/compiler/plugins/mdx.ts
@@ -67,13 +67,6 @@ export function mdxPlugin(config: RemixConfig): esbuild.Plugin {
               break;
           }
 
-          let remixExports = `
-export const filename = ${JSON.stringify(path.basename(args.path))};
-export const headers = typeof attributes !== "undefined" && attributes.headers;
-export const meta = typeof attributes !== "undefined" && attributes.meta;
-export const links = undefined;
-          `;
-
           let compiled = await xdm.compile(fileContents, {
             jsx: true,
             jsxRuntime: "classic",
@@ -85,7 +78,12 @@ export const links = undefined;
 
           let contents = `
 ${compiled.value}
-${remixExports}`;
+export const filename = ${JSON.stringify(path.basename(args.path))};
+export const headers = typeof attributes !== "undefined" && attributes.headers;
+export const meta = typeof attributes !== "undefined" && attributes.meta;
+export const links = undefined;
+export const data = ${JSON.stringify(compiled.data)})};
+`;
 
           let errors: esbuild.PartialMessage[] = [];
           let warnings: esbuild.PartialMessage[] = [];

--- a/packages/remix-dev/modules.ts
+++ b/packages/remix-dev/modules.ts
@@ -29,6 +29,7 @@ declare module "*.jpg" {
 declare module "*.md" {
   import type { ComponentType as MdComponentType } from "react";
   export let attributes: any;
+  export let data: any;
   export let filename: string;
   let Component: MdComponentType;
   export default Component;
@@ -36,6 +37,7 @@ declare module "*.md" {
 declare module "*.mdx" {
   import type { ComponentType as MdxComponentType } from "react";
   export let attributes: any;
+  export let data: any;
   export let filename: string;
   let Component: MdxComponentType;
   export default Component;


### PR DESCRIPTION
Some remark plugins (such as [remark-reading-time](https://github.com/mattjennings/remark-reading-time) and [@stefanprobst/remark-extract-toc](https://github.com/stefanprobst/remark-extract-toc)) mutate `data`. The problem is that Remix doesn't expose `data`. The PR will solve this.

When I have my `remix.config.js` file setup like this:

```js
mdx: async function () {
  const remarkPlugins = await Promise.all([
    import('remark-reading-time').then((mod) => mod.default),
  ]);

  return {
    remarkPlugins,
  };
},
```

The inside of `mdx.ts` we get the reading time (or anything else)  from `compiled.data` and expose it as an export.

Here is an example. See the new `data` export in the last line.

```ts
export const filename = "ink.mdx";
export const headers = typeof attributes !== "undefined" && attributes.headers;
export const meta = typeof attributes !== "undefined" && attributes.meta;
export const links = undefined;
export const data = {"readingTime":{"text":"1 min read","minutes":0.02,"time":1200,"words":4}};
```

This allows me to `import` the MDX file and do what I please with it.

```ts
import { data } from './ink.mdx';

console.log(ink.data.readingTime.text);
// outputs: 1 min read
```

On my blog, I use it like this:

![image](https://user-images.githubusercontent.com/887639/161640186-86c43572-3d60-4669-a3d9-5be2f95bbe3a.png)



Note: as this is an API change, I'm tagging @ryanflorence and @mjackson 