### PR TITLE
chore(templates): ignore lockfiles

### DIFF
--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -1,0 +1,4 @@
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+pnpm-lock.yml


### PR DESCRIPTION
Just like in `examples`, we don't want to have lockfiles in `templates` either.

We're running `npm/yarn/pnpm install` in our CLI (both when creating & on `init`), so this could cause unnecessary lockfiles if the user's package manager is different from the one we included the lockfile for.

https://github.com/remix-run/remix/blob/a511d347a3c452c7532ddb396a16d246ae8ba70e/packages/remix-dev/cli/create.ts#L225-L228
https://github.com/remix-run/remix/blob/a511d347a3c452c7532ddb396a16d246ae8ba70e/packages/remix-dev/cli/commands.ts#L71-L74