### PR TITLE
bug reproduction: returned variable from fetch() is not an instance of global `Response`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -288,6 +288,7 @@
 - manan30
 - manosim
 - mantey-github
+- manV
 - manzano78
 - manzoorwanijk
 - marcisbee

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -87,7 +87,7 @@ test("returned variable from fetch() should be instance of global Response", asy
   // let app = new PlaywrightFixture(appFixture, page);
   // You can test any request your app might get using `fixture`.
   let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch('is not an instance of global Response');
+  expect(await response.text()).toMatch('is an instance of global Response');
 
   // If you need to test interactivity use the `app`
   // await app.goto("/");

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -49,10 +49,13 @@ test.beforeAll(async () => {
     files: {
       "app/routes/index.jsx": js`
         import { json } from "@remix-run/node";
-        import { useLoaderData, Link } from "@remix-run/react";
+        import { useLoaderData } from "@remix-run/react";
+        
 
-        export function loader() {
-          return json("pizza");
+        export async function loader() {
+          const resp = await fetch('https://reqres.in/api/users?page=2');
+        
+          return (resp instanceof Response) ? 'is an instance of global Response' : 'is not an instance of global Response';
         }
 
         export default function Index() {
@@ -60,15 +63,8 @@ test.beforeAll(async () => {
           return (
             <div>
               {data}
-              <Link to="/burgers">Other Route</Link>
             </div>
           )
-        }
-      `,
-
-      "app/routes/burgers.jsx": js`
-        export default function Index() {
-          return <div>cheeseburger</div>;
         }
       `,
     },
@@ -87,16 +83,16 @@ test.afterAll(() => {
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("[description of what you expect it to do]", async ({ page }) => {
-  let app = new PlaywrightFixture(appFixture, page);
+test("returned variable from fetch() should be instance of global Response", async ({ page }) => {
+  // let app = new PlaywrightFixture(appFixture, page);
   // You can test any request your app might get using `fixture`.
   let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch("pizza");
+  expect(await response.text()).toMatch('is not an instance of global Response');
 
   // If you need to test interactivity use the `app`
-  await app.goto("/");
-  await app.clickLink("/burgers");
-  expect(await app.getHtml()).toMatch("cheeseburger");
+  // await app.goto("/");
+  // await app.clickLink("/burgers");
+  // expect(await app.getHtml()).toMatch("cheeseburger");
 
   // If you're not sure what's going on, you can "poke" the app, it'll
   // automatically open up in your browser for 20 seconds, so be quick!


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

- [ ] Docs
- [x] Tests

Testing Strategy:

The returned variable from fetch should be an instance of global variable `Response` but it does not seem to be the case.

however it seems to be an instance of `Response` from `@remix-run/web-fetch`

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
