### PR TITLE
tests(remix-react): add failing test for default `Form` action

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -138,6 +138,7 @@
 - ianduvall
 - illright
 - imzshh
+- ionut-botizan
 - isaacrmoreno
 - ishan-me
 - IshanKBG

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-import { getElement, PlaywrightFixture } from "./helpers/playwright-fixture";
+import { PlaywrightFixture } from "./helpers/playwright-fixture";
 import type { Fixture, AppFixture } from "./helpers/create-fixture";
 import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
 
@@ -47,17 +47,28 @@ test.beforeAll(async () => {
     // `createFixture` will make an app and run your tests against it.
     ////////////////////////////////////////////////////////////////////////////
     files: {
-      "app/routes/login.jsx": js`
-        import { Form } from "@remix-run/react";
+      "app/routes/index.jsx": js`
+        import { json } from "@remix-run/node";
+        import { useLoaderData, Link } from "@remix-run/react";
 
-        export default function Login() {
+        export function loader() {
+          return json("pizza");
+        }
+
+        export default function Index() {
+          let data = useLoaderData();
           return (
             <div>
-              <Form method="post">
-                <button type="submit">Submit</button>
-              </Form>
+              {data}
+              <Link to="/burgers">Other Route</Link>
             </div>
           )
+        }
+      `,
+
+      "app/routes/burgers.jsx": js`
+        export default function Index() {
+          return <div>cheeseburger</div>;
         }
       `,
     },
@@ -74,16 +85,22 @@ test.afterAll(async () => appFixture.close());
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("default form action matches current path & search", async ({ page }) => {
+test("[description of what you expect it to do]", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);
-  let url = "/login?redirectTo=/profile";
+  // You can test any request your app might get using `fixture`.
+  let response = await fixture.requestDocument("/");
+  expect(await response.text()).toMatch("pizza");
 
-  await app.goto(url);
+  // If you need to test interactivity use the `app`
+  await app.goto("/");
+  await app.clickLink("/burgers");
+  expect(await app.getHtml()).toMatch("cheeseburger");
 
-  let html = await app.getHtml();
-  let form = getElement(html, `form`);
+  // If you're not sure what's going on, you can "poke" the app, it'll
+  // automatically open up in your browser for 20 seconds, so be quick!
+  // await app.poke(20);
 
-  expect(form.attr("action")).toEqual(url);
+  // Go check out the other tests to see what else you can do.
 });
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-import { PlaywrightFixture } from "./helpers/playwright-fixture";
+import { getElement, PlaywrightFixture } from "./helpers/playwright-fixture";
 import type { Fixture, AppFixture } from "./helpers/create-fixture";
 import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
 
@@ -47,28 +47,17 @@ test.beforeAll(async () => {
     // `createFixture` will make an app and run your tests against it.
     ////////////////////////////////////////////////////////////////////////////
     files: {
-      "app/routes/index.jsx": js`
-        import { json } from "@remix-run/node";
-        import { useLoaderData, Link } from "@remix-run/react";
+      "app/routes/login.jsx": js`
+        import { Form } from "@remix-run/react";
 
-        export function loader() {
-          return json("pizza");
-        }
-
-        export default function Index() {
-          let data = useLoaderData();
+        export default function Login() {
           return (
             <div>
-              {data}
-              <Link to="/burgers">Other Route</Link>
+              <Form method="post">
+                <button type="submit">Submit</button>
+              </Form>
             </div>
           )
-        }
-      `,
-
-      "app/routes/burgers.jsx": js`
-        export default function Index() {
-          return <div>cheeseburger</div>;
         }
       `,
     },
@@ -85,22 +74,16 @@ test.afterAll(async () => appFixture.close());
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("[description of what you expect it to do]", async ({ page }) => {
+test("default form action matches current path & search", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);
-  // You can test any request your app might get using `fixture`.
-  let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch("pizza");
+  let url = "/login?redirectTo=/profile";
 
-  // If you need to test interactivity use the `app`
-  await app.goto("/");
-  await app.clickLink("/burgers");
-  expect(await app.getHtml()).toMatch("cheeseburger");
+  await app.goto(url);
 
-  // If you're not sure what's going on, you can "poke" the app, it'll
-  // automatically open up in your browser for 20 seconds, so be quick!
-  // await app.poke(20);
+  let html = await app.getHtml();
+  let form = getElement(html, `form`);
 
-  // Go check out the other tests to see what else you can do.
+  expect(form.attr("action")).toEqual(url);
 });
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -40,7 +40,7 @@ test.describe("Forms", () => {
   let SPLAT_ROUTE_CURRENT_ACTION = "splat-route-cur";
   let SPLAT_ROUTE_PARENT_ACTION = "splat-route-parent";
   let SPLAT_ROUTE_TOO_MANY_DOTS_ACTION = "splat-route-too-many-dots";
-  let DEFAULT_ACTION_SEARCH_PARAMS = "default-action-search-params";
+  let UNDEFINED_ACTION_SEARCH_PARAMS = "undefined-action-search-params";
   let EXPLICIT_ACTION_SEARCH_PARAMS = "explicit-action-search-params";
 
   test.beforeAll(async () => {
@@ -285,7 +285,7 @@ test.describe("Forms", () => {
           export default function() {
             return (
               <>
-                <Form id="${DEFAULT_ACTION_SEARCH_PARAMS}">
+                <Form id="${UNDEFINED_ACTION_SEARCH_PARAMS}">
                   <button>Login</button>
                 </Form>
                 <Form id="${EXPLICIT_ACTION_SEARCH_PARAMS}" action="/auth?nonce=123">
@@ -594,14 +594,14 @@ test.describe("Forms", () => {
     });
 
     test.describe("in a route with search params", () => {
-      test("default action preserves current location's search params", async ({
+      test("undefined action preserves current location's search params", async ({
         page,
       }) => {
         let app = new PlaywrightFixture(appFixture, page);
         let url = "/login?redirectTo=/profile";
         await app.goto(url);
         let html = await app.getHtml();
-        let el = getElement(html, `#${DEFAULT_ACTION_SEARCH_PARAMS}`);
+        let el = getElement(html, `#${UNDEFINED_ACTION_SEARCH_PARAMS}`);
         expect(el.attr("action")).toMatch(url);
       });
 

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -933,7 +933,7 @@ let FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
       reloadDocument = false,
       replace = false,
       method = "get",
-      action = ".",
+      action,
       encType = "application/x-www-form-urlencoded",
       fetchKey,
       onSubmit,
@@ -988,21 +988,21 @@ type HTMLFormSubmitter = HTMLButtonElement | HTMLInputElement;
  * @see https://remix.run/api/remix#useformaction
  */
 export function useFormAction(
-  action = ".",
+  action?: string,
   // TODO: Remove method param in v2 as it's no longer needed and is a breaking change
   method: FormMethod = "get"
 ): string {
   let { id } = useRemixRouteContext();
-  let path = useResolvedPath(action);
+  let path = useResolvedPath(action ?? ".");
   let location = useLocation();
   let search = path.search;
   let isIndexRoute = id.endsWith("/index");
 
-  if (action === ".") {
+  if (action === undefined) {
     search = location.search;
   }
 
-  if (action === "." && isIndexRoute) {
+  if ((action === undefined || action === ".") && isIndexRoute) {
     search = search ? search.replace(/^\?/, "?index&") : "?index";
   }
 

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -994,8 +994,13 @@ export function useFormAction(
 ): string {
   let { id } = useRemixRouteContext();
   let path = useResolvedPath(action);
+  let location = useLocation();
   let search = path.search;
   let isIndexRoute = id.endsWith("/index");
+
+  if (action === ".") {
+    search = location.search;
+  }
 
   if (action === "." && isIndexRoute) {
     search = search ? search.replace(/^\?/, "?index&") : "?index";


### PR DESCRIPTION
Issue: #3133

The default `<Form />` action should match the current location. Currently, only the `path` is preserved, but the `search` parameters are lost.

E.g. For the `/login?redirectTo=/profile` location and a `<Form method="post" />` element, the generated form node looks like
`<form method="post" action="/login">`.