### PR TITLE
docs(pages/contributing): Fix typos

### DIFF
--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -163,7 +163,7 @@ The following steps will get you setup to contribute changes to this repo:
 **Important:** When creating the PR in GitHub, make sure that you set the base to the correct branch.
 
 - **`dev`** is for changes to code
-- **`main`**: is for changes to documentation, examples, and some templates
+- **`main`**: is for changes to documentation and some templates
 
 You can set the base in GitHub when authoring the PR with the dropdown below the "Compare changes" heading:
 
@@ -239,11 +239,11 @@ There may be other branches for various features and experimentation, but all of
 
 ## How the heck do nightly releases work?
 
-Nightly releases will run the action files from the `main` branch as scheduled workflows will always use the latest commit to the default branch, signified by [this comment on the nightly action file][nightly-action-comment] and the explicit branch appended to the reuasable workflows in the [postrelease action][postrelease-action], however they checkout the `dev` branch during their set up as that's where we want our nightly releases to be cut from. From there, we check if the git sha is the same and only cut a new nightly if something has changed.
+Nightly releases will run the action files from the `main` branch as scheduled workflows will always use the latest commit to the default branch, signified by [this comment on the nightly action file][nightly-action-comment] and the explicit branch appended to the reusable workflows in the [postrelease action][postrelease-action], however they checkout the `dev` branch during their set up as that's where we want our nightly releases to be cut from. From there, we check if the git sha is the same and only cut a new nightly if something has changed.
 
 ## End to end testing
 
-For every release of Remix (stable, experimental, nightly, and pre-releases), we will do a complete end-to-end test of Remix apps on each of our official adapters from `create-remix`, all the way to deploying them to production. We do this by by utilizing the default [templates][templates] and the CLIs for Fly, Vercel, Netlify, and Arc. We'll then run some simple Cypress assertions to make sure everything is running properly for both development and the deployed app.
+For every release of Remix (stable, experimental, nightly, and pre-releases), we will do a complete end-to-end test of Remix apps on each of our official adapters from `create-remix`, all the way to deploying them to production. We do this by utilizing the default [templates][templates] and the CLIs for Fly, Vercel, Netlify, and Arc. We'll then run some simple Cypress assertions to make sure everything is running properly for both development and the deployed app.
 
 ## Conclusion
 
@@ -253,7 +253,7 @@ Thanks
 [roadmap]: https://github.com/orgs/remix-run/projects/5
 [youtube]: https://www.youtube.com/c/Remix-Run/streams
 [discord]: https://rmx.as/discord
-[contributorsyaml]: https://github.com/buzinas/remix/blob/add-support-for-module-workers/contributors.yml
+[contributorsyaml]: https://github.com/remix-run/remix/blob/main/contributors.yml
 [cla]: https://github.com/remix-run/remix/blob/main/CLA.md
 [examples-repository]: https://github.com/remix-run/examples
 [this-page]: https://github.com/remix-run/remix


### PR DESCRIPTION
- Examples are not in this repo anymore.
- Fixed a couple of typos
- Fixed the contributors.yaml file url