### PR TITLE
feat(remix-node): add `getFilePath`& `remove` methods to `NodeOnDiskFile`

### DIFF
--- a/.changeset/flat-cobras-beam.md
+++ b/.changeset/flat-cobras-beam.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/node": minor
+---
+
+Add a "remove" and a "getFilePath" methods to fileUploadHandler

--- a/.changeset/flat-cobras-beam.md
+++ b/.changeset/flat-cobras-beam.md
@@ -2,4 +2,4 @@
 "@remix-run/node": minor
 ---
 
-Add a "remove" and a "getFilePath" methods to fileUploadHandler
+Add "remove" and "getFilePath" methods to fileUploadHandler

--- a/.changeset/flat-cobras-beam.md
+++ b/.changeset/flat-cobras-beam.md
@@ -2,4 +2,4 @@
 "@remix-run/node": minor
 ---
 
-Add "remove" and "getFilePath" methods to fileUploadHandler
+Add `remove` and `getFilePath` methods to `NodeOnDiskFile`

--- a/contributors.yml
+++ b/contributors.yml
@@ -224,6 +224,7 @@
 - juhanakristian
 - JulesBlm
 - juliaqiuxy
+- julienmonnard
 - justinnoel
 - justinsalasdev
 - justinwaite

--- a/packages/remix-node/__tests__/fileUploadHandler-test.ts
+++ b/packages/remix-node/__tests__/fileUploadHandler-test.ts
@@ -104,4 +104,18 @@ describe("NodeOnDiskFile", () => {
     expect(sliced.size).toBe(slicedRes.length);
     expect(await sliced.text()).toBe(slicedRes);
   });
+
+  it("returns the file path properly", async () => {
+    expect(file.getFilePath()).toEqual(filepath);
+  });
+
+  it("removes the file properly", async () => {
+    let newFilePath = `${filepath}-copy`;
+    fs.copyFileSync(filepath, newFilePath);
+
+    let copiedFile = (file = new NodeOnDiskFile(newFilePath, "text/plain"));
+    expect(fs.existsSync(copiedFile.getFilePath())).toBe(true);
+    await copiedFile.remove();
+    expect(fs.existsSync(copiedFile.getFilePath())).toBe(false);
+  });
 });

--- a/packages/remix-node/upload/fileUploadHandler.ts
+++ b/packages/remix-node/upload/fileUploadHandler.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "crypto";
 import { createReadStream, createWriteStream, statSync } from "fs";
-import { rm, mkdir, stat as statAsync } from "fs/promises";
+import { rm, mkdir, stat as statAsync, unlink } from "fs/promises";
 import { tmpdir } from "os";
 import { basename, dirname, extname, resolve as resolvePath } from "path";
 import type { Readable } from "stream";
@@ -230,5 +230,12 @@ export class NodeOnDiskFile implements File {
 
   public get [Symbol.toStringTag]() {
     return "File";
+  }
+
+  remove(): Promise<void> {
+    return unlink(this.filepath);
+  }
+  getFilePath(): string {
+    return this.filepath;
   }
 }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #3021

- [ ] Docs
- [x] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
One unit test for each new function, added in the remix-node package.

This is basically the same PR as #3034, but it got closed by its author before being merged. I believe this is a useful feature and would very much like to see it added.