### PR TITLE
chore(examples/blog-tutorial): revert update of `@testing-library/react` dependency

### DIFF
--- a/examples/blog-tutorial/package.json
+++ b/examples/blog-tutorial/package.json
@@ -46,7 +46,7 @@
     "@testing-library/cypress": "^8.0.2",
     "@testing-library/dom": "^8.13.0",
     "@testing-library/jest-dom": "^5.16.4",
-    "@testing-library/react": "^13.3.0",
+    "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^13.5.0",
     "@types/eslint": "^8.4.1",
     "@types/marked": "^4.0.3",


### PR DESCRIPTION
This shouldn't have been done in #3917, as that example is still using React v17