### PR TITLE
fix(remix-react): GET form submissions should replace current search params

### DIFF
--- a/.changeset/late-jars-wonder.md
+++ b/.changeset/late-jars-wonder.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+fix: GET form submissions should replace current search params (#4046)

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1221,13 +1221,19 @@ export function useSubmitImpl(key?: string): SubmitFunction {
       let url = new URL(action, `${protocol}//${host}`);
 
       if (method.toLowerCase() === "get") {
+        // Start with a fresh set of params and wipe out the old params to
+        // match default browser behavior
+        let params = new URLSearchParams();
+        let hasParams = false;
         for (let [name, value] of formData) {
           if (typeof value === "string") {
-            url.searchParams.append(name, value);
+            hasParams = true;
+            params.append(name, value);
           } else {
             throw new Error(`Cannot submit binary form data using GET`);
           }
         }
+        url.search = hasParams ? `?${params.toString()}` : "";
       }
 
       let submission: Submission = {


### PR DESCRIPTION
The recent work done in #3697 uncovered a previously unknown bug where we do not match default browser behavior.  By default, non-JS `<form method="get">` will replace any existing search parameters in the URL, but our behavior has been to append (without first resetting the params) since #814.  

Default browser behavior is shown in [this code sandbox](https://codesandbox.io/s/form-get-params-e26g6e).  You may have to open it in a new window and load it with some existing query params, and then submit the form.  I.e., https://e26g6e.sse.codesandbox.io/?junk=value

This new Remix behavior also has the side effect of no longer including the `?index` in the destination URL (even though it _is_ included in the form action).  This should have no impact since GET submissions run all relevant loaders.

```
// routes/parent/index.tsx
<Form>
  <input name="bar" value="2" />
  <button type="submit">Submit</button>
</Form>
```

* Current behavior after #3697
  * User loads `/parent?foo=1`
  * Rendered HTML is `<form action="/parent?index&foo=1">`
  * User clicks submit
  * Browser URL navigates to `/parent?index&foo=1&bar=2`
  * Rendered HTML is now `<form action="/parent?index&foo=1&bar=2">`
* New behavior
  * User loads `/parent?foo=1`
  * Rendered HTML is `<form action="/parent?index&foo=1">`
  * User clicks submit
  * Browser URL navigates to `/parent?bar=2`
  * Rendered HTML is now `<form action="/parent?index&bar=2">`

Closes: #4044

- [ ] Docs
- [x] Tests

Testing Strategy:
* Updated `form-test` integration tests