### PR TITLE
fix(remix-react): `FormMethod`'s `type` can only be `'get'` or `'post'`

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -809,11 +809,7 @@ function dedupe(array: any[]) {
 
 export interface FormProps extends FormHTMLAttributes<HTMLFormElement> {
   /**
-   * The HTTP verb to use when the form is submit. Supports "get", "post",
-   * "put", "delete", "patch".
-   *
-   * Note: If JavaScript is disabled, you'll need to implement your own "method
-   * override" to support more than just GET and POST.
+   * The HTTP verb to use when the form is submitted. Supports "get" and "post".   
    */
   method?: FormMethod;
 
@@ -993,7 +989,7 @@ export function useFormAction(
 export interface SubmitOptions {
   /**
    * The HTTP method used to submit the form. Overrides `<form method>`.
-   * Defaults to "GET".
+   * Defaults to "get".
    */
   method?: FormMethod;
 

--- a/packages/remix-react/data.ts
+++ b/packages/remix-react/data.ts
@@ -3,7 +3,7 @@ import type { Submission } from "./transition";
 
 export type AppData = any;
 
-export type FormMethod = "get" | "post" | "put" | "patch" | "delete";
+export type FormMethod = "get" | "post";
 
 export type FormEncType =
   | "application/x-www-form-urlencoded"


### PR DESCRIPTION
Fixes the `FormMethod` type to only allow `'get' | 'post'` to reflect both the HTML spec and the actual implementation.

Since the `<FormImpl />` component falls back to `'post'` as soon as `method` is anything other than `'get'`
```typescript
 let formMethod: FormMethod =
    method.toLowerCase() === "get" ? "get" : "post";
```
 _and_ since [the spec only allows get or post](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-method) (or dialog) anyway, it's best to adapt the `FormMethod` type accordingly.