### PR TITLE
chore(remix-testing): utilize react-router 6.5+

### DIFF
--- a/.changeset/silver-ducks-protect.md
+++ b/.changeset/silver-ducks-protect.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/testing": patch
+---
+
+use react router apis directly

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -42,7 +42,6 @@ export {
   Scripts,
   Link,
   NavLink,
-  RemixEntry,
   PrefetchPageLinks,
   LiveReload,
   useTransition,
@@ -59,11 +58,7 @@ export type { ThrownResponse } from "./errors";
 export { useCatch } from "./errorBoundaries";
 
 export type { HtmlLinkDescriptor } from "./links";
-export type {
-  HtmlMetaDescriptor,
-  CatchBoundaryComponent,
-  RouteModules,
-} from "./routeModules";
+export type { HtmlMetaDescriptor } from "./routeModules";
 
 export { ScrollRestoration } from "./scroll-restoration";
 
@@ -72,6 +67,4 @@ export { RemixServer } from "./server";
 
 export type { Fetcher } from "./transition";
 
-export type { AssetsManifest, EntryContext } from "./entry";
-export type { RouteData } from "./routeData";
-export type { EntryRoute, RouteManifest } from "./routes";
+export type { RouteData as UNSAFE_RouteData } from "./routeData";

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -51,6 +51,7 @@ export {
   useLoaderData,
   useMatches,
   useActionData,
+  RemixContext as UNSAFE_RemixContext,
 } from "./components";
 
 export type { FormMethod, FormEncType } from "./data";

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -50,6 +50,7 @@ export {
   useLoaderData,
   useMatches,
   useActionData,
+  RemixContext as UNSAFE_RemixContext,
 } from "./components";
 
 export type { FormMethod, FormEncType } from "./data";
@@ -58,7 +59,10 @@ export type { ThrownResponse } from "./errors";
 export { useCatch } from "./errorBoundaries";
 
 export type { HtmlLinkDescriptor } from "./links";
-export type { HtmlMetaDescriptor } from "./routeModules";
+export type {
+  HtmlMetaDescriptor,
+  RouteModules as UNSAFE_RouteModules,
+} from "./routeModules";
 
 export { ScrollRestoration } from "./scroll-restoration";
 
@@ -67,4 +71,13 @@ export { RemixServer } from "./server";
 
 export type { Fetcher } from "./transition";
 
-export type { RouteData as UNSAFE_RouteData } from "./routeData";
+export type {
+  FutureConfig as UNSAFE_FutureConfig,
+  AssetsManifest as UNSAFE_AssetsManifest,
+  RemixContextObject as UNSAFE_RemixContextObject,
+} from "./entry";
+
+export type {
+  EntryRoute as UNSAFE_EntryRoute,
+  RouteManifest as UNSAFE_RouteManifest,
+} from "./routes";

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -51,7 +51,6 @@ export {
   useLoaderData,
   useMatches,
   useActionData,
-  RemixContext as UNSAFE_RemixContext,
 } from "./components";
 
 export type { FormMethod, FormEncType } from "./data";

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -1,23 +1,9 @@
 import * as React from "react";
-import type {
-  AssetsManifest,
-  EntryContext,
-  EntryRoute,
-  RouteData,
-  RouteManifest,
-  RouteModules,
-} from "@remix-run/react";
-import { UNSAFE_RemixContext as RemixContext } from "@remix-run/react";
-import { StaticRouterProvider } from "react-router-dom/server";
+import type { RouteData } from "@remix-run/react";
 import type { RouteObject } from "react-router-dom";
+import { RouterProvider } from "react-router-dom";
 import { createMemoryRouter } from "react-router-dom";
-import { matchRoutes, json } from "react-router-dom";
-import type {
-  AgnosticDataRouteObject,
-  InitialEntry,
-  StaticHandler,
-  StaticHandlerContext,
-} from "@remix-run/router";
+import type { InitialEntry } from "@remix-run/router";
 import { createStaticHandler } from "@remix-run/router";
 
 type RemixStubOptions = {
@@ -36,26 +22,10 @@ type RemixStubOptions = {
   initialLoaderData?: RouteData;
 
   /**
-   * Used to set the route's initial loader headers.
-   * e.g. initialLoaderHeaders={{ "/contact": { "Content-Type": "application/json" } }}
-   */
-  initialLoaderHeaders?: Record<string, Headers>;
-
-  /**
    *  Used to set the route's initial action data.
    *  e.g. initialActionData={{ "/login": { errors: { email: "invalid email" } }}
    */
   initialActionData?: RouteData;
-
-  /**
-   * Used to set the route's initial action headers.
-   */
-  initialActionHeaders?: Record<string, Headers>;
-
-  /**
-   * Used to set the route's initial status code.
-   */
-  initialStatusCode?: number;
 
   /**
    * The initial index in the history stack to render. This allows you to start a test at a specific entry.
@@ -67,154 +37,24 @@ type RemixStubOptions = {
   initialIndex?: number;
 };
 
-type RemixConfigFuture = Partial<EntryContext["future"]>;
-
-export function createRemixStub(
-  routes: RouteObject[],
-  remixConfigFuture?: RemixConfigFuture
-) {
+export function createRemixStub(routes: RouteObject[]) {
   // Setup request handler to handle requests to the mock routes
   let staticHandler = createStaticHandler(routes);
   return function RemixStub({
     initialEntries,
     initialIndex,
-    initialLoaderData = {},
     initialActionData,
-    initialActionHeaders,
-    initialLoaderHeaders,
-    initialStatusCode: statusCode,
+    initialLoaderData,
   }: RemixStubOptions) {
-    let memoryRouter = createMemoryRouter(staticHandler.dataRoutes, {
+    let router = createMemoryRouter(staticHandler.dataRoutes, {
       initialEntries,
       initialIndex,
+      hydrationData: {
+        actionData: initialActionData,
+        loaderData: initialLoaderData,
+      },
     });
 
-    let manifest = createManifest(staticHandler.dataRoutes);
-    let matches = matchRoutes(routes, memoryRouter.state.location) || [];
-    let future: EntryContext["future"] = {
-      v2_meta: false,
-      ...remixConfigFuture,
-    };
-    let routeModules = createRouteModules(staticHandler.dataRoutes);
-
-    let staticHandlerContext: StaticHandlerContext = {
-      actionData: initialActionData || null,
-      actionHeaders: initialActionHeaders || {},
-      loaderData: initialLoaderData || {},
-      loaderHeaders: initialLoaderHeaders || {},
-      basename: "",
-      errors: null,
-      location: memoryRouter.state.location,
-      // @ts-expect-error
-      matches,
-      statusCode: statusCode || 200,
-    };
-
-    // Patch fetch so that mock routes can handle action/loader requests
-    monkeyPatchFetch(staticHandler);
-
-    return (
-      <RemixContext.Provider value={{ manifest, routeModules, future }}>
-        <StaticRouterProvider
-          router={memoryRouter}
-          context={staticHandlerContext}
-        />
-      </RemixContext.Provider>
-    );
-  };
-}
-
-function createManifest(routes: AgnosticDataRouteObject[]): AssetsManifest {
-  return {
-    routes: createRouteManifest(routes),
-    entry: { imports: [], module: "" },
-    url: "",
-    version: "",
-  };
-}
-
-function createRouteManifest(
-  routes: AgnosticDataRouteObject[],
-  manifest?: RouteManifest<EntryRoute>,
-  parentId?: string
-): RouteManifest<EntryRoute> {
-  return routes.reduce((manifest, route) => {
-    if (route.children) {
-      createRouteManifest(route.children, manifest, route.id);
-    }
-    manifest[route.id!] = convertToEntryRoute(route, parentId);
-    return manifest;
-  }, manifest || {});
-}
-
-function createRouteModules(
-  routes: AgnosticDataRouteObject[],
-  routeModules?: RouteModules
-): RouteModules {
-  return routes.reduce((modules, route) => {
-    if (route.children) {
-      createRouteModules(route.children, modules);
-    }
-
-    modules[route.id!] = {
-      CatchBoundary: undefined,
-      ErrorBoundary: undefined,
-      // @ts-expect-error - types are still `agnostic` here
-      default: () => route.element,
-      handle: route.handle,
-      links: undefined,
-      meta: undefined,
-      shouldRevalidate: undefined,
-    };
-    return modules;
-  }, routeModules || {});
-}
-
-const originalFetch =
-  typeof global !== "undefined" ? global.fetch : window.fetch;
-
-function monkeyPatchFetch(staticHandler: StaticHandler) {
-  let fetchPatch = async (
-    input: RequestInfo | URL,
-    init: RequestInit = {}
-  ): Promise<Response> => {
-    let request = new Request(input, init);
-    let url = new URL(request.url);
-
-    // if we have matches, send the request to mock routes via @remix-run/router rather than the normal
-    // @remix-run/server-runtime so that stubs can also be used in browser environments.
-    let matches = matchRoutes(staticHandler.dataRoutes, url);
-    if (matches && matches.length > 0) {
-      let response = await staticHandler.queryRoute(request);
-
-      if (response instanceof Response) {
-        return response;
-      }
-
-      return json(response);
-    }
-
-    // if no matches, passthrough to the original fetch as mock routes couldn't handle the request.
-    return originalFetch(request, init);
-  };
-
-  globalThis.fetch = fetchPatch;
-}
-
-function convertToEntryRoute(
-  route: AgnosticDataRouteObject,
-  parentId?: string
-): EntryRoute {
-  return {
-    id: route.id!,
-    index: route.index,
-    caseSensitive: route.caseSensitive,
-    path: route.path,
-    parentId,
-    hasAction: !!route.action,
-    hasLoader: !!route.loader,
-    module: "",
-    hasCatchBoundary: false,
-    hasErrorBoundary: false,
+    return <RouterProvider router={router} />;
   };
 }

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
 import type { RouteData } from "@remix-run/react";
-import type { RouteObject } from "react-router-dom";
-import { RouterProvider } from "react-router-dom";
-import { createMemoryRouter } from "react-router-dom";
 import type { InitialEntry, Router } from "@remix-run/router";
+import type { RouteObject } from "react-router-dom";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
 
 type RemixStubOptions = {
   /**

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -3,8 +3,7 @@ import type { RouteData } from "@remix-run/react";
 import type { RouteObject } from "react-router-dom";
 import { RouterProvider } from "react-router-dom";
 import { createMemoryRouter } from "react-router-dom";
-import type { InitialEntry } from "@remix-run/router";
-import { createStaticHandler } from "@remix-run/router";
+import type { InitialEntry, Router } from "@remix-run/router";
 
 type RemixStubOptions = {
   /**
@@ -38,23 +37,24 @@ type RemixStubOptions = {
 };
 
 export function createRemixStub(routes: RouteObject[]) {
-  // Setup request handler to handle requests to the mock routes
-  let staticHandler = createStaticHandler(routes);
   return function RemixStub({
     initialEntries,
     initialIndex,
     initialActionData,
     initialLoaderData,
   }: RemixStubOptions) {
-    let router = createMemoryRouter(staticHandler.dataRoutes, {
-      initialEntries,
-      initialIndex,
-      hydrationData: {
-        actionData: initialActionData,
-        loaderData: initialLoaderData,
-      },
-    });
+    let routerRef = React.useRef<Router>();
+    if (routerRef.current == null) {
+      routerRef.current = createMemoryRouter(routes, {
+        initialEntries,
+        initialIndex,
+        hydrationData: {
+          actionData: initialActionData,
+          loaderData: initialLoaderData,
+        },
+      });
+    }
 
-    return <RouterProvider router={router} />;
+    return <RouterProvider router={routerRef.current} />;
   };
 }

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -42,12 +42,7 @@ type RemixStubOptions = {
   remixConfigFuture?: Partial<FutureConfig>;
 };
 
-type StubRouteObject = Omit<
-  RouteObject,
-  "id" | "handle" | "shouldRevalidate" | "errorElement" | "hasErrorBoundary"
->;
-
-export function createRemixStub(routes: StubRouteObject[]) {
+export function createRemixStub(routes: RouteObject[]) {
   return function RemixStub({
     initialEntries,
     initialIndex,
@@ -58,7 +53,7 @@ export function createRemixStub(routes: StubRouteObject[]) {
     let remixContextRef = React.useRef<RemixContextObject>();
 
     if (routerRef.current == null) {
-      routerRef.current = createMemoryRouter(routes as RouteObject[], {
+      routerRef.current = createMemoryRouter(routes, {
         initialEntries,
         initialIndex,
         hydrationData,
@@ -71,8 +66,8 @@ export function createRemixStub(routes: StubRouteObject[]) {
           v2_meta: false,
           ...remixConfigFuture,
         },
-        manifest: createManifest(routes as RouteObject[]),
-        routeModules: createRouteModules(routes as RouteObject[]),
+        manifest: createManifest(routes),
+        routeModules: createRouteModules(routes),
       };
     }
 

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import type { RouteData } from "@remix-run/react";
+import type { UNSAFE_RouteData as RouteData } from "@remix-run/react";
 import type { InitialEntry, Router } from "@remix-run/router";
 import type { RouteObject } from "react-router-dom";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "@remix-run/node": "1.10.0-pre.1",
     "@remix-run/react": "1.10.0-pre.1",
-    "@remix-run/router": "1.1.0",
-    "@remix-run/server-runtime": "1.10.0-pre.1",
+    "@remix-run/router": "1.2.0",
+    "react-router-dom": "6.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2174,11 +2174,6 @@
     "@changesets/types" "^5.0.0"
     dotenv "^8.1.0"
 
-"@remix-run/router@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.1.0.tgz#b48db8148c8a888e50580a8152b6f68161c49406"
-  integrity sha512-rGl+jH/7x1KBCQScz9p54p0dtPLNeKGb3e0wD2H5/oZj41bwQUnXdzbj2TbUAFhvD7cp9EyEQA4dEgpUFa1O7Q==
-
 "@remix-run/router@1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.2.0.tgz#54eff8306938b64c521f4a9ed313d33a91ef019a"


### PR DESCRIPTION
supersedes #4899 

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy: https://github.com/mcansh/stubbbbbs

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
