### PR TITLE
fix: index route not detected if using folder

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -447,6 +447,7 @@
 - squidpunch
 - staylor
 - stephanerangaya
+- suciptoid
 - SufianBabri
 - supachaidev
 - Synvox

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -598,6 +598,23 @@ describe("flatRoutes", () => {
           path: "*",
         },
       ],
+      [
+        "routes/$invoice/route.jsx",
+        {
+          id: "routes/$invoice/route",
+          parentId: "root",
+          path: ":invoice"
+        }
+      ],
+      [
+        "routes/$invoice._index/route.jsx",
+        {
+          id: "routes/$invoice._index/route",
+          parentId: "root",
+          path: ":invoice",
+          index: true
+        }
+      ]
     ];
 
     let files: [string, ConfigRoute][] = testFiles.map(([file, route]) => {

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -121,7 +121,7 @@ export function flatRoutesUniversal(
 }
 
 export function isIndexRoute(routeId: string) {
-  return routeId.endsWith("_index");
+  return routeId.endsWith("_index") || routeId.endsWith("_index/route");
 }
 
 type State =


### PR DESCRIPTION
Fix flat routes when using folder as `_index/routes.jsx`

Example:
Throw error: Path "/:invoice" defined by route "$invoice._index/route" conflicts with route "$invoice/route" with route :

```
/routes/$invoice/route.tsx <-- layout
/routes/$invoice/_index/route.tsx
```

also close this issue

Closes: #5490

- [ ] Docs
- [x] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
