### PR TITLE
chore(templates): remove `description`, `license` & `name` keys from `package.json`

### DIFF
--- a/templates/arc/package.json
+++ b/templates/arc/package.json
@@ -1,8 +1,5 @@
 {
-  "name": "remix-template-arc",
   "private": true,
-  "description": "",
-  "license": "",
   "sideEffects": false,
   "scripts": {
     "build": "remix build",

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -1,8 +1,5 @@
 {
-  "name": "remix-template-cloudflare-pages",
   "private": true,
-  "description": "",
-  "license": "",
   "sideEffects": false,
   "scripts": {
     "build": "remix build",

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -1,8 +1,5 @@
 {
-  "name": "remix-template-cloudflare-workers",
   "private": true,
-  "description": "",
-  "license": "",
   "sideEffects": false,
   "main": "build/index.js",
   "scripts": {

--- a/templates/deno/package.json
+++ b/templates/deno/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "remix-template-deno",
   "private": true,
   "sideEffects": false,
   "scripts": {

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -1,8 +1,5 @@
 {
-  "name": "remix-template-express",
   "private": true,
-  "description": "",
-  "license": "",
   "sideEffects": false,
   "scripts": {
     "build": "remix build",

--- a/templates/fly/package.json
+++ b/templates/fly/package.json
@@ -1,8 +1,5 @@
 {
-  "name": "remix-template-fly",
   "private": true,
-  "description": "",
-  "license": "",
   "sideEffects": false,
   "scripts": {
     "build": "remix build",

--- a/templates/netlify/package.json
+++ b/templates/netlify/package.json
@@ -1,8 +1,5 @@
 {
-  "name": "remix-template-netlify",
   "private": true,
-  "description": "",
-  "license": "",
   "sideEffects": false,
   "scripts": {
     "build": "remix build",

--- a/templates/remix/package.json
+++ b/templates/remix/package.json
@@ -1,8 +1,5 @@
 {
-  "name": "remix-template-remix",
   "private": true,
-  "description": "",
-  "license": "",
   "sideEffects": false,
   "scripts": {
     "build": "remix build",

--- a/templates/vercel/package.json
+++ b/templates/vercel/package.json
@@ -1,8 +1,5 @@
 {
-  "name": "remix-template-vercel",
   "private": true,
-  "description": "",
-  "license": "",
   "sideEffects": false,
   "scripts": {
     "build": "remix build",


### PR DESCRIPTION
As mentioned by @pcattori in https://github.com/remix-run/remix/pull/3221#discussion_r876255891, these fields aren't necessary for apps.