### PR TITLE
chore(templates): update `vercel` template

### DIFF
--- a/templates/vercel/package.json
+++ b/templates/vercel/package.json
@@ -9,7 +9,7 @@
     "@remix-run/node": "*",
     "@remix-run/react": "*",
     "@remix-run/vercel": "*",
-    "@vercel/node": "^1.15.2",
+    "@vercel/node": "^2.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/templates/vercel/vercel.json
+++ b/templates/vercel/vercel.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "build": {
-    "env": {
-      "ENABLE_FILE_SYSTEM_API": "1"
-    }
-  }
-}


### PR DESCRIPTION
Follow-up of #2057

`vercel.json` isn't necessary anymore: https://github.com/vercel/vercel/pull/7886