### PR TITLE
Bug reproduction: web fetch fails on https://gmail.com and crashes entire server

### DIFF
--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -51,7 +51,8 @@ test.beforeAll(async () => {
         import { json } from "@remix-run/node";
         import { useLoaderData, Link } from "@remix-run/react";
 
-        export function loader() {
+        export async function loader() {
+          await fetch("https://gmail.com");
           return json("pizza");
         }
 


### PR DESCRIPTION
When we run `await fetch("https://gmail.com")`, in a loader, we get this error:

```
    Error: Premature close

        at TLSSocket.<anonymous> (/tmp/remix/node_modules/@remix-run/web-fetch/src/fetch.js:343:32)
        at TLSSocket.emit (node:events:532:35)
        at node:net:687:12
        at TCP.done (node:_tls_wrap:580:7)
```

On its own, this is no massive issue. The problem is that the server crashes after this, rendering it incapable of handling new requests.