### PR TITLE
fix: fix deep imports

### DIFF
--- a/packages/remix-dev/.gitignore
+++ b/packages/remix-dev/.gitignore
@@ -1,0 +1,3 @@
+# TODO: Delete in v2
+server-build.js
+server-build.d.ts

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -89,6 +89,8 @@
   "files": [
     "dist/",
     "compiler/shims/",
+    "server-build.js",
+    "server-build.d.ts",
     "CHANGELOG.md",
     "LICENSE.md",
     "README.md"

--- a/packages/remix-node/.gitignore
+++ b/packages/remix-node/.gitignore
@@ -1,0 +1,3 @@
+# TODO: Remove in v2
+globals.js
+globals.d.ts

--- a/packages/remix-node/.gitignore
+++ b/packages/remix-node/.gitignore
@@ -1,3 +1,2 @@
 # TODO: Remove in v2
-globals.js
 globals.d.ts

--- a/packages/remix-node/package.json
+++ b/packages/remix-node/package.json
@@ -34,6 +34,8 @@
   },
   "files": [
     "dist/",
+    "globals.js",
+    "globals.d.ts",
     "CHANGELOG.md",
     "LICENSE.md",
     "README.md"

--- a/packages/remix-node/package.json
+++ b/packages/remix-node/package.json
@@ -34,7 +34,6 @@
   },
   "files": [
     "dist/",
-    "globals.js",
     "globals.d.ts",
     "CHANGELOG.md",
     "LICENSE.md",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -252,11 +252,20 @@ function remixDev() {
         return true;
       },
       input: `${sourceDir}/server-build.ts`,
-      output: {
-        banner: executableBanner + createBanner("@remix-run/dev", version),
-        dir: outputDist,
-        format: "cjs",
-      },
+      output: [
+        {
+          // TODO: Remove deep import support in v2 or move to package.json
+          // "exports" field
+          banner: executableBanner + createBanner("@remix-run/dev", version),
+          dir: outputDir,
+          format: "cjs",
+        },
+        {
+          banner: executableBanner + createBanner("@remix-run/dev", version),
+          dir: outputDist,
+          format: "cjs",
+        },
+      ],
       plugins: [
         babel({
           babelHelpers: "bundled",

--- a/scripts/copy-build-to-dist.mjs
+++ b/scripts/copy-build-to-dist.mjs
@@ -71,7 +71,14 @@ async function copyBuildToDist() {
   // Write an export shim for @remix-run/node/globals types
   copyQueue.push(
     (async () => {
-      let dest = "./build/node_modules/@remix-run/node/globals.d.ts";
+      let dest = path.join(
+        ".",
+        "build",
+        "node_modules",
+        "@remix-run",
+        "node",
+        "globals.d.ts"
+      );
       console.log(chalk.yellow(`  🛠  Writing globals.d.ts shim to ${dest}`));
       await fse.writeFile(dest, "export * from './dist/globals.d.ts';");
     })()
@@ -82,13 +89,13 @@ async function copyBuildToDist() {
   // with the package.json "exports" field
   let oneOffCopies = [
     // server-build.js built by rollup outside of dist/, need to copy to
-    // package dir outside of dist/
+    // packages/ dir outside of dist/
     [
       "build/node_modules/@remix-run/dev/server-build.js",
       "packages/remix-dev/server-build.js",
     ],
     // server-build.d.ts only built by tsc to dist/.  Copy outside of dist/
-    // both in build and package dir
+    // both in build/ and packages/ dir
     [
       "build/node_modules/@remix-run/dev/dist/server-build.d.ts",
       "build/node_modules/@remix-run/dev/server-build.d.ts",
@@ -97,8 +104,8 @@ async function copyBuildToDist() {
       "build/node_modules/@remix-run/dev/dist/server-build.d.ts",
       "packages/remix-dev/server-build.d.ts",
     ],
-    // globals.d.ts shim written outside of dist/ in build above, copy to
-    // package dir outside of dist/
+    // globals.d.ts shim written outside of dist/ in above, copy to packages/
+    // dir outside of dist/
     [
       "build/node_modules/@remix-run/node/globals.d.ts",
       "packages/remix-node/globals.d.ts",

--- a/scripts/copy-build-to-dist.mjs
+++ b/scripts/copy-build-to-dist.mjs
@@ -67,6 +67,56 @@ async function copyBuildToDist() {
       );
     } catch (e) {}
   }
+
+  // One-off deep import copies so folks don't need to import from inside of
+  // dist/.  TODO: Remove in v2 and either get rid of the deep import or manage
+  // with the package.json "exports" field
+  let oneOffCopies = [
+    [
+      "build/node_modules/@remix-run/dev/dist/server-build.js",
+      "build/node_modules/@remix-run/dev/server-build.js",
+    ],
+    [
+      "build/node_modules/@remix-run/dev/dist/server-build.d.ts",
+      "build/node_modules/@remix-run/dev/server-build.d.ts",
+    ],
+    [
+      "build/node_modules/@remix-run/dev/dist/server-build.js",
+      "packages/remix-dev/server-build.js",
+    ],
+    [
+      "build/node_modules/@remix-run/dev/dist/server-build.d.ts",
+      "packages/remix-dev/server-build.d.ts",
+    ],
+    [
+      "build/node_modules/@remix-run/node/dist/globals.js",
+      "build/node_modules/@remix-run/node/globals.js",
+    ],
+    [
+      "build/node_modules/@remix-run/node/dist/globals.d.ts",
+      "build/node_modules/@remix-run/node/globals.d.ts",
+    ],
+    [
+      "build/node_modules/@remix-run/node/dist/globals.js",
+      "packages/remix-node/globals.js",
+    ],
+    [
+      "build/node_modules/@remix-run/node/dist/globals.d.ts",
+      "packages/remix-node/globals.d.ts",
+    ],
+  ];
+
+  oneOffCopies.forEach(([srcFile, destFile]) =>
+    copyQueue.push(
+      (async () => {
+        let src = path.relative(ROOT_DIR, path.join(...srcFile.split("/")));
+        let dest = path.relative(ROOT_DIR, path.join(...destFile.split("/")));
+        console.log(chalk.yellow(`  🛠  Copying ${src} to ${dest}`));
+        fse.copy(src, dest);
+      })()
+    )
+  );
+
   await Promise.all(copyQueue);
   console.log(
     chalk.green(


### PR DESCRIPTION
Fix deep imports for globals/server-build

* `@remix-run/dev/server-build`
  * JS file written outside of `dist/` by `rollup`, then copied from `build -> packages` in postbuild
  * Types file written into `dist/` by `tsc` - copied outside of `dist/` in both build and `packages/` dir by `postbuild` 
* `@remix-run/node/globals.d.ts`
  * Shim to do the re-export written out in `postbuild` and copied to `packages/` dir  