### PR TITLE
feat(remix-node): add `getFilePath`& `remove` methods to `NodeOnDiskFile`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -409,3 +409,4 @@
 - zachdtaylor
 - zainfathoni
 - zhe
+- cstrnt

--- a/packages/remix-node/__tests__/fileUploadHandler-test.ts
+++ b/packages/remix-node/__tests__/fileUploadHandler-test.ts
@@ -104,4 +104,18 @@ describe("NodeOnDiskFile", () => {
     expect(sliced.size).toBe(slicedRes.length);
     expect(await sliced.text()).toBe(slicedRes);
   });
+
+  it("returns the file path properly", async () => {
+    expect(file.getFilePath()).toEqual(filepath);
+  });
+
+  it("removes the file properly", async () => {
+    let newFilePath = `${filepath}-copy`;
+    fs.copyFileSync(filepath, newFilePath);
+
+    let copiedFile = (file = new NodeOnDiskFile(newFilePath, "text/plain"));
+    expect(fs.existsSync(copiedFile.getFilePath())).toBe(true);
+    await copiedFile.remove();
+    expect(fs.existsSync(copiedFile.getFilePath())).toBe(false);
+  });
 });

--- a/packages/remix-node/upload/fileUploadHandler.ts
+++ b/packages/remix-node/upload/fileUploadHandler.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "crypto";
 import { createReadStream, createWriteStream, statSync } from "fs";
-import { rm, mkdir, stat as statAsync } from "fs/promises";
+import { rm, mkdir, stat as statAsync, unlink } from "fs/promises";
 import { tmpdir } from "os";
 import { basename, dirname, extname, resolve as resolvePath } from "path";
 import type { Readable } from "stream";
@@ -230,5 +230,12 @@ export class NodeOnDiskFile implements File {
 
   public get [Symbol.toStringTag]() {
     return "File";
+  }
+
+  remove(): Promise<void> {
+    return unlink(this.filepath);
+  }
+  getFilePath(): string {
+    return this.filepath;
   }
 }


### PR DESCRIPTION
Closes: #3021

- [ ] Docs
- [x] Tests

Testing Strategy:

- Added a `test` script in the `remix-node` package (remix-node tests never ran before)
- Added a simple unit test for the `createFileUploadHandler` function
