### PR TITLE
feat(remix-serve): allow passing `getLoadContext` to `createApp`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -332,6 +332,7 @@
 - therealflyingcoder
 - thomasheyenbrock
 - thomasrettig
+- TillaTheHun0
 - tjefferson08
 - tombyrer
 - toyozaki

--- a/packages/remix-serve/index.ts
+++ b/packages/remix-serve/index.ts
@@ -2,8 +2,13 @@ import express from "express";
 import compression from "compression";
 import morgan from "morgan";
 import { createRequestHandler } from "@remix-run/express";
+import type { GetLoadContextFunction } from "@remix-run/express";
 
-export function createApp(buildPath: string, mode = "production") {
+export function createApp(
+  buildPath: string,
+  mode = "production",
+  getLoadContext?: GetLoadContextFunction
+) {
   let app = express();
 
   app.disable("x-powered-by");
@@ -21,11 +26,19 @@ export function createApp(buildPath: string, mode = "production") {
   app.all(
     "*",
     mode === "production"
-      ? createRequestHandler({ build: require(buildPath), mode })
+      ? createRequestHandler({
+          build: require(buildPath),
+          mode,
+          getLoadContext,
+        })
       : (req, res, next) => {
           // require cache is purged in @remix-run/dev where the file watcher is
           let build = require(buildPath);
-          return createRequestHandler({ build, mode })(req, res, next);
+          return createRequestHandler({ build, mode, getLoadContext })(
+            req,
+            res,
+            next
+          );
         }
   );
 


### PR DESCRIPTION
This PR allows passing `getLoadContext` into `@remix-run/express` from `@remix-run/serve`. It doesn't change current functionality, just exposes `getLoadContext` on `@remix-run/serve`

The use case is that as a developer, I want to programmatically invoke `createApp`, to get the built `express` app, and then manually start the server, or even modify the app further ie. more routes, middleware, etc. Allowing to pass `getLoadContext` seemed kosher to me.

This of course would not be available via the `remix serve` CLI.

An alternative approach would be for a developer to reimplement what `@remix-run/serve` is doing, if they want to provide a `getLoadContext`. Though I would rebut that since `@remix-run/serve` interfaces with `@remix-run/dev` and wires all of the Remix build outputs into express for the developer, I think exposing here would help avoid potential "issue bloat" from folks implementing a million different ways. They could just use `@mirex-run/serve`.

- [ ] Docs
- [ ] Tests
