### PR TITLE
fix(remix-dev/compiler): fix `getPackageDependenciesRecursive`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -530,6 +530,4 @@
 - iamzee
 - TimonVS
 - yudai-nkt
-- mitchelldirt
-- krolebord
 - nimaa77

--- a/contributors.yml
+++ b/contributors.yml
@@ -530,3 +530,6 @@
 - iamzee
 - TimonVS
 - yudai-nkt
+- mitchelldirt
+- krolebord
+- nimaa77

--- a/packages/remix-dev/dependencies.ts
+++ b/packages/remix-dev/dependencies.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import resolvePkg from "resolve-package-path";
 
 import type { RemixConfig } from "./config";
 
@@ -47,14 +48,10 @@ function getPackageDependenciesRecursive(
 ): void {
   visitedPackages.add(pkg);
 
-  let pkgPath = require.resolve(pkg);
-  let lastIndexOfPackageName = pkgPath.lastIndexOf(pkg);
-  if (lastIndexOfPackageName !== -1) {
-    pkgPath = pkgPath.substring(0, lastIndexOfPackageName);
-  }
-  let pkgJson = path.join(pkgPath, "package.json");
-  if (!fs.existsSync(pkgJson)) {
-    console.log(pkgJson, `does not exist`);
+  let pkgJson = resolvePkg(pkg, ".");
+
+  if (!pkgJson) {
+    console.log(`Could not find package.json for ${pkg}`);
     return;
   }
 

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -64,6 +64,7 @@
     "recast": "^0.21.5",
     "remark-frontmatter": "4.0.1",
     "remark-mdx-frontmatter": "^1.0.1",
+    "resolve-package-path": "^4.0.3",
     "semver": "^7.3.7",
     "sort-package-json": "^1.55.0",
     "tar-fs": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10718,6 +10718,18 @@ path-parse@^1.0.7:
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-root-regex@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz#bfccdc8df5b12dc52c8b43ec38d18d72c04ba96d"
+  integrity sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==
+
+path-root@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
+  integrity sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==
+  dependencies:
+    path-root-regex "^0.1.0"
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
@@ -11620,6 +11632,13 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve-package-path@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz#31dab6897236ea6613c72b83658d88898a9040aa"
+  integrity sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==
+  dependencies:
+    path-root "^0.1.1"
 
 resolve.exports@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
### Description

turns out `getDependenciesToBundle` has an issue that it can not find the package json of the passed dependency so it will skip the dependencies of that package,

that's why when you call it with a dependency you will get `my-remix-app/node_modules/package.json does not exist`

the logic of the function has some issues, if we want to get the package file

```js
  // packages/remix-dev/compiler/dependencies.ts
  
  let pkgPath = require.resolve(pkg);
  let lastIndexOfPackageName = pkgPath.lastIndexOf(pkg);
  if (lastIndexOfPackageName !== -1) {
    pkgPath = pkgPath.substring(0, lastIndexOfPackageName);
  }
  let pkgJson = path.join(pkgPath, "package.json");
  ```
  
`pkgPath.lastIndexOf(pkg)` gives us the index of the first character of the passed pkg name, but what developer intended to to was to get the last index of the pkg name so at next line when we take the substring from the pkgPath and pkgPath contains the package name as well

```js
// expected
"my-remix-app/node_modules/mdx-bundler"

// what we got
"my-remix-app/node_modules"
```

the fix for this simply would be:

```
 if (lastIndexOfPackageName !== -1) {
    pkgPath = pkgPath.substring(0, lastIndexOfPackageName + pkg.length);
  }
```

but changing this alone will not solve the issue, `require.resolve(pkg)` some times will throw

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in my-remix-app/node_modules/@babel/runtime/package.json
```

and all that we want to do is to get the package path, so we can use this package called  `resolve-package-path` to get the package path


playground link: https://stackblitz.com/edit/node-ddywpz?file=remix.config.js

- [ ] Docs
- [X] Tests

Testing Strategy:

This test covers this code: `integration/compiler-test.ts`

the way it works is by adding a new package to fixtures and this new package has another ESM package as its dependency so when the `getPackageDependenciesRecursive` reads the package.json it should the dependency 

this is the script that will run the tests `yarn test:integration integration/compiler-test.ts`

Closes: #5309