### PR TITLE
fix(remix-eslint-config): add `eslint-plugin-import` as peer dependency to prevent conflicts

### DIFF
--- a/packages/remix-eslint-config/package.json
+++ b/packages/remix-eslint-config/package.json
@@ -31,7 +31,6 @@
     "@typescript-eslint/parser": "^5.12.1",
     "eslint-import-resolver-node": "0.3.6",
     "eslint-import-resolver-typescript": "^2.5.0",
-    "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jest": "^26.1.1",
     "eslint-plugin-jest-dom": "^4.0.1",
     "eslint-plugin-jsx-a11y": "^6.5.1",
@@ -45,6 +44,7 @@
   },
   "peerDependencies": {
     "eslint": "^8.0.0",
+    "eslint-plugin-import": "^2.25.4",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "typescript": "^4.0.0"


### PR DESCRIPTION
Closes: #4448
