### PR TITLE
fix(remix-react): export `CatchBoundaryComponent` type

### DIFF
--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -70,6 +70,7 @@ export { useCatch } from "./errorBoundaries";
 
 export type { HtmlLinkDescriptor } from "./links";
 export type {
+  CatchBoundaryComponent,
   HtmlMetaDescriptor,
   RouteModules as UNSAFE_RouteModules,
   ShouldReloadFunction,


### PR DESCRIPTION
accidentally removed when we cleaned up non public exports https://github.com/remix-run/remix/pull/4915/files#diff-95ce3997ccff84362b71981aafc7cf2e4f5bac7285637badde43de2196445bacL64
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
