### PR TITLE
feat(vercel): Add Vercel Edge runtime entrypoint

### DIFF
--- a/packages/remix-vercel/edge.ts
+++ b/packages/remix-vercel/edge.ts
@@ -1,0 +1,26 @@
+import type { AppLoadContext, ServerBuild } from "@remix-run/server-runtime";
+import { createRequestHandler as createRemixRequestHandler } from "@remix-run/server-runtime";
+
+export type GetEdgeLoadContextFunction = (request: Request) => AppLoadContext;
+
+/**
+ * Returns a request handler for the Vercel Edge runtime that serves
+ * the Remix SSR response.
+ */
+export function createRequestHandler({
+  build,
+  getEdgeLoadContext,
+  mode,
+}: {
+  build: ServerBuild;
+  getEdgeLoadContext?: GetEdgeLoadContextFunction;
+  mode?: string;
+}) {
+  let handleRequest = createRemixRequestHandler(build, mode);
+
+  return (request: Request) => {
+    let loadContext = getEdgeLoadContext?.(request);
+
+    return handleRequest(request, loadContext);
+  };
+}

--- a/packages/remix-vercel/index.ts
+++ b/packages/remix-vercel/index.ts
@@ -1,4 +1,5 @@
 import "./globals";
 
 export type { GetLoadContextFunction, RequestHandler } from "./server";
+export type { GetEdgeLoadContextFunction } from "./edge";
 export { createRequestHandler } from "./server";

--- a/packages/remix-vercel/package.json
+++ b/packages/remix-vercel/package.json
@@ -12,9 +12,19 @@
   },
   "license": "MIT",
   "main": "dist/index.js",
+  "browser": "dist/edge.js",
   "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "edge-light": "./dist/edge.js",
+      "browser": "./dist/edge.js",
+      "node": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "dependencies": {
-    "@remix-run/node": "1.13.0"
+    "@remix-run/node": "1.13.0",
+    "@remix-run/server-runtime": "1.13.0"
   },
   "devDependencies": {
     "@types/supertest": "^2.0.10",

--- a/packages/remix-vercel/rollup.config.js
+++ b/packages/remix-vercel/rollup.config.js
@@ -2,5 +2,5 @@ const { getAdapterConfig } = require("../../rollup.utils");
 
 /** @returns {import("rollup").RollupOptions[]} */
 module.exports = function rollup() {
-  return [getAdapterConfig("vercel")];
+  return [getAdapterConfig("vercel"), getAdapterConfig("vercel", "edge.ts")];
 };

--- a/packages/remix-vercel/server.ts
+++ b/packages/remix-vercel/server.ts
@@ -13,6 +13,8 @@ import {
   writeReadableStreamToWritable,
 } from "@remix-run/node";
 
+import type { GetEdgeLoadContextFunction } from "./edge";
+
 /**
  * A function that returns the value to use as `context` in route `loader` and
  * `action` functions.
@@ -41,6 +43,7 @@ export function createRequestHandler({
 }: {
   build: ServerBuild;
   getLoadContext?: GetLoadContextFunction;
+  getEdgeLoadContext?: GetEdgeLoadContextFunction;
   mode?: string;
 }): RequestHandler {
   let handleRequest = createRemixRequestHandler(build, mode);

--- a/rollup.utils.js
+++ b/rollup.utils.js
@@ -135,7 +135,7 @@ function copyToPlaygrounds() {
  * @param {RemixAdapter} adapterName
  * @returns {import("rollup").RollupOptions}
  */
-function getAdapterConfig(adapterName) {
+function getAdapterConfig(adapterName, entrypoint = 'index.ts') {
   /** @type {`@remix-run/${RemixAdapter}`} */
   let packageName = `@remix-run/${adapterName}`;
   let sourceDir = `packages/remix-${adapterName}`;
@@ -147,7 +147,7 @@ function getAdapterConfig(adapterName) {
     external(id) {
       return isBareModuleId(id);
     },
-    input: `${sourceDir}/index.ts`,
+    input: `${sourceDir}/${entrypoint}`,
     output: {
       banner: createBanner(packageName, version),
       dir: outputDist,


### PR DESCRIPTION
These days, the `@remix-run/vercel` runtime adapter is not strictly required for usage of Remix on Vercel, since we are now auto-injecting a server entry point by default (we've even [updated our template](https://github.com/vercel/vercel/pull/9472) to not include a `server.js` file anymore).

_However_, [users may still be relying on a `server.js` file](https://github.com/orgs/vercel/discussions/1596) for the purposes of defining a `getLoadContext()` function (and possibly other edge cases).

So this PR adds a new entrypoint into `@remix-run/vercel` that will be utilized when building Remix for the Vercel Edge runtime to allow for usage of `@remix-run/vercel` for these edge cases. Since the signature of the Edge runtime does not match the Node runtime, there is a separate `getEdgeLoadContext()` function which may be used to define the load context when running on Edge.

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
