### PR TITLE
fix(remix-dev): ensure devServerPort config value is the same across reloads

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -306,6 +306,7 @@
 - SufianBabri
 - supachaidev
 - tascord
+- tessellator
 - TheRealAstoo
 - therealflyingcoder
 - thomasheyenbrock

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -52,4 +52,9 @@ describe("readConfig", () => {
     `
     );
   });
+
+  it("returns the same devServerPort value across reloads", async () => {
+    let newConfig = await readConfig(remixRoot);
+    expect(newConfig.devServerPort).toBe(config.devServerPort);
+  });
 });

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -8,6 +8,11 @@ import { defineConventionalRoutes } from "./config/routesConvention";
 import { ServerMode, isValidServerMode } from "./config/serverModes";
 import { serverBuildVirtualModule } from "./compiler/virtualModules";
 
+/* eslint-disable prefer-let/prefer-let */
+declare global {
+  var __devServerPort: number | undefined;
+}
+
 export interface RemixMdxConfig {
   rehypePlugins?: any[];
   remarkPlugins?: any[];
@@ -358,7 +363,10 @@ export async function readConfig(
       process.env.REMIX_DEV_SERVER_WS_PORT || 8002
     );
   }
-  let devServerPort = await getPort({ port: appConfig.devServerPort });
+  if (!global.__devServerPort) {
+    global.__devServerPort = await getPort({ port: appConfig.devServerPort });
+  }
+  let devServerPort = global.__devServerPort;
   // set env variable so un-bundled servers can use it
   process.env.REMIX_DEV_SERVER_WS_PORT = `${devServerPort}`;
   let devServerBroadcastDelay = appConfig.devServerBroadcastDelay || 0;


### PR DESCRIPTION
Closes: #2958

- [x] Tests

If the devServerPort changes values across config reloads then LiveReload will attempt to connect to an incorrect port. Files being created, deleted, or renamed under the app folder trigger config reloads.

Testing Strategy:

A test is included in the commit that ensures that the same devServerPort is always returned.

Additionally, I tested a new project with this code using the following steps:

1. Create a new project using create-remix@latest and replace @remix-run/dev with a build including the code in the attached commit.
2. Run `npm run dev`
3. Browse to localhost:3000. Verify LiveReload is working by editing `app/routes/index.tsx` and observing the change.
4. Create a new file `app/components/SomeComponent.tsx` and observe page refresh. Validate no websocket errors in browser console.
5. Verify LiveReload is still working by editing `app/routes/index.tsx` and observing the change.