### PR TITLE
fix(remix-react): set fetch referrer to document.referrer

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -152,6 +152,7 @@
 - isaacrmoreno
 - ishan-me
 - IshanKBG
+- itsMapleLeaf
 - jacob-ebey
 - JacobParis
 - jakewtaylor

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -70,6 +70,10 @@ test.beforeAll(async () => {
         export default function Index() {
           return <div>cheeseburger</div>;
         }
+        
+        export default function Render() {
+            return <span />;
+        }
       `,
     },
   });

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -70,10 +70,6 @@ test.beforeAll(async () => {
         export default function Index() {
           return <div>cheeseburger</div>;
         }
-        
-        export default function Render() {
-            return <span />;
-        }
       `,
     },
   });

--- a/integration/form-referer-test.ts
+++ b/integration/form-referer-test.ts
@@ -1,0 +1,127 @@
+import { test, expect } from "@playwright/test";
+
+import { PlaywrightFixture } from "./helpers/playwright-fixture";
+import type { Fixture, AppFixture } from "./helpers/create-fixture";
+import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
+
+let fixture: Fixture;
+let appFixture: AppFixture;
+
+////////////////////////////////////////////////////////////////////////////////
+// 💿 👋 Hola! It's me, Dora the Remix Disc, I'm here to help you write a great
+// bug report pull request.
+//
+// You don't need to fix the bug, this is just to report one.
+//
+// The pull request you are submitting is supposed to fail when created, to let
+// the team see the erroneous behavior, and understand what's going wrong.
+//
+// If you happen to have a fix as well, it will have to be applied in a subsequent
+// commit to this pull request, and your now-succeeding test will have to be moved
+// to the appropriate file.
+//
+// First, make sure to install dependencies and build Remix. From the root of
+// the project, run this:
+//
+//    ```
+//    yarn && yarn build
+//    ```
+//
+// Now try running this test:
+//
+//    ```
+//    yarn bug-report-test
+//    ```
+//
+// You can add `--watch` to the end to have it re-run on file changes:
+//
+//    ```
+//    yarn bug-report-test --watch
+//    ```
+////////////////////////////////////////////////////////////////////////////////
+
+test.beforeAll(async () => {
+  fixture = await createFixture({
+    ////////////////////////////////////////////////////////////////////////////
+    // 💿 Next, add files to this object, just like files in a real app,
+    // `createFixture` will make an app and run your tests against it.
+    ////////////////////////////////////////////////////////////////////////////
+    files: {
+      "app/routes/form.jsx": js`
+        import { useSearchParams, useFetcher, Form } from "@remix-run/react";
+
+        export default function FormPage() {
+          const [params] = useSearchParams()
+          const redirects = params.get("redirects") ?? 0
+          const fetcher = useFetcher()
+          return <>
+            <p>{'redirects: ' + redirects}</p>
+            <form action="/action" method="post">
+              <button name="redirects" value={redirects} data-testid="browser">browser form</button>
+            </form>
+            <Form action="/action" method="post">
+              <button name="redirects" value={redirects} data-testid="remix">remix form</button>
+            </Form>
+            <fetcher.Form action="/action" method="post">
+              <button name="redirects" value={redirects} data-testid="fetcher">fetcher form</button>
+            </fetcher.Form>
+          </>
+        }
+      `,
+
+      "app/routes/action.jsx": js`
+        import { redirect } from '@remix-run/node'
+        import { useActionData } from '@remix-run/react'
+        export async function action({ request }) {
+          const data = await request.formData()
+          const redirects = data.get("redirects")
+          const referer = new URL(request.headers.get("referer"))
+          referer.searchParams.set("redirects", Number(redirects) + 1)
+          return redirect(referer.toString())
+        }
+
+        export default function Render() {
+            return <span>This should not be shown</span>;
+        }
+      `,
+    },
+  });
+
+  // This creates an interactive app using puppeteer.
+  appFixture = await createAppFixture(fixture);
+});
+
+test.afterAll(async () => appFixture.close());
+
+////////////////////////////////////////////////////////////////////////////////
+// 💿 Almost done, now write your failing test case(s) down here Make sure to
+// add a good description for what you expect Remix to do 👇🏽
+////////////////////////////////////////////////////////////////////////////////
+
+test("should redirect via referrer header", async ({ page }) => {
+  let app = new PlaywrightFixture(appFixture, page);
+  // You can test any request your app might get using `fixture`.
+  // If you need to test interactivity use the `app`
+
+  await app.goto("/form");
+  expect(await app.getHtml()).toMatch("redirects: 0");
+  await app.clickElement("[data-testid=browser]");
+  expect(await app.getHtml()).toMatch("redirects: 1");
+  await app.clickElement("[data-testid=fetcher]");
+  expect(await app.getHtml()).toMatch("redirects: 2");
+  await app.clickElement("[data-testid=remix]");
+
+  let html = await app.getHtml();
+  expect(html).toMatch("redirects: 3");
+  expect(html).not.toMatch("This should not be shown");
+
+  // If you're not sure what's going on, you can "poke" the app, it'll
+  // automatically open up in your browser for 20 seconds, so be quick!
+  // await app.poke(20, "/form");
+
+  // Go check out the other tests to see what else you can do.
+});
+
+////////////////////////////////////////////////////////////////////////////////
+// 💿 Finally, push your changes to your fork of Remix and open a pull request!
+////////////////////////////////////////////////////////////////////////////////

--- a/packages/remix-react/data.ts
+++ b/packages/remix-react/data.ts
@@ -40,7 +40,7 @@ export async function fetchData(
 
   let init: RequestInit = submission
     ? getActionInit(submission, signal)
-    : { credentials: "same-origin", signal };
+    : { credentials: "same-origin", signal, referrer: document.referrer };
 
   let response = await fetch(url.href, init);
 
@@ -93,5 +93,6 @@ function getActionInit(
     signal,
     credentials: "same-origin",
     headers,
+    referrer: document.referrer,
   };
 }


### PR DESCRIPTION
though you really shouldn't use `referer` willynilly when redirecting without verifying it's value, but at least it's consistent with the browser now 😆

~~doesnt really explain why `fetcher.Form` was working though...~~

i think this is due to to `handleActionFetchSubmission` using the actual match, whereas `handleActionSubmissionNavigation` uses the leaf match 

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes #2110
Closes #3612

- [ ] Docs
- [x] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
