### PR TITLE
fix(remix-react): prevent form data loss by appending submitter's value in `useSubmit` (`<Form>`)

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -283,6 +283,7 @@
 - niwsa
 - nobeeakon
 - nordiauwu
+- nrako
 - nurul3101
 - nvh95
 - nwalters512

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -48,33 +48,27 @@ test.beforeAll(async () => {
     ////////////////////////////////////////////////////////////////////////////
     files: {
       "app/routes/index.jsx": js`
-        import { useLoaderData, useSubmit, Form } from "@remix-run/react";
+        import { json } from "@remix-run/node";
+        import { useLoaderData, Link } from "@remix-run/react";
 
-        export function loader({ request }) {
-          let url = new URL(request.url);
-          return url.searchParams.toString()
+        export function loader() {
+          return json("pizza");
         }
 
         export default function Index() {
-          let submit = useSubmit();
-          let handleClick = event => submit(nativeEvent.submitter || e.currentTarget)
           let data = useLoaderData();
           return (
-            <Form>
-              <input type="text" name="tasks" defaultValue="first" />
-              <input type="text" name="tasks" defaultValue="second" />
-
-              <button type="submit" name="tasks" value="">
-                Add Task
-              </button>
-
-              <button onClick={handleClick} name="tasks" value="third">
-                Prepare Third Task
-              </button>
-
-              <pre>{data}</pre>
-            </Form>
+            <div>
+              {data}
+              <Link to="/burgers">Other Route</Link>
+            </div>
           )
+        }
+      `,
+
+      "app/routes/burgers.jsx": js`
+        export default function Index() {
+          return <div>cheeseburger</div>;
         }
       `,
     },
@@ -91,28 +85,22 @@ test.afterAll(async () => appFixture.close());
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("<Form> submits the submitter's value appended to the form data", async ({
-  page,
-}) => {
+test("[description of what you expect it to do]", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);
-  await app.goto("/");
-  await app.clickElement("text=Add Task");
-  await page.waitForLoadState("load");
-  expect(await app.getHtml("pre")).toBe(
-    `<pre>tasks=first&amp;tasks=second&amp;tasks=</pre>`
-  );
-});
+  // You can test any request your app might get using `fixture`.
+  let response = await fixture.requestDocument("/");
+  expect(await response.text()).toMatch("pizza");
 
-test("`useSubmit()` returned function submits the submitter's value appended to the form data", async ({
-  page,
-}) => {
-  let app = new PlaywrightFixture(appFixture, page);
+  // If you need to test interactivity use the `app`
   await app.goto("/");
-  await app.clickElement("text=Prepare Third Task");
-  await page.waitForLoadState("load");
-  expect(await app.getHtml("pre")).toBe(
-    `<pre>tasks=first&amp;tasks=second&amp;tasks=third</pre>`
-  );
+  await app.clickLink("/burgers");
+  expect(await app.getHtml()).toMatch("cheeseburger");
+
+  // If you're not sure what's going on, you can "poke" the app, it'll
+  // automatically open up in your browser for 20 seconds, so be quick!
+  // await app.poke(20);
+
+  // Go check out the other tests to see what else you can do.
 });
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -277,6 +277,29 @@ test.describe("Forms", () => {
             )
           }
         `,
+
+        "app/routes/submitter.jsx": js`
+          import { useLoaderData, Form } from "@remix-run/react";
+
+          export function loader({ request }) {
+            let url = new URL(request.url);
+            return url.searchParams.toString()
+          }
+
+          export default function() {
+            let data = useLoaderData();
+            return (
+              <Form>
+                <input type="text" name="tasks" defaultValue="first" />
+                <input type="text" name="tasks" defaultValue="second" />
+                <button type="submit" name="tasks" value="">
+                  Add Task
+                </button>
+                <pre>{data}</pre>
+              </Form>
+            )
+          }
+        `,
       },
     });
 
@@ -574,5 +597,17 @@ test.describe("Forms", () => {
         expect(el.attr("action")).toMatch("/");
       });
     });
+  });
+
+  test("<Form> submits the submitter's value appended to the form data", async ({
+    page,
+  }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/submitter");
+    await app.clickElement("text=Add Task");
+    await page.waitForLoadState("load");
+    expect(await app.getHtml("pre")).toBe(
+      `<pre>tasks=first&amp;tasks=second&amp;tasks=</pre>`
+    );
   });
 });

--- a/integration/hook-useSubmit-test.ts
+++ b/integration/hook-useSubmit-test.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+
+import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
+import type { Fixture, AppFixture } from "./helpers/create-fixture";
+import { PlaywrightFixture } from "./helpers/playwright-fixture";
+
+test.describe("`useSubmit()` returned function", () => {
+  let fixture: Fixture;
+  let appFixture: AppFixture;
+
+  test.beforeAll(async () => {
+    fixture = await createFixture({
+      files: {
+        "app/routes/index.jsx": js`
+        import { useLoaderData, useSubmit } from "@remix-run/react";
+
+        export function loader({ request }) {
+          let url = new URL(request.url);
+          return url.searchParams.toString()
+        }
+
+        export default function Index() {
+          let submit = useSubmit();
+          let handleClick = event => {
+            event.preventDefault()
+            submit(event.nativeEvent.submitter || event.currentTarget)
+          }
+          let data = useLoaderData();
+          return (
+            <form>
+              <input type="text" name="tasks" defaultValue="first" />
+              <input type="text" name="tasks" defaultValue="second" />
+
+              <button onClick={handleClick} name="tasks" value="third">
+                Prepare Third Task
+              </button>
+
+              <pre>{data}</pre>
+            </form>
+          )
+        }
+      `,
+      },
+    });
+
+    appFixture = await createAppFixture(fixture);
+  });
+
+  test.afterAll(async () => {
+    await appFixture.close();
+  });
+
+  test("submits the submitter's value appended to the form data", async ({
+    page,
+  }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/");
+    await app.clickElement("text=Prepare Third Task");
+    await page.waitForLoadState("load");
+    expect(await app.getHtml("pre")).toBe(
+      `<pre>tasks=first&amp;tasks=second&amp;tasks=third</pre>`
+    );
+  });
+});

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1138,7 +1138,7 @@ export function useSubmitImpl(key?: string): SubmitFunction {
 
         // Include name + value from a <button>
         if (target.name) {
-          formData.set(target.name, target.value);
+          formData.append(target.name, target.value);
         }
       } else {
         if (isHtmlElement(target)) {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes:  (the following issue)

> Currently, remix-react's `<Form>` through `useSubmit` (`useSubmitImpl`) 
    implementation, includes the submitter value by setting it on the
    `formData`. Unfortunetly, this may override any existing inputs having the
    same name than the submitter; resulting in data loss.

- [x] ~~Docs~~ N/A
- [x] Tests

Testing Strategy:

```jsx
<Form>
  <input name="tasks" value="first" />
  <button name="tasks value="" type="submit">Add Task</button>
</Form>
// should submit `?tasks=first&tasks=` but submit `?tasks=`
```

See integration [Bug-Report-Test](https://github.com/remix-run/remix/blob/41870303f049c1fd8b7eec6d14777e31b44587b6/integration/bug-report-test.ts) via commit: https://github.com/remix-run/remix/commit/41870303f049c1fd8b7eec6d14777e31b44587b6



<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->

---

**test: failing test with submitter value not appended to form data**
41870303f &lt;Nicholas Rakoto&gt; Wed, 29 Jun 2022 22:30:59 +0200

    Currently, remix-react's `<Form>` through `useSubmit` (`useSubmitImpl`) 
    implementation, includes the submitter value by setting it on the
    `formData`. Unfortunetly, this may override any existing inputs having the
    same name than the submitter; resulting in data loss.

    Instead, the submitter's value should be appended to the `formData`.


**fix(remix-react): prevent form data loss by appending submitter's value**
2a7025077 &lt;Nicholas Rakoto&gt; Wed, 29 Jun 2022 22:34:39 +0200

    When submitting a form the submitter's value must be appended to the
    `formData` and not have it's value "set" or pre-existing data under the same
    name may be overidden resulting in data loss.

    This commit fixes the `useSubmit() hook (`useSubmitImpl`) and consequently
    it's indirect usage through the `<Form>` component.



