### PR TITLE
feat(remix-dev): add `.node` file support for Node based platforms

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -38,6 +38,7 @@
 - axel-habermaier
 - BasixKOR
 - BenMcH
+- benwis
 - bmarvinb
 - bmontalvo
 - bogas04

--- a/docs/guides/native-node-modules.md
+++ b/docs/guides/native-node-modules.md
@@ -1,0 +1,23 @@
+---
+title: Native Node Modules
+toc: false
+---
+
+# Native Node Modules
+
+Some node packages contain a binary `.node` file that contains code that is usually written in another language and that interacts with Node through the [Node-API](https://nodejs.org/api/n-api.html) foreign function interface. This can offer substantial benefits in speed, easy concurrency/multithreading, access to native interfaces, and/or interoperability with other languages. A popular example is the `Sharp` image processing library, which uses `libvips`, a C library, to increase performance.
+
+# Limitations
+
+Because these files use the Node FFI, they will only run on servers or edge environments that run Node.
+
+The browser does not run Node, so their use is limited to Loaders and Actions, or other server side code.
+
+# Setup
+
+Remix should work with these files out of the box, but you'll want to export the package that contains them from a `.server.{ts,js}` file and then import them from that file in your loaders and actions. This prevents them from being included in the browser bundle and causing errors.
+
+# Creating Native Node Modules
+
+If you're interested in creating a package with Node modules, look for a package that interacts with the Node API in your language of choice.For Rust, there is [napi-rs](https://napi.rs/) and [neon](https://neon-bindings.com/), and for C++ with the [Node Addon API](https://github.com/nodejs/node-addon-api).
+

--- a/docs/guides/native-node-modules.md
+++ b/docs/guides/native-node-modules.md
@@ -7,7 +7,7 @@ toc: false
 
 Some node packages contain a binary `.node` file that contains code that is usually written in another language and that interacts with Node through the [Node-API](https://nodejs.org/api/n-api.html) foreign function interface. This can offer substantial benefits in speed, easy concurrency/multithreading, access to native interfaces, and/or interoperability with other languages. A popular example is the `Sharp` image processing library, which uses `libvips`, a C library, to increase performance.
 
-# Limitations
+# #Limitations
 
 Because these files use the Node FFI, they will only run on servers or edge environments that run Node.
 
@@ -17,7 +17,7 @@ The browser does not run Node, so their use is limited to Loaders and Actions, o
 
 Remix should work with these files out of the box, but you'll want to export the package that contains them from a `.server.{ts,js}` file and then import them from that file in your loaders and actions. This prevents them from being included in the browser bundle and causing errors.
 
-# Creating Native Node Modules
+## Creating Native Node Modules
 
 If you're interested in creating a package with Node modules, look for a package that interacts with the Node API in your language of choice. 
 Here are some examples:

--- a/docs/guides/native-node-modules.md
+++ b/docs/guides/native-node-modules.md
@@ -19,5 +19,13 @@ Remix should work with these files out of the box, but you'll want to export the
 
 # Creating Native Node Modules
 
-If you're interested in creating a package with Node modules, look for a package that interacts with the Node API in your language of choice.For Rust, there is [napi-rs](https://napi.rs/) and [neon](https://neon-bindings.com/), and for C++ with the [Node Addon API](https://github.com/nodejs/node-addon-api).
+If you're interested in creating a package with Node modules, look for a package that interacts with the Node API in your language of choice. 
+Here are some examples:
+
+*Rust:*
+- [napi-rs](https://napi.rs/) 
+- [neon](https://neon-bindings.com/)
+
+*C++* 
+- [Node Addon API](https://github.com/nodejs/node-addon-api).
 

--- a/docs/guides/native-node-modules.md
+++ b/docs/guides/native-node-modules.md
@@ -7,7 +7,7 @@ toc: false
 
 Some node packages contain a binary `.node` file that contains code that is usually written in another language and that interacts with Node through the [Node-API](https://nodejs.org/api/n-api.html) foreign function interface. This can offer substantial benefits in speed, easy concurrency/multithreading, access to native interfaces, and/or interoperability with other languages. A popular example is the `Sharp` image processing library, which uses `libvips`, a C library, to increase performance.
 
-# #Limitations
+## Limitations
 
 Because these files use the Node FFI, they will only run on servers or edge environments that run Node.
 

--- a/packages/remix-dev/compiler/loaders.ts
+++ b/packages/remix-dev/compiler/loaders.ts
@@ -19,6 +19,7 @@ export const loaders: { [ext: string]: esbuild.Loader } = {
   ".mdx": "jsx",
   ".mp3": "file",
   ".mp4": "file",
+  ".node": "file",
   ".ogg": "file",
   ".otf": "file",
   ".png": "file",

--- a/packages/remix-dev/compiler/plugins/nativeNodeModules.ts
+++ b/packages/remix-dev/compiler/plugins/nativeNodeModules.ts
@@ -1,0 +1,42 @@
+import type esbuild from "esbuild";
+import * as path from "path";
+// See https://github.com/evanw/esbuild/issues/1051#issuecomment-806325487
+export function nativeNodeModulesPlugin(): esbuild.Plugin {
+    return {
+        name: 'native-node-modules',
+        setup(build) {
+            // If a ".node" file is imported within a module in the "file" namespace, resolve
+            // it to an absolute path and put it into the "node-file" virtual namespace.
+            build.onResolve({ filter: /\.node$/, namespace: 'file' }, args => ({
+                path: require.resolve(args.path, { paths: [args.resolveDir] }),
+                namespace: 'node-file',
+            }))
+
+            // Files in the "node-file" virtual namespace call "require()" on the
+            // path from esbuild of the ".node" file in the output directory.
+            build.onLoad({ filter: /.*/, namespace: 'node-file' }, args => ({
+                contents: `
+        import * as path from "path";
+        import modulePath from ${JSON.stringify(args.path)}
+        
+        // Esbuild gives a package path, so we want to convert to an absolute one
+        let projectRoot = "${path.resolve()}";
+        let absolutePath = path.join(projectRoot, modulePath)
+        
+        try { module.exports = require(absolutePath) }
+        catch (error){
+          console.error(error)
+        }
+      `,
+            }))
+
+            // If a ".node" file is imported within a module in the "node-file" namespace, put
+            // it in the "file" namespace where esbuild's default loading behavior will handle
+            // it. It is already an absolute path since we resolved it to one above.
+            build.onResolve({ filter: /\.node$/, namespace: 'node-file' }, args => ({
+                path: args.path,
+                namespace: 'file',
+            }))
+        },
+    }
+}


### PR DESCRIPTION
## Changes Made
This pull requests adds an esbuild plugin and some tweaks to the Remix compiler to allow the import of `.node` files in Remix's loaders and actions. While I was motivated by the desire to write Rust helper functions for server side modules, this was also mentioned in this [other pull request](https://github.com/remix-run/remix/pull/703) for .node imports for remix-tailwind, and in [a discussion](https://github.com/remix-run/remix/discussions/2560) by @nicksrandall for sharp support.

I have started [a discussion](https://github.com/remix-run/remix/discussions/3201) here, but as of now hasn't generated much traffic.

## Benefits
The primary benefit I see is the ability to run other language's code on your server easily in Remix. This could be done in Rust using napi-rs, in Python, or in C. That offers substantial benefits in performance, opens possibilities for easy concurrency, and other possibilities.

## Limitations
One of the biggest limitations is that it can only run on Node based platforms. Napi-rs is currently working on Deno support, so we may see this come there as well. 

## Testing
I have modified the Rust example in the main repo with to generate a sum() function with [napi-rs](https://napi.rs/) and use that to perform the addition that example does. The repo for this is [here](https://github.com/benwis/rust-remix). There are a few build steps as described in that README that must be performed, depending on the platform you're running Remix on.

- [x] Docs