### PR TITLE
fix(remix-dev/flat-routes): use `index` without leading underscore for colocation

### DIFF
--- a/.changeset/fresh-needles-join.md
+++ b/.changeset/fresh-needles-join.md
@@ -1,0 +1,24 @@
+---
+"remix": patch
+"@remix-run/dev": patch
+---
+
+use `index` without leading underscore for colocation
+
+when using flat routes with folder colocation, use `index` without leading underscore for route
+
+before:
+```
+  app_.projects.$id.roadmap/
+    _index.tsx
+    chart.tsx
+    update-timeline.server.tsx
+```
+
+after:
+```
+  app_.projects.$id.roadmap/
+    index.tsx
+    chart.tsx
+    update-timeline.server.tsx
+```

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -4,6 +4,7 @@ import {
   createRoutePath,
   flatRoutesUniversal,
   getRouteSegments,
+  isIndexRoute,
 } from "../config/flat-routes";
 import type { ConfigRoute } from "../config/routes";
 
@@ -25,10 +26,10 @@ describe("flatRoutes", () => {
       ["nested/$slug", "/nested/:slug"],
       ["flat.$slug", "/flat/:slug"],
       ["flat.sub", "/flat/sub"],
-      ["nested/_index", "/nested"],
+      ["nested/index", "/nested"],
       ["flat._index", "/flat"],
       ["_index", undefined],
-      ["_layout/_index", undefined],
+      ["_layout/index", undefined],
       ["_layout/test", "/test"],
       ["_layout.test", "/test"],
       ["_layout/$slug", "/:slug"],
@@ -88,7 +89,8 @@ describe("flatRoutes", () => {
     for (let [input, expected] of tests) {
       it(`"${input}" -> "${expected}"`, () => {
         let routeSegments = getRouteSegments(input);
-        expect(createRoutePath(routeSegments)).toBe(expected);
+        let isIndex = isIndexRoute(input);
+        expect(createRoutePath(routeSegments, isIndex)).toBe(expected);
       });
     }
 
@@ -332,9 +334,9 @@ describe("flatRoutes", () => {
         },
       ],
       [
-        "routes/app_.skipall_/_index.tsx",
+        "routes/app_.skipall_/index.tsx",
         {
-          id: "routes/app_.skipall_/_index",
+          id: "routes/app_.skipall_/index",
           index: true,
           parentId: "root",
           path: "app/skipall",
@@ -580,9 +582,9 @@ describe("flatRoutes", () => {
         },
       ],
       [
-        "routes/brand/_index.tsx",
+        "routes/brand/index.tsx",
         {
-          id: "routes/brand/_index",
+          id: "routes/brand/index",
           parentId: "root",
           path: "brand",
           index: true,

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -289,6 +289,16 @@ describe("flatRoutes", () => {
         },
       ],
 
+      // validate windows path
+      [
+        "routes\\app.windows\\path.tsx",
+        {
+          id: "routes/app.windows/path",
+          parentId: "routes/app",
+          path: "windows/path",
+        },
+      ],
+
       // Opt out of parent layout
       [
         "routes/app_.projects.$id.roadmap[.pdf].tsx",

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -602,18 +602,18 @@ describe("flatRoutes", () => {
 
     let files: [string, Omit<ConfigRoute, "file">][] = testFiles.map(
       ([file, route]) => {
-        let filepath = file.split("/").join(path.sep);
+        let filepath = file.split("/").join(path.win32.sep);
         return [filepath, { ...route, file: filepath }];
       }
     );
 
     let routeManifest = flatRoutesUniversal(
       APP_DIR,
-      files.map(([file]) => path.join(APP_DIR, file))
+      files.map(([file]) => path.win32.join(APP_DIR, file))
     );
     let routes = Object.values(routeManifest);
 
-    expect(routes).toHaveLength(files.length);
+    // expect(routes).toHaveLength(files.length);
 
     for (let [file, route] of files) {
       test(`hierarchy for ${file} - ${route.path}`, () => {

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -88,9 +88,8 @@ describe("flatRoutes", () => {
 
     for (let [input, expected] of tests) {
       it(`"${input}" -> "${expected}"`, () => {
-        let routeId = input.split(path.sep).join(path.posix.sep);
-        let routeSegments = getRouteSegments(routeId);
-        let isIndex = isIndexRoute(routeId);
+        let routeSegments = getRouteSegments(input);
+        let isIndex = isIndexRoute(input);
         expect(createRoutePath(routeSegments, isIndex)).toBe(expected);
       });
     }
@@ -614,7 +613,7 @@ describe("flatRoutes", () => {
     );
     let routes = Object.values(routeManifest);
 
-    // expect(routes).toHaveLength(files.length);
+    expect(routes).toHaveLength(files.length);
 
     for (let [file, route] of files) {
       test(`hierarchy for ${file} - ${route.path}`, () => {

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -602,14 +602,14 @@ describe("flatRoutes", () => {
 
     let files: [string, Omit<ConfigRoute, "file">][] = testFiles.map(
       ([file, route]) => {
-        let filepath = file.split("/").join(path.win32.sep);
+        let filepath = file.split("/").join(path.sep);
         return [filepath, { ...route, file: filepath }];
       }
     );
 
     let routeManifest = flatRoutesUniversal(
       APP_DIR,
-      files.map(([file]) => path.win32.join(APP_DIR, file))
+      files.map(([file]) => path.join(APP_DIR, file))
     );
     let routes = Object.values(routeManifest);
 

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -88,8 +88,9 @@ describe("flatRoutes", () => {
 
     for (let [input, expected] of tests) {
       it(`"${input}" -> "${expected}"`, () => {
-        let routeSegments = getRouteSegments(input);
-        let isIndex = isIndexRoute(input);
+        let routeId = input.split(path.sep).join(path.posix.sep);
+        let routeSegments = getRouteSegments(routeId);
+        let isIndex = isIndexRoute(routeId);
         expect(createRoutePath(routeSegments, isIndex)).toBe(expected);
       });
     }

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -289,16 +289,6 @@ describe("flatRoutes", () => {
         },
       ],
 
-      // validate windows path
-      [
-        "routes\\app.windows\\path.tsx",
-        {
-          id: "routes/app.windows/path",
-          parentId: "routes/app",
-          path: "windows/path",
-        },
-      ],
-
       // Opt out of parent layout
       [
         "routes/app_.projects.$id.roadmap[.pdf].tsx",

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -103,8 +103,9 @@ export function flatRoutesUniversal(
   return routes;
 }
 
-function isIndexRoute(routeId: string) {
-  return routeId.endsWith("_index");
+export function isIndexRoute(routeId: string) {
+  let isFlatFile = !routeId.includes(path.sep);
+  return isFlatFile ? routeId.endsWith("_index") : /\/index$/.test(routeId);
 }
 
 type State =
@@ -262,7 +263,7 @@ function getRouteInfo(
   let routeIdWithoutRoutes = routeId.slice(routeDirectory.length + 1);
   let index = isIndexRoute(routeIdWithoutRoutes);
   let routeSegments = getRouteSegments(routeIdWithoutRoutes);
-  let routePath = createRoutePath(routeSegments);
+  let routePath = createRoutePath(routeSegments, index);
 
   return {
     id: routeIdWithoutRoutes,
@@ -274,8 +275,12 @@ function getRouteInfo(
   };
 }
 
-export function createRoutePath(routeSegments: string[]) {
+export function createRoutePath(routeSegments: string[], isIndex: boolean) {
   let result = "";
+
+  if (isIndex) {
+    routeSegments = routeSegments.slice(0, -1);
+  }
 
   for (let segment of routeSegments) {
     // skip pathless layout segments

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -107,7 +107,7 @@ export function isIndexRoute(routeId: string) {
   let isFlatFile = !routeId.includes(path.posix.sep);
   return isFlatFile
     ? routeId.endsWith("_index")
-    : /^(.*)\/index$/.test(routeId);
+    : /\/index$/.test(routeId);
 }
 
 type State =

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -106,8 +106,13 @@ export function flatRoutesUniversal(
 
 export function isIndexRoute(routeId: string) {
   let isFlatFile = !routeId.includes(path.sep);
+  if (isFlatFile) {
+    return routeId.endsWith("_index");
+  }
+
   let normalized = normalizeSlashes(routeId);
-  return isFlatFile ? routeId.endsWith("_index") : /\/index$/.test(normalized);
+  console.log({ normalized });
+  return /\/index$/.test(normalized);
 }
 
 type State =

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import fg from "fast-glob";
 
 import type { ConfigRoute, DefineRouteFunction, RouteManifest } from "./routes";
+import { normalizeSlashes } from "./routes";
 import { createRouteId, defineRoutes } from "./routes";
 import {
   escapeEnd,
@@ -105,7 +106,8 @@ export function flatRoutesUniversal(
 
 export function isIndexRoute(routeId: string) {
   let isFlatFile = !routeId.includes(path.sep);
-  return isFlatFile ? routeId.endsWith("_index") : /\/index$/.test(routeId);
+  let normalized = normalizeSlashes(routeId);
+  return isFlatFile ? routeId.endsWith("_index") : /\/index$/.test(normalized);
 }
 
 type State =

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -105,14 +105,10 @@ export function flatRoutesUniversal(
 }
 
 export function isIndexRoute(routeId: string) {
-  let isFlatFile = !routeId.includes(path.sep);
-  if (isFlatFile) {
-    return routeId.endsWith("_index");
-  }
-
-  let normalized = normalizeSlashes(routeId);
-  console.log({ normalized });
-  return /\/index$/.test(normalized);
+  let isFlatFile = !routeId.includes(path.posix.sep);
+  return isFlatFile
+    ? routeId.endsWith("_index")
+    : /^(.*)\/index$/.test(routeId);
 }
 
 type State =

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -2,7 +2,6 @@ import path from "node:path";
 import fg from "fast-glob";
 
 import type { ConfigRoute, DefineRouteFunction, RouteManifest } from "./routes";
-import { normalizeSlashes } from "./routes";
 import { createRouteId, defineRoutes } from "./routes";
 import {
   escapeEnd,


### PR DESCRIPTION
before:
```
  app_.projects.$id.roadmap/
    _index.tsx
    chart.tsx
    update-timeline.server.tsx
```

after:
```
  app_.projects.$id.roadmap/
    index.tsx
    chart.tsx
    update-timeline.server.tsx
```

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
