### PR TITLE
feat(remix-dev): add `serverEntryFile` config option

### DIFF
--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -22,6 +22,7 @@ describe("readConfig", () => {
         assetsBuildDirectory: expect.any(String),
         relativeAssetsBuildDirectory: expect.any(String),
         tsconfigPath: expect.any(String),
+        serverEntryFile: expect.any(String),
       },
       `
       Object {
@@ -43,6 +44,7 @@ describe("readConfig", () => {
             "path": "",
           },
         },
+        "serverBuildFile": undefined,
         "serverBuildPath": Any<String>,
         "serverBuildTarget": undefined,
         "serverBuildTargetEntryModule": "export * from \\"@remix-run/dev/server-build\\";",
@@ -53,6 +55,7 @@ describe("readConfig", () => {
         "serverPlatform": "node",
         "tsconfigPath": Any<String>,
         "watchPaths": Array [],
+        "serverEntryFile": undefined,
       }
     `
     );

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -22,7 +22,7 @@ describe("readConfig", () => {
         assetsBuildDirectory: expect.any(String),
         relativeAssetsBuildDirectory: expect.any(String),
         tsconfigPath: expect.any(String),
-        serverEntryFile: expect.any(String),
+        serverEntryFile: undefined,
       },
       `
       Object {
@@ -44,18 +44,17 @@ describe("readConfig", () => {
             "path": "",
           },
         },
-        "serverBuildFile": undefined,
         "serverBuildPath": Any<String>,
         "serverBuildTarget": undefined,
         "serverBuildTargetEntryModule": "export * from \\"@remix-run/dev/server-build\\";",
         "serverDependenciesToBundle": Array [],
+        "serverEntryFile": undefined,
         "serverEntryPoint": undefined,
         "serverMode": "production",
         "serverModuleFormat": "cjs",
         "serverPlatform": "node",
         "tsconfigPath": Any<String>,
         "watchPaths": Array [],
-        "serverEntryFile": undefined,
       }
     `
     );

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -156,6 +156,14 @@ export interface AppConfig {
     | string
     | string[]
     | (() => Promise<string | string[]> | string | string[]);
+
+  /**
+   * A server entrypoint, relative to the root directory that becomes your
+   * server's main module. If specified, Remix will import this file from
+   * Remix App Server, instead of using the built-in configuration. This
+   * file can use either a `.js` or `.ts` file extension.
+   */
+  serverEntryFile?: string;
 }
 
 /**
@@ -274,6 +282,14 @@ export interface RemixConfig {
    * The path for the tsconfig file, if present on the root directory.
    */
   tsconfigPath: string | undefined;
+
+  /**
+   * A server entrypoint, relative to the root directory that becomes your
+   * server's main module. If specified, Remix will import this file from
+   * Remix App Server, instead of using the built-in configuration. This
+   * file can use either a `.js` or `.ts` file extension.
+   */
+  serverEntryFile?: string;
 }
 
 /**
@@ -318,6 +334,7 @@ export async function readConfig(
   }
 
   let customServerEntryPoint = appConfig.server;
+  let serverEntryFile = appConfig.serverEntryFile;
   let serverBuildTarget: ServerBuildTarget | undefined =
     appConfig.serverBuildTarget;
   let serverModuleFormat: ServerModuleFormat =
@@ -490,6 +507,7 @@ export async function readConfig(
     mdx,
     watchPaths,
     tsconfigPath,
+    serverEntryFile,
   };
 }
 

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -1,50 +1,73 @@
 import "./env";
 import path from "path";
 import os from "os";
+import { type Express } from "express";
 
-import { createApp } from "./index";
+import { createApp as createDefaultApp } from "./index";
 
 let port = process.env.PORT ? Number(process.env.PORT) : 3000;
 if (Number.isNaN(port)) port = 3000;
 
 let buildPathArg = process.argv[2];
+let serverEntryFile = process.argv[3];
 
 if (!buildPathArg) {
   console.error(`
-  Usage: remix-serve <build-dir>`);
+  Usage: remix-serve <build-dir> [server-entry-file]`);
   process.exit(1);
 }
 
 let buildPath = path.resolve(process.cwd(), buildPathArg);
-
-let onListen = () => {
-  let address =
-    process.env.HOST ||
-    Object.values(os.networkInterfaces())
-      .flat()
-      .find((ip) => String(ip?.family).includes("4") && !ip?.internal)?.address;
-
-  if (!address) {
-    console.log(`Remix App Server started at http://localhost:${port}`);
-  } else {
-    console.log(
-      `Remix App Server started at http://localhost:${port} (http://${address}:${port})`
-    );
-  }
-};
-
 let build = require(buildPath);
-
+let { createApp, createServer } = getServerEntry({ serverEntryFile });
 let app = createApp(
   buildPath,
   process.env.NODE_ENV,
   build.publicPath,
   build.assetsBuildDirectory
 );
-let server = process.env.HOST
-  ? app.listen(port, process.env.HOST, onListen)
-  : app.listen(port, onListen);
+let server = createServer(app, port);
 
 ["SIGTERM", "SIGINT"].forEach((signal) => {
   process.once(signal, () => server?.close(console.error));
 });
+
+function getServerEntry(config: { serverEntryFile: string }): {
+  createApp: typeof createDefaultApp;
+  createServer: typeof createDefaultServer;
+} {
+  if (config.serverEntryFile) {
+    let entry = require(path.resolve(serverEntryFile));
+    return {
+      createApp: entry.createApp,
+      createServer: entry.createServer ?? createDefaultServer,
+    };
+  }
+  return {
+    createApp: createDefaultApp,
+    createServer: createDefaultServer,
+  };
+}
+function createDefaultServer(app: Express, port: number) {
+  let onListen = () => {
+    let address =
+      process.env.HOST ||
+      Object.values(os.networkInterfaces())
+        .flat()
+        .find((ip) => String(ip?.family).includes("4") && !ip?.internal)
+        ?.address;
+
+    if (!address) {
+      console.log(`Remix App Server started at http://localhost:${port}`);
+    } else {
+      console.log(
+        `Remix App Server started at http://localhost:${port} (http://${address}:${port})`
+      );
+    }
+  };
+
+  let server = process.env.HOST
+    ? app.listen(port, process.env.HOST, onListen)
+    : app.listen(port, onListen);
+  return server;
+}


### PR DESCRIPTION
Currently if a dev wants to extend the configuration of Remix App Server, they
must eject from RAS to the Express adapter. This PR adds a new config option 
`serverEntryFile` that specifies the file that will be used by RAS instead of
its default configuration. If the file is TypeScript, it will be transpiled
automatically.

```js
// remix.config.js
module.exports = {
  serverEntryFile: './server.ts'
}
```

Running `npm run dev` will launch Remix App Server and import the server file.

For production builds, the dev should update the `start` script to specify the
server file for `remix-serve`. NOTE: If the server file is TypeScript, this must
be transpiled manually during the build process.

```json
"build": "remix build && npm run build:server",
"build:server": "esbuild --format=cjs --platform=node --outfile=build/server.js server.ts",
"start": "remix-serve build build/server.js",
```
    
The server file should export the following functions:

```ts
// REQUIRED: create the Express app and return it
export function createApp(
  buildPath: string,
  mode = "production",
  publicPath = "/build/",
  assetsBuildDirectory = "public/build/"
): Express

// OPTIONAL: create an HTTP/HTTPS server and return it
function createServer(app: Express, port: number): Server

// OPTIONAL: create a WebSocket server and return it
function createSocketServer(port: number): WebSocket.Server
```

Here's a sample server file that includes all the exports.

https://github.com/kiliman/remix-ras-server-example/blob/main/server.ts
