### PR TITLE
fix(remix-dev): convert `config.appDirectory` to relative unix path

### DIFF
--- a/packages/remix-dev/__tests__/migrations/convert-to-javascript-test.ts
+++ b/packages/remix-dev/__tests__/migrations/convert-to-javascript-test.ts
@@ -7,6 +7,7 @@ import {
   readJSONSync,
   realpathSync,
   removeSync,
+  readFile
 } from "fs-extra";
 import shell from "shelljs";
 import stripAnsi from "strip-ansi";
@@ -98,6 +99,10 @@ const checkMigrationRanSuccessfully = async (projectDir: string) => {
   expect(exportDefaultResult.stdout.trim()).toBe("");
   expect(exportDefaultResult.stderr).toBeNull();
   expect(exportDefaultResult.code).toBe(0);
+
+  let rootRouteContent = await readFile(join(projectDir, "app", "root.jsx"), "utf-8")
+
+  expect(!(rootRouteContent).includes('require("@remix-run/react")'))
 };
 
 const makeApp = () => {

--- a/packages/remix-dev/__tests__/migrations/convert-to-javascript-test.ts
+++ b/packages/remix-dev/__tests__/migrations/convert-to-javascript-test.ts
@@ -7,7 +7,7 @@ import {
   readJSONSync,
   realpathSync,
   removeSync,
-  readFile
+  readFile,
 } from "fs-extra";
 import shell from "shelljs";
 import stripAnsi from "strip-ansi";
@@ -100,9 +100,12 @@ const checkMigrationRanSuccessfully = async (projectDir: string) => {
   expect(exportDefaultResult.stderr).toBeNull();
   expect(exportDefaultResult.code).toBe(0);
 
-  let rootRouteContent = await readFile(join(projectDir, "app", "root.jsx"), "utf-8")
+  let rootRouteContent = await readFile(
+    join(projectDir, "app", "root.jsx"),
+    "utf-8"
+  );
 
-  expect(!(rootRouteContent).includes('require("@remix-run/react")'))
+  expect(rootRouteContent).not.toContain('require("@remix-run/react")');
 };
 
 const makeApp = () => {

--- a/packages/remix-dev/__tests__/migrations/convert-to-javascript-test.ts
+++ b/packages/remix-dev/__tests__/migrations/convert-to-javascript-test.ts
@@ -1,5 +1,5 @@
 import { tmpdir } from "os";
-import { join } from "path";
+import path from "path";
 import glob from "fast-glob";
 import {
   copySync,
@@ -38,8 +38,8 @@ const mockLog = (message: unknown = "", ...rest: unknown[]) => {
   output += "\n" + stripAnsi(messageString);
 };
 
-const FIXTURE = join(__dirname, "fixtures", "indie-stack");
-const TEMP_DIR = join(
+const FIXTURE = path.join(__dirname, "fixtures", "indie-stack");
+const TEMP_DIR = path.join(
   realpathSync(tmpdir()),
   `remix-tests-${Math.random().toString(32).slice(2)}`
 );
@@ -67,7 +67,7 @@ const checkMigrationRanSuccessfully = async (projectDir: string) => {
   let config = await readConfig(projectDir);
 
   let jsConfigJson: TsConfigJson = readJSONSync(
-    join(projectDir, "jsconfig.json")
+    path.join(projectDir, "jsconfig.json")
   );
   expect(jsConfigJson.include).not.toContain("remix.env.d.ts");
   expect(jsConfigJson.include).not.toContain("**/*.ts");
@@ -75,21 +75,31 @@ const checkMigrationRanSuccessfully = async (projectDir: string) => {
   expect(jsConfigJson.include).not.toContain("**/*.tsx");
   expect(jsConfigJson.include).toContain("**/*.jsx");
 
-  let packageJson: PackageJson = readJSONSync(join(projectDir, "package.json"));
+  let packageJson: PackageJson = readJSONSync(
+    path.join(projectDir, "package.json")
+  );
   expect(packageJson.devDependencies).not.toContain("@types/react");
   expect(packageJson.devDependencies).not.toContain("@types/react-dom");
   expect(packageJson.devDependencies).not.toContain("typescript");
   expect(packageJson.scripts).not.toContain("typecheck");
 
+  let relativeAppDirectory = path.relative(
+    config.rootDirectory,
+    config.appDirectory
+  );
+  let unixAppDirectory = path.posix.join(
+    ...relativeAppDirectory.split(path.delimiter)
+  );
+
   let TSFiles = glob.sync("**/*.@(ts|tsx)", {
     cwd: config.rootDirectory,
-    ignore: [`./${config.appDirectory}/**/*`],
+    ignore: [`./${unixAppDirectory}/**/*`],
   });
   expect(TSFiles).toHaveLength(0);
   let JSFiles = glob.sync("**/*.@(js|jsx)", {
     absolute: true,
     cwd: config.rootDirectory,
-    ignore: [`./${config.appDirectory}/**/*`],
+    ignore: [`./${unixAppDirectory}/**/*`],
   });
   let importResult = shell.grep("-l", 'from "', JSFiles);
   expect(importResult.stdout.trim()).toBe("");
@@ -101,7 +111,7 @@ const checkMigrationRanSuccessfully = async (projectDir: string) => {
   expect(exportDefaultResult.code).toBe(0);
 
   let rootRouteContent = await readFile(
-    join(projectDir, "app", "root.jsx"),
+    path.join(projectDir, "app", "root.jsx"),
     "utf-8"
   );
 
@@ -109,7 +119,7 @@ const checkMigrationRanSuccessfully = async (projectDir: string) => {
 };
 
 const makeApp = () => {
-  let projectDir = join(TEMP_DIR, "convert-to-javascript");
+  let projectDir = path.join(TEMP_DIR, "convert-to-javascript");
   copySync(FIXTURE, projectDir);
   return projectDir;
 };

--- a/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/index.ts
+++ b/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/index.ts
@@ -23,16 +23,20 @@ export const convertToJavaScript: MigrationFunction = async (
   // 2. Remove @types/* & TypeScript dependencies + `typecheck` script from `package.json`
   await cleanupPackageJson(config.rootDirectory);
 
-  // 3. Force unix style path for `appDirectory`
+  // 3. cConvert appDirectory to relative and force unix style path
+  let relativeAppDirectory = path.relative(
+    config.rootDirectory,
+    config.appDirectory
+  );
   let unixAppDirectory = path.posix.join(
-    ...config.appDirectory.split(path.delimiter)
+    ...relativeAppDirectory.split(path.delimiter)
   );
 
   // 4. Run codemod
   let files = glob.sync("**/*.+(ts|tsx)", {
     absolute: true,
     cwd: config.rootDirectory,
-    ignore: [`./${unixAppDirectory}/**/*`, "**/node_modules/**"],
+    ignore: [`${unixAppDirectory}/**/*`, "**/node_modules/**"],
   });
   let codemodOk = await jscodeshift.run({
     files,

--- a/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/index.ts
+++ b/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/index.ts
@@ -23,7 +23,7 @@ export const convertToJavaScript: MigrationFunction = async (
   // 2. Remove @types/* & TypeScript dependencies + `typecheck` script from `package.json`
   await cleanupPackageJson(config.rootDirectory);
 
-  // 3. cConvert appDirectory to relative and force unix style path
+  // 3. convert appDirectory to relative and force unix style path
   let relativeAppDirectory = path.relative(
     config.rootDirectory,
     config.appDirectory

--- a/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/index.ts
+++ b/packages/remix-dev/cli/migrate/migrations/convert-to-javascript/index.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import path from "path";
 import glob from "fast-glob";
 
 import { readConfig } from "../../../../config";
@@ -9,7 +9,7 @@ import { convertTSConfigs } from "./convertTSConfigs";
 import { convertTSFilesToJS } from "./convertTSFilesToJS";
 import { CliError } from "../../../error";
 
-const TRANSFORM_PATH = join(__dirname, "transform");
+const TRANSFORM_PATH = path.join(__dirname, "transform");
 
 export const convertToJavaScript: MigrationFunction = async (
   projectDir,
@@ -23,11 +23,16 @@ export const convertToJavaScript: MigrationFunction = async (
   // 2. Remove @types/* & TypeScript dependencies + `typecheck` script from `package.json`
   await cleanupPackageJson(config.rootDirectory);
 
-  // 3. Run codemod
+  // 3. Force unix style path for `appDirectory`
+  let unixAppDirectory = path.posix.join(
+    ...config.appDirectory.split(path.delimiter)
+  );
+
+  // 4. Run codemod
   let files = glob.sync("**/*.+(ts|tsx)", {
     absolute: true,
     cwd: config.rootDirectory,
-    ignore: [`./${config.appDirectory}/**/*`, "**/node_modules/**"],
+    ignore: [`./${unixAppDirectory}/**/*`, "**/node_modules/**"],
   });
   let codemodOk = await jscodeshift.run({
     files,


### PR DESCRIPTION
first off, shout out to the lovely discord folks for uncovering this one https://canary.discord.com/channels/770287896669978684/1046094365426208818/1046094365426208818

fast-glob requires unix style paths

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
