### PR TITLE
templates(cloudflare-pages,netlify): add `immutable` to `Cache-Control` header

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -33,6 +33,7 @@
 - AntoninBeaufort
 - anubra266
 - apeltop
+- appden
 - Aprillion
 - arange
 - archwebio

--- a/templates/cloudflare-pages/public/_headers
+++ b/templates/cloudflare-pages/public/_headers
@@ -1,2 +1,2 @@
 /build/*
-  Cache-Control: public, max-age=31536000, s-maxage=31536000
+  Cache-Control: public, max-age=31536000, immutable

--- a/templates/netlify/netlify.toml
+++ b/templates/netlify/netlify.toml
@@ -14,4 +14,4 @@
 [[headers]]
   for = "/build/*"
   [headers.values]
-    "Cache-Control" = "public, max-age=31536000, s-maxage=31536000"
+    "Cache-Control" = "public, max-age=31536000, immutable"


### PR DESCRIPTION
This is a minor improvement to both the Netlify and Cloudflare Pages templates to include the `immutable` directive in the `Cache-Control` header for the hashed build assets. This removes the `s-maxage` for those as well since they are redundant to the `max-age` given they are equal. These now exactly match `Cache-Control` headers for hashes assets in the Deno, Express, and fly.io (via `remix-serve`) templates.

See `immutable` docs here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#immutable