### PR TITLE
Update node version required to generate project

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -334,3 +334,4 @@
 - zachdtaylor
 - zainfathoni
 - zhe
+- michaelkoelewijn91

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -19,7 +19,7 @@ Click this button to create a [Gitpod](https://gitpod.io) workspace with the pro
 
 If you want to follow this tutorial locally on your own computer, it is important for you to have these things installed:
 
-- [Node.js](https://nodejs.org) 14 or greater
+- [Node.js](https://nodejs.org) 15 or greater
 - [npm](https://www.npmjs.com) 7 or greater
 - A code editor
 


### PR DESCRIPTION
The docs mention the project can be generated using node v14.
Running ```npx create-remix@latest``` using v14 resolves in a ```.replaceAll function is not defined```.
This function has been introduced as of node v15  (see https://nodejs.org/en/blog/release/v15.0.0/#v8-8-6-35415).
I have updated the docs in this PR to include the correct minimum version.