### PR TITLE
feat(remix-dev): allow importing `.avif` files

### DIFF
--- a/packages/remix-architect/binaryTypes.ts
+++ b/packages/remix-architect/binaryTypes.ts
@@ -20,6 +20,7 @@ const binaryTypes = [
   "font/woff",
   "font/woff2",
   // Images
+  "image/avif",
   "image/bmp",
   "image/gif",
   "image/jpeg",

--- a/packages/remix-dev/compiler/loaders.ts
+++ b/packages/remix-dev/compiler/loaders.ts
@@ -3,6 +3,7 @@ import type * as esbuild from "esbuild";
 
 export const loaders: { [ext: string]: esbuild.Loader } = {
   ".aac": "file",
+  ".avif": "file",
   ".css": "file",
   ".eot": "file",
   ".flac": "file",

--- a/packages/remix-dev/modules.ts
+++ b/packages/remix-dev/modules.ts
@@ -2,6 +2,10 @@ declare module "*.aac" {
   let asset: string;
   export default asset;
 }
+declare module "*.avif" {
+  let asset: string;
+  export default asset;
+}
 declare module "*.css" {
   let asset: string;
   export default asset;

--- a/packages/remix-netlify/binaryTypes.ts
+++ b/packages/remix-netlify/binaryTypes.ts
@@ -20,6 +20,7 @@ const binaryTypes = [
   "font/woff",
   "font/woff2",
   // Images
+  "image/avif",
   "image/bmp",
   "image/gif",
   "image/jpeg",


### PR DESCRIPTION
While looking at #3771 I noticed that we were missing the avif file type declaration.