### PR TITLE
fix: Handle revalidations across multi-redirects

### DIFF
--- a/integration/redirects-test.ts
+++ b/integration/redirects-test.ts
@@ -1,0 +1,165 @@
+import { test, expect } from "@playwright/test";
+
+import { createFixture, createAppFixture, js } from "./helpers/create-fixture";
+import type { Fixture, AppFixture } from "./helpers/create-fixture";
+import { PlaywrightFixture } from "./helpers/playwright-fixture";
+
+test.describe("redirects", () => {
+  let fixture: Fixture;
+  let appFixture: AppFixture;
+
+  test.beforeAll(async () => {
+    fixture = await createFixture({
+      files: {
+        "app/routes/action-submission.jsx": js`
+          import { Outlet, useLoaderData } from "@remix-run/react";
+
+          if (typeof global.count === "undefined") {
+            global.count = 0;
+          }
+
+          export async function loader({ request }) {
+            return { count: ++count };
+          };
+
+          export default function Parent() {
+            let data = useLoaderData();
+            return (
+              <div id="app">
+                <p id="count">{data.count}</p>
+                <Outlet/>
+              </div>
+            );
+          }
+        `,
+
+        [`app/routes/action-submission/form.jsx`]: js`
+          import { redirect } from "@remix-run/node";
+          import { Form } from "@remix-run/react";
+
+          export async function action({ request }) {
+            return redirect("/action-submission/1");
+          };
+
+          export default function Login() {
+            return (
+              <Form method="post" action="/action-submission/form">
+                <input type="hidden" name="key" value="value" />
+                <button type="submit">Submit</button>
+              </Form>
+            );
+          }
+        `,
+
+        [`app/routes/action-submission/1.jsx`]: js`
+          import { redirect } from "@remix-run/node";
+
+          export async function loader({ request }) {
+            return redirect("/action-submission/2");
+          };
+        `,
+
+        [`app/routes/action-submission/2.jsx`]: js`
+          export default function () {
+            return <h1>Page 2</h1>
+          }
+        `,
+
+        "app/session.server.js": js`
+          import { createCookie } from "@remix-run/node";
+          export const session = createCookie("session");
+        `,
+
+        "app/routes/loader-cookie.jsx": js`
+          import { Outlet, useLoaderData } from "@remix-run/react";
+          import { session } from "~/session.server";
+
+          if (typeof global.count === "undefined") {
+            global.count = 0;
+          }
+
+          export async function loader({ request }) {
+            const cookieHeader = request.headers.get("Cookie");
+            const { value } = (await session.parse(cookieHeader)) || {};
+            return { count: ++global.count, value };
+          };
+
+          export default function Parent() {
+            let data = useLoaderData();
+            return (
+              <div id="app">
+                {data.value ? <p>{data.value}</p> : null}
+                <Outlet/>
+              </div>
+            );
+          }
+        `,
+
+        [`app/routes/loader-cookie/login.jsx`]: js`
+          import { redirect } from "@remix-run/node";
+          import { Form } from "@remix-run/react";
+          import { session } from "~/session.server";
+
+          export async function loader({ request }) {
+            const cookieHeader = request.headers.get("Cookie");
+            const cookie = (await session.parse(cookieHeader)) || {};
+            cookie.value = 'cookie-value';
+            return redirect("/loader-cookie/1", {
+              headers: {
+                "Set-Cookie": await session.serialize(cookie),
+              },
+            });
+          };
+        `,
+
+        [`app/routes/loader-cookie/1.jsx`]: js`
+          import { redirect } from "@remix-run/node";
+
+          export async function loader({ request }) {
+            return redirect("/loader-cookie/2");
+          };
+        `,
+
+        [`app/routes/loader-cookie/2.jsx`]: js`
+          export default function () {
+            return <h1>Page 2</h1>
+          }
+        `,
+      },
+    });
+
+    appFixture = await createAppFixture(fixture);
+  });
+
+  test.afterAll(async () => {
+    await appFixture.close();
+  });
+
+  test("preserves revalidation across action multi-redirects", async ({
+    page,
+  }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto(`/action-submission/form`);
+    expect(await app.getHtml("#count")).toMatch(">1<");
+    expect(await app.getHtml("#app")).toMatch("Submit");
+    // Submitting this form will trigger an action -> actionRedirect -> normalRedirect
+    // and we need to ensure that the parent loader is called on both redirects
+    await app.clickElement('button[type="submit"]');
+    await new Promise((r) => setTimeout(r, 1000));
+    expect(await app.getHtml("#app")).toMatch("Page 2");
+    // Loader called twice
+    expect(await app.getHtml("#count")).toMatch(">3<");
+  });
+
+  test("preserves revalidation across loader multi-redirects with cookies set", async ({
+    page,
+  }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    // Loading this page will trigger an normalRedirect -> normalRedirect with
+    // a cookie set on the first one, and we need to ensure that the parent
+    // loader is called on both redirects
+    await app.goto(`/loader-cookie/login`);
+    expect(await app.getHtml("#app")).toMatch("Page 2");
+    expect(await app.getHtml("#app")).toMatch("cookie-value");
+  });
+});

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -1288,8 +1288,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
       // submission sticks around for optimistic/pending UI.
       if (
         state.transition.type === "actionReload" ||
-        ((location.state as any)?.isRedirect &&
-          (location.state as any)?.type === "action")
+        isActionRedirectLocation(location)
       ) {
         let locationState: Redirects["Action"] = {
           isRedirect: true,

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -1217,7 +1217,9 @@ export function createTransitionManager(init: TransitionManagerInit) {
     invariant(
       state.transition.type === "actionSubmission" ||
         // loader redirected during action reload
-        state.transition.type === "actionReload",
+        state.transition.type === "actionReload" ||
+        // loader redirected during action redirect
+        state.transition.type === "actionRedirect",
       `Unexpected transition: ${JSON.stringify(state.transition)}`
     );
     let { submission } = state.transition;
@@ -1284,7 +1286,11 @@ export function createTransitionManager(init: TransitionManagerInit) {
       // loader redirected during an action reload, treat it like an
       // actionRedirect instead so that all the loaders get called again and the
       // submission sticks around for optimistic/pending UI.
-      if (state.transition.type === "actionReload") {
+      if (
+        state.transition.type === "actionReload" ||
+        ((location.state as any)?.isRedirect &&
+          (location.state as any)?.type === "action")
+      ) {
         let locationState: Redirects["Action"] = {
           isRedirect: true,
           type: "action",
@@ -1302,7 +1308,10 @@ export function createTransitionManager(init: TransitionManagerInit) {
         let locationState: Redirects["Loader"] = {
           isRedirect: true,
           type: "loader",
-          setCookie: redirect.setCookie,
+          // If we're in the middle of a setCookie redirect, we need to preserve
+          // the flag so we handle revalidations across multi-redirect scenarios
+          setCookie:
+            redirect.setCookie || (location.state as any)?.setCookie === true,
         };
         init.onRedirect(redirect.location, locationState);
       }


### PR DESCRIPTION
There is some stateful information driving whether or not we revalidate inside transition manager which was getting lost across a redirect boundaries in certain scenarios.  This PR fixes two potential flows:

1. action submission redirects, then loader redirects
   1. We go `actionRedirect -> normalRedirect` and the second loader execution skips reused parent routes
   2. This is fixed by keeping subsequent redirects marked as `actionRedirect`
2. loader redirects with a cookie
   1. We go normalRedirect -> normalRedirect but we lose the `location.state.setCookie` flag on the second redirect
   2. This is fixed by carrying forth the `setCookie` flag from the current navigation when kicking off a new `normalRedirect`

Closes: #3302 

- [x] Tests

Testing Strategy:
* Tested locally with https://github.com/jangerhofer/remixRootRouteRedirectReproduction
* Added 2 new integration tests