### PR TITLE
The new dev server

### DIFF
--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -239,6 +239,6 @@ export async function codemod(
 export async function dev2(projectDir?: string) {
   projectDir ??= process.cwd();
   let config = await readConfig(projectDir);
-  let dispose = await devServer2.serve(config, 3000);
-  await new Promise(() => {})
+  await devServer2.serve(config);
+  await new Promise(() => {});
 }

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -8,6 +8,7 @@ import * as esbuild from "esbuild";
 import * as colors from "../colors";
 import * as compiler from "../compiler";
 import * as devServer from "../devServer";
+import * as devServer2 from "../devServer2";
 import type { RemixConfig } from "../config";
 import { readConfig } from "../config";
 import { formatRoutes, RoutesFormat, isRoutesFormat } from "../config/format";
@@ -233,4 +234,11 @@ export async function codemod(
     }
     throw error;
   }
+}
+
+export async function dev2(projectDir?: string) {
+  projectDir ??= process.cwd();
+  let config = await readConfig(projectDir);
+  let dispose = await devServer2.serve(config, 3000);
+  await new Promise(() => {})
 }

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -482,6 +482,9 @@ export async function run(argv: string[] = process.argv.slice(2)) {
     case "dev":
       await dev(input[1], flags);
       break;
+    case "dev2":
+      await commands.dev2(input[1]);
+      break;
     default:
       // `remix ./my-project` is shorthand for `remix dev ./my-project`
       await dev(input[0], flags);

--- a/packages/remix-dev/compiler/compilerServer.ts
+++ b/packages/remix-dev/compiler/compilerServer.ts
@@ -70,7 +70,7 @@ const createEsbuildConfig = (
     mdxPlugin(config),
     emptyModulesPlugin(config, /\.client(\.[jt]sx?)?$/),
     serverRouteModulesPlugin(config),
-    serverEntryModulePlugin(config),
+    serverEntryModulePlugin(config, options.liveReloadPort),
     serverAssetsManifestPlugin(assetsManifestChannel.read()),
     serverBareModulesPlugin(config, options.onWarning),
   ].filter(isNotNull);

--- a/packages/remix-dev/compiler/options.ts
+++ b/packages/remix-dev/compiler/options.ts
@@ -22,6 +22,7 @@ type Target =
 
 export type CompileOptions = {
   mode: Mode;
+  liveReloadPort?: number;
   target: Target;
   sourcemap: boolean;
   onWarning?: (message: string, key: string) => void;

--- a/packages/remix-dev/compiler/plugins/serverEntryModulePlugin.ts
+++ b/packages/remix-dev/compiler/plugins/serverEntryModulePlugin.ts
@@ -12,7 +12,10 @@ import {
  * for you to consume the build in a custom server entry that is also fed through
  * the compiler.
  */
-export function serverEntryModulePlugin(config: RemixConfig): Plugin {
+export function serverEntryModulePlugin(
+  config: RemixConfig,
+  liveReloadPort?: number
+): Plugin {
   let filter = serverBuildVirtualModule.filter;
 
   return {
@@ -50,6 +53,11 @@ ${Object.keys(config.routes)
   export const future = ${JSON.stringify(config.future)};
   export const publicPath = ${JSON.stringify(config.publicPath)};
   export const entry = { module: entryServer };
+  ${
+    liveReloadPort
+      ? `export const dev = ${JSON.stringify({ liveReloadPort })};`
+      : ""
+  }
   export const routes = {
     ${Object.keys(config.routes)
       .map((key, index) => {

--- a/packages/remix-dev/compiler/remixCompiler.ts
+++ b/packages/remix-dev/compiler/remixCompiler.ts
@@ -28,12 +28,13 @@ export const compile = async (
   options: {
     onCompileFailure?: OnCompileFailure;
   } = {}
-): Promise<void> => {
+): Promise<AssetsManifest | undefined> => {
   try {
     let assetsManifestChannel = createChannel<AssetsManifest>();
     let browserPromise = compiler.browser.compile(assetsManifestChannel);
     let serverPromise = compiler.server.compile(assetsManifestChannel);
     await Promise.all([browserPromise, serverPromise]);
+    return assetsManifestChannel.read()
   } catch (error: unknown) {
     options.onCompileFailure?.(error as Error);
   }

--- a/packages/remix-dev/compiler/watch.ts
+++ b/packages/remix-dev/compiler/watch.ts
@@ -2,6 +2,7 @@ import chokidar from "chokidar";
 import debounce from "lodash.debounce";
 import * as path from "path";
 
+import { type AssetsManifest } from "../assets-manifest";
 import type { RemixConfig } from "../config";
 import { readConfig } from "../config";
 import { logCompileFailure } from "./onCompileFailure";
@@ -21,7 +22,7 @@ function isEntryPoint(config: RemixConfig, file: string): boolean {
 
 export type WatchOptions = Partial<CompileOptions> & {
   onRebuildStart?(): void;
-  onRebuildFinish?(durationMs: number): void;
+  onRebuildFinish?(durationMs: number, assetsManifest?: AssetsManifest): void;
   onFileCreated?(file: string): void;
   onFileChanged?(file: string): void;
   onFileDeleted?(file: string): void;
@@ -72,15 +73,15 @@ export async function watch(
     }
 
     compiler = createRemixCompiler(config, options);
-    await compile(compiler);
-    onRebuildFinish?.(Date.now() - start);
+    let assetsManifest = await compile(compiler);
+    onRebuildFinish?.(Date.now() - start, assetsManifest);
   }, 500);
 
   let rebuild = debounce(async () => {
     onRebuildStart?.();
     let start = Date.now();
-    await compile(compiler, { onCompileFailure });
-    onRebuildFinish?.(Date.now() - start);
+    let assetsManifest = await compile(compiler, { onCompileFailure });
+    await onRebuildFinish?.(Date.now() - start, assetsManifest);
   }, 100);
 
   let toWatch = [config.appDirectory];

--- a/packages/remix-dev/compiler/watch.ts
+++ b/packages/remix-dev/compiler/watch.ts
@@ -33,6 +33,7 @@ export async function watch(
   config: RemixConfig,
   {
     mode = "development",
+    liveReloadPort,
     target = "node14",
     sourcemap = true,
     onWarning = warnOnce,
@@ -47,6 +48,7 @@ export async function watch(
 ): Promise<() => Promise<void>> {
   let options: CompileOptions = {
     mode,
+    liveReloadPort,
     target,
     sourcemap,
     onCompileFailure,
@@ -81,7 +83,7 @@ export async function watch(
     onRebuildStart?.();
     let start = Date.now();
     let assetsManifest = await compile(compiler, { onCompileFailure });
-    await onRebuildFinish?.(Date.now() - start, assetsManifest);
+    onRebuildFinish?.(Date.now() - start, assetsManifest);
   }, 100);
 
   let toWatch = [config.appDirectory];

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -536,11 +536,10 @@ export async function readConfig(
     unstable_vanillaExtract: appConfig.future?.unstable_vanillaExtract === true,
     v2_errorBoundary: appConfig.future?.v2_errorBoundary === true,
     v2_dev: {
-      proxyPort: appConfig.future?.v2_dev?.proxyPort ?? 3000,
-      proxyRebuildPollIntervalMs:
-        appConfig.future?.v2_dev?.proxyRebuildPollIntervalMs ?? 50,
-      proxyRebuildTimeoutMs:
-        appConfig.future?.v2_dev?.proxyRebuildTimeoutMs ?? 1000,
+      appServerPort: appConfig.future?.v2_dev?.appServerPort ?? 3000,
+      rebuildPollIntervalMs:
+        appConfig.future?.v2_dev!.rebuildPollIntervalMs ?? 50,
+      rebuildTimeoutMs: appConfig.future?.v2_dev?.rebuildTimeoutMs ?? 1000,
       remixRequestHandlerPath:
         appConfig.future?.v2_dev?.remixRequestHandlerPath ?? "",
     },

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -71,12 +71,22 @@ type V2_Dev = {
   rebuildTimeoutMs?: number;
 };
 
+interface FutureConfigInput {
+  unstable_cssModules?: boolean;
+  unstable_cssSideEffectImports?: boolean;
+  unstable_vanillaExtract?: boolean;
+  v2_errorBoundary?: boolean;
+  v2_dev?: false | V2_Dev;
+  v2_meta?: boolean;
+  v2_routeConvention?: boolean;
+}
+
 interface FutureConfig {
   unstable_cssModules: boolean;
   unstable_cssSideEffectImports: boolean;
   unstable_vanillaExtract: boolean;
   v2_errorBoundary: boolean;
-  v2_dev: false | V2_Dev;
+  v2_dev: false | Required<V2_Dev>;
   v2_meta: boolean;
   v2_routeConvention: boolean;
 }
@@ -208,7 +218,7 @@ export interface AppConfig {
     | string[]
     | (() => Promise<string | string[]> | string | string[]);
 
-  future?: Partial<FutureConfig>;
+  future?: FutureConfigInput;
 }
 
 /**
@@ -537,17 +547,16 @@ export async function readConfig(
       appConfig.future?.unstable_cssSideEffectImports === true,
     unstable_vanillaExtract: appConfig.future?.unstable_vanillaExtract === true,
     v2_errorBoundary: appConfig.future?.v2_errorBoundary === true,
-    v2_dev:
-      appConfig.future?.v2_dev === undefined
-        ? undefined
-        : {
-            appServerPort: appConfig.future.v2_dev.appServerPort,
-            remixRequestHandlerPath:
-              appConfig.future.v2_dev.remixRequestHandlerPath ?? "",
-            rebuildPollIntervalMs:
-              appConfig.future.v2_dev.rebuildPollIntervalMs ?? 50,
-            rebuildTimeoutMs: appConfig.future.v2_dev.rebuildTimeoutMs ?? 1000,
-          },
+    v2_dev: appConfig.future?.v2_dev
+      ? {
+          appServerPort: appConfig.future.v2_dev.appServerPort,
+          remixRequestHandlerPath:
+            appConfig.future.v2_dev.remixRequestHandlerPath ?? "",
+          rebuildPollIntervalMs:
+            appConfig.future.v2_dev.rebuildPollIntervalMs ?? 50,
+          rebuildTimeoutMs: appConfig.future.v2_dev.rebuildTimeoutMs ?? 1000,
+        }
+      : false,
     v2_meta: appConfig.future?.v2_meta === true,
     v2_routeConvention: appConfig.future?.v2_routeConvention === true,
   };

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -37,6 +37,44 @@ interface FutureConfig {
   unstable_cssSideEffectImports: boolean;
   unstable_vanillaExtract: boolean;
   v2_errorBoundary: boolean;
+  v2_dev: {
+    /**
+     * URL path to the Remix request handler.
+     *
+     * When a rebuild finishes, the dev server polls `/__REMIX_ASSETS_MANIFEST`
+     * to check that the app server is running and serving up-to-date routes and assets.
+     *
+     * Most apps will place the Remix request handler at the root, but some apps
+     * may only route requests with a specific path prefix to the Remix request handler.
+     * Those apps will need to provide that request handler path prefix so that the
+     * dev server can prefix the assets manifest request:
+     * `{remixRequestHandlerPath}/__REMIX_ASSETS_MANIFEST`
+     */
+    remixRequestHandlerPath: string;
+    /**
+     * Port for the Remix app server.
+     *
+     * When a rebuild finishes, the dev server polls `/__REMIX_ASSETS_MANIFEST`
+     * to check that the app server is running and serving up-to-date routes and assets.
+     *
+     * To send each poll request, the dev server needs to know the app server's port.
+     */
+    appServerPort: number;
+    /**
+     * Milliseconds to wait between poll requests to the app server.
+     *
+     * When a rebuild finishes, the dev server polls `/__REMIX_ASSETS_MANIFEST`
+     * to check that the app server is running and serving up-to-date routes and assets.
+     */
+    rebuildPollIntervalMs: number;
+    /**
+     * Milliseconds to wait for app server to be running and up-to-date before timing out.
+     *
+     * When a rebuild finishes, the dev server polls `/__REMIX_ASSETS_MANIFEST`
+     * to check that the app server is running and serving up-to-date routes and assets.
+     */
+    rebuildTimeoutMs: number;
+  };
   v2_meta: boolean;
   v2_routeConvention: boolean;
 }
@@ -491,12 +529,21 @@ export async function readConfig(
     writeConfigDefaults(tsconfigPath);
   }
 
-  let future = {
+  let future: FutureConfig = {
     unstable_cssModules: appConfig.future?.unstable_cssModules === true,
     unstable_cssSideEffectImports:
       appConfig.future?.unstable_cssSideEffectImports === true,
     unstable_vanillaExtract: appConfig.future?.unstable_vanillaExtract === true,
     v2_errorBoundary: appConfig.future?.v2_errorBoundary === true,
+    v2_dev: {
+      proxyPort: appConfig.future?.v2_dev?.proxyPort ?? 3000,
+      proxyRebuildPollIntervalMs:
+        appConfig.future?.v2_dev?.proxyRebuildPollIntervalMs ?? 50,
+      proxyRebuildTimeoutMs:
+        appConfig.future?.v2_dev?.proxyRebuildTimeoutMs ?? 1000,
+      remixRequestHandlerPath:
+        appConfig.future?.v2_dev?.remixRequestHandlerPath ?? "",
+    },
     v2_meta: appConfig.future?.v2_meta === true,
     v2_routeConvention: appConfig.future?.v2_routeConvention === true,
   };

--- a/packages/remix-dev/devServer2/index.ts
+++ b/packages/remix-dev/devServer2/index.ts
@@ -1,0 +1,1 @@
+export { serve } from './serve'

--- a/packages/remix-dev/devServer2/serve.ts
+++ b/packages/remix-dev/devServer2/serve.ts
@@ -1,0 +1,99 @@
+import getPort, { makeRange } from "get-port";
+import os from "os";
+import path from "node:path";
+import prettyMs from "pretty-ms";
+import fetch from "node-fetch";
+
+import { type AssetsManifest } from "../assets-manifest";
+import * as Compiler from "../compiler";
+import { type RemixConfig } from "../config";
+import { loadEnv } from "../env";
+import * as Socket from "./utils/socket";
+
+let relativePath = (file: string) => path.relative(process.cwd(), file);
+
+let getHost = () =>
+  process.env.HOST ??
+  Object.values(os.networkInterfaces())
+    .flat()
+    .find((ip) => String(ip?.family).includes("4") && !ip?.internal)?.address;
+
+let findPort = async (portPreference?: number) =>
+  getPort({
+    port:
+      // prettier-ignore
+      portPreference ? Number(portPreference) :
+        process.env.PORT ? Number(process.env.PORT) :
+          makeRange(3001, 3100),
+  });
+
+let sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+let fetchAssetsManifest = async (
+  origin: string,
+  config: RemixConfig
+): Promise<AssetsManifest | undefined> => {
+  let { remixRequestHandlerPath } = config.future.v2_dev;
+  try {
+    let url = origin + remixRequestHandlerPath + "/__REMIX_ASSETS_MANIFEST";
+    let res = await fetch(url);
+    let assetsManifest = (await res.json()) as AssetsManifest;
+    return assetsManifest;
+  } catch (error) {
+    return undefined;
+  }
+};
+
+let info = (message: string) => console.info(`💿 ${message}`);
+
+export let serve = async (config: RemixConfig, proxyPort: number) => {
+  await loadEnv(config.rootDirectory);
+
+  let host = getHost();
+  let port = await findPort();
+  let appServerOrigin = `http://${host ?? "localhost"}:${proxyPort}`;
+  let waitForProxyServer = async (buildHash: string) => {
+    let { rebuildPollIntervalMs, rebuildTimeoutMs } = config.future.v2_dev;
+    let elapsedMs = 0;
+    while (elapsedMs < rebuildTimeoutMs) {
+      let assetsManifest = await fetchAssetsManifest(appServerOrigin, config);
+      if (assetsManifest?.version === buildHash) return;
+
+      await sleep(rebuildPollIntervalMs);
+      elapsedMs += rebuildPollIntervalMs;
+    }
+    throw Error(
+      `Timeout: waited ${rebuildTimeoutMs}ms and app server running at ${appServerOrigin} did not respond with up-to-date build hash ${buildHash}`
+    );
+  };
+
+  // watch and live reload on rebuilds
+  let socket = Socket.serve({ port: config.devServerPort });
+  let dispose = await Compiler.watch(config, {
+    // TODO: inject websocket port into build
+    mode: "development",
+    onInitialBuild: (durationMs) => info(`Built in ${prettyMs(durationMs)}`),
+    onRebuildStart: () => socket.log("Rebuilding..."),
+    onRebuildFinish: async (durationMs, assetsManifest) => {
+      if (!assetsManifest) return;
+      socket.log(`Rebuilt in ${prettyMs(durationMs)}`);
+
+      info(`Waiting for ${appServerOrigin}...`);
+      let start = Date.now();
+      await waitForProxyServer(assetsManifest.version);
+      info(`${appServerOrigin} ready in ${prettyMs(Date.now() - start)}`);
+
+      socket.reload();
+    },
+    onFileCreated: (file) => socket.log(`File created: ${relativePath(file)}`),
+    onFileChanged: (file) => socket.log(`File changed: ${relativePath(file)}`),
+    onFileDeleted: (file) => socket.log(`File deleted: ${relativePath(file)}`),
+  });
+
+  // TODO exit hook: clean up assetsBuildDirectory and serverBuildPath?
+
+  return async () => {
+    await dispose();
+    socket.close();
+  };
+};

--- a/packages/remix-dev/devServer2/utils/socket.ts
+++ b/packages/remix-dev/devServer2/utils/socket.ts
@@ -1,0 +1,27 @@
+import WebSocket from "ws";
+
+type Message = { type: "RELOAD" } | { type: "LOG"; message: string };
+
+type Broadcast = (message: Message) => void;
+
+export let serve = (options: { port: number }) => {
+  let wss = new WebSocket.Server({ port: options.port });
+
+  let broadcast: Broadcast = (message) => {
+    wss.clients.forEach((client) => {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(JSON.stringify(message));
+      }
+    });
+  };
+
+  let reload = () => broadcast({ type: "RELOAD" });
+
+  let log = (messageText: string) => {
+    let _message = `💿 ${messageText}`;
+    console.log(_message);
+    broadcast({ type: "LOG", message: _message });
+  };
+
+  return { reload, log, close: wss.close };
+};

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -20,9 +20,9 @@
   "dependencies": {
     "@babel/core": "^7.18.6",
     "@babel/generator": "^7.18.6",
+    "@babel/parser": "^7.18.6",
     "@babel/plugin-syntax-jsx": "^7.18.6",
     "@babel/plugin-syntax-typescript": "^7.20.0",
-    "@babel/parser": "^7.18.6",
     "@babel/preset-env": "^7.18.6",
     "@babel/preset-typescript": "^7.18.6",
     "@babel/traverse": "^7.18.6",

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1535,7 +1535,6 @@ export const LiveReload =
         port = Number(process.env.REMIX_DEV_SERVER_WS_PORT || 8002),
         nonce = undefined,
       }: {
-        // TODO deprecate port?
         port?: number;
         /**
          * @deprecated this property is no longer relevant.
@@ -1550,9 +1549,9 @@ export const LiveReload =
             dangerouslySetInnerHTML={{
               __html: js`
                 function remixLiveReloadConnect(config) {
-                  let protocol = location.protocol ===(window.__remixDevLiveReloadPort "https:" ? "wss:" : "ws:";
+                  let protocol = location.protocol === "https:" ? "wss:" : "ws:";
                   let host = location.hostname;
-                  let socketPath = protocol + "//" + host + ":" + (window.__remixDevLiveReloadPort ||${String(
+                  let socketPath = protocol + "//" + host + ":" + ((window.__remixContext.dev && window.__remixContext.dev.liveReloadPort) ||${String(
                     port
                   )}) + "/socket";
                   let ws = new WebSocket(socketPath);

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1535,6 +1535,7 @@ export const LiveReload =
         port = Number(process.env.REMIX_DEV_SERVER_WS_PORT || 8002),
         nonce = undefined,
       }: {
+        // TODO deprecate port?
         port?: number;
         /**
          * @deprecated this property is no longer relevant.
@@ -1549,11 +1550,11 @@ export const LiveReload =
             dangerouslySetInnerHTML={{
               __html: js`
                 function remixLiveReloadConnect(config) {
-                  let protocol = location.protocol === "https:" ? "wss:" : "ws:";
+                  let protocol = location.protocol ===(window.__remixDevLiveReloadPort "https:" ? "wss:" : "ws:";
                   let host = location.hostname;
-                  let socketPath = protocol + "//" + host + ":" + ${String(
+                  let socketPath = protocol + "//" + host + ":" + (window.__remixDevLiveReloadPort ||${String(
                     port
-                  )} + "/socket";
+                  )}) + "/socket";
                   let ws = new WebSocket(socketPath);
                   ws.onmessage = (message) => {
                     let event = JSON.parse(message.data);

--- a/packages/remix-react/entry.ts
+++ b/packages/remix-react/entry.ts
@@ -10,6 +10,9 @@ export interface RemixContextObject {
   serverHandoffString?: string;
   future: FutureConfig;
   abortDelay?: number;
+  dev?: {
+    liveReloadPort: number;
+  };
 }
 
 // Additional React-Router information needed at runtime, but not hydrated

--- a/packages/remix-server-runtime/build.ts
+++ b/packages/remix-server-runtime/build.ts
@@ -14,6 +14,9 @@ export interface ServerBuild {
   publicPath: string;
   assetsBuildDirectory: string;
   future: FutureConfig;
+  dev?: {
+    liveReloadPort: number;
+  };
 }
 
 export interface HandleDocumentRequestFunction {

--- a/packages/remix-server-runtime/entry.ts
+++ b/packages/remix-server-runtime/entry.ts
@@ -16,6 +16,9 @@ export interface FutureConfig {
   unstable_cssSideEffectImports: boolean;
   unstable_vanillaExtract: boolean;
   v2_errorBoundary: boolean;
+  v2_dev: {
+    remixRequestHandlerPath: string;
+  };
   v2_meta: boolean;
 }
 

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -36,7 +36,7 @@ export type RequestHandler = (
 
 export type CreateRequestHandlerFunction = (
   build: ServerBuild,
-  mode?: string
+  mode?: string // TODO strongly type this!
 ) => RequestHandler;
 
 export const createRequestHandler: CreateRequestHandlerFunction = (
@@ -50,6 +50,21 @@ export const createRequestHandler: CreateRequestHandlerFunction = (
 
   return async function requestHandler(request, loadContext = {}) {
     let url = new URL(request.url);
+
+    if (
+      mode === "development" &&
+      url.pathname ===
+        build.future.v2_dev.remixRequestHandlerPath + "/__REMIX_ASSETS_MANIFEST"
+    ) {
+      if (request.method !== "GET") {
+        return new Response("Method not allowed", { status: 405 });
+      }
+      return new Response(JSON.stringify(build.assets), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
     let matches = matchServerRoutes(routes, url.pathname);
 
     let response: Response;

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -282,6 +282,7 @@ async function handleDocumentRequestRR(
         errors: serializeErrors(context.errors),
       },
       future: build.future,
+      dev: build.dev,
     }),
     future: build.future,
   };

--- a/packages/remix-server-runtime/serverHandoff.ts
+++ b/packages/remix-server-runtime/serverHandoff.ts
@@ -20,6 +20,7 @@ export function createServerHandoffString<T>(serverHandoff: {
   // we'd end up including duplicate info
   state: ValidateShape<T, HydrationState>;
   future: FutureConfig;
+  dev?: { liveReloadPort: number };
 }): string {
   // Uses faster alternative of jsesc to escape data returned from the loaders.
   // This string is inserted directly into the HTML in the `<Scripts>` element.


### PR DESCRIPTION
## Approach

Running the new dev server does the following:
1. Builds an initial build
2. Watches for changes to app source code and rebuilds when changes occur
3. Waits for the app server (i.e. `server.js`) to be ready
4. Sends a `RELOAD` message over the websocket

For step (3), the dev server polls `GET <app server>/__REMIX_ASSETS_MANIFEST` and compares the build hash received from the app server with the latest build hash produced by the compiler run within the dev server.

## Benefits

### 1 No more require cache purge

App server is now only restarted when a rebuild happens, not on every request.
That means that in-memory persistence is fixed. So no need to use the `global` trick anymore when dealing with DB connections, in-memory caches, etc..

In fact app server might not need to restart _at all_ if the app server supports some sort of server-side HMR.

### 2 Supports _any_ app server

Previously, dev mode only worked for `@remix-run/serve`, [not for custom servers](https://github.com/remix-run/remix/blob/main/packages/remix-dev/devServer/serve.ts#L34) like `server.{js,ts}`.
Now _any_ custom server is compatible with the new dev server.

### 3 Support ESM mode for Node server?

Previously, we needed fine-grain control of the require cache, which prevented Remix servers from being run in ESM mode.
Since the new dev server does not need to purge the require cache at all, this limitation has been removed.

I _think_ this means we could support ESM-mode Remix servers now if we wanted to.

## Future work

- Stop compiling/bundling custom app servers into `build/index.js`
- Deprecate / remove the virtual module for the server build. Just import from `./build/index.js` manually.
- Give back control to users for how they want to compile/run their server. E.g. if using TS, just run `ts-node ./server.js`

## TODO

- [x] future flag so that `remix dev` uses the new dev server
- [x] add configuration for Remix request handler path (so we can calculate full path for `__REMIX_ASSETS_MANIFEST`)
- [x] add configuration for poll interval and max retries
- [x] Tune the default values for poll interval and max retries/timeout
- [x] Use `http-proxy` directly (not `http-proxy-middleware`)
- [x] Inject websocket port into server build in dev
- [ ] CLI flag for app server port: `remix dev2 --app-server-port=3000`
- [ ] default websocket port preference in v2_dev config
- [ ] change future flag to `unstable_dev`
- [ ] Changeset
- [ ] dev server should hang (not crash) when app server is down. with a warning for timeout
---

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:
