### PR TITLE
fix(tests): fix `typecheck` script in fixtures

### DIFF
--- a/packages/remix-dev/__tests__/fixtures/replace-remix-magic-imports/package.json
+++ b/packages/remix-dev/__tests__/fixtures/replace-remix-magic-imports/package.json
@@ -9,7 +9,7 @@
     "generate:css": "tailwindcss -o ./app/styles/tailwind.css",
     "postinstall": "remix setup node",
     "start": "remix-serve build",
-    "typecheck": "tsc && tsc cypress"
+    "typecheck": "tsc && tsc -p cypress"
   },
   "prettier": {},
   "eslintIgnore": [

--- a/packages/remix-dev/__tests__/migrations/fixtures/indie-stack/package.json
+++ b/packages/remix-dev/__tests__/migrations/fixtures/indie-stack/package.json
@@ -2,7 +2,7 @@
   "name": "indie-stack-template",
   "private": true,
   "scripts": {
-    "typecheck": "tsc && tsc cypress"
+    "typecheck": "tsc && tsc -p cypress"
   },
   "dependencies": {
     "@remix-run/node": "*",


### PR DESCRIPTION
Apparently we need to add the `-p` flag when running `tsc` on the `cypress` folder
- https://github.com/remix-run/indie-stack/actions/runs/3951228293/jobs/6764810424
- https://github.com/remix-run/blues-stack/actions/runs/3951125579/jobs/6764576532
- https://github.com/remix-run/grunge-stack/actions/runs/3951229138/jobs/6764812112