### PR TITLE
fix(remix-testing): fix deps

### DIFF
--- a/packages/remix-server-runtime/index.ts
+++ b/packages/remix-server-runtime/index.ts
@@ -74,21 +74,3 @@ export type {
   UploadHandler,
   UploadHandlerPart,
 } from "./reexport";
-
-export type {
-  AgnosticDataRouteObject,
-  AgnosticIndexRouteObject,
-  AgnosticNonIndexRouteObject,
-  AgnosticRouteObject,
-  InitialEntry,
-  Location,
-  MemoryHistory,
-  StaticHandler,
-} from "./router";
-export {
-  createMemoryHistory,
-  matchRoutes,
-  unstable_createStaticHandler,
-} from "./router";
-export type { Update } from "./router/history";
-export type { AgnosticRouteMatch } from "./router/utils";

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -8,14 +8,11 @@ import type {
   RouteModules,
 } from "@remix-run/react";
 import { RemixEntry } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
-
 import type {
   Action,
   AgnosticDataRouteObject,
   AgnosticIndexRouteObject,
   AgnosticNonIndexRouteObject,
-  AgnosticRouteObject,
   AgnosticRouteMatch,
   InitialEntry,
   Location,
@@ -27,6 +24,7 @@ import {
   matchRoutes,
   unstable_createStaticHandler as createStaticHandler,
 } from "@remix-run/router";
+import { json } from "@remix-run/server-runtime";
 
 type Update = {
   action: Action;

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -8,23 +8,30 @@ import type {
   RouteModules,
 } from "@remix-run/react";
 import { RemixEntry } from "@remix-run/react";
+import { json } from "@remix-run/server-runtime";
+
 import type {
+  Action,
   AgnosticDataRouteObject,
   AgnosticIndexRouteObject,
   AgnosticNonIndexRouteObject,
+  AgnosticRouteObject,
   AgnosticRouteMatch,
   InitialEntry,
   Location,
   MemoryHistory,
   StaticHandler,
-  Update,
-} from "@remix-run/server-runtime";
+} from "@remix-run/router";
 import {
   createMemoryHistory,
-  json,
   matchRoutes,
   unstable_createStaticHandler as createStaticHandler,
-} from "@remix-run/server-runtime";
+} from "@remix-run/router";
+
+type Update = {
+  action: Action;
+  location: Location;
+};
 
 type RemixStubOptions = {
   /**

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remix-run/testing",
-  "version": "1.7.6",
+  "version": "1.8.0",
   "description": "Testing utilities for Remix apps",
   "homepage": "https://remix.run",
   "bugs": {
@@ -16,9 +16,10 @@
   "typings": "./dist/index.d.ts",
   "module": "./dist/esm/index.js",
   "dependencies": {
-    "@remix-run/node": "1.7.6",
-    "@remix-run/react": "1.7.6",
-    "@remix-run/server-runtime": "1.7.6",
+    "@remix-run/node": "1.8.0",
+    "@remix-run/react": "1.8.0",
+    "@remix-run/router": "1.0.4",
+    "@remix-run/server-runtime": "1.8.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
The feature branch for the `remix-testing` got a bit stale once we released 1.8.0 and deleted the dup router code