### PR TITLE
ci: add typechecking for deno

### DIFF
--- a/.changeset/clean-clocks-float.md
+++ b/.changeset/clean-clocks-float.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/deno": patch
+---
+
+Fix types for request handler context

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -107,6 +107,11 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: "yarn"
 
+      - name: 🦕 Setup deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: vx.x.x
+
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
 
@@ -138,6 +143,11 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: "yarn"
 
+      - name: 🦕 Setup deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: vx.x.x
+
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
 
@@ -168,6 +178,11 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: "yarn"
+
+      - name: 🦕 Setup deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: vx.x.x
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -35,6 +35,11 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "yarn"
 
+      - name: 🦕 Setup deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: vx.x.x
+
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
 
@@ -64,6 +69,11 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: "yarn"
+
+      - name: 🦕 Setup deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: vx.x.x
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.vscode/deno_resolve_npm_imports.json
+++ b/.vscode/deno_resolve_npm_imports.json
@@ -1,11 +1,13 @@
 {
-  "// Resolve NPM imports for `packages/remix-deno`.": "",
-  "// This import map is used solely for the denoland.vscode-deno extension.": "",
-  "// Remix does not support import maps.": "",
-  "// Dependency management is done through `npm` and `node_modules/` instead.": "",
-  "// Deno-only dependencies may be imported via URL imports (without using import maps).": "",
+  "comment": [
+    "Resolve NPM imports for `packages/remix-deno`.",
+    "This import map is used solely for the denoland.vscode-deno extension.",
+    "Remix does not support import maps.",
+    "Dependency management is done through `npm` and `node_modules/` instead.",
+    "Deno-only dependencies may be imported via URL imports (without using import maps)."
+  ],
   "imports": {
-    "@remix-run/server-runtime": "https://esm.sh/@remix-run/server-runtime@1.6.4",
+    "@remix-run/server-runtime": "https://esm.sh/@remix-run/server-runtime@nightly",
     "mime": "https://esm.sh/mime@3.0.0"
   }
 }

--- a/packages/remix-deno/server.ts
+++ b/packages/remix-deno/server.ts
@@ -1,7 +1,7 @@
 import * as path from "https://deno.land/std@0.128.0/path/mod.ts";
 import mime from "mime";
 import { createRequestHandler as createRemixRequestHandler } from "@remix-run/server-runtime";
-import type { ServerBuild } from "@remix-run/server-runtime";
+import type { AppLoadContext, ServerBuild } from "@remix-run/server-runtime";
 
 function defaultCacheControl(url: URL, assetsPublicPath = "/build/") {
   if (url.pathname.startsWith(assetsPublicPath)) {
@@ -11,7 +11,9 @@ function defaultCacheControl(url: URL, assetsPublicPath = "/build/") {
   }
 }
 
-export function createRequestHandler<Context = unknown>({
+export function createRequestHandler<
+  Context extends AppLoadContext | undefined = undefined
+>({
   build,
   mode,
   getLoadContext,
@@ -51,7 +53,7 @@ export async function serveStaticFiles(
     cacheControl?: string | ((url: URL) => string);
     publicDir?: string;
     assetsPublicPath?: string;
-  },
+  }
 ) {
   const url = new URL(request.url);
 
@@ -81,7 +83,9 @@ export async function serveStaticFiles(
   }
 }
 
-export function createRequestHandlerWithStaticFiles<Context = unknown>({
+export function createRequestHandlerWithStaticFiles<
+  Context extends AppLoadContext | undefined = undefined
+>({
   build,
   mode,
   getLoadContext,

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,11 +1,22 @@
 import { spawn } from "cross-spawn";
+import glob from "glob";
 
 const args = process.argv.slice(2);
 const tsc = process.env.CI || args.includes("--tsc");
 const publish = process.env.CI || args.includes("--publish");
+const denoCheck = process.env.CI || args.includes("--deno");
 
 exec("yarn", ["rollup", "-c"])
   .then(() => tsc && exec("yarn", ["tsc", "-b"]))
+  .then(
+    () =>
+      denoCheck &&
+      exec("deno", [
+        "check",
+        "--import-map=.vscode/deno_resolve_npm_imports.json",
+        ...glob.sync("packages/remix-deno/**/*.ts"),
+      ])
+  )
   .then(() => publish && exec("node", ["scripts/copy-build-to-dist.mjs"]))
   .then(() => process.exit(0))
   .catch((err) => {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Currently no typechecking is performed on the `remix-deno` package, because `tsc` cannot handle `.ts` file extension imports. This PR adds support for typechecking using the `deno check` command. 

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

Run `yarn build --deno`

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
