### PR TITLE
feat(examples/firebase): add Google Account auth

### DIFF
--- a/examples/firebase/README.md
+++ b/examples/firebase/README.md
@@ -31,7 +31,14 @@ When the SERVICE_ACCOUNT and CLIENT_CONFIG environment variables have not been s
 
 When you run `npm run emulators`, an initial user is created with credentials `user@example.com:password`. This can be configured in `firebase-fixtures/auth/accounts.json` or via the emulator UI.
 
-## Auth (`app/server/auth.server.ts`)
+## Integration with Google Sign-in Provider
+
+- In the [Firebase Console](https://console.firebase.google.com), navigate to Authentication > Sign-in method > Add new provider > Google. Make a note of the client ID and secret and add them to the .env file.
+- In the [Google Cloud Credentials Console](https://console.cloud.google.com/apis/credentials), select the Web client (under OAuth 2.0 Client IDs) and add `http://localhost:3000/auth/google` and `https://<projectid>.firebaseapp.com/auth/google` as authorised redirects.
+
+## Details
+
+### Auth (`app/server/auth.server.ts`)
 
 `signIn` returns a Firebase session-cookie-string, when sign-in is successfull. Then Remix `cookieSessionStorage` is used to set, read and destroy it.
 

--- a/examples/firebase/app/firebase-rest.ts
+++ b/examples/firebase/app/firebase-rest.ts
@@ -54,9 +54,114 @@ export const signInWithPassword = async (
   }
 ) => {
   const response: SignInWithPasswordResponse = await fetch(
-    `${restConfig!.domain}/v1/accounts:signInWithPassword?key=${
-      restConfig!.apiKey
-    }`,
+    `${restConfig.domain}/v1/accounts:signInWithPassword?key=${restConfig.apiKey}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }
+  );
+  return response.json();
+};
+
+// https://firebase.google.com/docs/reference/rest/auth#section-sign-in-email-password
+interface SignInWithIdpResponse extends Response {
+  json(): Promise<
+    | RestError
+    | {
+        /**
+         * 	The unique ID identifies the IdP account.
+         */
+        federatedId: string;
+        /**
+         * 	The linked provider ID (e.g. "google.com" for the Google provider).
+         */
+        providerId: string;
+        /**
+         * 	The uid of the authenticated user.
+         */
+        localId: string;
+        /**
+         * 	Whether the sign-in email is verified.
+         */
+        emailVerified: boolean;
+        /**
+         * 	The email of the account.
+         */
+        email: string;
+        /**
+         * 	The OIDC id token if available.
+         */
+        oauthIdToken: string;
+        /**
+         * 	The OAuth access token if available.
+         */
+        oauthAccessToken: string;
+        /**
+         * 	The OAuth 1.0 token secret if available.
+         */
+        oauthTokenSecret: string;
+        /**
+         * 	The stringified JSON response containing all the IdP data corresponding to the provided OAuth credential.
+         */
+        rawUserInfo: string;
+        /**
+         * 	The first name for the account.
+         */
+        firstName: string;
+        /**
+         * 	The last name for the account.
+         */
+        lastName: string;
+        /**
+         * 	The full name for the account.
+         */
+        fullName: string;
+        /**
+         * 	The display name for the account.
+         */
+        displayName: string;
+        /**
+         * 	The photo Url for the account.
+         */
+        photoUrl: string;
+        /**
+         * 	A Firebase Auth ID token for the authenticated user.
+         */
+        idToken: string;
+        /**
+         * 	A Firebase Auth refresh token for the authenticated user.
+         */
+        refreshToken: string;
+        /**
+         * 	The number of seconds in which the ID token expires.
+         */
+        expiresIn: string;
+        /**
+         * 	Whether another account with the same credential already exists. The user will need to sign in to the original account and then link the current credential to it.
+         */
+        needConfirmation: boolean;
+      }
+  >;
+}
+export const signInWithIdp = async (
+  idToken: string,
+  providerId: string,
+  restConfig: {
+    apiKey: string;
+    domain: string;
+  }
+) => {
+  const body = {
+    postBody: "id_token=" + idToken + "&providerId=" + providerId,
+    requestUri: "http://localhost",
+    returnIdpCredential: true,
+    returnSecureToken: true,
+  };
+  const response: SignInWithIdpResponse = await fetch(
+    `${restConfig.domain}/v1/accounts:signInWithIdp?key=${restConfig.apiKey}`,
     {
       method: "POST",
       headers: {

--- a/examples/firebase/app/routes/auth/google.tsx
+++ b/examples/firebase/app/routes/auth/google.tsx
@@ -1,0 +1,32 @@
+import type { LoaderFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import { signInWithIdp } from "~/server/auth.server";
+import { commitSession, getSession } from "~/sessions";
+
+export const loader: LoaderFunction = async ({ request }) => {
+  // https://developers.google.com/identity/protocols/oauth2/openid-connect
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const response = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      client_id: process.env.GOOGLE_CLIENT_ID,
+      client_secret: process.env.GOOGLE_CLIENT_SECRET,
+      code,
+      redirect_uri: "http://localhost:3000/auth/google",
+      grant_type: "authorization_code",
+    }),
+  });
+  const token = await response.json();
+  const sessionCookie = await signInWithIdp(token.id_token, "google.com");
+  const session = await getSession(request.headers.get("cookie"));
+  session.set("session", sessionCookie);
+  return redirect("/", {
+    headers: {
+      "Set-Cookie": await commitSession(session),
+    },
+  });
+};

--- a/examples/firebase/app/routes/login.tsx
+++ b/examples/firebase/app/routes/login.tsx
@@ -20,6 +20,7 @@ import { getRestConfig } from "~/server/firebase.server";
 interface LoaderData {
   apiKey: string;
   domain: string;
+  GOOGLE_CLIENT_ID?: string;
 }
 export const loader: LoaderFunction = async ({ request }) => {
   const session = await getSession(request.headers.get("cookie"));
@@ -31,7 +32,10 @@ export const loader: LoaderFunction = async ({ request }) => {
     return redirect("/", { headers });
   }
   const { apiKey, domain } = getRestConfig();
-  return json<LoaderData>({ apiKey, domain }, { headers });
+  return json<LoaderData>(
+    { apiKey, domain, GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID },
+    { headers }
+  );
 };
 
 interface ActionData {
@@ -73,6 +77,8 @@ export default function Login() {
   const action = useActionData<ActionData>();
   const restConfig = useLoaderData<LoaderData>();
   const submit = useSubmit();
+
+  const { GOOGLE_CLIENT_ID } = restConfig;
 
   const handleSubmit = useCallback(
     async (event: React.FormEvent<HTMLFormElement>) => {
@@ -117,6 +123,17 @@ export default function Login() {
           Login
         </button>
       </form>
+      <p>
+        <a
+          href={`https://accounts.google.com/o/oauth2/v2/auth\
+?response_type=code\
+&client_id=${GOOGLE_CLIENT_ID}\
+&redirect_uri=http://localhost:3000/auth/google\
+&scope=openid%20email%20profile`}
+        >
+          Login with Google
+        </a>
+      </p>
       <p>
         Do you want to <Link to="/join">join</Link>?
       </p>

--- a/examples/firebase/app/server/auth.server.ts
+++ b/examples/firebase/app/server/auth.server.ts
@@ -40,6 +40,11 @@ export const signInWithToken = async (idToken: string) => {
   return sessionCookie;
 };
 
+export const signInWithIdp = async (token: string, providerId: string) => {
+  const { idToken } = await auth.signInWithIdp(token, providerId);
+  return signInWithToken(idToken);
+};
+
 export const signUp = async (name: string, email: string, password: string) => {
   await auth.server.createUser({
     email,

--- a/examples/firebase/app/server/firebase.server.ts
+++ b/examples/firebase/app/server/firebase.server.ts
@@ -72,7 +72,22 @@ const signInWithPassword = async (email: string, password: string) => {
   return signInResponse;
 };
 
+const signInWithIdp = async (token: string, providerId: string) => {
+  const signInResponse = await firebaseRest.signInWithIdp(
+    token,
+    providerId,
+    restConfig
+  );
+
+  if (firebaseRest.isError(signInResponse)) {
+    throw new Error(signInResponse.error.message);
+  }
+
+  return signInResponse;
+};
+
 export const auth = {
   server: getServerAuth(),
   signInWithPassword,
+  signInWithIdp,
 };


### PR DESCRIPTION
Firebase example - Integration with Google Sign-in Provider

Closes: "sign-in with Google" suggestion at https://github.com/remix-run/remix/pull/1811#issuecomment-1050238130

Adds a "Login with Google" link:

> <img width="179" alt="Screenshot 2022-08-24 at 15 16 57" src="https://user-images.githubusercontent.com/1027024/186442693-e4862675-dfbb-498d-8a66-bda1da3f1fc0.png">


...that takes a user to the Google's auth screen:

> <img width="520" alt="Screenshot 2022-08-24 at 15 17 22" src="https://user-images.githubusercontent.com/1027024/186442810-dd58d3b8-785c-40d3-b8be-48a77b4df417.png">

 ...and then creates an account (if it doesn't yet exist) and signs them in:

> <img width="253" alt="Screenshot 2022-08-24 at 15 19 26" src="https://user-images.githubusercontent.com/1027024/186442912-18af6e25-8609-4111-b627-1ad08b531388.png">

