### PR TITLE
fix(remix-server-runtime): make `serializeError` a synchronous function

### DIFF
--- a/.changeset/tame-dots-wash.md
+++ b/.changeset/tame-dots-wash.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+fix: change `serializeError` to sync function

--- a/contributors.yml
+++ b/contributors.yml
@@ -489,6 +489,7 @@
 - XiNiHa
 - xstevenyung
 - xdivby0
+- xuchaobei
 - yauri-io
 - yesmeck
 - yomeshgupta

--- a/packages/remix-server-runtime/errors.ts
+++ b/packages/remix-server-runtime/errors.ts
@@ -57,7 +57,7 @@ export type SerializedError = {
   stack?: string;
 };
 
-export async function serializeError(error: Error): Promise<SerializedError> {
+export function serializeError(error: Error): SerializedError {
   return {
     message: error.message,
     stack: error.stack,

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -373,8 +373,8 @@ async function handleResourceRequestRR(
   }
 }
 
-async function errorBoundaryError(error: Error, status: number) {
-  return json(await serializeError(error), {
+function errorBoundaryError(error: Error, status: number) {
+  return json(serializeError(error), {
     status,
     headers: {
       "X-Remix-Error": "yes",


### PR DESCRIPTION
Error occurred in streaming SSR cannot be serialized correctly,  since `serializeError` return a Promise.  I suppose  `serializeError` can just be a sync function. 


<img width="622" alt="image" src="https://user-images.githubusercontent.com/5110783/220882446-3c294755-e450-4896-a694-0cf24bce45c5.png">


https://github.com/remix-run/remix/blob/main/packages/remix-server-runtime/responses.ts#L209


Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

 I opened up my mac machine and ran this script:
```
 npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
 cd my-test
 npm run dev
```

