### PR TITLE
chore(remix-dev): fix flaky tests, make CLI more testable

### DIFF
--- a/packages/remix-dev/__tests__/migrations/convert-to-javascript-test.ts
+++ b/packages/remix-dev/__tests__/migrations/convert-to-javascript-test.ts
@@ -43,6 +43,7 @@ const TEMP_DIR = join(
   `remix-tests-${Math.random().toString(32).slice(2)}`
 );
 
+jest.setTimeout(30_000);
 beforeEach(() => {
   output = "";
   console.log = mockLog;

--- a/packages/remix-dev/__tests__/replace-remix-imports-test.ts
+++ b/packages/remix-dev/__tests__/replace-remix-imports-test.ts
@@ -38,6 +38,7 @@ const TEMP_DIR = path.join(
   `remix-tests-${Math.random().toString(32).slice(2)}`
 );
 
+jest.setTimeout(30_000);
 beforeEach(async () => {
   output = "";
   console.log = mockLog;

--- a/packages/remix-dev/cli.ts
+++ b/packages/remix-dev/cli.ts
@@ -1,11 +1,13 @@
-import { cli } from "./index";
+import { cli, CliError } from "./index";
 
 cli.run().then(
   () => {
     process.exit(0);
   },
-  (error: Error) => {
-    console.error(error);
+  (error: unknown) => {
+    // for expected errors we only show the message (if any), no stack trace
+    if (error instanceof CliError) error = error.message;
+    if (error) console.error(error);
     process.exit(1);
   }
 );

--- a/packages/remix-dev/cli/error.ts
+++ b/packages/remix-dev/cli/error.ts
@@ -1,0 +1,2 @@
+/** An expected error, for aborting the CLI */
+export class CliError extends Error {}

--- a/packages/remix-dev/cli/migrate/jscodeshift.ts
+++ b/packages/remix-dev/cli/migrate/jscodeshift.ts
@@ -28,7 +28,7 @@ export const run = async <TransformOptions extends Options = Options>({
     babel: true, // without this, `jscodeshift` will not be able to parse TS transforms
     dry,
     extensions: "tsx,ts,jsx,js",
-    failOnError: true,
+    failOnError: false,
     ignorePattern: ["**/node_modules/**", "**/.cache/**", "**/build/**"],
     parser: "tsx",
     print,

--- a/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/index.ts
+++ b/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/index.ts
@@ -7,6 +7,7 @@ import type { MigrationFunction } from "../../types";
 import { cleanupPackageJson } from "./cleanupPackageJson";
 import { convertTSConfigs } from "./convertTSConfigs";
 import { convertTSFilesToJS } from "./convertTSFilesToJS";
+import { CliError } from "../../../error";
 
 const TRANSFORM_PATH = join(__dirname, "transform");
 
@@ -38,7 +39,7 @@ export const convertToJavaScript: MigrationFunction = async ({
     if (!flags.debug) {
       console.log("👉 Try again with the `--debug` flag to see what failed.");
     }
-    process.exit(1);
+    throw new CliError();
   }
 
   // 4. Convert all .ts files to .js

--- a/packages/remix-dev/cli/migrate/migrations/replace-remix-imports/index.ts
+++ b/packages/remix-dev/cli/migrate/migrations/replace-remix-imports/index.ts
@@ -20,20 +20,19 @@ import {
 } from "./remixSetup";
 import { resolveTransformOptions } from "./resolveTransformOptions";
 import type { Options } from "./transform/options";
+import { CliError } from "../../../error";
 
 const TRANSFORM_PATH = join(__dirname, "transform");
 
 const getRemixVersionSpec = (remixDeps: Dependency[]): string => {
   let candidate = maxBy(remixDeps, (dep) => semver.minVersion(dep.versionSpec));
   if (candidate === undefined) {
-    console.error("❌ I couldn't find versions for your Remix packages.");
-    process.exit(1);
+    throw new CliError("❌ I couldn't find versions for your Remix packages.");
   }
 
   let candidateMin = semver.minVersion(candidate.versionSpec);
   if (candidateMin === null) {
-    console.error("❌ I couldn't find versions for your Remix packages.");
-    process.exit(1);
+    throw new CliError("❌ I couldn't find versions for your Remix packages.");
   }
   if (semver.lt(candidateMin, "1.3.3")) {
     console.log("⬆️  I'm upgrading your Remix dependencies");
@@ -170,7 +169,7 @@ export const replaceRemixImports: MigrationFunction = async ({
     if (!flags.debug) {
       console.log("👉 Try again with the `--debug` flag to see what failed.");
     }
-    process.exit(1);
+    throw new CliError();
   }
   console.log("✅ Your Remix imports look good!");
 

--- a/packages/remix-dev/cli/migrate/migrations/replace-remix-imports/resolveTransformOptions.ts
+++ b/packages/remix-dev/cli/migrate/migrations/replace-remix-imports/resolveTransformOptions.ts
@@ -2,6 +2,7 @@ import type { PackageJson } from "@npmcli/package-json";
 import inquirer from "inquirer";
 
 import * as colors from "../../../../colors";
+import { CliError } from "../../../error";
 import { depsToEntries, isRemixPackage } from "./dependency";
 import { because, detected } from "./messages";
 import { remixSetup, remixSetupRuntime } from "./remixSetup";
@@ -109,7 +110,7 @@ const resolveAdapter = (packageJson: PackageJson): Adapter | undefined => {
       adapters.map((adapter) => `   - @remix-run/${adapter}`).join("\n")
     );
     console.log("👉 Uninstall unused adapters and try again.");
-    process.exit(1);
+    throw new CliError();
   }
 
   if (adapters.length === 1) {

--- a/packages/remix-dev/index.ts
+++ b/packages/remix-dev/index.ts
@@ -4,5 +4,6 @@ export type { AppConfig } from "./config";
 
 export * as cli from "./cli/index";
 export { createApp } from "./cli/create";
+export { CliError } from "./cli/error";
 
 export { getDependenciesToBundle } from "./compiler/dependencies";


### PR DESCRIPTION
Rather than `process.exit(1)`, throw an error so we don't kill the jest worker. Also increase the timeout for two tests that often go more than 10 seconds (especially on Windows). The CLI entrypoint already exits appropriately if there's an error, it just needs a little tweak to better handle "expected" errors.

Because these tests are slow (running yarn, etc.), they would often time out while jscodeshift was still running, causing the afterEach callbacks to delete things underneath it and transforms to fail. `failOnError: true` would then cause jscodeshift to call `process.exit(1)`, which would then kill the current process (the jest worker). Depending on the exact timing, you'd see one or more of the following in the test output:

* A bunch of lines like:
    ```
    ERR C:/Users/RUNNER~1/AppData/Local/Temp/remix-tests-1179c2p2ev8/replace-remix-imports/app/db.server.ts File error: Error: ENOENT: no such file or directory, open 'C:\Users\RUNNER~1\AppData\Local\Temp\remix-tests-1179c2p2ev8\replace-remix-imports\app\db.server.ts'
    ERR C:/Users/RUNNER~1/AppData/Local/Temp/remix-tests-1179c2p2ev8/replace-remix-imports/app/entry.client.tsx File error: Error: ENOENT: no such file or directory, open 'C:\Users\RUNNER~1\AppData\Local\Temp\remix-tests-1179c2p2ev8\replace-remix-imports\app\entry.client.tsx'
    ERR C:/Users/RUNNER~1/AppData/Local/Temp/remix-tests-1179c2p2ev8/replace-remix-imports/app/entry.server.tsx File error: Error: ENOENT: no such file or directory, open 'C:\Users\RUNNER~1\AppData\Local\Temp\remix-tests-1179c2p2ev8\replace-remix-imports\app\entry.server.tsx'
    ```
* A test failure like:
    ```
        thrown: "Exceeded timeout of 10000 ms for a test.
        Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."
    ```
* Jest aborting altogether:
    ```
      ●  process.exit called with "1"
          45 |
          46 |   try {
        > 47 |     let { error } = await jscodeshift(transformPath, files, options);
    ```

This PR focuses solely on the migration code/tests, but it's probably worth moving away from `process.exit(1)` elsewhere in the CLI.

Testing Strategy:
* Broken behavior was diagnosed/debugged and the fix was validated here:
  https://github.com/jenseng/remix/actions?query=branch%3Afix-jscodeshift-tests
  In particular, test run # 13 shows the directory structure as it gets mutated underneath jscodeshift by the afterEach
* Manually validated CLI still works normally and a CliError behaves as expected
