### PR TITLE
feat(remix-eslint-config): enable deprecated imports warnings

### DIFF
--- a/packages/remix-eslint-config/rules/core.js
+++ b/packages/remix-eslint-config/rules/core.js
@@ -1,45 +1,45 @@
-// const {
-//   defaultAdapterExports,
-//   defaultRuntimeExports,
-//   architectSpecificExports,
-//   cloudflareSpecificExports,
-//   cloudflarePagesSpecificExports,
-//   cloudflareWorkersSpecificExports,
-//   nodeSpecificExports,
-//   reactSpecificExports,
-// } = require("./packageExports");
+const {
+  defaultAdapterExports,
+  defaultRuntimeExports,
+  architectSpecificExports,
+  cloudflareSpecificExports,
+  cloudflarePagesSpecificExports,
+  cloudflareWorkersSpecificExports,
+  nodeSpecificExports,
+  reactSpecificExports,
+} = require("./packageExports");
 
 // const OFF = 0;
 const WARN = 1;
 const ERROR = 2;
 
-// const getReplaceRemixImportsMessage = (packageName) =>
-//   `All \`remix\` exports are considered deprecated as of v1.3.3. Please use \`@remix-run/${packageName}\` instead. You can run \`remix migrate --migration replace-remix-imports\` to automatically migrate your code.`;
+const getReplaceRemixImportsMessage = (packageName) =>
+  `All \`remix\` exports are considered deprecated as of v1.3.3. Please use \`@remix-run/${packageName}\` instead. You can run \`remix migrate --migration replace-remix-imports\` to automatically migrate your code.`;
 
-//   const replaceRemixImportsOptions = [
-//   {
-//     packageExports: defaultAdapterExports,
-//     packageName:
-//       "{architect|cloudflare-pages|cloudflare-workers|express|netlify|vercel}",
-//   },
-//   { packageExports: defaultRuntimeExports, packageName: "{cloudflare|node}" },
-//   { packageExports: architectSpecificExports, packageName: "architect" },
-//   { packageExports: cloudflareSpecificExports, packageName: "cloudflare" },
-//   {
-//     packageExports: cloudflarePagesSpecificExports,
-//     packageName: "cloudflare-pages",
-//   },
-//   {
-//     packageExports: cloudflareWorkersSpecificExports,
-//     packageName: "cloudflare-workers",
-//   },
-//   { packageExports: nodeSpecificExports, packageName: "node" },
-//   { packageExports: reactSpecificExports, packageName: "react" },
-// ].map(({ packageExports, packageName }) => ({
-//   importNames: [...packageExports.value, ...packageExports.type],
-//   message: getReplaceRemixImportsMessage(packageName),
-//   name: "remix",
-// }));
+const replaceRemixImportsOptions = [
+  {
+    packageExports: defaultAdapterExports,
+    packageName:
+      "{architect|cloudflare-pages|cloudflare-workers|express|netlify|vercel}",
+  },
+  { packageExports: defaultRuntimeExports, packageName: "{cloudflare|node}" },
+  { packageExports: architectSpecificExports, packageName: "architect" },
+  { packageExports: cloudflareSpecificExports, packageName: "cloudflare" },
+  {
+    packageExports: cloudflarePagesSpecificExports,
+    packageName: "cloudflare-pages",
+  },
+  {
+    packageExports: cloudflareWorkersSpecificExports,
+    packageName: "cloudflare-workers",
+  },
+  { packageExports: nodeSpecificExports, packageName: "node" },
+  { packageExports: reactSpecificExports, packageName: "react" },
+].map(({ packageExports, packageName }) => ({
+  importNames: [...packageExports.value, ...packageExports.type],
+  message: getReplaceRemixImportsMessage(packageName),
+  name: "remix",
+}));
 
 module.exports = {
   "array-callback-return": WARN,
@@ -89,8 +89,7 @@ module.exports = {
   "no-new-object": WARN,
   "no-octal": WARN,
   "no-redeclare": ERROR,
-  // TODO: once we officially deprecate this we can bring this back
-  // "no-restricted-imports": [WARN, ...replaceRemixImportsOptions],
+  "no-restricted-imports": [WARN, ...replaceRemixImportsOptions],
   "no-script-url": WARN,
   "no-self-assign": WARN,
   "no-self-compare": WARN,


### PR DESCRIPTION
Companion PR of #3284

I think we can enable these again, as:

> - The first release supporting separate packages was `1.3.3`, which was released on 23 Mar 2022
>   https://github.com/remix-run/remix/releases/tag/v1.3.3
> - The `replace-remix-imports` migration was added in `1.4.0`, which was released on 14 Apr 2022
>   https://github.com/remix-run/remix/releases/tag/v1.4.0
> - We now export functions/types that aren't available anymore through the `remix` package, as they're not included in the `magicExports` anymore (see both `@remix-run/cloudflare` & `@remix-run/node`) since `1.5.0`
> - We now have a runtime package (`@remix-run/deno`) that doesn't have *any* magic exports *at all* since `1.5.0`
> https://github.com/remix-run/remix/releases/tag/v1.5.0