### PR TITLE
Added better detection for absolute urls in link component

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -270,6 +270,7 @@
 - lili21
 - lionotm
 - liranm
+- lkwr
 - lordofthecactus
 - lpsinger
 - lswest

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -291,8 +291,7 @@ function usePrefetchBehavior(
 let NavLink = React.forwardRef<HTMLAnchorElement, RemixNavLinkProps>(
   ({ to, prefetch = "none", ...props }, forwardedRef) => {
     let isAbsolute =
-      typeof to === "string" &&
-      (/^[a-z+]+:\/\//i.test(to) || to.startsWith("//"));
+      typeof to === "string" && /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(to);
 
     let href = useHref(to);
     let [shouldPrefetch, prefetchHandlers] = usePrefetchBehavior(
@@ -326,8 +325,7 @@ export { NavLink };
 let Link = React.forwardRef<HTMLAnchorElement, RemixLinkProps>(
   ({ to, prefetch = "none", ...props }, forwardedRef) => {
     let isAbsolute =
-      typeof to === "string" &&
-      (/^[a-z+]+:\/\//i.test(to) || to.startsWith("//"));
+      typeof to === "string" && /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(to);
 
     let href = useHref(to);
     let [shouldPrefetch, prefetchHandlers] = usePrefetchBehavior(


### PR DESCRIPTION
This merge request uses the same improved detection as in remix-run/react-router#9994.