### PR TITLE
fix: clear build directory before new builds

### DIFF
--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -144,6 +144,7 @@ export async function build(
 
   let start = Date.now();
   let config = await readConfig(remixRoot);
+  fse.emptyDirSync(config.assetsBuildDirectory);
   await compiler.build(config, {
     mode: mode,
     sourcemap,


### PR DESCRIPTION
This clears the `public/build` directory before the build when running `remix build`, to avoid stale artifacts from persisting on subsequent builds/deploys

Closes: #83

Testing Strategy: Not a great way to write a unit test for this, but it can be tested locally via:

* `npm run build`
* Inspect `public/build/routes/` for a given route JS file
* Rename the route TS/JS file
* `npm run build`
* Inspect `public/build/routes/` and confirm the old route file is no longer present and the new route exists
