### PR TITLE
fix: mark Vanilla Extract files as side effects

### DIFF
--- a/.changeset/healthy-beers-nail.md
+++ b/.changeset/healthy-beers-nail.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Mark Vanilla Extract files as side effects to ensure that files only containing global styles aren't tree-shaken

--- a/integration/vanilla-extract-test.ts
+++ b/integration/vanilla-extract-test.ts
@@ -47,6 +47,8 @@ test.describe("Vanilla Extract", () => {
         ...javaScriptFixture(),
         ...classCompositionFixture(),
         ...rootRelativeClassCompositionFixture(),
+        ...sideEffectImportsFixture(),
+        ...sideEffectImportsWithinChildCompilationFixture(),
         ...stableIdentifiersFixture(),
         ...imageUrlsViaCssUrlFixture(),
         ...imageUrlsViaRootRelativeCssUrlFixture(),
@@ -200,6 +202,71 @@ test.describe("Vanilla Extract", () => {
     await app.goto("/root-relative-class-composition-test");
     let locator = await page.locator(
       "[data-testid='root-relative-class-composition']"
+    );
+    let padding = await locator.evaluate(
+      (element) => window.getComputedStyle(element).padding
+    );
+    expect(padding).toBe(TEST_PADDING_VALUE);
+  });
+
+  let sideEffectImportsFixture = () => ({
+    "app/fixtures/side-effect-imports/styles.css.ts": js`
+      import { globalStyle } from "@vanilla-extract/css";
+      
+      globalStyle(".side-effect-imports", {
+        padding: ${JSON.stringify(TEST_PADDING_VALUE)}
+      });
+    `,
+    "app/routes/side-effect-imports-test.jsx": js`
+      import "../fixtures/side-effect-imports/styles.css";
+      
+      export default function() {
+        return (
+          <div data-testid="side-effect-imports" className="side-effect-imports">
+            Side-effect imports test
+          </div>
+        )
+      }
+    `,
+  });
+  test("side-effect imports", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/side-effect-imports-test");
+    let locator = await page.locator("[data-testid='side-effect-imports']");
+    let padding = await locator.evaluate(
+      (element) => window.getComputedStyle(element).padding
+    );
+    expect(padding).toBe(TEST_PADDING_VALUE);
+  });
+
+  let sideEffectImportsWithinChildCompilationFixture = () => ({
+    "app/fixtures/side-effect-imports-within-child-compilation/styles.css.ts": js`
+      import "./nested-side-effect.css";
+    `,
+    "app/fixtures/side-effect-imports-within-child-compilation/nested-side-effect.css.ts": js`
+      import { globalStyle } from "@vanilla-extract/css";
+      
+      globalStyle(".side-effect-imports-within-child-compilation", {
+        padding: ${JSON.stringify(TEST_PADDING_VALUE)}
+      });
+    `,
+    "app/routes/side-effect-imports-within-child-compilation-test.jsx": js`
+      import "../fixtures/side-effect-imports-within-child-compilation/styles.css";
+      
+      export default function() {
+        return (
+          <div data-testid="side-effect-imports-within-child-compilation" className="side-effect-imports-within-child-compilation">
+            Side-effect imports within child compilation test
+          </div>
+        )
+      }
+    `,
+  });
+  test("side-effect imports within child compilation", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/side-effect-imports-within-child-compilation-test");
+    let locator = await page.locator(
+      "[data-testid='side-effect-imports-within-child-compilation']"
     );
     let padding = await locator.evaluate(
       (element) => window.getComputedStyle(element).padding

--- a/packages/remix-dev/compiler/plugins/cssSideEffectImportsPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/cssSideEffectImportsPlugin.ts
@@ -74,9 +74,16 @@ export const cssSideEffectImportsPlugin = (options: {
             })
           ).path;
 
+          // If the resolved path isn't a CSS file then we don't want
+          // to handle it. In our case this is specifically done to
+          // avoid matching Vanilla Extract's .css.ts/.js files.
+          if (!resolvedPath.split("?")[0].endsWith(".css")) {
+            return null;
+          }
+
           return {
             path: path.relative(options.rootDirectory, resolvedPath),
-            namespace: resolvedPath.endsWith(".css") ? namespace : undefined,
+            namespace,
           };
         }
       );

--- a/packages/remix-dev/compiler/plugins/vanillaExtractPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/vanillaExtractPlugin.ts
@@ -178,7 +178,7 @@ const vanillaExtractSideEffectsPlugin: esbuild.Plugin = {
       { filter: /\.css(\.(j|t)sx?)?(\?.*)?$/, namespace: "file" },
       async (args) => {
         if (args.pluginData === preventInfiniteLoop) {
-          return;
+          return null;
         }
 
         let resolvedPath = (
@@ -190,7 +190,7 @@ const vanillaExtractSideEffectsPlugin: esbuild.Plugin = {
         ).path;
 
         if (!cssFileFilter.test(resolvedPath)) {
-          return;
+          return null;
         }
 
         return {

--- a/packages/remix-dev/compiler/plugins/vanillaExtractPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/vanillaExtractPlugin.ts
@@ -31,12 +31,17 @@ export function vanillaExtractPlugin({
     setup(build) {
       let { rootDirectory } = config;
 
+      // Resolve virtual CSS files first to avoid resolving the same
+      // file multiple times since this filter is more specific and
+      // doesn't require a file system lookup.
       build.onResolve({ filter: virtualCssFileFilter }, (args) => {
         return {
           path: args.path,
           namespace,
         };
       });
+
+      vanillaExtractSideEffectsPlugin.setup(build);
 
       build.onLoad(
         { filter: virtualCssFileFilter, namespace },
@@ -65,6 +70,7 @@ export function vanillaExtractPlugin({
           platform: "node",
           write: false,
           plugins: [
+            vanillaExtractSideEffectsPlugin,
             vanillaExtractTransformPlugin({ rootDirectory, identOption }),
           ],
           loader: loaders,
@@ -157,3 +163,41 @@ function vanillaExtractTransformPlugin({
     },
   };
 }
+
+/**
+ * This plugin marks all .css.ts/js files as having side effects. This is
+ * to ensure that all usages of `globalStyle` are included in the CSS bundle,
+ * even if a .css.ts/js file has no exports or is otherwise tree-shaken.
+ */
+const vanillaExtractSideEffectsPlugin: esbuild.Plugin = {
+  name: "vanilla-extract-side-effects-plugin",
+  setup(build) {
+    let preventInfiniteLoop = {};
+
+    build.onResolve(
+      { filter: /\.css(\.(j|t)sx?)?(\?.*)?$/, namespace: "file" },
+      async (args) => {
+        if (args.pluginData === preventInfiniteLoop) {
+          return;
+        }
+
+        let resolvedPath = (
+          await build.resolve(args.path, {
+            resolveDir: args.resolveDir,
+            kind: args.kind,
+            pluginData: preventInfiniteLoop,
+          })
+        ).path;
+
+        if (!cssFileFilter.test(resolvedPath)) {
+          return;
+        }
+
+        return {
+          path: resolvedPath,
+          sideEffects: true,
+        };
+      }
+    );
+  },
+};


### PR DESCRIPTION
Fixes: #5238

- [ ] Docs
- [x] Tests

Testing Strategy:

I added integration tests for side-effect imports of Vanilla Extract files, both within the app context and within the Vanilla Extract child compilation since it's a separate esbuild pass. I've confirmed that these tests fail when the fix hasn't been applied.