### PR TITLE
feat(remix-react): add `typeof action` inference to `useFetcher`

### DIFF
--- a/.changeset/witty-kiwis-flow.md
+++ b/.changeset/witty-kiwis-flow.md
@@ -1,0 +1,8 @@
+---
+"remix": patch
+"@remix-run/react": patch
+---
+
+Infer the type of the `.data` property of `useFetcher` from `loader` and `action` functions.
+Similarly to how you can write useLoaderData<typeof loader>. e.g. you can now write useFetcher<typeof action>, and fetcher.data will be inferred correctly.
+Previously, you had to write useFetcher<SerializeFrom<typeof action>>.

--- a/contributors.yml
+++ b/contributors.yml
@@ -294,6 +294,7 @@
 - michaeldebetaz
 - michaeldeboey
 - michaelfriedman
+- michaelhelvey
 - michaseel
 - mikeybinnswebdesign
 - mirzafaizan

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1436,7 +1436,9 @@ export type FetcherWithComponents<TData> = Fetcher<TData> & {
  *
  * @see https://remix.run/api/remix#usefetcher
  */
-export function useFetcher<TData = any>(): FetcherWithComponents<TData> {
+export function useFetcher<TData = any>(): FetcherWithComponents<
+  SerializeFrom<TData>
+> {
   let { transitionManager } = useRemixEntryContext();
 
   let [key] = React.useState(() => String(++fetcherId));
@@ -1446,7 +1448,7 @@ export function useFetcher<TData = any>(): FetcherWithComponents<TData> {
   });
   let submit = useSubmitImpl(key);
 
-  let fetcher = transitionManager.getFetcher<TData>(key);
+  let fetcher = transitionManager.getFetcher<SerializeFrom<TData>>(key);
 
   let fetcherWithComponents = React.useMemo(
     () => ({


### PR DESCRIPTION
**Closes Issue #**: no official issue that I can find, but Kent mentioned in Discord that this would be a good contribution opportunity: https://discord.com/channels/770287896669978684/770287896669978687/1032333166402351154

This PR adds support for inferring the type of the `.data` property of `useFetcher` from loader and action functions, similarly to how you can write `useLoaderData<typeof loader>`.  e.g. you can now write `useFetcher<typeof action>`, and `fetcher.data` will be inferred correctly.  Previously, you had to write `useFetcher<SerializeFrom<typeof action>>`.

**Docs**:

How should this change best be documented?  I struggled to find documentation for the matching changes to `useActionData` and `useLoaderData` outside of the changelog and the `decisions` documentation.

**Testing strategy:**

_If there are more official "type-level" tests for this sort of thing, to automate this testing, please point me in the right direction!  I pattern-matched off of the similar inference that `useActionData` and `useLoaderData` support, and couldn't find any automated tests related to the types._

* I created a new playground by following the instructions in `contributing.md`
*  I noted that before the change the `.data` property of a fetcher (using `useFetcher<typeof action>`) was typed as the action function type, with no inference of the return value.
* I noted that after the change, the return type of the above was correctly inferred as `SerializeObject<UndefinedToOptional<{
    /* action data */
}>> | undefined`