### PR TITLE
feat(remix-dev/cli): add `--debug-binding` flag

### DIFF
--- a/docs/other-api/dev.md
+++ b/docs/other-api/dev.md
@@ -80,9 +80,12 @@ The same as `watch`, but also boots the [Remix App Server][remix-app-server] in 
 remix dev
 ```
 
-### `remix dev --debug`
+### `remix dev --debug [--debug-binding]`
 
-Attaches a [Node inspector][node-inspector] to develop your app in debug mode.
+Attaches a [Node inspector][node-inspector] to develop your app in debug 
+mode. By default, the host is set to `127.0.0.1` and the port is set to 
+`9229`. Using the `--debug-binding` allows you to set a custom host and port.
+For example, `remix dev --debug --debug-binding 0.0.0.0:9229`.
 
 ### `remix dev --port`
 

--- a/packages/remix-dev/__tests__/cli-test.ts
+++ b/packages/remix-dev/__tests__/cli-test.ts
@@ -114,6 +114,7 @@ describe("remix CLI", () => {
             --sourcemap         Generate source maps for production
           \`dev\` Options:
             --debug             Attach Node.js inspector
+            --debug-binding     Choose the Node.js inspector host and port
             --port, -p          Choose the port from which to run your app
           \`init\` Options:
             --no-delete         Skip deleting the \`remix.init\` script
@@ -169,6 +170,7 @@ describe("remix CLI", () => {
             $ remix dev
             $ remix dev my-app
             $ remix dev --debug
+            $ remix dev --debug-binding 0.0.0.0:9229
 
           Start your server separately and watch for changes:
 

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -148,6 +148,7 @@ async function dev(
     appServerPort?: number;
   }
 ) {
+  console.log("-----DEV FUNCTION------");
   if (!process.env.NODE_ENV) process.env.NODE_ENV = "development";
 
   if (flags.debug) {
@@ -158,7 +159,10 @@ async function dev(
       inspector.open();
     }
   }
-  await commands.dev(projectDir, process.env.NODE_ENV, flags);
+  await commands.dev(projectDir, process.env.NODE_ENV, {
+    port: flags.port,
+    appServerPort: flags.appServerPort,
+  });
 }
 
 /**


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [x] Docs
- [x] Tests

My preference would be to make `--debug` accept an optional value as described here: https://github.com/remix-run/remix/issues/4216#issuecomment-1253134476. However, I was not able to figure how to make that work. I've tried making it a string instead of boolean, but it is rejected when no value is provided. I also tried creating a custom handler, with the same result. If anyone has a suggestion on how to approach that, please let me know. There is currently an open issue about this for the `arg` package: https://github.com/vercel/arg/issues/61#issue-1191180455.


Testing Strategy:

- Tested out different combinations of using the `--debug-binding` flag using a playground, including:
  - `remix dev --debug` (default)
  - `remix dev --debug --debug-binding 0:0:0:0:9229` 
  -  `remix dev --debug --debug-binding 0:0:0:0`
  - `remix dev --debug-binding 0:0:0:0:9229` (shouldn't load debug at all)
 - Ran `yarn test` and all tests passed

 

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
