### PR TITLE
Please allow the user to set the session key in cloudflare workers kv.

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -504,3 +504,4 @@
 - zainfathoni
 - zayenz
 - zhe
+- YankeeTube

--- a/packages/remix-cloudflare/sessions/workersKVStorage.ts
+++ b/packages/remix-cloudflare/sessions/workersKVStorage.ts
@@ -34,7 +34,7 @@ export function createWorkersKVSessionStorage<
 }: WorkersKVSessionStorageOptions): SessionStorage<Data, FlashData> {
   return createSessionStorage({
     cookie,
-    async createData(data, expires) {
+    async createData(data, expires, key='') {
       while (true) {
         let randomBytes = new Uint8Array(8);
         crypto.getRandomValues(randomBytes);
@@ -42,7 +42,7 @@ export function createWorkersKVSessionStorage<
         // than the maximum number of files allowed on an NTFS or ext4 volume
         // (2^32). However, the larger id space should help to avoid collisions
         // with existing ids when creating new sessions, which speeds things up.
-        let id = [...randomBytes]
+        let id = key ? key : [...randomBytes]
           .map((x) => x.toString(16).padStart(2, "0"))
           .join("");
 


### PR DESCRIPTION
 - Cloudflarekv is powerful, but for future session management queries, the user must be able to set up prefixes, etc.
 - But we don't have the option to set the session key.
 - Therefore, you should be able to give the key as an option.