### PR TITLE
feat(templates/vercel): enable Build Output API v3

### DIFF
--- a/examples/turborepo-vercel/apps/remix-app/vercel.json
+++ b/examples/turborepo-vercel/apps/remix-app/vercel.json
@@ -1,7 +1,8 @@
 {
   "build": {
     "env": {
-      "ENABLE_FILE_SYSTEM_API": "1"
+      "ENABLE_FILE_SYSTEM_API": "1",
+      "ENABLE_VC_BUILD": "1"
     }
   }
 }

--- a/templates/vercel/vercel.json
+++ b/templates/vercel/vercel.json
@@ -1,7 +1,8 @@
 {
   "build": {
     "env": {
-      "ENABLE_FILE_SYSTEM_API": "1"
+      "ENABLE_FILE_SYSTEM_API": "1",
+      "ENABLE_VC_BUILD": "1"
     }
   }
 }


### PR DESCRIPTION
esbuild works correctly on this version of Build Output API, it bundles the correct binary, or something like that. I discovered this problem when I tried to deploy my blog to Vercel that was using `mdx-bundler` (and therefore esbuild).

Closes: vercel/vercel#7287 (it contains the discussion)

I'm not sure how to write tests for this, but I do have deployments of my [repro app](https://github.com/silvenon/repro-remix-esbuild-vercel) to prove that this fixed the problem:

- [without the fix](https://repro-remix-esbuild-vercel-37yqgr02x-silvenon.vercel.app)
- [with the fix](https://repro-remix-esbuild-vercel-72x4eh7fe-silvenon.vercel.app)

If you write some JS in the box and select "bundle" (calls esbuild's `transform` function under the hood), you'll notice that the first one fails and the second one doesn't.

The error for the first one is the following:

```
2022-05-28T15:24:16.945Z	bd17bdd4-d9ca-4e93-b973-eb8425d2c17c	ERROR	Error: The package "esbuild-linux-64" could not be found, and is needed by esbuild.
If you are installing esbuild with npm, make sure that you don't specify the
"--no-optional" flag. The "optionalDependencies" package.json feature is used
by esbuild to install the correct binary executable for your current platform.
    at generateBinPath (/var/task/output/server/pages/node_modules/esbuild/lib/main.js:1816:15)
    at esbuildCommandAndArgs (/var/task/output/server/pages/node_modules/esbuild/lib/main.js:1872:31)
    at ensureServiceIsRunning (/var/task/output/server/pages/node_modules/esbuild/lib/main.js:2034:25)
    at transform (/var/task/output/server/pages/node_modules/esbuild/lib/main.js:1929:37)
    at action (/var/task/output/server/pages/api/index.js:121:24)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at Object.callRouteAction (/var/task/output/server/pages/node_modules/@remix-run/server-runtime/data.js:40:14)
    at handleDataRequest (/var/task/output/server/pages/node_modules/@remix-run/server-runtime/server.js:94:18)
    at requestHandler (/var/task/output/server/pages/node_modules/@remix-run/server-runtime/server.js:34:18)
    at /var/task/output/server/pages/node_modules/@remix-run/vercel/server.js:39:20
```

(I wasn't sure how to display the error in the app itself, the code above is copied from Vercel's Functions logs.)

So, what do you think?