### PR TITLE
feat(examples/firebase-auth-firestore): use rest api for server auth

### DIFF
--- a/examples/firebase-auth-firestore/.env.example
+++ b/examples/firebase-auth-firestore/.env.example
@@ -1,5 +1,5 @@
 # Set the SERVICE_ACCOUNT value to be the minified contents of Admin SDK JSON file for your Firebase project
 SERVICE_ACCOUNT={"type":"service_account","project_id": "your-project-id","private_key_id": "123123123123asdf123123","private_key": "-----BEGIN PRIVATE KEY-----\nLongStringOfAlphanumericCharactersWillBeHere=\n-----END PRIVATE KEY-----\n","client_email": "firebase-adminsdk-123abc@your-project--id.iam.gserviceaccount.com","client_id": "123455678901234567890","auth_uri": "https://accounts.google.com/o/oauth2/auth","token_uri": "https://oauth2.googleapis.com/token","auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs","client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk-qh94c%40your-project-id.iam.gserviceaccount.com"}
 
-# Set the CLIENT_CONFIG value to be the JSON stringified value of the client credentials for your Firebase project
-CLIENT_CONFIG={"apiKey":"abcdefg_1234567890","authDomain":"your-project-id.firebaseapp.com","projectId":"your-project-id","storageBucket":"your-project-id.appspot.com","messagingSenderId":"1234567890","appId":"1:1234567890:web:01234567890abc"}
+# Set the API_KEY value to the Web API Key, which can be obtained on the project settings page in your Firebase admin console
+API_KEY="abcdefg_1234567890"

--- a/examples/firebase-auth-firestore/README.md
+++ b/examples/firebase-auth-firestore/README.md
@@ -19,8 +19,8 @@ To run it, you need to either:
 1. [Create a Firebase Project](https://console.firebase.google.com)
 2. Enable Auth (with email) and Firestore
 3. Add a Web App
-4. Get the [admin-sdk](https://firebase.google.com/docs/admin/setup#initialize-sdk) and [client-sdk credentials](https://firebase.google.com/docs/web/learn-more#config-object)
-5. Save them to SERVICE_ACCOUNT and CLIENT_CONFIG in the `.env`-file
+4. Get the [admin-sdk](https://firebase.google.com/docs/admin/setup#initialize-sdk) and [Web API Key](https://firebase.google.com/docs/reference/rest/auth)
+5. Save them to SERVICE_ACCOUNT and API_KEY in the `.env`-file
 
 ### 2. Use the Firebase emulators
 

--- a/examples/firebase-auth-firestore/app/server/auth.server.ts
+++ b/examples/firebase-auth-firestore/app/server/auth.server.ts
@@ -1,6 +1,5 @@
 import type { Session } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
-import { signInWithEmailAndPassword } from "firebase/auth";
 import type { UserRecord } from "firebase-admin/auth";
 
 import { destroySession, getSession } from "~/sessions";
@@ -29,12 +28,7 @@ export const requireAuth = async (request: Request): Promise<UserRecord> => {
 };
 
 export const signIn = async (email: string, password: string) => {
-  const { user } = await signInWithEmailAndPassword(
-    auth.client,
-    email,
-    password
-  );
-  const idToken = await user.getIdToken();
+  const { idToken } = await auth.signInWithPassword(email, password);
   const expiresIn = 1000 * 60 * 60 * 24 * 7; // 1 week
   const sessionCookie = await auth.server.createSessionCookie(idToken, {
     expiresIn,

--- a/examples/firebase-auth-firestore/app/server/firebase-rest.server.ts
+++ b/examples/firebase-auth-firestore/app/server/firebase-rest.server.ts
@@ -1,0 +1,69 @@
+interface RestError {
+  error: {
+    code: number;
+    message: string;
+    errors: any[];
+  };
+}
+
+export const isError = (input: unknown): input is RestError =>
+  !!input && typeof input === "object" && "error" in input;
+
+// https://firebase.google.com/docs/reference/rest/auth#section-sign-in-email-password
+interface SignInWithPasswordResponse extends Response {
+  json(): Promise<
+    | RestError
+    | {
+        /**
+         * A Firebase Auth ID token for the authenticated user.
+         */
+        idToken: string;
+        /**
+         * The email for the authenticated user.
+         */
+        email: string;
+        /**
+         * A Firebase Auth refresh token for the authenticated user.
+         */
+        refreshToken: string;
+        /**
+         * The number of seconds in which the ID token expires.
+         */
+        expiresIn: string;
+        /**
+         * The uid of the authenticated user.
+         */
+        localId: string;
+        /**
+         * Whether the email is for an existing account.
+         */
+        registered: boolean;
+      }
+  >;
+}
+
+export const signInWithPassword = async (
+  body: {
+    email: string;
+    password: string;
+    returnSecureToken: true;
+  },
+  restConfig: {
+    apiKey: string;
+    domain: string;
+  }
+) => {
+  const response: SignInWithPasswordResponse = await fetch(
+    `${restConfig!.domain}/v1/accounts:signInWithPassword?key=${
+      restConfig!.apiKey
+    }`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }
+  );
+  return response.json();
+};

--- a/examples/firebase-auth-firestore/package.json
+++ b/examples/firebase-auth-firestore/package.json
@@ -11,7 +11,6 @@
     "@remix-run/node": "1.5.1",
     "@remix-run/react": "1.5.1",
     "@remix-run/serve": "1.5.1",
-    "firebase": "^9.6.10",
     "firebase-admin": "^10.0.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"


### PR DESCRIPTION
Use the [Firebase Auth REST API](https://firebase.google.com/docs/reference/rest/auth) for authenticating server side, instead of the [Firebase client SDK](https://github.com/firebase/firebase-js-sdk).

The [Firebase Client Auth SDK is stateful](https://firebase.google.com/docs/auth/web/auth-state-persistence). It seems to have been built for the purpose of using it within an application where only one user is logged in at a time (i.e. client applications). It _may_ not pose a security risk if it is _only_ used for authentication calls, but login state is persisted in the module and this could lead to security issues if other features such as `firebase/firestore` were used, as these would behave as the last user to log in.

The Firebase Auth REST API gives us the same functionality with no external dependencies and control over state.

This is the API that the client SDK is calling, so it is unnecessary to include the client sdk to call a single endpoint. 

As far as I'm aware, there are rate limiting issues with both approaches, which I plan to address in a follow up PR by calling the REST API client side and falling back to server side. 

This was previously discussed at https://github.com/remix-run/remix/pull/1811#discussion_r884011463


Closes: discussion at https://github.com/remix-run/remix/pull/1811#discussion_r884011463

- [x] Docs
- [ ] Tests

Testing Strategy:

- ensuring examples/firebase-auth-firestore works with and without JavaScript against emulator and production instances