### PR TITLE
fix(remix-react): don't strip `undefined` from `UseDataFunctionReturn`

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1336,10 +1336,11 @@ type JsonPrimitives =
   | Number
   | Boolean
   | null;
-type NonJsonPrimitives = undefined | Function | symbol;
-
+type NonJsonPrimitives = Function | symbol;
 type SerializeType<T> = T extends JsonPrimitives
   ? T
+  : T extends undefined
+  ? undefined
   : T extends NonJsonPrimitives
   ? never
   : T extends { toJSON(): infer U }


### PR DESCRIPTION
Closes: #3794

To expound a bit on why IMO this is the correct change: the job of the `SerializeType` type is not to guess at what set of types `JSON.parse(someRandomString)` could return. It's to guess what types could result from `JSON.parse(JSON.stringify(someJavascriptValue))`. The thesis is that given the value of `someJavascriptValue` it's possible to ascertain what the return type of `JSON.parse` should be in that expression. And if the input is an object with some nested keys that are `undefined`, so is the output and so the types should reflect that.

All of that sounds very abstract, but returning an object with keys that might be undefined is fairly basic behavior for a function. And for Remix to throw away that those properties might be `undefined` on the client side (causing Typescript not to warn users that attempt to use those properties as if they are there) is pretty unambiguously a bug.

- [ ] Docs
- [ ] Tests

Testing Strategy:

Started a new Remix repo, made the change in node-modules, observed that the error became what it's supposed to be.

Of note: I wish I could have written a test for this, but I could not figure out how to make it work. It would look [like this typescript playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbwDIQIYBMCmUCCUDmAzgDRwBWhEAdgL5wBmUEIcA5AAJSYjAAeAtFACuVAPRUIWVgChQkWIiGFMKDNgAiqGKjqNmbTtz6CRorqgDGMGdPoirwag0wwLAC03aAFAEoAXHCEMFDAVPhwAD5wIlj0oZjoiNJwKXBcMEJQVNFUsfHo0jTS0pi88vCohACeVBYM9jCO2QA2aFhQXgD6AarteEQ+SalpLpnZFNReCKWo4M2YAfQu7p6ovjQ+hcWl5XCxqELN8Ha1jU4AwsyQVJhUML5DqRbUQXtaqHAAvNHKvRrvAB4YFUwJgIPQ4K01FAAHy+YrDUSiODsGCEfg7TBWDFQJhQZKpdJjN7aAB0MzmmFJwVA8JoQA) and would merely need to be typechecked, not executed - if the file typechecked without errors the test would pass (`// @ts-expect-error` causes an error if the next line does NOT cause an error, which it should because we aren't checking whether `data.example` is a `string` or `undefined` before calling `.trim()`). Unfortunately I could not figure out where in the monorepo would be the appropriate place to put such a thing.