### PR TITLE
templates(vercel): update `@vercel/node` dependency

### DIFF
--- a/templates/vercel/package.json
+++ b/templates/vercel/package.json
@@ -9,7 +9,7 @@
     "@remix-run/node": "*",
     "@remix-run/react": "*",
     "@remix-run/vercel": "*",
-    "@vercel/node": "^1.15.2",
+    "@vercel/node": "^2.4.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },


### PR DESCRIPTION
Follow-up of #3420

---

Base branch is `dev`, because we need #3420 to be merged in order for this to work