### PR TITLE
types(remix-server-runtime): make AppLoadContext an empty interface instead of any

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -359,3 +359,4 @@
 - zachdtaylor
 - zainfathoni
 - zhe
+- marwan38

--- a/contributors.yml
+++ b/contributors.yml
@@ -69,6 +69,7 @@
 - cysp
 - damiensedgwick
 - dan-gamble
+- danielfgray
 - danielweinmann
 - davecalnan
 - DavidHollins6

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -6,7 +6,9 @@ import { json, isResponse, isRedirectResponse } from "./responses";
  * An object of arbitrary for route loaders and actions provided by the
  * server's `getLoadContext()` function.
  */
-export interface AppLoadContext {};
+export interface AppLoadContext {
+  [key: string]: unknown;
+};
 
 /**
  * Data for a route that was returned from a `loader()`.

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -7,7 +7,7 @@ import { json, isResponse, isRedirectResponse } from "./responses";
  * server's `getLoadContext()` function.
  */
 export interface AppLoadContext {
-  [key: string]: unknown;
+  [key: string]: any;
 };
 
 /**
@@ -20,7 +20,7 @@ export async function callRouteAction({
   match,
   request,
 }: {
-  loadContext: unknown;
+  loadContext?: AppLoadContext;
   match: RouteMatch<ServerRoute>;
   request: Request;
 }) {
@@ -67,7 +67,7 @@ export async function callRouteLoader({
 }: {
   request: Request;
   match: RouteMatch<ServerRoute>;
-  loadContext: unknown;
+  loadContext?: AppLoadContext;
 }) {
   let loader = match.route.module.loader;
 

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -6,7 +6,7 @@ import { json, isResponse, isRedirectResponse } from "./responses";
  * An object of arbitrary for route loaders and actions provided by the
  * server's `getLoadContext()` function.
  */
-export type AppLoadContext = any;
+export interface AppLoadContext {};
 
 /**
  * Data for a route that was returned from a `loader()`.

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -15,7 +15,7 @@ export interface RouteModules<RouteModule> {
  */
 export interface DataFunctionArgs {
   request: Request;
-  context: AppLoadContext;
+  context?: AppLoadContext;
   params: Params;
 }
 

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -82,7 +82,7 @@ async function handleDataRequest({
   serverMode,
 }: {
   handleDataRequest?: HandleDataRequestFunction;
-  loadContext: unknown;
+  loadContext?: AppLoadContext;
   matches: RouteMatch<ServerRoute>[];
   request: Request;
   serverMode: ServerMode;
@@ -180,7 +180,7 @@ async function handleDocumentRequest({
   serverMode,
 }: {
   build: ServerBuild;
-  loadContext: unknown;
+  loadContext?: AppLoadContext;
   matches: RouteMatch<ServerRoute>[] | null;
   request: Request;
   routes: ServerRoute[];
@@ -519,7 +519,7 @@ async function handleResourceRequest({
   serverMode,
 }: {
   request: Request;
-  loadContext: unknown;
+  loadContext?: AppLoadContext;
   matches: RouteMatch<ServerRoute>[];
   serverMode: ServerMode;
 }): Promise<Response> {


### PR DESCRIPTION
👋 Hey, 

This PR builds on top of another PR that was created https://github.com/remix-run/remix/pull/1876.
I found that there were some issues with typing due to the original change of the `AppLoadContext` type to an interface.

The issue was this:
```typescript
- type AppLoadContext = any;
+ interface AppLoadContext {
+    [key: string]: unknown;
+ }

// Other functions that rely on the context
const someLoaderThing = (loadContext: unknown) => { // ... } // type error, type unknown conflicts with the new interface
```

Based on the fact that the documentation shows that the `getLoadContext` function returns an object https://remix.run/docs/en/v1/other-api/adapter#createrequesthandler, I thought that original change to `AppLoadContext` was suitable.

I cherry picked the original commits to ensure that the credits to the original author remain.


Closes: #1876

Testing Strategy:

I initiated a new playground and added the typescript override within the default `remix.env.d.ts`.

The override looks like this:
```typescript
/// <reference types="@remix-run/dev" />
/// <reference types="@remix-run/node/globals" />
import "@remix-run/server-runtime";

declare module "@remix-run/server-runtime" {
  interface AppLoadContext {
    foo: {
      bar: true;
    };
  }
}

```

Success! Context within action and loaders are now strongly typed.
