### PR TITLE
fix(remix-react): detect index route from manifest in `useFormAction`

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1150,6 +1150,7 @@ export function useFormAction(
   method: FormMethod = "get"
 ): string {
   let { id } = useRemixRouteContext();
+  let { manifest } = useRemixEntryContext();
   let resolvedPath = useResolvedPath(action ? action : ".");
 
   // Previously we set the default action to ".". The problem with this is that
@@ -1159,7 +1160,7 @@ export function useFormAction(
   // https://github.com/remix-run/remix/issues/927
   let location = useLocation();
   let { search, hash } = resolvedPath;
-  let isIndexRoute = id.endsWith("/index");
+  let isIndexRoute = Boolean(manifest.routes[id].index);
 
   if (action == null) {
     search = location.search;


### PR DESCRIPTION
The `useFormAction` hook detects the file ID ending in "/index" to determine whether or not to return a form action with the  `?index` search param. This holds true in Remix's default route convention. However, in the case where the consumer defines custom routes, this may not hold true anymore.

---

Testing Strategy:

I'm using the [Remix Flat Routes](https://github.com/kiliman/remix-flat-routes/) flat-folders convention in my project.

Let's say I have a route `_auth.dashboard.index/_routes.tsx`. That's considered to be an index route in the flat-folders convention. However, rendering a `<Form>` in that route results in a form with the action `"/dashboard"` while the action should be `"/dashboard?index"`.