### PR TITLE
docs(api/remix): fix `NavLink` example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -282,6 +282,7 @@
 - penx
 - phishy
 - plastic041
+- poteirard
 - princerajroy
 - prvnbist
 - ptitFicus

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -167,7 +167,7 @@ function NavList() {
           <NavLink
             to="messages"
             style={({ isActive }) =>
-              isActive ? activeStyle : undefined
+              isActive ? activeStyle : {}
             }
           >
             Messages


### PR DESCRIPTION
I think the types forces you to return an empty object instead of `undefined`

<img width="769" alt="Cursor_and_secrets-vault_–_NavList_tsx" src="https://user-images.githubusercontent.com/7198934/171597736-9cf48c3c-ae69-44a8-876b-33c3e0f9e8db.png">
