### PR TITLE
fix(remix-dev/compiler): fix typo in `serverBareModulesPlugin` message

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -38,6 +38,7 @@
 - arganaphangquestian
 - AriGunawan
 - arjunyel
+- armandabric
 - arnaudambro
 - arvigeus
 - arvindell

--- a/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
@@ -182,7 +182,7 @@ function warnOnceIfEsmOnlyPackage(
       if (isEsmOnly) {
         onWarning(
           `${packageName} is possibly an ESM only package and should be bundled with ` +
-            `"serverDependenciesToBundle in remix.config.js.`,
+            `"serverDependenciesToBundle" in remix.config.js.`,
           packageName + ":esm-only"
         );
       }


### PR DESCRIPTION
This a typo PR fix the ESM only warning in the console: the missing closing quote around `serverDependenciesToBundle`.

<img width="1227" alt="Screenshot 2023-02-16 at 11 42 51" src="https://user-images.githubusercontent.com/95120/219343079-eb562656-faae-4788-a259-1a2eaf43ab9c.png">

