### PR TITLE
docs(api/remix): fix infinite loop in `useFetcher` example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -48,6 +48,7 @@
 - BenMcH
 - bgschiller
 - binajmen
+- bjacobso
 - bmarvinb
 - bmontalvo
 - bogas04

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -766,7 +766,7 @@ function SomeComponent() {
   useEffect(() => {
     fetcher.submit(data, options);
     fetcher.load(href);
-  }, [fetcher]);
+  }, []);
 
   // build UI with these
   fetcher.state;


### PR DESCRIPTION
I believe this causes an infinite loop because the fetcher is changing, this should instead be on initial mount