### PR TITLE
fix(templates/deno): remix's `createRequestHandler` no longer has a `platform` arg

### DIFF
--- a/templates/deno/remix-deno/server.ts
+++ b/templates/deno/remix-deno/server.ts
@@ -21,7 +21,7 @@ export function createRequestHandler<Context = unknown>({
   mode?: string;
   getLoadContext?: (request: Request) => Promise<Context> | Context;
 }) {
-  const remixHandler = createRemixRequestHandler(build, {}, mode);
+  const remixHandler = createRemixRequestHandler(build, mode);
   return async (request: Request) => {
     try {
       const loadContext = getLoadContext


### PR DESCRIPTION
See https://github.com/remix-run/remix/pull/2359/commits/bd2fadfe548498028ceee242364fcedf7df7af48