### PR TITLE
chore: ensure AbortController installed globally

### DIFF
--- a/packages/remix-node/globals.ts
+++ b/packages/remix-node/globals.ts
@@ -2,6 +2,7 @@ import {
   ReadableStream as NodeReadableStream,
   WritableStream as NodeWritableStream,
 } from "@remix-run/web-stream";
+import { AbortController as NodeAbortController } from "abort-controller";
 
 import { atob, btoa } from "./base64";
 import {
@@ -35,6 +36,8 @@ declare global {
 
       ReadableStream: typeof ReadableStream;
       WritableStream: typeof WritableStream;
+
+      AbortController: typeof AbortController;
     }
   }
 }
@@ -54,4 +57,6 @@ export function installGlobals() {
 
   global.ReadableStream = NodeReadableStream;
   global.WritableStream = NodeWritableStream;
+
+  global.AbortController = global.AbortController || NodeAbortController;
 }


### PR DESCRIPTION
Make sure AbortController is installed globally for node version less than 15.

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

Existing deployment tests will validate the change.
