### PR TITLE
fix: pin bahmutov/npm-install version

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -53,7 +53,7 @@ jobs:
         working-directory: ./scripts/deployment-test
 
       - name: 📥 Install deployment-test deps
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
         with:
           working-directory: ./scripts/deployment-test
           useLockFile: false
@@ -90,7 +90,7 @@ jobs:
         working-directory: ./scripts/deployment-test
 
       - name: 📥 Install deployment-test deps
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
         with:
           working-directory: ./scripts/deployment-test
           useLockFile: false
@@ -128,7 +128,7 @@ jobs:
         working-directory: ./scripts/deployment-test
 
       - name: 📥 Install deployment-test deps
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
         with:
           working-directory: ./scripts/deployment-test
           useLockFile: false
@@ -165,7 +165,7 @@ jobs:
         working-directory: ./scripts/deployment-test
 
       - name: 📥 Install deployment-test deps
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
         with:
           working-directory: ./scripts/deployment-test
           useLockFile: false
@@ -207,7 +207,7 @@ jobs:
         working-directory: ./scripts/deployment-test
 
       - name: 📥 Install deployment-test deps
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
         with:
           working-directory: ./scripts/deployment-test
           useLockFile: false
@@ -245,7 +245,7 @@ jobs:
         working-directory: ./scripts/deployment-test
 
       - name: 📥 Install deployment-test deps
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
         with:
           working-directory: ./scripts/deployment-test
           useLockFile: false
@@ -280,7 +280,7 @@ jobs:
         working-directory: ./scripts/deployment-test
 
       - name: 📥 Install deployment-test deps
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
         with:
           working-directory: ./scripts/deployment-test
           useLockFile: false

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,7 +29,7 @@ jobs:
       - name: 📥 Install deps
         # even though this is called "npm-install" it does use yarn to install
         # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
 
       - name: 🔗 Convert Docs links to references
         run: node scripts/markdown-references.mjs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,7 +38,7 @@ jobs:
       - name: 📥 Install deps
         # even though this is called "npm-install" it does use yarn to install
         # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
 
       - name: ⤴️ Update Version if needed
         id: version

--- a/.github/workflows/release-comments.yml
+++ b/.github/workflows/release-comments.yml
@@ -25,7 +25,7 @@ jobs:
       - name: 📥 Install deps
         # even though this is called "npm-install" it does use yarn to install
         # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
         with:
           working-directory: ./scripts/release
 

--- a/.github/workflows/release-private.yml
+++ b/.github/workflows/release-private.yml
@@ -24,7 +24,7 @@ jobs:
       - name: 📥 Install deps
         # even though this is called "npm-install" it does use yarn to install
         # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
 
       - name: 🏗 Build
         run: yarn build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: 📥 Install deps
         # even though this is called "npm-install" it does use yarn to install
         # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
 
       - name: 🏗 Build
         run: yarn build

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: 📥 Install deps
         # even though this is called "npm-install" it does use yarn to install
         # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
 
       - name: 🏗 Build
         run: yarn build
@@ -53,7 +53,7 @@ jobs:
       - name: 📥 Install deps
         # even though this is called "npm-install" it does use yarn to install
         # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
 
       - name: 🔬 Lint
         run: yarn lint
@@ -93,7 +93,7 @@ jobs:
       - name: 📥 Install deps
         # even though this is called "npm-install" it does use yarn to install
         # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
 
       - name: 🧪 Run Primary Tests
         run: "yarn test:primary"
@@ -133,7 +133,7 @@ jobs:
       - name: 📥 Install deps
         # even though this is called "npm-install" it does use yarn to install
         # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
 
       # playwright recommends if you cache the binaries to keep it tied to the version of playwright you are using.
       # https://playwright.dev/docs/ci#caching-browsers

--- a/.github/workflows/stacks.yml
+++ b/.github/workflows/stacks.yml
@@ -35,7 +35,7 @@ jobs:
           npx -y create-remix@${{ inputs.version }} ${{ matrix.stack.name }} --template ${{ matrix.stack.repo }} --typescript --no-install
 
       - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
         with:
           working-directory: ${{ matrix.stack.name }}
           useLockFile: false
@@ -91,7 +91,7 @@ jobs:
         run: unzip ${{ matrix.stack.name }}.zip
 
       - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
         with:
           working-directory: ${{ matrix.stack.name }}
 
@@ -132,7 +132,7 @@ jobs:
         run: unzip ${{ matrix.stack.name }}.zip
 
       - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
         with:
           working-directory: ${{ matrix.stack.name }}
 
@@ -173,7 +173,7 @@ jobs:
         run: unzip ${{ matrix.stack.name }}.zip
 
       - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
         with:
           working-directory: ${{ matrix.stack.name }}
 
@@ -217,7 +217,7 @@ jobs:
         run: unzip ${{ matrix.stack.name }}.zip
 
       - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@v1.8.15
         with:
           working-directory: ${{ matrix.stack.name }}
 


### PR DESCRIPTION
v1.8.16 breaks cache miss installs on windows, which blocks any PRs/commits that change dependencies. Opened [this issue](https://github.com/bahmutov/npm-install/issues/146) to address the underlying bug, but in the meantime we can pin to the prior version to get things working again.

Making this PR against `main` instead `dev`, since the jobs explicitly use `remix-run/remix/.github/workflows/reusable-test.yml@main`, but I can switch it up if y'all like. Just trying to get my 4-month-old PR unblocked yet again 😆😭 

Additional context:
- Discord: https://discord.com/channels/770287896669978684/940264701785423992/991085961972707338
- Initial PR affected: https://github.com/remix-run/remix/pull/2027
- Repro/Debug PR: https://github.com/remix-run/remix/pull/3584

Testing Strategy:
* Validated that v1.8.15 fixes cache miss installs on windows [here](https://github.com/remix-run/remix/pull/3584)