### PR TITLE
ci: run integration tests on appropriate platforms

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -71,39 +71,8 @@ jobs:
       - name: 🧪 Run Primary Tests
         run: "yarn test:primary"
 
-  macos-integration:
-    name: "👀 Integration Test: (OS: macos-latest Node: ${{ matrix.node }} Browser: ${{ matrix.browser }})"
-    strategy:
-      fail-fast: false
-      matrix:
-        node: ${{ fromJSON(inputs.node_version) }}
-        browser: ["webkit"]
-
-    runs-on: macos-latest
-    steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.10.0
-
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
-
-      - name: ⎔ Setup node ${{ matrix.node }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node }}
-          cache: "yarn"
-
-      - name: 📥 Install deps
-        run: yarn --frozen-lockfile
-
-      - name: 📥 Install Playwright
-        run: npx playwright install --with-deps
-
-      - name: 👀 Run Integration Tests ${{ matrix.browser }}
-        run: "yarn test:integration --project=${{ matrix.browser }}"
-
   ubuntu-integration:
-    name: "👀 Integration Test: (OS: ubuntu-latest Node: ${{ matrix.node }} Browser: ${{ matrix.browser }})"
+    name: '👀 Integration Test: (OS: "ubuntu-latest" Node: "${{ matrix.node }}" Browser: "${{ matrix.browser }}")'
     strategy:
       fail-fast: false
       matrix:
@@ -133,8 +102,39 @@ jobs:
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         run: "yarn test:integration --project=${{ matrix.browser }}"
 
+  macos-integration:
+    name: '👀 Integration Test: (OS: "macos-latest" Node: "${{ matrix.node }}" Browser: "${{ matrix.browser }}")'
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ${{ fromJSON(inputs.node_version) }}
+        browser: ["webkit"]
+
+    runs-on: macos-latest
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.10.0
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: ⎔ Setup node ${{ matrix.node }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: "yarn"
+
+      - name: 📥 Install deps
+        run: yarn --frozen-lockfile
+
+      - name: 📥 Install Playwright
+        run: npx playwright install --with-deps
+
+      - name: 👀 Run Integration Tests ${{ matrix.browser }}
+        run: "yarn test:integration --project=${{ matrix.browser }}"
+
   windows-integration:
-    name: "👀 Integration Test: (OS: windows-latest Node: ${{ matrix.node }} Browser: ${{ matrix.browser }})"
+    name: '👀 Integration Test: (OS: "windows-latest" Node: "${{ matrix.node }}" Browser: "${{ matrix.browser }}")'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -71,21 +71,77 @@ jobs:
       - name: 🧪 Run Primary Tests
         run: "yarn test:primary"
 
-  integration:
-    name: "👀 Integration Test: (OS: ${{ matrix.stack.os }} Node: ${{ matrix.node }} Browser: ${{ matrix.stack.browser }})"
+  macos-integration:
+    name: "👀 Integration Test: (OS: macos-latest Node: ${{ matrix.node }} Browser: ${{ matrix.browser }})"
     strategy:
       fail-fast: false
       matrix:
         node: ${{ fromJSON(inputs.node_version) }}
-        stack:
-          - os: "ubuntu-latest"
-            browsers: ["chromium", "firefox"] # match the browsers to playwright projects
-          - os: macos-latest
-            browsers: ["webkit"] # match the browsers to playwright projects
-          - os: windows-latest
-            browsers: ["edge"] # match the browsers to playwright projects
+        browser: ["webkit"]
 
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.10.0
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: ⎔ Setup node ${{ matrix.node }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: "yarn"
+
+      - name: 📥 Install deps
+        run: yarn --frozen-lockfile
+
+      - name: 📥 Install Playwright
+        run: npx playwright install --with-deps
+
+      - name: 👀 Run Integration Tests ${{ matrix.browser }}
+        run: "yarn test:integration --project=${{ matrix.browser }}"
+
+  ubuntu-integration:
+    name: "👀 Integration Test: (OS: ubuntu-latest Node: ${{ matrix.node }} Browser: ${{ matrix.browser }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ${{ fromJSON(inputs.node_version) }}
+        browser: ["chromium", "firefox"]
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.10.0
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: ⎔ Setup node ${{ matrix.node }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: "yarn"
+
+      - name: 📥 Install deps
+        run: yarn --frozen-lockfile
+
+      - name: 📥 Install Playwright
+        run: npx playwright install --with-deps
+
+      - name: 👀 Run Integration Tests ${{ matrix.browser }}
+        run: "yarn test:integration --project=${{ matrix.browser }}"
+
+  windows-integration:
+    name: "👀 Integration Test: (OS: windows-latest Node: ${{ matrix.node }} Browser: ${{ matrix.browser }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ${{ fromJSON(inputs.node_version) }}
+        browser: ["edge"]
+
+    runs-on: windows-latest
     steps:
       - name: 🛑 Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.10.0

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -72,19 +72,18 @@ jobs:
         run: "yarn test:primary"
 
   integration:
-    name: "👀 Integration Test: (OS: ${{ matrix.os }} Node: ${{ matrix.node }} Browser: ${{ matrix.browser }})"
+    name: "👀 Integration Test: (OS: ${{ matrix.stack.os }} Node: ${{ matrix.node }} Browser: ${{ matrix.stack.browser }})"
     strategy:
       fail-fast: false
       matrix:
         node: ${{ fromJSON(inputs.node_version) }}
-        os:
-          - ubuntu-latest
-          # - macos-latest
-          - windows-latest
-        browser:
-          - chromium
-          # - firefox
-          - webkit
+        stack:
+          - os: "ubuntu-latest"
+            browsers: ["chromium", "firefox"] # match the browsers to playwright projects
+          - os: macos-latest
+            browsers: ["webkit"] # match the browsers to playwright projects
+          - os: windows-latest
+            browsers: ["edge"] # match the browsers to playwright projects
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/integration/abort-signal-test.ts
+++ b/integration/abort-signal-test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test } from "@playwright/test";
 
 import { PlaywrightFixture } from "./helpers/playwright-fixture";
 import type { Fixture, AppFixture } from "./helpers/create-fixture";
@@ -50,10 +50,11 @@ test.afterAll(async () => appFixture.close());
 test("should not abort the request in a new event loop", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);
   await app.goto("/");
-  expect(await app.getHtml(".action")).toMatch("empty");
-  expect(await app.getHtml(".loader")).toMatch("false");
+  await page.waitForSelector(`.action:has-text("empty")`);
+  await page.waitForSelector(`.loader:has-text("false")`);
 
   await app.clickElement('button[type="submit"]');
-  expect(await app.getHtml(".action")).toMatch("false");
-  expect(await app.getHtml(".loader")).toMatch("false");
+
+  await page.waitForSelector(`.action:has-text("false")`);
+  await page.waitForSelector(`.loader:has-text("false")`);
 });

--- a/integration/action-test.ts
+++ b/integration/action-test.ts
@@ -62,7 +62,7 @@ test.describe("actions", () => {
 
         [`app/routes/${REDIRECT_TARGET}.jsx`]: js`
           export default function () {
-            return <div>${PAGE_TEXT}</div>
+            return <div id="${REDIRECT_TARGET}">${PAGE_TEXT}</div>
           }
         `,
       },
@@ -108,13 +108,11 @@ test.describe("actions", () => {
   test("is called on script transition POST requests", async ({ page }) => {
     let app = new PlaywrightFixture(appFixture, page);
     await app.goto(`/urlencoded`);
-    let html = await app.getHtml("#text");
-    expect(html).toMatch(WAITING_VALUE);
+    await page.waitForSelector(`#text:has-text("${WAITING_VALUE}")`);
 
     await page.click("button[type=submit]");
     await page.waitForSelector("#action-text");
-    html = await app.getHtml("#text");
-    expect(html).toMatch(SUBMITTED_VALUE);
+    await page.waitForSelector(`#text:has-text("${SUBMITTED_VALUE}")`);
   });
 
   test("redirects a thrown response on document requests", async () => {
@@ -131,6 +129,9 @@ test.describe("actions", () => {
     await app.goto(`/${THROWS_REDIRECT}`);
     let responses = app.collectDataResponses();
     await app.clickSubmitButton(`/${THROWS_REDIRECT}`);
+
+    await page.waitForSelector(`#${REDIRECT_TARGET}`);
+
     expect(responses.length).toBe(1);
     expect(responses[0].status()).toBe(204);
 

--- a/integration/helpers/cleanup.mjs
+++ b/integration/helpers/cleanup.mjs
@@ -1,0 +1,14 @@
+import * as path from "path";
+import rimraf from "rimraf";
+
+if (process.env.CI) {
+  console.log("Skipping cleanup in CI");
+  process.exit();
+}
+
+const pathsToRemove = [path.resolve(process.cwd(), ".tmp/integration")];
+
+for (let pathToRemove of pathsToRemove) {
+  console.log(`Removing ${path.relative(process.cwd(), pathToRemove)}`);
+  rimraf.sync(pathToRemove);
+}

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -19,15 +19,19 @@ const config: PlaywrightTestConfig = {
   projects: [
     {
       name: "chromium",
-      use: {
-        ...devices["Desktop Chrome"],
-      },
+      use: devices["Desktop Chrome"],
     },
     {
       name: "webkit",
-      use: {
-        ...devices["Desktop Safari"],
-      },
+      use: devices["Desktop Safari"],
+    },
+    {
+      name: "edge",
+      use: devices["Desktop Edge"],
+    },
+    {
+      name: "firefox",
+      use: devices["Desktop Firefox"],
     },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test": "run-p \"test:*\"",
     "pretest:integration": "yarn build",
     "test:integration": "playwright test --config ./integration/playwright.config.ts",
-    "posttest:integration": "rimraf ./.tmp/integration",
+    "posttest:integration": "node ./integration/helpers/cleanup.mjs",
     "test:primary": "jest",
     "changeset": "changeset",
     "changeset:version": "changeset version",


### PR DESCRIPTION
an alternate approach to this is conditionally setting projects in `integration/playwright.config.ts`, but you lose out on quickly knowing which browser/os failed in the GitHub Actions UI

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
