### PR TITLE
feat(remix-eslint-config): add ESLint warning when using deprecated `remix` imports

### DIFF
--- a/packages/remix-eslint-config/rules/core.js
+++ b/packages/remix-eslint-config/rules/core.js
@@ -1,6 +1,44 @@
+const {
+  defaultAdapterExports,
+  defaultRuntimeExports,
+  architectSpecificExports,
+  cloudflareSpecificExports,
+  cloudflarePagesSpecificExports,
+  cloudflareWorkersSpecificExports,
+  nodeSpecificExports,
+  reactSpecificExports,
+} = require("./packageExports");
+
 // const OFF = 0;
 const WARN = 1;
 const ERROR = 2;
+
+const getReplaceRemixImportsMessage = (packageName) =>
+  `All \`remix\` exports are considered deprecated as of v1.3.3. Please use \`@remix-run/${packageName}\` instead. You can run \`remix migrate --migration replace-remix-imports\` to automatically migrate your code.`;
+const replaceRemixImportsOptions = [
+  {
+    packageExports: defaultAdapterExports,
+    packageName:
+      "{architect|cloudflare-pages|cloudflare-workers|express|netlify|vercel}",
+  },
+  { packageExports: defaultRuntimeExports, packageName: "{cloudflare|node}" },
+  { packageExports: architectSpecificExports, packageName: "architect" },
+  { packageExports: cloudflareSpecificExports, packageName: "cloudflare" },
+  {
+    packageExports: cloudflarePagesSpecificExports,
+    packageName: "cloudflare-pages",
+  },
+  {
+    packageExports: cloudflareWorkersSpecificExports,
+    packageName: "cloudflare-workers",
+  },
+  { packageExports: nodeSpecificExports, packageName: "node" },
+  { packageExports: reactSpecificExports, packageName: "react" },
+].map(({ packageExports, packageName }) => ({
+  importNames: [...packageExports.value, ...packageExports.type],
+  message: getReplaceRemixImportsMessage(packageName),
+  name: "remix",
+}));
 
 module.exports = {
   "array-callback-return": WARN,
@@ -50,6 +88,7 @@ module.exports = {
   "no-new-object": WARN,
   "no-octal": WARN,
   "no-redeclare": ERROR,
+  "no-restricted-imports": [WARN, ...replaceRemixImportsOptions],
   "no-script-url": WARN,
   "no-self-assign": WARN,
   "no-self-compare": WARN,

--- a/packages/remix-eslint-config/rules/packageExports.js
+++ b/packages/remix-eslint-config/rules/packageExports.js
@@ -1,0 +1,159 @@
+const defaultAdapterExports = {
+  value: ["createRequestHandler"],
+  type: ["GetLoadContextFunction", "RequestHandler"],
+};
+
+const defaultRuntimeExports = {
+  value: [
+    "createCookie",
+    "createCookieSessionStorage",
+    "createMemorySessionStorage",
+    "createSessionStorage",
+    "createRequestHandler",
+    "createSession",
+    "isCookie",
+    "isSession",
+    "json",
+    "redirect",
+  ],
+  type: [
+    "ActionFunction",
+    "AppData",
+    "AppLoadContext",
+    "CreateRequestHandlerFunction",
+    "Cookie",
+    "CookieOptions",
+    "CookieParseOptions",
+    "CookieSerializeOptions",
+    "CookieSignatureOptions",
+    "DataFunctionArgs",
+    "EntryContext",
+    "ErrorBoundaryComponent",
+    "HandleDataRequestFunction",
+    "HandleDocumentRequestFunction",
+    "HeadersFunction",
+    "HtmlLinkDescriptor",
+    "HtmlMetaDescriptor",
+    "LinkDescriptor",
+    "LinksFunction",
+    "LoaderFunction",
+    "MetaDescriptor",
+    "MetaFunction",
+    "PageLinkDescriptor",
+    "RequestHandler",
+    "RouteComponent",
+    "RouteHandle",
+    "ServerBuild",
+    "ServerEntryModule",
+    "Session",
+    "SessionData",
+    "SessionIdStorageStrategy",
+    "SessionStorage",
+  ],
+};
+
+const architectSpecificExports = {
+  value: ["createArcTableSessionStorage"],
+  type: [],
+};
+
+const cloudflareSpecificExports = {
+  value: ["createCloudflareKVSessionStorage"],
+  type: [],
+};
+
+const cloudflarePagesSpecificExports = {
+  value: ["createPagesFunctionHandler"],
+  type: ["createPagesFunctionHandlerParams"],
+};
+
+const cloudflareWorkersSpecificExports = {
+  value: ["createEventHandler", "handleAsset"],
+  type: [],
+};
+
+const nodeSpecificExports = {
+  value: [
+    "AbortController",
+    "createFileSessionStorage",
+    "fetch",
+    "FormData",
+    "Headers",
+    "NodeOnDiskFile",
+    "Request",
+    "Response",
+    "unstable_createFileUploadHandler",
+    "unstable_createMemoryUploadHandler",
+    "unstable_parseMultipartFormData",
+  ],
+  type: [
+    "HeadersInit",
+    "RequestInfo",
+    "RequestInit",
+    "ResponseInit",
+    "UploadHandler",
+    "UploadHandlerArgs",
+  ],
+};
+
+const reactSpecificExports = {
+  value: [
+    "Form",
+    "Link",
+    "Links",
+    "LiveReload",
+    "Meta",
+    "NavLink",
+    "Outlet",
+    "PrefetchPageLinks",
+    "RemixBrowser",
+    "RemixServer",
+    "Scripts",
+    "ScrollRestoration",
+    "useActionData",
+    "useBeforeUnload",
+    "useCatch",
+    "useFetcher",
+    "useFetchers",
+    "useFormAction",
+    "useHref",
+    "useLoaderData",
+    "useLocation",
+    "useMatches",
+    "useNavigate",
+    "useNavigationType",
+    "useOutlet",
+    "useOutletContext",
+    "useParams",
+    "useResolvedPath",
+    "useSearchParams",
+    "useSubmit",
+    "useTransition",
+  ],
+  type: [
+    "FormEncType",
+    "FormMethod",
+    "FormProps",
+    "HtmlLinkDescriptor",
+    "HtmlMetaDescriptor",
+    "LinkProps",
+    "NavLinkProps",
+    "RemixBrowserProps",
+    "RemixServerProps",
+    "ShouldReloadFunction",
+    "SubmitFunction",
+    "SubmitOptions",
+    "ThrownResponse",
+  ],
+};
+
+module.exports = {
+  defaultAdapterExports,
+  defaultRuntimeExports,
+  architectSpecificExports,
+  cloudflareSpecificExports,
+  cloudflarePagesSpecificExports,
+  cloudflareWorkersSpecificExports,
+  nodeSpecificExports,
+  reactSpecificExports,
+};


### PR DESCRIPTION
This way people will know that all `remix` exports are considered deprecated & that they can use the `replace-remix-imports` migration to fix it all.

I needed to copy over all values from `packageExports` of `replace-remix-imports`' migration, since those values are only available in `@remix-run/dev`.

https://github.com/remix-run/remix/blob/main/packages/remix-dev/cli/migrate/migrations/replace-remix-imports/transform/mapNormalizedImports/packageExports.ts