### PR TITLE
feat(remix-dev): add additional package export conditions

### DIFF
--- a/.changeset/kind-files-destroy.md
+++ b/.changeset/kind-files-destroy.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": minor
+---
+
+Adding support for the "development" and "production" package export conditions.

--- a/contributors.yml
+++ b/contributors.yml
@@ -126,6 +126,7 @@
 - fgiuliani
 - fishel-feng
 - francisudeji
+- frehner
 - frontsideair
 - fx109138
 - gabimor

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -388,6 +388,9 @@ async function createBrowserBuild(
     jsx: "automatic",
     jsxDev: options.mode !== BuildMode.Production,
     plugins,
+    conditions: [
+      options.mode === BuildMode.Production ? "production" : "development",
+    ],
   });
 }
 
@@ -429,6 +432,9 @@ function createServerBuild(
     plugins.unshift(NodeModulesPolyfillPlugin());
   }
 
+  let conditionsMode =
+    options.mode === BuildMode.Production ? "production" : "development";
+
   return esbuild
     .build({
       absWorkingDir: config.rootDirectory,
@@ -437,10 +443,10 @@ function createServerBuild(
       outfile: config.serverBuildPath,
       write: false,
       conditions: isCloudflareRuntime
-        ? ["worker"]
+        ? ["worker", conditionsMode]
         : isDenoRuntime
-        ? ["deno", "worker"]
-        : undefined,
+        ? ["deno", "worker", conditionsMode]
+        : [conditionsMode],
       platform: config.serverPlatform,
       format: config.serverModuleFormat,
       treeShaking: true,


### PR DESCRIPTION
Adding support for the "development" and "production" package export conditions, which are currently encouraged/supported by webpack, Vite, and NodeJS. 

`BuildMode.Test` would mean `"development"`, but let me know if you agree with that or not. 

I set this changeset as a minor, but if you want it to be a patch, let me know and I'll update that too!

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

Added a new integration test in `compiler-test.ts`. However, the current fixture setup only compiles the app in `"production"` mode, so I only tested that condition. 

I'm willing to add an additional test for the `"development"` condition, but that would probably require a bit of rework/additions to `createFixture()`, `createAppFixture()`, etc., and I wasn't sure if you all wanted to go that far or not. 