### PR TITLE
Fix: log errors during initial build in development

### DIFF
--- a/.changeset/tidy-doors-judge.md
+++ b/.changeset/tidy-doors-judge.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Log errors thrown during initial build in development.

--- a/packages/remix-dev/compiler/watch.ts
+++ b/packages/remix-dev/compiler/watch.ts
@@ -77,7 +77,7 @@ export async function watch(
     }
 
     compiler = createRemixCompiler(config, options);
-    let assetsManifest = await compile(compiler);
+    let assetsManifest = await compile(compiler, { onCompileFailure });
     onRebuildFinish?.(Date.now() - start, assetsManifest);
   }, 500);
 

--- a/packages/remix-dev/compiler/watch.ts
+++ b/packages/remix-dev/compiler/watch.ts
@@ -61,7 +61,7 @@ export async function watch(
   let compiler = createRemixCompiler(config, options);
 
   // initial build
-  await compile(compiler);
+  await compile(compiler, { onCompileFailure });
   onInitialBuild?.(Date.now() - start);
 
   let restart = debounce(async () => {


### PR DESCRIPTION
The `onCompileFailure` was not passed to the `compile` function so errors were not logged during initial build in dev.

It is passed to `createRemixCompiler` instead but it doesn't seem to be used there, so perhaps you want to remove it.