### PR TITLE
bug: scroll restoration does not work during development.

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -465,3 +465,4 @@
 - zhe
 - dabdine
 - akamfoad
+- gijsroge

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -1,8 +1,8 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
-import { PlaywrightFixture } from "./helpers/playwright-fixture";
-import type { Fixture, AppFixture } from "./helpers/create-fixture";
+import type { AppFixture, Fixture } from "./helpers/create-fixture";
 import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
+import { PlaywrightFixture } from "./helpers/playwright-fixture";
 
 let fixture: Fixture;
 let appFixture: AppFixture;
@@ -87,22 +87,15 @@ test.afterAll(() => {
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("[description of what you expect it to do]", async ({ page }) => {
+test("[after scrolling and reloading the scroll position should be restored]", async ({
+  page,
+}) => {
   let app = new PlaywrightFixture(appFixture, page);
-  // You can test any request your app might get using `fixture`.
-  let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch("pizza");
-
-  // If you need to test interactivity use the `app`
   await app.goto("/");
-  await app.clickLink("/burgers");
-  expect(await app.getHtml()).toMatch("cheeseburger");
-
-  // If you're not sure what's going on, you can "poke" the app, it'll
-  // automatically open up in your browser for 20 seconds, so be quick!
-  // await app.poke(20);
-
-  // Go check out the other tests to see what else you can do.
+  await page.setViewportSize({ width: 320, height: 800 });
+  await page.evaluate(() => window.scrollTo(0, 300));
+  await page.reload();
+  expect(await page.evaluate(() => window.scrollY)).toBe(300);
 });
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
References: https://discord.com/channels/770287896669978684/1006494470356861024

Closes: #

- [ ] Docs
- [x] Tests

Currently if a reload gets triggered during development, either by the `<LiveReload>` component or manually by the user, the scroll position always gets reset to `0`.

Also added a small reproduction in Stackblitz https://stackblitz.com/edit/remix-cvejzc?file=app%2Froutes%2Findex.tsx
Just change something and you will see the page will scroll to the top.

Good to know, if you modify something you can see the changes for a few 100ms and after that the page scrolls to the top.