### PR TITLE
docs(styling.md): fix filename path in code block

### DIFF
--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -108,7 +108,7 @@ export function links() {
 }
 ```
 
-```tsx filename=routes/dashboard/sales.tsx
+```tsx filename=app/routes/dashboard/sales.tsx
 import styles from "~/styles/sales.css";
 
 export function links() {


### PR DESCRIPTION
Fix inconsistency with missing `app/` before `routes/`.

Note code examples on proceeding lines start with `app/`:

https://github.com/remix-run/remix/blob/dc417f6876620ce2fd23977145efd16f4fe02413/docs/guides/styling.md?plain=1#L91-L117