### PR TITLE
feat(remix-eslint-config): warn on possible leaked render

### DIFF
--- a/packages/remix-eslint-config/rules/react.js
+++ b/packages/remix-eslint-config/rules/react.js
@@ -7,6 +7,7 @@ module.exports = {
   "react/forbid-foreign-prop-types": [WARN, { allowInPropTypes: true }],
   "react/jsx-key": WARN,
   "react/jsx-no-comment-textnodes": WARN,
+  "react/jsx-no-leaked-render": [WARN, { validStrategies: ["ternary"] }],
   "react/jsx-no-target-blank": WARN,
   "react/jsx-no-undef": ERROR,
   "react/jsx-pascal-case": [WARN, { allowAllCaps: true, ignore: [] }],


### PR DESCRIPTION
Not doing this can result in bugs.
More info in @kentcdodds' blogpost: https://kentcdodds.com/blog/use-ternaries-rather-than-and-and-in-jsx