### PR TITLE
Remove fetcher.type/fetcher.submission

### DIFF
--- a/.changeset/remove-fetcher-back-compat.md
+++ b/.changeset/remove-fetcher-back-compat.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": major
+---
+
+Remove back-compat layer for useFetcher/useFetchers

--- a/.changeset/remove-fetcher-back-compat.md
+++ b/.changeset/remove-fetcher-back-compat.md
@@ -2,4 +2,7 @@
 "@remix-run/react": major
 ---
 
-Remove back-compat layer for useFetcher/useFetchers
+Remove back-compat layer for `useFetcher`/`useFetchers`.  This includes a few small breaking changes:
+* `fetcher.type` has been removed since it can be derived from other available information
+* "Submission" fields have been flattened from `fetcher.submission` down onto the root `fetcher` object, and prefixed with `form` in some cases (`fetcher.submission.action` => `fetcher.formAction`)
+* `<fetcher.Form method="get">` is now more accurately categorized as `state:"loading"` instead of `state:"submitting"` to better align with the underlying GET request

--- a/integration/fetcher-state-test.ts
+++ b/integration/fetcher-state-test.ts
@@ -35,16 +35,10 @@ test.describe("fetcher states", () => {
               const savedStates = fetcherRef.current || [];
               savedStates.push({
                 state: fetcher.state,
-                type: fetcher.type,
                 formMethod: fetcher.formMethod,
                 formAction: fetcher.formAction,
                 formData:fetcher.formData ? Object.fromEntries(fetcher.formData.entries()) : undefined,
                 formEncType: fetcher.formEncType,
-                submission: fetcher.submission ? {
-                  ...fetcher.submission,
-                  formData: Object.fromEntries(fetcher.submission.formData.entries()),
-                  key: undefined
-                }: undefined,
                 data: fetcher.data,
               });
               fetcherRef.current = savedStates;
@@ -163,38 +157,23 @@ test.describe("fetcher states", () => {
     expect(JSON.parse(text)).toEqual([
       {
         state: "submitting",
-        type: "actionSubmission",
         formData: { key: "value" },
         formAction: "/page",
         formMethod: "POST",
         formEncType: "application/x-www-form-urlencoded",
-        submission: {
-          formData: { key: "value" },
-          action: "/page",
-          method: "POST",
-          encType: "application/x-www-form-urlencoded",
-        },
       },
       {
         state: "loading",
-        type: "actionReload",
         formData: { key: "value" },
         formAction: "/page",
         formMethod: "POST",
         formEncType: "application/x-www-form-urlencoded",
-        submission: {
-          formData: { key: "value" },
-          action: "/page",
-          method: "POST",
-          encType: "application/x-www-form-urlencoded",
-        },
         data: {
           from: "action",
         },
       },
       {
         state: "idle",
-        type: "done",
         data: {
           from: "action",
         },
@@ -211,24 +190,13 @@ test.describe("fetcher states", () => {
     expect(JSON.parse(text)).toEqual([
       {
         state: "submitting",
-        type: "loaderSubmission",
         formData: { key: "value" },
         formAction: "/page",
         formMethod: "GET",
         formEncType: "application/x-www-form-urlencoded",
-        submission: {
-          formData: { key: "value" },
-          // Note: This is a bug in Remix but we're going to keep it that way
-          // in useTransition (including the back-compat version) and it'll be
-          // fixed with useNavigation
-          action: "/page?key=value",
-          method: "GET",
-          encType: "application/x-www-form-urlencoded",
-        },
       },
       {
         state: "idle",
-        type: "done",
         data: {
           from: "loader",
         },
@@ -245,35 +213,20 @@ test.describe("fetcher states", () => {
     expect(JSON.parse(text)).toEqual([
       {
         state: "submitting",
-        type: "actionSubmission",
         formData: { redirect: "yes" },
         formAction: "/page",
         formMethod: "POST",
         formEncType: "application/x-www-form-urlencoded",
-        submission: {
-          formData: { redirect: "yes" },
-          action: "/page",
-          method: "POST",
-          encType: "application/x-www-form-urlencoded",
-        },
       },
       {
         state: "loading",
-        type: "actionRedirect",
         formData: { redirect: "yes" },
         formAction: "/page",
         formMethod: "POST",
         formEncType: "application/x-www-form-urlencoded",
-        submission: {
-          formData: { redirect: "yes" },
-          action: "/page",
-          method: "POST",
-          encType: "application/x-www-form-urlencoded",
-        },
       },
       {
         state: "idle",
-        type: "done",
       },
     ]);
   });
@@ -287,12 +240,10 @@ test.describe("fetcher states", () => {
     expect(JSON.parse(text)).toEqual([
       {
         state: "loading",
-        type: "normalLoad",
       },
       {
         data: { from: "loader" },
         state: "idle",
-        type: "done",
       },
     ]);
   });

--- a/integration/fetcher-state-test.ts
+++ b/integration/fetcher-state-test.ts
@@ -80,12 +80,11 @@ test.describe("fetcher states", () => {
             const fetcher = useFetcher();
             return (
               <>
-                {fetcher.type === 'init' ?
+                {fetcher.state === 'idle' && fetcher.data == null ?
                   <pre id="initial-state">
                     {
                       JSON.stringify({
                         state: fetcher.state,
-                        type: fetcher.type,
                         formMethod: fetcher.formMethod,
                         formAction: fetcher.formAction,
                         formData: fetcher.formData,
@@ -144,7 +143,11 @@ test.describe("fetcher states", () => {
     let text = (await app.getElement("#initial-state")).text();
     expect(JSON.parse(text)).toEqual({
       state: "idle",
-      type: "init",
+      data: undefined,
+      formData: undefined,
+      formAction: undefined,
+      formMethod: undefined,
+      formEncType: undefined,
     });
   });
 
@@ -189,7 +192,7 @@ test.describe("fetcher states", () => {
     let text = (await app.getElement("#states")).text();
     expect(JSON.parse(text)).toEqual([
       {
-        state: "submitting",
+        state: "loading",
         formData: { key: "value" },
         formAction: "/page",
         formMethod: "GET",

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1168,17 +1168,7 @@ export function useActionData<T = AppData>(): SerializeFrom<T> | undefined {
  */
 export function useFetchers(): Fetcher[] {
   let fetchers = useFetchersRR();
-  return fetchers.map((f) => {
-    let fetcher = convertRouterFetcherToRemixFetcher({
-      state: f.state,
-      data: f.data,
-      formMethod: f.formMethod,
-      formAction: f.formAction,
-      formData: f.formData,
-      formEncType: f.formEncType,
-    });
-    return fetcher;
-  });
+  return fetchers.map((f) => convertRouterFetcherToRemixFetcher(f));
 }
 
 export type FetcherWithComponents<TData> = Fetcher<TData> & {
@@ -1201,14 +1191,7 @@ export function useFetcher<TData = any>(): FetcherWithComponents<
   let fetcherRR = useFetcherRR();
 
   return React.useMemo(() => {
-    let remixFetcher = convertRouterFetcherToRemixFetcher({
-      state: fetcherRR.state,
-      data: fetcherRR.data,
-      formMethod: fetcherRR.formMethod,
-      formAction: fetcherRR.formAction,
-      formData: fetcherRR.formData,
-      formEncType: fetcherRR.formEncType,
-    });
+    let remixFetcher = convertRouterFetcherToRemixFetcher(fetcherRR);
     let fetcherWithComponents = {
       ...remixFetcher,
       load: fetcherRR.load,

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -1,158 +1,31 @@
-import type { Location, NavigationType as Action } from "react-router-dom";
+import type { FormEncType, FormMethod } from "./data";
 
-export interface CatchData<T = any> {
-  status: number;
-  statusText: string;
-  data: T;
-}
-
-export interface Submission {
-  action: string;
-  method: string;
-  formData: FormData;
-  encType: string;
-  key: string;
-}
-
-export interface ActionSubmission extends Submission {
-  method: "POST" | "PUT" | "PATCH" | "DELETE";
-}
-
-export interface LoaderSubmission extends Submission {
-  method: "GET";
-}
-
-export type Redirects = {
-  Loader: {
-    isRedirect: true;
-    type: "loader";
-    setCookie: boolean;
-  };
-  Action: {
-    isRedirect: true;
-    type: "action";
-    setCookie: boolean;
-  };
-  LoaderSubmission: {
-    isRedirect: true;
-    type: "loaderSubmission";
-    setCookie: boolean;
-  };
-  FetchAction: {
-    isRedirect: true;
-    type: "fetchAction";
-    setCookie: boolean;
-  };
-};
-
-// TODO: keep data around on resubmission?
 export type FetcherStates<TData = any> = {
   Idle: {
     state: "idle";
-    type: "init";
     formMethod: undefined;
     formAction: undefined;
-    formData: undefined;
     formEncType: undefined;
-    submission: undefined;
-    data: undefined;
-  };
-  SubmittingAction: {
-    state: "submitting";
-    type: "actionSubmission";
-    formMethod: ActionSubmission["method"];
-    formAction: string;
-    formData: FormData;
-    formEncType: string;
-    submission: ActionSubmission;
+    formData: undefined;
     data: TData | undefined;
-  };
-  SubmittingLoader: {
-    state: "submitting";
-    type: "loaderSubmission";
-    formMethod: LoaderSubmission["method"];
-    formAction: string;
-    formData: FormData;
-    formEncType: string;
-    submission: LoaderSubmission;
-    data: TData | undefined;
-  };
-  ReloadingAction: {
-    state: "loading";
-    type: "actionReload";
-    formMethod: ActionSubmission["method"];
-    formAction: string;
-    formData: FormData;
-    formEncType: string;
-    submission: ActionSubmission;
-    data: TData;
-  };
-  LoadingActionRedirect: {
-    state: "loading";
-    type: "actionRedirect";
-    formMethod: ActionSubmission["method"];
-    formAction: string;
-    formData: FormData;
-    formEncType: string;
-    submission: ActionSubmission;
-    data: undefined;
   };
   Loading: {
     state: "loading";
-    type: "normalLoad";
-    formMethod: undefined;
-    formAction: undefined;
-    formData: undefined;
-    formEncType: undefined;
-    submission: undefined;
+    formMethod: FormMethod | undefined;
+    formAction: string | undefined;
+    formEncType: FormEncType | undefined;
+    formData: FormData | undefined;
     data: TData | undefined;
   };
-  Done: {
-    state: "idle";
-    type: "done";
-    formMethod: undefined;
-    formAction: undefined;
-    formData: undefined;
-    formEncType: undefined;
-    submission: undefined;
-    data: TData;
+  Submitting: {
+    state: "submitting";
+    formMethod: FormMethod;
+    formAction: string;
+    formEncType: FormEncType;
+    formData: FormData;
+    data: TData | undefined;
   };
 };
 
 export type Fetcher<TData = any> =
   FetcherStates<TData>[keyof FetcherStates<TData>];
-
-export class CatchValue {
-  constructor(
-    public status: number,
-    public statusText: string,
-    public data: any
-  ) {}
-}
-
-export type NavigationEvent = {
-  type: "navigation";
-  action: Action;
-  location: Location;
-  submission?: Submission;
-};
-
-export type FetcherEvent = {
-  type: "fetcher";
-  key: string;
-  submission?: Submission;
-  href: string;
-};
-
-export type DataEvent = NavigationEvent | FetcherEvent;
-
-export const IDLE_FETCHER: FetcherStates["Idle"] = {
-  state: "idle",
-  type: "init",
-  data: undefined,
-  formMethod: undefined,
-  formAction: undefined,
-  formData: undefined,
-  formEncType: undefined,
-  submission: undefined,
-};


### PR DESCRIPTION
 - [x] ~~**⚠️ Repoint to `v2` once https://github.com/remix-run/remix/pull/5689 is merged**~~

Removes `fetcher.type` and `fetcher.submission` for v2.  We still keep a small back-compat layer for now since there's an unintentional mismatch in casing between `formMethod` on Remix `useFetcher`/`useTransition` versus react Router `useFetcher`/`useNavigation`