### PR TITLE
docs(route/handle): fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -165,6 +165,7 @@
 - Holben888
 - hollandThomas
 - Hopsken
+- humphd
 - hzhu
 - IAmLuisJ
 - ianduvall

--- a/docs/route/handle.md
+++ b/docs/route/handle.md
@@ -12,6 +12,6 @@ export const handle = {
 };
 ```
 
-This is almost always used on conjunction with `useMatches`. To see what kinds of things you can do with it, refer to [`useMatches`][use-matches] for more information.
+This is almost always used in conjunction with `useMatches`. To see what kinds of things you can do with it, refer to [`useMatches`][use-matches] for more information.
 
 [use-matches]: ../hooks/use-matches


### PR DESCRIPTION
I noticed a minor issue while reading the docs for `handle`.
