### PR TITLE
bug: submit multipart/form-data with empty file input, got error on request.formData()

### DIFF
--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -92,7 +92,7 @@ test("request.formData() should not crash when a file is not provided", async ({
 
   // If you need to test interactivity use the `app`
   await app.goto("/");
-  await app.clickSubmitButton("/?index");
+  await app.clickSubmitButton("/?index"); 
 
   let html = await app.getHtml();
   expect(html).toMatch("pizza");


### PR DESCRIPTION
Originally reported in #3570, request.formData() shouldn't throw if a file is not provided.