### PR TITLE
fix(scripts): Prevent publishing without a tag

### DIFF
--- a/scripts/publish-private.js
+++ b/scripts/publish-private.js
@@ -10,6 +10,10 @@ function getTaggedVersion() {
   return output.replace(/^v/g, "");
 }
 
+/**
+ * @param {string} dir
+ * @param {string} tag
+ */
 function publish(dir, tag) {
   execSync(`npm publish --tag ${tag} ${dir}`, { stdio: "inherit" });
 }
@@ -23,7 +27,14 @@ async function run() {
   }
 
   let prerelease = semver.prerelease(taggedVersion);
-  let tag = prerelease ? prerelease[0] : "latest";
+  let prereleaseTag = prerelease ? String(prerelease[0]) : undefined;
+  let tag = prereleaseTag
+    ? prereleaseTag.includes("nightly")
+      ? "nightly"
+      : prereleaseTag.includes("experimental")
+      ? "experimental"
+      : prereleaseTag
+    : "latest";
 
   // Publish all @remix-run/* packages
   for (let name of [

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -10,11 +10,14 @@ function getTaggedVersion() {
   return output.replace(/^v/g, "");
 }
 
+/**
+ * @param {string} dir
+ * @param {string} tag
+ */
 function publish(dir, tag) {
-  execSync(
-    `npm publish --access public${tag != null ? ` --tag ${tag}` : ""} ${dir}`,
-    { stdio: "inherit" }
-  );
+  execSync(`npm publish --access public --tag ${tag} ${dir}`, {
+    stdio: "inherit",
+  });
 }
 
 async function run() {
@@ -31,7 +34,7 @@ async function run() {
     ? prereleaseTag.includes("nightly")
       ? "nightly"
       : prereleaseTag.includes("experimental")
-      ? null
+      ? "experimental"
       : prereleaseTag
     : "latest";
 


### PR DESCRIPTION
Publishing without a tag to npm will default to use `latest`, which we definitely don't want for experimental releases. It looks like npm requires a dist-tag when publishing, so we will use `experimental` instead.

I also noticed we were doing something different for the private publish script. Not sure if this even matters any more, but I fixed that as well.