### PR TITLE
types(remix-server-runtime): make `context` mandatory in `DataFunctionArgs`

### DIFF
--- a/.changeset/thirty-pots-lay.md
+++ b/.changeset/thirty-pots-lay.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+Make the loadContext parameter not optional so that augmenting AppLoadContext does not require checking if the context is undefined

--- a/contributors.yml
+++ b/contributors.yml
@@ -203,6 +203,7 @@
 - juliaqiuxy
 - justinnoel
 - justinsalasdev
+- justinwaite
 - justsml
 - juwiragiye
 - jveldridge

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -20,7 +20,7 @@ export async function callRouteAction({
   match,
   request,
 }: {
-  loadContext?: AppLoadContext;
+  loadContext: AppLoadContext;
   match: RouteMatch<ServerRoute>;
   request: Request;
 }) {
@@ -67,7 +67,7 @@ export async function callRouteLoader({
 }: {
   request: Request;
   match: RouteMatch<ServerRoute>;
-  loadContext?: AppLoadContext;
+  loadContext: AppLoadContext;
 }) {
   let loader = match.route.module.loader;
 

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -15,7 +15,7 @@ export interface RouteModules<RouteModule> {
  */
 export interface DataFunctionArgs {
   request: Request;
-  context?: AppLoadContext;
+  context: AppLoadContext;
   params: Params;
 }
 

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -110,7 +110,7 @@ async function handleDataRequest({
       match = getRequestMatch(url, matches);
 
       response = await callRouteAction({
-        loadContext,
+        loadContext: loadContext ?? {},
         match,
         request: request,
       });
@@ -129,7 +129,7 @@ async function handleDataRequest({
       }
       match = tempMatch;
 
-      response = await callRouteLoader({ loadContext, match, request });
+      response = await callRouteLoader({ loadContext: loadContext ?? {}, match, request });
     }
 
     if (isRedirectResponse(response)) {
@@ -151,7 +151,7 @@ async function handleDataRequest({
 
     if (handleDataRequest) {
       response = await handleDataRequest(response, {
-        context: loadContext,
+        context: loadContext ?? {},
         params: match.params,
         request,
       });
@@ -225,7 +225,7 @@ async function handleDocumentRequest({
 
     try {
       actionResponse = await callRouteAction({
-        loadContext,
+        loadContext: loadContext ?? {},
         match: actionMatch,
         request: request,
       });
@@ -302,7 +302,7 @@ async function handleDocumentRequest({
     matchesToLoad.map((match) =>
       match.route.module.loader
         ? callRouteLoader({
-            loadContext,
+            loadContext: loadContext ?? {},
             match,
             request: loaderRequest,
           })
@@ -524,9 +524,9 @@ async function handleResourceRequest({
 
   try {
     if (isActionRequest(request)) {
-      return await callRouteAction({ match, loadContext, request });
+      return await callRouteAction({ match, loadContext: loadContext ?? {}, request });
     } else {
-      return await callRouteLoader({ match, loadContext, request });
+      return await callRouteLoader({ match, loadContext: loadContext ?? {}, request });
     }
   } catch (error: any) {
     if (serverMode !== ServerMode.Test) {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #3988

My strategy for addressing this issue is to always pass an empty object for the context, rather than passing nothing (or undefined). Since we've already declared the AppLoadContext interface to be `{[key: string]: unknown}`, I feel like this would be a reasonable approach. 

- [ ] Docs
- [ ] Tests

Testing Strategy:

I created an app in the playground and (manually had to) copy over the built remix-server-runtime directory into it. I then augmented the AppLoadContext interface with a property called `notes`. I then tried to access both a known and unknown property to make sure that typescript knew the difference.

```typescript
declare module '@remix-run/server-runtime' {
  export interface AppLoadContext {
    notes: string[]
  }
}

export const loader: LoaderFunction = async ({ request, context }) => {
  console.log(context.asdf.toString());
  
  console.log(context.notes.map(n => n.toLowerCase())); // Look Ma! No undefined check for context!

  let userId = await requireUserId(request);
  let noteListItems = await getNoteListItems({ userId });
  return json<LoaderData>({ noteListItems });
};
```

Here you can see the difference. Since `asdf` isn't part of the AppLoadContext augmented interface, Typescript correctly infers it as `unknown`. However, since `notes` _was_ added to the interface, it correctly infers it as a `string[]`. Note in either case that we didn't need to add an undefined check for the context, since it will always be at least an empty object (`{}`).
![Screen Shot 2022-08-12 at 6 17 05 PM](https://user-images.githubusercontent.com/8517615/184459606-b63f67a3-ddd0-4078-88bf-84516bbe3283.png)
![Screen Shot 2022-08-12 at 6 17 30 PM](https://user-images.githubusercontent.com/8517615/184459621-4077045f-0fe8-407c-a996-2cf5a5b4c8e5.png)


<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
