### PR TITLE
fix: avoid collisions on pathless routes with indices

### DIFF
--- a/.changeset/stale-spoons-tie.md
+++ b/.changeset/stale-spoons-tie.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Avoid collisions between pathless layout routes and their nested index routes

--- a/integration/conventional-routes-test.ts
+++ b/integration/conventional-routes-test.ts
@@ -50,8 +50,6 @@ test.beforeAll(async () => {
         }
       `,
       "app/routes/nested/__pathless/foo.jsx": js`
-        import { useMatches } from '@remix-run/react';
-
         export default function Foo() {
           return <h1>Foo</h1>;
         }

--- a/integration/conventional-routes-test.ts
+++ b/integration/conventional-routes-test.ts
@@ -1,0 +1,107 @@
+import { test, expect } from "@playwright/test";
+
+import { PlaywrightFixture } from "./helpers/playwright-fixture";
+import type { Fixture, AppFixture } from "./helpers/create-fixture";
+import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
+
+let fixture: Fixture;
+let appFixture: AppFixture;
+
+test.beforeAll(async () => {
+  fixture = await createFixture({
+    files: {
+      "app/root.tsx": js`
+        import { Link, Outlet, Scripts, useMatches } from "@remix-run/react";
+
+        export default function App() {
+          let matches = 'Number of matches: ' + useMatches().length;
+          return (
+            <html lang="en">
+              <body>
+                <nav>
+                  <Link to="/nested">/nested</Link>
+                  <br />
+                  <Link to="/nested/foo">/nested/foo</Link>
+                  <br />
+                </nav>
+                <p>{matches}</p>
+                <Outlet />
+                <Scripts />
+              </body>
+            </html>
+          );
+        }
+      `,
+      "app/routes/nested/index.jsx": js`
+        export default function Index() {
+          return <h1>Index</h1>;
+        }
+      `,
+      "app/routes/nested/__pathless.jsx": js`
+        import { Outlet } from "@remix-run/react";
+
+        export default function Layout() {
+          return (
+            <>
+              <div>Pathless Layout</div>
+              <Outlet />
+            </>
+          );
+        }
+      `,
+      "app/routes/nested/__pathless/foo.jsx": js`
+        import { useMatches } from '@remix-run/react';
+
+        export default function Foo() {
+          return <h1>Foo</h1>;
+        }
+      `,
+    },
+  });
+
+  appFixture = await createAppFixture(fixture);
+});
+
+test.afterAll(async () => appFixture.close());
+
+test.describe("with JavaScript", () => {
+  runTests();
+});
+
+test.describe("without JavaScript", () => {
+  test.use({ javaScriptEnabled: false });
+  runTests();
+});
+
+/**
+ * Routes for this test look like this, for reference for the matches assertions:
+ *
+ * <Routes>
+ *   <Route file="root.jsx">
+ *     <Route path="nested" file="routes/nested/__pathless.jsx">
+ *       <Route path="foo" file="routes/nested/__pathless/foo.jsx" />
+ *     </Route>
+ *     <Route path="nested" index file="routes/nested/index.jsx" />
+ *     <Route index file="routes/index.jsx" />
+ *   </Route>
+ * </Routes>
+ */
+
+function runTests() {
+  test("displays index page and not pathless layout page", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/nested");
+    expect(await app.getHtml()).toMatch("Index");
+    expect(await app.getHtml()).not.toMatch("Pathless Layout");
+    expect(await app.getHtml()).toMatch("Number of matches: 2");
+  });
+
+  test("displays page inside of pathless layout", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/nested/foo");
+    expect(await app.getHtml()).not.toMatch("Index");
+    expect(await app.getHtml()).toMatch("Pathless Layout");
+    expect(await app.getHtml()).toMatch("Foo");
+    expect(await app.getHtml()).toMatch("Number of matches: 3");
+  });
+}

--- a/packages/remix-dev/config/routesConvention.ts
+++ b/packages/remix-dev/config/routesConvention.ts
@@ -188,6 +188,8 @@ export function createRoutePath(partialRouteId: string): string | undefined {
 
   if (rawSegmentBuffer === "index" && result.endsWith("index")) {
     result = result.replace(/\/?index$/, "");
+  } else {
+    result = result.replace(/\/$/, "");
   }
 
   return result || undefined;


### PR DESCRIPTION
This is a drastically simpler approach to fix #3014 than the one I originally proposed in #3986, since it turns out `index` routes with `path`'s _are_ valid in react-router's matching algorithm (see https://github.com/remix-run/react-router/pull/8151).  They effectively serve as a shorthand to avoid adding the nested `index` under the `path` route.

Therefore, it turns out that the underlying issue here was just the inadvertent trailing slash generated by `defineConventionalRoutes`.

For the following `routes/` folder:

```
routes/
  nested/
    __pathless/
      foo.jsx
    __pathless.jsx
   index.jsx
```

We were generating a route tree of:

```jsx
<Routes>
  <Route file="root.jsx">
    <Route path="nested/" file="routes/nested/__pathless.jsx">
      <Route path="foo" file="routes/nested/__pathless/foo.jsx" />
    </Route>
    <Route path="nested" index file="routes/nested/index.jsx" />
    <Route index file="routes/index.jsx" />
  </Route>
</Routes>
```

Notice the trailing slash on the pathless layout route, which was causing it to score higher due to the segment score since `path.split('/')` produced an empty segment at the end.  We just need to also trim trailing slashes from our generated non-index paths and get the following route tree which scores correctly and ranks the index route higher:

```jsx
<Routes>
  <Route file="root.jsx">
    <Route path="nested" file="routes/nested/__pathless.jsx">
      <Route path="foo" file="routes/nested/__pathless/foo.jsx" />
    </Route>
    <Route path="nested" index file="routes/nested/index.jsx" />
    <Route index file="routes/index.jsx" />
  </Route>
</Routes>
```

Closes: #3014

- [x] Tests

Testing Strategy: `yarn test:integration conventional-routes`
