### PR TITLE
docs(file-conventions/routes-files): Fix headers link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -14,6 +14,7 @@
 - airondumael
 - aissa-bouguern
 - akamfoad
+- alanhoskins
 - Alarid
 - alex-ketch
 - alextes

--- a/docs/file-conventions/routes-files.md
+++ b/docs/file-conventions/routes-files.md
@@ -306,7 +306,7 @@ The Route file naming convention is changing in v2 to make file organization sim
 [loader]: ../route/loader
 [action]: ../route/action
 [meta]: ../route/meta
-[headers]: ../routes/headers
+[headers]: ../route/headers
 [links]: ../route/links
 [error-boundary]: ../route/error-boundary
 [catch-boundary]: ../route/catch-boundary


### PR DESCRIPTION
- [x] Docs

The link to `headers` in the Route File Naming was pointing to https://remix.run/docs/en/v1/routes/headers when it should have been point to https://remix.run/docs/en/v1/route/headers
