### PR TITLE
docs(tutorials/jokes): fix typo + code highlighting

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -434,3 +434,4 @@
 - zachdtaylor
 - zainfathoni
 - zhe
+- wtlin1228

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1615,7 +1615,7 @@ Remix and the `tsconfig.json` you get from the starter template are configured t
 
 <summary>app/routes/jokes.tsx</summary>
 
-```tsx filename=app/routes/jokes.tsx lines=[3,6,8,16,23-25,27-32,35,59-63]
+```tsx filename=app/routes/jokes.tsx lines=[3,5-6,10,13,20-32,56-60]
 import type {
   LinksFunction,
   LoaderFunction,

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1320,7 +1320,7 @@ As we work through the rest of the tutorial, you may want to check the class nam
 
 One quick note about CSS. A lot of you folks may be used to using runtime libraries for CSS (like [Styled-Components][styled-components]). While you can use those with Remix, we'd like to encourage you to look into more traditional approaches to CSS. Many of the problems that led to the creation of these styling solutions aren't really problems in Remix, so you can often go with a simpler styling approach.
 
-That said, many Remix users are very happy with [Tailwind][tailwind] and we recommend this approach. Basically, if it can give you a URL (or a CSS file which you can import to get a URL), then it's a generally a good approach because Remix can then leverage the browser platform for caching and loading/unloading.
+That said, many Remix users are very happy with [Tailwind][tailwind] and we recommend this approach. Basically, if it can give you a URL (or a CSS file which you can import to get a URL), then it's generally a good approach because Remix can then leverage the browser platform for caching and loading/unloading.
 
 ## Database
 

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1615,7 +1615,7 @@ Remix and the `tsconfig.json` you get from the starter template are configured t
 
 <summary>app/routes/jokes.tsx</summary>
 
-```tsx filename=app/routes/jokes.tsx lines=[3,5-6,10,13,20-32,56-60]
+```tsx filename=app/routes/jokes.tsx lines=[3,5-6,10,13,20-22,24-29,32,56-60]
 import type {
   LinksFunction,
   LoaderFunction,


### PR DESCRIPTION
- Fix a typo.
- Fix the wrong highlighted lines for one codeblock.