### PR TITLE
chore(revert): Remove `UseDataFunctionReturn` type export

### DIFF
--- a/.changeset/loud-emus-cross.md
+++ b/.changeset/loud-emus-cross.md
@@ -1,6 +1,0 @@
----
-"remix": patch
-"@remix-run/react": patch
----
-
-export `UseDataFunctionReturn` type

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -27,7 +27,6 @@ export type {
   SubmitFunction,
   RemixNavLinkProps as NavLinkProps,
   RemixLinkProps as LinkProps,
-  UseDataFunctionReturn,
 } from "./components";
 export {
   Meta,

--- a/rollup.utils.js
+++ b/rollup.utils.js
@@ -314,7 +314,6 @@ function getMagicExports(packageName) {
         "SubmitFunction",
         "SubmitOptions",
         "ThrownResponse",
-        "UseDataFunctionReturn",
       ],
     },
     "@remix-run/server-runtime": {


### PR DESCRIPTION
We moved a bit hastily on exposing this type. We need to bikeshed the name a bit and possibly expose it from the runtime instead of `@remix-run/react`