### PR TITLE
feat(remix-dev): pass `packageManager` to `remix.init` script

### DIFF
--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -74,7 +74,7 @@ export async function init(
     });
     let initFn = require(initScript);
     try {
-      await initFn({ rootDirectory: projectDir, isTypeScript });
+      await initFn({ isTypeScript, packageManager, rootDirectory: projectDir });
     } catch (error) {
       if (error instanceof Error) {
         error.message = `${colors.error("🚨 Oops, remix.init failed")}\n\n${


### PR DESCRIPTION
This way, the `remix.init` script can call `npm/yarn/pnpm install` if needed.

The use-case I'm thinking about is having different dependencies when using JavaScript or TypeScript.