### PR TITLE
chore(remix-dev/cli): fix broken stacks link

### DIFF
--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -332,7 +332,7 @@ export async function run(argv: string[] = process.argv.slice(2)) {
             },
             message: "Which Stack do you want? ",
             loop: false,
-            suffix: "(Learn more about these stacks: https://remix.run/stacks)",
+            suffix: "(Learn more about these stacks: 'https://remix.run/stacks')",
             choices: [
               {
                 name: "Blues",


### PR DESCRIPTION
Found an issue with the CLI when on the stack selection. The link includes ) in the link when clicking the link from the terminal. This resulted in a 404 page.