### PR TITLE
chore: rename non public exports

### DIFF
--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -35,7 +35,7 @@ export {
   Link,
   NavLink,
   Form,
-  RemixEntry,
+  RemixEntry as UNSAFE_RemixEntry,
   PrefetchPageLinks,
   LiveReload,
   useFormAction,
@@ -58,8 +58,8 @@ export type { HtmlLinkDescriptor } from "./links";
 export type {
   ShouldReloadFunction,
   HtmlMetaDescriptor,
-  CatchBoundaryComponent,
-  RouteModules,
+  CatchBoundaryComponent as UNSAFE_CatchBoundaryComponent,
+  RouteModules as UNSAFE_RouteModules,
 } from "./routeModules";
 
 export { ScrollRestoration } from "./scroll-restoration";
@@ -69,6 +69,12 @@ export { RemixServer } from "./server";
 
 export type { Fetcher } from "./transition";
 
-export type { AssetsManifest, EntryContext } from "./entry";
+export type {
+  AssetsManifest as UNSAFE_AssetsManifest,
+  EntryContext as UNSAFE_EntryContext,
+} from "./entry";
 export type { RouteData } from "./routeData";
-export type { EntryRoute, RouteManifest } from "./routes";
+export type {
+  EntryRoute as UNSAFE_EntryRoute,
+  RouteManifest as UNSAFE_RouteManifest,
+} from "./routes";

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 import type {
-  AssetsManifest,
-  EntryContext,
-  EntryRoute,
+  UNSAFE_AssetsManifest,
+  UNSAFE_EntryContext,
+  UNSAFE_EntryRoute,
   RouteData,
-  RouteManifest,
-  RouteModules,
+  UNSAFE_RouteManifest,
+  UNSAFE_RouteModules,
 } from "@remix-run/react";
-import { RemixEntry } from "@remix-run/react";
+import { UNSAFE_RemixEntry } from "@remix-run/react";
 import type {
   Action,
   AgnosticDataRouteObject,
@@ -75,7 +75,7 @@ type NonIndexStubRouteObject = AgnosticNonIndexRouteObject & {
 // TODO: once Remix is on RR@6.4 we can just use the native type
 type StubRouteObject = IndexStubRouteObject | NonIndexStubRouteObject;
 
-type RemixConfigFuture = Partial<EntryContext["future"]>;
+type RemixConfigFuture = Partial<UNSAFE_EntryContext["future"]>;
 
 export function createRemixStub(
   routes: StubRouteObject[],
@@ -124,7 +124,7 @@ export function createRemixStub(
     monkeyPatchFetch(queryRoute, dataRoutes);
 
     return (
-      <RemixEntry
+      <UNSAFE_RemixEntry
         context={remixContext}
         action={state.action}
         location={state.location}
@@ -140,7 +140,7 @@ function createRemixContext(
   initialLoaderData?: RouteData,
   initialActionData?: RouteData,
   future?: RemixConfigFuture
-): EntryContext {
+): UNSAFE_EntryContext {
   let manifest = createManifest(routes);
   let matches = matchRoutes(routes, currentLocation) || [];
 
@@ -164,7 +164,9 @@ function createRemixContext(
   };
 }
 
-function createManifest(routes: AgnosticDataRouteObject[]): AssetsManifest {
+function createManifest(
+  routes: AgnosticDataRouteObject[]
+): UNSAFE_AssetsManifest {
   return {
     routes: createRouteManifest(routes),
     entry: { imports: [], module: "" },
@@ -175,9 +177,9 @@ function createManifest(routes: AgnosticDataRouteObject[]): AssetsManifest {
 
 function createRouteManifest(
   routes: AgnosticDataRouteObject[],
-  manifest?: RouteManifest<EntryRoute>,
+  manifest?: UNSAFE_RouteManifest<UNSAFE_EntryRoute>,
   parentId?: string
-): RouteManifest<EntryRoute> {
+): UNSAFE_RouteManifest<UNSAFE_EntryRoute> {
   return routes.reduce((manifest, route) => {
     if (route.children) {
       createRouteManifest(route.children, manifest, route.id);
@@ -189,8 +191,8 @@ function createRouteManifest(
 
 function createRouteModules(
   routes: AgnosticDataRouteObject[],
-  routeModules?: RouteModules
-): RouteModules {
+  routeModules?: UNSAFE_RouteModules
+): UNSAFE_RouteModules {
   return routes.reduce((modules, route) => {
     if (route.children) {
       createRouteModules(route.children, modules);
@@ -247,7 +249,7 @@ function monkeyPatchFetch(
 function convertToEntryRoute(
   route: AgnosticDataRouteObject,
   parentId?: string
-): EntryRoute {
+): UNSAFE_EntryRoute {
   return {
     id: route.id!,
     index: route.index,


### PR DESCRIPTION
exposed a few things that were needed for `@remix-run/testing` but shouldn't be public API #4539

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
