### PR TITLE
Add .env line to blog tutorial

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -393,6 +393,7 @@
 - SufianBabri
 - supachaidev
 - Synvox
+- someshkar
 - tagraves
 - tascord
 - TheRealAstoo

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -47,6 +47,12 @@ We're using [the Indie stack][the-indie-stack], which is a full application read
 
 💿 Now, open the project that was generated in your preferred editor and check the instructions in the `README.md` file. Feel free to read over this. We'll get to the deployment bit later in the tutorial.
 
+💿 Copy `.env.example` to `.env` to start with a default config:
+
+```sh
+cp .env.example .env
+```
+
 💿 Let's start the dev server:
 
 ```sh


### PR DESCRIPTION
When I was trying out the blog tutorial for the first time, I got stuck at the step where I followed every step very cautiously but I ran into an error where no database URL was defined in the prisma schema, which gets it from an env variable called `DATABASE_URL`.

This was an easy fix (copying `.env.example` to `.env`), but would definitely hinder first time JavaScript users in what is supposed to be a begginer friendly tutorial.

This is what the error looks like:

![image](https://user-images.githubusercontent.com/14039437/192133659-ad516c51-ffb9-4b18-bed8-82d7ab598026.png)

While this is an easy fix with a bit of googling, it might be fairly intimidating to the target audience.