### PR TITLE
bug: CSS modules are ignored when component is re-exported using index.js

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -173,6 +173,7 @@
 - Hopsken
 - humphd
 - hzhu
+- iamkd
 - IAmLuisJ
 - ianduvall
 - illright


### PR DESCRIPTION
I know CSS Modules are unstable but hopefully this will help improve and release them faster 😄 

This is happening when the file structure is roughly like this (other combinations could also be prone to this bug):
```
components/
├─ Button/
│  ├─ index.js
│  ├─ Button.js
│  ├─ Button.module.css
```

where `Button.js` is importing the CSS module and using it, while `index.js` is re-exporting it using
`export * from './Button.js'`.

Basically, the bug happens depending on how this component is imported:
* `import { Button } from '~/components/Button'` will ignore the CSS module and will not add it to the bundle. The classname will still be generated but will be useless.
* `import { Button } from '~/components/Button/Button'` will bypass the `index.js` and work as expected.

Using `index.js` to re-export stuff and make imports prettier is not something everybody likes, but this is still valid code and CSS modules should be bundled in this case as well. 

This PR includes a bug report test that checks if the `cssBundleHref` is defined when the component is imported in a way described above. Because the test consists of a single component, it will fail with `cssBundleHref` being undefined. In case of multiple components, only the styles that are imported correctly will be included in the bundle.