### PR TITLE
docs(guides/not-found): add notice about catch propagation requiring a React component export

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -429,6 +429,7 @@
 - rossipedia
 - RossJHagan
 - RossMcMillan92
+- rowanc1
 - rowinbot
 - rphlmr
 - rtabulov

--- a/docs/guides/not-found.md
+++ b/docs/guides/not-found.md
@@ -40,6 +40,8 @@ What's nice about throwing a response is that code in your loader _stops executi
 
 Throwing also ensures that your route component doesn't render if the loader wasn't successful. Your route components only have to consider the "happy path". They don't need pending states, error states, or in our case here, not-found states.
 
+Note, you must have a default route component exported on every child route for the `CatchBoundary` to propogate properly (e.g. no redirects in loaders, etc.).
+
 ## Root Catch Boundary
 
 You probably already have one at the root of your app. This will handle all thrown responses that weren't handled in a nested route (more on that in a sec). Here's a sample:


### PR DESCRIPTION
Scenario:
* I had an index page that redirected to another page, and so I didn't have an exported react component `Outlet`
* This meant that the catch boundary didn't propagate to the root, and it was really hard to track down :(

I think it makes sense as a feature/design, but could use a note in the docs!

Not sure about the wording, but gave it a shot ... !