### PR TITLE
chore(templates/cloudflare-pages): ignore `/functions/[[path]].js.map`

### DIFF
--- a/templates/cloudflare-pages/.gitignore
+++ b/templates/cloudflare-pages/.gitignore
@@ -2,5 +2,6 @@ node_modules
 
 /.cache
 /functions/\[\[path\]\].js
+/functions/\[\[path\]\].js.map
 /public/build
 .env


### PR DESCRIPTION
Every time we run the dev script, the `/functions/path.js.map` is generated. So, it's unneccessary to commit it to the Git repo.