### PR TITLE
chore(remix-dev): only check if dir is empty, not if it exists

### DIFF
--- a/packages/remix-dev/__tests__/create-test.ts
+++ b/packages/remix-dev/__tests__/create-test.ts
@@ -402,7 +402,6 @@ describe("the create command", () => {
     expect(fse.existsSync(path.join(projectDir, "test.txt"))).toBeTruthy();
     // if you run `remix init` keep around the remix.init directory for future use
     expect(fse.existsSync(path.join(projectDir, "remix.init"))).toBeTruthy();
-    // deps can take a bit to install
   });
 
   it("throws an error when invalid remix.init script when automatically ran", async () => {
@@ -422,7 +421,6 @@ describe("the create command", () => {
     expect(fse.existsSync(path.join(projectDir, "app/root.tsx"))).toBeTruthy();
     // we should keep remix.init around if the init script fails
     expect(fse.existsSync(path.join(projectDir, "remix.init"))).toBeTruthy();
-    // deps can take a bit to install
   });
 
   it("throws an error when invalid remix.init script when manually ran", async () => {
@@ -449,7 +447,6 @@ describe("the create command", () => {
     expect(fse.existsSync(path.join(projectDir, "app/root.tsx"))).toBeTruthy();
     // we should keep remix.init around if the init script fails
     expect(fse.existsSync(path.join(projectDir, "remix.init"))).toBeTruthy();
-    // deps can take a bit to install
   });
 
   it("recognizes when Yarn was used to run the command", async () => {
@@ -621,6 +618,39 @@ describe("the create command", () => {
         ])
       ).rejects.toMatchInlineSnapshot(
         `[Error: 🚨 The template file could not be verified. The server returned a response with a 400 status. Please double check the URL and try again.]`
+      );
+    });
+
+    it("allows creating an app in the current dir if it's empty", async () => {
+      let projectDir = await getProjectDir("empty-dir");
+      await run([
+        "create",
+        projectDir,
+        "--template",
+        "grunge-stack",
+        "--no-install",
+        "--typescript",
+      ]);
+
+      expect(
+        fse.existsSync(path.join(projectDir, "package.json"))
+      ).toBeTruthy();
+    });
+
+    it("doesn't allow creating an app in the current dir if it's not empty", async () => {
+      let projectDir = await getProjectDir("not-empty-dir");
+      fse.createFileSync(path.join(projectDir, "some-file.txt"));
+      await expect(() =>
+        run([
+          "create",
+          projectDir,
+          "--template",
+          "grunge-stack",
+          "--no-install",
+          "--typescript",
+        ])
+      ).rejects.toMatchInlineSnapshot(
+        `[Error: 🚨 The current directory must be empty to create a new project. Please clear the contents of the directory or choose a different path.]`
       );
     });
   });

--- a/packages/remix-dev/__tests__/create-test.ts
+++ b/packages/remix-dev/__tests__/create-test.ts
@@ -650,7 +650,7 @@ describe("the create command", () => {
           "--typescript",
         ])
       ).rejects.toMatchInlineSnapshot(
-        `[Error: 🚨 The current directory must be empty to create a new project. Please clear the contents of the directory or choose a different path.]`
+        `[Error: 🚨 The project directory must be empty to create a new project. Please clear the contents of the directory or choose a different path.]`
       );
     });
   });

--- a/packages/remix-dev/__tests__/create-test.ts
+++ b/packages/remix-dev/__tests__/create-test.ts
@@ -621,8 +621,8 @@ describe("the create command", () => {
       );
     });
 
-    it("allows creating an app in the current dir if it's empty", async () => {
-      let projectDir = await getProjectDir("empty-dir");
+    it("allows creating an app in a dir if it's empty", async () => {
+      let projectDir = await getProjectDir("other-empty-dir");
       await run([
         "create",
         projectDir,
@@ -637,8 +637,9 @@ describe("the create command", () => {
       ).toBeTruthy();
     });
 
-    it("doesn't allow creating an app in the current dir if it's not empty", async () => {
+    it("doesn't allow creating an app in a dir if it's not empty", async () => {
       let projectDir = await getProjectDir("not-empty-dir");
+      fse.mkdirSync(projectDir);
       fse.createFileSync(path.join(projectDir, "some-file.txt"));
       await expect(() =>
         run([
@@ -652,6 +653,47 @@ describe("the create command", () => {
       ).rejects.toMatchInlineSnapshot(
         `[Error: 🚨 The project directory must be empty to create a new project. Please clear the contents of the directory or choose a different path.]`
       );
+    });
+
+    it("allows creating an app in the current dir if it's empty", async () => {
+      let projectDir = await getProjectDir("empty-dir");
+      let cwd = process.cwd();
+      fse.mkdirSync(projectDir);
+      process.chdir(projectDir);
+      await run([
+        "create",
+        ".",
+        "--template",
+        "grunge-stack",
+        "--no-install",
+        "--typescript",
+      ]);
+      process.chdir(cwd);
+
+      expect(
+        fse.existsSync(path.join(projectDir, "package.json"))
+      ).toBeTruthy();
+    });
+
+    it("doesn't allow creating an app in the current dir if it's not empty", async () => {
+      let projectDir = await getProjectDir("not-empty-dir");
+      let cwd = process.cwd();
+      fse.mkdirSync(projectDir);
+      fse.createFileSync(path.join(projectDir, "some-file.txt"));
+      process.chdir(projectDir);
+      await expect(() =>
+        run([
+          "create",
+          ".",
+          "--template",
+          "grunge-stack",
+          "--no-install",
+          "--typescript",
+        ])
+      ).rejects.toMatchInlineSnapshot(
+        `[Error: 🚨 The project directory must be empty to create a new project. Please clear the contents of the directory or choose a different path.]`
+      );
+      process.chdir(cwd);
     });
   });
 });

--- a/packages/remix-dev/cli/create.ts
+++ b/packages/remix-dev/cli/create.ts
@@ -446,11 +446,6 @@ export async function validateNewProjectPath(input: string): Promise<void> {
         "🚨 The current directory must be empty to create a new project. Please " +
           "clear the contents of the directory or choose a different path."
       );
-    } else {
-      throw Error(
-        "🚨 The directory provided already exists. Please try again with a " +
-          "different directory."
-      );
     }
   }
 }

--- a/packages/remix-dev/cli/create.ts
+++ b/packages/remix-dev/cli/create.ts
@@ -38,17 +38,6 @@ export async function createApp({
   githubToken = process.env.GITHUB_TOKEN,
   debug,
 }: CreateAppArgs) {
-  // Create the app directory
-  let relativeProjectDir = path.relative(process.cwd(), projectDir);
-  let projectDirIsCurrentDir = relativeProjectDir === "";
-  if (!projectDirIsCurrentDir) {
-    if (fse.existsSync(projectDir)) {
-      throw new Error(
-        `️🚨 Oops, "${relativeProjectDir}" already exists. Please try again with a different directory.`
-      );
-    }
-  }
-
   /**
    * Grab the template
    * First we'll need to determine if the template we got is

--- a/packages/remix-dev/cli/create.ts
+++ b/packages/remix-dev/cli/create.ts
@@ -443,7 +443,7 @@ export async function validateNewProjectPath(input: string): Promise<void> {
   ) {
     if ((await fse.readdir(projectDir)).length > 0) {
       throw Error(
-        "🚨 The current directory must be empty to create a new project. Please " +
+        "🚨 The project directory must be empty to create a new project. Please " +
           "clear the contents of the directory or choose a different path."
       );
     }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #2828

- [ ] Docs
- [x] Tests

Testing Strategy:

This test covers this code: https://github.com/remix-run/remix/pull/3087/files#diff-44fd7b47d36d99648d628196603ec193162f8cc64062cde2d76bbe36f89c6356R624

I also ran the build `yarn build` and ran the following:
success cases:
```shell
cd ~/Desktop && \
mkdir test && \
cd test && \
node ~/<path-to-remix>/build/node_modules/create-remix/cli.js .
```

and also
```shell
mkdir ~/Desktop/test && \
node ./build/node_modules/create-remix/cli.js ~/Desktop/test
```

failing cases:
```shell
cd ~/Desktop && \
mkdir test && \
cd test && \
touch .some-file && \
node ~/<path-to-remix>/build/node_modules/create-remix/cli.js .
```

and also
```shell
mkdir ~/Desktop/test && \
touch ~/Desktop/test/.some-file && \
node ./build/node_modules/create-remix/cli.js ~/Desktop/test
```



<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
