### PR TITLE
[Bug]: App crash on fast browser navigation or shows wrong url

### DIFF
--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -93,149 +93,17 @@ test("[description of what you expect it to do]", async ({ page }) => {
   await app.clickLink("/burgers");
   expect(await app.getHtml()).toMatch("cheeseburger");
 
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
+  let retry = 100;
 
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
-
-  await page.goBack({ waitUntil: "commit" });
-  await page.goBack({ waitUntil: "networkidle" });
-  await page.goForward({ waitUntil: "commit" });
-  await page.goForward({ waitUntil: "commit" });
-  expect(await app.getHtml()).not.toContain(
-    `Cannot destructure property 'default'`
-  );
+  for (let i = 0; i < retry; i++) {
+    await page.goBack({ waitUntil: "commit" });
+    await page.goBack({ waitUntil: "networkidle" });
+    await page.goForward({ waitUntil: "commit" });
+    await page.goForward({ waitUntil: "commit" });
+    expect(await app.getHtml()).not.toContain(
+      `Cannot destructure property 'default'`
+    );
+  }
 
   // If you're not sure what's going on, you can "poke" the app, it'll
   // automatically open up in your browser for 20 seconds, so be quick!

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -88,7 +88,10 @@ test("expect to be able to go forward and backward in browser history without er
   let app = new PlaywrightFixture(appFixture, page);
 
   // This sets up the module cache in memory, priming the error case.
+
+  // TypeError: Comment out this line to view the TypeError exception:
   await page.goto("https://remix.run/");
+
   await app.goto("/");
   await app.clickLink("/burgers");
   expect(await page.content()).toMatch("cheeseburger");
@@ -98,13 +101,19 @@ test("expect to be able to go forward and backward in browser history without er
   // for example Chromium's 'no url' page, or remix.run, and a page
   // 2 deep in history that's part of a remix app (eg click forward twice).
   let appErrorStr = "Application Error!";
+
+  // TypeError: increase retries to something large, like 40, to view the
+  // TyepError failures
   let retry = 4;
+
   for (let i = 0; i < retry; i++) {
     // Back to /
     await page.goBack();
     expect(await app.getHtml()).toContain("pizza");
     // Takes the browser to "https://remix.run"
     await page.goBack();
+
+    // TypeError: Comment out these two lines to view the TypeError exception
     expect(page.url()).toContain("remix.run");
     expect(await app.getHtml()).toContain("web standards");
 
@@ -122,9 +131,12 @@ test("expect to be able to go forward and backward in browser history without er
     expect(page.url()).toContain("/burgers");
     // But now the content won't contain the string "cheeseburger"
     let appHtml2 = await app.getHtml();
+
+    // TypeError: comment out this line to view the TypeError
     expect(appHtml2).toMatch("cheeseburger");
-    if (appHtml2.includes(appErrorStr)) break;
+
     expect(appHtml2).not.toContain(appErrorStr);
+    if (appHtml2.includes(appErrorStr)) break;
   }
 });
 

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -48,27 +48,24 @@ test.beforeAll(async () => {
     ////////////////////////////////////////////////////////////////////////////
     files: {
       "app/routes/index.jsx": js`
-        import { json } from "@remix-run/node";
-        import { useLoaderData, Link } from "@remix-run/react";
-
-        export function loader() {
-          return json("pizza");
-        }
+        import { Link } from "@remix-run/react";
 
         export default function Index() {
-          let data = useLoaderData();
           return (
             <div>
-              {data}
-              <Link to="/burgers">Other Route</Link>
+              <div>pizza</div>
+              <Link to="/burgers">burger link</Link>
             </div>
           )
         }
       `,
 
       "app/routes/burgers.jsx": js`
+
         export default function Index() {
-          return <div>cheeseburger</div>;
+          return (
+            <div>cheeseburger</div>
+          );
         }
       `,
     },
@@ -88,13 +85,157 @@ test.afterAll(() => appFixture.close());
 test("[description of what you expect it to do]", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);
   // You can test any request your app might get using `fixture`.
-  let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch("pizza");
+  // let response = await fixture.requestDocument("/");
+  // expect(await response.text()).toMatch("pizza");
 
   // If you need to test interactivity use the `app`
   await app.goto("/");
   await app.clickLink("/burgers");
   expect(await app.getHtml()).toMatch("cheeseburger");
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
+
+  await page.goBack({ waitUntil: "commit" });
+  await page.goBack({ waitUntil: "networkidle" });
+  await page.goForward({ waitUntil: "commit" });
+  await page.goForward({ waitUntil: "commit" });
+  expect(await app.getHtml()).not.toContain(
+    `Cannot destructure property 'default'`
+  );
 
   // If you're not sure what's going on, you can "poke" the app, it'll
   // automatically open up in your browser for 20 seconds, so be quick!

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -98,12 +98,12 @@ test("expect to be able to go forward and backward in browser history without er
   // for example Chromium's 'no url' page, or remix.run, and a page
   // 2 deep in history that's part of a remix app (eg click forward twice).
   let appErrorStr = "Application Error!";
-  let retry = 1;
+  let retry = 4;
   for (let i = 0; i < retry; i++) {
     // Back to /
     await page.goBack();
     expect(await app.getHtml()).toContain("pizza");
-    // Takes the browser to its undefined route
+    // Takes the browser to "https://remix.run"
     await page.goBack();
     expect(page.url()).toContain("remix.run");
     expect(await app.getHtml()).toContain("web standards");


### PR DESCRIPTION
Reproduction case for issue: https://github.com/remix-run/remix/issues/1757

To run:

```
yarn bug-report-test
```

Failure is either an error where javascript complains about `default` missing from an object, or a url not matching its content. In the case of the test, we expect `/burgers` to contain the string `cheeseburgers`, but often only gets to the first route in history, `/`

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

* this is a test that reproduces the behavior in issue #1757 

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
