### PR TITLE
fix(remix-react): prevent form data duplicated value

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -418,3 +418,4 @@
 - zachdtaylor
 - zainfathoni
 - zhe
+- raskyer

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -320,6 +320,29 @@ test.describe("Forms", () => {
             )
           }
         `,
+
+        "app/routes/submitter-duplicate.jsx": js`
+          import { useLoaderData, Form } from "@remix-run/react";
+
+          export function loader({ request }) {
+            let url = new URL(request.url);
+            return url.searchParams.toString()
+          }
+
+          export default function() {
+            let data = useLoaderData();
+            return (
+              <Form>
+                <input type="text" name="tasks" defaultValue="first" />
+                <input type="text" name="tasks" defaultValue="second" />
+                <button type="submit" name="tasks" value="second">
+                  Add Task
+                </button>
+                <pre>{data}</pre>
+              </Form>
+            )
+          }
+        `
       },
     });
 
@@ -768,6 +791,19 @@ test.describe("Forms", () => {
     await page.waitForLoadState("load");
     expect(await app.getHtml("pre")).toBe(
       `<pre>tasks=first&amp;tasks=second&amp;tasks=</pre>`
+    );
+  });
+
+  // IN ORDER TO AVOID DUPLICATED VALUE ON SAFARI
+  test("<Form> doesn't submits the submitter's duplicated value to the form data", async ({
+    page,
+  }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/submitter-duplicate");
+    await app.clickElement("text=Add Task");
+    await page.waitForLoadState("load");
+    expect(await app.getHtml("pre")).toBe(
+      `<pre>tasks=first&amp;tasks=second</pre>`
     );
   });
 });

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1161,7 +1161,9 @@ export function useSubmitImpl(key?: string): SubmitFunction {
 
         // Include name + value from a <button>
         if (target.name) {
-          formData.append(target.name, target.value);
+          if (!formData.getAll(target.name).includes(target.value)) {
+            formData.append(target.name, target.value);
+          }
         }
       } else {
         if (isHtmlElement(target)) {


### PR DESCRIPTION
After : https://github.com/remix-run/remix/commit/5894598c75d0e542651dc92bc400320c108eae8d
A bug was introduced on Safari. Duplicated value of the form button was appended to the form data.

In Chrome, Firefox (and maybe other's) `new FormData(form)`, where form is a form dom element, will parse the form's input + value into the form data without getting the button element. On Safari, on the other hand, the button's name + value pair are added. With https://github.com/remix-run/remix/commit/5894598c75d0e542651dc92bc400320c108eae8d we don't `set` the button's value anymore but we `append` it. It solves @nrako use case where inputs and button have the same name and that you wan't to keep those. On the other hand, on Safari, it cause a duplicated entry of your button's name + value.

In an attempt to fix this behaviour without affecting @nrako effort, we introduce a check before appending to see if the button's name + value pair is already in the form data.

It's not a perfect solution because some use case would probably like to add also the button value even if it's already in the form data. But since it's a less common use case than just using "Safari" it might be better.

Closes: #4023 

- [ ] Docs
- [x] Tests

Testing Strategy:

copy / past the tests already made by @nrako (thank you) but just checked if the value was already submitted.