### PR TITLE
fix(remix-dev/compiler): fix Yarn PnP resolution for empty modules

### DIFF
--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -357,9 +357,8 @@ async function createBrowserBuild(
     mdxPlugin(config),
     browserRouteModulesPlugin(config, /\?browser$/),
     emptyModulesPlugin(config, /\.server(\.[jt]sx?)?$/),
-    // Must be placed before NodeModulesPolyfillPlugin, so yarn can resolve polyfills correctly
-    yarnPnpPlugin(),
     NodeModulesPolyfillPlugin(),
+    yarnPnpPlugin(),
   ];
 
   return esbuild.build({

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -26,7 +26,7 @@
     "@npmcli/package-json": "^2.0.0",
     "@remix-run/server-runtime": "1.6.2",
     "arg": "^5.0.1",
-    "@yarnpkg/esbuild-plugin-pnp": "^2.0.0",
+    "@yarnpkg/esbuild-plugin-pnp": "3.0.0-rc.11",
     "cacache": "^15.0.5",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2572,10 +2572,10 @@
   resolved "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz"
   integrity sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==
 
-"@yarnpkg/esbuild-plugin-pnp@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@yarnpkg/esbuild-plugin-pnp/-/esbuild-plugin-pnp-2.0.1.tgz#120faad903d40e8f000ed3c9db9f9055c9612800"
-  integrity sha512-M8nYJr8S0riwy4Jgm3ja88m5ZfW6zZSV8fgLtO1mXpwTg0tD9ki1ShPOSm9DEbicc350TVf+k/jVNh6v1xApCw==
+"@yarnpkg/esbuild-plugin-pnp@3.0.0-rc.11":
+  version "3.0.0-rc.11"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/esbuild-plugin-pnp/-/esbuild-plugin-pnp-3.0.0-rc.11.tgz#5cd829662b916a3dbbdc5a76913380f1913d2b65"
+  integrity sha512-uwTdgbw9XIisx7oxqHrX7GFjsObxo5EhUYGjIg17TdHyAqgwZV6Ca7rqTjKZryLFoxkCFyMloxkclyze0onpQQ==
   dependencies:
     tslib "^1.13.0"
 


### PR DESCRIPTION
Closes: (No issue yet)

- [ ] Docs
- [ ] Tests

#### Testing Strategy:
Still no testing strategy for yarn pnp compatibility (though sounding like we might need to work out how to integration test this, given the complexity)

#### Related issues/PRs
This is another fix for yarn pnp, in the same realm as #3594, and related to [this fix](https://github.com/yarnpkg/berry/pull/4569) in `@yarnpkg/esbuild-plugin-pnp` by @jenseng, with the `resolveDir` esbuild property. However, this may not solve the issues with Deno that @lensbart is having.

This also un-does #3579 because that didn't actually work at all, just hid some errors (I was lazy there). After looking in much more detail I think I have solved a related problem.

### Issue/fix
I've noticed that all imports in the `pnp` namespace being resolved (in the `onResolve` esbuild callback) have an *empty* `resolveDir` value by default, which is actually breaking the remix `EmptyModulesPlugin` for pnp imports. That plugin assumes a `resolveDir` is present, and uses it to find the absolute path of files in the `app` folder, which does not work correctly when `resolveDir` is empty.

I've created a fairly easy fix in remix land, but wondering if this should instead be fixed in `@yarnpkg/esbuild-plugin-pnp`. Though I'm not sure if this is the expected behaviour from that plugin (maybe @jenseng has a better idea?).

I've seen [here](https://esbuild.github.io/plugins/#on-load-arguments) that the `resolveDir` can be returned from the esbuild `onLoad` callback in the plugin, I guess by just finding the directory part of the import path.

#### Client bundle issue (very related)

@MichaelDeBoey I've also noticed a similar issue when using yarn pnp, where even with this fix, imports from `@remix-run/node` fail in the browser because that module tries to require node built-ins (fs, path, etc.), which then throws errors in the browser. I'm not sure how this works with regular node resolution because the `EmptyModulesPlugin` actually doesn't strip out `@remix-run/node` imports in the client bundles at all. Have you got any ideas about this works with normal node resolution? Is it being stripped out elsewhere or is it failing silently, whilst yarn fails very loudly when it sees those node imports?

My hacky fix at the moment is to just re-export all `@remix-run/node` exports from a file like `node.server.ts`, so the `EmptyModulesPlugin` picks it up and removes it from the bundle. But maybe `remix-run/node` itself should automatically be explicitly removed from client bundles too?


