### PR TITLE
feat(remix-react): add `RouteAnnouncer` component

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -364,6 +364,7 @@
 - ryanflorence
 - ryankshaw
 - sandulat
+- sanjaiyan-dev
 - sbernheim4
 - schpet
 - scottybrown

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -214,6 +214,7 @@ export function RemixEntry({
             static={staticProp}
           >
             <Routes />
+            <RouteAnnouncer />
           </Router>
         </RemixCatchBoundary>
       </RemixErrorBoundary>
@@ -226,6 +227,47 @@ function deserializeError(data: SerializedError): Error {
   error.stack = data.stack;
   return error;
 }
+
+const RouteAnnouncer = React.memo(() => {
+  const { pathname } = useLocation();
+  const [routeAnnouncement, setRouteAnnouncement] = React.useState("");
+  const previouslyLoadedPath = React.useRef(pathname);
+
+  React.useEffect(() => {
+    if (previouslyLoadedPath.current === pathname) return;
+    previouslyLoadedPath.current = pathname;
+
+    if (document?.title) {
+      setRouteAnnouncement(document.title);
+    } else {
+      const pageHeader = document.querySelector("h1");
+      const content = pageHeader?.innerText ?? pageHeader?.textContent;
+
+      setRouteAnnouncement(content || pathname);
+    }
+  }, [pathname]);
+  return (
+    <p
+      aria-live="assertive"
+      id="__remix-route-announcer__"
+      role="alert"
+      style={{
+        border: 0,
+        clip: "rect(0 0 0 0)",
+        height: "1px",
+        margin: "-1px",
+        overflow: "hidden",
+        padding: 0,
+        position: "absolute",
+        width: "1px",
+        whiteSpace: "nowrap",
+        wordWrap: "normal",
+      }}
+    >
+      {routeAnnouncement}
+    </p>
+  );
+});
 
 function Routes() {
   // TODO: Add `renderMatches` function to RR that we can use and then we don't


### PR DESCRIPTION
Adding Route Announcer to `Remix js` for better accessibility.
Inspired by https://nextjs.org/docs/accessibility#route-announcements.

_Extremely sorry if I made any mistakes :(._