### PR TITLE
feat(remix-dev): add `serverBasename` config option

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -471,6 +471,7 @@
 - yomeshgupta
 - youbicode
 - youngvform
+- yracnet
 - zachdtaylor
 - zainfathoni
 - zhe

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -60,6 +60,7 @@ describe("readConfig", () => {
             "path": "",
           },
         },
+        "serverBasename": "",
         "serverBuildPath": Any<String>,
         "serverBuildTarget": undefined,
         "serverBuildTargetEntryModule": "export * from \\"@remix-run/dev/server-build\\";",

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -92,6 +92,14 @@ export interface AppConfig {
   serverBuildPath?: string;
 
   /**
+   * Server Basename is a location path for app deploy on server.
+   *
+   * If omitted, the default location path is / (root directory)
+   * {@link ServerConfig.serverBasename}.
+   */
+  serverBasename?: string;
+
+  /**
    * The path to the browser build, relative to `remix.config.js`. Defaults to
    * "public/build".
    */
@@ -220,6 +228,14 @@ export interface RemixConfig {
   serverBuildPath: string;
 
   /**
+   * Server Basename is a location path for app deploy on server.
+   *
+   * If omitted, the default location path is / (root directory)
+   * {@link ServerConfig.serverBasename}.
+   */
+  serverBasename?: string;
+
+  /**
    * The absolute path to the assets build directory.
    */
   assetsBuildDirectory: string;
@@ -340,6 +356,7 @@ export async function readConfig(
     }
   }
 
+  let serverBasename = appConfig.serverBasename || "";
   let customServerEntryPoint = appConfig.server;
   let serverBuildTarget: ServerBuildTarget | undefined =
     appConfig.serverBuildTarget;
@@ -438,7 +455,11 @@ export async function readConfig(
   }
 
   let routes: RouteManifest = {
-    root: { path: "", id: "root", file: rootRouteFile },
+    root: {
+      path: serverBasename,
+      id: "root",
+      file: rootRouteFile,
+    },
   };
 
   let routesConvention = appConfig.future?.v2_routeConvention
@@ -517,7 +538,8 @@ export async function readConfig(
     devServerBroadcastDelay,
     assetsBuildDirectory: absoluteAssetsBuildDirectory,
     relativeAssetsBuildDirectory: assetsBuildDirectory,
-    publicPath,
+    serverBasename,
+    publicPath: path.join(serverBasename, publicPath).replace(/\\/g, "/"),
     rootDirectory,
     routes,
     serverBuildPath,

--- a/packages/remix-dev/devServer/serve.ts
+++ b/packages/remix-dev/devServer/serve.ts
@@ -60,9 +60,12 @@ export async function serve(
   app.use(
     createApp(
       config.serverBuildPath,
-      mode,
-      config.publicPath,
-      config.assetsBuildDirectory
+      {
+        mode,
+        basename: config.serverBasename,
+        publicPath: config.publicPath,
+        assetsBuildDirectory: config.assetsBuildDirectory
+      }
     )
   );
 

--- a/packages/remix-express/server.ts
+++ b/packages/remix-express/server.ts
@@ -94,7 +94,7 @@ export function createRemixRequest(
   res: express.Response
 ): NodeRequest {
   let origin = `${req.protocol}://${req.get("host")}`;
-  let url = new URL(req.url, origin);
+  let url = new URL(req.originalUrl, origin);
 
   // Abort action/loaders once we can no longer write a response
   let controller = new NodeAbortController();

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -35,12 +35,12 @@ let onListen = () => {
 
 let build = require(buildPath);
 
-let app = createApp(
-  buildPath,
-  process.env.NODE_ENV,
-  build.publicPath,
-  build.assetsBuildDirectory
-);
+let app = createApp(buildPath, {
+  mode: process.env.NODE_ENV,
+  basename: build.serverBasename,
+  publicPath: build.publicPath,
+  assetsBuildDirectory: build.assetsBuildDirectory,
+});
 let server = process.env.HOST
   ? app.listen(port, process.env.HOST, onListen)
   : app.listen(port, onListen);


### PR DESCRIPTION
I have implemented the feature described on the https://github.com/remix-run/remix/discussions/2891.

This include the serverBasename attribute on remix.config.js for declare a prefix to URL

> serverBasename default value is ""
> fix deploy on path server (basename)
> fix the navegation in client side or server side components

**clean branch from from https://github.com/remix-run/remix/pull/4459**