### PR TITLE
ci: update needs-response workflow to use official stale action

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -35,4 +35,3 @@ jobs:
           days-before-stale: -1
           any-of-labels: needs-response
           labels-to-remove-when-unstale: needs-response
-          repo-token: ${{ github.token }}

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: 🥺 Handle Ghosting
-        uses: actions/stale@v5.0.0
+        uses: actions/stale@v5
         with:
           close-issue-message: >
             This issue has been automatically closed because we haven't received a

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -31,7 +31,8 @@ jobs:
             tracker clean from PRs that are unactionable. Please reach out if you
             have more information for us! 🙂
           days-before-close: 10
+          # don't automatically mark issues/PRs as stale
+          days-before-stale: -1
           any-of-labels: needs-response
           labels-to-remove-when-unstale: needs-response
-          exempt-draft-pr: true
           repo-token: ${{ github.token }}

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -7,6 +7,10 @@ on:
     # Schedule for five minutes after the hour, every hour
     - cron: "5 * * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   noResponse:
     if: github.repository == 'remix-run/remix'
@@ -14,13 +18,20 @@ jobs:
 
     steps:
       - name: 🥺 Handle Ghosting
-        uses: lee-dohm/no-response@v0.5.0
+        uses: actions/stale@v5.0.0
         with:
-          closeComment: >
+          close-issue-message: >
             This issue has been automatically closed because we haven't received a
             response from the original author 🙈. This automation helps keep the issue
             tracker clean from issues that are unactionable. Please reach out if you
             have more information for us! 🙂
-          daysUntilClose: 10
-          responseRequiredLabel: needs-response
-          token: ${{ github.token }}
+          close-pr-message: >
+            This PR has been automatically closed because we haven't received a
+            response from the original author 🙈. This automation helps keep the issue
+            tracker clean from PRs that are unactionable. Please reach out if you
+            have more information for us! 🙂
+          days-before-close: 10
+          any-of-labels: needs-response
+          labels-to-remove-when-unstale: needs-response
+          exempt-draft-pr: true
+          repo-token: ${{ github.token }}


### PR DESCRIPTION
Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
