### PR TITLE
tests: don't call `remix init` when creating fixtures

### DIFF
--- a/integration/cf-compiler-test.ts
+++ b/integration/cf-compiler-test.ts
@@ -9,7 +9,6 @@ test.describe("cloudflare compiler", () => {
 
   test.beforeAll(async () => {
     projectDir = await createFixtureProject({
-      setup: "cloudflare",
       template: "cf-template",
       files: {
         "package.json": json({

--- a/integration/compiler-test.ts
+++ b/integration/compiler-test.ts
@@ -17,7 +17,6 @@ test.describe("compiler", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
-      setup: "node",
       files: {
         "app/fake.server.js": js`
           export const hello = "server";

--- a/integration/helpers/create-fixture.ts
+++ b/integration/helpers/create-fixture.ts
@@ -19,7 +19,6 @@ interface FixtureInit {
   sourcemap?: boolean;
   files: { [filename: string]: string };
   template?: "cf-template" | "node-template";
-  setup?: "node" | "cloudflare";
 }
 
 export type Fixture = Awaited<ReturnType<typeof createFixture>>;
@@ -156,13 +155,6 @@ export async function createFixtureProject(init: FixtureInit): Promise<string> {
     path.join(projectDir, "node_modules"),
     { overwrite: true }
   );
-  if (init.setup) {
-    spawnSync(
-      "node",
-      ["node_modules/@remix-run/dev/cli.js", "setup", init.setup],
-      { cwd: projectDir }
-    );
-  }
   await writeTestFiles(init, projectDir);
   build(projectDir, init.buildStdio, init.sourcemap);
 


### PR DESCRIPTION
All tests are using the new imports, so there's no need to run `remix init` in the tests when creating fixtures