### PR TITLE
ci(comment) use current branch when gathering PRs for stable release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           git config --local user.email "hello@remix.run"
           git config --local user.name "Remix Run Bot"
-          git checkout -b nightly/${{steps.version.outputs.NEXT_VERSION}}
+          git checkout -b nightly/${{ steps.version.outputs.NEXT_VERSION }}
           yarn run version ${{steps.version.outputs.NEXT_VERSION}} --skip-prompt
           git push origin --tags
 
@@ -94,7 +94,7 @@ jobs:
     needs: [nightly]
     name: 📝 Comment on related issues and pull requests
     if: github.repository == 'remix-run/remix' && needs.nightly.outputs.NEXT_VERSION
-    uses: remix-run/remix/.github/workflows/release-comments.yml@main
+    uses: ./.github/workflows/release-comments.yml
     with:
       ref: "refs/tags/v${{ needs.nightly.outputs.NEXT_VERSION }}"
       package_version_to_follow: "remix"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -97,7 +97,8 @@ jobs:
     uses: remix-run/remix/.github/workflows/release-comments.yml@main
     with:
       ref: "refs/tags/v${{ needs.nightly.outputs.NEXT_VERSION }}"
-      packageVersionToFollow: "remix"
+      package_version_to_follow: "remix"
+      release_branch: "dev"
 
   deployments:
     needs: [nightly]

--- a/.github/workflows/release-comments.yml
+++ b/.github/workflows/release-comments.yml
@@ -6,7 +6,10 @@ on:
       ref:
         required: true
         type: string
-      packageVersionToFollow:
+      package_version_to_follow:
+        required: true
+        type: string
+      release_branch:
         required: true
         type: string
 
@@ -38,5 +41,5 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.ref }}
           DEFAULT_BRANCH: "main"
-          NIGHTLY_BRANCH: "dev"
-          PACKAGE_VERSION_TO_FOLLOW: ${{ inputs.packageVersionToFollow }}
+          RELEASE_BRANCH: ${{ inputs.release_branch }}
+          PACKAGE_VERSION_TO_FOLLOW: ${{ inputs.package_version_to_follow }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       !contains(github.ref, 'nightly')
     runs-on: ubuntu-latest
     outputs:
-      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
+      published_packages: ${{ steps.changesets.outputs.published_packages }}
       published: ${{ steps.changesets.outputs.published }}
     steps:
       - name: 🛑 Cancel Previous Runs
@@ -65,13 +65,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.NIGHTLY_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  findPackageVersion:
+  find_package_version:
     name: 🦋 Find Package
     needs: [release]
     runs-on: ubuntu-latest
     if: github.repository == 'remix-run/remix' && needs.release.outputs.published == 'true'
     outputs:
-      packageVersion: ${{ steps.findPackageVersion.outputs.packageVersion }}
+      package_version: ${{ steps.find_package_version.outputs.package_version }}
     steps:
       - name: 🛑 Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -85,27 +85,28 @@ jobs:
           node-version: 16
           cache: "npm"
 
-      - id: findPackageVersion
+      - id: find_package_version
         run: |
-          packageVersion=$(node ./scripts/release/find-release-from-changeset.js)
-          echo "packageVersion=${packageVersion}" >> $GITHUB_OUTPUT
+          package_version=$(node ./scripts/release/find-release-from-changeset.js)
+          echo "package_version=${package_version}" >> $GITHUB_OUTPUT
         env:
-          packageVersionToFollow: "remix"
-          publishedPackages: ${{ needs.release.outputs.publishedPackages }}
+          package_version_to_follow: "remix"
+          published_packages: ${{ needs.release.outputs.published_packages }}
 
   comment:
     name: 📝 Comment on related issues and pull requests
-    if: github.repository == 'remix-run/remix' && needs.findPackageVersion.outputs.packageVersion != ''
-    needs: [release, findPackageVersion]
+    if: github.repository == 'remix-run/remix' && needs.find_package_version.outputs.packageVersion != ''
+    needs: [release, find_package_version]
     uses: ./.github/workflows/release-comments.yml
     with:
-      ref: refs/tags/remix@${{ needs.findPackageVersion.outputs.packageVersion }}
-      packageVersionToFollow: "remix"
+      ref: refs/tags/remix@${{ needs.find_package_version.outputs.packageVersion }}
+      package_version_to_follow: "remix"
+      release_branch: ${{ github.ref_name }}
 
   deployments:
     name: 🚀 Deployment Tests
     if: github.repository == 'remix-run/remix'
-    needs: [release, findPackageVersion]
+    needs: [release, find_package_version]
     uses: ./.github/workflows/deployments.yml
     secrets:
       TEST_AWS_ACCESS_KEY_ID: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
@@ -124,7 +125,7 @@ jobs:
   stacks:
     name: 🥞 Remix Stacks Test
     if: github.repository == 'remix-run/remix'
-    needs: [release, findPackageVersion]
+    needs: [release, find_package_version]
     uses: ./.github/workflows/stacks.yml
     with:
-      version: ${{ needs.findPackageVersion.outputs.packageVersion }}
+      version: ${{ needs.find_package_version.outputs.package_version }}

--- a/scripts/release/comment.ts
+++ b/scripts/release/comment.ts
@@ -5,6 +5,7 @@ import {
   PR_FILES_STARTS_WITH,
   IS_STABLE_RELEASE,
   AWAITING_RELEASE_LABEL,
+  DRY_RUN,
 } from "./constants";
 import {
   closeIssue,
@@ -41,19 +42,21 @@ async function commentOnIssuesAndPrsAboutRelease() {
   for (let pr of merged) {
     console.log(`commenting on pr ${getGitHubUrl("pull", pr.number)}`);
 
-    promises.push(
-      commentOnPullRequest({
-        owner: OWNER,
-        repo: REPO,
-        pr: pr.number,
-        version: VERSION,
-      })
-    );
+    if (!DRY_RUN) {
+      promises.push(
+        commentOnPullRequest({
+          owner: OWNER,
+          repo: REPO,
+          pr: pr.number,
+          version: VERSION,
+        })
+      );
+    }
 
     let prLabels = pr.labels.map((label) => label.name);
     let prIsAwaitingRelease = prLabels.includes(AWAITING_RELEASE_LABEL);
 
-    if (IS_STABLE_RELEASE && prIsAwaitingRelease) {
+    if (IS_STABLE_RELEASE && prIsAwaitingRelease && !DRY_RUN) {
       promises.push(
         removeLabel({ owner: OWNER, repo: REPO, issue: pr.number })
       );
@@ -75,20 +78,24 @@ async function commentOnIssuesAndPrsAboutRelease() {
       let issueUrl = getGitHubUrl("issue", issue.number);
       console.log(`commenting on issue ${issueUrl}`);
 
-      promises.push(
-        commentOnIssue({
-          owner: OWNER,
-          repo: REPO,
-          issue: issue.number,
-          version: VERSION,
-        })
-      );
+      if (!DRY_RUN) {
+        promises.push(
+          commentOnIssue({
+            owner: OWNER,
+            repo: REPO,
+            issue: issue.number,
+            version: VERSION,
+          })
+        );
+      }
 
       if (IS_STABLE_RELEASE) {
         console.log(`closing issue ${issueUrl}`);
-        promises.push(
-          closeIssue({ owner: OWNER, repo: REPO, issue: issue.number })
-        );
+        if (!DRY_RUN) {
+          promises.push(
+            closeIssue({ owner: OWNER, repo: REPO, issue: issue.number })
+          );
+        }
       }
     }
   }

--- a/scripts/release/constants.ts
+++ b/scripts/release/constants.ts
@@ -3,8 +3,8 @@ import { cleanupRef, cleanupTagName, isNightly, isStable } from "./utils";
 if (!process.env.DEFAULT_BRANCH) {
   throw new Error("DEFAULT_BRANCH is required");
 }
-if (!process.env.NIGHTLY_BRANCH) {
-  throw new Error("NIGHTLY_BRANCH is required");
+if (!process.env.RELEASE_BRANCH) {
+  throw new Error("RELEASE_BRANCH is required");
 }
 if (!process.env.GITHUB_TOKEN) {
   throw new Error("GITHUB_TOKEN is required");
@@ -28,7 +28,7 @@ export const VERSION = cleanupTagName(cleanupRef(process.env.VERSION));
 export const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 export const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY;
 export const DEFAULT_BRANCH = process.env.DEFAULT_BRANCH;
-export const NIGHTLY_BRANCH = process.env.NIGHTLY_BRANCH;
+export const RELEASE_BRANCH = process.env.RELEASE_BRANCH;
 export const PR_FILES_STARTS_WITH = ["packages/"];
 export const IS_NIGHTLY_RELEASE = isNightly(VERSION);
 export const AWAITING_RELEASE_LABEL = "awaiting release";

--- a/scripts/release/constants.ts
+++ b/scripts/release/constants.ts
@@ -33,3 +33,4 @@ export const PR_FILES_STARTS_WITH = ["packages/"];
 export const IS_NIGHTLY_RELEASE = isNightly(VERSION);
 export const AWAITING_RELEASE_LABEL = "awaiting release";
 export const IS_STABLE_RELEASE = isStable(VERSION);
+export const DRY_RUN = process.env.DRY_RUN === "true";

--- a/scripts/release/find-release-from-changeset.js
+++ b/scripts/release/find-release-from-changeset.js
@@ -32,6 +32,6 @@ function findReleaseFromChangeset(publishedPackages, packageVersionToFollow) {
 }
 
 findReleaseFromChangeset(
-  process.env.publishedPackages,
-  process.env.packageVersionToFollow
+  process.env.published_packages,
+  process.env.package_version_to_follow
 );

--- a/scripts/release/github.ts
+++ b/scripts/release/github.ts
@@ -3,7 +3,7 @@ import * as semver from "semver";
 
 import {
   PR_FILES_STARTS_WITH,
-  NIGHTLY_BRANCH,
+  RELEASE_BRANCH,
   DEFAULT_BRANCH,
   PACKAGE_VERSION_TO_FOLLOW,
   AWAITING_RELEASE_LABEL,
@@ -54,15 +54,15 @@ export async function prsMergedSinceLastTag({
   let prs: Awaited<ReturnType<typeof getMergedPRsBetweenTags>> = [];
 
   // if both the current and previous tags are prereleases
-  // we can just get the PRs for the "dev" branch
-  // but if one of them is stable, we should wind up all of them from both the main and dev branches
+  // we can just get the PRs for the `release` branch
+  // but if one of them is stable, we should wind up all of them from both the main and `release` branches
   if (currentTag.isPrerelease && previousTag.isPrerelease) {
     prs = await getMergedPRsBetweenTags(
       owner,
       repo,
       previousTag,
       currentTag,
-      NIGHTLY_BRANCH
+      RELEASE_BRANCH
     );
   } else {
     let [nightly, stable] = await Promise.all([
@@ -71,7 +71,7 @@ export async function prsMergedSinceLastTag({
         repo,
         previousTag,
         currentTag,
-        NIGHTLY_BRANCH
+        RELEASE_BRANCH
       ),
       getMergedPRsBetweenTags(
         owner,


### PR DESCRIPTION
https://twitter.com/rossipedia/status/1620562196303613953

before it would get PRs merged to dev and compare dates, now it will get PRs for the current release branch

![image](https://user-images.githubusercontent.com/11698668/216157009-8d435fe4-ae2a-4627-85d2-05c43b9d3757.png)


Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
