### PR TITLE
fix: write assets from CSS bundle build

### DIFF
--- a/integration/css-modules-test.ts
+++ b/integration/css-modules-test.ts
@@ -482,12 +482,17 @@ test.describe("CSS Modules", () => {
   });
   test("image URLs", async ({ page }) => {
     let app = new PlaywrightFixture(appFixture, page);
+    let imgStatus: number | null = null;
+    app.page.on("response", (res) => {
+      if (res.url().endsWith(".svg")) imgStatus = res.status();
+    });
     await app.goto("/image-urls-test");
     let locator = await page.locator("[data-testid='image-urls']");
     let backgroundImage = await locator.evaluate(
       (element) => window.getComputedStyle(element).backgroundImage
     );
     expect(backgroundImage).toContain(".svg");
+    expect(imgStatus).toBe(200);
   });
 
   let rootRelativeImageUrlsFixture = () => ({
@@ -522,6 +527,10 @@ test.describe("CSS Modules", () => {
   });
   test("root relative image URLs", async ({ page }) => {
     let app = new PlaywrightFixture(appFixture, page);
+    let imgStatus: number | null = null;
+    app.page.on("response", (res) => {
+      if (res.url().endsWith(".svg")) imgStatus = res.status();
+    });
     await app.goto("/root-relative-image-urls-test");
     let locator = await page.locator(
       "[data-testid='root-relative-image-urls']"
@@ -530,6 +539,7 @@ test.describe("CSS Modules", () => {
       (element) => window.getComputedStyle(element).backgroundImage
     );
     expect(backgroundImage).toContain(".svg");
+    expect(imgStatus).toBe(200);
   });
 
   let clientEntrySideEffectsFixture = () => ({

--- a/integration/css-side-effect-imports-test.ts
+++ b/integration/css-side-effect-imports-test.ts
@@ -148,12 +148,17 @@ test.describe("CSS side-effect imports", () => {
   });
   test("image URLs", async ({ page }) => {
     let app = new PlaywrightFixture(appFixture, page);
+    let imgStatus: number | null = null;
+    app.page.on("response", (res) => {
+      if (res.url().endsWith(".svg")) imgStatus = res.status();
+    });
     await app.goto("/image-urls-test");
     let locator = await page.locator("[data-testid='image-urls']");
     let backgroundImage = await locator.evaluate(
       (element) => window.getComputedStyle(element).backgroundImage
     );
     expect(backgroundImage).toContain(".svg");
+    expect(imgStatus).toBe(200);
   });
 
   let rootRelativeImageUrlsFixture = () => ({
@@ -183,6 +188,10 @@ test.describe("CSS side-effect imports", () => {
   });
   test("root relative image URLs", async ({ page }) => {
     let app = new PlaywrightFixture(appFixture, page);
+    let imgStatus: number | null = null;
+    app.page.on("response", (res) => {
+      if (res.url().endsWith(".svg")) imgStatus = res.status();
+    });
     await app.goto("/root-relative-image-urls-test");
     let locator = await page.locator(
       "[data-testid='root-relative-image-urls']"
@@ -191,6 +200,7 @@ test.describe("CSS side-effect imports", () => {
       (element) => window.getComputedStyle(element).backgroundImage
     );
     expect(backgroundImage).toContain(".svg");
+    expect(imgStatus).toBe(200);
   });
 
   let commonJsPackageFixture = () => ({

--- a/packages/remix-dev/compiler/compileBrowser.ts
+++ b/packages/remix-dev/compiler/compileBrowser.ts
@@ -245,6 +245,12 @@ export const createBrowserCompiler = (
         options.mode !== "production" && map
           ? fse.writeFile(`${cssBundlePath}.map`, map.toString()) // Write our updated source map rather than esbuild's
           : null,
+        ...outputFiles
+          .filter((outputFile) => !/\.(css|js|map)$/.test(outputFile.path))
+          .map(async (asset) => {
+            await fse.ensureDir(path.dirname(asset.path));
+            await fse.writeFile(asset.path, asset.contents);
+          }),
       ]);
 
       // Return the CSS bundle path so we can use it to generate the manifest


### PR DESCRIPTION
This fixes an issue where assets that are _only_ referenced in the CSS bundle build aren't written to disk, which impacts images referenced in CSS Modules files. This wasn't picked up in the test suite because we weren't asserting that requests for the image were successful, so I've updated all CSS bundle tests to catch this. I've confirmed that these updated tests fail against the latest code in dev.

This slipped through during development because the test image I was using was also referenced in the browser app build (via a regular style sheet) which _does_ write files to disk. I was able to reproduce this issue when I updated my test app to only use CSS Modules.