### PR TITLE
chore(templates/arc): move arc to devDependencies

### DIFF
--- a/templates/arc/README.md
+++ b/templates/arc/README.md
@@ -2,19 +2,6 @@
 
 - [Remix Docs](https://remix.run/docs)
 
-## Architect Setup
-
-When deploying to AWS Lambda with Architect, you'll need:
-
-- Architect (`arc`) CLI
-- AWS SDK
-
-Architect recommends installing these globally:
-
-```sh
-npm i -g @architect/architect aws-sdk
-```
-
 ## Development
 
 The following command will run two processes during development when using Architect as your server.

--- a/templates/arc/package.json
+++ b/templates/arc/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
+    "@architect/architect": "^10.3.3",
     "@remix-run/dev": "*",
     "@remix-run/eslint-config": "*",
     "@types/react": "^17.0.45",


### PR DESCRIPTION
as of arc v10, they recommend a local install of the arc cli https://arc.codes/docs/en/get-started/detailed-aws-setup#install-architect – a global install is still supported, but having it locally ensures that it's installed

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
