### PR TITLE
Bump remix to react-router-dom@6.4.3

### DIFF
--- a/.changeset/early-camels-guess.md
+++ b/.changeset/early-camels-guess.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Update `@remix-run/react` to use `Router` from `react-router-dom@6.4.3`

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -239,6 +239,10 @@ function Routes() {
   // need this component, we can just `renderMatches` from RemixEntry
   let { clientRoutes } = useRemixEntryContext();
   // fallback to the root if we don't have a match
+
+  // TODO: clientRoutes currently errors here since RR 6.4 dropped signal as a
+  // loader argument.  We'll be adding tat bac in as part of the rendering work.
+  // @ts-expect-error
   let element = useRoutes(clientRoutes) || (clientRoutes[0].element as any);
   return element;
 }

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -241,7 +241,7 @@ function Routes() {
   // fallback to the root if we don't have a match
 
   // TODO: clientRoutes currently errors here since RR 6.4 dropped signal as a
-  // loader argument.  We'll be adding tat bac in as part of the rendering work.
+  // loader argument.  We'll be adding that back in as part of the rendering work.
   // @ts-expect-error
   let element = useRoutes(clientRoutes) || (clientRoutes[0].element as any);
   return element;

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -17,7 +17,7 @@
   "module": "dist/esm/index.js",
   "dependencies": {
     "history": "^5.3.0",
-    "react-router-dom": "6.3.0"
+    "react-router-dom": "~6.4.3"
   },
   "devDependencies": {
     "@remix-run/server-runtime": "1.7.6",

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -19,7 +19,6 @@
     "@types/cookie": "^0.4.0",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie": "^0.4.1",
-    "react-router-dom": "6.3.0",
     "set-cookie-parser": "^2.4.8",
     "source-map": "^0.7.3"
   },

--- a/packages/remix-server-runtime/routeMatching.ts
+++ b/packages/remix-server-runtime/routeMatching.ts
@@ -1,6 +1,6 @@
-import type { Params, RouteObject } from "react-router"; // TODO: export/import from react-router-dom
-import { matchRoutes } from "react-router-dom";
-
+// TODO: export/import @remix-run/router
+import type { Params, AgnosticRouteObject } from "./router";
+import { matchRoutes } from "./router";
 import type { ServerRoute } from "./routes";
 
 export interface RouteMatch<Route> {
@@ -13,7 +13,10 @@ export function matchServerRoutes(
   routes: ServerRoute[],
   pathname: string
 ): RouteMatch<ServerRoute>[] | null {
-  let matches = matchRoutes(routes as unknown as RouteObject[], pathname);
+  let matches = matchRoutes(
+    routes as unknown as AgnosticRouteObject[],
+    pathname
+  );
   if (!matches) return null;
 
   return matches.map((match) => ({

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -1,10 +1,10 @@
 import type { Location } from "history";
 import type { ComponentType } from "react";
-import type { Params } from "react-router-dom";
 
 import type { AppLoadContext, AppData } from "./data";
 import type { LinkDescriptor } from "./links";
 import type { RouteData } from "./routeData";
+import type { Params } from "./router";
 import type { Route } from "./routes";
 import type { SerializeFrom } from "./serialize";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2257,6 +2257,11 @@
     "@changesets/types" "^5.0.0"
     dotenv "^8.1.0"
 
+"@remix-run/router@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.0.3.tgz#953b88c20ea00d0eddaffdc1b115c08474aa295d"
+  integrity sha512-ceuyTSs7PZ/tQqi19YZNBc5X7kj1f8p+4DIyrcIYFY9h+hd1OKm4RqtiWldR9eGEvIiJfsqwM4BsuCtRIuEw6Q==
+
 "@remix-run/web-blob@^3.0.3", "@remix-run/web-blob@^3.0.4":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@remix-run/web-blob/-/web-blob-3.0.4.tgz"
@@ -7032,7 +7037,7 @@ headers-polyfill@^3.0.4:
   resolved "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.0.7.tgz"
   integrity sha512-JoLCAdCEab58+2/yEmSnOlficyHFpIl0XJqwu3l+Unkm1gXpFUYsThz6Yha3D6tNhocWkCPfyW0YVIGWFqTi7w==
 
-history@^5.2.0, history@^5.3.0:
+history@^5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/history/-/history-5.3.0.tgz"
   integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
@@ -10735,20 +10740,20 @@ react-is@^17.0.1:
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-router-dom@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz"
-  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
+react-router-dom@~6.4.3:
+  version "6.4.3"
+  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.3.tgz#70093b5f65f85f1df9e5d4182eb7ff3a08299275"
+  integrity sha512-MiaYQU8CwVCaOfJdYvt84KQNjT78VF0TJrA17SIQgNHRvLnXDJO6qsFqq8F/zzB1BWZjCFIrQpu4QxcshitziQ==
   dependencies:
-    history "^5.2.0"
-    react-router "6.3.0"
+    "@remix-run/router" "1.0.3"
+    react-router "6.4.3"
 
-react-router@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz"
-  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+react-router@6.4.3:
+  version "6.4.3"
+  resolved "https://registry.npmjs.org/react-router/-/react-router-6.4.3.tgz#9ed3ee4d6e95889e9b075a5d63e29acc7def0d49"
+  integrity sha512-BT6DoGn6aV1FVP5yfODMOiieakp3z46P1Fk0RNzJMACzE7C339sFuHebfvWtnB4pzBvXXkHP2vscJzWRuUjTtA==
   dependencies:
-    history "^5.2.0"
+    "@remix-run/router" "1.0.3"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
* Remove the `react-router-dom` dependency from `@remix-run/server-runtime` since it can pull everything from `./router` now
* Upgrade `@remix-run/react` to use `react-router-dom@~6.4.3`.  Went with a `~` here so we inherit bug fixes automatically but have to manually perform minor version upgrades so we have a chance to ensure full compatibility

Note this is not using `StaticRouterProvider`/`RouterRrovider` yet, still using the old approach (direct `Router` usage), just from the latest deployed version.