### PR TITLE
add fullyParallel setting to playwright

### DIFF
--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -12,10 +12,10 @@ const config: PlaywrightTestConfig = {
   },
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI ? "github" : [["html", { open: "never" }]],
   use: { actionTimeout: 0 },
-  fullyParallel: false,
+  fullyParallel: true,
 
   projects: [
     {

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -15,7 +15,7 @@ const config: PlaywrightTestConfig = {
   workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? "github" : [["html", { open: "never" }]],
   use: { actionTimeout: 0 },
-  fullyParallel: true,
+  fullyParallel: false,
 
   projects: [
     {

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -15,7 +15,7 @@ const config: PlaywrightTestConfig = {
   workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? "github" : [["html", { open: "never" }]],
   use: { actionTimeout: 0 },
-  fullyParallel: false,
+  fullyParallel: true,
 
   projects: [
     {

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -12,10 +12,10 @@ const config: PlaywrightTestConfig = {
   },
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 2 : undefined,
+  workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? "github" : [["html", { open: "never" }]],
   use: { actionTimeout: 0 },
-  fullyParallel: true,
+  fullyParallel: false,
 
   projects: [
     {

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -15,6 +15,7 @@ const config: PlaywrightTestConfig = {
   workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? "github" : [["html", { open: "never" }]],
   use: { actionTimeout: 0 },
+  fullyParallel: true,
 
   projects: [
     {


### PR DESCRIPTION
## Summary of Change
- add `fullyParallel` playwright setting; this is a relatively new setting announced < 2 weeks ago

## Motivation For Change
As the codebase's test suite grows running them parallel can help reduce overall time of test suite

NOTE: I tested on a 16in intel macbook; had tons of apps and tabs open; would be curious to see what other folks get for the time since I had lots of work stuff open; the test suite was reduce by a few seconds (better than nothing 😎 ), but I think it may be worth having it enabled for a bit since it doesn't seem to harm

![image](https://user-images.githubusercontent.com/6743796/163094654-e287fc36-22ea-4c2d-8461-34f38b0a091f.png)

## References
- Playwright Parallelization docs: https://playwright.dev/docs/test-parallel
- Playwright `fullyParallel` docs: https://playwright.dev/docs/api/class-testproject#test-project-fully-parallel



CC @mcansh 

Closes: (N/A)
- [ ] Docs
- [X] Tests
