### PR TITLE
docs(file-conventions/route-files-v2): use new `route.tsx` convention

### DIFF
--- a/docs/file-conventions/route-files-v2.md
+++ b/docs/file-conventions/route-files-v2.md
@@ -307,7 +307,7 @@ If you want one of the special characters Remix uses for these route conventions
 
 ## Folders for Organization
 
-Routes can also be folders with a conventional node module resolution `index.tsx` file inside defining the route module. The rest of the files in the folder will not become routes. This allows you to organize your code closer to the routes that use them instead of repeating the feature names across other folders.
+Routes can also be folders with a `route.tsx` file inside defining the route module. The rest of the files in the folder will not become routes. This allows you to organize your code closer to the routes that use them instead of repeating the feature names across other folders.
 
 <docs-info>The files inside a folder have no meaning for the route paths, the route path is completely defined by the folder name</docs-info>
 


### PR DESCRIPTION
The intro paragraph on the Folders for Organization section wasn't updated to use the new convention of `route.tsx` added in 1.13.0.