### PR TITLE
fix(templates/deno): fix `resolve_nom_imports`

### DIFF
--- a/templates/deno/.vscode/resolve_npm_imports.json
+++ b/templates/deno/.vscode/resolve_npm_imports.json
@@ -5,7 +5,7 @@
   "// Deno-only dependencies may be imported via URL imports (without using import maps).": "",
   "imports": {
     "// `@remix-run/deno` code is already a Deno module, so just get types for it directly from `node_modules/`": "",
-    "@remix-run/deno": "https://esm.sh/@remix-run/deno@1.6.0",
+    "@remix-run/deno": "../node_modules/@remix-run/deno/index.ts",
     "@remix-run/dev/server-build": "https://esm.sh/@remix-run/dev@1.6.0/server-build",
     "@remix-run/react": "https://esm.sh/@remix-run/react@1.6.0",
     "react": "https://esm.sh/react@17.0.2",


### PR DESCRIPTION
Seems like this went wrong when merging `main` into `release-v1.6.0` (1cd43bee)

This PR is making sure we keep what @pcattori did in #3278