### PR TITLE
chore(docs,examples,templates): use short JSDOC type notation in configs

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -12,9 +12,7 @@ A lot of Remix APIs aren't imported from the `"@remix-run/*"` packages, but are 
 This file has a few build and development configuration options, but does not actually run on your server.
 
 ```tsx filename=remix.config.js
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   appDirectory: "app",
   assetsBuildDirectory: "public/build",
@@ -143,10 +141,8 @@ A list of regex patterns that determines if a module is transpiled and included 
 
 For example, the `unified` ecosystem is all ESM-only. Let's also say we're using a `@sindresorhus/slugify` which is ESM-only as well. Here's how you would be able to consume those packages in a CJS app without having to use dynamic imports:
 
-```ts filename=remix.config.js lines=[10-15]
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+```ts filename=remix.config.js lines=[8-13]
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   appDirectory: "app",
   assetsBuildDirectory: "public/build",

--- a/docs/guides/migrating-react-router-app.md
+++ b/docs/guides/migrating-react-router-app.md
@@ -332,6 +332,7 @@ Further configuration is optional, but the following may be helpful to optimize 
 Every Remix app accepts a `remix.config.js` file in the project root. While its settings are optional, we recommend you include a few of them for clarity's sake. See the [docs on configuration](../api/conventions#remixconfigjs) for more information about all available options.
 
 ```js filename=remix.config.js
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   appDirectory: "app",
   ignoredRouteFiles: ["**/.*"],

--- a/docs/pages/gotchas.md
+++ b/docs/pages/gotchas.md
@@ -109,6 +109,7 @@ To fix it, add the ESM package to the `serverDependenciesToBundle` option in you
 In our case here we're using the `dot-prop` package, so we would do it like this:
 
 ```js filename=remix.config.js
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   serverDependenciesToBundle: ["dot-prop"],
   // ...

--- a/docs/prettier.config.js
+++ b/docs/prettier.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('prettier').Options}
- */
+/** @type {import('prettier').Options} */
 module.exports = {
   ...require("../prettier.config"),
   printWidth: 60,

--- a/examples/basic/remix.config.js
+++ b/examples/basic/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/blog-tutorial/remix.config.js
+++ b/examples/blog-tutorial/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   cacheDirectory: "./node_modules/.cache/remix",
   ignoredRouteFiles: ["**/.*", "**/*.css", "**/*.test.{js,jsx,ts,tsx}"],

--- a/examples/bullmq-task-queue/remix.config.js
+++ b/examples/bullmq-task-queue/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev/config').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   appDirectory: "app",
   browserBuildDirectory: "public/build",

--- a/examples/catch-boundary/remix.config.js
+++ b/examples/catch-boundary/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/chakra-ui/remix.config.js
+++ b/examples/chakra-ui/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/client-only-components/remix.config.js
+++ b/examples/client-only-components/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/client-side-validation/remix.config.js
+++ b/examples/client-side-validation/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/collected-notes/remix.config.js
+++ b/examples/collected-notes/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/combobox-resource-route/remix.config.js
+++ b/examples/combobox-resource-route/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/dark-mode/remix.config.js
+++ b/examples/dark-mode/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/dataloader/remix.config.js
+++ b/examples/dataloader/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   serverBuildDirectory: "server/build",

--- a/examples/emotion/remix.config.js
+++ b/examples/emotion/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/file-and-cloudinary-upload/remix.config.js
+++ b/examples/file-and-cloudinary-upload/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/firebase-auth-firestore/remix.config.js
+++ b/examples/firebase-auth-firestore/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/form-to-notion-db/remix.config.js
+++ b/examples/form-to-notion-db/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/framer-motion/remix.config.js
+++ b/examples/framer-motion/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/framer-route-animation/remix.config.js
+++ b/examples/framer-route-animation/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/gdpr-cookie-consent/remix.config.js
+++ b/examples/gdpr-cookie-consent/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/google-analytics/remix.config.js
+++ b/examples/google-analytics/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/graphql-api/remix.config.js
+++ b/examples/graphql-api/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/image-resize/remix.config.js
+++ b/examples/image-resize/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/infinite-scrolling/remix.config.js
+++ b/examples/infinite-scrolling/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/io-ts-formdata-decoding/remix.config.js
+++ b/examples/io-ts-formdata-decoding/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/ioredis/remix.config.js
+++ b/examples/ioredis/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/jokes/remix.config.js
+++ b/examples/jokes/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/mantine/remix.config.js
+++ b/examples/mantine/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/msw/remix.config.js
+++ b/examples/msw/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/multiple-forms/remix.config.js
+++ b/examples/multiple-forms/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/multiple-params/remix.config.js
+++ b/examples/multiple-params/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/newsletter-signup/remix.config.js
+++ b/examples/newsletter-signup/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/nprogress/remix.config.js
+++ b/examples/nprogress/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/on-demand-hydration/remix.config.js
+++ b/examples/on-demand-hydration/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/outlet-form-rerender/remix.config.js
+++ b/examples/outlet-form-rerender/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/pathless-routes/remix.config.js
+++ b/examples/pathless-routes/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/pm-app/remix.config.js
+++ b/examples/pm-app/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/quirrel/remix.config.js
+++ b/examples/quirrel/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/react-spring/remix.config.js
+++ b/examples/react-spring/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/redis-upstash-session/remix.config.js
+++ b/examples/redis-upstash-session/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/remix-auth-auth0/remix.config.js
+++ b/examples/remix-auth-auth0/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/remix-auth-form/remix.config.js
+++ b/examples/remix-auth-form/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/remix-auth-github/remix.config.js
+++ b/examples/remix-auth-github/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/remix-auth-supabase-github/remix.config.js
+++ b/examples/remix-auth-supabase-github/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/remix-auth-supabase/remix.config.js
+++ b/examples/remix-auth-supabase/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/route-modal/remix.config.js
+++ b/examples/route-modal/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/routes-gen/remix.config.js
+++ b/examples/routes-gen/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/rust/remix.config.js
+++ b/examples/rust/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/sanity/remix.config.js
+++ b/examples/sanity/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/sass/remix.config.js
+++ b/examples/sass/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/search-input/remix.config.js
+++ b/examples/search-input/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/session-flash/remix.config.js
+++ b/examples/session-flash/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/sharing-loader-data/remix.config.js
+++ b/examples/sharing-loader-data/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/socket.io/remix.config.js
+++ b/examples/socket.io/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   serverBuildDirectory: "server/build",

--- a/examples/stitches/remix.config.js
+++ b/examples/stitches/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/strapi/remix.config.js
+++ b/examples/strapi/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/stripe-integration/remix.config.js
+++ b/examples/stripe-integration/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/styled-components/remix.config.js
+++ b/examples/styled-components/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/styletron/remix.config.js
+++ b/examples/styletron/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: [".*"],
   // appDirectory: "app",

--- a/examples/supabase-subscription/remix.config.js
+++ b/examples/supabase-subscription/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/tailwindcss/remix.config.js
+++ b/examples/tailwindcss/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/template/remix.config.js
+++ b/examples/template/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/tiptap-collab-editing/remix.config.js
+++ b/examples/tiptap-collab-editing/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/toast-message/remix.config.js
+++ b/examples/toast-message/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/turborepo-vercel/apps/remix-app/remix.config.js
+++ b/examples/turborepo-vercel/apps/remix-app/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/examples/twind/remix.config.js
+++ b/examples/twind/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   appDirectory: "app",

--- a/examples/usematches-loader-data/remix.config.js
+++ b/examples/usematches-loader-data/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/integration/helpers/cf-template/remix.config.js
+++ b/integration/helpers/cf-template/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   serverBuildTarget: "cloudflare-workers",
   server: "./server.js",

--- a/integration/helpers/deno-template/remix.config.js
+++ b/integration/helpers/deno-template/remix.config.js
@@ -1,3 +1,4 @@
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   serverBuildTarget: "deno",
   server: "./server.ts",

--- a/integration/helpers/node-template/remix.config.js
+++ b/integration/helpers/node-template/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/packages/remix-dev/__tests__/fixtures/replace-remix-imports/remix.config.js
+++ b/packages/remix-dev/__tests__/fixtures/replace-remix-imports/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   cacheDirectory: "./node_modules/.cache/remix",
   ignoredRouteFiles: [".*", "**/*.css", "**/*.test.{js,jsx,ts,tsx}"],

--- a/packages/remix-dev/__tests__/fixtures/stack/remix.config.js
+++ b/packages/remix-dev/__tests__/fixtures/stack/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/packages/remix-eslint-config/index.js
+++ b/packages/remix-eslint-config/index.js
@@ -18,9 +18,7 @@ const OFF = 0;
 // const WARN = 1;
 // const ERROR = 2;
 
-/**
- * @type {import("eslint").Linter.Config}
- */
+/** @type {import('eslint').Linter.Config} */
 const config = {
   parser: "@babel/eslint-parser",
   parserOptions: {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,2 @@
-/**
- * @type {import('prettier').Options}
- */
+/** @type {import('prettier').Options} */
 module.exports = {};

--- a/scripts/playground/template/remix.config.js
+++ b/scripts/playground/template/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   cacheDirectory: "./node_modules/.cache/remix",
   ignoredRouteFiles: ["**/.*", "**/*.css", "**/*.test.{js,jsx,ts,tsx}"],

--- a/templates/arc/remix.config.js
+++ b/templates/arc/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   serverBuildTarget: "arc",
   server: "./server.js",

--- a/templates/cloudflare-pages/remix.config.js
+++ b/templates/cloudflare-pages/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   serverBuildTarget: "cloudflare-pages",
   server: "./server.js",

--- a/templates/cloudflare-workers/remix.config.js
+++ b/templates/cloudflare-workers/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   serverBuildTarget: "cloudflare-workers",
   server: "./server.js",

--- a/templates/deno/remix.config.js
+++ b/templates/deno/remix.config.js
@@ -1,3 +1,4 @@
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   serverBuildTarget: "deno",
   server: "./server.ts",

--- a/templates/express/remix.config.js
+++ b/templates/express/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/templates/fly/remix.config.js
+++ b/templates/fly/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/templates/netlify/remix.config.js
+++ b/templates/netlify/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   serverBuildTarget: "netlify",
   server: "./server.js",

--- a/templates/remix/remix.config.js
+++ b/templates/remix/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",

--- a/templates/vercel/remix.config.js
+++ b/templates/vercel/remix.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   serverBuildTarget: "vercel",
   // When running locally in development mode, we use the built in remix


### PR DESCRIPTION
We do this in all our configs, except examples & templates