### PR TITLE
enhancement: Export additional types from `@remix-run/react`

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -8,7 +8,7 @@ import type {
   TouchEventHandler,
 } from "react";
 import * as React from "react";
-import type { Navigator } from "react-router";
+import type { Navigator, Params } from "react-router";
 import {
   Router,
   Link as RouterLink,
@@ -44,7 +44,7 @@ import { createHtml } from "./markup";
 import type { ClientRoute } from "./routes";
 import { createClientRoutes } from "./routes";
 import type { RouteData } from "./routeData";
-import type { RouteMatch } from "./routeMatching";
+import type { RouteMatch as BaseRouteMatch } from "./routeMatching";
 import { matchClientRoutes } from "./routeMatching";
 import type { RouteModules, HtmlMetaDescriptor } from "./routeModules";
 import { createTransitionManager } from "./transition";
@@ -55,7 +55,7 @@ import type { Transition, Fetcher, Submission } from "./transition";
 
 interface RemixEntryContextType {
   manifest: AssetsManifest;
-  matches: RouteMatch<ClientRoute>[];
+  matches: BaseRouteMatch<ClientRoute>[];
   routeData: { [routeId: string]: RouteData };
   actionData?: RouteData;
   pendingLocation?: Location;
@@ -571,7 +571,7 @@ export function PrefetchPageLinks({
   );
 }
 
-function usePrefetchedStylesheets(matches: RouteMatch<ClientRoute>[]) {
+function usePrefetchedStylesheets(matches: BaseRouteMatch<ClientRoute>[]) {
   let { routeModules } = useRemixEntryContext();
 
   let [styleLinks, setStyleLinks] = React.useState<HtmlLinkDescriptor[]>([]);
@@ -596,7 +596,7 @@ function PrefetchPageLinksImpl({
   matches: nextMatches,
   ...linkProps
 }: PrefetchPageDescriptor & {
-  matches: RouteMatch<ClientRoute>[];
+  matches: BaseRouteMatch<ClientRoute>[];
 }) {
   let location = useLocation();
   let { matches, manifest } = useRemixEntryContext();
@@ -1264,13 +1264,40 @@ export function useBeforeUnload(callback: () => any): void {
   }, [callback]);
 }
 
+export interface RouteMatch {
+  /**
+   * The id of the matched route
+   */
+  id: string;
+  /**
+   * The pathname of the matched route
+   */
+  pathname: string;
+  /**
+   * The dynamic parameters of the matched route
+   *
+   * @see https://remix.run/docs/api/conventions#dynamic-route-parameters
+   */
+  params: Params<string>;
+  /**
+   * Any route data associated with the matched route
+   */
+  data: RouteData;
+  /**
+   * The exported `handle` object of the matched route.
+   *
+   * @see https://remix.run/docs/api/conventions#handle
+   */
+  handle: undefined | { [key: string]: any };
+}
+
 /**
  * Returns the current route matches on the page. This is useful for creating
  * layout abstractions with your current routes.
  *
  * @see https://remix.run/api/remix#usematches
  */
-export function useMatches() {
+export function useMatches(): RouteMatch[] {
   let { matches, routeData, routeModules } = useRemixEntryContext();
 
   return React.useMemo(
@@ -1336,9 +1363,11 @@ function createFetcherForm(fetchKey: string) {
 
 let fetcherId = 0;
 
-type FetcherWithComponents<TData> = Fetcher<TData> & {
-  Form: ReturnType<typeof createFetcherForm>;
-  submit: ReturnType<typeof useSubmitImpl>;
+export type FetcherWithComponents<TData> = Fetcher<TData> & {
+  Form: React.ForwardRefExoticComponent<
+    FormProps & React.RefAttributes<HTMLFormElement>
+  >;
+  submit: SubmitFunction;
   load: (href: string) => void;
 };
 

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -1,20 +1,28 @@
 export type { RemixBrowserProps } from "./browser";
 export { RemixBrowser } from "./browser";
+export type {
+  Location,
+  NavigateFunction,
+  Params,
+  Path,
+} from "react-router-dom";
 export {
+  Outlet,
   useHref,
   useLocation,
   useNavigate,
   useNavigationType,
   useOutlet,
+  useOutletContext,
   useParams,
   useResolvedPath,
   useSearchParams,
-  Outlet,
-  useOutletContext,
 } from "react-router-dom";
 
 export type {
+  FetcherWithComponents,
   FormProps,
+  RouteMatch,
   SubmitOptions,
   SubmitFunction,
   RemixNavLinkProps as NavLinkProps,
@@ -52,3 +60,5 @@ export { ScrollRestoration } from "./scroll-restoration";
 
 export type { RemixServerProps } from "./server";
 export { RemixServer } from "./server";
+
+export type { Fetcher } from "./transition";


### PR DESCRIPTION
This PR exposes additional types that are helpful when passing values via context or props.

Complex return types from functions should be exposed directly IMO. Usage is a little simpler than relying on `ReturnType<typeof someFunc>`, and in the case of generics like `Fetcher` and `FetcherWithComponents` it is necessary.

```ts
// instead of this...
type Ctx = {
  fetcher: ReturnType<typeof useFetcher>;
  location: ReturnType<typeof useLocation>;
};

// ...I can do this
type Ctx = {
  fetcher: FetcherWithComponents<SomeData>;
  location: Location;
};
```