### PR TITLE
docs(examples): update `.env.example` of `firebase-auth-firestore` example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -165,6 +165,7 @@
 - joaosamouco
 - jodygeraldo
 - johannesbraeunig
+- johnpolacek
 - johnson444
 - johnson444
 - joms

--- a/examples/firebase-auth-firestore/.env.example
+++ b/examples/firebase-auth-firestore/.env.example
@@ -1,2 +1,5 @@
-SERVICE_ACCOUNT=
-CLIENT_CONFIG=
+# Set the SERVICE_ACCOUNT value to be the minified contents of Admin SDK JSON file for your Firebase project
+SERVICE_ACCOUNT={"type":"service_account","project_id": "your-project-id","private_key_id": "123123123123asdf123123","private_key": "-----BEGIN PRIVATE KEY-----\nLongStringOfAlphanumericCharactersWillBeHere=\n-----END PRIVATE KEY-----\n","client_email": "firebase-adminsdk-123abc@your-project--id.iam.gserviceaccount.com","client_id": "123455678901234567890","auth_uri": "https://accounts.google.com/o/oauth2/auth","token_uri": "https://oauth2.googleapis.com/token","auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs","client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk-qh94c%40your-project-id.iam.gserviceaccount.com"}
+
+# Set the CLIENT_CONFIG value to be the JSON stringified value of the client credentials for your Firebase project
+CLIENT_CONFIG={"apiKey":"abcdefg_1234567890","authDomain":"your-project-id.firebaseapp.com","projectId":"your-project-id","storageBucket":"your-project-id.appspot.com","messagingSenderId":"1234567890","appId":"1:1234567890:web:01234567890abc"}


### PR DESCRIPTION
This is an update to `.env.example` for the Firebase Auth Example that makes it more clear what goes where and how to format.

- [ ] Docs
- [ ] Tests
- [x] Examples
