### PR TITLE
docs(examples/blog): Remove `_` as separator in port number to avoid confusion

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -140,6 +140,7 @@
 - goncy
 - gonzoscript
 - graham42
+- grantnorwood
 - GregBrimble
 - GSt4r
 - guatedude2

--- a/examples/blog-tutorial/fly.toml
+++ b/examples/blog-tutorial/fly.toml
@@ -19,7 +19,7 @@ source = "data"
 destination = "/data"
 
 [[services]]
-internal_port = 8_080
+internal_port = 8080
 processes = [ "app" ]
 protocol = "tcp"
 script_checks = [ ]


### PR DESCRIPTION
There is an underscore `_` in the `internal_port` number in blog tutorial's `fly.toml`, which is inconsistent from other references to that port number, and I've simply removed that.  No other code or configuration changes have been made.

As this change is located within an example template, I've branched from `main` instead of `dev`.  _(If this PR should instead be branched from `dev`, please let me know!)_

Signed CLA by including `grantnorwood` in `contributors.yml`.

