### PR TITLE
docs(pages/technical-explanation): update code highlighting

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -14,6 +14,7 @@
 - andrelandgraf
 - andrewbrey
 - AndrewIngram
+- amorriscode
 - anishpras
 - anmolm96
 - anmonteiro

--- a/docs/pages/technical-explanation.md
+++ b/docs/pages/technical-explanation.md
@@ -168,7 +168,7 @@ Taking our route module from before, here are a few small, but useful UX improve
 2. Focus the input when server side form validation fails
 3. Animate in the error messages
 
-```jsx nocopy lines=[4-6,8-12,21,22,28-30]
+```jsx nocopy lines=[4-6,8-12,23-26,30-32]
 export default function Projects() {
   const projects = useLoaderData();
   const actionData = useActionData();


### PR DESCRIPTION
- [x] Docs

### Description

While reading the [technical explanation docs](https://remix.run/docs/en/v1/pages/technical-explanation), it seemed like the code highlighting in the [Browser Framework section](https://remix.run/docs/en/v1/pages/technical-explanation#browser-framework) was off. I _believe_ the inside of the form should be highlighted as well as the `FadeIn`.

This PR updates the code highlighting to highlight the features discussed in the section.