### PR TITLE
perf(remix-dev/config): improve `createRoutPath`'s footprint & unit tests

### DIFF
--- a/packages/remix-dev/__tests__/routesConvention-test.ts
+++ b/packages/remix-dev/__tests__/routesConvention-test.ts
@@ -14,6 +14,7 @@ describe("createRoutePath", () => {
       ["routes/$slug", "routes/:slug"],
       ["routes/sub/$slug", "routes/sub/:slug"],
       ["routes.sub/$slug", "routes/sub/:slug"],
+      ["routes/index/children", "routeschildren"],
       ["$", "*"],
       ["nested/$", "nested/*"],
       ["flat.$", "flat/*"],

--- a/packages/remix-dev/config/routesConvention.ts
+++ b/packages/remix-dev/config/routesConvention.ts
@@ -120,7 +120,6 @@ export let escapeEnd = "]" as const;
 export let optionalStart = "(" as const;
 export let optionalEnd = ")" as const;
 
-// TODO: Cleanup and write some tests for this function
 export function createRoutePath(partialRouteId: string): string | undefined {
   let result = "";
   let rawSegmentBuffer = "";
@@ -135,39 +134,30 @@ export function createRoutePath(partialRouteId: string): string | undefined {
     let nextChar =
       i < partialRouteId.length - 1 ? partialRouteId.charAt(i + 1) : undefined;
 
-    function isNewEscapeSequence() {
-      return (
-        !inEscapeSequence && char === escapeStart && prevChar !== escapeStart
-      );
-    }
+    let isNewEscapeSequence =
+      !inEscapeSequence && char === escapeStart && prevChar !== escapeStart;
 
-    function isCloseEscapeSequence() {
-      return inEscapeSequence && char === escapeEnd && nextChar !== escapeEnd;
-    }
+    let isCloseEscapeSequence =
+      inEscapeSequence && char === escapeEnd && nextChar !== escapeEnd;
 
-    function isStartOfLayoutSegment() {
-      return char === "_" && nextChar === "_" && !rawSegmentBuffer;
-    }
+    let isStartOfLayoutSegment =
+      char === "_" && nextChar === "_" && !rawSegmentBuffer;
 
-    function isNewOptionalSegment() {
-      return (
-        char === optionalStart &&
-        prevChar !== optionalStart &&
-        (isSegmentSeparator(prevChar) || prevChar === undefined) &&
-        !inOptionalSegment &&
-        !inEscapeSequence
-      );
-    }
+    let isNewOptionalSegment = (
+      char === optionalStart &&
+      prevChar !== optionalStart &&
+      (isSegmentSeparator(prevChar) || prevChar === undefined) &&
+      !inOptionalSegment &&
+      !inEscapeSequence
+    );
 
-    function isCloseOptionalSegment() {
-      return (
-        char === optionalEnd &&
-        nextChar !== optionalEnd &&
-        (isSegmentSeparator(nextChar) || nextChar === undefined) &&
-        inOptionalSegment &&
-        !inEscapeSequence
-      );
-    }
+    let isCloseOptionalSegment = (
+      char === optionalEnd &&
+      nextChar !== optionalEnd &&
+      (isSegmentSeparator(nextChar) || nextChar === undefined) &&
+      inOptionalSegment &&
+      !inEscapeSequence
+    );
 
     if (skipSegment) {
       if (isSegmentSeparator(char)) {
@@ -176,24 +166,24 @@ export function createRoutePath(partialRouteId: string): string | undefined {
       continue;
     }
 
-    if (isNewEscapeSequence()) {
+    if (isNewEscapeSequence) {
       inEscapeSequence++;
       continue;
     }
 
-    if (isCloseEscapeSequence()) {
+    if (isCloseEscapeSequence) {
       inEscapeSequence--;
       continue;
     }
 
-    if (isNewOptionalSegment()) {
+    if (isNewOptionalSegment) {
       inOptionalSegment++;
       optionalSegmentIndex = result.length;
       result += optionalStart;
       continue;
     }
 
-    if (isCloseOptionalSegment()) {
+    if (isCloseOptionalSegment) {
       if (optionalSegmentIndex !== null) {
         result =
           result.slice(0, optionalSegmentIndex) +
@@ -223,7 +213,7 @@ export function createRoutePath(partialRouteId: string): string | undefined {
       continue;
     }
 
-    if (isStartOfLayoutSegment()) {
+    if (isStartOfLayoutSegment) {
       skipSegment = true;
       continue;
     }


### PR DESCRIPTION
Hi Remix,

I chose a todo at random in the code and came across the createRoutePath function of remix-dev.

I added the last missing unit test to have 100% coverage but I'm not sure if the case reacts correctly.

Indeed, a routes/index/children path will generate `routeschildren`. I did not change the way it works to avoid a braking change.
I don't know what we want in this case `createRoutePath('routes/index/children')`:

`routeschildren`
`routes/children`
`routes/index/children`

https://github.com/gyx1000/remix/blob/perf/dev-create-route-path/packages/remix-dev/config/routesConvention.ts#L201

By analyzing the function, I also realized that we could improve its performance by about 50% (with the tests I performed).
Several functions are initialized for each iterated character. I simply converted the function to a variable to avoid this. 

```javascript
console.time('createRoutePath');
for(let i=0; i<1_000; ++i) {
    createRoutePath('routes/children/subchildren')
}
console.timeEnd('createRoutePath');

// before change: 22.96ms
// after change: 11.143ms
```

Thanks again for this wonderful project.