### PR TITLE
bug(remix-react): add failing test for scroll-restoration

### DIFF
--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -48,27 +48,37 @@ test.beforeAll(async () => {
     ////////////////////////////////////////////////////////////////////////////
     files: {
       "app/routes/index.jsx": js`
-        import { json } from "@remix-run/node";
-        import { useLoaderData, Link } from "@remix-run/react";
-
-        export function loader() {
-          return json("pizza");
-        }
-
+        import { redirect } from "@remix-run/node";
+        import { Form } from "@remix-run/react";
+        
+        export const action = async () => {
+          await new Promise((resolve) => setTimeout(resolve, 500));
+        
+          return redirect("/test");
+        };
+        
         export default function Index() {
-          let data = useLoaderData();
           return (
             <div>
-              {data}
-              <Link to="/burgers">Other Route</Link>
+              <h1>Scroll down to test</h1>
+        
+              <Form method="post" action="/?index" style={{ marginTop: "150vh" }}>
+                <h1>Test here</h1>
+                <button type="submit">test</button>
+              </Form>
             </div>
-          )
-        }
+          );
+        }      
       `,
 
-      "app/routes/burgers.jsx": js`
+      "app/routes/test.jsx": js`
         export default function Index() {
-          return <div>cheeseburger</div>;
+          return (
+            <div>
+              <h1>This is the top</h1>
+              <h1 style={{ marginTop: "150vh" }}>This is the bottom</h1>
+            </div>
+          )
         }
       `,
     },
@@ -85,16 +95,22 @@ test.afterAll(async () => appFixture.close());
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("[description of what you expect it to do]", async ({ page }) => {
+test("page scroll should be at the top on the new page", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);
   // You can test any request your app might get using `fixture`.
   let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch("pizza");
+  expect(await response.text()).toMatch("Scroll down to test");
 
   // If you need to test interactivity use the `app`
   await app.goto("/");
-  await app.clickLink("/burgers");
-  expect(await app.getHtml()).toMatch("cheeseburger");
+  // scroll to the bottom
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await app.clickSubmitButton("/?index");
+
+  expect(await app.getHtml()).toMatch("This is the bottom");
+
+  let newScrollY = await page.evaluate(() => window.scrollY);
+  expect(newScrollY).toBe(0);
 
   // If you're not sure what's going on, you can "poke" the app, it'll
   // automatically open up in your browser for 20 seconds, so be quick!


### PR DESCRIPTION
After redirect the new page isn't scrolled to the top