### PR TITLE
chore(remix-testing): update dependencies

### DIFF
--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remix-run/testing",
-  "version": "1.7.6",
+  "version": "1.8.0",
   "description": "Testing utilities for Remix apps",
   "homepage": "https://remix.run",
   "bugs": {
@@ -16,9 +16,9 @@
   "typings": "./dist/index.d.ts",
   "module": "./dist/esm/index.js",
   "dependencies": {
-    "@remix-run/node": "1.7.6",
-    "@remix-run/react": "1.7.6",
-    "@remix-run/server-runtime": "1.7.6",
+    "@remix-run/node": "1.8.0",
+    "@remix-run/react": "1.8.0",
+    "@remix-run/server-runtime": "1.8.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
Without this, an older version (`1.7.6`) of `@remix-run/node`, `@remix-run/react` & `@remix-run/server-runtime` would be added to `yarn.lock` when running `yarn install`