### PR TITLE
fix(cli): don't use system path separator on remote repo URLs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -313,6 +313,7 @@
 - vimutti77
 - visormatt
 - weavdale
+- wKovacs64
 - wladiston
 - XiNiHa
 - xstevenyung

--- a/packages/remix-dev/cli/create.ts
+++ b/packages/remix-dev/cli/create.ts
@@ -340,7 +340,7 @@ function getRepoInfo(validatedGithubUrl: string): RepoInfo {
     Branch: string | undefined,
     FileInfo: string | undefined
   ];
-  let filePath = file.join(path.sep);
+  let filePath = file.join("/");
 
   if (tree === undefined) {
     return {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Rolls back a change made in e93f08773ff0cad8f9f09ee24f9d32916b52d07d.

Closes: #2714

- [ ] Docs
- [ ] Tests

---

The tests don't run on Windows (or at least, not on my machine) - not sure what to do about a related regression test.