### PR TITLE
feat(templates): add Link header for Early Hints, HTTP2 Server Push etc.

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -386,6 +386,7 @@
 - phishy
 - plastic041
 - plondon
+- plopix
 - pmbanugo
 - princerajroy
 - prvnbist

--- a/packages/remix-dev/config/defaults/entry.server.node.tsx
+++ b/packages/remix-dev/config/defaults/entry.server.node.tsx
@@ -15,17 +15,17 @@ export default function handleRequest(
 ) {
   return isbot(request.headers.get("user-agent"))
     ? handleBotRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      )
+      request,
+      responseStatusCode,
+      responseHeaders,
+      remixContext
+    )
     : handleBrowserRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      );
+      request,
+      responseStatusCode,
+      responseHeaders,
+      remixContext
+    );
 }
 
 function handleBotRequest(
@@ -46,6 +46,13 @@ function handleBotRequest(
           const body = new PassThrough();
 
           responseHeaders.set("Content-Type", "text/html");
+          responseHeaders.set(
+            "Link",
+            httpPushLinks(remixContext).map((link: string) => `<${link}>; rel=preload; as=script; crossorigin=anonymous`)
+              .concat(responseHeaders.get("Link") as string)
+              .filter(Boolean)
+              .join(",")
+          );
 
           resolve(
             new Response(body, {
@@ -88,6 +95,13 @@ function handleBrowserRequest(
           const body = new PassThrough();
 
           responseHeaders.set("Content-Type", "text/html");
+          responseHeaders.set(
+            "Link",
+            httpPushLinks(remixContext).map((link: string) => `<${link}>; rel=preload; as=script; crossorigin=anonymous`)
+              .concat(responseHeaders.get("Link") as string)
+              .filter(Boolean)
+              .join(",")
+          );
 
           resolve(
             new Response(body, {
@@ -110,4 +124,12 @@ function handleBrowserRequest(
 
     setTimeout(abort, ABORT_DELAY);
   });
+}
+
+function httpPushLinks(remixContext: EntryContext) {
+  return [
+    remixContext.manifest.url,
+    remixContext.manifest.entry.module,
+    ...remixContext.manifest.entry.imports,
+  ];
 }


### PR DESCRIPTION
Hello,

# Context

When using HTTP/2 we can optimize the first loading with HTTP/2 Server Push `Link` header.
I had to implement it for a project and I wonder if it might cool to have it in Remix directly.

Probably not be the best place to put this code but at least this PR open the topic, and make it simple to test ;)
Should we have that in Remix by default? or with a configuration?

What do you think?

# Testing with HTTPS and HTTP2 locally

- install Caddy Server
- install mkcert and generate certificates

Then here a simple Caddyfile

```
my.custom.domain.com {
    tls ./provisioning/dev/certs/domains.pem ./provisioning/dev/certs/key.pem

    push
    
    @websockets {
        header Connection *Upgrade*
        header Upgrade websocket
    }
    # (3019 is custom, change for you)
    reverse_proxy @websockets localhost:3019
    
    # (3018 is custom, change for you)
    reverse_proxy 127.0.0.1:3018
}
```

# Results
<img width="1001" alt="Screen Shot 2022-05-15 at 12 44 52 PM" src="https://user-images.githubusercontent.com/313532/168491138-bfde795f-cd8e-4985-8dbc-4249513090d1.png">

