### PR TITLE
fix(remix-dev): fast glob will return posix style paths even on windows

### DIFF
--- a/.changeset/hip-cats-warn.md
+++ b/.changeset/hip-cats-warn.md
@@ -1,0 +1,8 @@
+---
+"remix": patch
+"@remix-run/dev": patch
+---
+
+fix flat routes on windows, so that it picks up new files and renames
+
+fast glob will return posix style paths even on windows

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -25,7 +25,12 @@ export function flatRoutes(
     ignore: ignoredFilePatterns,
   });
 
-  return flatRoutesUniversal(appDirectory, routePaths);
+  let routePathsForOS = routePaths.map((routePath) => {
+    if (path.sep === "/") return routePath;
+    return routePath.split("/").join(path.sep);
+  });
+
+  return flatRoutesUniversal(appDirectory, routePathsForOS);
 }
 
 interface RouteInfo extends ConfigRoute {

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -25,9 +25,10 @@ export function flatRoutes(
     ignore: ignoredFilePatterns,
   });
 
+  // fast-glob will return posix paths even on windows
+  // convert posix to os specific paths
   let routePathsForOS = routePaths.map((routePath) => {
-    if (path.sep === "/") return routePath;
-    return routePath.split("/").join(path.sep);
+    return path.join(...routePath.split(path.posix.sep));
   });
 
   return flatRoutesUniversal(appDirectory, routePathsForOS);


### PR DESCRIPTION
however that causes remix dev to not pick up new files or file renames. 

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
