### PR TITLE
feat: deprecate all functions & types exported from `magicExports`

### DIFF
--- a/packages/remix-architect/magicExports/remix.ts
+++ b/packages/remix-architect/magicExports/remix.ts
@@ -1,5 +1,21 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
+import * as architect from "@remix-run/architect";
+
+const warn = <T extends Function>(fn: T, message: string): T =>
+  ((...args: unknown[]) => {
+    console.warn(message);
+
+    return fn(...args);
+  }) as unknown as T;
+
+const getDeprecatedMessage = (functionName: string, packageName: string) =>
+  `All \`remix\` exports are considered deprecated as of v1.3.3. Please import \`${functionName}\` from \`@remix-run/${packageName}\` instead. You can run \`remix migrate --migration replace-remix-imports\` to automatically migrate your code.`;
+
 // Re-export everything from this package that is available in `remix`.
 
-export { createArcTableSessionStorage } from "@remix-run/architect";
+/** @deprecated Import `createArcTableSessionStorage` from `@remix-run/architect` instead. */
+export const createArcTableSessionStorage = warn(
+  architect.createArcTableSessionStorage,
+  getDeprecatedMessage("createArcTableSessionStorage", "architect")
+);

--- a/packages/remix-cloudflare-pages/magicExports/remix.ts
+++ b/packages/remix-cloudflare-pages/magicExports/remix.ts
@@ -1,3 +1,19 @@
+import * as cloudflare from "@remix-run/cloudflare";
+
+const warn = <T extends Function>(fn: T, message: string): T =>
+  ((...args: unknown[]) => {
+    console.warn(message);
+
+    return fn(...args);
+  }) as unknown as T;
+
+const getDeprecatedMessage = (functionName: string, packageName: string) =>
+  `All \`remix\` exports are considered deprecated as of v1.3.3. Please import \`${functionName}\` from \`@remix-run/${packageName}\` instead. You can run \`remix migrate --migration replace-remix-imports\` to automatically migrate your code.`;
+
 // Re-export everything from this package that is available in `remix`.
 
-export { createCloudflareKVSessionStorage } from "@remix-run/cloudflare";
+/** @deprecated Import `createCloudflareKVSessionStorage` from `@remix-run/cloudflare` instead. */
+export const createCloudflareKVSessionStorage = warn(
+  cloudflare.createCloudflareKVSessionStorage,
+  getDeprecatedMessage("createCloudflareKVSessionStorage", "cloudflare")
+);

--- a/packages/remix-cloudflare-workers/magicExports/remix.ts
+++ b/packages/remix-cloudflare-workers/magicExports/remix.ts
@@ -1,3 +1,19 @@
+import * as cloudflare from "@remix-run/cloudflare";
+
+const warn = <T extends Function>(fn: T, message: string): T =>
+  ((...args: unknown[]) => {
+    console.warn(message);
+
+    return fn(...args);
+  }) as unknown as T;
+
+const getDeprecatedMessage = (functionName: string, packageName: string) =>
+  `All \`remix\` exports are considered deprecated as of v1.3.3. Please import \`${functionName}\` from \`@remix-run/${packageName}\` instead. You can run \`remix migrate --migration replace-remix-imports\` to automatically migrate your code.`;
+
 // Re-export everything from this package that is available in `remix`.
 
-export { createCloudflareKVSessionStorage } from "@remix-run/cloudflare";
+/** @deprecated Import `createCloudflareKVSessionStorage` from `@remix-run/cloudflare` instead. */
+export const createCloudflareKVSessionStorage = warn(
+  cloudflare.createCloudflareKVSessionStorage,
+  getDeprecatedMessage("createCloudflareKVSessionStorage", "cloudflare")
+);

--- a/packages/remix-cloudflare/magicExports/remix.ts
+++ b/packages/remix-cloudflare/magicExports/remix.ts
@@ -1,11 +1,41 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
+import * as cloudflare from "@remix-run/cloudflare";
+
+const warn = <T extends Function>(fn: T, message: string): T =>
+  ((...args: unknown[]) => {
+    console.warn(message);
+
+    return fn(...args);
+  }) as unknown as T;
+
+const getDeprecatedMessage = (functionName: string, packageName: string) =>
+  `All \`remix\` exports are considered deprecated as of v1.3.3. Please import \`${functionName}\` from \`@remix-run/${packageName}\` instead. You can run \`remix migrate --migration replace-remix-imports\` to automatically migrate your code.`;
+
 // Re-export everything from this package that is available in `remix`.
 
-export {
-  createCloudflareKVSessionStorage,
-  createCookie,
-  createSessionStorage,
-  createCookieSessionStorage,
-  createMemorySessionStorage,
-} from "@remix-run/cloudflare";
+/** @deprecated Import `createCloudflareKVSessionStorage` from `@remix-run/cloudflare` instead. */
+export const createCloudflareKVSessionStorage = warn(
+  cloudflare.createCloudflareKVSessionStorage,
+  getDeprecatedMessage("createCloudflareKVSessionStorage", "cloudflare")
+);
+/** @deprecated Import `createCookie` from `@remix-run/cloudflare` instead. */
+export const createCookie = warn(
+  cloudflare.createCookie,
+  getDeprecatedMessage("createCookie", "cloudflare")
+);
+/** @deprecated Import `createSessionStorage` from `@remix-run/cloudflare` instead. */
+export const createSessionStorage = warn(
+  cloudflare.createSessionStorage,
+  getDeprecatedMessage("createSessionStorage", "cloudflare")
+);
+/** @deprecated Import `createCookieSessionStorage` from `@remix-run/cloudflare` instead. */
+export const createCookieSessionStorage = warn(
+  cloudflare.createCookieSessionStorage,
+  getDeprecatedMessage("createCookieSessionStorage", "cloudflare")
+);
+/** @deprecated Import `createMemorySessionStorage` from `@remix-run/cloudflare` instead. */
+export const createMemorySessionStorage = warn(
+  cloudflare.createMemorySessionStorage,
+  getDeprecatedMessage("createMemorySessionStorage", "cloudflare")
+);

--- a/packages/remix-node/magicExports/remix.ts
+++ b/packages/remix-node/magicExports/remix.ts
@@ -1,16 +1,62 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
+import * as node from "@remix-run/node";
+import type * as NodeTypes from "@remix-run/node";
+
+const warn = <T extends Function>(fn: T, message: string): T =>
+  ((...args: unknown[]) => {
+    console.warn(message);
+
+    return fn(...args);
+  }) as unknown as T;
+
+const getDeprecatedMessage = (functionName: string, packageName: string) =>
+  `All \`remix\` exports are considered deprecated as of v1.3.3. Please import \`${functionName}\` from \`@remix-run/${packageName}\` instead. You can run \`remix migrate --migration replace-remix-imports\` to automatically migrate your code.`;
+
 // Re-export everything from this package that is available in `remix`.
 
-export {
-  createCookie,
-  createSessionStorage,
-  createCookieSessionStorage,
-  createMemorySessionStorage,
-  createFileSessionStorage,
-  unstable_createFileUploadHandler,
-  unstable_createMemoryUploadHandler,
-  unstable_parseMultipartFormData,
-} from "@remix-run/node";
+/** @deprecated Import `createCookie` from `@remix-run/node` instead. */
+export const createCookie = warn(
+  node.createCookie,
+  getDeprecatedMessage("createCookie", "node")
+);
+/** @deprecated Import `createSessionStorage` from `@remix-run/node` instead. */
+export const createSessionStorage = warn(
+  node.createSessionStorage,
+  getDeprecatedMessage("createSessionStorage", "node")
+);
+/** @deprecated Import `createCookieSessionStorage` from `@remix-run/node` instead. */
+export const createCookieSessionStorage = warn(
+  node.createCookieSessionStorage,
+  getDeprecatedMessage("createCookieSessionStorage", "node")
+);
+/** @deprecated Import `createMemorySessionStorage` from `@remix-run/node` instead. */
+export const createMemorySessionStorage = warn(
+  node.createMemorySessionStorage,
+  getDeprecatedMessage("createMemorySessionStorage", "node")
+);
+/** @deprecated Import `createFileSessionStorage` from `@remix-run/node` instead. */
+export const createFileSessionStorage = warn(
+  node.createFileSessionStorage,
+  getDeprecatedMessage("createFileSessionStorage", "node")
+);
+/** @deprecated Import `unstable_createFileUploadHandler` from `@remix-run/node` instead. */
+export const unstable_createFileUploadHandler = warn(
+  node.unstable_createFileUploadHandler,
+  getDeprecatedMessage("unstable_createFileUploadHandler", "node")
+);
+/** @deprecated Import `unstable_createMemoryUploadHandler` from `@remix-run/node` instead. */
+export const unstable_createMemoryUploadHandler = warn(
+  node.unstable_createMemoryUploadHandler,
+  getDeprecatedMessage("unstable_createMemoryUploadHandler", "node")
+);
+/** @deprecated Import `unstable_parseMultipartFormData` from `@remix-run/node` instead. */
+export const unstable_parseMultipartFormData = warn(
+  node.unstable_parseMultipartFormData,
+  getDeprecatedMessage("unstable_parseMultipartFormData", "node")
+);
 
-export type { UploadHandler, UploadHandlerArgs } from "@remix-run/node";
+/** @deprecated Import type `UploadHandler` from `@remix-run/node` instead. */
+export type UploadHandler = NodeTypes.UploadHandler;
+/** @deprecated Import type `UploadHandlerArgs` from `@remix-run/node` instead. */
+export type UploadHandlerArgs = NodeTypes.UploadHandlerArgs;

--- a/packages/remix-react/magicExports/remix.ts
+++ b/packages/remix-react/magicExports/remix.ts
@@ -1,57 +1,187 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
+import * as react from "@remix-run/react";
+import type * as ReactTypes from "@remix-run/react";
+
+const warn = <T extends Function>(fn: T, message: string): T =>
+  ((...args: unknown[]) => {
+    console.warn(message);
+
+    return fn(...args);
+  }) as unknown as T;
+
+const getDeprecatedMessage = (functionName: string, packageName: string) =>
+  `All \`remix\` exports are considered deprecated as of v1.3.3. Please import \`${functionName}\` from \`@remix-run/${packageName}\` instead. You can run \`remix migrate --migration replace-remix-imports\` to automatically migrate your code.`;
+
 // Re-export everything from this package that is available in `remix`.
 // Note: We need to name all exports individually so the compiler is able
 // to remove the ones we don't need in the browser builds.
 
-export type {
-  RemixBrowserProps,
-  FormProps,
-  SubmitOptions,
-  SubmitFunction,
-  FormMethod,
-  FormEncType,
-  RemixServerProps,
-  ShouldReloadFunction,
-  ThrownResponse,
-  LinkProps,
-  NavLinkProps,
-} from "@remix-run/react";
-
-export {
-  RemixBrowser,
-  Meta,
-  Links,
-  Scripts,
-  Link,
-  NavLink,
-  Form,
-  PrefetchPageLinks,
-  ScrollRestoration,
-  LiveReload,
-  useFormAction,
-  useSubmit,
-  useTransition,
-  useFetcher,
-  useFetchers,
-  useCatch,
-  useLoaderData,
-  useActionData,
-  useBeforeUnload,
-  useMatches,
-  RemixServer,
-} from "@remix-run/react";
+/** @deprecated Import `Form` from `@remix-run/react` instead. */
+export const Form = warn(react.Form, getDeprecatedMessage("Form", "react"));
+/** @deprecated Import `Link` from `@remix-run/react` instead. */
+export const Link = warn(react.Link, getDeprecatedMessage("Link", "react"));
+/** @deprecated Import `Links` from `@remix-run/react` instead. */
+export const Links = warn(react.Links, getDeprecatedMessage("Links", "react"));
+/** @deprecated Import `LiveReload` from `@remix-run/react` instead. */
+export const LiveReload = warn(
+  react.LiveReload,
+  getDeprecatedMessage("LiveReload", "react")
+);
+/** @deprecated Import `Meta` from `@remix-run/react` instead. */
+export const Meta = warn(react.Meta, getDeprecatedMessage("Meta", "react"));
+/** @deprecated Import `NavLink` from `@remix-run/react` instead. */
+export const NavLink = warn(
+  react.NavLink,
+  getDeprecatedMessage("NavLink", "react")
+);
+/** @deprecated Import `PrefetchPageLinks` from `@remix-run/react` instead. */
+export const PrefetchPageLinks = warn(
+  react.PrefetchPageLinks,
+  getDeprecatedMessage("PrefetchPageLinks", "react")
+);
+/** @deprecated Import `RemixBrowser` from `@remix-run/react` instead. */
+export const RemixBrowser = warn(
+  react.RemixBrowser,
+  getDeprecatedMessage("RemixBrowser", "react")
+);
+/** @deprecated Import `RemixServer` from `@remix-run/react` instead. */
+export const RemixServer = warn(
+  react.RemixServer,
+  getDeprecatedMessage("RemixServer", "react")
+);
+/** @deprecated Import `Scripts` from `@remix-run/react` instead. */
+export const Scripts = warn(
+  react.Scripts,
+  getDeprecatedMessage("Scripts", "react")
+);
+/** @deprecated Import `ScrollRestoration` from `@remix-run/react` instead. */
+export const ScrollRestoration = warn(
+  react.ScrollRestoration,
+  getDeprecatedMessage("ScrollRestoration", "react")
+);
+/** @deprecated Import `useActionData` from `@remix-run/react` instead. */
+export const useActionData = warn(
+  react.useActionData,
+  getDeprecatedMessage("useActionData", "react")
+);
+/** @deprecated Import `useBeforeUnload` from `@remix-run/react` instead. */
+export const useBeforeUnload = warn(
+  react.useBeforeUnload,
+  getDeprecatedMessage("useBeforeUnload", "react")
+);
+/** @deprecated Import `useCatch` from `@remix-run/react` instead. */
+export const useCatch = warn(
+  react.useCatch,
+  getDeprecatedMessage("useCatch", "react")
+);
+/** @deprecated Import `useFetcher` from `@remix-run/react` instead. */
+export const useFetcher = warn(
+  react.useFetcher,
+  getDeprecatedMessage("useFetcher", "react")
+);
+/** @deprecated Import `useFetchers` from `@remix-run/react` instead. */
+export const useFetchers = warn(
+  react.useFetchers,
+  getDeprecatedMessage("useFetchers", "react")
+);
+/** @deprecated Import `useFormAction` from `@remix-run/react` instead. */
+export const useFormAction = warn(
+  react.useFormAction,
+  getDeprecatedMessage("useFormAction", "react")
+);
+/** @deprecated Import `useLoaderData` from `@remix-run/react` instead. */
+export const useLoaderData = warn(
+  react.useLoaderData,
+  getDeprecatedMessage("useLoaderData", "react")
+);
+/** @deprecated Import `useMatches` from `@remix-run/react` instead. */
+export const useMatches = warn(
+  react.useMatches,
+  getDeprecatedMessage("useMatches", "react")
+);
+/** @deprecated Import `useSubmit` from `@remix-run/react` instead. */
+export const useSubmit = warn(
+  react.useSubmit,
+  getDeprecatedMessage("useSubmit", "react")
+);
+/** @deprecated Import `useTransition` from `@remix-run/react` instead. */
+export const useTransition = warn(
+  react.useTransition,
+  getDeprecatedMessage("useTransition", "react")
+);
 
 // react-router-dom exports
-export {
-  Outlet,
-  useHref,
-  useLocation,
-  useNavigate,
-  useNavigationType,
-  useOutlet,
-  useParams,
-  useResolvedPath,
-  useSearchParams,
-  useOutletContext,
-} from "@remix-run/react";
+/** @deprecated Import `Outlet` from `@remix-run/react` instead. */
+export const Outlet = warn(
+  react.Outlet,
+  getDeprecatedMessage("Outlet", "react")
+);
+/** @deprecated Import `useHref` from `@remix-run/react` instead. */
+export const useHref = warn(
+  react.useHref,
+  getDeprecatedMessage("useHref", "react")
+);
+/** @deprecated Import `useLocation` from `@remix-run/react` instead. */
+export const useLocation = warn(
+  react.useLocation,
+  getDeprecatedMessage("useLocation", "react")
+);
+/** @deprecated Import `useNavigate` from `@remix-run/react` instead. */
+export const useNavigate = warn(
+  react.useNavigate,
+  getDeprecatedMessage("useNavigate", "react")
+);
+/** @deprecated Import `useNavigationType` from `@remix-run/react` instead. */
+export const useNavigationType = warn(
+  react.useNavigationType,
+  getDeprecatedMessage("useNavigationType", "react")
+);
+/** @deprecated Import `useOutlet` from `@remix-run/react` instead. */
+export const useOutlet = warn(
+  react.useOutlet,
+  getDeprecatedMessage("useOutlet", "react")
+);
+/** @deprecated Import `useOutletContext` from `@remix-run/react` instead. */
+export const useOutletContext = warn(
+  react.useOutletContext,
+  getDeprecatedMessage("useOutletContext", "react")
+);
+/** @deprecated Import `useParams` from `@remix-run/react` instead. */
+export const useParams = warn(
+  react.useParams,
+  getDeprecatedMessage("useParams", "react")
+);
+/** @deprecated Import `useResolvedPath` from `@remix-run/react` instead. */
+export const useResolvedPath = warn(
+  react.useResolvedPath,
+  getDeprecatedMessage("useResolvedPath", "react")
+);
+/** @deprecated Import `useSearchParams` from `@remix-run/react` instead. */
+export const useSearchParams = warn(
+  react.useSearchParams,
+  getDeprecatedMessage("useSearchParams", "react")
+);
+
+/** @deprecated Import type `FormEncType` from `@remix-run/react` instead. */
+export type FormEncType = ReactTypes.FormEncType;
+/** @deprecated Import type `FormMethod` from `@remix-run/react` instead. */
+export type FormMethod = ReactTypes.FormMethod;
+/** @deprecated Import type `FormProps` from `@remix-run/react` instead. */
+export type FormProps = ReactTypes.FormProps;
+/** @deprecated Import type `LinkProps` from `@remix-run/react` instead. */
+export type LinkProps = ReactTypes.LinkProps;
+/** @deprecated Import type `NavLinkProps` from `@remix-run/react` instead. */
+export type NavLinkProps = ReactTypes.NavLinkProps;
+/** @deprecated Import type `RemixBrowserProps` from `@remix-run/react` instead. */
+export type RemixBrowserProps = ReactTypes.RemixBrowserProps;
+/** @deprecated Import type `RemixServerProps` from `@remix-run/react` instead. */
+export type RemixServerProps = ReactTypes.RemixServerProps;
+/** @deprecated Import type `ShouldReloadFunction` from `@remix-run/react` instead. */
+export type ShouldReloadFunction = ReactTypes.ShouldReloadFunction;
+/** @deprecated Import type `SubmitFunction` from `@remix-run/react` instead. */
+export type SubmitFunction = ReactTypes.SubmitFunction;
+/** @deprecated Import type `SubmitOptions` from `@remix-run/react` instead. */
+export type SubmitOptions = ReactTypes.SubmitOptions;
+/** @deprecated Import type `ThrownResponse` from `@remix-run/react` instead. */
+export type ThrownResponse = ReactTypes.ThrownResponse;

--- a/packages/remix-server-runtime/magicExports/remix.ts
+++ b/packages/remix-server-runtime/magicExports/remix.ts
@@ -1,44 +1,104 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
+import * as runtime from "@remix-run/server-runtime";
+import type * as RuntimeTypes from "@remix-run/server-runtime";
+
+const warn = <T extends Function>(fn: T, message: string): T =>
+  ((...args: unknown[]) => {
+    console.warn(message);
+
+    return fn(...args);
+  }) as unknown as T;
+
+const getDeprecatedMessage = (functionName: string, packageName: string) =>
+  `All \`remix\` exports are considered deprecated as of v1.3.3. Please import \`${functionName}\` from \`@remix-run/${packageName}\` instead. You can run \`remix migrate --migration replace-remix-imports\` to automatically migrate your code.`;
+
 // Re-export everything from this package that is available in `remix`.
 
-export type {
-  ServerBuild,
-  ServerEntryModule,
-  HandleDataRequestFunction,
-  HandleDocumentRequestFunction,
-  CookieParseOptions,
-  CookieSerializeOptions,
-  CookieSignatureOptions,
-  CookieOptions,
-  Cookie,
-  AppLoadContext,
-  AppData,
-  EntryContext,
-  LinkDescriptor,
-  HtmlLinkDescriptor,
-  PageLinkDescriptor,
-  ErrorBoundaryComponent,
-  ActionFunction,
-  HeadersFunction,
-  LinksFunction,
-  LoaderFunction,
-  MetaDescriptor,
-  HtmlMetaDescriptor,
-  MetaFunction,
-  RouteComponent,
-  RouteHandle,
-  RequestHandler,
-  SessionData,
-  Session,
-  SessionStorage,
-  SessionIdStorageStrategy,
-} from "@remix-run/server-runtime";
+/** @deprecated Import `createSession` from `@remix-run/{cloudflare|node}` instead. */
+export const createSession = warn(
+  runtime.createSession,
+  getDeprecatedMessage("createSession", "{cloudflare|node}")
+);
+/** @deprecated Import `isCookie` from `@remix-run/{cloudflare|node}` instead. */
+export const isCookie = warn(
+  runtime.isCookie,
+  getDeprecatedMessage("isCookie", "{cloudflare|node}")
+);
+/** @deprecated Import `isSession` from `@remix-run/{cloudflare|node}` instead. */
+export const isSession = warn(
+  runtime.isSession,
+  getDeprecatedMessage("isSession", "{cloudflare|node}")
+);
+/** @deprecated Import `json` from `@remix-run/{cloudflare|node}` instead. */
+export const json = warn(
+  runtime.json,
+  getDeprecatedMessage("json", "{cloudflare|node}")
+);
+/** @deprecated Import `redirect` from `@remix-run/{cloudflare|node}` instead. */
+export const redirect = warn(
+  runtime.redirect,
+  getDeprecatedMessage("redirect", "{cloudflare|node}")
+);
 
-export {
-  isCookie,
-  createSession,
-  isSession,
-  json,
-  redirect,
-} from "@remix-run/server-runtime";
+/** @deprecated Import type `ActionFunction` from `@remix-run/{cloudflare|node}` instead. */
+export type ActionFunction = RuntimeTypes.ActionFunction;
+/** @deprecated Import type `AppData` from `@remix-run/{cloudflare|node}` instead. */
+export type AppData = RuntimeTypes.AppData;
+/** @deprecated Import type `AppLoadContext` from `@remix-run/{cloudflare|node}` instead. */
+export type AppLoadContext = RuntimeTypes.AppLoadContext;
+/** @deprecated Import type `Cookie` from `@remix-run/{cloudflare|node}` instead. */
+export type Cookie = RuntimeTypes.Cookie;
+/** @deprecated Import type `CookieOptions` from `@remix-run/{cloudflare|node}` instead. */
+export type CookieOptions = RuntimeTypes.CookieOptions;
+/** @deprecated Import type `CookieParseOptions` from `@remix-run/{cloudflare|node}` instead. */
+export type CookieParseOptions = RuntimeTypes.CookieParseOptions;
+/** @deprecated Import type `CookieSerializeOptions` from `@remix-run/{cloudflare|node}` instead. */
+export type CookieSerializeOptions = RuntimeTypes.CookieSerializeOptions;
+/** @deprecated Import type `CookieSignatureOptions` from `@remix-run/{cloudflare|node}` instead. */
+export type CookieSignatureOptions = RuntimeTypes.CookieSignatureOptions;
+/** @deprecated Import type `EntryContext` from `@remix-run/{cloudflare|node}` instead. */
+export type EntryContext = RuntimeTypes.EntryContext;
+/** @deprecated Import type `ErrorBoundaryComponent` from `@remix-run/{cloudflare|node}` instead. */
+export type ErrorBoundaryComponent = RuntimeTypes.ErrorBoundaryComponent;
+/** @deprecated Import type `HandleDataRequestFunction` from `@remix-run/{cloudflare|node}` instead. */
+export type HandleDataRequestFunction = RuntimeTypes.HandleDataRequestFunction;
+/** @deprecated Import type `HandleDocumentRequestFunction` from `@remix-run/{cloudflare|node}` instead. */
+export type HandleDocumentRequestFunction =
+  RuntimeTypes.HandleDocumentRequestFunction;
+/** @deprecated Import type `HeadersFunction` from `@remix-run/{cloudflare|node}` instead. */
+export type HeadersFunction = RuntimeTypes.HeadersFunction;
+/** @deprecated Import type `HtmlLinkDescriptor` from `@remix-run/{cloudflare|node}` instead. */
+export type HtmlLinkDescriptor = RuntimeTypes.HtmlLinkDescriptor;
+/** @deprecated Import type `HtmlMetaDescriptor` from `@remix-run/{cloudflare|node}` instead. */
+export type HtmlMetaDescriptor = RuntimeTypes.HtmlMetaDescriptor;
+/** @deprecated Import type `LinkDescriptor` from `@remix-run/{cloudflare|node}` instead. */
+export type LinkDescriptor = RuntimeTypes.LinkDescriptor;
+/** @deprecated Import type `LinksFunction` from `@remix-run/{cloudflare|node}` instead. */
+export type LinksFunction = RuntimeTypes.LinksFunction;
+/** @deprecated Import type `LoaderFunction` from `@remix-run/{cloudflare|node}` instead. */
+export type LoaderFunction = RuntimeTypes.LoaderFunction;
+/** @deprecated Import type `MetaDescriptor` from `@remix-run/{cloudflare|node}` instead. */
+export type MetaDescriptor = RuntimeTypes.MetaDescriptor;
+/** @deprecated Import type `MetaFunction` from `@remix-run/{cloudflare|node}` instead. */
+export type MetaFunction = RuntimeTypes.MetaFunction;
+/** @deprecated Import type `PageLinkDescriptor` from `@remix-run/{cloudflare|node}` instead. */
+export type PageLinkDescriptor = RuntimeTypes.PageLinkDescriptor;
+/** @deprecated Import type `RequestHandler` from `@remix-run/{cloudflare|node}` instead. */
+export type RequestHandler = RuntimeTypes.RequestHandler;
+/** @deprecated Import type `RouteComponent` from `@remix-run/{cloudflare|node}` instead. */
+export type RouteComponent = RuntimeTypes.RouteComponent;
+/** @deprecated Import type `RouteHandle` from `@remix-run/{cloudflare|node}` instead. */
+export type RouteHandle = RuntimeTypes.RouteHandle;
+/** @deprecated Import type `ServerBuild` from `@remix-run/{cloudflare|node}` instead. */
+export type ServerBuild = RuntimeTypes.ServerBuild;
+/** @deprecated Import type `ServerEntryModule` from `@remix-run/{cloudflare|node}` instead. */
+export type ServerEntryModule = RuntimeTypes.ServerEntryModule;
+/** @deprecated Import type `Session` from `@remix-run/{cloudflare|node}` instead. */
+export type Session = RuntimeTypes.Session;
+/** @deprecated Import type `SessionData` from `@remix-run/{cloudflare|node}` instead. */
+export type SessionData = RuntimeTypes.SessionData;
+/** @deprecated Import type `SessionIdStorageStrategy` from `@remix-run/{cloudflare|node}` instead. */
+export type SessionIdStorageStrategy = RuntimeTypes.SessionIdStorageStrategy;
+/** @deprecated Import type `SessionStorage` from `@remix-run/{cloudflare|node}` instead. */
+export type SessionStorage = RuntimeTypes.SessionStorage;


### PR DESCRIPTION
As a follow-up of #2731, this will show deprecation warnings in the IDE + in console whenever people aren't using the ESLint config.

Inspired by @pcattori's remark (https://github.com/remix-run/remix/pull/2542#discussion_r838804227) on @mjackson's PR to rename `createCloudflareKVSessionStorage` to `createWorkersKVSessionStorage` (#2542). 

Since each package is on it's own, I had to copy/paste the `warn` & `getDeprecatedMessage` functions over to each package.

If this somehow could be simplified (as this is doing the same thing over & over again), I'd be happy to do so.