### PR TITLE
chore: remove references to deep globals import

### DIFF
--- a/docs/guides/migrating-react-router-app.md
+++ b/docs/guides/migrating-react-router-app.md
@@ -382,7 +382,7 @@ If you are using TypeScript, you also need to create the `remix.env.d.ts` file i
 
 ```ts filename=remix.env.d.ts
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />
 ```
 
 ### A note about non-standard imports

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -71,7 +71,7 @@ Remix has TypeScript type definitions built-in as well. The starter templates cr
 
 ```ts filename=remix.env.d.ts
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />
 ```
 
 <docs-info>Note that the types referenced in `remix.env.d.ts` will depend on which environment you're running your app in. For example, there are different globals available in Cloudflare</docs-info>

--- a/examples/basic/remix.env.d.ts
+++ b/examples/basic/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/blog-tutorial/remix.env.d.ts
+++ b/examples/blog-tutorial/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/bullmq-task-queue/remix.env.d.ts
+++ b/examples/bullmq-task-queue/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/catch-boundary/remix.env.d.ts
+++ b/examples/catch-boundary/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/chakra-ui/remix.env.d.ts
+++ b/examples/chakra-ui/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/client-only-components/remix.env.d.ts
+++ b/examples/client-only-components/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/client-side-validation/remix.env.d.ts
+++ b/examples/client-side-validation/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/collected-notes/remix.env.d.ts
+++ b/examples/collected-notes/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/combobox-resource-route/remix.env.d.ts
+++ b/examples/combobox-resource-route/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/dark-mode/remix.env.d.ts
+++ b/examples/dark-mode/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/dataloader/remix.env.d.ts
+++ b/examples/dataloader/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/emotion/remix.env.d.ts
+++ b/examples/emotion/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/file-and-cloudinary-upload/remix.env.d.ts
+++ b/examples/file-and-cloudinary-upload/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/file-and-s3-upload/remix.env.d.ts
+++ b/examples/file-and-s3-upload/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/firebase/remix.env.d.ts
+++ b/examples/firebase/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/form-to-notion-db/remix.env.d.ts
+++ b/examples/form-to-notion-db/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/framer-route-animation/remix.env.d.ts
+++ b/examples/framer-route-animation/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/gdpr-cookie-consent/remix.env.d.ts
+++ b/examples/gdpr-cookie-consent/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/google-analytics/remix.env.d.ts
+++ b/examples/google-analytics/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/graphql-api/remix.env.d.ts
+++ b/examples/graphql-api/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/image-resize/remix.env.d.ts
+++ b/examples/image-resize/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/infinite-scrolling/remix.env.d.ts
+++ b/examples/infinite-scrolling/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/io-ts-formdata-decoding/remix.env.d.ts
+++ b/examples/io-ts-formdata-decoding/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/ioredis/remix.env.d.ts
+++ b/examples/ioredis/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/jokes/remix.env.d.ts
+++ b/examples/jokes/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/mantine/remix.env.d.ts
+++ b/examples/mantine/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/msw/remix.env.d.ts
+++ b/examples/msw/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/multiple-forms/remix.env.d.ts
+++ b/examples/multiple-forms/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/multiple-params/remix.env.d.ts
+++ b/examples/multiple-params/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/newsletter-signup/remix.env.d.ts
+++ b/examples/newsletter-signup/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/nprogress/remix.env.d.ts
+++ b/examples/nprogress/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/on-demand-hydration/remix.env.d.ts
+++ b/examples/on-demand-hydration/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/outlet-form-rerender/remix.env.d.ts
+++ b/examples/outlet-form-rerender/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/pathless-routes/remix.env.d.ts
+++ b/examples/pathless-routes/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/pm-app/remix.env.d.ts
+++ b/examples/pm-app/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/quirrel/remix.env.d.ts
+++ b/examples/quirrel/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/react-spring/remix.env.d.ts
+++ b/examples/react-spring/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/redis-upstash-session/remix.env.d.ts
+++ b/examples/redis-upstash-session/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/remix-auth-auth0/remix.env.d.ts
+++ b/examples/remix-auth-auth0/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/remix-auth-form/remix.env.d.ts
+++ b/examples/remix-auth-form/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/remix-auth-github/remix.env.d.ts
+++ b/examples/remix-auth-github/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/remix-auth-supabase-github/remix.env.d.ts
+++ b/examples/remix-auth-supabase-github/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/remix-auth-supabase/remix.env.d.ts
+++ b/examples/remix-auth-supabase/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/route-modal/remix.env.d.ts
+++ b/examples/route-modal/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/routes-gen/remix.env.d.ts
+++ b/examples/routes-gen/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/rust/remix.env.d.ts
+++ b/examples/rust/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/sanity/remix.env.d.ts
+++ b/examples/sanity/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/sass/remix.env.d.ts
+++ b/examples/sass/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/search-input/remix.env.d.ts
+++ b/examples/search-input/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/session-flash/remix.env.d.ts
+++ b/examples/session-flash/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/sharing-loader-data/remix.env.d.ts
+++ b/examples/sharing-loader-data/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/socket.io/remix.env.d.ts
+++ b/examples/socket.io/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/stitches/remix.env.d.ts
+++ b/examples/stitches/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/strapi/remix.env.d.ts
+++ b/examples/strapi/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/stripe-integration/remix.env.d.ts
+++ b/examples/stripe-integration/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/styled-components/remix.env.d.ts
+++ b/examples/styled-components/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/styletron/remix.env.d.ts
+++ b/examples/styletron/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/supabase-subscription/remix.env.d.ts
+++ b/examples/supabase-subscription/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/tailwindcss/remix.env.d.ts
+++ b/examples/tailwindcss/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/template/remix.env.d.ts
+++ b/examples/template/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/theme-ui/remix.env.d.ts
+++ b/examples/theme-ui/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/tiptap-collab-editing/remix.env.d.ts
+++ b/examples/tiptap-collab-editing/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/toast-message/remix.env.d.ts
+++ b/examples/toast-message/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/turborepo-vercel/apps/remix-app/remix.env.d.ts
+++ b/examples/turborepo-vercel/apps/remix-app/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/twind/remix.env.d.ts
+++ b/examples/twind/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/usematches-loader-data/remix.env.d.ts
+++ b/examples/usematches-loader-data/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/examples/yarn-pnp/remix.env.d.ts
+++ b/examples/yarn-pnp/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/integration/helpers/node-template/remix.env.d.ts
+++ b/integration/helpers/node-template/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/scripts/playground/template/remix.env.d.ts
+++ b/scripts/playground/template/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/templates/arc/remix.env.d.ts
+++ b/templates/arc/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/templates/cloudflare-pages/remix.env.d.ts
+++ b/templates/cloudflare-pages/remix.env.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/cloudflare/globals" />
+/// <reference types="@remix-run/cloudflare" />
 /// <reference types="@cloudflare/workers-types" />

--- a/templates/cloudflare-workers/remix.env.d.ts
+++ b/templates/cloudflare-workers/remix.env.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/cloudflare/globals" />
+/// <reference types="@remix-run/cloudflare" />
 /// <reference types="@cloudflare/workers-types" />

--- a/templates/express/remix.env.d.ts
+++ b/templates/express/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/templates/fly/remix.env.d.ts
+++ b/templates/fly/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/templates/netlify/remix.env.d.ts
+++ b/templates/netlify/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/templates/remix/remix.env.d.ts
+++ b/templates/remix/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />

--- a/templates/vercel/remix.env.d.ts
+++ b/templates/vercel/remix.env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@remix-run/dev" />
-/// <reference types="@remix-run/node/globals" />
+/// <reference types="@remix-run/node" />


### PR DESCRIPTION
Removes the rest of the deep imports to `@remix-run/xxx/globals`.