### PR TITLE
bug: LiveReload causes infinite reload loops on Firefox if the loader is slow

### DIFF
--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -1,15 +1,11 @@
 import { test, expect } from "@playwright/test";
-import { spawn } from "cross-spawn";
-import getPort from "get-port";
-import * as readline from "node:readline";
-import fs from "fs";
-import path from "path";
 
 import { PlaywrightFixture } from "./helpers/playwright-fixture";
-import { createFixtureProject } from "./helpers/create-fixture";
-import { js } from "./helpers/create-fixture";
+import type { Fixture, AppFixture } from "./helpers/create-fixture";
+import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
 
-let appFixture: Awaited<ReturnType<typeof startDevServer>>;
+let fixture: Fixture;
+let appFixture: AppFixture;
 
 ////////////////////////////////////////////////////////////////////////////////
 // 💿 👋 Hola! It's me, Dora the Remix Disc, I'm here to help you write a great
@@ -44,138 +40,67 @@ let appFixture: Awaited<ReturnType<typeof startDevServer>>;
 //    ```
 ////////////////////////////////////////////////////////////////////////////////
 
-async function startDevServer(fixture: {
-  files?: { [filename: string]: string };
-}) {
-  let port = await getPort();
-  let serverUrl = `http://localhost:${port}`;
-
-  let projectDir = await createFixtureProject(fixture);
-
-  let watchProcess = spawn(
-    "node",
-    ["node_modules/@remix-run/dev/dist/cli.js", "dev"],
-    {
-      cwd: projectDir,
-      env: {
-        ...process.env,
-        PORT: port.toString(),
-      },
-    }
-  );
-
-  await new Promise<void>((isReady, onError) => {
-    let rl = readline.createInterface(watchProcess.stdout);
-    let timeout = setTimeout(() => {
-      onError(new Error("Timed out waiting for watch server"));
-    }, 10000);
-
-    rl.on("line", (input) => {
-      if (input.match(/Remix App Server started at http:\/\/localhost/)) {
-        rl.removeAllListeners();
-        clearTimeout(timeout);
-        isReady();
-      }
-    });
-    rl.on("close", () => {
-      clearTimeout(timeout);
-      onError(new Error("Watch server did not start correctly"));
-    });
-  });
-
-  let waitForRebuild = (timeout: number = 10000) => {
-    let rl = readline.createInterface(watchProcess.stdout);
-    return new Promise<void>((resolve, reject) => {
-      let timeoutRef = setTimeout(() => {
-        reject(new Error("Timed out waiting for watch server rebuild"));
-      }, timeout);
-
-      rl.on("line", (input) => {
-        if (input.match(/Rebuilt in/)) {
-          rl.removeAllListeners();
-          clearTimeout(timeoutRef);
-          resolve();
-        }
-      });
-      rl.on("close", () => {
-        clearTimeout(timeoutRef);
-        reject(new Error("Watch server died unexpectedly"));
-      });
-    });
-  };
-
-  return {
-    projectDir,
-    serverUrl,
-    waitForRebuild,
-    close: async () => {
-      if (!watchProcess.kill()) {
-        watchProcess.kill(9);
-      }
-    },
-  };
-}
-
-test.beforeEach(async () => {
-  appFixture = await startDevServer({
+test.beforeAll(async () => {
+  fixture = await createFixture({
+    ////////////////////////////////////////////////////////////////////////////
+    // 💿 Next, add files to this object, just like files in a real app,
+    // `createFixture` will make an app and run your tests against it.
+    ////////////////////////////////////////////////////////////////////////////
     files: {
       "app/routes/index.jsx": js`
         import { json } from "@remix-run/node";
+        import { useLoaderData, Link } from "@remix-run/react";
 
-        export async function loader() {
-          return json({});
+        export function loader() {
+          return json("pizza");
         }
 
         export default function Index() {
-          return "initial";
+          let data = useLoaderData();
+          return (
+            <div>
+              {data}
+              <Link to="/burgers">Other Route</Link>
+            </div>
+          )
+        }
+      `,
+
+      "app/routes/burgers.jsx": js`
+        export default function Index() {
+          return <div>cheeseburger</div>;
         }
       `,
     },
   });
+
+  // This creates an interactive app using puppeteer.
+  appFixture = await createAppFixture(fixture);
 });
 
-test.afterEach(() => appFixture.close());
+test.afterAll(() => appFixture.close());
 
 ////////////////////////////////////////////////////////////////////////////////
 // 💿 Almost done, now write your failing test case(s) down here Make sure to
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("after file changes the app reloads if the loader is slow", async ({
-  page,
-}) => {
+test("[description of what you expect it to do]", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);
+  // You can test any request your app might get using `fixture`.
+  let response = await fixture.requestDocument("/");
+  expect(await response.text()).toMatch("pizza");
 
+  // If you need to test interactivity use the `app`
   await app.goto("/");
-  expect(await app.getHtml()).toMatch("initial");
+  await app.clickLink("/burgers");
+  expect(await app.getHtml()).toMatch("cheeseburger");
 
-  await Promise.all([
-    fs.promises.writeFile(
-      path.join(appFixture.projectDir, "app", "routes", "index.jsx"),
-      js`
-        import { json } from "@remix-run/node";
+  // If you're not sure what's going on, you can "poke" the app, it'll
+  // automatically open up in your browser for 20 seconds, so be quick!
+  // await app.poke(20);
 
-        export async function loader() {
-          await new Promise((resolve) => {
-            setTimeout(resolve, 2000);
-          });
-
-          return json({});
-        }
-
-        export default function Index() {
-          return (
-            <div id="changed">changed</div>
-          );
-        }
-      `
-    ),
-    appFixture.waitForRebuild(),
-    app.page.waitForNavigation(),
-    app.page.waitForSelector("#changed"),
-  ]);
-
-  expect(await app.getHtml()).toMatch("changed");
+  // Go check out the other tests to see what else you can do.
 });
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/integration/dev-server-reload-test.ts
+++ b/integration/dev-server-reload-test.ts
@@ -1,0 +1,143 @@
+import { test, expect } from "@playwright/test";
+import { spawn } from "cross-spawn";
+import getPort from "get-port";
+import * as readline from "node:readline";
+import fs from "fs";
+import path from "path";
+
+import { PlaywrightFixture } from "./helpers/playwright-fixture";
+import { createFixtureProject } from "./helpers/create-fixture";
+import { js } from "./helpers/create-fixture";
+
+async function startDevServer(fixture: {
+  files?: { [filename: string]: string };
+}) {
+  let port = await getPort();
+  let serverUrl = `http://localhost:${port}`;
+
+  let projectDir = await createFixtureProject(fixture);
+
+  let watchProcess = spawn(
+    "node",
+    ["node_modules/@remix-run/dev/dist/cli.js", "dev"],
+    {
+      cwd: projectDir,
+      env: {
+        ...process.env,
+        PORT: port.toString(),
+      },
+    }
+  );
+
+  await new Promise<void>((isReady, onError) => {
+    let rl = readline.createInterface(watchProcess.stdout);
+    let timeout = setTimeout(() => {
+      onError(new Error("Timed out waiting for watch server"));
+    }, 10000);
+
+    rl.on("line", (input) => {
+      if (input.match(/Remix App Server started at http:\/\/localhost/)) {
+        rl.removeAllListeners();
+        clearTimeout(timeout);
+        isReady();
+      }
+    });
+    rl.on("close", () => {
+      clearTimeout(timeout);
+      onError(new Error("Watch server did not start correctly"));
+    });
+  });
+
+  let waitForRebuild = (timeout: number = 10000) => {
+    let rl = readline.createInterface(watchProcess.stdout);
+    return new Promise<void>((resolve, reject) => {
+      let timeoutRef = setTimeout(() => {
+        reject(new Error("Timed out waiting for watch server rebuild"));
+      }, timeout);
+
+      rl.on("line", (input) => {
+        if (input.match(/Rebuilt in/)) {
+          rl.removeAllListeners();
+          clearTimeout(timeoutRef);
+          resolve();
+        }
+      });
+      rl.on("close", () => {
+        clearTimeout(timeoutRef);
+        reject(new Error("Watch server died unexpectedly"));
+      });
+    });
+  };
+
+  return {
+    projectDir,
+    serverUrl,
+    waitForRebuild,
+    close: async () => {
+      if (!watchProcess.kill()) {
+        watchProcess.kill(9);
+      }
+    },
+  };
+}
+
+test.describe("dev server reload", () => {
+  let appFixture: Awaited<ReturnType<typeof startDevServer>>;
+
+  test.beforeEach(async () => {
+    appFixture = await startDevServer({
+      files: {
+        "app/routes/index.jsx": js`
+          import { json } from "@remix-run/node";
+
+          export async function loader() {
+            return json({});
+          }
+
+          export default function Index() {
+            return "initial";
+          }
+        `,
+      },
+    });
+  });
+
+  test.afterEach(() => appFixture.close());
+
+  test("after file changes the app reloads if the loader is slow", async ({
+    page,
+  }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+
+    await app.goto("/");
+    expect(await app.getHtml()).toMatch("initial");
+
+    await Promise.all([
+      fs.promises.writeFile(
+        path.join(appFixture.projectDir, "app", "routes", "index.jsx"),
+        js`
+          import { json } from "@remix-run/node";
+
+          export async function loader() {
+            await new Promise((resolve) => {
+              setTimeout(resolve, 2000);
+            });
+
+            return json({});
+          }
+
+          export default function Index() {
+            return (
+              <div id="changed">changed</div>
+            );
+          }
+        `
+      ),
+      appFixture.waitForRebuild(),
+      app.page.waitForNavigation(),
+      app.page.waitForSelector("#changed"),
+    ]);
+
+    expect(await app.getHtml()).toMatch("changed");
+  });
+});

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1533,6 +1533,7 @@ export const LiveReload =
                   let socketPath = protocol + "//" + host + ":" + ${String(
                     port
                   )} + "/socket";
+                  let alreadyReloading = false;
 
                   let ws = new WebSocket(socketPath);
                   ws.onmessage = (message) => {
@@ -1542,6 +1543,7 @@ export const LiveReload =
                     }
                     if (event.type === "RELOAD") {
                       console.log("💿 Reloading window ...");
+                      alreadyReloading = true;
                       window.location.reload();
                     }
                   };
@@ -1551,6 +1553,9 @@ export const LiveReload =
                     }
                   };
                   ws.onclose = (error) => {
+                    if (alreadyReloading) {
+                      return;
+                    }
                     console.log("Remix dev asset server web socket closed. Reconnecting...");
                     setTimeout(
                       () =>


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

- [ ] Docs
- [x] Tests

I recently upgraded Remix from v1.4.3 to v1.7.5 on one of my projects. Since the update, LiveReload _sometimes_ didn't work properly on Firefox anymore.

After some investigation, it turns out that the script used by the `LiveReload` component to reload the page causes an infinite reload loop when the page takes too long to load.
This is easily reproducable by adding a loader with the following code to an empty page:
```jsx
export async function loader() {
  await new Promise((resolve) => {
    setTimeout(resolve, 2000);
  });

  return json({});
}
```

Digging deeper, this looks to be an issue with how Firefox is handling WebSockets differently than e.g. Chrome when it comes to reloads. When the page reloads in Chrome, the WebSocket connection never closes and the WebSocket's `onclose` handler is never called. Firefox however closes the WebSocket connection right after calling `window.location.reload()`, leading to the following scenario: (I'm referencing line numbers from the [LiveReload implementation](https://github.com/remix-run/remix/blob/cb7416beb87f2f008f05bafb0c25d263bf59851f/packages/remix-react/components.tsx))
1. after detecting a file change and rebuilding, the remix server sends the `RELOAD` event to the client, which triggers a window reload ([L1547](https://github.com/remix-run/remix/blob/cb7416beb87f2f008f05bafb0c25d263bf59851f/packages/remix-react/components.tsx#L1547))
2. the window reload leads to Firefox closing the WebSocket connection, calling the `onclose` handler ([L1555](https://github.com/remix-run/remix/blob/cb7416beb87f2f008f05bafb0c25d263bf59851f/packages/remix-react/components.tsx#L1555))
3. reloading the page takes longer than 1 second. The timeout in the `onclose` handler ([L1557](https://github.com/remix-run/remix/blob/cb7416beb87f2f008f05bafb0c25d263bf59851f/packages/remix-react/components.tsx#L1557)) calls `remixLiveReloadConnect(...)`
4. a new connection to the WebSocket is established ([L1539](https://github.com/remix-run/remix/blob/cb7416beb87f2f008f05bafb0c25d263bf59851f/packages/remix-react/components.tsx#L1539))
5. this new connection calls the `onOpen` callback that was passed from [L1559](https://github.com/remix-run/remix/blob/cb7416beb87f2f008f05bafb0c25d263bf59851f/packages/remix-react/components.tsx#L1559)
6. the `onOpen` callback calls `window.location.reload()` ([L1560](https://github.com/remix-run/remix/blob/cb7416beb87f2f008f05bafb0c25d263bf59851f/packages/remix-react/components.tsx#L1560)), cancelling the previous reload request and starting a new one
7. this again causes the `onclose` handler to set a new timeout and the cycle starts again.

As far as I can tell there aren't any integration tests yet that use `cli.js dev` to watch for file changes, so I added a `startDevServer` function to handle this scenario.