### PR TITLE
feat!(remix-dev): remove `unstable_cssModules`

### DIFF
--- a/.changeset/remove-unstable-css-modules.md
+++ b/.changeset/remove-unstable-css-modules.md
@@ -1,0 +1,8 @@
+---
+"@remix-run/dev": major
+"@remix-run/react": major
+"@remix-run/server-runtime": major
+"@remix-run/testing": major
+---
+
+Remove `unstable_cssModules` option. CSS Modules support is now enabled automatically.

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -895,8 +895,6 @@ NOTE: You may run into hydration warnings when using Styled Components. Hopefull
 
 ## CSS Bundling
 
-<docs-warning>CSS-bundling features are unstable and currently only available behind feature flags. We're confident in the use cases they solve, but the API and implementation may change in the future.</docs-warning>
-
 <docs-warning>When using CSS-bundling features, you should avoid using `export *` due to an [issue with esbuild's CSS tree shaking][esbuild-css-tree-shaking-issue].</docs-warning>
 
 Many common approaches to CSS within the React community are only possible when bundling CSS, meaning that the CSS files you write during development are collected into a separate bundle as part of the build process.
@@ -931,23 +929,11 @@ With this link tag inserted into the page, you're now ready to start using the v
 
 ### CSS Modules
 
-<docs-warning>This feature is unstable and currently only available behind a feature flag. We're confident in the use cases it solves but the API and implementation may change in the future.</docs-warning>
-
 First, ensure you've set up [CSS bundling][css-bundling] in your application.
 
-Then, to enable [CSS Modules], set the `future.unstable_cssModules` feature flag in `remix.config.js`.
+<docs-warning>If you're using v1, you'll also need to set the `future.unstable_cssModules` feature flag to `true` in `remix.config.js`.</docs-warning>
 
-```js filename=remix.config.js
-/** @type {import('@remix-run/dev').AppConfig} */
-module.exports = {
-  future: {
-    unstable_cssModules: true,
-  },
-  // ...
-};
-```
-
-With this feature flag enabled, you can now opt into CSS Modules via the `.module.css` file name convention. For example:
+You can then opt into [CSS Modules] via the `.module.css` file name convention. For example:
 
 ```css filename=app/components/button/styles.module.css
 .root {

--- a/integration/css-modules-test.ts
+++ b/integration/css-modules-test.ts
@@ -23,7 +23,6 @@ test.describe("CSS Modules", () => {
         v2_routeConvention: true,
         // Enable all CSS future flags to
         // ensure features don't clash
-        unstable_cssModules: true,
         unstable_cssSideEffectImports: true,
         unstable_postcss: true,
         unstable_tailwind: true,

--- a/integration/css-side-effect-imports-test.ts
+++ b/integration/css-side-effect-imports-test.ts
@@ -25,7 +25,6 @@ test.describe("CSS side-effect imports", () => {
             future: {
               // Enable all CSS future flags to
               // ensure features don't clash
-              unstable_cssModules: true,
               unstable_cssSideEffectImports: true,
               unstable_postcss: true,
               unstable_tailwind: true,

--- a/integration/deterministic-build-output-test.ts
+++ b/integration/deterministic-build-output-test.ts
@@ -27,7 +27,6 @@ test("builds deterministically under different paths", async () => {
   //  * vanillaExtractPlugin (via app/routes/foo.tsx' .css.ts file import)
   let init: FixtureInit = {
     future: {
-      unstable_cssModules: true,
       unstable_cssSideEffectImports: true,
       unstable_postcss: true,
       unstable_vanillaExtract: true,

--- a/integration/postcss-test.ts
+++ b/integration/postcss-test.ts
@@ -35,7 +35,6 @@ test.describe("PostCSS", () => {
     fixture = await createFixture({
       future: {
         v2_routeConvention: true,
-        unstable_cssModules: true,
         unstable_cssSideEffectImports: true,
         unstable_postcss: true,
         unstable_tailwind: true,

--- a/integration/tailwind-test.ts
+++ b/integration/tailwind-test.ts
@@ -21,7 +21,6 @@ test.describe("Tailwind", () => {
         v2_routeConvention: true,
         // Enable all CSS future flags to
         // ensure features don't clash
-        unstable_cssModules: true,
         unstable_cssSideEffectImports: true,
         unstable_postcss: true,
         unstable_tailwind: true,

--- a/integration/vanilla-extract-test.ts
+++ b/integration/vanilla-extract-test.ts
@@ -23,7 +23,6 @@ test.describe("Vanilla Extract", () => {
             v2_routeConvention: true,
             // Enable all CSS future flags to
             // ensure features don't clash
-            unstable_cssModules: true,
             unstable_cssSideEffectImports: true,
             unstable_postcss: true,
             unstable_tailwind: true,

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -25,7 +25,6 @@ describe("readConfig", () => {
         entryServerFilePath: expect.any(String),
         tsconfigPath: expect.any(String),
         future: {
-          unstable_cssModules: expect.any(Boolean),
           unstable_cssSideEffectImports: expect.any(Boolean),
           unstable_postcss: expect.any(Boolean),
           unstable_tailwind: expect.any(Boolean),
@@ -47,7 +46,6 @@ describe("readConfig", () => {
         "entryServerFile": "entry.server.tsx",
         "entryServerFilePath": Any<String>,
         "future": Object {
-          "unstable_cssModules": Any<Boolean>,
           "unstable_cssSideEffectImports": Any<Boolean>,
           "unstable_dev": false,
           "unstable_postcss": Any<Boolean>,

--- a/packages/remix-dev/compiler/compileBrowser.ts
+++ b/packages/remix-dev/compiler/compileBrowser.ts
@@ -72,12 +72,6 @@ const writeAssetsManifest = async (
   );
 };
 
-const isCssBundlingEnabled = (config: RemixConfig): boolean =>
-  Boolean(
-    config.future.unstable_cssModules ||
-      config.future.unstable_cssSideEffectImports ||
-      config.future.unstable_vanillaExtract
-  );
 const createEsbuildConfig = (
   build: "app" | "css",
   config: RemixConfig,
@@ -109,12 +103,8 @@ const createEsbuildConfig = (
 
   let plugins: esbuild.Plugin[] = [
     deprecatedRemixPackagePlugin(options.onWarning),
-    isCssBundlingEnabled(config) && isCssBuild
-      ? cssBundleEntryModulePlugin(config)
-      : null,
-    config.future.unstable_cssModules
-      ? cssModulesPlugin({ config, mode, outputCss })
-      : null,
+    isCssBuild ? cssBundleEntryModulePlugin(config) : null,
+    cssModulesPlugin({ config, mode, outputCss }),
     config.future.unstable_vanillaExtract
       ? vanillaExtractPlugin({ config, mode, outputCss })
       : null,
@@ -230,10 +220,6 @@ export const createBrowserCompiler = (
     };
 
     let cssBuildTask = async () => {
-      if (!isCssBundlingEnabled(remixConfig)) {
-        return;
-      }
-
       // The types aren't great when combining write: false and incremental: true
       //  so we need to assert that it's an incremental build
       cssCompiler = (await (!cssCompiler

--- a/packages/remix-dev/compiler/compilerServer.ts
+++ b/packages/remix-dev/compiler/compilerServer.ts
@@ -53,9 +53,7 @@ const createEsbuildConfig = (
 
   let plugins: esbuild.Plugin[] = [
     deprecatedRemixPackagePlugin(options.onWarning),
-    config.future.unstable_cssModules
-      ? cssModulesPlugin({ config, mode, outputCss })
-      : null,
+    cssModulesPlugin({ config, mode, outputCss }),
     config.future.unstable_vanillaExtract
       ? vanillaExtractPlugin({ config, mode, outputCss })
       : null,

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -39,7 +39,6 @@ export type VanillaExtractOptions = {
 };
 
 interface FutureConfig {
-  unstable_cssModules: boolean;
   unstable_cssSideEffectImports: boolean;
   unstable_dev: boolean | Dev;
   unstable_postcss: boolean;
@@ -575,7 +574,6 @@ export async function readConfig(
   }
 
   let future: FutureConfig = {
-    unstable_cssModules: appConfig.future?.unstable_cssModules === true,
     unstable_cssSideEffectImports:
       appConfig.future?.unstable_cssSideEffectImports === true,
     unstable_dev: appConfig.future?.unstable_dev ?? false,

--- a/packages/remix-react/entry.ts
+++ b/packages/remix-react/entry.ts
@@ -31,7 +31,6 @@ type VanillaExtractOptions = {
 };
 
 export interface FutureConfig {
-  unstable_cssModules: boolean;
   unstable_cssSideEffectImports: boolean;
   unstable_dev: boolean | Dev;
   unstable_postcss: boolean;

--- a/packages/remix-server-runtime/entry.ts
+++ b/packages/remix-server-runtime/entry.ts
@@ -23,7 +23,6 @@ type VanillaExtractOptions = {
 };
 
 export interface FutureConfig {
-  unstable_cssModules: boolean;
   unstable_cssSideEffectImports: boolean;
   unstable_dev: boolean | Dev;
   unstable_postcss: boolean;

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -63,7 +63,6 @@ export function createRemixStub(routes: (RouteObject | DataRouteObject)[]) {
     if (remixContextRef.current == null) {
       remixContextRef.current = {
         future: {
-          unstable_cssModules: false,
           unstable_cssSideEffectImports: false,
           unstable_dev: false,
           unstable_postcss: false,


### PR DESCRIPTION
Removes the `unstable_cssModules` future flag and automatically enables CSS Modules. This means that CSS bundling is no longer conditional within the Remix compiler.