### PR TITLE
fix(remix-dev/cli/init): only run `npm install` when `package.json` is available

### DIFF
--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -64,14 +64,18 @@ export async function init(
 ) {
   let initScriptDir = path.join(projectDir, "remix.init");
   let initScript = path.resolve(initScriptDir, "index.js");
+  let initPackageJson = path.resolve(initScriptDir, "package.json");
 
   let isTypeScript = fse.existsSync(path.join(projectDir, "tsconfig.json"));
 
   if (await fse.pathExists(initScript)) {
-    execSync(`${packageManager} install`, {
-      stdio: "ignore",
-      cwd: initScriptDir,
-    });
+    if (await fse.pathExists(initPackageJson)) {
+      execSync(`${packageManager} install`, {
+        stdio: "ignore",
+        cwd: initScriptDir,
+      });
+    }
+
     let initFn = require(initScript);
     try {
       await initFn({ rootDirectory: projectDir, isTypeScript });


### PR DESCRIPTION
This will otherwise give the following error:

```sh
npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path .../remix.init/package.json
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, open '.../remix.init/package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! A complete log of this run can be found in:
npm ERR!     .../.npm/_logs/2022-05-09T22_37_36_176Z-debug.log
```