### PR TITLE
build(templates/netlify): remove unused `@netlify/functions` dependency

### DIFF
--- a/templates/netlify/package.json
+++ b/templates/netlify/package.json
@@ -10,7 +10,6 @@
     "start": "cross-env NODE_ENV=production netlify dev"
   },
   "dependencies": {
-    "@netlify/functions": "^1.0.0",
     "@remix-run/netlify": "*",
     "@remix-run/node": "*",
     "@remix-run/react": "*",


### PR DESCRIPTION
template code does not use it and it is not a peer dependency. `@remix-run/netlify` is the only
thing that depends on `@netlify/functions`, but it already declares it as a dependency.