### PR TITLE
fix: do more tree-shaking in dev mode

### DIFF
--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -442,6 +442,12 @@ function createServerBuild(
       format: config.serverModuleFormat,
       treeShaking: true,
       minify: options.mode === BuildMode.Production && isCloudflareRuntime,
+      // The type of dead code elimination we want to do depends on the
+      // minify syntax property: https://github.com/evanw/esbuild/issues/672#issuecomment-1029682369
+      // without this we have dev builds that run fine in production, but
+      // ship server code to the browser, blowing it up due to not optimizing
+      // out imports and module level blocks like `if (process.env.NODE_ENV === "test") {`.
+      minifySyntax: true,
       mainFields: isCloudflareRuntime
         ? ["browser", "module", "main"]
         : config.serverModuleFormat === "esm"


### PR DESCRIPTION
The type of dead code elimination we want to do depends on the minify syntax property: https://github.com/evanw/esbuild/issues/672#issuecomment-1029682369. Without this we have dev builds that run fine in production, but ship server code / dependencies to the browser, blowing it up due to not optimizing out imports and module level blocks like `if (process.env.NODE_ENV === "test") {`.

This will fix the issue seen by those trying to integrate react-three-fiber into their app, as well as enable a good vitest in-source testing story.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

This is covered by existing integration tests.

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
