### PR TITLE
feat: remix optional segments

### DIFF
--- a/packages/remix-dev/__tests__/routesConvention-test.ts
+++ b/packages/remix-dev/__tests__/routesConvention-test.ts
@@ -36,6 +36,47 @@ describe("createRoutePath", () => {
       ["[index]", "index"],
       ["test/inde[x]", "test/index"],
       ["[i]ndex/[[].[[]]", "index/[/[]"],
+
+      // Optional segment routes
+      ["(routes)/$", "routes?/*"],
+      ["(routes)/($)", "routes?/*?"], // TODO: Fails, do we want to allow this?
+      ["(routes)/(sub)/$", "routes?/sub?/*"],
+      ["(routes).(sub)/$", "routes?/sub?/*"],
+      ["(routes.sub)/$", "routes?/sub?/*"], // TODO: Fails, do we want to allow this?
+      ["(routes)/($slug)", "routes?/:slug?"],
+      ["(routes)/sub/($slug)", "routes?/sub/:slug?"],
+      ["(routes).sub/($slug)", "routes?/sub/:slug?"],
+      ["($)", "*?"], // TODO: Fails, do we want to allow this?
+      ["(nested)/$", "nested?/*"],
+      ["(flat).$", "flat?/*"],
+      ["($slug)", ":slug?"],
+      ["(nested)/($slug)", "nested?/:slug?"],
+      ["(flat).($slug)", "flat?/:slug?"],
+      ["flat.(sub)", "flat/sub?"],
+      ["(nested)/(index)", "nested?"], // Fails with `"flat?/index?"`
+      ["(flat).(index)", "flat?"], // Fails with `"flat?/index?"`
+      ["(index)", undefined], // Fails with `"index?"`"
+      ["(__layout)/(index)", undefined], // Fails with __layout?/index?
+      ["__layout/(test)", "test?"],
+      ["__layout.(test)", "test?"],
+      ["__layout/($slug)", ":slug?"],
+      ["(nested)/__layout/($slug)", "nested?/:slug?"],
+      ["($slug[.]json)", ":slug.json?"],
+      ["(sub)/([sitemap.xml])", "sub?/sitemap.xml?"],
+      ["(sub)/[(sitemap.xml)]", "sub?/sitemap.xml?"], // TODO should this have been sub?/(sitemap.xml)
+      ["(posts)/($slug)/([image.jpg])", "posts?/:slug?/image.jpg?"],
+      [
+        "($[$dollabills]).([.]lol)[/](what)/([$]).($)", // TODO outputs ":$dollabills?/.lol?/what?/$?/:?"
+        ":$dollabills/.lol/what/$/*",
+      ],
+      ["(sub).([[])", "sub?/[?"],
+      ["(sub).(])", "sub?/)?"],
+      ["(sub).([([])])", "sub/[]"], // Fails with "sub?/([)]?"
+      ["(sub).([[])", "sub?/[?"],
+      ["(beef])", "beef]?"],
+      ["([index])", "index?"],
+      ["(test)/(inde[x])", "test?/index?"],
+      ["([i]ndex)/([[]).([[]])", "index?/[?/[]?"],
     ];
 
     for (let [input, expected] of tests) {

--- a/packages/remix-dev/config/routesConvention.ts
+++ b/packages/remix-dev/config/routesConvention.ts
@@ -190,7 +190,20 @@ export function createRoutePath(partialRouteId: string): string | undefined {
     result = result.replace(/\/?index$/, "");
   }
 
-  return result || undefined;
+  return generateOptionalDynamicRoutes(result) || undefined;
+}
+
+function generateOptionalDynamicRoutes(routeId: string) {
+  let segments = routeId.split("/");
+
+  let newSegments = [];
+  for (let segment of segments) {
+    console.log(segment, "segment");
+    console.log(segment.replace(/^\((.+)\)$/, "$1"));
+    newSegments.push(segment.replace(/^\((.+)\)$/, "$1?"));
+  }
+
+  return newSegments.join("/");
 }
 
 function findParentRouteId(


### PR DESCRIPTION
Closes: https://github.com/remix-run/react-router/discussions/9550
Related: https://github.com/remix-run/react-router/pull/9650

As discussed this would transform remix routes`/($lang)/about`
into `/:lang?/about` which would then be matched by react-router (https://github.com/remix-run/react-router/pull/9650)
```
/lang/about
/about
```

Another example `/(one)/($two)/(three).($four)` file routing would get transformed into `/one?/:two?/three?/:four? which then would get matched by react-router:
```
/
/one
/one/:two
/one/:two/three
/one/:two/three/:four
```

## Context
Parenthesis was chosen to denote optionality since windows file systems can't have `?` 

## Feedback needed
left some tests failing, for some edge cases. I would like feedback on how would be best to handle them or how to be more defensive about this.

- [ ] Docs
- [X] Tests

Testing Strategy:
This test covers this code: https://github.com/remix-run/remix/compare/dev...lordofthecactus:remix:feat/remix-optional-segments?expand=1#diff-04792fa211911bb758e39db1e8bc1dfffb55657840b8f9f17fbc2330d7b346e1R41-R79