### PR TITLE
docs(other-api/dev): fix broken link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -318,6 +318,7 @@
 - plastic041
 - plondon
 - princerajroy
+- protofarer
 - prvnbist
 - ptitFicus
 - pyr0gan

--- a/docs/other-api/dev.md
+++ b/docs/other-api/dev.md
@@ -95,6 +95,6 @@ remix dev --port 4001
 
 Alternatively, a port can be assigned to the `PORT` environment variable.
 
-[remix-app-server]: serve.md
+[remix-app-server]: serve
 [node-inspector]: https://nodejs.org/en/docs/guides/debugging-getting-started
 [templates-folder-of-the-remix-repository]: https://github.com/remix-run/remix/tree/main/templates


### PR DESCRIPTION
Link to Remix App Server page broken, just remove md extension.