### PR TITLE
ci(nightly): move git operations after build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,38 +46,28 @@ jobs:
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
 
-      - name: ⤴️ Update Version if needed
+      - name: 🕵️ Check for changes
         id: version
         run: |
           # get latest commit sha
           SHA=$(git rev-parse HEAD)
+          # get first 7 characters of sha
           SHORT_SHA=${SHA::7}
 
           # get latest nightly tag
           LATEST_NIGHTLY_TAG=$(git tag -l v0.0.0-nightly-\* --sort=-committerdate | head -n 1)
 
+          # get changes since last nightly
           CHANGES=$(git diff $LATEST_NIGHTLY_TAG..dev -- ./packages/ -- ':!packages/**/package.json')
 
           # check if there are changes to ./packages
           if [[ -n $(echo $CHANGES | xargs) ]]; then
-            git config --local user.email "hello@remix.run"
-            git config --local user.name "Remix Run Bot"
-
+            # yyyyMMdd format (e.g. 20221207)
             DATE=$(date '+%Y%m%d')
+            # v0.0.0-nightly-<short sha>-<date>
             NEXT_VERSION=0.0.0-nightly-${SHORT_SHA}-${DATE}
+            # set output so it can be used in other jobs
             echo "NEXT_VERSION=${NEXT_VERSION}" >> $GITHUB_OUTPUT
-
-            git checkout -b nightly/${NEXT_VERSION}
-
-            if [ -z "$(git status --porcelain)" ]; then
-              echo "✨"
-            else
-              echo "dirty working directory..."
-              git add .
-              git commit -m "dirty working directory..."
-            fi
-
-            yarn run version ${NEXT_VERSION} --skip-prompt
           else
             echo "🛑 no changes since last nightly, skipping..."
           fi
@@ -85,6 +75,14 @@ jobs:
       - name: 🏗 Build
         if: steps.version.outputs.NEXT_VERSION
         run: yarn build
+
+      - name: ⤴️ Update version
+        if: steps.version.outputs.NEXT_VERSION
+        run: |
+          git config --local user.email "hello@remix.run"
+          git config --local user.name "Remix Run Bot"
+          git checkout -b nightly/${steps.version.outputs.NEXT_VERSION}
+          yarn run version ${steps.version.outputs.NEXT_VERSION} --skip-prompt
 
       - name: 🏷 Push Tag
         if: steps.version.outputs.NEXT_VERSION


### PR DESCRIPTION
same as #4797, but for main - where the nightly releases actually run 😮‍💨

when adding deno typechecking (https://github.com/remix-run/remix/pull/4715), nightly now refers to the version we just calculated which hasnt been published when trying to build and typecheck https://github.com/remix-run/remix/actions/runs/3636615016/jobs/6136755201

Signed-off-by: Logan McAnsh [logan@mcan.sh](mailto:logan@mcan.sh) 

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
