### PR TITLE
fix: fix rollup playground livereload

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -869,8 +869,9 @@ export default function rollup(options) {
 }
 
 async function triggerLiveReload(appDir) {
-  // Tickle live reload by touching the server entry.  Include all extensions
-  // since they may or may not use TS and/or JSX
+  // Tickle live reload by touching the server entry
+  // Consider all of entry.server.{tsx,ts,jsx,js} since React may be used 
+  // via `React.createElement` without the need for JSX.
   let serverEntryPaths = [
     "entry.server.ts",
     "entry.server.tsx",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -868,37 +868,44 @@ export default function rollup(options) {
   return builds;
 }
 
+async function triggerLiveReload(appDir) {
+  // tickle live reload by touching the server entry
+  let serverEntryPaths = [
+    "entry.server.tsx",
+    "entry.server.js",
+    "entry.server.jsx",
+  ];
+  let serverEntryPath = serverEntryPaths
+    .map((entryFile) => path.join(appDir, "app", entryFile))
+    .find((entryPath) => fse.existsSync(entryPath));
+  let date = new Date();
+  await fs.promises.utimes(serverEntryPath, date, date);
+}
+
 function copyToPlaygrounds() {
   return {
     name: "copy-to-remix-playground",
     async writeBundle(options, bundle) {
-      let playgroundsDir = path.join(__dirname, "playground");
-      let playgrounds = await fs.promises.readdir(playgroundsDir);
-      let writtenDir = path.join(__dirname, options.dir);
-      for (let playground of playgrounds) {
-        let playgroundDir = path.join(playgroundsDir, playground);
-        if (!fse.statSync(playgroundDir).isDirectory()) {
-          continue;
+      if (activeOutputDir === "build") {
+        let playgroundsDir = path.join(__dirname, "playground");
+        let playgrounds = await fs.promises.readdir(playgroundsDir);
+        let writtenDir = path.join(__dirname, options.dir);
+        for (let playground of playgrounds) {
+          let playgroundDir = path.join(playgroundsDir, playground);
+          if (!fse.statSync(playgroundDir).isDirectory()) {
+            continue;
+          }
+          let destDir = writtenDir.replace(
+            path.join(__dirname, "build"),
+            playgroundDir
+          );
+          await fse.copy(writtenDir, destDir);
+          await triggerLiveReload(playgroundDir);
         }
-        let destDir = writtenDir.replace(
-          path.join(__dirname, "build"),
-          playgroundDir
-        );
-        await fse.copy(writtenDir, destDir);
-
-        // tickle live reload by touching the server entry
-        let serverEntry = ["tsx", "js", "jsx"].find((entryPathExtension) =>
-          fse.existsSync(
-            path.join(
-              playgroundDir,
-              "app",
-              `entry.server.${entryPathExtension}`
-            )
-          )
-        );
-        let serverEntryPath = path.join(playgroundDir, "app", serverEntry);
-        let serverEntryContent = await fse.readFile(serverEntryPath);
-        await fse.writeFile(serverEntryPath, serverEntryContent);
+      } else {
+        // If we're not building to "build" then trigger live reload on our
+        // external "playground" app
+        await triggerLiveReload(activeOutputDir);
       }
     },
   };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -869,7 +869,8 @@ export default function rollup(options) {
 }
 
 async function triggerLiveReload(appDir) {
-  // tickle live reload by touching the server entry
+  // Tickle live reload by touching the server entry.  Include all extensions
+  // since they may or may not use TS and/or JSX
   let serverEntryPaths = [
     "entry.server.ts",
     "entry.server.tsx",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -872,8 +872,9 @@ async function triggerLiveReload(appDir) {
   // tickle live reload by touching the server entry
   let serverEntryPaths = [
     "entry.server.tsx",
-    "entry.server.js",
     "entry.server.jsx",
+    // .js included because our build supports JSX in a .js file, but not a .ts file
+    "entry.server.js",
   ];
   let serverEntryPath = serverEntryPaths
     .map((entryFile) => path.join(appDir, "app", entryFile))

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -871,10 +871,10 @@ export default function rollup(options) {
 async function triggerLiveReload(appDir) {
   // tickle live reload by touching the server entry
   let serverEntryPaths = [
+    "entry.server.ts",
     "entry.server.tsx",
-    "entry.server.jsx",
-    // .js included because our build supports JSX in a .js file, but not a .ts file
     "entry.server.js",
+    "entry.server.jsx",
   ];
   let serverEntryPath = serverEntryPaths
     .map((entryFile) => path.join(appDir, "app", entryFile))


### PR DESCRIPTION
We made a small change in #3059 that broke the playground live reload trigger from the rollup build.  This fixes that and also adds the same live reload for usages of `REMIX_LOCAL_DEV_OUTPUT_DIRECTORY`

Testing Strategy:
* Test out live-reload of playground apps
* Or try using `REMIX_LOCAL_DEV_OUTPUT_DIRECTORY=../path/to/remix/app yarn watch` and confirm live reload works there as well
