### PR TITLE
chore: Typing changes in remix-react

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -169,6 +169,7 @@
 - HenryVogt
 - hicksy
 - himorishige
+- hjonasson
 - hkan
 - hokaccha
 - Holben888

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -149,7 +149,7 @@ The following steps will get you setup to contribute changes to this repo:
    cd remix
 
    # if you are making *any* code changes, make sure to checkout the dev branch
-   git checkout dev
+   git checkout -b dev
    ```
 
 3. Install dependencies by running `yarn`. Remix uses [Yarn (version 1)][yarn-version-1], so you should too. If you install using `npm`, unnecessary `package-lock.json` files will be generated.

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -7,7 +7,6 @@ import * as React from "react";
 import type {
   AgnosticDataRouteMatch,
   UNSAFE_DeferredData as DeferredData,
-  ErrorResponse,
   Navigation,
   TrackedPromise,
 } from "@remix-run/router";
@@ -42,7 +41,6 @@ import {
 } from "react-router-dom";
 import type { SerializeFrom } from "@remix-run/server-runtime";
 
-import type { AppData } from "./data";
 import type { EntryContext, RemixContextObject } from "./entry";
 import {
   RemixRootDefaultErrorBoundary,
@@ -75,6 +73,7 @@ import type {
   TransitionStates,
 } from "./transition";
 import { IDLE_TRANSITION, IDLE_FETCHER } from "./transition";
+import type { RouteData } from "./routeData";
 
 function useDataRouterContext() {
   let context = React.useContext(DataRouterContext);
@@ -177,7 +176,7 @@ export function RemixRouteError({ id }: { id: string }) {
   }
 
   if (isRouteErrorResponse(error)) {
-    let tError = error as any;
+    let tError = error;
     if (
       tError?.error instanceof Error &&
       tError.status !== 404 &&
@@ -191,7 +190,7 @@ export function RemixRouteError({ id }: { id: string }) {
       return (
         <RemixCatchBoundary
           component={CatchBoundary!}
-          catch={error as ErrorResponse}
+          catch={error}
         />
       );
     }
@@ -557,7 +556,7 @@ function V1Meta() {
   let location = useLocation();
 
   let meta: V1_HtmlMetaDescriptor = {};
-  let parentsData: { [routeId: string]: AppData } = {};
+  let parentsData: { [routeId: string]: RouteData } = {};
 
   for (let match of matches) {
     let routeId = match.route.id;
@@ -574,7 +573,7 @@ function V1Meta() {
               parentsData,
               params,
               location,
-              matches: undefined as any,
+              matches: undefined,
             })
           : routeModule.meta;
       if (routeMeta && Array.isArray(routeMeta)) {
@@ -657,7 +656,7 @@ function V2Meta() {
 
   let meta: V2_HtmlMetaDescriptor[] = [];
   let leafMeta: V2_HtmlMetaDescriptor[] | null = null;
-  let parentsData: { [routeId: string]: AppData } = {};
+  let parentsData: { [routeId: string]: RouteData } = {};
 
   let matchesWithMeta: RouteMatchWithMeta[] = matches.map((match) => ({
     ...match,
@@ -730,7 +729,7 @@ function V2Meta() {
           return (
             <meta
               key="charset"
-              charSet={metaProps.charSet || (metaProps as any).charset}
+              charSet={metaProps.charSet || metaProps.charset}
             />
           );
         }
@@ -1150,7 +1149,7 @@ export function useMatches(): RouteMatch[] {
  *
  * @see https://remix.run/hooks/use-loader-data
  */
-export function useLoaderData<T = AppData>(): SerializeFrom<T> {
+export function useLoaderData<T>(): SerializeFrom<T> {
   return useLoaderDataRR() as SerializeFrom<T>;
 }
 
@@ -1159,7 +1158,7 @@ export function useLoaderData<T = AppData>(): SerializeFrom<T> {
  *
  * @see https://remix.run/hooks/use-action-data
  */
-export function useActionData<T = AppData>(): SerializeFrom<T> | undefined {
+export function useActionData<T>(): SerializeFrom<T> | undefined {
   return useActionDataRR() as SerializeFrom<T> | undefined;
 }
 

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -556,7 +556,7 @@ function V1Meta() {
   let location = useLocation();
 
   let meta: V1_HtmlMetaDescriptor = {};
-  let parentsData: { [routeId: string]: RouteData } = {};
+  let parentsData: RouteData = {};
 
   for (let match of matches) {
     let routeId = match.route.id;
@@ -656,7 +656,7 @@ function V2Meta() {
 
   let meta: V2_HtmlMetaDescriptor[] = [];
   let leafMeta: V2_HtmlMetaDescriptor[] | null = null;
-  let parentsData: { [routeId: string]: RouteData } = {};
+  let parentsData: RouteData = {};
 
   let matchesWithMeta: RouteMatchWithMeta[] = matches.map((match) => ({
     ...match,
@@ -1149,7 +1149,7 @@ export function useMatches(): RouteMatch[] {
  *
  * @see https://remix.run/hooks/use-loader-data
  */
-export function useLoaderData<T>(): SerializeFrom<T> {
+export function useLoaderData<T = unknown>(): SerializeFrom<T> {
   return useLoaderDataRR() as SerializeFrom<T>;
 }
 
@@ -1158,7 +1158,7 @@ export function useLoaderData<T>(): SerializeFrom<T> {
  *
  * @see https://remix.run/hooks/use-action-data
  */
-export function useActionData<T>(): SerializeFrom<T> | undefined {
+export function useActionData<T = unknown>(): SerializeFrom<T> | undefined {
   return useActionDataRR() as SerializeFrom<T> | undefined;
 }
 

--- a/packages/remix-react/data.ts
+++ b/packages/remix-react/data.ts
@@ -2,38 +2,34 @@ import {
   AbortedDeferredError,
   UNSAFE_DeferredData as DeferredData,
 } from "@remix-run/router";
-import type { FormMethod as FormMethodRR } from "react-router-dom";
-
-export type AppData = any;
-
-export type FormMethod = FormMethodRR;
+export type { FormMethod } from "react-router-dom";
 
 export type FormEncType =
   | "application/x-www-form-urlencoded"
   | "multipart/form-data";
 
-export function isCatchResponse(response: any): boolean {
+export function isCatchResponse(response: Response): boolean {
   return (
     response instanceof Response &&
     response.headers.get("X-Remix-Catch") != null
   );
 }
 
-export function isErrorResponse(response: any): boolean {
+export function isErrorResponse(response: Response): boolean {
   return (
     response instanceof Response &&
     response.headers.get("X-Remix-Error") != null
   );
 }
 
-export function isRedirectResponse(response: any): boolean {
+export function isRedirectResponse(response: Response): boolean {
   return (
     response instanceof Response &&
     response.headers.get("X-Remix-Redirect") != null
   );
 }
 
-export function isDeferredResponse(response: any): boolean {
+export function isDeferredResponse(response: Response): boolean {
   return (
     response instanceof Response &&
     !!response.headers.get("Content-Type")?.match(/text\/remix-deferred/)
@@ -108,7 +104,7 @@ export async function parseDeferredReadableStream(
 
         deferredData = deferredData || {};
 
-        deferredData[eventKey] = new Promise<any>((resolve, reject) => {
+        deferredData[eventKey] = new Promise((resolve, reject) => {
           deferredResolvers[eventKey] = {
             resolve: (value: unknown) => {
               resolve(value);

--- a/packages/remix-react/errors.ts
+++ b/packages/remix-react/errors.ts
@@ -1,15 +1,10 @@
 import type { Router as RemixRouter } from "@remix-run/router";
 import { ErrorResponse } from "@remix-run/router";
 
-import type { AppData } from "./data";
-
-export interface ThrownResponse<
-  Status extends number = number,
-  Data = AppData
-> {
-  status: Status;
+export interface ThrownResponse {
+  status: number;
   statusText: string;
-  data: Data;
+  data: unknown;
 }
 
 export function deserializeErrors(

--- a/packages/remix-react/routeData.ts
+++ b/packages/remix-react/routeData.ts
@@ -1,5 +1,3 @@
-import type { AppData } from "./data";
-
 export interface RouteData {
-  [routeId: string]: AppData;
+  [routeId: string]: unknown;
 }

--- a/packages/remix-react/routeModules.ts
+++ b/packages/remix-react/routeModules.ts
@@ -6,7 +6,6 @@ import type {
   ShouldRevalidateFunction,
 } from "react-router-dom";
 
-import type { AppData } from "./data";
 import type { LinkDescriptor } from "./links";
 import type { EntryRoute } from "./routes";
 import type { RouteData } from "./routeData";
@@ -69,7 +68,7 @@ export interface LinksFunction {
  */
 export interface V1_MetaFunction {
   (args: {
-    data: AppData;
+    data: unknown;
     parentsData: RouteData;
     params: Params;
     location: Location;
@@ -85,11 +84,11 @@ export interface RouteMatchWithMeta extends DataRouteMatch {
 
 export interface V2_MetaFunction {
   (args: {
-    data: AppData;
+    data: unknown;
     parentsData: RouteData;
     params: Params;
     location: Location;
-    matches: RouteMatchWithMeta[];
+    matches: RouteMatchWithMeta[] | undefined;
   }): V2_HtmlMetaDescriptor[] | undefined;
 }
 
@@ -115,7 +114,7 @@ export interface V1_HtmlMetaDescriptor {
 export type HtmlMetaDescriptor = V1_HtmlMetaDescriptor;
 
 export type V2_HtmlMetaDescriptor =
-  | { charSet: "utf-8" }
+  | { charSet: "utf-8"; charset?: "utf-8" }
   | { title: string }
   | { name: string; content: string }
   | { property: string; content: string }


### PR DESCRIPTION
I wanted to start with a simple change before taking on bigger tasks here. If anything here goes against convention or is unhelpful in any way I don't mind reverting parts or all of it 😉 I did not set the base branch to `dev` as suggested in `contributing.md` as I forked from main and they are not in sync 😕 

This PR:

- Removes a re-declaration of `RouteData` in `components.tsx` in two places
- Removes the type `AppData` which was a renaming of `any`. Changes uses of `AppData` to `unknown`
- Removes (seemingly😇 ) unnecessary type casts where I found them
- Adds `charset` as a prop on `metaProps` as it is used in code. Both `charSet` and `charset` made optional as they seem from the code to indeed be optional 🤔 
- Adds a type to inputs for utility functions that check response headers.