### PR TITLE
chore(remix-eslint-config): simplify `internal` config

### DIFF
--- a/packages/remix-eslint-config/internal.js
+++ b/packages/remix-eslint-config/internal.js
@@ -17,16 +17,13 @@ module.exports = {
   root: true,
   extends: [
     require.resolve("./index.js"),
+    require.resolve("./node.js"),
     require.resolve("./jest-testing-library.js"),
   ],
-  env: {
-    node: true,
-  },
   plugins: [
     // Plugins used in the internal config should be installed in our
     // repositories. We don't want to ship these as dependencies to consumers
     // who may not use them.
-    "node",
     "prefer-let",
   ],
   rules: {


### PR DESCRIPTION
No need to copy over `node` config environment/rules