### PR TITLE
ci: use GitHub Actions account to commit format changes

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.FORMAT_PAT }}
 
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
@@ -45,8 +43,8 @@ jobs:
 
       - name: 💪 Commit
         run: |
-          git config --local user.email "hello@remix.run"
-          git config --local user.name "Remix Run Bot"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
 
           git add .
           if [ -z "$(git status --porcelain)" ]; then


### PR DESCRIPTION
Just like we do in https://github.com/remix-run/examples

https://github.com/remix-run/examples/blob/8c122f535a345c35400e06b77de0628b53342200/.github/workflows/format.yml#L42-L43