### PR TITLE
fix(remix-react): dedupe `link`s in `getStylesheetPrefetchLinks`

### DIFF
--- a/.changeset/hip-moose-fold.md
+++ b/.changeset/hip-moose-fold.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Deduplicate links in `getStylesheetPrefetchLinks`

--- a/contributors.yml
+++ b/contributors.yml
@@ -166,6 +166,7 @@
 - gonzoscript
 - graham42
 - GregBrimble
+- grinkus-adapt
 - GSt4r
 - guatedude2
 - guerra08

--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -338,6 +338,15 @@ export async function getStylesheetPrefetchLinks(
     .flat(1)
     .filter(isHtmlLinkDescriptor)
     .filter((link) => link.rel === "stylesheet" || link.rel === "preload")
+    .filter(
+      // Dedupe links by rel and href
+      (link, indexToFind, linksArr) => {
+        let foundIndex = linksArr.findIndex(needle => {
+          return needle.href === link.href && needle.rel === link.rel;
+        });
+        return foundIndex === indexToFind
+      }
+    )
     .map((link) =>
       link.rel === "preload"
         ? ({ ...link, rel: "prefetch" } as HtmlLinkDescriptor)


### PR DESCRIPTION
Closes: #5677

- [ ] Docs
- [ ] Tests

Deduplicating links in `getStylesheetPrefetchLinks` avoids inserting `link`s with the same `key` prop, which React dev complains about. It's not an issue in prod build, but this tweak makes the developer experience a bit better in an edge-case where there's a stylesheet that's imported in the sub-page that a `Link` with `prefetch` prop is pointing to.