### PR TITLE
feat(remix-dev): load env vars sooner

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -126,6 +126,7 @@
 - hardingmatt
 - helderburato
 - HenryVogt
+- herecydev
 - hicksy
 - himorishige
 - hkan

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -249,10 +249,14 @@ export async function dev(remixRoot: string, modeArg?: string) {
     );
   }
 
+  if (!remixRoot) {
+    remixRoot = process.env.REMIX_ROOT || process.cwd();
+  }
+
+  await loadEnv(path.resolve(remixRoot));
+
   let config = await readConfig(remixRoot);
   let mode = isBuildMode(modeArg) ? modeArg : BuildMode.Development;
-
-  await loadEnv(config.rootDirectory);
 
   let port = await getPort({
     port: process.env.PORT ? Number(process.env.PORT) : makeRange(3000, 3100),


### PR DESCRIPTION
Move loading of .env file to top of dev function, which allows access to `process.env` as early as possible. This more closely resembles conventions of environment variables by being available sooner and permits using the variables within the `remix.config.js` file.

A good use case might be that a developer needs environment variables to influence programmatic creation of the "routes" within `remix.config.js`

Testing Strategy:

Ran locally with `remix dev` to confirm correct behavior.
