### PR TITLE
chore(templates): update cloudflare templates to support streaming and `defer` in entry.server.tsx

### DIFF
--- a/docs/utils/defer.md
+++ b/docs/utils/defer.md
@@ -42,4 +42,12 @@ export const loader: LoaderFunction = async () => {
 };
 ```
 
+## How to update an older Remix app to use `defer`
+
+- Update all `@remix-run/*` packages to the latest version
+- Update `react` and `react-dom` to the latest version, `18` or above
+- If using TypeScript, update `@types/react` and `@types/react-dom` to the latest version
+- Find the [adapter you're using](https://github.com/remix-run/remix/tree/dev/templates) and update your `app/entry.client.tsx` and `app/entry.server.tsx` files to match what is in the template. This will ensure that your project supports React 18 hydration on the client and streaming responses on the server.
+- You should be ready to use `defer`!
+
 [json]: ./json

--- a/docs/utils/defer.md
+++ b/docs/utils/defer.md
@@ -48,6 +48,7 @@ export const loader: LoaderFunction = async () => {
 - Update `react` and `react-dom` to the latest version, `18` or above
 - If using TypeScript, update `@types/react` and `@types/react-dom` to the latest version
 - Find the [adapter you're using](https://github.com/remix-run/remix/tree/dev/templates) and update your `app/entry.client.tsx` and `app/entry.server.tsx` files to match what is in the template. This will ensure that your project supports React 18 hydration on the client and streaming responses on the server.
+- Check for any updates to the development or build commands in the template's `package.json`
 - You should be ready to use `defer`!
 
 [json]: ./json

--- a/templates/cloudflare-pages/README.md
+++ b/templates/cloudflare-pages/README.md
@@ -11,7 +11,7 @@ You will be utilizing Wrangler for local development to emulate the Cloudflare r
 npm run dev
 ```
 
-Open up [http://127.0.0.1:8788](http://127.0.0.1:8788) and you should be ready to go!
+Open up [http://127.0.0.1:3000](http://127.0.0.1:3000) and you should be ready to go!
 
 ## Deployment
 

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -28,7 +28,7 @@
     "eslint": "^8.27.0",
     "npm-run-all": "^4.1.5",
     "typescript": "^4.8.4",
-    "wrangler": "^2.2.1"
+    "wrangler": "^2.8.1"
   },
   "engines": {
     "node": ">=16.13"

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -15,6 +15,7 @@
     "@remix-run/cloudflare-pages": "*",
     "@remix-run/react": "*",
     "cross-env": "^7.0.3",
+    "isbot": "^3.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -22,8 +23,8 @@
     "@cloudflare/workers-types": "^3.18.0",
     "@remix-run/dev": "*",
     "@remix-run/eslint-config": "*",
-    "@types/react": "^18.0.25",
-    "@types/react-dom": "^18.0.8",
+    "@types/react": "^18.0.27",
+    "@types/react-dom": "^18.0.10",
     "eslint": "^8.27.0",
     "npm-run-all": "^4.1.5",
     "typescript": "^4.8.4",

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -8,7 +8,7 @@
     "dev": "remix build && run-p \"dev:*\"",
     "start": "cross-env NODE_ENV=production npm run wrangler",
     "typecheck": "tsc",
-    "wrangler": "wrangler pages dev ./public --compatibility-date=2023-01-18"
+    "wrangler": "wrangler pages dev ./public --port 3000 --compatibility-date=2023-01-18"
   },
   "dependencies": {
     "@remix-run/cloudflare": "*",

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -8,7 +8,7 @@
     "dev": "remix build && run-p \"dev:*\"",
     "start": "cross-env NODE_ENV=production npm run wrangler",
     "typecheck": "tsc",
-    "wrangler": "wrangler pages dev ./public"
+    "wrangler": "wrangler pages dev ./public --compatibility-date=2023-01-18"
   },
   "dependencies": {
     "@remix-run/cloudflare": "*",

--- a/templates/cloudflare-pages/wrangler.toml
+++ b/templates/cloudflare-pages/wrangler.toml
@@ -1,0 +1,2 @@
+compatibility_date = "2023-01-18"
+compatibility_flags = ["streams_enable_constructors"]

--- a/templates/cloudflare-pages/wrangler.toml
+++ b/templates/cloudflare-pages/wrangler.toml
@@ -1,2 +1,4 @@
+name = "remix-cloudflare-pages"
+
 compatibility_date = "2023-01-18"
 compatibility_flags = ["streams_enable_constructors"]

--- a/templates/cloudflare-workers/README.md
+++ b/templates/cloudflare-workers/README.md
@@ -15,7 +15,7 @@ Both are started with one command:
 npm run dev
 ```
 
-Open up [http://127.0.0.1:8787](http://127.0.0.1:8787) and you should be ready to go!
+Open up [http://127.0.0.1:3000](http://127.0.0.1:3000) and you should be ready to go!
 
 If you want to check the production build, you can stop the dev server and run following commands:
 

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -5,7 +5,7 @@
     "build": "remix build",
     "deploy": "wrangler publish",
     "dev:remix": "remix watch",
-    "dev:miniflare": "cross-env NODE_ENV=development miniflare ./build/index.js --watch",
+    "dev:miniflare": "cross-env NODE_ENV=development miniflare ./build/index.js --watch --port=3000",
     "dev": "remix build && run-p \"dev:*\"",
     "start": "cross-env NODE_ENV=production miniflare ./build/index.js",
     "typecheck": "tsc"

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -15,6 +15,7 @@
     "@remix-run/cloudflare-workers": "*",
     "@remix-run/react": "*",
     "cross-env": "^7.0.3",
+    "isbot": "^3.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -22,13 +23,13 @@
     "@cloudflare/workers-types": "^3.18.0",
     "@remix-run/dev": "*",
     "@remix-run/eslint-config": "*",
-    "@types/react": "^18.0.25",
-    "@types/react-dom": "^18.0.8",
+    "@types/react": "^18.0.27",
+    "@types/react-dom": "^18.0.10",
     "eslint": "^8.27.0",
     "miniflare": "^2.11.0",
     "npm-run-all": "^4.1.5",
     "typescript": "^4.8.4",
-    "wrangler": "^2.2.1"
+    "wrangler": "^2.8.1"
   },
   "engines": {
     "node": ">=16.13"

--- a/templates/cloudflare-workers/wrangler.toml
+++ b/templates/cloudflare-workers/wrangler.toml
@@ -3,7 +3,8 @@ name = "remix-cloudflare-workers"
 workers_dev = true
 main = "./build/index.js"
 # https://developers.cloudflare.com/workers/platform/compatibility-dates
-compatibility_date = "2022-04-05"
+compatibility_date = "2023-01-18"
+compatibility_flags = ["streams_enable_constructors"]
 
 [site]
   bucket = "./public"


### PR DESCRIPTION
The `cloudflare-pages` and `cloudflare-workers` templates had been updated to React 18, but do not currently support streaming responses and `defer`.

This PR:
- Updates those templates to do so. Now a new project initialized with either of those templates should support `defer` out of the box. 
- Updates the docs for `defer` to include steps on how to upgrade an older Remix app to support `defer`, including necessary changes in `entry.client.tsx` and `entry.server.ts` that enable client-side React 18 hydration and streaming responses.
- Run `cloudflare-pages`/`cloudflare-workers` local dev servers on port 3000 to match the default `remix` server behavior 

I pulled the `entry.server.tsx` code from @jacob-ebey's [example project](https://github.com/jacob-ebey/remix-d1-northwind/blob/main/app/entry.server.tsx) which deploys to Cloudflare and tested that the updated `cloudflare-pages`/`cloudflare-workers` templates run successfully for local dev, including with `defer`.

Thanks for all your great work and very excited to begin playing around with `defer`. 