### PR TITLE
docs(guides/typescript): fix code highlighting

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -378,6 +378,7 @@
 - visormatt
 - vkrol
 - vlindhol
+- vmosyaykin
 - weavdale
 - wKovacs64
 - wladiston

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -8,7 +8,7 @@ Remix seamlessly supports both JavaScript and TypeScript. If you name a file wit
 
 The Remix compiler will not do any type checking (it simply removes the types). If you want to do type checking, you'll want to use TypeScript's `tsc` CLI yourself. A common solution is to add a `typecheck` script to your package.json:
 
-```json filename=package.json lines=[11]
+```json filename=package.json lines=[9]
 {
   "name": "remix-app",
   "private": true,


### PR DESCRIPTION
I noticed that the line highlight in the Typescript guide is misplaced:

![image](https://user-images.githubusercontent.com/4989930/178259253-ff6aa4da-7d3d-4ca3-9e32-bce85ac907f7.png)

The `package.json` template was updated in e9692e11, but the hightlight stayed on the old line number, this PR fixes that.

Other snippets of `package.json` and `tsconfig.json` in the docs are correct,