### PR TITLE
fix: Ignore pathless layout routes when matching actions

### DIFF
--- a/.changeset/stupid-games-build.md
+++ b/.changeset/stupid-games-build.md
@@ -1,0 +1,6 @@
+---
+"@remix-run/react": patch
+"@remix-run/server-runtime": patch
+---
+
+Ignore pathless layout routes in action matches

--- a/integration/abort-signal-test.ts
+++ b/integration/abort-signal-test.ts
@@ -15,14 +15,12 @@ test.beforeAll(async () => {
         import { useActionData, useLoaderData, Form } from "@remix-run/react";
 
         export async function action ({ request }) {
-          console.log('action request.signal', request.signal)
           // New event loop causes express request to close
           await new Promise(r => setTimeout(r, 0));
           return json({ aborted: request.signal.aborted });
         }
 
         export function loader({ request }) {
-          console.log('loader request.signal', request.signal)
           return json({ aborted: request.signal.aborted });
         }
 

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -3,6 +3,7 @@ import { test, expect } from "@playwright/test";
 import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
 import type { Fixture, AppFixture } from "./helpers/create-fixture";
 import { getElement, PlaywrightFixture } from "./helpers/playwright-fixture";
+import { ServerMode } from "@remix-run/server-runtime/mode";
 
 test.describe("Forms", () => {
   let fixture: Fixture;
@@ -398,6 +399,47 @@ test.describe("Forms", () => {
                 <pre>{data}</pre>
               </Form>
             )
+          }
+        `,
+
+        "app/routes/pathless-layout-parent.jsx": js`
+          import { json } from '@remix-run/server-runtime'
+          import { Form, Outlet, useActionData } from '@remix-run/react'
+
+          export async function action({ request }) {
+            return json({ submitted: true });
+          }
+          export default function () {
+            let data = useActionData();
+            return (
+              <>
+                <Form method="post">
+                  <h1>Pathless Layout Parent</h1>
+                  <button type="submit">Submit</button>
+                </Form>
+                <Outlet />
+                <p>{data?.submitted === true ? 'Submitted - Yes' : 'Submitted - No'}</p>
+              </>
+            );
+          }
+        `,
+
+        "app/routes/pathless-layout-parent/__pathless.jsx": js`
+          import { Outlet } from '@remix-run/react';
+
+          export default function () {
+            return (
+              <>
+                <h2>Pathless Layout</h2>
+                <Outlet />
+              </>
+            );
+          }
+        `,
+
+        "app/routes/pathless-layout-parent/__pathless/index.jsx": js`
+          export default function () {
+            return <h3>Pathless Layout Index</h3>
           }
         `,
       },
@@ -942,5 +984,25 @@ test.describe("Forms", () => {
         `<pre>tasks=first&amp;tasks=second&amp;tasks=</pre>`
       );
     }
+  });
+
+  test("pathless layout routes are ignored in form actions", async ({
+    page,
+  }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/pathless-layout-parent");
+    let html = await app.getHtml();
+    expect(html).toMatch("Pathless Layout Parent");
+    expect(html).toMatch("Pathless Layout ");
+    expect(html).toMatch("Pathless Layout Index");
+
+    let el = getElement(html, `form`);
+    expect(el.attr("action")).toMatch("/pathless-layout-parent");
+
+    expect(await app.getHtml()).toMatch("Submitted - No");
+    // This submission should ignore the index route and the pathless layout
+    // route above it and hit the action in routes/pathless-layout-parent.jsx
+    await app.clickSubmitButton("/pathless-layout-parent");
+    expect(await app.getHtml()).toMatch("Submitted - Yes");
   });
 });

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -3,7 +3,6 @@ import { test, expect } from "@playwright/test";
 import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
 import type { Fixture, AppFixture } from "./helpers/create-fixture";
 import { getElement, PlaywrightFixture } from "./helpers/playwright-fixture";
-import { ServerMode } from "@remix-run/server-runtime/mode";
 
 test.describe("Forms", () => {
   let fixture: Fixture;

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -576,7 +576,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
         invariant(matches, "No matches found");
         if (fetchControllers.has(key)) abortFetcher(key);
 
-        let match = getFetcherRequestMatch(
+        let match = getRequestMatch(
           new URL(href, window.location.href),
           matches
         );
@@ -630,17 +630,22 @@ export function createTransitionManager(init: TransitionManagerInit) {
     return false;
   }
 
-  function getFetcherRequestMatch(
-    url: URL,
-    matches: RouteMatch<ClientRoute>[]
-  ) {
+  function getRequestMatch(url: URL, matches: ClientMatch[]) {
     let match = matches.slice(-1)[0];
 
-    if (!isIndexRequestUrl(url) && match.route.index) {
-      return matches.slice(-2)[0];
+    if (isIndexRequestUrl(url) && match.route.index) {
+      return match;
     }
 
-    return match;
+    return getPathContributingMatches(matches).slice(-1)[0];
+  }
+
+  function getPathContributingMatches(matches: ClientMatch[]) {
+    return matches.filter(
+      (match, index) =>
+        index === 0 ||
+        (!match.route.index && match.route.path && match.route.path.length > 0)
+    );
   }
 
   async function handleActionFetchSubmission(
@@ -1064,14 +1069,10 @@ export function createTransitionManager(init: TransitionManagerInit) {
     // to run on layout/index routes.  We do not want to mutate the eventual
     // matches used for revalidation
     let actionMatches = matches;
-    if (
-      !isIndexRequestUrl(createUrl(submission.action)) &&
-      actionMatches[matches.length - 1].route.index
-    ) {
-      actionMatches = actionMatches.slice(0, -1);
-    }
-
-    let leafMatch = actionMatches.slice(-1)[0];
+    let leafMatch = getRequestMatch(
+      createUrl(submission.action),
+      actionMatches
+    );
     let result = await callAction(submission, leafMatch, controller.signal);
 
     if (controller.signal.aborted) {
@@ -1583,6 +1584,17 @@ function filterMatchesToLoad(
         (location.state as any)?.setCookie)
     );
   });
+}
+
+/**
+ * Filter index and pathless routes when looking for submission targets
+ */
+function getPathContributingMatches(matches: ClientMatch[]) {
+  return matches.filter(
+    (match, index) =>
+      index === 0 ||
+      (!match.route.index && match.route.path && match.route.path.length > 0)
+  );
 }
 
 function isRedirectResult(result: DataResult): result is DataRedirectResult {

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -659,6 +659,7 @@ export function createTransitionManager(init: TransitionManagerInit) {
     return getPathContributingMatches(matches).slice(-1)[0];
   }
 
+  // Filter index and pathless routes when looking for submission targets
   function getPathContributingMatches(matches: ClientMatch[]) {
     return matches.filter(
       (match, index) =>
@@ -1596,17 +1597,6 @@ function filterMatchesToLoad(
         (location.state as any)?.setCookie)
     );
   });
-}
-
-/**
- * Filter index and pathless routes when looking for submission targets
- */
-function getPathContributingMatches(matches: ClientMatch[]) {
-  return matches.filter(
-    (match, index) =>
-      index === 0 ||
-      (!match.route.index && match.route.path && match.route.path.length > 0)
-  );
 }
 
 function isRedirectResult(result: DataResult): result is DataRedirectResult {

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -644,6 +644,11 @@ export function createTransitionManager(init: TransitionManagerInit) {
     return false;
   }
 
+  // Return the correct single match for a route (used for submission
+  // navigations and  and fetchers)
+  // - ?index should try to match the leaf index route
+  // - otherwise it should match the deepest "path contributing" match, which
+  //   ignores index and pathless routes
   function getRequestMatch(url: URL, matches: ClientMatch[]) {
     let match = matches.slice(-1)[0];
 

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -633,11 +633,19 @@ function isIndexRequestUrl(url: URL) {
 function getRequestMatch(url: URL, matches: RouteMatch<ServerRoute>[]) {
   let match = matches.slice(-1)[0];
 
-  if (!isIndexRequestUrl(url) && match.route.id.endsWith("/index")) {
-    return matches.slice(-2)[0];
+  if (isIndexRequestUrl(url) && match.route.id.endsWith("/index")) {
+    return match;
   }
 
-  return match;
+  return getPathContributingMatches(matches).slice(-1)[0];
+}
+
+function getPathContributingMatches(matches: RouteMatch<ServerRoute>[]) {
+  return matches.filter(
+    (match, index) =>
+      index === 0 ||
+      (!match.route.index && match.route.path && match.route.path.length > 0)
+  );
 }
 
 function getDeepestRouteIdWithBoundary(


### PR DESCRIPTION
Same fix as https://github.com/remix-run/react-router/pull/9455 in react router

If you have a route tree of:

```jsx
<Route path="parent" action={...} element={<Parent />}>
  <Route element={<Pathless />}>
    <Route index element={<Index />} />
  </Route>
</Route>
```

And a `<Form method="post">` in `<Parent />` submits, then it should ignore the pathless layout route in the middle and walk upwards to the last path-contributing matches action.


Closes: #2498

- [ ] Docs
- [x] Tests

Testing Strategy: Added integration tests
