### PR TITLE
fix(templates/vercel): add `index.js.map` to `.gitignore`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -155,6 +155,7 @@
 - jesse-deboer
 - jesseflorig
 - jgarrow
+- jiahao-c
 - jkup
 - jmasson
 - jo-ninja

--- a/templates/vercel/.gitignore
+++ b/templates/vercel/.gitignore
@@ -8,3 +8,4 @@ node_modules
 /build/
 /public/build
 /api/index.js
+/api/index.js.map


### PR DESCRIPTION
In the Vercel template,  `/api/index.js.map` should also be ignored along with `/api/index.js`. Otherwise, that mapping file would be committed into version control, which is not desired.

This PR only touches `/templates`, therefore requesting merge at `main` instead of `dev` branch.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->


Testing Strategy: `git commit` 

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
