### PR TITLE
feat(remix-react): emulate put/patch/delete when JS is unavailable

### DIFF
--- a/.changeset/cuddly-bottles-drum.md
+++ b/.changeset/cuddly-bottles-drum.md
@@ -1,0 +1,6 @@
+---
+"@remix-run/react": minor
+"@remix-run/server-runtime": minor
+---
+
+emulate put/patch/delete when JS is unavailable

--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -57,11 +57,9 @@ This determines the [HTTP verb][http-verb] to be used: get, post, put, patch, de
 <Form method="post" />
 ```
 
-Native `<form>` only supports get and post, so if you want your form to work with JavaScript on or off the page you'll need to stick with those two.
+Although a native `<form>` only supports get and post, Remix can emulate put/patch/delete even when client-side JavaScript is unavailable. It does this by converting forms to "post" and including a `_method` parameter in the form action URL. On the server-side, your actions will see the appropriate method on the request.
 
-Without JavaScript, Remix will turn non-get requests into "post", but you'll still need to instruct your server with a hidden input like `<input type="hidden" name="_method" value="delete" />`. If you always include JavaScript, you don't need to worry about this.
-
-<docs-info>We generally recommend sticking with "get" and "post" because the other verbs are not supported by HTML</docs-info>
+<docs-info>When overriding the form method via `<button formMethod=...>`, only "get" and "post" may be used because the other verbs are not supported by HTML.</docs-info>
 
 ## `encType`
 

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -32,7 +32,7 @@ export async function callRouteActionRR({
   routeId: string;
 }) {
   let result = await action({
-    request: stripDataParam(stripIndexParam(request)),
+    request: applyMethodOverride(stripDataParam(stripIndexParam(request))),
     context: loadContext,
     params,
   });
@@ -102,4 +102,15 @@ function stripDataParam(request: Request) {
   let url = new URL(request.url);
   url.searchParams.delete("_data");
   return new Request(url.href, request);
+}
+
+function applyMethodOverride(request: Request) {
+  let url = new URL(request.url);
+  let overrideMethod = url.searchParams.get("_method") ?? "";
+  if (!["put", "patch", "delete"].includes(overrideMethod)) return request;
+
+  url.searchParams.delete("_method");
+  return new Request(new Request(url.href, request), {
+    method: overrideMethod,
+  });
 }


### PR DESCRIPTION
References #4420

- [x] Docs
- [x] Tests

Ensure `<Form method=...>` behaves the same with and without JavaScript. Although native forms don't support PUT/PATCH/DELETE, we can emulate them by doing a POST and injecting a `_method` parameter into the action URL. The Remix server runtime then provides action handlers a `Request` with the overridden `method` so they are none the wiser.

This provides a more reliable way to use these methods, which can be more ergonomic to write and handle than hidden inputs or buttons with values.

Note:
The emulation only works for action requests handled by Remix; if the form is submitted to another endpoint, it would need to handle the `_method` URL parameter accordingly.
