### PR TITLE
feat(remix-react): export `react-router-dom`'s `useMatch` hook

### DIFF
--- a/.changeset/export-use-match.md
+++ b/.changeset/export-use-match.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Add `useMatch` re-export from `react-router-dom`

--- a/contributors.yml
+++ b/contributors.yml
@@ -375,6 +375,7 @@
 - nicksrandall
 - nickytonline
 - niconiahi
+- nicksrandall
 - nielsdb97
 - NikkiDelRosso
 - ninjaPixel

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -24,6 +24,7 @@ export {
   useFormAction,
   useHref,
   useLocation,
+  useMatch,
   useNavigate,
   useNavigation,
   useNavigationType,


### PR DESCRIPTION
This is useful if you need to give a component some added functionality if a specific path is "active" or not. 
