### PR TITLE
chore: fix internal watch command (upgrading rollup)

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "remark": "14.0.2",
     "remark-frontmatter": "4.0.1",
     "remark-gfm": "3.0.1",
-    "rollup": "^2.36.1",
+    "rollup": "^2.75.7",
     "rollup-plugin-copy": "^3.3.0",
     "semver": "^7.3.4",
     "simple-git": "^3.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9624,10 +9624,10 @@ rollup-pluginutils@^2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.36.1:
-  version "2.57.0"
-  resolved "https://registry.npmjs.org/rollup/-/rollup-2.57.0.tgz"
-  integrity sha512-bKQIh1rWKofRee6mv8SrF2HdP6pea5QkwBZSMImJysFj39gQuiV8MEPBjXOCpzk3wSYp63M2v2wkWBmFC8O/rg==
+rollup@^2.75.7:
+  version "2.75.7"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.75.7.tgz#221ff11887ae271e37dcc649ba32ce1590aaa0b9"
+  integrity sha512-VSE1iy0eaAYNCxEXaleThdFXqZJ42qDBatAwrfnPlENEZ8erQ+0LYX4JXOLPceWfZpV1VtZwZ3dFCuOZiSyFtQ==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
Closes: (No issue yet)

- [ ] Docs
- [ ] Tests

Testing Strategy:
**For maintainers/contributers only**

When running the top level `watch` script in the remix monorepo, currently the watch does not work correctly. The `tsc` part of the build pipeline does not re-run when files change, so the watch command is pointless at the moment.

This is because the `--watch.onEnd` (and others) arguments only work from rollup version [2.72.0]([v2.72.0](https://github.com/rollup/rollup/releases/tag/v2.72.0)), and the current version is set to `2.57.0` in the lockfile.

Simply upgrading to the latest version fixes this.
