### PR TITLE
fix(remix-dev): improve `appTemplate` message

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -266,6 +266,7 @@
 - nobeeakon
 - nordiauwu
 - nurul3101
+- nvh95
 - nwalters512
 - octokatherine
 - omamazainab

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -103,8 +103,8 @@ R E M I X
 
 ? Where would you like to create your app? remix-jokes
 ? What type of app do you want to create? Just the basics
-? Where do you want to deploy? Choose Remix if you're unsure, it's easy to change deployment targets. Remix
- App Server
+? Where do you want to deploy? Choose Remix App Server if you're unsure, 
+it's easy to change deployment targets. Remix App Server
 ? TypeScript or JavaScript? TypeScript
 ? Do you want me to run `npm install`? Yes
 ```

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -288,7 +288,7 @@ export async function run(argv: string[] = process.argv.slice(2)) {
               return answers.appType === "template";
             },
             message:
-              "Where do you want to deploy? Choose Remix if you're unsure; " +
+              "Where do you want to deploy? Choose Remix App Server if you're unsure; " +
               "it's easy to change deployment targets.",
             loop: false,
             choices: templateChoices,


### PR DESCRIPTION
When running `npx create-remix@latest`, The CLI asks me 

"Where do you want to deploy? Choose **Remix** if you're unsure; it's easy to  change deployment targets."

But there is no option such as **Remix**, but **Remix App Server**. This PR is to make users not confused when first using `create-remix`

<img width="553" alt="using create-remix to bootstrap a remix project" src="https://user-images.githubusercontent.com/8603085/169279415-a26b6d87-2472-4934-ae8f-c154dd1402f5.png">