### PR TITLE
fix: remove bahmutov/npm-install to fix windows builds

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -44,6 +44,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: ./scripts/deployment-test/package.json # no lockfile, key caching off package.json
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -53,10 +55,8 @@ jobs:
         working-directory: ./scripts/deployment-test
 
       - name: 📥 Install deployment-test deps
-        uses: bahmutov/npm-install@v1
-        with:
-          working-directory: ./scripts/deployment-test
-          useLockFile: false
+        run: npm install
+        working-directory: ./scripts/deployment-test
 
       - name: 🚀 Deploy to Arc
         run: node ./arc.mjs
@@ -81,6 +81,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: ./scripts/deployment-test/package.json # no lockfile, key caching off package.json
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -90,10 +92,8 @@ jobs:
         working-directory: ./scripts/deployment-test
 
       - name: 📥 Install deployment-test deps
-        uses: bahmutov/npm-install@v1
-        with:
-          working-directory: ./scripts/deployment-test
-          useLockFile: false
+        run: npm install
+        working-directory: ./scripts/deployment-test
 
       - name: 🚀 Deploy to Cloudflare Pages
         run: node ./cf-pages.mjs
@@ -119,6 +119,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: ./scripts/deployment-test/package.json # no lockfile, key caching off package.json
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -128,10 +130,8 @@ jobs:
         working-directory: ./scripts/deployment-test
 
       - name: 📥 Install deployment-test deps
-        uses: bahmutov/npm-install@v1
-        with:
-          working-directory: ./scripts/deployment-test
-          useLockFile: false
+        run: npm install
+        working-directory: ./scripts/deployment-test
 
       - name: 🚀 Deploy to Cloudflare Workers
         run: node ./cf-workers.mjs
@@ -156,6 +156,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: ./scripts/deployment-test/package.json # no lockfile, key caching off package.json
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -165,10 +167,8 @@ jobs:
         working-directory: ./scripts/deployment-test
 
       - name: 📥 Install deployment-test deps
-        uses: bahmutov/npm-install@v1
-        with:
-          working-directory: ./scripts/deployment-test
-          useLockFile: false
+        run: npm install
+        working-directory: ./scripts/deployment-test
 
       - name: 🦕 Install Deno
         uses: denoland/setup-deno@v1
@@ -198,6 +198,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: ./scripts/deployment-test/package.json # no lockfile, key caching off package.json
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -207,10 +209,8 @@ jobs:
         working-directory: ./scripts/deployment-test
 
       - name: 📥 Install deployment-test deps
-        uses: bahmutov/npm-install@v1
-        with:
-          working-directory: ./scripts/deployment-test
-          useLockFile: false
+        run: npm install
+        working-directory: ./scripts/deployment-test
 
       - name: 🎈 Install the Fly CLI
         run: curl -L https://fly.io/install.sh | FLYCTL_INSTALL=/usr/local sh
@@ -236,6 +236,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: ./scripts/deployment-test/package.json # no lockfile, key caching off package.json
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -245,10 +247,8 @@ jobs:
         working-directory: ./scripts/deployment-test
 
       - name: 📥 Install deployment-test deps
-        uses: bahmutov/npm-install@v1
-        with:
-          working-directory: ./scripts/deployment-test
-          useLockFile: false
+        run: npm install
+        working-directory: ./scripts/deployment-test
 
       - name: 🚀 Deploy to Netlify
         run: node ./netlify.mjs
@@ -271,6 +271,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: ./scripts/deployment-test/package.json # no lockfile, key caching off package.json
 
       # some deployment targets require the latest version of npm
       # TODO: remove this eventually when the default version we get
@@ -280,10 +282,8 @@ jobs:
         working-directory: ./scripts/deployment-test
 
       - name: 📥 Install deployment-test deps
-        uses: bahmutov/npm-install@v1
-        with:
-          working-directory: ./scripts/deployment-test
-          useLockFile: false
+        run: npm install
+        working-directory: ./scripts/deployment-test
 
       - name: 🚀 Deploy to Vercel
         run: node ./vercel.mjs

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,9 +27,7 @@ jobs:
           cache: "yarn"
 
       - name: 📥 Install deps
-        # even though this is called "npm-install" it does use yarn to install
-        # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        run: yarn --frozen-lockfile
 
       - name: 🔗 Convert Docs links to references
         run: node scripts/markdown-references.mjs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,9 +36,7 @@ jobs:
           cache: "yarn"
 
       - name: 📥 Install deps
-        # even though this is called "npm-install" it does use yarn to install
-        # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        run: yarn --frozen-lockfile
 
       - name: ⤴️ Update Version if needed
         id: version

--- a/.github/workflows/release-comments.yml
+++ b/.github/workflows/release-comments.yml
@@ -20,14 +20,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
-          cache: "yarn"
+          cache: "npm"
+          cache-dependency-path: scripts/release/package-lock.json
 
       - name: 📥 Install deps
-        # even though this is called "npm-install" it does use yarn to install
-        # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
-        with:
-          working-directory: ./scripts/release
+        run: npm ci
+        working-directory: ./scripts/release
 
       - name: 📝 Comment on issues
         working-directory: ./scripts/release

--- a/.github/workflows/release-private.yml
+++ b/.github/workflows/release-private.yml
@@ -22,9 +22,7 @@ jobs:
           cache: "yarn"
 
       - name: 📥 Install deps
-        # even though this is called "npm-install" it does use yarn to install
-        # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        run: yarn --frozen-lockfile
 
       - name: 🏗 Build
         run: yarn build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,7 @@ jobs:
           cache: "yarn"
 
       - name: 📥 Install deps
-        # even though this is called "npm-install" it does use yarn to install
-        # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        run: yarn --frozen-lockfile
 
       - name: 🏗 Build
         run: yarn build

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -27,9 +27,7 @@ jobs:
           cache: "yarn"
 
       - name: 📥 Install deps
-        # even though this is called "npm-install" it does use yarn to install
-        # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        run: yarn --frozen-lockfile
 
       - name: 🏗 Build
         run: yarn build
@@ -51,9 +49,7 @@ jobs:
           cache: "yarn"
 
       - name: 📥 Install deps
-        # even though this is called "npm-install" it does use yarn to install
-        # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        run: yarn --frozen-lockfile
 
       - name: 🔬 Lint
         run: yarn lint
@@ -91,9 +87,7 @@ jobs:
           cache: "yarn"
 
       - name: 📥 Install deps
-        # even though this is called "npm-install" it does use yarn to install
-        # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        run: yarn --frozen-lockfile
 
       - name: 🧪 Run Primary Tests
         run: "yarn test:primary"
@@ -131,9 +125,7 @@ jobs:
           cache: "yarn"
 
       - name: 📥 Install deps
-        # even though this is called "npm-install" it does use yarn to install
-        # because we have a yarn.lock and caches efficiently.
-        uses: bahmutov/npm-install@v1
+        run: yarn --frozen-lockfile
 
       # playwright recommends if you cache the binaries to keep it tied to the version of playwright you are using.
       # https://playwright.dev/docs/ci#caching-browsers

--- a/.github/workflows/stacks.yml
+++ b/.github/workflows/stacks.yml
@@ -34,8 +34,8 @@ jobs:
         run: |
           npx -y create-remix@${{ inputs.version }} ${{ matrix.stack.name }} --template ${{ matrix.stack.repo }} --typescript --no-install
 
-      - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
+      - name: 📥 Install deps
+        uses: bahmutov/npm-install@v1 # more fine grained control than actions/setup-node@v3 caching, i.e. package.json doesn't exist until after the create-remix step
         with:
           working-directory: ${{ matrix.stack.name }}
           useLockFile: false
@@ -90,8 +90,8 @@ jobs:
       - name: 📁 Unzip artifact
         run: unzip ${{ matrix.stack.name }}.zip
 
-      - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
+      - name: 📥 Install deps
+        uses: bahmutov/npm-install@v1 # more fine grained control than actions/setup-node@v3 caching, i.e. package.json doesn't exist until after the unzip step
         with:
           working-directory: ${{ matrix.stack.name }}
 
@@ -131,8 +131,8 @@ jobs:
       - name: 📁 Unzip artifact
         run: unzip ${{ matrix.stack.name }}.zip
 
-      - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
+      - name: 📥 Install deps
+        uses: bahmutov/npm-install@v1 # more fine grained control than actions/setup-node@v3 caching, i.e. package.json doesn't exist until after the unzip step
         with:
           working-directory: ${{ matrix.stack.name }}
 
@@ -172,8 +172,8 @@ jobs:
       - name: 📁 Unzip artifact
         run: unzip ${{ matrix.stack.name }}.zip
 
-      - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
+      - name: 📥 Install deps
+        uses: bahmutov/npm-install@v1 # more fine grained control than actions/setup-node@v3 caching, i.e. package.json doesn't exist until after the unzip step
         with:
           working-directory: ${{ matrix.stack.name }}
 
@@ -216,8 +216,8 @@ jobs:
       - name: 📁 Unzip artifact
         run: unzip ${{ matrix.stack.name }}.zip
 
-      - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
+      - name: 📥 Install deps
+        uses: bahmutov/npm-install@v1 # more fine grained control than actions/setup-node@v3 caching, i.e. package.json doesn't exist until after the unzip step
         with:
           working-directory: ${{ matrix.stack.name }}
 


### PR DESCRIPTION
We already use `actions/setup-node@v3` which has equivalent caching functionality that isn't broken for yarn+windows (or yarn 2+ across the board). So just use that wherever possible. In addition to fixing builds, this has the added benefit of slightly speeding them up, since we won't double-cache things (in some cases we had both caches enabled).

Making this PR against `main` instead `dev`, since the jobs explicitly use `remix-run/remix/.github/workflows/reusable-test.yml@main`, but I can switch it up if y'all like. Just trying to get my 4-month-old PR unblocked yet again 😆😭

For context, see https://github.com/bahmutov/npm-install/issues/146, in particular [this comment](https://github.com/bahmutov/npm-install/issues/146#issuecomment-1169226551) and linked test output.

This is an alternative to #3587 or otherwise waiting for `bahmutov/npm-install` to get fixed.