### PR TITLE
fix(remix-dev): `require.resolve` isolateChunks for pnpm

### DIFF
--- a/.changeset/fluffy-dragons-reflect.md
+++ b/.changeset/fluffy-dragons-reflect.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/dev": patch
+---
+
+resolves an issue when resolving react-refresh for pnpm users

--- a/packages/remix-dev/compiler/compileBrowser.ts
+++ b/packages/remix-dev/compiler/compileBrowser.ts
@@ -134,13 +134,13 @@ const createEsbuildConfig = (
   if (mode === "development" && config.future.unstable_dev) {
     // TODO prebundle deps instead of chunking just these ones
     let isolateChunks = [
-      "react",
-      "react/jsx-dev-runtime",
-      "react/jsx-runtime",
-      "react-dom",
-      "react-dom/client",
+      require.resolve("react"),
+      require.resolve("react/jsx-dev-runtime"),
+      require.resolve("react/jsx-runtime"),
+      require.resolve("react-dom"),
+      require.resolve("react-dom/client"),
       require.resolve("react-refresh/runtime"),
-      "@remix-run/react",
+      require.resolve("@remix-run/react"),
       "remix:hmr",
     ];
     entryPoints = {

--- a/packages/remix-dev/compiler/compileBrowser.ts
+++ b/packages/remix-dev/compiler/compileBrowser.ts
@@ -139,7 +139,7 @@ const createEsbuildConfig = (
       "react/jsx-runtime",
       "react-dom",
       "react-dom/client",
-      "react-refresh/runtime",
+      require.resolve("react-refresh/runtime"),
       "@remix-run/react",
       "remix:hmr",
     ];

--- a/packages/remix-dev/compiler/plugins/hmrPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/hmrPlugin.ts
@@ -19,8 +19,11 @@ export let hmrPlugin = ({
         };
       });
       build.onLoad({ filter: /.*/, namespace: "hmr-runtime" }, () => {
+        let reactRefreshRuntime = require
+          .resolve("react-refresh/runtime")
+          .replace(/\\/g, "/");
         let contents = `
-import RefreshRuntime from "${require.resolve("react-refresh/runtime")}";
+import RefreshRuntime from "${reactRefreshRuntime}";
 
 declare global {
   interface Window {

--- a/packages/remix-dev/compiler/plugins/hmrPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/hmrPlugin.ts
@@ -20,7 +20,7 @@ export let hmrPlugin = ({
       });
       build.onLoad({ filter: /.*/, namespace: "hmr-runtime" }, () => {
         let contents = `
-import RefreshRuntime from "react-refresh/runtime";
+import RefreshRuntime from "${require.resolve("react-refresh/runtime")}";
 
 declare global {
   interface Window {


### PR DESCRIPTION
`react-refresh` is a dependency of `@remix-run/dev`, not of your app so it's not "hoisted" to node_modules.

so we can use require.resolve to find it. This fixes an issue where remix-dev would not work with pnpm.

see https://github.com/pnpm/pnpm/issues/2957#issuecomment-719832332 for a similar issue in CRAv4 and how they fixed it there https://github.com/pmmmwh/react-refresh-webpack-plugin/pull/230/files

confirmed working: https://twitter.com/jplhomer/status/1631375544263516180

closes #5811

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
