### PR TITLE
fix: Better support for `imageSrcSet` + `imageSizes` in route `links` (#184)

### DIFF
--- a/examples/basic/app/routes/index.tsx
+++ b/examples/basic/app/routes/index.tsx
@@ -1,8 +1,4 @@
-import type {
-  LoaderFunction,
-  MetaFunction,
-  LinksFunction,
-} from "@remix-run/node";
+import type { LoaderFunction, MetaFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
 
@@ -49,10 +45,6 @@ export const loader: LoaderFunction = async () => {
 
   // https://remix.run/api/remix#json
   return json(data);
-};
-
-export const links: LinksFunction = () => {
-  return [{ rel: "preload", as: "image", imagesrcset: "", href: "" }];
 };
 
 // https://remix.run/api/conventions#meta

--- a/examples/basic/app/routes/index.tsx
+++ b/examples/basic/app/routes/index.tsx
@@ -1,4 +1,8 @@
-import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import type {
+  LoaderFunction,
+  MetaFunction,
+  LinksFunction,
+} from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
 
@@ -45,6 +49,10 @@ export const loader: LoaderFunction = async () => {
 
   // https://remix.run/api/remix#json
   return json(data);
+};
+
+export const links: LinksFunction = () => {
+  return [{ rel: "preload", as: "image", imagesrcset: "", href: "" }];
 };
 
 // https://remix.run/api/conventions#meta

--- a/integration/link-test.ts
+++ b/integration/link-test.ts
@@ -281,7 +281,7 @@ test.describe("route module link export", () => {
               {
                 rel: "preload",
                 as: "image",
-                imageSrcSet: guitar600 + " 600w, " + guitar900 + " 800w",
+                imageSrcSet: guitar600 + " 600w, " + guitar900 + " 900w",
                 imageSizes: "100vw",
               },
             ];
@@ -293,7 +293,7 @@ test.describe("route module link export", () => {
                 <p>
                   <img
                     alt="a guitar"
-                    srcSet={guitar600 + " 600w, " + guitar900 + " 800w"}
+                    srcSet={guitar600 + " 600w, " + guitar900 + " 900w"}
                     sizes="100vw"
                     data-test-id="blocked"
                   />{" "}

--- a/integration/link-test.ts
+++ b/integration/link-test.ts
@@ -37,6 +37,10 @@ test.describe("route module link export", () => {
 
         "app/guitar.jpg": js``,
 
+        "app/guitar-600.jpg": js``,
+
+        "app/guitar-900.jpg": js``,
+
         "app/reset.css": css`
           * {
             box-sizing: border-box;
@@ -267,6 +271,39 @@ test.describe("route module link export", () => {
           }
         `,
 
+        "app/routes/responsive-image-preload.jsx": js`
+          import { Link } from "@remix-run/react";
+          import guitar600 from "~/guitar-600.jpg";
+          import guitar900 from "~/guitar-900.jpg";
+
+          export function links()  {
+            return [
+              {
+                rel: "preload",
+                as: "image",
+                imageSrcSet: guitar600 + " 600w, " + guitar900 + " 800w",
+                imageSizes: "100vw",
+              },
+            ];
+          }
+          export default function LinksPage() {
+            return (
+              <div data-test-id="/responsive-image-preload">
+                <h2>Responsive Guitar</h2>
+                <p>
+                  <img
+                    alt="a guitar"
+                    srcSet={guitar600 + " 600w, " + guitar900 + " 800w"}
+                    sizes="100vw"
+                    data-test-id="blocked"
+                  />{" "}
+                  Prefetched because it's a preload.
+                </p>
+              </div>
+            );
+          }
+        `,
+
         "app/routes/gists.jsx": js`
           import { json } from "@remix-run/node";
           import { Link, Outlet, useLoaderData, useTransition } from "@remix-run/react";
@@ -438,6 +475,20 @@ test.describe("route module link export", () => {
     await appFixture.close();
   });
 
+  test("adds responsive image preload links to the document", async ({
+    page,
+  }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    let responses = app.collectResponses((url) =>
+      url.pathname.endsWith(".jpg")
+    );
+    await app.goto("/responsive-image-preload");
+    await page.waitForSelector('[data-test-id="/responsive-image-preload"]');
+
+    // We expect only one response based on the size of the screen
+    expect(responses.length).toEqual(1);
+  });
+
   test("waits for new styles to load before transitioning", async ({
     page,
   }) => {
@@ -471,6 +522,20 @@ test.describe("route module link export", () => {
       await app.goto("/links");
       await page.waitForSelector('[data-test-id="/links"]');
       expect(responses.length).toEqual(4);
+    });
+
+    test("adds responsive image preload links to the document", async ({
+      page,
+    }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      let responses = app.collectResponses((url) =>
+        url.pathname.endsWith(".jpg")
+      );
+      await app.goto("/responsive-image-preload");
+      await page.waitForSelector('[data-test-id="/responsive-image-preload"]');
+
+      // We expect only one response based on the size of the screen
+      expect(responses.length).toEqual(1);
     });
   });
 });

--- a/integration/link-test.ts
+++ b/integration/link-test.ts
@@ -479,14 +479,10 @@ test.describe("route module link export", () => {
     page,
   }) => {
     let app = new PlaywrightFixture(appFixture, page);
-    let responses = app.collectResponses((url) =>
-      url.pathname.endsWith(".jpg")
-    );
     await app.goto("/responsive-image-preload");
     await page.waitForSelector('[data-test-id="/responsive-image-preload"]');
-
-    // We expect only one response based on the size of the screen
-    expect(responses.length).toEqual(1);
+    let locator = page.locator("link[rel=preload][as=image]");
+    expect(await locator.getAttribute("imagesizes")).toBe("100vw");
   });
 
   test("waits for new styles to load before transitioning", async ({
@@ -524,18 +520,14 @@ test.describe("route module link export", () => {
       expect(responses.length).toEqual(4);
     });
 
-    test("adds responsive image preload links to the document", async ({
+    test.only("adds responsive image preload links to the document", async ({
       page,
     }) => {
       let app = new PlaywrightFixture(appFixture, page);
-      let responses = app.collectResponses((url) =>
-        url.pathname.endsWith(".jpg")
-      );
       await app.goto("/responsive-image-preload");
       await page.waitForSelector('[data-test-id="/responsive-image-preload"]');
-
-      // We expect only one response based on the size of the screen
-      expect(responses.length).toEqual(1);
+      let locator = page.locator("link[rel=preload][as=image]");
+      expect(await locator.getAttribute("imagesizes")).toBe("100vw");
     });
   });
 });

--- a/integration/link-test.ts
+++ b/integration/link-test.ts
@@ -520,7 +520,7 @@ test.describe("route module link export", () => {
       expect(responses.length).toEqual(4);
     });
 
-    test.only("adds responsive image preload links to the document", async ({
+    test("adds responsive image preload links to the document", async ({
       page,
     }) => {
       let app = new PlaywrightFixture(appFixture, page);

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1470,22 +1470,14 @@ export const LiveReload =
             console.log("Remix dev asset server web socket error:");
             console.error(error);
           };
-
-          return () => {
-            ws.close();
-          };
         };
 
         React.useEffect(() => {
           if (!liveReloadMounted) {
-            let cleanup = setupLiveReload(port);
+            setupLiveReload(port);
             liveReloadMounted = true;
-            return () => {
-              cleanup();
-              liveReloadMounted = false;
-            };
           }
-        }, [port]);
+        }, []);
 
         return null;
       };

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -543,31 +543,22 @@ export function Links() {
         // them in all lowercase to forward the attributes to the node without a
         // warning. Normalize so that either property can be used in Remix.
         if ("useId" in React) {
-          // @ts-expect-error
           if (link.imagesrcset) {
-            // @ts-expect-error
             link.imageSrcSet = imageSrcSet = link.imagesrcset;
-            // @ts-expect-error
             delete link.imagesrcset;
           }
 
-          // @ts-expect-error
           if (link.imagesizes) {
-            // @ts-expect-error
             link.imageSizes = link.imagesizes;
-            // @ts-expect-error
             delete link.imagesizes;
           }
         } else {
           if (link.imageSrcSet) {
-            // @ts-expect-error
             link.imagesrcset = imageSrcSet = link.imageSrcSet;
-            // @ts-expect-error
             delete link.imageSrcSet;
           }
 
           if (link.imageSizes) {
-            // @ts-expect-error
             link.imagesizes = link.imageSizes;
             delete link.imageSizes;
           }

--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -16,16 +16,11 @@ type LiteralUnion<LiteralType, BaseType extends Primitive> =
   | LiteralType
   | (BaseType & Record<never, never>);
 
-/**
- * Represents a `<link>` element.
- *
- * WHATWG Specification: https://html.spec.whatwg.org/multipage/semantics.html#the-link-element
- */
-export interface HtmlLinkDescriptor {
+interface HtmlLinkProps {
   /**
    * Address of the hyperlink
    */
-  href: string;
+  href?: string;
 
   /**
    * How the element handles crossorigin requests
@@ -92,16 +87,6 @@ export interface HtmlLinkDescriptor {
   sizes?: string;
 
   /**
-   * Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (for rel="preload")
-   */
-  imagesrcset?: string;
-
-  /**
-   * Image sizes for different page layouts (for rel="preload")
-   */
-  imagesizes?: string;
-
-  /**
    * Potential destination for a preload request (for rel="preload" and rel="modulepreload")
    */
   as?: LiteralUnion<
@@ -143,7 +128,59 @@ export interface HtmlLinkDescriptor {
    * The title attribute has special semantics on this element: Title of the link; CSS style sheet set name.
    */
   title?: string;
+
+  /**
+   * Images to use in different situations, e.g., high-resolution displays,
+   * small monitors, etc. (for rel="preload")
+   */
+  imageSrcSet: string;
+
+  /**
+   * Image sizes for different page layouts (for rel="preload")
+   */
+  imageSizes?: string;
 }
+
+interface HtmlLinkPreloadImage extends HtmlLinkProps {
+  /**
+   * Relationship between the document containing the hyperlink and the destination resource
+   */
+  rel: "preload";
+
+  /**
+   * Potential destination for a preload request (for rel="preload" and rel="modulepreload")
+   */
+  as: "image";
+
+  /**
+   * Address of the hyperlink
+   */
+  href?: string;
+
+  /**
+   * Images to use in different situations, e.g., high-resolution displays,
+   * small monitors, etc. (for rel="preload")
+   */
+  imageSrcSet: string;
+
+  /**
+   * Image sizes for different page layouts (for rel="preload")
+   */
+  imageSizes?: string;
+}
+
+/**
+ * Represents a `<link>` element.
+ *
+ * WHATWG Specification: https://html.spec.whatwg.org/multipage/semantics.html#the-link-element
+ */
+export type HtmlLinkDescriptor =
+  // Must have an href *unless* it's a `<link rel="preload" as="image">` with an
+  // `imageSrcSet` and `imageSizes` props
+  | (HtmlLinkProps & Pick<Required<HtmlLinkProps>, "href">)
+  | (HtmlLinkPreloadImage & Pick<Required<HtmlLinkPreloadImage>, "imageSizes">)
+  | (HtmlLinkPreloadImage &
+      Pick<Required<HtmlLinkPreloadImage>, "href"> & { imageSizes?: never });
 
 export interface PrefetchPageDescriptor
   extends Omit<
@@ -152,8 +189,8 @@ export interface PrefetchPageDescriptor
     | "rel"
     | "type"
     | "sizes"
-    | "imagesrcset"
-    | "imagesizes"
+    | "imageSrcSet"
+    | "imageSizes"
     | "as"
     | "color"
     | "title"
@@ -195,10 +232,14 @@ export async function prefetchStyleLinks(
   let descriptors = routeModule.links();
   if (!descriptors) return;
 
-  let styleLinks = [];
+  let styleLinks: HtmlLinkDescriptor[] = [];
   for (let descriptor of descriptors) {
     if (!isPageLinkDescriptor(descriptor) && descriptor.rel === "stylesheet") {
-      styleLinks.push({ ...descriptor, rel: "preload", as: "style" });
+      styleLinks.push({
+        ...descriptor,
+        rel: "preload",
+        as: "style",
+      } as HtmlLinkDescriptor);
     }
   }
 
@@ -250,17 +291,25 @@ export function isPageLinkDescriptor(
 export function isHtmlLinkDescriptor(
   object: any
 ): object is HtmlLinkDescriptor {
-  return (
-    object != null &&
-    typeof object.rel === "string" &&
-    typeof object.href === "string"
-  );
+  if (object == null) return false;
+
+  // <link> may not have an href if <link rel="preload"> is used with imagesrcset + imagesizes
+  // https://github.com/remix-run/remix/issues/184
+  // https://html.spec.whatwg.org/commit-snapshots/cb4f5ff75de5f4cbd7013c4abad02f21c77d4d1c/#attr-link-imagesrcset
+  if (object.href == null) {
+    return (
+      object.rel === "preload" &&
+      typeof object.imageSrcSet === "string" &&
+      typeof object.imageSizes === "string"
+    );
+  }
+  return typeof object.rel === "string" && typeof object.href === "string";
 }
 
 export async function getStylesheetPrefetchLinks(
   matches: RouteMatch<ClientRoute>[],
   routeModules: RouteModules
-) {
+): Promise<HtmlLinkDescriptor[]> {
   let links = await Promise.all(
     matches.map(async (match) => {
       let mod = await loadRouteModule(match.route, routeModules);
@@ -272,10 +321,10 @@ export async function getStylesheetPrefetchLinks(
     .flat(1)
     .filter(isHtmlLinkDescriptor)
     .filter((link) => link.rel === "stylesheet" || link.rel === "preload")
-    .map(({ rel, ...attrs }) =>
-      rel === "preload"
-        ? { rel: "prefetch", ...attrs }
-        : { rel: "prefetch", as: "style", ...attrs }
+    .map((link) =>
+      link.rel === "preload"
+        ? ({ ...link, rel: "prefetch" } as HtmlLinkDescriptor)
+        : ({ ...link, rel: "prefetch", as: "style" } as HtmlLinkDescriptor)
     );
 }
 

--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -133,7 +133,7 @@ interface HtmlLinkProps {
    * Images to use in different situations, e.g., high-resolution displays,
    * small monitors, etc. (for rel="preload")
    */
-  imageSrcSet: string;
+  imageSrcSet?: string;
 
   /**
    * Image sizes for different page layouts (for rel="preload")
@@ -177,10 +177,23 @@ interface HtmlLinkPreloadImage extends HtmlLinkProps {
 export type HtmlLinkDescriptor =
   // Must have an href *unless* it's a `<link rel="preload" as="image">` with an
   // `imageSrcSet` and `imageSizes` props
-  | (HtmlLinkProps & Pick<Required<HtmlLinkProps>, "href">)
-  | (HtmlLinkPreloadImage & Pick<Required<HtmlLinkPreloadImage>, "imageSizes">)
-  | (HtmlLinkPreloadImage &
-      Pick<Required<HtmlLinkPreloadImage>, "href"> & { imageSizes?: never });
+  (
+    | (HtmlLinkProps & Pick<Required<HtmlLinkProps>, "href">)
+    | (HtmlLinkPreloadImage &
+        Pick<Required<HtmlLinkPreloadImage>, "imageSizes">)
+    | (HtmlLinkPreloadImage &
+        Pick<Required<HtmlLinkPreloadImage>, "href"> & { imageSizes?: never })
+  ) & {
+    /**
+     * @deprecated Use `imageSrcSet` instead.
+     */
+    imagesrcset?: string;
+
+    /**
+     * @deprecated Use `imageSizes` instead.
+     */
+    imagesizes?: string;
+  };
 
 export interface PrefetchPageDescriptor
   extends Omit<
@@ -191,6 +204,8 @@ export interface PrefetchPageDescriptor
     | "sizes"
     | "imageSrcSet"
     | "imageSizes"
+    | "imagesrcset"
+    | "imagesizes"
     | "as"
     | "color"
     | "title"
@@ -299,8 +314,10 @@ export function isHtmlLinkDescriptor(
   if (object.href == null) {
     return (
       object.rel === "preload" &&
-      typeof object.imageSrcSet === "string" &&
-      typeof object.imageSizes === "string"
+      (typeof object.imageSrcSet === "string" ||
+        typeof object.imagesrcset === "string") &&
+      (typeof object.imageSizes === "string" ||
+        typeof object.imagesizes === "string")
     );
   }
   return typeof object.rel === "string" && typeof object.href === "string";

--- a/packages/remix-server-runtime/links.ts
+++ b/packages/remix-server-runtime/links.ts
@@ -1,13 +1,14 @@
-/**
- * Represents a `<link>` element.
- *
- * WHATWG Specification: https://html.spec.whatwg.org/multipage/semantics.html#the-link-element
- */
-export interface HtmlLinkDescriptor {
+type Primitive = null | undefined | string | number | boolean | symbol | bigint;
+
+type LiteralUnion<LiteralType, BaseType extends Primitive> =
+  | LiteralType
+  | (BaseType & Record<never, never>);
+
+interface HtmlLinkProps {
   /**
    * Address of the hyperlink
    */
-  href: string;
+  href?: string;
 
   /**
    * How the element handles crossorigin requests
@@ -17,7 +18,7 @@ export interface HtmlLinkDescriptor {
   /**
    * Relationship between the document containing the hyperlink and the destination resource
    */
-  rel:
+  rel: LiteralUnion<
     | "alternate"
     | "dns-prefetch"
     | "icon"
@@ -30,8 +31,9 @@ export interface HtmlLinkDescriptor {
     | "preload"
     | "prerender"
     | "search"
-    | "stylesheet"
-    | string;
+    | "stylesheet",
+    string
+  >;
 
   /**
    * Applicable media: "screen", "print", "(max-width: 764px)"
@@ -73,19 +75,9 @@ export interface HtmlLinkDescriptor {
   sizes?: string;
 
   /**
-   * Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (for rel="preload")
-   */
-  imagesrcset?: string;
-
-  /**
-   * Image sizes for different page layouts (for rel="preload")
-   */
-  imagesizes?: string;
-
-  /**
    * Potential destination for a preload request (for rel="preload" and rel="modulepreload")
    */
-  as?:
+  as?: LiteralUnion<
     | "audio"
     | "audioworklet"
     | "document"
@@ -106,8 +98,9 @@ export interface HtmlLinkDescriptor {
     | "track"
     | "video"
     | "worker"
-    | "xslt"
-    | string;
+    | "xslt",
+    string
+  >;
 
   /**
    * Color to use when customizing a site's icon (for rel="mask-icon")
@@ -123,7 +116,59 @@ export interface HtmlLinkDescriptor {
    * The title attribute has special semantics on this element: Title of the link; CSS style sheet set name.
    */
   title?: string;
+
+  /**
+   * Images to use in different situations, e.g., high-resolution displays,
+   * small monitors, etc. (for rel="preload")
+   */
+  imageSrcSet: string;
+
+  /**
+   * Image sizes for different page layouts (for rel="preload")
+   */
+  imageSizes?: string;
 }
+
+interface HtmlLinkPreloadImage extends HtmlLinkProps {
+  /**
+   * Relationship between the document containing the hyperlink and the destination resource
+   */
+  rel: "preload";
+
+  /**
+   * Potential destination for a preload request (for rel="preload" and rel="modulepreload")
+   */
+  as: "image";
+
+  /**
+   * Address of the hyperlink
+   */
+  href?: string;
+
+  /**
+   * Images to use in different situations, e.g., high-resolution displays,
+   * small monitors, etc. (for rel="preload")
+   */
+  imageSrcSet: string;
+
+  /**
+   * Image sizes for different page layouts (for rel="preload")
+   */
+  imageSizes?: string;
+}
+
+/**
+ * Represents a `<link>` element.
+ *
+ * WHATWG Specification: https://html.spec.whatwg.org/multipage/semantics.html#the-link-element
+ */
+export type HtmlLinkDescriptor =
+  // Must have an href *unless* it's a `<link rel="preload" as="image">` with an
+  // `imageSrcSet` and `imageSizes` props
+  | (HtmlLinkProps & Pick<Required<HtmlLinkProps>, "href">)
+  | (HtmlLinkPreloadImage & Pick<Required<HtmlLinkPreloadImage>, "imageSizes">)
+  | (HtmlLinkPreloadImage &
+      Pick<Required<HtmlLinkPreloadImage>, "href"> & { imageSizes?: never });
 
 export interface PageLinkDescriptor
   extends Omit<
@@ -132,8 +177,8 @@ export interface PageLinkDescriptor
     | "rel"
     | "type"
     | "sizes"
-    | "imagesrcset"
-    | "imagesizes"
+    | "imageSrcSet"
+    | "imageSizes"
     | "as"
     | "color"
     | "title"

--- a/packages/remix-server-runtime/links.ts
+++ b/packages/remix-server-runtime/links.ts
@@ -121,7 +121,7 @@ interface HtmlLinkProps {
    * Images to use in different situations, e.g., high-resolution displays,
    * small monitors, etc. (for rel="preload")
    */
-  imageSrcSet: string;
+  imageSrcSet?: string;
 
   /**
    * Image sizes for different page layouts (for rel="preload")
@@ -165,10 +165,23 @@ interface HtmlLinkPreloadImage extends HtmlLinkProps {
 export type HtmlLinkDescriptor =
   // Must have an href *unless* it's a `<link rel="preload" as="image">` with an
   // `imageSrcSet` and `imageSizes` props
-  | (HtmlLinkProps & Pick<Required<HtmlLinkProps>, "href">)
-  | (HtmlLinkPreloadImage & Pick<Required<HtmlLinkPreloadImage>, "imageSizes">)
-  | (HtmlLinkPreloadImage &
-      Pick<Required<HtmlLinkPreloadImage>, "href"> & { imageSizes?: never });
+  (
+    | (HtmlLinkProps & Pick<Required<HtmlLinkProps>, "href">)
+    | (HtmlLinkPreloadImage &
+        Pick<Required<HtmlLinkPreloadImage>, "imageSizes">)
+    | (HtmlLinkPreloadImage &
+        Pick<Required<HtmlLinkPreloadImage>, "href"> & { imageSizes?: never })
+  ) & {
+    /**
+     * @deprecated Use `imageSrcSet` instead.
+     */
+    imagesrcset?: string;
+
+    /**
+     * @deprecated Use `imageSizes` instead.
+     */
+    imagesizes?: string;
+  };
 
 export interface PageLinkDescriptor
   extends Omit<
@@ -179,6 +192,8 @@ export interface PageLinkDescriptor
     | "sizes"
     | "imageSrcSet"
     | "imageSizes"
+    | "imagesrcset"
+    | "imagesizes"
     | "as"
     | "color"
     | "title"


### PR DESCRIPTION
This PR improves support for returned links that include an `imagesrcset` attribute to preload images when matched against a responsive set of URLs. This only works when `rel === 'preload'` and `as === 'image'`.  https://html.spec.whatwg.org/commit-snapshots/cb4f5ff75de5f4cbd7013c4abad02f21c77d4d1c/#attr-link-imagesrcset

Prior to this PR, a few problems with our implementation:

1. Our types for `HtmlLinkDescriptor` make `href` required. This is true *unless* a link includes `imagesrcset` and `imagesizes`, though `imagesrcset` and `href` will also work with or without `imagesizes` according to the spec. This PR uses an intersection type to account for these cases.
2. React 17 was released prior to these attributes being accepted into the spec and implemented by browsers, so passing the props as camel-cased will throw a warning about unsupported DOM props. Our types recognized this and supported the all-lowercase version to skip the warning and forward the attribute to the node, but React 18 now recognizes the camel-cased version. This PR updates our types to use the camel-cased prop names, but it will support either at runtime and normalize the object based on the detected version of React.
3. Because we use `href` + `rel` as a key, links without an href will have duplicate keys. So `imageSrcSet` is added as a fallback to prevent that.

---

Closes: #184

- [ ] Docs
- [x] Tests
