### PR TITLE
Fix 4199: TypedResponse allows incompatible types

### DIFF
--- a/.changeset/light-sheep-give.md
+++ b/.changeset/light-sheep-give.md
@@ -1,0 +1,26 @@
+---
+"remix": patch
+"@remix-run/serve": patch
+"@remix-run/server-runtime": patch
+---
+
+Fix `TypedResponse` so that Typescript correctly shows errors for incompatible types in loaders and actions.
+
+Previously, when the return type of a loader or action was explicitly set to `TypedResponse<SomeType>`,
+Typescript would not show errors when the loader or action returned an incompatible type.
+
+For example:
+
+```ts
+export const action = async (args: ActionArgs): Promise<TypedResponse<string>> => {
+    return json(42);
+};
+```
+
+In this case, Typescript would now show an error even though `42` is clearly not a `string`.
+
+In this case, happens because `json` returns a `TypedResponse<string>`,
+but because `TypedReponse<string>` is just `Response & { json: () => Promise<string> }`
+and `Response` already defines `{ json: () => Promise<any> }`, then type erasure caused `Promise<any>` to be used for `42`.
+
+To fix this, we explicitly omit the `Response`'s `json` property before intersecting with `{ json: () => Promise<T> }`.

--- a/.changeset/light-sheep-give.md
+++ b/.changeset/light-sheep-give.md
@@ -17,10 +17,10 @@ export const action = async (args: ActionArgs): Promise<TypedResponse<string>> =
 };
 ```
 
-In this case, Typescript would now show an error even though `42` is clearly not a `string`.
+In this case, Typescript would not show an error even though `42` is clearly not a `string`.
 
-In this case, happens because `json` returns a `TypedResponse<string>`,
+This happens because `json` returns a `TypedResponse<string>`,
 but because `TypedReponse<string>` is just `Response & { json: () => Promise<string> }`
-and `Response` already defines `{ json: () => Promise<any> }`, then type erasure caused `Promise<any>` to be used for `42`.
+and `Response` already defines `{ json: () => Promise<any> }`, type erasure causes `Promise<any>` to be used for `42`.
 
 To fix this, we explicitly omit the `Response`'s `json` property before intersecting with `{ json: () => Promise<T> }`.

--- a/.changeset/light-sheep-give.md
+++ b/.changeset/light-sheep-give.md
@@ -20,7 +20,7 @@ export const action = async (args: ActionArgs): Promise<TypedResponse<string>> =
 In this case, Typescript would not show an error even though `42` is clearly not a `string`.
 
 This happens because `json` returns a `TypedResponse<string>`,
-but because `TypedReponse<string>` is just `Response & { json: () => Promise<string> }`
-and `Response` already defines `{ json: () => Promise<any> }`, type erasure causes `Promise<any>` to be used for `42`.
+but because `TypedReponse<string>` was previously just `Response & { json: () => Promise<string> }`
+and `Response` already defines `{ json: () => Promise<any> }`, type erasure caused `Promise<any>` to be used for `42`.
 
 To fix this, we explicitly omit the `Response`'s `json` property before intersecting with `{ json: () => Promise<T> }`.

--- a/contributors.yml
+++ b/contributors.yml
@@ -452,3 +452,4 @@
 - zachdtaylor
 - zainfathoni
 - zhe
+- dabdine

--- a/packages/remix-server-runtime/__tests__/responses-test.ts
+++ b/packages/remix-server-runtime/__tests__/responses-test.ts
@@ -44,6 +44,11 @@ describe("json", () => {
     expect(result).toMatchObject({ hello: "remix" });
   });
 
+  it("disallows unmatched typed responses", async () => {
+    let response = json("hello");
+    isEqual<TypedResponse<number>, typeof response>(false);
+  });
+
   it("disallows unserializables", () => {
     // @ts-expect-error
     expect(() => json(124n)).toThrow();

--- a/packages/remix-server-runtime/responses.ts
+++ b/packages/remix-server-runtime/responses.ts
@@ -5,7 +5,7 @@ export type JsonFunction = <Data extends unknown>(
 
 // must be a type since this is a subtype of response
 // interfaces must conform to the types they extend
-export type TypedResponse<T extends unknown = unknown> = Response & {
+export type TypedResponse<T extends unknown = unknown> = Omit<Response, 'json'> & {
   json(): Promise<T>;
 };
 


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #4199: TypedResponse allows incompatible types

NOTE: I believe there's a _small_ chance this can be a breaking change for some people who may have been counting on the previous TypedResponse behavior. To be more explicit, something like this would fail now, as the actual return type is different than the declared return type (which was not enforced prior to this patch):

```typescript
export const action = async (args: ActionArgs): Promise<TypedResponse<string>> => {
    return json(42);
};
```

This should have been the desired behavior though, and would be a benefit as users would either have to update their method declarations or fix their code as we're uncovering errors that were previously hidden.

[Playground link demonstrating the issue](https://www.typescriptlang.org/play?&q=483#code/LAKALgngDgpgBAFWjAJgJRgZygewHaYwA8CcMAHmDHipnAK54DWeOA7nnALwPOscA+bnAzZ8hOADI4Ab1Bw4AK0z4AFAEoAXHAAKAJxwBbAJaESAgDSgAvgG5QoSLDgA5GGySx0WXAWKkKKho6RhZ2Th5Q-jwhHgB5EzAiUV9CCzgAcmV8DKFpORAFbLwNbX0jU39LG3sQUAB6ergASRcAYTi0NABRNoRtMAALUzhMQZx6ABsUOFYwOAAjeFxMTGMFyZhQTfnjPABjHD09GH2wbU9UFPFiPHpDJb1Y2Ws4AEM6S+8xPyJMMD0ewA5gJag0mh0ur1+nAAJoTOBAmDzN5wJxYfaAqDzGDHI5wPZo4Z0fYfLYgHZwQ7HU7nVzuL7XX53B6454yV4fekeZDfVLEf6AvAg2pAA)

- [ ] Docs
- [X] Tests

Testing Strategy:

Added a test case to `responses-test.ts`. Note, it's a compile-time test, so it's not something `yarn test` would normally catch. However, I also ran the following from my command line:

```bash
yarn test
```

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
