### PR TITLE
fix(remix-dev): make MDX builds deterministic

### DIFF
--- a/.changeset/purple-ligers-drive.md
+++ b/.changeset/purple-ligers-drive.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Make MDX builds deterministic

--- a/packages/remix-dev/compiler/plugins/mdx.ts
+++ b/packages/remix-dev/compiler/plugins/mdx.ts
@@ -39,14 +39,15 @@ export function mdxPlugin(config: RemixConfig): esbuild.Plugin {
         let resolved = path.resolve(args.resolveDir, resolvedPath);
 
         return {
-          path: resolved,
+          path: path.relative(config.appDirectory, resolved),
           namespace: "mdx",
         };
       });
 
       build.onLoad({ filter: /\.mdx?$/ }, async (args) => {
+        let absolutePath = path.join(config.appDirectory, args.path);
         try {
-          let fileContents = await fsp.readFile(args.path, "utf-8");
+          let fileContents = await fsp.readFile(absolutePath, "utf-8");
 
           let rehypePlugins = [];
           let remarkPlugins = [
@@ -115,7 +116,7 @@ ${remixExports}`;
             errors: errors.length ? errors : undefined,
             warnings: warnings.length ? warnings : undefined,
             contents,
-            resolveDir: path.dirname(args.path),
+            resolveDir: path.dirname(absolutePath),
             loader: getLoaderForFile(args.path),
           };
         } catch (err: any) {


### PR DESCRIPTION
This is a fix along the lines of #2027; because the MDX virtual modules resolve to absolute paths, the manifest/hashes/etc. differ based on the parent directory structure.

Refs: #2024

- [x] Tests

Testing Strategy:
1. Expanded existing integration test to cover this scenario (fails without the fix). Also add other virtual module scenarios that weren't already covered
2. Validated in a real MDX Remix app that has split client / server builds (applied fix via patch-package)