### PR TITLE
ci: opt out of caching deployment test dependencies

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
-          cache: "npm"
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -57,7 +56,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
-          cache: "npm"
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -95,7 +93,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
-          cache: "npm"
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -131,7 +128,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
-          cache: "npm"
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -169,7 +165,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
-          cache: "npm"
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -204,7 +199,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
-          cache: "npm"
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
-          cache-dependency-path: ./scripts/deployment-test/package-lock.json
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -59,7 +58,6 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
-          cache-dependency-path: ./scripts/deployment-test/package-lock.json
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -98,7 +96,6 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
-          cache-dependency-path: ./scripts/deployment-test/package-lock.json
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -135,7 +132,6 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
-          cache-dependency-path: ./scripts/deployment-test/package-lock.json
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -174,7 +170,6 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
-          cache-dependency-path: ./scripts/deployment-test/package-lock.json
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -210,7 +205,6 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
-          cache-dependency-path: ./scripts/deployment-test/package-lock.json
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get


### PR DESCRIPTION
the `@remix-run/dev` version is bumped by our version script so that it uses the most up to date version, so we can't have a lock file

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests
