### PR TITLE
chore(templates): convert all `.eslintrc` files to JS

### DIFF
--- a/packages/remix-server-runtime/__tests__/.eslintrc
+++ b/packages/remix-server-runtime/__tests__/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "rules": {
-    "no-restricted-globals": "off",
-    "import/no-nodejs-modules": "off"
-  }
-}

--- a/packages/remix-server-runtime/__tests__/.eslintrc.js
+++ b/packages/remix-server-runtime/__tests__/.eslintrc.js
@@ -1,0 +1,7 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  rules: {
+    "no-restricted-globals": "off",
+    "import/no-nodejs-modules": "off",
+  },
+};

--- a/templates/arc/.eslintrc
+++ b/templates/arc/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": ["@remix-run/eslint-config", "@remix-run/eslint-config/node"]
-}

--- a/templates/arc/.eslintrc.js
+++ b/templates/arc/.eslintrc.js
@@ -1,0 +1,4 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  extends: ["@remix-run/eslint-config", "@remix-run/eslint-config/node"],
+};

--- a/templates/cloudflare-pages/.eslintrc
+++ b/templates/cloudflare-pages/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": ["@remix-run/eslint-config"]
-}

--- a/templates/cloudflare-pages/.eslintrc.js
+++ b/templates/cloudflare-pages/.eslintrc.js
@@ -1,0 +1,4 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  extends: ["@remix-run/eslint-config", "@remix-run/eslint-config/node"],
+};

--- a/templates/cloudflare-workers/.eslintrc
+++ b/templates/cloudflare-workers/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": ["@remix-run/eslint-config"]
-}

--- a/templates/cloudflare-workers/.eslintrc.js
+++ b/templates/cloudflare-workers/.eslintrc.js
@@ -1,0 +1,4 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  extends: ["@remix-run/eslint-config", "@remix-run/eslint-config/node"],
+};

--- a/templates/express/.eslintrc
+++ b/templates/express/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": ["@remix-run/eslint-config", "@remix-run/eslint-config/node"]
-}

--- a/templates/express/.eslintrc.js
+++ b/templates/express/.eslintrc.js
@@ -1,0 +1,4 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  extends: ["@remix-run/eslint-config", "@remix-run/eslint-config/node"],
+};

--- a/templates/fly/.eslintrc
+++ b/templates/fly/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": ["@remix-run/eslint-config", "@remix-run/eslint-config/node"]
-}

--- a/templates/fly/.eslintrc.js
+++ b/templates/fly/.eslintrc.js
@@ -1,0 +1,4 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  extends: ["@remix-run/eslint-config", "@remix-run/eslint-config/node"],
+};

--- a/templates/netlify/.eslintrc
+++ b/templates/netlify/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": ["@remix-run/eslint-config", "@remix-run/eslint-config/node"]
-}

--- a/templates/netlify/.eslintrc.js
+++ b/templates/netlify/.eslintrc.js
@@ -1,0 +1,4 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  extends: ["@remix-run/eslint-config", "@remix-run/eslint-config/node"],
+};

--- a/templates/remix/.eslintrc
+++ b/templates/remix/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": ["@remix-run/eslint-config", "@remix-run/eslint-config/node"]
-}

--- a/templates/remix/.eslintrc.js
+++ b/templates/remix/.eslintrc.js
@@ -1,0 +1,4 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  extends: ["@remix-run/eslint-config", "@remix-run/eslint-config/node"],
+};

--- a/templates/vercel/.eslintrc
+++ b/templates/vercel/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": ["@remix-run/eslint-config", "@remix-run/eslint-config/node"]
-}

--- a/templates/vercel/.eslintrc.js
+++ b/templates/vercel/.eslintrc.js
@@ -1,0 +1,4 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  extends: ["@remix-run/eslint-config", "@remix-run/eslint-config/node"],
+};


### PR DESCRIPTION
ESLint has a new flat config feature (which is going to be the default in v9 or v10), which [requires a JS config file](https://eslint.org/blog/2022/08/new-config-system-part-2/#the-new-config-file%3A-eslint.config.js)

https://eslint.org/blog/2022/08/new-config-system-part-1
https://eslint.org/blog/2022/08/new-config-system-part-2
https://eslint.org/blog/2022/08/new-config-system-part-3