### PR TITLE
chore: fix `postrelease` workflow

### DIFF
--- a/.github/workflows/postrelease.yml
+++ b/.github/workflows/postrelease.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       # only run on `remix` tags
-      - "remix@*"
+      - remix@**
 
 jobs:
   comment:


### PR DESCRIPTION
The workflow apparently never ran: https://github.com/remix-run/remix/actions/workflows/postrelease.yml

Found that we had a small bug: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-only-when-a-push-of-specific-tags-occurs