### PR TITLE
fix: use `path.normalize` to convert POSIX paths to OS-specific paths

### DIFF
--- a/.changeset/slimy-insects-greet.md
+++ b/.changeset/slimy-insects-greet.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fixed issue with `v2_routeConvention` on Unix-like systems

--- a/contributors.yml
+++ b/contributors.yml
@@ -165,6 +165,7 @@
 - gunners6518
 - gyx1000
 - hadizz
+- haines
 - hardingmatt
 - helderburato
 - HenryVogt

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -602,7 +602,7 @@ describe("flatRoutes", () => {
 
     let files: [string, Omit<ConfigRoute, "file">][] = testFiles.map(
       ([file, route]) => {
-        let filepath = file.split("/").join(path.sep);
+        let filepath = path.normalize(file);
         return [filepath, { ...route, file: filepath }];
       }
     );

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -28,7 +28,7 @@ export function flatRoutes(
   // fast-glob will return posix paths even on windows
   // convert posix to os specific paths
   let routePathsForOS = routePaths.map((routePath) => {
-    return path.join(...routePath.split(path.posix.sep));
+    return path.normalize(routePath);
   });
 
   return flatRoutesUniversal(appDirectory, routePathsForOS);


### PR DESCRIPTION
Closes: #5322

(from #5324): The build currently breaks when loading routes

``` 
ENOENT: no such file or directory, open '<root>/app/outes/<route file>'
```

Note it is trying to load from `outes` not `routes`!

The bug was introduced in https://github.com/remix-run/remix/pull/5266. By splitting and rejoining the paths, it drops the leading `/` on Unix-like systems, converting `/Users/me/...` to  `Users/me/...`. However `appDirectory` still has a leading `/` so removing directory prefixes with `slice` drops one too many characters.

This PR resolves the issue by using [`path.normalize`](https://nodejs.org/docs/latest-v14.x/api/path.html#path_path_normalize_path) to covert `/` to `\` on Windows, rather than splitting and rejoining the paths.

- [x] Tests

Testing Strategy:

This test covers this code (sort of... the test mirrors the production code so does not expose the bug): https://github.com/remix-run/remix/blob/ebfa6458af3f1e4ccf137200da05ac8f31df5a50/packages/remix-dev/__tests__/flat-routes-test.ts#L141