### PR TITLE
fix(server-runtime/session): unexpected behaviour in update of session data

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -61,6 +61,7 @@
 - bsides
 - bustamantedev
 - c43721
+- cairin
 - camiaei
 - CanRau
 - ccssmnn

--- a/packages/remix-server-runtime/sessions.ts
+++ b/packages/remix-server-runtime/sessions.ts
@@ -242,7 +242,14 @@ export const createSessionStorageFactory =
       async commitSession(session, options) {
         let { id, data } = session;
 
-        if (id) {
+        let storageData;
+        try {
+          storageData = await readData(id);
+        } catch (e) {
+          storageData = null;
+        }
+
+        if (id && storageData != null) {
           await updateData(id, data, cookie.expires);
         } else {
           id = await createData(data, cookie.expires);

--- a/packages/remix-server-runtime/sessions/memoryStorage.ts
+++ b/packages/remix-server-runtime/sessions/memoryStorage.ts
@@ -28,11 +28,13 @@ export type CreateMemorySessionStorageFunction = (
  */
 export const createMemorySessionStorageFactory =
   (
-    createSessionStorage: CreateSessionStorageFunction
+    createSessionStorage: CreateSessionStorageFunction,
+    dataStore?: Map<string, { data: SessionData; expires?: Date }>
   ): CreateMemorySessionStorageFunction =>
   ({ cookie } = {}) => {
     let uniqueId = 0;
-    let map = new Map<string, { data: SessionData; expires?: Date }>();
+    let map =
+      dataStore ?? new Map<string, { data: SessionData; expires?: Date }>();
 
     return createSessionStorage({
       cookie,
@@ -56,7 +58,7 @@ export const createMemorySessionStorageFactory =
         return null;
       },
       async updateData(id, data, expires) {
-        map.set(id, { data, expires });
+        if (map.has(id)) map.set(id, { data, expires });
       },
       async deleteData(id) {
         map.delete(id);


### PR DESCRIPTION
### Description

> **TLDR**: `commitSession(session)` will always perform an update when there is a valid cookie. Even if the underlying data no longer exists.

The following usage of `createSessionStorage` is currently producing unexpected results:

```js
export const { getSession, commitSession, destroySession } =
  createSessionStorage({
    cookie,
    async createData(data, expires) {
      const id = v4()
      await redisClient.set(id, JSON.stringify(data), {
        PXAT: expires?.valueOf(),
        NX: true // Only perform set if data doesn't exist
      })
      return id
    },
    async readData(id) {
      const data = await redisClient.get(id)
      if (data == null) return null
      return JSON.parse(data)
    },
    async updateData(id, data, expires) {
      await redisClient.set(id, JSON.stringify(data), {
        PXAT: expires?.valueOf(),
        XX: true // Only perform set if data exists
      })
    },
    async deleteData(id) {
      await redisClient.del(id)
    }
  })

```

It would seem reasonable that we can enforce data create/update in the respective CRUD controllers. However, the current implementation of [commitSession](https://github.com/remix-run/remix/blob/dev/packages/remix-server-runtime/sessions.ts#L242-L252) doesn't check if the session data exists when deciding on whether it should create/update the session. If the database fails and the session data is destroyed (before the cookie expires), the above implementation will silently fail. `updateData` won't update the session because it no longer exists, but `commitSession` will not create the data again either. No errors will be thrown.

One could argue that `updateData` should be able to set data, but then why have a full CRUD interface? Also, a decision like that should be documented.

### Testing

The testing strategy and fix is documented in the relevant commit descriptions.

Tests ran using `yarn test:primary --selectProjects server-runtime` during development and `yarn test:primary` to check it didn't have any unexpected implications.
