### PR TITLE
enhancement(cli): Ask about TypeScript before `npm install`

### DIFF
--- a/packages/remix-dev/__tests__/cli-test.ts
+++ b/packages/remix-dev/__tests__/cli-test.ts
@@ -204,8 +204,8 @@ describe("remix CLI", () => {
         { question: /Where.*create.*app/i, type: [projectDir, ENTER] },
         { question: /What type of app/i, answer: /basics/i },
         { question: /Where.*deploy/i, answer: /express/i },
-        { question: /install/i, type: ["n", ENTER] },
         { question: /typescript or javascript/i, answer: /typescript/i },
+        { question: /install/i, type: ["n", ENTER] },
       ]);
     });
 
@@ -229,8 +229,8 @@ describe("remix CLI", () => {
         { question: /Where.*create.*app/i, type: [projectDir, ENTER] },
         { question: /What type of app/i, answer: /basics/i },
         { question: /Where.*deploy/i, answer: /express/i },
-        { question: /install/i, type: ["n", ENTER] },
         { question: /typescript or javascript/i, answer: /javascript/i },
+        { question: /install/i, type: ["n", ENTER] },
       ]);
 
       expect(

--- a/packages/remix-dev/cli/create.ts
+++ b/packages/remix-dev/cli/create.ts
@@ -191,8 +191,14 @@ export async function createApp({
   appPkg = sortPackageJSON(appPkg);
   await fse.writeJSON(pkgJsonPath, appPkg, { spaces: 2 });
 
-  if (!useTypeScript) {
+  if (
+    !useTypeScript &&
+    fse.existsSync(path.join(projectDir, "tsconfig.json"))
+  ) {
+    let spinner = ora("Converting template to JavaScript…").start();
     await convertTemplateToJavaScript(projectDir);
+    spinner.stop();
+    spinner.clear();
   }
 
   if (installDeps) {

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -5,11 +5,9 @@ import meow from "meow";
 import inquirer from "inquirer";
 import semver from "semver";
 import fse from "fs-extra";
-import ora from "ora";
 
 import * as colors from "../colors";
 import * as commands from "./commands";
-import { convertTemplateToJavaScript } from "./convert-to-javascript";
 import { validateNewProjectPath, validateTemplate } from "./create";
 import { getPreferredPackageManager } from "./getPreferredPackageManager";
 

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -300,6 +300,19 @@ export async function run(argv: string[] = process.argv.slice(2)) {
             choices: templateChoices,
           },
           {
+            name: "useTypeScript",
+            type: "list",
+            message: "TypeScript or JavaScript?",
+            default: true,
+            when() {
+              return flags.typescript === undefined;
+            },
+            choices: [
+              { name: "TypeScript", value: true },
+              { name: "JavaScript", value: false },
+            ],
+          },
+          {
             name: "install",
             type: "confirm",
             message: `Do you want me to run \`${packageManager} install\`?`,
@@ -332,40 +345,17 @@ export async function run(argv: string[] = process.argv.slice(2)) {
 
       let installDeps = flags.install !== false && answers.install !== false;
 
+      let useTypeScript = flags.typescript ?? answers.useTypeScript;
+
       await commands.create({
         appTemplate: flags.template || answers.appTemplate,
         projectDir,
         remixVersion: flags.remixVersion,
         installDeps,
-        useTypeScript: flags.typescript !== false,
+        useTypeScript,
         githubToken: process.env.GITHUB_TOKEN,
         debug: flags.debug,
       });
-
-      let isTypeScript = fse.existsSync(path.join(projectDir, "tsconfig.json"));
-
-      if (flags.typescript === undefined && isTypeScript) {
-        let { useTypeScript } = await inquirer.prompt<{
-          useTypeScript: boolean;
-        }>([
-          {
-            name: "useTypeScript",
-            type: "list",
-            message: "TypeScript or JavaScript?",
-            choices: [
-              { name: "TypeScript", value: true },
-              { name: "JavaScript", value: false },
-            ],
-          },
-        ]);
-
-        if (useTypeScript === false) {
-          let spinner = ora("Converting template to JavaScript…").start();
-          await convertTemplateToJavaScript(projectDir);
-          spinner.stop();
-          spinner.clear();
-        }
-      }
 
       let initScriptDir = path.join(projectDir, "remix.init");
       let hasInitScript = await fse.pathExists(initScriptDir);


### PR DESCRIPTION
This PR improves the CLI by asking about using TypeScript or JavaScropt *before* running `npm install`. This is a better UX because:

- We ask all questions up front, so it just flows a bit better
- If we convert the template first, `npm install` won't include all of the TS-related modules previously in the `package.json`

---

- [ ] Docs
- [x] Tests
