### PR TITLE
fix(docs/tutorials): update pre-requisite Node version

### DIFF
--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -19,7 +19,7 @@ Click this button to create a [Gitpod][gitpod] workspace with the project set up
 
 If you want to follow this tutorial locally on your own computer, it is important for you to have these things installed:
 
-- [Node.js][node-js] 14 or greater
+- [Node.js][node-js] version (^12.22.0, ^14.17.0, or >=16.0.0)
 - [npm][npm] 7 or greater
 - A code editor
 

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -57,7 +57,7 @@ You'll find links to the sections of the tutorial in the navbar (top of the page
 
 You can follow along with this tutorial on [CodeSandbox][code-sandbox] (a fantastic in-browser editor) or locally on your own computer. If you use the CodeSandbox approach then all you need is a good internet connection and a modern browser. If you run things locally then you're going to need some things installed:
 
-- [Node.js][node-js] 14 or greater
+- [Node.js][node-js] version (^12.22.0, ^14.17.0, or >=16.0.0)
 - [npm][npm] 7 or greater
 - A code editor ([VSCode][vs-code] is a nice one)
 


### PR DESCRIPTION
## Summary of Changes
- update pre-requisite node version requirements for docs.
- `eslint` version 8 requires the following node version (^12.22.0, ^14.17.0, or >=16.0.0)

Closes: #3652

## Motivation for Changes
- `npm install / yarn install` failure 
  ![image](https://user-images.githubusercontent.com/6743796/177436895-0e294411-cf89-49ba-a8b8-be7317884156.png)

- `eslint` v8 requires the 3 versions specified above
   ![image](https://user-images.githubusercontent.com/6743796/177436914-60e20260-c57d-4135-97e7-6d62a11f244b.png)


- [X] Docs
- [ ] Tests

Testing Strategy:
- N/A docs changes only
