### PR TITLE
fix(templates/deno): use `Deno.env` instead of `process.env`

### DIFF
--- a/templates/deno/server.ts
+++ b/templates/deno/server.ts
@@ -5,7 +5,7 @@ import * as build from "@remix-run/dev/server-build";
 
 const remixHandler = createRequestHandlerWithStaticFiles({
   build,
-  mode: process.env.NODE_ENV,
+  mode: Deno.env.get("NODE_ENV"),
   getLoadContext: () => ({}),
 });
 


### PR DESCRIPTION
 `process.env.NODE_ENV` works, but VSCode unnecessarily complains and it also doesn't feel Deno-y enough so I would propose changing it to the appropriate `Deno.env.get("NODE_ENV")`.

Please correct me if I'm mistaken 🙏

Also so happy to finally get Deno Remix just working, with the latest Deno and all 🥳 Thanks so much @pcattori  👏