### PR TITLE
docs(guides/not-found): Set statusText correctly in not-found guide

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -142,6 +142,7 @@
 - eps1lon
 - esamattis
 - evanwinter
+- everdimension
 - exegeteio
 - F3n67u
 - federicoestevez

--- a/docs/guides/not-found.md
+++ b/docs/guides/not-found.md
@@ -24,8 +24,9 @@ export async function loader({ params }: LoaderArgs) {
   });
 
   if (!page) {
-    throw new Response("Not Found", {
+    throw new Response(null, {
       status: 404,
+      statusText: "Not Found",
     });
   }
 
@@ -82,8 +83,9 @@ export async function loader({ params }: LoaderArgs) {
   });
 
   if (!page) {
-    throw new Response("Not Found", {
+    throw new Response(null, {
       status: 404,
+      statusText: "Not Found",
     });
   }
 


### PR DESCRIPTION
This is a fix to set `statusText` correctly in the [not-found](https://remix.run/docs/en/main/guides/not-found#how-to-send-a-404) guide example.
I assume the example is meant to set "statusText" and not the response body, because the following CatchBoundary displays it:

```jsx
...
<h1>
  {caught.status} {caught.statusText}
</h1>
...
```