### PR TITLE
fix GET /__REMIX_ASSETS_MANIFEST loop #5663

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -88,6 +88,7 @@
 - codymjarrett
 - colinhacks
 - confix
+- conundrumer
 - coryhouse
 - craigglennie
 - crismali

--- a/packages/remix-dev/devServer2.ts
+++ b/packages/remix-dev/devServer2.ts
@@ -98,8 +98,11 @@ export let serve = async (
   let host = getHost();
   let appServerOrigin = `http://${host ?? "localhost"}:${dev.appServerPort}`;
 
+  let currentBuildHash;
   let waitForAppServer = async (buildHash: string) => {
+    currentBuildHash = buildHash;
     while (true) {
+      if (buildHash !== currentBuildHash) return;
       // TODO AbortController signal to cancel responses?
       let assetsManifest = await fetchAssetsManifest(
         appServerOrigin,


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #5663

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->

The loop occurs when you run the unstable dev server, make a change, and quickly undo that change. [See this for more details](https://github.com/remix-run/remix/issues/5663#issuecomment-1458390579)