### PR TITLE
fix(dev): Specify "paths" in `require.resolve()` check

### DIFF
--- a/.changeset/pretty-walls-bake.md
+++ b/.changeset/pretty-walls-bake.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fix Remix CLI printing false positive warning messages about missing `node_modules` dependencies when invoked from a different directory.

--- a/packages/remix-dev/compiler/compilerServer.ts
+++ b/packages/remix-dev/compiler/compilerServer.ts
@@ -66,7 +66,7 @@ const createEsbuildConfig = (
     serverRouteModulesPlugin(config),
     serverEntryModulePlugin(config, { liveReloadPort: options.liveReloadPort }),
     serverAssetsManifestPlugin(assetsManifestChannel.read()),
-    serverBareModulesPlugin(config, options.onWarning),
+    serverBareModulesPlugin(config, process.cwd(), options.onWarning),
   ].filter(isNotNull);
 
   if (config.serverPlatform !== "node") {

--- a/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/serverBareModulesPlugin.ts
@@ -20,6 +20,7 @@ import { getPreferredPackageManager } from "../../cli/getPreferredPackageManager
  */
 export function serverBareModulesPlugin(
   remixConfig: RemixConfig,
+  cwd: string,
   onWarning?: (warning: string, key: string) => void
 ): Plugin {
   // Resolve paths according to tsconfig paths property
@@ -89,11 +90,11 @@ export function serverBareModulesPlugin(
             (pkgManager === "yarn" && process.versions.pnp == null))
         ) {
           try {
-            require.resolve(path);
+            require.resolve(path, { paths: [cwd] });
           } catch (error: unknown) {
             onWarning(
               `The path "${path}" is imported in ` +
-                `${relative(process.cwd(), importer)} but ` +
+                `${relative(cwd, importer)} but ` +
                 `"${path}" was not found in your node_modules. ` +
                 `Did you forget to install it?`,
               path


### PR DESCRIPTION
`require.resolve()` by default will resolve module paths relative to the `__filename` of the code that is invoking it (so relative to `serverBareModulesPlugin.js` in this case). This normally works, by coincidence, because usually `@remix-run/dev` is located within the project's `node_modules` directory.

However, we get a false positive when `remix` CLI is located *outside* of the project directory, for example when testing changes in a local checkout of this repo.

To fix, specify `paths` array to `require.resolve()` and explcitly specify the `cwd` to resolve from.

### Before

```bash
~/remix $ node ~/Code/remix-run/remix/packages/remix-dev/dist/cli.js build
Building Remix app in production mode...
The path "@remix-run/react" is imported in app/entry.server.tsx but "@remix-run/react" was not found in your node_modules. Did you forget to install it?
The path "react-dom/server" is imported in app/entry.server.tsx but "react-dom/server" was not found in your node_modules. Did you forget to install it?
Built in 190ms
```

(The modules are definitely installed, I promise)

### After

```bash
~/remix $ node ~/Code/remix-run/remix/packages/remix-dev/dist/cli.js build
Building Remix app in production mode...
Built in 176ms
```

Closes: #5535

- [ ] Docs
- [ ] Tests