### PR TITLE
fix(remix-dev): pass `devServerPort` to React

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -11,6 +11,7 @@
 - Alarid
 - alex-ketch
 - alexuxui
+- alishi973
 - andrelandgraf
 - AndrewIngram
 - anishpras

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -455,10 +455,7 @@ function createServerBuild(
       assetNames: "_assets/[name]-[hash]",
       publicPath: config.publicPath,
       define: {
-        "process.env.NODE_ENV": JSON.stringify(options.mode),
-        "process.env.REMIX_DEV_SERVER_WS_PORT": JSON.stringify(
-          config.devServerPort
-        ),
+        "process.env.NODE_ENV": JSON.stringify(options.mode)
       },
       plugins,
     })

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -352,6 +352,8 @@ export async function readConfig(
   );
 
   let devServerPort = await getPort({ port: appConfig.devServerPort || 8002 });
+  // TODO: find better way for passing remix config to react, temporary assign to process directly.
+  process.env.REMIX_DEV_SERVER_WS_PORT = JSON.stringify(devServerPort);
   let devServerBroadcastDelay = appConfig.devServerBroadcastDelay || 0;
 
   let defaultPublicPath = "/build/";


### PR DESCRIPTION
Closes: #2620 

This issue demonstrates that ``devServerPort`` on ``remix.config.js`` will not inject into react-dev-server.

Then I reviewed #1352 by @kentcdodds and found something:

In this PR, we tried to pass remix config with ``esbuild`` module to react-dev-server:

https://github.com/remix-run/remix/blob/c3c3627374ef8b3e7b4eb7f30d614eeae48b37ef/packages/remix-dev/compiler.ts#L365-L370

According to ``esbuild`` test files, it's correct, and everything should be working fine and passes the parameter.
here is ``esbuild`` test files for the ``define`` property:
https://github.com/evanw/esbuild/blob/c02c99fc74373aed6d58e7a349b463cd26e1d86f/scripts/js-api-tests.js#L3847-L3861

Also, check this test:
https://github.com/remix-run/remix/blob/c3c3627374ef8b3e7b4eb7f30d614eeae48b37ef/packages/remix-react/__tests__/components-test.tsx#L48-L54
 
On line 49 we assign ``devServerPort`` directly to ``process.env``, so react-dev-server will pick this variable, but in a normal situation, we did not use ``process.env`` for passing variables and used ``define`` property on ``esbuild`` .

and finally, any change on this PR or suggestion about passing data from remix config to react dev server is appreciated✌️.

