### PR TITLE
chore: don't log server errors for aborted requests

### DIFF
--- a/.changeset/no-log-on-aborted-request.md
+++ b/.changeset/no-log-on-aborted-request.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+Don't log server errors for aborted requests as that is an expected flow

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -182,9 +182,7 @@ async function handleDataRequestRR(
       errorInstance = error.error || errorInstance;
     }
 
-    if (serverMode !== ServerMode.Test && !request.signal.aborted) {
-      console.error(errorInstance);
-    }
+    logServerErrorIfNotAborted(errorInstance, request, serverMode);
 
     if (
       serverMode === ServerMode.Development &&
@@ -259,10 +257,7 @@ async function handleDocumentRequestRR(
       requestContext: loadContext,
     });
   } catch (error: unknown) {
-    if (!request.signal.aborted && serverMode !== ServerMode.Test) {
-      console.error(error);
-    }
-
+    logServerErrorIfNotAborted(error, request, serverMode);
     return new Response(null, { status: 500 });
   }
 
@@ -336,9 +331,7 @@ async function handleDocumentRequestRR(
         entryContext
       );
     } catch (error: any) {
-      if (serverMode !== ServerMode.Test && !request.signal.aborted) {
-        console.error(error);
-      }
+      logServerErrorIfNotAborted(error, request, serverMode);
       return returnLastResortErrorResponse(error, serverMode);
     }
   }
@@ -372,9 +365,7 @@ async function handleResourceRequestRR(
       error.headers.set("X-Remix-Catch", "yes");
       return error;
     }
-    if (serverMode !== ServerMode.Test && !request.signal.aborted) {
-      console.error(error);
-    }
+    logServerErrorIfNotAborted(error, request, serverMode);
     return returnLastResortErrorResponse(error, serverMode);
   }
 }
@@ -386,6 +377,16 @@ async function errorBoundaryError(error: Error, status: number) {
       "X-Remix-Error": "yes",
     },
   });
+}
+
+function logServerErrorIfNotAborted(
+  error: unknown,
+  request: Request,
+  serverMode: ServerMode
+) {
+  if (serverMode !== ServerMode.Test && !request.signal.aborted) {
+    console.error(error);
+  }
 }
 
 function returnLastResortErrorResponse(error: any, serverMode?: ServerMode) {

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -336,6 +336,9 @@ async function handleDocumentRequestRR(
         entryContext
       );
     } catch (error: any) {
+      if (serverMode !== ServerMode.Test && !request.signal.aborted) {
+        console.error(error);
+      }
       return returnLastResortErrorResponse(error, serverMode);
     }
   }
@@ -369,6 +372,9 @@ async function handleResourceRequestRR(
       error.headers.set("X-Remix-Catch", "yes");
       return error;
     }
+    if (serverMode !== ServerMode.Test && !request.signal.aborted) {
+      console.error(error);
+    }
     return returnLastResortErrorResponse(error, serverMode);
   }
 }
@@ -383,10 +389,6 @@ async function errorBoundaryError(error: Error, status: number) {
 }
 
 function returnLastResortErrorResponse(error: any, serverMode?: ServerMode) {
-  if (serverMode !== ServerMode.Test) {
-    console.error(error);
-  }
-
   let message = "Unexpected Server Error";
 
   if (serverMode !== ServerMode.Production) {


### PR DESCRIPTION
Since aborted requests is an ecpedted flow, we should not log the error from the router (i.e., `new Error("queryRoute() call aborted")`).  We had this check for some flows but not all.