### PR TITLE
fix(create-remix): Allow private GitHub repos to use the latest release url for tarballs

### DIFF
--- a/.changeset/tame-hotels-attack.md
+++ b/.changeset/tame-hotels-attack.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/dev": patch
+---
+
+Allow private GitHub repos to use the latest release url for tarballs when using `create-remix`

--- a/contributors.yml
+++ b/contributors.yml
@@ -195,6 +195,7 @@
 - jodygeraldo
 - joelazar
 - johannesbraeunig
+- johnmberger
 - johnpolacek
 - johnson444
 - joms

--- a/docs/other-api/dev.md
+++ b/docs/other-api/dev.md
@@ -40,6 +40,7 @@ remix create ./my-app --template :username/:repo
 remix create ./my-app --template https://github.com/:username/:repo
 remix create ./my-app --template https://github.com/:username/:repo/tree/:branch
 remix create ./my-app --template https://github.com/:username/:repo/archive/refs/tags/:tag.tar.gz
+remix create ./my-app --template https://github.com/:username/:repo/releases/latest/download/:tag.tar.gz
 remix create ./my-app --template https://example.com/remix-template.tar.gz
 ```
 

--- a/packages/remix-dev/__tests__/create-test.ts
+++ b/packages/remix-dev/__tests__/create-test.ts
@@ -260,38 +260,13 @@ describe("the create command", () => {
     );
   });
 
-  it("succeeds for links to latest private github release tarballs when including token", async () => {
-    let projectDir = await getProjectDir(
-      "latest-private-release-tarball-with-token"
-    );
-    await run([
-      "create",
-      projectDir,
-      "--template",
-      "https://github.com/private-org/private-repo/releases/latest/download/stack.tar.gz",
-      "--no-install",
-      "--typescript",
-      "--token",
-      "valid-token",
-    ]);
-    expect(output.trim()).toBe(
-      getOptOutOfInstallMessage() +
-        "\n\n" +
-        getSuccessMessage(
-          path.join("<TEMP_DIR>", "latest-private-release-tarball-with-token")
-        )
-    );
-    expect(fse.existsSync(path.join(projectDir, "package.json"))).toBeTruthy();
-    expect(fse.existsSync(path.join(projectDir, "app/root.tsx"))).toBeTruthy();
-  });
-
   it("succeeds for private github release tarballs when including token", async () => {
     let projectDir = await getProjectDir("private-release-tarball-with-token");
     await run([
       "create",
       projectDir,
       "--template",
-      "https://example.com/remix-stack.tar.gz",
+      "https://github.com/private-org/private-repo/releases/download/v0.0.1/stack.tar.gz",
       "--no-install",
       "--typescript",
       "--token",

--- a/packages/remix-dev/__tests__/create-test.ts
+++ b/packages/remix-dev/__tests__/create-test.ts
@@ -260,6 +260,31 @@ describe("the create command", () => {
     );
   });
 
+  it("succeeds for links to latest private github release tarballs when including token", async () => {
+    let projectDir = await getProjectDir(
+      "latest-private-release-tarball-with-token"
+    );
+    await run([
+      "create",
+      projectDir,
+      "--template",
+      "https://github.com/private-org/private-repo/releases/latest/download/stack.tar.gz",
+      "--no-install",
+      "--typescript",
+      "--token",
+      "valid-token",
+    ]);
+    expect(output.trim()).toBe(
+      getOptOutOfInstallMessage() +
+        "\n\n" +
+        getSuccessMessage(
+          path.join("<TEMP_DIR>", "latest-private-release-tarball-with-token")
+        )
+    );
+    expect(fse.existsSync(path.join(projectDir, "package.json"))).toBeTruthy();
+    expect(fse.existsSync(path.join(projectDir, "app/root.tsx"))).toBeTruthy();
+  });
+
   it("succeeds for private github release tarballs when including token", async () => {
     let projectDir = await getProjectDir("private-release-tarball-with-token");
     await run([

--- a/packages/remix-dev/cli/create.ts
+++ b/packages/remix-dev/cli/create.ts
@@ -300,10 +300,14 @@ async function downloadAndExtractTarball(
     // asset id
     let info = getGithubReleaseAssetInfo(url);
     headers.Accept = "application/vnd.github.v3+json";
-    let response = await fetch(
-      `https://api.github.com/repos/${info.owner}/${info.name}/releases/tags/${info.tag}`,
-      { headers }
-    );
+
+    let releaseUrl =
+      info.tag === "latest"
+        ? `https://api.github.com/repos/${info.owner}/${info.name}/releases/latest`
+        : `https://api.github.com/repos/${info.owner}/${info.name}/releases/tags/${info.tag}`;
+
+    let response = await fetch(releaseUrl, { headers });
+
     if (response.status !== 200) {
       throw Error(
         "🚨 There was a problem fetching the file from GitHub. The request " +
@@ -311,9 +315,13 @@ async function downloadAndExtractTarball(
       );
     }
     let body = await response.json();
-    let assetId: number | undefined = body?.assets?.find(
-      (a: any) => a?.browser_download_url === url
-    )?.id;
+    // If the release is "latest", the url won't match the download url, so we grab the id from the response
+    let assetId: number | undefined =
+      info.tag === "latest"
+        ? body?.assets?.find((a: any) =>
+            a?.browser_download_url?.includes(info.asset)
+          )?.id
+        : body?.assets?.find((a: any) => a?.browser_download_url === url)?.id;
     if (!assetId) {
       throw Error(
         "🚨 There was a problem fetching the file from GitHub. No asset was " +
@@ -424,8 +432,16 @@ function getGithubUrl(info: Omit<RepoInfo, "url">) {
 }
 
 function isGithubReleaseAssetUrl(url: string) {
+  /**
+   * Accounts for the following formats:
+   * https://github.com/owner/repository/releases/download/v0.0.1/stack.tar.gz
+   * ~or~
+   * https://github.com/owner/repository/releases/latest/download/stack.tar.gz
+   */
   return (
-    url.startsWith("https://github.com") && url.includes("/releases/download/")
+    url.startsWith("https://github.com") &&
+    (url.includes("/releases/download/") ||
+      url.includes("/releases/latest/download/"))
   );
 }
 interface ReleaseAssetInfo {
@@ -436,17 +452,29 @@ interface ReleaseAssetInfo {
   tag: string;
 }
 function getGithubReleaseAssetInfo(browserUrl: string): ReleaseAssetInfo {
-  // for example, https://github.com/owner/repository/releases/download/v0.0.1/stack.tar.gz
+  /**
+   * https://github.com/owner/repository/releases/download/v0.0.1/stack.tar.gz
+   * ~or~
+   * https://github.com/owner/repository/releases/latest/download/stack.tar.gz
+   */
+
   let url = new URL(browserUrl);
-  let [, owner, name, , , tag, asset] = url.pathname.split("/") as [
+  let [, owner, name, , downloadOrLatest, tag, asset] = url.pathname.split(
+    "/"
+  ) as [
     _: string,
     Owner: string,
     Name: string,
     Releases: string,
-    Download: string,
+    DownloadOrLatest: string,
     Tag: string,
     AssetFilename: string
   ];
+
+  if (downloadOrLatest === "latest" && tag === "download") {
+    // handle the Github URL quirk for latest releases
+    tag = "latest";
+  }
 
   return {
     browserUrl,
@@ -573,7 +601,10 @@ export async function validateTemplate(
       let headers: Record<string, string> = {};
       if (isGithubReleaseAssetUrl(input)) {
         let info = getGithubReleaseAssetInfo(input);
-        apiUrl = `https://api.github.com/repos/${info.owner}/${info.name}/releases/tags/${info.tag}`;
+        apiUrl =
+          info.tag === "latest"
+            ? `https://api.github.com/repos/${info.owner}/${info.name}/releases/latest`
+            : `https://api.github.com/repos/${info.owner}/${info.name}/releases/tags/${info.tag}`;
         headers = {
           Authorization: `token ${options?.githubToken}`,
           Accept: "application/vnd.github.v3+json",
@@ -595,9 +626,17 @@ export async function validateTemplate(
       switch (response.status) {
         case 200:
           if (isGithubReleaseAssetUrl(input)) {
+            let info = getGithubReleaseAssetInfo(input);
             let body = await response.json();
             if (
-              !body?.assets?.some((a: any) => a?.browser_download_url === input)
+              // if a tag is specified, make sure it exists.
+              !body?.assets?.some(
+                (a: any) => a?.browser_download_url === input
+              ) &&
+              // if the latest is specified, make sure there is an asset
+              !body?.assets?.some((a: any) =>
+                a?.browser_download_url?.includes(info.asset)
+              )
             ) {
               throw Error(
                 "🚨 The template file could not be verified. Please double check " +

--- a/packages/remix-dev/cli/create.ts
+++ b/packages/remix-dev/cli/create.ts
@@ -635,7 +635,7 @@ export async function validateTemplate(
               ) &&
               // if the latest is specified, make sure there is an asset
               !body?.assets?.some((a: any) =>
-                a?.browser_download_url?.includes(info.asset)
+                a?.browser_download_url.includes(info.asset)
               )
             ) {
               throw Error(


### PR DESCRIPTION
Closes: #4328

- [x] Docs
- [ ] Tests

Testing Strategy:

My main mode of testing was to try this out against a private repo with a stack tarball by running these three permutations:

```sh
# 🟢  new functionality
npx create-remix ./my-project --template https://github.com/<owner>/<repo>/releases/download/v.1.1/stack.tar.gz --token <my-token>

# 🟢  existing functionality
npx create-remix ./my-project --template https://github.com/<owner>/<repo>/releases/download/<version>/stack.tar.gz --token <my-token>

# 🔴 using a non-existent version (should fail)
npx create-remix ./my-project --template https://github.com/<owner>/<repo>/releases/download/<bad version>/stack.tar.gz --token <my-token>

# Verify all existing tests pass
yarn test
```

I attempted unsuccessfully to unit test this, but without spending much more time mocking out github api calls, I wasn't able to write anything worthwhile... happy to revisit if you disagree! I also cleaned up a tertiary test to make more sense. 