### PR TITLE
feat(remix-react): preload critical style-sheets

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -364,6 +364,7 @@
 - ryanflorence
 - ryankshaw
 - sandulat
+- sanjaiyan-dev
 - sbernheim4
 - schpet
 - scottybrown

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -682,7 +682,10 @@ function PrefetchPageLinksImpl({
       {styleLinks.map((link) => (
         // these don't spread `linkProps` because they are full link descriptors
         // already with their own props
-        <link key={link.href} {...link} />
+        <React.Fragment key={link.href}>
+          <link rel="preload" href={link?.href} as="style" />
+          <link {...link} />
+        </React.Fragment>
       ))}
     </>
   );


### PR DESCRIPTION
This is inspired from `Next.js`.
[Preload critical stylesheets to improve loading speed](https://web.dev/preload-critical-assets/).

_Sorry if I made any mistakes :(_