### PR TITLE
(bug report) Submitting a form to the same page when the url has an anchor does nots an anchor does not revalidate the loaders

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -496,3 +496,4 @@
 - krolebord
 - panteliselef
 - mattcroat
+- BenoitAverty


### PR DESCRIPTION
**This is a bug report with a failing test attached**

When an action redirects to the current page, remix usually revalidates the loaders to fetch any potential changes to the data that the action could have done.

However, if the url when the form is submitted contains a hash (for example after clicking a link to the anchor) and the action redirects to the same page but without the anchor, the loaders are not called after the form submission. This results in stale data being shown to the client.

in line 96, if the url is replaced by only `/` then the tet passes. But the hash shouldn't prevent the loader from being called again.