### PR TITLE
fix: remove `magicExports` from Cloudflare adapters

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -569,18 +569,6 @@ function getMagicExports(packageName) {
           "@remix-run/architect": ["createArcTableSessionStorage"],
         },
       };
-    case "@remix-run/cloudflare-pages":
-      return {
-        values: {
-          "@remix-run/cloudflare": ["createCloudflareKVSessionStorage"],
-        },
-      };
-    case "@remix-run/cloudflare-workers":
-      return {
-        values: {
-          "@remix-run/cloudflare": ["createCloudflareKVSessionStorage"],
-        },
-      };
     case "@remix-run/cloudflare":
       return {
         values: {


### PR DESCRIPTION
As mentioned in https://github.com/remix-run/remix/pull/3543#discussion_r904351212, we already have these exported by `@remix-run/cloudflare` & people will have `remix setup cloudflare` in their `postinstall` script