### PR TITLE
feat(remix-react): Add timeout prop for <LiveReload /> component

### DIFF
--- a/packages/remix-react/__tests__/components-test.tsx
+++ b/packages/remix-react/__tests__/components-test.tsx
@@ -65,6 +65,14 @@ describe("<LiveReload />", () => {
         `1234 + "/socket"`
       );
     });
+
+    it("timeout of reload is set to 200ms", () => {
+      LiveReload = require("../components").LiveReload;
+      let { container } = render(<LiveReload timeout={200} />);
+      expect(container.querySelector("script")).toHaveTextContent(
+        "setTimeout( () => remixLiveReloadConnect({ onOpen: () => window.location.reload(), }), 200 );"
+      );
+    });
   });
 });
 

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1489,9 +1489,11 @@ export const LiveReload =
     ? () => null
     : function LiveReload({
         port = Number(process.env.REMIX_DEV_SERVER_WS_PORT || 8002),
+        timeout = 1000,
         nonce = undefined,
       }: {
         port?: number;
+        timeout?: number;
         /**
          * @deprecated this property is no longer relevant.
          */
@@ -1534,7 +1536,7 @@ export const LiveReload =
                         remixLiveReloadConnect({
                           onOpen: () => window.location.reload(),
                         }),
-                      1000
+                      ${String(timeout)}
                     );
                   };
                   ws.onerror = (error) => {


### PR DESCRIPTION
`LiveReload` component's reconnect attempt was hard coded to 1 sec. However, this breaks the feature if the page which attempts to be loaded has a loader that takes more than 1 sec to load (which communicates with :snail: 3rd-party APIs :cry:). In that case, the `LiveReload` component gets into an infinity loop.

This change allows the consumer to configure the timeout manually.

Also, you could even argue that the default timeout limit should be increased too.

Closes: #

- [ ] Docs
- [x] Tests