### PR TITLE
Bug: files in folder are resolved with status code 200 (routing v2)

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -51,6 +51,7 @@
 - axel-habermaier
 - barclayd
 - BasixKOR
+- BenjaVR
 - BenMcH
 - benwis
 - bgschiller


### PR DESCRIPTION
Given these files:
```
├── routes
│   ├── _index
│   │   ├── route.jsx
│   ├── feature
│   │   ├── route.jsx
│   │   └── SomeComponent.jsx
```

I do expect to have only these routes:
- `/` (`_index/route.jsx`)
- `/feature` (`feature/route.jsx`)

When I try to navigate to e.g., `/feature/NonExisting` I receive a 404 as expected.

However, when I navigate to `/feature/SomeComponent` I receive a 200 response with the content of `feature/route.jsx`. As far as I understand this happens because I happen to have a file in my `feature` folder that has the same name as the route.

I think files like these should not impact the routing mechanism and should just return 404, because there is no explicit route defined? Or am I missing something here?