### PR TITLE
fix(remix-eslint-config): use `require.resolve` when importing `@babel/preset-react`

### DIFF
--- a/.changeset/blue-starfishes-study.md
+++ b/.changeset/blue-starfishes-study.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/eslint-config": patch
+---
+
+fix(remix-eslint-config): use `require.resolve` when importing `@babel/preset-react`

--- a/contributors.yml
+++ b/contributors.yml
@@ -391,3 +391,4 @@
 - zainfathoni
 - zhe
 - garand
+- kiancross

--- a/packages/remix-eslint-config/index.js
+++ b/packages/remix-eslint-config/index.js
@@ -26,7 +26,7 @@ const config = {
     requireConfigFile: false,
     ecmaVersion: "latest",
     babelOptions: {
-      presets: ["@babel/preset-react"],
+      presets: [require.resolve("@babel/preset-react")],
     },
   },
   env: {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #3715

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->

1. In a new directory run `yarn init -2`.
2. Then run `yarn add -D eslint @remix-run/eslint-config`.
3. Create a file called `.eslintrc` with the following:
```json
{
  "extends": [ "@remix-run/eslint-config" ]
}
```
4. Create a file called `test.js` with the following:
```js
eslint_Wont_like_This = true
```
5. Run `yarn eslint test.js`.
6. Ensure that the output is an ESlint problem and not a Yarn error (as shown in #3715).

I attempted to write an automated test, however, I couldn't find any preexisting ones for this package, so I didn't have anything to go off.