### PR TITLE
docs: add pages for React Router components/hooks

### DIFF
--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -6,6 +6,8 @@ title: Form
 
 <docs-success>Watch the <a href="https://www.youtube.com/playlist?list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">📼 Remix Singles</a>: <a href="https://www.youtube.com/watch?v=Iv25HAHaFDs&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Data Mutations with Form + action</a>, <a href="https://www.youtube.com/watch?v=w2i-9cYxSdc&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Multiple Forms and Single Button Mutations</a> and <a href="https://www.youtube.com/watch?v=bMLej7bg5Zo&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Clearing Inputs After Form Submissions</a></docs-success>
 
+<docs-info>This component is simply a re-export of [React Router's `Form`][rr-form].</docs-info>
+
 The `<Form>` component is a declarative way to perform data mutations: creating, updating, and deleting data. While it might be a mind-shift to think about these tasks as "navigation", it's how the web has handled mutations since before JavaScript was created!
 
 ```tsx
@@ -92,6 +94,8 @@ When the `action` prop is omitted, `<Form>` and `<form>` will sometimes call dif
 - `<form>` uses the current URL as the default which can lead to surprising results: forms inside parent routes will post to the child action if you're at the child's URL and the parents action when you're at the parent's URL. This means as the user navigates, the form's behavior changes.
 - `<Form>` will always post to the route's action, independent of the URL. A form in a parent route will always post to the parent, even if you're at the child's URL.
 
+For more information and usage, please refer to the [React Router `Form` docs][rr-form].
+
 See also:
 
 - [`useTransition`][usetransition]
@@ -103,3 +107,4 @@ See also:
 [useactiondata]: ../hooks/use-action-data
 [usesubmit]: ../hooks/use-submit
 [http-verb]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+[rr-form]: https://reactrouter.com/components/form

--- a/docs/components/outlet.md
+++ b/docs/components/outlet.md
@@ -4,6 +4,6 @@ title: Outlet
 
 # `<Outlet>`
 
-Re-export of [React Router Outlet][rr-outlet].
+This <docs-info> is simply a re-export of [React Router's `Outlet`][rr-outlet].</docs-info>
 
 [rr-outlet]: https://reactrouter.com/components/outlet

--- a/docs/hooks/use-async-error.md
+++ b/docs/hooks/use-async-error.md
@@ -1,0 +1,9 @@
+---
+title: useAsyncError
+---
+
+# `useAsyncError`
+
+<docs-info>This hook is simply a re-export of [React Router's `useAsyncError`][rr-useassyncerror].</docs-info>
+
+[rr-useassyncerror]: https://reactrouter.com/hooks/use-async-error

--- a/docs/hooks/use-async-error.md
+++ b/docs/hooks/use-async-error.md
@@ -1,5 +1,6 @@
 ---
 title: useAsyncError
+toc: false
 ---
 
 # `useAsyncError`

--- a/docs/hooks/use-async-value.md
+++ b/docs/hooks/use-async-value.md
@@ -1,0 +1,9 @@
+---
+title: useAsyncValue
+---
+
+# `useAsyncValue`
+
+<docs-info>This hook is simply a re-export of [React Router's `useAsyncValue`][rr-useassyncvalue].</docs-info>
+
+[rr-useassyncvalue]: https://reactrouter.com/hooks/use-async-value

--- a/docs/hooks/use-async-value.md
+++ b/docs/hooks/use-async-value.md
@@ -1,5 +1,6 @@
 ---
 title: useAsyncValue
+toc: false
 ---
 
 # `useAsyncValue`

--- a/docs/hooks/use-before-unload.md
+++ b/docs/hooks/use-before-unload.md
@@ -1,5 +1,6 @@
 ---
 title: useBeforeUnload
+toc: false
 ---
 
 # `useBeforeUnload`

--- a/docs/hooks/use-before-unload.md
+++ b/docs/hooks/use-before-unload.md
@@ -4,6 +4,8 @@ title: useBeforeUnload
 
 # `useBeforeUnload`
 
+<docs-info>This hook is simply a re-export of [React Router's `useBeforeUnload`][rr-usebeforeunload].</docs-info>
+
 This hook is just a helper around `window.onbeforeunload`.
 
 When users click links to pages they haven't visited yet, Remix loads the code-split modules for that page. If you deploy in the middle of a user's session, and you or your host removes the old files from the server (many do 😭), then Remix's requests for those modules will fail. Remix recovers by automatically reloading the browser at the new URL. This should start over from the server with the latest version of your application. Most of the time this works out great, and user doesn't even know anything happened.
@@ -35,3 +37,7 @@ function SomeForm() {
   return <>{/*... */}</>;
 }
 ```
+
+For more information and usage, please refer to the [React Router `useBeforeUnload` docs][rr-usebeforeunload].
+
+[rr-usebeforeunload]: https://reactrouter.com/hooks/use-before-unload

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -1,5 +1,6 @@
 ---
 title: useFetcher
+toc: false
 ---
 
 # `useFetcher`

--- a/docs/hooks/use-form-action.md
+++ b/docs/hooks/use-form-action.md
@@ -4,6 +4,8 @@ title: useFormAction
 
 # `useFormAction`
 
+<docs-info>This hook is simply a re-export of [React Router's `useFormAction`][rr-useformaction].</docs-info>
+
 Resolves the value of a `<form action>` attribute using React Router's relative paths. This can be useful when computing the correct action for a `<button formAction>`, for example, when a `<button>` changes the action of its `<form>`.
 
 ```tsx
@@ -20,3 +22,7 @@ function SomeComponent() {
 ```
 
 (Yes, HTML buttons can change the action of their form!)
+
+For more information and usage, please refer to the [React Router `useFormAction` docs][rr-useformaction].
+
+[rr-useformaction]: https://reactrouter.com/hooks/use-form-action

--- a/docs/hooks/use-href.md
+++ b/docs/hooks/use-href.md
@@ -1,0 +1,9 @@
+---
+title: useHref
+---
+
+# `useHref`
+
+<docs-info>This hook is simply a re-export of [React Router's `useHref`][rr-usehref].</docs-info>
+
+[rr-usehref]: https://reactrouter.com/hooks/use-href

--- a/docs/hooks/use-href.md
+++ b/docs/hooks/use-href.md
@@ -1,5 +1,6 @@
 ---
 title: useHref
+toc: false
 ---
 
 # `useHref`

--- a/docs/hooks/use-location.md
+++ b/docs/hooks/use-location.md
@@ -1,0 +1,9 @@
+---
+title: useLocation
+---
+
+# `useLocation`
+
+<docs-info>This hook is simply a re-export of [React Router's `useLocation`][rr-uselocation].</docs-info>
+
+[rr-uselocation]: https://reactrouter.com/hooks/use-location

--- a/docs/hooks/use-location.md
+++ b/docs/hooks/use-location.md
@@ -1,5 +1,6 @@
 ---
 title: useLocation
+toc: false
 ---
 
 # `useLocation`

--- a/docs/hooks/use-navigate.md
+++ b/docs/hooks/use-navigate.md
@@ -1,0 +1,9 @@
+---
+title: useNavigate
+---
+
+# `useNavigate`
+
+<docs-info>This hook is simply a re-export of [React Router's `useNavigate`][rr-usenavigate].</docs-info>
+
+[rr-usenavigate]: https://reactrouter.com/hooks/use-navigate

--- a/docs/hooks/use-navigate.md
+++ b/docs/hooks/use-navigate.md
@@ -1,5 +1,6 @@
 ---
 title: useNavigate
+toc: false
 ---
 
 # `useNavigate`

--- a/docs/hooks/use-navigation-type.md
+++ b/docs/hooks/use-navigation-type.md
@@ -1,0 +1,9 @@
+---
+title: useNavigationType
+---
+
+# `useNavigationType`
+
+<docs-info>This hook is simply a re-export of [React Router's `useNavigationType`][rr-usenavigationtype].</docs-info>
+
+[rr-usenavigationtype]: https://reactrouter.com/hooks/use-navigation-type

--- a/docs/hooks/use-navigation-type.md
+++ b/docs/hooks/use-navigation-type.md
@@ -1,5 +1,6 @@
 ---
 title: useNavigationType
+toc: false
 ---
 
 # `useNavigationType`

--- a/docs/hooks/use-navigation.md
+++ b/docs/hooks/use-navigation.md
@@ -5,7 +5,7 @@ toc: false
 
 # `useNavigation`
 
-This hook is simply a re-export of [React Router `useNavigation`][rr-usenavigation].
+<docs-info>This hook is simply a re-export of [React Router `useNavigation`][rr-usenavigation].</docs-info>
 
 ```tsx
 import { useNavigation } from "@remix-run/react";
@@ -20,6 +20,6 @@ function SomeComponent() {
 }
 ```
 
-For information and usage, please refer to the [React Router `useNavigation` docs][rr-usenavigation].
+For more information and usage, please refer to the [React Router `useNavigation` docs][rr-usenavigation].
 
-[rr-usenavigation]: https://reactrouter.com/en/main/hooks/use-navigation
+[rr-usenavigation]: https://reactrouter.com/hooks/use-navigation

--- a/docs/hooks/use-outlet-context.md
+++ b/docs/hooks/use-outlet-context.md
@@ -1,0 +1,9 @@
+---
+title: useOutletContext
+---
+
+# `useOutletContext`
+
+<docs-info>This hook is simply a re-export of [React Router's `useOutletContext`][rr-useoutletcontext].</docs-info>
+
+[rr-useoutletcontext]: https://reactrouter.com/hooks/use-outlet-context

--- a/docs/hooks/use-outlet-context.md
+++ b/docs/hooks/use-outlet-context.md
@@ -1,5 +1,6 @@
 ---
 title: useOutletContext
+toc: false
 ---
 
 # `useOutletContext`

--- a/docs/hooks/use-outlet.md
+++ b/docs/hooks/use-outlet.md
@@ -1,5 +1,6 @@
 ---
 title: useOutlet
+toc: false
 ---
 
 # `useOutlet`

--- a/docs/hooks/use-outlet.md
+++ b/docs/hooks/use-outlet.md
@@ -1,0 +1,9 @@
+---
+title: useOutlet
+---
+
+# `useOutlet`
+
+<docs-info>This hook is simply a re-export of [React Router's `useOutlet`][rr-useoutlet].</docs-info>
+
+[rr-useoutlet]: https://reactrouter.com/hooks/use-outlet

--- a/docs/hooks/use-params.md
+++ b/docs/hooks/use-params.md
@@ -1,0 +1,9 @@
+---
+title: useParams
+---
+
+# `useParams`
+
+<docs-info>This hook is simply a re-export of [React Router's `useParams`][rr-useparams].</docs-info>
+
+[rr-useparams]: https://reactrouter.com/hooks/use-params

--- a/docs/hooks/use-params.md
+++ b/docs/hooks/use-params.md
@@ -1,5 +1,6 @@
 ---
 title: useParams
+toc: false
 ---
 
 # `useParams`

--- a/docs/hooks/use-resolved-path.md
+++ b/docs/hooks/use-resolved-path.md
@@ -1,0 +1,9 @@
+---
+title: useResolvedPath
+---
+
+# `useResolvedPath`
+
+<docs-info>This hook is simply a re-export of [React Router's `useResolvedPath`][rr-useresolvedpath].</docs-info>
+
+[rr-useresolvedpath]: https://reactrouter.com/hooks/use-resolved-path

--- a/docs/hooks/use-resolved-path.md
+++ b/docs/hooks/use-resolved-path.md
@@ -1,5 +1,6 @@
 ---
 title: useResolvedPath
+toc: false
 ---
 
 # `useResolvedPath`

--- a/docs/hooks/use-revalidator.md
+++ b/docs/hooks/use-revalidator.md
@@ -4,6 +4,8 @@ title: useRevalidator
 
 # `useRevalidator`
 
+<docs-info>This hook is simply a re-export of [React Router's `useRevalidator`][rr-userevalidator].</docs-info>
+
 This hook allows you to revalidate the data for any reason. React Router automatically revalidates the data after actions are called, but you may want to revalidate for other reasons like when focus returns to the window.
 
 ```jsx
@@ -24,6 +26,6 @@ function WindowFocusRevalidator() {
 }
 ```
 
-For more information see the [React Router `useRevalidator` docs][rr-userevalidator]
+For more information and usage, please refer to the [React Router `useRevalidator` docs][rr-userevalidator].
 
-[rr-userevalidator]: https://reactrouter.com/en/main/hooks/use-revalidator
+[rr-userevalidator]: https://reactrouter.com/hooks/use-revalidator

--- a/docs/hooks/use-route-error.md
+++ b/docs/hooks/use-route-error.md
@@ -1,5 +1,6 @@
 ---
 title: useRouteError
+toc: false
 ---
 
 # `useRouteError`

--- a/docs/hooks/use-route-error.md
+++ b/docs/hooks/use-route-error.md
@@ -1,0 +1,9 @@
+---
+title: useRouteError
+---
+
+# `useRouteError`
+
+<docs-info>This hook is simply a re-export of [React Router's `useRouteError`][rr-userouteerror].</docs-info>
+
+[rr-userouteerror]: https://reactrouter.com/hooks/use-route-error

--- a/docs/hooks/use-route-loader-data.md
+++ b/docs/hooks/use-route-loader-data.md
@@ -5,7 +5,9 @@ toc: false
 
 # `useRouteLoaderData`
 
-This hook is simply a re-export of [React Router `useRouteLoaderData`][userouteloaderdata]. Pass in a route ID and it will return the loader data for that route.
+<docs-info>This hook is simply a re-export of [React Router `useRouteLoaderData`][rr-userouteloaderdata].</docs-info>
+
+Pass in a route ID and it will return the loader data for that route.
 
 ```tsx
 import { useRouteLoaderData } from "@remix-run/react";
@@ -23,6 +25,6 @@ Remix creates the route IDs automatically. They are simply the path of the route
 | `app/routes/teams.tsx`     | `"routes/teams"`     |
 | `app/routes/teams.$id.jsx` | `"routes/teams.$id"` |
 
-For more information and usage, please refer to the [React Router `useRouteLoaderData` docs][userouteloaderdata].
+For more information and usage, please refer to the [React Router `useRouteLoaderData` docs][rr-userouteloaderdata].
 
-[userouteloaderdata]: https://reactrouter.com/en/main/hooks/use-route-loader-data
+[rr-userouteloaderdata]: https://reactrouter.com/hooks/use-route-loader-data

--- a/docs/hooks/use-search-params.md
+++ b/docs/hooks/use-search-params.md
@@ -1,0 +1,9 @@
+---
+title: useSearchParams
+---
+
+# `useSearchParams`
+
+<docs-info>This hook is simply a re-export of [React Router's `useSearchParams`][rr-usesearchparams].</docs-info>
+
+[rr-usesearchparams]: https://reactrouter.com/hooks/use-search-params

--- a/docs/hooks/use-search-params.md
+++ b/docs/hooks/use-search-params.md
@@ -1,5 +1,6 @@
 ---
 title: useSearchParams
+toc: false
 ---
 
 # `useSearchParams`

--- a/docs/hooks/use-submit.md
+++ b/docs/hooks/use-submit.md
@@ -4,6 +4,8 @@ title: useSubmit
 
 # `useSubmit`
 
+<docs-info>This hook is simply a re-export of [React Router's `useSubmit`][rr-usesubmit].</docs-info>
+
 Returns the function that may be used to submit a `<form>` (or some raw `FormData`) to the server using the same process that `<Form>` uses internally `onSubmit`. If you're familiar with React Router's `useNavigate`, you can think about this as the same thing but for `<Form>` instead of `<Link>`.
 
 This is useful whenever you need to programmatically submit a form. For example, you may wish to save a user preferences form whenever any field changes.
@@ -68,3 +70,7 @@ function useSessionTimeout() {
   }, [submit, transition]);
 }
 ```
+
+For more information and usage, please refer to the [React Router `useSubmit` docs][rr-usesubmit].
+
+[rr-usesubmit]: https://reactrouter.com/hooks/use-submit


### PR DESCRIPTION
We already have docs for `Outlet` that point to the RR docs: https://remix.run/components/outlet