### PR TITLE
fix(remix-server-runtime): keep memory storage data across cache clears

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -278,6 +278,7 @@
 - sean-roberts
 - selfish
 - sergiodxa
+- sheepsteak
 - shumuu
 - sidkh
 - sidv1905

--- a/packages/remix-server-runtime/sessions/memoryStorage.ts
+++ b/packages/remix-server-runtime/sessions/memoryStorage.ts
@@ -5,6 +5,21 @@ import type {
   CreateSessionStorageFunction,
 } from "../sessions";
 
+let memoryStorageData: {
+  map: Map<string, { data: SessionData; expires?: Date }>;
+  uniqueId: number;
+};
+
+declare global {
+  // eslint-disable-next-line prefer-let/prefer-let
+  var __memoryStorageData:
+    | {
+        map: Map<string, { data: SessionData; expires?: Date }>;
+        uniqueId: number;
+      }
+    | undefined;
+}
+
 interface MemorySessionStorageOptions {
   /**
    * The Cookie used to store the session id on the client, or options used
@@ -31,35 +46,47 @@ export const createMemorySessionStorageFactory =
     createSessionStorage: CreateSessionStorageFunction
   ): CreateMemorySessionStorageFunction =>
   ({ cookie } = {}) => {
-    let uniqueId = 0;
-    let map = new Map<string, { data: SessionData; expires?: Date }>();
+    if (process.env.NODE_ENV === "production") {
+      memoryStorageData = {
+        map: new Map<string, { data: SessionData; expires?: Date }>(),
+        uniqueId: 0,
+      };
+    } else {
+      if (!global.__memoryStorageData) {
+        global.__memoryStorageData = {
+          map: new Map<string, { data: SessionData; expires?: Date }>(),
+          uniqueId: 0,
+        };
+      }
+      memoryStorageData = global.__memoryStorageData;
+    }
 
     return createSessionStorage({
       cookie,
       async createData(data, expires) {
-        let id = (++uniqueId).toString();
-        map.set(id, { data, expires });
+        let id = (++memoryStorageData.uniqueId).toString();
+        memoryStorageData.map.set(id, { data, expires });
         return id;
       },
       async readData(id) {
-        if (map.has(id)) {
-          let { data, expires } = map.get(id)!;
+        if (memoryStorageData.map.has(id)) {
+          let { data, expires } = memoryStorageData.map.get(id)!;
 
           if (!expires || expires > new Date()) {
             return data;
           }
 
           // Remove expired session data.
-          if (expires) map.delete(id);
+          if (expires) memoryStorageData.map.delete(id);
         }
 
         return null;
       },
       async updateData(id, data, expires) {
-        map.set(id, { data, expires });
+        memoryStorageData.map.set(id, { data, expires });
       },
       async deleteData(id) {
-        map.delete(id);
+        memoryStorageData.map.delete(id);
       },
     });
   };


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Fixes #1832 

This is a repost of #1878 as I'd deleted my fork since I'd done this PR and wasn't able to update the PR anymore.

Using an object stored on global the memory session storage will now keep data when the require cache is purged.

~~I started adding tests for this but I wasn't sure if they were useful. I can add them if needed.~~ @ryanflorence said this wasn't necessary in original PR.