### PR TITLE
chore(remix-testing): use `@remix-run/router` directly

### DIFF
--- a/packages/remix-server-runtime/index.ts
+++ b/packages/remix-server-runtime/index.ts
@@ -74,21 +74,3 @@ export type {
   UploadHandler,
   UploadHandlerPart,
 } from "./reexport";
-
-export type {
-  AgnosticDataRouteObject,
-  AgnosticIndexRouteObject,
-  AgnosticNonIndexRouteObject,
-  AgnosticRouteObject,
-  InitialEntry,
-  Location,
-  MemoryHistory,
-  StaticHandler,
-} from "./router";
-export {
-  createMemoryHistory,
-  matchRoutes,
-  unstable_createStaticHandler,
-} from "./router";
-export type { Update } from "./router/history";
-export type { AgnosticRouteMatch } from "./router/utils";

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -18,13 +18,13 @@ import type {
   MemoryHistory,
   StaticHandler,
   Update,
-} from "@remix-run/server-runtime";
+} from "@remix-run/router";
 import {
   createMemoryHistory,
   json,
   matchRoutes,
   unstable_createStaticHandler as createStaticHandler,
-} from "@remix-run/server-runtime";
+} from "@remix-run/router";
 
 type RemixStubOptions = {
   /**

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@remix-run/node": "1.7.6",
     "@remix-run/react": "1.7.6",
-    "@remix-run/server-runtime": "1.7.6",
+    "@remix-run/router": "1.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
Follow-up of #4539 

Fixes CI failures 