### PR TITLE
fix(remix-node): add `REMIX_DISABLE_SOURCE_MAPS` environment variable support

### DIFF
--- a/packages/remix-node/index.ts
+++ b/packages/remix-node/index.ts
@@ -1,6 +1,8 @@
 import sourceMapSupport from "source-map-support";
 
-sourceMapSupport.install();
+if (!process.env.REMIX_DISABLE_SOURCE_MAPS) {
+  sourceMapSupport.install();
+}
 
 export { AbortController } from "abort-controller";
 


### PR DESCRIPTION
Closes: #3105

The `source-map-support` module can collide with other tools using it or tools like it causing line numbers to be off. One example of these tools is Jest. See the #3105 issue.

This PR allows users of such tools to disable source maps from Remix.

Here's a repro with Jest with patch demonstration:
https://github.com/esamattis/remix-jest-line-numbers-bug

Testing Strategy:

Manual. I have no idea how one could write a unit tests for this. 