### PR TITLE
docs(guides/data-writes): fix `form`/`Form` explanation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -359,6 +359,7 @@
 - vimutti77
 - visormatt
 - vkrol
+- vlindhol
 - weavdale
 - wKovacs64
 - wladiston

--- a/docs/guides/data-writes.md
+++ b/docs/guides/data-writes.md
@@ -292,7 +292,7 @@ You can ship this code as-is. The browser will handle the pending UI and interru
 
 ### Graduate to `<Form>` and add pending UI
 
-Let's use progressive enhancement to make this UX a bit more fancy. By changing it from `<Form reloadDocument>` to `<Form>`, Remix will emulate the browser behavior with `fetch`. It will also give you access to the pending form data so you can build pending UI.
+Let's use progressive enhancement to make this UX a bit more fancy. By changing it from `<form>` to `<Form>`, Remix will emulate the browser behavior with `fetch`. It will also give you access to the pending form data so you can build pending UI.
 
 ```tsx [2, 11]
 import { redirect } from "@remix-run/node"; // or "@remix-run/cloudflare"


### PR DESCRIPTION
The issue here is that `<Form reloadDocument />` hasn't been mentioned yet, neither in text nor code. So the reader following along with the guide will have `<form />` implemented in their editor at this point.

Note that the next paragraph goes into why `Form` needs the `reloadDocument` prop to be equivalent to `form`, which makes sense, and then we can forget about `form` altogether.
