### PR TITLE
chore(remix-react): make LiveReload port required

### DIFF
--- a/examples/basic/app/root.tsx
+++ b/examples/basic/app/root.tsx
@@ -75,7 +75,7 @@ function Document({
         <RouteChangeAnnouncement />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/blog-tutorial/app/root.tsx
+++ b/examples/blog-tutorial/app/root.tsx
@@ -47,7 +47,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/bullmq-task-queue/app/root.tsx
+++ b/examples/bullmq-task-queue/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/catch-boundary/app/root.tsx
+++ b/examples/catch-boundary/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/chakra-ui/app/root.tsx
+++ b/examples/chakra-ui/app/root.tsx
@@ -33,7 +33,7 @@ function Document({
         {children}
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/client-only-components/app/root.tsx
+++ b/examples/client-only-components/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/client-side-validation/app/root.tsx
+++ b/examples/client-side-validation/app/root.tsx
@@ -32,7 +32,7 @@ export const action: ActionFunction = async ({ request }) => {
   const message = `Successfully submitted data:
       - Required text: ${form.get("required-text")}
       - Required checkbox: ${form.get("required-checkbox")}
-      - Text with regex: ${form.get("text-with-regex")} 
+      - Text with regex: ${form.get("text-with-regex")}
       - Number with min max: ${form.get("number-with-min-max")}
       - Text with minlength maxlength: ${form.get(
         "text-with-minlength-maxlength"
@@ -196,7 +196,7 @@ export default function App() {
         </div>
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/collected-notes/app/root.tsx
+++ b/examples/collected-notes/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/combobox-resource-route/app/root.tsx
+++ b/examples/combobox-resource-route/app/root.tsx
@@ -31,7 +31,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/dark-mode/app/root.tsx
+++ b/examples/dark-mode/app/root.tsx
@@ -54,7 +54,7 @@ function App() {
         <ThemeBody ssrTheme={Boolean(data.theme)} />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/dataloader/app/root.tsx
+++ b/examples/dataloader/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/emotion/app/root.tsx
+++ b/examples/emotion/app/root.tsx
@@ -71,7 +71,7 @@ const Document = withEmotionCache(
           {children}
           <ScrollRestoration />
           <Scripts />
-          <LiveReload />
+          <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
         </body>
       </html>
     );

--- a/examples/file-and-cloudinary-upload/app/root.tsx
+++ b/examples/file-and-cloudinary-upload/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/firebase-auth-firestore/app/root.tsx
+++ b/examples/firebase-auth-firestore/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/form-to-notion-db/app/root.tsx
+++ b/examples/form-to-notion-db/app/root.tsx
@@ -79,7 +79,7 @@ export default function App() {
         </div>
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/framer-motion/app/root.tsx
+++ b/examples/framer-motion/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/framer-route-animation/app/root.tsx
+++ b/examples/framer-route-animation/app/root.tsx
@@ -45,7 +45,7 @@ export default function App() {
         </AnimatePresence>
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/gdpr-cookie-consent/app/root.tsx
+++ b/examples/gdpr-cookie-consent/app/root.tsx
@@ -64,7 +64,7 @@ export default function App() {
         )}
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/google-analytics/app/root.tsx
+++ b/examples/google-analytics/app/root.tsx
@@ -107,7 +107,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/graphql-api/app/root.tsx
+++ b/examples/graphql-api/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/image-resize/app/root.tsx
+++ b/examples/image-resize/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/infinite-scrolling/app/root.tsx
+++ b/examples/infinite-scrolling/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/io-ts-formdata-decoding/app/root.tsx
+++ b/examples/io-ts-formdata-decoding/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/ioredis/app/root.tsx
+++ b/examples/ioredis/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/jokes/app/root.tsx
+++ b/examples/jokes/app/root.tsx
@@ -60,7 +60,7 @@ function Document({
       <body>
         {children}
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/mantine/app/root.tsx
+++ b/examples/mantine/app/root.tsx
@@ -31,7 +31,7 @@ export default function App() {
 
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/msw/app/root.tsx
+++ b/examples/msw/app/root.tsx
@@ -42,7 +42,7 @@ export default function App() {
         <h1>{loaderData.message}</h1>
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/multiple-forms/app/root.tsx
+++ b/examples/multiple-forms/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/multiple-params/app/root.tsx
+++ b/examples/multiple-params/app/root.tsx
@@ -42,7 +42,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/newsletter-signup/app/root.tsx
+++ b/examples/newsletter-signup/app/root.tsx
@@ -37,7 +37,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/nprogress/app/root.tsx
+++ b/examples/nprogress/app/root.tsx
@@ -43,7 +43,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/on-demand-hydration/app/root.tsx
+++ b/examples/on-demand-hydration/app/root.tsx
@@ -27,7 +27,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         {shouldHydrate && <Scripts />}
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/outlet-form-rerender/app/root.tsx
+++ b/examples/outlet-form-rerender/app/root.tsx
@@ -92,7 +92,7 @@ function Document({
         {children}
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/pathless-routes/app/root.tsx
+++ b/examples/pathless-routes/app/root.tsx
@@ -40,7 +40,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/pm-app/app/root.tsx
+++ b/examples/pm-app/app/root.tsx
@@ -66,7 +66,7 @@ function Document({
         />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/quirrel/app/root.tsx
+++ b/examples/quirrel/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/react-spring/app/root.tsx
+++ b/examples/react-spring/app/root.tsx
@@ -33,7 +33,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/redis-upstash-session/app/root.tsx
+++ b/examples/redis-upstash-session/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/remix-auth-auth0/app/root.tsx
+++ b/examples/remix-auth-auth0/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/remix-auth-form/app/root.tsx
+++ b/examples/remix-auth-form/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/remix-auth-github/app/root.tsx
+++ b/examples/remix-auth-github/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/remix-auth-supabase-github/app/root.tsx
+++ b/examples/remix-auth-supabase-github/app/root.tsx
@@ -43,7 +43,7 @@ export default function App() {
           }}
         />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/remix-auth-supabase/app/root.tsx
+++ b/examples/remix-auth-supabase/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/route-modal/app/root.tsx
+++ b/examples/route-modal/app/root.tsx
@@ -28,7 +28,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/routes-gen/app/root.tsx
+++ b/examples/routes-gen/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/rust/app/root.tsx
+++ b/examples/rust/app/root.tsx
@@ -31,7 +31,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/sanity/app/root.jsx
+++ b/examples/sanity/app/root.jsx
@@ -31,7 +31,7 @@ function Document({ children, title }) {
       <body>
         {children}
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/sass/app/root.tsx
+++ b/examples/sass/app/root.tsx
@@ -31,7 +31,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/search-input/app/root.tsx
+++ b/examples/search-input/app/root.tsx
@@ -63,7 +63,7 @@ function Document({
         {children}
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/session-flash/app/root.tsx
+++ b/examples/session-flash/app/root.tsx
@@ -17,7 +17,7 @@ export default function App() {
       <body>
         <Outlet />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/sharing-loader-data/app/root.tsx
+++ b/examples/sharing-loader-data/app/root.tsx
@@ -35,7 +35,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/socket.io/app/root.tsx
+++ b/examples/socket.io/app/root.tsx
@@ -48,7 +48,7 @@ export default function App() {
         </SocketProvider>
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/stitches/app/root.tsx
+++ b/examples/stitches/app/root.tsx
@@ -54,7 +54,7 @@ const Document = ({ children, title }: DocumentProps) => {
         {children}
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/strapi/app/root.tsx
+++ b/examples/strapi/app/root.tsx
@@ -17,7 +17,7 @@ const App: React.FC = () => {
       </head>
       <body>
         <Outlet />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/stripe-integration/app/root.tsx
+++ b/examples/stripe-integration/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/styled-components/app/root.tsx
+++ b/examples/styled-components/app/root.tsx
@@ -26,7 +26,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/styletron/app/root.tsx
+++ b/examples/styletron/app/root.tsx
@@ -32,7 +32,7 @@ export default function App() {
         </StyletronProvider>
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/supabase-subscription/app/root.tsx
+++ b/examples/supabase-subscription/app/root.tsx
@@ -54,7 +54,7 @@ export default function App() {
         ) : null}
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/tailwindcss/app/root.tsx
+++ b/examples/tailwindcss/app/root.tsx
@@ -31,7 +31,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/template/app/root.tsx
+++ b/examples/template/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/tiptap-collab-editing/app/root.tsx
+++ b/examples/tiptap-collab-editing/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/toast-message/app/root.tsx
+++ b/examples/toast-message/app/root.tsx
@@ -76,7 +76,7 @@ export default function App() {
         <Toaster />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/turborepo-vercel/apps/remix-app/app/root.tsx
+++ b/examples/turborepo-vercel/apps/remix-app/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/twind/app/root.tsx
+++ b/examples/twind/app/root.tsx
@@ -30,7 +30,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/examples/usematches-loader-data/app/root.tsx
+++ b/examples/usematches-loader-data/app/root.tsx
@@ -38,7 +38,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/integration/helpers/cf-template/app/root.tsx
+++ b/integration/helpers/cf-template/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/integration/helpers/deno-template/app/root.tsx
+++ b/integration/helpers/deno-template/app/root.tsx
@@ -26,7 +26,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/integration/helpers/node-template/app/root.tsx
+++ b/integration/helpers/node-template/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/packages/remix-deno/globals.ts
+++ b/packages/remix-deno/globals.ts
@@ -5,6 +5,7 @@ Declare types for `process` here so that they are available in Deno.
 
 interface ProcessEnv {
   NODE_ENV: "development" | "production" | "test";
+  REMIX_DEV_SERVER_WS_PORT: string;
 }
 interface Process {
   env: ProcessEnv;

--- a/packages/remix-dev/__tests__/fixtures/replace-remix-imports/app/root.tsx
+++ b/packages/remix-dev/__tests__/fixtures/replace-remix-imports/app/root.tsx
@@ -43,7 +43,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/packages/remix-dev/__tests__/fixtures/stack/app/root.tsx
+++ b/packages/remix-dev/__tests__/fixtures/stack/app/root.tsx
@@ -18,7 +18,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/packages/remix-node/globals.ts
+++ b/packages/remix-node/globals.ts
@@ -18,6 +18,7 @@ declare global {
   namespace NodeJS {
     interface ProcessEnv {
       NODE_ENV: "development" | "production" | "test";
+      REMIX_DEV_SERVER_WS_PORT: string;
     }
 
     interface Global {

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1426,10 +1426,10 @@ export const LiveReload =
   process.env.NODE_ENV !== "development"
     ? () => null
     : function LiveReload({
-        port = Number(process.env.REMIX_DEV_SERVER_WS_PORT || 8002),
+        port,
         nonce = undefined,
       }: {
-        port?: number;
+        port: number;
         /**
          * @deprecated this property is no longer relevant.
          */

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1426,15 +1426,24 @@ export const LiveReload =
   process.env.NODE_ENV !== "development"
     ? () => null
     : function LiveReload({
-        port,
+        port = Number(process.env.REMIX_DEV_SERVER_WS_PORT),
         nonce = undefined,
       }: {
-        port: number;
+        port?: number;
         /**
          * @deprecated this property is no longer relevant.
          */
         nonce?: string;
       }) {
+        if (!port) {
+          throw new Error(
+            "We were unable to connect to the Remix dev asset server web socket. " +
+              "This usually happens when you use an unbundled server" +
+              "you can replace `<LiveReload />` with `<LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />`" +
+              "to manually set the port."
+          );
+        }
+
         let js = String.raw;
         return (
           <script

--- a/scripts/playground/template/app/root.tsx
+++ b/scripts/playground/template/app/root.tsx
@@ -47,7 +47,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/templates/arc/app/root.tsx
+++ b/templates/arc/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/templates/cloudflare-pages/app/root.tsx
+++ b/templates/cloudflare-pages/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/templates/cloudflare-workers/app/root.tsx
+++ b/templates/cloudflare-workers/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/templates/deno/app/root.tsx
+++ b/templates/deno/app/root.tsx
@@ -26,7 +26,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/templates/express/app/root.tsx
+++ b/templates/express/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/templates/fly/app/root.tsx
+++ b/templates/fly/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/templates/netlify/app/root.tsx
+++ b/templates/netlify/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/templates/remix/app/root.tsx
+++ b/templates/remix/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );

--- a/templates/vercel/app/root.tsx
+++ b/templates/vercel/app/root.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
+        <LiveReload port={Number(process.env.REMIX_DEV_SERVER_WS_PORT)} />
       </body>
     </html>
   );


### PR DESCRIPTION
without this change, unbundled servers wouldn't properly connect to the web socket connection

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
