### PR TITLE
refactor: use type imports instead of type modifiers

### DIFF
--- a/packages/remix-dev/codemod/index.ts
+++ b/packages/remix-dev/codemod/index.ts
@@ -4,7 +4,7 @@ import { blue, yellow } from "../colors";
 import * as git from "./utils/git";
 import * as log from "./utils/log";
 import { task } from "./utils/task";
-import { type Options } from "./codemod";
+import type { Options } from "./codemod";
 import replaceRemixMagicImports from "./replace-remix-magic-imports";
 import { CodemodError } from "./utils/error";
 

--- a/packages/remix-dev/codemod/replace-remix-magic-imports/transform.ts
+++ b/packages/remix-dev/codemod/replace-remix-magic-imports/transform.ts
@@ -1,22 +1,18 @@
-import { type NodePath } from "@babel/core";
+import type { NodePath } from "@babel/core";
 import * as t from "@babel/types";
 import _ from "lodash";
 
 import createTransform from "../createTransform";
 import type { BabelPlugin } from "../utils/babel";
 import { CodemodError } from "../utils/error";
+import type { Export } from "./utils/export";
 import {
-  type Export,
   getAdapterExports,
   getRendererExports,
   getRuntimeExports,
 } from "./utils/export";
-import {
-  isRemixPackage,
-  type Adapter,
-  type RemixPackage,
-  type Runtime,
-} from "./utils/remix";
+import type { Adapter, RemixPackage, Runtime } from "./utils/remix";
+import { isRemixPackage } from "./utils/remix";
 
 type Options = {
   runtime: Runtime;

--- a/packages/remix-dev/codemod/replace-remix-magic-imports/utils/detect.ts
+++ b/packages/remix-dev/codemod/replace-remix-magic-imports/utils/detect.ts
@@ -1,9 +1,10 @@
-import { type PackageJson } from "@npmcli/package-json";
+import type { PackageJson } from "@npmcli/package-json";
 
 import { CodemodError } from "../../utils/error";
 import * as Dependencies from "./dependencies";
 import * as Postinstall from "./postinstall";
-import { type Adapter, type Runtime, isAdapter, isRemixPackage } from "./remix";
+import type { Adapter, Runtime } from "./remix";
+import { isAdapter, isRemixPackage } from "./remix";
 
 const autoDetectPostinstallRuntime = (
   packageJson: PackageJson

--- a/packages/remix-dev/codemod/replace-remix-magic-imports/utils/export.ts
+++ b/packages/remix-dev/codemod/replace-remix-magic-imports/utils/export.ts
@@ -1,4 +1,4 @@
-import { type Adapter, type Renderer, type Runtime } from "./remix";
+import type { Adapter, Renderer, Runtime } from "./remix";
 
 export type Export<Source extends string = string> = {
   source: Source;

--- a/packages/remix-dev/codemod/replace-remix-magic-imports/utils/postinstall.ts
+++ b/packages/remix-dev/codemod/replace-remix-magic-imports/utils/postinstall.ts
@@ -1,4 +1,5 @@
-import { type Runtime, isRuntime } from "./remix";
+import type { Runtime } from "./remix";
+import { isRuntime } from "./remix";
 
 const remixSetup = /\s*remix\s+setup(?:$|\s+)/;
 const remixSetupRuntime = /\s*remix\s+setup\s+(\w+)\s*/;

--- a/packages/remix-dev/compiler/build.ts
+++ b/packages/remix-dev/compiler/build.ts
@@ -1,7 +1,7 @@
-import { type RemixConfig } from "../config";
+import type { RemixConfig } from "../config";
 import { warnOnce } from "./warnings";
 import { logCompileFailure } from "./onCompileFailure";
-import { type CompileOptions } from "./options";
+import type { CompileOptions } from "./options";
 import { compile, createRemixCompiler } from "./remixCompiler";
 
 export async function build(

--- a/packages/remix-dev/compiler/compileBrowser.ts
+++ b/packages/remix-dev/compiler/compileBrowser.ts
@@ -3,12 +3,13 @@ import { builtinModules as nodeBuiltins } from "module";
 import * as esbuild from "esbuild";
 import { NodeModulesPolyfillPlugin } from "@esbuild-plugins/node-modules-polyfill";
 
-import { type WriteChannel } from "../channel";
-import { type RemixConfig } from "../config";
-import { createAssetsManifest, type AssetsManifest } from "./assets";
+import type { WriteChannel } from "../channel";
+import type { RemixConfig } from "../config";
+import type { AssetsManifest } from "./assets";
+import { createAssetsManifest } from "./assets";
 import { getAppDependencies } from "./dependencies";
 import { loaders } from "./loaders";
-import { type CompileOptions } from "./options";
+import type { CompileOptions } from "./options";
 import { browserRouteModulesPlugin } from "./plugins/browserRouteModulesPlugin";
 import { cssFilePlugin } from "./plugins/cssFilePlugin";
 import { deprecatedRemixPackagePlugin } from "./plugins/deprecatedRemixPackagePlugin";

--- a/packages/remix-dev/compiler/compilerServer.ts
+++ b/packages/remix-dev/compiler/compilerServer.ts
@@ -3,11 +3,11 @@ import * as esbuild from "esbuild";
 import * as fse from "fs-extra";
 import { NodeModulesPolyfillPlugin } from "@esbuild-plugins/node-modules-polyfill";
 
-import { type ReadChannel } from "../channel";
-import { type RemixConfig } from "../config";
-import { type AssetsManifest } from "./assets";
+import type { ReadChannel } from "../channel";
+import type { RemixConfig } from "../config";
+import type { AssetsManifest } from "./assets";
 import { loaders } from "./loaders";
-import { type CompileOptions } from "./options";
+import type { CompileOptions } from "./options";
 import { cssFilePlugin } from "./plugins/cssFilePlugin";
 import { deprecatedRemixPackagePlugin } from "./plugins/deprecatedRemixPackagePlugin";
 import { emptyModulesPlugin } from "./plugins/emptyModulesPlugin";

--- a/packages/remix-dev/compiler/plugins/cssFilePlugin.ts
+++ b/packages/remix-dev/compiler/plugins/cssFilePlugin.ts
@@ -3,7 +3,7 @@ import * as fse from "fs-extra";
 import esbuild from "esbuild";
 
 import invariant from "../../invariant";
-import { type CompileOptions } from "../options";
+import type { CompileOptions } from "../options";
 
 const isExtendedLengthPath = /^\\\\\?\\/;
 

--- a/packages/remix-dev/compiler/remixCompiler.ts
+++ b/packages/remix-dev/compiler/remixCompiler.ts
@@ -1,10 +1,12 @@
 import { createChannel } from "../channel";
-import { type RemixConfig } from "../config";
-import { type AssetsManifest } from "./assets";
-import { type BrowserCompiler, createBrowserCompiler } from "./compileBrowser";
-import { type ServerCompiler, createServerCompiler } from "./compilerServer";
-import { type OnCompileFailure } from "./onCompileFailure";
-import { type CompileOptions } from "./options";
+import type { RemixConfig } from "../config";
+import type { AssetsManifest } from "./assets";
+import type { BrowserCompiler } from "./compileBrowser";
+import { createBrowserCompiler } from "./compileBrowser";
+import type { ServerCompiler } from "./compilerServer";
+import { createServerCompiler } from "./compilerServer";
+import type { OnCompileFailure } from "./onCompileFailure";
+import type { CompileOptions } from "./options";
 
 type RemixCompiler = {
   browser: BrowserCompiler;

--- a/packages/remix-dev/compiler/watch.ts
+++ b/packages/remix-dev/compiler/watch.ts
@@ -2,9 +2,10 @@ import chokidar from "chokidar";
 import debounce from "lodash.debounce";
 import * as path from "path";
 
-import { type RemixConfig, readConfig } from "../config";
+import type { RemixConfig } from "../config";
+import { readConfig } from "../config";
 import { logCompileFailure } from "./onCompileFailure";
-import { type CompileOptions } from "./options";
+import type { CompileOptions } from "./options";
 import { compile, createRemixCompiler, dispose } from "./remixCompiler";
 import { warnOnce } from "./warnings";
 


### PR DESCRIPTION
This way we use type imports consistently throughout the codebase