### PR TITLE
docs: remove `description` & `license` keys from `package.json`

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -12,8 +12,6 @@ The Remix compiler will not do any type checking (it simply removes the types). 
 {
   "name": "remix-app",
   "private": true,
-  "description": "Example remix app using TypeScript",
-  "license": "",
   "sideEffects": false,
   "scripts": {
     "build": "remix build",


### PR DESCRIPTION
Follow-up of #3287