### PR TITLE
fix(templates/cloudflare-pages): fix start script

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -162,6 +162,7 @@
 - hicksy
 - himorishige
 - hkan
+- hokaccha
 - Holben888
 - hollandThomas
 - Hopsken

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -3,10 +3,11 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
+    "wrangler": "wrangler pages dev ./public",
     "dev:remix": "remix watch",
-    "dev:wrangler": "cross-env NODE_ENV=development wrangler pages dev ./public",
+    "dev:wrangler": "cross-env NODE_ENV=development npm run wrangler",
     "dev": "remix build && run-p \"dev:*\"",
-    "start": "cross-env NODE_ENV=production wrangler pages dev ./public",
+    "start": "cross-env NODE_ENV=production npm run wrangler",
     "typecheck": "tsc -b"
   },
   "dependencies": {

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -6,7 +6,7 @@
     "dev:remix": "remix watch",
     "dev:wrangler": "cross-env NODE_ENV=development wrangler pages dev ./public",
     "dev": "remix build && run-p \"dev:*\"",
-    "start": "cross-env NODE_ENV=production npm run dev:wrangler",
+    "start": "cross-env NODE_ENV=production wrangler pages dev ./public",
     "typecheck": "tsc -b"
   },
   "dependencies": {

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -3,12 +3,12 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
-    "wrangler": "wrangler pages dev ./public",
     "dev:remix": "remix watch",
     "dev:wrangler": "cross-env NODE_ENV=development npm run wrangler",
     "dev": "remix build && run-p \"dev:*\"",
     "start": "cross-env NODE_ENV=production npm run wrangler",
-    "typecheck": "tsc -b"
+    "typecheck": "tsc -b",
+    "wrangler": "wrangler pages dev ./public"
   },
   "dependencies": {
     "@remix-run/cloudflare": "*",


### PR DESCRIPTION
`NODE_ENV` in `start` script was set to `development` instead of `production` because `dev:wrangler` script overwrites `NODE_ENV` with `development`.

Testing Strategy:

```
$ cd ~/path/to/remix-run/remix
$ yarn install
$ yarn build
$ node ./build/node_modules/create-remix/cli.js --template ./templates/cloudflare-pages my-app
$ cd my-app
$ echo 'console.log("NODE_ENV:", process.env.NODE_ENV);' >> ./node_modules/.bin/wrangler
$ npm run start | grep NODE_ENV:
NODE_ENV: production
```

