### PR TITLE
fix(cli/migrate): remove `@remix-run/` prefix when checking for remix adapters

### DIFF
--- a/packages/remix-dev/cli/migrate/migrations/replace-remix-imports/resolveTransformOptions.ts
+++ b/packages/remix-dev/cli/migrate/migrations/replace-remix-imports/resolveTransformOptions.ts
@@ -98,7 +98,9 @@ const resolveAdapter = (packageJson: PackageJson): Adapter | undefined => {
   // find adapter in package.json dependencies
   let deps = depsToEntries(packageJson.dependencies);
   let remixDeps = deps.filter(({ name }) => isRemixPackage(name));
-  let adapters = remixDeps.map(({ name }) => name).filter(isAdapter);
+  let adapters = remixDeps
+    .map(({ name }) => name.replace(/^@remix-run\//, ""))
+    .filter(isAdapter);
 
   if (adapters.length > 1) {
     console.error(


### PR DESCRIPTION
Same bug fix for `dev`: #2784 

E.g. `"netlify"` is an `Adapter` whose package is `@remix-run/netlify`
