### PR TITLE
fix(remix-react): undeprecate `LiveReload`'s `nonce` prop

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1677,9 +1677,6 @@ export const LiveReload =
       }: {
         port?: number;
         timeoutMs?: number;
-        /**
-         * @deprecated this property is no longer relevant.
-         */
         nonce?: string;
       }) {
         let js = String.raw;


### PR DESCRIPTION
It was necessary for CSPs before, then it was no longer necessary thanks to https://github.com/remix-run/remix/pull/2783, but then it became necessary again when this PR was merged: https://github.com/remix-run/remix/pull/2874 but the deprecation warning was never removed.

Until this is released, people will get this in their editors:

<img width="1061" alt="image" src="https://user-images.githubusercontent.com/1500684/213763904-c10392eb-bbd9-4b3f-a915-f4d049fd41f7.png">
