### PR TITLE
refactor(remix-server-runtime): remove `react` & `react-dom` from `peerDependencies`

### DIFF
--- a/.changeset/short-bobcats-switch.md
+++ b/.changeset/short-bobcats-switch.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": minor
+---
+
+remove `react` & `react-dom` from `peerDependencies`

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@remix-run/router": "1.3.0",
     "@types/cookie": "^0.4.0",
+    "@types/react": "^18.0.15",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie": "^0.4.1",
     "set-cookie-parser": "^2.4.8",
@@ -25,13 +26,7 @@
   },
   "devDependencies": {
     "@remix-run/web-file": "^3.0.2",
-    "@types/set-cookie-parser": "^2.4.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
-  "peerDependencies": {
-    "react": ">=16.8",
-    "react-dom": ">=16.8"
+    "@types/set-cookie-parser": "^2.4.1"
   },
   "engines": {
     "node": ">=14"

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -1,5 +1,5 @@
-import type { ComponentType } from "react";
 import type { Location, Params } from "@remix-run/router";
+import type { ComponentType } from "react";
 
 import type { AppLoadContext, AppData } from "./data";
 import type { LinkDescriptor } from "./links";
@@ -37,7 +37,7 @@ export interface ActionFunction {
 /**
  * A React component that is rendered when the server throws a Response.
  */
-export type CatchBoundaryComponent = ComponentType<{}>;
+export type CatchBoundaryComponent = ComponentType;
 
 /**
  * A React component that is rendered when there is an error on a route.


### PR DESCRIPTION
Follow-up of #4731