### PR TITLE
ci(release-test): remove pull_request trigger

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -10,10 +10,6 @@ on:
       - "docs/**"
       - "scripts/**"
       - "**/README.md"
-  pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
 
 jobs:
   test:


### PR DESCRIPTION
we only want to test against the latest node on normal commits/PRs, but on releases we can test against 14, 16, and 18. follow up fix to https://github.com/remix-run/remix/pull/3561