### PR TITLE
fix(templates/cloudflare-pages): fix runtime globals reference

### DIFF
--- a/templates/cloudflare-pages/remix.env.d.ts
+++ b/templates/cloudflare-pages/remix.env.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/cloudflare-pages" />
+/// <reference types="@remix-run/cloudflare/globals" />
 /// <reference types="@cloudflare/workers-types" />

--- a/templates/cloudflare-pages/remix.env.d.ts
+++ b/templates/cloudflare-pages/remix.env.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/cloudflare-pages/globals" />
+/// <reference types="@remix-run/cloudflare-pages" />
 /// <reference types="@cloudflare/workers-types" />


### PR DESCRIPTION
The globals file got removed in a previous commit and the d.ts has not been updated to reflect that change.
