### PR TITLE
docs(other-api): Fix 404 on react-router links

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -426,3 +426,4 @@
 - zachdtaylor
 - zainfathoni
 - zhe
+- crtdaniele

--- a/docs/other-api/react-router.md
+++ b/docs/other-api/react-router.md
@@ -16,7 +16,7 @@ Remix is built on top of React Router v6. Here are the most common APIs that you
 Most of the other APIs are either used internally by Remix or just aren't commonly needed in your app.
 
 [outlet]: https://reactrouter.com/main/components/outlet
-[use-location]: https://reactrouter.com/docs/hooks/use-location
-[use-navigate]: https://reactrouter.com/docs/hooks/use-navigate
-[use-params]: https://reactrouter.com/docs/hooks/use-params
-[use-resolved-path]: https://reactrouter.com/docs/hooks/use-resolved-path
+[use-location]: https://reactrouter.com/main/hooks/use-location
+[use-navigate]: https://reactrouter.com/main/hooks/use-navigate
+[use-params]: https://reactrouter.com/main/hooks/use-params
+[use-resolved-path]: https://reactrouter.com/main/hooks/use-resolved-path

--- a/docs/other-api/react-router.md
+++ b/docs/other-api/react-router.md
@@ -15,7 +15,7 @@ Remix is built on top of React Router v6. Here are the most common APIs that you
 
 Most of the other APIs are either used internally by Remix or just aren't commonly needed in your app.
 
-[outlet]: https://reactrouter.com/docs/components/outlet
+[outlet]: https://reactrouter.com/main/components/outlet
 [use-location]: https://reactrouter.com/docs/hooks/use-location
 [use-navigate]: https://reactrouter.com/docs/hooks/use-navigate
 [use-params]: https://reactrouter.com/docs/hooks/use-params


### PR DESCRIPTION
Fix 404 url react router. Example:

Current url (404): https://reactrouter.com/docs/components/outlet
Correct url: https://reactrouter.com/main/components/outlet

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [x] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
