### PR TITLE
chore(remix-dev/tests): run `replace-remix-imports` migration over stack fixture

### DIFF
--- a/packages/remix-dev/__tests__/fixtures/stack/app/entry.client.tsx
+++ b/packages/remix-dev/__tests__/fixtures/stack/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from "@remix-run/react";
 import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
 
 hydrate(<RemixBrowser />, document);

--- a/packages/remix-dev/__tests__/fixtures/stack/app/entry.server.tsx
+++ b/packages/remix-dev/__tests__/fixtures/stack/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
 
 export default function handleRequest(
   request: Request,

--- a/packages/remix-dev/__tests__/fixtures/stack/app/root.tsx
+++ b/packages/remix-dev/__tests__/fixtures/stack/app/root.tsx
@@ -5,7 +5,7 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-} from "remix";
+} from "@remix-run/react";
 
 export default function App() {
   return (

--- a/packages/remix-dev/__tests__/fixtures/stack/package.json
+++ b/packages/remix-dev/__tests__/fixtures/stack/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "remix-template-remix-ts",
+  "name": "remix-template-remix",
   "private": true,
   "description": "",
   "license": "",


### PR DESCRIPTION
Seems like this one was missed in #2655