### PR TITLE
ci(deploy/vercel): pass token via `--token`

### DIFF
--- a/scripts/deployment-test/vercel.mjs
+++ b/scripts/deployment-test/vercel.mjs
@@ -119,7 +119,7 @@ async function createAndDeployApp() {
   // deploy to vercel
   let deployCommand = spawnSync(
     "npx",
-    ["vercel", "deploy", "--prod"],
+    ["vercel", "deploy", "--prod", "--token", process.env.VERCEL_TOKEN],
     spawnOpts
   );
   if (deployCommand.status !== 0) {


### PR DESCRIPTION
i don't think vercel deploy allows for the environment variable, instead requiring the flag to be passed, but other vercel commands allow it 🤷‍♂️ https://github.com/vercel/vercel/blob/695bfbdd60a97030457ea1861c5bb89bcfe92353/packages/cli/src/index.ts#L439, so I'll keep in spawn's `env`.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
