### PR TITLE
fix(remix-dev): Use normalized file path when analyzing flat routes

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -336,6 +336,7 @@
 - michaeldebetaz
 - michaeldeboey
 - michaelfriedman
+- michaelgmcd
 - michaelhelvey
 - michaseel
 - mikeybinnswebdesign

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -672,6 +672,20 @@ describe("flatRoutes", () => {
       );
     });
 
+    test("nested index files", () => {
+      let testFiles = ["routes/_index/index.tsx", "routes/_index/utils.ts"];
+
+      let routeManifest = flatRoutesUniversal(
+        APP_DIR,
+        testFiles.map((file) => path.join(APP_DIR, normalizePath(file)))
+      );
+
+      let routes = Object.values(routeManifest);
+
+      expect(routes).toHaveLength(1);
+      expect(consoleError).not.toHaveBeenCalled();
+    });
+
     test("folder/route.tsx matching folder.tsx", () => {
       // we'll add file manually before running the tests
       let testFiles = ["routes/dashboard.tsx", "routes/dashboard/route.tsx"];

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -379,7 +379,7 @@ function getRouteMap(
 function isRouteModuleFile(filePath: string) {
   // flat files only need correct extension
   let normalizedFilePath = normalizeSlashes(filePath);
-  let isFlatFile = !filePath.includes(path.posix.sep);
+  let isFlatFile = !normalizedFilePath.includes(path.posix.sep);
   let hasExt = routeModuleExts.includes(path.extname(filePath));
   if (isFlatFile) return hasExt;
   let basename = normalizedFilePath.slice(0, -path.extname(filePath).length);


### PR DESCRIPTION
Fixes #5672.

I've added a test in remix-dev for the functionality as well. Before this change, this test failed on Windows and passed on MacOS.