### PR TITLE
docs: update incorrect fetcher.type "load" to "normalLoad"

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -153,6 +153,7 @@
 - jaydiablo
 - jca41
 - jdeniau
+- JeffBeltran
 - jenseng
 - jeremyjfleming
 - jesse-deboer

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -812,7 +812,7 @@ This is the type of state the fetcher is in. It's like `fetcher.state`, but more
 
   - **actionReload** - The action from an "actionSubmission" returned data and the loaders on the page are being reloaded.
   - **actionRedirect** - The action from an "actionSubmission" returned a redirect and the page is transitioning to the new location.
-  - **load** - A route's loader is being called without a submission (`fetcher.load()`).
+  - **normalLoad** - A route's loader is being called without a submission (`fetcher.load()`).
 
 #### `fetcher.submission`
 


### PR DESCRIPTION
updated the docs for `fetcher.type` from `load` to `normalLoad`