### PR TITLE
docs(tutorials/jokes): update Fly commands

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -282,6 +282,7 @@
 - pcattori
 - penspinner
 - penx
+- petercr
 - phishy
 - plastic041
 - princerajroy

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -6253,7 +6253,7 @@ I feel pretty great about the user experience we've created here. So let's get t
 💿 Once you've done that, run this command from within your project directory:
 
 ```sh
-fly launch
+flyctl launch
 ```
 
 The folks at fly were kind enough to put together a great setup experience. They'll detect your Remix project and ask you a few questions to get you started. Here's my output/choices:
@@ -6292,7 +6292,7 @@ Fly generated a few files for us:
 💿 Now set the `SESSION_SECRET` environment variable by running this command:
 
 ```sh
-fly secrets set SESSION_SECRET=your-secret-here
+flyctl secrets set SESSION_SECRET=your-secret-here
 ```
 
 `your-secret-here` can be whatever you want. It's just a string that's used to encrypt the session cookie. Use a password generator if you like.
@@ -6344,7 +6344,7 @@ With that done, you're ready to deploy.
 💿 Run this command:
 
 ```sh
-fly deploy
+flyctl deploy
 ```
 
 This will build the docker image and deploy it on Fly in the region you selected. It will take a little while. While you wait, you can think of someone you haven't talked to in a while and shoot them a message telling them why you appreciate them.
@@ -6353,7 +6353,7 @@ Great! We're done and you made someone's day! Success!
 
 Your app is now live at `https://<your-app-name>.fly.dev`! You can find that URL in your fly account online as well: [fly.io/apps](https://fly.io/apps).
 
-Any time you make a change, simply run `fly deploy` again to redeploy.
+Any time you make a change, simply run `flyctl deploy` again to redeploy.
 
 ## Conclusion
 


### PR DESCRIPTION
## Update Fly commands to reflect their new syntax

Hey thanks so much for making this **awesome project**, and especially for making it ***open source!***
It's a great new way to work with React 🎉

It appears that Fly.io has changed their syntax for running commands from the terminal. 
Instead of using `fly <command>`, they now use `flyctl <command>`.
Here is a link to the docs where they show this, [Fly docs login page.](https://fly.io/docs/getting-started/log-in-to-fly/)

And here's a screenshot of it ⬇️ 
![msedge_vOtMshVt0Y](https://user-images.githubusercontent.com/26460352/173209600-df68ee47-8d45-4eb0-9a66-0e8bd2f67d94.png)

I have changed all the terminal commands to reflect the new syntax in `jokes.md `

Feel free to ask me any questions you have on this, or if you want me to change anything 👌 

Thanks,

Pete


