### PR TITLE
chore(remix-dev): resolve `extends` in tsconfig when applying defaults

### DIFF
--- a/integration/cf-compiler-test.ts
+++ b/integration/cf-compiler-test.ts
@@ -12,28 +12,26 @@ test.describe("cloudflare compiler", () => {
       setup: "cloudflare",
       template: "cf-template",
       files: {
-        "package.json": json`
-          {
-            "name": "remix-template-cloudflare-workers",
-            "private": true,
-            "sideEffects": false,
-            "main": "build/index.js",
-            "dependencies": {
-              "@remix-run/cloudflare-workers": "0.0.0-local-version",
-              "@remix-run/react": "0.0.0-local-version",
-              "react": "0.0.0-local-version",
-              "react-dom": "0.0.0-local-version",
-              "worker-pkg": "0.0.0-local-version",
-              "browser-pkg": "0.0.0-local-version",
-              "esm-only-pkg": "0.0.0-local-version",
-              "cjs-only-pkg": "0.0.0-local-version"
-            },
-            "devDependencies": {
-              "@remix-run/dev": "0.0.0-local-version",
-              "@remix-run/eslint-config": "0.0.0-local-version"
-            }
-          }
-        `,
+        "package.json": json({
+          name: "remix-template-cloudflare-workers",
+          private: true,
+          sideEffects: false,
+          main: "build/index.js",
+          dependencies: {
+            "@remix-run/cloudflare-workers": "0.0.0-local-version",
+            "@remix-run/react": "0.0.0-local-version",
+            react: "0.0.0-local-version",
+            "react-dom": "0.0.0-local-version",
+            "worker-pkg": "0.0.0-local-version",
+            "browser-pkg": "0.0.0-local-version",
+            "esm-only-pkg": "0.0.0-local-version",
+            "cjs-only-pkg": "0.0.0-local-version",
+          },
+          devDependencies: {
+            "@remix-run/dev": "0.0.0-local-version",
+            "@remix-run/eslint-config": "0.0.0-local-version",
+          },
+        }),
         "app/routes/index.jsx": js`
           import fake from "worker-pkg";
           import { content as browserPackage } from "browser-pkg";
@@ -51,36 +49,32 @@ test.describe("cloudflare compiler", () => {
             )
           }
         `,
-        "node_modules/worker-pkg/package.json": json`
-          {
-            "name": "worker-pkg",
-            "version": "1.0.0",
-            "type": "module",
-            "main": "./default.js",
-            "exports": {
-              "worker": "./worker.js",
-              "default": "./default.js"
-            }
-          }
-        `,
+        "node_modules/worker-pkg/package.json": json({
+          name: "worker-pkg",
+          version: "1.0.0",
+          type: "module",
+          main: "./default.js",
+          exports: {
+            worker: "./worker.js",
+            default: "./default.js",
+          },
+        }),
         "node_modules/worker-pkg/worker.js": js`
           export default "__WORKER_EXPORTS_SHOULD_BE_IN_BUNDLE__";
         `,
         "node_modules/worker-pkg/default.js": js`
           export default "__DEFAULT_EXPORTS_SHOULD_NOT_BE_IN_BUNDLE__";
         `,
-        "node_modules/browser-pkg/package.json": json`
-          {
-            "name": "browser-pkg",
-            "version": "1.0.0",
-            "main": "./node-cjs.js",
-            "module": "./node-esm.mjs",
-            "browser": {
-                "./node-cjs.js": "./browser-cjs.js",
-                "./node-esm.mjs": "./browser-esm.mjs"
-            }
-          }
-        `,
+        "node_modules/browser-pkg/package.json": json({
+          name: "browser-pkg",
+          version: "1.0.0",
+          main: "./node-cjs.js",
+          module: "./node-esm.mjs",
+          browser: {
+            "./node-cjs.js": "./browser-cjs.js",
+            "./node-esm.mjs": "./browser-esm.mjs",
+          },
+        }),
         "node_modules/browser-pkg/browser-esm.mjs": js`
           export const content = "browser-pkg/browser-esm.mjs";
         `,
@@ -93,29 +87,25 @@ test.describe("cloudflare compiler", () => {
         "node_modules/browser-pkg/node-cjs.js": js`
           module.exports = { content: "browser-pkg/node-cjs.js" };
         `,
-        "node_modules/esm-only-pkg/package.json": json`
-          {
-            "name": "esm-only-pkg",
-            "version": "1.0.0",
-            "type": "module",
-            "main": "./node-esm.js",
-            "browser": "./browser-esm.js"
-          }
-        `,
+        "node_modules/esm-only-pkg/package.json": json({
+          name: "esm-only-pkg",
+          version: "1.0.0",
+          type: "module",
+          main: "./node-esm.js",
+          browser: "./browser-esm.js",
+        }),
         "node_modules/esm-only-pkg/browser-esm.js": js`
           export const content = "esm-only-pkg/browser-esm.js";
         `,
         "node_modules/esm-only-pkg/node-esm.js": js`
           export const content = "esm-only-pkg/node-esm.js";
         `,
-        "node_modules/cjs-only-pkg/package.json": json`
-          {
-            "name": "cjs-only-pkg",
-            "version": "1.0.0",
-            "main": "./node-cjs.js",
-            "browser": "./browser-cjs.js"
-          }
-        `,
+        "node_modules/cjs-only-pkg/package.json": json({
+          name: "cjs-only-pkg",
+          version: "1.0.0",
+          main: "./node-cjs.js",
+          browser: "./browser-cjs.js",
+        }),
         "node_modules/cjs-only-pkg/browser-cjs.js": js`
           module.exports = { content: "cjs-only-pkg/browser-cjs.js" };
         `,

--- a/integration/compiler-test.ts
+++ b/integration/compiler-test.ts
@@ -97,59 +97,47 @@ test.describe("compiler", () => {
             ],
           };
         `,
-        "node_modules/esm-only-pkg/package.json": json`
-          {
-            "name": "esm-only-pkg",
-            "version": "1.0.0",
-            "type": "module",
-            "main": "./esm-only-pkg.js"
-          }
-        `,
+        "node_modules/esm-only-pkg/package.json": json({
+          name: "esm-only-pkg",
+          version: "1.0.0",
+          type: "module",
+          main: "./esm-only-pkg.js",
+        }),
         "node_modules/esm-only-pkg/esm-only-pkg.js": js`
           export default "esm-only-pkg";
         `,
-        "node_modules/esm-only-exports-pkg/package.json": json`
-          {
-            "name": "esm-only-exports-pkg",
-            "version": "1.0.0",
-            "type": "module",
-            "exports": {
-              ".": "./esm-only-exports-pkg.js"
-            }
-          }
-        `,
+        "node_modules/esm-only-exports-pkg/package.json": json({
+          name: "esm-only-exports-pkg",
+          version: "1.0.0",
+          type: "module",
+          exports: {
+            ".": "./esm-only-exports-pkg.js",
+          },
+        }),
         "node_modules/esm-only-exports-pkg/esm-only-exports-pkg.js": js`
           export default "esm-only-exports-pkg";
         `,
-        "node_modules/esm-only-single-export/package.json": json`
-          {
-            "name": "esm-only-exports-pkg",
-            "version": "1.0.0",
-            "type": "module",
-            "exports": "./esm-only-single-export.js"
-          }
-        `,
+        "node_modules/esm-only-single-export/package.json": json({
+          name: "esm-only-exports-pkg",
+          version: "1.0.0",
+          type: "module",
+          exports: "./esm-only-single-export.js",
+        }),
         "node_modules/esm-only-single-export/esm-only-single-export.js": js`
           export default "esm-only-single-export";
         `,
-        "node_modules/@org/package/package.json": json`
-          {
-            "name": "@org/package",
-            "version": "1.0.0"
-          }
-        `,
-        "node_modules/@org/package/sub-package/package.json": json`
-          {
-            "module": "./esm/index.js",
-            "sideEffects": false
-          }
-        `,
-        "node_modules/@org/package/sub-package/esm/package.json": json`
-          {
-            "type": "module",
-            "sideEffects": false
-          }
-        `,
+        "node_modules/@org/package/package.json": json({
+          name: "@org/package",
+          version: "1.0.0",
+        }),
+        "node_modules/@org/package/sub-package/package.json": json({
+          module: "./esm/index.js",
+          sideEffects: false,
+        }),
+        "node_modules/@org/package/sub-package/esm/package.json": json({
+          type: "module",
+          sideEffects: false,
+        }),
         "node_modules/@org/package/sub-package/esm/index.js": js`
           export { default as submodule } from "./submodule.js";
         `,

--- a/integration/esm-only-warning-test.ts
+++ b/integration/esm-only-warning-test.ts
@@ -11,32 +11,30 @@ test.beforeAll(async () => {
   await createFixtureProject({
     buildStdio,
     files: {
-      "package.json": json`
-        {
-          "name": "remix-integration-9v4bpv66vd",
-          "private": true,
-          "sideEffects": false,
-          "scripts": {
-            "build": "remix build",
-            "dev": "remix dev",
-            "start": "remix-serve build"
-          },
-          "dependencies": {
-            "@remix-run/node": "0.0.0-local-version",
-            "@remix-run/react": "0.0.0-local-version",
-            "@remix-run/serve": "0.0.0-local-version",
-            "react": "0.0.0-local-version",
-            "react-dom": "0.0.0-local-version",
-            "esm-only-no-exports": "0.0.0-local-version",
-            "esm-only-exports": "0.0.0-local-version",
-            "esm-only-sub-exports": "0.0.0-local-version",
-            "esm-cjs-exports": "0.0.0-local-version"
-          },
-          "devDependencies": {
-            "@remix-run/dev": "0.0.0-local-version"
-          }
-        }
-      `,
+      "package.json": json({
+        name: "remix-integration-9v4bpv66vd",
+        private: true,
+        sideEffects: false,
+        scripts: {
+          build: "remix build",
+          dev: "remix dev",
+          start: "remix-serve build",
+        },
+        dependencies: {
+          "@remix-run/node": "0.0.0-local-version",
+          "@remix-run/react": "0.0.0-local-version",
+          "@remix-run/serve": "0.0.0-local-version",
+          react: "0.0.0-local-version",
+          "react-dom": "0.0.0-local-version",
+          "esm-only-no-exports": "0.0.0-local-version",
+          "esm-only-exports": "0.0.0-local-version",
+          "esm-only-sub-exports": "0.0.0-local-version",
+          "esm-cjs-exports": "0.0.0-local-version",
+        },
+        devDependencies: {
+          "@remix-run/dev": "0.0.0-local-version",
+        },
+      }),
       "app/routes/index.jsx": js`
         import { json } from "@remix-run/node";
         import { Link, useLoaderData } from "@remix-run/react";
@@ -59,70 +57,62 @@ test.beforeAll(async () => {
           return null;
         }
       `,
-      "node_modules/esm-only-no-exports/package.json": json`
-        {
-          "name": "esm-only-no-exports",
-          "version": "1.0.0",
-          "type": "module",
-          "main": "index.js"
-        }
-      `,
+      "node_modules/esm-only-no-exports/package.json": json({
+        name: "esm-only-no-exports",
+        version: "1.0.0",
+        type: "module",
+        main: "index.js",
+      }),
       "node_modules/esm-only-no-exports/index.js": js`
         export default () => "esm-only-no-exports";
       `,
-      "node_modules/esm-only-exports/package.json": json`
-        {
-          "name": "esm-only-exports",
-          "version": "1.0.0",
-          "type": "module",
-          "main": "index.js",
-          "exports": {
-            ".": "./index.js",
-            "./package.json": "./package.json"
-          }
-        }
-      `,
+      "node_modules/esm-only-exports/package.json": json({
+        name: "esm-only-exports",
+        version: "1.0.0",
+        type: "module",
+        main: "index.js",
+        exports: {
+          ".": "./index.js",
+          "./package.json": "./package.json",
+        },
+      }),
       "node_modules/esm-only-exports/index.js": js`
         export default () => "esm-only-no-exports";
       `,
-      "node_modules/esm-only-sub-exports/package.json": json`
-        {
-          "name": "esm-only-sub-exports",
-          "version": "1.0.0",
-          "type": "module",
-          "main": "index.js",
-          "exports": {
-            ".": "./index.js",
-            "./sub": "./sub.js",
-            "./package.json": "./package.json"
-          }
-        }
-      `,
+      "node_modules/esm-only-sub-exports/package.json": json({
+        name: "esm-only-sub-exports",
+        version: "1.0.0",
+        type: "module",
+        main: "index.js",
+        exports: {
+          ".": "./index.js",
+          "./sub": "./sub.js",
+          "./package.json": "./package.json",
+        },
+      }),
       "node_modules/esm-only-sub-exports/index.js": js`
         export default () => "esm-only-no-exports";
       `,
       "node_modules/esm-only-sub-exports/sub.js": js`
         export default () => "esm-only-no-exports/sub";
       `,
-      "node_modules/esm-cjs-exports/package.json": json`
-        {
-          "name": "esm-cjs-exports",
-          "version": "1.0.0",
-          "type": "module",
-          "main": "index.js",
-          "exports": {
-            ".": {
-              "require": "./index.cjs",
-              "default": "./index.js"
-            },
-            "./sub": {
-              "require": "./sub.cjs",
-              "default": "./sub.js"
-            },
-            "./package.json": "./package.json"
-          }
-        }
-      `,
+      "node_modules/esm-cjs-exports/package.json": json({
+        name: "esm-cjs-exports",
+        version: "1.0.0",
+        type: "module",
+        main: "index.js",
+        exports: {
+          ".": {
+            require: "./index.cjs",
+            default: "./index.js",
+          },
+          "./sub": {
+            require: "./sub.cjs",
+            default: "./sub.js",
+          },
+          "./package.json": "./package.json",
+        },
+      }),
       "node_modules/esm-cjs-exports/index.js": js`
         export default () => "esm-only-no-exports";
       `,

--- a/integration/helpers/create-fixture.ts
+++ b/integration/helpers/create-fixture.ts
@@ -6,6 +6,7 @@ import getPort from "get-port";
 import stripIndent from "strip-indent";
 import chalk from "chalk";
 import { sync as spawnSync } from "cross-spawn";
+import type { JsonObject } from "type-fest";
 
 import type { ServerBuild } from "../../build/node_modules/@remix-run/server-runtime";
 import { createRequestHandler } from "../../build/node_modules/@remix-run/server-runtime";
@@ -25,9 +26,11 @@ export type Fixture = Awaited<ReturnType<typeof createFixture>>;
 export type AppFixture = Awaited<ReturnType<typeof createAppFixture>>;
 
 export const js = String.raw;
-export const json = String.raw;
 export const mdx = String.raw;
 export const css = String.raw;
+export function json(value: JsonObject) {
+  return JSON.stringify(value, null, 2);
+}
 
 export async function createFixture(init: FixtureInit) {
   let projectDir = await createFixtureProject(init);

--- a/integration/path-mapping-test.ts
+++ b/integration/path-mapping-test.ts
@@ -74,30 +74,28 @@ test.beforeAll(async () => {
         <PizzaComponent />
       `,
 
-      "tsconfig.json": json`
-        {
-          "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
-          "compilerOptions": {
-            "lib": ["DOM", "DOM.Iterable", "ES2019"],
-            "isolatedModules": true,
-            "esModuleInterop": true,
-            "jsx": "react-jsx",
-            "moduleResolution": "node",
-            "resolveJsonModule": true,
-            "target": "ES2019",
-            "strict": true,
-            "baseUrl": ".",
-            "paths": {
-              "~/*": ["./app/*"],
-              "@mylib": ["./app/components/my-lib/index"],
-              "@component": ["./app/components/component.jsx"],
-            },
+      "tsconfig.json": json({
+        include: ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
+        compilerOptions: {
+          lib: ["DOM", "DOM.Iterable", "ES2019"],
+          isolatedModules: true,
+          esModuleInterop: true,
+          jsx: "react-jsx",
+          moduleResolution: "node",
+          resolveJsonModule: true,
+          target: "ES2019",
+          strict: true,
+          baseUrl: ".",
+          paths: {
+            "~/*": ["./app/*"],
+            "@mylib": ["./app/components/my-lib/index"],
+            "@component": ["./app/components/component.jsx"],
+          },
 
-            // Remix takes care of building everything in \`remix build\`.
-            "noEmit": true
-          }
-        }
-      `,
+          // Remix takes care of building everything in \`remix build\`.
+          noEmit: true,
+        },
+      }),
     },
   });
 });

--- a/integration/server-code-in-browser-message-test.ts
+++ b/integration/server-code-in-browser-message-test.ts
@@ -15,13 +15,11 @@ let appFixture: AppFixture;
 test.beforeAll(async () => {
   fixture = await createFixture({
     files: {
-      "node_modules/has-side-effects/package.json": json`
-        {
-          "name": "has-side-effects",
-          "version": "1.0.0",
-          "main": "index.js"
-        }
-      `,
+      "node_modules/has-side-effects/package.json": json({
+        name: "has-side-effects",
+        version: "1.0.0",
+        main: "index.js",
+      }),
       "node_modules/has-side-effects/index.js": js`
         let message;
         (() => { message = process.env.___SOMETHING___ || "hello, world"; })();

--- a/integration/tsconfig-test.ts
+++ b/integration/tsconfig-test.ts
@@ -1,0 +1,94 @@
+import { test, expect } from "@playwright/test";
+import fse from "fs-extra";
+import path from "path";
+import JSON5 from "json5";
+
+import { createFixture, json } from "./helpers/create-fixture";
+
+const DEFAULT_CONFIG = {
+  include: ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
+  compilerOptions: {
+    allowJs: true,
+    esModuleInterop: true,
+    forceConsistentCasingInFileNames: true,
+    isolatedModules: true,
+    jsx: "react-jsx",
+    lib: ["DOM", "DOM.Iterable", "ES2019"],
+    moduleResolution: "node",
+    noEmit: true,
+    resolveJsonModule: true,
+    strict: true,
+    target: "es2019",
+    baseUrl: ".",
+    paths: {
+      "~/*": ["./app/*"],
+    },
+  },
+};
+
+// besides baseUrl, due to an upstream issue in tsconfig-paths
+// https://github.com/dividab/tsconfig-paths/pull/208
+test("should output default tsconfig if file is empty", async () => {
+  let fixture = await createFixture({
+    files: {
+      "tsconfig.json": json({ compilerOptions: { baseUrl: "." } }),
+    },
+  });
+
+  let content = JSON5.parse(
+    await fse.readFile(path.join(fixture.projectDir, "tsconfig.json"), "utf8")
+  );
+  expect(content).toEqual(DEFAULT_CONFIG);
+});
+
+test("should add/update mandatory config", async () => {
+  let fixture = await createFixture({
+    files: {
+      "tsconfig.json": json({
+        include: ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
+        compilerOptions: {
+          allowJs: true,
+          baseUrl: ".",
+          esModuleInterop: true,
+          forceConsistentCasingInFileNames: true,
+          isolatedModules: false, // true is required by esbuild
+          jsx: "react-jsx",
+          lib: ["DOM", "DOM.Iterable", "ES2019"],
+          // moduleResolution: "node", // this is required by esbuild
+          noEmit: true,
+          resolveJsonModule: true,
+          strict: true,
+          target: "es2019",
+        },
+      }),
+    },
+  });
+
+  let content = JSON5.parse(
+    await fse.readFile(path.join(fixture.projectDir, "tsconfig.json"), "utf8")
+  );
+  expect(content).toEqual(DEFAULT_CONFIG);
+});
+
+test("shouldn't change suggested config if set", async () => {
+  let config = {
+    ...DEFAULT_CONFIG,
+    compilerOptions: {
+      ...DEFAULT_CONFIG.compilerOptions,
+      strict: false,
+    },
+  };
+
+  let fixture = await createFixture({
+    files: {
+      "tsconfig.json": json(config),
+    },
+  });
+
+  let content = JSON5.parse(
+    await fse.readFile(path.join(fixture.projectDir, "tsconfig.json"), "utf8")
+  );
+  expect(content).toEqual(config);
+});
+
+// TODO: add test for nested tsconfig

--- a/integration/tsconfig-test.ts
+++ b/integration/tsconfig-test.ts
@@ -11,6 +11,7 @@ async function getTsConfig(projectDir: string) {
   return JSON5.parse(config);
 }
 
+// this is the default tsconfig.json that is shipped with `create-remix` templates
 const DEFAULT_CONFIG = {
   include: ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
   compilerOptions: {
@@ -46,17 +47,16 @@ test("should output default tsconfig if file is empty", async () => {
 });
 
 test("should add/update mandatory config", async () => {
-  let fixture = await createFixture({
-    files: {
-      "tsconfig.json": json({
-        ...DEFAULT_CONFIG,
-        compilerOptions: {
-          ...DEFAULT_CONFIG.compilerOptions,
-          isolatedModules: false, // true is required by esbuild
-          // moduleResolution: "node", // this is required by esbuild
-        },
-      }),
+  let config = {
+    ...DEFAULT_CONFIG,
+    compilerOptions: {
+      ...DEFAULT_CONFIG.compilerOptions,
+      isolatedModules: false, // true is required by esbuild
     },
+  };
+  delete config.compilerOptions.moduleResolution; // this is required by esbuild
+  let fixture = await createFixture({
+    files: { "tsconfig.json": json(config) },
   });
 
   let tsconfig = await getTsConfig(fixture.projectDir);

--- a/integration/tsconfig-test.ts
+++ b/integration/tsconfig-test.ts
@@ -91,4 +91,46 @@ test("shouldn't change suggested config if set", async () => {
   expect(content).toEqual(config);
 });
 
-// TODO: add test for nested tsconfig
+test("allows for `extends` in tsconfig", async () => {
+  let config = {
+    extends: "./tsconfig.base.json",
+  };
+
+  let baseConfig = {
+    compilerOptions: {
+      allowJs: true,
+      baseUrl: ".",
+    },
+  };
+
+  let fixture = await createFixture({
+    files: {
+      "tsconfig.json": json(config),
+      "tsconfig.base.json": json(baseConfig),
+    },
+  });
+
+  let content = JSON5.parse(
+    await fse.readFile(path.join(fixture.projectDir, "tsconfig.json"), "utf8")
+  );
+  // our base config only sets a few options, so our local config should fill in the missing ones
+  expect(content).toEqual({
+    extends: "./tsconfig.base.json",
+    include: ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
+    compilerOptions: {
+      esModuleInterop: true,
+      forceConsistentCasingInFileNames: true,
+      isolatedModules: true,
+      jsx: "react-jsx",
+      lib: ["DOM", "DOM.Iterable", "ES2019"],
+      moduleResolution: "node",
+      noEmit: true,
+      resolveJsonModule: true,
+      strict: true,
+      target: "es2019",
+      paths: {
+        "~/*": ["./app/*"],
+      },
+    },
+  });
+});

--- a/integration/tsconfig-test.ts
+++ b/integration/tsconfig-test.ts
@@ -102,24 +102,15 @@ test("allows for `extends` in tsconfig", async () => {
   });
 
   let tsconfig = await getTsConfig(fixture.projectDir);
+
   // our base config only sets a few options, so our local config should fill in the missing ones
+  let expected = { ...DEFAULT_CONFIG };
+  // these were defined by the base config
+  delete expected.compilerOptions.allowJs;
+  delete expected.compilerOptions.baseUrl;
+
   expect(tsconfig).toEqual({
     extends: "./tsconfig.base.json",
-    include: ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
-    compilerOptions: {
-      esModuleInterop: true,
-      forceConsistentCasingInFileNames: true,
-      isolatedModules: true,
-      jsx: "react-jsx",
-      lib: ["DOM", "DOM.Iterable", "ES2019"],
-      moduleResolution: "node",
-      noEmit: true,
-      resolveJsonModule: true,
-      strict: true,
-      target: "ES2019",
-      paths: {
-        "~/*": ["./app/*"],
-      },
-    },
+    ...expected,
   });
 });

--- a/integration/tsconfig-test.ts
+++ b/integration/tsconfig-test.ts
@@ -25,7 +25,7 @@ const DEFAULT_CONFIG = {
     noEmit: true,
     resolveJsonModule: true,
     strict: true,
-    target: "es2019",
+    target: "ES2019",
     baseUrl: ".",
     paths: {
       "~/*": ["./app/*"],
@@ -116,7 +116,7 @@ test("allows for `extends` in tsconfig", async () => {
       noEmit: true,
       resolveJsonModule: true,
       strict: true,
-      target: "es2019",
+      target: "ES2019",
       paths: {
         "~/*": ["./app/*"],
       },

--- a/packages/remix-dev/compiler/utils/tsconfig/write-config-defaults.ts
+++ b/packages/remix-dev/compiler/utils/tsconfig/write-config-defaults.ts
@@ -38,11 +38,18 @@ function objectKeys<Type extends object>(value: Type): Array<ObjectKeys<Type>> {
 }
 
 export function writeConfigDefaults(configPath: string) {
+  // check files exist
+  if (!fse.existsSync(configPath)) return;
+
   // this will be the *full* tsconfig.json with any extensions deeply merged
   let fullConfig = loadTsconfig(configPath) as TsConfigJson | undefined;
   // this will be the user's actual tsconfig file
   let configContents = fse.readFileSync(configPath, "utf8");
-  let config = JSON5.parse(configContents) as TsConfigJson | undefined;
+
+  let config: TsConfigJson | undefined;
+  try {
+    config = JSON5.parse(configContents);
+  } catch (error: unknown) {}
 
   if (!fullConfig || !config) {
     // how did we get here?

--- a/packages/remix-dev/compiler/utils/tsconfig/write-config-defaults.ts
+++ b/packages/remix-dev/compiler/utils/tsconfig/write-config-defaults.ts
@@ -1,8 +1,8 @@
 import * as path from "path";
 import fse from "fs-extra";
-import JSON5 from "json5";
 import type { TsConfigJson } from "type-fest";
 import prettier from "prettier";
+import { loadTsconfig } from "tsconfig-paths/lib/tsconfig-loader";
 
 import * as colors from "../../../colors";
 
@@ -37,8 +37,13 @@ function objectKeys<Type extends object>(value: Type): Array<ObjectKeys<Type>> {
 }
 
 export function writeConfigDefaults(configPath: string) {
-  let configContents = fse.readFileSync(configPath, "utf-8");
-  let config = JSON5.parse(configContents);
+  let config = loadTsconfig(configPath) as TsConfigJson | undefined;
+
+  if (!config) {
+    // how did we get here?
+    return;
+  }
+
   let configType = path.basename(configPath);
   if (!config.compilerOptions) {
     config.compilerOptions = {};

--- a/packages/remix-dev/compiler/utils/tsconfig/write-config-defaults.ts
+++ b/packages/remix-dev/compiler/utils/tsconfig/write-config-defaults.ts
@@ -10,14 +10,14 @@ import * as colors from "../../../colors";
 // These are suggested values and will be set when not present in the
 // tsconfig.json
 let suggestedCompilerOptions: TsConfigJson.CompilerOptions = {
-  forceConsistentCasingInFileNames: true,
-  target: "es2019",
-  lib: ["DOM", "DOM.Iterable", "ES2019"] as TsConfigJson.CompilerOptions.Lib[],
   allowJs: true,
-  strict: true,
+  forceConsistentCasingInFileNames: true,
+  lib: ["DOM", "DOM.Iterable", "ES2019"],
   paths: {
     "~/*": ["./app/*"],
   },
+  strict: true,
+  target: "ES2019",
 };
 
 // These values are required and cannot be changed by the user
@@ -27,8 +27,8 @@ let requiredCompilerOptions: TsConfigJson.CompilerOptions = {
   isolatedModules: true,
   jsx: "react-jsx",
   moduleResolution: "node",
-  resolveJsonModule: true,
   noEmit: true,
+  resolveJsonModule: true,
 };
 
 // taken from https://github.com/sindresorhus/ts-extras/blob/781044f0412ec4a4224a1b9abce5ff0eacee3e72/source/object-keys.ts

--- a/packages/remix-dev/compiler/utils/tsconfig/write-config-defaults.ts
+++ b/packages/remix-dev/compiler/utils/tsconfig/write-config-defaults.ts
@@ -65,7 +65,7 @@ export function writeConfigDefaults(configPath: string) {
   let requiredChanges = [];
 
   if (!("include" in fullConfig)) {
-    fullConfig.include = ["remix.env.d.ts", "**/*.ts", "**/*.tsx"];
+    config.include = ["remix.env.d.ts", "**/*.ts", "**/*.tsx"];
     suggestedChanges.push(
       colors.blue("include") +
         " was set to " +

--- a/packages/remix-dev/compiler/utils/tsconfig/write-config-defaults.ts
+++ b/packages/remix-dev/compiler/utils/tsconfig/write-config-defaults.ts
@@ -52,7 +52,10 @@ export function writeConfigDefaults(configPath: string) {
   } catch (error: unknown) {}
 
   if (!fullConfig || !config) {
-    // how did we get here?
+    // how did we get here? we validated a tsconfig existed in the first place
+    console.warn(
+      "This should never happen, please open an issue with a reproduction https://github.com/remix-run/remix/issues/new"
+    );
     return;
   }
 


### PR DESCRIPTION
follow up to #2786

the merging worked prior to 02b60f5 in the PR due to parsing the config before writing the defaults, but now it happens after that due to the tsconfig loader being there temporarily. the writing of _just_ the missing options to the resolved tsconfig is new behavior

Signed-off-by: Logan McAnsh <logan@mcan.sh>