### PR TITLE
feat(remix-react): allow `<Link>`'s "to" prop to accept absolute urls

### DIFF
--- a/.changeset/odd-plants-doubt.md
+++ b/.changeset/odd-plants-doubt.md
@@ -1,0 +1,8 @@
+---
+"remix": patch
+"@remix-run/react": patch
+---
+
+allow `<Link>`'s "to" prop to accept absolute urls
+
+if absolute url, don't prefetch

--- a/integration/prefetch-test.ts
+++ b/integration/prefetch-test.ts
@@ -204,7 +204,7 @@ test.describe("prefetch=intent (hover)", () => {
       `#nav link[rel='prefetch'][as='document'][href='${EXTERNAL_URL}']`,
       { state: "attached" }
     );
-    expect(await page.locator("#nav link").count()).toBe(1);
+    expect(await page.locator("#nav link").count()).toBe(2);
   });
 
   test("removes prefetch tags after navigating to/from the page", async ({
@@ -221,7 +221,7 @@ test.describe("prefetch=intent (hover)", () => {
     // Links added on hover (external)
     await page.hover(`a[href='${EXTERNAL_URL}']`);
     await page.waitForSelector("#nav link", { state: "attached" });
-    expect(await page.locator("#nav link").count()).toBe(1);
+    expect(await page.locator("#nav link").count()).toBe(2);
 
     // Links removed upon navigating to the page
     await page.click("a[href='/with-loader']");
@@ -290,6 +290,6 @@ test.describe("prefetch=intent (focus)", () => {
       `#nav link[rel='prefetch'][as='document'][href='${EXTERNAL_URL}']`,
       { state: "attached" }
     );
-    expect(await page.locator("#nav link").count()).toBe(1);
+    expect(await page.locator("#nav link").count()).toBe(2);
   });
 });

--- a/integration/prefetch-test.ts
+++ b/integration/prefetch-test.ts
@@ -5,8 +5,6 @@ import type { Fixture, AppFixture } from "./helpers/create-fixture";
 import type { RemixLinkProps } from "../build/node_modules/@remix-run/react/dist/components";
 import { PlaywrightFixture } from "./helpers/playwright-fixture";
 
-let EXTERNAL_URL = "https://remix.run";
-
 // Generate the test app using the given prefetch mode
 function fixtureFactory(mode: RemixLinkProps["prefetch"]) {
   return {
@@ -42,9 +40,6 @@ function fixtureFactory(mode: RemixLinkProps["prefetch"]) {
                   <br/>
                   <Link to="/without-loader" prefetch="${mode}">
                     Non-Loader Page
-                  </Link>
-                  <Link to="${EXTERNAL_URL}" prefetch="${mode}">
-                    External Page
                   </Link>
                 </nav>
                 <Outlet />
@@ -141,14 +136,9 @@ test.describe("prefetch=render", () => {
       "#nav link[rel='modulepreload'][href^='/build/routes/without-loader-']",
       { state: "attached" }
     );
-    // Only document fetch for external link
-    await page.waitForSelector(
-      `#nav link[rel='prefetch'][as='document'][href='${EXTERNAL_URL}']`,
-      { state: "attached" }
-    );
 
     // Ensure no other links in the #nav element
-    expect(await page.locator("#nav link").count()).toBe(4);
+    expect(await page.locator("#nav link").count()).toBe(3);
   });
 });
 
@@ -198,13 +188,6 @@ test.describe("prefetch=intent (hover)", () => {
       { state: "attached" }
     );
     expect(await page.locator("#nav link").count()).toBe(1);
-
-    await page.hover(`a[href='${EXTERNAL_URL}']`);
-    await page.waitForSelector(
-      `#nav link[rel='prefetch'][as='document'][href='${EXTERNAL_URL}']`,
-      { state: "attached" }
-    );
-    expect(await page.locator("#nav link").count()).toBe(2);
   });
 
   test("removes prefetch tags after navigating to/from the page", async ({
@@ -215,11 +198,6 @@ test.describe("prefetch=intent (hover)", () => {
 
     // Links added on hover
     await page.hover("a[href='/with-loader']");
-    await page.waitForSelector("#nav link", { state: "attached" });
-    expect(await page.locator("#nav link").count()).toBe(2);
-
-    // Links added on hover (external)
-    await page.hover(`a[href='${EXTERNAL_URL}']`);
     await page.waitForSelector("#nav link", { state: "attached" });
     expect(await page.locator("#nav link").count()).toBe(2);
 
@@ -284,12 +262,5 @@ test.describe("prefetch=intent (focus)", () => {
       { state: "attached" }
     );
     expect(await page.locator("#nav link").count()).toBe(1);
-
-    await page.focus(`a[href='${EXTERNAL_URL}']`);
-    await page.waitForSelector(
-      `#nav link[rel='prefetch'][as='document'][href='${EXTERNAL_URL}']`,
-      { state: "attached" }
-    );
-    expect(await page.locator("#nav link").count()).toBe(2);
   });
 });

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -291,7 +291,7 @@ function usePrefetchBehavior(
  */
 let NavLink = React.forwardRef<HTMLAnchorElement, RemixNavLinkProps>(
   ({ to, prefetch = "none", ...props }, forwardedRef) => {
-    let isAbsolute = 
+    let isAbsolute =
       typeof to === "string" &&
       (/^[a-z+]+:\/\//i.test(to) || to.startsWith("//"));
 
@@ -325,12 +325,12 @@ export { NavLink };
  * @see https://remix.run/components/link
  */
 let Link = React.forwardRef<HTMLAnchorElement, RemixLinkProps>(
-  ({ to, prefetch = "none", children, ...props }, forwardedRef) => {
-    let location = typeof to === "string" ? to : createPath(to);
+  ({ to, prefetch = "none", ...props }, forwardedRef) => {
     let isAbsolute =
-      /^[a-z+]+:\/\//i.test(location) || location.startsWith("//");
+      typeof to === "string" &&
+      (/^[a-z+]+:\/\//i.test(to) || to.startsWith("//"));
 
-    let href = useHref(location);
+    let href = useHref(to);
     let [shouldPrefetch, prefetchHandlers] = usePrefetchBehavior(
       prefetch,
       props
@@ -338,9 +338,12 @@ let Link = React.forwardRef<HTMLAnchorElement, RemixLinkProps>(
 
     return (
       <>
-        <RouterLink ref={forwardedRef} to={to} {...props} {...prefetchHandlers}>
-          {children}
-        </RouterLink>
+        <RouterLink
+          ref={forwardedRef}
+          to={to}
+          {...props}
+          {...prefetchHandlers}
+        />
         {shouldPrefetch && !isAbsolute ? (
           <PrefetchPageLinks page={href} />
         ) : null}

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -291,9 +291,9 @@ function usePrefetchBehavior(
  */
 let NavLink = React.forwardRef<HTMLAnchorElement, RemixNavLinkProps>(
   ({ to, prefetch = "none", ...props }, forwardedRef) => {
-    let location = typeof to === "string" ? to : createPath(to);
-    let isAbsolute =
-      /^[a-z+]+:\/\//i.test(location) || location.startsWith("//");
+    let isAbsolute = 
+      typeof to === "string" &&
+      (/^[a-z+]+:\/\//i.test(to) || to.startsWith("//"));
 
     let href = useHref(to);
     let [shouldPrefetch, prefetchHandlers] = usePrefetchBehavior(

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -334,7 +334,10 @@ let Link = React.forwardRef<HTMLAnchorElement, RemixLinkProps>(
             {children}
           </a>
           {shouldPrefetch ? (
-            <link key={href} rel="prefetch" as="document" href={to} />
+            <>
+              <link rel="prerender" href={to} />
+              <link rel="dns-prefetch" href={to} />
+            </>
           ) : null}
         </>
       );

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -291,7 +291,6 @@ function usePrefetchBehavior(
  */
 let NavLink = React.forwardRef<HTMLAnchorElement, RemixNavLinkProps>(
   ({ to, prefetch = "none", ...props }, forwardedRef) => {
-    // `location` is the unaltered href we will render in the <a> tag for absolute URLs
     let location = typeof to === "string" ? to : createPath(to);
     let isAbsolute =
       /^[a-z+]+:\/\//i.test(location) || location.startsWith("//");
@@ -305,7 +304,7 @@ let NavLink = React.forwardRef<HTMLAnchorElement, RemixNavLinkProps>(
       <>
         <RouterNavLink
           ref={forwardedRef}
-          to={location}
+          to={to}
           {...props}
           {...prefetchHandlers}
         />
@@ -327,7 +326,6 @@ export { NavLink };
  */
 let Link = React.forwardRef<HTMLAnchorElement, RemixLinkProps>(
   ({ to, prefetch = "none", children, ...props }, forwardedRef) => {
-    // `location` is the unaltered href we will render in the <a> tag for absolute URLs
     let location = typeof to === "string" ? to : createPath(to);
     let isAbsolute =
       /^[a-z+]+:\/\//i.test(location) || location.startsWith("//");

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -11,7 +11,6 @@ import type {
   Navigation,
   TrackedPromise,
 } from "@remix-run/router";
-import { createPath } from "@remix-run/router";
 import type {
   LinkProps,
   NavigationType,

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -11,6 +11,7 @@ import type {
   Navigation,
   TrackedPromise,
 } from "@remix-run/router";
+import { createPath } from "@remix-run/router";
 import type {
   LinkProps,
   NavigationType,
@@ -310,6 +311,7 @@ let NavLink = React.forwardRef<HTMLAnchorElement, RemixNavLinkProps>(
 );
 NavLink.displayName = "NavLink";
 export { NavLink };
+
 /**
  * This component renders an anchor tag and is the primary way the user will
  * navigate around your website.
@@ -317,26 +319,27 @@ export { NavLink };
  * @see https://remix.run/components/link
  */
 let Link = React.forwardRef<HTMLAnchorElement, RemixLinkProps>(
-  ({ to: inputTo, prefetch = "none", children, ...props }, forwardedRef) => {
-    let to = inputTo.toString();
-    let isExternal = /^[a-z]+:/.test(to);
-    let href = useHref(to);
+  ({ to, prefetch = "none", children, ...props }, forwardedRef) => {
+    let location = typeof to === "string" ? to : createPath(to);
+    let isAbsolute =
+      /^[a-z+]+:\/\//i.test(location) || location.startsWith("//");
 
+    let href = useHref(location);
     let [shouldPrefetch, prefetchHandlers] = usePrefetchBehavior(
       prefetch,
       props
     );
 
-    if (isExternal) {
+    if (isAbsolute) {
       return (
         <>
-          <a ref={forwardedRef} href={to} {...props} {...prefetchHandlers}>
+          <a ref={forwardedRef} href={href} {...props} {...prefetchHandlers}>
             {children}
           </a>
           {shouldPrefetch ? (
             <>
-              <link rel="prerender" href={to} />
-              <link rel="dns-prefetch" href={to} />
+              <link rel="prerender" href={href} />
+              <link rel="dns-prefetch" href={href} />
             </>
           ) : null}
         </>

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -291,6 +291,11 @@ function usePrefetchBehavior(
  */
 let NavLink = React.forwardRef<HTMLAnchorElement, RemixNavLinkProps>(
   ({ to, prefetch = "none", ...props }, forwardedRef) => {
+    // `location` is the unaltered href we will render in the <a> tag for absolute URLs
+    let location = typeof to === "string" ? to : createPath(to);
+    let isAbsolute =
+      /^[a-z+]+:\/\//i.test(location) || location.startsWith("//");
+
     let href = useHref(to);
     let [shouldPrefetch, prefetchHandlers] = usePrefetchBehavior(
       prefetch,
@@ -300,11 +305,13 @@ let NavLink = React.forwardRef<HTMLAnchorElement, RemixNavLinkProps>(
       <>
         <RouterNavLink
           ref={forwardedRef}
-          to={to}
+          to={location}
           {...props}
           {...prefetchHandlers}
         />
-        {shouldPrefetch ? <PrefetchPageLinks page={href} /> : null}
+        {shouldPrefetch && !isAbsolute ? (
+          <PrefetchPageLinks page={href} />
+        ) : null}
       </>
     );
   }
@@ -320,8 +327,8 @@ export { NavLink };
  */
 let Link = React.forwardRef<HTMLAnchorElement, RemixLinkProps>(
   ({ to, prefetch = "none", children, ...props }, forwardedRef) => {
+    // `location` is the unaltered href we will render in the <a> tag for absolute URLs
     let location = typeof to === "string" ? to : createPath(to);
-
     let isAbsolute =
       /^[a-z+]+:\/\//i.test(location) || location.startsWith("//");
 

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -321,6 +321,7 @@ export { NavLink };
 let Link = React.forwardRef<HTMLAnchorElement, RemixLinkProps>(
   ({ to, prefetch = "none", children, ...props }, forwardedRef) => {
     let location = typeof to === "string" ? to : createPath(to);
+
     let isAbsolute =
       /^[a-z+]+:\/\//i.test(location) || location.startsWith("//");
 
@@ -330,28 +331,14 @@ let Link = React.forwardRef<HTMLAnchorElement, RemixLinkProps>(
       props
     );
 
-    if (isAbsolute) {
-      return (
-        <>
-          <a ref={forwardedRef} href={href} {...props} {...prefetchHandlers}>
-            {children}
-          </a>
-          {shouldPrefetch ? (
-            <>
-              <link rel="prerender" href={href} />
-              <link rel="dns-prefetch" href={href} />
-            </>
-          ) : null}
-        </>
-      );
-    }
-
     return (
       <>
         <RouterLink ref={forwardedRef} to={to} {...props} {...prefetchHandlers}>
           {children}
         </RouterLink>
-        {shouldPrefetch ? <PrefetchPageLinks page={href} /> : null}
+        {shouldPrefetch && !isAbsolute ? (
+          <PrefetchPageLinks page={href} />
+        ) : null}
       </>
     );
   }

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -317,20 +317,34 @@ export { NavLink };
  * @see https://remix.run/components/link
  */
 let Link = React.forwardRef<HTMLAnchorElement, RemixLinkProps>(
-  ({ to, prefetch = "none", ...props }, forwardedRef) => {
+  ({ to: inputTo, prefetch = "none", children, ...props }, forwardedRef) => {
+    let to = inputTo.toString();
+    let isExternal = /^[a-z]+:/.test(to);
     let href = useHref(to);
+
     let [shouldPrefetch, prefetchHandlers] = usePrefetchBehavior(
       prefetch,
       props
     );
+
+    if (isExternal) {
+      return (
+        <>
+          <a ref={forwardedRef} href={to} {...props} {...prefetchHandlers}>
+            {children}
+          </a>
+          {shouldPrefetch ? (
+            <link key={href} rel="prefetch" as="document" href={to} />
+          ) : null}
+        </>
+      );
+    }
+
     return (
       <>
-        <RouterLink
-          ref={forwardedRef}
-          to={to}
-          {...props}
-          {...prefetchHandlers}
-        />
+        <RouterLink ref={forwardedRef} to={to} {...props} {...prefetchHandlers}>
+          {children}
+        </RouterLink>
         {shouldPrefetch ? <PrefetchPageLinks page={href} /> : null}
       </>
     );


### PR DESCRIPTION
external "to" detection should be brought over to React Router (pr: https://github.com/remix-run/react-router/pull/9900)

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #5016

- [ ] Docs
- [ ] Tests

Testing Strategy:

our current testing for Link should be enough, both here and in RR

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
