### PR TITLE
fix(remix-dev/create): use path.split and path.join to always make path posix style

### DIFF
--- a/packages/remix-dev/cli/create.ts
+++ b/packages/remix-dev/cli/create.ts
@@ -308,7 +308,7 @@ async function downloadAndExtractTarball(
 
   // file paths returned from github are always unix style
   if (filePath) {
-    filePath = filePath.replaceAll("\\", "/");
+    filePath = filePath.split(path.sep).join(path.posix.sep)
   }
 
   try {


### PR DESCRIPTION
the CLI needs to work on Node 12, but replaceAll wasn't added until [Node 15](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll#browser_compatibility)

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests
