### PR TITLE
docs(other-api/adapter): add community adapters

### DIFF
--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -28,7 +28,7 @@ Each adapter has the same API. In the future we may have helpers specific to the
 
 - [`remix-google-cloud-functions`][remix-google-cloud-functions] - For [Google Cloud][google-cloud-functions] and [Firebase][firebase-functions] functions.
 
-## Creating an adapter
+## Creating an Adapter
 
 ### `createRequestHandler`
 

--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -5,6 +5,8 @@ order: 2
 
 # Server Adapters
 
+## Official Adapters
+
 Idiomatic Remix apps can generally be deployed anywhere because Remix adapt's the server's request/response to the [Web Fetch API][web-fetch-api]. It does this through adapters. We maintain a few adapters:
 
 - `@remix-run/architect`
@@ -22,7 +24,11 @@ If you initialized your app with `npx create-remix@latest` with something other 
 
 Each adapter has the same API. In the future we may have helpers specific to the platform you're deploying to.
 
-## `createRequestHandler`
+### Community Adapters
+
+- [remix-google-cloud-functions](https://github.com/penx/remix-google-cloud-functions) - For [Google Cloud](https://cloud.google.com/functions) and [Firebase](https://firebase.google.com/docs/functions) functions.
+
+### `createRequestHandler`
 
 Creates a request handler for your server to serve the app. This is the ultimate entry point of your Remix application.
 

--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -24,9 +24,11 @@ If you initialized your app with `npx create-remix@latest` with something other 
 
 Each adapter has the same API. In the future we may have helpers specific to the platform you're deploying to.
 
-### Community Adapters
+## Community Adapters
 
 - [remix-google-cloud-functions][remix-google-cloud-functions] - For [Google Cloud][google-cloud-functions] and [Firebase][firebase-functions] functions.
+
+## Creating an adapter
 
 ### `createRequestHandler`
 

--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -26,7 +26,7 @@ Each adapter has the same API. In the future we may have helpers specific to the
 
 ### Community Adapters
 
-- [remix-google-cloud-functions](https://github.com/penx/remix-google-cloud-functions) - For [Google Cloud](https://cloud.google.com/functions) and [Firebase](https://firebase.google.com/docs/functions) functions.
+- [remix-google-cloud-functions][remix-google-cloud-functions] - For [Google Cloud][google-cloud-functions] and [Firebase][firebase-functions] functions.
 
 ### `createRequestHandler`
 
@@ -175,3 +175,6 @@ addEventListener("fetch", (event) => {
 ```
 
 [web-fetch-api]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+[remix-google-cloud-functions]: https://github.com/penx/remix-google-cloud-functions
+[google-cloud-functions]: https://cloud.google.com/functions
+[firebase-functions]: https://firebase.google.com/docs/functions

--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -26,7 +26,7 @@ Each adapter has the same API. In the future we may have helpers specific to the
 
 ## Community Adapters
 
-- [remix-google-cloud-functions][remix-google-cloud-functions] - For [Google Cloud][google-cloud-functions] and [Firebase][firebase-functions] functions.
+- [`remix-google-cloud-functions`][remix-google-cloud-functions] - For [Google Cloud][google-cloud-functions] and [Firebase][firebase-functions] functions.
 
 ## Creating an adapter
 

--- a/docs/pages/community.md
+++ b/docs/pages/community.md
@@ -25,7 +25,9 @@ You can find (and create) examples in the [Remix examples repository][the-exampl
 
 ## Community Adapters
 
-You can find Community Adapters int the [Adapters Documentation][community-adapters]. If you've written your own, you can [update this list on GitHub][community-adapters-github].
+You can find Community Adapters in the [Adapters][community-adapters] section of the documentation. 
+
+If you've written your own adapter, and think it will be valuable for others, you can [update this list on GitHub][community-adapters-github].
 
 ## Courses
 
@@ -103,4 +105,4 @@ There are Remix Meetups all over the world with thousands of members. Some onlin
 [remix-fundamentals]: https://frontendmasters.com/courses/remix/
 [advanced-remix]: https://frontendmasters.com/courses/advanced-remix/
 [community-adapters]: ../other-api/adapter#community-adapters
-[community-adapters-github]: https://github.com/remix-run/remix/blob/main/docs/pages/community.md#community-adapters
+[community-adapters-github]: https://github.com/remix-run/remix/blob/main/docs/other-api/adapter.md#community-adapters

--- a/docs/pages/community.md
+++ b/docs/pages/community.md
@@ -23,6 +23,10 @@ Our [GitHub discussions forum][git-hub-discussions-forum] is a good place to cha
 
 You can find (and create) examples in the [Remix examples repository][the-examples-repository].
 
+## Community Adapters
+
+You can find Community Adapters int the [Adapters Documentation][community-adapters]. If you've written your own, you can [update this list on GitHub][community-adapters-github].
+
 ## Courses
 
 Here's a list of courses (in no particular order) you can take to help learn Remix:
@@ -98,3 +102,5 @@ There are Remix Meetups all over the world with thousands of members. Some onlin
 [frontend-masters]: https://frontendmasters.com
 [remix-fundamentals]: https://frontendmasters.com/courses/remix/
 [advanced-remix]: https://frontendmasters.com/courses/advanced-remix/
+[community-adapters]: ../other-api/adapter#community-adapters
+[community-adapters-github]: https://github.com/remix-run/remix/blob/main/docs/pages/community.md#community-adapters


### PR DESCRIPTION
After discussion with @machour on Discord, I have added remix-google-cloud-functions to a new "community adapters" list in the docs.