### PR TITLE
docs(examples): add firestore rules to `firebase-auth-firestore` example

### DIFF
--- a/examples/firebase-auth-firestore/firebase-fixtures/auth/config.json
+++ b/examples/firebase-auth-firestore/firebase-fixtures/auth/config.json
@@ -1,0 +1,6 @@
+{
+  "signIn": {
+    "allowDuplicateEmails": false
+  },
+  "usageMode": "DEFAULT"
+}

--- a/examples/firebase-auth-firestore/firebase-fixtures/auth/config.json
+++ b/examples/firebase-auth-firestore/firebase-fixtures/auth/config.json
@@ -1,6 +1,5 @@
 {
   "signIn": {
     "allowDuplicateEmails": false
-  },
-  "usageMode": "DEFAULT"
+  }
 }

--- a/examples/firebase-auth-firestore/firebase-fixtures/firestore.rules
+++ b/examples/firebase-auth-firestore/firebase-fixtures/firestore.rules
@@ -1,0 +1,10 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // All reads and writes are done via firebase-admin, which skips Firebase rules.
+    // This disables public access to all Firestore data.
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/examples/firebase-auth-firestore/firebase.json
+++ b/examples/firebase-auth-firestore/firebase.json
@@ -9,5 +9,8 @@
     "ui": {
       "enabled": true
     }
+  },
+  "firestore": {
+    "rules": "./firebase-fixtures/firestore.rules"
   }
 }


### PR DESCRIPTION
Add a firestore.rules file ([docs](https://firebase.google.com/docs/firestore/security/get-started)) that disables public access to all Firestore data.

All reads and writes are done via firebase-admin, which skips Firebase rules.

Also added a auth/config.json file to silence auth warning during emulator startup:

```sh
$ yarn emulators
...
⚠  auth: Skipped importing config because /remix/examples/firebase-auth-firestore/firebase-fixtures/auth/config.json does not exist.
```