### PR TITLE
feat(dev): Add support for `serverBundles` config to output multiple server bundles

### DIFF
--- a/.changeset/angry-gorillas-battle.md
+++ b/.changeset/angry-gorillas-battle.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": minor
+---
+
+Add support for new `serverBundles` configuration to generate multiple server bundles.

--- a/packages/remix-dev/compiler/compilerServer.ts
+++ b/packages/remix-dev/compiler/compilerServer.ts
@@ -190,33 +190,11 @@ export const createServerCompiler = (
   };
 
   let compileBundles = (manifestChannel: ReadChannel<AssetsManifest>) => {
-    if (Array.isArray(remixConfig.serverBundles)) {
-      let serverBundles = remixConfig.serverBundles.map(bundle => {
-        // Build up the resolved `routes` including any parent routes
-        let routes: RouteManifest = {};
-        for (let id of bundle.routes) {
-          let currentRoute: RouteManifest[string] | undefined = remixConfig.routes[id];
-          do {
-            routes[currentRoute.id] = currentRoute;
-            if (currentRoute.parentId) {
-              currentRoute = remixConfig.routes[currentRoute.parentId];
-            } else {
-              currentRoute = undefined;
-            }
-          } while(currentRoute);
-        }
-
-        return {
-          serverBuildPath: bundle.serverBuildPath,
-          routes
-        }
-      });
-
-      return serverBundles.map(({ serverBuildPath, routes }) =>
+    if (remixConfig.serverBundles) {
+      return remixConfig.serverBundles.map(({ serverBuildPath, routes }) =>
         compile(manifestChannel, serverBuildPath, routes)
       );
     }
-
     return [compile(manifestChannel)];
   };
 

--- a/packages/remix-dev/compiler/plugins/serverEntryModulePlugin.ts
+++ b/packages/remix-dev/compiler/plugins/serverEntryModulePlugin.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from "esbuild";
 
 import type { RemixConfig } from "../../config";
+import type { RouteManifest } from "../../config/routes";
 import {
   serverBuildVirtualModule,
   assetsManifestVirtualModule,
@@ -14,6 +15,7 @@ import {
  */
 export function serverEntryModulePlugin(
   config: RemixConfig,
+  routes: RouteManifest,
   options: { liveReloadPort?: number } = {}
 ): Plugin {
   let filter = serverBuildVirtualModule.filter;
@@ -34,11 +36,11 @@ export function serverEntryModulePlugin(
           loader: "js",
           contents: `
 import * as entryServer from ${JSON.stringify(config.entryServerFilePath)};
-${Object.keys(config.routes)
+${Object.keys(routes)
   .map((key, index) => {
     // IMPORTANT: Any values exported from this generated module must also be
     // typed in `packages/remix-dev/server-build.ts` to avoid tsc errors.
-    let route = config.routes[key];
+    let route = routes[key];
     return `import * as route${index} from ${JSON.stringify(
       `./${route.file}`
     )};`;
@@ -61,9 +63,9 @@ ${Object.keys(config.routes)
       : ""
   }
   export const routes = {
-    ${Object.keys(config.routes)
+    ${Object.keys(routes)
       .map((key, index) => {
-        let route = config.routes[key];
+        let route = routes[key];
         return `${JSON.stringify(key)}: {
       id: ${JSON.stringify(route.id)},
       parentId: ${JSON.stringify(route.parentId)},

--- a/packages/remix-dev/compiler/plugins/serverRouteModulesPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/serverRouteModulesPlugin.ts
@@ -4,18 +4,19 @@ import type esbuild from "esbuild";
 
 import type { RemixConfig } from "../../config";
 import { getLoaderForFile } from "../loaders";
+import type { RouteManifest } from "../../config/routes";
 
 /**
  * This plugin loads route modules for the server build and prevents errors
  * while adding new files in development mode.
  */
-export function serverRouteModulesPlugin(config: RemixConfig): esbuild.Plugin {
+export function serverRouteModulesPlugin(config: RemixConfig, routes: RouteManifest): esbuild.Plugin {
   return {
     name: "server-route-modules",
     setup(build) {
       let routeFiles = new Set(
-        Object.keys(config.routes).map((key) =>
-          path.resolve(config.appDirectory, config.routes[key].file)
+        Object.keys(routes).map((key) =>
+          path.resolve(config.appDirectory, routes[key].file)
         )
       );
 

--- a/packages/remix-dev/compiler/remixCompiler.ts
+++ b/packages/remix-dev/compiler/remixCompiler.ts
@@ -32,8 +32,8 @@ export const compile = async (
   try {
     let assetsManifestChannel = createChannel<AssetsManifest>();
     let browserPromise = compiler.browser.compile(assetsManifestChannel);
-    let serverPromise = compiler.server.compile(assetsManifestChannel);
-    await Promise.all([browserPromise, serverPromise]);
+    let serverBundlesPromises = compiler.server.compileBundles(assetsManifestChannel);
+    await Promise.all([browserPromise, ...serverBundlesPromises]);
     return assetsManifestChannel.read();
   } catch (error: unknown) {
     options.onCompileFailure?.(error as Error);

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -42,6 +42,11 @@ type Dev = {
   rebuildPollIntervalMs?: number;
 };
 
+interface ServerBundle {
+  serverBuildPath: string;
+  routes: string[];
+}
+
 interface FutureConfig {
   unstable_cssModules: boolean;
   unstable_cssSideEffectImports: boolean;
@@ -182,6 +187,12 @@ export interface AppConfig {
    * The platform the server build is targeting. Defaults to "node".
    */
   serverPlatform?: ServerPlatform;
+
+  /**
+   * Configuration of server bundles to produce. If this is defined then the
+   * top-level `serverBuildPath` value is ignored.
+   */
+  serverBundles?: ServerBundle[];
 
   /**
    * A list of filenames or a glob patterns to match files in the `app/routes`
@@ -343,6 +354,12 @@ export interface RemixConfig {
   serverPlatform: ServerPlatform;
 
   /**
+   * Configuration of server bundles to produce. If this is defined then the
+   * top-level `serverBuildPath` value is ignored.
+   */
+  serverBundles?: ServerBundle[];
+
+  /**
    * A list of directories to watch.
    */
   watchPaths: string[];
@@ -413,6 +430,7 @@ export async function readConfig(
   let serverMinify = appConfig.serverMinify;
   let serverModuleFormat = appConfig.serverModuleFormat || "cjs";
   let serverPlatform = appConfig.serverPlatform || "node";
+  let serverBundles = appConfig.serverBundles;
   if (isCloudflareRuntime) {
     serverConditions ??= ["worker"];
     serverDependenciesToBundle = "all";
@@ -643,6 +661,7 @@ export async function readConfig(
     serverMode,
     serverModuleFormat,
     serverPlatform,
+    serverBundles,
     mdx,
     watchPaths,
     tsconfigPath,


### PR DESCRIPTION
This adds the ability to split up the server-side build into multiple bundles via a new config property: `serverBundles`.

Example:

```js
  serverBundles: [
    { serverBuildPath: 'build/build1.js', routes: ['routes/index', 'routes/about'] },
    { serverBuildPath: 'build/build2.js', routes: ['routes/generate', 'routes/error'] }
  ],
```

When `serverBundles` is defined, it takes precedence over the top-level `serverBuildPath` property, since each "bundle" entry can define its output file path.

Related to Discussion: [#5405](https://github.com/remix-run/remix/discussions/5405#discussioncomment-4990250)

- [ ] Docs
- [ ] Tests

I will add docs / tests if this proposal is agreed upon.

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
