### PR TITLE
docs(tutorials/jokes): Fix Prisma Client v4.5 seed example code

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -169,6 +169,7 @@
 - ishan-me
 - IshanKBG
 - itsMapleLeaf
+- ivanjuric
 - jacargentina
 - jacob-ebey
 - JacobParis

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -2242,7 +2242,7 @@ import { PrismaClient } from "@prisma/client";
 const db = new PrismaClient();
 
 async function seed() {
-  const kody = await db.user.create({
+  await db.user.create({
     data: {
       username: "kody",
       // this is a hashed version of "twixrox"

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -2248,14 +2248,11 @@ async function seed() {
       // this is a hashed version of "twixrox"
       passwordHash:
         "$2b$10$K7L1OJ45/4Y2nIvhRVpCe.FSmhDdWoXehVzJptJ/op0lSsvqNu/1u",
+      jokes: {
+        create: getJokes(),
+      },
     },
   });
-  await Promise.all(
-    getJokes().map((joke) => {
-      const data = { jokesterId: kody.id, ...joke };
-      return db.joke.create({ data });
-    })
-  );
 }
 
 seed();


### PR DESCRIPTION
Running a command `npx prisma db seed` in Authentication section resulted with Prisma Client error.
The fix is creating the user with jokes using the create() API from Prisma Client actual version 4.5.