### PR TITLE
fix(remix-dev): add try/catch to `warnOnceIfEsmOnlyPackage` for when a package's dependency isn't installed

### DIFF
--- a/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
@@ -170,6 +170,8 @@ function warnOnceIfEsmOnlyPackage(
     }
   } catch (error: unknown) {
     // module not installed
+    // we warned earlier if a package is used without being in package.json
+    // if the build fails, the reason will be right there
   }
 }
 

--- a/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
@@ -134,38 +134,42 @@ function warnOnceIfEsmOnlyPackage(
   fullImportPath: string,
   onWarning: (msg: string, key: string) => void
 ) {
-  let packageDir = resolveModuleBasePath(packageName, fullImportPath);
-  let packageJsonFile = path.join(packageDir, "package.json");
+  try {
+    let packageDir = resolveModuleBasePath(packageName, fullImportPath);
+    let packageJsonFile = path.join(packageDir, "package.json");
 
-  if (!fs.existsSync(packageJsonFile)) {
-    console.log(packageJsonFile, `does not exist`);
-    return;
-  }
-  let pkg = JSON.parse(fs.readFileSync(packageJsonFile, "utf-8"));
+    if (!fs.existsSync(packageJsonFile)) {
+      console.log(packageJsonFile, `does not exist`);
+      return;
+    }
+    let pkg = JSON.parse(fs.readFileSync(packageJsonFile, "utf-8"));
 
-  let subImport = fullImportPath.slice(packageName.length + 1);
+    let subImport = fullImportPath.slice(packageName.length + 1);
 
-  if (pkg.type === "module") {
-    let isEsmOnly = true;
-    if (pkg.exports) {
-      if (!subImport) {
-        if (pkg.exports.require) {
-          isEsmOnly = false;
-        } else if (pkg.exports["."]?.require) {
+    if (pkg.type === "module") {
+      let isEsmOnly = true;
+      if (pkg.exports) {
+        if (!subImport) {
+          if (pkg.exports.require) {
+            isEsmOnly = false;
+          } else if (pkg.exports["."]?.require) {
+            isEsmOnly = false;
+          }
+        } else if (pkg.exports[`./${subImport}`]?.require) {
           isEsmOnly = false;
         }
-      } else if (pkg.exports[`./${subImport}`]?.require) {
-        isEsmOnly = false;
+      }
+
+      if (isEsmOnly) {
+        onWarning(
+          `${packageName} is possibly an ESM only package and should be bundled with ` +
+            `"serverDependenciesToBundle in remix.config.js.`,
+          packageName + ":esm-only"
+        );
       }
     }
-
-    if (isEsmOnly) {
-      onWarning(
-        `${packageName} is possibly an ESM only package and should be bundled with ` +
-          `"serverDependenciesToBundle in remix.config.js.`,
-        packageName + ":esm-only"
-      );
-    }
+  } catch (error: unknown) {
+    // module not installed
   }
 }
 


### PR DESCRIPTION
like `encoding` when using prisma and a custom output directory

we warn earlier on if a package is used without being in package.json so this seems fine, if we fail to build, the reason will be right there

closes https://github.com/remix-run/remix/issues/2691

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #2691
