### PR TITLE
Fix `json()` when inferring the return type

### DIFF
--- a/.changeset/long-taxis-drop.md
+++ b/.changeset/long-taxis-drop.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/node": patch
+---
+
+Fix `json()` when inferring the return type

--- a/contributors.yml
+++ b/contributors.yml
@@ -395,3 +395,4 @@
 - garand
 - kiancross
 - tagraves
+- esamattis

--- a/packages/remix-node/index.ts
+++ b/packages/remix-node/index.ts
@@ -41,6 +41,8 @@ export {
   isCookie,
   isSession,
   json,
+  JsonFunction,
+  TypedResponse,
   MaxPartSizeExceededError,
   redirect,
   unstable_composeUploadHandlers,


### PR DESCRIPTION
Closes: #3758

The explanation is in this comment:
https://github.com/remix-run/remix/issues/3758#issuecomment-1188882909


- [ ] Docs
- [ ] Tests

Testing Strategy:

Manual. This fixes a bug that only appears with build packages as it is basically a packaging issue.
