### PR TITLE
chore: add `declarationMap` for command+click to source

### DIFF
--- a/packages/create-remix/tsconfig.json
+++ b/packages/create-remix/tsconfig.json
@@ -13,6 +13,7 @@
     "strict": true,
     "resolveJsonModule": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/create-remix/dist"

--- a/packages/remix-architect/tsconfig.json
+++ b/packages/remix-architect/tsconfig.json
@@ -11,6 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/@remix-run/architect/dist"

--- a/packages/remix-cloudflare-pages/tsconfig.json
+++ b/packages/remix-cloudflare-pages/tsconfig.json
@@ -11,6 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/@remix-run/cloudflare-pages/dist",

--- a/packages/remix-cloudflare-workers/tsconfig.json
+++ b/packages/remix-cloudflare-workers/tsconfig.json
@@ -11,6 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/@remix-run/cloudflare-workers/dist",

--- a/packages/remix-cloudflare/tsconfig.json
+++ b/packages/remix-cloudflare/tsconfig.json
@@ -11,6 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/@remix-run/cloudflare/dist",

--- a/packages/remix-css-bundle/tsconfig.json
+++ b/packages/remix-css-bundle/tsconfig.json
@@ -5,10 +5,13 @@
     "lib": ["ES2019", "DOM.Iterable"],
     "target": "ES2019",
     "module": "CommonJS",
+    "composite": true,
+
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,

--- a/packages/remix-dev/tsconfig.json
+++ b/packages/remix-dev/tsconfig.json
@@ -13,6 +13,7 @@
     "strict": true,
     "skipLibCheck": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/@remix-run/dev/dist"

--- a/packages/remix-express/tsconfig.json
+++ b/packages/remix-express/tsconfig.json
@@ -11,9 +11,9 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
-    "outDir": "../../build/node_modules/@remix-run/express/dist",
-    "composite": true
+    "outDir": "../../build/node_modules/@remix-run/express/dist"
   }
 }

--- a/packages/remix-netlify/tsconfig.json
+++ b/packages/remix-netlify/tsconfig.json
@@ -10,6 +10,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/@remix-run/netlify/dist"

--- a/packages/remix-node/tsconfig.json
+++ b/packages/remix-node/tsconfig.json
@@ -10,6 +10,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/@remix-run/node/dist",

--- a/packages/remix-react/tsconfig.json
+++ b/packages/remix-react/tsconfig.json
@@ -13,6 +13,7 @@
     "strict": true,
     "jsx": "react",
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/@remix-run/react/dist"

--- a/packages/remix-serve/tsconfig.json
+++ b/packages/remix-serve/tsconfig.json
@@ -11,6 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/@remix-run/serve/dist"

--- a/packages/remix-server-runtime/tsconfig.json
+++ b/packages/remix-server-runtime/tsconfig.json
@@ -10,6 +10,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/@remix-run/server-runtime/dist",

--- a/packages/remix-testing/tsconfig.json
+++ b/packages/remix-testing/tsconfig.json
@@ -13,6 +13,7 @@
     "strict": true,
     "jsx": "react",
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/@remix-run/testing/dist"

--- a/packages/remix-vercel/tsconfig.json
+++ b/packages/remix-vercel/tsconfig.json
@@ -11,6 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/@remix-run/vercel/dist"

--- a/packages/remix/tsconfig.json
+++ b/packages/remix/tsconfig.json
@@ -13,6 +13,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": ".",
     "outDir": "../../build/node_modules/remix/dist"


### PR DESCRIPTION
[declarationMap](https://www.typescriptlang.org/tsconfig#declarationMap) is essentially a source map for types 

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
