### PR TITLE
fix(remix-react): don't warn about runtime deprecation warnings in production

### DIFF
--- a/.changeset/mean-deers-wink.md
+++ b/.changeset/mean-deers-wink.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/react": patch
+---
+
+don't warn about runtime deprecation warnings in production

--- a/packages/remix-react/browser.tsx
+++ b/packages/remix-react/browser.tsx
@@ -14,7 +14,7 @@ import {
 import { deserializeErrors } from "./errors";
 import type { RouteModules } from "./routeModules";
 import { createClientRoutes } from "./routes";
-import { warnOnce } from "./warnings";
+import { logDeprecationOnce } from "./warnings";
 
 /* eslint-disable prefer-let/prefer-let */
 declare global {
@@ -140,8 +140,7 @@ if (import.meta && import.meta.hot) {
 export function RemixBrowser(_props: RemixBrowserProps): ReactElement {
   if (!router) {
     if (!window.__remixContext.future.v2_errorBoundary) {
-      warnOnce(
-        false,
+      logDeprecationOnce(
         "⚠️  DEPRECATED: The separation of `CatchBoundary` and `ErrorBoundary` has " +
           "been deprecated and Remix v2 will use a singular `ErrorBoundary` for " +
           "all thrown values (`Response` and `Error`). Please migrate to the new " +
@@ -152,8 +151,7 @@ export function RemixBrowser(_props: RemixBrowserProps): ReactElement {
     }
 
     if (!window.__remixContext.future.v2_normalizeFormMethod) {
-      warnOnce(
-        false,
+      logDeprecationOnce(
         "⚠️  DEPRECATED: Please enable the `future.v2_normalizeFormMethod` flag to " +
           "prepare for the Remix v2 release. Lowercase `useNavigation().formMethod`" +
           "values are being normalized to uppercase in v2 to align with the `fetch()` " +

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -368,13 +368,15 @@ export function Links() {
   );
 
   React.useEffect(() => {
-    warnOnce(
-      links.some((link) => "imagesizes" in link || "imagesrcset" in link),
-      "⚠️ DEPRECATED: The `imagesizes` & `imagesrcset` properties in " +
-        "your links have been deprecated in favor of `imageSizes` & " +
-        "`imageSrcSet` and support will be removed in Remix v2. Please update " +
-        "your code to use the new property names instead."
-    );
+    if (links.some((link) => "imagesizes" in link || "imagesrcset" in link)) {
+      warnOnce(
+        false,
+        "⚠️ DEPRECATED: The `imagesizes` & `imagesrcset` properties in " +
+          "your links have been deprecated in favor of `imageSizes` & " +
+          "`imageSrcSet` and support will be removed in Remix v2. Please update " +
+          "your code to use the new property names instead."
+      );
+    }
   }, [links]);
 
   return (

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -75,7 +75,7 @@ import type {
   TransitionStates,
 } from "./transition";
 import { IDLE_TRANSITION, IDLE_FETCHER } from "./transition";
-import { warnOnce } from "./warnings";
+import { logDeprecationOnce } from "./warnings";
 
 function useDataRouterContext() {
   let context = React.useContext(DataRouterContext);
@@ -369,8 +369,7 @@ export function Links() {
 
   React.useEffect(() => {
     if (links.some((link) => "imagesizes" in link || "imagesrcset" in link)) {
-      warnOnce(
-        false,
+      logDeprecationOnce(
         "⚠️ DEPRECATED: The `imagesizes` & `imagesrcset` properties in " +
           "your links have been deprecated in favor of `imageSizes` & " +
           "`imageSrcSet` and support will be removed in Remix v2. Please update " +
@@ -1236,8 +1235,7 @@ export function useTransition(): Transition {
   let navigation = useNavigation();
 
   React.useEffect(() => {
-    warnOnce(
-      false,
+    logDeprecationOnce(
       "⚠️ DEPRECATED: The `useTransition` hook has been deprecated in favor of " +
         "`useNavigation` and will be removed in Remix v2.  Please update your " +
         "code to leverage `useNavigation`.\n\nSee https://remix.run/docs/hooks/use-transition " +
@@ -1474,8 +1472,7 @@ function addFetcherDeprecationWarnings(fetcher: Fetcher) {
   let type: Fetcher["type"] = fetcher.type;
   Object.defineProperty(fetcher, "type", {
     get() {
-      warnOnce(
-        false,
+      logDeprecationOnce(
         "⚠️ DEPRECATED: The `useFetcher().type` field has been deprecated and " +
           "will be removed in Remix v2.  Please update your code to rely on " +
           "`fetcher.state`.\n\nSee https://remix.run/docs/hooks/use-fetcher for " +
@@ -1496,8 +1493,7 @@ function addFetcherDeprecationWarnings(fetcher: Fetcher) {
   let submission: Fetcher["submission"] = fetcher.submission;
   Object.defineProperty(fetcher, "submission", {
     get() {
-      warnOnce(
-        false,
+      logDeprecationOnce(
         "⚠️ DEPRECATED: The `useFetcher().submission` field has been deprecated and " +
           "will be removed in Remix v2.  The submission fields now live directly " +
           "on the fetcher (`fetcher.formData`).\n\n" +

--- a/packages/remix-react/warnings.ts
+++ b/packages/remix-react/warnings.ts
@@ -1,12 +1,18 @@
 const alreadyWarned: { [message: string]: boolean } = {};
 
 export function warnOnce(condition: boolean, message: string): void {
-  if (
-    !condition &&
-    !alreadyWarned[message] &&
-    process.env.NODE_ENV !== "production"
-  ) {
+  if (!condition && !alreadyWarned[message]) {
     alreadyWarned[message] = true;
+    console.warn(message);
+  }
+}
+
+export function logDeprecationOnce(
+  message: string,
+  key: string = message
+): void {
+  if (process.env.NODE_ENV !== "production" && !alreadyWarned[key]) {
+    alreadyWarned[key] = true;
     console.warn(message);
   }
 }

--- a/packages/remix-react/warnings.ts
+++ b/packages/remix-react/warnings.ts
@@ -1,7 +1,11 @@
 const alreadyWarned: { [message: string]: boolean } = {};
 
 export function warnOnce(condition: boolean, message: string): void {
-  if (!condition && !alreadyWarned[message]) {
+  if (
+    !condition &&
+    !alreadyWarned[message] &&
+    process.env.NODE_ENV !== "production"
+  ) {
     alreadyWarned[message] = true;
     console.warn(message);
   }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
