### PR TITLE
docs(changelogs): Update verbiage on loader/action type changes

### DIFF
--- a/packages/remix-cloudflare/CHANGELOG.md
+++ b/packages/remix-cloudflare/CHANGELOG.md
@@ -4,22 +4,43 @@
 
 ### Patch Changes
 
-- We enhanced the type signatures of `loader`/`action` and `useLoaderData`/`useActionData` to make it possible to infer the data type from return type of its related server function.
+- We enhanced the type signatures of `loader`/`action` and
+  `useLoaderData`/`useActionData` to make it possible to infer the data type
+  from return type of its related server function.
 
-  ```tsx
-  import type { LoaderArgs } from "@remix-run/cloudflare";
+  To enable this feature, you will need to use the `LoaderArgs` type from
+  `@remix-run/cloudflare` instead of typing the function directly:
 
-  export async function loader(args: LoaderArgs) {
-    return json({ greeting: "Hello!" }); // TypedResponse<{ greeting: string }>
-  }
+  ```diff
+  - import type { LoaderFunction } from "@remix-run/cloudflare";
+  + import type { LoaderArgs } from "@remix-run/cloudflare";
 
-  export default function App() {
-    let data = useLoaderData<typeof loader>(); // { greeting: string }
-    return <div>{data.greeting}</div>;
-  }
+  - export const loader: LoaderFunction = async (args) => {
+  -   return json<LoaderData>(data);
+  - }
+  + export async function loader(args: LoaderArgs) {
+  +   return json(data);
+  + }
   ```
 
-  See the discussion in [#1254](https://github.com/remix-run/remix/pull/1254) for more context.
+  Then you can infer the loader data by using `typeof loader` as the type
+  variable in `useLoaderData`:
+
+  ```diff
+  - let data = useLoaderData() as LoaderData;
+  + let data = useLoaderData<typeof loader>();
+  ```
+
+  The API above is exactly the same for your route `action` and `useActionData`
+  via the `ActionArgs` type.
+
+  With this change you no longer need to manually define a `LoaderData` type
+  (huge time and typo saver!), and we serialize all values so that
+  `useLoaderData` can't return types that are impossible over the network, such
+  as `Date` objects or functions.
+
+  See the discussions in [#1254](https://github.com/remix-run/remix/pull/1254)
+  and [#3276](https://github.com/remix-run/remix/pull/3276) for more context.
 
 - Updated dependencies
   - `@remix-run/server-runtime@1.6.5`

--- a/packages/remix-deno/CHANGELOG.md
+++ b/packages/remix-deno/CHANGELOG.md
@@ -8,21 +8,39 @@
   `useLoaderData`/`useActionData` to make it possible to infer the data type
   from return type of its related server function.
 
-  ```tsx
-  import type { LoaderArgs } from "@remix-run/deno";
+  To enable this feature, you will need to use the `LoaderArgs` type from
+  `@remix-run/deno` instead of typing the function directly:
 
-  export async function loader(args: LoaderArgs) {
-    return json({ greeting: "Hello!" }); // TypedResponse<{ greeting: string }>
-  }
+  ```diff
+  - import type { LoaderFunction } from "@remix-run/deno";
+  + import type { LoaderArgs } from "@remix-run/deno";
 
-  export default function App() {
-    let data = useLoaderData<typeof loader>(); // { greeting: string }
-    return <div>{data.greeting}</div>;
-  }
+  - export const loader: LoaderFunction = async (args) => {
+  -   return json<LoaderData>(data);
+  - }
+  + export async function loader(args: LoaderArgs) {
+  +   return json(data);
+  + }
   ```
 
-  See the discussion in [#1254](https://github.com/remix-run/remix/pull/1254)
-  for more context.
+  Then you can infer the loader data by using `typeof loader` as the type
+  variable in `useLoaderData`:
+
+  ```diff
+  - let data = useLoaderData() as LoaderData;
+  + let data = useLoaderData<typeof loader>();
+  ```
+
+  The API above is exactly the same for your route `action` and `useActionData`
+  via the `ActionArgs` type.
+
+  With this change you no longer need to manually define a `LoaderData` type
+  (huge time and typo saver!), and we serialize all values so that
+  `useLoaderData` can't return types that are impossible over the network, such
+  as `Date` objects or functions.
+
+  See the discussions in [#1254](https://github.com/remix-run/remix/pull/1254)
+  and [#3276](https://github.com/remix-run/remix/pull/3276) for more context.
 
 - Updated dependencies
   - `@remix-run/server-runtime@1.6.5`

--- a/packages/remix-node/CHANGELOG.md
+++ b/packages/remix-node/CHANGELOG.md
@@ -4,22 +4,43 @@
 
 ### Patch Changes
 
-- We enhanced the type signatures of `loader`/`action` and `useLoaderData`/`useActionData` to make it possible to infer the data type from return type of its related server function.
+- We enhanced the type signatures of `loader`/`action` and
+  `useLoaderData`/`useActionData` to make it possible to infer the data type
+  from return type of its related server function.
 
-  ```tsx
-  import type { LoaderArgs } from "@remix-run/node";
+  To enable this feature, you will need to use the `LoaderArgs` type from
+  `@remix-run/node` instead of typing the function directly:
 
-  export async function loader(args: LoaderArgs) {
-    return json({ greeting: "Hello!" }); // TypedResponse<{ greeting: string }>
-  }
+  ```diff
+  - import type { LoaderFunction } from "@remix-run/node";
+  + import type { LoaderArgs } from "@remix-run/node";
 
-  export default function App() {
-    let data = useLoaderData<typeof loader>(); // { greeting: string }
-    return <div>{data.greeting}</div>;
-  }
+  - export const loader: LoaderFunction = async (args) => {
+  -   return json<LoaderData>(data);
+  - }
+  + export async function loader(args: LoaderArgs) {
+  +   return json(data);
+  + }
   ```
 
-  See the discussion in [#1254](https://github.com/remix-run/remix/pull/1254) for more context.
+  Then you can infer the loader data by using `typeof loader` as the type
+  variable in `useLoaderData`:
+
+  ```diff
+  - let data = useLoaderData() as LoaderData;
+  + let data = useLoaderData<typeof loader>();
+  ```
+
+  The API above is exactly the same for your route `action` and `useActionData`
+  via the `ActionArgs` type.
+
+  With this change you no longer need to manually define a `LoaderData` type
+  (huge time and typo saver!), and we serialize all values so that
+  `useLoaderData` can't return types that are impossible over the network, such
+  as `Date` objects or functions.
+
+  See the discussions in [#1254](https://github.com/remix-run/remix/pull/1254)
+  and [#3276](https://github.com/remix-run/remix/pull/3276) for more context.
 
 - Updated dependencies
   - `@remix-run/server-runtime`

--- a/packages/remix-react/CHANGELOG.md
+++ b/packages/remix-react/CHANGELOG.md
@@ -4,21 +4,42 @@
 
 ### Patch Changes
 
-- We enhanced the type signatures of `loader`/`action` and `useLoaderData`/`useActionData` to make it possible to infer the data type from return type of its related server function.
+- We enhanced the type signatures of `loader`/`action` and
+  `useLoaderData`/`useActionData` to make it possible to infer the data type
+  from return type of its related server function.
 
-  ```tsx
-  import type { LoaderArgs } from "@remix-run/[runtime]";
+  To enable this feature, you will need to use the `LoaderArgs` type from your
+  Remix runtime package instead of typing the function directly:
 
-  export async function loader(args: LoaderArgs) {
-    return json({ greeting: "Hello!" }); // TypedResponse<{ greeting: string }>
-  }
+  ```diff
+  - import type { LoaderFunction } from "@remix-run/[runtime]";
+  + import type { LoaderArgs } from "@remix-run/[runtime]";
 
-  export default function App() {
-    let data = useLoaderData<typeof loader>(); // { greeting: string }
-    return <div>{data.greeting}</div>;
-  }
+  - export const loader: LoaderFunction = async (args) => {
+  -   return json<LoaderData>(data);
+  - }
+  + export async function loader(args: LoaderArgs) {
+  +   return json(data);
+  + }
   ```
 
-  See the discussion in [#1254](https://github.com/remix-run/remix/pull/1254) for more context.
+  Then you can infer the loader data by using `typeof loader` as the type
+  variable in `useLoaderData`:
+
+  ```diff
+  - let data = useLoaderData() as LoaderData;
+  + let data = useLoaderData<typeof loader>();
+  ```
+
+  The API above is exactly the same for your route `action` and `useActionData`
+  via the `ActionArgs` type.
+
+  With this change you no longer need to manually define a `LoaderData` type
+  (huge time and typo saver!), and we serialize all values so that
+  `useLoaderData` can't return types that are impossible over the network, such
+  as `Date` objects or functions.
+
+  See the discussions in [#1254](https://github.com/remix-run/remix/pull/1254)
+  and [#3276](https://github.com/remix-run/remix/pull/3276) for more context.
 
 - Add `WebSocket` reconnect to `LiveReload`

--- a/packages/remix-server-runtime/CHANGELOG.md
+++ b/packages/remix-server-runtime/CHANGELOG.md
@@ -4,19 +4,40 @@
 
 ### Patch Changes
 
-- We enhanced the type signatures of `loader`/`action` and `useLoaderData`/`useActionData` to make it possible to infer the data type from return type of its related server function.
+- We enhanced the type signatures of `loader`/`action` and
+  `useLoaderData`/`useActionData` to make it possible to infer the data type
+  from return type of its related server function.
 
-  ```tsx
-  import type { LoaderArgs } from "@remix-run/[runtime]";
+  To enable this feature, you will need to use the `LoaderArgs` type from your
+  Remix runtime package instead of typing the function directly:
 
-  export async function loader(args: LoaderArgs) {
-    return json({ greeting: "Hello!" }); // TypedResponse<{ greeting: string }>
-  }
+  ```diff
+  - import type { LoaderFunction } from "@remix-run/[runtime]";
+  + import type { LoaderArgs } from "@remix-run/[runtime]";
 
-  export default function App() {
-    let data = useLoaderData<typeof loader>(); // { greeting: string }
-    return <div>{data.greeting}</div>;
-  }
+  - export const loader: LoaderFunction = async (args) => {
+  -   return json<LoaderData>(data);
+  - }
+  + export async function loader(args: LoaderArgs) {
+  +   return json(data);
+  + }
   ```
 
-  See the discussion in [#1254](https://github.com/remix-run/remix/pull/1254) for more context.
+  Then you can infer the loader data by using `typeof loader` as the type
+  variable in `useLoaderData`:
+
+  ```diff
+  - let data = useLoaderData() as LoaderData;
+  + let data = useLoaderData<typeof loader>();
+  ```
+
+  The API above is exactly the same for your route `action` and `useActionData`
+  via the `ActionArgs` type.
+
+  With this change you no longer need to manually define a `LoaderData` type
+  (huge time and typo saver!), and we serialize all values so that
+  `useLoaderData` can't return types that are impossible over the network, such
+  as `Date` objects or functions.
+
+  See the discussions in [#1254](https://github.com/remix-run/remix/pull/1254)
+  and [#3276](https://github.com/remix-run/remix/pull/3276) for more context.


### PR DESCRIPTION
This PR updates the description of our changes to the loader/action types. I'll cherry-pick this one into `main` since it's technically docs (sort of?), but it's probably best kept in sync on both branches. 