### PR TITLE
feat(remix-react): make `actionData` available in `meta` function

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -266,6 +266,7 @@
 - kayac-chang
 - kbariotis
 - KenanYusuf
+- kenneth-gray
 - kentcdodds
 - kevinrambaud
 - kevlened

--- a/docs/route/meta.md
+++ b/docs/route/meta.md
@@ -68,6 +68,7 @@ export const meta: MetaFunction = () => ({
 `meta` function is passed an object that has following data:
 
 - `data` is whatever exported by `loader` function
+- `actionData` is the data returned by the `action` function
 - `location` is a `window.location`-like object that has some data about the current route
 - `params` is an object containing route params
 - `parentsData` is a hashmap of all the data exported by `loader` functions of current route and all of its parents

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -61,6 +61,24 @@ test.describe("meta", () => {
           }
         `,
 
+        "app/routes/action.jsx": js`
+          export const action = async () => {
+            return { error: true };
+          };
+
+          export const meta = ({ actionData }) => ({
+            title: (actionData && actionData.error ? 'Error: ' : '') + 'Action',
+          });
+
+          export default function Action() {
+            return (
+              <form method="POST">
+                <button type="submit">Submit</button>
+              </form>
+            );
+          }
+        `,
+
         "app/routes/music.jsx": js`
           export function meta({ data }) {
             return {
@@ -383,6 +401,16 @@ test.describe("meta", () => {
       await app.goto("/blog");
       expect(await app.getHtml("title")).toBe("<title>Blog Posts</title>");
     });
+  });
+
+  test("meta receives actionData when available", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+
+    await app.goto("/action");
+    expect((await app.getElement("title")).text()).toEqual("Action");
+
+    await page.click("button[type=submit]");
+    expect((await app.getElement("title")).text()).toEqual("Error: Action");
   });
 });
 

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -589,6 +589,7 @@ function V1Meta() {
     errors,
     matches: routerMatches,
     loaderData,
+    actionData: actionRouteData,
   } = useDataRouterStateContext();
   let location = useLocation();
 
@@ -605,6 +606,7 @@ function V1Meta() {
   for (let match of matches) {
     let routeId = match.route.id;
     let data = loaderData[routeId];
+    let actionData = actionRouteData ? actionRouteData[routeId] : null;
     let params = match.params;
 
     let routeModule = routeModules[routeId];
@@ -614,6 +616,7 @@ function V1Meta() {
         typeof routeModule.meta === "function"
           ? (routeModule.meta as V1_MetaFunction)({
               data,
+              actionData,
               parentsData,
               params,
               location,

--- a/packages/remix-react/routeModules.ts
+++ b/packages/remix-react/routeModules.ts
@@ -77,6 +77,7 @@ export interface LinksFunction {
 export interface V1_MetaFunction {
   (args: {
     data: AppData;
+    actionData: AppData;
     parentsData: RouteData;
     params: Params;
     location: Location;


### PR DESCRIPTION
Hey folks :wave:

Thought I'd give this a go as it didn't take long - no hard feelings if you feel it's the wrong way to go of course!

Things to consider:
- As mentioned in the discussion I suspect it would be nicer to rename `data` => `loaderData`, but that's a breaking change to the API.
- If `data` was renamed to `loaderData`, should `parentsData` be renamed to `parentsLoaderData`?
- I started to wonder if the cookie header should also be made available (if it's not `http` only), so that if your strategy is to use session cookies for error messaging then you'd be able to access that too.

Closes: #3524

- [x] Docs
- [x] Tests

Testing Strategy:

This test covers this code: `integration/meta-test.ts` (added additional test)