### PR TITLE
fix(remix-react): switch `name` & `content` position in `meta` tags

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -33,6 +33,7 @@
 - archwebio
 - arganaphangquestian
 - AriGunawan
+- arnaudambro
 - arvigeus
 - arvindell
 - ascorbic

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -729,15 +729,15 @@ export function Meta() {
           if (isOpenGraphTag) {
             return (
               <meta
+                property={name}
                 content={content as string}
                 key={name + content}
-                property={name}
               />
             );
           }
 
           if (typeof content === "string") {
-            return <meta content={content} name={name} key={name + content} />;
+            return <meta name={name} content={content} key={name + content} />;
           }
 
           return <meta key={name + JSON.stringify(content)} {...content} />;


### PR DESCRIPTION
When we visualize the html meta tags on a browswer inspector, I think it's better to see
```html
<meta name="twitter:card" content="summary">
```
than
```html
<meta content="summary" name="twitter:card">
```

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
