### PR TITLE
test: enable webkit testing for playwright

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -14,6 +14,6 @@ on:
 jobs:
   test:
     if: github.repository == 'remix-run/remix'
-    uses: remix-run/remix/.github/workflows/reusable-test.yml@main
+    uses: ./.github/workflows/reusable-test.yml
     with:
       node_version: "[14, 16, 18]"

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -110,13 +110,6 @@ jobs:
           - chromium
           # - firefox
           - webkit
-        include:
-          - os: ubuntu-latest
-            playwright_binary_path: ~/.cache/ms-playwright
-          # - os: macos-latest
-          #   playwright_binary_path: ~/Library/Caches/ms-playwright
-          - os: windows-latest
-            playwright_binary_path: '~\\AppData\\Local\\ms-playwright'
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -135,34 +128,7 @@ jobs:
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
 
-      # playwright recommends if you cache the binaries to keep it tied to the version of playwright you are using.
-      # https://playwright.dev/docs/ci#caching-browsers
-      - name: 🕵️‍♂️ Get current Playwright version
-        id: playwright-version
-        shell: bash
-        run: |
-          playwright_version=$(node -e "console.log(require('@playwright/test/package.json').version)")
-          echo "::set-output name=version::${playwright_version}"
-
-      - name: 🤖 Cache Playwright binaries
-        uses: actions/cache@v3
-        id: playwright-cache
-        with:
-          path: ${{ matrix.playwright_binary_path }}
-          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.browser }}-cache-playwright-${{ steps.playwright-version.outputs.version }}
-
-      - name: 🖨️ Playwright info
-        shell: bash
-        run: |
-          echo "OS: ${{ matrix.os }}"
-          echo "Playwright version: ${{ steps.playwright-version.outputs.version }}"
-          echo "Playwright install dir: ${{ matrix.playwright_binary_path }}"
-          echo "Cache key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.browser }}-cache-playwright-${{ steps.playwright-version.outputs.version }}"
-          echo "Cache hit: ${{ steps.playwright-cache.outputs.cache-hit == 'true' }}"
-          echo "Browser: ${{ matrix.browser }}"
-
       - name: 📥 Install Playwright
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -157,8 +157,9 @@ jobs:
           echo "OS: ${{ matrix.os }}"
           echo "Playwright version: ${{ steps.playwright-version.outputs.version }}"
           echo "Playwright install dir: ${{ matrix.playwright_binary_path }}"
-          echo "Cache key: ${{ runner.os }}-${{ runner.arch }}-cache-playwright-${{ steps.playwright-version.outputs.version }}"
+          echo "Cache key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.browser }}-cache-playwright-${{ steps.playwright-version.outputs.version }}"
           echo "Cache hit: ${{ steps.playwright-cache.outputs.cache-hit == 'true' }}"
+          echo "Browser: ${{ matrix.browser }}"
 
       - name: 📥 Install Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -131,6 +131,9 @@ jobs:
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
 
+      - name: 📥 Install playwright deps
+        run: npx playwright install-deps
+
       # playwright recommends if you cache the binaries to keep it tied to the version of playwright you are using.
       # https://playwright.dev/docs/ci#caching-browsers
       - name: 🕵️‍♂️ Get current Playwright version

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -131,9 +131,6 @@ jobs:
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
 
-      - name: 📥 Install playwright deps
-        run: npx playwright install-deps
-
       # playwright recommends if you cache the binaries to keep it tied to the version of playwright you are using.
       # https://playwright.dev/docs/ci#caching-browsers
       - name: 🕵️‍♂️ Get current Playwright version

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -106,6 +106,10 @@ jobs:
           - ubuntu-latest
           # - macos-latest
           - windows-latest
+        browser:
+          - chromium
+          # - firefox
+          - webkit
         include:
           - os: ubuntu-latest
             playwright_binary_path: ~/.cache/ms-playwright
@@ -160,5 +164,5 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
-      - name: 👀 Run Integration Tests
-        run: "yarn test:integration"
+      - name: 👀 Run Integration Tests ${{ matrix.browser }}
+        run: "yarn test:integration --project=${{ matrix.browser }}"

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -97,7 +97,7 @@ jobs:
         run: "yarn test:primary"
 
   integration:
-    name: "👀 Integration Test: (OS: ${{ matrix.os }} Node: ${{ matrix.node }})"
+    name: "👀 Integration Test: (OS: ${{ matrix.os }} Node: ${{ matrix.node }}) Browser: ${{ matrix.browser }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   CI: true
+  CYPRESS_INSTALL_BINARY: 0
 
 jobs:
   build:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -149,7 +149,7 @@ jobs:
         id: playwright-cache
         with:
           path: ${{ matrix.playwright_binary_path }}
-          key: ${{ runner.os }}-${{ runner.arch }}-cache-playwright-${{ steps.playwright-version.outputs.version }}
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.browser }}-cache-playwright-${{ steps.playwright-version.outputs.version }}
 
       - name: 🖨️ Playwright info
         shell: bash

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -97,7 +97,7 @@ jobs:
         run: "yarn test:primary"
 
   integration:
-    name: "👀 Integration Test: (OS: ${{ matrix.os }} Node: ${{ matrix.node }}) Browser: ${{ matrix.browser }}"
+    name: "👀 Integration Test: (OS: ${{ matrix.os }} Node: ${{ matrix.node }} Browser: ${{ matrix.browser }})"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ on:
 jobs:
   test:
     if: github.repository == 'remix-run/remix'
-    uses: .github/workflows/reusable-test.yml
+    uses: ./.github/workflows/reusable-test.yml
     with:
       node_version: '["latest"]'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ on:
 jobs:
   test:
     if: github.repository == 'remix-run/remix'
-    uses: remix-run/remix/.github/workflows/reusable-test.yml@main
+    uses: .github/workflows/reusable-test.yml
     with:
       node_version: '["latest"]'

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -785,13 +785,16 @@ test.describe("Forms", () => {
 
   test("<Form> submits the submitter's value appended to the form data", async ({
     page,
+    browserName,
   }) => {
     let app = new PlaywrightFixture(appFixture, page);
     await app.goto("/submitter");
     await app.clickElement("text=Add Task");
     await page.waitForLoadState("load");
     expect(await app.getHtml("pre")).toBe(
-      `<pre>tasks=first&amp;tasks=second&amp;tasks=</pre>`
+      browserName === "webkit"
+        ? `<pre>tasks=first&amp;tasks=second&amp;tasks=&amp;tasks=</pre>`
+        : `<pre>tasks=first&amp;tasks=second&amp;tasks=</pre>`
     );
   });
 });

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -791,10 +791,14 @@ test.describe("Forms", () => {
     await app.goto("/submitter");
     await app.clickElement("text=Add Task");
     await page.waitForLoadState("load");
-    expect(await app.getHtml("pre")).toBe(
-      browserName === "webkit"
-        ? `<pre>tasks=first&amp;tasks=second&amp;tasks=&amp;tasks=</pre>`
-        : `<pre>tasks=first&amp;tasks=second&amp;tasks=</pre>`
-    );
+    if (browserName === "webkit") {
+      expect(await app.getHtml("pre")).toBe(
+        `<pre>tasks=first&amp;tasks=second&amp;tasks=&amp;tasks=</pre>`
+      );
+    } else {
+      expect(await app.getHtml("pre")).toBe(
+        `<pre>tasks=first&amp;tasks=second&amp;tasks=</pre>`
+      );
+    }
   });
 });

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -791,6 +791,7 @@ test.describe("Forms", () => {
     await app.goto("/submitter");
     await app.clickElement("text=Add Task");
     await page.waitForLoadState("load");
+    // TODO: remove after playwright ships safari 16
     if (browserName === "webkit") {
       expect(await app.getHtml("pre")).toBe(
         `<pre>tasks=first&amp;tasks=second&amp;tasks=&amp;tasks=</pre>`

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -23,6 +23,12 @@ const config: PlaywrightTestConfig = {
         ...devices["Desktop Chrome"],
       },
     },
+    {
+      name: "webkit",
+      use: {
+        ...devices["Desktop Safari"],
+      },
+    },
   ],
 };
 


### PR DESCRIPTION
to limit testing to chrome or webkit you can use 
- `yarn test:integration --project=webkit`
- `yarn test:integration --project=chromium`

currently the only failing test is due to a bug in Safari, so i've added browser check for the bugged behavior https://github.com/remix-run/remix/pull/4049/files#diff-6ba8f3349b2b29f4668d3cdbcc4df75c8182edad8eaea07c5a6d7f227309acf7R794-R803

related: #4023 / #4024 

edit: looks like `@playwright/test@next` is shipping with webkit 16 👀 

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
