### PR TITLE
Allow readonly arrays in SerializeType

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1350,7 +1350,7 @@ type SerializeType<T> = T extends JsonPrimitives
         ? null
         : SerializeType<T[k]>;
     }
-  : T extends (infer U)[]
+  : T extends ReadonlyArray<infer U>
   ? (U extends NonJsonPrimitives ? null : SerializeType<U>)[]
   : T extends object
   ? {


### PR DESCRIPTION
Closes: #3762

- [ ] Docs
- [ ] Tests

Testing Strategy:

Patched `node_modules` in the package in the original repo and confirmed that it fixed the issue.
