### PR TITLE
chore(integration): fix type errors and start enforcing type checks

### DIFF
--- a/integration/esm-only-warning-test.ts
+++ b/integration/esm-only-warning-test.ts
@@ -128,7 +128,7 @@ test.beforeAll(async () => {
     },
   });
 
-  let chunks = [];
+  let chunks: Buffer[] = [];
   buildOutput = await new Promise<string>((resolve, reject) => {
     buildStdio.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
     buildStdio.on("error", (err) => reject(err));

--- a/integration/prefetch-test.ts
+++ b/integration/prefetch-test.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
 import type { Fixture, AppFixture } from "./helpers/create-fixture";
-import type { RemixLinkProps } from "../build/node_modules/@remix-run/react/components";
+import type { RemixLinkProps } from "../build/node_modules/@remix-run/react/dist/components";
 import { PlaywrightFixture } from "./helpers/playwright-fixture";
 
 // Generate the test app using the given prefetch mode

--- a/integration/tsconfig-test.ts
+++ b/integration/tsconfig-test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "@playwright/test";
 import fse from "fs-extra";
 import path from "path";
 import JSON5 from "json5";
+import type { TsConfigJson } from "type-fest";
 
 import { createFixture, json } from "./helpers/create-fixture";
 
@@ -11,8 +12,15 @@ async function getTsConfig(projectDir: string) {
   return JSON5.parse(config);
 }
 
+// Omit non JSON-serializable things we don't need
+type SerializableTsConfigJson = Omit<
+  TsConfigJson,
+  "compilerOptions" | "references" | "typeAcquisition" | "watchOptions"
+> & {
+  compilerOptions: Omit<TsConfigJson.CompilerOptions, "plugins">;
+};
 // this is the default tsconfig.json that is shipped with `create-remix` templates
-const DEFAULT_CONFIG = {
+const DEFAULT_CONFIG: SerializableTsConfigJson = {
   include: ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
   compilerOptions: {
     allowJs: true,

--- a/integration/tsconfig.json
+++ b/integration/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "exclude": ["helpers/*-template"],
+  "compilerOptions": {
+    "lib": ["ES2019"],
+    "target": "ES2019",
+    "module": "CommonJS",
+    "skipLibCheck": true,
+
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "resolveJsonModule": true,
+
+    "noEmit": true,
+
+    "rootDir": "."
+  },
+  "references": [
+    { "path": "../packages/remix-express" },
+    { "path": "../packages/remix-react" },
+    { "path": "../packages/remix-server-runtime" }
+  ]
+}

--- a/packages/remix-express/tsconfig.json
+++ b/packages/remix-express/tsconfig.json
@@ -10,6 +10,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
-    "outDir": "../../build/node_modules/@remix-run/express/dist"
+    "outDir": "../../build/node_modules/@remix-run/express/dist",
+    "composite": true
   }
 }

--- a/packages/remix-react/tsconfig.json
+++ b/packages/remix-react/tsconfig.json
@@ -12,6 +12,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
-    "outDir": "../../build/node_modules/@remix-run/react/dist"
+    "outDir": "../../build/node_modules/@remix-run/react/dist",
+    "composite": true
   }
 }

--- a/packages/remix-server-runtime/tsconfig.json
+++ b/packages/remix-server-runtime/tsconfig.json
@@ -11,6 +11,7 @@
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/@remix-run/server-runtime/dist",
+    "composite": true,
 
     // Avoid naming conflicts between lib.dom.d.ts and globals.ts
     "skipLibCheck": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "exclude": ["node_modules", "build"],
   "references": [
+    { "path": "integration" },
     { "path": "packages/create-remix" },
     { "path": "packages/remix" },
     { "path": "packages/remix-architect" },


### PR DESCRIPTION
Fix errors that currently show up in VSCode with typescript 4.5.5 (the current version Remix uses). Playwright only transpiles typescript, it doesn't do any type checking. In addition to fixing the errors, start type checking `integration` when we build.