### PR TITLE
fix(remix-dev): only call `onInitialBuild` when the build succeeds

### DIFF
--- a/.changeset/mean-rocks-shout.md
+++ b/.changeset/mean-rocks-shout.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Hooks like `onInitialBuild` and `onRebuildFinish` should only be called when the build succeeds.


### PR DESCRIPTION
Remix is calling `onInitialBuild` hook even when the build fails without any information about the error. In Hydrogen, we use this hook to start the MiniOxygen server but it fails because the server bundle has not been generated.

This PR changes the Remix watch logic to only call `onInitialBuild` (and `onRebuildFinish` for consistency) after the first successful build. However, feel free to close this PR if the intended behavior is to actually call `onInitialBuild` even when the build throws errors. We can still workaround this in Hydrogen by manually checking the file system for the server build.

Another thing I noticed is that `onInitialBuild` is not getting the asset manifest in the parameters, unlike `onRebuildFinish`. Not sure if this is on purpose so I have not modified it.
