### PR TITLE
fix(examples): use `post` action in `firebase-auth-firestore` example

### DIFF
--- a/examples/firebase-auth-firestore/app/routes/index.tsx
+++ b/examples/firebase-auth-firestore/app/routes/index.tsx
@@ -34,18 +34,21 @@ export type ActionData = {
 export const action: ActionFunction = async ({ request }) => {
   const { uid } = await requireAuth(request);
   const form = await request.formData();
-  if (request.method === "POST") {
+  const action = form.get("action");
+  if (action === "create") {
     const title = form.get("title");
-    if (typeof title !== "string")
+    if (typeof title !== "string" || !title.length) {
       return json<ActionData>({ error: "title is required" }, { status: 400 });
+    }
 
     await addTodo(uid, title);
     return redirect("/");
   }
-  if (request.method === "DELETE") {
+  if (action === "delete") {
     const id = form.get("id");
-    if (typeof id !== "string")
+    if (typeof id !== "string") {
       return json<ActionData>({ error: "id is required" }, { status: 400 });
+    }
     await removeTodo(uid, id);
     return redirect("/");
   }
@@ -56,10 +59,12 @@ const TodoComponent: React.FC<{ id: string; title: string }> = (props) => {
   const fetcher = useFetcher();
   return (
     <li>
-      <fetcher.Form method="delete">
+      <fetcher.Form method="post">
         <input type="hidden" name="id" value={props.id} />
         <span>{props.title}</span>
-        <button type="submit">Delete</button>
+        <button type="submit" name="action" value="delete">
+          Delete
+        </button>
       </fetcher.Form>
     </li>
   );
@@ -82,7 +87,9 @@ export default function Index() {
       <Form method="post">
         <h2>Create new Todo:</h2>
         <input ref={ref} name="title" type="text" placeholder="Get Milk" />
-        <button type="submit">Create</button>
+        <button type="submit" name="action" value="create">
+          Create
+        </button>
       </Form>
       <ul>
         {data.todos.map((todo) => (

--- a/examples/firebase-auth-firestore/app/routes/index.tsx
+++ b/examples/firebase-auth-firestore/app/routes/index.tsx
@@ -37,7 +37,7 @@ export const action: ActionFunction = async ({ request }) => {
   const action = form.get("action");
   if (action === "create") {
     const title = form.get("title");
-    if (typeof title !== "string" || !title.length) {
+    if (typeof title !== "string" || title.length === 0) {
       return json<ActionData>({ error: "title is required" }, { status: 400 });
     }
 


### PR DESCRIPTION
Fix the Firebase example when JavaScript is disabled.

`method="delete"` is not a valid form action.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-method

While this works when JavaScript is enabled, it does not fall back gracefully.

Instead, use specify form action using name + value on buttons, as shown in FAQs:

https://remix.run/docs/en/v1/pages/faq#how-do-i-handle-multiple-forms-in-one-route

Closes: a bug I encountered while working on the Firebase example - no open issue.

- [ ] Docs N/A
- [ ] Tests

Testing Strategy:

- is it possible to write integration tests for the examples?

In order to test this manually, I ran the Firebase example with JavaScript enabled and ensured:

- when submitting new TODO: entries with a blank input, the validation error shows
- when deleting TODO: entries, the entries are removed