### PR TITLE
refactor(dev): remove unused compiler code

### DIFF
--- a/packages/remix-dev/compiler/browserjs/compiler.ts
+++ b/packages/remix-dev/compiler/browserjs/compiler.ts
@@ -19,10 +19,6 @@ import { cssBundleUpdatePlugin } from "./plugins/cssBundleUpdate";
 import { cssModulesPlugin } from "../plugins/cssModuleImports";
 import { cssSideEffectImportsPlugin } from "../plugins/cssSideEffectImports";
 import { vanillaExtractPlugin } from "../plugins/vanillaExtract";
-// import {
-//   cssBundleEntryModulePlugin,
-//   cssBundleEntryModuleId,
-// } from "../plugins/cssBundleEntryModulePlugin";
 import invariant from "../../invariant";
 import { hmrPlugin } from "./plugins/hmr";
 import { createMatchPath } from "../utils/tsconfig";
@@ -79,34 +75,23 @@ const isCssBundlingEnabled = (config: RemixConfig): boolean =>
   );
 
 const createEsbuildConfig = (
-  build: "app" | "css",
   config: RemixConfig,
   options: CompileOptions,
   onLoader: (filename: string, code: string) => void,
   readCssBundleHref: () => Promise<string | undefined>
 ): esbuild.BuildOptions | esbuild.BuildIncremental => {
-  let isCssBuild = build === "css";
-  let entryPoints: Record<string, string>;
+  let entryPoints: Record<string, string> = {
+    "entry.client": config.entryClientFilePath,
+  };
 
-  if (isCssBuild) {
-    entryPoints = {
-      // "css-bundle": cssBundleEntryModuleId,
-    };
-  } else {
-    entryPoints = {
-      "entry.client": config.entryClientFilePath,
-    };
-
-    for (let id of Object.keys(config.routes)) {
-      // All route entry points are virtual modules that will be loaded by the
-      // browserEntryPointsPlugin. This allows us to tree-shake server-only code
-      // that we don't want to run in the browser (i.e. action & loader).
-      entryPoints[id] = config.routes[id].file + "?browser";
-    }
+  for (let id of Object.keys(config.routes)) {
+    // All route entry points are virtual modules that will be loaded by the
+    // browserEntryPointsPlugin. This allows us to tree-shake server-only code
+    // that we don't want to run in the browser (i.e. action & loader).
+    entryPoints[id] = config.routes[id].file + "?browser";
   }
 
   let { mode } = options;
-  let outputCss = isCssBuild;
 
   let matchPath = config.tsconfigPath
     ? createMatchPath(config.tsconfigPath)
@@ -126,10 +111,10 @@ const createEsbuildConfig = (
     //   ? cssBundleEntryModulePlugin(config)
     //   : null,
     config.future.unstable_cssModules
-      ? cssModulesPlugin({ config, mode, outputCss })
+      ? cssModulesPlugin({ config, mode, outputCss: false })
       : null,
     config.future.unstable_vanillaExtract
-      ? vanillaExtractPlugin({ config, mode, outputCss })
+      ? vanillaExtractPlugin({ config, mode, outputCss: false })
       : null,
     config.future.unstable_cssSideEffectImports
       ? cssSideEffectImportsPlugin({ config, options })
@@ -186,7 +171,7 @@ const createEsbuildConfig = (
     } as esbuild.Plugin,
   ].filter(isNotNull);
 
-  if (build === "app" && mode === "development" && config.future.unstable_dev) {
+  if (mode === "development" && config.future.unstable_dev) {
     // TODO prebundle deps instead of chunking just these ones
     let isolateChunks = [
       require.resolve("react"),
@@ -231,7 +216,7 @@ const createEsbuildConfig = (
     loader: loaders,
     bundle: true,
     logLevel: "silent",
-    splitting: !isCssBuild,
+    splitting: true,
     sourcemap: options.sourcemap,
     // As pointed out by https://github.com/evanw/esbuild/issues/2440, when tsconfig is set to
     // `undefined`, esbuild will keep looking for a tsconfig.json recursively up. This unwanted
@@ -278,7 +263,6 @@ export const create = (
       appCompiler = await (!appCompiler
         ? esbuild.build({
             ...createEsbuildConfig(
-              "app",
               remixConfig,
               options,
               onLoader,

--- a/packages/remix-dev/compiler/browserjs/compiler.ts
+++ b/packages/remix-dev/compiler/browserjs/compiler.ts
@@ -107,9 +107,6 @@ const createEsbuildConfig = (
 
   let plugins: esbuild.Plugin[] = [
     deprecatedRemixPackagePlugin(options.onWarning),
-    // isCssBundlingEnabled(config) && isCssBuild
-    //   ? cssBundleEntryModulePlugin(config)
-    //   : null,
     config.future.unstable_cssModules
       ? cssModulesPlugin({ config, mode, outputCss: false })
       : null,

--- a/packages/remix-dev/compiler/css/compiler.ts
+++ b/packages/remix-dev/compiler/css/compiler.ts
@@ -10,14 +10,10 @@ import type { RemixConfig } from "../../config";
 import { getAppDependencies } from "../../dependencies";
 import { loaders } from "../utils/loaders";
 import type { CompileOptions } from "../options";
-// import { browserRouteModulesPlugin } from "../plugins/browserRouteModulesPlugin";
-// import { browserRouteModulesPlugin as browserRouteModulesPlugin_v2 } from "../plugins/browserRouteModulesPlugin_v2";
 import { cssFilePlugin } from "../plugins/cssImports";
-import { deprecatedRemixPackagePlugin } from "../plugins/deprecatedRemixPackage";
 import { emptyModulesPlugin } from "../plugins/emptyModules";
 import { mdxPlugin } from "../plugins/mdx";
 import { externalPlugin } from "../plugins/external";
-// import { cssBundleUpdatePlugin } from "../plugins/cssBundleUpdatePlugin";
 import { cssModulesPlugin } from "../plugins/cssModuleImports";
 import { cssSideEffectImportsPlugin } from "../plugins/cssSideEffectImports";
 import { vanillaExtractPlugin } from "../plugins/vanillaExtract";
@@ -26,7 +22,6 @@ import {
   cssBundleEntryModuleId,
 } from "./plugins/bundleEntry";
 import invariant from "../../invariant";
-// import { hmrPlugin } from "../plugins/hmrPlugin";
 
 function isNotNull<Value>(value: Value): value is Exclude<Value, null> {
   return value !== null;
@@ -59,44 +54,18 @@ const getExternals = (remixConfig: RemixConfig): string[] => {
 };
 
 const createEsbuildConfig = (
-  build: "app" | "css",
   config: RemixConfig,
   options: CompileOptions
-  // onLoader: (filename: string, code: string) => void
 ): esbuild.BuildOptions | esbuild.BuildIncremental => {
-  let isCssBuild = build === "css";
-  let entryPoints: Record<string, string>;
-
-  if (isCssBuild) {
-    entryPoints = {
-      "css-bundle": cssBundleEntryModuleId,
-    };
-  } else {
-    entryPoints = {
-      "entry.client": config.entryClientFilePath,
-    };
-
-    for (let id of Object.keys(config.routes)) {
-      // All route entry points are virtual modules that will be loaded by the
-      // browserEntryPointsPlugin. This allows us to tree-shake server-only code
-      // that we don't want to run in the browser (i.e. action & loader).
-      entryPoints[id] = config.routes[id].file + "?browser";
-    }
-  }
-
   let { mode } = options;
-  let outputCss = isCssBuild;
 
   let plugins: esbuild.Plugin[] = [
-    deprecatedRemixPackagePlugin(options.onWarning),
-    isCssBundlingEnabled(config) && isCssBuild
-      ? cssBundleEntryModulePlugin(config)
-      : null,
+    isCssBundlingEnabled(config) ? cssBundleEntryModulePlugin(config) : null,
     config.future.unstable_cssModules
-      ? cssModulesPlugin({ config, mode, outputCss })
+      ? cssModulesPlugin({ config, mode, outputCss: true })
       : null,
     config.future.unstable_vanillaExtract
-      ? vanillaExtractPlugin({ config, mode, outputCss })
+      ? vanillaExtractPlugin({ config, mode, outputCss: true })
       : null,
     config.future.unstable_cssSideEffectImports
       ? cssSideEffectImportsPlugin({ config, options })
@@ -104,40 +73,15 @@ const createEsbuildConfig = (
     cssFilePlugin({ config, options }),
     externalPlugin(/^https?:\/\//, { sideEffects: false }),
     mdxPlugin(config),
-    // config.future.unstable_dev
-    //   ? browserRouteModulesPlugin_v2(config, /\?browser$/, onLoader, mode)
-    //   : browserRouteModulesPlugin(config, /\?browser$/),
     emptyModulesPlugin(config, /\.server(\.[jt]sx?)?$/),
     NodeModulesPolyfillPlugin(),
     externalPlugin(/^node:.*/, { sideEffects: false }),
   ].filter(isNotNull);
 
-  if (build === "app" && mode === "development" && config.future.unstable_dev) {
-    // TODO prebundle deps instead of chunking just these ones
-    let isolateChunks = [
-      require.resolve("react"),
-      require.resolve("react/jsx-dev-runtime"),
-      require.resolve("react/jsx-runtime"),
-      require.resolve("react-dom"),
-      require.resolve("react-dom/client"),
-      require.resolve("react-refresh/runtime"),
-      require.resolve("@remix-run/react"),
-      "remix:hmr",
-    ];
-    entryPoints = {
-      ...entryPoints,
-      ...Object.fromEntries(isolateChunks.map((imprt) => [imprt, imprt])),
-    };
-
-    // plugins.push(hmrPlugin({ remixConfig: config }));
-
-    if (isCssBundlingEnabled(config)) {
-      // plugins.push(cssBundleUpdatePlugin({ getCssBundleHref }));
-    }
-  }
-
   return {
-    entryPoints,
+    entryPoints: {
+      "css-bundle": cssBundleEntryModuleId,
+    },
     outdir: config.assetsBuildDirectory,
     platform: "browser",
     format: "esm",
@@ -155,7 +99,6 @@ const createEsbuildConfig = (
     loader: loaders,
     bundle: true,
     logLevel: "silent",
-    splitting: !isCssBuild,
     sourcemap: options.sourcemap,
     // As pointed out by https://github.com/evanw/esbuild/issues/2440, when tsconfig is set to
     // `undefined`, esbuild will keep looking for a tsconfig.json recursively up. This unwanted
@@ -189,7 +132,6 @@ export let create = (
   writeCssBundleHref: (cssBundleHref?: string) => void
 ) => {
   let cssCompiler: esbuild.BuildIncremental;
-  // let onLoader = () => {};
   let cssBuildTask = async () => {
     if (!isCssBundlingEnabled(remixConfig)) {
       return;
@@ -200,7 +142,7 @@ export let create = (
       //  so we need to assert that it's an incremental build
       cssCompiler = (await (!cssCompiler
         ? esbuild.build({
-            ...createEsbuildConfig("css", remixConfig, options /* onLoader */),
+            ...createEsbuildConfig(remixConfig, options),
             metafile: true,
             incremental: true,
             write: false,


### PR DESCRIPTION
As a follow-up to #5854, this PR removes unused and commented-out code once the `build: 'app' | 'css'` value was inlined in the `browserjs` and `css` compilers. This also removes `deprecatedRemixPackagePlugin` from the CSS build since it will just result in duplicate warnings from the `browserjs` build.