### PR TITLE
refactor(remix-react): use `react-router-dom` import instead of `react-router`

### DIFF
--- a/packages/remix-react/__tests__/transition-test.tsx
+++ b/packages/remix-react/__tests__/transition-test.tsx
@@ -1877,10 +1877,6 @@ describe("navigating with inflight fetchers", () => {
   });
 });
 
-// describe("react-router", () => {
-//   it.todo("replaces pending locations even on a push");
-// });
-
 ////////////////////////////////////////////////////////////////////////////////
 type Deferred = ReturnType<typeof defer>;
 

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -1,6 +1,6 @@
 import type { ComponentType, ReactNode } from "react";
 import * as React from "react";
-import type { Params } from "react-router";
+import type { Params } from "react-router-dom";
 
 import type { RouteModules, ShouldReloadFunction } from "./routeModules";
 import { loadRouteModule } from "./routeModules";


### PR DESCRIPTION
Follow-up of https://github.com/remix-run/remix/pull/4731