### PR TITLE
feat(remix-dev): add `extraPathsToWatch` config option

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -331,3 +331,4 @@
 - zachdtaylor
 - zainfathoni
 - zhe
+- npirotte

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -215,7 +215,7 @@ export async function watch(
     if (onRebuildFinish) onRebuildFinish();
   }, 100);
 
-  let toWatch = [config.appDirectory];
+  let toWatch = [config.appDirectory, ...config.extraPathsToWatch];
   if (config.serverEntryPoint) {
     toWatch.push(config.serverEntryPoint);
   }

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -40,6 +40,12 @@ export interface AppConfig {
   appDirectory?: string;
 
   /**
+  * List of extra paths or globs to watch changes on in addition to the main app directory.
+  * relative to `remix.config.js`. Defaults to `[]`.
+  */
+  extraPathsToWatch?: string | string[];
+
+  /**
    * The path to a directory Remix can use for caching things in development,
    * relative to `remix.config.js`. Defaults to `".cache"`.
    */
@@ -162,6 +168,11 @@ export interface RemixConfig {
    * The absolute path to the application source directory.
    */
   appDirectory: string;
+
+  /**
+  * List of extra paths or globs to watch changes on in addition to the main app directory.
+  */
+   extraPathsToWatch: string[];
 
   /**
    * The absolute path to the cache directory.
@@ -404,8 +415,15 @@ export async function readConfig(
 
   let serverDependenciesToBundle = appConfig.serverDependenciesToBundle || [];
 
+  let extraPathsToWatch: string[] = [];
+
+  if (appConfig.extraPathsToWatch) {
+    extraPathsToWatch = extraPathsToWatch.concat(Array.isArray(appConfig.extraPathsToWatch) ? appConfig.extraPathsToWatch : [appConfig.extraPathsToWatch]);
+  }
+
   return {
     appDirectory,
+    extraPathsToWatch,
     cacheDirectory,
     entryClientFile,
     entryServerFile,


### PR DESCRIPTION
This adds the possibility to watch extra directories/files/globs in dev mode.

This should make integration with mono repos lix NX easier.

Will spend more time documenting and testing if necessary and if feature is approved.

Closes: #2983

- [x] Docs
- [ ] Tests
