### PR TITLE
fix `create-remix` missing peerDeps

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -368,3 +368,4 @@
 - zachdtaylor
 - zainfathoni
 - zhe
+- vovsemenv

--- a/packages/create-remix/package.json
+++ b/packages/create-remix/package.json
@@ -16,6 +16,8 @@
     "create-remix": "cli.js"
   },
   "dependencies": {
-    "@remix-run/dev": "1.5.1"
+    "@remix-run/dev": "1.5.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   }
 }


### PR DESCRIPTION
Testing Strategy:
just run `pnpx create-remix` and you will get this warnings

```
 WARN  Issues with peer dependencies found
.
└─┬ create-remix
  └─┬ @remix-run/dev
    ├─┬ @remix-run/server-runtime
    │ ├── ✕ missing peer react@>=16.8
    │ ├── ✕ missing peer react-dom@>=16.8
    │ └─┬ react-router-dom
    │   ├── ✕ missing peer react@>=16.8
    │   ├── ✕ missing peer react-dom@>=16.8
    │   └─┬ react-router
    │     └── ✕ missing peer react@>=16.8
    └─┬ jscodeshift
      └── ✕ missing peer @babel/preset-env@^7.1.6
Peer dependencies that should be installed:
  @babel/preset-env@^7.1.6  react-dom@>=16.8.0        react@>=16.8.0    
```

`@babel/preset-env` warnings was fixed by https://github.com/remix-run/remix/pull/3413
and this PR fix two other warnings
