### PR TITLE
fix(dev): exclude `node:`-prefixed built-ins from the browser build

### DIFF
--- a/integration/compiler-test.ts
+++ b/integration/compiler-test.ts
@@ -58,8 +58,11 @@ test.describe("compiler", () => {
           import { useLoaderData } from "@remix-run/react";
           import * as path from "path";
 
+          // "node:"-prefixed built-in
+          import * as fs from "node:fs";
+
           export let loader = () => {
-            return path.join("test", "file.txt");
+            return path.join("test", fs.existsSync("./index.jsx") ? "file.txt" : "no_file.txt");
           }
 
           export default function BuiltIns() {
@@ -223,7 +226,7 @@ test.describe("compiler", () => {
 
     // rendered the page instead of the error boundary
     expect(await app.getHtml("#built-ins")).toBe(
-      `<div id="built-ins">test${path.sep}file.txt</div>`
+      `<div id="built-ins">test${path.sep}no_file.txt</div>`
     );
 
     let routeModule = await fixture.getBrowserAsset(

--- a/packages/remix-dev/compiler/compileBrowser.ts
+++ b/packages/remix-dev/compiler/compileBrowser.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import * as fse from "fs-extra";
-import { builtinModules as nodeBuiltins } from "module";
+import { builtinModules } from "module";
 import * as esbuild from "esbuild";
 import { NodeModulesPolyfillPlugin } from "@esbuild-plugins/node-modules-polyfill";
 import postcss from "postcss";
@@ -38,6 +38,11 @@ export type BrowserCompiler = {
   ) => Promise<esbuild.Metafile>;
   dispose: () => void;
 };
+
+// Node v14 compat: include `node:`-prefixed built-ins like `"node:fs"`
+let nodeBuiltins = Array.from(
+  new Set(builtinModules.flatMap((mod) => [mod, `node:${mod}`]))
+);
 
 const getExternals = (remixConfig: RemixConfig): string[] => {
   // For the browser build, exclude node built-ins that don't have a


### PR DESCRIPTION
Closes: #4544 

- [ ] Docs
- [x] Tests

## TODO
- [ ] can we get rid of the `fakeBuiltins` check introduced in https://github.com/remix-run/remix/issues/190 ?