### PR TITLE
docs: add information about throwing `redirect`s

### DIFF
--- a/docs/route/loader.md
+++ b/docs/route/loader.md
@@ -190,7 +190,7 @@ See also:
 
 ## Throwing Responses in Loaders
 
-Along with returning responses, you can also throw Response objects from your loaders, allowing you to break through the call stack and show an alternate UI with contextual data through the `CatchBoundary`.
+Along with returning responses, you can also throw Response objects from your loaders, allowing you to break through the call stack and either redirect or show an alternate UI with contextual data through the `CatchBoundary`.
 
 Here is a full example showing how you can create utility functions that throw responses to stop code execution in the loader and move over to an alternative UI.
 
@@ -223,7 +223,8 @@ export async function requireUserSession(request) {
   );
   if (!session) {
     // can throw our helpers like `redirect` and `json` because they
-    // return responses.
+    // return responses. A redirect response will redirect, other
+    // responses will trigger the `CatchBoundary`.
     throw redirect("/login", 302);
   }
   return session.get("user");

--- a/docs/utils/redirect.md
+++ b/docs/utils/redirect.md
@@ -4,7 +4,7 @@ title: redirect
 
 # `redirect`
 
-This is shortcut for sending 30x responses.
+This is a shortcut for sending 30x responses.
 
 ```tsx lines=[1,7]
 import { redirect } from "@remix-run/node"; // or cloudflare/deno
@@ -57,4 +57,12 @@ return new Response(null, {
     Location: "/else/where",
   },
 });
+```
+
+And you can throw redirects to break through the call stack and redirect right away:
+
+```ts
+if (!session) {
+  throw redirect("/login", 302);
+}
 ```


### PR DESCRIPTION
The current docs don't highlight that you can throw a redirect response. Also, it's not mentioned that throwing a `redirect` is different from throwing any other response (does not trigger `CatchBoundary`). The goal is to emphasize that throwing a redirect is kind of a special case.