### PR TITLE
feat(revalidate): add special response to send revalidation data on mutations

### DIFF
--- a/packages/remix-node/index.ts
+++ b/packages/remix-node/index.ts
@@ -41,6 +41,7 @@ export {
   isCookie,
   isSession,
   json,
+  revalidate,
   JsonFunction,
   MaxPartSizeExceededError,
   redirect,

--- a/packages/remix-react/data.ts
+++ b/packages/remix-react/data.ts
@@ -30,6 +30,13 @@ export function isRedirectResponse(response: any): boolean {
   );
 }
 
+export function isRevalidatedResponse(response: any): boolean {
+  return (
+    response instanceof Response &&
+    response.headers.get("X-Remix-Revalidated") != null
+  );
+}
+
 export async function fetchData(
   url: URL,
   routeId: string,

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -9,8 +9,10 @@ import {
   fetchData,
   isCatchResponse,
   isRedirectResponse,
+  isRevalidatedResponse,
 } from "./data";
 import type { Submission } from "./transition";
+import { Revalidated } from "./transition";
 import { CatchValue, TransitionRedirect } from "./transition";
 import { prefetchStyleLinks } from "./links";
 import invariant from "./invariant";
@@ -192,6 +194,10 @@ function createAction(route: EntryRoute, routeModules: RouteModules) {
 
     let redirect = await checkRedirect(result);
     if (redirect) return redirect;
+
+    if (isRevalidatedResponse(result)) {
+      return new Revalidated(result);
+    }
 
     await loadRouteModuleWithBlockingLinks(route, routeModules);
 

--- a/packages/remix-server-runtime/responses.ts
+++ b/packages/remix-server-runtime/responses.ts
@@ -3,6 +3,11 @@ export type JsonFunction = <Data extends unknown>(
   init?: number | ResponseInit
 ) => TypedResponse<Data>;
 
+export type RevalidateFunction = <Data extends unknown>(
+  data?: Data,
+  init?: number | ResponseInit
+) => TypedResponse<Data>;
+
 // must be a type since this is a subtype of response
 // interfaces must conform to the types they extend
 export type TypedResponse<T extends unknown = unknown> = Response & {
@@ -27,6 +32,15 @@ export const json: JsonFunction = (data, init = {}) => {
     ...responseInit,
     headers,
   });
+};
+
+export const revalidate: RevalidateFunction = (data, init = {}) => {
+  let responseInit = typeof init === "number" ? { status: init } : init;
+
+  let headers = new Headers(responseInit.headers);
+  headers.set("X-Remix-Revalidate", "true");
+
+  return json(data, init);
 };
 
 export type RedirectFunction = (
@@ -74,4 +88,8 @@ export function isRedirectResponse(response: Response): boolean {
 
 export function isCatchResponse(response: Response) {
   return response.headers.get("X-Remix-Catch") != null;
+}
+
+export function isRevalidateResponse(response: Response) {
+  return response.headers.get("X-Remix-Revalidate") != null;
 }

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -15,7 +15,12 @@ import type { RouteMatch } from "./routeMatching";
 import { matchServerRoutes } from "./routeMatching";
 import type { ServerRoute } from "./routes";
 import { createStaticHandlerDataRoutes, createRoutes } from "./routes";
-import { json, isRedirectResponse, isCatchResponse } from "./responses";
+import {
+  json,
+  isRedirectResponse,
+  isCatchResponse,
+  isRevalidateResponse,
+} from "./responses";
 import { createServerHandoffString } from "./serverHandoff";
 
 export type RequestHandler = (
@@ -177,6 +182,37 @@ async function handleDataRequest({
         routeId: match.route.id,
         params: match.params,
         request,
+      });
+    }
+
+    if (isRevalidateResponse(response)) {
+      let routeLoaderResults = await Promise.allSettled(
+        matches.map((match) =>
+          match.route.module.loader
+            ? callRouteLoader({
+                loadContext,
+                loader: match.route.module.loader,
+                routeId: match.route.id,
+                params: match.params,
+                request,
+              }).then((r) => r.json())
+            : Promise.resolve(undefined)
+        )
+      );
+      let data: { loaders: Record<string, unknown>; fetcher: unknown } = {
+        loaders: {},
+        fetcher: await extractData(response),
+      };
+      for (let index = 0; index < routeLoaderResults.length; index++) {
+        let result = routeLoaderResults[index];
+        let routeId = matches[index].route.id;
+        data.loaders[routeId] =
+          result.status === "fulfilled" ? result.value : null;
+      }
+      return json(data, {
+        headers: {
+          "X-Remix-Revalidated": "true",
+        },
       });
     }
 


### PR DESCRIPTION
Hey, I was looking at this:

<img width="938" alt="image" src="https://user-images.githubusercontent.com/1500684/193799522-eba6ffb6-d1b8-49eb-81df-862be47b7959.png">

And thought it would be better if it could look like this:

<img width="940" alt="image" src="https://user-images.githubusercontent.com/1500684/193799553-2c086755-b5c1-45ea-9512-b670b4567503.png">

The idea is simple, have the mutation response include revalidation data. This could speed up revalidation by a *lot* for most use cases.

Here's a quick video demonstrating what this does:

https://user-images.githubusercontent.com/1500684/193799965-34b03519-6293-485e-8cd6-46242b9e2269.mp4

The API for this is simple:

```tsx
export async function action({ request }: ActionArgs) {
  const formData = await request.formData();
  const title = formData.get("title");
  invariant(typeof title === "string", "title must be a string");
  await db.createTodo({ title });
  return revalidate(); // <-- this is all actions need to do to trigger revalidation of all applicable loaders
}
```

`revalidate` accepts `data` which will be used for the fetcher's `data` property and ResponseInit.

My implementation is missing a bunch of stuff. I just spent a few minutes working on this to play around with the idea and make sure it would work. Feel free to close the PR and re-implement it correctly if you'd like.

Let me know what you think!