### PR TITLE
docs(guides/styling): fix highlighted lines for CSS bundle setup

### DIFF
--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -784,7 +784,7 @@ npm install @remix-run/css-bundle
 
 Then, import `cssBundleHref` and add it to a link descriptor—most likely in `root.tsx` so that it applies to your entire application.
 
-```tsx filename=root.tsx lines=[2,6]
+```tsx filename=root.tsx lines=[2,6-8]
 import type { LinksFunction } from "@remix-run/node"; // or cloudflare/deno
 import { cssBundleHref } from "@remix-run/css-bundle";
 


### PR DESCRIPTION
The formatting was automatically updated, causing a ternary to wrap over three lines, but the highlighted lines weren't updated to reflect this.