### PR TITLE
fix 404 urls of react router v6 pages

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -60,6 +60,7 @@
 - c43721
 - camiaei
 - CanRau
+- CaptainOfPhB
 - ccssmnn
 - chaance
 - chenc041

--- a/docs/other-api/react-router.md
+++ b/docs/other-api/react-router.md
@@ -15,8 +15,8 @@ Remix is built on top of React Router v6. Here are the most common APIs that you
 
 Most of the other APIs are either used internally by Remix or just aren't commonly needed in your app.
 
-[outlet]: https://reactrouter.com/docs/components/outlet
-[use-location]: https://reactrouter.com/docs/hooks/use-location
-[use-navigate]: https://reactrouter.com/docs/hooks/use-navigate
-[use-params]: https://reactrouter.com/docs/hooks/use-params
-[use-resolved-path]: https://reactrouter.com/docs/hooks/use-resolved-path
+[outlet]: https://reactrouter.com/en/main/components/outlet
+[use-location]: https://reactrouter.com/en/main/hooks/use-location
+[use-navigate]: https://reactrouter.com/en/main/hooks/use-navigate
+[use-params]: https://reactrouter.com/en/main/hooks/use-params
+[use-resolved-path]: https://reactrouter.com/en/main/hooks/use-resolved-path


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

- [x] Docs
- [ ] Tests

Testing Strategy:

Reopen the replaced link and display the correct content of React-Router docs.

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
