### PR TITLE
[Docs] Blog Tutorial Workaround for "Top-level 'await' expressions" error

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -58,6 +58,7 @@
 - danielweinmann
 - davecalnan
 - DavidHollins6
+- davidkrisch
 - davongit
 - denissb
 - derekr

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -366,13 +366,16 @@ Isn't it great?
   },
 ];
 
-for (const post of posts) {
-  await prisma.post.upsert({
-    where: { slug: post.slug },
-    update: post,
-    create: post,
-  });
-}
+const loadPosts = async () => {
+  for (const post of posts) {
+    await prisma.post.upsert({
+      where: { slug: post.slug },
+      update: post,
+      create: post,
+    });
+  }
+};
+loadPosts();
 ```
 
 <docs-info>Note that we're using `upsert` so you can run the seed script over and over without adding multiple versions of the same post every time.</docs-info>


### PR DESCRIPTION
I was working through the excellent Blog Tutorial and got this error 

```
TSError: ⨯ Unable to compile TypeScript:
prisma/seed.ts:93:3 - error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', or 'nodenext', and the 'target' option is set to 'es2017' or higher. 
```
when I ran `npx prisma db seed`.  This PR works around the error by wrapping the top-level `await` in a function and then running it on the next line.

This is on node v14.18.

ref: #1355 