### PR TITLE
docs(route/index): fix broken link

### DIFF
--- a/docs/route/index.md
+++ b/docs/route/index.md
@@ -9,4 +9,4 @@ A route in Remix can be used for many things. Usually they’re used for the use
 
 It's important to read [Route Module Constraints][route-module-constraints].
 
-[route-module-constraints]: ../guides/constraints
+[route-module-constraints]: ./guides/constraints


### PR DESCRIPTION
The link on https://remix.run/docs/en/v1/route to `Route Module Constraints` 404s, as it goes to

```
https://remix.run/docs/en/guides/constraints
```

instead of 

```
https://remix.run/docs/en/v1/guides/constraints
```

`Route Modules API` is the only nav section with a linked index page; seems like even though the index is literally a directory deeper, it's not being treated that way. 🤷 