### PR TITLE
Defer manifest

### DIFF
--- a/.changeset/witty-emus-grab.md
+++ b/.changeset/witty-emus-grab.md
@@ -1,0 +1,8 @@
+---
+"remix": patch
+"@remix-run/deno": patch
+"@remix-run/dev": patch
+"@remix-run/react": patch
+---
+
+defer manifest script to speed up TTI

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -811,7 +811,7 @@ window.__remixRouteModules = {${matches
           suppressHydrationWarning
           dangerouslySetInnerHTML={createHtml(contextScript)}
         />
-        <script {...props} src={manifest.url} />
+        <script {...props} src={manifest.url} defer />
         <script
           {...props}
           dangerouslySetInnerHTML={createHtml(routeModulesScript)}


### PR DESCRIPTION
w/o `defer` loading this script is a blocking resource, but it doesn't need to be. The scripts that need it are already `<script type=module>` which are automatically deferred. Deferred scripts are executed in order, so it's guaranteed to be available before the following scripts that need it are executed.

Testing Strategy: It's just `<script defer>` so we don't need to test that chromium defers correctly. Since all existing tests pass, we know it doesn't break apps.
