### PR TITLE
docs(guides/constraints): handle root path in `removeTrailingSlash` helper

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -34,6 +34,7 @@
 - bmontalvo
 - bogas04
 - BogdanDevBst
+- bolchowka
 - brophdawg11
 - bruno-oliveira
 - bsharrow

--- a/docs/guides/constraints.md
+++ b/docs/guides/constraints.md
@@ -160,7 +160,7 @@ export function removeTrailingSlash(loader) {
   return function (arg) {
     const { request } = arg;
     const url = new URL(request.url);
-    if (url.pathname.endsWith("/")) {
+    if (url.pathname !== '/' && url.pathname.endsWith("/")) {
       return redirect(request.url.slice(0, -1), {
         status: 308,
       });
@@ -188,7 +188,7 @@ This type of abstraction is introduced to try to return a response early. Since 
 import { redirect } from "@remix-run/{runtime}";
 
 export function removeTrailingSlash(url) {
-  if (url.pathname.endsWith("/")) {
+  if (url.pathname !== '/' && url.pathname.endsWith("/")) {
     throw redirect(request.url.slice(0, -1), {
       status: 308,
     });


### PR DESCRIPTION
Fixed `removeTrailingSlash` helper example which incorrectly handles root path which caused infinite redirection loop.