### PR TITLE
ci: Fix netlify/architect node 14 tests with AbortController polyfill

### DIFF
--- a/packages/remix-architect/__tests__/server-test.ts
+++ b/packages/remix-architect/__tests__/server-test.ts
@@ -290,13 +290,7 @@ describe("architect createRemixRequest", () => {
           "method": "GET",
           "parsedURL": "https://localhost:3333/",
           "redirect": "follow",
-          "signal": AbortSignal {
-            Symbol(kEvents): Map {},
-            Symbol(events.maxEventTargetListeners): 10,
-            Symbol(events.maxEventTargetListenersWarned): false,
-            Symbol(kAborted): false,
-            Symbol(kReason): undefined,
-          },
+          "signal": AbortSignal {},
         },
       }
     `);

--- a/packages/remix-architect/server.ts
+++ b/packages/remix-architect/server.ts
@@ -1,9 +1,11 @@
 import type {
   AppLoadContext,
   ServerBuild,
+  RequestInit as NodeRequestInit,
   Response as NodeResponse,
 } from "@remix-run/node";
 import {
+  AbortController as NodeAbortController,
   Headers as NodeHeaders,
   Request as NodeRequest,
   createRequestHandler as createRemixRequestHandler,
@@ -66,12 +68,14 @@ export function createRemixRequest(event: APIGatewayProxyEventV2): NodeRequest {
   );
   // Note: No current way to abort these for Architect, but our router expects
   // requests to contain a signal so it can detect aborted requests
-  let controller = new AbortController();
+  let controller = new NodeAbortController();
 
   return new NodeRequest(url.href, {
     method: event.requestContext.http.method,
     headers: createRemixHeaders(event.headers, event.cookies),
-    signal: controller.signal,
+    // Cast until reason/throwIfAborted added
+    // https://github.com/mysticatea/abort-controller/issues/36
+    signal: controller.signal as NodeRequestInit["signal"],
     body:
       event.body && event.isBase64Encoded
         ? isFormData

--- a/packages/remix-express/server.ts
+++ b/packages/remix-express/server.ts
@@ -6,7 +6,7 @@ import type {
   Response as NodeResponse,
 } from "@remix-run/node";
 import {
-  AbortController,
+  AbortController as NodeAbortController,
   createRequestHandler as createRemixRequestHandler,
   Headers as NodeHeaders,
   Request as NodeRequest,
@@ -97,12 +97,14 @@ export function createRemixRequest(
   let url = new URL(req.url, origin);
 
   // Abort action/loaders once we can no longer write a response
-  let controller = new AbortController();
+  let controller = new NodeAbortController();
   res.on("close", () => controller.abort());
 
   let init: NodeRequestInit = {
     method: req.method,
     headers: createRemixHeaders(req.headers),
+    // Cast until reason/throwIfAborted added
+    // https://github.com/mysticatea/abort-controller/issues/36
     signal: controller.signal as NodeRequestInit["signal"],
   };
 

--- a/packages/remix-netlify/__tests__/server-test.ts
+++ b/packages/remix-netlify/__tests__/server-test.ts
@@ -271,13 +271,7 @@ describe("netlify createRemixRequest", () => {
           "method": "GET",
           "parsedURL": "http://localhost:3000/",
           "redirect": "follow",
-          "signal": AbortSignal {
-            Symbol(kEvents): Map {},
-            Symbol(events.maxEventTargetListeners): 10,
-            Symbol(events.maxEventTargetListenersWarned): false,
-            Symbol(kAborted): false,
-            Symbol(kReason): undefined,
-          },
+          "signal": AbortSignal {},
         },
       }
     `);

--- a/packages/remix-netlify/server.ts
+++ b/packages/remix-netlify/server.ts
@@ -1,4 +1,11 @@
+import type {
+  AppLoadContext,
+  ServerBuild,
+  RequestInit as NodeRequestInit,
+  Response as NodeResponse,
+} from "@remix-run/node";
 import {
+  AbortController as NodeAbortController,
   createRequestHandler as createRemixRequestHandler,
   Headers as NodeHeaders,
   Request as NodeRequest,
@@ -10,12 +17,6 @@ import type {
   HandlerContext,
   HandlerResponse,
 } from "@netlify/functions";
-import type {
-  AppLoadContext,
-  ServerBuild,
-  RequestInit as NodeRequestInit,
-  Response as NodeResponse,
-} from "@remix-run/node";
 
 import { isBinaryType } from "./binaryTypes";
 
@@ -67,12 +68,14 @@ export function createRemixRequest(event: HandlerEvent): NodeRequest {
 
   // Note: No current way to abort these for Netlify, but our router expects
   // requests to contain a signal so it can detect aborted requests
-  let controller = new AbortController();
+  let controller = new NodeAbortController();
 
   let init: NodeRequestInit = {
     method: event.httpMethod,
     headers: createRemixHeaders(event.multiValueHeaders),
-    signal: controller.signal,
+    // Cast until reason/throwIfAborted added
+    // https://github.com/mysticatea/abort-controller/issues/36
+    signal: controller.signal as NodeRequestInit["signal"],
   };
 
   if (event.httpMethod !== "GET" && event.httpMethod !== "HEAD" && event.body) {

--- a/packages/remix-vercel/server.ts
+++ b/packages/remix-vercel/server.ts
@@ -6,7 +6,7 @@ import type {
   Response as NodeResponse,
 } from "@remix-run/node";
 import {
-  AbortController,
+  AbortController as NodeAbortController,
   createRequestHandler as createRemixRequestHandler,
   Headers as NodeHeaders,
   Request as NodeRequest,
@@ -85,12 +85,14 @@ export function createRemixRequest(
   let url = new URL(req.url!, `${protocol}://${host}`);
 
   // Abort action/loaders once we can no longer write a response
-  let controller = new AbortController();
+  let controller = new NodeAbortController();
   res.on("close", () => controller.abort());
 
   let init: NodeRequestInit = {
     method: req.method,
     headers: createRemixHeaders(req.headers),
+    // Cast until reason/throwIfAborted added
+    // https://github.com/mysticatea/abort-controller/issues/36
     signal: controller.signal as NodeRequestInit["signal"],
   };
 


### PR DESCRIPTION
Fix node 14 netlify/architect tests by leveraging the remix`@remix-run/node` `AbortController`.  Follow up to https://github.com/remix-run/remix/pull/3626.
