### PR TITLE
ci: fix regex when parsing pr body for mentioned issues

### DIFF
--- a/scripts/release/octokit.mjs
+++ b/scripts/release/octokit.mjs
@@ -169,7 +169,7 @@ export async function getIssuesClosedByPullRequests(prHtmlUrl, prBody) {
    * https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    */
   let regex =
-    /([close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved]*.?\s+).?#([0-9]+)/gi;
+    /(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s#([0-9]+)/gi;
   let matches = prBody.match(regex);
   if (!matches) return linked;
 


### PR DESCRIPTION
before: 
<img width="631" alt="image" src="https://user-images.githubusercontent.com/11698668/167654126-994adcb1-a60d-42ce-8328-22ba77f1535b.png">


after: 
<img width="631" alt="image" src="https://user-images.githubusercontent.com/11698668/167654058-a2610516-3779-436f-95a7-26f471740aa3.png">
