### PR TITLE
chore(tests): Only retry on failed tests in CI

### DIFF
--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -12,7 +12,7 @@ const config: PlaywrightTestConfig = {
     timeout: 5_000,
   },
   forbidOnly: !!process.env.CI,
-  retries: 3,
+  retries: process.env.CI ? 3 : 0,
   reporter: process.env.CI ? "github" : [["html", { open: "never" }]],
   use: { actionTimeout: 0 },
 


### PR DESCRIPTION
This will prevent tests from running multiple times locally when failing. This makes error stack traces easier to follow and reduces overall output noise in the terminal (plus it's just unnecessary for local dev).