### PR TITLE
feat(remix-express): remove dependency on `express`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -341,6 +341,7 @@
 - ni554n
 - nicholaschiang
 - nickytonline
+- nicksrandall
 - niconiahi
 - nielsdb97
 - ninjaPixel

--- a/packages/remix-dev/compiler/loaders.ts
+++ b/packages/remix-dev/compiler/loaders.ts
@@ -27,6 +27,7 @@ export const loaders: { [ext: string]: esbuild.Loader } = {
   ".mov": "file",
   ".mp3": "file",
   ".mp4": "file",
+  ".node": "file",
   ".ogg": "file",
   ".otf": "file",
   ".png": "file",

--- a/packages/remix-dev/compiler/plugins/serverNativeNodeModulesPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/serverNativeNodeModulesPlugin.ts
@@ -1,0 +1,44 @@
+
+import type esbuild from "esbuild";
+import * as path from "path";
+// See https://github.com/evanw/esbuild/issues/1051#issuecomment-806325487
+export function serverNativeNodeModulesPlugin(): esbuild.Plugin {
+    return {
+        name: 'native-node-modules',
+        setup(build) {
+            // If a ".node" file is imported within a module in the "file" namespace, resolve
+            // it to an absolute path and put it into the "node-file" virtual namespace.
+            build.onResolve({ filter: /\.node$/, namespace: 'file' }, args => ({
+                path: require.resolve(args.path, { paths: [args.resolveDir] }),
+                sideEffects: false,
+                namespace: 'node-file',
+            }))
+
+            // Files in the "node-file" virtual namespace call "require()" on the
+            // path from esbuild of the ".node" file in the output directory.
+            build.onLoad({ filter: /.*/, namespace: 'node-file' }, args => ({
+                contents: `
+                import * as path from "path";
+                import modulePath from ${JSON.stringify(args.path)}
+                
+                // Esbuild gives a package path, so we want to convert to an absolute one
+                let projectRoot = "${path.resolve()}";
+                let absolutePath = path.join(projectRoot, modulePath)
+                
+                try { module.exports = require(absolutePath) }
+                catch (error){
+                console.error(error)
+                }
+            `,
+            }))
+
+            // If a ".node" file is imported within a module in the "node-file" namespace, put
+            // it in the "file" namespace where esbuild's default loading behavior will handle
+            // it. It is already an absolute path since we resolved it to one above.
+            build.onResolve({ filter: /\.node$/, namespace: 'node-file' }, args => ({
+                path: args.path,
+                namespace: 'file',
+            }))
+        },
+    }
+}


### PR DESCRIPTION
This PR removes express as a dependency from the "express" handler (using only vanilla `http` module). This allows the handler to be used by any "express like" router (like polka) or using `http.createServer` directly! This should improve remix's compatibility with many node based http server frameworks. 

## Example (using http.createServer & sirv)

```ts
import * as http from 'http';
import * as path from 'path';
import sirv from 'sirv';
import { createRequestHandler } from '@remix-run/express';

const BUILD_DIR = path.join(process.cwd(), "build");

const remixHandler = createRequestHandler({ build: require(BUILD_DIR) });

const server = http.createServer(sirv("public", {
	  maxAge: 3600,
	  setHeaders(res, pathname) {
		    if (pathname.startsWith("/build/")) {
		      res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
		    }
	  },
	  onNoMatch: remixHandler
}));

server.listen(process.env.PORT || 3000);
```

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

All tests pass.
