### PR TITLE
fix(remix-dev/cli/migrate): directly use `jscodeshift` instead of via CLI

### DIFF
--- a/packages/remix-dev/cli/migrate/migrations/replace-remix-imports/index.ts
+++ b/packages/remix-dev/cli/migrate/migrations/replace-remix-imports/index.ts
@@ -151,11 +151,11 @@ export const replaceRemixImports: MigrationFunction = async ({
     cwd: config.appDirectory,
     absolute: true,
   });
-  let codemodOk = jscodeshift.run<Options>({
-    transformPath: TRANSFORM_PATH,
+  let codemodOk = await jscodeshift.run<Options>({
     files,
     flags,
-    transformOptions: { runtime, adapter },
+    transformOptions: { adapter, runtime },
+    transformPath: TRANSFORM_PATH,
   });
   if (!codemodOk) {
     console.error("❌ I couldn't replace all of your `remix` imports.");

--- a/packages/remix-dev/cli/migrate/migrations/replace-remix-imports/transform/options.ts
+++ b/packages/remix-dev/cli/migrate/migrations/replace-remix-imports/transform/options.ts
@@ -7,7 +7,7 @@
 import type { Adapter } from "./adapter";
 import type { Runtime } from "./runtime";
 
-export interface Options {
-  runtime: Runtime;
+export type Options = {
   adapter?: Adapter;
-}
+  runtime: Runtime;
+};

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -28,7 +28,6 @@
     "dotenv": "^16.0.0",
     "esbuild": "0.14.22",
     "esbuild-plugin-cache": "^0.2.9",
-    "execa": "^5.1.1",
     "exit-hook": "2.2.1",
     "express": "4.17.3",
     "fast-glob": "3.2.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4728,7 +4728,7 @@ events@^3.3.0:
   resolved "https://registry.npmjs.org/events/-/events-3.3.0.tgz"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-execa@^5.0.0, execa@^5.1.1:
+execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==


### PR DESCRIPTION
Fixed the problem @lensbart mentioned in https://github.com/remix-run/remix/issues/683#issuecomment-1103507342