### PR TITLE
fix(remix-react): avoid dynamic import of relative file

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -577,3 +577,4 @@
 - ledniy
 - robbtraister
 - TrySound
+- MatthieuCoelho

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -667,6 +667,7 @@ export function Scripts(props: ScriptProps) {
     let contextScript = staticContext
       ? `window.__remixContext = ${serverHandoffString};`
       : " ";
+      let manifestEntryModule = JSON.stringify(manifest.entry.module);
 
     let activeDeferreds = staticContext?.activeDeferreds;
     // This sets up the __remixContext with utility functions used by the
@@ -786,7 +787,7 @@ window.__remixRouteModules = {${matches
           )
           .join(",")}};
 
-import(${JSON.stringify(manifest.entry.module)});`;
+import(${manifestEntryModule}.startsWith('.') ? new URL(${manifestEntryModule}, document.baseURI).toString() : ${manifestEntryModule});`;
 
     return (
       <>


### PR DESCRIPTION
Problem :
- Setting a relative "publicPath" in remix.config produce error on Safari.
![image](https://user-images.githubusercontent.com/19164676/210812476-876e8be5-f425-46e4-ba8e-d529d6f92d72.png)

Cause :
- Relative import ignore base path in safari : 
https://bugs.webkit.org/show_bug.cgi?id=201692

Solution : 
- Create the full path instead of letting the "import"

I tested it successfully on safari and safari mobile.
