### PR TITLE
test: update e2e tests to use flat routes 

### DIFF
--- a/integration/abort-signal-test.ts
+++ b/integration/abort-signal-test.ts
@@ -10,7 +10,7 @@ let appFixture: AppFixture;
 test.beforeAll(async () => {
   fixture = await createFixture({
     files: {
-      "app/routes/index.jsx": js`
+      "app/routes/_index.jsx": js`
         import { json } from "@remix-run/node";
         import { useActionData, useLoaderData, Form } from "@remix-run/react";
 

--- a/integration/abort-signal-test.ts
+++ b/integration/abort-signal-test.ts
@@ -9,6 +9,7 @@ let appFixture: AppFixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "app/routes/_index.jsx": js`
         import { json } from "@remix-run/node";

--- a/integration/action-test.ts
+++ b/integration/action-test.ts
@@ -17,6 +17,7 @@ test.describe("actions", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/routes/urlencoded.jsx": js`
           import { Form, useActionData } from "@remix-run/react";

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -47,7 +47,7 @@ test.beforeAll(async () => {
     // `createFixture` will make an app and run your tests against it.
     ////////////////////////////////////////////////////////////////////////////
     files: {
-      "app/routes/index.jsx": js`
+      "app/routes/_index.jsx": js`
         import { json } from "@remix-run/node";
         import { useLoaderData, Link } from "@remix-run/react";
 

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -42,6 +42,7 @@ let appFixture: AppFixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    future: { v2_routeConvention: true },
     ////////////////////////////////////////////////////////////////////////////
     // 💿 Next, add files to this object, just like files in a real app,
     // `createFixture` will make an app and run your tests against it.

--- a/integration/catch-boundary-data-test.ts
+++ b/integration/catch-boundary-data-test.ts
@@ -7,13 +7,19 @@ import { PlaywrightFixture } from "./helpers/playwright-fixture";
 let fixture: Fixture;
 let appFixture: AppFixture;
 
-let ROOT_BOUNDARY_TEXT = "ROOT_TEXT";
-let LAYOUT_BOUNDARY_TEXT = "LAYOUT_BOUNDARY_TEXT";
-let OWN_BOUNDARY_TEXT = "OWN_BOUNDARY_TEXT";
+let ROOT_BOUNDARY_TEXT = "ROOT_TEXT" as const;
+let LAYOUT_BOUNDARY_TEXT = "LAYOUT_BOUNDARY_TEXT" as const;
+let OWN_BOUNDARY_TEXT = "OWN_BOUNDARY_TEXT" as const;
 
-let NO_BOUNDARY_LOADER = "/no/loader";
-let HAS_BOUNDARY_LAYOUT_NESTED_LOADER = "/yes/loader-layout-boundary";
-let HAS_BOUNDARY_NESTED_LOADER = "/yes/loader-self-boundary";
+let NO_BOUNDARY_LOADER_FILE = "/no.loader" as const;
+let NO_BOUNDARY_LOADER = "/no/loader" as const;
+
+let HAS_BOUNDARY_LAYOUT_NESTED_LOADER_FILE =
+  "/yes.loader-layout-boundary" as const;
+let HAS_BOUNDARY_LAYOUT_NESTED_LOADER = "/yes/loader-layout-boundary" as const;
+
+let HAS_BOUNDARY_NESTED_LOADER_FILE = "/yes.loader-self-boundary" as const;
+let HAS_BOUNDARY_NESTED_LOADER = "/yes/loader-self-boundary" as const;
 
 let ROOT_DATA = "root data";
 let LAYOUT_DATA = "root data";
@@ -69,7 +75,7 @@ test.beforeAll(async () => {
         }
       `,
 
-      "app/routes/index.jsx": js`
+      "app/routes/_index.jsx": js`
         import { Link } from "@remix-run/react";
         export default function Index() {
           return (
@@ -82,7 +88,7 @@ test.beforeAll(async () => {
         }
       `,
 
-      [`app/routes${NO_BOUNDARY_LOADER}.jsx`]: js`
+      [`app/routes${NO_BOUNDARY_LOADER_FILE}.jsx`]: js`
         export function loader() {
           throw new Response("", { status: 401 });
         }
@@ -91,7 +97,7 @@ test.beforeAll(async () => {
         }
       `,
 
-      [`app/routes${HAS_BOUNDARY_LAYOUT_NESTED_LOADER}.jsx`]: js`
+      [`app/routes${HAS_BOUNDARY_LAYOUT_NESTED_LOADER_FILE}.jsx`]: js`
         import { useMatches } from "@remix-run/react";
         export function loader() {
           return "${LAYOUT_DATA}";
@@ -101,7 +107,7 @@ test.beforeAll(async () => {
         }
         export function CatchBoundary() {
           let matches = useMatches();
-          let { data } = matches.find(match => match.id === "routes${HAS_BOUNDARY_LAYOUT_NESTED_LOADER}");
+          let { data } = matches.find(match => match.id === "routes${HAS_BOUNDARY_LAYOUT_NESTED_LOADER_FILE}");
 
           return (
             <div>
@@ -112,7 +118,7 @@ test.beforeAll(async () => {
         }
       `,
 
-      [`app/routes${HAS_BOUNDARY_LAYOUT_NESTED_LOADER}/index.jsx`]: js`
+      [`app/routes${HAS_BOUNDARY_LAYOUT_NESTED_LOADER_FILE}._index.jsx`]: js`
         export function loader() {
           throw new Response("", { status: 401 });
         }
@@ -121,7 +127,7 @@ test.beforeAll(async () => {
         }
       `,
 
-      [`app/routes${HAS_BOUNDARY_NESTED_LOADER}.jsx`]: js`
+      [`app/routes${HAS_BOUNDARY_NESTED_LOADER_FILE}.jsx`]: js`
         import { Outlet, useLoaderData } from "@remix-run/react";
         export function loader() {
           return "${LAYOUT_DATA}";
@@ -137,7 +143,7 @@ test.beforeAll(async () => {
         }
       `,
 
-      [`app/routes${HAS_BOUNDARY_NESTED_LOADER}/index.jsx`]: js`
+      [`app/routes${HAS_BOUNDARY_NESTED_LOADER_FILE}._index.jsx`]: js`
         export function loader() {
           throw new Response("", { status: 401 });
         }

--- a/integration/catch-boundary-data-test.ts
+++ b/integration/catch-boundary-data-test.ts
@@ -26,6 +26,7 @@ let LAYOUT_DATA = "root data";
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "app/root.jsx": js`
         import { json } from "@remix-run/node";

--- a/integration/catch-boundary-test.ts
+++ b/integration/catch-boundary-test.ts
@@ -8,13 +8,17 @@ test.describe("CatchBoundary", () => {
   let fixture: Fixture;
   let appFixture: AppFixture;
 
-  let ROOT_BOUNDARY_TEXT = "ROOT_TEXT";
-  let OWN_BOUNDARY_TEXT = "OWN_BOUNDARY_TEXT";
+  let ROOT_BOUNDARY_TEXT = "ROOT_TEXT" as const;
+  let OWN_BOUNDARY_TEXT = "OWN_BOUNDARY_TEXT" as const;
 
-  let HAS_BOUNDARY_LOADER = "/yes/loader";
-  let HAS_BOUNDARY_ACTION = "/yes/action";
-  let NO_BOUNDARY_ACTION = "/no/action";
-  let NO_BOUNDARY_LOADER = "/no/loader";
+  let HAS_BOUNDARY_LOADER = "/yes/loader" as const;
+  let HAS_BOUNDARY_LOADER_FILE = "/yes.loader" as const;
+  let HAS_BOUNDARY_ACTION = "/yes/action" as const;
+  let HAS_BOUNDARY_ACTION_FILE = "/yes.action" as const;
+  let NO_BOUNDARY_ACTION = "/no/action" as const;
+  let NO_BOUNDARY_ACTION_FILE = "/no.action" as const;
+  let NO_BOUNDARY_LOADER = "/no/loader" as const;
+  let NO_BOUNDARY_LOADER_FILE = "/no.loader" as const;
 
   let NOT_FOUND_HREF = "/not/found";
 
@@ -59,7 +63,7 @@ test.describe("CatchBoundary", () => {
           }
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           import { Link, Form } from "@remix-run/react";
           export default function() {
             return (
@@ -85,7 +89,7 @@ test.describe("CatchBoundary", () => {
           }
         `,
 
-        [`app/routes${HAS_BOUNDARY_ACTION}.jsx`]: js`
+        [`app/routes${HAS_BOUNDARY_ACTION_FILE}.jsx`]: js`
           import { Form } from "@remix-run/react";
           export async function action() {
             throw new Response("", { status: 401 })
@@ -104,7 +108,7 @@ test.describe("CatchBoundary", () => {
           }
         `,
 
-        [`app/routes${NO_BOUNDARY_ACTION}.jsx`]: js`
+        [`app/routes${NO_BOUNDARY_ACTION_FILE}.jsx`]: js`
           import { Form } from "@remix-run/react";
           export function action() {
             throw new Response("", { status: 401 })
@@ -120,7 +124,7 @@ test.describe("CatchBoundary", () => {
           }
         `,
 
-        [`app/routes${HAS_BOUNDARY_LOADER}.jsx`]: js`
+        [`app/routes${HAS_BOUNDARY_LOADER_FILE}.jsx`]: js`
           import { useCatch } from '@remix-run/react';
           export function loader() {
             throw new Response("", { status: 401 })
@@ -139,7 +143,7 @@ test.describe("CatchBoundary", () => {
           }
         `,
 
-        [`app/routes${HAS_BOUNDARY_LOADER}/child.jsx`]: js`
+        [`app/routes${HAS_BOUNDARY_LOADER_FILE}.child.jsx`]: js`
           export function loader() {
             throw new Response("", { status: 404 })
           }
@@ -148,7 +152,7 @@ test.describe("CatchBoundary", () => {
           }
         `,
 
-        [`app/routes${NO_BOUNDARY_LOADER}.jsx`]: js`
+        [`app/routes${NO_BOUNDARY_LOADER_FILE}.jsx`]: js`
           export function loader() {
             throw new Response("", { status: 401 })
           }
@@ -174,7 +178,7 @@ test.describe("CatchBoundary", () => {
           }
         `,
 
-        "app/routes/action/child-catch.jsx": js`
+        "app/routes/action.child-catch.jsx": js`
           import { Form, useCatch, useLoaderData } from "@remix-run/react";
 
           export function loader() {

--- a/integration/catch-boundary-test.ts
+++ b/integration/catch-boundary-test.ts
@@ -24,6 +24,7 @@ test.describe("CatchBoundary", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import { json } from "@remix-run/node";

--- a/integration/cf-compiler-test.ts
+++ b/integration/cf-compiler-test.ts
@@ -34,7 +34,7 @@ test.describe("cloudflare compiler", () => {
             "@remix-run/eslint-config": "0.0.0-local-version",
           },
         }),
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           import fake from "worker-pkg";
           import { content as browserPackage } from "browser-pkg";
           import { content as esmOnlyPackage } from "esm-only-pkg";

--- a/integration/cf-compiler-test.ts
+++ b/integration/cf-compiler-test.ts
@@ -9,6 +9,7 @@ test.describe("cloudflare compiler", () => {
 
   test.beforeAll(async () => {
     projectDir = await createFixtureProject({
+      future: { v2_routeConvention: true },
       setup: "cloudflare",
       template: "cf-template",
       files: {

--- a/integration/compiler-test.ts
+++ b/integration/compiler-test.ts
@@ -34,7 +34,7 @@ test.describe("compiler", () => {
           export default clientHello || serverHello;
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           import fake from "~/fake.js";
 
           export default function Index() {
@@ -387,7 +387,7 @@ test.describe("compiler", () => {
         createFixtureProject({
           buildStdio,
           files: {
-            "app/routes/index.jsx": js`
+            "app/routes/_index.jsx": js`
             import { json } from "@remix-run/node";
             import { useLoaderData } from "@remix-run/react";
             import notInstalledMain from "some-not-installed-module";
@@ -419,7 +419,7 @@ test.describe("compiler", () => {
         });
       });
 
-      let importer = path.join("app", "routes", "index.jsx");
+      let importer = path.join("app", "routes", "_index.jsx");
 
       expect(buildOutput).toContain(
         `The path "some-not-installed-module" is imported in ${importer} but "some-not-installed-module" was not found in your node_modules. Did you forget to install it?`

--- a/integration/compiler-test.ts
+++ b/integration/compiler-test.ts
@@ -22,6 +22,19 @@ test.describe("compiler", () => {
     fixture = await createFixture({
       setup: "node",
       files: {
+        "remix.config.js": js`
+          let { getDependenciesToBundle } = require("@remix-run/dev");
+          module.exports = {
+            future: {
+              v2_routeConvention: true,
+            },
+            serverDependenciesToBundle: [
+              "esm-only-pkg",
+              "esm-only-single-export",
+              ...getDependenciesToBundle("esm-only-exports-pkg"),
+            ],
+          };
+        `,
         "app/fake.server.js": js`
           export const hello = "server";
         `,
@@ -33,7 +46,6 @@ test.describe("compiler", () => {
           import { hello as serverHello } from "./fake.server.js";
           export default clientHello || serverHello;
         `,
-
         "app/routes/_index.jsx": js`
           import fake from "~/fake.js";
 
@@ -100,17 +112,6 @@ test.describe("compiler", () => {
           export default function PackageWithSubModule() {
             return <div id="package-with-submodule">{submodule()}</div>;
           }
-        `,
-
-        "remix.config.js": js`
-          let { getDependenciesToBundle } = require("@remix-run/dev");
-          module.exports = {
-            serverDependenciesToBundle: [
-              "esm-only-pkg",
-              "esm-only-single-export",
-              ...getDependenciesToBundle("esm-only-exports-pkg"),
-            ],
-          };
         `,
         "node_modules/esm-only-pkg/package.json": json({
           name: "esm-only-pkg",
@@ -385,6 +386,7 @@ test.describe("compiler", () => {
 
       await expect(() =>
         createFixtureProject({
+          future: { v2_routeConvention: true },
           buildStdio,
           files: {
             "app/routes/_index.jsx": js`

--- a/integration/css-modules-test.ts
+++ b/integration/css-modules-test.ts
@@ -72,9 +72,7 @@ test.describe("CSS Modules", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
-  });
+  test.afterAll(() => appFixture.close());
 
   let basicStylesFixture = () => ({
     "app/routes/basic-styles-test.jsx": js`
@@ -550,7 +548,7 @@ test.describe("CSS Modules", () => {
       import { RemixBrowser } from "@remix-run/react";
       import { startTransition, StrictMode } from "react";
       import { hydrateRoot } from "react-dom/client";
-      import "./entry.client.module.css";      
+      import "./entry.client.module.css";
       const hydrate = () => {
         startTransition(() => {
           hydrateRoot(
@@ -560,14 +558,14 @@ test.describe("CSS Modules", () => {
             </StrictMode>
           );
         });
-      };      
+      };
       if (window.requestIdleCallback) {
         window.requestIdleCallback(hydrate);
       } else {
         // Safari doesn't support requestIdleCallback
         // https://caniuse.com/requestidlecallback
         window.setTimeout(hydrate, 1);
-      }        
+      }
     `,
     "app/entry.client.module.css": css`
       :global(.clientEntry) {

--- a/integration/css-modules-test.ts
+++ b/integration/css-modules-test.ts
@@ -19,20 +19,17 @@ test.describe("CSS Modules", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: {
+        v2_routeConvention: true,
+        // Enable all CSS future flags to
+        // ensure features don't clash
+        unstable_cssModules: true,
+        unstable_cssSideEffectImports: true,
+        unstable_postcss: true,
+        unstable_tailwind: true,
+        unstable_vanillaExtract: true,
+      },
       files: {
-        "remix.config.js": js`
-          module.exports = {
-            future: {
-              // Enable all CSS future flags to
-              // ensure features don't clash
-              unstable_cssModules: true,
-              unstable_cssSideEffectImports: true,
-              unstable_postcss: true,
-              unstable_tailwind: true,
-              unstable_vanillaExtract: true,
-            },
-          };
-        `,
         "app/root.jsx": js`
           import { Links, Outlet } from "@remix-run/react";
           import { cssBundleHref } from "@remix-run/css-bundle";

--- a/integration/css-side-effect-imports-test.ts
+++ b/integration/css-side-effect-imports-test.ts
@@ -62,9 +62,7 @@ test.describe("CSS side-effect imports", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
-  });
+  test.afterAll(() => appFixture.close());
 
   let basicSideEffectFixture = () => ({
     "app/basicSideEffect/styles.css": css`
@@ -75,7 +73,7 @@ test.describe("CSS side-effect imports", () => {
     `,
     "app/routes/basic-side-effect-test.jsx": js`
       import "../basicSideEffect/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="basic-side-effect" className="basicSideEffect">
@@ -104,7 +102,7 @@ test.describe("CSS side-effect imports", () => {
     `,
     "app/routes/root-relative-test.jsx": js`
       import "~/rootRelative/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="root-relative" className="rootRelative">
@@ -139,7 +137,7 @@ test.describe("CSS side-effect imports", () => {
     `,
     "app/routes/image-urls-test.jsx": js`
       import "../imageUrls/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="image-urls" className="imageUrls">
@@ -179,7 +177,7 @@ test.describe("CSS side-effect imports", () => {
     `,
     "app/routes/root-relative-image-urls-test.jsx": js`
       import "../rootRelativeImageUrls/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="root-relative-image-urls" className="rootRelativeImageUrls">

--- a/integration/css-side-effect-imports-test.ts
+++ b/integration/css-side-effect-imports-test.ts
@@ -29,6 +29,7 @@ test.describe("CSS side-effect imports", () => {
               unstable_postcss: true,
               unstable_tailwind: true,
               unstable_vanillaExtract: true,
+              v2_routeConvention: true,
             },
           };
         `,

--- a/integration/custom-entry-server-test.ts
+++ b/integration/custom-entry-server-test.ts
@@ -32,7 +32,7 @@ test.beforeAll(async () => {
           });
         }
       `,
-      "app/routes/index.jsx": js`
+      "app/routes/_index.jsx": js`
         export default function Index() {
           return <h1>Hello World</h1>
         }

--- a/integration/custom-entry-server-test.ts
+++ b/integration/custom-entry-server-test.ts
@@ -9,6 +9,7 @@ let appFixture: AppFixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "app/entry.server.jsx": js`
         import * as React from "react";

--- a/integration/defer-loader-test.ts
+++ b/integration/defer-loader-test.ts
@@ -10,7 +10,7 @@ let appFixture: AppFixture;
 test.beforeAll(async () => {
   fixture = await createFixture({
     files: {
-      "app/routes/index.jsx": js`
+      "app/routes/_index.jsx": js`
         import { useLoaderData, Link } from "@remix-run/react";
         export default function Index() {
           return (

--- a/integration/defer-loader-test.ts
+++ b/integration/defer-loader-test.ts
@@ -9,6 +9,7 @@ let appFixture: AppFixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "app/routes/_index.jsx": js`
         import { useLoaderData, Link } from "@remix-run/react";

--- a/integration/defer-test.ts
+++ b/integration/defer-test.ts
@@ -33,6 +33,7 @@ test.describe("non-aborted", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       ////////////////////////////////////////////////////////////////////////////
       // 💿 Next, add files to this object, just like files in a real app,
       // `createFixture` will make an app and run your tests against it.
@@ -940,6 +941,7 @@ test.describe("aborted", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       ////////////////////////////////////////////////////////////////////////////
       // 💿 Next, add files to this object, just like files in a real app,
       // `createFixture` will make an app and run your tests against it.

--- a/integration/defer-test.ts
+++ b/integration/defer-test.ts
@@ -107,7 +107,7 @@ test.describe("non-aborted", () => {
           }
         `,
 
-        "app/routes/index.tsx": js`
+        "app/routes/_index.tsx": js`
           import { defer } from "@remix-run/node";
           import { Link, useLoaderData } from "@remix-run/react";
           import Counter from "~/components/counter";

--- a/integration/deno-compiler-test.ts
+++ b/integration/deno-compiler-test.ts
@@ -52,7 +52,7 @@ test.beforeAll(async () => {
           "@remix-run/dev": "0.0.0-local-version",
         },
       }),
-      "app/routes/index.jsx": js`
+      "app/routes/_index.jsx": js`
         import fake from "deno-pkg";
         import { urlComponent } from "https://deno.land/x/component.ts";
         import { urlUtil } from "https://deno.land/x/util.ts";

--- a/integration/deno-compiler-test.ts
+++ b/integration/deno-compiler-test.ts
@@ -34,6 +34,7 @@ const searchFiles = async (pattern: string | RegExp, files: string[]) => {
 
 test.beforeAll(async () => {
   projectDir = await createFixtureProject({
+    future: { v2_routeConvention: true },
     template: "deno-template",
     files: {
       "package.json": json({

--- a/integration/deterministic-build-output-test.ts
+++ b/integration/deterministic-build-output-test.ts
@@ -19,7 +19,7 @@ test("builds deterministically under different paths", async () => {
   //  * cssModulesPlugin (via app/routes/foo.tsx' CSS Modules import)
   //  * cssSideEffectImportsPlugin (via app/routes/foo.tsx' CSS side-effect import)
   //  * emptyModulesPlugin (via app/routes/foo.tsx' server import)
-  //  * mdx (via app/routes/index.mdx)
+  //  * mdx (via app/routes/_index.mdx)
   //  * serverAssetsManifestPlugin (implicitly tested by build)
   //  * serverEntryModulePlugin (implicitly tested by build)
   //  * serverRouteModulesPlugin (implicitly tested by build)
@@ -36,7 +36,7 @@ test("builds deterministically under different paths", async () => {
           },
         };
       `,
-      "app/routes/index.mdx": "# hello world",
+      "app/routes/_index.mdx": "# hello world",
       "app/routes/foo.tsx": js`
         export * from "~/foo/bar.server";
         import styles from "~/styles/foo.module.css";

--- a/integration/deterministic-build-output-test.ts
+++ b/integration/deterministic-build-output-test.ts
@@ -25,17 +25,14 @@ test("builds deterministically under different paths", async () => {
   //  * serverRouteModulesPlugin (implicitly tested by build)
   //  * vanillaExtractPlugin (via app/routes/foo.tsx' .css.ts file import)
   let init = {
+    future: {
+      unstable_cssModules: true,
+      unstable_cssSideEffectImports: true,
+      unstable_postcss: true,
+      unstable_vanillaExtract: true,
+      v2_routeConvention: true,
+    },
     files: {
-      "remix.config.js": js`
-        module.exports = {
-          future: {
-            unstable_cssModules: true,
-            unstable_cssSideEffectImports: true,
-            unstable_postcss: true,
-            unstable_vanillaExtract: true,
-          },
-        };
-      `,
       "app/routes/_index.mdx": "# hello world",
       "app/routes/foo.tsx": js`
         export * from "~/foo/bar.server";

--- a/integration/error-boundary-test.ts
+++ b/integration/error-boundary-test.ts
@@ -13,15 +13,24 @@ test.describe("ErrorBoundary", () => {
   let ROOT_BOUNDARY_TEXT = "ROOT_BOUNDARY_TEXT";
   let OWN_BOUNDARY_TEXT = "OWN_BOUNDARY_TEXT";
 
-  let HAS_BOUNDARY_LOADER = "/yes/loader";
-  let HAS_BOUNDARY_ACTION = "/yes/action";
-  let HAS_BOUNDARY_RENDER = "/yes/render";
-  let HAS_BOUNDARY_NO_LOADER_OR_ACTION = "/yes/no-loader-or-action";
+  let HAS_BOUNDARY_LOADER = "/yes/loader" as const;
+  let HAS_BOUNDARY_LOADER_FILE = "/yes.loader" as const;
+  let HAS_BOUNDARY_ACTION = "/yes/action" as const;
+  let HAS_BOUNDARY_ACTION_FILE = "/yes.action" as const;
+  let HAS_BOUNDARY_RENDER = "/yes/render" as const;
+  let HAS_BOUNDARY_RENDER_FILE = "/yes.render" as const;
+  let HAS_BOUNDARY_NO_LOADER_OR_ACTION = "/yes/no-loader-or-action" as const;
+  let HAS_BOUNDARY_NO_LOADER_OR_ACTION_FILE =
+    "/yes.no-loader-or-action" as const;
 
-  let NO_BOUNDARY_ACTION = "/no/action";
-  let NO_BOUNDARY_LOADER = "/no/loader";
-  let NO_BOUNDARY_RENDER = "/no/render";
-  let NO_BOUNDARY_NO_LOADER_OR_ACTION = "/no/no-loader-or-action";
+  let NO_BOUNDARY_ACTION = "/no/action" as const;
+  let NO_BOUNDARY_ACTION_FILE = "/no.action" as const;
+  let NO_BOUNDARY_LOADER = "/no/loader" as const;
+  let NO_BOUNDARY_LOADER_FILE = "/no.loader" as const;
+  let NO_BOUNDARY_RENDER = "/no/render" as const;
+  let NO_BOUNDARY_RENDER_FILE = "/no.render" as const;
+  let NO_BOUNDARY_NO_LOADER_OR_ACTION = "/no/no-loader-or-action" as const;
+  let NO_BOUNDARY_NO_LOADER_OR_ACTION_FILE = "/no.no-loader-or-action" as const;
 
   let NOT_FOUND_HREF = "/not/found";
 
@@ -68,7 +77,7 @@ test.describe("ErrorBoundary", () => {
           }
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           import { Link, Form } from "@remix-run/react";
           export default function () {
             return (
@@ -107,7 +116,7 @@ test.describe("ErrorBoundary", () => {
           }
         `,
 
-        [`app/routes${HAS_BOUNDARY_ACTION}.jsx`]: js`
+        [`app/routes${HAS_BOUNDARY_ACTION_FILE}.jsx`]: js`
           import { Form } from "@remix-run/react";
           export async function action() {
             throw new Error("Kaboom!")
@@ -126,7 +135,7 @@ test.describe("ErrorBoundary", () => {
           }
         `,
 
-        [`app/routes${NO_BOUNDARY_ACTION}.jsx`]: js`
+        [`app/routes${NO_BOUNDARY_ACTION_FILE}.jsx`]: js`
           import { Form } from "@remix-run/react";
           export function action() {
             throw new Error("Kaboom!")
@@ -142,7 +151,7 @@ test.describe("ErrorBoundary", () => {
           }
         `,
 
-        [`app/routes${HAS_BOUNDARY_LOADER}.jsx`]: js`
+        [`app/routes${HAS_BOUNDARY_LOADER_FILE}.jsx`]: js`
           export function loader() {
             throw new Error("Kaboom!")
           }
@@ -154,7 +163,7 @@ test.describe("ErrorBoundary", () => {
           }
         `,
 
-        [`app/routes${NO_BOUNDARY_LOADER}.jsx`]: js`
+        [`app/routes${NO_BOUNDARY_LOADER_FILE}.jsx`]: js`
           export function loader() {
             throw new Error("Kaboom!")
           }
@@ -163,14 +172,14 @@ test.describe("ErrorBoundary", () => {
           }
         `,
 
-        [`app/routes${NO_BOUNDARY_RENDER}.jsx`]: js`
+        [`app/routes${NO_BOUNDARY_RENDER_FILE}.jsx`]: js`
           export default function () {
             throw new Error("Kaboom!")
             return <div/>
           }
         `,
 
-        [`app/routes${HAS_BOUNDARY_RENDER}.jsx`]: js`
+        [`app/routes${HAS_BOUNDARY_RENDER_FILE}.jsx`]: js`
           export default function () {
             throw new Error("Kaboom!")
             return <div/>
@@ -181,7 +190,7 @@ test.describe("ErrorBoundary", () => {
           }
         `,
 
-        [`app/routes${HAS_BOUNDARY_NO_LOADER_OR_ACTION}.jsx`]: js`
+        [`app/routes${HAS_BOUNDARY_NO_LOADER_OR_ACTION_FILE}.jsx`]: js`
           export function ErrorBoundary() {
             return <div id="boundary-no-loader-or-action">${OWN_BOUNDARY_TEXT}</div>
           }
@@ -190,7 +199,7 @@ test.describe("ErrorBoundary", () => {
           }
         `,
 
-        [`app/routes${NO_BOUNDARY_NO_LOADER_OR_ACTION}.jsx`]: js`
+        [`app/routes${NO_BOUNDARY_NO_LOADER_OR_ACTION_FILE}.jsx`]: js`
           export default function Index() {
             return <div/>
           }
@@ -248,7 +257,7 @@ test.describe("ErrorBoundary", () => {
           }
         `,
 
-        "app/routes/action/child-error.jsx": js`
+        "app/routes/action.child-error.jsx": js`
           import { Form, useLoaderData } from "@remix-run/react";
 
           export function loader() {
@@ -474,10 +483,10 @@ test.describe("ErrorBoundary", () => {
   });
 
   test.describe("if no error boundary exists in the app", () => {
-    let NO_ROOT_BOUNDARY_LOADER = "/loader-bad";
-    let NO_ROOT_BOUNDARY_ACTION = "/action-bad";
-    let NO_ROOT_BOUNDARY_LOADER_RETURN = "/loader-no-return";
-    let NO_ROOT_BOUNDARY_ACTION_RETURN = "/action-no-return";
+    let NO_ROOT_BOUNDARY_LOADER = "/loader-bad" as const;
+    let NO_ROOT_BOUNDARY_ACTION = "/action-bad" as const;
+    let NO_ROOT_BOUNDARY_LOADER_RETURN = "/loader-no-return" as const;
+    let NO_ROOT_BOUNDARY_ACTION_RETURN = "/action-no-return" as const;
 
     test.beforeAll(async () => {
       fixture = await createFixture({
@@ -501,7 +510,7 @@ test.describe("ErrorBoundary", () => {
             }
           `,
 
-          "app/routes/index.jsx": js`
+          "app/routes/_index.jsx": js`
             import { Link, Form } from "@remix-run/react";
 
             export default function () {
@@ -697,7 +706,7 @@ test.describe("loaderData in ErrorBoundary", () => {
           }
         `,
 
-        "app/routes/parent/child-with-boundary.jsx": js`
+        "app/routes/parent.child-with-boundary.jsx": js`
           import { Form, useLoaderData } from "@remix-run/react";
 
           export function loader() {
@@ -731,7 +740,7 @@ test.describe("loaderData in ErrorBoundary", () => {
           }
         `,
 
-        "app/routes/parent/child-without-boundary.jsx": js`
+        "app/routes/parent.child-without-boundary.jsx": js`
           import { Form, useLoaderData } from "@remix-run/react";
 
           export function loader() {
@@ -824,7 +833,7 @@ test.describe("loaderData in ErrorBoundary", () => {
       // network error but firefox does not
       //   "Failed to load resource: the server responded with a status of 500 (Internal Server Error)",
       let msg =
-        "You cannot `useLoaderData` in an errorElement (routeId: routes/parent/child-with-boundary)";
+        "You cannot `useLoaderData` in an errorElement (routeId: routes/parent.child-with-boundary)";
       if (javaScriptEnabled) {
         expect(consoleErrors.filter((m) => m === msg)).toEqual([msg]);
       } else {
@@ -946,7 +955,7 @@ test.describe("Default ErrorBoundary", () => {
         ${errorBoundaryCode}
       `,
 
-      "app/routes/index.jsx": js`
+      "app/routes/_index.jsx": js`
         import { Link } from "@remix-run/react";
         export default function () {
           return (
@@ -983,7 +992,7 @@ test.describe("Default ErrorBoundary", () => {
 
   test.afterAll(async () => {
     console.error = _consoleError;
-    await appFixture.close();
+    appFixture.close();
   });
 
   test.describe("When the root route does not have a boundary", () => {
@@ -994,9 +1003,7 @@ test.describe("Default ErrorBoundary", () => {
       appFixture = await createAppFixture(fixture, ServerMode.Development);
     });
 
-    test.afterAll(async () => {
-      await appFixture.close();
-    });
+    test.afterAll(() => appFixture.close());
 
     test.describe("document requests", () => {
       test("renders default boundary on loader errors", async () => {
@@ -1064,9 +1071,7 @@ test.describe("Default ErrorBoundary", () => {
       appFixture = await createAppFixture(fixture, ServerMode.Development);
     });
 
-    test.afterAll(async () => {
-      await appFixture.close();
-    });
+    test.afterAll(() => appFixture.close());
 
     test.describe("document requests", () => {
       test("renders root boundary on loader errors", async () => {
@@ -1132,9 +1137,7 @@ test.describe("Default ErrorBoundary", () => {
       appFixture = await createAppFixture(fixture, ServerMode.Development);
     });
 
-    test.afterAll(async () => {
-      await appFixture.close();
-    });
+    test.afterAll(() => appFixture.close());
 
     test.describe("document requests", () => {
       test("tries to render root boundary on loader errors but bubbles to default boundary", async () => {

--- a/integration/error-boundary-test.ts
+++ b/integration/error-boundary-test.ts
@@ -41,6 +41,7 @@ test.describe("ErrorBoundary", () => {
     _consoleError = console.error;
     console.error = () => {};
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
@@ -490,6 +491,9 @@ test.describe("ErrorBoundary", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
+        future: {
+          v2_routeConvention: true,
+        },
         files: {
           "app/root.jsx": js`
             import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
@@ -655,6 +659,7 @@ test.describe("loaderData in ErrorBoundary", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
@@ -998,6 +1003,9 @@ test.describe("Default ErrorBoundary", () => {
   test.describe("When the root route does not have a boundary", () => {
     test.beforeAll(async () => {
       fixture = await createFixture({
+        future: {
+          v2_routeConvention: true,
+        },
         files: getFiles({ includeRootErrorBoundary: false }),
       });
       appFixture = await createAppFixture(fixture, ServerMode.Development);
@@ -1066,6 +1074,9 @@ test.describe("Default ErrorBoundary", () => {
   test.describe("When the root route has a boundary", () => {
     test.beforeAll(async () => {
       fixture = await createFixture({
+        future: {
+          v2_routeConvention: true,
+        },
         files: getFiles({ includeRootErrorBoundary: true }),
       });
       appFixture = await createAppFixture(fixture, ServerMode.Development);
@@ -1129,6 +1140,9 @@ test.describe("Default ErrorBoundary", () => {
   test.describe("When the root route has a boundary but it also throws 😦", () => {
     test.beforeAll(async () => {
       fixture = await createFixture({
+        future: {
+          v2_routeConvention: true,
+        },
         files: getFiles({
           includeRootErrorBoundary: true,
           rootErrorBoundaryThrows: true,

--- a/integration/error-boundary-v2-test.ts
+++ b/integration/error-boundary-v2-test.ts
@@ -79,7 +79,7 @@ test.describe("V2 Singular ErrorBoundary (future.v2_errorBoundary)", () => {
           }
         `,
 
-        "app/routes/parent/child-with-boundary.jsx": js`
+        "app/routes/parent.child-with-boundary.jsx": js`
           import {
             isRouteErrorResponse,
             useLoaderData,
@@ -113,7 +113,7 @@ test.describe("V2 Singular ErrorBoundary (future.v2_errorBoundary)", () => {
           }
         `,
 
-        "app/routes/parent/child-without-boundary.jsx": js`
+        "app/routes/parent.child-without-boundary.jsx": js`
           import { useLoaderData, useLocation } from "@remix-run/react";
 
           export function loader({ request }) {

--- a/integration/error-boundary-v2-test.ts
+++ b/integration/error-boundary-v2-test.ts
@@ -15,6 +15,7 @@ test.describe("V2 Singular ErrorBoundary (future.v2_errorBoundary)", () => {
     fixture = await createFixture({
       future: {
         v2_errorBoundary: true,
+        v2_routeConvention: true,
       },
       files: {
         "app/root.jsx": js`

--- a/integration/error-data-request-test.ts
+++ b/integration/error-data-request-test.ts
@@ -36,7 +36,7 @@ test.describe("ErrorBoundary", () => {
         }
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           import { Link, Form } from "@remix-run/react";
 
           export default function () {
@@ -106,24 +106,24 @@ test.describe("ErrorBoundary", () => {
   }
 
   test("returns a 400 x-remix-error on a data fetch to a path with no loader", async () => {
-    let response = await fixture.requestData("/", "routes/index");
+    let response = await fixture.requestData("/", "routes/_index");
     expect(response.status).toBe(400);
     expect(response.headers.get("X-Remix-Error")).toBe("yes");
     expect(await response.text()).toMatch("Unexpected Server Error");
     assertConsoleError(
-      'Error: You made a GET request to "/" but did not provide a `loader` for route "routes/index", so there is no way to handle the request.'
+      'Error: You made a GET request to "/" but did not provide a `loader` for route "routes/_index", so there is no way to handle the request.'
     );
   });
 
   test("returns a 405 x-remix-error on a data fetch POST to a path with no action", async () => {
-    let response = await fixture.requestData("/?index", "routes/index", {
+    let response = await fixture.requestData("/?index", "routes/_index", {
       method: "POST",
     });
     expect(response.status).toBe(405);
     expect(response.headers.get("X-Remix-Error")).toBe("yes");
     expect(await response.text()).toMatch("Unexpected Server Error");
     assertConsoleError(
-      'Error: You made a POST request to "/" but did not provide an `action` for route "routes/index", so there is no way to handle the request.'
+      'Error: You made a POST request to "/" but did not provide an `action` for route "routes/_index", so there is no way to handle the request.'
     );
   });
 

--- a/integration/error-data-request-test.ts
+++ b/integration/error-data-request-test.ts
@@ -16,6 +16,7 @@ test.describe("ErrorBoundary", () => {
     };
 
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import { Links, Meta, Outlet, Scripts } from "@remix-run/react";

--- a/integration/esm-only-warning-test.ts
+++ b/integration/esm-only-warning-test.ts
@@ -36,7 +36,7 @@ test.beforeAll(async () => {
           "@remix-run/dev": "0.0.0-local-version",
         },
       }),
-      "app/routes/index.jsx": js`
+      "app/routes/_index.jsx": js`
         import { json } from "@remix-run/node";
         import { Link, useLoaderData } from "@remix-run/react";
         import a from "esm-only-no-exports";

--- a/integration/esm-only-warning-test.ts
+++ b/integration/esm-only-warning-test.ts
@@ -10,6 +10,7 @@ test.beforeAll(async () => {
 
   await createFixtureProject({
     buildStdio,
+    future: { v2_routeConvention: true },
     files: {
       "package.json": json({
         name: "remix-integration-9v4bpv66vd",

--- a/integration/fetcher-layout-test.ts
+++ b/integration/fetcher-layout-test.ts
@@ -35,7 +35,7 @@ test.beforeAll(async () => {
         }
       `,
 
-      "app/routes/layout-action/index.jsx": js`
+      "app/routes/layout-action._index.jsx": js`
         import { json } from "@remix-run/node";
         import {
           useFetcher,
@@ -66,7 +66,7 @@ test.beforeAll(async () => {
         }
       `,
 
-      "app/routes/layout-action/$param.jsx": js`
+      "app/routes/layout-action.$param.jsx": js`
         import { json } from "@remix-run/node";
         import {
           useFetcher,
@@ -122,7 +122,7 @@ test.beforeAll(async () => {
         }
       `,
 
-      "app/routes/layout-loader/index.jsx": js`
+      "app/routes/layout-loader._index.jsx": js`
         import { json } from "@remix-run/node";
         import {
           useFetcher,
@@ -149,7 +149,7 @@ test.beforeAll(async () => {
         }
       `,
 
-      "app/routes/layout-loader/$param.jsx": js`
+      "app/routes/layout-loader.$param.jsx": js`
         import { json } from "@remix-run/node";
         import {
           useFetcher,

--- a/integration/fetcher-layout-test.ts
+++ b/integration/fetcher-layout-test.ts
@@ -9,6 +9,7 @@ let appFixture: AppFixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "app/routes/layout-action.jsx": js`
         import { json } from "@remix-run/node";

--- a/integration/fetcher-state-test.ts
+++ b/integration/fetcher-state-test.ts
@@ -141,9 +141,7 @@ test.describe("fetcher states", () => {
     appFixture = await createAppFixture(fixture, ServerMode.Development);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
-  });
+  test.afterAll(() => appFixture.close());
 
   test("represents a initial fetcher", async ({ page }) => {
     let app = new PlaywrightFixture(appFixture, page);

--- a/integration/fetcher-state-test.ts
+++ b/integration/fetcher-state-test.ts
@@ -19,6 +19,7 @@ test.describe("fetcher states", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import { useMemo, useRef } from "react";

--- a/integration/fetcher-test.ts
+++ b/integration/fetcher-test.ts
@@ -56,7 +56,7 @@ test.describe("useFetcher", () => {
           }
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           import { useFetcher } from "@remix-run/react";
           export default function Index() {
             let fetcher = useFetcher();
@@ -101,7 +101,7 @@ test.describe("useFetcher", () => {
           }
         `,
 
-        "app/routes/parent/index.jsx": js`
+        "app/routes/parent._index.jsx": js`
           import { useFetcher } from "@remix-run/react";
 
           export function action() {

--- a/integration/fetcher-test.ts
+++ b/integration/fetcher-test.ts
@@ -17,6 +17,7 @@ test.describe("useFetcher", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/routes/resource-route-action-only.ts": js`
           import { json } from "@remix-run/node";

--- a/integration/flat-routes-test.ts
+++ b/integration/flat-routes-test.ts
@@ -13,6 +13,7 @@ let appFixture: AppFixture;
 test.describe("flat routes", () => {
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
@@ -161,6 +162,7 @@ test.describe("warns when v1 routesConvention is used", () => {
     console.error = () => {};
     await createFixtureProject({
       buildStdio,
+      future: { v2_routeConvention: false },
       files: {
         "routes/index.tsx": js`
           export default function () {
@@ -206,6 +208,7 @@ test.describe("emits warnings for route conflicts", async () => {
     console.error = () => {};
     await createFixtureProject({
       buildStdio,
+      future: { v2_routeConvention: true },
       files: {
         "routes/_dashboard._index.tsx": js`
           export default function () {

--- a/integration/flat-routes-test.ts
+++ b/integration/flat-routes-test.ts
@@ -13,7 +13,6 @@ let appFixture: AppFixture;
 test.describe("flat routes", () => {
   test.beforeAll(async () => {
     fixture = await createFixture({
-      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
@@ -207,7 +206,6 @@ test.describe("emits warnings for route conflicts", async () => {
     console.error = () => {};
     await createFixtureProject({
       buildStdio,
-      future: { v2_routeConvention: true },
       files: {
         "routes/_dashboard._index.tsx": js`
           export default function () {

--- a/integration/form-data-test.ts
+++ b/integration/form-data-test.ts
@@ -8,7 +8,7 @@ let fixture: Fixture;
 test.beforeAll(async () => {
   fixture = await createFixture({
     files: {
-      "app/routes/index.jsx": js`
+      "app/routes/_index.jsx": js`
         import { json } from "@remix-run/node";
 
         export async function action({ request }) {

--- a/integration/form-data-test.ts
+++ b/integration/form-data-test.ts
@@ -7,6 +7,7 @@ let fixture: Fixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "app/routes/_index.jsx": js`
         import { json } from "@remix-run/node";

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -184,7 +184,7 @@ test.describe("Forms", () => {
           }
         `,
 
-        "app/routes/blog/index.jsx": js`
+        "app/routes/blog._index.jsx": js`
           import { Form } from "@remix-run/react";
           export function action() {
             return { ok: true };
@@ -218,7 +218,7 @@ test.describe("Forms", () => {
           }
         `,
 
-        "app/routes/blog/$postId.jsx": js`
+        "app/routes/blog.$postId.jsx": js`
           import { Form } from "@remix-run/react";
           export default function() {
             return (
@@ -255,13 +255,13 @@ test.describe("Forms", () => {
           }
         `,
 
-        "app/routes/projects/index.jsx": js`
+        "app/routes/projects._index.jsx": js`
           export default function() {
             return <h2>All projects</h2>
           }
         `,
 
-        "app/routes/projects/$.jsx": js`
+        "app/routes/projects.$.jsx": js`
           import { Form } from "@remix-run/react";
           export default function() {
             return (
@@ -431,7 +431,7 @@ test.describe("Forms", () => {
           }
         `,
 
-        "app/routes/pathless-layout-parent/__pathless.jsx": js`
+        "app/routes/pathless-layout-parent._pathless/layout.jsx": js`
           import { Outlet } from '@remix-run/react';
 
           export default function () {
@@ -444,7 +444,7 @@ test.describe("Forms", () => {
           }
         `,
 
-        "app/routes/pathless-layout-parent/__pathless/index.jsx": js`
+        "app/routes/pathless-layout-parent._pathless._index.jsx": js`
           export default function () {
             return <h3>Pathless Layout Index</h3>
           }

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -49,6 +49,7 @@ test.describe("Forms", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/routes/get-submission.jsx": js`
           import { useLoaderData, Form } from "@remix-run/react";
@@ -431,7 +432,7 @@ test.describe("Forms", () => {
           }
         `,
 
-        "app/routes/pathless-layout-parent._pathless/layout.jsx": js`
+        "app/routes/pathless-layout-parent._pathless.jsx": js`
           import { Outlet } from '@remix-run/react';
 
           export default function () {

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -432,7 +432,7 @@ test.describe("Forms", () => {
           }
         `,
 
-        "app/routes/pathless-layout-parent._pathless.jsx": js`
+        "app/routes/pathless-layout-parent._pathless.nested.jsx": js`
           import { Outlet } from '@remix-run/react';
 
           export default function () {
@@ -445,7 +445,7 @@ test.describe("Forms", () => {
           }
         `,
 
-        "app/routes/pathless-layout-parent._pathless._index.jsx": js`
+        "app/routes/pathless-layout-parent._pathless.nested._index.jsx": js`
           export default function () {
             return <h3>Pathless Layout Index</h3>
           }
@@ -1065,7 +1065,7 @@ test.describe("Forms", () => {
       page,
     }) => {
       let app = new PlaywrightFixture(appFixture, page);
-      await app.goto("/pathless-layout-parent");
+      await app.goto("/pathless-layout-parent/nested");
       let html = await app.getHtml();
       expect(html).toMatch("Pathless Layout Parent");
       expect(html).toMatch("Pathless Layout ");

--- a/integration/headers-test.ts
+++ b/integration/headers-test.ts
@@ -36,7 +36,7 @@ test.describe("headers export", () => {
           }
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           import { json } from "@remix-run/node";
 
           export function loader() {
@@ -119,7 +119,7 @@ test.describe("headers export", () => {
           }
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           import { json } from "@remix-run/node";
 
           export function loader() {

--- a/integration/headers-test.ts
+++ b/integration/headers-test.ts
@@ -13,6 +13,7 @@ test.describe("headers export", () => {
 
   test.beforeAll(async () => {
     appFixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import { json } from "@remix-run/node";
@@ -99,6 +100,7 @@ test.describe("headers export", () => {
     let HEADER_VALUE = "SUCCESS";
 
     let fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import { Links, Meta, Outlet, Scripts } from "@remix-run/react";

--- a/integration/helpers/cf-template/remix.config.js
+++ b/integration/helpers/cf-template/remix.config.js
@@ -13,4 +13,8 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
+
+  // !!! Don't adust this without changing the code that overwrites this
+  // in createFixtureProject()
+  future: {},
 };

--- a/integration/helpers/deno-template/remix.config.js
+++ b/integration/helpers/deno-template/remix.config.js
@@ -18,4 +18,8 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
+
+  // !!! Don't adust this without changing the code that overwrites this
+  // in createFixtureProject()
+  future: {},
 };

--- a/integration/hook-useSubmit-test.ts
+++ b/integration/hook-useSubmit-test.ts
@@ -11,7 +11,7 @@ test.describe("`useSubmit()` returned function", () => {
   test.beforeAll(async () => {
     fixture = await createFixture({
       files: {
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
         import { useLoaderData, useSubmit } from "@remix-run/react";
 
         export function loader({ request }) {

--- a/integration/hook-useSubmit-test.ts
+++ b/integration/hook-useSubmit-test.ts
@@ -10,6 +10,7 @@ test.describe("`useSubmit()` returned function", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/routes/_index.jsx": js`
         import { useLoaderData, useSubmit } from "@remix-run/react";

--- a/integration/js-routes-test.ts
+++ b/integration/js-routes-test.ts
@@ -10,6 +10,9 @@ test.describe(".js route files", () => {
   test.beforeAll(async () => {
     appFixture = await createAppFixture(
       await createFixture({
+        future: {
+          v2_routeConvention: true,
+        },
         files: {
           "app/routes/js.js": js`
             export default () => <div data-testid="route-js">Rendered with .js ext</div>;

--- a/integration/layout-route-test.ts
+++ b/integration/layout-route-test.ts
@@ -11,23 +11,23 @@ test.describe("pathless layout routes", () => {
     appFixture = await createAppFixture(
       await createFixture({
         files: {
-          "app/routes/__layout.jsx": js`
+          "app/routes/_layout.jsx": js`
             import { Outlet } from "@remix-run/react";
 
             export default () => <div data-testid="layout-route"><Outlet /></div>;
           `,
-          "app/routes/__layout/index.jsx": js`
+          "app/routes/_layout._index.jsx": js`
             export default () => <div data-testid="layout-index">Layout index</div>;
           `,
-          "app/routes/__layout/subroute.jsx": js`
+          "app/routes/_layout.subroute.jsx": js`
             export default () => <div data-testid="layout-subroute">Layout subroute</div>;
           `,
-          "app/routes/sandwiches/__pathless.jsx": js`
+          "app/routes/sandwiches._pathless.jsx": js`
             import { Outlet } from "@remix-run/react";
 
             export default () => <div data-testid="sandwiches-pathless-route"><Outlet /></div>;
           `,
-          "app/routes/sandwiches/__pathless/index.jsx": js`
+          "app/routes/sandwiches._pathless._index.jsx": js`
             export default () => <div data-testid="sandwiches-pathless-index">Sandwiches pathless index</div>;
           `,
         },

--- a/integration/layout-route-test.ts
+++ b/integration/layout-route-test.ts
@@ -10,6 +10,9 @@ test.describe("pathless layout routes", () => {
   test.beforeAll(async () => {
     appFixture = await createAppFixture(
       await createFixture({
+        future: {
+          v2_routeConvention: true,
+        },
         files: {
           "app/routes/_layout.jsx": js`
             import { Outlet } from "@remix-run/react";

--- a/integration/link-test.ts
+++ b/integration/link-test.ts
@@ -191,7 +191,7 @@ test.describe("route module link export", () => {
           }
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           import { useEffect } from "react";
           import { Link } from "@remix-run/react";
 
@@ -355,7 +355,7 @@ test.describe("route module link export", () => {
           }
         `,
 
-        "app/routes/gists/$username.jsx": js`
+        "app/routes/gists.$username.jsx": js`
           import { json, redirect } from "@remix-run/node";
           import { Link, useLoaderData, useParams } from "@remix-run/react";
           export async function loader({ params }) {
@@ -411,7 +411,7 @@ test.describe("route module link export", () => {
           }
         `,
 
-        "app/routes/gists/index.jsx": js`
+        "app/routes/gists._index.jsx": js`
           import { useLoaderData } from "@remix-run/react";
           export async function loader() {
             return ${JSON.stringify(fakeGists)};
@@ -452,7 +452,7 @@ test.describe("route module link export", () => {
           }
         `,
 
-        "app/routes/resources/theme-css.jsx": js`
+        "app/routes/resources.theme-css.jsx": js`
           import { redirect } from "@remix-run/node";
           export async function loader({ request }) {
             return new Response(":root { --nc-tx-1: #ffffff; --nc-tx-2: #eeeeee; }",

--- a/integration/link-test.ts
+++ b/integration/link-test.ts
@@ -32,6 +32,7 @@ test.describe("route module link export", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/favicon.ico": js``,
 

--- a/integration/loader-test.ts
+++ b/integration/loader-test.ts
@@ -35,7 +35,7 @@ test.describe("loader", () => {
           }
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           import { json } from "@remix-run/node";
 
           export function loader() {
@@ -53,7 +53,7 @@ test.describe("loader", () => {
   test("returns responses for a specific route", async () => {
     let [root, index] = await Promise.all([
       fixture.requestData("/", "root"),
-      fixture.requestData("/", "routes/index"),
+      fixture.requestData("/", "routes/_index"),
     ]);
 
     expect(root.headers.get("Content-Type")).toBe(

--- a/integration/loader-test.ts
+++ b/integration/loader-test.ts
@@ -12,6 +12,7 @@ test.describe("loader", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
         import { json } from "@remix-run/node";
@@ -75,6 +76,9 @@ test.describe("loader in an app", () => {
   test.beforeAll(async () => {
     appFixture = await createAppFixture(
       await createFixture({
+        future: {
+          v2_routeConvention: true,
+        },
         files: {
           "app/root.jsx": js`
             import { Outlet } from '@remix-run/react'

--- a/integration/matches-test.ts
+++ b/integration/matches-test.ts
@@ -42,7 +42,7 @@ test.describe("useMatches", () => {
           }
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           import { json } from "@remix-run/node";
           export const handle = { stuff: "index handle"};
           export const loader = () => json("INDEX");
@@ -113,7 +113,7 @@ test.describe("useMatches", () => {
     }
   },
   {
-    "id": "routes/index",
+    "id": "routes/_index",
     "pathname": "/",
     "params": {},
     "data": "INDEX",
@@ -139,7 +139,7 @@ test.describe("useMatches", () => {
     }
   },
   {
-    "id": "routes/index",
+    "id": "routes/_index",
     "pathname": "/",
     "params": {},
     "data": "INDEX",

--- a/integration/matches-test.ts
+++ b/integration/matches-test.ts
@@ -10,6 +10,7 @@ test.describe("useMatches", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import * as React from 'react';

--- a/integration/mdx-test.ts
+++ b/integration/mdx-test.ts
@@ -17,7 +17,7 @@ test.describe("mdx", () => {
     fixture = await createFixture({
       files: {
         "app/root.jsx": js`
-        import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
+          import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
 
           export default function Root() {
             return (
@@ -51,7 +51,7 @@ test.describe("mdx", () => {
           }
         `,
 
-        "app/routes/blog/post.mdx": mdx`---
+        "app/routes/blog.post.mdx": mdx`---
 meta:
   title: My First Post
   description: Isn't this awesome?

--- a/integration/mdx-test.ts
+++ b/integration/mdx-test.ts
@@ -15,6 +15,7 @@ test.describe("mdx", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import { Links, Meta, Outlet, Scripts } from "@remix-run/react";

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -54,7 +54,7 @@ test.describe("meta", () => {
           }
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           export default function Index() {
             return <div>This is the index file</div>;
           }
@@ -180,7 +180,7 @@ test.describe("meta", () => {
           }
         `,
 
-        "app/routes/blog/index.jsx": js`
+        "app/routes/blog._index.jsx": js`
           import { Link, useLoaderData } from "@remix-run/react";
           import { json } from "@remix-run/node";
 
@@ -212,7 +212,7 @@ test.describe("meta", () => {
           }
         `,
 
-        "app/routes/blog/$pid.jsx": js`
+        "app/routes/blog.$pid.jsx": js`
           import { useLoaderData } from "@remix-run/react";
           import { json } from "@remix-run/node";
 
@@ -440,7 +440,7 @@ test.describe("v2_meta", () => {
           }
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           export const meta = ({ data, matches }) => [
             ...matches.map((match) => match.meta),
           ];

--- a/integration/meta-test.ts
+++ b/integration/meta-test.ts
@@ -15,6 +15,7 @@ test.describe("meta", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import { json } from "@remix-run/node";
@@ -402,6 +403,7 @@ test.describe("v2_meta", () => {
             ignoredRouteFiles: ["**/.*"],
             future: {
               v2_meta: true,
+              v2_routeConvention: true,
             },
           };
         `,

--- a/integration/multiple-cookies-test.ts
+++ b/integration/multiple-cookies-test.ts
@@ -11,7 +11,7 @@ test.describe("pathless layout routes", () => {
     appFixture = await createAppFixture(
       await createFixture({
         files: {
-          "app/routes/index.jsx": js`
+          "app/routes/_index.jsx": js`
             import { redirect, json } from "@remix-run/node";
             import { Form, useActionData } from "@remix-run/react";
 

--- a/integration/multiple-cookies-test.ts
+++ b/integration/multiple-cookies-test.ts
@@ -10,6 +10,9 @@ test.describe("pathless layout routes", () => {
   test.beforeAll(async () => {
     appFixture = await createAppFixture(
       await createFixture({
+        future: {
+          v2_routeConvention: true,
+        },
         files: {
           "app/routes/_index.jsx": js`
             import { redirect, json } from "@remix-run/node";

--- a/integration/path-mapping-test.ts
+++ b/integration/path-mapping-test.ts
@@ -12,7 +12,7 @@ test.beforeAll(async () => {
         export const pizza = "this is a pizza";
       `,
 
-      "app/routes/index.tsx": js`
+      "app/routes/_index.tsx": js`
         import { pizza } from "@mylib";
         import { json } from "@remix-run/node";
         import { useLoaderData, Link } from "@remix-run/react";

--- a/integration/path-mapping-test.ts
+++ b/integration/path-mapping-test.ts
@@ -7,6 +7,7 @@ let fixture: Fixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "app/components/my-lib/index.ts": js`
         export const pizza = "this is a pizza";

--- a/integration/postcss-test.ts
+++ b/integration/postcss-test.ts
@@ -112,14 +112,12 @@ test.describe("PostCSS", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
-  });
+  test.afterAll(() => appFixture.close());
 
   let regularStylesSheetsFixture = () => ({
     "app/routes/regular-style-sheets-test.jsx": js`
       import { Test, links as testLinks } from "~/test-components/regular-style-sheets";
-    
+
       export function links() {
         return [...testLinks()];
       }
@@ -138,7 +136,7 @@ test.describe("PostCSS", () => {
       export function Test() {
         return (
           <div data-testid="regular-style-sheets" className="regular-style-sheets-test">
-            <p>Regular style sheets test.</p>            
+            <p>Regular style sheets test.</p>
             <p>PostCSS context (base64): <span data-testid="regular-style-sheets-postcss-context" /></p>
           </div>
         );
@@ -185,7 +183,7 @@ test.describe("PostCSS", () => {
       export function Test() {
         return (
           <div data-testid="css-modules" className={styles.root}>
-            <p>CSS Modules test.</p>            
+            <p>CSS Modules test.</p>
             <p>PostCSS context (base64): <span data-testid="css-modules-postcss-context" /></p>
           </div>
         );
@@ -232,7 +230,7 @@ test.describe("PostCSS", () => {
       export function Test() {
         return (
           <div data-testid="vanilla-extract" className={styles.root}>
-            <p>Vanilla Extract test.</p>            
+            <p>Vanilla Extract test.</p>
             <p>PostCSS context (base64): <span data-testid="vanilla-extract-postcss-context" /></p>
           </div>
         );
@@ -240,7 +238,7 @@ test.describe("PostCSS", () => {
     `,
     "app/test-components/vanilla-extract/styles.css.ts": js`
       import { style, globalStyle } from "@vanilla-extract/css";
-    
+
       export const root = style({
         padding: "TEST_PADDING_VALUE",
       });
@@ -281,7 +279,7 @@ test.describe("PostCSS", () => {
       export function Test() {
         return (
           <div data-testid="css-side-effect-imports" className="css-side-effect-imports-test">
-            <p>CSS side-effect imports test.</p>            
+            <p>CSS side-effect imports test.</p>
             <p>PostCSS context (base64): <span data-testid="css-side-effect-imports-postcss-context" /></p>
           </div>
         );
@@ -317,7 +315,7 @@ test.describe("PostCSS", () => {
   let automaticTailwindPluginInsertionFixture = () => ({
     "app/routes/automatic-tailwind-plugin-insertion-test.jsx": js`
       import { Test, links as testLinks } from "~/test-components/automatic-tailwind-plugin-insertion";
-    
+
       export function links() {
         return [...testLinks()];
       }

--- a/integration/postcss-test.ts
+++ b/integration/postcss-test.ts
@@ -33,20 +33,15 @@ test.describe("PostCSS", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: {
+        v2_routeConvention: true,
+        unstable_cssModules: true,
+        unstable_cssSideEffectImports: true,
+        unstable_postcss: true,
+        unstable_tailwind: true,
+        unstable_vanillaExtract: true,
+      },
       files: {
-        "remix.config.js": js`
-          module.exports = {
-            future: {
-              // Enable all CSS future flags to
-              // ensure features don't clash
-              unstable_cssModules: true,
-              unstable_cssSideEffectImports: true,
-              unstable_postcss: true,
-              unstable_tailwind: true,
-              unstable_vanillaExtract: true,
-            },
-          };
-        `,
         // We provide a test plugin that replaces the strings
         // "TEST_PADDING_VALUE" and "TEST_POSTCSS_CONTEXT".
         // This lets us assert that the plugin is being run

--- a/integration/prefetch-test.ts
+++ b/integration/prefetch-test.ts
@@ -50,7 +50,7 @@ function fixtureFactory(mode: RemixLinkProps["prefetch"]) {
         }
       `,
 
-      "app/routes/index.jsx": js`
+      "app/routes/_index.jsx": js`
         export default function() {
           return <h2 className="index">Index</h2>;
         }

--- a/integration/prefetch-test.ts
+++ b/integration/prefetch-test.ts
@@ -8,6 +8,7 @@ import { PlaywrightFixture } from "./helpers/playwright-fixture";
 // Generate the test app using the given prefetch mode
 function fixtureFactory(mode: RemixLinkProps["prefetch"]) {
   return {
+    future: { v2_routeConvention: true },
     files: {
       "app/root.jsx": js`
         import {

--- a/integration/redirects-test.ts
+++ b/integration/redirects-test.ts
@@ -39,7 +39,7 @@ test.describe("redirects", () => {
           }
         `,
 
-        [`app/routes/action/form.jsx`]: js`
+        [`app/routes/action.form.jsx`]: js`
           import { redirect } from "@remix-run/node";
           import { Form } from "@remix-run/react";
 
@@ -56,7 +56,7 @@ test.describe("redirects", () => {
           }
         `,
 
-        [`app/routes/action/1.jsx`]: js`
+        [`app/routes/action.1.jsx`]: js`
           import { redirect } from "@remix-run/node";
 
           export async function loader({ request }) {
@@ -64,7 +64,7 @@ test.describe("redirects", () => {
           };
         `,
 
-        [`app/routes/action/2.jsx`]: js`
+        [`app/routes/action.2.jsx`]: js`
           export default function () {
             return <h1>Page 2</h1>
           }
@@ -107,14 +107,14 @@ test.describe("redirects", () => {
           }
         `,
 
-        "app/routes/loader/link.jsx": js`
+        "app/routes/loader.link.jsx": js`
           import { Link } from "@remix-run/react";
           export default function Parent() {
             return <Link to="/loader/redirect">Redirect</Link>;
           }
         `,
 
-        [`app/routes/loader/redirect.jsx`]: js`
+        [`app/routes/loader.redirect.jsx`]: js`
             import { redirect } from "@remix-run/node";
             import { Form } from "@remix-run/react";
             import { session } from "~/session.server";
@@ -131,7 +131,7 @@ test.describe("redirects", () => {
             };
         `,
 
-        [`app/routes/loader/1.jsx`]: js`
+        [`app/routes/loader.1.jsx`]: js`
           import { redirect } from "@remix-run/node";
 
           export async function loader({ request }) {
@@ -139,12 +139,12 @@ test.describe("redirects", () => {
           };
         `,
 
-        [`app/routes/loader/2.jsx`]: js`
+        [`app/routes/loader.2.jsx`]: js`
           export default function () {
             return <h1>Page 2</h1>
           }
         `,
-        [`app/routes/loader/external.js`]: js`
+        [`app/routes/loader.external.js`]: js`
           import { redirect } from "@remix-run/node";
           export const loader = () => {
             return redirect("https://remix.run/");

--- a/integration/redirects-test.ts
+++ b/integration/redirects-test.ts
@@ -10,6 +10,7 @@ test.describe("redirects", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/routes/action.jsx": js`
           import { Outlet, useLoaderData } from "@remix-run/react";

--- a/integration/rendering-test.ts
+++ b/integration/rendering-test.ts
@@ -33,7 +33,7 @@ test.describe("rendering", () => {
           }
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           export default function() {
             return <h2>Index</h2>;
           }

--- a/integration/rendering-test.ts
+++ b/integration/rendering-test.ts
@@ -10,6 +10,7 @@ test.describe("rendering", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import { Links, Meta, Outlet, Scripts } from "@remix-run/react";

--- a/integration/request-test.ts
+++ b/integration/request-test.ts
@@ -10,7 +10,7 @@ let appFixture: AppFixture;
 test.beforeAll(async () => {
   fixture = await createFixture({
     files: {
-      "app/routes/index.jsx": js`
+      "app/routes/_index.jsx": js`
         import { json } from "@remix-run/node";
         import { Form, useLoaderData, useActionData } from "@remix-run/react";
 

--- a/integration/request-test.ts
+++ b/integration/request-test.ts
@@ -9,6 +9,7 @@ let appFixture: AppFixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "app/routes/_index.jsx": js`
         import { json } from "@remix-run/node";

--- a/integration/resource-routes-test.ts
+++ b/integration/resource-routes-test.ts
@@ -14,7 +14,7 @@ test.describe("loader in an app", async () => {
   test.beforeAll(async () => {
     fixture = await createFixture({
       files: {
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           import { Form, Link } from "@remix-run/react";
 
           export default () => (

--- a/integration/resource-routes-test.ts
+++ b/integration/resource-routes-test.ts
@@ -13,6 +13,7 @@ test.describe("loader in an app", async () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/routes/_index.jsx": js`
           import { Form, Link } from "@remix-run/react";

--- a/integration/revalidate-test.ts
+++ b/integration/revalidate-test.ts
@@ -81,7 +81,7 @@ test.describe("Revalidation", () => {
             }
           `,
 
-          "app/routes/parent/child.jsx": js`
+          "app/routes/parent.child.jsx": js`
             import { json } from "@remix-run/node";
             import { Form, useLoaderData, useRevalidator } from "@remix-run/react";
 

--- a/integration/revalidate-test.ts
+++ b/integration/revalidate-test.ts
@@ -10,6 +10,9 @@ test.describe("Revalidation", () => {
   test.beforeAll(async () => {
     appFixture = await createAppFixture(
       await createFixture({
+        future: {
+          v2_routeConvention: true,
+        },
         files: {
           "app/root.jsx": js`
             import { Link, Outlet, Scripts, useNavigation } from "@remix-run/react";

--- a/integration/scroll-test.ts
+++ b/integration/scroll-test.ts
@@ -10,7 +10,7 @@ let appFixture: AppFixture;
 test.beforeAll(async () => {
   fixture = await createFixture({
     files: {
-      "app/routes/index.jsx": js`
+      "app/routes/_index.jsx": js`
         import { redirect } from "@remix-run/node";
         import { Form } from "@remix-run/react";
 

--- a/integration/scroll-test.ts
+++ b/integration/scroll-test.ts
@@ -9,6 +9,7 @@ let appFixture: AppFixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "app/routes/_index.jsx": js`
         import { redirect } from "@remix-run/node";

--- a/integration/server-code-in-browser-message-test.ts
+++ b/integration/server-code-in-browser-message-test.ts
@@ -20,12 +20,14 @@ test.beforeAll(async () => {
         version: "1.0.0",
         main: "index.js",
       }),
+
       "node_modules/has-side-effects/index.js": js`
         let message;
         (() => { message = process.env.___SOMETHING___ || "hello, world"; })();
         module.exports = () => message;
       `,
-      "app/routes/index.jsx": js`
+
+      "app/routes/_index.jsx": js`
         import { json } from "@remix-run/node";
         import { useLoaderData, Link } from "@remix-run/react";
         import sideEffectModules from "has-side-effects";

--- a/integration/server-code-in-browser-message-test.ts
+++ b/integration/server-code-in-browser-message-test.ts
@@ -14,6 +14,7 @@ let appFixture: AppFixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "node_modules/has-side-effects/package.json": json({
         name: "has-side-effects",

--- a/integration/server-entry-test.ts
+++ b/integration/server-entry-test.ts
@@ -23,7 +23,7 @@ test.describe("Server Entry", () => {
           }
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           export function loader() {
             return ""
           }
@@ -36,7 +36,7 @@ test.describe("Server Entry", () => {
   });
 
   test("can manipulate a data response", async () => {
-    let response = await fixture.requestData("/", "routes/index");
+    let response = await fixture.requestData("/", "routes/_index");
     expect(response.headers.get(DATA_HEADER_NAME)).toBe(DATA_HEADER_VALUE);
   });
 });

--- a/integration/server-entry-test.ts
+++ b/integration/server-entry-test.ts
@@ -11,6 +11,7 @@ test.describe("Server Entry", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/entry.server.jsx": js`
           export default function handleRequest() {

--- a/integration/server-source-maps-test.ts
+++ b/integration/server-source-maps-test.ts
@@ -11,7 +11,7 @@ test.beforeAll(async () => {
   fixture = await createFixture({
     sourcemap: true,
     files: {
-      "app/routes/index.jsx": js`
+      "app/routes/_index.jsx": js`
         import { json } from "@remix-run/node";
         import { useLoaderData } from "@remix-run/react";
 

--- a/integration/server-source-maps-test.ts
+++ b/integration/server-source-maps-test.ts
@@ -9,6 +9,7 @@ let fixture: Fixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    future: { v2_routeConvention: true },
     sourcemap: true,
     files: {
       "app/routes/_index.jsx": js`

--- a/integration/set-cookie-revalidation-test.ts
+++ b/integration/set-cookie-revalidation-test.ts
@@ -69,7 +69,7 @@ test.beforeAll(async () => {
         }
       `,
 
-      "app/routes/index.jsx": js`
+      "app/routes/_index.jsx": js`
         import { Link } from "@remix-run/react";
 
         export default function Index() {

--- a/integration/set-cookie-revalidation-test.ts
+++ b/integration/set-cookie-revalidation-test.ts
@@ -11,6 +11,7 @@ let BANNER_MESSAGE = "you do not have permission to view /protected";
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "app/session.server.js": js`
         import { createCookieSessionStorage } from "@remix-run/node";

--- a/integration/splat-routes-test.ts
+++ b/integration/splat-routes-test.ts
@@ -36,7 +36,7 @@ test.describe("rendering", () => {
           }
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           export default function() {
             return <h2>${ROOT_INDEX}</h2>;
           }
@@ -66,19 +66,19 @@ test.describe("rendering", () => {
           }
         `,
 
-        "app/routes/nested/$.jsx": js`
+        "app/routes/nested.$.jsx": js`
           export default function() {
             return <h2>${NESTED_$}</h2>
           }
         `,
 
-        "app/routes/nested/index.jsx": js`
+        "app/routes/nested._index.jsx": js`
           export default function() {
             return <h2>${NESTED_INDEX}</h2>
           }
         `,
 
-        "app/routes/parentless/$.jsx": js`
+        "app/routes/parentless.$.jsx": js`
           export default function() {
             return <h2>${PARENTLESS_$}</h2>
           }

--- a/integration/splat-routes-test.ts
+++ b/integration/splat-routes-test.ts
@@ -16,6 +16,7 @@ test.describe("rendering", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import { Links, Meta, Outlet, Scripts } from "@remix-run/react";

--- a/integration/tailwind-test.ts
+++ b/integration/tailwind-test.ts
@@ -80,9 +80,7 @@ test.describe("Tailwind", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
-  });
+  test.afterAll(() => appFixture.close());
 
   let basicUsageFixture = () => ({
     "app/routes/basic-usage-test.jsx": js`
@@ -108,7 +106,7 @@ test.describe("Tailwind", () => {
   let regularStylesSheetsFixture = () => ({
     "app/routes/regular-style-sheets-test.jsx": js`
       import { Test, links as testLinks } from "~/test-components/regular-style-sheets";
-    
+
       export function links() {
         return [...testLinks()];
       }

--- a/integration/tailwind-test.ts
+++ b/integration/tailwind-test.ts
@@ -17,20 +17,17 @@ test.describe("Tailwind", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: {
+        v2_routeConvention: true,
+        // Enable all CSS future flags to
+        // ensure features don't clash
+        unstable_cssModules: true,
+        unstable_cssSideEffectImports: true,
+        unstable_postcss: true,
+        unstable_tailwind: true,
+        unstable_vanillaExtract: true,
+      },
       files: {
-        "remix.config.js": js`
-          module.exports = {
-            future: {
-              // Enable all CSS future flags to
-              // ensure features don't clash
-              unstable_cssModules: true,
-              unstable_cssSideEffectImports: true,
-              unstable_postcss: true,
-              unstable_tailwind: true,
-              unstable_vanillaExtract: true,
-            },
-          };
-        `,
         "tailwind.config.js": js`
           module.exports = {
             content: ["./app/**/*.{ts,tsx,jsx,js}"],

--- a/integration/transition-state-test.ts
+++ b/integration/transition-state-test.ts
@@ -59,7 +59,8 @@ test.describe("rendering", () => {
             );
           }
         `,
-        "app/routes/index.jsx": js`
+
+        "app/routes/_index.jsx": js`
           import { Form, Link, useFetcher } from "@remix-run/react";
           export function loader() { return null; }
           export default function() {
@@ -115,6 +116,7 @@ test.describe("rendering", () => {
             );
           }
         `,
+
         [`app/routes/${STATES.NORMAL_LOAD}.jsx`]: js`
           export default function() {
             return (
@@ -124,6 +126,7 @@ test.describe("rendering", () => {
             );
           }
         `,
+
         [`app/routes/${STATES.LOADING_REDIRECT}.jsx`]: js`
           import { redirect } from "@remix-run/node";
           export function loader() {
@@ -137,6 +140,7 @@ test.describe("rendering", () => {
             );
           }
         `,
+
         [`app/routes/${STATES.SUBMITTING_LOADER}.jsx`]: js`
           export default function() {
             return (
@@ -146,6 +150,7 @@ test.describe("rendering", () => {
             );
           }
         `,
+
         [`app/routes/${STATES.SUBMITTING_LOADER_REDIRECT}.jsx`]: js`
           import { redirect } from "@remix-run/node";
           export function loader() {
@@ -159,6 +164,7 @@ test.describe("rendering", () => {
             );
           }
         `,
+
         [`app/routes/${STATES.SUBMITTING_ACTION}.jsx`]: js`
           export function loader() { return null; }
           export function action() { return null; }
@@ -170,6 +176,7 @@ test.describe("rendering", () => {
             );
           }
         `,
+
         [`app/routes/${STATES.SUBMITTING_ACTION_REDIRECT}.jsx`]: js`
           import { redirect } from "@remix-run/node";
           export function action() {
@@ -183,6 +190,7 @@ test.describe("rendering", () => {
             );
           }
         `,
+
         [`app/routes/${STATES.FETCHER_REDIRECT}.jsx`]: js`
           import { redirect } from "@remix-run/node";
           export function action() {

--- a/integration/transition-state-test.ts
+++ b/integration/transition-state-test.ts
@@ -25,6 +25,7 @@ test.describe("rendering", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import { useMemo, useRef } from "react";

--- a/integration/transition-test.ts
+++ b/integration/transition-test.ts
@@ -41,7 +41,7 @@ test.describe("rendering", () => {
           }
         `,
 
-        "app/routes/index.jsx": js`
+        "app/routes/_index.jsx": js`
           import { Link } from "@remix-run/react";
           export default function() {
             return (
@@ -73,7 +73,7 @@ test.describe("rendering", () => {
           }
         `,
 
-        [`app/routes/${PAGE}/index.jsx`]: js`
+        [`app/routes/${PAGE}._index.jsx`]: js`
           import { useLoaderData, Link } from "@remix-run/react";
 
           export function loader() {
@@ -91,7 +91,7 @@ test.describe("rendering", () => {
           }
         `,
 
-        [`app/routes/${PAGE}/${CHILD}.jsx`]: js`
+        [`app/routes/${PAGE}.${CHILD}.jsx`]: js`
           import { useLoaderData } from "@remix-run/react";
 
           export function loader() {
@@ -180,7 +180,7 @@ test.describe("rendering", () => {
           }
         `,
 
-        "app/routes/parent/child.jsx": js`
+        "app/routes/parent.child.jsx": js`
           import { redirect } from "@remix-run/node";
           import { useFetcher} from "@remix-run/react";
 
@@ -219,7 +219,7 @@ test.describe("rendering", () => {
       responses
         .map((res) => new URL(res.url()).searchParams.get("_data"))
         .sort()
-    ).toEqual([`routes/${PAGE}`, `routes/${PAGE}/index`].sort());
+    ).toEqual([`routes/${PAGE}`, `routes/${PAGE}._index`].sort());
 
     await page.waitForSelector(`h2:has-text("${PAGE_TEXT}")`);
     await page.waitForSelector(`h3:has-text("${PAGE_INDEX_TEXT}")`);
@@ -234,7 +234,7 @@ test.describe("rendering", () => {
 
     expect(
       responses.map((res) => new URL(res.url()).searchParams.get("_data"))
-    ).toEqual([`routes/${PAGE}/${CHILD}`]);
+    ).toEqual([`routes/${PAGE}.${CHILD}`]);
 
     await page.waitForSelector(`h2:has-text("${PAGE_TEXT}")`);
     await page.waitForSelector(`h3:has-text("${CHILD_TEXT}")`);
@@ -255,7 +255,7 @@ test.describe("rendering", () => {
         .map((res) => new URL(res.url()).searchParams.get("_data"))
         .sort()
     ).toEqual(
-      [`routes/${REDIRECT}`, `routes/${PAGE}`, `routes/${PAGE}/index`].sort()
+      [`routes/${REDIRECT}`, `routes/${PAGE}`, `routes/${PAGE}._index`].sort()
     );
 
     await page.waitForSelector(`h2:has-text("${PAGE_TEXT}")`);
@@ -285,7 +285,7 @@ test.describe("rendering", () => {
 
     expect(
       responses.map((res) => new URL(res.url()).searchParams.get("_data"))
-    ).toEqual([`routes/${PAGE}/index`]);
+    ).toEqual([`routes/${PAGE}._index`]);
 
     await page.waitForSelector(`h2:has-text("${PAGE_TEXT}")`);
     await page.waitForSelector(`h3:has-text("${PAGE_INDEX_TEXT}")`);

--- a/integration/transition-test.ts
+++ b/integration/transition-test.ts
@@ -19,6 +19,7 @@ test.describe("rendering", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: { v2_routeConvention: true },
       files: {
         "app/root.jsx": js`
           import { Links, Meta, Outlet, Scripts } from "@remix-run/react";

--- a/integration/tsconfig-test.ts
+++ b/integration/tsconfig-test.ts
@@ -45,6 +45,7 @@ const DEFAULT_CONFIG: SerializableTsConfigJson = {
 // https://github.com/dividab/tsconfig-paths/pull/208
 test("should output default tsconfig if file is empty", async () => {
   let fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "tsconfig.json": json({ compilerOptions: { baseUrl: "." } }),
     },
@@ -64,6 +65,7 @@ test("should add/update mandatory config", async () => {
   };
   delete config.compilerOptions.moduleResolution; // this is required by esbuild
   let fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: { "tsconfig.json": json(config) },
   });
 
@@ -82,6 +84,7 @@ test("shouldn't change suggested config if set", async () => {
   };
 
   let fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "tsconfig.json": json(config),
     },
@@ -102,6 +105,7 @@ test("shouldn't change suggested config for moduleResolution: bundler", async ()
   };
 
   let fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "tsconfig.json": json(config),
     },
@@ -124,6 +128,7 @@ test("allows for `extends` in tsconfig", async () => {
   };
 
   let fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "tsconfig.json": json(config),
       "tsconfig.base.json": json(baseConfig),
@@ -150,6 +155,7 @@ test("works with jsconfig", async () => {
   };
 
   let fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "jsconfig.json": json(config),
     },

--- a/integration/upload-test.ts
+++ b/integration/upload-test.ts
@@ -10,6 +10,7 @@ let appFixture: AppFixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    future: { v2_routeConvention: true },
     files: {
       "app/routes/file-upload-handler.jsx": js`
         import {

--- a/integration/vanilla-extract-test.ts
+++ b/integration/vanilla-extract-test.ts
@@ -65,9 +65,7 @@ test.describe("Vanilla Extract", () => {
     appFixture = await createAppFixture(fixture);
   });
 
-  test.afterAll(async () => {
-    await appFixture.close();
-  });
+  test.afterAll(() => appFixture.close());
 
   let typeScriptFixture = () => ({
     "app/fixtures/typescript/styles.css.ts": js`
@@ -80,7 +78,7 @@ test.describe("Vanilla Extract", () => {
     `,
     "app/routes/typescript-test.jsx": js`
       import * as styles from "../fixtures/typescript/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="typescript" className={styles.root}>
@@ -111,7 +109,7 @@ test.describe("Vanilla Extract", () => {
     `,
     "app/routes/javascript-test.jsx": js`
       import * as styles from "../fixtures/javascript/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="javascript" className={styles.root}>
@@ -150,7 +148,7 @@ test.describe("Vanilla Extract", () => {
     `,
     "app/routes/class-composition-test.jsx": js`
       import * as styles from "../fixtures/class-composition/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="class-composition" className={styles.root}>
@@ -189,7 +187,7 @@ test.describe("Vanilla Extract", () => {
     `,
     "app/routes/root-relative-class-composition-test.jsx": js`
       import * as styles from "../fixtures/root-relative-class-composition/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="root-relative-class-composition" className={styles.root}>
@@ -214,14 +212,14 @@ test.describe("Vanilla Extract", () => {
   let sideEffectImportsFixture = () => ({
     "app/fixtures/side-effect-imports/styles.css.ts": js`
       import { globalStyle } from "@vanilla-extract/css";
-      
+
       globalStyle(".side-effect-imports", {
         padding: ${JSON.stringify(TEST_PADDING_VALUE)}
       });
     `,
     "app/routes/side-effect-imports-test.jsx": js`
       import "../fixtures/side-effect-imports/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="side-effect-imports" className="side-effect-imports">
@@ -247,14 +245,14 @@ test.describe("Vanilla Extract", () => {
     `,
     "app/fixtures/side-effect-imports-within-child-compilation/nested-side-effect.css.ts": js`
       import { globalStyle } from "@vanilla-extract/css";
-      
+
       globalStyle(".side-effect-imports-within-child-compilation", {
         padding: ${JSON.stringify(TEST_PADDING_VALUE)}
       });
     `,
     "app/routes/side-effect-imports-within-child-compilation-test.jsx": js`
       import "../fixtures/side-effect-imports-within-child-compilation/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="side-effect-imports-within-child-compilation" className="side-effect-imports-within-child-compilation">
@@ -302,7 +300,7 @@ test.describe("Vanilla Extract", () => {
       import * as styles_b from "../fixtures/stable-identifiers/styles_b.css";
 
       const styles = new Set([styles_a.root, styles_b.root]);
-      
+
       export default function() {
         return (
           <div data-testid="stable-identifiers" className={Array.from(styles).join(' ')}>
@@ -345,7 +343,7 @@ test.describe("Vanilla Extract", () => {
     `,
     "app/routes/image-urls-via-css-url-test.jsx": js`
       import * as styles from "../fixtures/imageUrlsViaCssUrl/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="image-urls-via-css-url" className={styles.root}>
@@ -387,7 +385,7 @@ test.describe("Vanilla Extract", () => {
     `,
     "app/routes/image-urls-via-root-relative-css-url-test.jsx": js`
       import * as styles from "../fixtures/imageUrlsViaRootRelativeCssUrl/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="image-urls-via-root-relative-css-url" className={styles.root}>
@@ -432,7 +430,7 @@ test.describe("Vanilla Extract", () => {
     `,
     "app/routes/image-urls-via-js-import-test.jsx": js`
       import * as styles from "../fixtures/imageUrlsViaJsImport/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="image-urls-via-js-import" className={styles.root}>
@@ -477,7 +475,7 @@ test.describe("Vanilla Extract", () => {
     `,
     "app/routes/image-urls-via-root-relative-js-import-test.jsx": js`
       import * as styles from "../fixtures/imageUrlsViaRootRelativeJsImport/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="image-urls-via-root-relative-js-import" className={styles.root}>
@@ -531,7 +529,7 @@ test.describe("Vanilla Extract", () => {
     `,
     "app/routes/image-urls-via-class-composition-test.jsx": js`
       import * as styles from "../fixtures/imageUrlsViaClassComposition/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="image-urls-via-class-composition" className={styles.root}>
@@ -586,7 +584,7 @@ test.describe("Vanilla Extract", () => {
     `,
     "app/routes/image-urls-via-js-import-class-composition-test.jsx": js`
       import * as styles from "../fixtures/imageUrlsViaJsImportClassComposition/styles.css";
-      
+
       export default function() {
         return (
           <div data-testid="image-urls-via-js-import-class-composition" className={styles.root}>
@@ -616,7 +614,7 @@ test.describe("Vanilla Extract", () => {
   let standardImageUrlsViaJsImportFixture = () => ({
     "app/fixtures/standardImageUrlsViaJsImport/styles.css.ts": js`
       import { style } from "@vanilla-extract/css";
-      
+
       export { default as src } from "./image.svg";
 
       export const root = style({
@@ -631,7 +629,7 @@ test.describe("Vanilla Extract", () => {
     `,
     "app/routes/standard-image-urls-via-js-import-test.jsx": js`
       import { root, src } from "../fixtures/standardImageUrlsViaJsImport/styles.css";
-      
+
       export default function() {
         return (
           <img
@@ -681,7 +679,7 @@ test.describe("Vanilla Extract", () => {
     `,
     "app/routes/standard-image-urls-via-root-relative-js-import-test.jsx": js`
       import { root, src } from "../fixtures/standardImageUrlsViaRootRelativeJsImport/styles.css";
-      
+
       export default function() {
         return (
           <img

--- a/integration/vanilla-extract-test.ts
+++ b/integration/vanilla-extract-test.ts
@@ -12,20 +12,17 @@ test.describe("Vanilla Extract", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      future: {
+        v2_routeConvention: true,
+        // Enable all CSS future flags to
+        // ensure features don't clash
+        unstable_cssModules: true,
+        unstable_cssSideEffectImports: true,
+        unstable_postcss: true,
+        unstable_tailwind: true,
+        unstable_vanillaExtract: true,
+      },
       files: {
-        "remix.config.js": js`
-          module.exports = {
-            future: {
-              // Enable all CSS future flags to
-              // ensure features don't clash
-              unstable_cssModules: true,
-              unstable_cssSideEffectImports: true,
-              unstable_postcss: true,
-              unstable_tailwind: true,
-              unstable_vanillaExtract: true,
-            },
-          };
-        `,
         "app/root.jsx": js`
           import { Links, Outlet } from "@remix-run/react";
           import { cssBundleHref } from "@remix-run/css-bundle";


### PR DESCRIPTION
migrates our integration tests to use `v2_routeConvention`

one thing to note is that but due to checking for conflicts at the url, the [`form-test`](https://github.com/remix-run/remix/pull/5686/files#diff-6ba8f3349b2b29f4668d3cdbcc4df75c8182edad8eaea07c5a6d7f227309acf7R435) has been updated from this

```jsx
<Route path="pathless-layout-parent" file="routes/pathless-layout-parent.jsx">
  <Route file="routes/pathless-layout-parent._pathless.tsx">
    <Route index file="routes/pathless-layout-parent._pathless._index.jsx" />
  </Route>
</Route>
```

to:


```jsx
<Route path="pathless-layout-parent" file="routes/pathless-layout-parent.jsx">
  <Route file="routes/pathless-layout-parent._pathless.nested.tsx">
    <Route index file="routes/pathless-layout-parent._pathless.nested._index.jsx" />
  </Route>
</Route>
```

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
