### PR TITLE
fix(remix-dev/create): check for undefined `--token`

### DIFF
--- a/packages/remix-dev/cli/create.ts
+++ b/packages/remix-dev/cli/create.ts
@@ -639,10 +639,13 @@ export async function validateTemplate(
         method = "GET";
       }
       try {
-        response = await fetch(apiUrl, {
-          method,
-          headers: { Authorization: `token ${options?.githubToken}` },
-        });
+        let headers: Record<string, string> = {};
+        if (options?.githubToken) {
+          headers = {
+            Authorization: `token ${options.githubToken}`,
+          };
+        }
+        response = await fetch(apiUrl, { method, headers });
       } catch (_) {
         throw Error(
           "🚨 There was a problem fetching the template. Please ensure you " +
@@ -674,7 +677,7 @@ export async function validateTemplate(
           return;
         case 401:
           throw Error(
-            "🚨 The template could not be verified because you do are not " +
+            "🚨 The template could not be verified because you are not " +
               "authorized to access that repository. Please double check the " +
               "access rights of the repo or consider passing a `--token`"
           );


### PR DESCRIPTION
i'm quite interested in why our tests all passed without this...

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #3618

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
