### PR TITLE
ci: move comments, deploy and stacks test to different action (#3744, #3803)

### DIFF
--- a/.github/workflows/postrelease.yml
+++ b/.github/workflows/postrelease.yml
@@ -1,0 +1,45 @@
+name: 🕊 Release
+
+on:
+  push:
+    tags:
+      # only run on `remix` tags
+      - "remix@*"
+
+jobs:
+  comment:
+    needs: [release]
+    name: 📝 Comment on related issues and pull requests
+    if: github.repository == 'remix-run/remix'
+    uses: remix-run/remix/.github/workflows/release-comments.yml@main
+    with:
+      ref: ${{ github.ref }}
+      # this should match the above tag to watch including the trailing "@"
+      packageVersionToFollow: "remix@"
+
+  deployments:
+    needs: [release]
+    name: 🚀 Deployment Tests
+    if: github.repository == 'remix-run/remix'
+    uses: remix-run/remix/.github/workflows/deployments.yml@main
+    secrets:
+      TEST_AWS_ACCESS_KEY_ID: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
+      TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
+      TEST_CF_ACCOUNT_ID: ${{ secrets.TEST_CF_ACCOUNT_ID }}
+      TEST_CF_GLOBAL_API_KEY: ${{ secrets.TEST_CF_GLOBAL_API_KEY }}
+      TEST_CF_EMAIL: ${{ secrets.TEST_CF_EMAIL }}
+      TEST_CF_PAGES_API_TOKEN: ${{ secrets.TEST_CF_PAGES_API_TOKEN }}
+      TEST_CF_API_TOKEN: ${{ secrets.TEST_CF_API_TOKEN }}
+      TEST_DENO_DEPLOY_TOKEN: ${{ secrets.TEST_DENO_DEPLOY_TOKEN }}
+      TEST_FLY_TOKEN: ${{ secrets.TEST_FLY_TOKEN }}
+      TEST_NETLIFY_TOKEN: ${{ secrets.TEST_NETLIFY_TOKEN }}
+      TEST_VERCEL_TOKEN: ${{ secrets.TEST_VERCEL_TOKEN }}
+      TEST_VERCEL_USER_ID: ${{ secrets.TEST_VERCEL_USER_ID }}
+
+  stacks:
+    needs: [release]
+    name: 🥞 Remix Stacks Test
+    if: github.repository == 'remix-run/remix'
+    uses: remix-run/remix/.github/workflows/stacks.yml@main
+    with:
+      version: ${{ github.ref_name }}

--- a/.github/workflows/release-comments.yml
+++ b/.github/workflows/release-comments.yml
@@ -6,6 +6,9 @@ on:
       ref:
         required: true
         type: string
+      packageVersionToFollow:
+        required: false
+        type: string
 
 jobs:
   comment:
@@ -15,6 +18,8 @@ jobs:
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
@@ -36,3 +41,4 @@ jobs:
           VERSION: ${{ inputs.ref }}
           DEFAULT_BRANCH: "main"
           NIGHTLY_BRANCH: "dev"
+          PACKAGE_VERSION_TO_FOLLOW: ${{ inputs.packageToWatch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: 🕊 Release
+name: 🦋 Changesets Release
 on:
   push:
     branches:
@@ -60,38 +60,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  comment:
-    needs: [release]
-    name: 📝 Comment on related issues and pull requests
-    if: github.repository == 'remix-run/remix'
-    uses: remix-run/remix/.github/workflows/release-comments.yml@main
-    with:
-      ref: ${{ github.ref }}
-
-  deployments:
-    needs: [release]
-    name: 🚀 Deployment Tests
-    if: github.repository == 'remix-run/remix'
-    uses: remix-run/remix/.github/workflows/deployments.yml@main
-    secrets:
-      TEST_AWS_ACCESS_KEY_ID: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
-      TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
-      TEST_CF_ACCOUNT_ID: ${{ secrets.TEST_CF_ACCOUNT_ID }}
-      TEST_CF_GLOBAL_API_KEY: ${{ secrets.TEST_CF_GLOBAL_API_KEY }}
-      TEST_CF_EMAIL: ${{ secrets.TEST_CF_EMAIL }}
-      TEST_CF_PAGES_API_TOKEN: ${{ secrets.TEST_CF_PAGES_API_TOKEN }}
-      TEST_CF_API_TOKEN: ${{ secrets.TEST_CF_API_TOKEN }}
-      TEST_DENO_DEPLOY_TOKEN: ${{ secrets.TEST_DENO_DEPLOY_TOKEN }}
-      TEST_FLY_TOKEN: ${{ secrets.TEST_FLY_TOKEN }}
-      TEST_NETLIFY_TOKEN: ${{ secrets.TEST_NETLIFY_TOKEN }}
-      TEST_VERCEL_TOKEN: ${{ secrets.TEST_VERCEL_TOKEN }}
-      TEST_VERCEL_USER_ID: ${{ secrets.TEST_VERCEL_USER_ID }}
-
-  stacks:
-    needs: [release]
-    name: 🥞 Remix Stacks Test
-    if: github.repository == 'remix-run/remix'
-    uses: remix-run/remix/.github/workflows/stacks.yml@main
-    with:
-      version: ${{ github.ref_name }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -6,7 +6,8 @@ on:
       node_version:
         required: true
         # this is limited to string | boolean | number (https://github.community/t/can-action-inputs-be-arrays/16457)
-        # but we want to pass an array, so we'll need to manually stringify it for now
+        # but we want to pass an array (node_version: "[14, 16, 18]"),
+        # so we'll need to manually stringify it for now
         type: string
 
 env:

--- a/scripts/release/comment.ts
+++ b/scripts/release/comment.ts
@@ -1,4 +1,4 @@
-import { REF, OWNER, REPO, PR_FILES_STARTS_WITH } from "./constants";
+import { VERSION, OWNER, REPO, PR_FILES_STARTS_WITH } from "./constants";
 import {
   commentOnIssue,
   commentOnPullRequest,
@@ -8,14 +8,14 @@ import {
 import { getGitHubUrl } from "./utils";
 
 async function commentOnIssuesAndPrsAboutRelease() {
-  if (REF.includes("experimental")) {
+  if (VERSION.includes("experimental")) {
     return;
   }
 
   let { merged, previousTag } = await prsMergedSinceLastTag({
     owner: OWNER,
     repo: REPO,
-    githubRef: REF,
+    githubRef: VERSION,
   });
 
   let suffix = merged.length === 1 ? "" : "s";
@@ -23,7 +23,7 @@ async function commentOnIssuesAndPrsAboutRelease() {
   console.log(
     `Found ${merged.length} PR${suffix} merged ` +
       `that touched \`${prFilesDirs}\` since ` +
-      `previous release (current: ${REF}, previous: ${previousTag})`
+      `previous release (current: ${VERSION}, previous: ${previousTag})`
   );
 
   let promises: Array<ReturnType<typeof commentOnIssue>> = [];
@@ -37,7 +37,7 @@ async function commentOnIssuesAndPrsAboutRelease() {
         owner: OWNER,
         repo: REPO,
         pr: pr.number,
-        version: REF,
+        version: VERSION,
       })
     );
 
@@ -59,7 +59,7 @@ async function commentOnIssuesAndPrsAboutRelease() {
           issue: issueNumber,
           owner: OWNER,
           repo: REPO,
-          version: REF,
+          version: VERSION,
         })
       );
     }

--- a/scripts/release/constants.ts
+++ b/scripts/release/constants.ts
@@ -1,3 +1,5 @@
+import { cleanupRef, cleanupTagName } from "./utils";
+
 if (!process.env.DEFAULT_BRANCH) {
   throw new Error("DEFAULT_BRANCH is required");
 }
@@ -13,12 +15,15 @@ if (!process.env.GITHUB_REPOSITORY) {
 if (!process.env.VERSION) {
   throw new Error("VERSION is required");
 }
-if (!process.env.VERSION.startsWith("refs/tags/")) {
-  throw new Error("VERSION must be a tag, received " + process.env.VERSION);
+if (!/^refs\/tags\//.test(process.env.VERSION)) {
+  throw new Error("VERSION must start with refs/tags/");
 }
 
 export const [OWNER, REPO] = process.env.GITHUB_REPOSITORY.split("/");
-export const REF = process.env.VERSION.replace("refs/tags/", "");
+// this one is optional, nightlies only create a single tag,
+// but stable releases create one for each package
+export const PACKAGE_VERSION_TO_FOLLOW = process.env.PACKAGE_VERSION_TO_FOLLOW;
+export const VERSION = cleanupTagName(cleanupRef(process.env.VERSION));
 export const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 export const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY;
 export const DEFAULT_BRANCH = process.env.DEFAULT_BRANCH;

--- a/scripts/release/github.ts
+++ b/scripts/release/github.ts
@@ -5,9 +5,10 @@ import {
   PR_FILES_STARTS_WITH,
   NIGHTLY_BRANCH,
   DEFAULT_BRANCH,
+  PACKAGE_VERSION_TO_FOLLOW,
 } from "./constants";
 import { gql, graphqlWithAuth, octokit } from "./octokit";
-import type { MinimalTag } from "./utils";
+import { cleanupTagName, MinimalTag } from "./utils";
 import { checkIfStringStartsWith, sortByDate } from "./utils";
 
 type PullRequest =
@@ -43,20 +44,38 @@ export async function prsMergedSinceLastTag({
     nightly > stable => 'main'
     stable > nightly => 'dev'
    */
-  let baseRef =
-    currentTag.isPrerelease && previousTag.isPrerelease
-      ? NIGHTLY_BRANCH
-      : currentTag.isPrerelease && !previousTag.isPrerelease
-      ? NIGHTLY_BRANCH
-      : DEFAULT_BRANCH;
+  let prs: Awaited<ReturnType<typeof getMergedPRsBetweenTags>> = [];
 
-  let prs = await getMergedPRsBetweenTags(
-    owner,
-    repo,
-    previousTag,
-    currentTag,
-    baseRef
-  );
+  // if both the current and previous tags are prereleases
+  // we can just get the PRs for the "dev" branch
+  // but if one of them is stable, we should wind up all of them from both the main and dev branches
+  if (currentTag.isPrerelease && previousTag.isPrerelease) {
+    prs = await getMergedPRsBetweenTags(
+      owner,
+      repo,
+      previousTag,
+      currentTag,
+      NIGHTLY_BRANCH
+    );
+  } else {
+    let [nightly, stable] = await Promise.all([
+      getMergedPRsBetweenTags(
+        owner,
+        repo,
+        previousTag,
+        currentTag,
+        NIGHTLY_BRANCH
+      ),
+      getMergedPRsBetweenTags(
+        owner,
+        repo,
+        previousTag,
+        currentTag,
+        DEFAULT_BRANCH
+      ),
+    ]);
+    prs = nightly.concat(stable);
+  }
 
   let prsThatTouchedFiles = await getPullRequestWithFiles(owner, repo, prs);
 
@@ -103,13 +122,22 @@ function getPreviousTagFromCurrentTag(
   currentTag: MinimalTag;
 } {
   let validTags = tags
+    .filter((tag) => {
+      // if we have a `PACKAGE_VERSION_TO_FOLLOW`
+      // we only want to get the tags related to it
+      if (PACKAGE_VERSION_TO_FOLLOW) {
+        return tag.name.startsWith(PACKAGE_VERSION_TO_FOLLOW);
+      }
+      return true;
+    })
     .map((tag) => {
-      let isPrerelease = semver.prerelease(tag.name) !== null;
+      let tagName = cleanupTagName(tag.name);
+      let isPrerelease = semver.prerelease(tagName) !== null;
 
       if (!tag.commit.committer?.date) return null;
 
       return {
-        tag: tag.name,
+        tag: tagName,
         date: new Date(tag.commit.committer.date),
         isPrerelease,
       };

--- a/scripts/release/github.ts
+++ b/scripts/release/github.ts
@@ -8,7 +8,8 @@ import {
   PACKAGE_VERSION_TO_FOLLOW,
 } from "./constants";
 import { gql, graphqlWithAuth, octokit } from "./octokit";
-import { cleanupTagName, MinimalTag } from "./utils";
+import type { MinimalTag } from "./utils";
+import { cleanupTagName } from "./utils";
 import { checkIfStringStartsWith, sortByDate } from "./utils";
 
 type PullRequest =

--- a/scripts/release/utils.ts
+++ b/scripts/release/utils.ts
@@ -1,4 +1,4 @@
-import { GITHUB_REPOSITORY } from "./constants";
+import { GITHUB_REPOSITORY, PACKAGE_VERSION_TO_FOLLOW } from "./constants";
 
 export function checkIfStringStartsWith(
   string: string,
@@ -20,4 +20,17 @@ export function sortByDate(a: MinimalTag, b: MinimalTag) {
 export function getGitHubUrl(type: "pull" | "issue", number: number) {
   let segment = type === "pull" ? "pull" : "issues";
   return `https://github.com/${GITHUB_REPOSITORY}/${segment}/${number}`;
+}
+
+export function cleanupTagName(tagName: string) {
+  if (PACKAGE_VERSION_TO_FOLLOW) {
+    let regex = new RegExp(`^${PACKAGE_VERSION_TO_FOLLOW}`);
+    return tagName.replace(regex, "");
+  }
+
+  return tagName;
+}
+
+export function cleanupRef(ref: string) {
+  return ref.replace(/^refs\/tags\//, "");
 }


### PR DESCRIPTION
Same as https://github.com/remix-run/remix/pull/3744. I cherry-picked the squashed commit to `dev` because we should keep workflow changes in sync between releases as much as possible.