### PR TITLE
fix(templates/vercel): add `index.js.map` to `.gitignore`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -265,6 +265,7 @@
 - niwsa
 - nobeeakon
 - nordiauwu
+- nshki
 - nurul3101
 - nvh95
 - nwalters512

--- a/templates/vercel/.gitignore
+++ b/templates/vercel/.gitignore
@@ -7,4 +7,4 @@ node_modules
 
 /build/
 /public/build
-/api/index.js
+/api/index.js*


### PR DESCRIPTION
First off, thank you all for this lovely project. Remix gives me the same excitement as when I first discovered HTML back in the 2000s.

This is something I noticed as I was upgrading a Remix v1.2.3 project to v1.3.5—Git kept telling me it detected some untracked files in `/api` and after a closer look, `/api/index.js.map` was the new file.

This change is to ignore `/api/index.js.map` in addition to `/api/index.js` and prevent `/api` from getting checked into repositories.