### PR TITLE
fix: Ensure parent loaders are called on fetchActionRedirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:integration": "playwright test --config ./integration/playwright.config.ts",
     "pretest:integration": "rollup -c",
     "posttest:integration": "rimraf ./.tmp/integration",
-    "bug-report-test": "playwright test --config ./integration/jest.config.ts integration/bug-report-test.ts",
+    "bug-report-test": "playwright test --config ./integration/playwright.config.ts integration/bug-report-test.ts",
     "playground:new": "node ./scripts/playground/new.js",
     "version": "node ./scripts/version.js",
     "watch": "rollup -c -w",

--- a/packages/remix-react/__tests__/transition-test.tsx
+++ b/packages/remix-react/__tests__/transition-test.tsx
@@ -1408,6 +1408,8 @@ describe("fetcher redirects", () => {
         "type": "done",
       }
     `);
+    // Root loader should be re-called after fetchActionRedirect
+    expect(t.rootLoaderMock.calls.length).toBe(1);
   });
 });
 

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -1536,6 +1536,7 @@ function filterMatchesToLoad(
     // mutation, reload for fresh data
     state.transition.type === "actionReload" ||
     state.transition.type === "actionRedirect" ||
+    state.transition.type === "fetchActionRedirect" ||
     // clicked the same link, resubmitted a GET form
     createHref(url) === createHref(state.location) ||
     // search affects all loaders


### PR DESCRIPTION
Existing loaders were not being properly revalidated during `fetchActionRedirect`

Closes: #1616 and #2361

- [x] Tests
