### PR TITLE
fix: Avoid path collisions between pathless and index routes

### DIFF
--- a/integration/conventional-routes-test.ts
+++ b/integration/conventional-routes-test.ts
@@ -1,0 +1,153 @@
+import { test, expect } from "@playwright/test";
+
+import { PlaywrightFixture } from "./helpers/playwright-fixture";
+import type { Fixture, AppFixture } from "./helpers/create-fixture";
+import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
+
+let fixture: Fixture;
+let appFixture: AppFixture;
+
+let appFiles = {
+  "app/routes/nested/index.jsx": js`
+    import { Link, useMatches } from '@remix-run/react';
+    export default function Index() {
+      let matches = 'Number of Matches: ' + useMatches().length;
+      return (
+        <>
+          <div>Index</div>
+          <p>{matches}</p>
+        </>
+      )
+    }
+  `,
+  "app/routes/nested/__pathless.jsx": js`
+    import { Outlet } from "@remix-run/react";
+    export default function Layout() {
+      return (
+        <>
+          <div>Pathless Layout</div>
+          <Outlet />
+        </>
+      );
+    }
+  `,
+  "app/routes/nested/__pathless/foo.jsx": js`
+    import { Link, useMatches } from '@remix-run/react';
+    export default function Foo() {
+      let matches = 'Number of Matches: ' + useMatches().length;
+      return (
+        <>
+          <div>Foo</div>
+          <p>{matches}</p>
+        </>
+      );
+    }
+  `,
+};
+
+test.describe("No JS", () => {
+  test.beforeAll(async () => {
+    fixture = await createFixture({
+      files: {
+        "app/root.tsx": js`
+          import { Link, Outlet } from "@remix-run/react";
+
+          export default function App() {
+            return (
+              <html lang="en">
+                <body>
+                  <nav>
+                    <Link to="/nested">/nested</Link>
+                    <br />
+                    <Link to="/nested/foo">/nested/foo</Link>
+                    <br />
+                  </nav>
+                  <Outlet />
+                </body>
+              </html>
+            );
+          }
+        `,
+        ...appFiles,
+      },
+    });
+
+    appFixture = await createAppFixture(fixture);
+  });
+
+  test.afterAll(async () => appFixture.close());
+
+  test("displays index page and links to the pathless layout page", async ({
+    page,
+  }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/nested");
+    expect(await app.getHtml()).toMatch("Index");
+    expect(await app.getHtml()).not.toMatch("Pathless Layout");
+    // We should have an injected folder match here in addition to root.tsx +
+    // routes/nested/index.tsx
+    expect(await app.getHtml()).toMatch("Number of Matches: 3");
+
+    await app.clickLink("/nested/foo");
+    expect(await app.getHtml()).not.toMatch("Index");
+    expect(await app.getHtml()).toMatch("Pathless Layout");
+    expect(await app.getHtml()).toMatch("Foo");
+    // We should have an injected folder match here in addition to root.tsx +
+    // routes/nested/__pathless.tsx + routes/nested/__pathless/foo.tsx
+    expect(await app.getHtml()).toMatch("Number of Matches: 4");
+  });
+});
+
+test.describe("With JS", () => {
+  test.beforeAll(async () => {
+    fixture = await createFixture({
+      files: {
+        "app/root.tsx": js`
+          import { Link, Outlet, Scripts } from "@remix-run/react";
+
+          export default function App() {
+            return (
+              <html lang="en">
+                <body>
+                  <nav>
+                    <Link to="/nested">/nested</Link>
+                    <br />
+                    <Link to="/nested/foo">/nested/foo</Link>
+                    <br />
+                  </nav>
+                  <Outlet />
+                  <Scripts />
+                </body>
+              </html>
+            );
+          }
+        `,
+        ...appFiles,
+      },
+    });
+
+    appFixture = await createAppFixture(fixture);
+  });
+
+  test.afterAll(async () => appFixture.close());
+
+  test("displays index page and links to the pathless layout page", async ({
+    page,
+  }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/nested");
+    expect(await app.getHtml()).toMatch("Index");
+    expect(await app.getHtml()).not.toMatch("Pathless Layout");
+    // We should have an injected folder match here in addition to root.tsx +
+    // routes/nested/index.tsx
+    expect(await app.getHtml()).toMatch("Number of Matches: 3");
+
+    await app.clickLink("/nested/foo");
+    expect(await app.getHtml()).not.toMatch("Index");
+    expect(await app.getHtml()).toMatch("Pathless Layout");
+    expect(await app.getHtml()).toMatch("Foo");
+    // We should have an injected folder match here in addition to root.tsx +
+    // routes/nested/__pathless.tsx + routes/nested/__pathless/foo.tsx
+    expect(await app.getHtml()).toMatch("Number of Matches: 4");
+  });
+});

--- a/packages/remix-dev/__tests__/formatRoutes-test.ts
+++ b/packages/remix-dev/__tests__/formatRoutes-test.ts
@@ -4,12 +4,6 @@ import {
   RoutesFormat,
 } from "../config/format";
 
-function createHierarchyRoute(route) {
-  let { id, path, file, index } = route;
-  // lazy way to remove undefined values from output :)
-  return JSON.parse(JSON.stringify({ id, path, file, index }));
-}
-
 describe("createHierarchicalRoutes", () => {
   test("adds parent route for index routes with path", () => {
     let manifestRoutes = {
@@ -28,6 +22,13 @@ describe("createHierarchicalRoutes", () => {
         file: "routes/nested/index.tsx",
       },
     };
+
+    function createHierarchyRoute(id: string, path: string | undefined) {
+      let { file, index } = manifestRoutes[id] || {};
+      // lazy way to remove undefined values from output :)
+      return JSON.parse(JSON.stringify({ id, path, file, index }));
+    }
+
     expect(createHierarchicalRoutes(manifestRoutes, createHierarchyRoute))
       .toMatchInlineSnapshot(`
       Array [
@@ -83,6 +84,13 @@ describe("createHierarchicalRoutes", () => {
         file: "routes/nested/__pathless/foo.tsx",
       },
     };
+
+    function createHierarchyRoute(id: string, path: string | undefined) {
+      let { file, index } = manifestRoutes[id] || {};
+      // lazy way to remove undefined values from output :)
+      return JSON.parse(JSON.stringify({ id, path, file, index }));
+    }
+
     expect(createHierarchicalRoutes(manifestRoutes, createHierarchyRoute))
       .toMatchInlineSnapshot(`
       Array [
@@ -145,6 +153,13 @@ describe("createHierarchicalRoutes", () => {
         file: "routes/nested/index.tsx",
       },
     };
+
+    function createHierarchyRoute(id: string, path: string | undefined) {
+      let { file, index } = manifestRoutes[id] || {};
+      // lazy way to remove undefined values from output :)
+      return JSON.parse(JSON.stringify({ id, path, file, index }));
+    }
+
     expect(createHierarchicalRoutes(manifestRoutes, createHierarchyRoute))
       .toMatchInlineSnapshot(`
       Array [
@@ -194,7 +209,7 @@ describe("createHierarchicalRoutes", () => {
   test("creates hierarchy for non-index route structures", () => {
     let manifestRoutes = {
       root: { path: "", id: "root", file: "root.tsx" },
-      "routes/parent1.tsx": {
+      "routes/parent1": {
         path: "parent1",
         id: "routes/parent1",
         parentId: "root",
@@ -206,7 +221,7 @@ describe("createHierarchicalRoutes", () => {
         parentId: "routes/parent1",
         file: "routes/parent1/child1.tsx",
       },
-      "routes/parent2.tsx": {
+      "routes/parent2": {
         path: "parent2",
         id: "routes/parent2",
         parentId: "root",
@@ -219,6 +234,13 @@ describe("createHierarchicalRoutes", () => {
         file: "routes/parent2/child2.tsx",
       },
     };
+
+    function createHierarchyRoute(id: string, path: string | undefined) {
+      let { file, index } = manifestRoutes[id] || {};
+      // lazy way to remove undefined values from output :)
+      return JSON.parse(JSON.stringify({ id, path, file, index }));
+    }
+
     expect(createHierarchicalRoutes(manifestRoutes, createHierarchyRoute))
       .toMatchInlineSnapshot(`
       Array [

--- a/packages/remix-dev/__tests__/formatRoutes-test.ts
+++ b/packages/remix-dev/__tests__/formatRoutes-test.ts
@@ -1,4 +1,3 @@
-import { identity } from "lodash";
 import {
   createHierarchicalRoutes,
   formatRoutes,

--- a/packages/remix-dev/__tests__/formatRoutes-test.ts
+++ b/packages/remix-dev/__tests__/formatRoutes-test.ts
@@ -1,21 +1,139 @@
-import { formatRoutes, RoutesFormat } from "../config/format";
+import { identity } from "lodash";
+import {
+  createHierarchicalRoutes,
+  formatRoutes,
+  RoutesFormat,
+} from "../config/format";
 
-describe("formatRoutes", () => {
-  test("create hierarchical routes with inserted folder routes where needed", () => {
-    let configRoutes = {
+function createHierarchyRoute(route) {
+  let { id, path, file, index } = route;
+  // lazy way to remove undefined values from output :)
+  return JSON.parse(JSON.stringify({ id, path, file, index }));
+}
+
+describe("createHierarchicalRoutes", () => {
+  test("adds parent route for index routes with path", () => {
+    let manifestRoutes = {
       root: { path: "", id: "root", file: "root.tsx" },
+      "routes/index": {
+        index: true,
+        id: "routes/index",
+        parentId: "root",
+        file: "routes/index.tsx",
+      },
+      "routes/nested/index": {
+        path: "nested",
+        index: true,
+        id: "routes/nested/index",
+        parentId: "root",
+        file: "routes/nested/index.tsx",
+      },
+    };
+    expect(createHierarchicalRoutes(manifestRoutes, createHierarchyRoute))
+      .toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "file": "routes/index.tsx",
+              "id": "routes/index",
+              "index": true,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "file": "routes/nested/index.tsx",
+                  "id": "routes/nested/index",
+                  "index": true,
+                  "path": undefined,
+                },
+              ],
+              "id": "routes/nested",
+              "path": "nested",
+            },
+          ],
+          "file": "root.tsx",
+          "id": "root",
+          "path": "",
+        },
+      ]
+    `);
+  });
+
+  test("does not adds parent route for pathless route without index sibling", () => {
+    let manifestRoutes = {
+      root: { path: "", id: "root", file: "root.tsx" },
+      "routes/index": {
+        index: true,
+        id: "routes/index",
+        parentId: "root",
+        file: "routes/index.tsx",
+      },
       "routes/nested/__pathless": {
         path: "nested",
-        index: undefined,
-        caseSensitive: undefined,
         id: "routes/nested/__pathless",
         parentId: "root",
         file: "routes/nested/__pathless.tsx",
       },
       "routes/nested/__pathless/foo": {
         path: "foo",
-        index: undefined,
-        caseSensitive: undefined,
+        id: "routes/nested/__pathless/foo",
+        parentId: "routes/nested/__pathless",
+        file: "routes/nested/__pathless/foo.tsx",
+      },
+    };
+    expect(createHierarchicalRoutes(manifestRoutes, createHierarchyRoute))
+      .toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "file": "routes/index.tsx",
+              "id": "routes/index",
+              "index": true,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "file": "routes/nested/__pathless/foo.tsx",
+                  "id": "routes/nested/__pathless/foo",
+                  "path": "foo",
+                },
+              ],
+              "file": "routes/nested/__pathless.tsx",
+              "id": "routes/nested/__pathless",
+              "path": "nested",
+            },
+          ],
+          "file": "root.tsx",
+          "id": "root",
+          "path": "",
+        },
+      ]
+    `);
+  });
+
+  test("adds parent route for pathless routes with index sibling", () => {
+    let manifestRoutes = {
+      root: { path: "", id: "root", file: "root.tsx" },
+      "routes/index": {
+        index: true,
+        id: "routes/index",
+        parentId: "root",
+        file: "routes/index.tsx",
+      },
+      "routes/nested/__pathless": {
+        path: "nested",
+        id: "routes/nested/__pathless",
+        parentId: "root",
+        file: "routes/nested/__pathless.tsx",
+      },
+      "routes/nested/__pathless/foo": {
+        path: "foo",
         id: "routes/nested/__pathless/foo",
         parentId: "routes/nested/__pathless",
         file: "routes/nested/__pathless/foo.tsx",
@@ -23,18 +141,154 @@ describe("formatRoutes", () => {
       "routes/nested/index": {
         path: "nested",
         index: true,
-        caseSensitive: undefined,
         id: "routes/nested/index",
         parentId: "root",
         file: "routes/nested/index.tsx",
       },
+    };
+    expect(createHierarchicalRoutes(manifestRoutes, createHierarchyRoute))
+      .toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "file": "routes/index.tsx",
+              "id": "routes/index",
+              "index": true,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [],
+                      "file": "routes/nested/__pathless/foo.tsx",
+                      "id": "routes/nested/__pathless/foo",
+                      "path": "foo",
+                    },
+                  ],
+                  "file": "routes/nested/__pathless.tsx",
+                  "id": "routes/nested/__pathless",
+                  "path": undefined,
+                },
+                Object {
+                  "children": Array [],
+                  "file": "routes/nested/index.tsx",
+                  "id": "routes/nested/index",
+                  "index": true,
+                  "path": undefined,
+                },
+              ],
+              "id": "routes/nested",
+              "path": "nested",
+            },
+          ],
+          "file": "root.tsx",
+          "id": "root",
+          "path": "",
+        },
+      ]
+    `);
+  });
+
+  test("creates hierarchy for non-index route structures", () => {
+    let manifestRoutes = {
+      root: { path: "", id: "root", file: "root.tsx" },
+      "routes/parent1.tsx": {
+        path: "parent1",
+        id: "routes/parent1",
+        parentId: "root",
+        file: "routes/parent1.tsx",
+      },
+      "routes/parent1/child1": {
+        path: "child1",
+        id: "routes/parent1/child1",
+        parentId: "routes/parent1",
+        file: "routes/parent1/child1.tsx",
+      },
+      "routes/parent2.tsx": {
+        path: "parent2",
+        id: "routes/parent2",
+        parentId: "root",
+        file: "routes/parent2.tsx",
+      },
+      "routes/parent2/child2": {
+        path: "child2",
+        id: "routes/parent2/child2",
+        parentId: "routes/parent2",
+        file: "routes/parent2/child2.tsx",
+      },
+    };
+    expect(createHierarchicalRoutes(manifestRoutes, createHierarchyRoute))
+      .toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "file": "routes/parent1/child1.tsx",
+                  "id": "routes/parent1/child1",
+                  "path": "child1",
+                },
+              ],
+              "file": "routes/parent1.tsx",
+              "id": "routes/parent1",
+              "path": "parent1",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "file": "routes/parent2/child2.tsx",
+                  "id": "routes/parent2/child2",
+                  "path": "child2",
+                },
+              ],
+              "file": "routes/parent2.tsx",
+              "id": "routes/parent2",
+              "path": "parent2",
+            },
+          ],
+          "file": "root.tsx",
+          "id": "root",
+          "path": "",
+        },
+      ]
+    `);
+  });
+});
+
+describe("formatRoutes", () => {
+  test("formats in JSX and JSON", () => {
+    let configRoutes = {
+      root: { path: "", id: "root", file: "root.tsx" },
       "routes/index": {
-        path: undefined,
         index: true,
-        caseSensitive: undefined,
         id: "routes/index",
         parentId: "root",
         file: "routes/index.tsx",
+      },
+      "routes/nested/__pathless": {
+        path: "nested",
+        id: "routes/nested/__pathless",
+        parentId: "root",
+        file: "routes/nested/__pathless.tsx",
+      },
+      "routes/nested/__pathless/foo": {
+        path: "foo",
+        id: "routes/nested/__pathless/foo",
+        parentId: "routes/nested/__pathless",
+        file: "routes/nested/__pathless/foo.tsx",
+      },
+      "routes/nested/index": {
+        path: "nested",
+        index: true,
+        id: "routes/nested/index",
+        parentId: "root",
+        file: "routes/nested/index.tsx",
       },
     };
     expect(formatRoutes(configRoutes, RoutesFormat.jsx)).toMatchInlineSnapshot(`
@@ -65,7 +319,7 @@ describe("formatRoutes", () => {
               \\"children\\": []
             },
             {
-              \\"id\\": \\"folder:routes/nested\\",
+              \\"id\\": \\"routes/nested\\",
               \\"path\\": \\"nested\\",
               \\"children\\": [
                 {

--- a/packages/remix-dev/__tests__/formatRoutes-test.ts
+++ b/packages/remix-dev/__tests__/formatRoutes-test.ts
@@ -1,0 +1,96 @@
+import { formatRoutes, RoutesFormat } from "../config/format";
+
+describe("formatRoutes", () => {
+  test("create hierarchical routes with inserted folder routes where needed", () => {
+    let configRoutes = {
+      root: { path: "", id: "root", file: "root.tsx" },
+      "routes/nested/__pathless": {
+        path: "nested",
+        index: undefined,
+        caseSensitive: undefined,
+        id: "routes/nested/__pathless",
+        parentId: "root",
+        file: "routes/nested/__pathless.tsx",
+      },
+      "routes/nested/__pathless/foo": {
+        path: "foo",
+        index: undefined,
+        caseSensitive: undefined,
+        id: "routes/nested/__pathless/foo",
+        parentId: "routes/nested/__pathless",
+        file: "routes/nested/__pathless/foo.tsx",
+      },
+      "routes/nested/index": {
+        path: "nested",
+        index: true,
+        caseSensitive: undefined,
+        id: "routes/nested/index",
+        parentId: "root",
+        file: "routes/nested/index.tsx",
+      },
+      "routes/index": {
+        path: undefined,
+        index: true,
+        caseSensitive: undefined,
+        id: "routes/index",
+        parentId: "root",
+        file: "routes/index.tsx",
+      },
+    };
+    expect(formatRoutes(configRoutes, RoutesFormat.jsx)).toMatchInlineSnapshot(`
+      "<Routes>
+        <Route file=\\"root.tsx\\">
+          <Route index file=\\"routes/index.tsx\\" />
+          <Route path=\\"nested\\">
+            <Route file=\\"routes/nested/__pathless.tsx\\">
+              <Route path=\\"foo\\" file=\\"routes/nested/__pathless/foo.tsx\\" />
+            </Route>
+            <Route index file=\\"routes/nested/index.tsx\\" />
+          </Route>
+        </Route>
+      </Routes>"
+    `);
+    expect(formatRoutes(configRoutes, RoutesFormat.json))
+      .toMatchInlineSnapshot(`
+      "[
+        {
+          \\"id\\": \\"root\\",
+          \\"path\\": \\"\\",
+          \\"file\\": \\"root.tsx\\",
+          \\"children\\": [
+            {
+              \\"id\\": \\"routes/index\\",
+              \\"index\\": true,
+              \\"file\\": \\"routes/index.tsx\\",
+              \\"children\\": []
+            },
+            {
+              \\"id\\": \\"folder:routes/nested\\",
+              \\"path\\": \\"nested\\",
+              \\"children\\": [
+                {
+                  \\"id\\": \\"routes/nested/__pathless\\",
+                  \\"file\\": \\"routes/nested/__pathless.tsx\\",
+                  \\"children\\": [
+                    {
+                      \\"id\\": \\"routes/nested/__pathless/foo\\",
+                      \\"path\\": \\"foo\\",
+                      \\"file\\": \\"routes/nested/__pathless/foo.tsx\\",
+                      \\"children\\": []
+                    }
+                  ]
+                },
+                {
+                  \\"id\\": \\"routes/nested/index\\",
+                  \\"index\\": true,
+                  \\"file\\": \\"routes/nested/index.tsx\\",
+                  \\"children\\": []
+                }
+              ]
+            }
+          ]
+        }
+      ]"
+    `);
+  });
+});

--- a/packages/remix-dev/config/format.ts
+++ b/packages/remix-dev/config/format.ts
@@ -148,11 +148,11 @@ export function createHierarchicalRoutes<
           otherPathRoutes.push(r);
         }
       });
-      // TODO: Need to figure out this typing error :/
-      // @ts-expect-error
-      let folderRoute: HierarchyRoute = {
-        id: `routes/${path}`,
-        path,
+      let folderRoute = {
+        ...createRoute({
+          id: `routes/${path}`,
+          path,
+        } as ManifestRoute),
         children: dupPathRoutes.map((r) => ({ ...r, path: undefined })),
       };
       children = [...otherPathRoutes, folderRoute];

--- a/packages/remix-dev/config/format.ts
+++ b/packages/remix-dev/config/format.ts
@@ -84,11 +84,11 @@ interface BaseManifestRoute {
   parentId?: string;
 }
 
-interface BaseHierarchyRoute {
+type BaseHierarchyRoute<T> = T & {
   id: string;
   path?: string;
-  children?: BaseHierarchyRoute[];
-}
+  children?: BaseHierarchyRoute<T>[];
+};
 
 /**
  * NOTE: This function is duplicated in remix-dev, remix-react, and
@@ -110,11 +110,11 @@ interface BaseHierarchyRoute {
  */
 export function createHierarchicalRoutes<
   ManifestRoute extends BaseManifestRoute,
-  HierarchyRoute extends BaseHierarchyRoute
+  HierarchyRoute extends Omit<BaseHierarchyRoute<unknown>, "children">
 >(
   manifest: Record<string, ManifestRoute>,
   createRoute: (r: ManifestRoute) => HierarchyRoute
-) {
+): HierarchyRoute[] {
   function recurse(parentId?: string) {
     let routes = Object.values(manifest).filter(
       (route) => route.parentId === parentId
@@ -131,9 +131,10 @@ export function createHierarchicalRoutes<
       if (route.index && route.path) {
         indexRoutesWithPath.push(route.path);
       }
-      let hierarchicalRoute = createRoute(route);
-      hierarchicalRoute.children = recurse(route.id);
-      children.push(hierarchicalRoute);
+      children.push({
+        ...createRoute(route),
+        children: recurse(route.id),
+      });
     }
 
     // For each index route that _also_ had a path, create a new parent route

--- a/packages/remix-dev/config/format.ts
+++ b/packages/remix-dev/config/format.ts
@@ -79,6 +79,7 @@ export function formatRoutesAsJsx(routes: JsonFormattedRoute[]) {
 
 interface BaseManifestRoute {
   id: string;
+  index?: boolean;
   path?: string;
   parentId?: string;
 }
@@ -107,7 +108,7 @@ interface BaseHierarchyRoute {
  *                     ignoring children
  * @returns
  */
-function createHierarchicalRoutes<
+export function createHierarchicalRoutes<
   ManifestRoute extends BaseManifestRoute,
   HierarchyRoute extends BaseHierarchyRoute
 >(
@@ -120,41 +121,41 @@ function createHierarchicalRoutes<
     );
 
     let children: HierarchyRoute[] = [];
-    let pathCounts: Record<string, number> = {};
+
+    // Our manifest flattens index routes and their paths into a single
+    // per-route-file entry, so we use this to track which index routes need
+    // to be split back into a hierarchical pattern
+    let indexRoutesWithPath: string[] = [];
 
     for (let route of routes) {
-      // Track in case we find duplicate paths and the same level, indicating
-      // we need to insert a folder route
-      if (route.path) {
-        pathCounts[route.path] = (pathCounts[route.path] || 0) + 1;
+      if (route.index && route.path) {
+        indexRoutesWithPath.push(route.path);
       }
       let hierarchicalRoute = createRoute(route);
       hierarchicalRoute.children = recurse(route.id);
       children.push(hierarchicalRoute);
     }
 
-    // If we found any duplicate paths, create a new folder-route and nest
-    // the duplicate entires under that without paths since they inherit
-    // from the new parent now
-    Object.entries(pathCounts).forEach(([path, count]) => {
-      if (count > 1) {
-        let otherPathRoutes: HierarchyRoute[] = [];
-        let dupPathRoutes: HierarchyRoute[] = [];
-        children.forEach((r) => {
-          if (r.path === path) {
-            dupPathRoutes.push(r);
-          } else {
-            otherPathRoutes.push(r);
-          }
-        });
-        // TODO: Need to figure out this typing error :/
-        let folderRoute: HierarchyRoute = {
-          id: `folder:routes/${path}`,
-          path,
-          children: dupPathRoutes.map((r) => ({ ...r, path: undefined })),
-        };
-        children = [...otherPathRoutes, folderRoute];
-      }
+    // For each index route that _also_ had a path, create a new parent route
+    // for the path and nest the index route and any other matching path routes
+    indexRoutesWithPath.forEach((path) => {
+      let otherPathRoutes: HierarchyRoute[] = [];
+      let dupPathRoutes: HierarchyRoute[] = [];
+      children.forEach((r) => {
+        if (r.path === path) {
+          dupPathRoutes.push(r);
+        } else {
+          otherPathRoutes.push(r);
+        }
+      });
+      // TODO: Need to figure out this typing error :/
+      // @ts-expect-error
+      let folderRoute: HierarchyRoute = {
+        id: `routes/${path}`,
+        path,
+        children: dupPathRoutes.map((r) => ({ ...r, path: undefined })),
+      };
+      children = [...otherPathRoutes, folderRoute];
     });
 
     return children;

--- a/packages/remix-dev/config/format.ts
+++ b/packages/remix-dev/config/format.ts
@@ -1,4 +1,4 @@
-import type { ConfigRoute, RouteManifest } from "./routes";
+import type { RouteManifest } from "./routes";
 
 export enum RoutesFormat {
   json = "json",
@@ -13,15 +13,18 @@ export function formatRoutes(
   routeManifest: RouteManifest,
   format: RoutesFormat
 ) {
-  let routes = createHierarchicalRoutes<ConfigRoute, JsonFormattedRoute>(
+  let routes = createHierarchicalRoutes<JsonFormattedRoute>(
     routeManifest,
-    (route) => ({
-      id: route.id,
-      index: route.index,
-      path: route.path,
-      caseSensitive: route.caseSensitive,
-      file: route.file,
-    })
+    (id, path) => {
+      let route = routeManifest[id];
+      return {
+        id,
+        path,
+        index: route?.index,
+        caseSensitive: route?.caseSensitive,
+        file: route?.file,
+      };
+    }
   );
 
   switch (format) {
@@ -109,33 +112,29 @@ type BaseHierarchyRoute<T> = T & {
  * @returns
  */
 export function createHierarchicalRoutes<
-  ManifestRoute extends BaseManifestRoute,
   HierarchyRoute extends Omit<BaseHierarchyRoute<unknown>, "children">
 >(
-  manifest: Record<string, ManifestRoute>,
-  createRoute: (r: ManifestRoute) => HierarchyRoute
+  manifest: Record<string, BaseManifestRoute>,
+  createRoute: (id: string, path: string | undefined) => HierarchyRoute
 ): HierarchyRoute[] {
   function recurse(parentId?: string) {
-    let routes = Object.values(manifest).filter(
-      (route) => route.parentId === parentId
-    );
-
-    let children: HierarchyRoute[] = [];
-
     // Our manifest flattens index routes and their paths into a single
     // per-route-file entry, so we use this to track which index routes need
     // to be split back into a hierarchical pattern
     let indexRoutesWithPath: string[] = [];
+    let children: HierarchyRoute[] = [];
 
-    for (let route of routes) {
-      if (route.index && route.path) {
-        indexRoutesWithPath.push(route.path);
+    Object.values(manifest).forEach((route) => {
+      if (route.parentId == parentId) {
+        if (route.index && route.path) {
+          indexRoutesWithPath.push(route.path);
+        }
+        children.push({
+          ...createRoute(route.id, route.path),
+          children: recurse(route.id),
+        });
       }
-      children.push({
-        ...createRoute(route),
-        children: recurse(route.id),
-      });
-    }
+    });
 
     // For each index route that _also_ had a path, create a new parent route
     // for the path and nest the index route and any other matching path routes
@@ -150,10 +149,7 @@ export function createHierarchicalRoutes<
         }
       });
       let folderRoute = {
-        ...createRoute({
-          id: `routes/${path}`,
-          path,
-        } as ManifestRoute),
+        ...createRoute(`routes/${path}`, path),
         children: dupPathRoutes.map((r) => ({ ...r, path: undefined })),
       };
       children = [...otherPathRoutes, folderRoute];

--- a/packages/remix-dev/config/format.ts
+++ b/packages/remix-dev/config/format.ts
@@ -1,4 +1,4 @@
-import type { RouteManifest } from "./routes";
+import type { ConfigRoute, RouteManifest } from "./routes";
 
 export enum RoutesFormat {
   json = "json",
@@ -13,11 +13,22 @@ export function formatRoutes(
   routeManifest: RouteManifest,
   format: RoutesFormat
 ) {
+  let routes = createHierarchicalRoutes<ConfigRoute, JsonFormattedRoute>(
+    routeManifest,
+    (route) => ({
+      id: route.id,
+      index: route.index,
+      path: route.path,
+      caseSensitive: route.caseSensitive,
+      file: route.file,
+    })
+  );
+
   switch (format) {
     case RoutesFormat.json:
-      return formatRoutesAsJson(routeManifest);
+      return JSON.stringify(routes || null, null, 2);
     case RoutesFormat.jsx:
-      return formatRoutesAsJsx(routeManifest);
+      return formatRoutesAsJsx(routes || []);
   }
 }
 
@@ -30,44 +41,13 @@ type JsonFormattedRoute = {
   children?: JsonFormattedRoute[];
 };
 
-export function formatRoutesAsJson(routeManifest: RouteManifest): string {
-  function handleRoutesRecursive(
-    parentId?: string
-  ): JsonFormattedRoute[] | undefined {
-    let routes = Object.values(routeManifest).filter(
-      (route) => route.parentId === parentId
-    );
-
-    let children = [];
-
-    for (let route of routes) {
-      children.push({
-        id: route.id,
-        index: route.index,
-        path: route.path,
-        caseSensitive: route.caseSensitive,
-        file: route.file,
-        children: handleRoutesRecursive(route.id),
-      });
-    }
-
-    if (children.length > 0) {
-      return children;
-    }
-    return undefined;
-  }
-
-  return JSON.stringify(handleRoutesRecursive() || null, null, 2);
-}
-
-export function formatRoutesAsJsx(routeManifest: RouteManifest) {
+export function formatRoutesAsJsx(routes: JsonFormattedRoute[]) {
   let output = "<Routes>";
 
-  function handleRoutesRecursive(parentId?: string, level = 1): boolean {
-    let routes = Object.values(routeManifest).filter(
-      (route) => route.parentId === parentId
-    );
-
+  function handleRoutesRecursive(
+    routes: JsonFormattedRoute[],
+    level = 1
+  ): boolean {
     let indent = Array(level * 2)
       .fill(" ")
       .join("");
@@ -79,7 +59,7 @@ export function formatRoutesAsJsx(routeManifest: RouteManifest) {
       }${route.index ? " index" : ""}${
         route.file ? ` file=${JSON.stringify(route.file)}` : ""
       }>`;
-      if (handleRoutesRecursive(route.id, level + 1)) {
+      if (handleRoutesRecursive(route.children || [], level + 1)) {
         output += "\n" + indent;
         output += "</Route>";
       } else {
@@ -90,9 +70,89 @@ export function formatRoutesAsJsx(routeManifest: RouteManifest) {
     return routes.length > 0;
   }
 
-  handleRoutesRecursive();
+  handleRoutesRecursive(routes);
 
   output += "\n</Routes>";
 
   return output;
+}
+
+interface BaseManifestRoute {
+  id: string;
+  path?: string;
+  parentId?: string;
+}
+
+interface BaseOutputRoute {
+  id: string;
+  path?: string;
+  children?: BaseOutputRoute[];
+}
+
+/**
+ * Generic reusable function to convert a manifest into a react-router style
+ * route hierarchy.  For use in server-side and client-side route creation,
+ * as well and `remix routes` to keep them all in sync.
+ *
+ * This also handles inserting "folder" parent routes to help disambiguate
+ * between pathless layout routes and index routes at the same level
+ *
+ * @param manifest     Map of string -> Route Object
+ * @param createRoute  Function to create a hierarchical route given a manifest
+ *                     ignoring children
+ * @returns
+ */
+function createHierarchicalRoutes<
+  ManifestRoute extends BaseManifestRoute,
+  OutputRoute extends BaseOutputRoute
+>(
+  manifest: Record<string, ManifestRoute>,
+  createRoute: (r: ManifestRoute) => OutputRoute
+) {
+  function recurse(parentId?: string) {
+    let routes = Object.values(manifest).filter(
+      (route) => route.parentId === parentId
+    );
+
+    let children: OutputRoute[] = [];
+    let pathCounts: Record<string, number> = {};
+
+    for (let route of routes) {
+      // Track in case we find duplicate paths and the same level, indicating
+      // we need to insert a folder route
+      if (route.path) {
+        pathCounts[route.path] = (pathCounts[route.path] || 0) + 1;
+      }
+      let hierarchicalRoute = createRoute(route);
+      hierarchicalRoute.children = recurse(route.id);
+      children.push(hierarchicalRoute);
+    }
+
+    // If we found any duplicate paths, create a new folder-route and nest
+    // the duplicate entires under that without paths since they inherit
+    // from the new parent now
+    Object.entries(pathCounts).forEach(([path, count]) => {
+      if (count > 1) {
+        let otherPathRoutes: OutputRoute[] = [];
+        let dupPathRoutes: OutputRoute[] = [];
+        children.forEach((r) => {
+          if (r.path === path) {
+            dupPathRoutes.push(r);
+          } else {
+            otherPathRoutes.push(r);
+          }
+        });
+        let folderRoute: OutputRoute = {
+          id: `folder:routes/${path}`,
+          path,
+          children: dupPathRoutes.map((r) => ({ ...r, path: undefined })),
+        };
+        children = [...otherPathRoutes, folderRoute];
+      }
+    });
+
+    return children;
+  }
+
+  return recurse();
 }

--- a/packages/remix-dev/config/format.ts
+++ b/packages/remix-dev/config/format.ts
@@ -83,10 +83,10 @@ interface BaseManifestRoute {
   parentId?: string;
 }
 
-interface BaseOutputRoute {
+interface BaseHierarchyRoute {
   id: string;
   path?: string;
-  children?: BaseOutputRoute[];
+  children?: BaseHierarchyRoute[];
 }
 
 /**
@@ -109,17 +109,17 @@ interface BaseOutputRoute {
  */
 function createHierarchicalRoutes<
   ManifestRoute extends BaseManifestRoute,
-  OutputRoute extends BaseOutputRoute
+  HierarchyRoute extends BaseHierarchyRoute
 >(
   manifest: Record<string, ManifestRoute>,
-  createRoute: (r: ManifestRoute) => OutputRoute
+  createRoute: (r: ManifestRoute) => HierarchyRoute
 ) {
   function recurse(parentId?: string) {
     let routes = Object.values(manifest).filter(
       (route) => route.parentId === parentId
     );
 
-    let children: OutputRoute[] = [];
+    let children: HierarchyRoute[] = [];
     let pathCounts: Record<string, number> = {};
 
     for (let route of routes) {
@@ -138,8 +138,8 @@ function createHierarchicalRoutes<
     // from the new parent now
     Object.entries(pathCounts).forEach(([path, count]) => {
       if (count > 1) {
-        let otherPathRoutes: OutputRoute[] = [];
-        let dupPathRoutes: OutputRoute[] = [];
+        let otherPathRoutes: HierarchyRoute[] = [];
+        let dupPathRoutes: HierarchyRoute[] = [];
         children.forEach((r) => {
           if (r.path === path) {
             dupPathRoutes.push(r);
@@ -148,7 +148,7 @@ function createHierarchicalRoutes<
           }
         });
         // TODO: Need to figure out this typing error :/
-        let folderRoute: OutputRoute = {
+        let folderRoute: HierarchyRoute = {
           id: `folder:routes/${path}`,
           path,
           children: dupPathRoutes.map((r) => ({ ...r, path: undefined })),

--- a/packages/remix-dev/config/format.ts
+++ b/packages/remix-dev/config/format.ts
@@ -90,6 +90,11 @@ interface BaseOutputRoute {
 }
 
 /**
+ * NOTE: This function is duplicated in remix-dev, remix-react, and
+ * remix-server-runtime so if you make changes please make them in all 3
+ * locations. We'll look into DRY-ing this up after we layer Remix on top of
+ * react-router@6.4
+ *
  * Generic reusable function to convert a manifest into a react-router style
  * route hierarchy.  For use in server-side and client-side route creation,
  * as well and `remix routes` to keep them all in sync.
@@ -142,6 +147,7 @@ function createHierarchicalRoutes<
             otherPathRoutes.push(r);
           }
         });
+        // TODO: Need to figure out this typing error :/
         let folderRoute: OutputRoute = {
           id: `folder:routes/${path}`,
           path,

--- a/packages/remix-dev/config/format.ts
+++ b/packages/remix-dev/config/format.ts
@@ -112,9 +112,9 @@ type BaseHierarchyRoute<T> = T & {
  * @returns
  */
 export function createHierarchicalRoutes<
-  HierarchyRoute extends Omit<BaseHierarchyRoute<unknown>, "children">
+  HierarchyRoute extends BaseHierarchyRoute<unknown>
 >(
-  manifest: Record<string, BaseManifestRoute>,
+  manifest: Record<string, BaseManifestRoute | undefined>,
   createRoute: (id: string, path: string | undefined) => HierarchyRoute
 ): HierarchyRoute[] {
   function recurse(parentId?: string) {
@@ -125,7 +125,7 @@ export function createHierarchicalRoutes<
     let children: HierarchyRoute[] = [];
 
     Object.values(manifest).forEach((route) => {
-      if (route.parentId == parentId) {
+      if (route && route.parentId == parentId) {
         if (route.index && route.path) {
           indexRoutesWithPath.push(route.path);
         }

--- a/packages/remix-dev/config/routesConvention.ts
+++ b/packages/remix-dev/config/routesConvention.ts
@@ -188,6 +188,8 @@ export function createRoutePath(partialRouteId: string): string | undefined {
 
   if (rawSegmentBuffer === "index" && result.endsWith("index")) {
     result = result.replace(/\/?index$/, "");
+  } else {
+    result = result.replace(/\/$/, "");
   }
 
   return result || undefined;

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -707,7 +707,7 @@ export function Meta() {
 
     let routeModule = routeModules[routeId];
 
-    if (routeModule.meta) {
+    if (routeModule?.meta) {
       let routeMeta =
         typeof routeModule.meta === "function"
           ? routeModule.meta({ data, parentsData, params, location })
@@ -804,7 +804,10 @@ export function Scripts(props: ScriptProps) {
       ? `window.__remixContext = ${serverHandoffString};`
       : "";
 
-    let routeModulesScript = `${matches
+    let matchesWithModules = matches.filter(
+      (match) => manifest.routes[match.route.id]
+    );
+    let routeModulesScript = `${matchesWithModules
       .map(
         (match, index) =>
           `import ${JSON.stringify(manifest.url)};
@@ -813,7 +816,7 @@ import * as route${index} from ${JSON.stringify(
           )};`
       )
       .join("\n")}
-window.__remixRouteModules = {${matches
+window.__remixRouteModules = {${matchesWithModules
       .map((match, index) => `${JSON.stringify(match.route.id)}:route${index}`)
       .join(",")}};
 
@@ -857,7 +860,7 @@ import(${JSON.stringify(manifest.entry.module)});`;
     .concat(nextMatches)
     .map((match) => {
       let route = manifest.routes[match.route.id];
-      return (route.imports || []).concat([route.module]);
+      return route ? (route.imports || []).concat([route.module]) : [];
     })
     .flat(1);
 

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -860,7 +860,10 @@ import(${JSON.stringify(manifest.entry.module)});`;
     .concat(nextMatches)
     .map((match) => {
       let route = manifest.routes[match.route.id];
-      return route ? (route.imports || []).concat([route.module]) : [];
+      if (!route) {
+        return [];
+      }
+      return (route.imports || []).concat([route.module]);
     })
     .flat(1);
 

--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -232,7 +232,7 @@ export function getLinksForMatches(
   let descriptors = matches
     .map((match): LinkDescriptor[] => {
       let module = routeModules[match.route.id];
-      return module.links?.() || [];
+      return module?.links?.() || [];
     })
     .flat(1);
 
@@ -434,6 +434,9 @@ export function getModuleLinkHrefs(
     matches
       .map((match) => {
         let route = manifestPatch.routes[match.route.id];
+        if (!route) {
+          return [];
+        }
         let hrefs = [route.module];
         if (route.imports) {
           hrefs = hrefs.concat(route.imports);
@@ -455,6 +458,9 @@ function getCurrentPageModulePreloadHrefs(
     matches
       .map((match) => {
         let route = manifest.routes[match.route.id];
+        if (!route) {
+          return [];
+        }
         let hrefs = [route.module];
 
         if (route.imports) {

--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -330,7 +330,7 @@ export async function getStylesheetPrefetchLinks(
   let links = await Promise.all(
     matches.map(async (match) => {
       let mod = await loadRouteModule(match.route, routeModules);
-      return mod.links ? mod.links() : [];
+      return mod?.links ? mod.links() : [];
     })
   );
 
@@ -416,7 +416,7 @@ export function getDataLinkHrefs(
   let path = parsePathPatch(page);
   return dedupeHrefs(
     matches
-      .filter((match) => manifest.routes[match.route.id].hasLoader)
+      .filter((match) => manifest.routes[match.route.id]?.hasLoader)
       .map((match) => {
         let { pathname, search } = path;
         let searchParams = new URLSearchParams(search);
@@ -434,7 +434,7 @@ export function getModuleLinkHrefs(
     matches
       .map((match) => {
         let route = manifestPatch.routes[match.route.id];
-        if (!route) {
+        if (!route?.module) {
           return [];
         }
         let hrefs = [route.module];
@@ -458,7 +458,7 @@ function getCurrentPageModulePreloadHrefs(
     matches
       .map((match) => {
         let route = manifest.routes[match.route.id];
-        if (!route) {
+        if (!route?.module) {
           return [];
         }
         let hrefs = [route.module];

--- a/packages/remix-react/routeModules.ts
+++ b/packages/remix-react/routeModules.ts
@@ -11,7 +11,7 @@ import type { RouteData } from "./routeData";
 import type { Submission } from "./transition";
 
 export interface RouteModules {
-  [routeId: string]: RouteModule;
+  [routeId: string]: RouteModule | undefined;
 }
 
 export interface RouteModule {
@@ -119,9 +119,16 @@ export type RouteHandle = any;
 export async function loadRouteModule(
   route: EntryRoute | ClientRoute,
   routeModulesCache: RouteModules
-): Promise<RouteModule> {
-  if (route.id in routeModulesCache) {
-    return routeModulesCache[route.id];
+): Promise<RouteModule | undefined> {
+  if (!route.module) {
+    // This was a module-less parent route inserted to disambiguate between
+    // index and pathless routes
+    return undefined;
+  }
+
+  let cachedModule = routeModulesCache[route.id];
+  if (cachedModule) {
+    return cachedModule;
   }
 
   try {

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -14,6 +14,7 @@ import type { Submission } from "./transition";
 import { CatchValue, TransitionRedirect } from "./transition";
 import { prefetchStyleLinks } from "./links";
 import invariant from "./invariant";
+import { Outlet } from ".";
 
 export interface RouteManifest<Route> {
   [routeId: string]: Route;
@@ -84,7 +85,9 @@ export function createClientRoute(
 ): ClientRoute {
   return {
     caseSensitive: !!entryRoute.caseSensitive,
-    element: <Component id={entryRoute.id} />,
+    // If this route doesn't have a module, then it's an inserted parent path
+    // route, and it should just render it's children through an outlet
+    element: entryRoute.module ? <Component id={entryRoute.id} /> : <Outlet />,
     id: entryRoute.id,
     path: entryRoute.path,
     index: entryRoute.index,
@@ -291,11 +294,11 @@ export function createHierarchicalRoutes<
           otherPathRoutes.push(r);
         }
       });
-      // TODO: Need to figure out this typing error :/
-      // @ts-expect-error
-      let folderRoute: HierarchyRoute = {
-        id: `routes/${path}`,
-        path,
+      let folderRoute = {
+        ...createRoute({
+          id: `routes/${path}`,
+          path,
+        } as ManifestRoute),
         children: dupPathRoutes.map((r) => ({ ...r, path: undefined })),
       };
       children = [...otherPathRoutes, folderRoute];

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -222,6 +222,7 @@ async function checkRedirect(
 
 interface BaseManifestRoute {
   id: string;
+  index?: boolean;
   path?: string;
   parentId?: string;
 }
@@ -263,41 +264,41 @@ export function createHierarchicalRoutes<
     );
 
     let children: HierarchyRoute[] = [];
-    let pathCounts: Record<string, number> = {};
+
+    // Our manifest flattens index routes and their paths into a single
+    // per-route-file entry, so we use this to track which index routes need
+    // to be split back into a hierarchical pattern
+    let indexRoutesWithPath: string[] = [];
 
     for (let route of routes) {
-      // Track in case we find duplicate paths and the same level, indicating
-      // we need to insert a folder route
-      if (route.path) {
-        pathCounts[route.path] = (pathCounts[route.path] || 0) + 1;
+      if (route.index && route.path) {
+        indexRoutesWithPath.push(route.path);
       }
       let hierarchicalRoute = createRoute(route);
       hierarchicalRoute.children = recurse(route.id);
       children.push(hierarchicalRoute);
     }
 
-    // If we found any duplicate paths, create a new folder-route and nest
-    // the duplicate entires under that without paths since they inherit
-    // from the new parent now
-    Object.entries(pathCounts).forEach(([path, count]) => {
-      if (count > 1) {
-        let otherPathRoutes: HierarchyRoute[] = [];
-        let dupPathRoutes: HierarchyRoute[] = [];
-        children.forEach((r) => {
-          if (r.path === path) {
-            dupPathRoutes.push(r);
-          } else {
-            otherPathRoutes.push(r);
-          }
-        });
-        // TODO: Need to figure out this typing error :/
-        let folderRoute: HierarchyRoute = {
-          id: `folder:routes/${path}`,
-          path,
-          children: dupPathRoutes.map((r) => ({ ...r, path: undefined })),
-        };
-        children = [...otherPathRoutes, folderRoute];
-      }
+    // For each index route that _also_ had a path, create a new parent route
+    // for the path and nest the index route and any other matching path routes
+    indexRoutesWithPath.forEach((path) => {
+      let otherPathRoutes: HierarchyRoute[] = [];
+      let dupPathRoutes: HierarchyRoute[] = [];
+      children.forEach((r) => {
+        if (r.path === path) {
+          dupPathRoutes.push(r);
+        } else {
+          otherPathRoutes.push(r);
+        }
+      });
+      // TODO: Need to figure out this typing error :/
+      // @ts-expect-error
+      let folderRoute: HierarchyRoute = {
+        id: `routes/${path}`,
+        path,
+        children: dupPathRoutes.map((r) => ({ ...r, path: undefined })),
+      };
+      children = [...otherPathRoutes, folderRoute];
     });
 
     return children;

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -226,10 +226,10 @@ interface BaseManifestRoute {
   parentId?: string;
 }
 
-interface BaseOutputRoute {
+interface BaseHierarchyRoute {
   id: string;
   path?: string;
-  children?: BaseOutputRoute[];
+  children?: BaseHierarchyRoute[];
 }
 
 /**
@@ -252,17 +252,17 @@ interface BaseOutputRoute {
  */
 export function createHierarchicalRoutes<
   ManifestRoute extends BaseManifestRoute,
-  OutputRoute extends BaseOutputRoute
+  HierarchyRoute extends BaseHierarchyRoute
 >(
   manifest: Record<string, ManifestRoute>,
-  createRoute: (r: ManifestRoute) => OutputRoute
+  createRoute: (r: ManifestRoute) => HierarchyRoute
 ) {
   function recurse(parentId?: string) {
     let routes = Object.values(manifest).filter(
       (route) => route.parentId === parentId
     );
 
-    let children: OutputRoute[] = [];
+    let children: HierarchyRoute[] = [];
     let pathCounts: Record<string, number> = {};
 
     for (let route of routes) {
@@ -281,8 +281,8 @@ export function createHierarchicalRoutes<
     // from the new parent now
     Object.entries(pathCounts).forEach(([path, count]) => {
       if (count > 1) {
-        let otherPathRoutes: OutputRoute[] = [];
-        let dupPathRoutes: OutputRoute[] = [];
+        let otherPathRoutes: HierarchyRoute[] = [];
+        let dupPathRoutes: HierarchyRoute[] = [];
         children.forEach((r) => {
           if (r.path === path) {
             dupPathRoutes.push(r);
@@ -291,7 +291,7 @@ export function createHierarchicalRoutes<
           }
         });
         // TODO: Need to figure out this typing error :/
-        let folderRoute: OutputRoute = {
+        let folderRoute: HierarchyRoute = {
           id: `folder:routes/${path}`,
           path,
           children: dupPathRoutes.map((r) => ({ ...r, path: undefined })),

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -233,6 +233,11 @@ interface BaseOutputRoute {
 }
 
 /**
+ * NOTE: This function is duplicated in remix-dev, remix-react, and
+ * remix-server-runtime so if you make changes please make them in all 3
+ * locations. We'll look into DRY-ing this up after we layer Remix on top of
+ * react-router@6.4
+ *
  * Generic reusable function to convert a manifest into a react-router style
  * route hierarchy.  For use in server-side and client-side route creation,
  * as well and `remix routes` to keep them all in sync.
@@ -285,6 +290,7 @@ export function createHierarchicalRoutes<
             otherPathRoutes.push(r);
           }
         });
+        // TODO: Need to figure out this typing error :/
         let folderRoute: OutputRoute = {
           id: `folder:routes/${path}`,
           path,

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -1459,6 +1459,7 @@ async function callAction(
   match: ClientMatch,
   signal: AbortSignal
 ): Promise<DataResult> {
+  invariant(match.route.action, `Expected action for ${match.route.id}"`);
   try {
     let value = await match.route.action({
       url: createUrl(submission.action),

--- a/packages/remix-server-runtime/__tests__/handler-test.ts
+++ b/packages/remix-server-runtime/__tests__/handler-test.ts
@@ -6,8 +6,14 @@ describe("createRequestHandler", () => {
     let handler = createRequestHandler({
       routes: {
         root: {
+          id: "root",
+          path: "/",
+          module: {},
+        },
+        "routes/test": {
           id: "routes/test",
-          path: "/test",
+          path: "test",
+          parentId: "root",
           module: {
             loader: ({ request }) => json(request.headers.get("X-Foo")),
           } as any,

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -24,7 +24,7 @@ export async function callRouteAction({
   match: RouteMatch<ServerRoute>;
   request: Request;
 }) {
-  let action = match.route.module.action;
+  let action = match.route.module?.action;
 
   if (!action) {
     let response = new Response(null, { status: 405 });
@@ -69,7 +69,7 @@ export async function callRouteLoader({
   match: RouteMatch<ServerRoute>;
   loadContext: AppLoadContext;
 }) {
-  let loader = match.route.module.loader;
+  let loader = match.route.module?.loader;
 
   if (!loader) {
     throw new Error(

--- a/packages/remix-server-runtime/entry.ts
+++ b/packages/remix-server-runtime/entry.ts
@@ -8,6 +8,7 @@ import type {
 import type { RouteData } from "./routeData";
 import type { RouteMatch } from "./routeMatching";
 import type { RouteModules, EntryRouteModule } from "./routeModules";
+import invariant from "./invariant";
 
 export interface EntryContext {
   appState: AppState;
@@ -44,7 +45,9 @@ export function createEntryRouteModules(
   manifest: ServerRouteManifest
 ): RouteModules<EntryRouteModule> {
   return Object.keys(manifest).reduce((memo, routeId) => {
-    memo[routeId] = manifest[routeId].module;
+    let routeModule = manifest[routeId].module;
+    invariant(routeModule, "No module found in server manifest route");
+    memo[routeId] = routeModule;
     return memo;
   }, {} as RouteModules<EntryRouteModule>);
 }

--- a/packages/remix-server-runtime/headers.ts
+++ b/packages/remix-server-runtime/headers.ts
@@ -11,7 +11,10 @@ export function getDocumentHeaders(
   actionResponse?: Response
 ): Headers {
   return matches.reduce((parentHeaders, match, index) => {
-    let routeModule = build.routes[match.route.id].module;
+    let routeModule = build.routes[match.route.id]?.module;
+    if (!routeModule) {
+      return parentHeaders;
+    }
     let routeLoaderResponse = routeLoaderResponses[match.route.id];
     let loaderHeaders = routeLoaderResponse
       ? routeLoaderResponse.headers

--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -1,4 +1,3 @@
-import invariant from "./invariant";
 import type { ServerRouteModule } from "./routeModules";
 
 export interface RouteManifest<Route> {

--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -62,33 +62,29 @@ type BaseHierarchyRoute<T> = T & {
  * @returns
  */
 export function createHierarchicalRoutes<
-  ManifestRoute extends BaseManifestRoute,
   HierarchyRoute extends Omit<BaseHierarchyRoute<unknown>, "children">
 >(
-  manifest: Record<string, ManifestRoute>,
-  createRoute: (r: ManifestRoute) => HierarchyRoute
+  manifest: Record<string, BaseManifestRoute>,
+  createRoute: (id: string, path: string | undefined) => HierarchyRoute
 ): HierarchyRoute[] {
   function recurse(parentId?: string) {
-    let routes = Object.values(manifest).filter(
-      (route) => route.parentId === parentId
-    );
-
-    let children: HierarchyRoute[] = [];
-
     // Our manifest flattens index routes and their paths into a single
     // per-route-file entry, so we use this to track which index routes need
     // to be split back into a hierarchical pattern
     let indexRoutesWithPath: string[] = [];
+    let children: HierarchyRoute[] = [];
 
-    for (let route of routes) {
-      if (route.index && route.path) {
-        indexRoutesWithPath.push(route.path);
+    Object.values(manifest).forEach((route) => {
+      if (route.parentId == parentId) {
+        if (route.index && route.path) {
+          indexRoutesWithPath.push(route.path);
+        }
+        children.push({
+          ...createRoute(route.id, route.path),
+          children: recurse(route.id),
+        });
       }
-      children.push({
-        ...createRoute(route),
-        children: recurse(route.id),
-      });
-    }
+    });
 
     // For each index route that _also_ had a path, create a new parent route
     // for the path and nest the index route and any other matching path routes
@@ -103,10 +99,7 @@ export function createHierarchicalRoutes<
         }
       });
       let folderRoute = {
-        ...createRoute({
-          id: `routes/${path}`,
-          path,
-        } as ManifestRoute),
+        ...createRoute(`routes/${path}`, path),
         children: dupPathRoutes.map((r) => ({ ...r, path: undefined })),
       };
       children = [...otherPathRoutes, folderRoute];

--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -30,8 +30,6 @@ export interface ServerRoute extends Route {
   module: ServerRouteModule;
 }
 
-// https://github.com/remix-run/remix/discussions/3014
-// https://github.com/remix-run/react-router/issues/9145
 interface BaseManifestRoute {
   id: string;
   index?: boolean;
@@ -103,11 +101,11 @@ export function createHierarchicalRoutes<
           otherPathRoutes.push(r);
         }
       });
-      // TODO: Need to figure out this typing error :/
-      // @ts-expect-error
-      let folderRoute: HierarchyRoute = {
-        id: `routes/${path}`,
-        path,
+      let folderRoute = {
+        ...createRoute({
+          id: `routes/${path}`,
+          path,
+        } as ManifestRoute),
         children: dupPathRoutes.map((r) => ({ ...r, path: undefined })),
       };
       children = [...otherPathRoutes, folderRoute];

--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -37,11 +37,11 @@ interface BaseManifestRoute {
   parentId?: string;
 }
 
-interface BaseHierarchyRoute {
+type BaseHierarchyRoute<T> = T & {
   id: string;
   path?: string;
-  children?: BaseHierarchyRoute[];
-}
+  children?: BaseHierarchyRoute<T>[];
+};
 
 /**
  * NOTE: This function is duplicated in remix-dev, remix-react, and
@@ -63,11 +63,11 @@ interface BaseHierarchyRoute {
  */
 export function createHierarchicalRoutes<
   ManifestRoute extends BaseManifestRoute,
-  HierarchyRoute extends BaseHierarchyRoute
+  HierarchyRoute extends Omit<BaseHierarchyRoute<unknown>, "children">
 >(
   manifest: Record<string, ManifestRoute>,
   createRoute: (r: ManifestRoute) => HierarchyRoute
-) {
+): HierarchyRoute[] {
   function recurse(parentId?: string) {
     let routes = Object.values(manifest).filter(
       (route) => route.parentId === parentId
@@ -84,9 +84,10 @@ export function createHierarchicalRoutes<
       if (route.index && route.path) {
         indexRoutesWithPath.push(route.path);
       }
-      let hierarchicalRoute = createRoute(route);
-      hierarchicalRoute.children = recurse(route.id);
-      children.push(hierarchicalRoute);
+      children.push({
+        ...createRoute(route),
+        children: recurse(route.id),
+      });
     }
 
     // For each index route that _also_ had a path, create a new parent route

--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -46,6 +46,11 @@ interface BaseOutputRoute {
 }
 
 /**
+ * NOTE: This function is duplicated in remix-dev, remix-react, and
+ * remix-server-runtime so if you make changes please make them in all 3
+ * locations. We'll look into DRY-ing this up after we layer Remix on top of
+ * react-router@6.4
+ *
  * Generic reusable function to convert a manifest into a react-router style
  * route hierarchy.  For use in server-side and client-side route creation,
  * as well and `remix routes` to keep them all in sync.
@@ -98,6 +103,7 @@ export function createHierarchicalRoutes<
             otherPathRoutes.push(r);
           }
         });
+        // TODO: Need to figure out this typing error :/
         let folderRoute: OutputRoute = {
           id: `folder:routes/${path}`,
           path,

--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -1,3 +1,4 @@
+import invariant from "./invariant";
 import type { ServerRouteModule } from "./routeModules";
 
 export interface RouteManifest<Route> {
@@ -30,14 +31,84 @@ export interface ServerRoute extends Route {
   module: ServerRouteModule;
 }
 
-export function createRoutes(
-  manifest: ServerRouteManifest,
-  parentId?: string
-): ServerRoute[] {
-  return Object.entries(manifest)
-    .filter(([, route]) => route.parentId === parentId)
-    .map(([id, route]) => ({
-      ...route,
-      children: createRoutes(manifest, id),
-    }));
+// https://github.com/remix-run/remix/discussions/3014
+// https://github.com/remix-run/react-router/issues/9145
+interface BaseManifestRoute {
+  id: string;
+  path?: string;
+  parentId?: string;
+}
+
+interface BaseOutputRoute {
+  id: string;
+  path?: string;
+  children?: BaseOutputRoute[];
+}
+
+/**
+ * Generic reusable function to convert a manifest into a react-router style
+ * route hierarchy.  For use in server-side and client-side route creation,
+ * as well and `remix routes` to keep them all in sync.
+ *
+ * This also handles inserting "folder" parent routes to help disambiguate
+ * between pathless layout routes and index routes at the same level
+ *
+ * @param manifest     Map of string -> Route Object
+ * @param createRoute  Function to create a hierarchical route given a manifest
+ *                     ignoring children
+ * @returns
+ */
+export function createHierarchicalRoutes<
+  ManifestRoute extends BaseManifestRoute,
+  OutputRoute extends BaseOutputRoute
+>(
+  manifest: Record<string, ManifestRoute>,
+  createRoute: (r: ManifestRoute) => OutputRoute
+) {
+  function recurse(parentId?: string) {
+    let routes = Object.values(manifest).filter(
+      (route) => route.parentId === parentId
+    );
+
+    let children: OutputRoute[] = [];
+    let pathCounts: Record<string, number> = {};
+
+    for (let route of routes) {
+      // Track in case we find duplicate paths and the same level, indicating
+      // we need to insert a folder route
+      if (route.path) {
+        pathCounts[route.path] = (pathCounts[route.path] || 0) + 1;
+      }
+      let hierarchicalRoute = createRoute(route);
+      hierarchicalRoute.children = recurse(route.id);
+      children.push(hierarchicalRoute);
+    }
+
+    // If we found any duplicate paths, create a new folder-route and nest
+    // the duplicate entires under that without paths since they inherit
+    // from the new parent now
+    Object.entries(pathCounts).forEach(([path, count]) => {
+      if (count > 1) {
+        let otherPathRoutes: OutputRoute[] = [];
+        let dupPathRoutes: OutputRoute[] = [];
+        children.forEach((r) => {
+          if (r.path === path) {
+            dupPathRoutes.push(r);
+          } else {
+            otherPathRoutes.push(r);
+          }
+        });
+        let folderRoute: OutputRoute = {
+          id: `folder:routes/${path}`,
+          path,
+          children: dupPathRoutes.map((r) => ({ ...r, path: undefined })),
+        };
+        children = [...otherPathRoutes, folderRoute];
+      }
+    });
+
+    return children;
+  }
+
+  return recurse();
 }

--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -39,10 +39,10 @@ interface BaseManifestRoute {
   parentId?: string;
 }
 
-interface BaseOutputRoute {
+interface BaseHierarchyRoute {
   id: string;
   path?: string;
-  children?: BaseOutputRoute[];
+  children?: BaseHierarchyRoute[];
 }
 
 /**
@@ -65,17 +65,17 @@ interface BaseOutputRoute {
  */
 export function createHierarchicalRoutes<
   ManifestRoute extends BaseManifestRoute,
-  OutputRoute extends BaseOutputRoute
+  HierarchyRoute extends BaseHierarchyRoute
 >(
   manifest: Record<string, ManifestRoute>,
-  createRoute: (r: ManifestRoute) => OutputRoute
+  createRoute: (r: ManifestRoute) => HierarchyRoute
 ) {
   function recurse(parentId?: string) {
     let routes = Object.values(manifest).filter(
       (route) => route.parentId === parentId
     );
 
-    let children: OutputRoute[] = [];
+    let children: HierarchyRoute[] = [];
     let pathCounts: Record<string, number> = {};
 
     for (let route of routes) {
@@ -94,8 +94,8 @@ export function createHierarchicalRoutes<
     // from the new parent now
     Object.entries(pathCounts).forEach(([path, count]) => {
       if (count > 1) {
-        let otherPathRoutes: OutputRoute[] = [];
-        let dupPathRoutes: OutputRoute[] = [];
+        let otherPathRoutes: HierarchyRoute[] = [];
+        let dupPathRoutes: HierarchyRoute[] = [];
         children.forEach((r) => {
           if (r.path === path) {
             dupPathRoutes.push(r);
@@ -104,7 +104,7 @@ export function createHierarchicalRoutes<
           }
         });
         // TODO: Need to figure out this typing error :/
-        let folderRoute: OutputRoute = {
+        let folderRoute: HierarchyRoute = {
           id: `folder:routes/${path}`,
           path,
           children: dupPathRoutes.map((r) => ({ ...r, path: undefined })),

--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -27,7 +27,10 @@ export interface EntryRoute extends Route {
 
 export interface ServerRoute extends Route {
   children: ServerRoute[];
-  module: ServerRouteModule;
+  // Note: When accessed from the manifest, we will always have a module, but
+  // once we convert these into a hierarchy we may not
+  // (see createHierarchicalRoutes)
+  module?: ServerRouteModule;
 }
 
 interface BaseManifestRoute {

--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -65,9 +65,9 @@ type BaseHierarchyRoute<T> = T & {
  * @returns
  */
 export function createHierarchicalRoutes<
-  HierarchyRoute extends Omit<BaseHierarchyRoute<unknown>, "children">
+  HierarchyRoute extends BaseHierarchyRoute<unknown>
 >(
-  manifest: Record<string, BaseManifestRoute>,
+  manifest: Record<string, BaseManifestRoute | undefined>,
   createRoute: (id: string, path: string | undefined) => HierarchyRoute
 ): HierarchyRoute[] {
   function recurse(parentId?: string) {
@@ -78,7 +78,7 @@ export function createHierarchicalRoutes<
     let children: HierarchyRoute[] = [];
 
     Object.values(manifest).forEach((route) => {
-      if (route.parentId == parentId) {
+      if (route && route.parentId == parentId) {
         if (route.index && route.path) {
           indexRoutesWithPath.push(route.path);
         }

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -28,10 +28,15 @@ export const createRequestHandler: CreateRequestHandlerFunction = (
   build,
   mode
 ) => {
-  let routes = createHierarchicalRoutes<
-    Omit<ServerRoute, "children">,
-    ServerRoute
-  >(build.routes, (route) => ({ ...route, children: [] }));
+  let routes = createHierarchicalRoutes<ServerRoute>(
+    build.routes,
+    (id, path) => ({
+      ...(build.routes[id] || {}),
+      id,
+      path,
+      children: [],
+    })
+  );
 
   let serverMode = isServerMode(mode) ? mode : ServerMode.Production;
 

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -192,7 +192,7 @@ async function handleDocumentRequest({
   loadContext: AppLoadContext;
   matches: RouteMatch<ServerRoute>[] | null;
   request: Request;
-  rootRoute?: ServerRoute;
+  rootRoute: ServerRoute;
   serverMode?: ServerMode;
 }): Promise<Response> {
   let url = new URL(request.url);
@@ -419,7 +419,7 @@ async function handleDocumentRequest({
   if (!renderableMatches) {
     renderableMatches = [];
 
-    if (rootRoute?.module.CatchBoundary) {
+    if (rootRoute.module?.CatchBoundary) {
       appState.catchBoundaryRouteId = "root";
       renderableMatches.push({
         params: {},

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -61,7 +61,7 @@ export const createRequestHandler: CreateRequestHandlerFunction = (
         loadContext,
         matches,
         request,
-        routes,
+        rootRoute: routes[0],
         serverMode,
       });
     }
@@ -180,14 +180,14 @@ async function handleDocumentRequest({
   loadContext,
   matches,
   request,
-  routes,
+  rootRoute,
   serverMode,
 }: {
   build: ServerBuild;
   loadContext: AppLoadContext;
   matches: RouteMatch<ServerRoute>[] | null;
   request: Request;
-  routes: ServerRoute[];
+  rootRoute?: ServerRoute;
   serverMode?: ServerMode;
 }): Promise<Response> {
   let url = new URL(request.url);
@@ -414,13 +414,12 @@ async function handleDocumentRequest({
   if (!renderableMatches) {
     renderableMatches = [];
 
-    let root = routes[0];
-    if (root?.module.CatchBoundary) {
+    if (rootRoute?.module.CatchBoundary) {
       appState.catchBoundaryRouteId = "root";
       renderableMatches.push({
         params: {},
         pathname: "",
-        route: routes[0],
+        route: rootRoute,
       });
     }
   }

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -53,7 +53,7 @@ export const createRequestHandler: CreateRequestHandlerFunction = (
         handleDataRequest: build.entry.module.handleDataRequest,
         serverMode,
       });
-    } else if (matches && !matches[matches.length - 1].route.module.default) {
+    } else if (matches && !matches[matches.length - 1].route.module?.default) {
       response = await handleResourceRequest({
         request,
         loadContext,
@@ -612,7 +612,7 @@ function getMatchesUpToDeepestBoundary(
   let deepestBoundaryIndex: number = -1;
 
   matches.forEach((match, index) => {
-    if (match.route.module[key]) {
+    if (match.route.module?.[key]) {
       deepestBoundaryIndex = index;
     }
   });


### PR DESCRIPTION
This fixes a path collision bug when using pathless layout routes and index routes at the same level currently.

The routes folder structure:
```
app/routes
└── nested
    ├── __pathless
    │   └── foo.jsx
    ├── __pathless.jsx
    └── index.jsx
```

Currently produces a route hierarchy of:
```jsx
<Route file="root.tsx">
  <Route path="nested/" file="routes/nested/__pathless.tsx">
    <Route path="foo" file="routes/nested/__pathless/foo.tsx" />
  </Route>
  <Route path="nested" index file="routes/nested/index.tsx" />
  <Route index file="routes/index.tsx" />
</Route>
```

However, you can see that we're creating _two_ routes with `path="nested"` and we also have a route with both a `path` and an `index`.

Instead, we should be detecting that `routes/nested/index` and `routes/nested/__pathless.tsx` both share the same parent `nested` path and they should be nested together under `<Route path="nested">`.

We don't want to have to start representing the `routes/nested` folder in the asset manifest, since it's not an asset, so we can do this determination as hierarchical route creation time and just insert parent routes as needed.  By inserting the parent route and removing `path` from the two pathless route children, we end up with the proper hierarchy of:

```jsx
<Route file="root.tsx">
  <Route path="nested">
    <Route file="routes/nested/__pathless.tsx">
      <Route path="foo" file="routes/nested/__pathless/foo.tsx" />
    </Route>
    <Route index file="routes/nested/index.tsx" />
  </Route>
  <Route index file="routes/index.tsx" />
</Route>
```

Closes: #3014

Testing Strategy:
* Unit tests for `formatRoute` to ensure we capture this in the CLI
* Integration test brought over from #3052
