### PR TITLE
chore(remix-dev): don't allow `*` to be anywhere in segment

### DIFF
--- a/.changeset/little-lobsters-decide.md
+++ b/.changeset/little-lobsters-decide.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/dev": patch
+---
+
+don't allow `*` to be anywhere in flat route segment

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -109,6 +109,7 @@ describe("flatRoutes", () => {
     let invalidSplatFiles: string[] = [
       "routes/about.[*].tsx",
       "routes/about.*.tsx",
+      "routes/about.[.[.*].].tsx",
     ];
 
     for (let invalid of invalidSplatFiles) {
@@ -367,14 +368,6 @@ describe("flatRoutes", () => {
           id: "routes/about.[.]",
           parentId: "routes/about",
           path: ".",
-        },
-      ],
-      [
-        "routes/about.[.[.*].].tsx",
-        {
-          id: "routes/about.[.[.*].]",
-          parentId: "routes/about",
-          path: ".[.*/]",
         },
       ],
 

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -126,7 +126,7 @@ export function getRouteSegments(routeId: string) {
   let pushRouteSegment = (routeSegment: string) => {
     if (!routeSegment) return;
 
-    if (rawRouteSegment === "*") {
+    if (rawRouteSegment.includes("*")) {
       throw new Error(
         `Route segment "${rawRouteSegment}" for "${routeId}" cannot contain "*"`
       );


### PR DESCRIPTION
Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
