### PR TITLE
feat(templates/cloudflare-pages): bind local `.env` variables in development

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -330,6 +330,7 @@
 - SufianBabri
 - supachaidev
 - tascord
+- theeomm
 - TheRealAstoo
 - therealflyingcoder
 - thomasheyenbrock

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "remix build",
     "dev:remix": "remix watch",
-    "dev:wrangler": "cross-env NODE_ENV=development wrangler pages dev ./public",
+    "dev:wrangler": "cross-env NODE_ENV=development wrangler pages dev ./public --binding $(cat .env)",
     "dev": "remix build && run-p dev:*",
     "start": "cross-env NODE_ENV=production npm run dev:wrangler"
   },


### PR DESCRIPTION
- Passed `--binding $(cat .env)` argument to the `dev:wrangler` script in the cloudflare-pages template as suggested [here](https://github.com/remix-run/remix/issues/1186#issuecomment-1019492493)