### PR TITLE
docs: jokes app tutorial in fetching jokes part

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -375,3 +375,4 @@
 - zachdtaylor
 - zainfathoni
 - zhe
+- justinsalasdev

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1620,20 +1620,23 @@ Remix and the `tsconfig.json` you get from the starter template are configured t
 
 <summary>app/routes/jokes.tsx</summary>
 
-```tsx filename=app/routes/jokes.tsx lines=[3,4,6,12,19-21,23-28,31,55-59]
+```tsx filename=app/routes/jokes.tsx lines=[3,6,8,16,23-25,27-32,35,59-63]
 import type {
   LinksFunction,
   LoaderFunction,
-  json,
 } from "@remix-run/node";
+
 import type { Joke } from "@prisma/client";
+
+import { json } from "@remix-run/node";
+
 import {
   Link,
   Outlet,
   useLoaderData,
 } from "@remix-run/react";
 
-import { db } from "~/utils/db.server";
+import { db } from "~/utils/db.server"; 
 import stylesUrl from "~/styles/jokes.css";
 
 export const links: LinksFunction = () => {
@@ -1652,7 +1655,7 @@ export const loader: LoaderFunction = async () => {
 };
 
 export default function JokesRoute() {
-  const data = useLoaderData<LoaderData>();
+  const data = useLoaderData<LoaderData>();35
 
   return (
     <div className="jokes-layout">
@@ -1708,7 +1711,7 @@ I want to call out something specific in my solution. Here's my loader:
 
 ```tsx lines=[2,8-10]
 type LoaderData = {
-  jokeListItems: Array<Pick<Joke,"id" | "name">>;
+  jokeListItems: Array<{ id: string; name: string }>;
 };
 
 export const loader: LoaderFunction = async () => {

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1655,7 +1655,7 @@ export const loader: LoaderFunction = async () => {
 };
 
 export default function JokesRoute() {
-  const data = useLoaderData<LoaderData>();35
+  const data = useLoaderData<LoaderData>();
 
   return (
     <div className="jokes-layout">

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1706,9 +1706,9 @@ And here's what we have with that now:
 
 I want to call out something specific in my solution. Here's my loader:
 
-```tsx lines=[8-10]
+```tsx lines=[2,8-10]
 type LoaderData = {
-  jokeListItems: Array<{ id: string; name: string }>;
+  jokeListItems: Array<Pick<Joke,"id" | "name">>;
 };
 
 export const loader: LoaderFunction = async () => {

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1585,11 +1585,11 @@ import type { Joke } from "@prisma/client";
 
 import { db } from "~/utils/db.server";
 
-type LoaderData = { users: Array<Joke> };
+type LoaderData = { jokes: Array<Joke> };
 
 export const loader: LoaderFunction = async () => {
   const data: LoaderData = {
-    users: await db.user.findMany(),
+    users: await db.joke.findMany(),
   };
   return json(data);
 };

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1581,25 +1581,25 @@ To _load_ data in a Remix route module, you use a [`loader`][loader]. This is si
 import type { LoaderFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
-import type { Joke } from "@prisma/client";
+import type { Sandwich } from "@prisma/client";
 
 import { db } from "~/utils/db.server";
 
-type LoaderData = { jokes: Array<Joke> };
+type LoaderData = { sandwiches: Array<Sandwich> };
 
 export const loader: LoaderFunction = async () => {
   const data: LoaderData = {
-    users: await db.joke.findMany(),
+    sandwiches: await db.sandwich.findMany(),
   };
   return json(data);
 };
 
-export default function Jokes() {
+export default function Sandwiches() {
   const data = useLoaderData<LoaderData>();
   return (
     <ul>
-      {data.jokes.map((joke) => (
-        <li key={joke.id}>{joke.name}</li>
+      {data.sandwiches.map((sandwich) => (
+        <li key={sandwich.id}>{sandwich.name}</li>
       ))}
     </ul>
   );

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1581,11 +1581,11 @@ To _load_ data in a Remix route module, you use a [`loader`][loader]. This is si
 import type { LoaderFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
-import type { User } from "@prisma/client";
+import type { Joke } from "@prisma/client";
 
 import { db } from "~/utils/db.server";
 
-type LoaderData = { users: Array<User> };
+type LoaderData = { users: Array<Joke> };
 
 export const loader: LoaderFunction = async () => {
   const data: LoaderData = {
@@ -1594,12 +1594,12 @@ export const loader: LoaderFunction = async () => {
   return json(data);
 };
 
-export default function Users() {
+export default function Jokes() {
   const data = useLoaderData<LoaderData>();
   return (
     <ul>
-      {data.users.map((user) => (
-        <li key={user.id}>{user.name}</li>
+      {data.jokes.map((joke) => (
+        <li key={joke.id}>{joke.name}</li>
       ))}
     </ul>
   );

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1620,12 +1620,13 @@ Remix and the `tsconfig.json` you get from the starter template are configured t
 
 <summary>app/routes/jokes.tsx</summary>
 
-```tsx filename=app/routes/jokes.tsx lines=[3,5,12,19-21,23-28,31,55-59]
+```tsx filename=app/routes/jokes.tsx lines=[3,4,6,12,19-21,23-28,31,55-59]
 import type {
   LinksFunction,
   LoaderFunction,
+  json,
 } from "@remix-run/node";
-import { json } from "@remix-run/node";
+import type { Joke } from "@prisma/client";
 import {
   Link,
   Outlet,
@@ -1640,7 +1641,7 @@ export const links: LinksFunction = () => {
 };
 
 type LoaderData = {
-  jokeListItems: Array<{ id: string; name: string }>;
+  jokeListItems: Array<Joke>;
 };
 
 export const loader: LoaderFunction = async () => {


### PR DESCRIPTION
at point where reader is only done with building types for `Joke`, the example shows to import `type User` from `@prisma/client` where it is not there yet.

the succeeding code continuation also didn't use the built type from `@prisma/client`

