### PR TITLE
feat(remix-dev): upgrade `unstable_cssModules` config option to `v2_cssModules`

### DIFF
--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -935,13 +935,13 @@ With this link tag inserted into the page, you're now ready to start using the v
 
 First, ensure you've set up [CSS bundling][css-bundling] in your application.
 
-Then, to enable [CSS Modules], set the `future.unstable_cssModules` feature flag in `remix.config.js`.
+Then, to enable [CSS Modules], set the `future.v2_cssModules` feature flag in `remix.config.js`.
 
 ```js filename=remix.config.js
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   future: {
-    unstable_cssModules: true,
+    v2_cssModules: true,
   },
   // ...
 };

--- a/integration/css-modules-test.ts
+++ b/integration/css-modules-test.ts
@@ -23,7 +23,7 @@ test.describe("CSS Modules", () => {
         v2_routeConvention: true,
         // Enable all CSS future flags to
         // ensure features don't clash
-        unstable_cssModules: true,
+        v2_cssModules: true,
         unstable_cssSideEffectImports: true,
         unstable_postcss: true,
         unstable_tailwind: true,

--- a/integration/css-side-effect-imports-test.ts
+++ b/integration/css-side-effect-imports-test.ts
@@ -25,7 +25,7 @@ test.describe("CSS side-effect imports", () => {
             future: {
               // Enable all CSS future flags to
               // ensure features don't clash
-              unstable_cssModules: true,
+              v2_cssModules: true,
               unstable_cssSideEffectImports: true,
               unstable_postcss: true,
               unstable_tailwind: true,

--- a/integration/deterministic-build-output-test.ts
+++ b/integration/deterministic-build-output-test.ts
@@ -27,7 +27,7 @@ test("builds deterministically under different paths", async () => {
   //  * vanillaExtractPlugin (via app/routes/foo.tsx' .css.ts file import)
   let init: FixtureInit = {
     future: {
-      unstable_cssModules: true,
+      v2_cssModules: true,
       unstable_cssSideEffectImports: true,
       unstable_postcss: true,
       unstable_vanillaExtract: true,

--- a/integration/postcss-test.ts
+++ b/integration/postcss-test.ts
@@ -35,7 +35,7 @@ test.describe("PostCSS", () => {
     fixture = await createFixture({
       future: {
         v2_routeConvention: true,
-        unstable_cssModules: true,
+        v2_cssModules: true,
         unstable_cssSideEffectImports: true,
         unstable_postcss: true,
         unstable_tailwind: true,

--- a/integration/tailwind-test.ts
+++ b/integration/tailwind-test.ts
@@ -21,7 +21,7 @@ test.describe("Tailwind", () => {
         v2_routeConvention: true,
         // Enable all CSS future flags to
         // ensure features don't clash
-        unstable_cssModules: true,
+        v2_cssModules: true,
         unstable_cssSideEffectImports: true,
         unstable_postcss: true,
         unstable_tailwind: true,

--- a/integration/vanilla-extract-test.ts
+++ b/integration/vanilla-extract-test.ts
@@ -23,7 +23,7 @@ test.describe("Vanilla Extract", () => {
             v2_routeConvention: true,
             // Enable all CSS future flags to
             // ensure features don't clash
-            unstable_cssModules: true,
+            v2_cssModules: true,
             unstable_cssSideEffectImports: true,
             unstable_postcss: true,
             unstable_tailwind: true,

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -31,7 +31,7 @@ describe("readConfig", () => {
         entryServerFilePath: expect.any(String),
         tsconfigPath: expect.any(String),
         future: {
-          unstable_cssModules: expect.any(Boolean),
+          v2_cssModules: expect.any(Boolean),
           unstable_cssSideEffectImports: expect.any(Boolean),
           unstable_postcss: expect.any(Boolean),
           unstable_tailwind: expect.any(Boolean),
@@ -53,12 +53,12 @@ describe("readConfig", () => {
         "entryServerFile": "entry.server.tsx",
         "entryServerFilePath": Any<String>,
         "future": Object {
-          "unstable_cssModules": Any<Boolean>,
           "unstable_cssSideEffectImports": Any<Boolean>,
           "unstable_dev": false,
           "unstable_postcss": Any<Boolean>,
           "unstable_tailwind": Any<Boolean>,
           "unstable_vanillaExtract": Any<Boolean>,
+          "v2_cssModules": Any<Boolean>,
           "v2_errorBoundary": Any<Boolean>,
           "v2_meta": Any<Boolean>,
           "v2_routeConvention": Any<Boolean>,

--- a/packages/remix-dev/compiler/compileBrowser.ts
+++ b/packages/remix-dev/compiler/compileBrowser.ts
@@ -74,7 +74,7 @@ const writeAssetsManifest = async (
 
 const isCssBundlingEnabled = (config: RemixConfig): boolean =>
   Boolean(
-    config.future.unstable_cssModules ||
+    config.future.v2_cssModules ||
       config.future.unstable_cssSideEffectImports ||
       config.future.unstable_vanillaExtract
   );
@@ -112,7 +112,7 @@ const createEsbuildConfig = (
     isCssBundlingEnabled(config) && isCssBuild
       ? cssBundleEntryModulePlugin(config)
       : null,
-    config.future.unstable_cssModules
+    config.future.v2_cssModules
       ? cssModulesPlugin({ config, mode, outputCss })
       : null,
     config.future.unstable_vanillaExtract

--- a/packages/remix-dev/compiler/compilerServer.ts
+++ b/packages/remix-dev/compiler/compilerServer.ts
@@ -53,7 +53,7 @@ const createEsbuildConfig = (
 
   let plugins: esbuild.Plugin[] = [
     deprecatedRemixPackagePlugin(options.onWarning),
-    config.future.unstable_cssModules
+    config.future.v2_cssModules
       ? cssModulesPlugin({ config, mode, outputCss })
       : null,
     config.future.unstable_vanillaExtract

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -48,7 +48,7 @@ export type VanillaExtractOptions = {
 };
 
 interface FutureConfig {
-  unstable_cssModules: boolean;
+  v2_cssModules: boolean;
   unstable_cssSideEffectImports: boolean;
   unstable_dev: boolean | Dev;
   unstable_postcss: boolean;
@@ -628,7 +628,7 @@ export async function readConfig(
   }
 
   let future: FutureConfig = {
-    unstable_cssModules: appConfig.future?.unstable_cssModules === true,
+    v2_cssModules: appConfig.future?.v2_cssModules === true,
     unstable_cssSideEffectImports:
       appConfig.future?.unstable_cssSideEffectImports === true,
     unstable_dev: appConfig.future?.unstable_dev ?? false,

--- a/packages/remix-react/entry.ts
+++ b/packages/remix-react/entry.ts
@@ -31,7 +31,7 @@ type VanillaExtractOptions = {
 };
 
 export interface FutureConfig {
-  unstable_cssModules: boolean;
+  v2_cssModules: boolean;
   unstable_cssSideEffectImports: boolean;
   unstable_dev: boolean | Dev;
   unstable_postcss: boolean;

--- a/packages/remix-server-runtime/entry.ts
+++ b/packages/remix-server-runtime/entry.ts
@@ -23,7 +23,7 @@ type VanillaExtractOptions = {
 };
 
 export interface FutureConfig {
-  unstable_cssModules: boolean;
+  v2_cssModules: boolean;
   unstable_cssSideEffectImports: boolean;
   unstable_dev: boolean | Dev;
   unstable_postcss: boolean;

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -63,7 +63,7 @@ export function createRemixStub(routes: (RouteObject | DataRouteObject)[]) {
     if (remixContextRef.current == null) {
       remixContextRef.current = {
         future: {
-          unstable_cssModules: false,
+          v2_cssModules: false,
           unstable_cssSideEffectImports: false,
           unstable_dev: false,
           unstable_postcss: false,


### PR DESCRIPTION
Follow-up of @markdalgleish's #5800