### PR TITLE
docs: add remix watch example to cli

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -185,6 +185,7 @@
 - jo-ninja
 - joaosamouco
 - jodygeraldo
+- joelazar
 - johannesbraeunig
 - johnpolacek
 - johnson444

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -106,9 +106,11 @@ ${colors.logoBlue("R")} ${colors.logoGreen("E")} ${colors.logoYellow(
 
   ${colors.heading("Start your server separately and watch for changes")}:
 
-    $ # custom server start command, for example:
-	$ node --inspect --require ./node_modules/dotenv/config --require ./mocks ./build/server.js
-    $ remix watch
+    # custom server start command, for example:
+      $ remix watch
+
+      # in a separate tab:
+      $ node --inspect --require ./node_modules/dotenv/config --require ./mocks ./build/server.js
 
   ${colors.heading("Show all routes in your app")}:
 

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -24,6 +24,7 @@ ${colors.logoBlue("R")} ${colors.logoGreen("E")} ${colors.logoYellow(
     $ remix build [${colors.arg("projectDir")}]
     $ remix dev [${colors.arg("projectDir")}]
     $ remix routes [${colors.arg("projectDir")}]
+    $ remix watch [${colors.arg("projectDir")}]
     $ remix setup [${colors.arg("remixPlatform")}]
     $ remix migrate [-m ${colors.arg("migration")}] [${colors.arg(
   "projectDir"
@@ -102,6 +103,12 @@ ${colors.logoBlue("R")} ${colors.logoGreen("E")} ${colors.logoYellow(
     $ remix dev
     $ remix dev my-app
     $ remix dev --debug
+
+  ${colors.heading("Start your server separately and watch for changes")}:
+
+    $ # custom server start command, for example:
+	$ node --inspect --require ./node_modules/dotenv/config --require ./mocks ./build/server.js
+    $ remix watch
 
   ${colors.heading("Show all routes in your app")}:
 


### PR DESCRIPTION
Closes: #

- [x] Docs
- [ ] Tests

I noticed from [blues-stack](https://github.com/remix-run/blues-stack/blob/f006c2f7d7cf546496240874b1dbf3f761b7f888/package.json#L13) that there is a `watch` option for the `remix` CLI, but it was not present in the `--help`, so I've added it.
