### PR TITLE
fix: ensure dev script runs Remix in development

### DIFF
--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -3,8 +3,8 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
-    "dev": "remix build && run-p \"dev:*\"",
-    "dev:node": "cross-env NODE_ENV=development nodemon ./server.js --watch ./server.js",
+    "dev": "cross-env NODE_ENV=development remix build && run-p \"dev:*\"",
+    "dev:node": "nodemon ./server.js --watch ./server.js",
     "dev:remix": "remix watch",
     "start": "cross-env NODE_ENV=production node ./server.js"
   },


### PR DESCRIPTION
## Context

We're building a single Remix codebase to host multiple websites. They share a lot of code, such as components. We launch multiple instances of Remix and instruct each instance to run in a certain "mode". This will make Remix switch between different `appDirectory`.

```js
/** @type {import('@remix-run/dev').AppConfig} */
const invariant = require('tiny-invariant');

invariant(typeof process.env.APP_MODE !== 'undefined', 'APP_MODE environment variable must be set.');

module.exports = {
  ignoredRouteFiles: ['**/.*'],
  appDirectory: `app-${process.env.APP_MODE}`
};
```

During testing of this code I noticed that the error message was not printed. `tiny-invariant` only prints error messages in non-production environments.

So I examined the `dev` script, and noticed that `cross-env` is only called on a subscript. I examined console output when running this command and found:

```console
Building Remix app in production mode...
Error: Error loading Remix config at /path/to/project/remix.config.js
Error: Invariant failed
```

Re-running the command with `APP_MODE` set:

```console
Building Remix app in production mode...
Built in 422ms

Watching Remix app in development mode...
💿 Built in 702ms
```

Note that the first build is `production` and the second is `development`.

I've asked around on Discord but I haven't seen an explanation of why the initial build must be done in production mode. It seems this is an oversight, perhaps.

## Changes

- Moved the `cross-env` command into the parent script.

## Consequences

Console output of `npm run dev` now contains the error message as expected in development mode:

```console
Building Remix app in development mode...
Error: Error loading Remix config at /path/to/project/remix.config.js
Error: Invariant failed: APP_MODE environment variable must be set.
```

Console output of `APP_MODE="something" npm run dev` is now:

```console
Building Remix app in development mode...
Built in 474ms

Watching Remix app in development mode...
💿 Built in 388ms
```

Note `development` is used both times, as expected.
```