### PR TITLE
Ensure types for fetchers always include form* submission fields

### DIFF
--- a/.changeset/tidy-singers-battle.md
+++ b/.changeset/tidy-singers-battle.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Ensure types for fetchers always include form\* submission fields

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1406,6 +1406,10 @@ function convertRouterFetcherToRemixFetcher(
       let fetcher: FetcherStates["Done"] = {
         state: "idle",
         type: "done",
+        formMethod: undefined,
+        formAction: undefined,
+        formData: undefined,
+        formEncType: undefined,
         submission: undefined,
         data,
       };
@@ -1533,6 +1537,10 @@ function convertRouterFetcherToRemixFetcher(
   let fetcher: FetcherStates["Loading"] = {
     state: "loading",
     type: "normalLoad",
+    formMethod: undefined,
+    formAction: undefined,
+    formData: undefined,
+    formEncType: undefined,
     submission: undefined,
     data,
   };

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -109,6 +109,10 @@ export type FetcherStates<TData = any> = {
   Idle: {
     state: "idle";
     type: "init";
+    formMethod: undefined;
+    formAction: undefined;
+    formData: undefined;
+    formEncType: undefined;
     submission: undefined;
     data: undefined;
   };
@@ -155,12 +159,20 @@ export type FetcherStates<TData = any> = {
   Loading: {
     state: "loading";
     type: "normalLoad";
+    formMethod: undefined;
+    formAction: undefined;
+    formData: undefined;
+    formEncType: undefined;
     submission: undefined;
     data: TData | undefined;
   };
   Done: {
     state: "idle";
     type: "done";
+    formMethod: undefined;
+    formAction: undefined;
+    formData: undefined;
+    formEncType: undefined;
     submission: undefined;
     data: TData;
   };
@@ -204,5 +216,9 @@ export const IDLE_FETCHER: FetcherStates["Idle"] = {
   state: "idle",
   type: "init",
   data: undefined,
+  formMethod: undefined,
+  formAction: undefined,
+  formData: undefined,
+  formEncType: undefined,
   submission: undefined,
 };


### PR DESCRIPTION
Fix `Fetcher` types in the back-compat layer to reflect undefined form* fields on `Idle`/`Loading`/`Done` states so TS doesn't complain on `fetcher.formMethod` accesses in those states.