### PR TITLE
Expect ErrorBoundary to catch thrown errors when submitting POST request between routes.

### DIFF
--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -40,6 +40,8 @@ let appFixture: AppFixture;
 //    ```
 ////////////////////////////////////////////////////////////////////////////////
 
+const TARGET_ROUTE = "/target";
+
 test.beforeAll(async () => {
   fixture = await createFixture({
     ////////////////////////////////////////////////////////////////////////////
@@ -71,6 +73,36 @@ test.beforeAll(async () => {
           return <div>cheeseburger</div>;
         }
       `,
+
+      "app/routes/form.jsx": js`
+        import { Form } from "@remix-run/react";
+
+        export const ErrorBoundary = ({ error }) => {
+          return <div>[form] ErrorBoundary</div>
+        }
+
+        export default function Index() {
+          return (
+            <Form method="post" action="${TARGET_ROUTE}">
+              <button formAction="${TARGET_ROUTE}">Submit</button>
+            </Form>
+          )
+        }
+      `,
+
+      "app/routes/target.jsx": js`
+        export const ErrorBoundary = ({ error }) => {
+          return <div>[target] ErrorBoundary</div>
+        }
+        
+        export const action = () => {
+          throw new Error('[target] threw the error')
+        }
+
+        export default function Index() {
+          return <div>Target</div>
+        }   
+      `,
     },
   });
 
@@ -101,6 +133,16 @@ test("[description of what you expect it to do]", async ({ page }) => {
   // await app.poke(20);
 
   // Go check out the other tests to see what else you can do.
+});
+
+test("Expect exceptions thrown when cross posting routes are caught by an error boundary", async ({
+  page,
+}) => {
+  let app = new PlaywrightFixture(appFixture, page);
+  // You can test any request your app might get using `fixture`.
+  await app.goto("/form");
+  await app.clickSubmitButton(TARGET_ROUTE);
+  expect(await app.getHtml()).toMatch("[target] ErrorBoundary");
 });
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Bug Report

Observed: Route A submits to Route B. Route B throws an Error in its action. Route B exports an ErrorBoundary but the error is not captured. Interestingly, if Route B has been loaded once, the ErrorBoundary seems to work as expected.

Expected: Route B captures Errors thrown in action handler.

Hypothesis: Route B is not fully loaded or registered somewhere within the Remix framework before Route A submits its request. Loading Route B manually, then forcing Route A to submit to Route B demonstrates expected behavior, where the ErrorBoundary catches the exception.

Testing Strategy:

* created failing integration test to demonstrate issue
