### PR TITLE
feat(remix-server-runtime): add "jump to definition" support to `useActionData`/`useLoaderData`/`SerializeFrom`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -450,3 +450,4 @@
 - zachdtaylor
 - zainfathoni
 - zhe
+- sachinraja


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

These changes are upstreamed from [work I did for tRPC](https://github.com/trpc/trpc/pull/3261).

For data inferred from `useLoaderData`, properties do not have jump to definition. This is because [`serialize.ts`](https://github.com/remix-run/remix/blob/8f7100b2d5c40d5b2f0856958898cab70ef9d407/packages/remix-server-runtime/serialize.ts#L39) uses key remapping which breaks jump to definition support for TS (see https://github.com/microsoft/TypeScript/issues/47813). I changed it to use a different strategy for filtering that keeps jump to definition.

Testing Strategy: used the playground and attempted to jump to definition on a property from `useLoaderData`

Before this PR:

https://user-images.githubusercontent.com/58836760/204050884-4609367e-bdd4-4c9a-9afb-bc3618a8811d.mp4


After this PR:

https://user-images.githubusercontent.com/58836760/204050495-659e5d0f-888d-41ce-838b-e50ebdf19629.mp4


<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
