### PR TITLE
docs(tutorials/blog): clarify `@types/marked` installation is additional for TS users

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -278,6 +278,7 @@
 - lensbart
 - leo
 - leon
+- leovander
 - levippaul
 - LewisArdern
 - lifeiscontent

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -500,7 +500,7 @@ Now let's get that markdown parsed and rendered to HTML to the page. There are a
 
 ```sh
 npm add marked
-# if using typescript
+# additionally, if using typescript
 npm add @types/marked -D
 ```
 


### PR DESCRIPTION
Avoids instances like [this](https://stackoverflow.com/questions/70592530/not-able-to-import-marked-js-from-types-marked-in-react-app) where users may have thought that they only needed to run the TypeScript line to install `marked`, but both are required for TypeScript users.

Closes: 
- [x] Docs
