### PR TITLE
feat(remix-server-runtime): add `name` to `SerializedError`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -187,6 +187,7 @@
 - jkup
 - jmasson
 - JNaftali
+- jnicklas
 - jo-ninja
 - joaosamouco
 - jodygeraldo

--- a/packages/remix-server-runtime/errors.ts
+++ b/packages/remix-server-runtime/errors.ts
@@ -60,12 +60,14 @@ export interface ThrownResponse<T = any> {
 // must be type alias due to inference issues on interfaces
 // https://github.com/microsoft/TypeScript/issues/15300
 export type SerializedError = {
+  name: string;
   message: string;
   stack?: string;
 };
 
 export async function serializeError(error: Error): Promise<SerializedError> {
   return {
+    name: error.name,
     message: error.message,
     stack: error.stack,
   };


### PR DESCRIPTION
The name of the error is an important piece of information, which helps
in determining the cause of failures. Usually in Node, the name is also
part of the stack trace, so it may not be seen as completely necessary.
However, some tooling expects the name to be meaningful for diagnostics.
This change serializes the error name in the app state, making it
accessible for tooling which wants to introspect it.

- [ ] Docs (not necessary, I think?)
- [x] Tests

Testing Strategy:

Extending the existing tests to check the proper serialization of the error name, and that is properly obfuscated in production mode.