### PR TITLE
feat(remix-dev): add support for `fastly-compute-js` as `serverBuildTarget` value

### DIFF
--- a/.changeset/polite-humans-ring.md
+++ b/.changeset/polite-humans-ring.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": minor
+---
+
+Added support for `serverBuildTarget` value of `fastly-compute-js`.

--- a/contributors.yml
+++ b/contributors.yml
@@ -157,6 +157,7 @@
 - gunners6518
 - hadizz
 - hardingmatt
+- harmony7
 - helderburato
 - HenryVogt
 - hicksy

--- a/docs/file-conventions/remix-config.md
+++ b/docs/file-conventions/remix-config.md
@@ -130,6 +130,12 @@ The `serverBuildTarget` can be one of the following:
 - [`"node-cjs"`][node-cjs]
 - [`"vercel"`][vercel]
 
+Alternatively, it may also be set to the following:
+
+- [`"fastly-compute-js"`][fastly-compute-js]
+  Use this value to use Remix with [@fastly/remix-compute-js][fastly-remix-compute-js]
+
+
 ## serverDependenciesToBundle
 
 A list of regex patterns that determines if a module is transpiled and included in the server bundle. This can be useful when consuming ESM only packages in a CJS build.
@@ -179,6 +185,8 @@ There are a few conventions that Remix uses you should be aware of.
 [netlify]: https://www.netlify.com
 [node-cjs]: https://nodejs.org/en
 [vercel]: https://vercel.com
+[fastly-compute-js]: https://www.fastly.com/products/edge-compute
+[fastly-remix-compute-js]: https://github.com/fastly/remix-compute-js
 [dilum-sanjaya]: https://twitter.com/DilumSanjaya
 [an-awesome-visualization]: https://remix-routing-demo.netlify.app
 [remix-dev]: ../other-api/dev#remix-dev

--- a/packages/remix-dev/compiler/compilerServer.ts
+++ b/packages/remix-dev/compiler/compilerServer.ts
@@ -45,6 +45,7 @@ const createEsbuildConfig = (
   let isCloudflareRuntime = ["cloudflare-pages", "cloudflare-workers"].includes(
     config.serverBuildTarget ?? ""
   );
+  let isFastlyRuntime = config.serverBuildTarget === "fastly-compute-js";
   let isDenoRuntime = config.serverBuildTarget === "deno";
 
   let plugins: esbuild.Plugin[] = [
@@ -71,7 +72,7 @@ const createEsbuildConfig = (
     stdin,
     entryPoints,
     outfile: config.serverBuildPath,
-    conditions: isCloudflareRuntime
+    conditions: (isCloudflareRuntime || isFastlyRuntime)
       ? ["worker"]
       : isDenoRuntime
       ? ["deno", "worker"]
@@ -87,8 +88,8 @@ const createEsbuildConfig = (
     // PR makes dev mode behave closer to production in terms of dead
     // code elimination / tree shaking is concerned.
     minifySyntax: true,
-    minify: options.mode === "production" && isCloudflareRuntime,
-    mainFields: isCloudflareRuntime
+    minify: options.mode === "production" && (isCloudflareRuntime || isFastlyRuntime),
+    mainFields: (isCloudflareRuntime || isFastlyRuntime)
       ? ["browser", "module", "main"]
       : config.serverModuleFormat === "esm"
       ? ["module", "main"]

--- a/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
@@ -93,10 +93,11 @@ export function serverBareModulesPlugin(
         }
 
         switch (remixConfig.serverBuildTarget) {
-          // Always bundle everything for cloudflare.
+          // Always bundle everything for cloudflare/deno/fastly.
           case "cloudflare-pages":
           case "cloudflare-workers":
           case "deno":
+          case "fastly-compute-js":
             return undefined;
         }
 

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -26,7 +26,8 @@ export type ServerBuildTarget =
   | "vercel"
   | "cloudflare-pages"
   | "cloudflare-workers"
-  | "deno";
+  | "deno"
+  | "fastly-compute-js";
 
 export type ServerModuleFormat = "esm" | "cjs";
 export type ServerPlatform = "node" | "neutral";
@@ -336,6 +337,7 @@ export async function readConfig(
     case "cloudflare-pages":
     case "cloudflare-workers":
     case "deno":
+    case "fastly-compute-js":
       serverModuleFormat = "esm";
       serverPlatform = "neutral";
       break;


### PR DESCRIPTION
At Fastly we have created a runtime, a server adapter, and a template for running Remix on Fastly Compute@Edge. This PR adds support for settings `serverBuildTarget` to `fastly-compute-js`, which configures compiler settings to enable their use.

Our runtime, server adapter, and template are available at:
https://github.com/fastly/remix-compute-js

These will work once this PR is accepted.

This PR adds:

* Support for `fastly-compute-js` as an accepted value for `serverBuildTarget` in `remix.config.js`. This value:
  * Sets `serverModuleFormat` to `"esm"`
  * Sets `serverPlatform` to `"neutral"`
  * Causes `esbuild` config to:
    * use `condition` value of `["worker"]`
    * use `minify` value of `true`
    * use `mainFields` value of `["browser", "module", "main"]`
  * Causes `serverBareModulesPlugin` to always bundle everything

This PR is necessary because, except for the first two subitems in the list above, these behaviors cannot be set through `remix.config.js`.

This PR also adds the new value to the documentation page for the config file.

Relates to https://github.com/remix-run/remix/discussions/4613 as well as https://github.com/remix-run/remix/discussions/2888