### PR TITLE
feat(remix-dev/cli): let `replace-remix-imports` migration re-install to update lockfile

### DIFF
--- a/packages/remix-dev/__tests__/replace-remix-imports-test.ts
+++ b/packages/remix-dev/__tests__/replace-remix-imports-test.ts
@@ -1,10 +1,10 @@
+import os from "os";
 import path from "path";
 import fse from "fs-extra";
-import os from "os";
+import glob from "fast-glob";
+import shell from "shelljs";
 import stripAnsi from "strip-ansi";
 import type { PackageJson } from "type-fest";
-import shell from "shelljs";
-import glob from "fast-glob";
 
 import { run } from "../cli/run";
 import { readConfig } from "../config";
@@ -110,6 +110,5 @@ describe("`replace-remix-imports` migration", () => {
     expect(result.code).toBe(0);
 
     expect(output).toContain("successfully migrated");
-    expect(output).toContain("npm install");
-  }, 25_000);
+  }, 200_000);
 });

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -17,9 +17,10 @@ import * as compiler from "../compiler";
 import type { RemixConfig } from "../config";
 import { readConfig } from "../config";
 import { formatRoutes, RoutesFormat, isRoutesFormat } from "../config/format";
-import { createApp } from "./create";
 import { loadEnv } from "../env";
 import { log } from "../logging";
+import { createApp } from "./create";
+import { getPreferredPackageManager } from "./getPreferredPackageManager";
 import { setupRemix, isSetupPlatform, SetupPlatform } from "./setup";
 
 export * as migrate from "./migrate";
@@ -29,7 +30,6 @@ export async function create({
   projectDir,
   remixVersion,
   installDeps,
-  packageManager,
   useTypeScript,
   githubToken,
   debug,
@@ -38,7 +38,6 @@ export async function create({
   projectDir: string;
   remixVersion?: string;
   installDeps: boolean;
-  packageManager: "npm" | "yarn" | "pnpm";
   useTypeScript: boolean;
   githubToken?: string;
   debug?: boolean;
@@ -49,7 +48,6 @@ export async function create({
     projectDir,
     remixVersion,
     installDeps,
-    packageManager,
     useTypeScript,
     githubToken,
     debug,
@@ -58,10 +56,7 @@ export async function create({
   spinner.clear();
 }
 
-export async function init(
-  projectDir: string,
-  packageManager: "npm" | "yarn" | "pnpm"
-) {
+export async function init(projectDir: string) {
   let initScriptDir = path.join(projectDir, "remix.init");
   let initScript = path.resolve(initScriptDir, "index.js");
   let initPackageJson = path.resolve(initScriptDir, "package.json");
@@ -69,10 +64,12 @@ export async function init(
   let isTypeScript = fse.existsSync(path.join(projectDir, "tsconfig.json"));
 
   if (await fse.pathExists(initScript)) {
+    let packageManager = getPreferredPackageManager();
+
     if (await fse.pathExists(initPackageJson)) {
       execSync(`${packageManager} install`, {
-        stdio: "ignore",
         cwd: initScriptDir,
+        stdio: "ignore",
       });
     }
 

--- a/packages/remix-dev/cli/create.ts
+++ b/packages/remix-dev/cli/create.ts
@@ -14,6 +14,7 @@ import sortPackageJSON from "sort-package-json";
 import * as colors from "../colors";
 import packageJson from "../package.json";
 import { convertTemplateToJavaScript } from "./convert-to-javascript";
+import { getPreferredPackageManager } from "./getPreferredPackageManager";
 
 const remixDevPackageVersion = packageJson.version;
 
@@ -22,7 +23,6 @@ interface CreateAppArgs {
   projectDir: string;
   remixVersion?: string;
   installDeps: boolean;
-  packageManager: "npm" | "yarn" | "pnpm";
   useTypeScript: boolean;
   githubToken?: string;
   debug?: boolean;
@@ -33,7 +33,6 @@ export async function createApp({
   projectDir,
   remixVersion = remixDevPackageVersion,
   installDeps,
-  packageManager,
   useTypeScript = true,
   githubToken = process.env.GITHUB_TOKEN,
   debug,
@@ -197,6 +196,8 @@ export async function createApp({
   }
 
   if (installDeps) {
+    let packageManager = getPreferredPackageManager();
+
     let npmConfig = execSync(
       `${packageManager} config get @remix-run:registry`,
       {
@@ -212,8 +213,8 @@ export async function createApp({
     }
 
     execSync(`${packageManager} install`, {
-      stdio: "inherit",
       cwd: projectDir,
+      stdio: "inherit",
     });
   }
 }

--- a/packages/remix-dev/cli/getPreferredPackageManager.ts
+++ b/packages/remix-dev/cli/getPreferredPackageManager.ts
@@ -1,0 +1,12 @@
+type PackageManager = "npm" | "pnpm" | "yarn";
+
+/**
+ * Determine which package manager the user prefers.
+ *
+ * npm, pnpm and Yarn set the user agent environment variable
+ * that can be used to determine which package manager ran
+ * the command.
+ */
+export const getPreferredPackageManager = () =>
+  ((process.env.npm_config_user_agent ?? "").split("/")[0] ||
+    "npm") as PackageManager;

--- a/packages/remix-dev/cli/migrate/run.ts
+++ b/packages/remix-dev/cli/migrate/run.ts
@@ -1,9 +1,9 @@
 import fse from "fs-extra";
 
+import * as colors from "../../colors";
 import type { Flags } from "./flags";
 import { migrations } from "./migrations";
 import type { Migration } from "./types";
-import * as colors from "../../colors";
 
 const parseMigration = (migrationId: string): Migration => {
   let migration = migrations.find(({ id }) => id === migrationId);
@@ -27,11 +27,12 @@ const checkProjectDir = (projectDir: string): string => {
 };
 
 export const run = async (input: {
+  flags: Flags;
   migrationId: string;
   projectDir: string;
-  flags: Flags;
 }) => {
   let projectDir = checkProjectDir(input.projectDir);
   let migration = parseMigration(input.migrationId);
-  return migration.function({ projectDir, flags: input.flags });
+
+  return migration.function({ flags: input.flags, projectDir });
 };

--- a/packages/remix-dev/cli/migrate/types.ts
+++ b/packages/remix-dev/cli/migrate/types.ts
@@ -1,8 +1,8 @@
 import type { Flags } from "./flags";
 
 export type MigrationFunction = (args: {
-  projectDir: string;
   flags: Flags;
+  projectDir: string;
 }) => Promise<void>;
 
 export interface Migration {


### PR DESCRIPTION
Now that we have `packageManager` available since #2562, we can also use it in the migrations