### PR TITLE
feat(remix-dev): import `.gql` & `.graphql` files as text

### DIFF
--- a/.changeset/four-poets-stare.md
+++ b/.changeset/four-poets-stare.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": minor
+---
+
+feat(remix-dev): import `.gql` & `.graphql` files as text

--- a/packages/remix-dev/compiler/loaders.ts
+++ b/packages/remix-dev/compiler/loaders.ts
@@ -7,6 +7,8 @@ export const loaders: { [ext: string]: esbuild.Loader } = {
   ".eot": "file",
   ".flac": "file",
   ".gif": "file",
+  ".gql": "text",
+  ".graphql": "text",
   ".ico": "file",
   ".jpeg": "file",
   ".jpg": "file",

--- a/packages/remix-dev/modules.ts
+++ b/packages/remix-dev/modules.ts
@@ -18,6 +18,14 @@ declare module "*.gif" {
   let asset: string;
   export default asset;
 }
+declare module "*.gql" {
+  let asset: string;
+  export default asset;
+}
+declare module "*.graphql" {
+  let asset: string;
+  export default asset;
+}
 declare module "*.jpeg" {
   let asset: string;
   export default asset;
@@ -57,6 +65,10 @@ declare module "*.otf" {
   export default asset;
 }
 declare module "*.png" {
+  let asset: string;
+  export default asset;
+}
+declare module "*.sql" {
   let asset: string;
   export default asset;
 }


### PR DESCRIPTION
Follow-up of https://github.com/remix-run/remix/pull/3190#discussion_r873095942