### PR TITLE
docs(tutorials/blog): fix broken post link on admin page

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -7,6 +7,7 @@
 - adicuco
 - ahabhgk
 - ahbruns
+- ahgood
 - ahmedeldessouki
 - aiji42
 - airjp73

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -682,7 +682,7 @@ export default function PostAdmin() {
             {posts.map((post) => (
               <li key={post.slug}>
                 <Link
-                  to={post.slug}
+                  to={`/posts/${post.slug}`}
                   className="text-blue-600 underline"
                 >
                   {post.title}


### PR DESCRIPTION
Closes: #

- [x] Docs
- [ ] Tests

Testing Strategy:
I think currenlty the complete source code for this tutorial: https://remix.run/docs/en/v1/tutorials/blog is not available on github yet. I follow along with this tutorial and found the post link on admin page would look like:
`/posts/admin/90s-mixtape` (it should be `/posts/90s-mixtape`)
Click it will link to a 404 page.