### PR TITLE
docs(api/remix): add missing `id` on match object from `useMatches`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -141,6 +141,7 @@
 - jmasson
 - jo-ninja
 - joaosamouco
+- jodygeraldo
 - johannesbraeunig
 - johnson444
 - johnson444

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -1270,9 +1270,9 @@ function SomeComponent() {
 
 ```js
 [
-  { pathname, data, params, handle }, // root route
-  { pathname, data, params, handle }, // layout route
-  { pathname, data, params, handle }, // child route
+  { id, pathname, data, params, handle }, // root route
+  { id, pathname, data, params, handle }, // layout route
+  { id, pathname, data, params, handle }, // child route
   // etc.
 ];
 ```


### PR DESCRIPTION
Add missing id that added on [#1348](https://github.com/remix-run/remix/pull/1348)