### PR TITLE
docs(guides/envvars): clarify docs for local/production env variables

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -78,6 +78,7 @@
 - denissb
 - derekr
 - developit
+- dgurns
 - dhargitai
 - dhmacs
 - dima-takoy

--- a/docs/guides/envvars.md
+++ b/docs/guides/envvars.md
@@ -20,21 +20,17 @@ If your experience with web development is primarily with the JS frameworks in t
 
 ## Server Environment Variables
 
-Environment variables on your server will be handled by your host, for example:
+### Local Development
 
-- [Netlify](https://docs.netlify.com/configure-builds/environment-variables/)
-- [Fly.io](https://fly.io/docs/reference/secrets/)
-- [Cloudflare Workers](https://developers.cloudflare.com/workers/platform/environment-variables)
-- [Vercel](https://vercel.com/docs/environment-variables)
-- [Architect](https://arc.codes/docs/en/reference/cli/env)
+If you're using the `remix dev` server to run your project locally, it has built-in support for [dotenv](https://www.npmjs.com/package/dotenv).
 
-If your host doesn't have any conventions for environment variables during development, the `remix dev` server can help out as it provides built-in support for [dotenv](https://www.npmjs.com/package/dotenv).
-
-If you're using the `remix dev` server, you can do this very quickly:
+First, create an `.env` file in the root of your project:
 
 ```sh
 touch .env
 ```
+
+<docs-error>Do not commit your <code>.env</code> file to git, the point is that it contains secrets!</docs-error>
 
 Edit your `.env` file.
 
@@ -50,13 +46,9 @@ export async function loader() {
 }
 ```
 
-Note that `dotenv` is only for development, you should not use it in production, so Remix doesn't load these when running `remix serve`. You'll need to follow your host's guides on adding secrets to your production server.
+If you're using the `@remix-run/cloudflare-pages` adapter, env variables work a little differently. You'll need to manually pass your `.env` file to `wrangler` by doing this:
 
-<docs-error>Do not commit your <code>.env</code> file to git, the point is that it contains secrets!</docs-error>
-
-If you're using the `@remix-run/cloudflare-pages` adapter, env variables work a little differently. When running locally, you'll need to manually pass your `.env` file to `wrangler` by doing this:
-
-```sh
+```json
 // package.json
 
 {
@@ -66,14 +58,25 @@ If you're using the `@remix-run/cloudflare-pages` adapter, env variables work a 
 }
 ```
 
-When deploying to Cloudflare, you can use the Cloudflare Pages Project Settings UI to set env variables for Preview and Production.
-
-Then, in your `loader` functions, both locally and when deployed on Cloudflare, you can access environment variables directly on `context`:
-```
+Then, in your `loader` functions, you can access environment variables directly on `context`:
+```js
 export const loader = async ({ context }) => {
-  console.log('My env:', context.ENV_VAR);
+  console.log(context.SOME_SECRET);
 }
 ```
+
+Note that `dotenv` is only for development. You should not use it in production, so Remix doesn't load these when running `remix serve`. You'll need to follow your host's guides on adding secrets to your production server.
+
+### Production
+
+Environment variables when deployed to production will be handled by your host, for example:
+
+- [Netlify](https://docs.netlify.com/configure-builds/environment-variables/)
+- [Fly.io](https://fly.io/docs/reference/secrets/)
+- [Cloudflare Pages](https://developers.cloudflare.com/pages/platform/build-configuration/#environment-variables)
+- [Cloudflare Workers](https://developers.cloudflare.com/workers/platform/environment-variables)
+- [Vercel](https://vercel.com/docs/environment-variables)
+- [Architect](https://arc.codes/docs/en/reference/cli/env)
 
 ## Browser Environment Variables
 

--- a/docs/guides/envvars.md
+++ b/docs/guides/envvars.md
@@ -65,7 +65,7 @@ export const loader = async ({ context }) => {
 }
 ```
 
-Note that `dotenv` is only for development. You should not use it in production, so Remix doesn't load these when running `remix serve`. You'll need to follow your host's guides on adding secrets to your production server.
+Note that `.env` files are only for development. You should not use them in production, so Remix doesn't load them when running `remix serve`. You'll need to follow your host's guides on adding secrets to your production server, via the links below.
 
 ### Production
 

--- a/docs/guides/envvars.md
+++ b/docs/guides/envvars.md
@@ -54,6 +54,27 @@ Note that `dotenv` is only for development, you should not use it in production,
 
 <docs-error>Do not commit your <code>.env</code> file to git, the point is that it contains secrets!</docs-error>
 
+If you're using the `@remix-run/cloudflare-pages` adapter, env variables work a little differently. When running locally, you'll need to manually pass your `.env` file to `wrangler` by doing this:
+
+```sh
+// package.json
+
+{
+	"scripts": {
+		"dev:wrangler": "cross-env NODE_ENV=development wrangler pages dev ./public --binding $(cat .env)"
+	}
+}
+```
+
+When deploying to Cloudflare, you can use the Cloudflare Pages Project Settings UI to set env variables for Preview and Production.
+
+Then, in your `loader` functions, both locally and when deployed on Cloudflare, you can access environment variables directly on `context`:
+```
+export const loader = async ({ context }) => {
+  console.log('My env:', context.ENV_VAR);
+}
+```
+
 ## Browser Environment Variables
 
 Some folks ask if Remix can let them put environment variables into browser bundles. It's a common strategy in build-heavy frameworks. However, this approach is a problem for a few reasons:

--- a/docs/guides/envvars.md
+++ b/docs/guides/envvars.md
@@ -58,6 +58,8 @@ If you're using the `@remix-run/cloudflare-pages` adapter, env variables work a 
 }
 ```
 
+<docs-info>Learn more about <a href="https://npm.im/cross-env"><code>cross-env</code></a></docs-info>
+
 Then, in your `loader` functions, you can access environment variables directly on `context`:
 ```js
 export const loader = async ({ context }) => {


### PR DESCRIPTION
When I recently spun up a project using the `@remix-run/cloudflare-pages` adapter, it was not clear how to set up and use env variables, both locally and when deployed to Cloudflare Pages.

Thankfully @jemjam figured it out in [this issue comment](https://github.com/remix-run/remix/issues/1285#issuecomment-1124463689)

This updates the Environment Variables docs with that information. This should hopefully save people a lot of pain when initially setting up a new project with the Cloudflare Pages adapter.