### PR TITLE
fix(@remix-run/react): remove unused `type-fest` dependency

### DIFF
--- a/.changeset/hot-pugs-tie.md
+++ b/.changeset/hot-pugs-tie.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/react": patch
+---
+
+Remove unused `type-fest` dependency

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -17,8 +17,7 @@
   "module": "dist/esm/index.js",
   "dependencies": {
     "history": "^5.3.0",
-    "react-router-dom": "6.3.0",
-    "type-fest": "^2.17.0"
+    "react-router-dom": "6.3.0"
   },
   "devDependencies": {
     "@remix-run/server-runtime": "1.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12154,11 +12154,6 @@ type-fest@^2.16.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.16.0.tgz#1250fbd64dafaf4c8e405e393ef3fb16d9651db2"
   integrity sha512-qpaThT2HQkFb83gMOrdKVsfCN7LKxP26Yq+smPzY1FqoHRjqmjqHXA7n5Gkxi8efirtbeEUxzfEdePthQWCuHw==
 
-type-fest@^2.17.0:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.17.0.tgz#c677030ce61e5be0c90c077d52571eb73c506ea9"
-  integrity sha512-U+g3/JVXnOki1kLSc+xZGPRll3Ah9u2VIG6Sn9iH9YX6UkPERmt6O/0fIyTgsd2/whV0+gAaHAg8fz6sG1QzMA==
-
 type-is@^1.6.18, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz"


### PR DESCRIPTION
should have been removed when serialize type helpers were moved into server-runtime pkg
