### PR TITLE
chore(docs): Hide TOC in pages where only the title is displayed

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -96,6 +96,7 @@
 - danielweinmann
 - davecalnan
 - davecranwell-vocovo
+- davidblnc
 - DavidHollins6
 - davongit
 - Deanmv

--- a/docs/guides/bff.md
+++ b/docs/guides/bff.md
@@ -1,5 +1,6 @@
 ---
 title: Backend For Frontend
+toc: false
 ---
 
 # Backend For Your Frontend

--- a/docs/guides/browser-support.md
+++ b/docs/guides/browser-support.md
@@ -1,5 +1,6 @@
 ---
 title: Browser Support
+toc: false
 ---
 
 # Browser Support

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -1,5 +1,6 @@
 ---
 title: TypeScript
+toc: false
 ---
 
 # TypeScript

--- a/docs/other-api/serve.md
+++ b/docs/other-api/serve.md
@@ -1,6 +1,7 @@
 ---
 title: "@remix-run/serve"
 order: 3
+toc: false
 ---
 
 # Remix App Server


### PR DESCRIPTION
This PR aims to remove the table of contents in the docs where it's not necessary (example provided as screenshot).

![imagen](https://user-images.githubusercontent.com/40642621/181124887-e0a76b4c-ffe7-48e8-b029-e1ceeee2d215.png)
