### PR TITLE
fix(remix-react): fix unsafe access to sessionStorage

### DIFF
--- a/.changeset/wicked-bananas-taste.md
+++ b/.changeset/wicked-bananas-taste.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/react": patch
+---
+
+fix(remix-react): fix unsafe access to sessionStorage

--- a/contributors.yml
+++ b/contributors.yml
@@ -178,6 +178,7 @@
 - jamiebuilds
 - janhoogeveen
 - Jannis-Morgenstern
+- Jarrku
 - jasonadelia
 - jaydiablo
 - jca41


### PR DESCRIPTION
Solves: Remix apps crashing in incognito mode when embedded through an iframe in another webpage.

Safeguards accessing `sessionStorage` in cases where it's not available (iframe'd application on another website in incognito mode).


<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

CSB: https://codesandbox.io/s/zealous-knuth-btnb9r?file=/index.html

Testing Strategy:

Visit following csb url in both regular chrome & incognito chrome:  https://btnb9r.csb.app/

Regular chrome: It loads
Incognito chrome: Crashes due to accessing sessionStorage.

Context:
We're developing a plugin that third parties can embed in their own webpage through an iframe. However, remix currently crashes on those webpages in incognito mode because it accesses sessionStorages before checking if it's available.

Initially, we worked around this issue by removing the scroll restoration component, but it seems some of it's code is ran regardless. 

Thanks for your time and feedback in advance!

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
