### PR TITLE
docs(api/remix): fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -360,6 +360,7 @@
 - ruisaraiva19
 - runmoore
 - Runner-dev
+- runofthemill
 - rvlewerissa
 - ryanflorence
 - ryanjames1729

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -2256,7 +2256,7 @@ const { getSession, commitSession, destroySession } =
   });
 ```
 
-The `expires` argument to `readData` and `updateData` is the same `Date` at which the cookie itself expires and is no longer valid. You can use this information to automatically purge the session record from your database to save on space, or to ensure that you do not otherwise return any data for old, expired cookies.
+The `expires` argument to `createData` and `updateData` is the same `Date` at which the cookie itself expires and is no longer valid. You can use this information to automatically purge the session record from your database to save on space, or to ensure that you do not otherwise return any data for old, expired cookies.
 
 ### `createCookieSessionStorage`
 


### PR DESCRIPTION
Assuming the code block [here](https://remix.run/docs/en/v1/api/remix#createsessionstorage) is accurate, this fixes the reference in the note, as `readData` does not take an `expires` arg, but `createData` does! :)