### PR TITLE
test(integration): close server synchronously 

### DIFF
--- a/integration/abort-signal-test.ts
+++ b/integration/abort-signal-test.ts
@@ -45,7 +45,9 @@ test.beforeAll(async () => {
   appFixture = await createAppFixture(fixture);
 });
 
-test.afterAll(async () => appFixture.close());
+test.afterAll(async () => {
+  await appFixture.close();
+});
 
 test("should not abort the request in a new event loop", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);

--- a/integration/abort-signal-test.ts
+++ b/integration/abort-signal-test.ts
@@ -45,8 +45,8 @@ test.beforeAll(async () => {
   appFixture = await createAppFixture(fixture);
 });
 
-test.afterAll(async () => {
-  await appFixture.close();
+test.afterAll(() => {
+  appFixture.close();
 });
 
 test("should not abort the request in a new event loop", async ({ page }) => {

--- a/integration/action-test.ts
+++ b/integration/action-test.ts
@@ -71,8 +71,8 @@ test.describe("actions", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   let logs: string[] = [];

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -78,7 +78,9 @@ test.beforeAll(async () => {
   appFixture = await createAppFixture(fixture);
 });
 
-test.afterAll(() => appFixture.close());
+test.afterAll(async () => {
+  await appFixture.close();
+});
 
 ////////////////////////////////////////////////////////////////////////////////
 // 💿 Almost done, now write your failing test case(s) down here Make sure to

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -78,8 +78,8 @@ test.beforeAll(async () => {
   appFixture = await createAppFixture(fixture);
 });
 
-test.afterAll(async () => {
-  await appFixture.close();
+test.afterAll(() => {
+  appFixture.close();
 });
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/integration/catch-boundary-data-test.ts
+++ b/integration/catch-boundary-data-test.ts
@@ -156,8 +156,8 @@ test.beforeAll(async () => {
   appFixture = await createAppFixture(fixture);
 });
 
-test.afterAll(async () => {
-  await appFixture.close();
+test.afterAll(() => {
+  appFixture.close();
 });
 
 test("renders root boundary with data available", async () => {

--- a/integration/catch-boundary-data-test.ts
+++ b/integration/catch-boundary-data-test.ts
@@ -156,7 +156,9 @@ test.beforeAll(async () => {
   appFixture = await createAppFixture(fixture);
 });
 
-test.afterAll(async () => appFixture.close());
+test.afterAll(async () => {
+  await appFixture.close();
+});
 
 test("renders root boundary with data available", async () => {
   let res = await fixture.requestDocument(NO_BOUNDARY_LOADER);

--- a/integration/catch-boundary-test.ts
+++ b/integration/catch-boundary-test.ts
@@ -183,7 +183,9 @@ test.describe("CatchBoundary", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(() => appFixture.close());
+  test.afterAll(async () => {
+    await appFixture.close();
+  });
 
   test("non-matching urls on document requests", async () => {
     let res = await fixture.requestDocument(NOT_FOUND_HREF);

--- a/integration/catch-boundary-test.ts
+++ b/integration/catch-boundary-test.ts
@@ -183,8 +183,8 @@ test.describe("CatchBoundary", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("non-matching urls on document requests", async () => {

--- a/integration/compiler-test.ts
+++ b/integration/compiler-test.ts
@@ -191,8 +191,8 @@ test.describe("compiler", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("removes server code with `*.server` files", async ({ page }) => {

--- a/integration/compiler-test.ts
+++ b/integration/compiler-test.ts
@@ -191,7 +191,9 @@ test.describe("compiler", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => appFixture.close());
+  test.afterAll(async () => {
+    await appFixture.close();
+  });
 
   test("removes server code with `*.server` files", async ({ page }) => {
     let app = new PlaywrightFixture(appFixture, page);

--- a/integration/error-boundary-test.ts
+++ b/integration/error-boundary-test.ts
@@ -281,9 +281,9 @@ test.describe("ErrorBoundary", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
+  test.afterAll(() => {
     console.error = _consoleError;
-    await appFixture.close();
+    appFixture.close();
   });
 
   test("invalid request methods", async () => {

--- a/integration/error-data-request-test.ts
+++ b/integration/error-data-request-test.ts
@@ -96,9 +96,9 @@ test.describe("ErrorBoundary", () => {
     errorLogs = [];
   });
 
-  test.afterAll(async () => {
+  test.afterAll(() => {
     console.error = _consoleError;
-    await appFixture.close();
+    appFixture.close();
   });
 
   function assertConsoleError(str: string) {

--- a/integration/fetcher-layout-test.ts
+++ b/integration/fetcher-layout-test.ts
@@ -181,7 +181,9 @@ test.beforeAll(async () => {
   appFixture = await createAppFixture(fixture);
 });
 
-test.afterAll(() => appFixture.close());
+test.afterAll(async () => {
+  await appFixture.close();
+});
 
 test("fetcher calls layout route action when at index route", async ({
   page,

--- a/integration/fetcher-layout-test.ts
+++ b/integration/fetcher-layout-test.ts
@@ -181,8 +181,8 @@ test.beforeAll(async () => {
   appFixture = await createAppFixture(fixture);
 });
 
-test.afterAll(async () => {
-  await appFixture.close();
+test.afterAll(() => {
+  appFixture.close();
 });
 
 test("fetcher calls layout route action when at index route", async ({

--- a/integration/fetcher-test.ts
+++ b/integration/fetcher-test.ts
@@ -149,8 +149,8 @@ test.describe("useFetcher", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test.describe("No JavaScript", () => {

--- a/integration/file-uploads-test.ts
+++ b/integration/file-uploads-test.ts
@@ -80,8 +80,8 @@ test.describe("file-uploads", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("handles files under upload size limit", async ({ page }) => {

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -454,8 +454,8 @@ test.describe("Forms", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test.describe("without JavaScript", () => {

--- a/integration/helpers/create-fixture.ts
+++ b/integration/helpers/create-fixture.ts
@@ -127,12 +127,8 @@ export async function createAppFixture(fixture: Fixture, mode?: ServerMode) {
        * `beforeAll` block. Also make sure to `await app.close()` or else you'll
        * have memory leaks.
        */
-      close: async () => {
-        try {
-          return stop();
-        } catch (error) {
-          throw error;
-        }
+      close: () => {
+        return stop();
       },
     };
   };

--- a/integration/helpers/create-fixture.ts
+++ b/integration/helpers/create-fixture.ts
@@ -124,7 +124,7 @@ export async function createAppFixture(fixture: Fixture, mode?: ServerMode) {
       /**
        * Shuts down the fixture app, **you need to call this
        * at the end of a test** or `afterAll` if the fixture is initialized in a
-       * `beforeAll` block. Also make sure to `await app.close()` or else you'll
+       * `beforeAll` block. Also make sure to `app.close()` or else you'll
        * have memory leaks.
        */
       close: () => {

--- a/integration/hook-useSubmit-test.ts
+++ b/integration/hook-useSubmit-test.ts
@@ -46,8 +46,8 @@ test.describe("`useSubmit()` returned function", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("submits the submitter's value appended to the form data", async ({

--- a/integration/js-routes-test.ts
+++ b/integration/js-routes-test.ts
@@ -22,8 +22,8 @@ test.describe(".js route files", () => {
     );
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("should render all .js routes", async ({ page }) => {

--- a/integration/layout-route-test.ts
+++ b/integration/layout-route-test.ts
@@ -35,8 +35,8 @@ test.describe("pathless layout routes", () => {
     );
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("should render pathless index route", async ({ page }) => {

--- a/integration/link-test.ts
+++ b/integration/link-test.ts
@@ -471,8 +471,8 @@ test.describe("route module link export", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("adds responsive image preload links to the document", async ({

--- a/integration/loader-test.ts
+++ b/integration/loader-test.ts
@@ -116,8 +116,8 @@ test.describe("loader in an app", () => {
     );
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("sends a redirect", async ({ page }) => {

--- a/integration/mdx-test.ts
+++ b/integration/mdx-test.ts
@@ -92,8 +92,8 @@ export function ComponentUsingData() {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("can render basic markdown", async ({ page }) => {

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -256,8 +256,8 @@ test.describe("meta", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("empty meta does not render a tag", async ({ page }) => {
@@ -477,8 +477,8 @@ test.describe("v2_meta", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("empty meta does not render a tag", async ({ page }) => {

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -256,7 +256,9 @@ test.describe("meta", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(() => appFixture.close());
+  test.afterAll(async () => {
+    await appFixture.close();
+  });
 
   test("empty meta does not render a tag", async ({ page }) => {
     let app = new PlaywrightFixture(appFixture, page);
@@ -475,7 +477,9 @@ test.describe("v2_meta", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(() => appFixture.close());
+  test.afterAll(async () => {
+    await appFixture.close();
+  });
 
   test("empty meta does not render a tag", async ({ page }) => {
     let app = new PlaywrightFixture(appFixture, page);

--- a/integration/multiple-cookies-test.ts
+++ b/integration/multiple-cookies-test.ts
@@ -47,8 +47,8 @@ test.describe("pathless layout routes", () => {
     );
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("should get multiple cookies from the loader", async ({ page }) => {

--- a/integration/prefetch-test.ts
+++ b/integration/prefetch-test.ts
@@ -83,7 +83,9 @@ test.describe("prefetch=none", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(() => appFixture.close());
+  test.afterAll(async () => {
+    await appFixture.close();
+  });
 
   test("does not render prefetch tags during SSR", async ({ page }) => {
     let res = await fixture.requestDocument("/");

--- a/integration/prefetch-test.ts
+++ b/integration/prefetch-test.ts
@@ -83,8 +83,8 @@ test.describe("prefetch=none", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("does not render prefetch tags during SSR", async ({ page }) => {
@@ -109,8 +109,8 @@ test.describe("prefetch=render", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("does not render prefetch tags during SSR", async ({ page }) => {
@@ -151,8 +151,8 @@ test.describe("prefetch=intent (hover)", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("does not render prefetch tags during SSR", async ({ page }) => {
@@ -222,8 +222,8 @@ test.describe("prefetch=intent (focus)", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("does not render prefetch tags during SSR", async ({ page }) => {

--- a/integration/redirects-test.ts
+++ b/integration/redirects-test.ts
@@ -156,8 +156,8 @@ test.describe("redirects", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("preserves revalidation across action multi-redirects", async ({

--- a/integration/rendering-test.ts
+++ b/integration/rendering-test.ts
@@ -44,7 +44,9 @@ test.describe("rendering", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => appFixture.close());
+  test.afterAll(async () => {
+    await appFixture.close();
+  });
 
   test("server renders matching routes", async () => {
     let res = await fixture.requestDocument("/");

--- a/integration/rendering-test.ts
+++ b/integration/rendering-test.ts
@@ -44,8 +44,8 @@ test.describe("rendering", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("server renders matching routes", async () => {

--- a/integration/resource-routes-test.ts
+++ b/integration/resource-routes-test.ts
@@ -98,8 +98,8 @@ test.describe("loader in an app", async () => {
     appFixture = await createAppFixture(fixture, ServerMode.Test);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test.describe("with JavaScript", () => {

--- a/integration/server-code-in-browser-message-test.ts
+++ b/integration/server-code-in-browser-message-test.ts
@@ -49,7 +49,9 @@ test.beforeAll(async () => {
   appFixture = await createAppFixture(fixture);
 });
 
-test.afterAll(() => appFixture.close());
+test.afterAll(async () => {
+  await appFixture.close();
+});
 
 test.skip("should log relevant error message", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);

--- a/integration/server-code-in-browser-message-test.ts
+++ b/integration/server-code-in-browser-message-test.ts
@@ -49,8 +49,8 @@ test.beforeAll(async () => {
   appFixture = await createAppFixture(fixture);
 });
 
-test.afterAll(async () => {
-  await appFixture.close();
+test.afterAll(() => {
+  appFixture.close();
 });
 
 test.skip("should log relevant error message", async ({ page }) => {

--- a/integration/set-cookie-revalidation-test.ts
+++ b/integration/set-cookie-revalidation-test.ts
@@ -115,7 +115,9 @@ test.beforeAll(async () => {
   appFixture = await createAppFixture(fixture);
 });
 
-test.afterAll(() => appFixture.close());
+test.afterAll(async () => {
+  await appFixture.close();
+});
 
 test("should revalidate when cookie is set on redirect from loader", async ({
   page,

--- a/integration/set-cookie-revalidation-test.ts
+++ b/integration/set-cookie-revalidation-test.ts
@@ -115,8 +115,8 @@ test.beforeAll(async () => {
   appFixture = await createAppFixture(fixture);
 });
 
-test.afterAll(async () => {
-  await appFixture.close();
+test.afterAll(() => {
+  appFixture.close();
 });
 
 test("should revalidate when cookie is set on redirect from loader", async ({

--- a/integration/transition-state-test.ts
+++ b/integration/transition-state-test.ts
@@ -193,8 +193,8 @@ test.describe("rendering", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("transitions to normal load (Loading)", async ({ page }) => {

--- a/integration/transition-test.ts
+++ b/integration/transition-test.ts
@@ -204,8 +204,8 @@ test.describe("rendering", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
+  test.afterAll(() => {
+    appFixture.close();
   });
 
   test("calls all loaders for new routes", async ({ page }) => {

--- a/integration/upload-test.ts
+++ b/integration/upload-test.ts
@@ -175,7 +175,9 @@ test.beforeAll(async () => {
   appFixture = await createAppFixture(fixture);
 });
 
-test.afterAll(() => appFixture.close());
+test.afterAll(async () => {
+  await appFixture.close();
+});
 
 test("can upload a file with createFileUploadHandler", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);

--- a/integration/upload-test.ts
+++ b/integration/upload-test.ts
@@ -175,8 +175,8 @@ test.beforeAll(async () => {
   appFixture = await createAppFixture(fixture);
 });
 
-test.afterAll(async () => {
-  await appFixture.close();
+test.afterAll(() => {
+  appFixture.close();
 });
 
 test("can upload a file with createFileUploadHandler", async ({ page }) => {


### PR DESCRIPTION
- [chore: normalize afterAll](https://github.com/remix-run/remix/pull/4785/commits/d70a7dc813fabac2980140de10ab829f8bcb2acc)
- [test: close server synchronously](https://github.com/remix-run/remix/pull/4785/commits/b3f50205508151f5a0a611650b1b4e361236c969)

closing asynchronously would intermittently result in the `test.afterAll` hook to timeout

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
