### PR TITLE
fix(remix-dev): remove hardcoded links export from MDX compiler

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -16,6 +16,7 @@
 - alireza-bonab
 - alvinthen
 - amorriscode
+- andreiduca
 - andrelandgraf
 - andrewbrey
 - AndrewIngram

--- a/packages/remix-dev/compiler/plugins/mdx.ts
+++ b/packages/remix-dev/compiler/plugins/mdx.ts
@@ -71,7 +71,6 @@ export function mdxPlugin(config: RemixConfig): esbuild.Plugin {
 export const filename = ${JSON.stringify(path.basename(args.path))};
 export const headers = typeof attributes !== "undefined" && attributes.headers;
 export const meta = typeof attributes !== "undefined" && attributes.meta;
-export const links = undefined;
           `;
 
           let compiled = await xdm.compile(fileContents, {


### PR DESCRIPTION
Proposed fix for #3423.

I see this was added back in https://github.com/remix-run/remix/pull/254/files#diff-38dea30b5d212ef5a7a272ce3b9945d971604deb632155b47ebf6676cb8e570aR47 but the changes seem unrelated to the PR's intent. Wondering why it was originally added. The discussion around it also seems misleading, as removing that line like in this proposed PR seems to be providing the expected result.

But I'm most likely missing something, so opening this up for discussion.