### PR TITLE
Fix: blog.md type issues

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -232,6 +232,7 @@
 - kumard3
 - lachlanjc
 - laughnan
+- lawlesx
 - lawrencecchen
 - lensbart
 - leo

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -299,7 +299,12 @@ export const loader = async () => {
   });
 };
 
+
+export default function Posts() {
+  // You can also update the type as below
+  const { posts } = useLoaderData<LoaderData>();
 // ...
+}
 ```
 
 ## Pulling from a data source


### PR DESCRIPTION
While using
```ts
const { posts } = useLoaderData() as LoaderData;
``` 
Worked well when we had not used prisma to fetch the posts.

But after fetching the posts vs-code throws warning
```
Conversion of type 'SerializeObject<Simplify<Merge_<{ posts: Post[]; }, {}>>>' to type 'LoaderData' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
  Types of property 'posts' are incompatible.
    Type 'SerializeObject<Simplify<Merge_<{ slug: string; title: string; markdown: string; createdAt: Date; updatedAt: Date; }, {}>>>[]' is not comparable to type 'Post[]'.
      Type 'SerializeObject<Simplify<Merge_<{ slug: string; title: string; markdown: string; createdAt: Date; updatedAt: Date; }, {}>>>' is not comparable to type 'Post'.
        Types of property 'createdAt' are incompatible.
          Type 'string' is not comparable to type 'Date'.ts(2352)
```
![image](https://user-images.githubusercontent.com/52166437/189181814-7abacaa9-b877-4903-9aef-136f08df7be7.png)

So when I changed it to
```ts
const { posts } = useLoaderData<LoaderData>();
```
It worked without any warnings

Seems like a minor change but it helps.
Thanks
