### PR TITLE
create global context for remix express

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -470,3 +470,4 @@
 - zainfathoni
 - zhe
 - mitchelldirt
+- tomer-yechiel


### PR DESCRIPTION
Hello Remix team,

This is a draft PR just to get feedback.

I'm submitting this pull request to suggest the addition of a new API for setting global context in Remix.
The main motivation for this api is implementing contextual logger.

for example lets say I want to add the user id to all the logs that where created during the request response cycle.
currently there is the GetLoadContextFunction but it require to propagate the logger.


```
function getGlobalContext(request){
  const userId = extractUserId(request);
 return {logger:  createLogger({"userId: 1})};
}

createRequestHandler({getGlobalContext})
...
```
