### PR TITLE
docs(tutorials/jokes): Remove unused json import

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -88,6 +88,7 @@
 - craigglennie
 - crismali
 - cysp
+- d4vsanchez
 - dabdine
 - daganomri
 - damiensedgwick

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1965,7 +1965,7 @@ But if there's an error, you can return an object with the error messages and th
 
 ```tsx filename=app/routes/jokes/new.tsx lines=[2-3,6,8-12,14-18,28-32,35-38,40-46,53,64,66-74,77-85,91,93-101,104-112,115-122]
 import type { ActionArgs } from "@remix-run/node";
-import { json, redirect } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
 import { useActionData } from "@remix-run/react";
 
 import { db } from "~/utils/db.server";

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1963,7 +1963,7 @@ But if there's an error, you can return an object with the error messages and th
 
 <summary>app/routes/jokes/new.tsx</summary>
 
-```tsx filename=app/routes/jokes/new.tsx lines=[2-3,6,8-12,14-18,28-32,35-38,40-46,53,64,66-74,77-85,91,93-101,104-112,115-122]
+```tsx filename=app/routes/jokes/new.tsx lines=[3,6,8-12,14-18,28-32,35-38,40-46,53,64,66-74,77-85,91,93-101,104-112,115-122]
 import type { ActionArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 import { useActionData } from "@remix-run/react";


### PR DESCRIPTION
- [x] Docs
- [ ] Tests

This is a simple change. [!4684](https://github.com/remix-run/remix/pull/4684) moved the `badRequest` function from the `/jokes/new.tsx` file to the `/utils/requests.server.ts` file, but left the `json` import unused.

This PR removes the `json` import from the `/jokes/new.tsx` file as it's not needed somewhere in the file.