### PR TITLE
docs(api/remix): add note to sessions usage section

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -73,6 +73,7 @@
 - dan-gamble
 - danielweinmann
 - davecalnan
+- davecranwell-vocovo
 - DavidHollins6
 - davongit
 - denissb

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -2042,7 +2042,10 @@ const { getSession, commitSession, destroySession } =
 
       // all of these are optional
       domain: "remix.run",
-      expires: new Date(Date.now() + 60_000),
+      // Expires can also be set (although maxAge overrides it when used in combination).
+      // Note that this method is NOT recommended as `new Date` creates only one date each server deployment, not a dynamic date in the future!
+      //
+      // expires: new Date(Date.now() + 60_000),
       httpOnly: true,
       maxAge: 60,
       path: "/",
@@ -2054,8 +2057,6 @@ const { getSession, commitSession, destroySession } =
 
 export { getSession, commitSession, destroySession };
 ```
-
-Please note that using the `createCookieSessionStorage` code above as it stands is NOT recommended. Not only are `expires` and `maxAge` not intended for use together, but using this code would set a specific, one-off time for all future cookies, which would eventually elapse preventing any futher cookies being set!
 
 We recommend setting up your session storage object in `app/sessions.js` so all routes that need to access session data can import from the same spot (also, see our [Route Module Constraints][constraints]).
 

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -2055,6 +2055,8 @@ const { getSession, commitSession, destroySession } =
 export { getSession, commitSession, destroySession };
 ```
 
+Please note that using the `createCookieSessionStorage` code above as it stands is NOT recommended. Not only are `expires` and `maxAge` not intended for use together, but using this code would set a specific, one-off time for all future cookies, which would eventually elapse preventing any futher cookies being set!
+
 We recommend setting up your session storage object in `app/sessions.js` so all routes that need to access session data can import from the same spot (also, see our [Route Module Constraints][constraints]).
 
 The input/output to a session storage object are HTTP cookies. `getSession()` retrieves the current session from the incoming request's `Cookie` header, and `commitSession()`/`destroySession()` provide the `Set-Cookie` header for the outgoing response.

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -2043,7 +2043,7 @@ const { getSession, commitSession, destroySession } =
       // all of these are optional
       domain: "remix.run",
       // Expires can also be set (although maxAge overrides it when used in combination).
-      // Note that this method is NOT recommended as `new Date` creates only one date each server deployment, not a dynamic date in the future!
+      // Note that this method is NOT recommended as `new Date` creates only one date on each server deployment, not a dynamic date in the future!
       //
       // expires: new Date(Date.now() + 60_000),
       httpOnly: true,


### PR DESCRIPTION
Adds caveat around use of the code verbatim, as using `expires` in the way shown, outside any kind of dynamic function, would result in a fixed expiry for all future cookies