### PR TITLE
fix(remix-dev): fix sourcemap path replace in Cloudflare Pages build

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -507,3 +507,4 @@
 - zainfathoni
 - zayenz
 - zhe
+- fabiankaestner

--- a/packages/remix-dev/compiler/compilerServer.ts
+++ b/packages/remix-dev/compiler/compilerServer.ts
@@ -130,7 +130,10 @@ async function writeServerBuildResult(
     if (file.path.endsWith(".js")) {
       // fix sourceMappingURL to be relative to current path instead of /build
       let filename = file.path.substring(file.path.lastIndexOf(path.sep) + 1);
-      let escapedFilename = filename.replace(/\./g, "\\.");
+      let escapedFilename = filename
+        .replace(/\./g, "\\.")
+        .replace(/\[/g, "\\[")
+        .replace(/\]/g, "\\]");
       let pattern = `(//# sourceMappingURL=)(.*)${escapedFilename}`;
       let contents = Buffer.from(file.contents).toString("utf-8");
       contents = contents.replace(new RegExp(pattern), `$1${filename}`);


### PR DESCRIPTION
Closes: #3768

- [ ] Docs
- [ ] Tests

#### Testing Strategy:

I built the remix project, and linked remix-dev:

```
yarn build
cd packages/remix-dev/
yarn link
```
Then I linked the remix-dev build in a cloudflare-workers project:

```
cd some-cloudflare-project/
yarn link @remix-run/dev
yarn dev
```
and verified that the sourcemaps work.