### PR TITLE
fix(remix-dev): use path.resolve when re-exporting entry.client

### DIFF
--- a/.changeset/css-bundle-monorepo-fix.md
+++ b/.changeset/css-bundle-monorepo-fix.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/dev": patch
+---
+
+use path.resolve when re-exporting entry.client

--- a/packages/remix-dev/compiler/plugins/cssBundleEntryModulePlugin.ts
+++ b/packages/remix-dev/compiler/plugins/cssBundleEntryModulePlugin.ts
@@ -28,7 +28,7 @@ export function cssBundleEntryModulePlugin(config: RemixConfig): Plugin {
           contents: [
             // These need to be exports to avoid tree shaking
             `export * as entryClient from ${JSON.stringify(
-              path.relative(config.rootDirectory, config.entryClientFilePath)
+              path.resolve(config.rootDirectory, config.entryClientFilePath)
             )};`,
             ...Object.keys(config.routes).map((key, index) => {
               let route = config.routes[key];


### PR DESCRIPTION
fixes an issue when using `@remix-run/css-bundle` in a monorepo.

no integration tests as i don't think we can do that with our current test infra

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #5659

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
