### PR TITLE
fix(remix-dev): use correct require context in serverBareModulesPlugin

### DIFF
--- a/.changeset/stupid-rice-sort.md
+++ b/.changeset/stupid-rice-sort.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fixed incorrect missing package warnings when using PnP.


### PR DESCRIPTION
this fixes the issue with misleading warnings for pnp mentioned in [this comment](https://github.com/remix-run/remix/issues/4106#issuecomment-1239133762) where the compiler in `@remix-run/dev` is attempting to resolve packages against it's own `package.json` rather than the application's `package.json`.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
