### PR TITLE
feat: initial support for `.remixignore` when creating an app from a template

### DIFF
--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -65,7 +65,7 @@ export async function init(
   let initScriptTs = path.resolve(initScriptDir, "index.ts");
   let initScript = path.resolve(initScriptDir, "index.js");
 
-  if (await fse.pathExists(initScriptTs)) {
+  if (fse.pathExistsSync(initScriptTs)) {
     await esbuild.build({
       entryPoints: [initScriptTs],
       format: "cjs",
@@ -73,12 +73,13 @@ export async function init(
       outfile: initScript,
     });
   }
-  if (!(await fse.pathExists(initScript))) {
+
+  if (!fse.pathExistsSync(initScript)) {
     return;
   }
 
   let initPackageJson = path.resolve(initScriptDir, "package.json");
-  let isTypeScript = fse.existsSync(path.join(projectDir, "tsconfig.json"));
+  let isTypeScript = fse.pathExistsSync(path.join(projectDir, "tsconfig.json"));
   let packageManager = getPreferredPackageManager();
 
   if (await fse.pathExists(initPackageJson)) {

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -44,6 +44,7 @@
     "fs-extra": "^10.0.0",
     "get-port": "^5.1.1",
     "gunzip-maybe": "^1.4.2",
+    "ignore": "5.2.4",
     "inquirer": "^8.2.1",
     "jsesc": "3.0.2",
     "json5": "^2.2.1",

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -43,6 +43,7 @@
     "fast-glob": "3.2.11",
     "fs-extra": "^10.0.0",
     "get-port": "^5.1.1",
+    "glob": "8.1.0",
     "gunzip-maybe": "^1.4.2",
     "ignore": "5.2.4",
     "inquirer": "^8.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6833,6 +6833,17 @@ glob@8.0.3:
     minimatch "^5.0.1"
     once "^1.3.0"
 
+glob@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.2.0"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3410,18 +3410,6 @@
   version "1.9.3"
   resolved "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.9.3.tgz#59cd445e9ffa9676c4faf7f213ddf6538404c92c"
   integrity sha512-vitcD8usEOTWDLAnbtnZ46YbHADAp3Es+3xyHsMDMZOEWk03FhD+PbR58kdwtGpr258+hMryCYtQPeFh5lWFbA==
-  dependencies:
-    "@emotion/hash" "^0.9.0"
-    "@vanilla-extract/private" "^1.0.3"
-    ahocorasick "1.0.2"
-    chalk "^4.1.1"
-    css-what "^5.0.1"
-    cssesc "^3.0.0"
-    csstype "^3.0.7"
-    deep-object-diff "^1.1.0"
-    deepmerge "^4.2.2"
-    media-query-parser "^2.0.2"
-    outdent "^0.8.0"
 
 "@vanilla-extract/integration@^6.0.2":
   version "6.0.2"
@@ -7209,6 +7197,11 @@ ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
   integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
+
+ignore@5.2.4:
+  version "5.2.4"
+  resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
+  integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
 ignore@^5.1.1, ignore@^5.2.0:
   version "5.2.0"


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
