### PR TITLE
feat(remix-react): show deprecation warning when `imagesizes` & `imagesizes` properties are returned from `links` function

### DIFF
--- a/.changeset/thick-actors-juggle.md
+++ b/.changeset/thick-actors-juggle.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": minor
+---
+
+show deprecation warning when `imagesizes` & `imagesizes` properties are returned from `links` function

--- a/integration/action-test.ts
+++ b/integration/action-test.ts
@@ -109,7 +109,10 @@ test.describe("actions", () => {
 
   test.beforeEach(({ page }) => {
     page.on("console", (msg) => {
-      logs.push(msg.text());
+      let text = msg.text();
+      if (!/DEPRECATED.*imagesizes.*imagesrcset/.test(text)) {
+        logs.push(text);
+      }
     });
   });
 

--- a/integration/defer-test.ts
+++ b/integration/defer-test.ts
@@ -1287,7 +1287,8 @@ function monitorConsole(page: Page) {
         let arg0 = await args[0].jsonValue();
         if (
           typeof arg0 === "string" &&
-          arg0.includes("Download the React DevTools")
+          (arg0.includes("Download the React DevTools") ||
+            /DEPRECATED.*imagesizes.*imagesrcset/.test(arg0))
         ) {
           continue;
         }

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -383,6 +383,16 @@ export function Links() {
     [matches, routeModules, manifest]
   );
 
+  React.useEffect(() => {
+    warnOnce(
+      links.some((link) => "imagesizes" in link || "imagesrcset" in link),
+      "⚠️ DEPRECATED: The `imagesizes` & `imagesrcset` properties in " +
+        "your links have been deprecated in favor of `imageSizes` & " +
+        "`imageSrcSet` and support will be removed in Remix v2. Please update " +
+        "your code to use the new property names instead."
+    );
+  }, [links]);
+
   return (
     <>
       {links.map((link) => {


### PR DESCRIPTION
This will warn people about #5705