### PR TITLE
docs(guide): fix typo in Migrating React Router App

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -171,6 +171,7 @@
 - johnson444
 - joms
 - joshball
+- jrubins
 - jssisodiya
 - jstafman
 - juhanakristian

--- a/docs/guides/migrating-react-router-app.md
+++ b/docs/guides/migrating-react-router-app.md
@@ -7,7 +7,7 @@ description: Migrating your React Router app to Remix can be done all at once or
 
 # Migrating your React Router App to Remix
 
-Millions of React applications deployed worldwide are powered by [React Router](https://reactrouter.com/). Chances are you've shipped a few of them! Because Remix is built on top of React Router, we wave worked to make migration an easy process you can work through iteratively to avoid huge refactors.
+Millions of React applications deployed worldwide are powered by [React Router](https://reactrouter.com/). Chances are you've shipped a few of them! Because Remix is built on top of React Router, we have worked to make migration an easy process you can work through iteratively to avoid huge refactors.
 
 If you aren't already using React Router, we think there are several compelling reasons to reconsider! History management, dynamic path matching, nested routing, and much more. Take a look at the [React Router docs](https://reactrouter.com/docs/en/v6/getting-started/concepts) and see all what we have to offer.
 


### PR DESCRIPTION
### Summary

This fixes a typo in the "Migrating your React Router App to Remix" documentation: changes "wave" to "have".