### PR TITLE
docs(faq): Fix the mismatch between the button value and the expected value in the switch

### DIFF
--- a/docs/pages/faq.md
+++ b/docs/pages/faq.md
@@ -114,7 +114,7 @@ export default function Projects() {
             defaultValue={project.name}
           />
         </label>
-        <button type="submit" name="action" value="create">
+        <button type="submit" name="action" value="update">
           Update
         </button>
       </Form>


### PR DESCRIPTION
While reviewing the FAQs around multiple forms in one route I noticed this mismatch in the values. The case in the switch is looking for `update` while the button value was `create`.
- [x] Docs