### PR TITLE
docs(tutorials/jokes): fix code highlighting

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -459,3 +459,4 @@
 - zachdtaylor
 - zainfathoni
 - zhe
+- daganomri

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -3125,7 +3125,7 @@ You may also notice that our solution makes use of the `login` route's `redirect
 
 <summary>app/routes/jokes/new.tsx</summary>
 
-```tsx filename=app/routes/jokes/new.tsx lines=[7,22,61]
+```tsx filename=app/routes/jokes/new.tsx lines=[7,22,51]
 import type { ActionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import { useActionData } from "@remix-run/react";


### PR DESCRIPTION
I was going through the tutorial and saw that in one of the code samples a highlight was on the wrong line.

Closes: #

- [x] Docs
- [ ] Tests