### PR TITLE
chore(remix-dev): use fullImportPath to resolve package

### DIFF
--- a/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
@@ -68,7 +68,6 @@ export function serverBareModulesPlugin(
           onWarning &&
           !isNodeBuiltIn(packageName) &&
           !/\bnode_modules\b/.test(importer) &&
-          !builtinModules.includes(packageName) &&
           !dependencies[packageName]
         ) {
           onWarning(
@@ -135,7 +134,7 @@ function warnOnceIfEsmOnlyPackage(
   fullImportPath: string,
   onWarning: (msg: string, key: string) => void
 ) {
-  let packageDir = resolveModuleBasePath(packageName);
+  let packageDir = resolveModuleBasePath(packageName, fullImportPath);
   let packageJsonFile = path.join(packageDir, "package.json");
 
   if (!fs.existsSync(packageJsonFile)) {
@@ -171,8 +170,9 @@ function warnOnceIfEsmOnlyPackage(
 }
 
 // https://github.com/nodejs/node/issues/33460#issuecomment-919184789
-function resolveModuleBasePath(packageName: string) {
-  let moduleMainFilePath = require.resolve(packageName);
+// adapted to use the fullImportPath to resolve sub packages like @heroicons/react/solid
+function resolveModuleBasePath(packageName: string, fullImportPath: string) {
+  let moduleMainFilePath = require.resolve(fullImportPath);
 
   let packageNameParts = packageName.split("/");
 


### PR DESCRIPTION
some packages like `@heroicons/react` use a subdirectory package.json for things, like `@heroicons/react/solid`

closes #2691

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests
