### PR TITLE
fix(remix-server-runtime): use correct error/catch boundary on SSR action errors

### DIFF
--- a/packages/remix-server-runtime/__tests__/server-test.ts
+++ b/packages/remix-server-runtime/__tests__/server-test.ts
@@ -880,7 +880,8 @@ describe("shared server runtime", () => {
       let result = await handler(request);
       expect(result.status).toBe(400);
       expect(testAction.mock.calls.length).toBe(1);
-      expect(rootLoader.mock.calls.length).toBe(1);
+      // Should not call root loader since it is the boundary route
+      expect(rootLoader.mock.calls.length).toBe(0);
       expect(testLoader.mock.calls.length).toBe(0);
       expect(build.entry.module.default.mock.calls.length).toBe(1);
 
@@ -890,9 +891,7 @@ describe("shared server runtime", () => {
       expect(entryContext.appState.catch).toBeTruthy();
       expect(entryContext.appState.catch!.status).toBe(400);
       expect(entryContext.appState.catchBoundaryRouteId).toBe("root");
-      expect(entryContext.routeData).toEqual({
-        root: "root",
-      });
+      expect(entryContext.routeData).toEqual({});
     });
 
     test("thrown action responses bubble up for index routes", async () => {
@@ -926,7 +925,8 @@ describe("shared server runtime", () => {
       let result = await handler(request);
       expect(result.status).toBe(400);
       expect(indexAction.mock.calls.length).toBe(1);
-      expect(rootLoader.mock.calls.length).toBe(1);
+      // Should not call root loader since it is the boundary route
+      expect(rootLoader.mock.calls.length).toBe(0);
       expect(indexLoader.mock.calls.length).toBe(0);
       expect(build.entry.module.default.mock.calls.length).toBe(1);
 
@@ -936,9 +936,7 @@ describe("shared server runtime", () => {
       expect(entryContext.appState.catch).toBeTruthy();
       expect(entryContext.appState.catch!.status).toBe(400);
       expect(entryContext.appState.catchBoundaryRouteId).toBe("root");
-      expect(entryContext.routeData).toEqual({
-        root: "root",
-      });
+      expect(entryContext.routeData).toEqual({});
     });
 
     test("thrown action responses catch deep", async () => {
@@ -1263,7 +1261,8 @@ describe("shared server runtime", () => {
       let result = await handler(request);
       expect(result.status).toBe(500);
       expect(testAction.mock.calls.length).toBe(1);
-      expect(rootLoader.mock.calls.length).toBe(1);
+      // Should not call root loader since it is the boundary route
+      expect(rootLoader.mock.calls.length).toBe(0);
       expect(testLoader.mock.calls.length).toBe(0);
       expect(build.entry.module.default.mock.calls.length).toBe(1);
 
@@ -1273,9 +1272,7 @@ describe("shared server runtime", () => {
       expect(entryContext.appState.error).toBeTruthy();
       expect(entryContext.appState.error.message).toBe("test");
       expect(entryContext.appState.loaderBoundaryRouteId).toBe("root");
-      expect(entryContext.routeData).toEqual({
-        root: "root",
-      });
+      expect(entryContext.routeData).toEqual({});
     });
 
     test("action errors bubble up for index routes", async () => {
@@ -1309,7 +1306,8 @@ describe("shared server runtime", () => {
       let result = await handler(request);
       expect(result.status).toBe(500);
       expect(indexAction.mock.calls.length).toBe(1);
-      expect(rootLoader.mock.calls.length).toBe(1);
+      // Should not call root loader since it is the boundary route
+      expect(rootLoader.mock.calls.length).toBe(0);
       expect(indexLoader.mock.calls.length).toBe(0);
       expect(build.entry.module.default.mock.calls.length).toBe(1);
 
@@ -1319,9 +1317,7 @@ describe("shared server runtime", () => {
       expect(entryContext.appState.error).toBeTruthy();
       expect(entryContext.appState.error.message).toBe("index");
       expect(entryContext.appState.loaderBoundaryRouteId).toBe("root");
-      expect(entryContext.routeData).toEqual({
-        root: "root",
-      });
+      expect(entryContext.routeData).toEqual({});
     });
 
     test("action errors catch deep", async () => {

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -273,24 +273,21 @@ async function handleDocumentRequest({
   let routeModules = createEntryRouteModules(build.routes);
 
   let matchesToLoad = matches || [];
+
+  // get rid of the action, we don't want to call it's loader either
+  // because we'll be rendering the error/catch boundary, if you can get
+  // access to the loader data in the error/catch boundary then how the heck
+  // is it supposed to deal with thrown responses and/or errors in the loader?
   if (appState.catch) {
     matchesToLoad = getMatchesUpToDeepestBoundary(
-      // get rid of the action, we don't want to call it's loader either
-      // because we'll be rendering the catch boundary, if you can get access
-      // to the loader data in the catch boundary then how the heck is it
-      // supposed to deal with thrown responses?
-      matchesToLoad.slice(0, -1),
+      matchesToLoad,
       "CatchBoundary"
-    );
+    ).slice(0, -1);
   } else if (appState.error) {
     matchesToLoad = getMatchesUpToDeepestBoundary(
-      // get rid of the action, we don't want to call it's loader either
-      // because we'll be rendering the error boundary, if you can get access
-      // to the loader data in the error boundary then how the heck is it
-      // supposed to deal with errors in the loader, too?
-      matchesToLoad.slice(0, -1),
+      matchesToLoad,
       "ErrorBoundary"
-    );
+    ).slice(0, -1);
   }
 
   let loaderRequest = new Request(request.url, {


### PR DESCRIPTION
Closes: #599

- [x] Tests

Testing Strategy: I tested using the repo in #599 but the repro setup is basically:
* Parent route with loader data
* Child route that exports `ErrorBoundary` or `CatchBoundary`
* Child contains `form` or `<Form reloadDocument={true}>` submitting to child action that throws
  * This error only happens in server-side form submissions 
* Proper boundary should be used and the parent loaderData should not be wiped away on submission