### PR TITLE
fix: check index routes against route config instead of id suffix

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1038,6 +1038,7 @@ export function useFormAction(
   // TODO: Remove method param in v2 as it's no longer needed and is a breaking change
   method: FormMethod = "get"
 ): string {
+  let { manifest } = useRemixEntryContext();
   let { id } = useRemixRouteContext();
   let resolvedPath = useResolvedPath(action ?? ".");
 
@@ -1048,7 +1049,7 @@ export function useFormAction(
   // https://github.com/remix-run/remix/issues/927
   let location = useLocation();
   let { search, hash } = resolvedPath;
-  let isIndexRoute = id.endsWith("/index");
+  let isIndexRoute = manifest.routes[id].index;
 
   if (action == null) {
     search = location.search;

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -708,7 +708,7 @@ function isIndexRequestUrl(url: URL) {
 function getRequestMatch(url: URL, matches: RouteMatch<ServerRoute>[]) {
   let match = matches.slice(-1)[0];
 
-  if (isIndexRequestUrl(url) && match.route.id.endsWith("/index")) {
+  if (isIndexRequestUrl(url) && match.route.index) {
     return match;
   }
 


### PR DESCRIPTION
Index routes in Remix Flat Routes do not end in `/index` so these routes were not correctly identified.
