### PR TITLE
chore: Add script for faster builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: 🏗 Build
         if: steps.version.outputs.NEXT_VERSION
-        run: yarn build --tsc --publish
+        run: yarn build
 
       - name: 🏷 Push Tag
         if: steps.version.outputs.NEXT_VERSION

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 7 * * *" # every day at 12AM PST
 
+env:
+  CI: true
+
 jobs:
   # HEADS UP! this "nightly" job will only ever run on the `main` branch due to it being a cron job,
   # and the last commit on main will be what github shows as the trigger
@@ -76,7 +79,7 @@ jobs:
 
       - name: 🏗 Build
         if: steps.version.outputs.NEXT_VERSION
-        run: yarn build
+        run: yarn build --tsc --publish
 
       - name: 🏷 Push Tag
         if: steps.version.outputs.NEXT_VERSION

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -9,6 +9,9 @@ on:
         # but we want to pass an array, so we'll need to manually stringify it for now
         type: string
 
+env:
+  CI: true
+
 jobs:
   build:
     name: ⚙️ Build

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   ],
   "scripts": {
     "bug-report-test": "playwright test --config ./integration/playwright.config.ts integration/bug-report-test.ts",
-    "build": "rollup -c && tsc -b",
-    "postbuild": "node scripts/copy-build-to-dist.mjs",
+    "build": "node scripts/build.mjs",
     "clean": "git clean -fdX .",
     "clean:build": "node ./scripts/clean-build.mjs",
     "format": "prettier --ignore-path .eslintignore --write ./ && npm run lint:fix",
@@ -43,10 +42,10 @@
     "test:primary": "jest",
     "changeset": "changeset",
     "changeset:version": "changeset version",
-    "changeset:release": "yarn build && changeset publish",
+    "changeset:release": "yarn build --tsc --publish && changeset publish",
     "version": "node ./scripts/version.js",
     "version:experimental": "node scripts ./scripts/version experimental",
-    "watch": "rollup -c --watch --watch.onEnd=\"tsc -b && node scripts/copy-build-to-dist.mjs\""
+    "watch": "rollup -c --watch --watch.onEnd=\"node scripts/copy-build-to-dist.mjs\""
   },
   "dependencies": {
     "@babel/core": "^7.18.6",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -7,7 +7,11 @@ const publish = process.env.CI || args.includes("--publish");
 exec("yarn", ["rollup", "-c"])
   .then(() => tsc && exec("yarn", ["tsc", "-b"]))
   .then(() => publish && exec("node", ["scripts/copy-build-to-dist.mjs"]))
-  .then(() => process.exit(0));
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 
 /**
  * @param {string} command

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,36 @@
+import { spawn } from "cross-spawn";
+
+const args = process.argv.slice(2);
+const tsc = process.env.CI || args.includes("--tsc");
+const publish = process.env.CI || args.includes("--publish");
+
+exec("yarn", ["rollup", "-c"])
+  .then(() => tsc && exec("yarn", ["tsc", "-b"]))
+  .then(() => publish && exec("node", ["scripts/copy-build-to-dist.mjs"]))
+  .then(() => process.exit(0));
+
+/**
+ * @param {string} command
+ * @param {string[]} [args]
+ */
+function exec(command, args) {
+  /** @type {(data: any) => any} */
+  let handleData = (data) => console.log(data.toString().trim());
+
+  /** @type {(data: Error) => any} */
+  let handleError = (data) => console.error(data.toString().trim());
+
+  return new Promise((resolve, reject) => {
+    let ls = spawn(command, args, { cwd: process.cwd() });
+    ls.stdout.on("data", handleData);
+    ls.stderr.on("data", handleData);
+    ls.on("error", handleError);
+    ls.on("close", (code) => {
+      if (code === 0) {
+        resolve(void 0);
+      } else {
+        reject(new Error(`${command} exited with code ${code}`));
+      }
+    });
+  });
+}


### PR DESCRIPTION
This is a simple script that makes builds faster by default, making `tsc` and copying build artifacts to package `dist` directories opt-in via either `process.env.CI` or command line args.