### PR TITLE
chore: add @typescript-eslint/consistent-type-imports rule

### DIFF
--- a/packages/remix-eslint-config/rules/typescript.js
+++ b/packages/remix-eslint-config/rules/typescript.js
@@ -8,6 +8,8 @@ module.exports = {
 
   // Add TypeScript specific rules (and turn off ESLint equivalents)
   "@typescript-eslint/consistent-type-assertions": WARN,
+  "@typescript-eslint/consistent-type-imports": WARN,
+
   "no-array-constructor": OFF,
   "@typescript-eslint/no-array-constructor": WARN,
 


### PR DESCRIPTION
Adds the typescript [consistent-type-imports](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-type-imports.md) rule to the eslint config to enforce consistent separation of `import type` and `import`.

- [ ] Docs
- [ ] Tests
