### PR TITLE
docs(pages/contributing): add requirement to install `playwright`

### DIFF
--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -40,7 +40,7 @@ The following steps will get you setup to contribute changes to this repo:
 
 3. Install dependencies by running `yarn`. Remix uses [`yarn` (version 1)](https://classic.yarnpkg.com/lang/en/docs/install), so you should too. If you install using `npm`, unnecessary `package-lock.json` files will be generated.
 
-4. Install playwright to be able to run tests properly by running `npx playwright install` or [use visual studio plugin](https://playwright.dev/docs/intro#using-the-vs-code-extension)
+4. Install `playwright` to be able to run tests properly by running `npx playwright install` or [use visual studio plugin](https://playwright.dev/docs/intro#using-the-vs-code-extension)
 
 5. Verify you've got everything set up for local development by running `yarn test`
 

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -39,7 +39,10 @@ The following steps will get you setup to contribute changes to this repo:
    ```
 
 3. Install dependencies by running `yarn`. Remix uses [`yarn` (version 1)](https://classic.yarnpkg.com/lang/en/docs/install), so you should too. If you install using `npm`, unnecessary `package-lock.json` files will be generated.
-4. Verify you've got everything set up for local development by running `yarn test`
+
+4. Install playwright to be able to run tests properly by running `npx playwright install` or [use visual studio plugin](https://playwright.dev/docs/intro#using-the-vs-code-extension)
+
+5. Verify you've got everything set up for local development by running `yarn test`
 
 ## Think You Found a Bug?
 


### PR DESCRIPTION
When you get a fresh clone of your fork and run through the setup for contributing you are likely to get an error asking you to install browsers with playwright - unless it was previously installed for another project.  Message comes from [here](https://github.com/microsoft/playwright/blob/3853014fa74033110bd032b195e4bde812fe3cc8/packages/playwright-core/src/server/registry/index.ts#L318-L335)  in from playwright.

This is just a quick update to make sure to run the browser install before testing to confirm your ready to contribute!



- [x] Docs

