### PR TITLE
bug: Cookies incorrectly set via return json on LoaderFunction when also set on root LoaderFunction

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -100,6 +100,7 @@
 - danielweinmann
 - davecalnan
 - davecranwell-vocovo
+- davidmytton
 - DavidHollins6
 - davongit
 - Deanmv

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -108,7 +108,6 @@ test.beforeAll(async () => {
             // a Cookie from createCookie or the CookieOptions to create one
             cookie: {
               name: "__session",
-
               httpOnly: true,
               maxAge: 60,
               path: "/",

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -188,10 +188,9 @@ test.beforeAll(async () => {
           const session = await getSession(request.headers.get("Cookie"));
 
           const message = session.get("globalMessage") || null;
-          const csrf = session.get("csrf") || null;
 
           return json(
-            { message, csrf },
+            { message },
             {
               headers: {
                 "Set-Cookie": await commitSession(session),


### PR DESCRIPTION
### Remix version

1.7.2

### Description

A CSRF token is generated in the root `LoaderFunction` and then set on the default app context in `root.tsx`. This is used in a form input field and checked as part of the `ActionFunction`.  The `ActionFunction` also sets a `flash` session value which is then read by the `LoaderFunction`. The call to `json()` in the `LoaderFunction` returns the `Set-Cookie` headers to remove the flash session value ([as per the Remix docs](https://remix.run/docs/en/v1/api/remix#sessionflashkey-value)).

This appears to be related to https://github.com/remix-run/remix/issues/231#issuecomment-1218371334

An example project with this reproduced is also at https://github.com/davidmytton/remix-cookie-bug-example

### Expected result

Every time the form is submitted, the CSRF token is validated and the form submit happens correctly.

### What actually happens

The first form submit succeeds, but the regenerated CSRF token is not correctly stored in the session so a subsequent submit fails with a CSRF error.

This is "fixed" by changing the `LoaderFunction` return from:

```typescript
return json(
    { message },
    {
      headers: {
        "Set-Cookie": await commitSession(session),
      },
    }
  );
```

to remove the header:

```typescript
return json({ message });
```

However, this means the flash session value doesn't get removed.
