### PR TITLE
test(remix-dev): bring `replace-remix-magic-imports` fixture in line with template

### DIFF
--- a/packages/remix-dev/__tests__/fixtures/replace-remix-magic-imports/tsconfig.json
+++ b/packages/remix-dev/__tests__/fixtures/replace-remix-magic-imports/tsconfig.json
@@ -12,6 +12,8 @@
     "resolveJsonModule": true,
     "target": "ES2019",
     "strict": true,
+    "allowJs": true,
+    "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
       "~/*": ["./app/*"]
@@ -19,8 +21,6 @@
     "skipLibCheck": true,
 
     // Remix takes care of building everything in `remix build`.
-    "noEmit": true,
-    "allowJs": true,
-    "forceConsistentCasingInFileNames": true
+    "noEmit": true
   }
 }


### PR DESCRIPTION
For the reasons mentioned in https://github.com/remix-run/remix/pull/4572#discussion_r1022007355