### PR TITLE
BUG: UploadHandler filter runs on all form values

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -140,6 +140,7 @@
 - freeman
 - frontsideair
 - fx109138
+- g3offrey
 - gabimor
 - garand
 - gautamkrishnar


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->
Hello 👋 

Please find attached a bug report test case. 

Testing Strategy:

While developing a `<Form />` which handles text values and file upload (that are stored in memory) I encountered an issue.
 
I think the `filter` parameter in `unstable_createMemoryUploadHandler` (possibly in `unstable_createFileUploadHandler`) also test and filters out text values (from `input type=text`).

For example if I want to filter out the files that are not `text/csv`, Remix also filters out the text values.

The following code could possibly fix the issue on my side, but I think it would improve DX if Remix did this out of the box. 
```ts
filter(args: MemoryUploadHandlerFilterArgs): boolean | Promise<boolean> {
  const isFile = Boolean(args.filename);
  
  return isFile ? args.contentType === "text/csv" : true;
}
```

Remix should run the filter function only on file values (values with a filename), as I can't imagine a scenario where users want to filter out values from `input type=text`. 

If we agree on this, I can work on a fix on my side.

In any case thank you for developing Remix, a framework that I am glad to use day by day 😄 