### PR TITLE
docs(tutorials/jokes): filter RSS jokes by user

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -236,6 +236,7 @@
 - niwsa
 - nobeeakon
 - nordiauwu
+- Noriller
 - nurul3101
 - nwalters512
 - octokatherine

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -5566,26 +5566,27 @@ function escapeHtml(s: string) {
     .replace(/'/g, "&#039;");
 }
 
-export const loader: LoaderFunction = async ({ request }) => {
+export const loader: LoaderFunction = async ({
+  request,
+}) => {
   const url = new URL(request.url);
   const username = url.searchParams.get("jokester") || "kody";
 
   const jokes = await db.joke.findMany({
     take: 100,
     orderBy: { createdAt: "desc" },
-    where: {
-      jokester: {
-        username
-      }
-    }
+    where: { jokester: { username } }
   });
 
   const host =
-    request.headers.get("X-Forwarded-Host") ?? request.headers.get("host");
+    request.headers.get("X-Forwarded-Host") ??
+    request.headers.get("host");
   if (!host) {
     throw new Error("Could not determine domain URL.");
   }
-  const protocol = host.includes("localhost") ? "http" : "https";
+  const protocol = host.includes("localhost")
+    ? "http"
+    : "https";
   const domain = `${protocol}://${host}`;
   const jokesUrl = `${domain}/jokes`;
 
@@ -5602,9 +5603,15 @@ export const loader: LoaderFunction = async ({ request }) => {
           .map((joke) =>
             `
             <item>
-              <title><![CDATA[${escapeCdata(joke.name)}]]></title>
-              <description><![CDATA[A funny joke called ${escapeHtml(joke.name)}]]></description>
-              <author><![CDATA[${escapeCdata(username)}]]></author>
+              <title><![CDATA[${escapeCdata(
+                joke.name
+              )}]]></title>
+              <description><![CDATA[A funny joke called ${escapeHtml(
+                joke.name
+              )}]]></description>
+              <author><![CDATA[${escapeCdata(
+                username
+              )}]]></author>
               <pubDate>${joke.createdAt.toUTCString()}</pubDate>
               <link>${jokesUrl}/${joke.id}</link>
               <guid>${jokesUrl}/${joke.id}</guid>
@@ -5618,9 +5625,13 @@ export const loader: LoaderFunction = async ({ request }) => {
 
   return new Response(rssString, {
     headers: {
-      "Cache-Control": `public, max-age=${60 * 10}, s-maxage=${60 * 60 * 24}`,
+      "Cache-Control": `public, max-age=${
+        60 * 10
+      }, s-maxage=${60 * 60 * 24}`,
       "Content-Type": "application/xml",
-      "Content-Length": String(Buffer.byteLength(rssString)),
+      "Content-Length": String(
+        Buffer.byteLength(rssString)
+      ),
     },
   });
 };

--- a/examples/jokes/app/routes/jokes.tsx
+++ b/examples/jokes/app/routes/jokes.tsx
@@ -93,7 +93,7 @@ export default function JokesScreen() {
       </main>
       <footer className="jokes-footer">
         <div className="container">
-          <Link reloadDocument to="/jokes.rss">
+          <Link reloadDocument to={data.user ? `/jokes.rss?jokester=${data.user.username}` : "/jokes.rss"}>
             RSS
           </Link>
         </div>

--- a/examples/jokes/app/routes/jokes[.]rss.tsx
+++ b/examples/jokes/app/routes/jokes[.]rss.tsx
@@ -13,7 +13,6 @@ export const loader: LoaderFunction = async ({ request }) => {
   const jokes = await db.joke.findMany({
     take: 100,
     orderBy: { createdAt: "desc" },
-    include: { jokester: { select: { username: true } } },
     where: {
       jokester: {
         username
@@ -45,7 +44,7 @@ export const loader: LoaderFunction = async ({ request }) => {
             <item>
               <title>${joke.name}</title>
               <description>A funny joke called ${joke.name}</description>
-              <author>${joke.jokester.username}</author>
+              <author>${username}</author>
               <pubDate>${joke.createdAt}</pubDate>
               <link>${jokesUrl}/${joke.id}</link>
               <guid>${jokesUrl}/${joke.id}</guid>

--- a/examples/jokes/app/routes/jokes[.]rss.tsx
+++ b/examples/jokes/app/routes/jokes[.]rss.tsx
@@ -3,10 +3,18 @@ import type { LoaderFunction } from "@remix-run/node";
 import { db } from "~/utils/db.server";
 
 export const loader: LoaderFunction = async ({ request }) => {
+  const url = new URL(request.url);
+  const username = url.searchParams.get("jokester") || "kody";
+
   const jokes = await db.joke.findMany({
     take: 100,
     orderBy: { createdAt: "desc" },
     include: { jokester: { select: { username: true } } },
+    where: {
+      jokester: {
+        username
+      }
+    }
   });
 
   const host =

--- a/examples/jokes/app/routes/jokes[.]rss.tsx
+++ b/examples/jokes/app/routes/jokes[.]rss.tsx
@@ -4,6 +4,10 @@ import { db } from "~/utils/db.server";
 
 export const loader: LoaderFunction = async ({ request }) => {
   const url = new URL(request.url);
+  // in the official deployed version of the app, we don't want to deploy
+  // a site with unmoderated content, so we only show users their own jokes
+  // or jokes from kody, which are safe to show to everyone
+  // by using search params, you can still share and view jokes from other users
   const username = url.searchParams.get("jokester") || "kody";
 
   const jokes = await db.joke.findMany({

--- a/examples/jokes/app/routes/jokes[.]rss.tsx
+++ b/examples/jokes/app/routes/jokes[.]rss.tsx
@@ -2,6 +2,19 @@ import type { LoaderFunction } from "@remix-run/node";
 
 import { db } from "~/utils/db.server";
 
+function escapeCdata(s: string) {
+  return s.replace(/\]\]>/g, "]]]]><![CDATA[>");
+}
+
+function escapeHtml(s: string) {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
 export const loader: LoaderFunction = async ({ request }) => {
   const url = new URL(request.url);
   // in the official deployed version of the app, we don't want to deploy
@@ -42,10 +55,10 @@ export const loader: LoaderFunction = async ({ request }) => {
           .map((joke) =>
             `
             <item>
-              <title>${joke.name}</title>
-              <description>A funny joke called ${joke.name}</description>
-              <author>${username}</author>
-              <pubDate>${joke.createdAt}</pubDate>
+              <title><![CDATA[${escapeCdata(joke.name)}]]></title>
+              <description><![CDATA[A funny joke called ${escapeHtml(joke.name)}]]></description>
+              <author><![CDATA[${escapeCdata(username)}]]></author>
+              <pubDate>${joke.createdAt.toUTCString()}</pubDate>
               <link>${jokesUrl}/${joke.id}</link>
               <guid>${jokesUrl}/${joke.id}</guid>
             </item>


### PR DESCRIPTION
As I was doing the tutorial I saw that in the deployed version, the [RSS feed](https://remix-jokes.lol/jokes.rss) shows all jokes made by anyone.
The idea of some of the features in the example was to not have to have moderation, but the open RSS feed means that people could put things in the name of the joke or even in the user that would need moderation.

That said, to keep the example with minimal modifications, I've added a filter by username and I'm hoping that `kody` has some jokes in the deployed version.

By default, it will show only jokes by `kody`, but when logged, it adds a search param `jokester` with the username, so that you could potentially share only the jokes of your username in the feed.

Finally, I've updated the tutorial page with the last version of the `jokes[.]rss.tsx` file (that had an earlier version of the code).
