### PR TITLE
fix(remix-react): pass `port` to inline script of `LiveReload`

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1404,7 +1404,7 @@ export const LiveReload =
         port?: number;
         nonce?: string;
       }) {
-        let setupLiveReload = (() => {
+        let setupLiveReload = ((port: number) => {
           let protocol = location.protocol === "https:" ? "wss:" : "ws:";
           let host = location.hostname;
           let socketPath = `${protocol}//${host}:${port}/socket`;
@@ -1431,7 +1431,7 @@ export const LiveReload =
             nonce={nonce}
             suppressHydrationWarning
             dangerouslySetInnerHTML={{
-              __html: `(${setupLiveReload})()`,
+              __html: `(${setupLiveReload})(+${port})`,
             }}
           />
         );

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1431,7 +1431,7 @@ export const LiveReload =
             nonce={nonce}
             suppressHydrationWarning
             dangerouslySetInnerHTML={{
-              __html: `(${setupLiveReload})(+${port})`,
+              __html: `(${setupLiveReload})(${port})`,
             }}
           />
         );


### PR DESCRIPTION
Without this you get an error in the console indicating `port` is `undefined`.