### PR TITLE
Revert "ci: use GitHub Actions account to commit format changes"

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.FORMAT_PAT }}
 
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
@@ -43,8 +45,8 @@ jobs:
 
       - name: 💪 Commit
         run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
+          git config --local user.email "hello@remix.run"
+          git config --local user.name "Remix Run Bot"
 
           git add .
           if [ -z "$(git status --porcelain)" ]; then


### PR DESCRIPTION
we have branch protection on for the dev branch which requires all changes to be made through a PR, this changes the commit to be made from the `remix-run-bot` account which is allowed. 

Reverts remix-run/remix#4285