### PR TITLE
Use fetched item count for simple examples

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -330,6 +330,7 @@
 - real34
 - realjokele
 - reggie3
+- rkulinski
 - rlfarman
 - roachjc
 - robindrost

--- a/examples/infinite-scrolling/app/routes/offset/simple.tsx
+++ b/examples/infinite-scrolling/app/routes/offset/simple.tsx
@@ -49,7 +49,7 @@ export default function Index() {
   const parentRef = useRef<HTMLDivElement>(null);
 
   const rowVirtualizer = useVirtual({
-    size: data.totalItems,
+    size: items.length,
     parentRef,
     estimateSize: useCallback(() => 35, []),
     initialRect: { width: 0, height: 800 },

--- a/examples/infinite-scrolling/app/routes/page/simple.tsx
+++ b/examples/infinite-scrolling/app/routes/page/simple.tsx
@@ -49,7 +49,7 @@ export default function Index() {
   const parentRef = useRef<HTMLDivElement>(null);
 
   const rowVirtualizer = useVirtual({
-    size: data.totalItems,
+    size: items.length,
     parentRef,
     estimateSize: useCallback(() => 35, []),
     initialRect: { width: 0, height: 800 },


### PR DESCRIPTION
In order to prevent bugs related to scrolling with scroll bar use fetched items count instead of all available.