### PR TITLE
fix(remix-server-runtime): support interfaces in `JsonFunction`

### DIFF
--- a/packages/remix-server-runtime/responses.ts
+++ b/packages/remix-server-runtime/responses.ts
@@ -1,17 +1,4 @@
-type SerializablePrimitives =
-  | string
-  | number
-  | boolean
-  | null
-  | { toJSON(): unknown }
-  | undefined
-  | Function
-  | symbol;
-type Serializable =
-  | SerializablePrimitives
-  | { [key: string | number | symbol]: Serializable }
-  | Serializable[];
-export type JsonFunction = <Data extends Serializable>(
+export type JsonFunction = <Data extends unknown>(
   data: Data,
   init?: number | ResponseInit
 ) => TypedResponse<Data>;


### PR DESCRIPTION
In the original loader type inference PR #3276 I made an attempt to constrain the generic parameter of the `json` function to exclusively JSON-compatible types. This caused [typechecking errors](https://github.com/remix-run/remix/runs/7240224157?check_suite_focus=true) when attempting to assign an interface to the generic due to https://github.com/microsoft/TypeScript/issues/15300

```ts
interface MyInterface { arg: string };
json<MyInterface>();
// Index signature is missing in type
```

This PR implements the most straightforward solution: loosening the generic parameter of `json` to allow any type `<T extends unknown>`. This was the type signature before my PR landed so it will certainly be backwards compatible. Enforcing JSON serializability statically would have been nice but I don't think it's a big loss.
