### PR TITLE
fix(remix-dev): resolve asset entry full path to support mono-repo import of styles

### DIFF
--- a/.changeset/mighty-rules-drum.md
+++ b/.changeset/mighty-rules-drum.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/dev": patch
+---
+
+Resolve asset entry full path to support monorepo import of styles

--- a/packages/remix-dev/compiler/compileBrowser.ts
+++ b/packages/remix-dev/compiler/compileBrowser.ts
@@ -75,7 +75,7 @@ const createEsbuildConfig = (
     deprecatedRemixPackagePlugin(options.onWarning),
     cssFilePlugin({
       mode: options.mode,
-      rootDir: config.rootDirectory,
+      rootDirectory: config.rootDirectory,
     }),
     urlImportsPlugin(),
     mdxPlugin(config),

--- a/packages/remix-dev/compiler/compileBrowser.ts
+++ b/packages/remix-dev/compiler/compileBrowser.ts
@@ -73,7 +73,10 @@ const createEsbuildConfig = (
 
   let plugins: esbuild.Plugin[] = [
     deprecatedRemixPackagePlugin(options.onWarning),
-    cssFilePlugin(options),
+    cssFilePlugin({
+      mode: options.mode,
+      rootDir: config.rootDirectory,
+    }),
     urlImportsPlugin(),
     mdxPlugin(config),
     browserRouteModulesPlugin(config, /\?browser$/),

--- a/packages/remix-dev/compiler/compilerServer.ts
+++ b/packages/remix-dev/compiler/compilerServer.ts
@@ -49,7 +49,10 @@ const createEsbuildConfig = (
 
   let plugins: esbuild.Plugin[] = [
     deprecatedRemixPackagePlugin(options.onWarning),
-    cssFilePlugin(options),
+    cssFilePlugin({
+      mode: options.mode,
+      rootDirectory: config.rootDirectory,
+    }),
     urlImportsPlugin(),
     mdxPlugin(config),
     emptyModulesPlugin(config, /\.client(\.[jt]sx?)?$/),

--- a/packages/remix-dev/compiler/plugins/cssFilePlugin.ts
+++ b/packages/remix-dev/compiler/plugins/cssFilePlugin.ts
@@ -72,9 +72,11 @@ export function cssFilePlugin(options: {
         let entry = Object.keys(outputs).find((out) => outputs[out].entryPoint);
         invariant(entry, "entry point not found");
 
-        let normalizedEntry = normalizePathSlashes(entry);
+        let normalizedEntry = path.resolve(normalizePathSlashes(entry));
         let entryFile = outputFiles.find((file) => {
-          return normalizePathSlashes(file.path).endsWith(normalizedEntry);
+          return (
+            path.resolve(normalizePathSlashes(file.path)) === normalizedEntry
+          );
         });
 
         invariant(entryFile, "entry file not found");

--- a/packages/remix-dev/compiler/plugins/cssFilePlugin.ts
+++ b/packages/remix-dev/compiler/plugins/cssFilePlugin.ts
@@ -17,6 +17,7 @@ function normalizePathSlashes(p: string) {
  */
 export function cssFilePlugin(options: {
   mode: CompileOptions["mode"];
+  rootDirectory: string;
 }): esbuild.Plugin {
   return {
     name: "css-file",
@@ -72,10 +73,16 @@ export function cssFilePlugin(options: {
         let entry = Object.keys(outputs).find((out) => outputs[out].entryPoint);
         invariant(entry, "entry point not found");
 
-        let normalizedEntry = path.resolve(normalizePathSlashes(entry));
+        let normalizedEntry = path.resolve(
+          options.rootDirectory,
+          normalizePathSlashes(entry)
+        );
         let entryFile = outputFiles.find((file) => {
           return (
-            path.resolve(normalizePathSlashes(file.path)) === normalizedEntry
+            path.resolve(
+              options.rootDirectory,
+              normalizePathSlashes(file.path)
+            ) === normalizedEntry
           );
         });
 


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
