### PR TITLE
fix(remix-dev): update type for ServerBuild virtual module

### DIFF
--- a/.changeset/weak-icons-matter.md
+++ b/.changeset/weak-icons-matter.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/dev": patch
+---
+
+update type for `@remix-run/dev/server-build` virtual module #3743

--- a/packages/remix-dev/server-build.ts
+++ b/packages/remix-dev/server-build.ts
@@ -10,3 +10,6 @@ throw new Error(
 export const assets: ServerBuild["assets"] = undefined!;
 export const entry: ServerBuild["entry"] = undefined!;
 export const routes: ServerBuild["routes"] = undefined!;
+export const publicPath: ServerBuild["publicPath"] = undefined!;
+// prettier-ignore
+export const assetsBuildDirectory: ServerBuild["assetsBuildDirectory"] = undefined!;


### PR DESCRIPTION
closes https://github.com/remix-run/grunge-stack/issues/85

x-ref #3349

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
