### PR TITLE
chore: update tsconfigs to use composite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /packages/*/LICENSE.md
 node_modules/
 yarn-error.log
+tsconfig.tsbuildinfo
 
 /jacob
 /fixtures/cloudflare

--- a/integration/tsconfig.json
+++ b/integration/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "include": ["**/*.ts"],
   "exclude": ["helpers/*-template"],
   "compilerOptions": {
     "lib": ["ES2019"],

--- a/packages/create-remix/tsconfig.json
+++ b/packages/create-remix/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "ES2019",
     "module": "CommonJS",
     "skipLibCheck": true,
+    "composite": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/packages/remix-architect/tsconfig.json
+++ b/packages/remix-architect/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
     "skipLibCheck": true,
+    "composite": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/packages/remix-cloudflare-pages/tsconfig.json
+++ b/packages/remix-cloudflare-pages/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2019"],
     "target": "ES2019",
     "types": ["@cloudflare/workers-types"],
+    "composite": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/packages/remix-cloudflare-workers/tsconfig.json
+++ b/packages/remix-cloudflare-workers/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2019"],
     "target": "ES2019",
     "types": ["@cloudflare/workers-types"],
+    "composite": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/packages/remix-cloudflare/tsconfig.json
+++ b/packages/remix-cloudflare/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2019"],
     "target": "ES2019",
     "types": ["@cloudflare/workers-types"],
+    "composite": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/packages/remix-dev/tsconfig.json
+++ b/packages/remix-dev/tsconfig.json
@@ -1,9 +1,11 @@
 {
+  "include": ["**/*.ts", "package.json"],
   "exclude": ["dist", "__tests__", "node_modules", "./compiler/shims"],
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
     "module": "CommonJS",
+    "composite": true,
 
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/packages/remix-express/tsconfig.json
+++ b/packages/remix-express/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
     "skipLibCheck": true,
+    "composite": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/packages/remix-netlify/tsconfig.json
+++ b/packages/remix-netlify/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
     "skipLibCheck": true,
+    "composite": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/packages/remix-node/tsconfig.json
+++ b/packages/remix-node/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
+    "composite": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/packages/remix-react/tsconfig.json
+++ b/packages/remix-react/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "ES2020",
     "module": "ES2020",
     "skipLibCheck": true,
+    "composite": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
@@ -14,7 +15,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
-    "outDir": "../../build/node_modules/@remix-run/react/dist",
-    "composite": true
+    "outDir": "../../build/node_modules/@remix-run/react/dist"
   }
 }

--- a/packages/remix-serve/tsconfig.json
+++ b/packages/remix-serve/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
     "skipLibCheck": true,
+    "composite": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/packages/remix-server-runtime/tsconfig.json
+++ b/packages/remix-server-runtime/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "lib": ["ES2019", "DOM", "DOM.Iterable"],
     "target": "ES2019",
+    "composite": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
@@ -12,7 +13,6 @@
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/@remix-run/server-runtime/dist",
-    "composite": true,
 
     // Avoid naming conflicts between lib.dom.d.ts and globals.ts
     "skipLibCheck": true

--- a/packages/remix-vercel/tsconfig.json
+++ b/packages/remix-vercel/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
     "skipLibCheck": true,
+    "composite": true,
 
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/packages/remix/tsconfig.json
+++ b/packages/remix/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "ES2020",
     "module": "ES2020",
     "skipLibCheck": true,
+    "composite": true,
 
     "jsx": "react",
     "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "files": [],
-  "exclude": ["node_modules", "build"],
   "references": [
     { "path": "integration" },
     { "path": "packages/create-remix" },


### PR DESCRIPTION
Speeds up build a bit by allowing tsc to quickly find references: https://www.typescriptlang.org/docs/handbook/project-references.html#composite

Allows projects to build in more isolation and avoids wired x-project types to leak. For example I have a PR open right now that does not recognize `headers.entries()` as a method in the server-runtime, but with these changes it works fine.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
