### PR TITLE
chore: Add script to remove pre-release notes from changelogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "type-fest": "^2.16.0",
     "typescript": "^4.7.4",
     "unified": "^10.1.2",
+    "unist-util-remove": "^3.1.0",
     "unist-util-visit": "^4.1.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,8 @@
     "remark": "14.0.2",
     "remark-frontmatter": "4.0.1",
     "remark-gfm": "3.0.1",
+    "remark-parse": "^10.0.1",
+    "remark-stringify": "^10.0.2",
     "rollup": "^2.36.1",
     "rollup-plugin-copy": "^3.3.0",
     "semver": "^7.3.7",
@@ -121,7 +123,9 @@
     "strip-indent": "^3.0.0",
     "to-vfile": "7.2.3",
     "type-fest": "^2.16.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "unified": "^10.1.2",
+    "unist-util-visit": "^4.1.1"
   },
   "engines": {
     "node": ">=14"

--- a/scripts/remove-prerelease-changelogs.mjs
+++ b/scripts/remove-prerelease-changelogs.mjs
@@ -1,0 +1,95 @@
+import * as fs from "node:fs";
+import path from "node:path";
+import * as url from "node:url";
+import { getPackagesSync } from "@manypkg/get-packages";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import rehypeStringify from "remark-stringify";
+import { unified } from "unified";
+import { visit } from "unist-util-visit";
+
+const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
+const rootDir = path.join(__dirname, "..");
+
+removePreReleaseChangelogs().then(() =>
+  console.log("✅ Removed pre-release changelogs")
+);
+
+async function removePreReleaseChangelogs() {
+  let allPackages = getPackagesSync(rootDir).packages;
+
+  /** @type {Promise<any>[]} */
+  let processes = [];
+  for (let pkg of allPackages) {
+    let changelogPath = path.join(pkg.dir, "CHANGELOG.md");
+    if (!fs.existsSync(changelogPath)) {
+      continue;
+    }
+    let changelogFileContents = fs.readFileSync(changelogPath, "utf-8");
+    processes.push(
+      (async () => {
+        let file = await unified()
+          // Since we have multiple versions of remark-parse, TS resolves to the
+          // wrong one
+          // @ts-expect-error
+          .use(remarkParse)
+          .use(remarkGfm)
+          .use(removePreReleaseSectionFromMarkdown)
+          // same problem
+          // @ts-expect-error
+          .use(rehypeStringify, {
+            bullet: "-",
+            listItemIndent: "one",
+          })
+          .process(changelogFileContents);
+
+        let fileContents = file.toString();
+        await fs.promises.writeFile(changelogPath, fileContents, "utf-8");
+      })()
+    );
+  }
+  return Promise.all(processes);
+}
+
+function removePreReleaseSectionFromMarkdown() {
+  /**
+   * @param {import('./unist').RootNode} tree
+   * @returns {Promise<void>}
+   */
+  async function transformer(tree) {
+    visit(tree, "heading", (node, index, parent) => {
+      if (
+        node.depth === 2 &&
+        node.children[0].type === "text" &&
+        isPrereleaseVersion(node.children[0].value)
+      ) {
+        if (index == null || parent == null) return;
+        let nextIdx = 1;
+        let nextNode = parent.children[index + 1];
+        let found = false;
+        /** @type {import('./unist').FlowNode[]} */
+        let nodesToRemove = [node];
+        while (nextNode && !found) {
+          if (nextNode.type === "heading" && nextNode.depth === 2) {
+            found = true;
+            break;
+          }
+          nodesToRemove.push(nextNode);
+          nextNode = parent.children[++nextIdx + index];
+        }
+        for (let node of nodesToRemove) {
+          parent.children.splice(parent.children.indexOf(node), 1);
+        }
+      }
+    });
+  }
+  return transformer;
+}
+
+/**
+ * @param {string} str
+ * @returns
+ */
+function isPrereleaseVersion(str) {
+  return /^(v?\d+\.){2}\d+-[a-z]+\.\d+$/i.test(str.trim());
+}

--- a/scripts/unist.d.ts
+++ b/scripts/unist.d.ts
@@ -1,0 +1,60 @@
+import type { Parent, Literal } from "unist";
+
+export interface RootNode extends Parent {
+  type: "root";
+  children: FlowNode[];
+}
+
+export type PhrasingNode = TextNode | EmphasisNode;
+
+export type FlowNode =
+  | BlockquoteNode
+  | HeadingNode
+  | ParagraphNode
+  | LinkNode
+  | PreNode
+  | CodeNode;
+
+export interface BlockquoteNode extends Parent {
+  type: "blockquote";
+  children: FlowNode[];
+}
+
+export interface HeadingNode extends Parent {
+  type: "heading";
+  depth: number;
+  children: PhrasingNode[];
+}
+
+export interface ParagraphNode extends Parent {
+  type: "paragraph";
+  children: PhrasingNode[];
+}
+
+export interface PreNode extends Parent {
+  type: "pre";
+  children: PhrasingNode[];
+}
+
+export interface CodeNode extends Parent {
+  type: "code";
+  children: PhrasingNode[];
+  value?: string;
+  meta?: string | string[];
+}
+
+export interface EmphasisNode extends Parent {
+  type: "emphasis";
+  children: PhrasingNode[];
+}
+
+export interface LinkNode extends Parent {
+  type: "link";
+  children: FlowNode[];
+  url?: string;
+}
+
+export interface TextNode extends Literal {
+  type: "text";
+  value: string;
+}

--- a/scripts/unist.d.ts
+++ b/scripts/unist.d.ts
@@ -1,5 +1,7 @@
 import type { Parent, Literal } from "unist";
 
+export type Node = FlowNode | PhrasingNode | RootNode;
+
 export interface RootNode extends Parent {
   type: "root";
   children: FlowNode[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -12374,6 +12374,15 @@ unist-util-remove-position@^4.0.0:
     "@types/unist" "^2.0.0"
     unist-util-visit "^4.0.0"
 
+unist-util-remove@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-3.1.0.tgz#8042577e151dac989b7517976bfe4bac58f76ccd"
+  integrity sha512-rO/sIghl13eN8irs5OBN2a4RC10MsJdiePCfwrvnzGtgIbHcDXr2REr0qi9F2r/CIb1r9FyyFmcMRIGs+EyUFw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^5.0.0"
+
 unist-util-stringify-position@^2.0.0:
   version "2.0.3"
   resolved "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10798,6 +10798,15 @@ remark-parse@^10.0.0:
     mdast-util-from-markdown "^1.0.0"
     unified "^10.0.0"
 
+remark-parse@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.1.tgz#6f60ae53edbf0cf38ea223fe643db64d112e0775"
+  integrity sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-from-markdown "^1.0.0"
+    unified "^10.0.0"
+
 remark-rehype@^9.0.0:
   version "9.1.0"
   resolved "https://registry.npmjs.org/remark-rehype/-/remark-rehype-9.1.0.tgz"
@@ -10808,7 +10817,7 @@ remark-rehype@^9.0.0:
     mdast-util-to-hast "^11.0.0"
     unified "^10.0.0"
 
-remark-stringify@^10.0.0:
+remark-stringify@^10.0.0, remark-stringify@^10.0.2:
   version "10.0.2"
   resolved "https://registry.npmjs.org/remark-stringify/-/remark-stringify-10.0.2.tgz"
   integrity sha512-6wV3pvbPvHkbNnWB0wdDvVFHOe1hBRAx1Q/5g/EpH4RppAII6J8Gnwe7VbHuXaoKIF6LAg6ExTel/+kNqSQ7lw==
@@ -12395,6 +12404,14 @@ unist-util-visit-parents@^5.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^5.0.0"
 
+unist-util-visit-parents@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.1.tgz#868f353e6fce6bf8fa875b251b0f4fec3be709bb"
+  integrity sha512-gks4baapT/kNRaWxuGkl5BIhoanZo7sC/cUT/JToSRNL1dYoXRFl75d++NkjYk4TAu2uv2Px+l8guMajogeuiw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+
 unist-util-visit@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-3.1.0.tgz"
@@ -12412,6 +12429,15 @@ unist-util-visit@^4.0.0, unist-util-visit@^4.1.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^5.0.0"
     unist-util-visit-parents "^5.0.0"
+
+unist-util-visit@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.1.tgz#1c4842d70bd3df6cc545276f5164f933390a9aad"
+  integrity sha512-n9KN3WV9k4h1DxYR1LoajgN93wpEi/7ZplVe02IoB4gH5ctI1AaF2670BLHQYbwj+pY83gFtyeySFiyMHJklrg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^5.1.1"
 
 universal-user-agent@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
This creates a script that can be used after existing Changesets' pre-release mode to remove all of the generated pre-release changelogs.