### PR TITLE
docs(tutorials/blog): update line highlighting

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -168,6 +168,7 @@
 - kentcdodds
 - kevinrambaud
 - kgregory
+- kilian
 - kiliman
 - kimdontdoit
 - klauspaiva

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -934,7 +934,7 @@ Let's add some validation before we create the post.
 
 💿 Validate if the form data contains what we need, and return the errors if not
 
-```tsx filename=app/routes/posts/admin/new.tsx lines=[3,8-14,24-34]
+```tsx filename=app/routes/posts/admin/new.tsx lines=[2,7-13,23-33]
 import type { ActionFunction } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import { Form } from "@remix-run/react";


### PR DESCRIPTION
The highlighted lines were all off by one so this PR fixes that:

![wrongly highlighted lines in tutorial](https://user-images.githubusercontent.com/41970/165533004-6dfab3e1-0c45-4d04-8e2b-07848d890e1e.png)

