### PR TITLE
Support corepack

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -507,3 +507,4 @@
 - zainfathoni
 - zayenz
 - zhe
+- TrySound

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "yarn@1.22.19",
   "name": "remix-monorepo",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
See https://nodejs.org/api/corepack.html

Corepack is a great recent feature builtin in node. It allows to use package manager version specified in packageManager field and not have globally installed yarn or pnpm at all. Only need to run `corepack enable`