### PR TITLE
fix(remix-dev,remix-serve): fix network `family` detection

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -41,10 +41,10 @@
 - axel-habermaier
 - BasixKOR
 - BenMcH
+- bgschiller
 - binajmen
 - bmarvinb
 - bmontalvo
-- bgschiller
 - bogas04
 - BogdanDevBst
 - bolchowka

--- a/contributors.yml
+++ b/contributors.yml
@@ -41,10 +41,10 @@
 - axel-habermaier
 - BasixKOR
 - BenMcH
-- bgschiller
 - binajmen
 - bmarvinb
 - bmontalvo
+- bgschiller
 - bogas04
 - BogdanDevBst
 - bolchowka
@@ -185,6 +185,7 @@
 - juhanakristian
 - JulesBlm
 - justinnoel
+- justsml
 - juwiragiye
 - jveldridge
 - jvnm-dev

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -291,7 +291,7 @@ export async function dev(
             process.env.HOST ||
             Object.values(os.networkInterfaces())
               .flat()
-              .find((ip) => ip?.family === "IPv4" && !ip.internal)?.address;
+              .find((ip) => String(ip?.family).includes("4") && !ip?.internal)?.address;
 
           if (!address) {
             console.log(`Remix App Server started at http://localhost:${port}`);

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -24,7 +24,7 @@ let onListen = () => {
     process.env.HOST ||
     Object.values(os.networkInterfaces())
       .flat()
-      .find((ip) => `${ip?.family}`.includes("4") && !ip.internal)?.address;
+      .find((ip) => String(ip?.family).includes("4") && !ip?.internal)?.address;
 
   if (!address) {
     console.log(`Remix App Server started at http://localhost:${port}`);

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -24,7 +24,7 @@ let onListen = () => {
     process.env.HOST ||
     Object.values(os.networkInterfaces())
       .flat()
-      .find((ip) => ip?.family === "IPv4" && !ip.internal)?.address;
+      .find((ip) => `${ip?.family}`.includes("4") && !ip.internal)?.address;
 
   if (!address) {
     console.log(`Remix App Server started at http://localhost:${port}`);


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #3600

This patch addresses a specific regression in Node v18.3 by making the detection of IPv4 addresses more durable.


**References:** 

- [Broken network `family` detection](https://github.com/nodejs/node/blob/49362efd5b39f31a14260612422109e130068d08/lib/os.js#L251)
- [v18.4 patch from 1-2 weeks ago](https://github.com/nodejs/node/commit/70b516e4dbdfdfea2183995ec3b368dacaa38183#diff-f52f7c022afbe0147ec297ea168db37d7e5aa3a611f18d952c5ddb85ae689059R131)


- [x] Docs - n/a
- [x] Tests - n/a

Testing Strategy:

See reproduction steps in #3600
