### PR TITLE
fix: preload manifest

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -867,6 +867,11 @@ import(${JSON.stringify(manifest.entry.module)});`;
     <>
       <link
         rel="modulepreload"
+        href={manifest.url}
+        crossOrigin={props.crossOrigin}
+      />
+      <link
+        rel="modulepreload"
         href={manifest.entry.module}
         crossOrigin={props.crossOrigin}
       />


### PR DESCRIPTION
Fixes a regression where the manifest was not preloaded. This is omre of an issue now than before as we now dynamically import the manifest to avoid race contitions of async script tags

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
