### PR TITLE
docs(pages/*): punctuation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -204,6 +204,7 @@
 - jiahao-c
 - jimniels
 - jkup
+- jly36963
 - jmasson
 - jmorel88
 - JNaftali

--- a/docs/pages/community.md
+++ b/docs/pages/community.md
@@ -53,7 +53,7 @@ You can also subscribe to [releases on GitHub][releases-on-git-hub].
 
 In addition to the [official][official] [tutorials][tutorials], here are Remix tutorials you can follow to learn Remix:
 
-- [How to Debug Remix loaders and actions in VS Code][how-to-debug-remix-loaders-and-actions-in-vs-code] by [Michael Carter][michael-carter].
+- [How to Debug Remix loaders and actions in VS Code][how-to-debug-remix-loaders-and-actions-in-vs-code] by [Michael Carter][michael-carter]
 - [How to build a Remix website with Sanity.io and live preview][how-to-build-a-remix-website-with-sanity-io-and-live-preview] by [Simeon Griggs][simeon-griggs]
 - [Build A Pet Management System With Remix, Prisma, and Postgres][build-a-pet-management-system-with-remix-prisma-and-postgres]
   by [Austin Gil][austin-gil]

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -14,7 +14,7 @@ This document will familiarize you with our development process as well as how t
 
 ## Contributor License Agreement
 
-All contributors sending Pull Request need to sign the Contributor License Agreement (CLA) that explicitly assigns ownership of the contribution to us.
+All contributors sending a Pull Request need to sign the Contributor License Agreement (CLA) that explicitly assigns ownership of the contribution to us.
 
 When you start a pull request, the remix-cla-bot will prompt you to review the CLA and sign it by adding your name to [contributors.yml][contributorsyaml]
 
@@ -25,7 +25,7 @@ When you start a pull request, the remix-cla-bot will prompt you to review the C
 This document refers to contributors with the following roles:
 
 - **Admins**: GitHub organization team with admin rights, they set and manage the Roadmap.
-- **Collaborators**: GitHub organization team with write access. They manage issues, prs, discussion, etc.
+- **Collaborators**: GitHub organization team with write access. They manage issues, PRs, discussion, etc.
 - **Contributors**: you!
 
 ---
@@ -46,7 +46,7 @@ If you have an idea for a new feature, please don't send a Pull Request, but fol
 4. Owners create an **RFC** from the Proposal and development can begin.
 5. Pairing is highly encouraged, particularly at the start.
 
-### Bug Fix Pull Requests
+### Bug-Fix Pull Requests
 
 If you think you've found a bug we'd love a PR that fixes it! Please follow these guidelines:
 
@@ -54,8 +54,8 @@ If you think you've found a bug we'd love a PR that fixes it! Please follow thes
    - It's ideal if the first commit is a failing test followed by the changes to the code that fix it.
    - This is not strictly enforced but very appreciated!
 2. The Admins will review open bugfix PRs as part of Roadmap Planning.
-   - Simple bugfixes will be merged on the spot
-   - Others will be added to the Roadmap and assigned an Owner to review the work and get it over the finish line
+   - Simple bugfixes will be merged on the spot.
+   - Others will be added to the Roadmap and assigned an Owner to review the work and get it over the finish line.
 
 Bug fix PRs without a test case might be closed immediately (some things are hard to test, we’ll use discretion here)
 
@@ -67,7 +67,7 @@ If you think you've found a bug but don't have the time to send a PR, please fol
 
    - [https://remix.new][https-remix-new] makes this really easy
 
-2. If this is not possible (related to some hosting setup, etc.) please create a GitHub repo that we can run with clear instructions in the README to observe the bug
+2. If this is not possible (related to some hosting setup, etc.) please create a GitHub repo that we can run with clear instructions in the README to observe the bug.
 
 3. Open an issue and link to the reproduction.
 
@@ -75,38 +75,38 @@ Bug reports without a reproduction will be immediately closed asking for a repro
 
 ### Roadmap Planning Meeting
 
-You can always check in on Remix development in our live streamed planning meeting:
+You can always check in on Remix development in our live-streamed planning meeting:
 
 - The Remix Admin team will meet weekly to report progress to the community and add Proposals and Verified Bugs to the Roadmap.
-  - Unanimous agreement among the Remix Admin is required to add a Proposal to the Roadmap
-  - Proposals are not “rejected”, only “accepted” onto the Roadmap
-  - Contributors can continue to up-vote and comment on Proposals, they will bubble up for a future review if it’s getting new activity
-  - The Remix Admin team may lock Proposals for any reason
-- The meeting will be live streamed on the [Remix YouTube channel][youtube]
-  - Everyone is invited to the [Discord][discord] #roadmap-livestream-chat while the meeting is in progress
-  - Remix Collaborators are invited to attend
+  - Unanimous agreement among the Remix Admin is required to add a Proposal to the Roadmap.
+  - Proposals are not “rejected”, only “accepted” onto the Roadmap.
+  - Contributors can continue to up-vote and comment on Proposals, they will bubble up for a future review if it’s getting new activity.
+  - The Remix Admin team may lock Proposals for any reason.
+- The meeting will be live streamed on the [Remix YouTube channel][youtube].
+  - Everyone is invited to the [Discord][discord] #roadmap-livestream-chat while the meeting is in progress.
+  - Remix Collaborators are invited to attend.
 
 ### Issue Tracking
 
 If a Roadmap Issue is expected to be large (involving multiple tasks, authors, PRs, etc.) a temporary project board will be created by the Admin team.
 
-- The original issue will remain on the Roadmap project to see general progress
-- The sub-tasks will be tracked on the temporary project
-- When the work is complete, the temporary project will be archived
-- The Owner is responsible for populating the sub-project with issues and splitting the work up into shippable chunks of work
-- Build / feature flags are encouraged over long running branches
+- The original issue will remain on the Roadmap project to see general progress.
+- The subtasks will be tracked on the temporary project.
+- When the work is complete, the temporary project will be archived.
+- The Owner is responsible for populating the sub-project with issues and splitting the work up into shippable chunks of work.
+- Build / feature flags are encouraged over long-running branches.
 
 ### RFCs
 
-- All Issues that are planned must have an RFC posted in the Official RFCs Discussion category before the Issue moves from _Planned_ to _In Progress_
-- Some Proposals may already be a sufficient RFC and can simply be moved to the Official RFCs Discussion category
-- Once the RFC is posted, development can begin, though Owners are expected to consider the community's feedback to alter their direction when needed
+- All Issues that are planned must have an RFC posted in the Official RFCs Discussion category before the Issue moves from _Planned_ to _In Progress_.
+- Some Proposals may already be a sufficient RFC and can simply be moved to the Official RFCs Discussion category.
+- Once the RFC is posted, development can begin, though Owners are expected to consider the community's feedback to alter their direction when needed.
 
 ### Support for Owners
 
-- Owners will be added to the `#collaborators` private channel on [discord][discord] to get help with architecture and implementation. This channel is private to help keep noise to a minimum so Admins don't miss messages and owner's can get unblocked. Owners can also discuss these questions in any channel or anywhere!
-- Admins will actively work with owners to ensure their issues and projects are organized (correct status, links to related issues, etc.), documented, and moving forward
-- An issue's Owner may be reassigned if progress is stagnating
+- Owners will be added to the `#collaborators` private channel on [discord][discord] to get help with architecture and implementation. This channel is private to help keep noise to a minimum so Admins don't miss messages and owners can get unblocked. Owners can also discuss these questions in any channel or anywhere!
+- Admins will actively work with owners to ensure their issues and projects are organized (correct status, links to related issues, etc.), documented, and moving forward.
+- An issue's Owner may be reassigned if progress is stagnating.
 
 ### Weekly Roadmap Reviews
 
@@ -122,14 +122,14 @@ To help keep the repositories clean and organized, Collaborators will take the f
 ### Issues Tab
 
 - Bug reports without a reproduction will be immediately closed asking for a reproduction.
-- Issues that should be proposals will be converted to a Proposal
-- Questions will be converted to a **Q\&A Discussion**
+- Issues that should be proposals will be converted to a Proposal.
+- Questions will be converted to a **Q\&A Discussion**.
 - Issues with valid reproduction will be labeled as **Verified Bugs** and added to the Roadmap by the Admins in the Roadmap Planning Meeting.
 
 ### Pull Requests Tab
 
-- Features that did not go through the **Development Process** will be immediately closed and asked to open a discussion instead
-- Bug fix PRs without a test case might be closed immediately asking for a test (some things are hard to test, Collaborators will use discretion here)
+- Features that did not go through the **Development Process** will be immediately closed and asked to open a discussion instead.
+- Bug fix PRs without a test case might be closed immediately asking for a test. (Some things are hard to test, Collaborators will use discretion here.)
 
 ---
 
@@ -139,9 +139,9 @@ Before you can contribute to the codebase, you will need to fork the repo. This 
 
 The following steps will get you setup to contribute changes to this repo:
 
-1. Fork the repo (click the <kbd>Fork</kbd> button at the top right of [this page][this-page])
+1. Fork the repo (click the <kbd>Fork</kbd> button at the top right of [this page][this-page]).
 
-2. Clone your fork locally
+2. Clone your fork locally.
 
    ```bash
    # in a terminal, cd to parent directory where you want your clone to be, then
@@ -154,16 +154,16 @@ The following steps will get you setup to contribute changes to this repo:
 
 3. Install dependencies by running `yarn`. Remix uses [Yarn (version 1)][yarn-version-1], so you should too. If you install using `npm`, unnecessary `package-lock.json` files will be generated.
 
-4. Install Playwright to be able to run tests properly by running `npx playwright install`, or [use the Visual Studio Code plugin][vscode-playwright]
+4. Install Playwright to be able to run tests properly by running `npx playwright install`, or [use the Visual Studio Code plugin][vscode-playwright].
 
-5. Verify you've got everything set up for local development by running `yarn test`
+5. Verify you've got everything set up for local development by running `yarn test`.
 
 ### Branches
 
 **Important:** When creating the PR in GitHub, make sure that you set the base to the correct branch.
 
-- **`dev`** is for changes to code
-- **`main`**: is for changes to documentation and some templates
+- **`dev`** is for changes to code.
+- **`main`**: is for changes to documentation and some templates.
 
 You can set the base in GitHub when authoring the PR with the dropdown below the "Compare changes" heading:
 
@@ -173,7 +173,7 @@ You can set the base in GitHub when authoring the PR with the dropdown below the
 
 We use a mix of `jest` and `playwright` for our testing in this project. We have a suite of integration tests in the integration folder and packages have their own jest configuration, which are then referenced by the primary jest config in the root of the project.
 
-The integration tests, and the primary tests can be run in parallel using `npm-run-all` to make the tests run as quickly and efficiently as possible. To run these two sets of tests independently you'll need to run the individual script:
+The integration tests and the primary tests can be run in parallel using `npm-run-all` to make the tests run as quickly and efficiently as possible. To run these two sets of tests independently you'll need to run the individual script:
 
 - `yarn test:primary`
 - `yarn test:integration`
@@ -239,7 +239,7 @@ There may be other branches for various features and experimentation, but all of
 
 ## How the heck do nightly releases work?
 
-Nightly releases will run the action files from the `main` branch as scheduled workflows will always use the latest commit to the default branch, signified by [this comment on the nightly action file][nightly-action-comment] and the explicit branch appended to the reusable workflows in the [postrelease action][postrelease-action], however they checkout the `dev` branch during their set up as that's where we want our nightly releases to be cut from. From there, we check if the git sha is the same and only cut a new nightly if something has changed.
+Nightly releases will run the action files from the `main` branch as scheduled workflows will always use the latest commit to the default branch, signified by [this comment on the nightly action file][nightly-action-comment] and the explicit branch appended to the reusable workflows in the [postrelease action][postrelease-action], however they checkout the `dev` branch during their set up as that's where we want our nightly releases to be cut from. From there, we check if the git SHA is the same and only cut a new nightly if something has changed.
 
 ## End to end testing
 

--- a/docs/pages/faq.md
+++ b/docs/pages/faq.md
@@ -7,7 +7,7 @@ description: Frequently Asked Questions about Remix
 
 ## How can I have a parent route loader validate the user and protect all child routes?
 
-You can't 😅. During a client side transition, to make your app as speedy as possible, Remix will call all of your loaders _in parallel_, in separate fetch requests. Each one of them needs to have its own authentication check.
+You can't 😅. During a client-side transition, to make your app as speedy as possible, Remix will call all of your loaders _in parallel_, in separate fetch requests. Each one of them needs to have its own authentication check.
 
 This is probably not different than what you were doing before Remix, it might just be more obvious now. Outside of Remix, when you make multiple fetches to your "API Routes", each of those endpoints needs to validate the user session. In other words, Remix route loaders are their own "API Route" and must be treated as such.
 
@@ -168,7 +168,7 @@ export async function action({ request }: ActionArgs) {
 
 Using the same input name and `formData.getAll()` covers most cases for wanting to submit structured data in your forms.
 
-If you still want to submit nested structures as well, you can use non-standard form field naming conventions and the [`query-string`][query-string] package from npm:
+If you still want to submit nested structures as well, you can use non-standard form-field naming conventions and the [`query-string`][query-string] package from npm:
 
 ```tsx
 <>

--- a/docs/pages/gotchas.md
+++ b/docs/pages/gotchas.md
@@ -4,7 +4,7 @@ title: Gotchas
 
 # Gotchas
 
-As we've built Remix, we've been laser focused on production results and scalability for your users and team working in it. Because of this, some developer experience and ecosystem compatibility issues exist that we haven't smoothed over yet.
+As we've built Remix, we've been laser focused on production results and scalability for your users and team working in it. Because of this, some developer-experience and ecosystem-compatibility issues exist that we haven't smoothed over yet.
 
 This document should help you get over these bumps.
 
@@ -93,7 +93,7 @@ export async function action() {
 
 Remix uses "tree shaking" to remove server code from browser bundles. Anything inside of Route module `loader`, `action`, and `headers` exports will be removed. It's a great approach but suffers from ecosystem compatibility.
 
-When you import a third party module, Remix checks the `package.json` of that package for `"sideEffects": false`. If that is configured, Remix knows it can safely remove the code from the client bundles. Without it, the imports remain because code may depend on the module's side effects (like setting global polyfills, etc.).
+When you import a third-party module, Remix checks the `package.json` of that package for `"sideEffects": false`. If that is configured, Remix knows it can safely remove the code from the client bundles. Without it, the imports remain because code may depend on the module's side effects (like setting global polyfills, etc.).
 
 ## Importing ESM Packages
 
@@ -106,7 +106,7 @@ Instead change the require of /app/project/node_modules/dot-prop/index.js in /ap
 
 To fix it, add the ESM package to the `serverDependenciesToBundle` option in your `remix.config.js` file.
 
-In our case here we're using the `dot-prop` package, so we would do it like this:
+In our case here, we're using the `dot-prop` package, so we would do it like this:
 
 ```js filename=remix.config.js
 /** @type {import('@remix-run/dev').AppConfig} */

--- a/docs/pages/philosophy.md
+++ b/docs/pages/philosophy.md
@@ -5,7 +5,7 @@ order: 1
 
 # Philosophy
 
-We've worked on a lot of different types of websites: static sites for credit card companies, social media platforms, learning management systems, content management systems, and e-commerce to name a few. We've also trained hundreds of development teams with our training company, [React Training][react-training]. These teams build websites we all use regularly. Based on our personal development experience and our client's products, we built Remix to be able to handle the dynamic nature of both the front end and the back end of a web project.
+We've worked on a lot of different types of websites: static sites for credit card companies, social media platforms, learning management systems, content management systems, and e-commerce to name a few. We've also trained hundreds of development teams with our training company, [React Training][react-training]. These teams build websites we all use regularly. Based on our personal development experience and our clients' products, we built Remix to be able to handle the dynamic nature of both the front end and the back end of a web project.
 
 The Remix philosophy can be summed up in four points:
 
@@ -22,7 +22,7 @@ With today's web infrastructure you don't need static files to make your server 
 
 There are a lot of ways Remix helps you send less stuff over the network and we hope to talk about all of them, but for now here's one: fetching a list of records.
 
-Consider [the Github Gist API][the-github-gist-api]. This payload is 75kb unpacked and 12kb over the network compressed. If you fetch it in the browser you make the user download all of it. It might look like this:
+Consider [the Github Gist API][the-github-gist-api]. This payload is 75kb unpacked and 12kb over the network compressed. If you fetch it in the browser, you make the user download all of it. It might look like this:
 
 ```tsx
 export default function Gists() {

--- a/docs/pages/stacks.md
+++ b/docs/pages/stacks.md
@@ -6,7 +6,7 @@ order: 3
 
 # Remix Stacks
 
-Remix Stacks is a feature of the Remix CLI that allows you to generate a Remix project quickly and easily. There are several built-in and official stacks that are full blown applications. You can also make your own (read more below).
+Remix Stacks is a feature of the Remix CLI that allows you to generate a Remix project quickly and easily. There are several built-in and official stacks that are full-blown applications. You can also make your own (read more below).
 
 [Read the feature announcement blog post][read-the-feature-announcement-blog-post] and [watch Remix Stacks videos on YouTube][watch-remix-stacks-videos-on-you-tube].
 
@@ -38,7 +38,7 @@ npx create-remix@latest --template my-username/my-repo
 
 Custom stacks give an enormous amount of power and flexibility, and we hope you create your own that suites the preferences of you and your organization (feel free to fork ours!).
 
-<docs-success>Yes, we do recommend that you name your own stack after a music sub-genre (not "rock" but "indie"!). In the future, we will have a page where you can list your open source stacks for others to learn and discover. For now, please add the <a href="https://github.com/topics/remix-stack"><code>remix-stack</code></a> tag to your repo!</docs-success>
+<docs-success>Yes, we do recommend that you name your own stack after a music sub-genre (not "rock" but "indie"!). In the future, we will have a page where you can list your open-source stacks for others to learn and discover. For now, please add the <a href="https://github.com/topics/remix-stack"><code>remix-stack</code></a> tag to your repo!</docs-success>
 
 ### `--template`
 

--- a/docs/pages/technical-explanation.md
+++ b/docs/pages/technical-explanation.md
@@ -8,7 +8,7 @@ order: 2
 This document hopes to answer the question: "What _is_ Remix?" Remix is four things:
 
 1. A compiler
-2. A server side HTTP handler
+2. A server-side HTTP handler
 3. A server framework
 4. A browser framework
 
@@ -20,9 +20,9 @@ We often describe Remix as "a compiler for React Router" because everything abou
 
 Everything in Remix starts with the compiler: `remix build`. Using [esbuild][esbuild], this creates a few things:
 
-1. A server HTTP handler, usually in `server/build/index.js` (it's configurable) that includes all routes and modules together to be able to render on the server and handle any other server side requests for resources.
-2. A browser build, usually in `public/build/*`. This includes automatic code splitting by route, fingerprinted asset imports (like CSS and images), etc. Anything needed to run an application in the browser
-3. An asset manifest. Both the client and the server use this manifest to know the entire dependency graph. This is useful for preloading resources in the initial server render as well as prefetching them for client side transitions. This is how Remix is able to eliminate the render+fetch waterfalls so common in web apps today.
+1. A server HTTP handler, usually in `server/build/index.js` (it's configurable) that includes all routes and modules together to be able to render on the server and handle any other server-side requests for resources.
+2. A browser build, usually in `public/build/*`. This includes automatic code splitting by route, fingerprinted asset imports (like CSS and images), etc. Anything needed to run an application in the browser.
+3. An asset manifest. Both the client and the server use this manifest to know the entire dependency graph. This is useful for preloading resources in the initial server render as well as prefetching them for client-side transitions. This is how Remix is able to eliminate the render+fetch waterfalls so common in web apps today.
 
 With these build artifacts, an application can be deployed to any hosting service that runs JavaScript.
 
@@ -73,11 +73,11 @@ Additionally, if Remix doesn't have an adapter for your server already, you can 
 
 ## Server Framework
 
-If you're familiar with server side MVC web frameworks like Rails and Laravel, Remix is the View and Controller, but it leaves the Model up to you. There are a lot of great databases, ORMs, mailers, etc. in the JavaScript ecosystem to fill that space. Remix also has helpers around the Fetch API for cookie and session management.
+If you're familiar with server-side MVC web frameworks like Rails and Laravel, Remix is the View and Controller, but it leaves the Model up to you. There are a lot of great databases, ORMs, mailers, etc. in the JavaScript ecosystem to fill that space. Remix also has helpers around the Fetch API for cookie and session management.
 
 Instead of having a split between View and Controller, Remix Route modules take on both responsibilities.
 
-Most server side frameworks are "model focused". A controller manages _multiple URLs_ for a single model.
+Most server-side frameworks are "model focused". A controller manages _multiple URLs_ for a single model.
 
 Remix is _UI focused_. Routes can handle an entire URL or just a segment of the URL. When a route maps to just a segment, the nested URL segments become nested layouts in the UI. In this way, each layout (view) can be its own controller and then Remix will aggregate the data and components to build the complete UI.
 
@@ -128,7 +128,7 @@ export default function Projects() {
         <ErrorMessages errors={actionData.errors} />
       ) : null}
 
-      {/* outlets render the nested child routes 
+      {/* outlets render the nested child routes
           that match the URL deeper than this route,
           allowing each layout to co-locate the UI and
           controller code in the same file */}
@@ -138,23 +138,23 @@ export default function Projects() {
 }
 ```
 
-You can actually use Remix as just a server side framework without using any browser JavaScript at all. The route conventions for data loading with `loader`, mutations with `action` and HTML forms, and components that render at URLs, can provide the core feature set of a lot of web projects.
+You can actually use Remix as just a server-side framework without using any browser JavaScript at all. The route conventions for data loading with `loader`, mutations with `action` and HTML forms, and components that render at URLs, can provide the core feature set of a lot of web projects.
 
 In this way, **Remix scales down**. Not every page in your application needs a bunch of JavaScript in the browser and not every user interaction requires any extra flair than the browser's default behaviors. In Remix you can build it the simple way first, and then scale up without changing the fundamental model. Additionally, the majority of the app works before JavaScript loads in the browser, which makes Remix apps resilient to choppy network conditions by design.
 
-If you're not familiar with traditional back end web frameworks, you can think of Remix routes as React components that are already their own API route and already know how to load and submit data to themselves on the server.
+If you're not familiar with traditional back-end web frameworks, you can think of Remix routes as React components that are already their own API route and already know how to load and submit data to themselves on the server.
 
 ## Browser Framework
 
 Once Remix has served the document to the browser, it "hydrates" the page with the browser build's JavaScript modules. This is where we talk a lot about Remix "emulating the browser".
 
-When the user clicks a link, instead of making a round trip to the server for the entire document and all of the assets, Remix simply fetches the data for the next page and updates the UI. This has many performance benefits over making a full document request:
+When the user clicks a link, instead of making a round trip to the server for the entire document and all of the assets, Remix simply fetches the data for the next page and updates the UI. This has many performance benefits over making a full-document request:
 
 1. Assets don't need to be re-downloaded (or pulled from cache)
 2. Assets don't need to be parsed by the browser again
 3. The data fetched is much smaller than the entire document (sometimes orders of magnitude)
 
-Remix also has some built in optimizations for client side navigation. It knows which layouts will persist between the two URLs, so it only fetches the data for the ones that are changing. A full document request would require all data to be fetched on the server, wasting resources on your back end and slowing down your app.
+Remix also has some built in optimizations for client-side navigation. It knows which layouts will persist between the two URLs, so it only fetches the data for the ones that are changing. A full document request would require all data to be fetched on the server, wasting resources on your back end and slowing down your app.
 
 This approach also has UX benefits like not resetting the scroll position of a sidebar nav and allowing you to move focus to something that makes more sense than the top of the document.
 
@@ -165,7 +165,7 @@ Remix then provides client side APIs so you can create rich user experiences wit
 Taking our route module from before, here are a few small, but useful UX improvements to the form that you can only do with JavaScript in the browser:
 
 1. Disable the button when the form is being submitted
-2. Focus the input when server side form validation fails
+2. Focus the input when server-side form validation fails
 3. Animate in the error messages
 
 ```tsx nocopy lines=[4-6,8-12,23-26,30-32]
@@ -213,9 +213,9 @@ What's most interesting about this code sample is that it is **only additive**. 
 
 Because Remix reaches into the controller level of the backend, it can do this seamlessly.
 
-And while it doesn't reach as far back into the stack as server side frameworks like Rails and Laravel, it does reach way farther up the stack into the browser to make the transition from the back end to the front end seamless.
+And while it doesn't reach as far back into the stack as server-side frameworks like Rails and Laravel, it does reach way farther up the stack into the browser to make the transition from the back end to the front end seamless.
 
-For example. Building a plain HTML form and server side handler in a back end heavy web framework is just as easy to do as it is in Remix. But as soon as you want to cross over into an experience with animated validation messages, focus management, and pending UI, it requires a fundamental change in the code. Typically people build an API route and then bring in a splash of client side JavaScript to connect the two. With Remix you simply add some code around the existing "server side view" without changing how it works fundamentally.
+For example. Building a plain HTML form and server-side handler in a back-end heavy web framework is just as easy to do as it is in Remix. But as soon as you want to cross over into an experience with animated validation messages, focus management, and pending UI, it requires a fundamental change in the code. Typically people build an API route and then bring in a splash of client-side JavaScript to connect the two. With Remix you simply add some code around the existing "server side view" without changing how it works fundamentally.
 
 We borrowed an old term and called this Progressive Enhancement in Remix. Start small with a plain HTML form (Remix scales down) and then scale the UI up when you have the time and ambition.
 


### PR DESCRIPTION
Simple docs changes.
PR on main, let me know if that is wrong. ([ref](https://remix.run/docs/en/v1/pages/contributing#branches))

Sorry for being nitpicky, having a copy-editor mindset makes me read more attentively 😂 

(If there is linting on the markdown files, CI might fail. I normally use Deno for formatting, and I turn it off when I'm contributing to other codebases. I'll set up the dev environment properly and fix it if that ends up being the case.)