### PR TITLE
 docs(file-conventions/route-files-v2): Fix incorrect routes path

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -355,6 +355,7 @@
 - niwsa
 - nobeeakon
 - nordiauwu
+- not-ivy
 - nrako
 - nurul3101
 - nvh95

--- a/docs/file-conventions/route-files-v2.md
+++ b/docs/file-conventions/route-files-v2.md
@@ -368,7 +368,7 @@ routes/app/index.tsx
 
 # as are these
 routes/app._index.tsx
-route/app._index/index.tsx
+routes/app._index/index.tsx
 ```
 
 In other words `_index` has meaning for Remix index routes, `index` has node module resolution meaning and creates index modules.


### PR DESCRIPTION
Fixed incorrect route path in file conventions > route files v2 > folders for organization section
