### PR TITLE
docs(other-api/react-router): update links to `react-router` docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -159,6 +159,7 @@
 - jiahao-c
 - jkup
 - jmasson
+- JNaftali
 - jo-ninja
 - joaosamouco
 - jodygeraldo

--- a/docs/other-api/react-router.md
+++ b/docs/other-api/react-router.md
@@ -7,10 +7,10 @@ toc: false
 
 Remix is built on top of React Router v6. Here are the most common APIs that you'll use in your Remix app:
 
-- [`Outlet`](https://reactrouter.com/docs/api#outlet)
-- [`useLocation`](https://reactrouter.com/docs/api#uselocation)
-- [`useNavigate`](https://reactrouter.com/docs/api#usenavigate)
-- [`useParams`](https://reactrouter.com/docs/api#useparams)
-- [`useResolvedPath`](https://reactrouter.com/docs/api#useresolvedpath)
+- [`Outlet`](https://reactrouter.com/docs/en/v6/components/outlet)
+- [`useLocation`](https://reactrouter.com/docs/en/v6/hooks/use-location)
+- [`useNavigate`](https://reactrouter.com/docs/en/v6/hooks/use-navigate)
+- [`useParams`](https://reactrouter.com/docs/en/v6/hooks/use-params)
+- [`useResolvedPath`](https://reactrouter.com/docs/en/v6/hooks/use-resolved-path)
 
 Most of the other APIs are either used internally by Remix or just aren't commonly needed in your app.

--- a/docs/other-api/react-router.md
+++ b/docs/other-api/react-router.md
@@ -7,10 +7,10 @@ toc: false
 
 Remix is built on top of React Router v6. Here are the most common APIs that you'll use in your Remix app:
 
-- [`Outlet`](https://reactrouter.com/docs/en/v6/components/outlet)
-- [`useLocation`](https://reactrouter.com/docs/en/v6/hooks/use-location)
-- [`useNavigate`](https://reactrouter.com/docs/en/v6/hooks/use-navigate)
-- [`useParams`](https://reactrouter.com/docs/en/v6/hooks/use-params)
-- [`useResolvedPath`](https://reactrouter.com/docs/en/v6/hooks/use-resolved-path)
+- [`Outlet`](https://reactrouter.com/docs/components/outlet)
+- [`useLocation`](https://reactrouter.com/docs/hooks/use-location)
+- [`useNavigate`](https://reactrouter.com/docs/hooks/use-navigate)
+- [`useParams`](https://reactrouter.com/docs/hooks/use-params)
+- [`useResolvedPath`](https://reactrouter.com/docs/hooks/use-resolved-path)
 
 Most of the other APIs are either used internally by Remix or just aren't commonly needed in your app.


### PR DESCRIPTION
"Other api" docs about React Router were pointing at the old urls (which do not redirect properly). Updated to point to the new ones