### PR TITLE
fix: LiveReload only executes on client

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1392,6 +1392,7 @@ export function useFetchers(): Fetcher[] {
   return [...fetchers.values()];
 }
 
+let liveReloadMounted = false;
 // Dead Code Elimination magic for production builds.
 // This way devs don't have to worry about doing the NODE_ENV check themselves.
 export const LiveReload =
@@ -1402,9 +1403,12 @@ export const LiveReload =
         nonce = undefined,
       }: {
         port?: number;
+        /**
+         * @deprecated this property is no longer relevant.
+         */
         nonce?: string;
       }) {
-        let setupLiveReload = ((port: number) => {
+        let setupLiveReload = (port: number) => {
           let protocol = location.protocol === "https:" ? "wss:" : "ws:";
           let host = location.hostname;
           let socketPath = `${protocol}//${host}:${port}/socket`;
@@ -1424,17 +1428,16 @@ export const LiveReload =
             console.log("Remix dev asset server web socket error:");
             console.error(error);
           };
-        }).toString();
+        };
 
-        return (
-          <script
-            nonce={nonce}
-            suppressHydrationWarning
-            dangerouslySetInnerHTML={{
-              __html: `(${setupLiveReload})(${port})`,
-            }}
-          />
-        );
+        React.useEffect(() => {
+          if (!liveReloadMounted) {
+            setupLiveReload(port);
+            liveReloadMounted = true;
+          }
+        }, []);
+
+        return null;
       };
 
 function useComposedRefs<RefValueType = any>(


### PR DESCRIPTION
no more stringifying a func and dangerously setting innerHTML

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests
