### PR TITLE
fix: specify esbuild target

### DIFF
--- a/packages/remix-dev/compiler/compileBrowser.ts
+++ b/packages/remix-dev/compiler/compileBrowser.ts
@@ -154,6 +154,7 @@ const createEsbuildConfig = (
     entryPoints,
     outdir: config.assetsBuildDirectory,
     platform: "browser",
+    target: ['safari12'],
     format: "esm",
     external: [
       // This allows Vanilla Extract to bundle asset imports, e.g. `import href


### PR DESCRIPTION
> Remix only runs in browsers that support [ES Modules](https://caniuse.com/es6-module).

Remix should work in browsers that support ES Modules. But Remix doesn't handle some new syntax which break the statement.

fix #1901 