### PR TITLE
feat: add `remix-eslint-flat-config` package

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -284,6 +284,7 @@
 - michaeldeboey
 - michaelfriedman
 - michaseel
+- mikeybinns
 - mikeybinnswebdesign
 - mirzafaizan
 - mjackson

--- a/packages/remix-eslint-flat-config/README.md
+++ b/packages/remix-eslint-flat-config/README.md
@@ -1,0 +1,52 @@
+# `@remix-run/eslint-config`
+
+This package includes a shareable ESLint config for Remix projects.
+
+If you create your app with `create-remix` no additional configuration is necessary.
+
+## Installation
+
+First, install this package along with ESLint in your project. **This package requires at least version 8.1 of ESLint**
+
+```sh
+npm install -D eslint @remix-run/eslint-config
+```
+
+Then create a file named `eslint.config.js` in the root of your project:
+
+```js
+import { coreConfig } from "@remix-run/eslint-flat-config";
+
+export default [...coreConfig];
+```
+
+### Additional configs
+
+This packages also ships with optional configuration objects for projects that use the following:
+
+- [Node](https://nodejs.org/en/). To use this config, import `nodeConfig`.
+- [Jest](https://jestjs.io/) with [Testing Library](https://testing-library.com). To use this config, import `testingLibraryConfig`.
+
+Then, include the configs by spreading the config into your own `eslint.config.js`, like so:
+
+```js
+import {
+  coreConfig,
+  nodeConfig,
+  testingLibraryConfig,
+} from "@remix-run/eslint-flat-config";
+
+export default [...coreConfig, ...nodeConfig, ...testingLibraryConfig];
+```
+
+### Jest + Testing Library
+
+Please note that because the testing library ruleset is optional, we do not include the core libraries as peer dependencies for this package. If you use these rules, be sure that you have the following dependencies installed in your project:
+
+```json
+{
+  "@testing-library/jest-dom": ">=5.16.0",
+  "@testing-library/react": ">=12.0.0",
+  "jest": ">=26.0.0"
+}
+```

--- a/packages/remix-eslint-flat-config/README.md
+++ b/packages/remix-eslint-flat-config/README.md
@@ -25,6 +25,7 @@ export default [...coreConfig];
 This packages also ships with optional configuration objects for projects that use the following:
 
 - [Node](https://nodejs.org/en/). To use this config, import `nodeConfig`.
+- [Typescript](https://www.typescriptlang.org/). To use this config, import `typescriptConfig`.
 - [Jest](https://jestjs.io/) with [Testing Library](https://testing-library.com). To use this config, import `testingLibraryConfig`.
 
 Then, include the configs by spreading the config into your own `eslint.config.js`, like so:
@@ -33,10 +34,16 @@ Then, include the configs by spreading the config into your own `eslint.config.j
 import {
   coreConfig,
   nodeConfig,
+  typescriptConfig,
   testingLibraryConfig,
 } from "@remix-run/eslint-flat-config";
 
-export default [...coreConfig, ...nodeConfig, ...testingLibraryConfig];
+export default [
+  ...coreConfig,
+  ...typescriptConfig,
+  ...nodeConfig,
+  ...testingLibraryConfig,
+];
 ```
 
 ### Jest + Testing Library

--- a/packages/remix-eslint-flat-config/configs/core.js
+++ b/packages/remix-eslint-flat-config/configs/core.js
@@ -3,6 +3,7 @@ import {
   commonjs as commonjsGlobals,
   es6 as es6Globals,
 } from "globals";
+import babelParser from "@babel/eslint-parser";
 
 import { coreRules } from "../rules/core";
 import { importRules } from "../rules/import";
@@ -13,20 +14,20 @@ import { reactSettings } from "../settings/react";
 
 export const coreConfig = [
   {
-    files: ["**/*.js", "**/*.mjs"],
-    parser: "@babel/eslint-parser",
-    parserOptions: {
-      requireConfigFile: false,
-      babelOptions: {
-        presets: [require.resolve("@babel/preset-react")],
-      },
-    },
+    files: ["**/*.js"],
     languageOptions: {
       ...browserGlobals,
       ...commonjsGlobals,
       ...es6Globals,
       ecmaVersion: "latest",
       sourceType: "module",
+      parser: babelParser,
+      parserOptions: {
+        requireConfigFile: false,
+        babelOptions: {
+          presets: ["@babel/preset-react"],
+        },
+      },
     },
     plugins: ["import", "react", "react-hooks", "jsx-a11y"],
     settings: {

--- a/packages/remix-eslint-flat-config/configs/core.js
+++ b/packages/remix-eslint-flat-config/configs/core.js
@@ -1,3 +1,9 @@
+import {
+  browser as browserGlobals,
+  commonjs as commonjsGlobals,
+  es6 as es6Globals,
+} from "globals";
+
 import { coreRules } from "../rules/core";
 import { importRules } from "../rules/import";
 import { reactRules } from "../rules/react";
@@ -17,10 +23,10 @@ export const coreConfig = [
         presets: [require.resolve("@babel/preset-react")],
       },
     },
-    env: {
-      browser: true,
-      commonjs: true,
-      es6: true,
+    languageOptions: {
+      ...browserGlobals,
+      ...commonjsGlobals,
+      ...es6Globals,
     },
     plugins: ["import", "react", "react-hooks", "jsx-a11y"],
     settings: {

--- a/packages/remix-eslint-flat-config/configs/core.js
+++ b/packages/remix-eslint-flat-config/configs/core.js
@@ -16,7 +16,6 @@ export const coreConfig = [
     files: ["**/*.js", "**/*.mjs"],
     parser: "@babel/eslint-parser",
     parserOptions: {
-      sourceType: "module",
       requireConfigFile: false,
       babelOptions: {
         presets: [require.resolve("@babel/preset-react")],
@@ -27,6 +26,7 @@ export const coreConfig = [
       ...commonjsGlobals,
       ...es6Globals,
       ecmaVersion: "latest",
+      sourceType: "module",
     },
     plugins: ["import", "react", "react-hooks", "jsx-a11y"],
     settings: {

--- a/packages/remix-eslint-flat-config/configs/core.js
+++ b/packages/remix-eslint-flat-config/configs/core.js
@@ -1,0 +1,45 @@
+import { coreRules } from "../rules/core";
+import { importRules } from "../rules/import";
+import { reactRules } from "../rules/react";
+import { jsxA11yRules } from "../rules/jsx-a11y";
+import { importSettings } from "../settings/import";
+import { reactSettings } from "../settings/react";
+
+export const coreConfig = [
+  {
+    files: ["**/*.js", "**/*.mjs"],
+    parser: "@babel/eslint-parser",
+    parserOptions: {
+      sourceType: "module",
+      requireConfigFile: false,
+      ecmaVersion: "latest",
+      babelOptions: {
+        presets: [require.resolve("@babel/preset-react")],
+      },
+    },
+    env: {
+      browser: true,
+      commonjs: true,
+      es6: true,
+    },
+    plugins: ["import", "react", "react-hooks", "jsx-a11y"],
+    settings: {
+      ...reactSettings,
+      ...importSettings,
+    },
+    // NOTE: In general - we want to use prettier for the majority of stylistic
+    // concerns.  However there are some "stylistic" eslint rules we use that should
+    // not fail a PR since we can auto-fix them after merging to dev.  These rules
+    // should be set to WARN.
+    //
+    // ERROR should be used for "functional" rules that indicate a problem in the
+    // code, and these will cause a PR failure
+
+    // IMPORTANT: Ensure that rules used here are compatible with
+    // typescript-eslint. If they are not, we need to turn the rule off in our
+    // overrides for ts/tsx.
+
+    // To read the details for any rule, see https://eslint.org/docs/rules/[RULE-KEY]
+    rules: { ...coreRules, ...importRules, ...reactRules, ...jsxA11yRules },
+  },
+];

--- a/packages/remix-eslint-flat-config/configs/core.js
+++ b/packages/remix-eslint-flat-config/configs/core.js
@@ -4,6 +4,10 @@ import {
   es6 as es6Globals,
 } from "globals";
 import babelParser from "@babel/eslint-parser";
+import importPlugin from "eslint-plugin-import";
+import reactPlugin from "eslint-plugin-react";
+import reactHooksPlugin from "eslint-plugin-react-hooks";
+import jsxA11yPlugin from "eslint-plugin-jsx-a11y";
 
 import { coreRules } from "../rules/core";
 import { importRules } from "../rules/import";
@@ -29,7 +33,7 @@ export const coreConfig = [
         },
       },
     },
-    plugins: ["import", "react", "react-hooks", "jsx-a11y"],
+    plugins: [importPlugin, reactPlugin, reactHooksPlugin, jsxA11yPlugin],
     settings: {
       ...reactSettings,
       ...importSettings,

--- a/packages/remix-eslint-flat-config/configs/core.js
+++ b/packages/remix-eslint-flat-config/configs/core.js
@@ -18,7 +18,6 @@ export const coreConfig = [
     parserOptions: {
       sourceType: "module",
       requireConfigFile: false,
-      ecmaVersion: "latest",
       babelOptions: {
         presets: [require.resolve("@babel/preset-react")],
       },
@@ -27,6 +26,7 @@ export const coreConfig = [
       ...browserGlobals,
       ...commonjsGlobals,
       ...es6Globals,
+      ecmaVersion: "latest",
     },
     plugins: ["import", "react", "react-hooks", "jsx-a11y"],
     settings: {

--- a/packages/remix-eslint-flat-config/configs/core.js
+++ b/packages/remix-eslint-flat-config/configs/core.js
@@ -16,7 +16,7 @@ import { jsxA11yRules } from "../rules/jsx-a11y";
 import { importSettings } from "../settings/import";
 import { reactSettings } from "../settings/react";
 
-export const coreConfig = [
+export const unstable__coreConfig = [
   {
     files: ["**/*.js"],
     languageOptions: {

--- a/packages/remix-eslint-flat-config/configs/jest-testing-library.js
+++ b/packages/remix-eslint-flat-config/configs/jest-testing-library.js
@@ -2,7 +2,7 @@ import { jest as jestGlobals } from "globals";
 
 import { testingLibraryRules } from "../rules/testing-library";
 
-export const testingLibraryConfig = {
+export const unstable__testingLibraryConfig = {
   files: ["**/__tests__/**/*", "**/*.{spec,test}.*"],
   languageOptions: {
     ...jestGlobals,

--- a/packages/remix-eslint-flat-config/configs/jest-testing-library.js
+++ b/packages/remix-eslint-flat-config/configs/jest-testing-library.js
@@ -1,9 +1,11 @@
+import { jest as jestGlobals } from "globals";
+
 import { testingLibraryRules } from "../rules/testing-library";
 
 export const testingLibraryConfig = {
   files: ["**/__tests__/**/*", "**/*.{spec,test}.*"],
-  env: {
-    "jest/globals": true,
+  languageOptions: {
+    ...jestGlobals,
   },
   rules: testingLibraryRules,
 };

--- a/packages/remix-eslint-flat-config/configs/jest-testing-library.js
+++ b/packages/remix-eslint-flat-config/configs/jest-testing-library.js
@@ -1,0 +1,9 @@
+import { testingLibraryRules } from "../rules/testing-library";
+
+export const testingLibraryConfig = {
+  files: ["**/__tests__/**/*", "**/*.{spec,test}.*"],
+  env: {
+    "jest/globals": true,
+  },
+  rules: testingLibraryRules,
+};

--- a/packages/remix-eslint-flat-config/configs/node.js
+++ b/packages/remix-eslint-flat-config/configs/node.js
@@ -1,8 +1,9 @@
 import { node as nodeGlobals } from "globals";
+import nodePlugin from "eslint-plugin-node";
 
 export const nodeConfig = [
   {
-    plugins: ["node"],
+    plugins: [nodePlugin],
     languageOptions: {
       ...nodeGlobals,
     },

--- a/packages/remix-eslint-flat-config/configs/node.js
+++ b/packages/remix-eslint-flat-config/configs/node.js
@@ -1,7 +1,7 @@
 import { node as nodeGlobals } from "globals";
 import nodePlugin from "eslint-plugin-node";
 
-export const nodeConfig = [
+export const unstable__nodeConfig = [
   {
     plugins: [nodePlugin],
     languageOptions: {

--- a/packages/remix-eslint-flat-config/configs/node.js
+++ b/packages/remix-eslint-flat-config/configs/node.js
@@ -1,8 +1,10 @@
+import { node as nodeGlobals } from "globals";
+
 export const nodeConfig = [
   {
     plugins: ["node"],
-    env: {
-      node: true,
+    languageOptions: {
+      ...nodeGlobals,
     },
   },
 ];

--- a/packages/remix-eslint-flat-config/configs/node.js
+++ b/packages/remix-eslint-flat-config/configs/node.js
@@ -1,0 +1,8 @@
+export const nodeConfig = [
+  {
+    plugins: ["node"],
+    env: {
+      node: true,
+    },
+  },
+];

--- a/packages/remix-eslint-flat-config/configs/typescript.js
+++ b/packages/remix-eslint-flat-config/configs/typescript.js
@@ -1,0 +1,23 @@
+import { typescriptRules, typescriptJSXRules } from "../rules/typescript";
+
+export const typescriptConfig = [
+  {
+    files: ["**/*.ts?(x)"],
+    extends: ["plugin:import/typescript"],
+    parser: "@typescript-eslint/parser",
+    parserOptions: {
+      sourceType: "module",
+      ecmaVersion: 2019,
+      ecmaFeatures: {
+        jsx: true,
+      },
+      warnOnUnsupportedTypeScriptVersion: true,
+    },
+    plugins: ["@typescript-eslint"],
+    rules: typescriptRules,
+  },
+  {
+    files: ["**/routes/**/*.js?(x)", "**/routes/**/*.tsx"],
+    rules: typescriptJSXRules,
+  },
+];

--- a/packages/remix-eslint-flat-config/configs/typescript.js
+++ b/packages/remix-eslint-flat-config/configs/typescript.js
@@ -1,19 +1,21 @@
+import typescriptParser from "@typescript-eslint/parser";
+
 import { typescriptRules, typescriptJSXRules } from "../rules/typescript";
 
 export const typescriptConfig = [
   {
     files: ["**/*.ts?(x)"],
     extends: ["plugin:import/typescript"],
-    parser: "@typescript-eslint/parser",
-    parserOptions: {
-      ecmaFeatures: {
-        jsx: true,
-      },
-      warnOnUnsupportedTypeScriptVersion: true,
-    },
     languageOptions: {
       sourceType: "module",
       ecmaVersion: 2019,
+      parser: typescriptParser,
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+        warnOnUnsupportedTypeScriptVersion: true,
+      },
     },
     plugins: ["@typescript-eslint"],
     rules: typescriptRules,

--- a/packages/remix-eslint-flat-config/configs/typescript.js
+++ b/packages/remix-eslint-flat-config/configs/typescript.js
@@ -3,7 +3,7 @@ import typescriptPlugin from "@typescript-eslint/eslint-plugin";
 
 import { typescriptRules, typescriptJSXRules } from "../rules/typescript";
 
-export const typescriptConfig = [
+export const unstable__typescriptConfig = [
   "plugin:import/typescript",
   {
     files: ["**/*.ts?(x)"],

--- a/packages/remix-eslint-flat-config/configs/typescript.js
+++ b/packages/remix-eslint-flat-config/configs/typescript.js
@@ -1,4 +1,5 @@
 import typescriptParser from "@typescript-eslint/parser";
+import typescriptPlugin from "@typescript-eslint/eslint-plugin";
 
 import { typescriptRules, typescriptJSXRules } from "../rules/typescript";
 
@@ -17,7 +18,7 @@ export const typescriptConfig = [
         warnOnUnsupportedTypeScriptVersion: true,
       },
     },
-    plugins: ["@typescript-eslint"],
+    plugins: [typescriptPlugin],
     rules: typescriptRules,
   },
   {

--- a/packages/remix-eslint-flat-config/configs/typescript.js
+++ b/packages/remix-eslint-flat-config/configs/typescript.js
@@ -6,13 +6,13 @@ export const typescriptConfig = [
     extends: ["plugin:import/typescript"],
     parser: "@typescript-eslint/parser",
     parserOptions: {
-      sourceType: "module",
       ecmaFeatures: {
         jsx: true,
       },
       warnOnUnsupportedTypeScriptVersion: true,
     },
     languageOptions: {
+      sourceType: "module",
       ecmaVersion: 2019,
     },
     plugins: ["@typescript-eslint"],

--- a/packages/remix-eslint-flat-config/configs/typescript.js
+++ b/packages/remix-eslint-flat-config/configs/typescript.js
@@ -7,11 +7,13 @@ export const typescriptConfig = [
     parser: "@typescript-eslint/parser",
     parserOptions: {
       sourceType: "module",
-      ecmaVersion: 2019,
       ecmaFeatures: {
         jsx: true,
       },
       warnOnUnsupportedTypeScriptVersion: true,
+    },
+    languageOptions: {
+      ecmaVersion: 2019,
     },
     plugins: ["@typescript-eslint"],
     rules: typescriptRules,

--- a/packages/remix-eslint-flat-config/configs/typescript.js
+++ b/packages/remix-eslint-flat-config/configs/typescript.js
@@ -4,9 +4,9 @@ import typescriptPlugin from "@typescript-eslint/eslint-plugin";
 import { typescriptRules, typescriptJSXRules } from "../rules/typescript";
 
 export const typescriptConfig = [
+  "plugin:import/typescript",
   {
     files: ["**/*.ts?(x)"],
-    extends: ["plugin:import/typescript"],
     languageOptions: {
       sourceType: "module",
       ecmaVersion: 2019,

--- a/packages/remix-eslint-flat-config/index.js
+++ b/packages/remix-eslint-flat-config/index.js
@@ -1,0 +1,6 @@
+import { coreConfig } from "./configs/core";
+import { testingLibraryConfig } from "./configs/jest-testing-library";
+import { nodeConfig } from "./configs/node";
+import { typescriptConfig } from "./configs/typescript";
+
+export { coreConfig, testingLibraryConfig, nodeConfig, typescriptConfig };

--- a/packages/remix-eslint-flat-config/index.js
+++ b/packages/remix-eslint-flat-config/index.js
@@ -1,6 +1,6 @@
-import { coreConfig } from "./configs/core";
-import { testingLibraryConfig } from "./configs/jest-testing-library";
-import { nodeConfig } from "./configs/node";
-import { typescriptConfig } from "./configs/typescript";
+import { unstable__coreConfig } from "./configs/core";
+import { unstable__testingLibraryConfig } from "./configs/jest-testing-library";
+import { unstable__nodeConfig } from "./configs/node";
+import { unstable__typescriptConfig } from "./configs/typescript";
 
-export { coreConfig, testingLibraryConfig, nodeConfig, typescriptConfig };
+export { unstable__coreConfig:, unstable__testingLibraryConfig, unstable__nodeConfig, unstable__typescriptConfig };

--- a/packages/remix-eslint-flat-config/index.js
+++ b/packages/remix-eslint-flat-config/index.js
@@ -3,4 +3,9 @@ import { unstable__testingLibraryConfig } from "./configs/jest-testing-library";
 import { unstable__nodeConfig } from "./configs/node";
 import { unstable__typescriptConfig } from "./configs/typescript";
 
-export { unstable__coreConfig:, unstable__testingLibraryConfig, unstable__nodeConfig, unstable__typescriptConfig };
+export {
+  unstable__coreConfig,
+  unstable__testingLibraryConfig,
+  unstable__nodeConfig,
+  unstable__typescriptConfig,
+};

--- a/packages/remix-eslint-flat-config/internal.js
+++ b/packages/remix-eslint-flat-config/internal.js
@@ -2,6 +2,11 @@
  * This config is intended for internal Remix projects. It should not be
  * documented nor considered public API in regards to semver considerations.
  */
+import {
+  nodeBuiltin as nodeBuiltinGlobals,
+  jest as jestGlobals,
+} from "globals";
+
 import { coreConfig, testingLibraryConfig } from "./index";
 
 const OFF = 0;
@@ -11,8 +16,8 @@ const ERROR = 2;
 export const internalConfig = [
   {
     files: ["**/*.js"],
-    env: {
-      node: true,
+    languageOptions: {
+      ...nodeBuiltinGlobals,
     },
     plugins: [
       // Plugins used in the internal config should be installed in our
@@ -86,8 +91,8 @@ export const internalConfig = [
   },
   {
     files: ["integration/**/*.*"],
-    env: {
-      "jest/globals": false,
+    languageOptions: {
+      ...jestGlobals,
     },
   },
 ];

--- a/packages/remix-eslint-flat-config/internal.js
+++ b/packages/remix-eslint-flat-config/internal.js
@@ -6,6 +6,13 @@ import {
   nodeBuiltin as nodeBuiltinGlobals,
   jest as jestGlobals,
 } from "globals";
+// Plugins used in the internal config should be installed in our
+// repositories. We don't want to ship these as dependencies to consumers
+// who may not use them.
+/* eslint-disable import/no-extraneous-dependencies */
+import nodePlugin from "eslint-plugin-node";
+import preferLetPlugin from "eslint-plugin-prefer-let";
+/* eslint-enable import/no-extraneous-dependencies */
 
 import { coreConfig, testingLibraryConfig } from "./index";
 
@@ -23,8 +30,8 @@ export const internalConfig = [
       // Plugins used in the internal config should be installed in our
       // repositories. We don't want to ship these as dependencies to consumers
       // who may not use them.
-      "node",
-      "prefer-let",
+      nodePlugin,
+      preferLetPlugin,
     ],
     rules: {
       ...coreConfig,

--- a/packages/remix-eslint-flat-config/internal.js
+++ b/packages/remix-eslint-flat-config/internal.js
@@ -1,0 +1,93 @@
+/**
+ * This config is intended for internal Remix projects. It should not be
+ * documented nor considered public API in regards to semver considerations.
+ */
+import { coreConfig, testingLibraryConfig } from "./index";
+
+const OFF = 0;
+const WARN = 1;
+const ERROR = 2;
+
+export const internalConfig = [
+  {
+    files: ["**/*.js"],
+    env: {
+      node: true,
+    },
+    plugins: [
+      // Plugins used in the internal config should be installed in our
+      // repositories. We don't want to ship these as dependencies to consumers
+      // who may not use them.
+      "node",
+      "prefer-let",
+    ],
+    rules: {
+      ...coreConfig,
+      ...testingLibraryConfig,
+      "@typescript-eslint/consistent-type-imports": ERROR,
+      "import/order": [
+        ERROR,
+        {
+          "newlines-between": "always",
+          groups: [
+            ["builtin", "external", "internal"],
+            ["parent", "sibling", "index"],
+          ],
+        },
+      ],
+      "jest/no-disabled-tests": OFF,
+      "prefer-let/prefer-let": WARN,
+    },
+  },
+  {
+    // all code blocks in .md files
+    files: ["**/*.md/*.js?(x)", "**/*.md/*.ts?(x)"],
+    rules: {
+      "no-unreachable": OFF,
+      "no-unused-expressions": OFF,
+      "no-unused-labels": OFF,
+      "no-unused-vars": OFF,
+      "jsx-a11y/alt-text": OFF,
+      "jsx-a11y/anchor-has-content": OFF,
+      "prefer-let/prefer-let": OFF,
+      "react/jsx-no-comment-textnodes": OFF,
+      "react/jsx-no-undef": OFF,
+    },
+  },
+  {
+    // all ```ts & ```tsx code blocks in .md files
+    files: ["**/*.md/*.ts?(x)"],
+    rules: {
+      "@typescript-eslint/no-unused-expressions": OFF,
+      "@typescript-eslint/no-unused-vars": OFF,
+    },
+  },
+  {
+    files: [
+      // All examples and docs, including code blocks in .md files
+      "examples/**/*.js?(x)",
+      "examples/**/*.ts?(x)",
+    ],
+    rules: {
+      "import/order": OFF,
+      "no-unused-expressions": OFF,
+      "no-unused-labels": OFF,
+      "no-unused-vars": OFF,
+      "prefer-let/prefer-let": OFF,
+    },
+  },
+  {
+    files: ["packages/**/*.*"],
+    excludedFiles: "**/__tests__/**/*.*",
+    rules: {
+      // Validate dependencies are listed in workspace package.json files
+      "import/no-extraneous-dependencies": ERROR,
+    },
+  },
+  {
+    files: ["integration/**/*.*"],
+    env: {
+      "jest/globals": false,
+    },
+  },
+];

--- a/packages/remix-eslint-flat-config/internal.js
+++ b/packages/remix-eslint-flat-config/internal.js
@@ -20,7 +20,7 @@ const OFF = 0;
 const WARN = 1;
 const ERROR = 2;
 
-export const internalConfig = [
+export const unstable__internalConfig = [
   {
     files: ["**/*.js"],
     languageOptions: {

--- a/packages/remix-eslint-flat-config/package.json
+++ b/packages/remix-eslint-flat-config/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@remix-run/eslint-flat-config",
+  "version": "1.7.0",
+  "description": "ESLint flat-style configuration for Remix projects",
+  "bugs": {
+    "url": "https://github.com/remix-run/remix/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remix-run/remix",
+    "directory": "packages/remix-eslint-flat-config"
+  },
+  "license": "MIT",
+  "main": "index.js",
+  "files": [
+    "README.md",
+    "index.js",
+    "internal.js",
+    "configs",
+    "rules",
+    "settings"
+  ],
+  "dependencies": {
+    "@babel/core": "^7.18.6",
+    "@babel/eslint-parser": "^7.18.2",
+    "@babel/preset-react": "^7.18.6",
+    "@typescript-eslint/eslint-plugin": "^5.12.1",
+    "@typescript-eslint/parser": "^5.12.1",
+    "eslint-import-resolver-node": "0.3.6",
+    "eslint-import-resolver-typescript": "^2.5.0",
+    "eslint-plugin-import": "^2.25.4",
+    "eslint-plugin-jest": "^26.1.1",
+    "eslint-plugin-jest-dom": "^4.0.1",
+    "eslint-plugin-jsx-a11y": "^6.5.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-react": "^7.28.0",
+    "eslint-plugin-react-hooks": "^4.3.0",
+    "eslint-plugin-testing-library": "^5.0.5"
+  },
+  "devDependencies": {
+    "@types/eslint": "^8.4.1",
+    "eslint": "^8.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^4.7.4"
+  },
+  "peerDependencies": {
+    "eslint": "^8.0.0",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
+    "typescript": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
+  "engines": {
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+  }
+}

--- a/packages/remix-eslint-flat-config/package.json
+++ b/packages/remix-eslint-flat-config/package.json
@@ -35,7 +35,8 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
-    "eslint-plugin-testing-library": "^5.0.5"
+    "eslint-plugin-testing-library": "^5.0.5",
+    "globals": "^13.17.0"
   },
   "devDependencies": {
     "@types/eslint": "^8.4.1",

--- a/packages/remix-eslint-flat-config/rules/core.js
+++ b/packages/remix-eslint-flat-config/rules/core.js
@@ -1,0 +1,138 @@
+import {
+  defaultAdapterExports,
+  defaultRuntimeExports,
+  architectSpecificExports,
+  cloudflareSpecificExports,
+  cloudflarePagesSpecificExports,
+  cloudflareWorkersSpecificExports,
+  nodeSpecificExports,
+  reactSpecificExports,
+} from "./packageExports";
+
+// const OFF = 0;
+const WARN = 1;
+const ERROR = 2;
+
+const getReplaceRemixImportsMessage = (packageName) =>
+  `All \`remix\` exports are considered deprecated as of v1.3.3. Please use \`@remix-run/${packageName}\` instead. You can run \`remix migrate --migration replace-remix-imports\` to automatically migrate your code.`;
+
+const replaceRemixImportsOptions = [
+  {
+    packageExports: defaultAdapterExports,
+    packageName:
+      "{architect|cloudflare-pages|cloudflare-workers|express|netlify|vercel}",
+  },
+  { packageExports: defaultRuntimeExports, packageName: "{cloudflare|node}" },
+  { packageExports: architectSpecificExports, packageName: "architect" },
+  { packageExports: cloudflareSpecificExports, packageName: "cloudflare" },
+  {
+    packageExports: cloudflarePagesSpecificExports,
+    packageName: "cloudflare-pages",
+  },
+  {
+    packageExports: cloudflareWorkersSpecificExports,
+    packageName: "cloudflare-workers",
+  },
+  { packageExports: nodeSpecificExports, packageName: "node" },
+  { packageExports: reactSpecificExports, packageName: "react" },
+].map(({ packageExports, packageName }) => ({
+  importNames: [...packageExports.value, ...packageExports.type],
+  message: getReplaceRemixImportsMessage(packageName),
+  name: "remix",
+}));
+
+export const coreRules = {
+  "array-callback-return": WARN,
+  "getter-return": WARN,
+  "new-parens": WARN,
+  "no-array-constructor": WARN,
+  "no-caller": ERROR,
+  "no-cond-assign": [WARN, "except-parens"],
+  "no-const-assign": ERROR,
+  "no-control-regex": WARN,
+  "no-dupe-args": WARN,
+  "no-dupe-class-members": WARN,
+  "no-dupe-keys": WARN,
+  "no-duplicate-case": WARN,
+  "no-empty-character-class": WARN,
+  "no-empty-pattern": WARN,
+  "no-duplicate-imports": WARN,
+  "no-empty": [WARN, { allowEmptyCatch: true }],
+  "no-eval": ERROR,
+  "no-ex-assign": WARN,
+  "no-extend-native": WARN,
+  "no-extra-bind": WARN,
+  "no-extra-label": WARN,
+  "no-extra-boolean-cast": WARN,
+  "no-func-assign": ERROR,
+  "no-global-assign": ERROR,
+  "no-implied-eval": WARN,
+  "no-invalid-regexp": WARN,
+  "no-label-var": WARN,
+  "no-labels": [WARN, { allowLoop: true, allowSwitch: false }],
+  "no-lone-blocks": WARN,
+  "no-loop-func": WARN,
+  "no-mixed-operators": [
+    WARN,
+    {
+      groups: [
+        ["&", "|", "^", "~", "<<", ">>", ">>>"],
+        ["==", "!=", "===", "!==", ">", ">=", "<", "<="],
+        ["&&", "||"],
+        ["in", "instanceof"],
+      ],
+      allowSamePrecedence: false,
+    },
+  ],
+  "no-unsafe-negation": WARN,
+  "no-new-func": WARN,
+  "no-new-object": WARN,
+  "no-octal": WARN,
+  "no-redeclare": ERROR,
+  "no-restricted-imports": [WARN, ...replaceRemixImportsOptions],
+  "no-script-url": WARN,
+  "no-self-assign": WARN,
+  "no-self-compare": WARN,
+  "no-sequences": WARN,
+  "no-shadow-restricted-names": WARN,
+  "no-sparse-arrays": WARN,
+  "no-template-curly-in-string": WARN,
+  "no-this-before-super": WARN,
+  "no-undef": ERROR,
+  "no-unreachable": WARN,
+  "no-unused-expressions": [
+    WARN,
+    {
+      allowShortCircuit: true,
+      allowTernary: true,
+      allowTaggedTemplates: true,
+    },
+  ],
+  "no-unused-labels": WARN,
+  "no-unused-vars": [
+    WARN,
+    {
+      args: "none",
+      ignoreRestSiblings: true,
+    },
+  ],
+  "no-use-before-define": [
+    WARN,
+    { classes: false, functions: false, variables: false },
+  ],
+  "no-useless-computed-key": WARN,
+  "no-useless-concat": WARN,
+  "no-useless-constructor": WARN,
+  "no-useless-escape": WARN,
+  "no-useless-rename": [
+    WARN,
+    {
+      ignoreDestructuring: false,
+      ignoreImport: false,
+      ignoreExport: false,
+    },
+  ],
+  "require-yield": WARN,
+  "use-isnan": WARN,
+  "valid-typeof": WARN,
+};

--- a/packages/remix-eslint-flat-config/rules/import.js
+++ b/packages/remix-eslint-flat-config/rules/import.js
@@ -1,0 +1,9 @@
+// const OFF = 0;
+// const WARN = 1;
+const ERROR = 2;
+
+export const importRules = {
+  "import/first": ERROR,
+  "import/no-amd": ERROR,
+  "import/no-webpack-loader-syntax": ERROR,
+};

--- a/packages/remix-eslint-flat-config/rules/jest-dom.js
+++ b/packages/remix-eslint-flat-config/rules/jest-dom.js
@@ -1,0 +1,17 @@
+// const OFF = 0;
+const WARN = 1;
+// const ERROR = 2;
+
+export const jestDomRules = {
+  "jest-dom/prefer-checked": WARN,
+  "jest-dom/prefer-empty": WARN,
+  "jest-dom/prefer-enabled-disabled": WARN,
+  "jest-dom/prefer-focus": WARN,
+  "jest-dom/prefer-in-document": WARN,
+  "jest-dom/prefer-required": WARN,
+  "jest-dom/prefer-to-have-attribute": WARN,
+  "jest-dom/prefer-to-have-class": WARN,
+  "jest-dom/prefer-to-have-style": WARN,
+  "jest-dom/prefer-to-have-text-content": WARN,
+  "jest-dom/prefer-to-have-value": WARN,
+};

--- a/packages/remix-eslint-flat-config/rules/jest.js
+++ b/packages/remix-eslint-flat-config/rules/jest.js
@@ -1,0 +1,19 @@
+// const OFF = 0;
+const WARN = 1;
+const ERROR = 2;
+
+export const jestRules = {
+  "jest/no-conditional-expect": WARN,
+  "jest/no-deprecated-functions": WARN,
+  "jest/no-disabled-tests": WARN,
+  "jest/no-export": ERROR,
+  "jest/no-focused-tests": WARN,
+  "jest/no-identical-title": WARN,
+  "jest/no-interpolation-in-snapshots": WARN,
+  "jest/no-jasmine-globals": ERROR,
+  "jest/no-jest-import": WARN,
+  "jest/no-mocks-import": WARN,
+  "jest/valid-describe-callback": ERROR,
+  "jest/valid-expect": ERROR,
+  "jest/valid-expect-in-promise": ERROR,
+};

--- a/packages/remix-eslint-flat-config/rules/jsx-a11y.js
+++ b/packages/remix-eslint-flat-config/rules/jsx-a11y.js
@@ -1,0 +1,21 @@
+// const OFF = 0;
+const WARN = 1;
+// const ERROR = 2;
+
+export const jsxA11yRules = {
+  "jsx-a11y/alt-text": WARN,
+  "jsx-a11y/anchor-has-content": [WARN, { components: ["Link", "NavLink"] }],
+  "jsx-a11y/anchor-is-valid": [WARN, { aspects: ["noHref", "invalidHref"] }],
+  "jsx-a11y/aria-activedescendant-has-tabindex": WARN,
+  "jsx-a11y/aria-props": WARN,
+  "jsx-a11y/aria-proptypes": WARN,
+  "jsx-a11y/aria-role": [WARN, { ignoreNonDOM: true }],
+  "jsx-a11y/aria-unsupported-elements": WARN,
+  "jsx-a11y/iframe-has-title": WARN,
+  "jsx-a11y/img-redundant-alt": WARN,
+  "jsx-a11y/lang": WARN,
+  "jsx-a11y/no-access-key": WARN,
+  "jsx-a11y/no-redundant-roles": WARN,
+  "jsx-a11y/role-has-required-aria-props": WARN,
+  "jsx-a11y/role-supports-aria-props": WARN,
+};

--- a/packages/remix-eslint-flat-config/rules/packageExports.js
+++ b/packages/remix-eslint-flat-config/rules/packageExports.js
@@ -1,0 +1,163 @@
+const defaultAdapterExports = {
+  value: ["createRequestHandler"],
+  type: ["GetLoadContextFunction", "RequestHandler"],
+};
+
+const defaultRuntimeExports = {
+  value: [
+    "createCookie",
+    "createCookieSessionStorage",
+    "createMemorySessionStorage",
+    "createRequestHandler",
+    "createSession",
+    "createSessionStorage",
+    "isCookie",
+    "isSession",
+    "json",
+    "MaxPartSizeExceededError",
+    "redirect",
+    "unstable_composeUploadHandlers",
+    "unstable_createMemoryUploadHandler",
+    "unstable_parseMultipartFormData",
+  ],
+  type: [
+    "ActionFunction",
+    "AppData",
+    "AppLoadContext",
+    "Cookie",
+    "CookieOptions",
+    "CookieParseOptions",
+    "CookieSerializeOptions",
+    "CookieSignatureOptions",
+    "CreateRequestHandlerFunction",
+    "DataFunctionArgs",
+    "EntryContext",
+    "ErrorBoundaryComponent",
+    "HandleDataRequestFunction",
+    "HandleDocumentRequestFunction",
+    "HeadersFunction",
+    "HtmlLinkDescriptor",
+    "HtmlMetaDescriptor",
+    "LinkDescriptor",
+    "LinksFunction",
+    "LoaderFunction",
+    "MemoryUploadHandlerFilterArgs",
+    "MemoryUploadHandlerOptions",
+    "MetaDescriptor",
+    "MetaFunction",
+    "PageLinkDescriptor",
+    "RequestHandler",
+    "RouteComponent",
+    "RouteHandle",
+    "ServerBuild",
+    "ServerEntryModule",
+    "Session",
+    "SessionData",
+    "SessionIdStorageStrategy",
+    "SessionStorage",
+    "UploadHandler",
+    "UploadHandlerPart",
+  ],
+};
+
+const architectSpecificExports = {
+  value: ["createArcTableSessionStorage"],
+  type: [],
+};
+
+const cloudflareSpecificExports = {
+  value: ["createCloudflareKVSessionStorage"],
+  type: [],
+};
+
+const cloudflarePagesSpecificExports = {
+  value: ["createPagesFunctionHandler"],
+  type: ["createPagesFunctionHandlerParams"],
+};
+
+const cloudflareWorkersSpecificExports = {
+  value: ["createEventHandler", "handleAsset"],
+  type: [],
+};
+
+const nodeSpecificExports = {
+  value: [
+    "AbortController",
+    "createFileSessionStorage",
+    "createReadableStreamFromReadable",
+    "fetch",
+    "FormData",
+    "Headers",
+    "installGlobals",
+    "NodeOnDiskFile",
+    "readableStreamToString",
+    "Request",
+    "Response",
+    "unstable_createFileUploadHandler",
+    "writeAsyncIterableToWritable",
+    "writeReadableStreamToWritable",
+  ],
+  type: ["HeadersInit", "RequestInfo", "RequestInit", "ResponseInit"],
+};
+
+const reactSpecificExports = {
+  value: [
+    "Form",
+    "Link",
+    "Links",
+    "LiveReload",
+    "Meta",
+    "NavLink",
+    "Outlet",
+    "PrefetchPageLinks",
+    "RemixBrowser",
+    "RemixServer",
+    "Scripts",
+    "ScrollRestoration",
+    "useActionData",
+    "useBeforeUnload",
+    "useCatch",
+    "useFetcher",
+    "useFetchers",
+    "useFormAction",
+    "useHref",
+    "useLoaderData",
+    "useLocation",
+    "useMatches",
+    "useNavigate",
+    "useNavigationType",
+    "useOutlet",
+    "useOutletContext",
+    "useParams",
+    "useResolvedPath",
+    "useSearchParams",
+    "useSubmit",
+    "useTransition",
+  ],
+  type: [
+    "FormEncType",
+    "FormMethod",
+    "FormProps",
+    "HtmlLinkDescriptor",
+    "HtmlMetaDescriptor",
+    "LinkProps",
+    "NavLinkProps",
+    "RemixBrowserProps",
+    "RemixServerProps",
+    "ShouldReloadFunction",
+    "SubmitFunction",
+    "SubmitOptions",
+    "ThrownResponse",
+  ],
+};
+
+module.exports = {
+  defaultAdapterExports,
+  defaultRuntimeExports,
+  architectSpecificExports,
+  cloudflareSpecificExports,
+  cloudflarePagesSpecificExports,
+  cloudflareWorkersSpecificExports,
+  nodeSpecificExports,
+  reactSpecificExports,
+};

--- a/packages/remix-eslint-flat-config/rules/packageExports.js
+++ b/packages/remix-eslint-flat-config/rules/packageExports.js
@@ -151,7 +151,7 @@ const reactSpecificExports = {
   ],
 };
 
-module.exports = {
+export {
   defaultAdapterExports,
   defaultRuntimeExports,
   architectSpecificExports,

--- a/packages/remix-eslint-flat-config/rules/react.js
+++ b/packages/remix-eslint-flat-config/rules/react.js
@@ -1,0 +1,30 @@
+const OFF = 0;
+const WARN = 1;
+const ERROR = 2;
+
+export const reactRules = {
+  "react/display-name": WARN,
+  "react/forbid-foreign-prop-types": [WARN, { allowInPropTypes: true }],
+  "react/jsx-key": WARN,
+  "react/jsx-no-comment-textnodes": WARN,
+  "react/jsx-no-target-blank": WARN,
+  "react/jsx-no-undef": ERROR,
+  "react/jsx-pascal-case": [WARN, { allowAllCaps: true, ignore: [] }],
+  "react/jsx-uses-vars": WARN,
+  "react/jsx-uses-react": WARN,
+  "react/no-danger-with-children": WARN,
+  "react/no-direct-mutation-state": WARN,
+  "react/no-find-dom-node": WARN,
+  "react/no-is-mounted": WARN,
+  "react/no-render-return-value": ERROR,
+  "react/no-string-refs": WARN,
+  "react/no-typos": WARN,
+  "react/react-in-jsx-scope": OFF,
+  "react/require-render-return": ERROR,
+  "react/style-prop-object": WARN,
+
+  // react-hooks
+  // https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks
+  "react-hooks/exhaustive-deps": WARN,
+  "react-hooks/rules-of-hooks": ERROR,
+};

--- a/packages/remix-eslint-flat-config/rules/testing-library.js
+++ b/packages/remix-eslint-flat-config/rules/testing-library.js
@@ -1,0 +1,25 @@
+// const OFF = 0;
+const WARN = 1;
+const ERROR = 2;
+
+export const testingLibraryRules = {
+  "testing-library/await-async-query": ERROR,
+  "testing-library/await-async-utils": ERROR,
+  "testing-library/no-await-sync-events": ERROR,
+  "testing-library/no-await-sync-query": ERROR,
+  "testing-library/no-debugging-utils": WARN,
+  "testing-library/no-promise-in-fire-event": ERROR,
+  "testing-library/no-render-in-setup": ERROR,
+  "testing-library/no-unnecessary-act": ERROR,
+  "testing-library/no-wait-for-empty-callback": ERROR,
+  "testing-library/no-wait-for-multiple-assertions": ERROR,
+  "testing-library/no-wait-for-side-effects": ERROR,
+  "testing-library/no-wait-for-snapshot": ERROR,
+  "testing-library/prefer-find-by": WARN,
+  "testing-library/prefer-presence-queries": WARN,
+  "testing-library/prefer-query-by-disappearance": WARN,
+  "testing-library/prefer-screen-queries": WARN,
+  "testing-library/prefer-user-event": WARN,
+  "testing-library/prefer-wait-for": WARN,
+  "testing-library/render-result-naming-convention": WARN,
+};

--- a/packages/remix-eslint-flat-config/rules/typescript.js
+++ b/packages/remix-eslint-flat-config/rules/typescript.js
@@ -1,0 +1,61 @@
+const OFF = 0;
+const WARN = 1;
+const ERROR = 2;
+
+export const typescriptRules = {
+  "no-dupe-class-members": OFF,
+  "no-undef": OFF,
+
+  // Add TypeScript specific rules (and turn off ESLint equivalents)
+  "@typescript-eslint/consistent-type-assertions": WARN,
+  "@typescript-eslint/consistent-type-imports": WARN,
+
+  "no-array-constructor": OFF,
+  "@typescript-eslint/no-array-constructor": WARN,
+
+  // There is a bug w/ @typescript-eslint/no-duplicate-imports triggered
+  // by multiple imports inside of module declarations. We should reenable
+  // this rule when the bug is fixed.
+  // https://github.com/typescript-eslint/typescript-eslint/issues/3071
+  "no-duplicate-imports": OFF,
+  // "@typescript-eslint/no-duplicate-imports": WARN,
+
+  "no-redeclare": OFF,
+  "@typescript-eslint/no-redeclare": ERROR,
+  "no-use-before-define": OFF,
+  "@typescript-eslint/no-use-before-define": [
+    WARN,
+    {
+      functions: false,
+      classes: false,
+      variables: false,
+      typedefs: false,
+    },
+  ],
+  "no-unused-expressions": OFF,
+  "@typescript-eslint/no-unused-expressions": [
+    WARN,
+    {
+      allowShortCircuit: true,
+      allowTernary: true,
+      allowTaggedTemplates: true,
+    },
+  ],
+  "no-unused-vars": OFF,
+  "@typescript-eslint/no-unused-vars": [
+    WARN,
+    {
+      args: "none",
+      ignoreRestSiblings: true,
+    },
+  ],
+  "no-useless-constructor": OFF,
+  "@typescript-eslint/no-useless-constructor": WARN,
+};
+
+export const typescriptJSXRules = {
+  // Routes may use default exports without a name. At the route level
+  // identifying components for debugging purposes is less of an issue, as
+  // the route boundary is more easily identifiable.
+  "react/display-name": OFF,
+};

--- a/packages/remix-eslint-flat-config/settings/import.js
+++ b/packages/remix-eslint-flat-config/settings/import.js
@@ -1,0 +1,14 @@
+export const importSettings = {
+  "import/ignore": ["node_modules", "\\.(css|md|svg|json)$"],
+  "import/parsers": {
+    [require.resolve("@typescript-eslint/parser")]: [".ts", ".tsx", ".d.ts"],
+  },
+  "import/resolver": {
+    [require.resolve("eslint-import-resolver-node")]: {
+      extensions: [".js", ".jsx", ".ts", ".tsx"],
+    },
+    [require.resolve("eslint-import-resolver-typescript")]: {
+      alwaysTryTypes: true,
+    },
+  },
+};

--- a/packages/remix-eslint-flat-config/settings/react.js
+++ b/packages/remix-eslint-flat-config/settings/react.js
@@ -1,0 +1,16 @@
+export const reactSettings = {
+  react: {
+    version: "detect",
+    formComponents: ["Form"],
+    linkComponents: [
+      {
+        name: "Link",
+        linkAttribute: "to",
+      },
+      {
+        name: "NavLink",
+        linkAttribute: "to",
+      },
+    ],
+  },
+};


### PR DESCRIPTION
This PR is created after I created this discussion: #4201
I ended up doing the work anyway to learn about the new ESLint config standard. I accept that this might just be discarded as this work wasn't approved before the work was completed.

Tasks completed:
- [x] Convert the old require config to modern import exports
- [x] Document the new import config strategy in README
- [x] Convert env keys to imported globals package
- [x] Move ecmaVersion and sourceType to languageOptions
- [x] Move and modify parser and parserOptions to languageOptions
- [x] Convert plugin imports to new standard
- [x] Remove all extends references in favour of new ESLint flat merge
- [x] Check for `--rulesdir` usage and refactor (none found)
- [x] Check for use of `noInlineConfig` and `reportUnusedDisableDirectives` (none found)
- [x] Remove deprecated `jest.js` file
- [x] Remove multiple config files in favour of exporting separate configs from a single source
- [ ] Test new config against old config to ensure it generates the same errors (HELP WANTED)
- [ ] Confirm package.json contents with Remix team to ensure it matches package strategy

Testing Strategy:
Not yet tested, work in progress.

