### PR TITLE
chore(examples/theme-ui): fix styling

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -346,6 +346,7 @@
 - sandulat
 - sbernheim4
 - schpet
+- scottybrown
 - sdavids
 - sean-roberts
 - sebz

--- a/examples/theme-ui/app/entry.client.tsx
+++ b/examples/theme-ui/app/entry.client.tsx
@@ -1,7 +1,7 @@
 import { CacheProvider } from "@emotion/react";
 import { RemixBrowser } from "@remix-run/react";
 import type { FunctionComponent } from "react";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { hydrate } from "react-dom";
 
 import { ClientStyleContext } from "./styles/context";
@@ -10,9 +10,7 @@ import { createEmotionCache } from "./styles/createEmotionCache";
 const ClientCacheProvider: FunctionComponent = ({ children }) => {
   const [cache, setCache] = useState(createEmotionCache());
 
-  const reset = () => {
-    setCache(createEmotionCache());
-  };
+  const reset = useCallback(() => setCache(createEmotionCache()), []);
 
   return (
     <ClientStyleContext.Provider value={{ reset }}>

--- a/examples/theme-ui/app/root.tsx
+++ b/examples/theme-ui/app/root.tsx
@@ -27,20 +27,12 @@ const Document = withEmotionCache(
   ({ children }: DocumentProps, emotionCache) => {
     const serverStyleData = useContext(ServerStyleContext);
     const clientStyleData = useContext(ClientStyleContext);
+    const resetClientStyleData = clientStyleData?.reset;
 
     // Only executed on client
     useEffect(() => {
-      // re-link sheet container
-      emotionCache.sheet.container = document.head;
-      // re-inject tags
-      const tags = emotionCache.sheet.tags;
-      emotionCache.sheet.flush();
-      tags.forEach((tag) => {
-        (emotionCache.sheet as any)._insertTag(tag);
-      });
-      // reset cache to reapply global styles
-      clientStyleData?.reset();
-    }, []);
+      resetClientStyleData();
+    }, [resetClientStyleData]);
 
     return (
       <html lang="en">

--- a/examples/theme-ui/app/root.tsx
+++ b/examples/theme-ui/app/root.tsx
@@ -40,7 +40,7 @@ const Document = withEmotionCache(
       });
       // reset cache to reapply global styles
       clientStyleData?.reset();
-    }, [clientStyleData, emotionCache.sheet]);
+    }, []);
 
     return (
       <html lang="en">

--- a/examples/theme-ui/app/routes/index.tsx
+++ b/examples/theme-ui/app/routes/index.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { jsx } from "@theme-ui/core";
 import { Link } from "@remix-run/react";
 
 export default function Index() {

--- a/examples/theme-ui/app/routes/jokes.tsx
+++ b/examples/theme-ui/app/routes/jokes.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { jsx } from "@theme-ui/core";
 import { Link } from "@remix-run/react";
 
 export default function Jokes() {


### PR DESCRIPTION
We expect the [theme-ui example](https://github.com/remix-run/remix/tree/main/examples/theme-ui)'s pages to have a stark blue background, to demonstrate that the theme-ui theme is being applied.

Instead, it has no styling at all.

The cause is [this PR](https://github.com/remix-run/remix/pull/3664), which removes some lines which are fundamental to [how theme-ui works](https://theme-ui.com/getting-started#classic-jsx-runtime).

I have also removed 2 entries from a `useEffect` dependency array which were also added in the mentioned PR, which were causing repeated `Maximum update depth exceeded` to appear in the browser console. This does not seem to affect this example, but can cause UI hangs on apps with state.

I've been unsuccessful in running linting against this example, so I can't verify whether my changes have brought back lint warnings. But they've certainly made the example more useful :)

Testing Strategy:
- [ ] Test that blue background appears on `/` and `/jokes`/
- [ ] Test that `maximum update depth exceeded` does not repeatedly appear in browser console