### PR TITLE
BUG: web-fetch premature close

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -425,6 +425,7 @@
 - supachaidev
 - Synvox
 - tagraves
+- tarngerine
 - tascord
 - TheRealAstoo
 - therealflyingcoder


### PR DESCRIPTION
Related issue: #4993 

- [ ] Docs
- [x] Tests

Testing Strategy:

`yarn bug-report-test`

Expected: no errors

Actual: 

```
    at TLSSocket.onSocketClose (/Users/tarng/Code/oss/remix/node_modules/@remix-run/web-fetch/src/fetch.js:342:33)
    at TLSSocket.emit (node:events:538:35)
    at node:net:687:12
    at TCP.done (node:_tls_wrap:580:7)

  4 passed (6s)
  1 error was not a part of any test, see above for details
```