### PR TITLE
chore(templates): use typeof check for `requestIdleCallback`

### DIFF
--- a/integration/helpers/node-template/app/entry.client.tsx
+++ b/integration/helpers/node-template/app/entry.client.tsx
@@ -13,7 +13,7 @@ function hydrate() {
   });
 }
 
-if (requestIdleCallback) {
+if (typeof requestIdleCallback === "function") {
   requestIdleCallback(hydrate);
 } else {
   // Safari doesn't support requestIdleCallback

--- a/scripts/playground/template/app/entry.client.tsx
+++ b/scripts/playground/template/app/entry.client.tsx
@@ -13,7 +13,7 @@ const hydrate = () => {
   });
 };
 
-if (requestIdleCallback) {
+if (typeof requestIdleCallback === "function") {
   requestIdleCallback(hydrate);
 } else {
   // Safari doesn't support requestIdleCallback

--- a/templates/arc/app/entry.client.tsx
+++ b/templates/arc/app/entry.client.tsx
@@ -13,7 +13,7 @@ function hydrate() {
   });
 }
 
-if (requestIdleCallback) {
+if (typeof requestIdleCallback === "function") {
   requestIdleCallback(hydrate);
 } else {
   // Safari doesn't support requestIdleCallback

--- a/templates/cloudflare-pages/app/entry.client.tsx
+++ b/templates/cloudflare-pages/app/entry.client.tsx
@@ -13,7 +13,7 @@ function hydrate() {
   });
 }
 
-if (requestIdleCallback) {
+if (typeof requestIdleCallback === "function") {
   requestIdleCallback(hydrate);
 } else {
   // Safari doesn't support requestIdleCallback

--- a/templates/cloudflare-workers/app/entry.client.tsx
+++ b/templates/cloudflare-workers/app/entry.client.tsx
@@ -13,7 +13,7 @@ function hydrate() {
   });
 }
 
-if (requestIdleCallback) {
+if (typeof requestIdleCallback === "function") {
   requestIdleCallback(hydrate);
 } else {
   // Safari doesn't support requestIdleCallback

--- a/templates/deno/app/entry.client.tsx
+++ b/templates/deno/app/entry.client.tsx
@@ -8,12 +8,12 @@ function hydrate() {
       document,
       <StrictMode>
         <RemixBrowser />
-      </StrictMode>,
+      </StrictMode>
     );
   });
 }
 
-if (requestIdleCallback) {
+if (typeof requestIdleCallback === "function") {
   requestIdleCallback(hydrate);
 } else {
   // Safari doesn't support requestIdleCallback

--- a/templates/express/app/entry.client.tsx
+++ b/templates/express/app/entry.client.tsx
@@ -13,7 +13,7 @@ function hydrate() {
   });
 }
 
-if (requestIdleCallback) {
+if (typeof requestIdleCallback === "function") {
   requestIdleCallback(hydrate);
 } else {
   // Safari doesn't support requestIdleCallback

--- a/templates/fly/app/entry.client.tsx
+++ b/templates/fly/app/entry.client.tsx
@@ -13,7 +13,7 @@ function hydrate() {
   });
 }
 
-if (requestIdleCallback) {
+if (typeof requestIdleCallback === "function") {
   requestIdleCallback(hydrate);
 } else {
   // Safari doesn't support requestIdleCallback

--- a/templates/netlify/app/entry.client.tsx
+++ b/templates/netlify/app/entry.client.tsx
@@ -13,7 +13,7 @@ function hydrate() {
   });
 }
 
-if (requestIdleCallback) {
+if (typeof requestIdleCallback === "function") {
   requestIdleCallback(hydrate);
 } else {
   // Safari doesn't support requestIdleCallback

--- a/templates/remix/app/entry.client.tsx
+++ b/templates/remix/app/entry.client.tsx
@@ -13,7 +13,7 @@ function hydrate() {
   });
 }
 
-if (requestIdleCallback) {
+if (typeof requestIdleCallback === "function") {
   requestIdleCallback(hydrate);
 } else {
   // Safari doesn't support requestIdleCallback

--- a/templates/vercel/app/entry.client.tsx
+++ b/templates/vercel/app/entry.client.tsx
@@ -13,7 +13,7 @@ function hydrate() {
   });
 }
 
-if (requestIdleCallback) {
+if (typeof requestIdleCallback === "function") {
   requestIdleCallback(hydrate);
 } else {
   // Safari doesn't support requestIdleCallback


### PR DESCRIPTION
safari doesn't have `requestIdleCallback` thus logging errors to the console

```log
Unhandled Promise Rejection: ReferenceError: Can't find variable: requestIdleCallback
(anonymous function)
rejectPromise
promiseReactionJob
```

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
