### PR TITLE
fix(remix-dev): fix Yarn PnP resolve issue

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -15,6 +15,7 @@
 - alex-ketch
 - alexuxui
 - alireza-bonab
+- alisd23
 - alvinthen
 - amorriscode
 - andrelandgraf

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -353,8 +353,9 @@ async function createBrowserBuild(
     mdxPlugin(config),
     browserRouteModulesPlugin(config, /\?browser$/),
     emptyModulesPlugin(config, /\.server(\.[jt]sx?)?$/),
-    NodeModulesPolyfillPlugin(),
+    // Must be placed before NodeModulesPolyfillPlugin, so yarn can resolve polyfills correctly
     yarnPnpPlugin(),
+    NodeModulesPolyfillPlugin(),
   ];
 
   return esbuild.build({


### PR DESCRIPTION
Closes: (no issue yet - can create one if you like)

- [ ] Docs
- [ ] Tests

Testing Strategy:
There isn't currently an easy way for us to test yarn pnp / Remix compatibility, so this is just a local manual test.

Before this change (current dev branch, when running `remix build`, multiple errors (as below) appear, I guess because yarn cannot resolve the paths generated by the `NodeModulesPolyfills` plugin, unless the `esbuild-plugin-pnp` plugin runs first. I'm guessing the pnp plugin needs to set up some path transformation stuff before the polyfill plugin, but the docs for both are super light so I'm not 100% sure *why* it fixes the errors, but it does.

Thankfully when not using yarn pnp, `esbuild-plugin-pnp` is a no-op, so no risk to non-yarn users either way.

#### Errors before change

```
Build failed with 9 errors:
node-modules-polyfills:http:30:26: ERROR: [plugin: @yarnpkg/esbuild-plugin-pnp] Qualified path resolution failed: we looked for the following paths, but none could be accessed.

node-modules-polyfills:https:30:26: ERROR: [plugin: @yarnpkg/esbuild-plugin-pnp] Qualified path resolution failed: we looked for the following paths, but none could be accessed.

node-modules-polyfills:stream:4:21: ERROR: [plugin: @yarnpkg/esbuild-plugin-pnp] Qualified path resolution failed: we looked for the following paths, but none could be accessed.

node-modules-polyfills:stream:5:23: ERROR: [plugin: @yarnpkg/esbuild-plugin-pnp] Qualified path resolution failed: we looked for the following paths, but none could be accessed.

node-modules-polyfills:stream:6:23: ERROR: [plugin: @yarnpkg/esbuild-plugin-pnp] Qualified path resolution failed: we looked for the following paths, but none could be accessed.

```
