### PR TITLE
🐛 Bug! In v2_routeConvention non-route modules in route folder are treated as routes (with errors)

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -187,6 +187,7 @@
 - illright
 - imzshh
 - ionut-botizan
+- irshadahmad21
 - irsooti
 - isaacrmoreno
 - ishan-me


### PR DESCRIPTION
In `v2_routeConvention`, `content` and `heading` are treated as routes, though with errors. The expected behavior is 404.

```
app/
└── routes/
    └── post/
        ├── route.tsx
        ├── content.tsx
        └── heading.tsx
```

Run `yarn bug-report-test` to see the failing tests.