### PR TITLE
Add HMR support for dynamically imported modules.

### DIFF
--- a/.changeset/clever-stingrays-allow.md
+++ b/.changeset/clever-stingrays-allow.md
@@ -1,0 +1,7 @@
+---
+"remix": patch
+"@remix-run/dev": patch
+"@remix-run/react": patch
+---
+
+Add HMR support for dynamically imported modules.

--- a/packages/remix-dev/hmr.ts
+++ b/packages/remix-dev/hmr.ts
@@ -8,6 +8,7 @@ export type Update = {
   url: string;
   revalidate: boolean;
   reason: string;
+  dynamicImports?: string[];
 };
 
 // route id: filepaths relative to app/ dir without extension

--- a/packages/remix-dev/hmr.ts
+++ b/packages/remix-dev/hmr.ts
@@ -8,7 +8,6 @@ export type Update = {
   url: string;
   revalidate: boolean;
   reason: string;
-  dynamicImports?: string[];
 };
 
 // route id: filepaths relative to app/ dir without extension

--- a/packages/remix-react/browser.tsx
+++ b/packages/remix-react/browser.tsx
@@ -70,9 +70,25 @@ if (import.meta && import.meta.hot) {
                 if (!newManifest.routes[id]) {
                   return null;
                 }
+
+                let newManifestEntry = newManifest.routes[id];
+
+                // Dynamic imports need to be re-imported as well. Let's fetch
+                // those first so that the route bundle picks up the new code
+                // when it's re-imported below.
+                if (
+                  newManifestEntry.dynamicImports &&
+                  newManifestEntry.dynamicImports.length > 0
+                ) {
+                  await Promise.all(
+                    newManifestEntry.dynamicImports?.map(
+                      (i) => import(`${i}?t=${newManifest.hmr?.timestamp}`)
+                    )
+                  );
+                }
+
                 let imported = await import(
-                  newManifest.routes[id].module +
-                    `?t=${newManifest.hmr?.timestamp}`
+                  newManifestEntry.module + `?t=${newManifest.hmr?.timestamp}`
                 );
                 return [
                   id,

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -41,6 +41,7 @@ export interface EntryRoute extends Route {
   hasCatchBoundary: boolean;
   hasErrorBoundary: boolean;
   imports?: string[];
+  dynamicImports?: string[];
   module: string;
   parentId?: string;
 }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #5845 

- [ ] Docs
- [X] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->

I created a playground using `yarn playground:new`, created several dynamically imported components, and started editing them. Diving into how HMR was implemented, I noticed that dynamic imports weren't included in the route's manifest entries, so Remix had no way of knowing that they were dependencies of a given route module. But `esbuild` knows that they are, so when they were edited, esbuild picked up that the route module had changed, and correctly sent an HMR update message to the browser, which then dutifully re-imported the route module.

However, since dynamically imported modules become their own chunk, those were _not_ re-imported, and the browser's module cache still referenced the old code.

The implementation involved adding a `dynamicImports` array to the route manifest entry, and modifying the compiler to add any `kind == "dynamic-import"` nodes to that list. I didn't want to re-use `imports` because static imports end up being bundled into the route module, and so they don't really have their own entry in the manifest and thus no actual URL to re-import. I also wanted to make the distinction between static imports and dynamic imports explicit.

Then I updated the browser-side HMR code to check if the updated route module has any `dynamicImports`, and then re-import those before the route module itself re-imports, so that it can pick up the new changes when the new module is re-executed.

### Integration Tests

I added some code to `integration/hmr-test.ts` to verify that HMR works with dynamic imports. 