### PR TITLE
Change to getting GA_TRACKING_ID via .env and update README

### DIFF
--- a/examples/google-analytics/.env.example
+++ b/examples/google-analytics/.env.example
@@ -1,0 +1,1 @@
+GA_TRACKING_ID=Your google analytics id goes here.

--- a/examples/google-analytics/README.md
+++ b/examples/google-analytics/README.md
@@ -12,7 +12,7 @@ Open this example on [CodeSandbox](https://codesandbox.com):
 
 This example shows how to use Google analytics with Remix.
 
-First you have to get the Google analytics ID and add that key in the [app/utils/gtags.client.ts](./app/utils/gtags.client.ts) file.
+First you have to get the Google analytics ID and add that key in the [.env.example](./.env.example) file.
 
 Check [app/root.tsx](./app/root.tsx) where page tracking code is added. For tracking events check [app/routes/contact.tsx](./app/routes/contact.tsx) file.
 

--- a/examples/google-analytics/app/root.tsx
+++ b/examples/google-analytics/app/root.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "@remix-run/node";
+import { json, LoaderFunction, MetaFunction } from "@remix-run/node";
 // import { json } from "@remix-run/node";
 import {
   Link,
@@ -8,6 +8,7 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  useLoaderData,
   useLocation,
 } from "@remix-run/react";
 import { useEffect } from "react";
@@ -28,6 +29,15 @@ import * as gtag from "~/utils/gtags.client";
 //   });
 // }
 
+type LoaderData = {
+  gaTrackingId: string | undefined;
+};
+
+// Load the GA tracking id from the .env
+export const loader: LoaderFunction = async () => {
+  return json<LoaderData>({ gaTrackingId: process.env.GA_TRACKING_ID });
+};
+
 export const meta: MetaFunction = () => ({
   charset: "utf-8",
   title: "New Remix App",
@@ -36,10 +46,13 @@ export const meta: MetaFunction = () => ({
 
 export default function App() {
   const location = useLocation();
+  const { gaTrackingId } = useLoaderData<LoaderData>();
 
   useEffect(() => {
-    gtag.pageview(location.pathname);
-  }, [location]);
+    if (gaTrackingId?.length) {
+      gtag.pageview(location.pathname, gaTrackingId);
+    }
+  }, [location, gaTrackingId]);
 
   return (
     <html lang="en">
@@ -48,11 +61,11 @@ export default function App() {
         <Links />
       </head>
       <body>
-        {process.env.NODE_ENV === "development" ? null : (
+        {process.env.NODE_ENV === "development" || !gaTrackingId ? null : (
           <>
             <script
               async
-              src={`https://www.googletagmanager.com/gtag/js?id=${gtag.GA_TRACKING_ID}`}
+              src={`https://www.googletagmanager.com/gtag/js?id=${gaTrackingId}`}
             />
             <script
               async
@@ -63,7 +76,7 @@ export default function App() {
                 function gtag(){dataLayer.push(arguments);}
                 gtag('js', new Date());
 
-                gtag('config', '${gtag.GA_TRACKING_ID}', {
+                gtag('config', '${gaTrackingId}', {
                   page_path: window.location.pathname,
                 });
               `,

--- a/examples/google-analytics/app/utils/gtags.client.ts
+++ b/examples/google-analytics/app/utils/gtags.client.ts
@@ -1,5 +1,3 @@
-export const GA_TRACKING_ID = "Your google analytics id goes here.";
-
 declare global {
   interface Window {
     gtag: (
@@ -14,14 +12,14 @@ declare global {
  * @example
  * https://developers.google.com/analytics/devguides/collection/gtagjs/pages
  */
-export const pageview = (url: string) => {
+export const pageview = (url: string, trackingId: string) => {
   if (!window.gtag) {
     console.warn(
       "window.gtag is not defined. This could mean your google anylatics script has not loaded on the page yet."
     );
     return;
   }
-  window.gtag("config", GA_TRACKING_ID, {
+  window.gtag("config", trackingId, {
     page_path: url,
   });
 };


### PR DESCRIPTION
This PR updates the Google Analytics example. The example prior to this PR attempted to import the `GA_TRACKING_ID` in the client util  but the value won't be available when attempting to directly use it in the render.

The example in this PR has the `GA_TRACKING_ID` available in the process.env. Then the loader in `roots.tsx` provides and returned via useLoaderData.