### PR TITLE
chore(tests): use `intent` instead of `action`

### DIFF
--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -301,7 +301,7 @@ test.describe("Forms", () => {
               <div onClick={(event) => event.stopPropagation()}>
                 <pre>{JSON.stringify(actionData)}</pre>
                 <Form method="post">
-                  <button type="submit" name="action" value="add">Add</button>
+                  <button type="submit" name="intent" value="add">Add</button>
                 </Form>
               </div>
             )
@@ -530,7 +530,7 @@ test.describe("Forms", () => {
       let app = new PlaywrightFixture(appFixture, page);
       await app.goto("/stop-propagation");
       await app.clickSubmitButton("/stop-propagation", { wait: true });
-      expect(await app.getHtml()).toMatch('{"action":"add"}');
+      expect(await app.getHtml()).toMatch('{"intent":"add"}');
     });
 
     test.describe("<Form> action", () => {

--- a/integration/transition-test.ts
+++ b/integration/transition-test.ts
@@ -125,15 +125,15 @@ test.describe("rendering", () => {
         `,
 
         "app/routes/gh-1691.jsx": js`
-          import { redirect } from "@remix-run/node";
-          import { Form, useFetcher, useTransition} from "@remix-run/react";
+          import { json, redirect } from "@remix-run/node";
+          import { useFetcher} from "@remix-run/react";
 
-          export const action = async ({ request }) => {
+          export const action = async ( ) => {
             return redirect("/gh-1691");
           };
 
-          export const loader = async ({ request }) => {
-            return {};
+          export const loader = async () => {
+            return json({});
           };
 
           export default function GitHubIssue1691() {
@@ -144,7 +144,7 @@ test.describe("rendering", () => {
                 <span>{fetcher.state}</span>
                 <fetcher.Form method="post">
                   <input type="hidden" name="source" value="fetcher" />
-                  <button type="submit" name="action" value="add">
+                  <button type="submit" name="intent" value="add">
                     Submit
                   </button>
                 </fetcher.Form>


### PR DESCRIPTION
@kentcdodds switched to `intent` in his learning materials now, as this reduces overloading of the term `action`