### PR TITLE
docs(blog-tutorial): Fix link to posts in Blog Admin route

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -272,6 +272,7 @@
 - mush159
 - na2hiro
 - nareshbhatia
+- natomato
 - navid-kalaei
 - nexxeln
 - ni554n

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -694,7 +694,7 @@ export default function PostAdmin() {
 }
 ```
 
-You should recognize several of the things we're doing in there from what we've done so far. Note this time we did not want to use a relative links so our `to` prop begins with a leading slash "/posts/${post.slug}". With that, you should have a decent looking page with the posts on the left and a placeholder on the right.
+You should recognize several of the things we're doing in there from what we've done so far. Note this time we did not want to use a relative link so our `to` prop begins with a leading slash "/posts/${post.slug}". With that, you should have a decent looking page with the posts on the left and a placeholder on the right.
 Now, if you click on the Admin link, it'll take you to [http://localhost:3000/posts/admin][http-localhost-3000-posts-admin].
 
 ### Index Routes

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -676,7 +676,7 @@ export default function PostAdmin() {
             {posts.map((post) => (
               <li key={post.slug}>
                 <Link
-                  to={post.slug}
+                  to={`/posts/${post.slug}`}
                   className="text-blue-600 underline"
                 >
                   {post.title}
@@ -694,7 +694,7 @@ export default function PostAdmin() {
 }
 ```
 
-You should recognize several of the things we're doing in there from what we've done so far. With that, you should have a decent looking page with the posts on the left and a placeholder on the right.
+You should recognize several of the things we're doing in there from what we've done so far. Note this time we did not want to use a relative links so our `to` prop begins with a leading slash "/posts/${post.slug}". With that, you should have a decent looking page with the posts on the left and a placeholder on the right.
 Now, if you click on the Admin link, it'll take you to [http://localhost:3000/posts/admin][http-localhost-3000-posts-admin].
 
 ### Index Routes
@@ -758,7 +758,7 @@ export default function PostAdmin() {
             {posts.map((post) => (
               <li key={post.slug}>
                 <Link
-                  to={post.slug}
+                  to={`/posts/${post.slug}`}
                   className="text-blue-600 underline"
                 >
                   {post.title}

--- a/examples/blog-tutorial/app/routes/posts/admin.tsx
+++ b/examples/blog-tutorial/app/routes/posts/admin.tsx
@@ -22,7 +22,7 @@ export default function PostAdmin() {
           <ul>
             {posts.map((post) => (
               <li key={post.slug}>
-                <Link to={post.slug} className="text-blue-600 underline">
+                <Link to={`/posts/${post.slug}`} className="text-blue-600 underline">
                   {post.title}
                 </Link>
               </li>


### PR DESCRIPTION
While working through the developer-blog tutorial, the post links in the /posts/admin route were broken. They worked when the route was changed to not be relative.

<img width="543" alt="Screen Shot 2022-06-28 at 8 40 59 PM" src="https://user-images.githubusercontent.com/778135/176330940-65144443-6857-4937-ac64-bf125aae3705.png">
