### PR TITLE
feat(templates): update Cloudflare templates to use `wrangler` v2

### DIFF
--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -25,7 +25,7 @@
     "eslint": "^8.20.0",
     "npm-run-all": "^4.1.5",
     "typescript": "^4.7.4",
-    "wrangler": "beta"
+    "wrangler": "^2.0.22"
   },
   "engines": {
     "node": ">=14"

--- a/templates/cloudflare-workers/README.md
+++ b/templates/cloudflare-workers/README.md
@@ -28,8 +28,6 @@ Then refresh the same URL in your browser (no live reload for production builds)
 
 ## Deployment
 
-Use [wrangler](https://developers.cloudflare.com/workers/cli-wrangler) to build and deploy your application to Cloudflare Workers. If you don't have it yet, follow [the installation guide](https://developers.cloudflare.com/workers/cli-wrangler/install-update) to get it setup. Be sure to [authenticate the CLI](https://developers.cloudflare.com/workers/cli-wrangler/authentication) as well.
-
 If you don't already have an account, then [create a cloudflare account here](https://dash.cloudflare.com/sign-up) and after verifying your email address with Cloudflare, go to your dashboard and set up your free custom Cloudflare Workers subdomain.
 
 Once that's done, you should be able to deploy your app:

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -26,7 +26,8 @@
     "eslint": "^8.20.0",
     "miniflare": "^2.6.0",
     "npm-run-all": "^4.1.5",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "wrangler": "^2.0.22"
   },
   "engines": {
     "node": ">=14"

--- a/templates/cloudflare-workers/wrangler.toml
+++ b/templates/cloudflare-workers/wrangler.toml
@@ -1,6 +1,5 @@
 name = "remix-cloudflare-workers"
 
-account_id = ""
 workers_dev = true
 main = "./build/index.js"
 # https://developers.cloudflare.com/workers/platform/compatibility-dates


### PR DESCRIPTION
Update template for cloudflare workers. (https://github.com/remix-run/remix/discussions/3158)
- `wrangler.toml`: Changed to wrangler v2 style.
- `package.json`: Added wrangler to dependecncies. Updated @cloudflare/workers-types latest. (also pages template)
- `remix.env.d.ts`: Fixed dead link. (also pages template)
- `README`: Removed the sentence about installation of wrangler.

I have confirmed that it is deployable. (https://github.com/aiji42/remix-cf-wrangler-2)
```
uejima.aiji$ yarn deploy                                                                                             [~/git/remix-cf-wrangler-2]
yarn run v1.22.18
$ npm run build && wrangler publish

> build
> remix build

Building Remix app in production mode...
Built in 385ms
 ⛅️ wrangler 2.0.2
-------------------
Running custom build: npm run build

> build
> remix build

Building Remix app in production mode...
Built in 368ms
Reading public/build/_shared/chunk-LHODYXPX.js...
Skipping - already uploaded.
Reading public/build/_shared/chunk-OGYP3M3B.js...
Skipping - already uploaded.
Reading public/build/entry.client-GY23DEVV.js...
Skipping - already uploaded.
Reading public/build/manifest-289EFF28.js...
Skipping - already uploaded.
Reading public/build/root-NVPFOTJV.js...
Skipping - already uploaded.
Reading public/build/routes/index-UD6EN4U7.js...
Skipping - already uploaded.
Reading public/favicon.ico...
Skipping - already uploaded.
↗️  Done syncing assets
Uploaded remix-cf-wrangler-2 (2.18 sec)
Published remix-cf-wrangler-2 (0.31 sec)
  remix-cf-wrangler-2.aiji422990.workers.dev
✨  Done in 7.46s.
```