### PR TITLE
chore: reduce duplication across `packages/*/tsconfig.json` files

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -78,6 +78,7 @@
 - denissb
 - derekr
 - developit
+- devinrhode2
 - dhargitai
 - dhmacs
 - dima-takoy

--- a/packages/core.tsconfig.json
+++ b/packages/core.tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+
+    "declaration": true,
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/create-remix/tsconfig.json
+++ b/packages/create-remix/tsconfig.json
@@ -1,17 +1,12 @@
 {
+  "extends": "../core.tsconfig.json",
   "compilerOptions": {
     "lib": ["ES2019"],
     "target": "ES2019",
     "module": "CommonJS",
     "skipLibCheck": true,
 
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
     "resolveJsonModule": true,
-
-    "declaration": true,
-    "emitDeclarationOnly": true,
 
     "outDir": "../../build/node_modules/create-remix",
     "rootDir": "."

--- a/packages/remix-architect/tsconfig.json
+++ b/packages/remix-architect/tsconfig.json
@@ -1,15 +1,10 @@
 {
   "exclude": ["__tests__"],
+  "extends": "../core.tsconfig.json",
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
 
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-
-    "declaration": true,
-    "emitDeclarationOnly": true,
 
     "outDir": "../../build/node_modules/@remix-run/architect",
     "rootDir": "."

--- a/packages/remix-cloudflare-pages/tsconfig.json
+++ b/packages/remix-cloudflare-pages/tsconfig.json
@@ -1,16 +1,11 @@
 {
   "include": ["**/*.ts"],
+  "extends": "../core.tsconfig.json",
   "compilerOptions": {
     "lib": ["ES2019"],
     "target": "ES2019",
     "types": ["@cloudflare/workers-types"],
 
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-
-    "declaration": true,
-    "emitDeclarationOnly": true,
 
     "outDir": "../../build/node_modules/@remix-run/cloudflare-pages",
     "rootDir": ".",

--- a/packages/remix-cloudflare-workers/tsconfig.json
+++ b/packages/remix-cloudflare-workers/tsconfig.json
@@ -1,16 +1,11 @@
 {
   "include": ["**/*.ts"],
+  "extends": "../core.tsconfig.json",
   "compilerOptions": {
     "lib": ["ES2019"],
     "target": "ES2019",
     "types": ["@cloudflare/workers-types"],
 
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-
-    "declaration": true,
-    "emitDeclarationOnly": true,
 
     "outDir": "../../build/node_modules/@remix-run/cloudflare-workers",
     "rootDir": ".",

--- a/packages/remix-cloudflare/tsconfig.json
+++ b/packages/remix-cloudflare/tsconfig.json
@@ -1,16 +1,11 @@
 {
   "include": ["**/*.ts"],
+  "extends": "../core.tsconfig.json",
   "compilerOptions": {
     "lib": ["ES2019"],
     "target": "ES2019",
     "types": ["@cloudflare/workers-types"],
 
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-
-    "declaration": true,
-    "emitDeclarationOnly": true,
 
     "outDir": "../../build/node_modules/@remix-run/cloudflare",
     "rootDir": ".",

--- a/packages/remix-dev/tsconfig.json
+++ b/packages/remix-dev/tsconfig.json
@@ -1,18 +1,13 @@
 {
   "include": ["**/*"],
   "exclude": ["__tests__", "./compiler/shims/*"],
+  "extends": "../core.tsconfig.json",
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
     "module": "CommonJS",
 
-    "moduleResolution": "node",
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-
-    "declaration": true,
-    "emitDeclarationOnly": true,
     "skipLibCheck": true,
 
     "outDir": "../../build/node_modules/@remix-run/dev",

--- a/packages/remix-express/tsconfig.json
+++ b/packages/remix-express/tsconfig.json
@@ -1,15 +1,10 @@
 {
   "exclude": ["__tests__"],
+  "extends": "../core.tsconfig.json",
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
 
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-
-    "declaration": true,
-    "emitDeclarationOnly": true,
 
     "outDir": "../../build/node_modules/@remix-run/express",
     "rootDir": "."

--- a/packages/remix-netlify/tsconfig.json
+++ b/packages/remix-netlify/tsconfig.json
@@ -1,15 +1,10 @@
 {
   "exclude": ["__tests__"],
+  "extends": "../core.tsconfig.json",
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
 
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-
-    "declaration": true,
-    "emitDeclarationOnly": true,
 
     "outDir": "../../build/node_modules/@remix-run/netlify",
     "rootDir": "."

--- a/packages/remix-node/tsconfig.json
+++ b/packages/remix-node/tsconfig.json
@@ -1,15 +1,10 @@
 {
   "exclude": ["__tests__"],
+  "extends": "../core.tsconfig.json",
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
 
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-
-    "declaration": true,
-    "emitDeclarationOnly": true,
 
     "outDir": "../../build/node_modules/@remix-run/node",
     "rootDir": ".",

--- a/packages/remix-react/tsconfig.json
+++ b/packages/remix-react/tsconfig.json
@@ -1,17 +1,12 @@
 {
   "exclude": ["__tests__"],
+  "extends": "../core.tsconfig.json",
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "target": "ES2020",
     "module": "ES2020",
 
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
     "jsx": "react",
-
-    "declaration": true,
-    "emitDeclarationOnly": true,
 
     "outDir": "../../build/node_modules/@remix-run/react",
     "rootDir": "."

--- a/packages/remix-serve/tsconfig.json
+++ b/packages/remix-serve/tsconfig.json
@@ -1,15 +1,10 @@
 {
   "exclude": ["__tests__"],
+  "extends": "../core.tsconfig.json",
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
 
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-
-    "declaration": true,
-    "emitDeclarationOnly": true,
 
     "outDir": "../../build/node_modules/@remix-run/serve",
     "rootDir": "."

--- a/packages/remix-server-runtime/tsconfig.json
+++ b/packages/remix-server-runtime/tsconfig.json
@@ -1,15 +1,10 @@
 {
   "exclude": ["__tests__"],
+  "extends": "../core.tsconfig.json",
   "compilerOptions": {
     "lib": ["ES2019", "DOM", "DOM.Iterable"],
     "target": "ES2019",
 
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-
-    "declaration": true,
-    "emitDeclarationOnly": true,
 
     "outDir": "../../build/node_modules/@remix-run/server-runtime",
     "rootDir": ".",

--- a/packages/remix-vercel/tsconfig.json
+++ b/packages/remix-vercel/tsconfig.json
@@ -1,15 +1,10 @@
 {
   "exclude": ["__tests__"],
+  "extends": "../core.tsconfig.json",
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
 
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-
-    "declaration": true,
-    "emitDeclarationOnly": true,
 
     "outDir": "../../build/node_modules/@remix-run/vercel",
     "rootDir": "."

--- a/packages/remix/tsconfig.json
+++ b/packages/remix/tsconfig.json
@@ -1,16 +1,11 @@
 {
+  "extends": "../core.tsconfig.json",
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "target": "ES2020",
     "module": "ES2020",
 
     "jsx": "react",
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-
-    "declaration": true,
-    "emitDeclarationOnly": true,
 
     "outDir": "../../build/node_modules/remix",
     "rootDir": "."


### PR DESCRIPTION
No ts errors when running `yarn tsc -b` from root

(there are no other `tsc ` package.json scripts in the repo)

100% of the changes here were performed via search+replace.

There's more de-duplication that can be done later, outside of the packages/* directory.