### PR TITLE
fix(remix-dev): normalize `/route` routeId, update route collision warnings

### DIFF
--- a/.changeset/flat-routes-route-fixes.md
+++ b/.changeset/flat-routes-route-fixes.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/dev": patch
+---
+
+fixes flat route inconsistencies where `route.{ext}` wasn't always being treated like `index.{ext}` when used in a folder

--- a/.changeset/flat-routes-route-fixes.md
+++ b/.changeset/flat-routes-route-fixes.md
@@ -4,3 +4,31 @@
 ---
 
 fixes flat route inconsistencies where `route.{ext}` wasn't always being treated like `index.{ext}` when used in a folder
+
+route conflict no longer throw errors and instead display a helpful warning that we're using the first one we found.
+
+```log
+⚠️ Route Path Collision: "/products/:pid"
+
+The following routes all define the same URL, only the first one will be used
+
+🟢️️ routes/products.$pid.tsx
+⭕️️ routes/products.$productId.tsx
+```
+```log
+⚠️ Route Path Collision: "/dashboard"
+
+The following routes all define the same URL, only the first one will be used
+
+🟢️️ routes/dashboard/route.tsx
+⭕️️ routes/dashboard.tsx
+```
+```log
+⚠️ Route Path Collision: "/"
+
+The following routes all define the same URL, only the first one will be used
+
+🟢️️ routes/_landing._index.tsx
+⭕️️ routes/_dashboard._index.tsx
+⭕️ routes/_index.tsx
+```

--- a/integration/flat-routes-test.ts
+++ b/integration/flat-routes-test.ts
@@ -1,144 +1,204 @@
+import { PassThrough } from "node:stream";
 import { test, expect } from "@playwright/test";
 
 import { PlaywrightFixture } from "./helpers/playwright-fixture";
 import type { Fixture, AppFixture } from "./helpers/create-fixture";
+import { createFixtureProject } from "./helpers/create-fixture";
 import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
 
 let fixture: Fixture;
 let appFixture: AppFixture;
 
-test.beforeAll(async () => {
-  fixture = await createFixture({
-    future: { v2_routeConvention: true },
-    files: {
-      "app/root.jsx": js`
-        import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
+test.describe("flat routes", () => {
+  test.beforeAll(async () => {
+    fixture = await createFixture({
+      future: { v2_routeConvention: true },
+      files: {
+        "app/root.jsx": js`
+          import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
 
-        export default function Root() {
-          return (
-            <html lang="en">
-              <head>
-                <Meta />
-                <Links />
-              </head>
-              <body>
-                <div id="content">
-                  <h1>Root</h1>
-                  <Outlet />
-                </div>
-                <Scripts />
-              </body>
-            </html>
-          );
-        }
-      `,
+          export default function Root() {
+            return (
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
+                <body>
+                  <div id="content">
+                    <h1>Root</h1>
+                    <Outlet />
+                  </div>
+                  <Scripts />
+                </body>
+              </html>
+            );
+          }
+        `,
 
-      "app/routes/_index.jsx": js`
-        export default function () {
-          return <h2>Index</h2>;
-        }
-      `,
+        "app/routes/_index.jsx": js`
+          export default function () {
+            return <h2>Index</h2>;
+          }
+        `,
 
-      "app/routes/folder/route.jsx": js`
-        export default function () {
-          return <h2>Folder (Route.jsx)</h2>;
-        }
-      `,
+        "app/routes/folder/route.jsx": js`
+          export default function () {
+            return <h2>Folder (Route.jsx)</h2>;
+          }
+        `,
 
-      "app/routes/folder2/index.jsx": js`
-        export default function () {
-          return <h2>Folder (Index.jsx)</h2>;
-        }
-      `,
+        "app/routes/folder2/index.jsx": js`
+          export default function () {
+            return <h2>Folder (Index.jsx)</h2>;
+          }
+        `,
 
-      "app/routes/flat.file.jsx": js`
-        export default function () {
-          return <h2>Flat File</h2>;
-        }
-      `,
+        "app/routes/flat.file.jsx": js`
+          export default function () {
+            return <h2>Flat File</h2>;
+          }
+        `,
 
-      "app/routes/dashboard/route.jsx": js`
-        import { Outlet } from "@remix-run/react";
+        "app/routes/dashboard/route.jsx": js`
+          import { Outlet } from "@remix-run/react";
 
-        export default function () {
-          return (
-            <>
-              <h2>Dashboard Layout</h2>
-              <Outlet />
-            </>
-          )
-        }
-      `,
+          export default function () {
+            return (
+              <>
+                <h2>Dashboard Layout</h2>
+                <Outlet />
+              </>
+            )
+          }
+        `,
 
-      "app/routes/dashboard._index/route.jsx": js`
-        export default function () {
-          return <h3>Dashboard Index</h3>;
-        }
-      `,
-    },
+        "app/routes/dashboard._index/route.jsx": js`
+          export default function () {
+            return <h3>Dashboard Index</h3>;
+          }
+        `,
+      },
+    });
+
+    appFixture = await createAppFixture(fixture);
   });
 
-  appFixture = await createAppFixture(fixture);
-});
+  test.afterAll(() => {
+    appFixture.close();
+  });
 
-test.afterAll(() => {
-  appFixture.close();
-});
+  test.describe("without JavaScript", () => {
+    test.use({ javaScriptEnabled: false });
+    runTests();
+  });
 
-test.describe("without JavaScript", () => {
-  test.use({ javaScriptEnabled: false });
-  runTests();
-});
+  test.describe("with JavaScript", () => {
+    test.use({ javaScriptEnabled: true });
+    runTests();
+  });
 
-test.describe("with JavaScript", () => {
-  test.use({ javaScriptEnabled: true });
-  runTests();
-});
-
-function runTests() {
-  test("renders matching routes (index)", async ({ page }) => {
-    let app = new PlaywrightFixture(appFixture, page);
-    await app.goto("/");
-    expect(await app.getHtml("#content")).toBe(`<div id="content">
+  function runTests() {
+    test("renders matching routes (index)", async ({ page }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/");
+      expect(await app.getHtml("#content")).toBe(`<div id="content">
   <h1>Root</h1>
   <h2>Index</h2>
 </div>`);
-  });
+    });
 
-  test("renders matching routes (folder route.jsx)", async ({ page }) => {
-    let app = new PlaywrightFixture(appFixture, page);
-    await app.goto("/folder");
-    expect(await app.getHtml("#content")).toBe(`<div id="content">
+    test("renders matching routes (folder route.jsx)", async ({ page }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/folder");
+      expect(await app.getHtml("#content")).toBe(`<div id="content">
   <h1>Root</h1>
   <h2>Folder (Route.jsx)</h2>
 </div>`);
-  });
+    });
 
-  test("renders matching routes (folder index.jsx)", async ({ page }) => {
-    let app = new PlaywrightFixture(appFixture, page);
-    await app.goto("/folder2");
-    expect(await app.getHtml("#content")).toBe(`<div id="content">
+    test("renders matching routes (folder index.jsx)", async ({ page }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/folder2");
+      expect(await app.getHtml("#content")).toBe(`<div id="content">
   <h1>Root</h1>
   <h2>Folder (Index.jsx)</h2>
 </div>`);
-  });
+    });
 
-  test("renders matching routes (flat file)", async ({ page }) => {
-    let app = new PlaywrightFixture(appFixture, page);
-    await app.goto("/flat/file");
-    expect(await app.getHtml("#content")).toBe(`<div id="content">
+    test("renders matching routes (flat file)", async ({ page }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/flat/file");
+      expect(await app.getHtml("#content")).toBe(`<div id="content">
   <h1>Root</h1>
   <h2>Flat File</h2>
 </div>`);
-  });
+    });
 
-  test("renders matching routes (nested)", async ({ page }) => {
-    let app = new PlaywrightFixture(appFixture, page);
-    await app.goto("/dashboard");
-    expect(await app.getHtml("#content")).toBe(`<div id="content">
+    test("renders matching routes (nested)", async ({ page }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/dashboard");
+      expect(await app.getHtml("#content")).toBe(`<div id="content">
   <h1>Root</h1>
   <h2>Dashboard Layout</h2>
   <h3>Dashboard Index</h3>
 </div>`);
+    });
+  }
+});
+
+test.describe("emits warnings for route conflicts", async () => {
+  let buildStdio = new PassThrough();
+  let buildOutput: string;
+
+  let originalConsoleLog = console.log;
+  let originalConsoleWarn = console.warn;
+  let originalConsoleError = console.error;
+
+  test.beforeAll(async () => {
+    console.log = () => {};
+    console.warn = () => {};
+    console.error = () => {};
+    await createFixtureProject({
+      buildStdio,
+      future: { v2_routeConvention: true },
+      files: {
+        "routes/_dashboard._index.tsx": js`
+          export default function () {
+            return <p>routes/_dashboard._index</p>;
+          }
+        `,
+        "app/routes/_index.jsx": js`
+          export default function () {
+            return <p>routes._index</p>;
+          }
+        `,
+        "app/routes/_landing._index.jsx": js`
+          export default function () {
+            return <p>routes/_landing._index</p>;
+          }
+        `,
+      },
+    });
+
+    let chunks: Buffer[] = [];
+    buildOutput = await new Promise<string>((resolve, reject) => {
+      buildStdio.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+      buildStdio.on("error", (err) => reject(err));
+      buildStdio.on("end", () =>
+        resolve(Buffer.concat(chunks).toString("utf8"))
+      );
+    });
   });
-}
+
+  test.afterAll(() => {
+    console.log = originalConsoleLog;
+    console.warn = originalConsoleWarn;
+    console.error = originalConsoleError;
+  });
+
+  test("warns about conflicting routes", () => {
+    console.log(buildOutput);
+    expect(buildOutput).toContain(`⚠️ Route Path Collision: "/"`);
+  });
+});

--- a/integration/flat-routes-test.ts
+++ b/integration/flat-routes-test.ts
@@ -1,0 +1,144 @@
+import { test, expect } from "@playwright/test";
+
+import { PlaywrightFixture } from "./helpers/playwright-fixture";
+import type { Fixture, AppFixture } from "./helpers/create-fixture";
+import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
+
+let fixture: Fixture;
+let appFixture: AppFixture;
+
+test.beforeAll(async () => {
+  fixture = await createFixture({
+    future: { v2_routeConvention: true },
+    files: {
+      "app/root.jsx": js`
+        import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
+
+        export default function Root() {
+          return (
+            <html lang="en">
+              <head>
+                <Meta />
+                <Links />
+              </head>
+              <body>
+                <div id="content">
+                  <h1>Root</h1>
+                  <Outlet />
+                </div>
+                <Scripts />
+              </body>
+            </html>
+          );
+        }
+      `,
+
+      "app/routes/_index.jsx": js`
+        export default function () {
+          return <h2>Index</h2>;
+        }
+      `,
+
+      "app/routes/folder/route.jsx": js`
+        export default function () {
+          return <h2>Folder (Route.jsx)</h2>;
+        }
+      `,
+
+      "app/routes/folder2/index.jsx": js`
+        export default function () {
+          return <h2>Folder (Index.jsx)</h2>;
+        }
+      `,
+
+      "app/routes/flat.file.jsx": js`
+        export default function () {
+          return <h2>Flat File</h2>;
+        }
+      `,
+
+      "app/routes/dashboard/route.jsx": js`
+        import { Outlet } from "@remix-run/react";
+
+        export default function () {
+          return (
+            <>
+              <h2>Dashboard Layout</h2>
+              <Outlet />
+            </>
+          )
+        }
+      `,
+
+      "app/routes/dashboard._index/route.jsx": js`
+        export default function () {
+          return <h3>Dashboard Index</h3>;
+        }
+      `,
+    },
+  });
+
+  appFixture = await createAppFixture(fixture);
+});
+
+test.afterAll(() => {
+  appFixture.close();
+});
+
+test.describe("without JavaScript", () => {
+  test.use({ javaScriptEnabled: false });
+  runTests();
+});
+
+test.describe("with JavaScript", () => {
+  test.use({ javaScriptEnabled: true });
+  runTests();
+});
+
+function runTests() {
+  test("renders matching routes (index)", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/");
+    expect(await app.getHtml("#content")).toBe(`<div id="content">
+  <h1>Root</h1>
+  <h2>Index</h2>
+</div>`);
+  });
+
+  test("renders matching routes (folder route.jsx)", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/folder");
+    expect(await app.getHtml("#content")).toBe(`<div id="content">
+  <h1>Root</h1>
+  <h2>Folder (Route.jsx)</h2>
+</div>`);
+  });
+
+  test("renders matching routes (folder index.jsx)", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/folder2");
+    expect(await app.getHtml("#content")).toBe(`<div id="content">
+  <h1>Root</h1>
+  <h2>Folder (Index.jsx)</h2>
+</div>`);
+  });
+
+  test("renders matching routes (flat file)", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/flat/file");
+    expect(await app.getHtml("#content")).toBe(`<div id="content">
+  <h1>Root</h1>
+  <h2>Flat File</h2>
+</div>`);
+  });
+
+  test("renders matching routes (nested)", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/dashboard");
+    expect(await app.getHtml("#content")).toBe(`<div id="content">
+  <h1>Root</h1>
+  <h2>Dashboard Layout</h2>
+  <h3>Dashboard Index</h3>
+</div>`);
+  });
+}

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 
 import {
   flatRoutesUniversal,
+  getRouteConflictErrorMessage,
   getRouteInfo,
   getRouteSegments,
 } from "../config/flat-routes";
@@ -644,7 +645,7 @@ describe("flatRoutes", () => {
       // we had a collision as /route and /index are the same
       expect(routes).toHaveLength(1);
       expect(consoleError).toHaveBeenCalledWith(
-        getErrorMessage("/", testFiles)
+        getRouteConflictErrorMessage("/", testFiles)
       );
     });
 
@@ -664,7 +665,7 @@ describe("flatRoutes", () => {
       // we had a collision as /route and /index are the same
       expect(routes).toHaveLength(1);
       expect(consoleError).toHaveBeenCalledWith(
-        getErrorMessage("/dashboard", testFiles)
+        getRouteConflictErrorMessage("/dashboard", testFiles)
       );
     });
 
@@ -687,24 +688,8 @@ describe("flatRoutes", () => {
       // we had a collision as /route and /index are the same
       expect(routes).toHaveLength(1);
       expect(consoleError).toHaveBeenCalledWith(
-        getErrorMessage("/products/:pid", testFiles)
+        getRouteConflictErrorMessage("/products/:pid", testFiles)
       );
     });
   });
 });
-
-function normalizePath(filePath: string) {
-  return filePath.split("/").join(path.sep);
-}
-
-function getErrorMessage(pathname: string, routes: string[]) {
-  let [taken, ...others] = routes;
-
-  return (
-    `⚠️ Route Path Collision: "${pathname}"\n\n` +
-    `The following routes all define the same URL, only the first one will be used\n\n` +
-    `🟢 ${normalizePath(taken)}\n` +
-    others.map((route) => `⭕️️ ${normalizePath(route)}`).join("\n") +
-    "\n"
-  );
-}

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -700,7 +700,7 @@ describe("flatRoutes", () => {
       // we had a collision as /route and /index are the same
       expect(routes).toHaveLength(1);
       expect(consoleError).toHaveBeenCalledWith(
-        trimAllLines(`⚠️ Route Path Collision: "/products/:pid"
+        trimAllLines(`⚠️ Route Path Collision: "/products/:productId"
 
           The following routes all define the same URL, only the first one will be used
 

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -5,6 +5,7 @@ import {
   getRouteConflictErrorMessage,
   getRouteInfo,
   getRouteSegments,
+  normalizePath,
 } from "../config/flat-routes";
 import type { ConfigRoute } from "../config/routes";
 
@@ -599,7 +600,7 @@ describe("flatRoutes", () => {
     ];
 
     let files: [string, ConfigRoute][] = testFiles.map(([file, route]) => {
-      let filepath = file.split("/").join(path.sep);
+      let filepath = normalizePath(file);
       return [filepath, { ...route, file: filepath }];
     });
 
@@ -635,9 +636,7 @@ describe("flatRoutes", () => {
 
       let routeManifest = flatRoutesUniversal(
         APP_DIR,
-        testFiles.map((file) =>
-          path.join(APP_DIR, file.split("/").join(path.sep))
-        )
+        testFiles.map((file) => path.join(APP_DIR, normalizePath(file)))
       );
 
       let routes = Object.values(routeManifest);
@@ -655,9 +654,7 @@ describe("flatRoutes", () => {
 
       let routeManifest = flatRoutesUniversal(
         APP_DIR,
-        testFiles.map((file) =>
-          path.join(APP_DIR, file.split("/").join(path.sep))
-        )
+        testFiles.map((file) => path.join(APP_DIR, normalizePath(file)))
       );
 
       let routes = Object.values(routeManifest);
@@ -678,9 +675,7 @@ describe("flatRoutes", () => {
 
       let routeManifest = flatRoutesUniversal(
         APP_DIR,
-        testFiles.map((file) =>
-          path.join(APP_DIR, file.split("/").join(path.sep))
-        )
+        testFiles.map((file) => path.join(APP_DIR, normalizePath(file)))
       );
 
       let routes = Object.values(routeManifest);

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -648,9 +648,9 @@ describe("flatRoutes", () => {
 
           The following routes all define the same URL, only the first one will be used
 
-          🟢 routes/_landing._index.tsx
-          ⭕️️ routes/_dashboard._index.tsx
-          ⭕️️ routes/._index.tsx
+          🟢 routes${path.sep}_landing._index.tsx
+          ⭕️️ routes${path.sep}_dashboard._index.tsx
+          ⭕️️ routes${path.sep}._index.tsx
         `)
       );
     });
@@ -675,8 +675,8 @@ describe("flatRoutes", () => {
 
           The following routes all define the same URL, only the first one will be used
 
-          🟢 routes/dashboard/route.tsx
-          ⭕️️ routes/dashboard.tsx
+          🟢 routes${path.sep}dashboard${path.sep}route.tsx
+          ⭕️️ routes${path.sep}dashboard.tsx
         `)
       );
     });
@@ -704,8 +704,8 @@ describe("flatRoutes", () => {
 
           The following routes all define the same URL, only the first one will be used
 
-          🟢 routes/products.$productId.tsx
-          ⭕️️ routes/products.$pid.tsx
+          🟢 routes${path.sep}products.$productId.tsx
+          ⭕️️ routes${path.sep}products.$pid.tsx
         `)
       );
     });

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -680,6 +680,35 @@ describe("flatRoutes", () => {
         `)
       );
     });
+
+    test("same path, different param name", () => {
+      // we'll add file manually before running the tests
+      let testFiles = [
+        "routes/products.$pid.tsx",
+        "routes/products.$productId.tsx",
+      ];
+
+      let routeManifest = flatRoutesUniversal(
+        APP_DIR,
+        testFiles.map((file) =>
+          path.join(APP_DIR, file.split("/").join(path.sep))
+        )
+      );
+
+      let routes = Object.values(routeManifest);
+
+      // we had a collision as /route and /index are the same
+      expect(routes).toHaveLength(1);
+      expect(consoleError).toHaveBeenCalledWith(
+        trimAllLines(`⚠️ Route Path Collision: "/products/:pid"
+
+          The following routes all define the same URL, only the first one will be used
+
+          🟢 routes/products.$productId.tsx
+          ⭕️️ routes/products.$pid.tsx
+        `)
+      );
+    });
   });
 });
 

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -627,8 +627,8 @@ describe("flatRoutes", () => {
     test("index files", () => {
       // we'll add file manually before running the tests
       let testFiles = [
-        "routes/_landing._index.tsx",
         "routes/_dashboard._index.tsx",
+        "routes/_landing._index.tsx",
         "routes/_index.tsx",
       ];
 
@@ -644,20 +644,13 @@ describe("flatRoutes", () => {
       // we had a collision as /route and /index are the same
       expect(routes).toHaveLength(1);
       expect(consoleError).toHaveBeenCalledWith(
-        trimAllLines(`⚠️ Route Path Collision: "/"
-
-          The following routes all define the same URL, only the first one will be used
-
-          🟢 routes${path.sep}_landing._index.tsx
-          ⭕️️ routes${path.sep}_dashboard._index.tsx
-          ⭕️️ routes${path.sep}_index.tsx
-        `)
+        getErrorMessage("/", testFiles)
       );
     });
 
     test("folder/route.tsx matching folder.tsx", () => {
       // we'll add file manually before running the tests
-      let testFiles = ["routes/dashboard/route.tsx", "routes/dashboard.tsx"];
+      let testFiles = ["routes/dashboard.tsx", "routes/dashboard/route.tsx"];
 
       let routeManifest = flatRoutesUniversal(
         APP_DIR,
@@ -671,13 +664,7 @@ describe("flatRoutes", () => {
       // we had a collision as /route and /index are the same
       expect(routes).toHaveLength(1);
       expect(consoleError).toHaveBeenCalledWith(
-        trimAllLines(`⚠️ Route Path Collision: "/dashboard"
-
-          The following routes all define the same URL, only the first one will be used
-
-          🟢 routes${path.sep}dashboard${path.sep}route.tsx
-          ⭕️️ routes${path.sep}dashboard.tsx
-        `)
+        getErrorMessage("/dashboard", testFiles)
       );
     });
 
@@ -700,21 +687,24 @@ describe("flatRoutes", () => {
       // we had a collision as /route and /index are the same
       expect(routes).toHaveLength(1);
       expect(consoleError).toHaveBeenCalledWith(
-        trimAllLines(`⚠️ Route Path Collision: "/products/:productId"
-
-          The following routes all define the same URL, only the first one will be used
-
-          🟢 routes${path.sep}products.$productId.tsx
-          ⭕️️ routes${path.sep}products.$pid.tsx
-        `)
+        getErrorMessage("/products/:pid", testFiles)
       );
     });
   });
 });
 
-function trimAllLines(str: string) {
-  return str
-    .split("\n")
-    .map((line) => line.trim())
-    .join("\n");
+function normalizePath(filePath: string) {
+  return filePath.split("/").join(path.sep);
+}
+
+function getErrorMessage(pathname: string, routes: string[]) {
+  let [taken, ...others] = routes;
+
+  return (
+    `⚠️ Route Path Collision: "${pathname}"\n\n` +
+    `The following routes all define the same URL, only the first one will be used\n\n` +
+    `🟢 ${normalizePath(taken)}\n` +
+    others.map((route) => `⭕️️ ${normalizePath(route)}`).join("\n") +
+    "\n"
+  );
 }

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -629,7 +629,7 @@ describe("flatRoutes", () => {
       let testFiles = [
         "routes/_landing._index.tsx",
         "routes/_dashboard._index.tsx",
-        "routes/._index.tsx",
+        "routes/_index.tsx",
       ];
 
       let routeManifest = flatRoutesUniversal(
@@ -650,7 +650,7 @@ describe("flatRoutes", () => {
 
           🟢 routes${path.sep}_landing._index.tsx
           ⭕️️ routes${path.sep}_dashboard._index.tsx
-          ⭕️️ routes${path.sep}._index.tsx
+          ⭕️️ routes${path.sep}_index.tsx
         `)
       );
     });

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -1,10 +1,9 @@
 import path from "node:path";
 
 import {
-  createRoutePath,
   flatRoutesUniversal,
+  getRouteInfo,
   getRouteSegments,
-  isIndexRoute,
 } from "../config/flat-routes";
 import type { ConfigRoute } from "../config/routes";
 
@@ -88,11 +87,9 @@ describe("flatRoutes", () => {
 
     for (let [input, expected] of tests) {
       it(`"${input}" -> "${expected}"`, () => {
-        let isIndex = isIndexRoute(input);
-        let [routeSegments, rawRouteSegments] = getRouteSegments(input);
-        expect(createRoutePath(routeSegments, rawRouteSegments, isIndex)).toBe(
-          expected
-        );
+        let fullRoutePath = path.join(APP_DIR, "routes", `${input}.tsx`);
+        let routeInfo = getRouteInfo(APP_DIR, "routes", fullRoutePath);
+        expect(routeInfo.path).toBe(expected);
       });
     }
 
@@ -276,7 +273,7 @@ describe("flatRoutes", () => {
       [
         "routes/folder/route.tsx",
         {
-          id: "routes/folder/route",
+          id: "routes/folder",
           parentId: "root",
           path: "folder",
         },

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -369,7 +369,12 @@ function getRouteMap(
     for (let i = 0; i < segments.length; i++) {
       let segment = segments[i];
       let nextSegment = nextSegments[i];
-      if (segment.startsWith(":") && nextSegment.startsWith(":")) {
+
+      if (
+        segment !== nextSegment &&
+        segment.startsWith(":") &&
+        nextSegment.startsWith(":")
+      ) {
         conflicts[nextRoute.path || "/"] ||= [nextRoute];
         conflicts[nextRoute.path || "/"].push(routeInfo);
         return false;

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -358,7 +358,7 @@ function getRouteMap(
   }
 
   // find routes with same segments
-  let filteredDupParams = routes.filter((routeInfo, index) => {
+  let filteredParamCollisions = routes.filter((routeInfo, index) => {
     let nextRoute = routes[index + 1];
     if (!nextRoute) return true;
 
@@ -395,7 +395,7 @@ function getRouteMap(
 
   // rebuild routeMap
   routeMap = new Map<string, RouteInfo>();
-  for (let routeInfo of filteredDupParams) {
+  for (let routeInfo of filteredParamCollisions) {
     routeMap.set(routeInfo.id, routeInfo);
   }
 

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -400,15 +400,8 @@ function getRouteMap(
   // report conflicts
   if (conflicts.size > 0) {
     for (let [path, routes] of conflicts.entries()) {
-      let [taken, ...rest] = routes;
-
-      console.error(
-        `⚠️ Route Path Collision: "${path}"\n\n` +
-          `The following routes all define the same URL, only the first one will be used\n\n` +
-          `🟢 ${taken.file}\n` +
-          rest.map((conflict) => `⭕️️ ${conflict.file}`).join("\n") +
-          "\n"
-      );
+      let filePaths = routes.map((r) => r.file);
+      console.error(getRouteConflictErrorMessage(path, filePaths));
     }
   }
 
@@ -456,4 +449,23 @@ export function createFlatRouteId(filePath: string) {
     }
   }
   return routeId;
+}
+
+function normalizePath(filePath: string) {
+  return filePath.split("/").join(path.sep);
+}
+
+export function getRouteConflictErrorMessage(
+  pathname: string,
+  routes: string[]
+) {
+  let [taken, ...others] = routes;
+
+  return (
+    `⚠️ Route Path Collision: "${pathname}"\n\n` +
+    `The following routes all define the same URL, only the first one will be used\n\n` +
+    `🟢 ${normalizePath(taken)}\n` +
+    others.map((route) => `⭕️️ ${normalizePath(route)}`).join("\n") +
+    "\n"
+  );
 }

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -366,13 +366,14 @@ function getRouteMap(
     let nextSegments = nextRoute.segments;
     if (segments.length !== nextSegments.length) return true;
 
-    // check last segment for param
-    let lastSegment = segments[segments.length - 1];
-    let nextLastSegment = nextSegments[nextSegments.length - 1];
-    if (lastSegment.startsWith(":") && nextLastSegment.startsWith(":")) {
-      conflicts[nextRoute.path || "/"] ||= [nextRoute];
-      conflicts[nextRoute.path || "/"].push(routeInfo);
-      return false;
+    for (let i = 0; i < segments.length; i++) {
+      let segment = segments[i];
+      let nextSegment = nextSegments[i];
+      if (segment.startsWith(":") && nextSegment.startsWith(":")) {
+        conflicts[nextRoute.path || "/"] ||= [nextRoute];
+        conflicts[nextRoute.path || "/"].push(routeInfo);
+        return false;
+      }
     }
 
     return true;

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -360,28 +360,32 @@ function getRouteMap(
     return b.segments.length - a.segments.length;
   });
 
-  // update parentIds for all routes
   for (let i = 0; i < routes.length; i++) {
     let routeInfo = routes[i];
+    // update parentIds for all routes
     routeInfo.parentId = findParentRouteId(routeInfo, nameMap);
 
+    // remove routes that conflict with other routes
     let nextRouteInfo = routes[i + 1];
     if (!nextRouteInfo) continue;
 
     let segments = routeInfo.segments;
     let nextSegments = nextRouteInfo.segments;
+    // if segment count is different, there can't be a conflict
     if (segments.length !== nextSegments.length) continue;
 
     for (let k = 0; k < segments.length; k++) {
       let segment = segments[k];
       let nextSegment = nextSegments[k];
 
+      // if segments are different, but they're both dynamic, there's a conflict
       if (
         segment !== nextSegment &&
         segment.startsWith(":") &&
         nextSegment.startsWith(":")
       ) {
         let currentConflicts = conflicts.get(routeInfo.path || "/");
+        // collect conflicts for later reporting, marking the next route as the conflicting route
         if (!currentConflicts) {
           conflicts.set(routeInfo.path || "/", [routeInfo, nextRouteInfo]);
         } else {
@@ -389,7 +393,8 @@ function getRouteMap(
           conflicts.set(routeInfo.path || "/", currentConflicts);
         }
 
-        routeMap.delete(routeInfo.id);
+        // remove conflicting route
+        routeMap.delete(nextRouteInfo.id);
 
         continue;
       }

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -350,7 +350,9 @@ function getRouteMap(
     }
   }
 
-  let routes = Array.from(routeMap.values());
+  let routes = Array.from(routeMap.values()).sort((a, b) => {
+    return b.segments.length - a.segments.length;
+  });
 
   // update parentIds for all routes
   for (let routeInfo of routes) {

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -451,7 +451,7 @@ export function createFlatRouteId(filePath: string) {
   return routeId;
 }
 
-function normalizePath(filePath: string) {
+export function normalizePath(filePath: string) {
   return filePath.split("/").join(path.sep);
 }
 

--- a/packages/remix-server-runtime/entry.ts
+++ b/packages/remix-server-runtime/entry.ts
@@ -20,6 +20,7 @@ export interface FutureConfig {
   unstable_vanillaExtract: boolean;
   v2_errorBoundary: boolean;
   v2_meta: boolean;
+  v2_routeConvention: boolean;
 }
 
 export interface AssetsManifest {


### PR DESCRIPTION
updates some missed logic so `<dir>/route` no longer conflicts in some cases.

updates conflict logic so it no longer throws errors and instead displays a nice error message about your conflicts

```log
 ⚠️ Route Path Collision: "/products/:pid"
 The following routes all define the same URL, only the first one will be used
 🟢️️ routes/products.$pid.tsx
 ⭕️️ routes/products.$productId.tsx
 ```
 ```log
 ⚠️ Route Path Collision: "/dashboard"
 The following routes all define the same URL, only the first one will be used
 🟢️️ routes/dashboard/route.tsx
 ⭕️️ routes/dashboard.tsx
 ```
 ```log
 ⚠️ Route Path Collision: "/"
 The following routes all define the same URL, only the first one will be used
 🟢️️ routes/_landing._index.tsx
 ⭕️️ routes/_dashboard._index.tsx
 ⭕️ routes/_index.tsx
 ```

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #5470
Closes: #5471 
Closes: #5495

- [ ] Docs
- [x] Tests

Testing Strategy:

- https://github.com/remix-run/remix/pull/5459/files#diff-a06b1f5f341c3dcdd91bfc12a0161adb284981209bc7ef6ea129e62a3d513f82
- https://github.com/remix-run/remix/pull/5459/files#diff-9d539a136164c63dc19ad243c45da2ae620f194929b43c0f01b039ba1fce5241

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
