### PR TITLE
docs(api/remix): fix heading level (#3789)

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -235,6 +235,7 @@
 - lachlanjc
 - laughnan
 - lawrencecchen
+- leifarriens
 - lensbart
 - leo
 - leon

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -1522,7 +1522,7 @@ return new Response(null, {
 });
 ```
 
-## `unstable_parseMultipartFormData`
+### `unstable_parseMultipartFormData`
 
 Allows you to handle multipart forms (file uploads) for your app.
 


### PR DESCRIPTION
Closes: #3789

Fixed the heading `unstable_parseMultipartFormData` overflowing its container due to its heading level.
