### PR TITLE
chore(bug-report): Make sure the reporter have aligned remix dependencies

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,6 +25,12 @@ body:
       label: What version of Remix are you using?
     validations:
       required: true
+  - type: checkboxes
+    attributes:
+      label: Are all your remix dependencies & dev-dependencies using the same version?
+      options:
+        - label: Yes
+          required: true
   - type: textarea
     attributes:
       label: Steps to Reproduce


### PR DESCRIPTION
We often receive regressions reports where it turns out that the OP only updated a single package, leading to unexpected behaviors.

Example: #5073