### PR TITLE
fix(remix-dev): declare `--port` & `-p` flags

### DIFF
--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -163,6 +163,8 @@ export async function run(argv: string[] = process.argv.slice(2)) {
       "--json": Boolean,
       "--migration": String,
       "-m": "--migration",
+      "--port": Number,
+      "-p": "--port",
       "--remix-version": String,
       "--sourcemap": Boolean,
       "--template": String,


### PR DESCRIPTION
It seems that we forgot to declare it in #3447

Closes #3693