### PR TITLE
docs(api/conventions): add note about how to access server-side data in `meta` function

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -161,6 +161,7 @@
 - jesseflorig
 - jgarrow
 - jiahao-c
+- jimniels
 - jkup
 - jmasson
 - JNaftali

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -1011,6 +1011,8 @@ export const meta: MetaFunction = () => {
 };
 ```
 
+<docs-warning>The `meta` function _may_ run on the server (e.g. the initial page load) or the client (e.g. a client navigation), so you cannot access server-specific data like `process.env.NODE_ENV` directly. If you need server-side data in `meta`, get the data in a loader and access it via the meta functions `data` parameter.</docs-warning>
+
 There are a few special cases (read about those below). In the case of nested routes, the meta tags are merged automatically, so parent routes can add meta tags without the child routes needing to copy them.
 
 #### `HtmlMetaDescriptor`

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -1011,7 +1011,7 @@ export const meta: MetaFunction = () => {
 };
 ```
 
-<docs-warning>The `meta` function _may_ run on the server (e.g. the initial page load) or the client (e.g. a client navigation), so you cannot access server-specific data like `process.env.NODE_ENV` directly. If you need server-side data in `meta`, get the data in a loader and access it via the meta functions `data` parameter.</docs-warning>
+<docs-warning>The `meta` function _may_ run on the server (e.g. the initial page load) or the client (e.g. a client navigation), so you cannot access server-specific data like `process.env.NODE_ENV` directly. If you need server-side data in `meta`, get the data in the `loader` and access it via the `meta` function's `data` parameter.</docs-warning>
 
 There are a few special cases (read about those below). In the case of nested routes, the meta tags are merged automatically, so parent routes can add meta tags without the child routes needing to copy them.
 


### PR DESCRIPTION
Adds clarifying context about how `meta` works under the hood (it can run on both client and server) so don't try to access server-side data directly in it.

As I found it via: https://github.com/remix-run/remix-website/pull/46#discussion_r905343443

Given that open graph tags like `og:image` are supposed to be absolute URLs, it seems pretty likely that somebody is going to need to do this at some point in time.