### PR TITLE
docs(file-conventions/remix-config): update `watchPaths`' description

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -209,6 +209,7 @@
 - joshball
 - jrf0110
 - jrubins
+- jsbmg
 - jssisodiya
 - jstafman
 - juhanakristian

--- a/docs/file-conventions/remix-config.md
+++ b/docs/file-conventions/remix-config.md
@@ -155,12 +155,15 @@ module.exports = {
 
 ## watchPaths
 
-A function for defining custom directories to watch while running [remix dev][remix-dev], in addition to [`appDirectory`][app-directory].
+An array, string, or async function that defines custom directories, relative to the project root, to watch while running [remix dev][remix-dev]. These directories are in addition to [`appDirectory`][app-directory].
 
 ```tsx
 exports.watchPaths = async () => {
-  return ["/some/path/*"];
+  return ["./some/path/*"];
 };
+
+// also valid
+exports.watchPaths = ["./some/path/*"];
 ```
 
 ## File Name Conventions


### PR DESCRIPTION
* Update code example to reflect that watchPaths can be a string, array, or async function
* Clarify that watchPaths directories are relative to the project root

Updated from #4578 after documentation was moved, and closes [#4530](https://github.com/remix-run/remix/issues/4530).