### PR TITLE
docs(other-api/react-router): fix `react-router` links

### DIFF
--- a/docs/other-api/react-router.md
+++ b/docs/other-api/react-router.md
@@ -15,8 +15,8 @@ Remix is built on top of React Router v6. Here are the most common APIs that you
 
 Most of the other APIs are either used internally by Remix or just aren't commonly needed in your app.
 
-[outlet]: https://reactrouter.com/docs/components/outlet
-[use-location]: https://reactrouter.com/docs/hooks/use-location
-[use-navigate]: https://reactrouter.com/docs/hooks/use-navigate
-[use-params]: https://reactrouter.com/docs/hooks/use-params
-[use-resolved-path]: https://reactrouter.com/docs/hooks/use-resolved-path
+[outlet]: https://reactrouter.com/components/outlet
+[use-location]: https://reactrouter.com/hooks/use-location
+[use-navigate]: https://reactrouter.com/hooks/use-navigate
+[use-params]: https://reactrouter.com/hooks/use-params
+[use-resolved-path]: https://reactrouter.com/hooks/use-resolved-path


### PR DESCRIPTION
Fixes the broken URLs in [React Router v6 api page](https://remix.run/docs/en/v1/other-api/react-router) while I was reading the documentation. I assume those are the correct links, but pls correct me if I'm wrong. 