### PR TITLE
tests(integration): replace `rimraf` in cleanup

### DIFF
--- a/integration/helpers/cleanup.mjs
+++ b/integration/helpers/cleanup.mjs
@@ -1,5 +1,5 @@
 import * as path from "path";
-import rimraf from "rimraf";
+import spawn from "cross-spawn";
 
 if (process.env.CI) {
   console.log("Skipping cleanup in CI");
@@ -10,5 +10,18 @@ const pathsToRemove = [path.resolve(process.cwd(), ".tmp/integration")];
 
 for (let pathToRemove of pathsToRemove) {
   console.log(`Removing ${path.relative(process.cwd(), pathToRemove)}`);
-  rimraf.sync(pathToRemove);
+  let childProcess;
+  if (process.platform === "win32") {
+    childProcess = spawn("del", ["/s", "/q", pathToRemove], {
+      stdio: "inherit",
+    });
+  } else {
+    childProcess = spawn("rm", ["-rf", pathToRemove], {
+      stdio: "inherit",
+    });
+  }
+  childProcess.on("error", (err) => {
+    console.error(err);
+    process.exit(1);
+  });
 }

--- a/integration/helpers/cleanup.mjs
+++ b/integration/helpers/cleanup.mjs
@@ -12,7 +12,7 @@ for (let pathToRemove of pathsToRemove) {
   console.log(`Removing ${path.relative(process.cwd(), pathToRemove)}`);
   let childProcess;
   if (process.platform === "win32") {
-    childProcess = spawn("del", ["/s", "/q", pathToRemove], {
+    childProcess = spawn("rmdir", ["/s", "/q", pathToRemove], {
       stdio: "inherit",
     });
   } else {


### PR DESCRIPTION
Running `rimraf` after integration tests is really slow. Executing a shell command to remove the temporary directory instead is significantly faster, and I don't believe it should be an issue for this case (though if there's anything I'm missing here, particularly on the Windows side, someone feel free to push back).