### PR TITLE
refactor(remix-dev): flat routes perf improvements

### DIFF
--- a/.changeset/flat-routes-perf.md
+++ b/.changeset/flat-routes-perf.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/dev": patch
+---
+
+flat routes perf improvements

--- a/integration/flat-routes-test.ts
+++ b/integration/flat-routes-test.ts
@@ -209,7 +209,7 @@ test.describe("warns when v1 routesConvention is used", () => {
     console.error = originalConsoleError;
   });
 
-  test("warns about conflicting routes", () => {
+  test("v2_routeConvention is not enabled", () => {
     console.log(buildOutput);
     expect(buildOutput).toContain(flatRoutesWarning);
   });

--- a/integration/flat-routes-test.ts
+++ b/integration/flat-routes-test.ts
@@ -21,7 +21,7 @@ test.describe("flat routes", () => {
             future: {
               v2_routeConvention: true,
             },
-            ignoredRouteFiles: ['./ignore-me-pls'],
+            ignoredRouteFiles: ['${IGNORED_ROUTE}'],
           };
         `,
         "app/root.jsx": js`

--- a/integration/flat-routes-test.ts
+++ b/integration/flat-routes-test.ts
@@ -11,10 +11,19 @@ let fixture: Fixture;
 let appFixture: AppFixture;
 
 test.describe("flat routes", () => {
+  let IGNORED_ROUTE = "/ignore-me-pls";
   test.beforeAll(async () => {
     fixture = await createFixture({
-      future: { v2_routeConvention: true },
       files: {
+        "remix.config.js": js`
+          /** @type {import('@remix-run/dev').AppConfig} */
+          module.exports = {
+            future: {
+              v2_routeConvention: true,
+            },
+            ignoredRouteFiles: ['./ignore-me-pls'],
+          };
+        `,
         "app/root.jsx": js`
           import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
 
@@ -77,6 +86,12 @@ test.describe("flat routes", () => {
         "app/routes/dashboard._index/route.jsx": js`
           export default function () {
             return <h3>Dashboard Index</h3>;
+          }
+        `,
+
+        [`app/routes/${IGNORED_ROUTE}.jsx`]: js`
+          export default function () {
+            return <h2>i should 404</h2>;
           }
         `,
       },
@@ -146,6 +161,12 @@ test.describe("flat routes", () => {
 </div>`);
     });
   }
+
+  test("allows ignoredRouteFiles to be configured", async ({ page }) => {
+    let routeIds = Object.keys(fixture.build.routes);
+
+    expect(routeIds).not.toContain(IGNORED_ROUTE);
+  });
 });
 
 test.describe("warns when v1 routesConvention is used", () => {

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -696,7 +696,10 @@ describe("flatRoutes", () => {
       // we had a collision as /route and /index are the same
       expect(routes).toHaveLength(1);
       expect(consoleError).toHaveBeenCalledWith(
-        getRouteIdConflictErrorMessage("routes/dashboard", testFiles)
+        getRouteIdConflictErrorMessage(
+          "routes/dashboard",
+          testFiles.map((file) => path.relative(APP_DIR, file))
+        )
       );
     });
 

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -671,23 +671,6 @@ describe("flatRoutes", () => {
       );
     });
 
-    test("nested index files", () => {
-      let testFiles = [
-        path.join("routes", "_index", "index.tsx"),
-        path.join("routes", "_index", "utils.ts"),
-      ];
-
-      // route manifest uses the full path
-      let fullPaths = testFiles.map((file) => path.join(APP_DIR, file));
-
-      let routeManifest = flatRoutesUniversal(APP_DIR, fullPaths);
-
-      let routes = Object.values(routeManifest);
-
-      expect(routes).toHaveLength(1);
-      expect(consoleError).not.toHaveBeenCalled();
-    });
-
     test("folder/route.tsx matching folder.tsx", () => {
       let testFiles = [
         path.join("routes", "dashboard", "route.tsx"),

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -672,12 +672,15 @@ describe("flatRoutes", () => {
     });
 
     test("nested index files", () => {
-      let testFiles = ["routes/_index/index.tsx", "routes/_index/utils.ts"];
+      let testFiles = [
+        path.join("routes", "_index", "index.tsx"),
+        path.join("routes", "_index", "utils.ts"),
+      ];
 
-      let routeManifest = flatRoutesUniversal(
-        APP_DIR,
-        testFiles.map((file) => path.join(APP_DIR, normalizePath(file)))
-      );
+      // route manifest uses the full path
+      let fullPaths = testFiles.map((file) => path.join(APP_DIR, file));
+
+      let routeManifest = flatRoutesUniversal(APP_DIR, fullPaths);
 
       let routes = Object.values(routeManifest);
 

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -5,7 +5,6 @@ import {
   getRouteConflictErrorMessage,
   getRouteInfo,
   getRouteSegments,
-  normalizePath,
 } from "../config/flat-routes";
 import type { ConfigRoute } from "../config/routes";
 
@@ -14,83 +13,78 @@ let APP_DIR = path.join("test", "root", "app");
 describe("flatRoutes", () => {
   describe("creates proper route paths", () => {
     let tests: [string, string | undefined][] = [
-      ["routes/$", "/routes/*"],
-      ["routes/sub/$", "/routes/sub/*"],
-      ["routes.sub/$", "/routes/sub/*"],
-      ["routes/$slug", "/routes/:slug"],
-      ["routes/sub/$slug", "/routes/sub/:slug"],
-      ["routes.sub/$slug", "/routes/sub/:slug"],
-      ["$", "/*"],
-      ["nested/$", "/nested/*"],
-      ["flat.$", "/flat/*"],
-      ["$slug", "/:slug"],
-      ["nested/$slug", "/nested/:slug"],
-      ["flat.$slug", "/flat/:slug"],
-      ["flat.sub", "/flat/sub"],
-      ["nested/index", "/nested"],
-      ["flat._index", "/flat"],
+      ["routes.$", "routes/*"],
+      ["routes.sub.$", "routes/sub/*"],
+      ["routes.$slug", "routes/:slug"],
+      ["routes.sub.$slug", "routes/sub/:slug"],
+      ["$", "*"],
+      ["nested.$", "nested/*"],
+      ["flat.$", "flat/*"],
+      ["$slug", ":slug"],
+      ["nested.$slug", "nested/:slug"],
+      ["flat.$slug", "flat/:slug"],
+      ["flat.sub", "flat/sub"],
+      ["nested/index", "nested"],
+      ["flat._index", "flat"],
       ["_index", undefined],
       ["_layout/index", undefined],
-      ["_layout/test", "/test"],
-      ["_layout.test", "/test"],
-      ["_layout/$slug", "/:slug"],
-      ["nested/_layout/$slug", "/nested/:slug"],
-      ["$slug[.]json", "/:slug.json"],
-      ["sub/[sitemap.xml]", "/sub/sitemap.xml"],
-      ["posts/$slug/[image.jpg]", "/posts/:slug/image.jpg"],
-      ["sub.[[]", "/sub/["],
-      ["sub.]", "/sub/]"],
-      ["sub.[[]]", "/sub/[]"],
-      ["sub.[[]", "/sub/["],
-      ["beef]", "/beef]"],
-      ["[index]", "/index"],
-      ["test/inde[x]", "/test/index"],
-      ["[i]ndex/[[].[[]]", "/index/[/[]"],
+      ["_layout.test", "test"],
+      ["_layout.$slug", ":slug"],
+      ["nested._layout.$slug", "nested/:slug"],
+      ["$slug[.]json", ":slug.json"],
+      ["sub.[sitemap.xml]", "sub/sitemap.xml"],
+      ["posts.$slug.[image.jpg]", "posts/:slug/image.jpg"],
+      ["sub.[[]", "sub/["],
+      ["sub.]", "sub/]"],
+      ["sub.[[]]", "sub/[]"],
+      ["beef]", "beef]"],
+      ["[index]", "index"],
+      ["test.inde[x]", "test/index"],
+      ["[i]ndex.[[].[[]]", "index/[/[]"],
 
       // Optional segment routes
-      ["(routes)/$", "/routes?/*"],
-      ["(routes)/(sub)/$", "/routes?/sub?/*"],
-      ["(routes).(sub)/$", "/routes?/sub?/*"],
-      ["(routes)/($slug)", "/routes?/:slug?"],
-      ["(routes)/sub/($slug)", "/routes?/sub/:slug?"],
-      ["(routes).sub/($slug)", "/routes?/sub/:slug?"],
-      ["(nested)/$", "/nested?/*"],
-      ["(flat).$", "/flat?/*"],
-      ["($slug)", "/:slug?"],
-      ["(nested)/($slug)", "/nested?/:slug?"],
-      ["(flat).($slug)", "/flat?/:slug?"],
-      ["flat.(sub)", "/flat/sub?"],
-      ["_layout/(test)", "/test?"],
-      ["_layout.(test)", "/test?"],
-      ["_layout/($slug)", "/:slug?"],
-      ["(nested)/_layout/($slug)", "/nested?/:slug?"],
-      ["($slug[.]json)", "/:slug.json?"],
-      ["(sub)/([sitemap.xml])", "/sub?/sitemap.xml?"],
-      ["(sub)/[(sitemap.xml)]", "/sub?/(sitemap.xml)"],
-      ["(posts)/($slug)/([image.jpg])", "/posts?/:slug?/image.jpg?"],
+      ["(routes).$", "routes?/*"],
+      ["(routes).(sub).$", "routes?/sub?/*"],
+      ["(routes).($slug)", "routes?/:slug?"],
+      ["(routes).sub.($slug)", "routes?/sub/:slug?"],
+      ["(nested).$", "nested?/*"],
+      ["(flat).$", "flat?/*"],
+      ["($slug)", ":slug?"],
+      ["(nested).($slug)", "nested?/:slug?"],
+      ["(flat).($slug)", "flat?/:slug?"],
+      ["flat.(sub)", "flat/sub?"],
+      ["_layout.(test)", "test?"],
+      ["_layout.($slug)", ":slug?"],
+      ["(nested)._layout.($slug)", "nested?/:slug?"],
+      ["($slug[.]json)", ":slug.json?"],
+      ["(sub).([sitemap.xml])", "sub?/sitemap.xml?"],
+      ["(sub).[(sitemap.xml)]", "sub?/(sitemap.xml)"],
+      ["(posts).($slug).([image.jpg])", "posts?/:slug?/image.jpg?"],
       [
-        "($[$dollabills]).([.]lol)/(what)/([$]).($up)",
-        "/:$dollabills?/.lol?/what?/$?/:up?",
+        "($[$dollabills]).([.]lol).(what).([$]).($up)",
+        ":$dollabills?/.lol?/what?/$?/:up?",
       ],
-      ["(sub).([[])", "/sub?/[?"],
-      ["(sub).(])", "/sub?/]?"],
-      ["(sub).([[]])", "/sub?/[]?"],
-      ["(sub).([[])", "/sub?/[?"],
-      ["(beef])", "/beef]?"],
-      ["([index])", "/index?"],
-      ["(test)/(inde[x])", "/test?/index?"],
-      ["([i]ndex)/([[]).([[]])", "/index?/[?/[]?"],
+      ["(sub).(])", "sub?/]?"],
+      ["(sub).([[]])", "sub?/[]?"],
+      ["(sub).([[])", "sub?/[?"],
+      ["(beef])", "beef]?"],
+      ["([index])", "index?"],
+      ["(test).(inde[x])", "test?/index?"],
+      ["([i]ndex).([[]).([[]])", "index?/[?/[]?"],
 
       // Opting out of parent layout
-      ["app_.projects/$id.roadmap", "/app/projects/:id/roadmap"],
-      ["app.projects_/$id.roadmap", "/app/projects/:id/roadmap"],
-      ["app_.projects_/$id.roadmap", "/app/projects/:id/roadmap"],
+      ["app_.projects.$id.roadmap", "app/projects/:id/roadmap"],
+      ["app.projects_.$id.roadmap", "app/projects/:id/roadmap"],
+      ["app_.projects_.$id.roadmap", "app/projects/:id/roadmap"],
     ];
 
     for (let [input, expected] of tests) {
       it(`"${input}" -> "${expected}"`, () => {
-        let fullRoutePath = path.join(APP_DIR, "routes", `${input}.tsx`);
-        let routeInfo = getRouteInfo(APP_DIR, "routes", fullRoutePath);
+        let routeInfo = getRouteInfo(
+          APP_DIR,
+          "routes",
+          path.join(APP_DIR, "routes", `${input}.tsx`)
+        );
         expect(routeInfo.path).toBe(expected);
       });
     }
@@ -321,7 +315,7 @@ describe("flatRoutes", () => {
           id: "routes/app.skip_.layout",
           index: undefined,
           parentId: "routes/app",
-          path: "skip/layout",
+          path: "app/skip/layout",
         },
       ],
 
@@ -481,7 +475,7 @@ describe("flatRoutes", () => {
         {
           id: "routes/(_[i]ndex).([[]).([[]])",
           parentId: "routes/([_index])",
-          path: "[?/[]?",
+          path: "_index?/[?/[]?",
         },
       ],
       [
@@ -587,6 +581,7 @@ describe("flatRoutes", () => {
           id: "routes/brand._index",
           parentId: "routes/brand",
           index: true,
+          path: "brand",
         },
       ],
       [
@@ -600,8 +595,7 @@ describe("flatRoutes", () => {
     ];
 
     let files: [string, ConfigRoute][] = testFiles.map(([file, route]) => {
-      let filepath = normalizePath(file);
-      return [filepath, { ...route, file: filepath }];
+      return [file, { ...route, file }];
     });
 
     let routeManifest = flatRoutesUniversal(
@@ -610,7 +604,7 @@ describe("flatRoutes", () => {
     );
     let routes = Object.values(routeManifest);
 
-    expect(routes).toHaveLength(files.length);
+    // expect(routes).toHaveLength(files.length);
 
     for (let [file, route] of files) {
       test(`hierarchy for ${file} - ${route.path}`, () => {
@@ -628,14 +622,11 @@ describe("flatRoutes", () => {
 
     test("same number of segments and the same dynamic segment index", () => {
       let testFiles = [
-        "routes/_user.$username.tsx",
-        "routes/sneakers.$sneakerId.tsx",
+        path.join(APP_DIR, "routes", "_user.$username.tsx"),
+        path.join(APP_DIR, "routes", "sneakers.$sneakerId.tsx"),
       ];
 
-      let routeManifest = flatRoutesUniversal(
-        APP_DIR,
-        testFiles.map((file) => path.join(APP_DIR, normalizePath(file)))
-      );
+      let routeManifest = flatRoutesUniversal(APP_DIR, testFiles);
 
       let routes = Object.values(routeManifest);
 
@@ -652,16 +643,14 @@ describe("flatRoutes", () => {
     afterEach(consoleError.mockReset);
 
     test("index files", () => {
+      // we'll add file manually before running the tests
       let testFiles = [
-        "routes/_dashboard._index.tsx",
-        "routes/_landing._index.tsx",
-        "routes/_index.tsx",
+        path.join(APP_DIR, "routes", "_dashboard._index.tsx"),
+        path.join(APP_DIR, "routes", "_landing._index.tsx"),
+        path.join(APP_DIR, "routes", "_index.tsx"),
       ];
 
-      let routeManifest = flatRoutesUniversal(
-        APP_DIR,
-        testFiles.map((file) => path.join(APP_DIR, normalizePath(file)))
-      );
+      let routeManifest = flatRoutesUniversal(APP_DIR, testFiles);
 
       let routes = Object.values(routeManifest);
 
@@ -688,11 +677,11 @@ describe("flatRoutes", () => {
 
     test("folder/route.tsx matching folder.tsx", () => {
       // we'll add file manually before running the tests
-      let testFiles = ["routes/dashboard.tsx", "routes/dashboard/route.tsx"];
+      let testFiles = ["routes/dashboard/route.tsx", "routes/dashboard.tsx"];
 
       let routeManifest = flatRoutesUniversal(
         APP_DIR,
-        testFiles.map((file) => path.join(APP_DIR, normalizePath(file)))
+        testFiles.map((file) => path.join(APP_DIR, file))
       );
 
       let routes = Object.values(routeManifest);
@@ -713,7 +702,7 @@ describe("flatRoutes", () => {
 
       let routeManifest = flatRoutesUniversal(
         APP_DIR,
-        testFiles.map((file) => path.join(APP_DIR, normalizePath(file)))
+        testFiles.map((file) => path.join(APP_DIR, file))
       );
 
       let routes = Object.values(routeManifest);

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import {
   flatRoutesUniversal,
-  getRouteConflictErrorMessage,
+  getRoutePathConflictErrorMessage,
   getRouteIdConflictErrorMessage,
   getRouteSegments,
 } from "../config/flat-routes";
@@ -647,11 +647,10 @@ describe("flatRoutes", () => {
     afterEach(consoleError.mockReset);
 
     test("index files", () => {
-      // we'll add file manually before running the tests
       let testFiles = [
-        "routes/_dashboard._index.tsx",
-        "routes/_landing._index.tsx",
-        "routes/_index.tsx",
+        path.join("routes", "_dashboard._index.tsx"),
+        path.join("routes", "_landing._index.tsx"),
+        path.join("routes", "_index.tsx"),
       ];
 
       let routeManifest = flatRoutesUniversal(
@@ -661,10 +660,9 @@ describe("flatRoutes", () => {
 
       let routes = Object.values(routeManifest);
 
-      // we had a collision as /route and /index are the same
       expect(routes).toHaveLength(1);
       expect(consoleError).toHaveBeenCalledWith(
-        getRouteConflictErrorMessage("/", testFiles)
+        getRoutePathConflictErrorMessage("/", testFiles)
       );
     });
 
@@ -683,44 +681,37 @@ describe("flatRoutes", () => {
     });
 
     test("folder/route.tsx matching folder.tsx", () => {
-      // we'll add file manually before running the tests
       let testFiles = [
-        path.join(APP_DIR, "routes/dashboard/route.tsx"),
-        path.join(APP_DIR, "routes/dashboard.tsx"),
+        path.join(APP_DIR, "routes", "dashboard", "route.tsx"),
+        path.join(APP_DIR, "routes", "dashboard.tsx"),
       ];
 
       let routeManifest = flatRoutesUniversal(APP_DIR, testFiles);
 
       let routes = Object.values(routeManifest);
 
-      // we had a collision as /route and /index are the same
       expect(routes).toHaveLength(1);
       expect(consoleError).toHaveBeenCalledWith(
         getRouteIdConflictErrorMessage(
-          "routes/dashboard",
-          testFiles.map((file) => path.relative(APP_DIR, file))
+          path.join("routes", "dashboard"),
+          testFiles
         )
       );
     });
 
     test.skip("same path, different param name", () => {
-      // we'll add file manually before running the tests
       let testFiles = [
-        "routes/products.$pid.tsx",
-        "routes/products.$productId.tsx",
+        path.join(APP_DIR, "routes", "products.$pid.tsx"),
+        path.join(APP_DIR, "routes", "products.$productId.tsx"),
       ];
 
-      let routeManifest = flatRoutesUniversal(
-        APP_DIR,
-        testFiles.map((file) => path.join(APP_DIR, file))
-      );
+      let routeManifest = flatRoutesUniversal(APP_DIR, testFiles);
 
       let routes = Object.values(routeManifest);
 
-      // we had a collision as /route and /index are the same
       expect(routes).toHaveLength(1);
       expect(consoleError).toHaveBeenCalledWith(
-        getRouteConflictErrorMessage("/products/:pid", testFiles)
+        getRoutePathConflictErrorMessage("/products/:pid", testFiles)
       );
     });
   });

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import {
   flatRoutesUniversal,
   getRouteConflictErrorMessage,
-  getRouteInfo,
+  getRouteIdConflictErrorMessage,
   getRouteSegments,
 } from "../config/flat-routes";
 import type { ConfigRoute } from "../config/routes";
@@ -18,19 +18,20 @@ describe("flatRoutes", () => {
       ["routes.$slug", "routes/:slug"],
       ["routes.sub.$slug", "routes/sub/:slug"],
       ["$", "*"],
-      ["nested.$", "nested/*"],
       ["flat.$", "flat/*"],
       ["$slug", ":slug"],
-      ["nested.$slug", "nested/:slug"],
+      ["nested/index", "nested"],
+      ["nested.$", "*"],
+      ["nested.$slug", ":slug"],
+      ["nested._layout.$param", ":param"],
+
       ["flat.$slug", "flat/:slug"],
       ["flat.sub", "flat/sub"],
-      ["nested/index", "nested"],
       ["flat._index", "flat"],
       ["_index", undefined],
       ["_layout/index", undefined],
       ["_layout.test", "test"],
-      ["_layout.$slug", ":slug"],
-      ["nested._layout.$slug", "nested/:slug"],
+      ["_layout.$param", ":param"],
       ["$slug[.]json", ":slug.json"],
       ["sub.[sitemap.xml]", "sub/sitemap.xml"],
       ["posts.$slug.[image.jpg]", "posts/:slug/image.jpg"],
@@ -54,8 +55,8 @@ describe("flatRoutes", () => {
       ["(flat).($slug)", "flat?/:slug?"],
       ["flat.(sub)", "flat/sub?"],
       ["_layout.(test)", "test?"],
-      ["_layout.($slug)", ":slug?"],
-      ["(nested)._layout.($slug)", "nested?/:slug?"],
+      ["_layout.($user)", ":user?"],
+      ["(nested)._layout.($param)", "nested?/:param?"],
       ["($slug[.]json)", ":slug.json?"],
       ["(sub).([sitemap.xml])", "sub?/sitemap.xml?"],
       ["(sub).[(sitemap.xml)]", "sub?/(sitemap.xml)"],
@@ -73,18 +74,22 @@ describe("flatRoutes", () => {
       ["([i]ndex).([[]).([[]])", "index?/[?/[]?"],
 
       // Opting out of parent layout
-      ["app_.projects.$id.roadmap", "app/projects/:id/roadmap"],
+      ["user_.projects.$id.roadmap", "user/projects/:id/roadmap"],
       ["app.projects_.$id.roadmap", "app/projects/:id/roadmap"],
-      ["app_.projects_.$id.roadmap", "app/projects/:id/roadmap"],
+      ["shop_.projects_.$id.roadmap", "shop/projects/:id/roadmap"],
     ];
+
+    let manifest = flatRoutesUniversal(
+      APP_DIR,
+      tests.map((t) => path.join(APP_DIR, "routes", t[0] + ".tsx"))
+    );
 
     for (let [input, expected] of tests) {
       it(`"${input}" -> "${expected}"`, () => {
-        let routeInfo = getRouteInfo(
-          APP_DIR,
-          "routes",
-          path.join(APP_DIR, "routes", `${input}.tsx`)
-        );
+        if (input.endsWith("/route") || input.endsWith("/index")) {
+          input = input.replace(/\/(route|index)$/, "");
+        }
+        let routeInfo = manifest[path.join("routes", input)];
         expect(routeInfo.path).toBe(expected);
       });
     }
@@ -315,7 +320,7 @@ describe("flatRoutes", () => {
           id: "routes/app.skip_.layout",
           index: undefined,
           parentId: "routes/app",
-          path: "app/skip/layout",
+          path: "skip/layout",
         },
       ],
 
@@ -474,7 +479,7 @@ describe("flatRoutes", () => {
         "routes/(_[i]ndex).([[]).([[]]).tsx",
         {
           id: "routes/(_[i]ndex).([[]).([[]])",
-          parentId: "routes/([_index])",
+          parentId: "root",
           path: "_index?/[?/[]?",
         },
       ],
@@ -568,7 +573,7 @@ describe("flatRoutes", () => {
         },
       ],
       [
-        "routes/brand/index.tsx",
+        "routes/brand.tsx",
         {
           id: "routes/brand",
           parentId: "root",
@@ -581,7 +586,6 @@ describe("flatRoutes", () => {
           id: "routes/brand._index",
           parentId: "routes/brand",
           index: true,
-          path: "brand",
         },
       ],
       [
@@ -604,7 +608,7 @@ describe("flatRoutes", () => {
     );
     let routes = Object.values(routeManifest);
 
-    // expect(routes).toHaveLength(files.length);
+    expect(routes).toHaveLength(files.length);
 
     for (let [file, route] of files) {
       test(`hierarchy for ${file} - ${route.path}`, () => {
@@ -645,12 +649,15 @@ describe("flatRoutes", () => {
     test("index files", () => {
       // we'll add file manually before running the tests
       let testFiles = [
-        path.join(APP_DIR, "routes", "_dashboard._index.tsx"),
-        path.join(APP_DIR, "routes", "_landing._index.tsx"),
-        path.join(APP_DIR, "routes", "_index.tsx"),
+        "routes/_dashboard._index.tsx",
+        "routes/_landing._index.tsx",
+        "routes/_index.tsx",
       ];
 
-      let routeManifest = flatRoutesUniversal(APP_DIR, testFiles);
+      let routeManifest = flatRoutesUniversal(
+        APP_DIR,
+        testFiles.map((file) => path.join(APP_DIR, file))
+      );
 
       let routes = Object.values(routeManifest);
 
@@ -677,19 +684,19 @@ describe("flatRoutes", () => {
 
     test("folder/route.tsx matching folder.tsx", () => {
       // we'll add file manually before running the tests
-      let testFiles = ["routes/dashboard/route.tsx", "routes/dashboard.tsx"];
+      let testFiles = [
+        path.join(APP_DIR, "routes/dashboard/route.tsx"),
+        path.join(APP_DIR, "routes/dashboard.tsx"),
+      ];
 
-      let routeManifest = flatRoutesUniversal(
-        APP_DIR,
-        testFiles.map((file) => path.join(APP_DIR, file))
-      );
+      let routeManifest = flatRoutesUniversal(APP_DIR, testFiles);
 
       let routes = Object.values(routeManifest);
 
       // we had a collision as /route and /index are the same
       expect(routes).toHaveLength(1);
       expect(consoleError).toHaveBeenCalledWith(
-        getRouteConflictErrorMessage("/dashboard", testFiles)
+        getRouteIdConflictErrorMessage("routes/dashboard", testFiles)
       );
     });
 

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -148,8 +148,10 @@ export function flatRoutesUniversal(
 
     let conflict = routeIds.get(routeId);
     if (conflict) {
-      let currentConflicts = routeIdConflicts.get(routeId) || [conflict];
-      currentConflicts.push(file);
+      let currentConflicts = routeIdConflicts.get(routeId) || [
+        path.relative(appDirectory, conflict),
+      ];
+      currentConflicts.push(path.relative(appDirectory, file));
       routeIdConflicts.set(routeId, currentConflicts);
       continue;
     }

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -153,8 +153,11 @@ export function flatRoutesUniversal(
 
     let conflict = routeIds.get(routeId);
     if (conflict) {
-      let currentConflicts = routeIdConflicts.get(routeId) || [conflict];
-      currentConflicts.push(normalizedFile);
+      let currentConflicts = routeIdConflicts.get(routeId);
+      if (!currentConflicts) {
+        currentConflicts = [path.posix.relative(normalizedApp, conflict)];
+      }
+      currentConflicts.push(path.posix.relative(normalizedApp, normalizedFile));
       routeIdConflicts.set(routeId, currentConflicts);
       continue;
     }

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -140,25 +140,26 @@ export function flatRoutesUniversal(
   let routeIds = new Map<string, string>();
 
   for (let file of routes) {
-    let normalized = normalizeSlashes(file);
-    let routeExt = path.extname(normalized);
-    let routeDir = path.dirname(normalized);
+    let normalizedFile = normalizeSlashes(file);
+    let routeExt = path.extname(normalizedFile);
+    let routeDir = path.dirname(normalizedFile);
+    let normalizedApp = normalizeSlashes(appDirectory);
     let routeId =
-      routeDir === path.posix.join(appDirectory, prefix)
+      routeDir === path.posix.join(normalizedApp, prefix)
         ? path.posix
-            .relative(appDirectory, normalized)
+            .relative(normalizedApp, normalizedFile)
             .slice(0, -routeExt.length)
-        : path.posix.relative(appDirectory, routeDir);
+        : path.posix.relative(normalizedApp, routeDir);
 
     let conflict = routeIds.get(routeId);
     if (conflict) {
       let currentConflicts = routeIdConflicts.get(routeId) || [conflict];
-      currentConflicts.push(normalized);
+      currentConflicts.push(normalizedFile);
       routeIdConflicts.set(routeId, currentConflicts);
       continue;
     }
 
-    routeIds.set(routeId, normalized);
+    routeIds.set(routeId, normalizedFile);
   }
 
   let sortedRouteIds = Array.from(routeIds).sort(

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -104,7 +104,7 @@ export function flatRoutes(
 
   let routes: string[] = [];
   for (let entry of entries) {
-    let filepath: string | undefined = path.join(routesDir, entry.name);
+    let filepath = path.join(routesDir, entry.name);
 
     let route: string | null = null;
     // If it's a directory, don't recurse into it, instead just look for a route module
@@ -115,7 +115,7 @@ export function flatRoutes(
         ignoredFileRegex
       );
     } else if (entry.isFile()) {
-      route = findRouteModuleForFile(filepath, ignoredFileRegex);
+      route = findRouteModuleForFile(appDirectory, filepath, ignoredFileRegex);
     }
 
     if (route) routes.push(route);
@@ -252,10 +252,12 @@ export function flatRoutesUniversal(
 }
 
 function findRouteModuleForFile(
+  appDirectory: string,
   filepath: string,
   ignoredFileRegex: RegExp[]
 ): string | null {
-  let isIgnored = ignoredFileRegex.some((regex) => regex.test(filepath));
+  let relativePath = path.relative(appDirectory, filepath);
+  let isIgnored = ignoredFileRegex.some((regex) => regex.test(relativePath));
   if (isIgnored) return null;
   return filepath;
 }
@@ -265,7 +267,8 @@ function findRouteModuleForFolder(
   filepath: string,
   ignoredFileRegex: RegExp[]
 ): string | null {
-  let isIgnored = ignoredFileRegex.some((regex) => regex.test(filepath));
+  let relativePath = path.relative(appDirectory, filepath);
+  let isIgnored = ignoredFileRegex.some((regex) => regex.test(relativePath));
   if (isIgnored) return null;
 
   let routeRouteModule = findConfig(filepath, "route", routeModuleExts);

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -43,6 +43,7 @@
     "fast-glob": "3.2.11",
     "fs-extra": "^10.0.0",
     "get-port": "^5.1.1",
+    "glob-to-regexp": "0.4.1",
     "gunzip-maybe": "^1.4.2",
     "inquirer": "^8.2.1",
     "jsesc": "3.0.2",
@@ -74,6 +75,7 @@
   "devDependencies": {
     "@remix-run/serve": "1.14.3",
     "@types/cacache": "^15.0.0",
+    "@types/glob-to-regexp": "0.4.1",
     "@types/gunzip-maybe": "^1.4.0",
     "@types/inquirer": "^8.2.0",
     "@types/jsesc": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2916,6 +2916,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/glob-to-regexp@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/@types/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#f684bc7b9a24691f1f80d045dbb7260bf9cc415b"
+  integrity sha512-S0mIukll6fbF0tvrKic/jj+jI8SHoSvGU+Cs95b/jzZEnBYCbj+7aJtQ9yeABuK3xP1okwA3jEH9qIRayijnvQ==
+
 "@types/glob@*", "@types/glob@7.2.0", "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz"
@@ -6967,6 +6972,11 @@ glob-parent@^6.0.1, glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob-to-regexp@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob@8.0.3:
   version "8.0.3"


### PR DESCRIPTION
- Stop glob matching for routes, instead fs.readdirSync() just the routes directory, and if (isDir) look for a index or route module.
- Move away from define routes helper for something like this with a single iteration over routes sorted by reverse ID length

this is available as `v0.0.0-experimental-699baf49c`

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [x] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
