### PR TITLE
fix(remix-dev): Allow debugging for the remix shorthand

### DIFF
--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -126,6 +126,12 @@ const npxInterop = {
   pnpm: "pnpm exec",
 };
 
+async function dev(projectDir: string, flags: { debug: boolean|undefined }) {
+  if (!process.env.NODE_ENV) process.env.NODE_ENV = "development";
+  if (flags.debug) inspector.open();
+  await commands.dev(projectDir, process.env.NODE_ENV);
+}
+
 /**
  * Programmatic interface for running the Remix CLI with the given command line
  * arguments.
@@ -426,9 +432,10 @@ export async function run(argv: string[] = process.argv.slice(2)) {
       break;
     }
     case "dev":
-    default: // `remix ./my-project` is shorthand for `remix dev ./my-project`
-      if (!process.env.NODE_ENV) process.env.NODE_ENV = "development";
-      if (flags.debug) inspector.open();
-      await commands.dev(input[1], process.env.NODE_ENV);
+      await dev(input[1], flags);
+      break;
+    default:
+      // `remix ./my-project` is shorthand for `remix dev ./my-project`
+      await dev(input[0], flags);
   }
 }

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -430,6 +430,5 @@ export async function run(argv: string[] = process.argv.slice(2)) {
       if (!process.env.NODE_ENV) process.env.NODE_ENV = "development";
       if (flags.debug) inspector.open();
       await commands.dev(input[1], process.env.NODE_ENV);
-      break;
   }
 }

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -126,7 +126,7 @@ const npxInterop = {
   pnpm: "pnpm exec",
 };
 
-async function dev(projectDir: string, flags: { debug: boolean|undefined }) {
+async function dev(projectDir: string, flags: { debug?: boolean }) {
   if (!process.env.NODE_ENV) process.env.NODE_ENV = "development";
   if (flags.debug) inspector.open();
   await commands.dev(projectDir, process.env.NODE_ENV);

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -426,13 +426,10 @@ export async function run(argv: string[] = process.argv.slice(2)) {
       break;
     }
     case "dev":
+    default: // `remix ./my-project` is shorthand for `remix dev ./my-project`
       if (!process.env.NODE_ENV) process.env.NODE_ENV = "development";
       if (flags.debug) inspector.open();
       await commands.dev(input[1], process.env.NODE_ENV);
       break;
-    default:
-      // `remix ./my-project` is shorthand for `remix dev ./my-project`
-      if (!process.env.NODE_ENV) process.env.NODE_ENV = "development";
-      await commands.dev(input[0], process.env.NODE_ENV);
   }
 }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

I simply merged the default case with the dev case.
This allow to use the `--debug` CLI flag when using the `remix dev` shorthand. 

Testing Strategy:

I've built and tested from one of my projects using `node ../remix/build/node_modules/\@remix-run/dev/cli.js --debug`
