### PR TITLE
fix(remix-dev/cli/migrate): process default exports in `convert-to-javascript` migration

### DIFF
--- a/.changeset/red-apples-stew.md
+++ b/.changeset/red-apples-stew.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": patch
 ---
 
-Fixed a bug in the `import` to `require` conversion in the CLI's `.ts` to `.js` migration script
+Process default exports in `convert-to-javascript` migration

--- a/packages/remix-dev/__tests__/migrations/convert-to-javascript-test.ts
+++ b/packages/remix-dev/__tests__/migrations/convert-to-javascript-test.ts
@@ -90,10 +90,14 @@ const checkMigrationRanSuccessfully = async (projectDir: string) => {
     cwd: config.rootDirectory,
     ignore: [`./${config.appDirectory}/**/*`],
   });
-  let result = shell.grep("-l", 'from "', JSFiles);
-  expect(result.stdout.trim()).toBe("");
-  expect(result.stderr).toBeNull();
-  expect(result.code).toBe(0);
+  let importResult = shell.grep("-l", 'from "', JSFiles);
+  expect(importResult.stdout.trim()).toBe("");
+  expect(importResult.stderr).toBeNull();
+  expect(importResult.code).toBe(0);
+  let exportDefaultResult = shell.grep("-l", 'export default "', JSFiles);
+  expect(exportDefaultResult.stdout.trim()).toBe("");
+  expect(exportDefaultResult.stderr).toBeNull();
+  expect(exportDefaultResult.code).toBe(0);
 };
 
 const makeApp = () => {

--- a/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/transform/createExportExpressionStatementFromExportDefaultDeclaration.ts
+++ b/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/transform/createExportExpressionStatementFromExportDefaultDeclaration.ts
@@ -1,0 +1,81 @@
+import type { ExportDefaultDeclaration, JSCodeshift } from "jscodeshift";
+
+/**
+ * export default foo
+ * =>
+ * module.exports = foo
+ */
+export const createExportExpressionStatementFromExportDefaultDeclaration = (
+  j: JSCodeshift,
+  exportDefaultDeclaration: ExportDefaultDeclaration
+) => {
+  /**
+   * HACK: Can't use casts nor type guards in a `jscodeshift` transform
+   * https://github.com/facebook/jscodeshift/issues/467
+   *
+   * So to narrow declaration type, we check it against all possible
+   * `DeclarationKind` values instead.
+   */
+  if (
+    exportDefaultDeclaration.declaration.type === "ClassBody" ||
+    exportDefaultDeclaration.declaration.type === "ClassMethod" ||
+    exportDefaultDeclaration.declaration.type === "ClassPrivateMethod" ||
+    exportDefaultDeclaration.declaration.type === "ClassPrivateProperty" ||
+    exportDefaultDeclaration.declaration.type === "ClassProperty" ||
+    exportDefaultDeclaration.declaration.type === "ClassPropertyDefinition" ||
+    exportDefaultDeclaration.declaration.type === "DeclareClass" ||
+    exportDefaultDeclaration.declaration.type ===
+      "DeclareExportAllDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "DeclareExportDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "DeclareInterface" ||
+    exportDefaultDeclaration.declaration.type === "DeclareOpaqueType" ||
+    exportDefaultDeclaration.declaration.type === "DeclareTypeAlias" ||
+    exportDefaultDeclaration.declaration.type === "EnumDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "ExportAllDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "ExportDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "ExportDefaultDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "ExportNamedDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "FunctionDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "ImportDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "InterfaceDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "MethodDefinition" ||
+    exportDefaultDeclaration.declaration.type === "OpaqueType" ||
+    exportDefaultDeclaration.declaration.type ===
+      "TSCallSignatureDeclaration" ||
+    exportDefaultDeclaration.declaration.type ===
+      "TSConstructSignatureDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "TSDeclareFunction" ||
+    exportDefaultDeclaration.declaration.type === "TSDeclareMethod" ||
+    exportDefaultDeclaration.declaration.type === "TSEnumDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "TSExternalModuleReference" ||
+    exportDefaultDeclaration.declaration.type === "TSImportEqualsDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "TSIndexSignature" ||
+    exportDefaultDeclaration.declaration.type === "TSInterfaceDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "TSMethodSignature" ||
+    exportDefaultDeclaration.declaration.type === "TSModuleDeclaration" ||
+    exportDefaultDeclaration.declaration.type ===
+      "TSNamespaceExportDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "TSPropertySignature" ||
+    exportDefaultDeclaration.declaration.type === "TSTypeAliasDeclaration" ||
+    exportDefaultDeclaration.declaration.type ===
+      "TSTypeParameterDeclaration" ||
+    exportDefaultDeclaration.declaration.type === "TypeAlias" ||
+    exportDefaultDeclaration.declaration.type === "VariableDeclaration"
+  ) {
+    return exportDefaultDeclaration;
+  }
+
+  let expressionKind =
+    exportDefaultDeclaration.declaration.type === "ClassDeclaration"
+      ? j.classExpression.from(exportDefaultDeclaration.declaration)
+      : // : exportDefaultDeclaration.declaration.type === "FunctionDeclaration"
+        // ? j.functionExpression.from(exportDefaultDeclaration.declaration)
+        exportDefaultDeclaration.declaration;
+  return j.expressionStatement(
+    j.assignmentExpression(
+      "=",
+      j.memberExpression(j.identifier("module"), j.identifier("exports")),
+      expressionKind
+    )
+  );
+};

--- a/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/transform/createImportExpressionStatement.ts
+++ b/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/transform/createImportExpressionStatement.ts
@@ -1,6 +1,11 @@
 import type { ImportDeclaration, JSCodeshift } from "jscodeshift";
 
-export const createExpressionStatement = (
+/**
+ * import "foo"
+ * =>
+ * require("foo")
+ */
+export const createImportExpressionStatement = (
   j: JSCodeshift,
   { source }: ImportDeclaration
 ) => {

--- a/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/transform/createVariableDeclarationIdentifier.ts
+++ b/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/transform/createVariableDeclarationIdentifier.ts
@@ -1,10 +1,20 @@
 import type { ImportDeclaration, JSCodeshift } from "jscodeshift";
 
+/**
+ * import foo from "foo"
+ * import * as foo from "foo"
+ * =>
+ * const foo = require("foo").default
+ * const foo = require("foo")
+ */
 export const createVariableDeclarationIdentifier = (
   j: JSCodeshift,
   { source, specifiers }: ImportDeclaration
 ) => {
   let callExpression = j.callExpression(j.identifier("require"), [source]);
+  let isDefaultImport = (specifiers || []).some(
+    ({ type }) => type === "ImportDefaultSpecifier"
+  );
 
   return j.variableDeclaration("const", [
     j.variableDeclarator(
@@ -24,7 +34,9 @@ export const createVariableDeclarationIdentifier = (
               : []
           )[0].local?.name || ""
       ),
-      callExpression
+      isDefaultImport
+        ? j.memberExpression(callExpression, j.identifier("default"))
+        : callExpression
     ),
   ]);
 };

--- a/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/transform/createVariableDeclarationObjectPattern.ts
+++ b/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/transform/createVariableDeclarationObjectPattern.ts
@@ -1,5 +1,12 @@
 import type { ImportDeclaration, JSCodeshift } from "jscodeshift";
 
+/**
+ * import { foo } from "foo"
+ * import { foo as bar } from "foo"
+ * =>
+ * const { foo } = require("foo")
+ * const { foo: bar } = require("foo")
+ */
 export const createVariableDeclarationObjectPattern = (
   j: JSCodeshift,
   { source, specifiers }: ImportDeclaration


### PR DESCRIPTION
Re-submission of #3987, now without the named exports conversion

> This will partially resolve https://github.com/remix-run/indie-stack/issues/134

@kentcdodds Once told me that he's more familiar with `babel`'s own codemod instead of using `jscodeshift`.
Don't know if it's preferred to continue with `jscodeshift` or if we should look into `babel` instead? 🤔