### PR TITLE
chore(templates): ignore dotfiles in route subdirectories too

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -79,6 +79,7 @@
 - dwt47
 - dylanplayer
 - eastlondoner
+- eccentric-j
 - edgesoft
 - edmundhung
 - efkann

--- a/templates/arc/remix.config.js
+++ b/templates/arc/remix.config.js
@@ -4,7 +4,7 @@
 module.exports = {
   serverBuildTarget: "arc",
   server: "./server.js",
-  ignoredRouteFiles: [".*"],
+  ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "server/index.js",

--- a/templates/cloudflare-pages/remix.config.js
+++ b/templates/cloudflare-pages/remix.config.js
@@ -5,7 +5,7 @@ module.exports = {
   serverBuildTarget: "cloudflare-pages",
   server: "./server.js",
   devServerBroadcastDelay: 1000,
-  ignoredRouteFiles: [".*"],
+  ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "functions/[[path]].js",

--- a/templates/cloudflare-workers/remix.config.js
+++ b/templates/cloudflare-workers/remix.config.js
@@ -5,7 +5,7 @@ module.exports = {
   serverBuildTarget: "cloudflare-workers",
   server: "./server.js",
   devServerBroadcastDelay: 1000,
-  ignoredRouteFiles: [".*"],
+  ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",

--- a/templates/express/remix.config.js
+++ b/templates/express/remix.config.js
@@ -2,7 +2,7 @@
  * @type {import('@remix-run/dev').AppConfig}
  */
 module.exports = {
-  ignoredRouteFiles: [".*"],
+  ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",

--- a/templates/fly/remix.config.js
+++ b/templates/fly/remix.config.js
@@ -2,7 +2,7 @@
  * @type {import('@remix-run/dev').AppConfig}
  */
 module.exports = {
-  ignoredRouteFiles: [".*"],
+  ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",

--- a/templates/netlify/remix.config.js
+++ b/templates/netlify/remix.config.js
@@ -4,7 +4,7 @@
 module.exports = {
   serverBuildTarget: "netlify",
   server: "./server.js",
-  ignoredRouteFiles: [".*"],
+  ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: ".netlify/functions-internal/server.js",

--- a/templates/remix/remix.config.js
+++ b/templates/remix/remix.config.js
@@ -2,7 +2,7 @@
  * @type {import('@remix-run/dev').AppConfig}
  */
 module.exports = {
-  ignoredRouteFiles: [".*"],
+  ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",

--- a/templates/vercel/remix.config.js
+++ b/templates/vercel/remix.config.js
@@ -7,7 +7,7 @@ module.exports = {
   // server. This does not understand the vercel lambda module format,
   // so we default back to the standard build output.
   server: process.env.NODE_ENV === "development" ? undefined : "./server.js",
-  ignoredRouteFiles: [".*"],
+  ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "api/index.js",


### PR DESCRIPTION
cherry-picked #2739 onto `main`, as changes to `templates` should go to `main`