### PR TITLE
fix(remix-dev): use route.id verbatim for conflicts

### DIFF
--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -322,7 +322,6 @@ function getRouteMap(
 ): Readonly<Map<string, RouteInfo>> {
   let routeMap = new Map<string, RouteInfo>();
   let nameMap = new Map<string, RouteInfo>();
-  let uniqueRoutes = new Map<string, RouteInfo>();
   let conflicts = new Map<string, RouteInfo[]>();
 
   for (let routePath of routePaths) {
@@ -331,26 +330,19 @@ function getRouteMap(
     if (isRouteModuleFile(pathWithoutAppRoutes)) {
       let routeInfo = getRouteInfo(appDirectory, prefix, routePath);
 
-      let uniqueRouteId =
-        (routeInfo.path || "") + (routeInfo.index ? "?index" : "");
-
-      if (uniqueRouteId) {
-        let conflict = uniqueRoutes.get(uniqueRouteId);
-        // collect conflicts for later reporting
-        if (conflict) {
-          let currentConflicts = conflicts.get(routeInfo.path || "/");
-          if (!currentConflicts) {
-            conflicts.set(routeInfo.path || "/", [conflict, routeInfo]);
-          } else {
-            currentConflicts.push(routeInfo);
-            conflicts.set(routeInfo.path || "/", currentConflicts);
-          }
-
-          continue;
+      let conflict = routeMap.get(routeInfo.id);
+      // collect conflicts for later reporting
+      if (conflict) {
+        let currentConflicts = conflicts.get(routeInfo.path || "/");
+        if (!currentConflicts) {
+          conflicts.set(routeInfo.path || "/", [conflict, routeInfo]);
+        } else {
+          currentConflicts.push(routeInfo);
+          conflicts.set(routeInfo.path || "/", currentConflicts);
         }
-        uniqueRoutes.set(uniqueRouteId, routeInfo);
-      }
 
+        continue;
+      }
       routeMap.set(routeInfo.id, routeInfo);
       nameMap.set(routeInfo.name, routeInfo);
     }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
