### PR TITLE
feat(remix-dev): Add support for Cloudflare Module Workers

### DIFF
--- a/.changeset/honest-shoes-warn.md
+++ b/.changeset/honest-shoes-warn.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Add support for Cloudflare Module Workers

--- a/contributors.yml
+++ b/contributors.yml
@@ -58,6 +58,7 @@
 - bsharrow
 - bsides
 - bustamantedev
+- buzinas
 - c43721
 - camiaei
 - CanRau

--- a/packages/remix-dev/compiler.ts
+++ b/packages/remix-dev/compiler.ts
@@ -437,6 +437,7 @@ function createServerBuild(
       absWorkingDir: config.rootDirectory,
       stdin,
       entryPoints,
+      external: isCloudflareRuntime ? ["__STATIC_CONTENT_MANIFEST"] : undefined,
       outfile: config.serverBuildPath,
       write: false,
       conditions: isCloudflareRuntime


### PR DESCRIPTION
## What

Closes: #4399

- [ ] Docs
- [ ] Tests

See https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/ for more info about Module Workers and https://github.com/cloudflare/kv-asset-handler#asset_manifest-required-for-es-modules for how to set it up.

Testing Strategy:

This is a patch I've been using locally in order to build for Cloudflare Module Workers. `__STATIC_CONTENT_MANIFEST` module is needed in order to provide it to `handleAsset`.
