### PR TITLE
Docs: Add missing concerts.tsx layout in example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -445,6 +445,7 @@
 - UsamaHameed
 - ValentinH
 - valerie-makes
+- vegar
 - veritem
 - VictorPeralta
 - vimutti77

--- a/docs/file-conventions/route-files-v2.md
+++ b/docs/file-conventions/route-files-v2.md
@@ -192,7 +192,8 @@ app/
 │   ├── about.tsx
 │   ├── concerts.$city.tsx
 │   ├── concerts.trending.tsx
-│   └── concerts_.mine.tsx
+│   ├── concerts_.mine.tsx
+|   └── concerts.tsx
 └── root.tsx
 ```
 


### PR DESCRIPTION
The Nested URLs without Layout Nesting example shows how `concerts_.mine.tsx` opts out from the `concerts.tsx` layout. The url-route-layout table still reference the `concerts.tsx` layout, but the file is no longer part of the file structure. I guess it should be? Like in the previous example?

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [x] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
