### PR TITLE
perf(remix-dev): Optimize `parentRouteId` lookup in `defineConventionalRoutes`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -102,6 +102,7 @@
 - dhargitai
 - dhmacs
 - dima-takoy
+- dmarkow
 - DNLHC
 - dogukanakkaya
 - dokeet

--- a/packages/remix-dev/__tests__/routesConvention-test.ts
+++ b/packages/remix-dev/__tests__/routesConvention-test.ts
@@ -50,7 +50,7 @@ describe("createRoutePath", () => {
 
 describe("defineConventionalRoutes", () => {
   it("creates a route manifest from the routes directory", () => {
-    let routes = defineConventionalRoutes(path.join(__dirname, "fixtures/replace-remix-imports/app"));
+    let routes = defineConventionalRoutes(path.join(__dirname, "fixtures/replace-remix-magic-imports/app"));
     let keys = Object.keys(routes);
     expect(keys.length).toBe(14)
     expect(keys.filter(key => routes[key].parentId).length).toBe(5)

--- a/packages/remix-dev/__tests__/routesConvention-test.ts
+++ b/packages/remix-dev/__tests__/routesConvention-test.ts
@@ -1,4 +1,6 @@
-import { createRoutePath } from "../config/routesConvention";
+import * as path from "path";
+
+import { createRoutePath, defineConventionalRoutes } from "../config/routesConvention";
 
 describe("createRoutePath", () => {
   describe("creates proper route paths", () => {
@@ -45,3 +47,13 @@ describe("createRoutePath", () => {
     }
   });
 });
+
+describe("defineConventionalRoutes", () => {
+  it("creates a route manifest from the routes directory", () => {
+    let routes = defineConventionalRoutes(path.join(__dirname, "fixtures/replace-remix-imports/app"));
+    let keys = Object.keys(routes);
+    expect(keys.length).toBe(14)
+    expect(keys.filter(key => routes[key].parentId).length).toBe(5)
+    expect(keys.filter(key => routes[key].index).length).toBe(4)
+  })
+})

--- a/packages/remix-dev/config/routesConvention.ts
+++ b/packages/remix-dev/config/routesConvention.ts
@@ -49,6 +49,10 @@ export function defineConventionalRoutes(
   });
 
   let routeIds = Object.keys(files).sort(byLongestFirst);
+  let parentRouteIds: { [routeId: string]: string | undefined } = {};
+  for (let id of routeIds) {
+    parentRouteIds[id] = findParentRouteId(routeIds, id);
+  }
 
   let uniqueRoutes = new Map<string, string>();
 
@@ -58,7 +62,7 @@ export function defineConventionalRoutes(
     parentId?: string
   ): void {
     let childRouteIds = routeIds.filter(
-      (id) => findParentRouteId(routeIds, id) === parentId
+      (id) => parentRouteIds[id] === parentId
     );
 
     for (let routeId of childRouteIds) {
@@ -86,7 +90,7 @@ export function defineConventionalRoutes(
 
       if (isIndexRoute) {
         let invalidChildRoutes = routeIds.filter(
-          (id) => findParentRouteId(routeIds, id) === routeId
+          (id) => parentRouteIds[id] === routeId
         );
 
         if (invalidChildRoutes.length > 0) {

--- a/packages/remix-dev/config/routesConvention.ts
+++ b/packages/remix-dev/config/routesConvention.ts
@@ -49,10 +49,7 @@ export function defineConventionalRoutes(
   });
 
   let routeIds = Object.keys(files).sort(byLongestFirst);
-  let parentRouteIds: { [routeId: string]: string | undefined } = {};
-  for (let id of routeIds) {
-    parentRouteIds[id] = findParentRouteId(routeIds, id);
-  }
+  let parentRouteIds = getParentRouteIds(routeIds);
 
   let uniqueRoutes = new Map<string, string>();
 
@@ -197,11 +194,16 @@ export function createRoutePath(partialRouteId: string): string | undefined {
   return result || undefined;
 }
 
-function findParentRouteId(
-  routeIds: string[],
-  childRouteId: string
-): string | undefined {
-  return routeIds.find((id) => childRouteId.startsWith(`${id}/`));
+function getParentRouteIds(
+  routeIds: string[]
+): Record<string, string | undefined> {
+  return routeIds.reduce<Record<string, string | undefined>>(
+    (parentRouteIds, childRouteId) => ({
+      ...parentRouteIds,
+      [childRouteId]: routeIds.find((id) => childRouteId.startsWith(`${id}/`)),
+    }),
+    {}
+  );
 }
 
 function byLongestFirst(a: string, b: string): number {


### PR DESCRIPTION
Closes: #4480. `defineConventionalRoutes` was repeatedly running `.filter` and `.find` against the list of routeIds to find parents, which was causing an exponential slowdown in larger projects. This update first generates a `parentRouteIds` object and then filters against that instead.

- [ ] Docs
- [x] Tests

Testing Strategy: There weren't any direct tests for `defineConventionalRoutes` as far as I could tell, so I added one to make sure the necessary number of routes (including parent route ids) are generated. I used an existing fixture for the routes folders (`remix-dev/__tests__/fixtures/replace-remix-imports`) but I can add one specific to the `routesConventions` tests if you prefer this test remain uncoupled from the replace imports test.

I ran this against my production app with nearly 700 routes and the RouteManifest object was was identical before and after the patch. Before this update, my production app was taking around 10-15 seconds before "Watching Remix app in development mode..." showed up, now it's less than a second.

I also ran the [example test app from my original issue](https://github.com/dmarkow/remix-route-performance-example) against this new code and the speed up is drastic on large projects (almost 27 seconds before for 1,111 routes, now it's 0.104 seconds).

```
$ node run.js 1 | head
Creating sample routes...
defineConventionalRoutes: 0.008s for 112 routes (0.07ms per file)
<Routes>
  <Route file="root.tsx">
    <Route path="0/10/0/0" index file="routes/__a/__b/__c/0/10/0/0/index.js" />
    <Route path="0/10/0/1" index file="routes/__a/__b/__c/0/10/0/1/index.js" />
    <Route path="0/10/1/0" index file="routes/__a/__b/__c/0/10/1/0/index.js" />
    <Route path="0/10/1/1" index file="routes/__a/__b/__c/0/10/1/1/index.js" />
    <Route path="0/10/2/0" index file="routes/__a/__b/__c/0/10/2/0/index.js" />
    <Route path="0/10/2/1" index file="routes/__a/__b/__c/0/10/2/1/index.js" />

$ node run.js 5 | head
Creating sample routes...
defineConventionalRoutes: 0.044s for 556 routes (0.08ms per file)
<Routes>
  <Route file="root.tsx">
    <Route path="0/10/0/0" index file="routes/__a/__b/__c/0/10/0/0/index.js" />
    <Route path="0/10/0/1" index file="routes/__a/__b/__c/0/10/0/1/index.js" />
    <Route path="0/10/1/0" index file="routes/__a/__b/__c/0/10/1/0/index.js" />
    <Route path="0/10/1/1" index file="routes/__a/__b/__c/0/10/1/1/index.js" />
    <Route path="0/10/2/0" index file="routes/__a/__b/__c/0/10/2/0/index.js" />
    <Route path="0/10/2/1" index file="routes/__a/__b/__c/0/10/2/1/index.js" />

$ node run.js 10 | head
Creating sample routes...
defineConventionalRoutes: 0.104s for 1111 routes (0.09ms per file)
<Routes>
  <Route file="root.tsx">
    <Route path="0/10/0/0" index file="routes/__a/__b/__c/0/10/0/0/index.js" />
    <Route path="0/10/0/1" index file="routes/__a/__b/__c/0/10/0/1/index.js" />
    <Route path="0/10/1/0" index file="routes/__a/__b/__c/0/10/1/0/index.js" />
    <Route path="0/10/1/1" index file="routes/__a/__b/__c/0/10/1/1/index.js" />
    <Route path="0/10/2/0" index file="routes/__a/__b/__c/0/10/2/0/index.js" />
    <Route path="0/10/2/1" index file="routes/__a/__b/__c/0/10/2/1/index.js" />
```

