### PR TITLE
chore(ci): Trigger experimental release from tag instead of GitHub

### DIFF
--- a/.github/workflows/release-experimental.yml
+++ b/.github/workflows/release-experimental.yml
@@ -24,8 +24,7 @@
 
 name: 🧪 Release (experimental)
 on:
-  release:
-    types: [published]
+  push:
     tags:
       - "v0.0.0-experimental*"
 


### PR DESCRIPTION
We won't be triggering any releases from GitHub moving forward. For experimentals, we can trigger the workflow simply by pushing the version tag created after running `yarn run version experimental`.