### PR TITLE
fix(remix-react): Remove nullish coalescing operator

### DIFF
--- a/.changeset/curvy-countries-boil.md
+++ b/.changeset/curvy-countries-boil.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Fixed old browsers compatibility by removing a nullish coalescing operator

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1039,7 +1039,7 @@ export function useFormAction(
   method: FormMethod = "get"
 ): string {
   let { id } = useRemixRouteContext();
-  let resolvedPath = useResolvedPath(action ?? ".");
+  let resolvedPath = useResolvedPath(action ? action : ".");
 
   // Previously we set the default action to ".". The problem with this is that
   // `useResolvedPath(".")` excludes search params and the hash of the resolved


### PR DESCRIPTION
Closes: #

- [ ] Docs
- [ ] Tests

### Testing Strategy:

I was testing my app with an iPhone 6, and found out the client side was totally broken.

We had a [discussion](https://github.com/remix-run/remix/discussions/3240#discussioncomment-4086437) with @sergiodxa a few days ago where we uncovered that we re-introduced a nullish coalescing operator `??` in https://github.com/remix-run/remix/pull/3697 that could be problematic for old browsers.

I can now confirm that it is indeed problematic. 🙃 
This PR gets rid of it.

