### PR TITLE
feat(remix-dev): add `devServerCert` & `devServerKey` config option

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -142,6 +142,7 @@
 - illright
 - imzshh
 - isaacrmoreno
+- isaacs
 - ishan-me
 - IshanKBG
 - jacob-ebey

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -27,6 +27,8 @@ describe("readConfig", () => {
         "assetsBuildDirectory": Any<String>,
         "cacheDirectory": Any<String>,
         "devServerBroadcastDelay": 0,
+        "devServerCert": null,
+        "devServerKey": null,
         "devServerPort": Any<Number>,
         "entryClientFile": "entry.client.tsx",
         "entryServerFile": "entry.server.tsx",

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -97,6 +97,16 @@ export interface AppConfig {
   devServerPort?: number;
 
   /**
+   * The port number to use for the dev server. Defaults to 8002.
+   */
+  devServerCert?: string | null;
+
+  /**
+   * TLS key to use for dev server running on wss.
+   */
+  devServerKey?: string | null;
+
+  /**
    * The delay, in milliseconds, before the dev server broadcasts a reload
    * event. There is no delay by default.
    */
@@ -208,6 +218,16 @@ export interface RemixConfig {
    * The port number to use for the dev (asset) server.
    */
   devServerPort: number;
+
+  /**
+   * TLS key to use for dev server running on wss.
+   */
+  devServerCert: string | null;
+
+  /**
+   * TLS key to use for dev server running on wss.
+   */
+  devServerKey: string | null;
 
   /**
    * The delay before the dev (asset) server broadcasts a reload event.
@@ -360,6 +380,9 @@ export async function readConfig(
   process.env.REMIX_DEV_SERVER_WS_PORT = `${devServerPort}`;
   let devServerBroadcastDelay = appConfig.devServerBroadcastDelay || 0;
 
+  let devServerCert = appConfig.devServerCert || null;
+  let devServerKey = appConfig.devServerKey || null;
+
   let defaultPublicPath = "/build/";
   switch (serverBuildTarget) {
     case "arc":
@@ -408,6 +431,8 @@ export async function readConfig(
     entryServerFile,
     devServerPort,
     devServerBroadcastDelay,
+    devServerCert,
+    devServerKey,
     assetsBuildDirectory,
     publicPath,
     rootDirectory,


### PR DESCRIPTION
Fix: https://github.com/remix-run/remix/issues/2859

Closes: #2859

- [ ] Docs
- [ ] Tests

Lacking docs and tests, provided more as a clearer sort of bug report for #2859.