### PR TITLE
Make the dark mode example work without JS

### DIFF
--- a/examples/dark-mode/README.md
+++ b/examples/dark-mode/README.md
@@ -1,6 +1,6 @@
 # Dark Mode Example
 
-This example shows how you can add dark mode theming to your app
+This example shows how you can add dark mode theming to your app. It works even without JavaScript because it uses cookies and it's based on submitting a form.
 
 ## Preview
 
@@ -22,6 +22,9 @@ The Themed component is used to conditionally render two components depending on
 
 ## Related Links
 
+- [Using the &lt;Form&gt; component](https://remix.run/docs/en/v1/api/remix#form)
+- [Using the optimistic UI pattern](https://remix.run/docs/en/v1/guides/optimistic-ui) (updating the UI right away without having to wait for the server to respond)
 - [Creating cookie sessions in the Remix docs](https://remix.run/docs/en/v1/api/remix#createcookiesessionstorage)
-- [useFetcher in the Remix docs](https://remix.run/docs/en/v1/api/remix#usefetcher) (used to tell the server to update the cookie value when the theme changes)
+- [Redirect from the theme route](https://remix.run/docs/en/v1/api/remix#redirect)
 - [Blog post with complete explanation of each part of the code](https://www.mattstobbs.com/remix-dark-mode/)
+  - however, instead of using `useFetcher` we're using a regular form to make it work without JavaScript as well

--- a/examples/dark-mode/app/root.tsx
+++ b/examples/dark-mode/app/root.tsx
@@ -40,7 +40,7 @@ export const meta: MetaFunction = () => ({
 
 function App() {
   const data = useLoaderData<LoaderData>();
-  const [theme] = useTheme();
+  const theme = useTheme();
 
   return (
     <html lang="en" className={theme ?? ""}>

--- a/examples/dark-mode/app/routes/action/set-theme.tsx
+++ b/examples/dark-mode/app/routes/action/set-theme.tsx
@@ -6,9 +6,9 @@ import { isTheme } from "~/utils/theme-provider";
 
 export const action: ActionFunction = async ({ request }) => {
   const themeSession = await getThemeSession(request);
-  const requestText = await request.text();
-  const form = new URLSearchParams(requestText);
+  const form = await request.formData();
   const theme = form.get("theme");
+  const redirectTo = new URL(request.url).searchParams.get("redirectTo");
 
   if (!isTheme(theme)) {
     return json({
@@ -18,10 +18,14 @@ export const action: ActionFunction = async ({ request }) => {
   }
 
   themeSession.setTheme(theme);
-  return json(
-    { success: true },
-    { headers: { "Set-Cookie": await themeSession.commit() } }
-  );
+
+  const headers = { "Set-Cookie": await themeSession.commit() };
+
+  if (redirectTo) {
+    return redirect(redirectTo, { headers });
+  } else {
+    return json({ success: true }, { headers });
+  }
 };
 
 export const loader: LoaderFunction = () => redirect("/", { status: 404 });

--- a/examples/dark-mode/app/routes/action/set-theme.tsx
+++ b/examples/dark-mode/app/routes/action/set-theme.tsx
@@ -8,12 +8,19 @@ export const action: ActionFunction = async ({ request }) => {
   const themeSession = await getThemeSession(request);
   const form = await request.formData();
   const theme = form.get("theme");
-  const redirectTo = new URL(request.url).searchParams.get("redirectTo");
+  const redirectTo = form.get("redirectTo");
 
   if (!isTheme(theme)) {
     return json({
       success: false,
       message: `theme value of ${theme} is not a valid theme`,
+    });
+  }
+
+  if (redirectTo && typeof redirectTo !== "string") {
+    return json({
+      success: false,
+      message: `redirect URL should be a string`,
     });
   }
 
@@ -23,9 +30,9 @@ export const action: ActionFunction = async ({ request }) => {
 
   if (redirectTo) {
     return redirect(redirectTo, { headers });
-  } else {
-    return json({ success: true }, { headers });
   }
+
+  return json({ success: true }, { headers });
 };
 
 export const loader: LoaderFunction = () => redirect("/", { status: 404 });

--- a/examples/dark-mode/app/routes/index.tsx
+++ b/examples/dark-mode/app/routes/index.tsx
@@ -1,22 +1,14 @@
 import type { LinksFunction } from "@remix-run/node";
 
 import styles from "~/styles/styles.css";
-import { Theme, Themed, useTheme } from "~/utils/theme-provider";
+import { Themed, ThemeToggle } from "~/utils/theme-provider";
 
 export const links: LinksFunction = () => [{ rel: "stylesheet", href: styles }];
 
 export default function IndexRoute() {
-  const [, setTheme] = useTheme();
-
-  const toggleTheme = () => {
-    setTheme((prevTheme) =>
-      prevTheme === Theme.LIGHT ? Theme.DARK : Theme.LIGHT
-    );
-  };
-
   return (
     <>
-      <button onClick={toggleTheme}>Toggle</button>
+      <ThemeToggle>Toggle</ThemeToggle>
       <Themed
         dark={<h1 className="dark-component">I'm only seen in dark mode</h1>}
         light={<h1 className="light-component">I'm only seen in light mode</h1>}

--- a/examples/dark-mode/app/utils/theme-provider.tsx
+++ b/examples/dark-mode/app/utils/theme-provider.tsx
@@ -108,14 +108,10 @@ function ThemeToggle({
   className?: string;
 }) {
   const location = useLocation();
-  const searchParams = new URLSearchParams({ redirectTo: location.pathname });
 
   return (
-    <Form
-      action={`/action/set-theme?${searchParams}`}
-      method="post"
-      className={className}
-    >
+    <Form action="/action/set-theme" method="post" className={className}>
+      <input type="hidden" name="redirectTo" value={location.pathname} />
       <Themed
         dark={<input type="hidden" name="theme" value={Theme.LIGHT} />}
         light={<input type="hidden" name="theme" value={Theme.DARK} />}


### PR DESCRIPTION
@machour encouraged me to show you how I implemented a dark mode switch which works without JavaScript. It's derived from Matt's excellent blog post, just like your example, but it uses regular form submission instead of `useFetcher` in combination with optimistic UI to maintain the same speed (hopefully). Also, I'm aware that the architecture of this feature is largely a matter of taste, I tried to change as little as possible.

The main improvements are:

1. `persistThemeRef` can be removed, one less hack to think about
2. we don't really need to include `setTheme` in the context, so the context will update only when the theme value truly changes, not every time `ThemeProvider` re-renders, and without having to use `useMemo`
3. when the `(prefers-color-scheme: dark)` changes it will no longer be submitted as the specified theme, which was probably not the intended behavior

Is it a problem that the URL bar quickly switches to `/action/set-theme` and back? It probably causes a few extra re-renders, I could use `useFetcher` when JS is supported in the spirit of progressive enhancement, what do you think?

Ideas for further improvements:

- The dark mode toggle on my blog also features a reset button, which allows people to sync dark mode back to the OS settings. I can add it here as well if you want it.
- `ThemeHead` and `ThemeBody` are within `ThemeProvider`, I can make it so that it's not necessary to pass `ssrTheme` to them because `ThemeProvider` already knows about it.

- [x] Docs
- [ ] Tests

No tests yet, however I'd be very happy to write Playwright tests for this if you want because dark mode is a tricky functionality.

Btw, I'll probably make a `remix-dark-mode` library out of this soon, if there isn't one already. 🤔