### PR TITLE
Allow TypeScript v5 moduleResolution: "bundler"

### DIFF
--- a/.changeset/cool-planets-perform.md
+++ b/.changeset/cool-planets-perform.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": minor
+---
+
+Allow moduleResolution:"bundler" on tsconfig.json

--- a/contributors.yml
+++ b/contributors.yml
@@ -65,6 +65,7 @@
 - bsharrow
 - bsides
 - bustamantedev
+- buzinas
 - c43721
 - camiaei
 - CanRau

--- a/integration/tsconfig-test.ts
+++ b/integration/tsconfig-test.ts
@@ -91,6 +91,26 @@ test("shouldn't change suggested config if set", async () => {
   expect(tsconfig).toEqual(config);
 });
 
+test("shouldn't change suggested config for moduleResolution: bundler", async () => {
+  let config = {
+    ...DEFAULT_CONFIG,
+    compilerOptions: {
+      ...DEFAULT_CONFIG.compilerOptions,
+      strict: false,
+      moduleResolution: "bundler",
+    },
+  };
+
+  let fixture = await createFixture({
+    files: {
+      "tsconfig.json": json(config),
+    },
+  });
+
+  let tsconfig = await getTsConfig(fixture.projectDir);
+  expect(tsconfig).toEqual(config);
+});
+
 test("allows for `extends` in tsconfig", async () => {
   let config = {
     extends: "./tsconfig.base.json",

--- a/packages/remix-dev/compiler/utils/tsconfig/write-config-defaults.ts
+++ b/packages/remix-dev/compiler/utils/tsconfig/write-config-defaults.ts
@@ -126,7 +126,7 @@ export function writeConfigDefaults(configPath: string) {
   }
 
   if (
-    !["node", "node16", "nodenext"].includes(
+    !["node", "node16", "nodenext", "bundler"].includes(
       fullConfig.compilerOptions.moduleResolution.toLowerCase()
     )
   ) {


### PR DESCRIPTION
See https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-beta/#moduleresolution-bundler for more info.

- [ ] Docs (I don't think there is anything relevant to add to the docs, please let me know otherwise).
- [x] Tests

Testing Strategy:

I've been patching this since I moved to TypeScript v5 beta. I also added a unit test.