### PR TITLE
fix(templates/deno): get types for `@remix-run/deno` directly from `node_modules/`

### DIFF
--- a/templates/deno/.vscode/resolve_npm_imports.json
+++ b/templates/deno/.vscode/resolve_npm_imports.json
@@ -5,7 +5,8 @@
   "// Deno-only dependencies may be imported via URL imports (without using import maps).": "",
 
   "imports": {
-    "@remix-run/deno": "https://esm.sh/@remix-run/deno@1.5.0",
+    "// `@remix-run/deno` code is already a Deno module, so just get types for it directly from `node_modules/`": "",
+    "@remix-run/deno": "../node_modules/@remix-run/deno/index.ts",
     "@remix-run/dev/server-build": "https://esm.sh/@remix-run/dev@1.5.0/server-build",
     "@remix-run/react": "https://esm.sh/@remix-run/react@1.5.0",
     "react": "https://esm.sh/react@17.0.2",


### PR DESCRIPTION
`@remix-run/deno` code is already an ESM Deno module, so it should not be processed
by a Deno-friendly CDN expecting a CJS Node package.
