### PR TITLE
fix(examples/firebase-auth-firestore): Fix imports and throw meaningful errors when missing .env

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -279,6 +279,7 @@
 - pacexy
 - pcattori
 - penspinner
+- penx
 - phishy
 - plastic041
 - princerajroy

--- a/examples/firebase-auth-firestore/app/server/firebase.server.ts
+++ b/examples/firebase-auth-firestore/app/server/firebase.server.ts
@@ -1,15 +1,40 @@
-import admin from "firebase-admin/app";
-import client from "firebase/app";
+import {
+  getApps as getServerApps,
+  initializeApp as initializeServerApp,
+  cert as serverCert,
+} from "firebase-admin/app";
+import {
+  getApps as getClientApps,
+  initializeApp as initializeClientApp,
+} from "firebase/app";
 import { getAuth as getServerAuth } from "firebase-admin/auth";
 import { getAuth as getClientAuth } from "firebase/auth";
 
-if (client.getApps().length === 0) {
-  client.initializeApp(JSON.parse(process.env.CLIENT_CONFIG as string));
+if (getClientApps().length === 0) {
+  if (!process.env.CLIENT_CONFIG) {
+    throw new Error("Missing CLIENT_CONFIG environment variable");
+  }
+  let config;
+  try {
+    config = JSON.parse(process.env.CLIENT_CONFIG);
+  } catch {
+    throw Error("Invalid CLIENT_CONFIG environment variable");
+  }
+  initializeClientApp(config);
 }
 
-if (admin.getApps().length === 0) {
-  admin.initializeApp({
-    credential: admin.cert(JSON.parse(process.env.SERVICE_ACCOUNT as string)),
+if (getServerApps().length === 0) {
+  if (!process.env.SERVICE_ACCOUNT) {
+    throw new Error("Missing SERVICE_ACCOUNT environment variable");
+  }
+  let config;
+  try {
+    config = JSON.parse(process.env.SERVICE_ACCOUNT);
+  } catch {
+    throw Error("Invalid SERVICE_ACCOUNT environment variable");
+  }
+  initializeServerApp({
+    credential: serverCert(config),
   });
 }
 


### PR DESCRIPTION
Apply fixes as per comment by @mocon at https://github.com/remix-run/remix/pull/1811#issuecomment-1090544230

Also:

- throw meaningul errors when environment variables are missing or can't be parsed.
- check for existence of environment variable rather than cast to string

Closes: issue reported in comment https://github.com/remix-run/remix/pull/1811#issuecomment-1090544230

- [ ] Docs N/A
- [ ] Tests - is there a way to add integration tests for the examples?

Testing Strategy:


```sh
cd examples/firebase-auth-firestore
yarn
yarn dev
# open http://localhost:3000
# assert "Error: Missing CLIENT_CONFIG environment variable" thrown as env variables are missing
# exit ^C
cp .env.example .env
yarn dev
# open http://localhost:3000
# assert "Error: Failed to parse private key" thrown as example env does not contain valid keys
# exit ^C
# edit .env and set CLIENT_CONFIG to invalid JSON
yarn dev
# open http://localhost:3000
# assert "Error: Invalid CLIENT_CONFIG environment variable"
# exit ^C
# edit .env and set valid keys
yarn dev
# open http://localhost:3000
# assert login page loads
```

I plan to follow up with a few other PRs:

- [fallback to Firebase emulator](https://github.com/penx/remix/compare/fix-firebase-example...penx:firebase-emulator) on localhost when environment variables are not set
- use REST API for auth instead of client side SDK as detailed at https://github.com/remix-run/remix/pull/1811#discussion_r884011463
- use the REST API for auth client side (falling back to server side) to avoid rate limiting as detailed at https://github.com/remix-run/remix/pull/1811#discussion_r884011463
- integrate other Firebase services in to this example as suggested at https://github.com/remix-run/remix/pull/1811#issuecomment-1050238130