### PR TITLE
ci: bump cli test process timeout

### DIFF
--- a/packages/remix-dev/__tests__/cli-test.ts
+++ b/packages/remix-dev/__tests__/cli-test.ts
@@ -345,9 +345,10 @@ async function interactWithShell(
   // output as possible.
   let timeout = setTimeout(() => {
     if (deferred.state.current === "pending") {
+      proc.kill();
       deferred.reject({ status: "timeout", stdout, stderr });
     }
-  }, 6_000);
+  }, 10_000);
 
   await deferred.promise;
   clearTimeout(timeout);


### PR DESCRIPTION
We had a 6 second timeout in `interactWithShell` that seems to be firing on windows test fairly often making them a bit flakey.  It also seems that when the timeout fires, we didn't kill the process which left it potentially running in the background and continuing to execute, holding up the jest process from completing.  This PR bumps the timeout from 6->10 seconds and calls `proc.kill()` when the timeout elapses