### PR TITLE
docs: add docs on ?index query param

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -887,6 +887,7 @@ See also:
 
 - [`<Form>`][form]
 - [`<Form action>`][form action]
+- [`?index` query param][index query param]
 
 ### `headers`
 
@@ -1417,6 +1418,7 @@ export default function Page() {
 [urlsearchparams]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
 [form]: ./remix#form
 [form action]: ./remix#form-action
+[index query param]: ../guides/routing#what-is-the-index-query-param
 [link tag]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
 [minimatch]: https://www.npmjs.com/package/minimatch
 [handledatarequest]: #entryservertsx

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -253,6 +253,10 @@ If you want to post to an index route use `?index` in the action: `<Form action=
 | `/accounts?index` | `routes/accounts/index.js` |
 | `/accounts`       | `routes/accounts.js`       |
 
+See also:
+
+- [`?index` query param][index query param]
+
 #### `<Form method>`
 
 This determines the [HTTP verb](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) to be used: get, post, put, patch, delete. The default is "get".
@@ -852,6 +856,21 @@ function SomeComponent() {
 }
 ```
 
+Although a URL matches multiple Routes in a remix router hierarchy, a `fetcher.submit()` call will only call the action on the deepest matching route, unless the deepest matching route is an "index route". In this case, it will post to the parent route of the index route (because they share the same URL).
+
+If you want to submit to an index route use `?index` in the URL:
+
+```js
+fetcher.submit(
+  { some: "values" },
+  { method: "post", action: "/accounts?index" }
+);
+```
+
+See also:
+
+- [`?index` query param][index query param]
+
 #### `fetcher.load()`
 
 Loads data from a route loader.
@@ -869,6 +888,18 @@ function SomeComponent() {
   fetcher.data; // the data from the loader
 }
 ```
+
+Although a URL matches multiple Routes in a remix router hierarchy, a `fetcher.load()` call will only call the loader on the deepest matching route, unless the deepest matching route is an "index route". In this case, it will load the parent route of the index route (because they share the same URL).
+
+If you want to load an index route use `?index` in the URL:
+
+```js
+fetcher.load("/some/route?index");
+```
+
+See also:
+
+- [`?index` query param][index query param]
 
 #### Examples
 
@@ -2662,3 +2693,4 @@ export default function CompanyRoute() {
 [action]: #form-action
 [disabling-javascript]: ../guides/disabling-javascript
 [example-sharing-loader-data]: https://github.com/remix-run/remix/tree/main/examples/sharing-loader-data
+[index query param]: ../guides/routing#what-is-the-index-query-param

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -171,7 +171,7 @@ Index routes are "leaf routes". They're the end of the line. If you think you ne
 
 This usually comes up when folks are just getting started with Remix and put their global nav in `app/routes/index.jsx`. Move that global nav up into `app/root.jsx`. Everything inside of `app/routes/*` is already a child of `root.tsx`.
 
-**What is the `?index` query param?**
+### What is the `?index` query param?
 
 You may notice an `?index` query parameter showing up on your URLs from time to time, particularly when you are submitting a `<Form>` from an index route. This is required to differentiate index routes from their parent layout routes. Consider the following structure, where a URL such as `/sales/invoices/` would be ambiguous. Is that referring to the `routes/sales/invoices.jsx` file? Or is it referring to the `routes/sales/invoices/index.jsx` file? In order to avoid this ambiguity, Remix uses the `?index` parameter to indicate when a URL refers to the index route instead of the layout route.
 

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -173,7 +173,7 @@ This usually comes up when folks are just getting started with Remix and put the
 
 **What is the `?index` query param?**
 
-You may notice an `?index` query parameter showing up on your URLs from time to time, particularly when you are submitting a `<Form>` from an index route. This is required to differentiate index routes from their parent layout routes. Consider the following structure, where a URL such as `/sales/invoices/` would be ambiguous. Is that referring to the `routes/sales/invoices.jsx` file? Or is it referring to the `routes/sales/invoices/index.jsx` file? In order to avoid this ambiguity, Remix uses the `?index` parameter to indicate that a UL refers to the index route for a given URL.
+You may notice an `?index` query parameter showing up on your URLs from time to time, particularly when you are submitting a `<Form>` from an index route. This is required to differentiate index routes from their parent layout routes. Consider the following structure, where a URL such as `/sales/invoices/` would be ambiguous. Is that referring to the `routes/sales/invoices.jsx` file? Or is it referring to the `routes/sales/invoices/index.jsx` file? In order to avoid this ambiguity, Remix uses the `?index` parameter to indicate that a URL refers to the index route for a given URL.
 
 ```
 └── app

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -173,7 +173,7 @@ This usually comes up when folks are just getting started with Remix and put the
 
 **What is the `?index` query param?**
 
-You may notice an `?index` query parameter showing up on your URLs from time to time, particularly when you are submitting a `<Form>` from an index route. This is required to differentiate index routes from their parent layout routes. Consider the following structure, where a URL such as `/sales/invoices/` would be ambiguous. Is that referring to the `routes/sales/invoices.jsx` file? Or is it referring to the `routes/sales/invoices/index.jsx` file? In order to avoid this ambiguity, Remix uses the `?index` parameter to indicate that a URL refers to the index route for a given URL.
+You may notice an `?index` query parameter showing up on your URLs from time to time, particularly when you are submitting a `<Form>` from an index route. This is required to differentiate index routes from their parent layout routes. Consider the following structure, where a URL such as `/sales/invoices/` would be ambiguous. Is that referring to the `routes/sales/invoices.jsx` file? Or is it referring to the `routes/sales/invoices/index.jsx` file? In order to avoid this ambiguity, Remix uses the `?index` parameter to indicate when a URL refers to the index route instead of the layout route.
 
 ```
 └── app

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -171,6 +171,22 @@ Index routes are "leaf routes". They're the end of the line. If you think you ne
 
 This usually comes up when folks are just getting started with Remix and put their global nav in `app/routes/index.jsx`. Move that global nav up into `app/root.jsx`. Everything inside of `app/routes/*` is already a child of `root.tsx`.
 
+**What is the `?index` query param?**
+
+You may notice an `?index` query parameter showing up on your URLs from time to time, particularly when you are submitting a `<Form>` from an index route. This is required to differentiate index routes from their parent layout routes. Consider the following structure, where a URL such as `/sales/invoices/` would be ambiguous. Is that referring to the `routes/sales/invoices.jsx` file? Or is it referring to the `routes/sales/invoices/index.jsx` file? In order to avoid this ambiguity, Remix uses the `?index` parameter to indicate that a UL refers to the index route for a given URL.
+
+```
+└── app
+    ├── root.jsx
+    └── routes
+        ├── sales
+        │   ├── invoices
+        │   │   └── index.jsx   <-- /sales/invoices/?index
+        │   └── invoices.jsx    <-- /sales/invoices/
+```
+
+This is handled automatically for you when you submit from a `<Form>` contained within either the layout route or the index route. But if you are submitting forms to different routes, or using `fetcher.submit`/`fetcher.load` you may need to be aware of this URL pattern so you can target the correct route.
+
 ## Nested URLs without nesting layouts
 
 Sometimes you want to add nesting to the URL (slashes) but you don't want to create UI hierarchy. Consider an edit page for an invoice:

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -173,7 +173,7 @@ This usually comes up when folks are just getting started with Remix and put the
 
 ### What is the `?index` query param?
 
-You may notice an `?index` query parameter showing up on your URLs from time to time, particularly when you are submitting a `<Form>` from an index route. This is required to differentiate index routes from their parent layout routes. Consider the following structure, where a URL such as `/sales/invoices/` would be ambiguous. Is that referring to the `routes/sales/invoices.jsx` file? Or is it referring to the `routes/sales/invoices/index.jsx` file? In order to avoid this ambiguity, Remix uses the `?index` parameter to indicate when a URL refers to the index route instead of the layout route.
+You may notice an `?index` query parameter showing up on your URLs from time to time, particularly when you are submitting a `<Form>` from an index route. This is required to differentiate index routes from their parent layout routes. Consider the following structure, where a URL such as `/sales/invoices` would be ambiguous. Is that referring to the `routes/sales/invoices.jsx` file? Or is it referring to the `routes/sales/invoices/index.jsx` file? In order to avoid this ambiguity, Remix uses the `?index` parameter to indicate when a URL refers to the index route instead of the layout route.
 
 ```
 └── app
@@ -181,8 +181,8 @@ You may notice an `?index` query parameter showing up on your URLs from time to 
     └── routes
         ├── sales
         │   ├── invoices
-        │   │   └── index.jsx   <-- /sales/invoices/?index
-        │   └── invoices.jsx    <-- /sales/invoices/
+        │   │   └── index.jsx   <-- /sales/invoices?index
+        │   └── invoices.jsx    <-- /sales/invoices
 ```
 
 This is handled automatically for you when you submit from a `<Form>` contained within either the layout route or the index route. But if you are submitting forms to different routes, or using `fetcher.submit`/`fetcher.load` you may need to be aware of this URL pattern so you can target the correct route.


### PR DESCRIPTION
Adds a section to the routing docs on the `?index` parameter used on Index Routes

- [x] Docs
