### PR TITLE
chore(deps): pin sort-package-json@1.55.0

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -310,6 +310,7 @@
 - tascord
 - TheRealAstoo
 - therealflyingcoder
+- thisislawatts
 - thomasheyenbrock
 - thomasrettig
 - tjefferson08

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "rollup-plugin-copy": "^3.3.0",
     "semver": "^7.3.4",
     "simple-git": "^3.2.4",
-    "sort-package-json": "^1.54.0",
+    "sort-package-json": "1.55.0",
     "strip-ansi": "^6.0.1",
     "strip-indent": "^3.0.0",
     "type-fest": "^2.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9271,9 +9271,9 @@ sort-object-keys@^1.1.3:
   resolved "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz"
   integrity sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==
 
-sort-package-json@^1.54.0, sort-package-json@^1.55.0:
+sort-package-json@1.55.0, sort-package-json@^1.55.0:
   version "1.55.0"
-  resolved "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.55.0.tgz"
+  resolved "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.55.0.tgz#150328328a9ac8b417b43d5a1fae74e5f27254e9"
   integrity sha512-xhKvRD8WGbALjXQkVuk4/93Z/2NIO+5IzKamdMjN5kn3L+N+M9YWQssmM6GXlQr9v1F7PGWsOJEo1gvXOhM7Mg==
   dependencies:
     detect-indent "^6.0.0"


### PR DESCRIPTION
The most recent release to sort-package-json switched
to ESM format. This is a breaking change which has
not been released with an appropriate version, for example 2.x

The intention of this change is to explicitly pin the package
version and avoid the incompatible v1.56.0 being installed

Closes: #3044
