### PR TITLE
Fetchers should persist data through reload/resubmit

### DIFF
--- a/.changeset/eighty-donkeys-run.md
+++ b/.changeset/eighty-donkeys-run.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Fetchers should persist data through reload/resubmit

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1202,7 +1202,7 @@ function convertRouterFetcherToRemixFetcher(
           formData: formData,
           key: "",
         },
-        data: undefined,
+        data,
       };
       return fetcher;
     } else {
@@ -1285,7 +1285,7 @@ function convertRouterFetcherToRemixFetcher(
             formData: formData,
             key: "",
           },
-          data: undefined,
+          data,
         };
         return fetcher;
       }
@@ -1297,7 +1297,7 @@ function convertRouterFetcherToRemixFetcher(
     state: "loading",
     type: "normalLoad",
     submission: undefined,
-    data: undefined,
+    data,
   };
   return fetcher;
 }

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -120,7 +120,7 @@ export type FetcherStates<TData = any> = {
     formData: FormData;
     formEncType: string;
     submission: ActionSubmission;
-    data: undefined;
+    data: TData | undefined;
   };
   SubmittingLoader: {
     state: "submitting";


### PR DESCRIPTION
Fixes an issue in the fetcher back-compat layer where fetchers were losing their data during reload/resubmissions

Closes #5064