### PR TITLE
fix(remix-dev): update tailwind config detection to also look for cjs

### DIFF
--- a/.changeset/fresh-toes-shout.md
+++ b/.changeset/fresh-toes-shout.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/dev": patch
+---
+
+allow tailwind.config.cjs when using `future.unstable_tailwind`

--- a/packages/remix-dev/compiler/utils/postcss.ts
+++ b/packages/remix-dev/compiler/utils/postcss.ts
@@ -131,7 +131,7 @@ async function loadTailwindPlugin(
 
     // Load Tailwind from the project directory
     tailwindPath = require.resolve("tailwindcss", { paths: [rootDirectory] });
-  } catch (err) {
+  } catch {
     // If they don't have a Tailwind config or Tailwind installed, just ignore it.
     return null;
   }

--- a/packages/remix-dev/compiler/utils/postcss.ts
+++ b/packages/remix-dev/compiler/utils/postcss.ts
@@ -4,6 +4,7 @@ import type { AcceptedPlugin, Processor } from "postcss";
 import postcss from "postcss";
 
 import type { RemixConfig } from "../../config";
+import { findConfig } from "../../config";
 
 interface Options {
   config: RemixConfig;
@@ -119,12 +120,17 @@ async function loadTailwindPlugin(
 
   try {
     // First ensure they have a Tailwind config
-    require.resolve("./tailwind.config", { paths: [rootDirectory] });
+    // tailwind doesn't support esm config files yet
+    let tailwindConfigExtensions = [".js", ".cjs"];
+    let tailwindConfig = findConfig(
+      rootDirectory,
+      "tailwind.config",
+      tailwindConfigExtensions
+    );
+    if (!tailwindConfig) throw new Error("No Tailwind config found");
 
     // Load Tailwind from the project directory
-    tailwindPath = require.resolve("tailwindcss", {
-      paths: [rootDirectory],
-    });
+    tailwindPath = require.resolve("tailwindcss", { paths: [rootDirectory] });
   } catch (err) {
     // If they don't have a Tailwind config or Tailwind installed, just ignore it.
     return null;

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -359,7 +359,7 @@ export async function readConfig(
   }
 
   let rootDirectory = path.resolve(remixRoot);
-  let configFile = findConfig(rootDirectory, "remix.config");
+  let configFile = findConfig(rootDirectory, "remix.config", configExts);
 
   let appConfig: AppConfig = {};
   if (configFile) {
@@ -581,9 +581,14 @@ function findEntry(dir: string, basename: string): string | undefined {
 
 const configExts = [".js", ".cjs", ".mjs"];
 
-function findConfig(dir: string, basename: string): string | undefined {
-  for (let ext of configExts) {
-    let file = path.resolve(dir, basename + ext);
+export function findConfig(
+  dir: string,
+  basename: string,
+  extensions: string[]
+): string | undefined {
+  for (let ext of extensions) {
+    let name = basename + ext;
+    let file = path.join(dir, name);
     if (fse.existsSync(file)) return file;
   }
 


### PR DESCRIPTION
when using `type: "module"` in package.json you need to make any commonjs files have the `.cjs` extension however `require.resolve` won't look for them 🙈

note: tailwindcss doesn't currently support mjs so that extension is intentionally missing.

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
