### PR TITLE
test: windows testing updates

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -137,7 +137,7 @@ jobs:
         id: playwright-version
         shell: bash
         run: |
-          playwright_version=$(npm info @playwright/test version)
+          playwright_version=$(node -e "console.log(require('@playwright/test/package.json').version)")
           echo "::set-output name=version::${playwright_version}"
 
       - name: 🤖 Cache Playwright binaries

--- a/.github/workflows/stacks.yml
+++ b/.github/workflows/stacks.yml
@@ -13,6 +13,7 @@ jobs:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         stack:
           - repo: "remix-run/indie-stack"
@@ -69,6 +70,7 @@ jobs:
     needs: [setup]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         stack:
           - repo: "remix-run/indie-stack"
@@ -111,6 +113,7 @@ jobs:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         stack:
           - repo: "remix-run/indie-stack"
@@ -153,6 +156,7 @@ jobs:
     needs: [setup]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         stack:
           - repo: "remix-run/indie-stack"
@@ -195,6 +199,7 @@ jobs:
     needs: [setup]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         stack:
           - repo: "remix-run/indie-stack"

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -10,10 +10,8 @@ const config: PlaywrightTestConfig = {
     /* Maximum time expect() should wait for the condition to be met. */
     timeout: 5_000,
   },
-  fullyParallel: false,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  retries: 3,
   reporter: process.env.CI ? "github" : [["html", { open: "never" }]],
   use: { actionTimeout: 0 },
 

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -5,7 +5,8 @@ const config: PlaywrightTestConfig = {
   testDir: ".",
   testMatch: ["**/*-test.ts"],
   /* Maximum time one test can run for. */
-  timeout: 30_000,
+  timeout: process.platform === "win32" ? 60_000 : 30_000,
+  fullyParallel: true,
   expect: {
     /* Maximum time expect() should wait for the condition to be met. */
     timeout: 5_000,

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -10,6 +10,7 @@ const config: PlaywrightTestConfig = {
     /* Maximum time expect() should wait for the condition to be met. */
     timeout: 5_000,
   },
+  fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,

--- a/integration/upload-test.ts
+++ b/integration/upload-test.ts
@@ -54,7 +54,7 @@ test.beforeAll(async () => {
             return json({ message: "ERROR" }, 500);
           }
         };
-        
+
         export default function FileUpload() {
           let { message, size } = useActionData() || {};
           return (
@@ -71,7 +71,7 @@ test.beforeAll(async () => {
               </Form>
             </main>
           );
-        }      
+        }
       `,
 
       "app/routes/memory-upload-handler.jsx": js`
@@ -109,7 +109,7 @@ test.beforeAll(async () => {
             return json({ message: "ERROR" }, 500);
           }
         };
-        
+
         export default function MemoryUpload() {
           let { message, size } = useActionData() || {};
           return (
@@ -126,7 +126,7 @@ test.beforeAll(async () => {
               </Form>
             </main>
           );
-        }      
+        }
       `,
 
       "app/routes/passthrough-upload-handler.jsx": js`
@@ -150,7 +150,7 @@ test.beforeAll(async () => {
             );
           }
         };
-        
+
         export default function PassthroughUpload() {
           let { message, size } = useActionData() || {};
           return (
@@ -167,7 +167,7 @@ test.beforeAll(async () => {
               </Form>
             </main>
           );
-        }      
+        }
       `,
     },
   });
@@ -175,7 +175,7 @@ test.beforeAll(async () => {
   appFixture = await createAppFixture(fixture);
 });
 
-test.afterAll(async () => appFixture.close());
+test.afterAll(() => appFixture.close());
 
 test("can upload a file with createFileUploadHandler", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);
@@ -190,6 +190,7 @@ test("can upload a file with createFileUploadHandler", async ({ page }) => {
 test("can catch MaxPartSizeExceededError when file is too big with createFileUploadHandler", async ({
   page,
 }) => {
+  test.slow();
   let app = new PlaywrightFixture(appFixture, page);
   await app.goto("/file-upload-handler");
   await app.uploadFile(

--- a/packages/remix-dev/__tests__/cli-test.ts
+++ b/packages/remix-dev/__tests__/cli-test.ts
@@ -5,6 +5,8 @@ import util from "util";
 import fse from "fs-extra";
 import semver from "semver";
 
+import { jestTimeout } from "./setupAfterEnv";
+
 let DOWN = "\x1B\x5B\x42";
 let ENTER = "\x0D";
 
@@ -343,7 +345,7 @@ async function interactWithShell(
       proc.kill();
       deferred.reject({ status: "timeout", stdout, stderr });
     }
-  }, 10_000);
+  }, jestTimeout);
 
   await deferred.promise;
   clearTimeout(timeout);

--- a/packages/remix-dev/__tests__/migrations/convert-to-javascript-test.ts
+++ b/packages/remix-dev/__tests__/migrations/convert-to-javascript-test.ts
@@ -53,6 +53,7 @@ beforeEach(() => {
   removeSync(TEMP_DIR);
   ensureDirSync(TEMP_DIR);
 });
+
 afterEach(() => {
   console.log = ORIGINAL_IO.log;
   console.warn = ORIGINAL_IO.warn;
@@ -97,9 +98,7 @@ const checkMigrationRanSuccessfully = async (projectDir: string) => {
 
 const makeApp = () => {
   let projectDir = join(TEMP_DIR, "convert-to-javascript");
-
   copySync(FIXTURE, projectDir);
-
   return projectDir;
 };
 

--- a/packages/remix-dev/__tests__/replace-remix-imports-test.ts
+++ b/packages/remix-dev/__tests__/replace-remix-imports-test.ts
@@ -87,11 +87,18 @@ describe("`replace-remix-imports` migration", () => {
     );
     expect(packageJson.dependencies).not.toContain("remix");
     expect(packageJson.devDependencies).not.toContain("remix");
-    expect(packageJson.dependencies["@remix-run/react"]).toBe("1.3.4");
-    expect(packageJson.dependencies["@remix-run/node"]).toBe("1.3.4");
-    expect(packageJson.dependencies["@remix-run/serve"]).toBe("1.3.4");
-    expect(packageJson.devDependencies["@remix-run/dev"]).toBe("1.3.4");
-
+    expect(packageJson.dependencies).toEqual(
+      expect.objectContaining({
+        "@remix-run/node": "1.3.4",
+        "@remix-run/react": "1.3.4",
+        "@remix-run/serve": "1.3.4",
+      })
+    );
+    expect(packageJson.devDependencies).toEqual(
+      expect.objectContaining({
+        "@remix-run/dev": "1.3.4",
+      })
+    );
     expect(output).toContain(
       "🗑  I'm removing `remix setup` from your `postinstall` script."
     );

--- a/packages/remix-dev/__tests__/replace-remix-imports-test.ts
+++ b/packages/remix-dev/__tests__/replace-remix-imports-test.ts
@@ -47,6 +47,7 @@ beforeEach(async () => {
   await fse.remove(TEMP_DIR);
   await fse.ensureDir(TEMP_DIR);
 });
+
 afterEach(async () => {
   console.log = ORIGINAL_IO.log;
   console.warn = ORIGINAL_IO.warn;

--- a/packages/remix-dev/__tests__/setupAfterEnv.ts
+++ b/packages/remix-dev/__tests__/setupAfterEnv.ts
@@ -1,1 +1,3 @@
-jest.setTimeout(10_000);
+export let jestTimeout = process.platform === "win32" ? 20_000 : 10_000;
+
+jest.setTimeout(jestTimeout);

--- a/packages/remix-dev/__tests__/setupAfterEnv.ts
+++ b/packages/remix-dev/__tests__/setupAfterEnv.ts
@@ -1,3 +1,3 @@
-export let jestTimeout = process.platform === "win32" ? 20_000 : 10_000;
+export let jestTimeout = process.platform === "win32" ? 15_000 : 10_000;
 
 jest.setTimeout(jestTimeout);

--- a/packages/remix-dev/__tests__/setupAfterEnv.ts
+++ b/packages/remix-dev/__tests__/setupAfterEnv.ts
@@ -1,3 +1,3 @@
-export let jestTimeout = process.platform === "win32" ? 15_000 : 10_000;
+export let jestTimeout = process.platform === "win32" ? 20_000 : 10_000;
 
 jest.setTimeout(jestTimeout);


### PR DESCRIPTION
this PR does the following:

- increase jest timeout on windows
- fixes a cache issue where we'd always use the latest playwright version as the cache key
- allows stacks + deployment tests to continue if one of them fails
- enable playwright test retries locally so we can check for flakey tests
- uses default workers based on machine config
- mark upload test as slow
- update playwright timeout on windows
- enable fullyParallel

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

CI and locally using Git Bash and PowerShell in windows terminal

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
