### PR TITLE
fix(remix-react): fix submitter serialization

### DIFF
--- a/.changeset/lucky-eagles-whisper.md
+++ b/.changeset/lucky-eagles-whisper.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+fix submitter serialization

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -973,12 +973,7 @@ test.describe("Forms", () => {
 
     test("submits the submitter's value(s) in tree order in the form data", async ({
       page,
-      javaScriptEnabled,
     }) => {
-      test.fail(
-        Boolean(javaScriptEnabled),
-        "<Form> doesn't serialize submit buttons correctly #4342"
-      );
       let app = new PlaywrightFixture(appFixture, page);
 
       await app.goto("/submitter");


### PR DESCRIPTION
**Note: I have two proposals on how we can fix the submitter serialization bugs. The other approach is [here](https://github.com/remix-run/remix/pull/4475).**

Bring `<Form>` submissions in line with the spec with respect to how and where form submitters are serialized within the data set. 

**Solution:** We accomplish this by temporarily tweaking the form during submission to get the right entries.

- [x] Tests

Problems fixed:
1. Serialize submitters in tree order (i.e. where they appear in the DOM)
2. Serialize Image Button submitter correctly (i.e. separate x and y coordinate entries, rather than a single empty entry)
3. Stop sending multiple submitter entries in older WebKit

References: #4342
Spec: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-form-data-set