### PR TITLE
chore: update tsconfigs to exclude node_modules and skip lib checks

### DIFF
--- a/packages/create-remix/tsconfig.json
+++ b/packages/create-remix/tsconfig.json
@@ -1,5 +1,6 @@
 {
-  "exclude": ["dist", "__tests__"],
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "**/node_modules/**"],
   "compilerOptions": {
     "lib": ["ES2019"],
     "target": "ES2019",

--- a/packages/remix-architect/tsconfig.json
+++ b/packages/remix-architect/tsconfig.json
@@ -1,8 +1,10 @@
 {
-  "exclude": ["dist", "__tests__"],
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "__tests__", "node_modules"],
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
+    "skipLibCheck": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/packages/remix-cloudflare-pages/tsconfig.json
+++ b/packages/remix-cloudflare-pages/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": ["**/*.ts"],
-  "exclude": ["dist", "__tests__"],
+  "exclude": ["dist", "__tests__", "node_modules"],
   "compilerOptions": {
     "lib": ["ES2019"],
     "target": "ES2019",

--- a/packages/remix-cloudflare-workers/tsconfig.json
+++ b/packages/remix-cloudflare-workers/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": ["**/*.ts"],
-  "exclude": ["dist", "__tests__"],
+  "exclude": ["dist", "__tests__", "node_modules"],
   "compilerOptions": {
     "lib": ["ES2019"],
     "target": "ES2019",

--- a/packages/remix-cloudflare/tsconfig.json
+++ b/packages/remix-cloudflare/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": ["**/*.ts"],
-  "exclude": ["dist", "__tests__"],
+  "exclude": ["dist", "__tests__", "node_modules"],
   "compilerOptions": {
     "lib": ["ES2019"],
     "target": "ES2019",

--- a/packages/remix-dev/tsconfig.json
+++ b/packages/remix-dev/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "exclude": ["dist", "__tests__", "./compiler/shims"],
+  "exclude": ["dist", "__tests__", "node_modules", "./compiler/shims"],
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",

--- a/packages/remix-express/tsconfig.json
+++ b/packages/remix-express/tsconfig.json
@@ -1,5 +1,6 @@
 {
-  "exclude": ["dist", "__tests__"],
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "__tests__", "node_modules"],
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",

--- a/packages/remix-netlify/tsconfig.json
+++ b/packages/remix-netlify/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "exclude": ["dist", "__tests__"],
+  "exclude": ["dist", "__tests__", "node_modules"],
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
+    "skipLibCheck": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/packages/remix-node/tsconfig.json
+++ b/packages/remix-node/tsconfig.json
@@ -1,5 +1,6 @@
 {
-  "exclude": ["dist", "__tests__"],
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "__tests__", "node_modules"],
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",

--- a/packages/remix-react/tsconfig.json
+++ b/packages/remix-react/tsconfig.json
@@ -1,9 +1,11 @@
 {
-  "exclude": ["dist", "__tests__"],
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["dist", "__tests__", "node_modules"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "target": "ES2020",
     "module": "ES2020",
+    "skipLibCheck": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/packages/remix-serve/tsconfig.json
+++ b/packages/remix-serve/tsconfig.json
@@ -1,8 +1,10 @@
 {
-  "exclude": ["dist", "__tests__"],
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "__tests__", "node_modules"],
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
+    "skipLibCheck": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/packages/remix-server-runtime/tsconfig.json
+++ b/packages/remix-server-runtime/tsconfig.json
@@ -1,5 +1,6 @@
 {
-  "exclude": ["dist", "__tests__"],
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "__tests__", "node_modules"],
   "compilerOptions": {
     "lib": ["ES2019", "DOM", "DOM.Iterable"],
     "target": "ES2019",

--- a/packages/remix-vercel/tsconfig.json
+++ b/packages/remix-vercel/tsconfig.json
@@ -1,8 +1,10 @@
 {
-  "exclude": ["dist", "__tests__"],
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "__tests__", "node_modules"],
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
+    "skipLibCheck": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/packages/remix/tsconfig.json
+++ b/packages/remix/tsconfig.json
@@ -1,9 +1,11 @@
 {
-  "exclude": ["dist", "__tests__"],
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "__tests__", "node_modules"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "target": "ES2020",
     "module": "ES2020",
+    "skipLibCheck": true,
 
     "jsx": "react",
     "moduleResolution": "node",


### PR DESCRIPTION
This speeds up the build by telling TSC exactly what to check and what to skip reducing discovery time. It also is needed for our upgrade to react 18 otherwise types start loosing their s.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
