### PR TITLE
fix(types): Add missing type def for `future` value in `@remix-run/dev/server-build`

### DIFF
--- a/.changeset/blue-tigers-look.md
+++ b/.changeset/blue-tigers-look.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Added a missing type definition for the Remix config `future` option to the `@remix-run/dev/server-build` virtual module

--- a/packages/remix-dev/compiler/plugins/serverEntryModulePlugin.ts
+++ b/packages/remix-dev/compiler/plugins/serverEntryModulePlugin.ts
@@ -33,6 +33,8 @@ export function serverEntryModulePlugin(config: RemixConfig): Plugin {
 import * as entryServer from ${JSON.stringify(`./${config.entryServerFile}`)};
 ${Object.keys(config.routes)
   .map((key, index) => {
+    // IMPORTANT: Any values exported from this generated module must also be
+    // typed in `packages/remix-dev/server-build.ts` to avoid tsc errors.
     let route = config.routes[key];
     return `import * as route${index} from ${JSON.stringify(
       `./${route.file}`

--- a/packages/remix-dev/server-build.ts
+++ b/packages/remix-dev/server-build.ts
@@ -10,6 +10,7 @@ throw new Error(
 export const assets: ServerBuild["assets"] = undefined!;
 export const entry: ServerBuild["entry"] = undefined!;
 export const routes: ServerBuild["routes"] = undefined!;
+export const future: ServerBuild["future"] = undefined!;
 export const publicPath: ServerBuild["publicPath"] = undefined!;
 // prettier-ignore
 export const assetsBuildDirectory: ServerBuild["assetsBuildDirectory"] = undefined!;


### PR DESCRIPTION
This should fix https://github.com/remix-run/remix/issues/4766. Unrelated to https://github.com/remix-run/remix/issues/4759.

Changeset will be added to the release branch @brophdawg11 started. Aiming to cut a hotfix shortly.