### PR TITLE
feat(remix-server-runtime): RRR 2 - Deploy `@remix-run/server-runtime` changes

### DIFF
--- a/.changeset/beige-planes-type.md
+++ b/.changeset/beige-planes-type.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": minor
+---
+
+We have been busy at work [Layering Remix on top of React Router 6.4](https://github.com/remix-run/remix/blob/main/decisions/0007-remix-on-react-router-6-4-0.md) and are excited to be releasing the step 1 in this process that consists of running the server flow through a local copy the new framework agnostic `@remix-run/router`.

--- a/packages/remix-server-runtime/__tests__/data-test.ts
+++ b/packages/remix-server-runtime/__tests__/data-test.ts
@@ -1,8 +1,5 @@
 import type { ServerBuild } from "../build";
 import { createRequestHandler } from "../server";
-import { callRouteAction, callRouteLoader } from "../data";
-import type { RouteMatch } from "../routeMatching";
-import type { ServerRoute } from "../routes";
 
 describe("loaders", () => {
   // so that HTML/Fetch requests are the same, and so redirects don't hang on to
@@ -145,81 +142,5 @@ describe("loaders", () => {
 
     let res = await handler(request);
     expect(await res.json()).toMatchInlineSnapshot(`"?foo=bar&index=test"`);
-  });
-
-  it("throws the right error message when `loader` returns undefined", async () => {
-    let loader = async () => {};
-
-    let routeId = "routes/random";
-
-    let request = new Request("http://example.com/random?_data=routes/random");
-
-    let match = {
-      params: {},
-      pathname: "random",
-      route: {
-        id: routeId,
-        module: {
-          loader,
-        },
-      },
-    } as unknown as RouteMatch<ServerRoute>;
-
-    let possibleError: any;
-    try {
-      possibleError = await callRouteLoader({
-        request,
-        loader: match.route.module.loader,
-        routeId: match.route.id,
-        params: match.params,
-        loadContext: {},
-      });
-    } catch (error) {
-      possibleError = error;
-    }
-
-    expect(possibleError).toBeInstanceOf(Error);
-    expect(possibleError.message).toMatchInlineSnapshot(
-      '"You defined a loader for route \\"routes/random\\" but didn\'t return anything from your `loader` function. Please return a value or `null`."'
-    );
-  });
-});
-
-describe("actions", () => {
-  it("throws the right error message when `action` returns undefined", async () => {
-    let action = async () => {};
-
-    let routeId = "routes/random";
-
-    let request = new Request("http://example.com/random?_data=routes/random");
-
-    let match = {
-      params: {},
-      pathname: "random",
-      route: {
-        id: routeId,
-        module: {
-          action,
-        },
-      },
-    } as unknown as RouteMatch<ServerRoute>;
-
-    let possibleError: any;
-    try {
-      possibleError = await callRouteAction({
-        request,
-        action: match.route.module.action,
-        routeId: match.route.id,
-        params: match.params,
-        loadContext: {},
-      });
-    } catch (error) {
-      possibleError = error;
-    }
-
-    expect(possibleError).toBeInstanceOf(Error);
-    expect(possibleError.message).toMatchInlineSnapshot(
-      '"You defined an action for route \\"routes/random\\" but didn\'t return anything from your `action` function. Please return a value or `null`."'
-    );
   });
 });

--- a/packages/remix-server-runtime/headers.ts
+++ b/packages/remix-server-runtime/headers.ts
@@ -5,37 +5,6 @@ import type { ServerRoute } from "./routes";
 import type { RouteMatch } from "./routeMatching";
 import type { StaticHandlerContext } from "./router";
 
-export function getDocumentHeaders(
-  build: ServerBuild,
-  matches: RouteMatch<ServerRoute>[],
-  routeLoaderResponses: Record<string, Response>,
-  actionResponse?: Response
-): Headers {
-  return matches.reduce((parentHeaders, match, index) => {
-    let routeModule = build.routes[match.route.id].module;
-    let routeLoaderResponse = routeLoaderResponses[match.route.id];
-    let loaderHeaders = routeLoaderResponse
-      ? routeLoaderResponse.headers
-      : new Headers();
-    let actionHeaders = actionResponse ? actionResponse.headers : new Headers();
-    let headers = new Headers(
-      routeModule.headers
-        ? typeof routeModule.headers === "function"
-          ? routeModule.headers({ loaderHeaders, parentHeaders, actionHeaders })
-          : routeModule.headers
-        : undefined
-    );
-
-    // Automatically preserve Set-Cookie headers that were set either by the
-    // loader or by a parent route.
-    prependCookies(actionHeaders, headers);
-    prependCookies(loaderHeaders, headers);
-    prependCookies(parentHeaders, headers);
-
-    return headers;
-  }, new Headers());
-}
-
 export function getDocumentHeadersRR(
   build: ServerBuild,
   context: StaticHandlerContext,

--- a/packages/remix-server-runtime/responses.ts
+++ b/packages/remix-server-runtime/responses.ts
@@ -71,7 +71,3 @@ const redirectStatusCodes = new Set([301, 302, 303, 307, 308]);
 export function isRedirectResponse(response: Response): boolean {
   return redirectStatusCodes.has(response.status);
 }
-
-export function isCatchResponse(response: Response) {
-  return response.headers.get("X-Remix-Catch") != null;
-}

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -1,22 +1,21 @@
 // TODO: RRR - Change import to @remix-run/router
 import type { StaticHandler, StaticHandlerContext } from "./router";
-import { ErrorResponse, isRouteErrorResponse } from "./router";
+import { isRouteErrorResponse } from "./router";
 import { unstable_createStaticHandler } from "./router";
 import type { AppLoadContext } from "./data";
-import { callRouteAction, callRouteLoader, extractData } from "./data";
 import type { AppState } from "./errors";
 import type { ServerBuild, HandleDocumentRequestFunction } from "./build";
 import type { EntryContext } from "./entry";
 import { createEntryMatches, createEntryRouteModules } from "./entry";
 import { serializeError } from "./errors";
-import { getDocumentHeaders, getDocumentHeadersRR } from "./headers";
+import { getDocumentHeadersRR } from "./headers";
 import invariant from "./invariant";
 import { ServerMode, isServerMode } from "./mode";
 import type { RouteMatch } from "./routeMatching";
 import { matchServerRoutes } from "./routeMatching";
 import type { ServerRoute, ServerRouteManifest } from "./routes";
 import { createStaticHandlerDataRoutes, createRoutes } from "./routes";
-import { json, isRedirectResponse, isCatchResponse } from "./responses";
+import { json, isRedirectResponse } from "./responses";
 import { createServerHandoffString } from "./serverHandoff";
 
 export type RequestHandler = (
@@ -29,9 +28,6 @@ export type CreateRequestHandlerFunction = (
   mode?: string
 ) => RequestHandler;
 
-// This can be toggled to true for experimental releases
-const ENABLE_REMIX_ROUTER = process.env.ENABLE_REMIX_ROUTER;
-
 export const createRequestHandler: CreateRequestHandlerFunction = (
   build,
   mode
@@ -43,32 +39,20 @@ export const createRequestHandler: CreateRequestHandlerFunction = (
     let url = new URL(request.url);
     let matches = matchServerRoutes(routes, url.pathname);
 
-    let staticHandler: StaticHandler;
-    if (ENABLE_REMIX_ROUTER) {
-      staticHandler = unstable_createStaticHandler(
-        createStaticHandlerDataRoutes(build.routes, loadContext)
-      );
-    }
+    let staticHandler = unstable_createStaticHandler(
+      createStaticHandlerDataRoutes(build.routes, loadContext)
+    );
 
     let response: Response;
     if (url.searchParams.has("_data")) {
       let routeId = url.searchParams.get("_data")!;
 
-      if (ENABLE_REMIX_ROUTER) {
-        response = await handleDataRequestRR(
-          serverMode,
-          staticHandler!,
-          routeId,
-          request
-        );
-      } else {
-        response = await handleDataRequest({
-          request,
-          loadContext,
-          matches: matches!,
-          serverMode,
-        });
-      }
+      response = await handleDataRequestRR(
+        serverMode,
+        staticHandler!,
+        routeId,
+        request
+      );
 
       if (build.entry.module.handleDataRequest) {
         let match = matches!.find((match) => match.route.id == routeId)!;
@@ -82,39 +66,19 @@ export const createRequestHandler: CreateRequestHandlerFunction = (
       matches &&
       matches[matches.length - 1].route.module.default == null
     ) {
-      if (ENABLE_REMIX_ROUTER) {
-        response = await handleResourceRequestRR(
-          serverMode,
-          staticHandler!,
-          matches.slice(-1)[0].route.id,
-          request
-        );
-      } else {
-        response = await handleResourceRequest({
-          request,
-          loadContext,
-          matches,
-          serverMode,
-        });
-      }
+      response = await handleResourceRequestRR(
+        serverMode,
+        staticHandler!,
+        matches.slice(-1)[0].route.id,
+        request
+      );
     } else {
-      if (ENABLE_REMIX_ROUTER) {
-        response = await handleDocumentRequestRR(
-          serverMode,
-          build,
-          staticHandler!,
-          request
-        );
-      } else {
-        response = await handleDocumentRequest({
-          build,
-          loadContext,
-          matches,
-          request,
-          routes,
-          serverMode,
-        });
-      }
+      response = await handleDocumentRequestRR(
+        serverMode,
+        build,
+        staticHandler!,
+        request
+      );
     }
 
     if (request.method === "HEAD") {
@@ -128,124 +92,6 @@ export const createRequestHandler: CreateRequestHandlerFunction = (
     return response;
   };
 };
-
-async function handleDataRequest({
-  loadContext,
-  matches,
-  request,
-  serverMode,
-}: {
-  loadContext: AppLoadContext;
-  matches: RouteMatch<ServerRoute>[];
-  request: Request;
-  serverMode: ServerMode;
-}): Promise<Response> {
-  let response: Response;
-  let match: RouteMatch<ServerRoute>;
-
-  try {
-    if (!isValidRequestMethod(request)) {
-      throw new ErrorResponse(
-        405,
-        "Method Not Allowed",
-        new Error(`Invalid request method "${request.method}"`),
-        true
-      );
-    }
-
-    let url = new URL(request.url);
-
-    if (!matches) {
-      throw new ErrorResponse(
-        404,
-        "Not Found",
-        new Error(`No route matches URL "${url.pathname}"`),
-        true
-      );
-    }
-
-    let routeId = url.searchParams.get("_data");
-    if (!routeId) {
-      throw new ErrorResponse(
-        403,
-        "Forbidden",
-        new Error(`Missing route id in ?_data`),
-        true
-      );
-    }
-
-    let tempMatch = matches.find((match) => match.route.id === routeId);
-    if (!tempMatch) {
-      throw new ErrorResponse(
-        403,
-        "Forbidden",
-        new Error(`Route "${routeId}" does not match URL "${url.pathname}"`),
-        true
-      );
-    }
-    match = tempMatch;
-
-    if (isActionRequest(request)) {
-      match = getRequestMatch(url, matches);
-
-      response = await callRouteAction({
-        loadContext,
-        action: match.route.module.action,
-        routeId: match.route.id,
-        params: match.params,
-        request: request,
-      });
-    } else {
-      response = await callRouteLoader({
-        loadContext,
-        loader: match.route.module.loader,
-        routeId: match.route.id,
-        params: match.params,
-        request,
-      });
-    }
-
-    if (isRedirectResponse(response)) {
-      // We don't have any way to prevent a fetch request from following
-      // redirects. So we use the `X-Remix-Redirect` header to indicate the
-      // next URL, and then "follow" the redirect manually on the client.
-      let headers = new Headers(response.headers);
-      headers.set("X-Remix-Redirect", headers.get("Location")!);
-      headers.delete("Location");
-      if (response.headers.get("Set-Cookie") !== null) {
-        headers.set("X-Remix-Revalidate", "yes");
-      }
-
-      return new Response(null, {
-        status: 204,
-        headers,
-      });
-    }
-
-    return response;
-  } catch (error: unknown) {
-    let status = 500;
-    let errorInstance = error;
-
-    if (isRouteErrorResponse(error)) {
-      status = error.status;
-      errorInstance = error.error || errorInstance;
-    }
-
-    if (serverMode !== ServerMode.Test) {
-      console.error(errorInstance);
-    }
-
-    if (
-      serverMode === ServerMode.Development &&
-      errorInstance instanceof Error
-    ) {
-      return errorBoundaryError(errorInstance, status);
-    }
-
-    return errorBoundaryError(new Error("Unexpected Server Error"), status);
-  }
-}
 
 async function handleDataRequestRR(
   serverMode: ServerMode,
@@ -512,350 +358,6 @@ async function handleDocumentRequestRR(
   }
 }
 
-async function handleDocumentRequest({
-  build,
-  loadContext,
-  matches,
-  request,
-  routes,
-  serverMode,
-}: {
-  build: ServerBuild;
-  loadContext: AppLoadContext;
-  matches: RouteMatch<ServerRoute>[] | null;
-  request: Request;
-  routes: ServerRoute[];
-  serverMode?: ServerMode;
-}): Promise<Response> {
-  let url = new URL(request.url);
-
-  let appState: AppState = {
-    trackBoundaries: true,
-    trackCatchBoundaries: true,
-    catchBoundaryRouteId: null,
-    renderBoundaryRouteId: null,
-    loaderBoundaryRouteId: null,
-    error: undefined,
-    catch: undefined,
-  };
-
-  let errorStatus = 500;
-
-  if (!isValidRequestMethod(request)) {
-    matches = null;
-    appState.loaderBoundaryRouteId = routes[0].module.ErrorBoundary
-      ? routes[0].id
-      : null;
-    appState.trackBoundaries = false;
-    errorStatus = 405;
-    appState.error = await serializeError(
-      new Error(`Invalid request method "${request.method}"`)
-    );
-  } else if (!matches) {
-    appState.trackCatchBoundaries = false;
-    appState.catch = {
-      data: `No route matches URL "${new URL(request.url).pathname}"`,
-      status: 404,
-      statusText: "Not Found",
-    };
-  }
-
-  let actionStatus: { status: number; statusText: string } | undefined;
-  let actionData: Record<string, unknown> | undefined;
-  let actionMatch: RouteMatch<ServerRoute> | undefined;
-  let actionResponse: Response | undefined;
-
-  if (matches && isActionRequest(request)) {
-    actionMatch = getRequestMatch(url, matches);
-
-    try {
-      actionResponse = await callRouteAction({
-        loadContext,
-        action: actionMatch.route.module.action,
-        routeId: actionMatch.route.id,
-        params: actionMatch.params,
-        request: request,
-      });
-
-      if (isRedirectResponse(actionResponse)) {
-        return actionResponse;
-      }
-
-      actionStatus = {
-        status: actionResponse.status,
-        statusText: actionResponse.statusText,
-      };
-
-      if (isCatchResponse(actionResponse)) {
-        appState.catchBoundaryRouteId = getDeepestRouteIdWithBoundary(
-          matches,
-          "CatchBoundary"
-        );
-        appState.trackCatchBoundaries = false;
-        appState.catch = {
-          data: await extractData(actionResponse),
-          status: actionStatus.status,
-          statusText: actionStatus.statusText,
-        };
-      } else {
-        actionData = {
-          [actionMatch.route.id]: await extractData(actionResponse),
-        };
-      }
-    } catch (error: any) {
-      let errorInstance = error;
-      if (isRouteErrorResponse(error)) {
-        errorStatus = error.status;
-        errorInstance = error.error || errorInstance;
-      }
-
-      appState.loaderBoundaryRouteId = getDeepestRouteIdWithBoundary(
-        matches,
-        "ErrorBoundary"
-      );
-      appState.trackBoundaries = false;
-      appState.error = await serializeError(errorInstance);
-
-      if (serverMode !== ServerMode.Test) {
-        console.error(
-          `There was an error running the action for route ${actionMatch.route.id}`
-        );
-      }
-    }
-  }
-
-  let routeModules = createEntryRouteModules(build.routes);
-
-  let matchesToLoad = matches || [];
-
-  // get rid of the action, we don't want to call it's loader either
-  // because we'll be rendering the error/catch boundary, if you can get
-  // access to the loader data in the error/catch boundary then how the heck
-  // is it supposed to deal with thrown responses and/or errors in the loader?
-  if (appState.catch) {
-    matchesToLoad = getMatchesUpToDeepestBoundary(
-      matchesToLoad,
-      "CatchBoundary"
-    ).slice(0, -1);
-  } else if (appState.error) {
-    matchesToLoad = getMatchesUpToDeepestBoundary(
-      matchesToLoad,
-      "ErrorBoundary"
-    ).slice(0, -1);
-  }
-
-  let loaderRequest = new Request(request.url, {
-    body: null,
-    headers: request.headers,
-    method: request.method,
-    redirect: request.redirect,
-    signal: request.signal,
-  });
-
-  let routeLoaderResults = await Promise.allSettled(
-    matchesToLoad.map((match) =>
-      match.route.module.loader
-        ? callRouteLoader({
-            loadContext,
-            loader: match.route.module.loader,
-            routeId: match.route.id,
-            params: match.params,
-            request: loaderRequest,
-          })
-        : Promise.resolve(undefined)
-    )
-  );
-
-  // Store the state of the action. We will use this to determine later
-  // what catch or error boundary should be rendered under cases where
-  // actions don't throw but loaders do, actions throw and parent loaders
-  // also throw, etc.
-  let actionCatch = appState.catch;
-  let actionError = appState.error;
-  let actionCatchBoundaryRouteId = appState.catchBoundaryRouteId;
-  let actionLoaderBoundaryRouteId = appState.loaderBoundaryRouteId;
-  // Reset the app error and catch state to propagate the loader states
-  // from the results into the app state.
-  appState.catch = undefined;
-  appState.error = undefined;
-
-  let headerMatches: RouteMatch<ServerRoute>[] = [];
-  let routeLoaderResponses: Record<string, Response> = {};
-  let loaderStatusCodes: number[] = [];
-  let routeData: Record<string, unknown> = {};
-  for (let index = 0; index < matchesToLoad.length; index++) {
-    let match = matchesToLoad[index];
-    let result = routeLoaderResults[index];
-
-    let error = result.status === "rejected" ? result.reason : undefined;
-    let response = result.status === "fulfilled" ? result.value : undefined;
-    let isRedirect = response ? isRedirectResponse(response) : false;
-    let isCatch = response ? isCatchResponse(response) : false;
-
-    // If a parent loader has already caught or error'd, bail because
-    // we don't need any more child data.
-    if (appState.catch || appState.error) {
-      break;
-    }
-
-    // If there is a response and it's a redirect, do it unless there
-    // is an action error or catch state, those action boundary states
-    // take precedence over loader sates, this means if a loader redirects
-    // after an action catches or errors we won't follow it, and instead
-    // render the boundary caused by the action.
-    if (!actionCatch && !actionError && response && isRedirect) {
-      return response;
-    }
-
-    // Track the boundary ID's for the loaders
-    if (match.route.module.CatchBoundary) {
-      appState.catchBoundaryRouteId = match.route.id;
-    }
-    if (match.route.module.ErrorBoundary) {
-      appState.loaderBoundaryRouteId = match.route.id;
-    }
-
-    if (error) {
-      appState.trackBoundaries = false;
-
-      if (isRouteErrorResponse(error) && error.error) {
-        loaderStatusCodes.push(error.status);
-        appState.error = await serializeError(error.error);
-      } else {
-        loaderStatusCodes.push(500);
-        appState.error = await serializeError(error);
-      }
-
-      if (serverMode !== ServerMode.Test) {
-        console.error(
-          `There was an error running the data loader for route ${match.route.id}`
-        );
-      }
-      break;
-    } else if (response) {
-      headerMatches.push(match);
-      routeLoaderResponses[match.route.id] = response;
-      loaderStatusCodes.push(response.status);
-
-      if (isCatch) {
-        // If it's a catch response, store it in app state, and bail
-        appState.trackCatchBoundaries = false;
-        appState.catch = {
-          data: await extractData(response),
-          status: response.status,
-          statusText: response.statusText,
-        };
-        break;
-      } else {
-        // Extract and store the loader data
-        routeData[match.route.id] = await extractData(response);
-      }
-    }
-  }
-
-  // If there was not a loader catch or error state triggered reset the
-  // boundaries as they are probably deeper in the tree if the action
-  // initially triggered a boundary as that match would not exist in the
-  // matches to load.
-  if (!appState.catch) {
-    appState.catchBoundaryRouteId = actionCatchBoundaryRouteId;
-  }
-  if (!appState.error) {
-    appState.loaderBoundaryRouteId = actionLoaderBoundaryRouteId;
-  }
-  // If there was an action error or catch, we will reset the state to the
-  // initial values, otherwise we will use whatever came out of the loaders.
-  appState.catch = actionCatch || appState.catch;
-  appState.error = actionError || appState.error;
-
-  let renderableMatches = getRenderableMatches(matches, appState);
-  if (!renderableMatches) {
-    renderableMatches = [];
-
-    let root = routes[0];
-    if (root?.module.CatchBoundary) {
-      appState.catchBoundaryRouteId = "root";
-      renderableMatches.push({
-        params: {},
-        pathname: "",
-        route: routes[0],
-      });
-    }
-  }
-
-  // Handle responses with a non-200 status code. The first loader with a
-  // non-200 status code determines the status code for the whole response.
-  let notOkResponse =
-    actionStatus && actionStatus.status !== 200
-      ? actionStatus.status
-      : loaderStatusCodes.find((status) => status !== 200);
-
-  let responseStatusCode = appState.error
-    ? errorStatus
-    : typeof notOkResponse === "number"
-    ? notOkResponse
-    : appState.catch
-    ? appState.catch.status
-    : 200;
-
-  let responseHeaders = getDocumentHeaders(
-    build,
-    renderableMatches,
-    routeLoaderResponses,
-    actionResponse
-  );
-
-  let entryMatches = createEntryMatches(renderableMatches, build.assets.routes);
-
-  let serverHandoff = {
-    actionData,
-    appState: appState,
-    matches: entryMatches,
-    routeData,
-    future: build.future,
-  };
-
-  let entryContext: EntryContext = {
-    ...serverHandoff,
-    manifest: build.assets,
-    routeModules,
-    serverHandoffString: createServerHandoffString(serverHandoff),
-  };
-
-  let handleDocumentRequest = build.entry.module.default;
-  try {
-    return await handleDocumentRequest(
-      request,
-      responseStatusCode,
-      responseHeaders,
-      entryContext
-    );
-  } catch (error: any) {
-    responseStatusCode = 500;
-
-    // Go again, this time with the componentDidCatch emulation. As it rendered
-    // last time we mutated `componentDidCatch.routeId` for the last rendered
-    // route, now we know where to render the error boundary (feels a little
-    // hacky but that's how hooks work). This tells the emulator to stop
-    // tracking the `routeId` as we render because we already have an error to
-    // render.
-    appState.trackBoundaries = false;
-    appState.error = await serializeError(error);
-    entryContext.serverHandoffString = createServerHandoffString(serverHandoff);
-
-    try {
-      return await handleDocumentRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        entryContext
-      );
-    } catch (error: any) {
-      return returnLastResortErrorResponse(error, serverMode);
-    }
-  }
-}
-
 async function handleResourceRequestRR(
   serverMode: ServerMode,
   staticHandler: StaticHandler,
@@ -884,54 +386,6 @@ async function handleResourceRequestRR(
   }
 }
 
-async function handleResourceRequest({
-  loadContext,
-  matches,
-  request,
-  serverMode,
-}: {
-  request: Request;
-  loadContext: AppLoadContext;
-  matches: RouteMatch<ServerRoute>[];
-  serverMode: ServerMode;
-}): Promise<Response> {
-  let match = matches.slice(-1)[0];
-
-  try {
-    if (isActionRequest(request)) {
-      return await callRouteAction({
-        loadContext,
-        action: match.route.module.action,
-        routeId: match.route.id,
-        params: match.params,
-        request,
-      });
-    } else {
-      return await callRouteLoader({
-        loadContext,
-        loader: match.route.module.loader,
-        routeId: match.route.id,
-        params: match.params,
-        request,
-      });
-    }
-  } catch (error: any) {
-    return returnLastResortErrorResponse(error, serverMode);
-  }
-}
-
-const validActionMethods = new Set(["POST", "PUT", "PATCH", "DELETE"]);
-
-function isActionRequest({ method }: Request): boolean {
-  return validActionMethods.has(method.toUpperCase());
-}
-
-const validRequestMethods = new Set(["GET", "HEAD", ...validActionMethods]);
-
-function isValidRequestMethod({ method }: Request): boolean {
-  return validRequestMethods.has(method.toUpperCase());
-}
-
 async function errorBoundaryError(error: Error, status: number) {
   return json(await serializeError(error), {
     status,
@@ -939,61 +393,6 @@ async function errorBoundaryError(error: Error, status: number) {
       "X-Remix-Error": "yes",
     },
   });
-}
-
-function isIndexRequestUrl(url: URL) {
-  // only use bare `?index` params without a value
-  // ✅ /foo?index
-  // ✅ /foo?index&index=123
-  // ✅ /foo?index=123&index
-  // ❌ /foo?index=123
-  return url.searchParams.getAll("index").some((param) => param === "");
-}
-
-function getRequestMatch(url: URL, matches: RouteMatch<ServerRoute>[]) {
-  let match = matches.slice(-1)[0];
-
-  if (isIndexRequestUrl(url) && match.route.id.endsWith("/index")) {
-    return match;
-  }
-
-  return getPathContributingMatches(matches).slice(-1)[0];
-}
-
-function getPathContributingMatches(matches: RouteMatch<ServerRoute>[]) {
-  return matches.filter(
-    (match, index) =>
-      index === 0 ||
-      (!match.route.index && match.route.path && match.route.path.length > 0)
-  );
-}
-
-function getDeepestRouteIdWithBoundary(
-  matches: RouteMatch<ServerRoute>[],
-  key: "CatchBoundary" | "ErrorBoundary"
-) {
-  let matched = getMatchesUpToDeepestBoundary(matches, key).slice(-1)[0];
-  return matched ? matched.route.id : null;
-}
-
-function getMatchesUpToDeepestBoundary(
-  matches: RouteMatch<ServerRoute>[],
-  key: "CatchBoundary" | "ErrorBoundary"
-) {
-  let deepestBoundaryIndex: number = -1;
-
-  matches.forEach((match, index) => {
-    if (match.route.module[key]) {
-      deepestBoundaryIndex = index;
-    }
-  });
-
-  if (deepestBoundaryIndex === -1) {
-    // no route error boundaries, don't need to call any loaders
-    return [];
-  }
-
-  return matches.slice(0, deepestBoundaryIndex + 1);
 }
 
 // This prevents `<Outlet/>` from rendering anything below where the error threw
@@ -1046,120 +445,3 @@ function returnLastResortErrorResponse(error: any, serverMode?: ServerMode) {
     },
   });
 }
-
-// TODO: Remove before we "finalize" router migration
-// async function assert(
-//   a: Response,
-//   b: Response,
-//   accessor: (r: Response) => object | Promise<object>,
-//   message: string
-// ) {
-//   let aStr = JSON.stringify(await accessor(a));
-//   let bStr = JSON.stringify(await accessor(b));
-
-//   if (aStr !== bStr) {
-//     console.error(message);
-//     message += "\nResponse 1:\n" + aStr + "\nResponse 2:\n" + bStr;
-//     throw new Error(message);
-//   }
-// }
-
-// async function assertResponsesMatch(_a: Response, _b: Response) {
-//   let a = _a.clone();
-//   let b = _b.clone();
-//   assert(
-//     a,
-//     b,
-//     (r) => Object.fromEntries(r.headers.entries()),
-//     "Headers did not match!"
-//   );
-
-//   if (a.headers.get("Content-Type")?.startsWith("application/json")) {
-//     if (a.headers.get("X-Remix-Error")) {
-//       assert(
-//         a,
-//         b,
-//         async (r) => {
-//           let { stack, ...json } = await r.json();
-//           return {
-//             ...json,
-//             stack: stack ? "yes" : "no",
-//           };
-//         },
-//         "JSON error response body did not match!\n Response 1:\n" +
-//           (await a.clone().text()) +
-//           "\nResponse 2:\n" +
-//           (await b.clone().text())
-//       );
-//     } else {
-//       assert(
-//         a,
-//         b,
-//         (r) => r.json(),
-//         "JSON response body did not match!\nResponse 1:\n" +
-//           (await a.clone().text()) +
-//           "\nResponse 2:\n" +
-//           (await b.clone().text())
-//       );
-//     }
-//   } else {
-//     assert(
-//       a,
-//       b,
-//       async (r) => {
-//         let text = await r.text();
-
-//         // Strip stack trace from default error boundary HTML
-//         if (
-//           text.includes(">Application Error</h1>") &&
-//           text.includes("💿 Hey developer👋")
-//         ) {
-//           return stripStackTraceFromDefaultErrorBoundary(text);
-//         }
-
-//         if (text.includes("<script>window.__remixContext")) {
-//           return stripStackTraceFromRemixContext(text);
-//         }
-
-//         return text;
-//       },
-//       "Non-JSON response body did not match!\nResponse 1:\n" +
-//         (await a.clone().text()) +
-//         "\nResponse 2:\n" +
-//         (await b.clone().text())
-//     );
-//   }
-// }
-
-// function stripStackTraceFromDefaultErrorBoundary(text: string) {
-//   let openPreStart = text.indexOf("<pre ");
-//   let openPreEnd = text.indexOf('">', openPreStart + 1);
-//   let closePre = text.indexOf("</pre>", openPreEnd + 1);
-//   let error = text.substring(openPreEnd + 2, closePre);
-//   let stackStart = error.indexOf("\n");
-//   let errorWithoutStack = error.substring(0, stackStart);
-//   return (
-//     text.replace(error, "ERROR REMOVED") + "\n\nError:\n" + errorWithoutStack
-//   );
-// }
-
-// function stripStackTraceFromRemixContext(text: string) {
-//   let scriptStart = text.indexOf("<script>window.__remixContext");
-//   let scriptEnd = text.indexOf("</script>", scriptStart + 1);
-//   let scriptContents = text.substring(scriptStart, scriptEnd + 9);
-//   let remixContext = JSON.parse(
-//     scriptContents
-//       .replace("<script>window.__remixContext = ", "")
-//       .replace(";</script>", "")
-//   );
-//   // If we didn't have an error - assert the full document
-//   if (!remixContext?.appState?.error?.stack) {
-//     return text;
-//   }
-
-//   // Otherwise remove the stack trace and assert the text/JSON as a
-//   // concatenated string
-//   remixContext.appState.error.stack = "yes";
-//   text = text.replace(scriptContents, "CONTEXT REMOVED");
-//   return text + "\n\nContext:\n" + JSON.stringify(remixContext);
-// }


### PR DESCRIPTION
[decision doc](https://github-md.com/remix-run/remix/blob/dev/decisions/0007-remix-on-react-router-6-4-0.md#decision)

Step 2 in layering Remix back on top of React Router now that we have released `@remix-run/router`.

Changes:

- Deploy `@remix-run/server-runtime` on-top of a local copy of `@remix-run/router`.

Closes: #

- [ ] Docs
- [x] Tests

Testing Strategy:

Assert that existing tests pass and manually check new code is not in non-experimental production builds.
