### PR TITLE
Purge cache on file changes on dev servers

### DIFF
--- a/.changeset/breezy-emus-fetch.md
+++ b/.changeset/breezy-emus-fetch.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Purge cache on file changes on dev servers, in order to prevent every HTTP requests from reloading bundle

--- a/integration/dev-server-test.ts
+++ b/integration/dev-server-test.ts
@@ -1,0 +1,62 @@
+import path from "path";
+import fse from "fs-extra";
+import {test, expect} from "@playwright/test";
+
+import {
+    createFixture,
+    js,
+    createDevServerFixture,
+} from "./helpers/create-fixture";
+import type {Fixture, AppFixture} from "./helpers/create-fixture";
+import {PlaywrightFixture} from "./helpers/playwright-fixture";
+
+const INDEX_PATHS = ["app", "routes", "index.jsx"];
+const INDEX_ORIGINAL_CONTENT = js`
+  export default function Index() {
+    return <div id="index">Hello world!</div>
+  }
+`;
+const INDEX_MODIFIED_CONTENT = js`
+  export default function Index() {
+    return <div id="index">Changed!</div>
+  }
+`;
+
+test.describe("dev server", () => {
+    let fixture: Fixture;
+    let appFixture: AppFixture;
+
+    test.beforeAll(async () => {
+        fixture = await createFixture({
+            setup: "node",
+            files: {
+                [INDEX_PATHS.join("/")]: INDEX_ORIGINAL_CONTENT,
+            },
+        });
+        appFixture = await createDevServerFixture(fixture);
+    });
+
+    test.afterAll(async () => appFixture?.close());
+
+    test("serves ok", async ({page}) => {
+        let app = new PlaywrightFixture(appFixture, page);
+        await app.goto("/", true);
+        expect(await app.getHtml("#index")).toBe('<div id="index">Hello world!</div>');
+    });
+
+    test("live reloads after file changes under app", async ({page}) => {
+        let app = new PlaywrightFixture(appFixture, page);
+        await app.goto("/", true);
+        expect(await app.getHtml("#index")).toBe('<div id="index">Hello world!</div>');
+
+        let filePath = path.join(fixture.projectDir, ...INDEX_PATHS);
+        try {
+            await fse.writeFile(filePath, INDEX_MODIFIED_CONTENT);
+
+            await page.waitForNavigation();
+            expect(await app.getHtml("#index")).toBe('<div id="index">Changed!</div>');
+        } finally {
+            await fse.writeFile(filePath, INDEX_ORIGINAL_CONTENT);
+        }
+    });
+});

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -228,6 +228,7 @@ export async function watch(
     },
     onRebuildFinish() {
       log(`Rebuilt in ${prettyMs(Date.now() - start)}`);
+      purgeAppRequireCache(config.serverBuildPath);
       broadcast({ type: "RELOAD" });
     },
     onFileCreated(file) {
@@ -295,10 +296,6 @@ export async function dev(
 
   let app = express();
   app.disable("x-powered-by");
-  app.use((_, __, next) => {
-    purgeAppRequireCache(config.serverBuildPath);
-    next();
-  });
   app.use(
     createApp(
       config.serverBuildPath,

--- a/templates/express/remix.config.js
+++ b/templates/express/remix.config.js
@@ -1,6 +1,7 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
+  devServerBroadcastDelay: 100,
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",


### PR DESCRIPTION
Closes: -

- [ ] Docs
- [x] Tests

Testing Strategy:

* `remix-dev` (`remix` template): Added `dev-server-test.ts` integration test file to verify live reload works
* `express` template: Tested in my project which is based on remix express template

### Background

For the smooth live reload on dev server, `express` template and `remix dev` commands both has a mechanism to purge cache of server-side bundle built by Remix compiler, named `purgeRequireCache()`. This is currently called for every HTTP request.

```js
function purgeRequireCache() {
  // purge require cache on requests for "server side HMR" this won't let
  // you have in-memory objects between requests in development,
  // alternatively you can set up nodemon/pm2-dev to restart the server on
  // file changes, but then you'll have to reconnect to databases/etc on each
  // change. We prefer the DX of this, so we've included it for you by default
  for (const key in require.cache) {
    if (key.startsWith(BUILD_DIR)) {
      delete require.cache[key];
    }
  }
}
```

```js
app.all(
  "*",
  process.env.NODE_ENV === "development"
    ? (req, res, next) => {
        purgeRequireCache();

        return createRequestHandler({
          build: require(BUILD_DIR),
          mode: process.env.NODE_ENV,
        })(req, res, next);
      }
    : createRequestHandler({
        build: require(BUILD_DIR),
        mode: process.env.NODE_ENV,
      })
);
```

(From [templates/express/server.js](https://github.com/remix-run/remix/blob/5c868dceaa542d0ac61e742f62f7fc08d9f18de2/templates/express/server.js))

### Problem

However, this solution is not scalable in following ways and it's easy to get really slow compared to production builds:

* As the app grows, size of `build/index.js` grows and it takes longer and longer to parse and execute. We don't want to repeat unnecessary re-computation.
  * In my project, `app` directory is 600KB (9.5K lines), and the resulted bundle has 243KB (5K lines).
* As the nested routes get deeper, the purge happens multiple times per one navigation, because one navigation can make multiple requests to loaders for the ancestor routes 
* If we have resource routes which are loaded by a page, then it can create huge amount of HTTP requests, each of which causes the purge as well.

In my project, each HTTP request takes like 400ms, which can easily lead to 1s for page navigation depending on routes.

### Solution
Move purge call from HTTP request handler to...
* `remix-dev`: after build is done, right before sending reload event to browser
* `express` template: after build is done, watched by `chokidar`
  * Browser can be notified to reload and hit server before `chokidar` notifies to purge cache. 100ms delay is added before reload.

I didn't find integration tests for dev server, so I added one to test live reload happens after file changes.

### References
* [My report on Discord](https://discord.com/channels/770287896669978684/1035282927321350257/1035915667876085820)