### PR TITLE
fix: Integration test for external redirects

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -63,6 +63,7 @@
 - camiaei
 - CanRau
 - ccssmnn
+- cephalization
 - chaance
 - chenc041
 - chenxsan

--- a/integration/redirects-test.ts
+++ b/integration/redirects-test.ts
@@ -144,6 +144,12 @@ test.describe("redirects", () => {
             return <h1>Page 2</h1>
           }
         `,
+        [`app/routes/loader/external.js`]: js`
+          import { redirect } from "@remix-run/node";
+          export const loader = () => {
+            return redirect("https://www.google.com/");
+          }
+        `,
       },
     });
 
@@ -185,5 +191,12 @@ test.describe("redirects", () => {
     await page.waitForSelector(`#app:has-text("cookie-value")`);
     // Loader called twice
     await page.waitForSelector(`#count:has-text("3")`);
+  });
+
+  test("redirects to external URLs", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+
+    await app.waitForNetworkAfter(() => app.goto("/loader/external"));
+    expect(app.page.url()).toBe("https://www.google.com/");
   });
 });

--- a/packages/remix-server-runtime/router/utils.ts
+++ b/packages/remix-server-runtime/router/utils.ts
@@ -818,7 +818,8 @@ export function resolvePath(to: To, fromPathname = "/"): Path {
   } = typeof to === "string" ? parsePath(to) : to;
 
   let pathname = toPathname
-    ? toPathname.startsWith("/")
+    ? // we don't want to prepend the fromPathname on root or external toPathnames'
+      toPathname.startsWith("/") || toPathname.startsWith("http")
       ? toPathname
       : resolvePathname(toPathname, fromPathname)
     : fromPathname;

--- a/packages/remix-server-runtime/router/utils.ts
+++ b/packages/remix-server-runtime/router/utils.ts
@@ -818,8 +818,7 @@ export function resolvePath(to: To, fromPathname = "/"): Path {
   } = typeof to === "string" ? parsePath(to) : to;
 
   let pathname = toPathname
-    ? // we don't want to prepend the fromPathname on root or external toPathnames'
-      toPathname.startsWith("/") || toPathname.startsWith("http")
+    ? toPathname.startsWith("/")
       ? toPathname
       : resolvePathname(toPathname, fromPathname)
     : fromPathname;


### PR DESCRIPTION
Cherry-picked the integration test from https://github.com/remix-run/remix/pull/4579
