### PR TITLE
feat(remix-react): add `submitOptions` argument for `useSubmit` and `useFetcher`

### DIFF
--- a/.changeset/metal-bikes-notice.md
+++ b/.changeset/metal-bikes-notice.md
@@ -3,4 +3,4 @@
 "@remix-run/react": minor
 ---
 
-feat(remix-react): add `submitOptions` argument for `useSubmit` and `useFetcher`
+Add `submitOptions` argument for `useSubmit` and `useFetcher`

--- a/.changeset/metal-bikes-notice.md
+++ b/.changeset/metal-bikes-notice.md
@@ -1,0 +1,6 @@
+---
+"remix": minor
+"@remix-run/react": minor
+---
+
+feat(remix-react): add `submitOptions` argument for `useSubmit` and `useFetcher`

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -66,7 +66,7 @@ Notes about how it works:
 
 #### `submitOptions.method`
 
-The URL method to use when submitting. Defaults to `"GET"`.
+The URL method to use when submitting. Defaults to `"get"` (options are `"get"`, `"post"`, `"put"`, `"patch"`, `"delete"`).
 
 #### `submitOptions.action`
 

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -68,11 +68,11 @@ Notes about how it works:
 
 The URL method to use when submitting. Defaults to `"GET"`.
 
-### `submitOptions.action`
+#### `submitOptions.action`
 
 The URL to submit to. Defaults to the current URL.
 
-### `submitOptions.encType`
+#### `submitOptions.encType`
 
 The `enctype` to use when submitting. Defaults to `"application/x-www-form-urlencoded"`.
 

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -60,6 +60,24 @@ Notes about how it works:
 - Handles uncaught errors by rendering the nearest `ErrorBoundary` (just like a normal navigation from `<Link>` or `<Form>`)
 - Will redirect the app if your action/loader being called returns a redirect (just like a normal navigation from `<Link>` or `<Form>`)
 
+### Arguments
+
+`useFetcher` takes one optional argument which is the `submitOptions` that will be used as a default for calls to `fetcher.submit`. This is useful to avoid repetition and to ensure the reference to `fetcher` remains stable if you need to include it in a dependency array.
+
+#### `submitOptions.method`
+
+The URL method to use when submitting. Defaults to `"GET"`.
+
+### `submitOptions.action`
+
+The URL to submit to. Defaults to the current URL.
+
+### `submitOptions.encType`
+
+The `enctype` to use when submitting. Defaults to `"application/x-www-form-urlencoded"`.
+
+### Properties
+
 #### `fetcher.state`
 
 You can know the state of the fetcher with `fetcher.state`. It will be one of:

--- a/docs/hooks/use-submit.md
+++ b/docs/hooks/use-submit.md
@@ -67,3 +67,23 @@ function useSessionTimeout() {
   }, [submit, transition]);
 }
 ```
+
+## `useSubmit` Parameters
+
+`useSubmit` takes one optional argument which is the `submitOptions` that will be used as a default for calls to `submit`. This is useful to avoid repetition and to ensure the reference to `submit` remains stable if you need to include it in a dependency array.
+
+#### `submitOptions.method`
+
+The URL method to use when submitting. Defaults to `"GET"`.
+
+### `submitOptions.action`
+
+The URL to submit to. Defaults to the current URL.
+
+### `submitOptions.encType`
+
+The `enctype` to use when submitting. Defaults to `"application/x-www-form-urlencoded"`.
+
+### `submitOptions.replace`
+
+Whether to replace the current history entry or push a new one. Defaults to `false`.

--- a/docs/hooks/use-submit.md
+++ b/docs/hooks/use-submit.md
@@ -74,7 +74,7 @@ function useSessionTimeout() {
 
 #### `submitOptions.method`
 
-The URL method to use when submitting. Defaults to `"GET"`.
+The URL method to use when submitting. Defaults to `"get"` (options are `"get"`, `"post"`, `"put"`, `"patch"`, `"delete"`).
 
 #### `submitOptions.action`
 

--- a/docs/hooks/use-submit.md
+++ b/docs/hooks/use-submit.md
@@ -68,7 +68,7 @@ function useSessionTimeout() {
 }
 ```
 
-## `useSubmit` Parameters
+### Arguments
 
 `useSubmit` takes one optional argument which is the `submitOptions` that will be used as a default for calls to `submit`. This is useful to avoid repetition and to ensure the reference to `submit` remains stable if you need to include it in a dependency array.
 
@@ -76,14 +76,14 @@ function useSessionTimeout() {
 
 The URL method to use when submitting. Defaults to `"GET"`.
 
-### `submitOptions.action`
+#### `submitOptions.action`
 
 The URL to submit to. Defaults to the current URL.
 
-### `submitOptions.encType`
+#### `submitOptions.encType`
 
 The `enctype` to use when submitting. Defaults to `"application/x-www-form-urlencoded"`.
 
-### `submitOptions.replace`
+#### `submitOptions.replace`
 
 Whether to replace the current history entry or push a new one. Defaults to `false`.

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -48,30 +48,27 @@ test.beforeAll(async () => {
     ////////////////////////////////////////////////////////////////////////////
     files: {
       "app/routes/index.jsx": js`
-        import { useFetcher, useSearchParams } from "@remix-run/react";
-        import { useEffect, useRef } from "react";
-        
-        export default function Fetcher() {
-          const [, setSearchParams] = useSearchParams();
-          const clickedRef = useRef(false);
-          const fetcher = useFetcher({ action: "/whatever" });
-        
-          useEffect(() => {
-            if (clickedRef.current) {
-              throw new Error("fetcher changed!");
-            }
-          }, [fetcher]);
-        
+        import { json } from "@remix-run/node";
+        import { useLoaderData, Link } from "@remix-run/react";
+
+        export function loader() {
+          return json("pizza");
+        }
+
+        export default function Index() {
+          let data = useLoaderData();
           return (
-            <button
-              onClick={() => {
-                clickedRef.current = true;
-                setSearchParams({ random: Math.random().toString() });
-              }}
-            >
-              Set searchParams
-            </button>
-          );
+            <div>
+              {data}
+              <Link to="/burgers">Other Route</Link>
+            </div>
+          )
+        }
+      `,
+
+      "app/routes/burgers.jsx": js`
+        export default function Index() {
+          return <div>cheeseburger</div>;
         }
       `,
     },
@@ -90,14 +87,22 @@ test.afterAll(() => {
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("fetchers should be able to be stable when changing the search params", async ({
-  page,
-}) => {
+test("[description of what you expect it to do]", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);
   // You can test any request your app might get using `fixture`.
+  let response = await fixture.requestDocument("/");
+  expect(await response.text()).toMatch("pizza");
+
+  // If you need to test interactivity use the `app`
   await app.goto("/");
-  await app.clickElement("button");
-  expect(await app.getHtml()).not.toContain("fetcher changed!");
+  await app.clickLink("/burgers");
+  expect(await app.getHtml()).toMatch("cheeseburger");
+
+  // If you're not sure what's going on, you can "poke" the app, it'll
+  // automatically open up in your browser for 20 seconds, so be quick!
+  // await app.poke(20);
+
+  // Go check out the other tests to see what else you can do.
 });
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -48,27 +48,34 @@ test.beforeAll(async () => {
     ////////////////////////////////////////////////////////////////////////////
     files: {
       "app/routes/index.jsx": js`
-        import { json } from "@remix-run/node";
-        import { useLoaderData, Link } from "@remix-run/react";
+        import {useFetcher, useSearchParams} from '@remix-run/react'
+        import {useEffect, useRef} from 'react'
+      
+        export default function Fetcher() {
+          const [, setSearchParams] = useSearchParams()
+          const fetcher = useFetcher()
+          const mounted = useRef(false)
 
-        export function loader() {
-          return json("pizza");
-        }
+          useEffect(() => {
+            if (mounted.current) {
+              throw new Error('fetcher changed!')
+            }
+            mounted.current = true
+          }, [fetcher])
 
-        export default function Index() {
-          let data = useLoaderData();
           return (
-            <div>
-              {data}
-              <Link to="/burgers">Other Route</Link>
+            <div style={{fontFamily: 'system-ui, sans-serif', lineHeight: '1.4'}}>
+              <button
+                onClick={() =>
+                  setSearchParams({
+                    random: Math.random().toString(),
+                  })
+                }
+              >
+                Set searchParams
+              </button>
             </div>
           )
-        }
-      `,
-
-      "app/routes/burgers.jsx": js`
-        export default function Index() {
-          return <div>cheeseburger</div>;
         }
       `,
     },
@@ -87,22 +94,14 @@ test.afterAll(() => {
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("[description of what you expect it to do]", async ({ page }) => {
+test("fetchers should be able to be stable when changing the search params", async ({
+  page,
+}) => {
   let app = new PlaywrightFixture(appFixture, page);
   // You can test any request your app might get using `fixture`.
-  let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch("pizza");
-
-  // If you need to test interactivity use the `app`
   await app.goto("/");
-  await app.clickLink("/burgers");
-  expect(await app.getHtml()).toMatch("cheeseburger");
-
-  // If you're not sure what's going on, you can "poke" the app, it'll
-  // automatically open up in your browser for 20 seconds, so be quick!
-  // await app.poke(20);
-
-  // Go check out the other tests to see what else you can do.
+  await app.clickElement("button");
+  expect(await app.getHtml()).not.toContain("fetcher changed!");
 });
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -48,34 +48,30 @@ test.beforeAll(async () => {
     ////////////////////////////////////////////////////////////////////////////
     files: {
       "app/routes/index.jsx": js`
-        import {useFetcher, useSearchParams} from '@remix-run/react'
-        import {useEffect, useRef} from 'react'
-      
+        import { useFetcher, useSearchParams } from "@remix-run/react";
+        import { useEffect, useRef } from "react";
+        
         export default function Fetcher() {
-          const [, setSearchParams] = useSearchParams()
-          const fetcher = useFetcher()
-          const mounted = useRef(false)
-
+          const [, setSearchParams] = useSearchParams();
+          const clickedRef = useRef(false);
+          const fetcher = useFetcher({ action: "/whatever" });
+        
           useEffect(() => {
-            if (mounted.current) {
-              throw new Error('fetcher changed!')
+            if (clickedRef.current) {
+              throw new Error("fetcher changed!");
             }
-            mounted.current = true
-          }, [fetcher])
-
+          }, [fetcher]);
+        
           return (
-            <div style={{fontFamily: 'system-ui, sans-serif', lineHeight: '1.4'}}>
-              <button
-                onClick={() =>
-                  setSearchParams({
-                    random: Math.random().toString(),
-                  })
-                }
-              >
-                Set searchParams
-              </button>
-            </div>
-          )
+            <button
+              onClick={() => {
+                clickedRef.current = true;
+                setSearchParams({ random: Math.random().toString() });
+              }}
+            >
+              Set searchParams
+            </button>
+          );
         }
       `,
     },

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1264,7 +1264,7 @@ export function useSubmit(options?: SubmitOptions): SubmitFunction {
 const DEFAULT_METHOD = "get";
 const DEFAULT_ENC_TYPE = "application/x-www-form-urlencoded";
 
-// IDEA: remove the export here?
+// TODO: remove the export here?
 export function useSubmitImpl(
   key?: string,
   {

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1271,6 +1271,7 @@ export function useSubmitImpl(
     method: submitMethod = DEFAULT_METHOD,
     action: submitAction,
     encType: submitEncType = DEFAULT_ENC_TYPE,
+    replace,
   }: SubmitOptions = {}
 ): SubmitFunction {
   let navigate = useNavigate();
@@ -1420,7 +1421,10 @@ export function useSubmitImpl(
         });
       } else {
         setNextNavigationSubmission(submission);
-        navigate(url.pathname + url.search, { replace: options.replace });
+        navigate(url.pathname + url.search, {
+          replace:
+            typeof options.replace === "undefined" ? replace : options.replace,
+        });
       }
     },
     [
@@ -1429,6 +1433,7 @@ export function useSubmitImpl(
       defaultMethod,
       key,
       navigate,
+      replace,
       transitionManager,
     ]
   );
@@ -1598,7 +1603,8 @@ export type FetcherWithComponents<TData> = Fetcher<TData> & {
  * @see https://remix.run/api/remix#usefetcher
  */
 export function useFetcher<TData = any>(
-  submitOptions?: SubmitOptions
+  // replace doesn't make sense for fetchers
+  submitOptions?: Omit<SubmitOptions, "replace">
 ): FetcherWithComponents<SerializeFrom<TData>> {
   let { transitionManager } = useRemixEntryContext();
 


### PR DESCRIPTION
This fixes an actual bug I was having when trying to use a fetcher in a `useEffect`. It's also a handy API that I've seen people ask for as well.

Closes: #4872

- [x] Docs
- [x] Tests

Testing Strategy: Automated Integration test

~~This is just pushing the failing test to demonstrate the issue.~~

~~The issue is actually technically correct behavior, but I need a new feature to accomplish what I want so I'll be changing the test once this new API is supported. I'm working on that next.~~

Implementation is finished and documented. Ready to discuss/merge.

Until this is merged, the only way to reliably use a fetcher.submit in a dep array is to do something like this:

```tsx
const fetcher = useFetcher()
const submitRef = useRef(fetcher.submit)
useEffect(() => {
  submitRef.current = fetcher.submit
})
React.useEffect(() => {
  // can safely use submitRef without including in dep array
  submitRef({other, deps}, {action: '/some-path', method: 'post'})
}, [other, deps])
```

The drawback here is that if we actually *do* depend on the `defaultAction` then it's possible we'll get the wrong one when submit is called.

This PR fixes that by allowing users to specify an `action` (among other submit options):

```tsx
const fetcher = useFetcher({action: '/some-path', method: 'post'})
React.useEffect(() => {
  // can safely include fetcher in dep array
  fetcher.submit({other, deps})
}, [other, deps, fetcher])
```