### PR TITLE
docs(other-api/react-router): update `react-router` links

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -145,6 +145,7 @@
 - gunners6518
 - hadizz
 - hardingmatt
+- hawk94
 - helderburato
 - HenryVogt
 - hicksy

--- a/docs/other-api/react-router.md
+++ b/docs/other-api/react-router.md
@@ -15,8 +15,8 @@ Remix is built on top of React Router v6. Here are the most common APIs that you
 
 Most of the other APIs are either used internally by Remix or just aren't commonly needed in your app.
 
-[outlet]: https://reactrouter.com/docs/components/outlet
-[use-location]: https://reactrouter.com/docs/hooks/use-location
-[use-navigate]: https://reactrouter.com/docs/hooks/use-navigate
-[use-params]: https://reactrouter.com/docs/hooks/use-params
-[use-resolved-path]: https://reactrouter.com/docs/hooks/use-resolved-path
+[outlet]: https://reactrouter.com/en/main/hooks/use-outlet
+[use-location]: https://reactrouter.com/en/main/hooks/use-location
+[use-navigate]: https://reactrouter.com/en/main/hooks/use-navigate
+[use-params]: https://reactrouter.com/en/main/hooks/use-params
+[use-resolved-path]: https://reactrouter.com/en/main/hooks/use-resolved-path

--- a/docs/other-api/react-router.md
+++ b/docs/other-api/react-router.md
@@ -15,8 +15,9 @@ Remix is built on top of React Router v6. Here are the most common APIs that you
 
 Most of the other APIs are either used internally by Remix or just aren't commonly needed in your app.
 
-[outlet]: https://reactrouter.com/en/main/hooks/use-outlet
+[outlet]: https://reactrouter.com/en/main/components/outlet
 [use-location]: https://reactrouter.com/en/main/hooks/use-location
 [use-navigate]: https://reactrouter.com/en/main/hooks/use-navigate
 [use-params]: https://reactrouter.com/en/main/hooks/use-params
 [use-resolved-path]: https://reactrouter.com/en/main/hooks/use-resolved-path
+`


### PR DESCRIPTION
# Update broken links to React Router documentation

This change updates links to the React Router documentation for APIs that might be useful when developing Remix apps. Points to documentation on the main branch so that link stays up to date as project is updated.
