### PR TITLE
fix(remix-dev/cli/init): always remove `remix.init` folder

### DIFF
--- a/packages/remix-dev/__tests__/create-test.ts
+++ b/packages/remix-dev/__tests__/create-test.ts
@@ -476,8 +476,7 @@ describe("the create command", () => {
     expect(fse.existsSync(path.join(projectDir, "package.json"))).toBeTruthy();
     expect(fse.existsSync(path.join(projectDir, "app/root.tsx"))).toBeTruthy();
     expect(fse.existsSync(path.join(projectDir, "test.txt"))).toBeTruthy();
-    // if you run `remix init` keep around the remix.init directory for future use
-    expect(fse.existsSync(path.join(projectDir, "remix.init"))).toBeTruthy();
+    expect(fse.existsSync(path.join(projectDir, "remix.init"))).toBeFalsy();
   });
 
   it("throws an error when invalid remix.init script when automatically ran", async () => {

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -377,7 +377,6 @@ export async function run(argv: string[] = process.argv.slice(2)) {
         if (installDeps) {
           console.log("💿 Running remix.init script");
           await commands.init(projectDir);
-          await fse.remove(initScriptDir);
         } else {
           console.log();
           console.log(


### PR DESCRIPTION
This is important if people run `npx remix init` themselves, like suggested in https://github.com/remix-run/indie-stack/pull/112, https://github.com/remix-run/blues-stack/pull/89 & https://github.com/remix-run/grunge-stack/pull/76