### PR TITLE
feat(remix-dev): add warning when `future.v2_routeConvention` is not enabled

### DIFF
--- a/.changeset/lazy-dots-sip.md
+++ b/.changeset/lazy-dots-sip.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/dev": patch
+---
+
+add warning when `future.v2_routeConvention` is not enabled

--- a/integration/flat-routes-test.ts
+++ b/integration/flat-routes-test.ts
@@ -5,7 +5,7 @@ import { PlaywrightFixture } from "./helpers/playwright-fixture";
 import type { Fixture, AppFixture } from "./helpers/create-fixture";
 import { createFixtureProject } from "./helpers/create-fixture";
 import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
-import { flatRoutesWarning } from "../build/node_modules/@remix-run/dev/dist/config";
+import { flatRoutesWarning } from "../packages/remix-dev/config";
 
 let fixture: Fixture;
 let appFixture: AppFixture;

--- a/integration/flat-routes-test.ts
+++ b/integration/flat-routes-test.ts
@@ -5,6 +5,7 @@ import { PlaywrightFixture } from "./helpers/playwright-fixture";
 import type { Fixture, AppFixture } from "./helpers/create-fixture";
 import { createFixtureProject } from "./helpers/create-fixture";
 import { createAppFixture, createFixture, js } from "./helpers/create-fixture";
+import { flatRoutesWarning } from "../build/node_modules/@remix-run/dev/dist/config";
 
 let fixture: Fixture;
 let appFixture: AppFixture;
@@ -188,9 +189,7 @@ test.describe("warns when v1 routesConvention is used", () => {
 
   test("warns about conflicting routes", () => {
     console.log(buildOutput);
-    expect(buildOutput).toContain(
-      `The old route convention has been deprecated in favor of "flat routes". Please enable it via your remix.config https://remix.run/docs/en/main/file-conventions/route-files-v2`
-    );
+    expect(buildOutput).toContain(flatRoutesWarning);
   });
 });
 

--- a/integration/hmr-test.ts
+++ b/integration/hmr-test.ts
@@ -14,6 +14,7 @@ let fixture = (options: { port: number; appServerPort: number }) => ({
       appServerPort: options.appServerPort,
     },
     unstable_tailwind: true,
+    v2_routeConvention: true,
   },
   files: {
     "package.json": `
@@ -124,7 +125,7 @@ let fixture = (options: { port: number; appServerPort: number }) => ({
           );
         }
       `,
-    "app/routes/index.tsx": `
+    "app/routes/_index.tsx": `
         import { useLoaderData } from "@remix-run/react";
         export default function Index() {
           const t = useLoaderData();
@@ -235,7 +236,7 @@ test("HMR", async ({ page }) => {
     await counter.click();
     await page.waitForSelector(`#root-counter:has-text("inc 1")`);
 
-    let indexPath = path.join(projectDir, "app", "routes", "index.tsx");
+    let indexPath = path.join(projectDir, "app", "routes", "_index.tsx");
     let originalIndex = fs.readFileSync(indexPath, "utf8");
     let counterPath = path.join(projectDir, "app", "components", "counter.tsx");
     let originalCounter = fs.readFileSync(counterPath, "utf8");

--- a/integration/tsconfig.json
+++ b/integration/tsconfig.json
@@ -17,6 +17,7 @@
     "rootDir": "."
   },
   "references": [
+    { "path": "../packages/remix-dev" },
     { "path": "../packages/remix-express" },
     { "path": "../packages/remix-react" },
     { "path": "../packages/remix-server-runtime" }

--- a/packages/remix-dev/__tests__/create-test.ts
+++ b/packages/remix-dev/__tests__/create-test.ts
@@ -8,6 +8,7 @@ import stripAnsi from "strip-ansi";
 
 import { run } from "../cli/run";
 import { server } from "./msw";
+import { flatRoutesWarning } from "../config";
 
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterAll(() => server.close());
@@ -347,7 +348,9 @@ describe("the create command", () => {
       "--no-typescript",
     ]);
     expect(output.trim()).toBe(
-      getOptOutOfInstallMessage() +
+      flatRoutesWarning +
+        "\n\n" +
+        getOptOutOfInstallMessage() +
         "\n\n" +
         getSuccessMessage(path.join("<TEMP_DIR>", "template-to-js"))
     );

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -731,5 +731,6 @@ let listFormat = new Intl.ListFormat("en", {
   type: "conjunction",
 });
 
-export let serverBuildTargetWarning = `The "serverBuildTarget" config option is deprecated. Use a combination of "publicPath", "serverBuildPath", "serverConditions", "serverDependenciesToBundle", "serverMainFields", "serverMinify", "serverModuleFormat" and/or "serverPlatform" instead.`;
-export let flatRoutesWarning = `The old route convention has been deprecated in favor of "flat routes". Please enable it via your remix.config https://remix.run/docs/en/main/file-conventions/route-files-v2`;
+export let serverBuildTargetWarning = `⚠️ DEPRECATED: The "serverBuildTarget" config option is deprecated. Use a combination of "publicPath", "serverBuildPath", "serverConditions", "serverDependenciesToBundle", "serverMainFields", "serverMinify", "serverModuleFormat" and/or "serverPlatform" instead.`;
+
+export let flatRoutesWarning = `⚠️ DEPRECATED: The old nested folders route convention has been deprecated in favor of "flat routes".  Please enable the new routing convention via the \`future.v2_routeConvention\` flag in your \`remix.config.js\` file.  For more information, please see https://remix.run/docs/en/main/file-conventions/route-files-v2.`;

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -560,9 +560,14 @@ export async function readConfig(
     root: { path: "", id: "root", file: rootRouteFile },
   };
 
-  let routesConvention = appConfig.future?.v2_routeConvention
-    ? flatRoutes
-    : defineConventionalRoutes;
+  let routesConvention: typeof flatRoutes;
+
+  if (appConfig.future?.v2_routeConvention) {
+    routesConvention = flatRoutes;
+  } else {
+    warnOnce(flatRoutesWarning, "v2_routeConvention");
+    routesConvention = defineConventionalRoutes;
+  }
 
   if (fse.existsSync(path.resolve(appDirectory, "routes"))) {
     let conventionalRoutes = routesConvention(
@@ -727,3 +732,4 @@ let listFormat = new Intl.ListFormat("en", {
 });
 
 export let serverBuildTargetWarning = `The "serverBuildTarget" config option is deprecated. Use a combination of "publicPath", "serverBuildPath", "serverConditions", "serverDependenciesToBundle", "serverMainFields", "serverMinify", "serverModuleFormat" and/or "serverPlatform" instead.`;
+export let flatRoutesWarning = `The old route convention has been deprecated in favor of "flat routes". Please enable it via your remix.config https://remix.run/docs/en/main/file-conventions/route-files-v2`;


### PR DESCRIPTION
~~for some reason adding the warning is causing the HMR tests to fail 🤔 https://github.com/remix-run/remix/actions/runs/4317024896/jobs/7533572210~~

edit: it was checking stderr length and the warning goes to stderr 🤦‍♂️

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
