### PR TITLE
Update babel config to transpile down to node 14

### DIFF
--- a/.changeset/purple-ads-itch.md
+++ b/.changeset/purple-ads-itch.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Update babel config to transpile down to node 14

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,7 @@ module.exports = {
       "@babel/preset-env",
       {
         targets: {
-          node: "current",
+          node: "14",
         },
       },
     ],


### PR DESCRIPTION
Closes #5043 

To test, run `yarn build` and look at `build/node_modules/@remix-run/react/dist/components.js` and confirm that around line 108 you don't see any `||=` operators.

Here's the diff between a `1.10.0` build and a build on this branch:

```bash
~/me/shopify/repos/remix (brophdawg11/node-14-build)> diff -r build-current build
diff -r build-current/node_modules/@remix-run/react/dist/components.js build/node_modules/@remix-run/react/dist/components.js
109,110c109,110
<     CatchBoundary ||= errorBoundaries.RemixRootDefaultCatchBoundary;
<     ErrorBoundary ||= errorBoundaries.RemixRootDefaultErrorBoundary;
---
>     CatchBoundary || (CatchBoundary = errorBoundaries.RemixRootDefaultCatchBoundary);
>     ErrorBoundary || (ErrorBoundary = errorBoundaries.RemixRootDefaultErrorBoundary);
diff -r build-current/node_modules/@remix-run/react/dist/esm/components.js build/node_modules/@remix-run/react/dist/esm/components.js
85,86c85,86
<     CatchBoundary ||= RemixRootDefaultCatchBoundary;
<     ErrorBoundary ||= RemixRootDefaultErrorBoundary;
---
>     CatchBoundary || (CatchBoundary = RemixRootDefaultCatchBoundary);
>     ErrorBoundary || (ErrorBoundary = RemixRootDefaultErrorBoundary);
```
