### PR TITLE
Lift static handler creation and pass context through query/queryRoute

### DIFF
--- a/.changeset/silver-fireants-grab.md
+++ b/.changeset/silver-fireants-grab.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+Fix performance regression with ctreation of `@remix-run/router` static handler

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -16,7 +16,7 @@
   "typings": "dist/index.d.ts",
   "module": "dist/esm/index.js",
   "dependencies": {
-    "@remix-run/router": "1.0.5-pre.1",
+    "@remix-run/router": "1.0.5-pre.2",
     "@types/cookie": "^0.4.0",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie": "^0.4.1",

--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -1,11 +1,9 @@
-// TODO: RRR - Change import to @remix-run/router
 import type {
   AgnosticDataRouteObject,
   ActionFunctionArgs,
   LoaderFunctionArgs,
 } from "@remix-run/router";
 
-import { type AppLoadContext } from "./data";
 import { callRouteActionRR, callRouteLoaderRR } from "./data";
 import type { ServerRouteModule } from "./routeModules";
 
@@ -56,7 +54,6 @@ export function createRoutes(
 // createStaticHandler
 export function createStaticHandlerDataRoutes(
   manifest: ServerRouteManifest,
-  loadContext: AppLoadContext,
   parentId?: string
 ): AgnosticDataRouteObject[] {
   return Object.values(manifest)
@@ -73,8 +70,9 @@ export function createStaticHandlerDataRoutes(
         loader: route.module.loader
           ? (args: LoaderFunctionArgs) =>
               callRouteLoaderRR({
-                ...args,
-                loadContext,
+                request: args.request,
+                params: args.params,
+                loadContext: args.context,
                 loader: route.module.loader!,
                 routeId: route.id,
               })
@@ -82,8 +80,9 @@ export function createStaticHandlerDataRoutes(
         action: route.module.action
           ? (args: ActionFunctionArgs) =>
               callRouteActionRR({
-                ...args,
-                loadContext,
+                request: args.request,
+                params: args.params,
+                loadContext: args.context,
                 action: route.module.action!,
                 routeId: route.id,
               })
@@ -100,11 +99,7 @@ export function createStaticHandlerDataRoutes(
           }
         : {
             caseSensitive: route.caseSensitive,
-            children: createStaticHandlerDataRoutes(
-              manifest,
-              loadContext,
-              route.id
-            ),
+            children: createStaticHandlerDataRoutes(manifest, route.id),
             ...commonRoute,
           };
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2069,10 +2069,10 @@
     "@changesets/types" "^5.0.0"
     dotenv "^8.1.0"
 
-"@remix-run/router@1.0.5-pre.1":
-  version "1.0.5-pre.1"
-  resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.0.5-pre.1.tgz#dd0939d1631ebd56faa2bc69141e94a96887c7e5"
-  integrity sha512-dDfVwp0ta99+7vMKMDb5eh1Pc9CWZ5/Q+679YojyHyrZqSWJmlZyCP7prs6UAaXaGg5MveP1pCav/YFCINlcFw==
+"@remix-run/router@1.0.5-pre.2":
+  version "1.0.5-pre.2"
+  resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.0.5-pre.2.tgz#63a79484e70ac7b782dfbea011ece1f65158f3c1"
+  integrity sha512-5dD9v6wogaH2VbGsc74ua89pSAlsHmzhxgM/A8kpZXVd7ym33zWYBTxhqpaFzMWsMmvIEpvf7diJb3ACadyRnQ==
 
 "@remix-run/web-blob@^3.0.3", "@remix-run/web-blob@^3.0.4":
   version "3.0.4"


### PR DESCRIPTION
Updates to `@remix-run/router@1.0.5-pre.1` with support for `requestContext` in `query`/`queryRoute` and lifts the static handler creation outside of `requestHandler`

Closes #4733 