### PR TITLE
chore(ci): Trigger experimental release from tag instead of GitHub release

### DIFF
--- a/.github/workflows/release-experimental.yml
+++ b/.github/workflows/release-experimental.yml
@@ -1,3 +1,27 @@
+# Experimental releases are handled a bit differently than standard releases.
+# Experimental releases can be branched from anywhere as they are not intended
+# for general use, and all packages will be versioned and published with the
+# same hash for testing.
+#
+# This workflow will run when a GitHub release is created from experimental
+# version tag. Unlike standard releases created via Changesets, only one tag
+# should be created for all packages.
+#
+# To create a release:
+# - Create a new branch for the release: git checkout -b `release-experimental`
+#   - IMPORTANT: You should always create a new branch so that the version
+#     changes don't accidentally get merged into `dev` or `main`. The branch
+#     name must follow the convention of `release-experimental` or
+#     `release-experimental-[feature]`.
+# - Make whatever changes you need and commit them:
+#   - `git add . && git commit "experimental changes!"`
+# - Update version numbers and create a release tag:
+#   - `yarn run version:experimental`
+# - Push to GitHub:
+#   - `git push origin --follow-tags`
+# - Create a new release for the tag on GitHub to trigger the CI workflow that
+#   will publish the release to npm
+
 name: 🧪 Release (experimental)
 on:
   release:

--- a/.github/workflows/release-experimental.yml
+++ b/.github/workflows/release-experimental.yml
@@ -1,0 +1,44 @@
+name: 🧪 Release (experimental)
+on:
+  release:
+    types: [published]
+    tags:
+      - "v0.0.0-experimental*"
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+env:
+  CI: true
+
+jobs:
+  release:
+    name: 🧑‍🔬 Experimental Release
+    if: |
+      github.repository == 'remix-run/remix' &&
+      contains(github.ref, 'experimental')
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          cache: "yarn"
+
+      - name: 📥 Install deps
+        run: yarn --frozen-lockfile
+
+      - name: 🏗 Build
+        run: yarn build
+
+      - name: 🔐 Setup npm auth
+        run: |
+          echo "registry=https://registry.npmjs.org" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+
+      - name: 🚀 Publish
+        run: npm run publish


### PR DESCRIPTION
We won't be triggering any releases from GitHub moving forward. For experimentals, we can trigger the workflow simply by pushing the version tag created after running `yarn run version experimental`.