### PR TITLE
feat(remix-react): export `SerializeType` & `SerializeObject` types

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -276,6 +276,7 @@
 - michaeldeboey
 - michaelfriedman
 - michaseel
+- MichFont
 - mikeybinnswebdesign
 - mirzafaizan
 - mjackson

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1338,7 +1338,7 @@ type JsonPrimitives =
   | null;
 type NonJsonPrimitives = undefined | Function | symbol;
 
-type SerializeType<T> = T extends JsonPrimitives
+export type SerializeType<T> = T extends JsonPrimitives
   ? T
   : T extends NonJsonPrimitives
   ? never
@@ -1358,7 +1358,7 @@ type SerializeType<T> = T extends JsonPrimitives
   ? SerializeObject<UndefinedOptionals<T>>
   : never;
 
-type SerializeObject<T> = {
+export type SerializeObject<T> = {
   [k in keyof T as T[k] extends NonJsonPrimitives ? never : k]: SerializeType<
     T[k]
   >;


### PR DESCRIPTION
…synergy

This PR is simply to allow for the export of SerializeType and SerializeObject. After release 1.6.5 I created my own custom Serialize component, however, it closely mirrors the implementation that remix-react has and I was sad that it was not publicly accessible. Thus this PR.
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
Reran existing tests, all tests passed.
