### PR TITLE
feat(remix-dev): add `watchPaths` config option

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -62,6 +62,7 @@
 - chenxsan
 - chiangs
 - christianhg
+- christophertrudel
 - christophgockel
 - clarkmitchell
 - cliffordfajardo

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -158,6 +158,18 @@ module.exports = {
 };
 ```
 
+### watchDirectories
+
+A function for defining custom directories to watch while running [remix dev](https://remix.run/docs/en/v1/other-api/dev#remix-dev), in addition to [`appDirectory`](#appDirectory).
+
+```tsx
+exports.watchDirectories = async () => {
+  return [
+      "/some/path/*"
+  ];
+};
+```
+
 ## File Name Conventions
 
 There are a few conventions that Remix uses you should be aware of.

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -158,12 +158,12 @@ module.exports = {
 };
 ```
 
-### watchDirectories
+### watchPaths
 
 A function for defining custom directories to watch while running [remix dev](https://remix.run/docs/en/v1/other-api/dev#remix-dev), in addition to [`appDirectory`](#appDirectory).
 
 ```tsx
-exports.watchDirectories = async () => {
+exports.watchPaths = async () => {
   return [
       "/some/path/*"
   ];

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -48,7 +48,7 @@ describe("readConfig", () => {
         "serverMode": "production",
         "serverModuleFormat": "cjs",
         "serverPlatform": "node",
-        "watchDirectories": Array [],
+        "watchPaths": Array [],
       }
     `
     );

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -48,6 +48,7 @@ describe("readConfig", () => {
         "serverMode": "production",
         "serverModuleFormat": "cjs",
         "serverPlatform": "node",
+        "watchDirectories": Array [],
       }
     `
     );

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -221,6 +221,10 @@ export async function watch(
   if (config.serverEntryPoint) {
     toWatch.push(config.serverEntryPoint);
   }
+  
+  config.watchDirectories?.forEach((directory) => {
+    toWatch.push(directory);
+  });
 
   let watcher = chokidar
     .watch(toWatch, {

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -222,8 +222,8 @@ export async function watch(
     toWatch.push(config.serverEntryPoint);
   }
   
-  config.watchDirectories?.forEach((directory) => {
-    toWatch.push(directory);
+  config.watchPaths?.forEach((watchPath) => {
+    toWatch.push(watchPath);
   });
 
   let watcher = chokidar

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -147,6 +147,11 @@ export interface AppConfig {
    * in a CJS build.
    */
   serverDependenciesToBundle?: Array<string | RegExp>;
+
+  /**
+   * A function for defining custom directories to watch while running `remix dev`, in addition to `appDirectory`.
+   */
+  watchDirectories?: () => Promise<string | string[]>;
 }
 
 /**
@@ -250,6 +255,11 @@ export interface RemixConfig {
    * in a CJS build.
    */
   serverDependenciesToBundle: Array<string | RegExp>;
+
+  /**
+   * A list of directories to watch.
+   */
+   watchDirectories: string[];
 }
 
 /**
@@ -395,6 +405,12 @@ export async function readConfig(
     }
   }
 
+  let watchDirectories: string[] = [];
+  if (appConfig.watchDirectories) {
+    let directories = await appConfig.watchDirectories();
+    watchDirectories = watchDirectories.concat(Array.isArray(directories) ? directories : [directories]);
+  }
+
   let serverBuildTargetEntryModule = `export * from ${JSON.stringify(
     serverBuildVirtualModule.id
   )};`;
@@ -421,6 +437,7 @@ export async function readConfig(
     serverEntryPoint: customServerEntryPoint,
     serverDependenciesToBundle,
     mdx,
+    watchDirectories,
   };
 }
 

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -151,7 +151,10 @@ export interface AppConfig {
   /**
    * A function for defining custom directories to watch while running `remix dev`, in addition to `appDirectory`.
    */
-  watchPaths?: () => Promise<string | string[]>;
+  watchPaths?:
+    | string
+    | string[]
+    | (() => Promise<string | string[]> | string | string[]);
 }
 
 /**
@@ -406,10 +409,16 @@ export async function readConfig(
   }
 
   let watchPaths: string[] = [];
-  if (appConfig.watchPaths) {
+  if (typeof appConfig.watchPaths === "function") {
     let directories = await appConfig.watchPaths();
     watchPaths = watchPaths.concat(
       Array.isArray(directories) ? directories : [directories]
+    );
+  } else if (appConfig.watchPaths) {
+    watchPaths = watchPaths.concat(
+      Array.isArray(appConfig.watchPaths)
+        ? appConfig.watchPaths
+        : [appConfig.watchPaths]
     );
   }
 

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -151,7 +151,7 @@ export interface AppConfig {
   /**
    * A function for defining custom directories to watch while running `remix dev`, in addition to `appDirectory`.
    */
-  watchDirectories?: () => Promise<string | string[]>;
+  watchPaths?: () => Promise<string | string[]>;
 }
 
 /**
@@ -259,7 +259,7 @@ export interface RemixConfig {
   /**
    * A list of directories to watch.
    */
-   watchDirectories: string[];
+  watchPaths: string[];
 }
 
 /**
@@ -405,10 +405,12 @@ export async function readConfig(
     }
   }
 
-  let watchDirectories: string[] = [];
-  if (appConfig.watchDirectories) {
-    let directories = await appConfig.watchDirectories();
-    watchDirectories = watchDirectories.concat(Array.isArray(directories) ? directories : [directories]);
+  let watchPaths: string[] = [];
+  if (appConfig.watchPaths) {
+    let directories = await appConfig.watchPaths();
+    watchPaths = watchPaths.concat(
+      Array.isArray(directories) ? directories : [directories]
+    );
   }
 
   let serverBuildTargetEntryModule = `export * from ${JSON.stringify(
@@ -437,7 +439,7 @@ export async function readConfig(
     serverEntryPoint: customServerEntryPoint,
     serverDependenciesToBundle,
     mdx,
-    watchDirectories,
+    watchPaths,
   };
 }
 


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->
Support to watch directories other then remixes default directories. Will help integration with mono repos like NX/TurboRepo.

Closes: #2983
Agreed upon replacement of: https://github.com/remix-run/remix/pull/2985

- [ x ] Docs
- [ x ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
