### PR TITLE
test: expand test coverage around forms

### DIFF
--- a/integration/helpers/playwright-fixture.ts
+++ b/integration/helpers/playwright-fixture.ts
@@ -264,6 +264,7 @@ async function doAndWait(
   page.on("request", onRequest);
   page.on("requestfinished", onRequestDone);
   page.on("requestfailed", onRequestDone);
+  page.on("load", networkSettledCallback); // e.g. navigation with javascript disabled
 
   let timeoutId: NodeJS.Timer | undefined;
   if (DEBUG) {
@@ -287,6 +288,7 @@ async function doAndWait(
   page.removeListener("request", onRequest);
   page.removeListener("requestfinished", onRequestDone);
   page.removeListener("requestfailed", onRequestDone);
+  page.removeListener("load", networkSettledCallback);
 
   if (DEBUG && timeoutId) {
     clearTimeout(timeoutId);


### PR DESCRIPTION
Expand test coverage around forms:

* Rework all form tests to run both with and without JavaScript. This way we can better detect/prevent regressions or inconsistencies between how `<form>` and `<Form>` work.
* Dedup and expand form method tests to ensure we cover all supported Form `method`s and submitter `formMethod`s
* Expand coverage around form serialization (tree order, image submit buttons, files in URL-encoded payloads)
* Conditionally mark tests as failing (via [`test.fail`](https://playwright.dev/docs/api/class-test#test-fail-1)):
   * Non-get/post `<Form>` methods with JavaScript disabled (#4420)
   * Form serialization problems with JavaScript enabled (#4342)

References: #4342

- [x] Tests