### PR TITLE
fix(templates/deno): ignore `build` dirs from tooling

### DIFF
--- a/templates/deno/package.json
+++ b/templates/deno/package.json
@@ -8,8 +8,8 @@
     "dev": "remix build && run-p dev:*",
     "dev:deno": "cross-env NODE_ENV=development deno run --unstable --watch --allow-net --allow-read --allow-env ./build/index.js",
     "dev:remix": "remix watch",
-    "format": "deno fmt --ignore=node_modules",
-    "lint": "deno lint --ignore=node_modules",
+    "format": "deno fmt --ignore=node_modules,build,public/build",
+    "lint": "deno lint --ignore=node_modules,build,public/build",
     "start": "cross-env NODE_ENV=production deno run --unstable --allow-net --allow-read --allow-env ./build/index.js"
   },
   "dependencies": {


### PR DESCRIPTION
`format` and `lint` scripts were checking build directories, which produced tons of nonsensical errors.