### PR TITLE
chore: remove extension from global type shim

### DIFF
--- a/scripts/copy-build-to-dist.mjs
+++ b/scripts/copy-build-to-dist.mjs
@@ -80,7 +80,7 @@ async function copyBuildToDist() {
         "globals.d.ts"
       );
       console.log(chalk.yellow(`  🛠  Writing globals.d.ts shim to ${dest}`));
-      await fse.writeFile(dest, "export * from './dist/globals.d.ts';");
+      await fse.writeFile(dest, "export * from './dist/globals';");
     })()
   );
 


### PR DESCRIPTION
was running `tsc` in another project and it threw a fit about the extension, removing it fixed the error and continued to reference the correct file

before: 
```log
tsc
node_modules/@remix-run/node/globals.d.ts:1:15 - error TS2691: An import path cannot end with a '.d.ts' extension. Consider importing './dist/globals.js' instead.

1 export * from "./dist/globals.d.ts";
                ~~~~~~~~~~~~~~~~~~~~~


Found 1 error in node_modules/@remix-run/node/globals.d.ts:1
```

after:
```log
tsc
// no output
```


<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #3624

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
