### PR TITLE
chore(examples): remove `remix` types from `pm-app` example

### DIFF
--- a/examples/pm-app/typings/remix.d.ts
+++ b/examples/pm-app/typings/remix.d.ts
@@ -1,7 +1,0 @@
-export * from "remix";
-declare module "remix" {
-  export function json<Data>(
-    data: Data,
-    init?: number | ResponseInit
-  ): Response;
-}


### PR DESCRIPTION
These are incorrect with latest specific packages + are already in the remix codebase