### PR TITLE
docs(api/remix): replace `remix` imports

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -263,7 +263,7 @@ import { useParams } from "@remix-run/react";
 import type {
   LoaderFunction,
   ActionFunction,
-} from "@remix-run/node";
+} from "@remix-run/{runtime}";
 
 export const loader: LoaderFunction = async ({
   params,
@@ -426,7 +426,7 @@ import { useParams } from "@remix-run/react";
 import type {
   LoaderFunction,
   ActionFunction,
-} from "@remix-run/node";
+} from "@remix-run/{runtime}";
 
 export const loader: LoaderFunction = async ({
   params,
@@ -488,7 +488,7 @@ import { renderToString } from "react-dom/server";
 import type {
   EntryContext,
   HandleDataRequestFunction,
-} from "@remix-run/node";
+} from "@remix-run/{runtime}";
 import { RemixServer } from "@remix-run/react";
 
 export default function handleRequest(
@@ -549,7 +549,7 @@ export default function SomeRouteComponent() {
 Each route can define a "loader" function that will be called on the server before rendering to provide data to the route.
 
 ```js
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 
 export const loader = async () => {
   // The `json` function converts a serializable object into a JSON response
@@ -560,8 +560,8 @@ export const loader = async () => {
 
 ```ts
 // Typescript
-import { json } from "@remix-run/node";
-import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
+import type { LoaderFunction } from "@remix-run/{runtime}";
 
 export const loader: LoaderFunction = async () => {
   return json({ ok: true });
@@ -573,7 +573,7 @@ This function is only ever run on the server. On the initial server render it wi
 Using the database ORM Prisma as an example:
 
 ```tsx lines=[1-2,6-8,11]
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 import { useLoaderData } from "@remix-run/react";
 
 import { prisma } from "../db";
@@ -684,7 +684,7 @@ export const loader: LoaderFunction = async () => {
 Using the `json` helper simplifies this so you don't have to construct them yourself, but these two examples are effectively the same!
 
 ```tsx
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 
 export const loader: LoaderFunction = async () => {
   const users = await fakeDb.users.findMany();
@@ -695,7 +695,7 @@ export const loader: LoaderFunction = async () => {
 You can see how `json` just does a little of the work to make your loader a lot cleaner. You can also use the `json` helper to add headers or a status code to your response:
 
 ```tsx
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 
 export const loader: LoaderFunction = async ({
   params,
@@ -724,7 +724,7 @@ Along with returning responses, you can also throw Response objects from your lo
 Here is a full example showing how you can create utility functions that throw responses to stop code execution in the loader and move over to an alternative UI.
 
 ```ts filename=app/db.ts
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 import type { ThrownResponse } from "@remix-run/react";
 
 export type InvoiceNotFoundResponse = ThrownResponse<
@@ -742,7 +742,7 @@ export function getInvoice(id, user) {
 ```
 
 ```ts filename=app/http.ts
-import { redirect } from "@remix-run/node";
+import { redirect } from "@remix-run/{runtime}";
 
 import { getSession } from "./session";
 
@@ -838,7 +838,7 @@ Actions have the same API as loaders, the only difference is when they are calle
 This enables you to co-locate everything about a data set in a single route module: the data read, the component that renders the data, and the data writes:
 
 ```tsx
-import { json, redirect } from "@remix-run/node";
+import { json, redirect } from "@remix-run/{runtime}";
 import { Form } from "@remix-run/react";
 
 import { fakeGetTodos, fakeCreateTodo } from "~/utils/db";
@@ -970,7 +970,7 @@ Note that you can also add headers in your `entry.server` file for things that s
 ```tsx lines=[16]
 import { renderToString } from "react-dom/server";
 import { RemixServer } from "@remix-run/react";
-import type { EntryContext } from "@remix-run/node";
+import type { EntryContext } from "@remix-run/{runtime}";
 
 export default function handleRequest(
   request: Request,
@@ -999,7 +999,7 @@ Just keep in mind that doing this will apply to _all_ document requests, but doe
 The meta export will set meta tags for your html document. We highly recommend setting the title and description on every route besides layout routes (their index route will set the meta).
 
 ```tsx
-import type { MetaFunction } from "@remix-run/node";
+import type { MetaFunction } from "@remix-run/{runtime}";
 
 export const meta: MetaFunction = () => {
   return {
@@ -1029,7 +1029,7 @@ As a last option, you can also pass an object of attribute/value pairs as the va
 Examples:
 
 ```tsx
-import type { MetaFunction } from "@remix-run/node";
+import type { MetaFunction } from "@remix-run/{runtime}";
 
 export const meta: MetaFunction = () => ({
   // Special cases
@@ -1080,7 +1080,7 @@ export const meta: MetaFunction = ({ data, params }) => {
 The links function defines which `<link>` elements to add to the page when the user visits a route.
 
 ```tsx
-import type { LinksFunction } from "@remix-run/node";
+import type { LinksFunction } from "@remix-run/{runtime}";
 
 export const links: LinksFunction = () => {
   return [
@@ -1114,7 +1114,7 @@ The `links` export from a route should return an array of `HtmlLinkDescriptor` o
 Examples:
 
 ```tsx
-import type { LinksFunction } from "@remix-run/node";
+import type { LinksFunction } from "@remix-run/{runtime}";
 
 import stylesHref from "../styles/something.css";
 
@@ -1391,7 +1391,7 @@ Any files inside the `app` folder can be imported into your modules. Remix will:
 It's most common for stylesheets, but can used for anything.
 
 ```tsx filename=app/routes/root.tsx
-import type { LinksFunction } from "@remix-run/node";
+import type { LinksFunction } from "@remix-run/{runtime}";
 
 import styles from "./styles/app.css";
 import banner from "./images/banner.jpg";

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -1,11 +1,25 @@
 ---
-title: Remix Package
+title: Remix Packages
 order: 2
 ---
 
-# Remix Package
+# Remix Packages
 
-This package provides all the components, hooks, and [Web Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) objects and helpers.
+React: `@remix-run/react`
+
+Server runtimes:
+- `@remix-run/cloudflare`
+- `@remix-run/node`
+
+Server adapters:
+- `@remix-run/architect`
+- `@remix-run/cloudflare-pages`
+- `@remix-run/cloudflare-workers`
+- `@remix-run/express`
+- `@remix-run/netlify`
+- `@remix-run/vercel`
+
+These package provides all the components, hooks, and [Web Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) objects and helpers.
 
 ## Components and Hooks
 
@@ -14,7 +28,7 @@ This package provides all the components, hooks, and [Web Fetch API](https://dev
 These components are to be used once inside of your root route (`root.tsx`). They include everything Remix figured out or built in order for your page to render properly.
 
 ```tsx
-import type { LinksFunction, MetaFunction } from "remix";
+import type { LinksFunction, MetaFunction } from "@remix-run/{runtime}";
 import {
   Links,
   LiveReload,
@@ -22,7 +36,7 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-} from "remix";
+} from "@remix-run/react";
 
 import globalStylesheetUrl from "./global-styles.css";
 
@@ -76,7 +90,7 @@ This component renders an anchor tag and is the primary way the user will naviga
 It wraps React Router's Link with some extra behavior around resource prefetching.
 
 ```tsx
-import { Link } from "remix";
+import { Link } from "@remix-run/react";
 
 export default function GlobalNav() {
   return (
@@ -127,7 +141,7 @@ A `<NavLink>` is a special kind of `<Link>` that knows whether or not it is "act
 By default, an `active` class is added to a `<NavLink>` component when it is active. You can pass a function as children to customize the content of the `<NavLink>` component based on their active state, specially useful to change styles on internal elements.
 
 ```tsx
-import { NavLink } from "remix";
+import { NavLink } from "@remix-run/react";
 
 function NavList() {
   // This styling will be applied to a <NavLink> when the
@@ -193,7 +207,7 @@ If the `end` prop is used, it will ensure this component isn't matched as "activ
 The `<Form>` component is a declarative way to perform data mutations: creating, updating, and deleting data. While it might be a mind-shift to think about these tasks as "navigation", it's how the web has handled mutations since before JavaScript was created!
 
 ```tsx
-import { Form } from "remix";
+import { Form } from "@remix-run/react";
 
 function NewEvent() {
   return (
@@ -302,8 +316,9 @@ In order to avoid (usually) the client-side routing "scroll flash" on refresh or
 
 This hook returns the JSON parsed data from your route loader function.
 
-```tsx lines=[1,8]
-import { json, useLoaderData } from "remix";
+```tsx lines=[2,9]
+import { json } from "@remix-run/{runtime}";
+import { useLoaderData } from "@remix-run/react";
 
 export async function loader() {
   return json(await fakeDb.invoices.findAll());
@@ -319,8 +334,9 @@ export default function Invoices() {
 
 This hook returns the JSON parsed data from your route action. It returns `undefined` if there hasn't been a submission at the current location yet.
 
-```tsx lines=[1,10,19]
-import { json, useActionData, Form } from "remix";
+```tsx lines=[2,11,20]
+import { json } from "@remix-run/{runtime}";
+import { useActionData, Form } from "@remix-run/react";
 
 export async function action({ request }) {
   const body = await request.formData();
@@ -346,8 +362,9 @@ export default function Invoices() {
 
 The most common use-case for this hook is form validation errors. If the form isn't right, you can simply return the errors and let the user try again (instead of pushing all the errors into sessions and back out of the loader).
 
-```tsx lines=[21, 30, 38-40, 44-46]
-import { redirect, json, Form, useActionData } from "remix";
+```tsx lines=[22, 31, 39-41, 45-47]
+import { redirect, json } from "@remix-run/{runtime}";
+import { Form, useActionData } from "@remix-run/react";
 
 export async function action({ request }) {
   const form = await request.formData();
@@ -490,8 +507,9 @@ Returns the function that may be used to submit a `<form>` (or some raw `FormDat
 
 This is useful whenever you need to programmatically submit a form. For example, you may wish to save a user preferences form whenever any field changes.
 
-```tsx filename=app/routes/prefs.tsx lines=[1,13,17]
-import { json, useSubmit, useTransition } from "remix";
+```tsx filename=app/routes/prefs.tsx lines=[2,14,18]
+import { json } from "@remix-run/{runtime}";
+import { useSubmit, useTransition } from "@remix-run/react";
 
 export async function loader() {
   return json(await getUserPreferences());
@@ -527,7 +545,7 @@ function UserPreferences() {
 This can also be useful if you'd like to automatically sign someone out of your website after a period of inactivity. In this case, we've defined inactivity as the user hasn't navigated to any other pages after 5 minutes.
 
 ```tsx lines=[1,10,15]
-import { useSubmit, useTransition } from "remix";
+import { useSubmit, useTransition } from "@remix-run/react";
 import { useEffect } from "react";
 
 function AdminPage() {
@@ -563,7 +581,7 @@ This hook tells you everything you need to know about a page transition to build
 - Optimistically showing the new state of a record while it's being updated
 
 ```js
-import { useTransition } from "remix";
+import { useTransition } from "@remix-run/react";
 
 function SomeComponent() {
   const transition = useTransition();
@@ -674,7 +692,7 @@ This tells you what the next location is going to be. It's most useful when matc
 For example, this `Link` knows when its page is loading and about to become active:
 
 ```tsx lines=[7-9]
-import { Link, useResolvedPath } from "remix";
+import { Link, useResolvedPath } from "@remix-run/react";
 
 function PendingLink({ to, children }) {
   const transition = useTransition();
@@ -722,7 +740,7 @@ It is common for Remix newcomers to see this hook and think it is the primary wa
 If you're building a highly interactive, "app like" user interface, you will `useFetcher` often.
 
 ```tsx
-import { useFetcher } from "remix";
+import { useFetcher } from "@remix-run/react";
 
 function SomeComponent() {
   const fetcher = useFetcher();
@@ -941,7 +959,7 @@ export default function NewsletterSignupRoute() {
 You could even refactor the component to take props from the hooks and reuse it:
 
 ```tsx filename=routes/newsletter/subscribe.tsx
-import { Form, useFetcher } from "remix";
+import { Form, useFetcher } from "@remix-run/react";
 
 // used in the footer
 export function NewsletterSignup() {
@@ -970,7 +988,7 @@ export function NewsletterForm({
 And now you could reuse the same form, but it gets data from a different hook for the no-js experience:
 
 ```tsx filename=routes/newsletter/subscribe.tsx
-import { Form } from "remix";
+import { Form } from "@remix-run/react";
 
 import { NewsletterForm } from "~/NewsletterSignup";
 
@@ -1290,7 +1308,7 @@ You can put whatever you want on a route `handle`. Here we'll use `breadcrumb`. 
      Scripts,
      useLoaderData,
      useMatches,
-   } from "remix";
+   } from "@remix-run/react";
 
    export default function Root() {
      const matches = useMatches();
@@ -1344,7 +1362,7 @@ In this situation, you may need to save important application state on the page 
 Remix or not, this is a good practice. The user can change the url, accidentally close the browser window, etc.
 
 ```tsx lines=[1,7-11]
-import { useBeforeUnload } from "remix";
+import { useBeforeUnload } from "@remix-run/react";
 
 function SomeForm() {
   const [state, setState] = React.useState(null);
@@ -1374,8 +1392,8 @@ function SomeForm() {
 This is a shortcut for creating `application/json` responses. It assumes you are using `utf-8` encoding.
 
 ```ts lines=[2,6]
-import type { LoaderFunction } from "remix";
-import { json } from "remix";
+import type { LoaderFunction } from "@remix-run/{runtime}";
+import { json } from "@remix-run/{runtime}";
 
 export const loader: LoaderFunction = async () => {
   // So you can write this:
@@ -1411,8 +1429,8 @@ export const loader: LoaderFunction = async () => {
 This is shortcut for sending 30x responses.
 
 ```ts lines=[2,8]
-import type { ActionFunction } from "remix";
-import { redirect } from "remix";
+import type { ActionFunction } from "@remix-run/{runtime}";
+import { redirect } from "@remix-run/{runtime}";
 
 export const action: ActionFunction = async () => {
   const userSession = await getUserSessionOrWhatever();
@@ -1594,7 +1612,7 @@ Most of the time, you'll probably want to proxy the file stream to a file host.
 **Example:**
 
 ```tsx
-import type { UploadHandler } from "remix";
+import type { UploadHandler } from "@remix-run/{runtime}";
 import type {
   UploadApiErrorResponse,
   UploadApiOptions,
@@ -1682,8 +1700,8 @@ Your job is to do whatever you need with the `stream` and return a value that's 
 We have the built-in `unstable_createFileUploadHandler` and `unstable_createMemoryUploadHandler` and we also expect more upload handler utilities to be developed in the future. If you have a form that needs to use different upload handlers, you can compose them together with a custom handler, here's a theoretical example:
 
 ```tsx
-import type { UploadHandler } from "remix";
-import { unstable_createFileUploadHandler } from "remix";
+import type { UploadHandler } from "@remix-run/{runtime}";
+import { unstable_createFileUploadHandler } from "@remix-run/{runtime}";
 import { createCloudinaryUploadHandler } from "some-handy-remix-util";
 
 export const fileUploadHandler =
@@ -1724,7 +1742,7 @@ Let's say you have a banner on your e-commerce site that prompts users to check 
 First, create a cookie:
 
 ```js filename=app/cookies.js
-import { createCookie } from "remix";
+import { createCookie } from "@remix-run/{runtime}";
 
 export const userPrefs = createCookie("user-prefs", {
   maxAge: 604_800, // one week
@@ -1735,8 +1753,9 @@ Then, you can `import` the cookie and use it in your `loader` and/or `action`. T
 
 **Note:** We recommend (for now) that you create all the cookies your app needs in `app/cookies.js` and `import` them into your route modules. This allows the Remix compiler to correctly prune these imports out of the browser build where they are not needed. We hope to eventually remove this caveat.
 
-```tsx filename=app/routes/index.tsx lines=[3,7-8,14-15,19]
-import { useLoaderData, json, redirect } from "remix";
+```tsx filename=app/routes/index.tsx lines=[4,8-9,15-16,20]
+import { json, redirect } from "@remix-run/{runtime}";
+import { useLoaderData } from "@remix-run/react";
 
 import { userPrefs } from "~/cookies";
 
@@ -1855,7 +1874,7 @@ export async function loader({ request }) {
 Creates a logical container for managing a browser cookie from the server.
 
 ```ts
-import { createCookie } from "remix";
+import { createCookie } from "@remix-run/{runtime}";
 
 const cookie = createCookie("cookie-name", {
   // all of these are optional defaults that can be overridden at runtime
@@ -1877,7 +1896,7 @@ To learn more about each attribute, please see the [MDN Set-Cookie docs](https:/
 Returns `true` if an object is a Remix cookie container.
 
 ```ts
-import { isCookie } from "remix";
+import { isCookie } from "@remix-run/{runtime}";
 const cookie = createCookie("user-prefs");
 console.log(isCookie(cookie));
 // true
@@ -1969,7 +1988,7 @@ This is an example of a cookie session storage:
 
 ```js filename=app/sessions.js
 // app/sessions.js
-import { createCookieSessionStorage } from "remix";
+import { createCookieSessionStorage } from "@remix-run/{runtime}";
 
 const { getSession, commitSession, destroySession } =
   createCookieSessionStorage({
@@ -2000,8 +2019,9 @@ You'll use methods to get access to sessions in your `loader` and `action` funct
 
 A login form might look something like this:
 
-```tsx filename=app/routes/login.js lines=[3,6-8,10,15,19,25-27,38,43,48,53]
-import { json, redirect, useLoaderData } from "remix";
+```tsx filename=app/routes/login.js lines=[4,7-9,11,16,20,26-28,39,44,49,54]
+import { json, redirect } from "@remix-run/{runtime}";
+import { useLoaderData } from "@remix-run/react";
 
 import { getSession, commitSession } from "../sessions";
 
@@ -2127,7 +2147,7 @@ TODO:
 Returns `true` if an object is a Remix session.
 
 ```js
-import { isSession } from "remix";
+import { isSession } from "@remix-run/{runtime}";
 
 const sessionData = { foo: "bar" };
 const session = createSession(sessionData, "remix-session");
@@ -2142,7 +2162,7 @@ Remix makes it easy to store sessions in your own database if needed. The `creat
 The following example shows how you could do this using a generic database client:
 
 ```js
-import { createSessionStorage } from "remix";
+import { createSessionStorage } from "@remix-run/{runtime}";
 
 function createDatabaseSessionStorage({
   cookie,
@@ -2199,7 +2219,7 @@ The main advantage of cookie session storage is that you don't need any addition
 The downside is that you have to `commitSession` in almost every loader and action. If your loader or action changes the session at all, it must be committed. That means if you `session.flash` in an action, and then `session.get` in another, you must commit it for that flashed message to go away. With other session storage strategies you only have to commit it when it's created (the browser cookie doesn't need to change because it doesn't store the session data, just the key to find it elsewhere).
 
 ```js
-import { createCookieSessionStorage } from "remix";
+import { createCookieSessionStorage } from "@remix-run/{runtime}";
 
 const { getSession, commitSession, destroySession } =
   createCookieSessionStorage({
@@ -2223,7 +2243,7 @@ This storage keeps all the cookie information in your server's memory.
 import {
   createCookie,
   createMemorySessionStorage,
-} from "remix";
+} from "@remix-run/{runtime}";
 
 // In this example the Cookie is created separately.
 const sessionCookie = createCookie("__session", {
@@ -2252,7 +2272,7 @@ The advantage of file-backed sessions is that only the session ID is stored in t
 import {
   createCookie,
   createFileSessionStorage,
-} from "remix";
+} from "@remix-run/node";
 
 // In this example the Cookie is created separately.
 const sessionCookie = createCookie("__session", {
@@ -2282,7 +2302,7 @@ The advantage of KV backed sessions is that only the session ID is stored in the
 import {
   createCookie,
   createCloudflareKVSessionStorage,
-} from "remix";
+} from "@remix-run/cloudflare";
 
 // In this example the Cookie is created separately.
 const sessionCookie = createCookie("__session", {
@@ -2318,7 +2338,7 @@ sessions
 import {
   createCookie,
   createArcTableSessionStorage,
-} from "remix";
+} from "@remix-run/architect";
 
 // In this example the Cookie is created separately.
 const sessionCookie = createCookie("__session", {
@@ -2405,7 +2425,8 @@ Now we can read the message in a loader.
 <docs-info>You must commit the session whenever you read a `flash`. This is different than you might be used to where some type of middleware automatically sets the cookie header for you.</docs-info>
 
 ```jsx
-import { Meta, Links, Scripts, Outlet, json } from "remix";
+import { json } from "@remix-run/{runtime}";
+import { Meta, Links, Scripts, Outlet } from "@remix-run/react";
 
 import { getSession, commitSession } from "./sessions";
 
@@ -2486,12 +2507,12 @@ This component is a wrapper around React Router's Outlet with the ability to pas
 Here's a practical example of when you may want to use this feature. Let's say you've got a list of companies that have invoices and you want to display those companies in an accordion. We'll render our outlet in that accordion, but we want the invoice sorting to be controlled by the parent (so changing companies preserves the invoice sorting). This is a perfect use case for `<Outlet context>`.
 
 ```tsx filename=app/routes/companies.tsx lines=[5,28-31,36-44,53-57,68]
+import { json } from "@remix-run/{runtime}";
 import {
-  json,
   useLoaderData,
   useParams,
   Outlet,
-} from "remix";
+} from "@remix-run/react";
 import {
   Accordion,
   AccordionItem,
@@ -2571,12 +2592,12 @@ This hook returns the context from the `<Outlet />` that rendered you.
 Continuing from the `<Outlet context />` example above, here's what the child route could do to use the sort order.
 
 ```tsx filename=app/routes/companies/$companyId.tsx lines=[5,8,25,27-30]
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/{runtime}";
+import { json } from "@remix-run/{runtime}";
 import {
-  json,
   useLoaderData,
   useOutletContext,
-} from "remix";
+} from "@remix-run/react";
 
 import type { ContextType } from "../companies";
 
@@ -2613,18 +2634,6 @@ export default function CompanyRoute() {
     </div>
   );
 }
-```
-
-## Types
-
-```ts
-import type {
-  ActionFunction,
-  LoaderFunction,
-  MetaFunction,
-  LinksFunction,
-  ShouldReloadFunction,
-} from "remix";
 ```
 
 [meta-links-scripts]: #meta-links-scripts

--- a/docs/guides/constraints.md
+++ b/docs/guides/constraints.md
@@ -19,7 +19,7 @@ The Remix compiler will automatically remove server code from the browser bundle
 Consider a route module that exports `loader`, `meta`, and a component:
 
 ```tsx
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 import { useLoaderData } from "@remix-run/react";
 
 import PostsView from "../PostsView";
@@ -77,7 +77,7 @@ Simply put, a **side effect** is any code that might _do something_. A **module 
 Taking our code from earlier, we saw how the compiler can remove the exports and their imports that aren't used. But if we add this seemingly harmless line of code your app will break!
 
 ```tsx bad lines=[7]
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 import { useLoaderData } from "@remix-run/react";
 
 import PostsView from "../PostsView";
@@ -124,7 +124,7 @@ The loader is gone but the prisma dependency stayed! Had we logged something har
 To fix this, remove the side effect by simply moving the code _into the loader_.
 
 ```tsx lines=[8]
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 import { useLoaderData } from "@remix-run/react";
 
 import PostsView from "../PostsView";
@@ -154,7 +154,7 @@ Occasionally, the build may have trouble tree-shaking code that should only run 
 Some Remix newcomers try to abstract their loaders with "higher order functions". Something like this:
 
 ```js bad filename=app/http.js
-import { redirect } from "@remix-run/node";
+import { redirect } from "@remix-run/{runtime}";
 
 export function removeTrailingSlash(loader) {
   return function (arg) {
@@ -185,7 +185,7 @@ You can probably now see that this is a module side effect so the compiler can't
 This type of abstraction is introduced to try to return a response early. Since you can throw a Response in a loader, we can make this simpler and remove the module side effect at the same time so that the server code can be pruned:
 
 ```js filename=app/http.js
-import { redirect } from "@remix-run/node";
+import { redirect } from "@remix-run/{runtime}";
 
 export function removeTrailingSlash(url) {
   if (url.pathname.endsWith("/")) {
@@ -199,7 +199,7 @@ export function removeTrailingSlash(url) {
 And then use it like this:
 
 ```js bad filename=app/root.js
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 
 import { removeTrailingSlash } from "~/http";
 

--- a/docs/guides/data-loading.md
+++ b/docs/guides/data-loading.md
@@ -22,8 +22,8 @@ One of the primary features of Remix is simplifying interactions with the server
 Each [route module][route-module] can export a component and a [`loader`][loader]. [`useLoaderData`][useloaderdata] will provide the loader's data to your component:
 
 ```tsx filename=app/routes/products.tsx lines=[1-3,5-10,13]
-import type { LoaderFunction } from "@remix-run/node";
-import { json } from "@remix-run/node";
+import type { LoaderFunction } from "@remix-run/{runtime}";
+import { json } from "@remix-run/{runtime}";
 import { useLoaderData } from "@remix-run/react";
 
 export const loader: LoaderFunction = async () => {
@@ -55,7 +55,7 @@ If your server side modules end up in client bundles, move the imports for those
 When you name a file with `$` like `routes/users/$userId.tsx` and `routes/users/$userId/projects/$projectId.tsx` the dynamic segments (the ones starting with `$`) will be parsed from the URL and passed to your loader on a `params` object.
 
 ```tsx filename=routes/users/$userId/projects/$projectId.tsx
-import type { LoaderFunction } from "@remix-run/node";
+import type { LoaderFunction } from "@remix-run/{runtime}";
 
 export const loader: LoaderFunction = async ({
   params,
@@ -75,8 +75,8 @@ Given the following URLs, the params would be parsed as follows:
 These params are most useful for looking up data:
 
 ```tsx filename=routes/users/$userId/projects/$projectId.tsx lines=[8,9]
-import { json } from "@remix-run/node";
-import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
+import type { LoaderFunction } from "@remix-run/{runtime}";
 
 export const loader: LoaderFunction = async ({
   params,
@@ -98,7 +98,7 @@ Because these params come from the URL and not your source code, you can't know 
 
 ```tsx filename=routes/users/$userId/projects/$projectId.tsx lines=[1,7-8]
 import invariant from "tiny-invariant";
-import type { LoaderFunction } from "@remix-run/node";
+import type { LoaderFunction } from "@remix-run/{runtime}";
 
 export const loader: LoaderFunction = async ({
   params,
@@ -117,7 +117,7 @@ While you may be uncomfortable throwing errors like this with `invariant` when i
 Remix polyfills the `fetch` API on your server so it's very easy to fetch data from existing JSON APIs. Instead of managing state, errors, race conditions, and more yourself, you can do the fetch from your loader (on the server) and let Remix handle the rest.
 
 ```tsx filename=app/routes/gists.jsx lines=[5]
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 import { useLoaderData } from "@remix-run/react";
 
 export async function loader() {
@@ -154,8 +154,8 @@ export { db };
 And then your routes can import it and make queries against it:
 
 ```tsx filename=app/routes/products/$categoryId.tsx
-import type { LoaderFunction } from "@remix-run/node";
-import { json } from "@remix-run/node";
+import type { LoaderFunction } from "@remix-run/{runtime}";
+import { json } from "@remix-run/{runtime}";
 import { useLoaderData } from "@remix-run/react";
 
 import { db } from "~/db.server";
@@ -186,7 +186,7 @@ export default function ProductCategory() {
 If you are using TypeScript, you can use type inference to use Prisma Client generated types on when calling `useLoaderData`. This allowes better type safety and intellisense when writing your code that uses the loaded data.
 
 ```tsx filename=tsx filename=app/routes/products/$productId.tsx
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 import { useLoaderData } from "@remix-run/react";
 
 import { db } from "~/db.server";
@@ -224,8 +224,8 @@ export default function Product() {
 If you picked Cloudflare Workers as your environment, [Cloudflare Key Value][cloudflare-kv] storage allows you to persist data at the edge as if it were a static resource. You'll need to [do some configuration][cloudflare-kv-setup] but then you can access the data from your loaders:
 
 ```tsx filename=app/routes/products/$productId.tsx
-import type { LoaderFunction } from "@remix-run/node";
-import { json } from "@remix-run/node";
+import type { LoaderFunction } from "@remix-run/{runtime}";
+import { json } from "@remix-run/{runtime}";
 import { useLoaderData } from "@remix-run/react";
 
 export const loader: LoaderFunction = async ({
@@ -282,8 +282,8 @@ export const loader: LoaderFunction = async ({
 URL Search Params are the portion of the URL after a `?`. Other names for this are "query string", "search string", or "location search". You can access the values by creating a URL out of the `request.url`:
 
 ```tsx filename=routes/products.tsx lines=[7,8]
-import { json } from "@remix-run/node";
-import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
+import type { LoaderFunction } from "@remix-run/{runtime}";
 
 export const loader: LoaderFunction = async ({
   request,
@@ -363,7 +363,7 @@ Then the url will be: `/products/shoes?brand=nike&brand=adidas`
 Note that `brand` is repeated in the URL search string since both checkboxes were named `"brand"`. In your loader you can get access to all of those values with [`searchParams.getAll`][search-params-getall]
 
 ```tsx lines=[5]
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 
 export async function loader({ request }) {
   const url = new URL(request.url);

--- a/docs/guides/data-writes.md
+++ b/docs/guides/data-writes.md
@@ -176,8 +176,8 @@ export default function NewProject() {
 Now add the route action. Any form submissions that are "post" will call your data "action". Any "get" submissions (`<Form method="get">`) will be handled by your "loader".
 
 ```tsx [5-11]
-import type { ActionFunction } from "@remix-run/node";
-import { redirect } from "@remix-run/node";
+import type { ActionFunction } from "@remix-run/{runtime}";
+import { redirect } from "@remix-run/{runtime}";
 
 // Note the "action" export name, this will handle our form POST
 export const action: ActionFunction = async ({
@@ -230,7 +230,7 @@ export const action: ActionFunction = async ({
 Just like `useLoaderData` returns the values from the `loader`, `useActionData` will return the data from the action. It will only be there if the navigation was a form submission, so you always have to check if you've got it or not.
 
 ```tsx [2,11,21,26-30,38,43-47]
-import { redirect } from "@remix-run/node";
+import { redirect } from "@remix-run/{runtime}";
 import { useActionData } from "@remix-run/react";
 
 export const action: ActionFunction = async ({
@@ -295,7 +295,7 @@ You can ship this code as-is. The browser will handle the pending UI and interru
 Let's use progressive enhancement to make this UX a bit more fancy. By changing it from `<Form reloadDocument>` to `<Form>`, Remix will emulate the browser behavior with `fetch`. It will also give you access to the pending form data so you can build pending UI.
 
 ```tsx [2, 11]
-import { redirect } from "@remix-run/node";
+import { redirect } from "@remix-run/{runtime}";
 import { useActionData, Form } from "@remix-run/react";
 
 // ...
@@ -319,7 +319,7 @@ If you don't have the time or drive to do the rest of the job here, use `<Form r
 Now let's add some pending UI so the user has a clue something happened when they submit. There's a hook called `useTransition`. When there is a pending form submission, Remix will give you the serialized version of the form as a <a href="https://developer.mozilla.org/en-US/docs/Web/API/FormData">`FormData`</a> object. You'll be most interested in the <a href="https://developer.mozilla.org/en-US/docs/Web/API/FormData/get">`formData.get()`</a> method..
 
 ```tsx [5, 13, 19, 65-67]
-import { redirect } from "@remix-run/node";
+import { redirect } from "@remix-run/{runtime}";
 import {
   useActionData,
   Form,

--- a/docs/guides/mdx.md
+++ b/docs/guides/mdx.md
@@ -87,7 +87,7 @@ The following example demonstrates how you might build a simple blog with MDX, i
 In `app/routes/index.jsx`:
 
 ```tsx
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 import { Link, useLoaderData } from "@remix-run/react";
 
 // Import all your posts from the app/routes/posts directory. Since these are

--- a/docs/guides/optimistic-ui.md
+++ b/docs/guides/optimistic-ui.md
@@ -23,7 +23,7 @@ Remix can help you build optimistic UI with [`useTransition`][use-transition] an
 Consider the workflow for viewing and creating a new project. The project route loads the project and renders it.
 
 ```tsx filename=app/routes/project/$id.tsx
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 import { useLoaderData } from "@remix-run/react";
 
 import { ProjectView } from "~/components/project";
@@ -59,7 +59,7 @@ export function ProjectView({ project }) {
 Now we can get to the fun part. Here's what a "new project" route might look like:
 
 ```tsx filename=app/routes/projects/new.tsx
-import { redirect } from "@remix-run/node";
+import { redirect } from "@remix-run/{runtime}";
 import { Form } from "@remix-run/react";
 
 import { createProject } from "~/utils";
@@ -93,7 +93,7 @@ export default function NewProject() {
 At this point, typically you'd render a busy spinner on the page while the user waits for the project to be sent to the server, added to the database, and sent back to the browser and then redirected to the project. Remix makes that pretty easy:
 
 ```tsx filename=app/routes/projects/new.tsx lines=[2,16,28,30-32]
-import { redirect } from "@remix-run/node";
+import { redirect } from "@remix-run/{runtime}";
 import { Form, useTransition } from "@remix-run/react";
 
 import { createProject } from "~/utils";
@@ -135,7 +135,7 @@ export default function NewProject() {
 Since we know that almost every time this form is submitted it's going to succeed, we can just skip the busy spinners and show the UI as we know it's going to be: the `<ProjectView>`.
 
 ```tsx filename=app/routes/projects/new.tsx lines=[5,17-23]
-import { redirect } from "@remix-run/node";
+import { redirect } from "@remix-run/{runtime}";
 import { Form, useTransition } from "@remix-run/react";
 
 import { createProject } from "~/utils";
@@ -183,7 +183,7 @@ One of the hardest parts about implementing optimistic UI is how to handle failu
 If you want to have more control over the UI when an error occurs and put the user right back where they were without losing any state, you can catch your own error and send it down through action data.
 
 ```tsx filename=app/routes/projects/new.tsx lines=[4-5,16-24,29,48]
-import { json, redirect } from "@remix-run/node";
+import { json, redirect } from "@remix-run/{runtime}";
 import {
   Form,
   useTransition,

--- a/docs/guides/resource-routes.md
+++ b/docs/guides/resource-routes.md
@@ -86,8 +86,8 @@ app/routes/reports/$id[.]pdf.ts
 To handle `GET` requests export a loader function:
 
 ```ts
-import { json } from "@remix-run/node";
-import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
+import type { LoaderFunction } from "@remix-run/{runtime}";
 
 export const loader: LoaderFunction = async ({
   request,
@@ -101,7 +101,7 @@ export const loader: LoaderFunction = async ({
 To handle `POST`, `PUT`, `PATCH` or `DELETE` requests export an action function:
 
 ```ts
-import type { ActionFunction } from "@remix-run/node";
+import type { ActionFunction } from "@remix-run/{runtime}";
 
 export const action: ActionFunction = async ({
   request,
@@ -128,8 +128,8 @@ export const action: ActionFunction = async ({
 Resource routes can be used to handle webhooks. For example, you can create a webhook that receives notifications from GitHub when a new commit is pushed to a repository:
 
 ```ts
-import type { ActionFunction } from "@remix-run/node";
-import { json } from "@remix-run/node";
+import type { ActionFunction } from "@remix-run/{runtime}";
+import { json } from "@remix-run/{runtime}";
 import crypto from "crypto";
 
 export const action: ActionFunction = async ({

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -254,7 +254,7 @@ Now Remix can prefetch, load, and unload the styles for `button.css`, `primary-b
 An initial reaction to this is that routes have to know more than you want them to. Keep in mind each component must be imported already, so it's not introducing a new dependency, just some boilerplate to get the assets. For example, consider a product category page like this:
 
 ```tsx filename=app/routes/$category.js lines=[4-8,24-31]
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 import { useLoaderData } from "@remix-run/react";
 
 import { TileGrid } from "~/components/tile-grid";
@@ -510,7 +510,7 @@ If you're using VS Code, it's recommended you install the [Tailwind IntelliSense
 You can load stylesheets from any server, here's an example of loading a modern css reset from unpkg.
 
 ```ts filename=app/root.tsx
-import type { LinksFunction } from "@remix-run/node";
+import type { LinksFunction } from "@remix-run/{runtime}";
 
 export const links: LinksFunction = () => {
   return [
@@ -598,7 +598,7 @@ Here's how to set it up:
    Then import like any other css file:
 
    ```tsx filename=root.tsx
-   import type { LinksFunction } from "@remix-run/node";
+   import type { LinksFunction } from "@remix-run/{runtime}";
 
    import styles from "./styles/app.css";
 
@@ -687,7 +687,7 @@ Here's some sample code to show how you might use Styled Components with Remix (
 1. First you'll need to put a placeholder in your root component to control where the styles are inserted.
 
    ```tsx filename=app/root.tsx lines=[22-24]
-   import type { MetaFunction } from "@remix-run/node";
+   import type { MetaFunction } from "@remix-run/{runtime}";
    import {
      Links,
      LiveReload,
@@ -728,7 +728,7 @@ Here's some sample code to show how you might use Styled Components with Remix (
    ```tsx filename=entry.server.tsx lines=[4,12,15-20,22-23]
    import { renderToString } from "react-dom/server";
    import { RemixServer } from "@remix-run/react";
-   import type { EntryContext } from "@remix-run/node";
+   import type { EntryContext } from "@remix-run/{runtime}";
    import { ServerStyleSheet } from "styled-components";
 
    export default function handleRequest(

--- a/docs/other-api/node.md
+++ b/docs/other-api/node.md
@@ -13,7 +13,7 @@ Since Remix relies on browser API's such as fetch that are not natively availabl
 Your testing framework should provide you with a hook or location to polyfill globals / mock out API's; here you can add the following lines to install the globals that Remix relies on:
 
 ```ts
-import { installGlobals } from "@remix-run/node";
+import { installGlobals } from "@remix-run/{runtime}";
 
 // This installs globals such as "fetch", "Response", "Request" and "Headers".
 installGlobals();

--- a/docs/other-api/serve.md
+++ b/docs/other-api/serve.md
@@ -42,7 +42,7 @@ In development, `remix-serve` will ensure the latest code is run on each request
 - Any **module side effects** will remain in place! This may cause problems, but should probably be avoided anyway.
 
   ```ts [3-6]
-  import { json } from "@remix-run/node";
+  import { json } from "@remix-run/{runtime}";
 
   // this starts running the moment the module is imported
   setInterval(() => {

--- a/docs/pages/faq.md
+++ b/docs/pages/faq.md
@@ -17,7 +17,7 @@ We recommend you create a function that validates the user session that can be a
 import {
   createCookieSessionStorage,
   redirect,
-} from "@remix-run/node";
+} from "@remix-run/{runtime}";
 
 // somewhere you've got a session storage
 const { getSession } = createCookieSessionStorage();

--- a/docs/pages/gotchas.md
+++ b/docs/pages/gotchas.md
@@ -19,7 +19,7 @@ TypeError: Cannot read properties of undefined (reading 'root')
 For example, you can't import "fs-extra" directly into a route module:
 
 ```js lines=[2] filename=app/routes/index.jsx bad
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 import fs from "fs-extra";
 
 export async function loader() {
@@ -40,7 +40,7 @@ export * from "fs-extra";
 And then change our import in the route to the new "wrapper" module:
 
 ```js lines=[3] filename=app/routes/index.jsx
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 
 import fs from "../utils/fs-extra.server";
 

--- a/docs/pages/philosophy.md
+++ b/docs/pages/philosophy.md
@@ -56,7 +56,7 @@ export default function Gists() {
 With Remix, you can filter down the data _on the server_ before sending it to the user:
 
 ```js [3-16]
-import { json } from "@remix-run/node";
+import { json } from "@remix-run/{runtime}";
 
 export async function loader() {
   const res = await fetch("https://api.github.com/gists");


### PR DESCRIPTION
Also, switch from `@remix-run/node` to `@remix-run/{runtime}` in API, Guides  and general pages to be server-runtime-agnostic.
