### PR TITLE
docs(route/headers): Fix incorrect link on headers

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -95,7 +95,7 @@
 - davecranwell-vocovo
 - DavidHollins6
 - davongit
-- deanmv
+- Deanmv
 - denissb
 - derekr
 - developit

--- a/docs/route/headers.md
+++ b/docs/route/headers.md
@@ -113,4 +113,4 @@ export default function handleRequest(
 Just keep in mind that doing this will apply to _all_ document requests, but does not apply to `data` requests (for client-side transitions for example). For those, use [`handleDataRequest`][handledatarequest].
 
 [headers]: https://developer.mozilla.org/en-US/docs/Web/API/Headers
-[handledatarequest]: ../file-conventions/entry.server.tsx
+[handledatarequest]: ../file-conventions/entry.server


### PR DESCRIPTION
`handledatarequest` link was a 404 as it has a the trailing `.tsx` on the URL
