### PR TITLE
ci(test): cache and restore build and playwright binaries between jobs

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "yarn"
+          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,6 +20,13 @@ jobs:
         with:
           token: ${{ secrets.FORMAT_PAT }}
 
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          # this is for the *global* cache, and not `node_modules`
+          cache: "yarn"
+
       - name: 🕵️ Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
@@ -32,13 +39,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-
-      - name: ⎔ Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-          # this is for the *global* cache, and not `node_modules`
-          cache: "yarn"
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,12 +20,25 @@ jobs:
         with:
           token: ${{ secrets.FORMAT_PAT }}
 
+      - name: 🕵️ Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - name: 📤 Cache node_modules
+        id: yarn-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
-          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -31,7 +31,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - name: 📤 Cache node_modules
+      - name: 📥 Restore node_modules
         id: yarn-cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,12 +18,25 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
+      - name: 🕵️ Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - name: 📤 Cache node_modules
+        id: yarn-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
-          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,13 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          # this is for the *global* cache, and not `node_modules`
+          cache: "yarn"
+
       - name: 🕵️ Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
@@ -30,13 +37,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-
-      - name: ⎔ Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-          # this is for the *global* cache, and not `node_modules`
-          cache: "yarn"
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "yarn"
+          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - name: 📤 Cache node_modules
+      - name: 📥 Restore node_modules
         id: yarn-cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,12 +33,25 @@ jobs:
           token: ${{ secrets.NIGHTLY_PAT }}
           fetch-depth: 0
 
+      - name: 🕵️ Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - name: 📤 Cache node_modules
+        id: yarn-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
-          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "yarn"
+          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,6 +33,13 @@ jobs:
           token: ${{ secrets.NIGHTLY_PAT }}
           fetch-depth: 0
 
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          # this is for the *global* cache, and not `node_modules`
+          cache: "yarn"
+
       - name: 🕵️ Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
@@ -45,13 +52,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-
-      - name: ⎔ Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-          # this is for the *global* cache, and not `node_modules`
-          cache: "yarn"
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,7 +44,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - name: 📤 Cache node_modules
+      - name: 📥 Restore node_modules
         id: yarn-cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release-experimental.yml
+++ b/.github/workflows/release-experimental.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "yarn"
+          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/release-experimental.yml
+++ b/.github/workflows/release-experimental.yml
@@ -57,7 +57,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - name: 📤 Cache node_modules
+      - name: 📥 Restore node_modules
         id: yarn-cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release-experimental.yml
+++ b/.github/workflows/release-experimental.yml
@@ -46,12 +46,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: 🕵️ Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - name: 📤 Cache node_modules
+        id: yarn-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
-          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/release-experimental.yml
+++ b/.github/workflows/release-experimental.yml
@@ -46,6 +46,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          # this is for the *global* cache, and not `node_modules`
+          cache: "yarn"
+
       - name: 🕵️ Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
@@ -58,13 +65,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-
-      - name: ⎔ Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-          # this is for the *global* cache, and not `node_modules`
-          cache: "yarn"
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "yarn"
+          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,13 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.NIGHTLY_PAT }}
 
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          # this is for the *global* cache, and not `node_modules`
+          cache: "yarn"
+
       - name: 🕵️ Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
@@ -45,13 +52,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-
-      - name: ⎔ Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-          # this is for the *global* cache, and not `node_modules`
-          cache: "yarn"
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - name: 📤 Cache node_modules
+      - name: 📥 Restore node_modules
         id: yarn-cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,25 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.NIGHTLY_PAT }}
 
+      - name: 🕵️ Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - name: 📤 Cache node_modules
+        id: yarn-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
-          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -36,7 +36,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - name: 📤 Cache node_modules
+      - name: 📥 Restore node_modules
         id: yarn-cache
         uses: actions/cache@v3
         with:
@@ -94,7 +94,7 @@ jobs:
         id: yarn-cache-dir-path-windows
         run: echo "dir=$(yarn cache dir)" >> ${env:GITHUB_OUTPUT}
 
-      - name: 📤 Cache node_modules
+      - name: 📥 Restore node_modules
         id: yarn-cache
         uses: actions/cache@v3
         with:
@@ -134,7 +134,7 @@ jobs:
           # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
 
-      - name: 📤 Cache node_modules
+      - name: 📥 Restore node_modules
         uses: actions/cache@v3
         with:
           enableCrossOsArchive: true
@@ -148,7 +148,7 @@ jobs:
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_ENV
 
-      - name: 📤 Restore playwright binaries
+      - name: 📥 Restore playwright binaries
         uses: actions/cache@v3
         id: playwright-cache
         with:
@@ -198,7 +198,7 @@ jobs:
           # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
 
-      - name: 📤 Cache node_modules
+      - name: 📥 Restore node_modules
         uses: actions/cache@v3
         with:
           enableCrossOsArchive: true
@@ -212,7 +212,7 @@ jobs:
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_ENV
 
-      - name: 📤 Restore playwright binaries
+      - name: 📥 Restore playwright binaries
         uses: actions/cache@v3
         id: playwright-cache
         with:
@@ -262,7 +262,7 @@ jobs:
           # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
 
-      - name: 📤 Cache node_modules
+      - name: 📥 Restore node_modules
         uses: actions/cache@v3
         with:
           enableCrossOsArchive: true
@@ -278,7 +278,7 @@ jobs:
           chcp 65001 # set code page to utf-8
           echo ("PLAYWRIGHT_VERSION=" + (node -e "console.log(require('@playwright/test/package.json').version)")) >> $env:GITHUB_ENV
 
-      - name: 📤 Restore playwright binaries
+      - name: 📥 Restore playwright binaries
         uses: actions/cache@v3
         id: playwright-cache
         with:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -107,7 +107,7 @@ jobs:
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_ENV
 
-      - name: 📤 Cache playwright binaries
+      - name: 📤 Restore playwright binaries
         uses: actions/cache@v3
         id: playwright-cache
         with:
@@ -159,9 +159,9 @@ jobs:
 
       - name: 👀 Get installed Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_ENV
 
-      - name: 📤 Cache playwright binaries
+      - name: 📤 Restore playwright binaries
         uses: actions/cache@v3
         id: playwright-cache
         with:
@@ -213,9 +213,9 @@ jobs:
 
       - name: 👀 Get installed Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_ENV
 
-      - name: 📤 Cache playwright binaries
+      - name: 📤 Restore playwright binaries
         uses: actions/cache@v3
         id: playwright-cache
         with:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -25,19 +25,36 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
+      - name: 🕵️ Get yarn cache directory path
+        if: runner.os != 'Windows'
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - name: 🕵️ Get yarn cache directory path (Windows)
+        if: runner.os == 'Windows'
+        id: yarn-cache-dir-path-windows
+        run: echo "dir=$(yarn cache dir)" >> ${env:GITHUB_OUTPUT}
+
+      - name: 📤 Cache node_modules
+        id: yarn-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ runner.os == 'Windows' && steps.yarn-cache-dir-path-windows.outputs.dir || steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
-          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
-        shell: bash
         run: yarn --frozen-lockfile
 
       - name: 🏗 Build
-        shell: bash
         run: yarn build
 
       - name: 📤 Cache build
@@ -64,19 +81,30 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: ⎔ Setup node ${{ matrix.node }}
+      - name: 🕵️ Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - name: 📤 Cache node_modules
+        id: yarn-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version-file: ".nvmrc"
+          # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
-          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
-        shell: bash
         run: yarn --frozen-lockfile
 
       - name: 🧪 Run Primary Tests
-        shell: bash
         run: yarn test:primary
 
   ubuntu-integration:
@@ -96,19 +124,23 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: ⎔ Setup node ${{ matrix.node }}
+      - name: 📤 Cache node_modules
+        uses: actions/cache@v3
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+          # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
-          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
-        shell: bash
         run: yarn --frozen-lockfile
 
       - name: 👀 Get installed Playwright version
-        shell: bash
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_ENV
 
@@ -121,7 +153,6 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: 📥 Install Playwright
-        shell: bash
         run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
@@ -132,7 +163,6 @@ jobs:
           key: remix-build-${{ github.sha }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
-        shell: bash
         run: |
           npm pkg delete scripts.pretest:integration
           npm pkg delete scripts.posttest:integration
@@ -155,19 +185,23 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: ⎔ Setup node ${{ matrix.node }}
+      - name: 📤 Cache node_modules
+        uses: actions/cache@v3
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+          # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
-          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
-        shell: bash
         run: yarn --frozen-lockfile
 
       - name: 👀 Get installed Playwright version
-        shell: bash
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_ENV
 
@@ -180,7 +214,6 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: 📥 Install Playwright
-        shell: bash
         run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
@@ -191,7 +224,6 @@ jobs:
           key: remix-build-${{ github.sha }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
-        shell: bash
         run: |
           npm pkg delete scripts.pretest:integration
           npm pkg delete scripts.posttest:integration
@@ -214,19 +246,23 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: ⎔ Setup node ${{ matrix.node }}
+      - name: 📤 Cache node_modules
+        uses: actions/cache@v3
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+          # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
-          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
-        shell: pwsh
         run: yarn --frozen-lockfile
 
       - name: 👀 Get installed Playwright version
-        shell: pwsh
         id: playwright-version
         run: |
           chcp 65001 # set code page to utf-8
@@ -241,7 +277,6 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: 📥 Install Playwright
-        shell: pwsh
         run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
@@ -252,7 +287,6 @@ jobs:
           key: remix-build-${{ github.sha }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
-        shell: bash
         run: |
           npm pkg delete scripts.pretest:integration
           npm pkg delete scripts.posttest:integration

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -25,6 +25,13 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          # this is for the *global* cache, and not `node_modules`
+          cache: "yarn"
+
       - name: 🕵️ Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
@@ -37,13 +44,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-
-      - name: ⎔ Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-          # this is for the *global* cache, and not `node_modules`
-          cache: "yarn"
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
@@ -75,6 +75,13 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          # this is for the *global* cache, and not `node_modules`
+          cache: "yarn"
+
       - name: 🕵️ Get yarn cache directory path
         if: runner.os != 'Windows'
         id: yarn-cache-dir-path
@@ -93,13 +100,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-
-      - name: ⎔ Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-          # this is for the *global* cache, and not `node_modules`
-          cache: "yarn"
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
@@ -124,18 +124,18 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: 📤 Cache node_modules
-        uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
+
+      - name: 📤 Cache node_modules
+        uses: actions/cache@v3
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
@@ -185,18 +185,18 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: 📤 Cache node_modules
-        uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
+
+      - name: 📤 Cache node_modules
+        uses: actions/cache@v3
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
@@ -246,18 +246,18 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: 📤 Cache node_modules
-        uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           # this is for the *global* cache, and not `node_modules`
           cache: "yarn"
+
+      - name: 📤 Cache node_modules
+        uses: actions/cache@v3
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -37,11 +37,12 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: 🏗 Build
-        shell: bash
+        shell: pwsh
         if: runner.os == 'Windows'
         run: |
           yarn build
-          echo "date=$(/bin/date -u +%s)" >> $env:GITHUB_ENV
+          chcp 65001 # set code page to utf-8
+          echo ("date=" + (Get-Date -Date ((Get-Date).DateTime) -UFormat %s)) >> $env:GITHUB_ENV
 
       - name: 🏗 Build
         shell: bash
@@ -232,13 +233,15 @@ jobs:
           cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
-        shell: bash
+        shell: pwsh
         run: yarn --frozen-lockfile
 
       - name: 👀 Get installed Playwright version
-        shell: bash
+        shell: pwsh
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $env:GITHUB_ENV
+        run: |
+          chcp 65001 # set code page to utf-8
+          echo ("PLAYWRIGHT_VERSION=" + (node -e "console.log(require('@playwright/test/package.json').version)")) >> $env:GITHUB_ENV
 
       - name: 📤 Restore playwright binaries
         uses: actions/cache@v3
@@ -249,7 +252,7 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: 📥 Install Playwright
-        shell: bash
+        shell: pwsh
         run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -37,6 +37,17 @@ jobs:
       - name: 🏗 Build
         run: yarn build
 
+      - name: Get Date
+        id: get_date
+        run: echo "date=$(/bin/date -u "+%s")" >> $GITHUB_ENV
+        shell: bash
+
+      - name: 📤 Cache build
+        uses: actions/cache@v2
+        with:
+          path: ./build
+          key: ${{ runner.os }}-build-${{ env.get_date.date }}
+
   test:
     name: "🧪 Test: (OS: ${{ matrix.os }} Node: ${{ matrix.node }})"
     strategy:
@@ -69,7 +80,7 @@ jobs:
         run: yarn build
 
       - name: 🧪 Run Primary Tests
-        run: "yarn test:primary"
+        run: yarn test:primary
 
   ubuntu-integration:
     name: '👀 Integration Test: (OS: "ubuntu-latest" Node: "${{ matrix.node }}" Browser: "${{ matrix.browser }}")'
@@ -99,8 +110,17 @@ jobs:
       - name: 📥 Install Playwright
         run: npx playwright install --with-deps
 
+      - name: 📥 Restore build
+        uses: actions/cache@v2
+        with:
+          path: ./build
+          key: ${{ runner.os }}-build-${{ env.get_date.date }}
+
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
-        run: "yarn test:integration --project=${{ matrix.browser }}"
+        run: |
+          npm pkg delete pretest:integration
+          npm pkg delete posttest:integration
+          yarn test:integration --project=${{ matrix.browser }}
 
   macos-integration:
     name: '👀 Integration Test: (OS: "macos-latest" Node: "${{ matrix.node }}" Browser: "${{ matrix.browser }}")'
@@ -130,8 +150,17 @@ jobs:
       - name: 📥 Install Playwright
         run: npx playwright install --with-deps
 
+      - name: 📥 Restore build
+        uses: actions/cache@v2
+        with:
+          path: ./build
+          key: ${{ runner.os }}-build-${{ env.get_date.date }}
+
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
-        run: "yarn test:integration --project=${{ matrix.browser }}"
+        run: |
+          npm pkg delete pretest:integration
+          npm pkg delete posttest:integration
+          yarn test:integration --project=${{ matrix.browser }}
 
   windows-integration:
     name: '👀 Integration Test: (OS: "windows-latest" Node: "${{ matrix.node }}" Browser: "${{ matrix.browser }}")'
@@ -161,5 +190,14 @@ jobs:
       - name: 📥 Install Playwright
         run: npx playwright install --with-deps
 
+      - name: 📥 Restore build
+        uses: actions/cache@v2
+        with:
+          path: ./build
+          key: ${{ runner.os }}-build-${{ env.get_date.date }}
+
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
-        run: "yarn test:integration --project=${{ matrix.browser }}"
+        run: |
+          npm pkg delete pretest:integration
+          npm pkg delete posttest:integration
+          yarn test:integration --project=${{ matrix.browser }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -40,6 +40,7 @@ jobs:
         id: yarn-cache
         uses: actions/cache@v3
         with:
+          enableCrossOsArchive: true
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
@@ -54,6 +55,7 @@ jobs:
       - name: 📤 Cache build
         uses: actions/cache@v3
         with:
+          enableCrossOsArchive: true
           path: ./build
           key: remix-build-${{ github.sha }}
 
@@ -96,6 +98,7 @@ jobs:
         id: yarn-cache
         uses: actions/cache@v3
         with:
+          enableCrossOsArchive: true
           path: ${{ runner.os == 'Windows' && steps.yarn-cache-dir-path-windows.outputs.dir || steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
@@ -134,6 +137,7 @@ jobs:
       - name: 📤 Cache node_modules
         uses: actions/cache@v3
         with:
+          enableCrossOsArchive: true
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
@@ -148,6 +152,7 @@ jobs:
         uses: actions/cache@v3
         id: playwright-cache
         with:
+          enableCrossOsArchive: true
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
@@ -159,6 +164,7 @@ jobs:
       - name: 📥 Restore build
         uses: actions/cache@v3
         with:
+          enableCrossOsArchive: true
           path: ./build
           key: remix-build-${{ github.sha }}
 
@@ -195,6 +201,7 @@ jobs:
       - name: 📤 Cache node_modules
         uses: actions/cache@v3
         with:
+          enableCrossOsArchive: true
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
@@ -209,6 +216,7 @@ jobs:
         uses: actions/cache@v3
         id: playwright-cache
         with:
+          enableCrossOsArchive: true
           path: |
             ~/Library/Caches/ms-playwright
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
@@ -220,6 +228,7 @@ jobs:
       - name: 📥 Restore build
         uses: actions/cache@v3
         with:
+          enableCrossOsArchive: true
           path: ./build
           key: remix-build-${{ github.sha }}
 
@@ -256,6 +265,7 @@ jobs:
       - name: 📤 Cache node_modules
         uses: actions/cache@v3
         with:
+          enableCrossOsArchive: true
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
@@ -272,6 +282,7 @@ jobs:
         uses: actions/cache@v3
         id: playwright-cache
         with:
+          enableCrossOsArchive: true
           path: |
             %USERPROFILE%\AppData\Local\ms-playwright
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
@@ -283,6 +294,7 @@ jobs:
       - name: 📥 Restore build
         uses: actions/cache@v3
         with:
+          enableCrossOsArchive: true
           path: ./build
           key: remix-build-${{ github.sha }}
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -227,7 +227,7 @@ jobs:
       - name: 👀 Get installed Playwright version
         shell: bash
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $env:GITHUB_ENV
 
       - name: 📤 Restore playwright binaries
         uses: actions/cache@v3
@@ -235,7 +235,7 @@ jobs:
         with:
           path: |
             %USERPROFILE%\AppData\Local\ms-playwright
-          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+          key: ${{ runner.os }}-playwright-${{ $env:PLAYWRIGHT_VERSION }}
 
       - name: 📥 Install Playwright
         shell: bash
@@ -246,7 +246,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./build
-          key: remix-build-${{ env.date }}
+          key: remix-build-${{ $env:date }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         shell: bash

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: 📅 Get Date
         id: get_date
-        run: echo "date=$(/bin/date -u "+%s")" >> $GITHUB_ENV
+        run: echo "date=$(/bin/date -u +%s)" >> $GITHUB_ENV
         shell: bash
 
       - name: 📤 Cache build
@@ -80,6 +80,7 @@ jobs:
 
   ubuntu-integration:
     name: '👀 Integration Test: (OS: "ubuntu-latest" Node: "${{ matrix.node }}" Browser: "${{ matrix.browser }}")'
+    needs: [build]
     strategy:
       fail-fast: false
       matrix:
@@ -120,6 +121,7 @@ jobs:
 
   macos-integration:
     name: '👀 Integration Test: (OS: "macos-latest" Node: "${{ matrix.node }}" Browser: "${{ matrix.browser }}")'
+    needs: [build]
     strategy:
       fail-fast: false
       matrix:
@@ -160,6 +162,7 @@ jobs:
 
   windows-integration:
     name: '👀 Integration Test: (OS: "windows-latest" Node: "${{ matrix.node }}" Browser: "${{ matrix.browser }}")'
+    needs: [build]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -26,20 +26,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🕵️ Get yarn cache directory path
-        if: runner.os != 'Windows'
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - name: 🕵️ Get yarn cache directory path (Windows)
-        if: runner.os == 'Windows'
-        id: yarn-cache-dir-path-windows
-        run: echo "dir=$(yarn cache dir)" >> ${env:GITHUB_OUTPUT}
 
       - name: 📤 Cache node_modules
         id: yarn-cache
         uses: actions/cache@v3
         with:
-          path: ${{ runner.os == 'Windows' && steps.yarn-cache-dir-path-windows.outputs.dir || steps.yarn-cache-dir-path.outputs.dir }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
@@ -82,14 +76,20 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🕵️ Get yarn cache directory path
+        if: runner.os != 'Windows'
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - name: 🕵️ Get yarn cache directory path (Windows)
+        if: runner.os == 'Windows'
+        id: yarn-cache-dir-path-windows
+        run: echo "dir=$(yarn cache dir)" >> ${env:GITHUB_OUTPUT}
 
       - name: 📤 Cache node_modules
         id: yarn-cache
         uses: actions/cache@v3
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: ${{ runner.os == 'Windows' && steps.yarn-cache-dir-path-windows.outputs.dir || steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -235,7 +235,7 @@ jobs:
         with:
           path: |
             %USERPROFILE%\AppData\Local\ms-playwright
-          key: ${{ runner.os }}-playwright-${{ $env:PLAYWRIGHT_VERSION }}
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: 📥 Install Playwright
         shell: bash
@@ -246,7 +246,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./build
-          key: remix-build-${{ $env:date }}
+          key: remix-build-${{ env.date }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         shell: bash

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./build
-          key: ${{ runner.os }}-build-${{ env.date }}
+          key: remix-build-${{ env.date }}
 
   test:
     name: "🧪 Test: (OS: ${{ matrix.os }} Node: ${{ matrix.node }})"
@@ -106,6 +106,7 @@ jobs:
       - name: 👀 Get installed Playwright version
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_ENV
+        shell: bash
 
       - name: 📤 Restore playwright binaries
         uses: actions/cache@v3
@@ -123,7 +124,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./build
-          key: ${{ runner.os }}-build-${{ env.date }}
+          key: remix-build-${{ env.date }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         run: |
@@ -160,6 +161,7 @@ jobs:
       - name: 👀 Get installed Playwright version
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_ENV
+        shell: bash
 
       - name: 📤 Restore playwright binaries
         uses: actions/cache@v3
@@ -177,7 +179,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./build
-          key: ${{ runner.os }}-build-${{ env.date }}
+          key: remix-build-${{ env.date }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         run: |
@@ -231,7 +233,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./build
-          key: ${{ runner.os }}-build-${{ env.date }}
+          key: remix-build-${{ env.date }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         run: |

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -32,14 +32,16 @@ jobs:
           cache: "yarn"
 
       - name: 📥 Install deps
+        shell: bash
         run: yarn --frozen-lockfile
 
       - name: 🏗 Build
+        shell: bash
         run: yarn build
 
       - name: 📅 Get Date
-        run: echo "date=$(/bin/date -u +%s)" >> $GITHUB_ENV
         shell: bash
+        run: echo "date=$(/bin/date -u +%s)" >> $GITHUB_ENV
 
       - name: 📤 Cache build
         uses: actions/cache@v3
@@ -72,9 +74,11 @@ jobs:
           cache: "yarn"
 
       - name: 📥 Install deps
+        shell: bash
         run: yarn --frozen-lockfile
 
       - name: 🧪 Run Primary Tests
+        shell: bash
         run: yarn test:primary
 
   ubuntu-integration:
@@ -101,12 +105,13 @@ jobs:
           cache: "yarn"
 
       - name: 📥 Install deps
+        shell: bash
         run: yarn --frozen-lockfile
 
       - name: 👀 Get installed Playwright version
+        shell: bash
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_ENV
-        shell: bash
 
       - name: 📤 Restore playwright binaries
         uses: actions/cache@v3
@@ -117,6 +122,7 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: 📥 Install Playwright
+        shell: bash
         run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
@@ -127,6 +133,7 @@ jobs:
           key: remix-build-${{ env.date }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
+        shell: bash
         run: |
           npm pkg delete scripts.pretest:integration
           npm pkg delete scripts.posttest:integration
@@ -156,12 +163,13 @@ jobs:
           cache: "yarn"
 
       - name: 📥 Install deps
+        shell: bash
         run: yarn --frozen-lockfile
 
       - name: 👀 Get installed Playwright version
+        shell: bash
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_ENV
-        shell: bash
 
       - name: 📤 Restore playwright binaries
         uses: actions/cache@v3
@@ -172,6 +180,7 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: 📥 Install Playwright
+        shell: bash
         run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
@@ -182,6 +191,7 @@ jobs:
           key: remix-build-${{ env.date }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
+        shell: bash
         run: |
           npm pkg delete scripts.pretest:integration
           npm pkg delete scripts.posttest:integration
@@ -211,9 +221,11 @@ jobs:
           cache: "yarn"
 
       - name: 📥 Install deps
+        shell: bash
         run: yarn --frozen-lockfile
 
       - name: 👀 Get installed Playwright version
+        shell: bash
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_ENV
 
@@ -226,6 +238,7 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: 📥 Install Playwright
+        shell: bash
         run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
@@ -236,6 +249,7 @@ jobs:
           key: remix-build-${{ env.date }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
+        shell: bash
         run: |
           npm pkg delete scripts.pretest:integration
           npm pkg delete scripts.posttest:integration

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -38,7 +38,6 @@ jobs:
         run: yarn build
 
       - name: 📅 Get Date
-        id: get_date
         run: echo "date=$(/bin/date -u +%s)" >> $GITHUB_ENV
         shell: bash
 
@@ -46,7 +45,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./build
-          key: ${{ runner.os }}-build-${{ env.get_date.date }}
+          key: ${{ runner.os }}-build-${{ env.date }}
 
   test:
     name: "🧪 Test: (OS: ${{ matrix.os }} Node: ${{ matrix.node }})"
@@ -124,7 +123,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./build
-          key: ${{ runner.os }}-build-${{ env.get_date.date }}
+          key: ${{ runner.os }}-build-${{ env.date }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         run: |
@@ -178,7 +177,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./build
-          key: ${{ runner.os }}-build-${{ env.get_date.date }}
+          key: ${{ runner.os }}-build-${{ env.date }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         run: |
@@ -232,7 +231,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./build
-          key: ${{ runner.os }}-build-${{ env.get_date.date }}
+          key: ${{ runner.os }}-build-${{ env.date }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         run: |

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "yarn"
+          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
         shell: bash
@@ -78,6 +79,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: "yarn"
+          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
         shell: bash
@@ -109,6 +111,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: "yarn"
+          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
         shell: bash
@@ -167,6 +170,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: "yarn"
+          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
         shell: bash
@@ -225,6 +229,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: "yarn"
+          cache-dependency-path: yarn.lock
 
       - name: 📥 Install deps
         shell: bash

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -104,8 +104,21 @@ jobs:
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
 
+      - name: 👀 Get installed Playwright version
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+
+      - name: 📤 Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
       - name: 📥 Install Playwright
         run: npx playwright install --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       - name: 📥 Restore build
         uses: actions/cache@v3
@@ -145,8 +158,21 @@ jobs:
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
 
+      - name: 👀 Get installed Playwright version
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+
+      - name: 📤 Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/Library/Caches/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
       - name: 📥 Install Playwright
         run: npx playwright install --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       - name: 📥 Restore build
         uses: actions/cache@v3
@@ -186,8 +212,21 @@ jobs:
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
 
+      - name: 👀 Get installed Playwright version
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+
+      - name: 📤 Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            %USERPROFILE%\AppData\Local\ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
       - name: 📥 Install Playwright
         run: npx playwright install --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       - name: 📥 Restore build
         uses: actions/cache@v3

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -43,7 +43,7 @@ jobs:
         shell: bash
 
       - name: 📤 Cache build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./build
           key: ${{ runner.os }}-build-${{ env.get_date.date }}
@@ -107,7 +107,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: 📥 Restore build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./build
           key: ${{ runner.os }}-build-${{ env.get_date.date }}
@@ -147,7 +147,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: 📥 Restore build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./build
           key: ${{ runner.os }}-build-${{ env.get_date.date }}
@@ -187,7 +187,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: 📥 Restore build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./build
           key: ${{ runner.os }}-build-${{ env.get_date.date }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: 🏗 Build
         run: yarn build
 
-      - name: Get Date
+      - name: 📅 Get Date
         id: get_date
         run: echo "date=$(/bin/date -u "+%s")" >> $GITHUB_ENV
         shell: bash
@@ -74,10 +74,6 @@ jobs:
 
       - name: 📥 Install deps
         run: yarn --frozen-lockfile
-
-      # It's faster to use the built `cli.js` in tests if its available and up-to-date
-      - name: 🏗 Build
-        run: yarn build
 
       - name: 🧪 Run Primary Tests
         run: yarn test:primary

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -37,11 +37,17 @@ jobs:
 
       - name: 🏗 Build
         shell: bash
-        run: yarn build
+        if: runner.os == 'Windows'
+        run: |
+          yarn build
+          echo "date=$(/bin/date -u +%s)" >> $env:GITHUB_ENV
 
-      - name: 📅 Get Date
+      - name: 🏗 Build
         shell: bash
-        run: echo "date=$(/bin/date -u +%s)" >> $GITHUB_ENV
+        if: runner.os != 'Windows'
+        run: |
+          yarn build
+          echo "date=$(/bin/date -u +%s)" >> $GITHUB_ENV
 
       - name: 📤 Cache build
         uses: actions/cache@v3

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -127,8 +127,8 @@ jobs:
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         run: |
-          npm pkg delete pretest:integration
-          npm pkg delete posttest:integration
+          npm pkg delete scripts.pretest:integration
+          npm pkg delete scripts.posttest:integration
           yarn test:integration --project=${{ matrix.browser }}
 
   macos-integration:
@@ -181,8 +181,8 @@ jobs:
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         run: |
-          npm pkg delete pretest:integration
-          npm pkg delete posttest:integration
+          npm pkg delete scripts.pretest:integration
+          npm pkg delete scripts.posttest:integration
           yarn test:integration --project=${{ matrix.browser }}
 
   windows-integration:
@@ -235,6 +235,6 @@ jobs:
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         run: |
-          npm pkg delete pretest:integration
-          npm pkg delete posttest:integration
+          npm pkg delete scripts.pretest:integration
+          npm pkg delete scripts.posttest:integration
           yarn test:integration --project=${{ matrix.browser }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -37,25 +37,14 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: 🏗 Build
-        shell: pwsh
-        if: runner.os == 'Windows'
-        run: |
-          yarn build
-          chcp 65001 # set code page to utf-8
-          echo ("date=" + (Get-Date -Date ((Get-Date).DateTime) -UFormat %s)) >> $env:GITHUB_ENV
-
-      - name: 🏗 Build
         shell: bash
-        if: runner.os != 'Windows'
-        run: |
-          yarn build
-          echo "date=$(/bin/date -u +%s)" >> $GITHUB_ENV
+        run: yarn build
 
       - name: 📤 Cache build
         uses: actions/cache@v3
         with:
           path: ./build
-          key: remix-build-${{ env.date }}
+          key: remix-build-${{ github.sha }}
 
   test:
     name: "🧪 Test: (OS: ${{ matrix.os }} Node: ${{ matrix.node }})"
@@ -140,7 +129,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./build
-          key: remix-build-${{ env.date }}
+          key: remix-build-${{ github.sha }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         shell: bash
@@ -199,7 +188,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./build
-          key: remix-build-${{ env.date }}
+          key: remix-build-${{ github.sha }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         shell: bash
@@ -260,7 +249,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./build
-          key: remix-build-${{ env.date }}
+          key: remix-build-${{ github.sha }}
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         shell: bash

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: 👀 Get installed Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_ENV
 
       - name: 📤 Cache playwright binaries
         uses: actions/cache@v3


### PR DESCRIPTION
- cache `yarn build` between jobs by sha `remix-build-<sha>`
- cache playwright binaries by version `<os>-playwright-<version>`
- cache node_modules by hash of yarn.lock


<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
