### PR TITLE
enhancement(dev/cli): Add `--port` flag to `remix dev`

### DIFF
--- a/packages/remix-dev/__tests__/cli-test.ts
+++ b/packages/remix-dev/__tests__/cli-test.ts
@@ -110,6 +110,7 @@ describe("remix CLI", () => {
             --sourcemap         Generate source maps for production
           \`dev\` Options:
             --debug             Attach Node.js inspector
+            --port, -p          Choose the port from which to run your app
           \`routes\` Options:
             --json              Print the routes as JSON
           \`migrate\` Options:

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -234,7 +234,11 @@ export async function watch(
   });
 }
 
-export async function dev(remixRoot: string, modeArg?: string) {
+export async function dev(
+  remixRoot: string,
+  modeArg?: string,
+  portArg?: number
+) {
   let createApp: typeof createAppType;
   let express: typeof Express;
   try {
@@ -255,7 +259,11 @@ export async function dev(remixRoot: string, modeArg?: string) {
   await loadEnv(config.rootDirectory);
 
   let port = await getPort({
-    port: process.env.PORT ? Number(process.env.PORT) : makeRange(3000, 3100),
+    port: portArg
+      ? Number(portArg)
+      : process.env.PORT
+      ? Number(process.env.PORT)
+      : makeRange(3000, 3100),
   });
 
   if (config.serverEntryPoint) {

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -42,6 +42,7 @@ ${colors.heading("Options")}:
   --sourcemap         Generate source maps for production
 \`dev\` Options:
   --debug             Attach Node.js inspector
+  --port, -p          Choose the port from which to run your app
 \`routes\` Options:
   --json              Print the routes as JSON
 \`migrate\` Options:
@@ -126,10 +127,13 @@ const npxInterop = {
   pnpm: "pnpm exec",
 };
 
-async function dev(projectDir: string, flags: { debug?: boolean }) {
+async function dev(
+  projectDir: string,
+  flags: { debug?: boolean; port?: number }
+) {
   if (!process.env.NODE_ENV) process.env.NODE_ENV = "development";
   if (flags.debug) inspector.open();
-  await commands.dev(projectDir, process.env.NODE_ENV);
+  await commands.dev(projectDir, process.env.NODE_ENV, flags.port);
 }
 
 /**
@@ -157,6 +161,7 @@ export async function run(argv: string[] = process.argv.slice(2)) {
       install: { type: "boolean" },
       json: { type: "boolean" },
       migration: { type: "string", alias: "m" },
+      port: { type: "number", alias: "p" },
       remixVersion: { type: "string" },
       sourcemap: { type: "boolean" },
       template: { type: "string" },


### PR DESCRIPTION
This PR adds a `--port` flag to `remix dev` that takes precedence over `process.env.PORT`. This makes it easier to choose a new port on the fly.

Note, I updated the snapshot but didn't create any new tests yet. We don't currently have a test suite for `remix dev` commands and I need to follow up internally before adding a new process-intensive test that could further slow things down in CI. I did test it manually and things work as expected.