### PR TITLE
fix(remix-dev): handle absolute bundled CSS URLs

### DIFF
--- a/.changeset/absolute-css-urls.md
+++ b/.changeset/absolute-css-urls.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fix absolute paths in CSS `url()` rules when using CSS Modules, Vanilla Extract and CSS side-effect imports

--- a/integration/css-modules-test.ts
+++ b/integration/css-modules-test.ts
@@ -61,6 +61,7 @@ test.describe("CSS Modules", () => {
         ...rootRelativeImportedValueFixture(),
         ...imageUrlsFixture(),
         ...rootRelativeImageUrlsFixture(),
+        ...absoluteImageUrlsFixture(),
         ...clientEntrySideEffectsFixture(),
         ...deduplicatedCssFixture(),
         ...uniqueClassNamesFixture(),
@@ -533,6 +534,51 @@ test.describe("CSS Modules", () => {
     let locator = await page.locator(
       "[data-testid='root-relative-image-urls']"
     );
+    let backgroundImage = await locator.evaluate(
+      (element) => window.getComputedStyle(element).backgroundImage
+    );
+    expect(backgroundImage).toContain(".svg");
+    expect(imgStatus).toBe(200);
+  });
+
+  let absoluteImageUrlsFixture = () => ({
+    "app/routes/absolute-image-urls-test.jsx": js`
+      import { Test } from "~/test-components/absolute-image-urls";
+      export default function() {
+        return <Test />;
+      }
+    `,
+    "app/test-components/absolute-image-urls/index.jsx": js`
+      import styles from "./styles.module.css";
+      export function Test() {
+        return (
+          <div data-testid="absolute-image-urls" className={styles.root}>
+            Image URLs test
+          </div>
+        );
+      }
+    `,
+    "app/test-components/absolute-image-urls/styles.module.css": css`
+      .root {
+        background-color: peachpuff;
+        background-image: url(/absolute-image-urls/image.svg);
+        padding: ${TEST_PADDING_VALUE};
+      }
+    `,
+    "public/absolute-image-urls/image.svg": `
+      <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="50" cy="50" r="50" fill="coral" />
+      </svg>
+    `,
+  });
+  test("absolute image URLs", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    let imgStatus: number | null = null;
+    app.page.on("response", (res) => {
+      if (res.url().endsWith(".svg")) imgStatus = res.status();
+    });
+    await app.goto("/absolute-image-urls-test");
+    let locator = await page.locator("[data-testid='absolute-image-urls']");
     let backgroundImage = await locator.evaluate(
       (element) => window.getComputedStyle(element).backgroundImage
     );

--- a/integration/css-side-effect-imports-test.ts
+++ b/integration/css-side-effect-imports-test.ts
@@ -57,6 +57,7 @@ test.describe("CSS side-effect imports", () => {
         ...rootRelativeFixture(),
         ...imageUrlsFixture(),
         ...rootRelativeImageUrlsFixture(),
+        ...absoluteImageUrlsFixture(),
         ...commonJsPackageFixture(),
         ...esmPackageFixture(),
       },
@@ -199,6 +200,46 @@ test.describe("CSS side-effect imports", () => {
     let locator = await page.locator(
       "[data-testid='root-relative-image-urls']"
     );
+    let backgroundImage = await locator.evaluate(
+      (element) => window.getComputedStyle(element).backgroundImage
+    );
+    expect(backgroundImage).toContain(".svg");
+    expect(imgStatus).toBe(200);
+  });
+
+  let absoluteImageUrlsFixture = () => ({
+    "app/absoluteImageUrls/styles.css": css`
+      .absoluteImageUrls {
+        background-color: peachpuff;
+        background-image: url(/absoluteImageUrls/image.svg);
+        padding: ${TEST_PADDING_VALUE};
+      }
+    `,
+    "public/absoluteImageUrls/image.svg": `
+      <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="50" cy="50" r="50" fill="coral" />
+      </svg>
+    `,
+    "app/routes/absolute-image-urls-test.jsx": js`
+      import "../absoluteImageUrls/styles.css";
+
+      export default function() {
+        return (
+          <div data-testid="absolute-image-urls" className="absoluteImageUrls">
+            Absolute image URLs test
+          </div>
+        )
+      }
+    `,
+  });
+  test("absolute image URLs", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    let imgStatus: number | null = null;
+    app.page.on("response", (res) => {
+      if (res.url().endsWith(".svg")) imgStatus = res.status();
+    });
+    await app.goto("/absolute-image-urls-test");
+    let locator = await page.locator("[data-testid='absolute-image-urls']");
     let backgroundImage = await locator.evaluate(
       (element) => window.getComputedStyle(element).backgroundImage
     );

--- a/packages/remix-dev/compiler/compileBrowser.ts
+++ b/packages/remix-dev/compiler/compileBrowser.ts
@@ -16,6 +16,7 @@ import type { CompileOptions } from "./options";
 import { browserRouteModulesPlugin } from "./plugins/browserRouteModulesPlugin";
 import { browserRouteModulesPlugin as browserRouteModulesPlugin_v2 } from "./plugins/browserRouteModulesPlugin_v2";
 import { cssFilePlugin } from "./plugins/cssFilePlugin";
+import { absoluteCssUrlsPlugin } from "./plugins/absoluteCssUrlsPlugin";
 import { deprecatedRemixPackagePlugin } from "./plugins/deprecatedRemixPackagePlugin";
 import { emptyModulesPlugin } from "./plugins/emptyModulesPlugin";
 import { mdxPlugin } from "./plugins/mdx";
@@ -122,6 +123,7 @@ const createEsbuildConfig = (
       ? cssSideEffectImportsPlugin({ config, options })
       : null,
     cssFilePlugin({ config, options }),
+    absoluteCssUrlsPlugin(),
     urlImportsPlugin(),
     mdxPlugin(config),
     config.future.unstable_dev

--- a/packages/remix-dev/compiler/compilerServer.ts
+++ b/packages/remix-dev/compiler/compilerServer.ts
@@ -13,6 +13,7 @@ import { cssModulesPlugin } from "./plugins/cssModulesPlugin";
 import { cssSideEffectImportsPlugin } from "./plugins/cssSideEffectImportsPlugin";
 import { vanillaExtractPlugin } from "./plugins/vanillaExtractPlugin";
 import { cssFilePlugin } from "./plugins/cssFilePlugin";
+import { absoluteCssUrlsPlugin } from "./plugins/absoluteCssUrlsPlugin";
 import { deprecatedRemixPackagePlugin } from "./plugins/deprecatedRemixPackagePlugin";
 import { emptyModulesPlugin } from "./plugins/emptyModulesPlugin";
 import { mdxPlugin } from "./plugins/mdx";
@@ -63,6 +64,7 @@ const createEsbuildConfig = (
       ? cssSideEffectImportsPlugin({ config, options })
       : null,
     cssFilePlugin({ config, options }),
+    absoluteCssUrlsPlugin(),
     urlImportsPlugin(),
     mdxPlugin(config),
     emptyModulesPlugin(config, /\.client(\.[jt]sx?)?$/),

--- a/packages/remix-dev/compiler/plugins/absoluteCssUrlsPlugin.ts
+++ b/packages/remix-dev/compiler/plugins/absoluteCssUrlsPlugin.ts
@@ -1,0 +1,23 @@
+import path from "path";
+import type { Plugin, PluginBuild } from "esbuild";
+
+/**
+ * This plugin treats absolute paths in 'url()' css rules as external to prevent
+ * breaking changes
+ */
+export const absoluteCssUrlsPlugin = (): Plugin => {
+  return {
+    name: "absolute-css-urls-plugin",
+    setup: async (build: PluginBuild) => {
+      build.onResolve({ filter: /.*/ }, async (args) => {
+        let { kind, path: resolvePath } = args;
+        if (kind === "url-token" && path.isAbsolute(resolvePath)) {
+          return {
+            path: resolvePath,
+            external: true,
+          };
+        }
+      });
+    },
+  };
+};

--- a/packages/remix-dev/compiler/plugins/cssFilePlugin.ts
+++ b/packages/remix-dev/compiler/plugins/cssFilePlugin.ts
@@ -7,6 +7,7 @@ import invariant from "../../invariant";
 import type { RemixConfig } from "../../config";
 import type { CompileOptions } from "../options";
 import { getPostcssProcessor } from "../utils/postcss";
+import { absoluteCssUrlsPlugin } from "./absoluteCssUrlsPlugin";
 
 const isExtendedLengthPath = /^\\\\\?\\/;
 
@@ -52,22 +53,8 @@ export function cssFilePlugin({
             ...buildOps.loader,
             ".css": "css",
           },
-          // this plugin treats absolute paths in 'url()' css rules as external to prevent breaking changes
           plugins: [
-            {
-              name: "resolve-absolute",
-              async setup(build) {
-                build.onResolve({ filter: /.*/ }, async (args) => {
-                  let { kind, path: resolvePath } = args;
-                  if (kind === "url-token" && path.isAbsolute(resolvePath)) {
-                    return {
-                      path: resolvePath,
-                      external: true,
-                    };
-                  }
-                });
-              },
-            },
+            absoluteCssUrlsPlugin(),
             ...(postcssProcessor
               ? [postcssPlugin({ postcssProcessor, options })]
               : []),


### PR DESCRIPTION
Closes: #5739

- [ ] Docs
- [x] Tests

Testing Strategy:

A test case containing an absolute image URL has been added to the test suites for CSS Modules, Vanilla Extract and CSS side-effect imports.