### PR TITLE
feat(remix-react): add `reset` function to `fetcher`s

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -363,6 +363,7 @@
 - vimutti77
 - visormatt
 - vkrol
+- Vlemert
 - vlindhol
 - weavdale
 - wKovacs64

--- a/integration/fetcher-test.ts
+++ b/integration/fetcher-test.ts
@@ -10,6 +10,7 @@ test.describe("useFetcher", () => {
 
   let CHEESESTEAK = "CHEESESTEAK";
   let LUNCH = "LUNCH";
+  let EMPTY_PLATE = "EMPTY_PLATE";
 
   test.beforeAll(async () => {
     fixture = await createFixture({
@@ -75,7 +76,12 @@ test.describe("useFetcher", () => {
                 }}>
                   submit
                 </button>
-                <pre>{fetcher.data}</pre>
+                <button id="fetcher-reset" type="button" onClick={() => {
+                  fetcher.reset();
+                }}>
+                  reset
+                </button>
+                <pre>{fetcher.data != null ? fetcher.data : "${EMPTY_PLATE}"}</pre>
               </>
             );
           }
@@ -125,8 +131,18 @@ test.describe("useFetcher", () => {
   test("load can hit a loader", async ({ page }) => {
     let app = new PlaywrightFixture(appFixture, page);
     await app.goto("/");
+    expect(await app.getHtml("pre")).toMatch(EMPTY_PLATE);
     await app.clickElement("#fetcher-load");
     expect(await app.getHtml("pre")).toMatch(LUNCH);
+  });
+
+  test("fetcher can be reset", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/");
+    await app.clickElement("#fetcher-load");
+    expect(await app.getHtml("pre")).toMatch(LUNCH);
+    await app.clickElement("#fetcher-reset");
+    expect(await app.getHtml("pre")).toMatch(EMPTY_PLATE);
   });
 
   test("submit can hit an action", async ({ page }) => {

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1382,6 +1382,9 @@ export function useFetcher<TData = any>(): FetcherWithComponents<TData> {
   let [load] = React.useState(() => (href: string) => {
     transitionManager.send({ type: "fetcher", href, key });
   });
+  let [reset] = React.useState(() => () => {
+    transitionManager.resetFetcher(key);
+  });
   let submit = useSubmitImpl(key);
 
   let fetcher = transitionManager.getFetcher<TData>(key);
@@ -1391,6 +1394,7 @@ export function useFetcher<TData = any>(): FetcherWithComponents<TData> {
       Form,
       submit,
       load,
+      reset,
       ...fetcher,
     }),
     [fetcher, Form, submit, load]

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -1369,6 +1369,15 @@ export function createTransitionManager(init: TransitionManagerInit) {
     fetchControllers.delete(key);
   }
 
+  function resetFetcher(key: string) {
+    console.debug(`[transition] resetting fetcher (key: ${key})`);
+    let fetcher = getFetcher(key);
+    invariant(fetcher, `Expected fetcher: ${key}`);
+    if (fetchControllers.has(key)) abortFetcher(key);
+    setFetcher(key, IDLE_FETCHER);
+    update({ fetchers: new Map(state.fetchers) });
+  }
+
   function markFetchRedirectsDone(): void {
     let doneKeys = [];
     for (let key of fetchRedirectIds) {
@@ -1387,6 +1396,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
     getState,
     getFetcher,
     deleteFetcher,
+    resetFetcher,
     dispose,
     get _internalFetchControllers() {
       return fetchControllers;


### PR DESCRIPTION
I probably shouldn't reopen this discussion with a PR, but it was a great opportunity to gain some insight into how Remix works and even if not landed it might serve some purpose for future discussion around this topic.

## Why this change
I think there's a good case to be made for resetting fetchers, and found a [discussion on discord](https://discord.com/channels/770287896669978684/771068344320786452/897654633936347157) that seemed to come to the same conclusion.

The case I ran into is that I have a typeahead that loads data from the server using a fetcher. Every time you click on a search result it gets added to a list and the typeahead closes and clears. When clicking on the typeahead again a new fetch happens to repopulate the typeahead based on the empty query.

If in this scenario we do nothing special, stale data will be shown. This is because `fetcher.data` will keep the stale value around while loading new data. This is great in a lot of cases, but sometimes you explicitly don't want that to happen. In this case I _know_ the data is stale the moment the user clicks on one of the typeahead suggestions, and I really don't want to show it anymore.

There are probably many other scenarios where `fetcher.reset()` would be useful, the [discussion on discord](https://discord.com/channels/770287896669978684/771068344320786452/897654633936347157) is about a file upload that the user can clear for example.

There are some solutions to work around this problem:
1. Keep track of a copy of the fetcher state, clear that whenever I want
```
let typeaheadFetcher = useFetcher();
let [data, setData] = useState(null);
useEffect(() => {
  if (uploader.state === "done") {
    setData(typeaheadFetcher.data);
  }
}, [typeaheadFetcher])
...
function onItemClick() {
  setData(null);
  // do other stuff
}
```

2. Put the typeahead results and the fetcher in a separate component and remount it whenever it needs clearing
```
function TypeaheadResults({query}) {
  let typeaheadFetcher = useFetcher();
  useEffect(() => {
    // call typeaheadFetcher.load with the current query
  }, [query]);
  
  // render the results from typeaheadFetcher
}

function Typeahead() {
  const [resultsKey, setResultsKey] = useState(0);

  function onItemClick() {
    setResultsKey(resultsKey+1);
    // do other stuff
  }

  return <TypeaheadResults key={resultsKey} />
}
```
I was going to type a lot of reasons why I believe both these options are bad but Ryan already summarised this perfectly on Discord:
<img width="681" alt="image" src="https://user-images.githubusercontent.com/343610/175325550-b3a4e27d-c089-4e5b-b293-d0b304d26419.png">
(if that is still the current thinking, but I for one believe forcing developers to use `useEffect` in app code is the opposite of what Remix could be doing)

## Why not this change
I have no idea if there are any downsides to having this functionality. There's some mentions in the [discord discussion](https://discord.com/channels/770287896669978684/771068344320786452/897654633936347157) on why it isn't there _yet_, but I don't see any major reasons why this shouldn't be supported ever.

## Formalities

Closes: #2749

- [ ] Docs
- [x] Tests

Testing Strategy:

`yarn test`

These tests covers this code:
- `integration/fetcher-test.ts`
- `packages/remix-react/__tests__/transition-test.tsx`

