### PR TITLE
fix(remix-react): fix `<Form>` submit to not break `formMethod` functionality

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -250,6 +250,7 @@
 - mattstobbs
 - mbarto
 - mcansh
+- mdoury
 - medayz
 - meetbryce
 - mehulmpt
@@ -283,6 +284,7 @@
 - niwsa
 - nobeeakon
 - nordiauwu
+- nrako
 - nurul3101
 - nvh95
 - nwalters512

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -48,27 +48,32 @@ test.beforeAll(async () => {
     ////////////////////////////////////////////////////////////////////////////
     files: {
       "app/routes/index.jsx": js`
-        import { json } from "@remix-run/node";
-        import { useLoaderData, Link } from "@remix-run/react";
+        import { useActionData, useLoaderData, Form } from "@remix-run/react";
+        import { json } from '@remix-run/server-runtime'
 
-        export function loader() {
-          return json("pizza");
+        export function action({ request }) {
+          return json(request.method)
+        }
+
+        export function loader({ request }) {
+          return json(request.method)
         }
 
         export default function Index() {
-          let data = useLoaderData();
+          let actionData = useActionData();
+          let loaderData = useLoaderData();
           return (
-            <div>
-              {data}
-              <Link to="/burgers">Other Route</Link>
-            </div>
-          )
-        }
-      `,
+            <>
+              <Form method="post">
+                <button type="submit" formMethod="get">Submit with GET</button>
+              </Form>
+              <form method="get">
+                <button type="submit" formMethod="post">Submit with POST</button>
+              </form>
 
-      "app/routes/burgers.jsx": js`
-        export default function Index() {
-          return <div>cheeseburger</div>;
+              <pre>{loaderData || actionData}</pre>
+            </>
+          )
         }
       `,
     },
@@ -85,22 +90,17 @@ test.afterAll(async () => appFixture.close());
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("[description of what you expect it to do]", async ({ page }) => {
+test("`<Form>` should submit with the method set via the `formmethod` attribute set on the submitter (button)", async ({
+  page,
+}) => {
   let app = new PlaywrightFixture(appFixture, page);
-  // You can test any request your app might get using `fixture`.
-  let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch("pizza");
-
-  // If you need to test interactivity use the `app`
   await app.goto("/");
-  await app.clickLink("/burgers");
-  expect(await app.getHtml()).toMatch("cheeseburger");
-
-  // If you're not sure what's going on, you can "poke" the app, it'll
-  // automatically open up in your browser for 20 seconds, so be quick!
-  // await app.poke(20);
-
-  // Go check out the other tests to see what else you can do.
+  await app.clickElement("text=Submit with GET");
+  await page.waitForLoadState("load");
+  expect(await app.getHtml("pre")).toBe(`<pre>GET</pre>`);
+  await page.waitForLoadState("load");
+  await app.clickElement("text=Submit with POST");
+  expect(await app.getHtml("pre")).toBe(`<pre>POST</pre>`);
 });
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -48,32 +48,27 @@ test.beforeAll(async () => {
     ////////////////////////////////////////////////////////////////////////////
     files: {
       "app/routes/index.jsx": js`
-        import { useActionData, useLoaderData, Form } from "@remix-run/react";
-        import { json } from '@remix-run/server-runtime'
+        import { json } from "@remix-run/node";
+        import { useLoaderData, Link } from "@remix-run/react";
 
-        export function action({ request }) {
-          return json(request.method)
-        }
-
-        export function loader({ request }) {
-          return json(request.method)
+        export function loader() {
+          return json("pizza");
         }
 
         export default function Index() {
-          let actionData = useActionData();
-          let loaderData = useLoaderData();
+          let data = useLoaderData();
           return (
-            <>
-              <Form method="post">
-                <button type="submit" formMethod="get">Submit with GET</button>
-              </Form>
-              <form method="get">
-                <button type="submit" formMethod="post">Submit with POST</button>
-              </form>
-
-              <pre>{loaderData || actionData}</pre>
-            </>
+            <div>
+              {data}
+              <Link to="/burgers">Other Route</Link>
+            </div>
           )
+        }
+      `,
+
+      "app/routes/burgers.jsx": js`
+        export default function Index() {
+          return <div>cheeseburger</div>;
         }
       `,
     },
@@ -90,17 +85,22 @@ test.afterAll(async () => appFixture.close());
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("`<Form>` should submit with the method set via the `formmethod` attribute set on the submitter (button)", async ({
-  page,
-}) => {
+test("[description of what you expect it to do]", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);
+  // You can test any request your app might get using `fixture`.
+  let response = await fixture.requestDocument("/");
+  expect(await response.text()).toMatch("pizza");
+
+  // If you need to test interactivity use the `app`
   await app.goto("/");
-  await app.clickElement("text=Submit with GET");
-  await page.waitForLoadState("load");
-  expect(await app.getHtml("pre")).toBe(`<pre>GET</pre>`);
-  await page.waitForLoadState("load");
-  await app.clickElement("text=Submit with POST");
-  expect(await app.getHtml("pre")).toBe(`<pre>POST</pre>`);
+  await app.clickLink("/burgers");
+  expect(await app.getHtml()).toMatch("cheeseburger");
+
+  // If you're not sure what's going on, you can "poke" the app, it'll
+  // automatically open up in your browser for 20 seconds, so be quick!
+  // await app.poke(20);
+
+  // Go check out the other tests to see what else you can do.
 });
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -277,6 +277,36 @@ test.describe("Forms", () => {
             )
           }
         `,
+
+        "app/routes/submitter-formmethod.jsx": js`
+          import { useActionData, useLoaderData, Form } from "@remix-run/react";
+          import { json } from '@remix-run/server-runtime'
+
+          export function action({ request }) {
+            return json(request.method)
+          }
+
+          export function loader({ request }) {
+            return json(request.method)
+          }
+
+          export default function Index() {
+            let actionData = useActionData();
+            let loaderData = useLoaderData();
+            return (
+              <>
+                <Form method="post">
+                  <button type="submit" formMethod="get">Submit with GET</button>
+                </Form>
+                <Form method="get">
+                  <button type="submit" formMethod="post">Submit with POST</button>
+                </Form>
+
+                <pre>{actionData || loaderData}</pre>
+              </>
+            )
+          }
+        `,
       },
     });
 
@@ -573,6 +603,24 @@ test.describe("Forms", () => {
         let el = getElement(html, `#${SPLAT_ROUTE_TOO_MANY_DOTS_ACTION}`);
         expect(el.attr("action")).toMatch("/");
       });
+    });
+  });
+
+  test.describe("with submitter button having `formMethod` attribute", () => {
+    test("submits with GET instead of POST", async ({ page }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/submitter-formmethod");
+      await app.clickElement("text=Submit with GET");
+      await page.waitForLoadState("load");
+      expect(await app.getHtml("pre")).toBe("<pre>GET</pre>");
+    });
+
+    test("submits with POST instead of GET", async ({ page }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/submitter-formmethod");
+      await app.clickElement("text=Submit with POST");
+      await page.waitForLoadState("load");
+      expect(await app.getHtml("pre")).toBe("<pre>POST</pre>");
     });
   });
 });

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -963,7 +963,7 @@ let FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
                 let submitter = (event as unknown as HTMLSubmitEvent)
                   .nativeEvent.submitter as HTMLFormSubmitter | null;
 
-                submit(submitter || event.currentTarget, { method, replace });
+                submit(submitter || event.currentTarget, { replace });
               }
         }
         {...props}


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #2162 (supersede) – credits to @mdoury for his original PR

> the `<Form>` component – unlike native `<form>` - does not respect the `formmethod` attribute set
on the submitter (the button submitting the form).

- [x] ~~Docs~~ N/A
- [x] Tests

Testing Strategy:
```jsx
<Form method="post">
  <input name="eat" value="pizza" />
  <button type="submit"> Submit with GET </button>
</Form>
// should submit with a GET to `/?eat=pizza` but instead do a POST
```

See integration [Bug-Report-Test](https://github.com/remix-run/remix/blob/37b0140f80dfb333240da96fb9ff83e713848458/integration/bug-report-test.ts) via commit: https://github.com/remix-run/remix/commit/37b0140f80dfb333240da96fb9ff83e713848458

---

**test: failing test with `<Form>` not respecting `formMethod`**
06333c1ed &lt;Nicholas Rakoto&gt; Thu, 30 Jun 2022 00:33:15 +0200

    Bug report integration test demonstrating how the `<Form>` component – 
    unlike native `<form>` - does not respect the `formmethod` attribute set on
    the submitter (the `<button>` submitting the form).


**fix(remix-react): submit `<Form>` w/method set by submitter `formmethod`**
bfd1f88de &lt;Nicholas Rakoto&gt; Thu, 30 Jun 2022 00:32:22 +0200

    Fix `<Form>` component by not passing the form's `method` into the
    `options` when calling the `submit(target, options)` function (created with
    the `useSubmit()` hook). This ensures that the option does not take 
    precedence on any `formethod` set on the submitter which otherwise break the
    `formmethod` functionality.

    Since #3094 and #3094 the `<Form>` passes the "submitter" (if any) as the
    `target` to the `submit(target, options)` (`useSubmitImpl`) which will
    attempt to read the `formmethod`, `formaction` and `formenctype` attributes
    on the target. Therefore, the responsability to infer which method should be
    used should solely be on `useSubmitImpl` for the given
    `target`.

    Co-authored-by: Maxime Doury <maxime.doury@docavenue.com>

