### PR TITLE
Fix `useMatches` returning  different loader data on sub navigation on client side

### DIFF
--- a/.changeset/thirty-cameras-rule.md
+++ b/.changeset/thirty-cameras-rule.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/react": patch
+---
+
+Fix `useMatches` causing client side render twice on sub navigation

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,11 @@ jobs:
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
 
+      - name: Disable Eslint GitHub Actions Annotations
+        run: |
+          echo "::remove-matcher owner=eslint-compact::"
+          echo "::remove-matcher owner=eslint-stylish::"
+
       - name: 🔬 Lint
         run: yarn lint
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.10.0
+        uses: styfle/cancel-workflow-action@0.11.0
 
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
@@ -113,7 +113,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.10.0
+        uses: styfle/cancel-workflow-action@0.11.0
 
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,13 +33,14 @@ yarn test react --watch
 
 ## Releases
 
-New releases should be created from release branches originating from `dev`. When you are ready to begin the release process:
+New releases should be created from release branches originating from the `dev` branch. When you are ready to begin the release process:
 
+- Make sure you've pulled all of the changes from GitHub for both `dev` and `main` branches.
 - Check out the `dev` branch.
-- Pull all of the changes from GitHub.
-- Create a new release branch with the `release-` prefix (eg, `git checkout -b release-next`)
+- Create a new release branch with the `release-` prefix (eg, `git checkout -b release-next`).
   - **IMPORTANT:** The `release-` prefix is important, as this is what triggers our GitHub CI workflow that will ultimately publish the release.
   - Branches named `release-experimental` will not trigger our release workflow, as experimental releases handled differently (outlined below).
+- Merge `main` into the release branch.
 
 Changesets will do most of the heavy lifting for our releases. When changes are made to the codebase, an accompanying changeset file should be included to document the change. Those files will dictate how Changesets will version our packages and what shows up in the changelogs.
 
@@ -47,12 +48,13 @@ Changesets will do most of the heavy lifting for our releases. When changes are 
 
 - Ensure you are on the new `release-*` branch.
 - Enter Changesets pre-release mode using the `pre` tag: `yarn changeset pre enter pre`.
-- Commit the change and push the the `release-*` branch to GitHub.
+- Commit the change and push the `release-*` branch to GitHub.
 - Wait for the release workflow to finish. The Changesets action in the workflow will open a PR that will increment all versions and generate the changelogs.
-- Review the PR, make any adjustments necessary, and merge it into the `release-*` branch.
+- Review the updated `CHANGELOG` files and make any adjustments necessary, then merge the PR into the `release-*` branch.
+  - `find packages -name 'CHANGELOG.md' -mindepth 2 -maxdepth 2 -exec code {} \;`
 - Once the PR is merged, the release workflow will publish the updated packages to npm.
 
-### Incrementing a pre-release
+### Iterating a pre-release
 
 You may need to make changes to a pre-release prior to publishing a final stable release. To do so:
 
@@ -60,17 +62,25 @@ You may need to make changes to a pre-release prior to publishing a final stable
 - Create a new changeset: `yarn changeset`.
   - **IMPORTANT:** This is required even if you ultimately don't want to include these changes in the logs. Remember, changelogs can be edited prior to publishing, but the Changeset version script needs to see new changesets in order to create a new version.
 - Commit the changesets and push the the `release-*` branch to GitHub.
-- Wait for the release workflow to finish and the Changesets action to open its PR.
+- Wait for the release workflow to finish and the Changesets action to open its PR that will increment all versions.
 - Review the PR, make any adjustments necessary, and merge it into the `release-*` branch.
 - Once the PR is merged, the release workflow will publish the updated packages to npm.
 
 ### Publishing the stable release
 
 - Exit Changesets pre-release mode: `yarn changeset pre exit`.
-- Commit the deleted pre-release file along with any unpublished changesets, and push the the `release-*` branch to GitHub.
-- Wait for the release workflow to finish. The Changesets action in the workflow will open a PR that will increment all versions and generate the changelogs.
-- Review the PR. We should remove the changelogs for all pre-releases ahead of publishing the stable version. [TODO: We should automate this]
+- Commit the deleted pre-release file along with any unpublished changesets, and push the `release-*` branch to GitHub.
+- Wait for the release workflow to finish. The Changesets action in the workflow will open a PR that will increment all versions and generate the changelogs for the stable release.
+- Review the updated `CHANGELOG` files and make any adjustments necessary.
+  - We should remove the changelogs for all pre-releases ahead of publishing the stable version.
+  - [TODO: We should automate this]
+- Merge the PR into the `release-*` branch.
 - Once the PR is merged, the release workflow will publish the updated packages to npm.
+- Once the release is published:
+  - merge the `release-*` branch into `main` and push it up to GitHub
+  - merge the `release-*` branch into `dev` and push it up to GitHub
+  - Convert the `remix@1.x.y` tag to a Release on Github with the name `v1.x.y`
+  - Copy the relevant changelog entries from all packages into the Release Notes and adjust accordingly, matching the format used by prior releases
 
 ### Experimental releases
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -245,6 +245,7 @@
 - jwnx
 - kalch
 - kamtugeza
+- kandros
 - kanermichael
 - karimsan
 - kauffmanes
@@ -457,6 +458,7 @@
 - thomasheyenbrock
 - thomasrettig
 - tjefferson08
+- tombiju
 - tombyrer
 - toyozaki
 - turkerdev
@@ -485,6 +487,7 @@
 - wKovacs64
 - wladiston
 - wtlin1228
+- wxh06
 - xHomu
 - XiNiHa
 - xstevenyung

--- a/contributors.yml
+++ b/contributors.yml
@@ -498,3 +498,8 @@
 - zainfathoni
 - zayenz
 - zhe
+- mitchelldirt
+- krolebord
+- panteliselef
+- mattcroat
+- wizardlyhel

--- a/docs/file-conventions/route-files-v2.md
+++ b/docs/file-conventions/route-files-v2.md
@@ -324,7 +324,7 @@ routes/
   app_.projects.$id.roadmap.tsx
 ```
 
-Some, or all of them can be folders holding their own modules inside.
+Some, or all of them can be folders holding their own `route` module inside.
 
 ```
 routes/
@@ -359,7 +359,7 @@ routes/
   contact-us.tsx
 ```
 
-Note that `app/index.tsx` is _not_ the "index route" for `app/`. It is Note's "index module" for the directory `routes/app/`. The index route for `app/` is `app._index/index.tsx`. The only thing that contributes to the route path is the directory name.
+Note that when you turn a route module into a folder, the route module becomes `folder/route.tsx`, all other modules in the folder will not become routes. For example:
 
 ```
 # these are the same route:

--- a/docs/guides/constraints.md
+++ b/docs/guides/constraints.md
@@ -119,7 +119,7 @@ export default function Posts() {
 }
 ```
 
-The loader is gone but the prisma dependency stayed! Had we logged something harmless like `console.log("hello!")` it would be fine. But we logged the `prisma` module so the browser's gonna have a hard time with that.
+The loader is gone but the prisma dependency stayed! Had we logged something harmless like `console.log("hello!")` it would be fine. But we logged the `prisma` module so the browser's going to have a hard time with that.
 
 To fix this, remove the side effect by simply moving the code _into the loader_.
 

--- a/docs/guides/data-loading.md
+++ b/docs/guides/data-loading.md
@@ -314,7 +314,7 @@ Given the following URLs, the search params would be parsed as follows:
 
 ### Data Reloads
 
-When multiple nested routes are rendering and the search params change, all of the routes will be reloaded (instead of just the new or changed routes). This is because search params are a cross-cutting concern and could effect any loader. If you would like to prevent some of your routes from reloading in this scenario, use [shouldReload][should-reload].
+When multiple nested routes are rendering and the search params change, all of the routes will be reloaded (instead of just the new or changed routes). This is because search params are a cross-cutting concern and could effect any loader. If you would like to prevent some of your routes from reloading in this scenario, use [shouldRevalidate][should-revalidate].
 
 ### Search Params in Components
 
@@ -667,7 +667,7 @@ There are three cases where Remix will reload all of your routes:
 - If the url search params change (any loader could use them)
 - The user clicks a link to the exact same URL they are already at (this will also replace the current entry in the history stack)
 
-All of these behaviors emulate the browser's default behavior. In these cases, Remix doesn't know enough about your code to optimize the data loading, but you can optimize it yourself with [unstable_shouldReload][should-reload].
+All of these behaviors emulate the browser's default behavior. In these cases, Remix doesn't know enough about your code to optimize the data loading, but you can optimize it yourself with [shouldRevalidate][should-revalidate].
 
 ## Data Libraries
 
@@ -746,7 +746,7 @@ export default function RouteComp() {
 [prisma]: https://prisma.io
 [request]: https://developer.mozilla.org/en-US/docs/Web/API/Request
 [search-params-getall]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/getAll
-[should-reload]: ../route/should-reload
+[should-revalidate]: ../route/should-revalidate
 [url-search-params]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
 [url]: https://developer.mozilla.org/en-US/docs/Web/API/URL
 [use-submit]: ../hooks/use-submit

--- a/docs/hooks/use-fetchers.md
+++ b/docs/hooks/use-fetchers.md
@@ -74,7 +74,7 @@ This is awesome for the checkbox, but the sidebar will say 2/4 while the checkbo
 +-----------------+----------------------------┘
 ```
 
-Because Remix will automatically reload the routes, the sidebar will quickly update and be correct. But for a moment, it's gonna feel a little funny.
+Because Remix will automatically reload the routes, the sidebar will quickly update and be correct. But for a moment, it's going to feel a little funny.
 
 This is where `useFetchers` comes in. Up in the sidebar, we can access all the inflight fetcher states from the checkboxes - even though it's not the component that created them.
 

--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -26,6 +26,8 @@ Each adapter has the same API. In the future we may have helpers specific to the
 
 ## Community Adapters
 
+- [`@mcansh/remix-fastify`][remix-fastify] - For [Fastify][fastify].
+- [`@mcansh/remix-raw-http`][remix-raw-http] - For a good ol barebones Node server.
 - [`remix-google-cloud-functions`][remix-google-cloud-functions] - For [Google Cloud][google-cloud-functions] and [Firebase][firebase-functions] functions.
 
 ## Creating an Adapter
@@ -180,3 +182,6 @@ addEventListener("fetch", (event) => {
 [remix-google-cloud-functions]: https://github.com/penx/remix-google-cloud-functions
 [google-cloud-functions]: https://cloud.google.com/functions
 [firebase-functions]: https://firebase.google.com/docs/functions
+[remix-fastify]: https://github.com/mcansh/remix-fastify
+[fastify]: https://www.fastify.io
+[remix-raw-http]: https://github.com/mcansh/remix-node-http-server

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -202,7 +202,7 @@ A solid practice is to create a module that deals with a particular concern. In 
 touch app/models/post.server.ts
 ```
 
-We're mostly gonna copy/paste stuff from our route:
+We're mostly going to copy/paste stuff from our route:
 
 ```tsx filename=app/models/post.server.ts
 type Post = {
@@ -534,7 +534,7 @@ export default function PostSlug() {
 }
 ```
 
-Holy smokes, you did it. You have a blog. Check it out! Next, we're gonna make it easier to create new blog posts 📝
+Holy smokes, you did it. You have a blog. Check it out! Next, we're going to make it easier to create new blog posts 📝
 
 ## Nested Routing
 
@@ -700,7 +700,7 @@ Now click the link from the index route and watch the `<Outlet/>` automatically 
 
 ## Actions
 
-We're gonna get serious now. Let's build a form to create a new post in our new "new" route.
+We're going to get serious now. Let's build a form to create a new post in our new "new" route.
 
 💿 Add a form to the new route
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,4 +30,5 @@ module.exports = {
     require.resolve("jest-watch-typeahead/filename"),
     require.resolve("jest-watch-typeahead/testname"),
   ],
+  reporters: ["default"],
 };

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1133,18 +1133,20 @@ export interface RouteMatch {
 export function useMatches(): RouteMatch[] {
   let { routeModules } = useRemixContext();
   let matches = useMatchesRR();
-  return matches.map((match) => {
-    let remixMatch: RouteMatch = {
-      id: match.id,
-      pathname: match.pathname,
-      params: match.params,
-      data: match.data,
-      // Need to grab handle here since we don't have it at client-side route
-      // creation time
-      handle: routeModules[match.id].handle,
-    };
-    return remixMatch;
-  });
+  return React.useMemo(() => {
+    return matches.map((match) => {
+      let remixMatch: RouteMatch = {
+        id: match.id,
+        pathname: match.pathname,
+        params: match.params,
+        data: match.data,
+        // Need to grab handle here since we don't have it at client-side route
+        // creation time
+        handle: routeModules[match.id].handle,
+      };
+      return remixMatch;
+    });
+  }, [matches, routeModules]);
 }
 
 /**

--- a/templates/arc/package.json
+++ b/templates/arc/package.json
@@ -5,7 +5,7 @@
     "build": "remix build",
     "dev:remix": "remix watch",
     "dev:arc": "cross-env NODE_ENV=development arc sandbox",
-    "dev": "remix build && run-p \"dev:*\"",
+    "dev": "npm-run-all build --parallel \"dev:*\"",
     "start": "cross-env NODE_ENV=production arc sandbox",
     "typecheck": "tsc"
   },

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -5,7 +5,7 @@
     "build": "remix build",
     "dev:remix": "remix watch",
     "dev:wrangler": "cross-env NODE_ENV=development npm run wrangler",
-    "dev": "remix build && run-p \"dev:*\"",
+    "dev": "npm-run-all build --parallel \"dev:*\"",
     "start": "cross-env NODE_ENV=production npm run wrangler",
     "typecheck": "tsc",
     "wrangler": "wrangler pages dev ./public"

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -6,7 +6,7 @@
     "deploy": "wrangler publish",
     "dev:remix": "remix watch",
     "dev:miniflare": "cross-env NODE_ENV=development miniflare ./build/index.js --watch",
-    "dev": "remix build && run-p \"dev:*\"",
+    "dev": "npm-run-all build --parallel \"dev:*\"",
     "start": "cross-env NODE_ENV=production miniflare ./build/index.js",
     "typecheck": "tsc"
   },

--- a/templates/deno/package.json
+++ b/templates/deno/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "remix build",
     "deploy": "deployctl deploy --prod --include=build,public --project=<your deno deploy project> ./build/index.js",
-    "dev": "remix build && run-p \"dev:*\"",
+    "dev": "npm-run-all build --parallel \"dev:*\"",
     "dev:deno": "cross-env NODE_ENV=development deno run --unstable --watch --allow-net --allow-read --allow-env ./build/index.js",
     "dev:remix": "remix watch",
     "format": "deno fmt --ignore=node_modules,build,public/build",

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -3,7 +3,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
-    "dev": "remix build && run-p \"dev:*\"",
+    "dev": "npm-run-all build --parallel \"dev:*\"",
     "dev:node": "cross-env NODE_ENV=development nodemon --require dotenv/config ./server.js --watch ./server.js",
     "dev:remix": "remix watch",
     "start": "cross-env NODE_ENV=production node ./server.js",


### PR DESCRIPTION
Closes: #

- [ ] Docs
- [ ] Tests

**Problem:** `useMatches` returning different route match data on sub navigation. This problem isn't obvious because the last `useMatches` hook call always returns the correct route's loader data

https://stackblitz.com/edit/remix-run-remix-askr4f?file=app/root.tsx

Navigate between home, test and test 2 page.

1. On full page reload, you will see multiple logs from `useMatches` of the same route (This is fine and it is due to React re-renders)
2. On sub navigation, you will see multiple logs from `useMatches` but of different route loader data. It is always the current route and the previous route

Notice that the server side console only logs loader data for the correct route


