### PR TITLE
feat(remix-dev): allow importing `.psd` files

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -306,6 +306,7 @@
 - nickytonline
 - niconiahi
 - nielsdb97
+- NikkiDelRosso
 - ninjaPixel
 - niwsa
 - nobeeakon

--- a/packages/remix-dev/compiler/loaders.ts
+++ b/packages/remix-dev/compiler/loaders.ts
@@ -25,6 +25,7 @@ export const loaders: { [ext: string]: esbuild.Loader } = {
   ".ogg": "file",
   ".otf": "file",
   ".png": "file",
+  ".psd": "file",
   ".sql": "text",
   ".svg": "file",
   ".ts": "ts",

--- a/packages/remix-dev/modules.ts
+++ b/packages/remix-dev/modules.ts
@@ -72,6 +72,10 @@ declare module "*.png" {
   let asset: string;
   export default asset;
 }
+declare module "*.psd" {
+  let asset: string;
+  export default asset;
+}
 declare module "*.sql" {
   let asset: string;
   export default asset;


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Adds support for importing photoshop image files as assets.

Not sure if there's any need to add the MIME type to the `binaryTypes.ts` files in remix-architect and remix-netlify, but fwiw the MIME is `image/vnd.adobe.photoshop`

## Testing Strategy:

I was able to import a `.psd` file as an asset as expected:

```typescript
import sourceArt from "./assets/art.psd"

export default function PsdLink() {
  return (
    <a href={sourceArt}>Download PSD</a>
  )
}
```
