### PR TITLE
templates(netlify): improve DX for Netlify serverless template

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -286,6 +286,7 @@
 - nexxeln
 - ni554n
 - nicholaschiang
+- nickytonline
 - niconiahi
 - nielsdb97
 - ninjaPixel

--- a/templates/netlify/README.md
+++ b/templates/netlify/README.md
@@ -54,10 +54,9 @@ Note: When running the Netlify CLI, file changes will rebuild assets, but you wi
 There are two ways to deploy your app to Netlify, you can either link your app to your git repo and have it auto deploy changes to Netlify, or you can deploy your app manually. If you've followed the setup instructions already, all you need to do is run this:
 
 ```sh
-npm run build
 # preview deployment
-netlify deploy
+netlify deploy --build
 
 # production deployment
-netlify deploy --prod
+netlify deploy --build --prod
 ```

--- a/templates/netlify/README.md
+++ b/templates/netlify/README.md
@@ -44,7 +44,9 @@ The Netlify CLI starts your app in development mode for testing the serverless s
 netlify dev
 ```
 
-When running the Netlify CLI, file changes will rebuild assets, but you will not see the changes to the page you are on unless you do a browser refresh of the page. The reason being is the serverless version of the server does not support hot module reloading.
+Open up [http://localhost:3000](http://localhost:3000), and you should be ready to go!
+
+Note: When running the Netlify CLI, file changes will rebuild assets, but you will not see the changes to the page you are on unless you do a browser refresh of the page. The reason being is the serverless version of the server does not support hot module reloading.
 
 ## Deployment
 

--- a/templates/netlify/README.md
+++ b/templates/netlify/README.md
@@ -1,6 +1,7 @@
 # Welcome to Remix!
 
 - [Remix Docs](https://remix.run/docs)
+- [Netlify Functions](https://www.netlify.com/products/functions/)
 
 ## Netlify Setup
 

--- a/templates/netlify/README.md
+++ b/templates/netlify/README.md
@@ -30,7 +30,7 @@ netlify init
 
 ## Development
 
-The Remix dev server starts your app in development mode, rebuilding assets on file changes.
+The Remix dev server starts your app in development mode, rebuilding assets on file changes. To start the Remix dev server:
 
 ```sh
 npm run dev

--- a/templates/netlify/README.md
+++ b/templates/netlify/README.md
@@ -46,7 +46,7 @@ netlify dev
 
 Open up [http://localhost:3000](http://localhost:3000), and you should be ready to go!
 
-Note: When running the Netlify CLI, file changes will rebuild assets, but you will not see the changes to the page you are on unless you do a browser refresh of the page. The reason being is the serverless version of the server does not support hot module reloading.
+Note: When running the Netlify CLI, file changes will rebuild assets, but you will not see the changes to the page you are on unless you do a browser refresh of the page. Due to how the Netlify CLI builds the Remix App Server, it does not support hot module reloading.
 
 ## Deployment
 

--- a/templates/netlify/README.md
+++ b/templates/netlify/README.md
@@ -30,13 +30,21 @@ netlify init
 
 ## Development
 
-The Netlify CLI starts your app in development mode, rebuilding assets on file changes.
+The Remix dev server starts your app in development mode, rebuilding assets on file changes.
 
 ```sh
 npm run dev
 ```
 
 Open up [http://localhost:3000](http://localhost:3000), and you should be ready to go!
+
+The Netlify CLI starts your app in development mode for testing the serverless server and any custom Netlify functions you've developed.
+
+```sh
+netlify dev
+```
+
+When running the Netlify CLI, file changes will rebuild assets, but you will not see the changes to the page you are on unless you do a browser refresh of the page. The reason being is the serverless version of the server does not support hot module reloading.
 
 ## Deployment
 

--- a/templates/netlify/README.md
+++ b/templates/netlify/README.md
@@ -38,7 +38,7 @@ npm run dev
 
 Open up [http://localhost:3000](http://localhost:3000), and you should be ready to go!
 
-The Netlify CLI starts your app in development mode for testing the serverless server and any custom Netlify functions you've developed.
+The Netlify CLI builds a production version of your Remix App Server and splits it into Netlify Functions that run locally. This includes any custom Netlify functions you've developed. The Netlify CLI runs all of this in its development mode.
 
 ```sh
 netlify dev

--- a/templates/netlify/package.json
+++ b/templates/netlify/package.json
@@ -3,7 +3,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
-    "dev": "cross-env NODE_ENV=development netlify dev",
+    "dev": "remix dev",
     "start": "cross-env NODE_ENV=production netlify dev"
   },
   "dependencies": {
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@remix-run/dev": "*",
     "@remix-run/eslint-config": "*",
+    "@remix-run/serve": "*",
     "@types/react": "^17.0.45",
     "@types/react-dom": "^17.0.17",
     "eslint": "^8.15.0",

--- a/templates/netlify/remix.config.js
+++ b/templates/netlify/remix.config.js
@@ -1,7 +1,10 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   serverBuildTarget: "netlify",
-  server: "./server.js",
+  server:
+    process.NODE_ENV === "production" || process.env.CONTEXT?.length > 0
+      ? "./server.js"
+      : undefined,
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",

--- a/templates/netlify/remix.config.js
+++ b/templates/netlify/remix.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   serverBuildTarget: "netlify",
   server:
-    process.NODE_ENV === "production" || process.env.CONTEXT?.length > 0
+    process.env.NETLIFY || process.env.NETLIFY_LOCAL
       ? "./server.js"
       : undefined,
   ignoredRouteFiles: ["**/.*"],


### PR DESCRIPTION
This PR improves the DX when using the Netlify template to build out your Remix application. cc: @ascorbic. I've based this PR off of `main` because I believe @mcansh mentioned that if it's just template changes, there's no need to branch off of the `dev` branch.

Closes: #3753

- [ ] Docs
- [ ] Tests

Testing Strategy:

1. Create a new Remix application and select Netlify for the deployment target.
2. You can install whatever you'd like in the Remix CLI steps. It also doesn't matter if you select TypeScript or JavaScript
3. Once your application has been created, from a shell, change to the root directory of your new application.
4. Run `npm run dev`
5. The Remix dev server starts and renders the main page when navigating to http://localhost:3000
6. Stop the Remix dev server.
7. Run `netlify dev`. The server running on Netlify functions locally starts and renders the main page when navigating to http://localhost:3000.
8. Run `netlify deploy --build`. If you're application isn't configured to deploy yet, ensure you've followed the steps in the README first to get your app configured to deploy to Netlify.
9. The application builds and deploys. Navigate to the deploy preview. The site loads.
