### PR TITLE
fix: change how request is "cloned" for loaders

### DIFF
--- a/packages/remix-server-runtime/__tests__/handler-test.ts
+++ b/packages/remix-server-runtime/__tests__/handler-test.ts
@@ -1,0 +1,30 @@
+import { json } from "../responses";
+import { createRequestHandler } from "../server";
+
+describe("createRequestHandler", () => {
+  it("retains request headers when stripping body off for loaders", async () => {
+    let handler = createRequestHandler({
+      routes: {
+        root: {
+          id: "routes/test",
+          path: "/test",
+          module: {
+            loader: ({ request }) => json(request.headers.get("X-Foo")),
+          } as any,
+        },
+      },
+      assets: {} as any,
+      entry: { module: {} as any },
+    });
+
+    let response = await handler(
+      new Request("http://.../test", {
+        headers: {
+          "X-Foo": "bar",
+        },
+      })
+    );
+
+    expect(await response.json()).toBe("bar");
+  });
+});

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -295,16 +295,9 @@ async function handleDocumentRequest({
 
   let loaderRequest = new Request(request.url, {
     body: null,
-    cache: request.cache,
-    credentials: request.credentials,
     headers: request.headers,
-    integrity: request.integrity,
-    keepalive: request.keepalive,
     method: request.method,
-    mode: request.mode,
     redirect: request.redirect,
-    referrer: request.referrer,
-    referrerPolicy: request.referrerPolicy,
     signal: request.signal,
   });
 

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -294,8 +294,18 @@ async function handleDocumentRequest({
   }
 
   let loaderRequest = new Request(request.url, {
-    ...request,
     body: null,
+    cache: request.cache,
+    credentials: request.credentials,
+    headers: request.headers,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+    method: request.method,
+    mode: request.mode,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    signal: request.signal,
   });
 
   let routeLoaderResults = await Promise.allSettled(


### PR DESCRIPTION
Spreading a Request object yields an empty object. This explicitly passes through the init to the new Request.

- [ ] Docs
- [x] Tests
