### PR TITLE
fix(@remix-run/react): preserve `null` properties for `useLoaderData` and `useActionData` inference

### DIFF
--- a/.changeset/nervous-walls-sing.md
+++ b/.changeset/nervous-walls-sing.md
@@ -1,0 +1,10 @@
+---
+"remix": patch
+"@remix-run/react": patch
+---
+
+Fix inferred types for `useLoaderData` and `useActionData` to preserve `null`s.
+
+Previously, `null`s were being replaced by `never`s due to usage of `NonNullable` in `UndefinedOptionals`.
+Properties that aren't unions with `undefined` are now kept as-is, while properties that _do_ include `undefined`
+are still made optional, but _only_ remove `undefined` from the property type whereas `NonNullable` also removed `null`s.

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1364,12 +1364,20 @@ type SerializeObject<T> = {
   >;
 };
 
-type UndefinedOptionals<T> = Merge<
+/*
+ * For an object T, if it has any properties that are a union with `undefined`,
+ * make those into optional properties instead.
+ * 
+ * Example: { a: string | undefined} --> { a?: string}
+ */
+type UndefinedOptionals<T extends object> = Merge<
   {
-    [k in keyof T as undefined extends T[k] ? never : k]: NonNullable<T[k]>;
+    // Property is not a union with `undefined`, keep as-is
+    [k in keyof T as undefined extends T[k] ? never : k]: T[k];
   },
   {
-    [k in keyof T as undefined extends T[k] ? k : never]?: NonNullable<T[k]>;
+    // Property _is_ a union with `defined`. Set as optional (via `?`) and remove `undefined` from the union
+    [k in keyof T as undefined extends T[k] ? k : never]?: Exclude<T[k], undefined>;
   }
 >;
 


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
