### PR TITLE
fix(remix-react): An error in `MetaFunction` or `LinkFunction` should render `ErrorBoundary`

### DIFF
--- a/integration/error-boundary-test.ts
+++ b/integration/error-boundary-test.ts
@@ -711,7 +711,7 @@ test.describe("ErrorBoundary", () => {
     });
   });
 
-  test.describe("errors in meta and links dont result in internal server error", () => {
+  test.describe("errors in meta and links don't result in internal server error", () => {
     let ROOT_BOUNDARY_TEXT = "ROOT_BOUNDARY_TEXT";
     let META_ERROR = "/meta-error";
     let LINKS_ERROR = "/links-error";
@@ -820,6 +820,8 @@ test.describe("ErrorBoundary", () => {
       let app = new PlaywrightFixture(appFixture, page);
       await app.goto("/");
       await app.clickLink(META_ERROR);
+      expect(await app.getHtml("main")).toMatch(ROOT_BOUNDARY_TEXT);
+      await page.reload();
       expect(await app.getHtml("main")).toMatch(ROOT_BOUNDARY_TEXT);
     });
 

--- a/integration/error-boundary-test.ts
+++ b/integration/error-boundary-test.ts
@@ -25,6 +25,9 @@ test.describe("ErrorBoundary", () => {
 
   let NOT_FOUND_HREF = "/not/found";
 
+  let META_ERROR = "/meta-error";
+  let LINKS_ERROR = "/links-error";
+
   // packages/remix-react/errorBoundaries.tsx
   let INTERNAL_ERROR_BOUNDARY_HEADING = "Application Error";
 
@@ -102,6 +105,12 @@ test.describe("ErrorBoundary", () => {
                 <Link to="${NO_BOUNDARY_RENDER}">
                   ${NO_BOUNDARY_RENDER}
                 </Link>
+                <Link to="${META_ERROR}">
+                  ${META_ERROR}
+                </Link>
+                <Link to="${LINKS_ERROR}">
+                  ${LINKS_ERROR}
+                </Link>
               </div>
             )
           }
@@ -158,6 +167,26 @@ test.describe("ErrorBoundary", () => {
           export function loader() {
             throw new Error("Kaboom!")
           }
+          export default function () {
+            return <div/>
+          }
+        `,
+
+        [`app/routes${LINKS_ERROR}.jsx`]: js`
+          export function links() {
+            throw new Error("Kaboom!")
+          }
+
+          export default function () {
+            return <div/>
+          }
+        `,
+
+        [`app/routes${META_ERROR}.jsx`]: js`
+          export function meta() {
+            throw new Error("Kaboom!")
+          }
+
           export default function () {
             return <div/>
           }
@@ -405,6 +434,36 @@ test.describe("ErrorBoundary", () => {
     await app.clickLink(HAS_BOUNDARY_RENDER);
     await page.waitForSelector(`text=${OWN_BOUNDARY_TEXT}`);
     expect(await app.getHtml("main")).toMatch(OWN_BOUNDARY_TEXT);
+  });
+
+  test("ssr renders error boundary when meta throws", async () => {
+    let res = await fixture.requestDocument(META_ERROR);
+    expect(res.status).toBe(500);
+    expect(await res.text()).toMatch(ROOT_BOUNDARY_TEXT);
+  });
+
+  test("script transition renders error boundary when meta throws", async ({
+    page,
+  }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/");
+    await app.clickLink(META_ERROR);
+    expect(await app.getHtml("main")).toMatch(ROOT_BOUNDARY_TEXT);
+  });
+
+  test("ssr renders error boundary when links function throws", async () => {
+    let res = await fixture.requestDocument(LINKS_ERROR);
+    expect(res.status).toBe(500);
+    expect(await res.text()).toMatch(ROOT_BOUNDARY_TEXT);
+  });
+
+  test("script transition renders error boundary when links function throws", async ({
+    page,
+  }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/");
+    await app.clickLink(LINKS_ERROR);
+    expect(await app.getHtml("main")).toMatch(ROOT_BOUNDARY_TEXT);
   });
 
   test("uses correct error boundary on server action errors in nested routes", async ({

--- a/integration/error-boundary-test.ts
+++ b/integration/error-boundary-test.ts
@@ -664,14 +664,14 @@ test.describe("ErrorBoundary", () => {
           `,
 
           [`app/routes${LINKS_ERROR}.jsx`]: js`
-          export function links() {
-            throw new Error("Kaboom!")
-          }
+            export function links() {
+              throw new Error("Kaboom!")
+            }
 
-          export default function () {
-            return <div/>
-          }
-        `,
+            export default function () {
+              return <div/>
+            }
+          `,
 
           [`app/routes${META_ERROR}.jsx`]: js`
             export function meta() {

--- a/integration/error-boundary-test.ts
+++ b/integration/error-boundary-test.ts
@@ -780,27 +780,27 @@ test.describe("ErrorBoundary", () => {
           `,
 
           [`app/routes${LINKS_ERROR}.jsx`]: js`
-          export function links() {
-            throw new Error("Kaboom!")
-          }
+            export function links() {
+              throw new Error("Kaboom!")
+            }
 
-          export default function () {
-            return <div/>
-          }
-        `,
+            export default function () {
+              return <div/>
+            }
+          `,
 
           [`app/routes${META_ERROR}.jsx`]: js`
-          export function meta() {
-            throw new Error("Kaboom!")
-          }
+            export function meta() {
+              throw new Error("Kaboom!")
+            }
 
-          export default function () {
-            return <div/>
-          }
-        `,
+            export default function () {
+              return <div/>
+            }
+          `,
         },
       });
-      appFixture = await createAppFixture(fixture);
+      appFixture = await createAppFixture(fixture, ServerMode.Development);
     });
 
     test.afterAll(() => {

--- a/integration/helpers/create-fixture.ts
+++ b/integration/helpers/create-fixture.ts
@@ -6,7 +6,7 @@ import getPort from "get-port";
 import stripIndent from "strip-indent";
 import { sync as spawnSync } from "cross-spawn";
 import type { JsonObject } from "type-fest";
-import type { ServerMode } from "@remix-run/server-runtime/mode";
+import { ServerMode } from "@remix-run/server-runtime/mode";
 import type { FutureConfig } from "@remix-run/server-runtime/entry";
 
 import type { ServerBuild } from "../../build/node_modules/@remix-run/server-runtime";
@@ -92,7 +92,10 @@ export async function createFixture(init: FixtureInit) {
   };
 }
 
-export async function createAppFixture(fixture: Fixture, mode?: ServerMode) {
+export async function createAppFixture(
+  fixture: Fixture,
+  mode: ServerMode = ServerMode.Production
+) {
   let startAppServer = async (): Promise<{
     port: number;
     stop: VoidFunction;
@@ -102,13 +105,7 @@ export async function createAppFixture(fixture: Fixture, mode?: ServerMode) {
       let app = express();
       app.use(express.static(path.join(fixture.projectDir, "public")));
 
-      app.all(
-        "*",
-        createExpressHandler({
-          build: fixture.build,
-          mode: mode || "production",
-        })
-      );
+      app.all("*", createExpressHandler({ build: fixture.build, mode }));
 
       let server = app.listen(port);
 

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -385,11 +385,12 @@ export function Links() {
     if (root.ErrorBoundary) {
       renderableMatches.push({
         params: {},
-        pathname: "",
+        pathname: "/",
         pathnameBase: "/",
         route: {
           id: "root",
-          hasErrorBoundary: !!root.ErrorBoundary,
+          path: "/",
+          hasErrorBoundary: true,
         },
       });
     }
@@ -611,11 +612,12 @@ function V1Meta() {
     if (root.ErrorBoundary) {
       renderableMatches.push({
         params: {},
-        pathname: "",
+        pathname: "/",
         pathnameBase: "/",
         route: {
           id: "root",
-          hasErrorBoundary: !!root.ErrorBoundary,
+          path: "/",
+          hasErrorBoundary: true,
         },
       });
     }
@@ -729,11 +731,12 @@ function V2Meta() {
     if (root.ErrorBoundary) {
       renderableMatches.push({
         params: {},
-        pathname: "",
+        pathname: "/",
         pathnameBase: "/",
         route: {
           id: "root",
-          hasErrorBoundary: !!root.ErrorBoundary,
+          path: "/",
+          hasErrorBoundary: true,
         },
       });
     }

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -390,7 +390,9 @@ export function Links() {
         route: {
           id: "root",
           path: "/",
-          hasErrorBoundary: true,
+          hasErrorBoundary: !!root.ErrorBoundary,
+          handle: root.handle,
+          shouldRevalidate: root.shouldRevalidate,
         },
       });
     }
@@ -570,25 +572,12 @@ function getRenderableMatches(
   matches: AgnosticDataRouteMatch[],
   errors: RouteData | null
 ) {
-  if (!matches) {
-    return null;
+  if (errors) {
+    let index = matches.findIndex((match) => errors[match.route.id]);
+    return matches.slice(0, index + 1);
   }
 
-  // no error, no worries
-  if (!errors || Object.keys(errors).length === 0) {
-    return matches;
-  }
-
-  let lastRenderableIndex: number = -1;
-
-  matches.forEach((match, index) => {
-    let id = match.route.id;
-    if (errors[id]) {
-      lastRenderableIndex = index;
-    }
-  });
-
-  return matches.slice(0, lastRenderableIndex + 1);
+  return matches;
 }
 
 /**
@@ -602,7 +591,7 @@ function V1Meta() {
   let location = useLocation();
 
   let meta: V1_HtmlMetaDescriptor = {};
-  let parentsData: { [routeId: string]: AppData } = {};
+  let parentsData: RouteData = {};
 
   let renderableMatches = getRenderableMatches(matches, errors);
 
@@ -617,7 +606,9 @@ function V1Meta() {
         route: {
           id: "root",
           path: "/",
-          hasErrorBoundary: true,
+          hasErrorBoundary: !!root.ErrorBoundary,
+          handle: root.handle,
+          shouldRevalidate: root.shouldRevalidate,
         },
       });
     }
@@ -641,6 +632,7 @@ function V1Meta() {
               matches: undefined as any,
             })
           : routeModule.meta;
+
       if (routeMeta && Array.isArray(routeMeta)) {
         throw new Error(
           "The route at " +
@@ -720,7 +712,7 @@ function V2Meta() {
 
   let meta: V2_HtmlMetaDescriptor[] = [];
   let leafMeta: V2_HtmlMetaDescriptor[] | null = null;
-  let parentsData: { [routeId: string]: AppData } = {};
+  let parentsData: RouteData = {};
 
   let renderableMatches = getRenderableMatches(matches, errors);
 
@@ -735,7 +727,9 @@ function V2Meta() {
         route: {
           id: "root",
           path: "/",
-          hasErrorBoundary: true,
+          hasErrorBoundary: !!root.ErrorBoundary,
+          handle: root.handle,
+          shouldRevalidate: root.shouldRevalidate,
         },
       });
     }

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -648,9 +648,8 @@ function V1Meta() {
             " returns an array. This is only supported with the `v2_meta` future flag " +
             "in the Remix config. Either set the flag to `true` or update the route's " +
             "meta function to return an object." +
-            "\n\nTo reference the v1 meta function API, see https://remix.run/route/meta"
-          // TODO: Add link to the docs once they are written
-          // + "\n\nTo reference future flags and the v2 meta API, see https://remix.run/file-conventions/remix-config#future-v2-meta."
+            "\n\nTo reference the v1 meta function API, see https://remix.run/route/meta" +
+            "\n\nTo reference future flags and the v2 meta API, see https://remix.run/docs/en/v1/route/meta#metav2."
         );
       }
       Object.assign(meta, routeMeta);
@@ -786,8 +785,7 @@ function V2Meta() {
           match.route.path +
           " returns an invalid value. In v2, all route meta functions must " +
           "return an array of meta objects." +
-          // TODO: Add link to the docs once they are written
-          // "\n\nTo reference future flags and the v2 meta API, see https://remix.run/file-conventions/remix-config#future-v2-meta." +
+          "\n\nTo reference future flags and the v2 meta API, see https://remix.run/docs/en/v1/route/meta#metav2." +
           "\n\nTo reference the v1 meta function API, see https://remix.run/route/meta"
       );
     }

--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -236,6 +236,28 @@ export function getLinksForMatches(
   return dedupe(descriptors, preloads);
 }
 
+export async function metaPls(routeModule: RouteModule): Promise<void> {
+  if (!routeModule.meta) return;
+  // we're not actually gonna do anything with this...
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let meta =
+    typeof routeModule.meta === "function"
+      ? routeModule.meta({
+          data: {},
+          location: {
+            hash: "",
+            key: "",
+            pathname: "",
+            search: "",
+            state: undefined,
+          },
+          matches: undefined as any,
+          params: {},
+          parentsData: {},
+        })
+      : routeModule.meta;
+}
+
 export async function prefetchStyleLinks(
   routeModule: RouteModule
 ): Promise<void> {

--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -226,9 +226,9 @@ export function getLinksForMatches(
   manifest: AssetsManifest
 ): LinkDescriptor[] {
   let descriptors = matches
-    .map((match): LinkDescriptor[] => {
+    .map<LinkDescriptor[]>((match) => {
       let module = routeModules[match.route.id];
-      return module.links?.() || [];
+      return typeof module.links === "function" ? module.links() : [];
     })
     .flat(1);
 

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -17,7 +17,7 @@ import {
   parseDeferredReadableStream,
 } from "./data";
 import type { FutureConfig } from "./entry";
-import { prefetchStyleLinks } from "./links";
+import { metaPls, prefetchStyleLinks } from "./links";
 import invariant from "./invariant";
 import { RemixRoute, RemixRouteError } from "./components";
 
@@ -170,6 +170,7 @@ async function loadRouteModuleWithBlockingLinks(
 ) {
   let routeModule = await loadRouteModule(route, routeModules);
   await prefetchStyleLinks(routeModule);
+  await metaPls(routeModule);
   return routeModule;
 }
 

--- a/packages/remix-server-runtime/headers.ts
+++ b/packages/remix-server-runtime/headers.ts
@@ -1,18 +1,29 @@
-import type { StaticHandlerContext } from "@remix-run/router";
+import type {
+  AgnosticDataRouteMatch,
+  StaticHandlerContext,
+} from "@remix-run/router";
 import { splitCookiesString } from "set-cookie-parser";
 
 import type { ServerBuild } from "./build";
+import type { RouteData } from "./routeData";
+
+function getRenderableMatches(
+  matches: AgnosticDataRouteMatch[],
+  errors: RouteData | null
+) {
+  if (errors) {
+    let index = matches.findIndex((match) => errors[match.route.id]);
+    return matches.slice(0, index + 1);
+  }
+
+  return matches;
+}
 
 export function getDocumentHeadersRR(
   build: ServerBuild,
   context: StaticHandlerContext
 ): Headers {
-  let matches = context.errors
-    ? context.matches.slice(
-        0,
-        context.matches.findIndex((m) => context.errors![m.route.id]) + 1
-      )
-    : context.matches;
+  let matches = getRenderableMatches(context.matches, context.errors);
 
   return matches.reduce((parentHeaders, match) => {
     let { id } = match.route;


### PR DESCRIPTION
Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes #3140

- [ ] Docs
- [ ] Tests

Testing Strategy:

- these tests cover the changed code: [error-boundary-test.ts](https://github.com/remix-run/remix/blob/logan/rem-1298-meta-link-error-boundary/integration/error-boundary-test.ts)
- I also opened up a new playground to make sure it all worked there as well.

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
