### PR TITLE
fix(remix-dev): Server build should not be removed in `remix watch` and `remix dev` 

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -183,6 +183,7 @@
 - ishan-me
 - IshanKBG
 - itsMapleLeaf
+- izznatsir
 - jacargentina
 - jacob-ebey
 - JacobParis

--- a/packages/remix-dev/devServer/liveReload.ts
+++ b/packages/remix-dev/devServer/liveReload.ts
@@ -12,7 +12,6 @@ const relativePath = (file: string) => path.relative(process.cwd(), file);
 
 let clean = (config: RemixConfig) => {
   fse.emptyDirSync(config.assetsBuildDirectory);
-  fse.rmSync(config.serverBuildPath);
 };
 
 export async function liveReload(

--- a/packages/remix-dev/devServer2.ts
+++ b/packages/remix-dev/devServer2.ts
@@ -20,7 +20,6 @@ let sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 let clean = (config: RemixConfig) => {
   fs.emptyDirSync(config.relativeAssetsBuildDirectory);
-  fs.removeSync(config.serverBuildPath);
 };
 
 let getHost = () =>


### PR DESCRIPTION
Closes: #5248

- [ ] Docs
- [ ] Tests

Testing Strategy:

- Setup cloudflare pages template playground
- use npm run dev command with remix watch, then make change
- see if there is any wrangler error in console
- use npm run dev command with remix dev (new dev server), then make change
- see if there is any wrangler error in console
