### PR TITLE
feat(remix-dev): serverBuildTarget deprecation warning

### DIFF
--- a/.changeset/four-feet-grab.md
+++ b/.changeset/four-feet-grab.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+serverBuildTarget deprecation warning

--- a/docs/file-conventions/remix-config.md
+++ b/docs/file-conventions/remix-config.md
@@ -116,8 +116,7 @@ to `"build/index.js"`.
 
 ## serverBuildTarget
 
-<docs-warning>This option is deprecated and will likely be removed in a future
-stable release. Use a combination of [`publicPath`][public-path],
+<docs-warning>This option is deprecated and will be removed in the next major version release. Use a combination of [`publicPath`][public-path],
 [`serverBuildPath`][server-build-path], [`serverConditions`][server-conditions],
 [`serverDependenciesToBundle`][server-dependencies-to-bundle]
 [`serverMainFields`][server-main-fields], [`serverMinify`][server-minify],
@@ -135,6 +134,18 @@ The `serverBuildTarget` can be one of the following:
 - [`"netlify"`][netlify]
 - [`"node-cjs"`][node-cjs]
 - [`"vercel"`][vercel]
+
+**Migration Table:**
+
+| serverBuildTarget    | publicPath         | serverBuildPath                         | serverConditions | serverMainFields        | serverModuleFormat | serverPlatform | serverDependenciesToBundle | serverMinify |
+| -------------------- | ------------------ | --------------------------------------- | ---------------- | ----------------------- | ------------------ | -------------- | -------------------------- | ------------ |
+| `arc`                | `/\_static/build/` | `server/index.js`                       |                  | `main, module`          | `cjs`              | `node`         |                            | `false`      |
+| `cloudflare-pages`   | `/build/`          | `functions/[[path]].js`                 | `worker`         | `browser, module, main` | `esm`              | `neutral`      | `all`                      | `true`       |
+| `cloudflare-workers` | `/build/`          | `build/index.js`                        | `worker`         | `browser, module, main` | `esm`              | `neutral`      | `all`                      | `true`       |
+| `deno`               | `/build/`          | `build/index.js`                        | `deno, worker`   | `module, main`          | `esm`              | `neutral`      | `all`                      | `false`      |
+| `netlify`            | `/build/`          | `.netlify/functions-internal/server.js` |                  | `main, module`          | `cjs`              | `node`         |                            | `false`      |
+| `node-cjs`           | `/build/`          | `build/index.js`                        |                  | `main, module`          | `cjs`              | `node`         |                            | `false`      |
+| `vercel`             | `/build/`          | `api/index.js`                          |                  | `main, module`          | `cjs`              | `node`         |                            | `false`      |
 
 ## serverConditions
 

--- a/packages/remix-dev/__tests__/fixtures/stack/remix.config.js
+++ b/packages/remix-dev/__tests__/fixtures/stack/remix.config.js
@@ -1,5 +1,6 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
+  serverBuildTarget: "node-cjs",
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -1,17 +1,23 @@
 import path from "path";
 
 import type { RemixConfig } from "../config";
-import { readConfig } from "../config";
+import { serverBuildTargetWarning, readConfig } from "../config";
 
 const remixRoot = path.resolve(__dirname, "./fixtures/stack");
 
 describe("readConfig", () => {
   let config: RemixConfig;
+  let warnStub;
   beforeEach(async () => {
+    let consoleWarn = console.warn;
+    warnStub = jest.fn();
+    console.warn = warnStub;
     config = await readConfig(remixRoot);
+    console.warn = consoleWarn;
   });
 
   it("generates a config", async () => {
+    expect(warnStub).toHaveBeenCalledWith(serverBuildTargetWarning);
     expect(config).toMatchInlineSnapshot(
       {
         rootDirectory: expect.any(String),
@@ -69,7 +75,7 @@ describe("readConfig", () => {
           },
         },
         "serverBuildPath": Any<String>,
-        "serverBuildTarget": undefined,
+        "serverBuildTarget": "node-cjs",
         "serverBuildTargetEntryModule": "export * from \\"@remix-run/dev/server-build\\";",
         "serverConditions": undefined,
         "serverDependenciesToBundle": Array [],

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -13,6 +13,7 @@ import { serverBuildVirtualModule } from "./compiler/virtualModules";
 import { writeConfigDefaults } from "./compiler/utils/tsconfig/write-config-defaults";
 import { flatRoutes } from "./config/flat-routes";
 import { getPreferredPackageManager } from "./cli/getPreferredPackageManager";
+import { warnOnce } from "./compiler/warnings";
 
 export interface RemixMdxConfig {
   rehypePlugins?: any[];
@@ -397,9 +398,7 @@ export async function readConfig(
   }
 
   if (appConfig.serverBuildTarget) {
-    console.warn(
-      `The "serverBuildTarget" config option is deprecated. Use a combination of "publicPath", "serverBuildPath", "serverConditions", "serverDependenciesToBundle", "serverMainFields", "serverMinify", "serverModuleFormat" and/or "serverPlatform" instead.`
-    );
+    warnOnce(serverBuildTargetWarning, "v2_serverBuildTarget");
   }
 
   let isCloudflareRuntime = ["cloudflare-pages", "cloudflare-workers"].includes(
@@ -726,3 +725,5 @@ let listFormat = new Intl.ListFormat("en", {
   style: "long",
   type: "conjunction",
 });
+
+export let serverBuildTargetWarning = `The "serverBuildTarget" config option is deprecated. Use a combination of "publicPath", "serverBuildPath", "serverConditions", "serverDependenciesToBundle", "serverMainFields", "serverMinify", "serverModuleFormat" and/or "serverPlatform" instead.`;

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -396,6 +396,12 @@ export async function readConfig(
     }
   }
 
+  if (appConfig.serverBuildTarget) {
+    console.warn(
+      `The "serverBuildTarget" config option is deprecated. Use a combination of "publicPath", "serverBuildPath", "serverConditions", "serverDependenciesToBundle", "serverMainFields", "serverMinify", "serverModuleFormat" and/or "serverPlatform" instead.`
+    );
+  }
+
   let isCloudflareRuntime = ["cloudflare-pages", "cloudflare-workers"].includes(
     appConfig.serverBuildTarget ?? ""
   );


### PR DESCRIPTION
docs: add serverBuildTarget migration table

Closes: #

- [x] Docs
- [ ] Tests

Testing Strategy:

No functional changes, just a warning and docs.