### PR TITLE
docs(tutorials/blog): Don't mention removed errors typecheck

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -395,6 +395,7 @@
 - sergiodxa
 - shairez
 - shashankboosi
+- shubhaguha
 - shumuu
 - sidkh
 - sidv1905

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -921,7 +921,7 @@ export default function NewPost() {
 }
 ```
 
-TypeScript is still mad, because someone could call our API with non-string values, so let's add some invariants and a new type for the error object to make it happy.
+TypeScript is still mad, because someone could call our API with non-string values, so let's add some invariants to make it happy.
 
 ```tsx filename=app/routes/posts/admin/new.tsx nocopy
 //...


### PR DESCRIPTION
Very small and simple docs edit (fixing a typo in the blog tutorial). Looks like the "new type for the error object" mentioned on this line was removed from the code snippet in the following commit ~8 months ago: https://github.com/remix-run/remix/commit/28ef6426861e6f6b670b6bd654272726b3c5c936

This PR will remove the mention of said missing code snippet.