### PR TITLE
fix: remove duplicate manifest imports introduced by defer work

### DIFF
--- a/.changeset/new-bulldogs-allow.md
+++ b/.changeset/new-bulldogs-allow.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+remove duplicate manifest imports

--- a/integration/link-test.ts
+++ b/integration/link-test.ts
@@ -530,4 +530,33 @@ test.describe("route module link export", () => {
       expect(await locator.getAttribute("imagesizes")).toBe("100vw");
     });
   });
+
+  test.describe("script imports", () => {
+    test("are added to the document", async ({ page }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/");
+      let scripts = await page.$$("script");
+      expect(scripts.length).toEqual(2);
+      expect(await scripts[0].innerText()).toContain("__remixContext");
+      let moduleScript = scripts[1];
+      expect(await moduleScript.getAttribute("type")).toBe("module");
+      let moduleScriptText = await moduleScript.innerText();
+      expect(
+        Array.from(moduleScriptText.matchAll(/import "\/build\/manifest-/g)),
+        "invalid build manifest"
+      ).toHaveLength(1);
+      expect(
+        Array.from(moduleScriptText.matchAll(/import \* as route0 from "/g)),
+        "invalid route0"
+      ).toHaveLength(1);
+      expect(
+        Array.from(moduleScriptText.matchAll(/import \* as route1 from "/g)),
+        "invalid route1"
+      ).toHaveLength(1);
+      expect(
+        Array.from(moduleScriptText.matchAll(/import \* as route2 from "/g)),
+        "too many routes"
+      ).toHaveLength(0);
+    });
+  });
 });

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -904,11 +904,11 @@ export function Scripts(props: ScriptProps) {
 
     let routeModulesScript = !isStatic
       ? " "
-      : `${matches
+      : `import ${JSON.stringify(manifest.url)};
+        ${matches
           .map(
             (match, index) =>
-              `import ${JSON.stringify(manifest.url)};
-import * as route${index} from ${JSON.stringify(
+              `import * as route${index} from ${JSON.stringify(
                 manifest.routes[match.route.id].module
               )};`
           )


### PR DESCRIPTION
test: add test to assert generated scripts

Closes: https://github.com/remix-run/remix/issues/5531

- [ ] Docs
- [x] Tests

Testing Strategy:

Check known imports are there and the appropriate number exist.