### PR TITLE
fix(remix-server-runtime): fix `JsonFunction` type

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,3 +1,4 @@
+- 8balloon
 - aaronpowell96
 - aaronshaf
 - abereghici

--- a/packages/remix-server-runtime/responses.ts
+++ b/packages/remix-server-runtime/responses.ts
@@ -6,18 +6,16 @@ type Json =
   | Array<Json>
   | { [key: string]: Json };
 
-export type JsonFunction = (
-  data: Json,
-  init?: number | ResponseInit
-) => Response;
-
 /**
  * This is a shortcut for creating `application/json` responses. Converts `data`
  * to JSON and sets the `Content-Type` header.
  *
  * @see https://remix.run/api/remix#json
  */
-export const json: JsonFunction = (data, init = {}) => {
+export const json = <Data extends Json>(
+  data: Data,
+  init: number | ResponseInit = {}
+) => {
   let responseInit = typeof init === "number" ? { status: init } : init;
 
   let headers = new Headers(responseInit.headers);
@@ -30,6 +28,8 @@ export const json: JsonFunction = (data, init = {}) => {
     headers,
   });
 };
+
+export type JsonFunction = typeof json;
 
 export type RedirectFunction = (
   url: string,

--- a/packages/remix-server-runtime/responses.ts
+++ b/packages/remix-server-runtime/responses.ts
@@ -1,5 +1,13 @@
-export type JsonFunction = <Data>(
-  data: Data,
+type Json =
+  | null
+  | boolean
+  | number
+  | string
+  | Array<Json>
+  | { [key: string]: Json };
+
+export type JsonFunction = (
+  data: Json,
   init?: number | ResponseInit
 ) => Response;
 


### PR DESCRIPTION
## problem
`@remix-run/node`'s `json()` function accepts non-json types, which commonly leads to mistypings.

## example of the problem
```tsx
import type { LoaderFunction } from "@remix-run/node";
import { json } from "@remix-run/node";
import { useLoaderData } from "@remix-run/react";

function getLoaderData() {
  return {
    date: new Date(), // this could be a `createdAt` field, or something similar
  };
}

type LoaderData = ReturnType<typeof getLoaderData>;

export const loader: LoaderFunction = async () => {
  const data = getLoaderData();
  return json(data);
};

export default function DateDisplay() {
  const data = useLoaderData<LoaderData>();

  // This will cause a runtime error, because data.date is a string, although it's typed as a function.
  // The reason is because `json()` uses `JSON.stringify()`, which automatically converts dates to ISO strings
  return <div>Day from date is {data.date.getDay()}</div>;
}

```
## solution
`json(data)` would result in a type error in the above example, which would prevent a runtime error due to mistyping.

Also remove unused `Data` type parameterization (could easily revert this if we wish)