### PR TITLE
fix: add missing return to Fix remix dev command

### DIFF
--- a/.changeset/itchy-paws-remain.md
+++ b/.changeset/itchy-paws-remain.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fix missing async return in `remix dev` command

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -197,7 +197,7 @@ export async function watch(
 export async function dev(remixRoot: string, modeArg?: string, port?: number) {
   let config = await readConfig(remixRoot);
   let mode = compiler.parseMode(modeArg ?? "", "development");
-  devServer.serve(config, mode, port);
+  return devServer.serve(config, mode, port);
 }
 
 export async function codemod(


### PR DESCRIPTION
Fixes `remix dev` in `1.8.0-pre.0`

To reproduce:
```sh
> npx create-remix@1.8.0-pre.0
> cd my-remix-app/
> npm run dev
# Command exits without starting server
```
