### PR TITLE
feat(remix-dev): add `devServerSecureContextOptions` config option

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -422,3 +422,4 @@
 - zachdtaylor
 - zainfathoni
 - zhe
+- kyleharper

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -30,6 +30,7 @@ describe("readConfig", () => {
         "cacheDirectory": Any<String>,
         "devServerBroadcastDelay": 0,
         "devServerPort": Any<Number>,
+        "devServerSecureContextOptions": undefined,
         "entryClientFile": "entry.client.tsx",
         "entryServerFile": "entry.server.tsx",
         "mdx": undefined,

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -7,6 +7,9 @@ import ora from "ora";
 import prettyMs from "pretty-ms";
 import WebSocket from "ws";
 import type { Server } from "http";
+import type { Server as HTTPSServer } from "https";
+import http from "http";
+import https from "https";
 import type * as Express from "express";
 import type { createApp as createAppType } from "@remix-run/serve";
 import getPort, { makeRange } from "get-port";
@@ -202,7 +205,16 @@ export async function watch(
       ? remixRootOrConfig
       : await readConfig(remixRootOrConfig);
 
-  let wss = new WebSocket.Server({ port: config.devServerPort });
+  let wssServer: Server | HTTPSServer =
+    config.devServerSecureContextOptions
+      ? https.createServer({
+        cert: config.devServerSecureContextOptions.cert,
+        key: config.devServerSecureContextOptions.key,
+      })
+      : http.createServer();
+  wssServer.listen(config.devServerPort);
+  let wss = new WebSocket.Server({ server: wssServer });
+
   function broadcast(event: { type: string; [key: string]: any }) {
     setTimeout(() => {
       wss.clients.forEach((client) => {

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -1,3 +1,4 @@
+import type { SecureContextOptions } from "tls";
 import * as path from "path";
 import { pathToFileURL } from "url";
 import * as fse from "fs-extra";
@@ -96,6 +97,11 @@ export interface AppConfig {
    * The port number to use for the dev server. Defaults to 8002.
    */
   devServerPort?: number;
+
+  /**
+   * Key and cert to yse fir dev server running on wss.
+   */
+  devServerSecureContextOptions: Pick<SecureContextOptions, 'key' | 'cert'>;
 
   /**
    * The delay, in milliseconds, before the dev server broadcasts a reload
@@ -227,6 +233,11 @@ export interface RemixConfig {
    * The delay before the dev (asset) server broadcasts a reload event.
    */
   devServerBroadcastDelay: number;
+
+  /**
+   * Key and cert to yse fir dev server running on wss.
+   */
+  devServerSecureContextOptions: Pick<SecureContextOptions, 'key' | 'cert'>;
 
   /**
    * Additional MDX remark / rehype plugins.
@@ -407,6 +418,8 @@ export async function readConfig(
       break;
   }
 
+  let devServerSecureContextOptions = appConfig.devServerSecureContextOptions;
+
   let publicPath = addTrailingSlash(appConfig.publicPath || defaultPublicPath);
 
   let rootRouteFile = findEntry(appDirectory, "root");
@@ -473,6 +486,7 @@ export async function readConfig(
     entryClientFile,
     entryServerFile,
     devServerPort,
+    devServerSecureContextOptions,
     devServerBroadcastDelay,
     assetsBuildDirectory: absoluteAssetsBuildDirectory,
     relativeAssetsBuildDirectory: assetsBuildDirectory,

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -101,7 +101,7 @@ export interface AppConfig {
   /**
    * Key and cert to yse fir dev server running on wss.
    */
-  devServerSecureContextOptions: Pick<SecureContextOptions, 'key' | 'cert'>;
+  devServerSecureContextOptions?: Pick<SecureContextOptions, 'key' | 'cert'>;
 
   /**
    * The delay, in milliseconds, before the dev server broadcasts a reload
@@ -237,7 +237,7 @@ export interface RemixConfig {
   /**
    * Key and cert to yse fir dev server running on wss.
    */
-  devServerSecureContextOptions: Pick<SecureContextOptions, 'key' | 'cert'>;
+  devServerSecureContextOptions?: Pick<SecureContextOptions, 'key' | 'cert'>;
 
   /**
    * Additional MDX remark / rehype plugins.

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -99,7 +99,7 @@ export interface AppConfig {
   devServerPort?: number;
 
   /**
-   * Key and cert to yse fir dev server running on wss.
+   * Key and cert for dev server running on wss.
    */
   devServerSecureContextOptions?: Pick<SecureContextOptions, 'key' | 'cert'>;
 
@@ -235,7 +235,7 @@ export interface RemixConfig {
   devServerBroadcastDelay: number;
 
   /**
-   * Key and cert to yse fir dev server running on wss.
+   * Key and cert for dev server running on wss.
    */
   devServerSecureContextOptions?: Pick<SecureContextOptions, 'key' | 'cert'>;
 


### PR DESCRIPTION
My team have experienced issues with live reloading once moving over to https locally (the following issue documents the problem: https://github.com/remix-run/remix/issues/2859)

This PR resolves that by adding a new config item called `devServerSecureContextOptions`. This name is derived from the `tls` node package type definitions.

Big shout out for @isaacs for his PR (https://github.com/remix-run/remix/pull/2861), which helped me understand where to find the server implementation.

I'm happy for either PR to be merged in, the other PR is quite old and I didn't want to resolve conflicts on another fork etc. 

One difference is that this PR allows us to pass in more than just a string as `key` and `cert` can be any of the following;

- key: `string | Buffer | Array<Buffer | KeyObject> | undefined`
- cert: `string | Buffer | Array<string | Buffer> | undefined`

For now we're implementing a patch internally to get round this issue, but it'd be great to not require a patch 👍

Closes: https://github.com/remix-run/remix/issues/2859

- [ ] Docs
- [ ] Tests

Testing Strategy:

On the testing front we've covered all failing tests but couldn't find anything around the `watch` command. Perhaps we missed something or is there no tests for the watch command? (due to mocking challenges etc?)
