### PR TITLE
refactor(remix-architect): use `@architect/functions`' built-in types

### DIFF
--- a/.changeset/modern-pumas-hide.md
+++ b/.changeset/modern-pumas-hide.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/architect": patch
+---
+
+use `@architect/functions`' built-in types

--- a/packages/remix-architect/package.json
+++ b/packages/remix-architect/package.json
@@ -14,12 +14,11 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "dependencies": {
-    "@architect/functions": "^5.0.2",
+    "@architect/functions": "^5.2.0",
     "@remix-run/node": "1.9.0",
     "@types/aws-lambda": "^8.10.82"
   },
   "devDependencies": {
-    "@types/architect__functions": "^3.13.6",
     "@types/lambda-tester": "^3.6.1",
     "lambda-tester": "^4.0.1"
   },

--- a/packages/remix-architect/sessions/arcTableSessionStorage.ts
+++ b/packages/remix-architect/sessions/arcTableSessionStorage.ts
@@ -1,8 +1,12 @@
 import * as crypto from "crypto";
-import type { SessionStorage, SessionIdStorageStrategy } from "@remix-run/node";
+import type {
+  SessionData,
+  SessionStorage,
+  SessionIdStorageStrategy,
+} from "@remix-run/node";
 import { createSessionStorage } from "@remix-run/node";
 import arc from "@architect/functions";
-import type { ArcTable } from "@architect/functions/tables";
+import type { ArcTable } from "@architect/functions/types/tables";
 
 interface ArcTableSessionStorageOptions {
   /**
@@ -15,7 +19,7 @@ interface ArcTableSessionStorageOptions {
    * The table used to store sessions, or its name as it appears in your
    * project's app.arc file.
    */
-  table: ArcTable | string;
+  table: ArcTable<SessionData> | string;
 
   /**
    * The name of the DynamoDB attribute used to store the session ID.

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,12 +9,12 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@architect/functions@^5.0.2":
-  version "5.0.3"
-  resolved "https://registry.npmjs.org/@architect/functions/-/functions-5.0.3.tgz"
-  integrity sha512-C9+yqNAthyhXfhKl0BxLabNlbLo3ReefN598pr7OidMXU/wkSjR72xlpBmr/pnnZYGlJ8+yNr9OxU99d4S/hZQ==
+"@architect/functions@^5.2.0":
+  version "5.3.3"
+  resolved "https://registry.npmjs.org/@architect/functions/-/functions-5.3.3.tgz#b70d20c723e62dd984da90b23a51495ebbdc551e"
+  integrity sha512-q9ePtpw7SIl14B0KFIJGm4StL6jOWWYgGpD1HR7zkTKKiUIL/W0tkrAZnBhU8WPXRHPmpf5BcEjIXHQKyvz9Hg==
   dependencies:
-    cookie "^0.4.2"
+    cookie "^0.5.0"
     cookie-signature "^1.2.0"
     csrf "^3.1.0"
     node-webtokens "^1.0.4"
@@ -2399,15 +2399,6 @@
   dependencies:
     "@types/estree" "*"
 
-"@types/architect__functions@^3.13.6":
-  version "3.13.6"
-  resolved "https://registry.npmjs.org/@types/architect__functions/-/architect__functions-3.13.6.tgz"
-  integrity sha512-1XggtRqhJ7Hy47gAg3qcPZMSDeJuQNp3obL5OJEVt2oo+8CsfU4vk1GU385AHs/xkBGOp1cfgKcDTyBrDbqJdA==
-  dependencies:
-    "@types/aws-lambda" "*"
-    "@types/express" "*"
-    aws-sdk "^2.820.0"
-
 "@types/aria-query@^4.2.0":
   version "4.2.2"
   resolved "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz"
@@ -3804,7 +3795,7 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-sdk@^2.1055.0, aws-sdk@^2.820.0:
+aws-sdk@^2.1055.0:
   version "2.1069.0"
   resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1069.0.tgz"
   integrity sha512-AF7/5JotrVd8g/D3WWHgQto+IryB1V7iudIYm+H+qxmkGOU3xvL63ChhEoLTY/CxuK/diayg0oWILEsXUn3dfw==
@@ -4702,6 +4693,11 @@ cookie@0.4.2, cookie@^0.4.1, cookie@^0.4.2:
   version "0.4.2"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
+cookie@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
+  integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
 cookiejar@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
As of @architect/functions@5.2.0, types are included in the package itself and there is no longer a need for
@types/architect__functions.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

- [x] Docs (N/A)
- [x] Tests (no need for new tests; if the CI pipeline passes, then it's fine)

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
