### PR TITLE
test: increase timeout of test for windows

### DIFF
--- a/packages/remix-dev/__tests__/replace-remix-imports-test.ts
+++ b/packages/remix-dev/__tests__/replace-remix-imports-test.ts
@@ -112,5 +112,5 @@ describe("`replace-remix-imports` migration", () => {
 
     expect(output).toContain("successfully migrated");
     expect(output).toContain("npm install");
-  });
+  }, 25_000);
 });


### PR DESCRIPTION
- [x] Docs
- [x] Tests

Testing Strategy: I ran the tests locally and they run fast on my machine. I'm guessing the windows powershell thing is really slow or something, so my testing strategy is CI here to see whether the test times out in CI on windows.