### PR TITLE
feat(remix-server-runtime): make `Cookie` & `CreateCookieFunction` more type-safe

### DIFF
--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -32,7 +32,7 @@ export type CookieOptions = CookieParseOptions &
  *
  * @see https://remix.run/api/remix#cookie-api
  */
-export interface Cookie<Value extends any = any> {
+export interface Cookie<Value extends unknown = unknown> {
   /**
    * The name of the cookie, used in the `Cookie` and `Set-Cookie` headers.
    */
@@ -64,10 +64,13 @@ export interface Cookie<Value extends any = any> {
    * Serializes the given value to a string and returns the `Set-Cookie`
    * header.
    */
-  serialize(value: Value, options?: CookieSerializeOptions): Promise<string>;
+  serialize(
+    value: Value | null,
+    options?: CookieSerializeOptions
+  ): Promise<string>;
 }
 
-export type CreateCookieFunction = <Value extends any = any>(
+export type CreateCookieFunction = <Value extends unknown = unknown>(
   name: string,
   cookieOptions?: CookieOptions
 ) => Cookie<Value>;

--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -32,7 +32,7 @@ export type CookieOptions = CookieParseOptions &
  *
  * @see https://remix.run/api/remix#cookie-api
  */
-export interface Cookie<Type = any> {
+export interface Cookie<Value = any> {
   /**
    * The name of the cookie, used in the `Cookie` and `Set-Cookie` headers.
    */
@@ -58,19 +58,19 @@ export interface Cookie<Type = any> {
   parse(
     cookieHeader: string | null,
     options?: CookieParseOptions
-  ): Promise<Type | null>;
+  ): Promise<Value | null>;
 
   /**
    * Serializes the given value to a string and returns the `Set-Cookie`
    * header.
    */
-  serialize(value: Type, options?: CookieSerializeOptions): Promise<string>;
+  serialize(value: Value, options?: CookieSerializeOptions): Promise<string>;
 }
 
-export type CreateCookieFunction = <Type = any>(
+export type CreateCookieFunction = <Value = any>(
   name: string,
   cookieOptions?: CookieOptions
-) => Cookie<Type>;
+) => Cookie<Value>;
 
 /**
  * Creates a logical container for managing a browser cookie from the server.

--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -120,7 +120,9 @@ export const createCookieFactory =
       async serialize(value, serializeOptions) {
         return serialize(
           name,
-          value === "" ? "" : await encodeCookieValue(sign, value, secrets),
+          (value as any) === ""
+            ? ""
+            : await encodeCookieValue(sign, value, secrets),
           {
             ...options,
             ...serializeOptions,

--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -32,7 +32,7 @@ export type CookieOptions = CookieParseOptions &
  *
  * @see https://remix.run/api/remix#cookie-api
  */
-export interface Cookie<Value extends unknown = unknown> {
+export interface Cookie<Value extends any = any> {
   /**
    * The name of the cookie, used in the `Cookie` and `Set-Cookie` headers.
    */

--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -32,7 +32,7 @@ export type CookieOptions = CookieParseOptions &
  *
  * @see https://remix.run/api/remix#cookie-api
  */
-export interface Cookie<Value extends unknown = unknown> {
+export interface Cookie<Value extends any = any> {
   /**
    * The name of the cookie, used in the `Cookie` and `Set-Cookie` headers.
    */
@@ -70,7 +70,7 @@ export interface Cookie<Value extends unknown = unknown> {
   ): Promise<string>;
 }
 
-export type CreateCookieFunction = <Value extends unknown = unknown>(
+export type CreateCookieFunction = <Value extends any = any>(
   name: string,
   cookieOptions?: CookieOptions
 ) => Cookie<Value>;

--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -67,7 +67,7 @@ export interface Cookie<Value extends any = any> {
   serialize(value: Value, options?: CookieSerializeOptions): Promise<string>;
 }
 
-export type CreateCookieFunction = <Value extends unknown = unknown>(
+export type CreateCookieFunction = <Value extends any = any>(
   name: string,
   cookieOptions?: CookieOptions
 ) => Cookie<Value>;

--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -32,7 +32,7 @@ export type CookieOptions = CookieParseOptions &
  *
  * @see https://remix.run/api/remix#cookie-api
  */
-export interface Cookie<Value extends any = any> {
+export interface Cookie<Value extends unknown = unknown> {
   /**
    * The name of the cookie, used in the `Cookie` and `Set-Cookie` headers.
    */

--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -32,7 +32,7 @@ export type CookieOptions = CookieParseOptions &
  *
  * @see https://remix.run/api/remix#cookie-api
  */
-export interface Cookie {
+export interface Cookie<Type = any> {
   /**
    * The name of the cookie, used in the `Cookie` and `Set-Cookie` headers.
    */
@@ -58,19 +58,19 @@ export interface Cookie {
   parse(
     cookieHeader: string | null,
     options?: CookieParseOptions
-  ): Promise<any>;
+  ): Promise<Type>;
 
   /**
    * Serializes the given value to a string and returns the `Set-Cookie`
    * header.
    */
-  serialize(value: any, options?: CookieSerializeOptions): Promise<string>;
+  serialize(value: Type, options?: CookieSerializeOptions): Promise<string>;
 }
 
-export type CreateCookieFunction = (
+export type CreateCookieFunction = <Type = any>(
   name: string,
   cookieOptions?: CookieOptions
-) => Cookie;
+) => Cookie<Type>;
 
 /**
  * Creates a logical container for managing a browser cookie from the server.

--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -120,9 +120,7 @@ export const createCookieFactory =
       async serialize(value, serializeOptions) {
         return serialize(
           name,
-          (value as any) === ""
-            ? ""
-            : await encodeCookieValue(sign, value, secrets),
+          value === "" ? "" : await encodeCookieValue(sign, value, secrets),
           {
             ...options,
             ...serializeOptions,

--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -67,7 +67,7 @@ export interface Cookie<Value extends any = any> {
   serialize(value: Value, options?: CookieSerializeOptions): Promise<string>;
 }
 
-export type CreateCookieFunction = <Value = any>(
+export type CreateCookieFunction = <Value extends any = any>(
   name: string,
   cookieOptions?: CookieOptions
 ) => Cookie<Value>;

--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -32,7 +32,7 @@ export type CookieOptions = CookieParseOptions &
  *
  * @see https://remix.run/api/remix#cookie-api
  */
-export interface Cookie<Value = any> {
+export interface Cookie<Value extends any = any> {
   /**
    * The name of the cookie, used in the `Cookie` and `Set-Cookie` headers.
    */

--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -58,7 +58,7 @@ export interface Cookie<Type = any> {
   parse(
     cookieHeader: string | null,
     options?: CookieParseOptions
-  ): Promise<Type>;
+  ): Promise<Type | null>;
 
   /**
    * Serializes the given value to a string and returns the `Set-Cookie`

--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -67,7 +67,7 @@ export interface Cookie<Value extends unknown = unknown> {
   serialize(value: Value, options?: CookieSerializeOptions): Promise<string>;
 }
 
-export type CreateCookieFunction = <Value extends any = any>(
+export type CreateCookieFunction = <Value extends unknown = unknown>(
   name: string,
   cookieOptions?: CookieOptions
 ) => Cookie<Value>;

--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -64,10 +64,7 @@ export interface Cookie<Value extends any = any> {
    * Serializes the given value to a string and returns the `Set-Cookie`
    * header.
    */
-  serialize(
-    value: Value | null,
-    options?: CookieSerializeOptions
-  ): Promise<string>;
+  serialize(value: Value, options?: CookieSerializeOptions): Promise<string>;
 }
 
 export type CreateCookieFunction = <Value extends any = any>(


### PR DESCRIPTION
- [ ] Docs
- [ ] Tests

Testing Strategy:

I'm not really sure about how to automate testing this because it only adds an optional type. `npm run lint` and `yarn test` run with no issues with my code. I don't see a way to run a specific type check.

I can use Typescript Intellisense in VS Code to see that the type is correctly applied when it is specified using the generic parameter for createCookie and the type is set to any when it is not (current behaviour).

e.g.
```ts
let cookie = createCookie(); 
let variable = cookie.parse(); // variable type = any. Current behaviour. 
```
```ts
let cookie = createCookie<string>(); 
let variable = cookie.parse(); // variable type = string
```
```ts
let cookie = createCookie<{some_value: string}>(); 
let variable = cookie.parse(); // variable type = {some_value: string}
```

fix note:
Adding type safety to the serialise function produced an error in the function. 
`This condition will always return 'false' since the types 'Type' and 'string' have no overlap.`
I fixed it by adding a type assertion to the value to make it read as "any". I don't know why the error occurred, to me it looks like a shortcoming with Typescript rather than an actual bug, but I think this should be double checked.