### PR TITLE
fix(docs): switch to using generic type for useLoaderData

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -409,6 +409,7 @@
 - thomasrettig
 - tjefferson08
 - tombyrer
+- tomcorey26
 - toyozaki
 - turkerdev
 - tvanantwerp

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -223,7 +223,7 @@ export const loader = async () => {
 };
 
 export default function Posts() {
-  const { posts } = useLoaderData() as LoaderData;
+  const { posts } = useLoaderData<LoaderData>();
   return (
     <main>
       <h1>Posts</h1>
@@ -562,7 +562,7 @@ export const loader: LoaderFunction = async ({
 };
 
 export default function PostSlug() {
-  const { post } = useLoaderData() as LoaderData;
+  const { post } = useLoaderData<LoaderData>() ;
   return (
     <main className="mx-auto max-w-4xl">
       <h1 className="my-6 border-b-2 text-center text-3xl">
@@ -614,7 +614,7 @@ export const loader: LoaderFunction = async ({
 };
 
 export default function PostSlug() {
-  const { post, html } = useLoaderData() as LoaderData;
+  const { post, html } = useLoaderData<LoaderData>();
   return (
     <main className="mx-auto max-w-4xl">
       <h1 className="my-6 border-b-2 text-center text-3xl">
@@ -670,7 +670,7 @@ export const loader: LoaderFunction = async () => {
 };
 
 export default function PostAdmin() {
-  const { posts } = useLoaderData() as LoaderData;
+  const { posts } = useLoaderData<LoaderData>();
   return (
     <div className="mx-auto max-w-4xl">
       <h1 className="my-6 mb-2 border-b-2 text-center text-3xl">
@@ -752,7 +752,7 @@ export const loader: LoaderFunction = async () => {
 };
 
 export default function PostAdmin() {
-  const { posts } = useLoaderData() as LoaderData;
+  const { posts } = useLoaderData<LoaderData>();
   return (
     <div className="mx-auto max-w-4xl">
       <h1 className="my-6 mb-2 border-b-2 text-center text-3xl">


### PR DESCRIPTION
The blog tutorial has you set the typing for `useLoaderData` by using the type assertion `as LoaderData`. But typescript shows an error because of the way the hook is typed: 

```ts
useLoaderData<T = AppData>(): SerializeFrom<T> 
```

Since the `Post` model we created in this tutorial contains two fields that are `Date` (`createdAt` and `updatedAt`), typescript complains because it expects the serialized type where they are both `string`
```
Conversion of type 'SerializeObject<UndefinedToOptional<LoaderData>>' to type 'LoaderData' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
  The types of 'post.createdAt' are incompatible between these types.
    Type 'string' is not comparable to type 'Date'.ts(2352)
```

So I updated the docs to pass in the type as a generic instead `useLoaderData<LoaderData>()`.

Also an alternative way to fix the error is to just do the assertion with the `SerializeFrom` util. e.g
```ts
import type { LoaderFunction, SerializeFrom } from "@remix-run/node";

const { post, html } = useLoaderData() as SerializeFrom<LoaderData>;
```
Not sure if this way would be preferred