### PR TITLE
docs(tutorials/jokes): fix code highlighting

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -47,6 +47,7 @@
 - AustinGil
 - awthwathje
 - axel-habermaier
+- barclayd
 - BasixKOR
 - BenMcH
 - benwis

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -3400,7 +3400,7 @@ export async function createUserSession(
 
 <summary>app/routes/jokes.tsx</summary>
 
-```tsx filename=app/routes/jokes.tsx lines=[14,22,27,34,38,60-71]
+```tsx filename=app/routes/jokes.tsx lines=[14,22,27,52-63]
 import type { User } from "@prisma/client";
 import type {
   LinksFunction,


### PR DESCRIPTION
# Update highlighted lines for "Build out login action"

* Updates code example for [logout action UI update section](https://remix.run/docs/en/v1/tutorials/jokes#build-logout-action) where currently blank lines/incomplete code blocks are highlighted as changes

<table>
<tr>
	<td><strong>Current code highlighting</strong></td>
	<td><strong>Following PR changes</strong></td>
<tr>
	<td><img width="100%" alt="screenshot of current highlighting of docs" src="https://user-images.githubusercontent.com/39765499/210159940-32a12ff8-4860-4eb9-a066-635fb334c2c1.png"></td>
	<td><img width="100%" alt="screenshot of docs following changes in this PR" src="https://user-images.githubusercontent.com/39765499/210159948-bb5d31f0-f969-4cbd-8d6e-7e0d2ea4bb3d.png">
</td>
</table>

- [x] Docs