### PR TITLE
feat(dev): support disabling PostCSS and Tailwind

### DIFF
--- a/.changeset/remove-unstable-postcss.md
+++ b/.changeset/remove-unstable-postcss.md
@@ -5,4 +5,4 @@
 "@remix-run/testing": major
 ---
 
-Remove `unstable_postcss` option. PostCSS is now supported automatically.
+Remove `unstable_postcss` option. CSS files are now automatically processed using PostCSS if `postcss.config.js` is present. If needed, this feature can be disabled by setting the `postcss` option to `false` in `remix.config.js`.

--- a/.changeset/remove-unstable-tailwind.md
+++ b/.changeset/remove-unstable-tailwind.md
@@ -5,4 +5,4 @@
 "@remix-run/testing": major
 ---
 
-Remove `unstable_tailwind` option. Tailwind is now supported automatically.
+Remove `unstable_tailwind` option. Tailwind functions and directives are now automatically supported in CSS files if `tailwindcss` is installed. If needed, this feature can be disabled by setting the `tailwind` option to `false` in `remix.config.js`.

--- a/docs/file-conventions/remix-config.md
+++ b/docs/file-conventions/remix-config.md
@@ -66,6 +66,10 @@ dotfiles (like `.DS_Store` files) or CSS/test files you wish to colocate.
 The URL prefix of the browser build with a trailing slash. Defaults to
 `"/build/"`. This is the path the browser will use to find assets.
 
+## postcss
+
+Whether to process CSS using [PostCSS][postcss] if `postcss.config.js` is present. Defaults to `true`.
+
 ## routes
 
 A function for defining custom routes, in addition to those already defined
@@ -192,6 +196,10 @@ Defaults to `"cjs"`.
 The platform the server build is targeting, which can either be `"neutral"` or
 `"node"`. Defaults to `"node"`.
 
+## tailwind
+
+Whether to support [Tailwind functions and directives][tailwind-functions-and-directives] in CSS files if `tailwindcss` is installed. Defaults to `true`.
+
 ## watchPaths
 
 An array, string, or async function that defines custom directories, relative to the project root, to watch while running [remix dev][remix-dev]. These directories are in addition to [`appDirectory`][app-directory].
@@ -232,3 +240,5 @@ There are a few conventions that Remix uses you should be aware of.
 [remix-dev]: ../other-api/dev#remix-dev
 [app-directory]: #appDirectory
 [css-side-effect-imports]: ../guides/styling#css-side-effect-imports
+[postcss]: https://postcss.org
+[tailwind-functions-and-directives]: https://tailwindcss.com/docs/functions-and-directives

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -455,6 +455,8 @@ Note that if you're also using Remix's [built-in PostCSS support][built-in-post-
 
 If you're using VS Code, it's recommended you install the [Tailwind IntelliSense extension][tailwind-intelli-sense-extension] for the best developer experience.
 
+<docs-info>Built-in Tailwind support can be disabled by setting the `tailwind` option to `false` in `remix.config.js`.</docs-info>
+
 ## Remote Stylesheets
 
 You can load stylesheets from any server, here's an example of loading a modern css reset from unpkg.
@@ -505,6 +507,8 @@ module.exports = (ctx) => {
       };
 };
 ```
+
+<docs-info>Built-in PostCSS support can be disabled by setting the `postcss` option to `false` in `remix.config.js`.</docs-info>
 
 ## CSS Preprocessors
 

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -40,6 +40,7 @@ describe("readConfig", () => {
           "unstable_dev": false,
         },
         "mdx": undefined,
+        "postcss": true,
         "publicPath": "/build/",
         "relativeAssetsBuildDirectory": Any<String>,
         "rootDirectory": Any<String>,
@@ -63,6 +64,7 @@ describe("readConfig", () => {
         "serverMode": "production",
         "serverModuleFormat": "cjs",
         "serverPlatform": "node",
+        "tailwind": true,
         "tsconfigPath": Any<String>,
         "watchPaths": Array [],
       }

--- a/packages/remix-dev/compiler/utils/postcss.ts
+++ b/packages/remix-dev/compiler/utils/postcss.ts
@@ -65,6 +65,10 @@ export async function getPostcssProcessor({
   config,
   context = defaultContext,
 }: Options): Promise<Processor | null> {
+  if (!config.postcss) {
+    return null;
+  }
+
   let cacheKey = getCacheKey({ config, context });
   let cachedProcessor = processorCache.get(cacheKey);
   if (cachedProcessor !== undefined) {
@@ -89,6 +93,10 @@ let tailwindPluginCache = new Map<string, AcceptedPlugin | null>();
 async function loadTailwindPlugin(
   config: RemixConfig
 ): Promise<AcceptedPlugin | null> {
+  if (!config.tailwind) {
+    return null;
+  }
+
   let { rootDirectory } = config;
   let cacheKey = rootDirectory;
   let cachedTailwindPlugin = tailwindPluginCache.get(cacheKey);

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -92,6 +92,12 @@ export interface AppConfig {
   mdx?: RemixMdxConfig | RemixMdxConfigFunction;
 
   /**
+   * Whether to process CSS using PostCSS if `postcss.config.js` is present.
+   * Defaults to `true`.
+   */
+  postcss?: boolean;
+
+  /**
    * A server entrypoint, relative to the root directory that becomes your
    * server's main module. If specified, Remix will compile this file along with
    * your application into a single file to be deployed to your server. This
@@ -143,6 +149,12 @@ export interface AppConfig {
    * The platform the server build is targeting. Defaults to "node".
    */
   serverPlatform?: ServerPlatform;
+
+  /**
+   * Whether to support Tailwind functions and directives in CSS files if `tailwindcss` is installed.
+   * Defaults to `true`.
+   */
+  tailwind?: boolean;
 
   /**
    * A list of filenames or a glob patterns to match files in the `app/routes`
@@ -237,6 +249,12 @@ export interface RemixConfig {
   mdx?: RemixMdxConfig | RemixMdxConfigFunction;
 
   /**
+   * Whether to process CSS using PostCSS if `postcss.config.js` is present.
+   * Defaults to `true`.
+   */
+  postcss: boolean;
+
+  /**
    * The path to the server build file. This file should end in a `.js`.
    */
   serverBuildPath: string;
@@ -296,6 +314,12 @@ export interface RemixConfig {
    * The platform the server build is targeting. Defaults to "node".
    */
   serverPlatform: ServerPlatform;
+
+  /**
+   * Whether to support Tailwind functions and directives in CSS files if `tailwindcss` is installed.
+   * Defaults to `true`.
+   */
+  tailwind: boolean;
 
   /**
    * A list of directories to watch.
@@ -370,6 +394,8 @@ export async function readConfig(
   serverMinify ??= false;
 
   let mdx = appConfig.mdx;
+  let postcss = appConfig.postcss ?? true;
+  let tailwind = appConfig.tailwind ?? true;
 
   let appDirectory = path.resolve(
     rootDirectory,
@@ -599,6 +625,8 @@ export async function readConfig(
     serverModuleFormat,
     serverPlatform,
     mdx,
+    postcss,
+    tailwind,
     watchPaths,
     tsconfigPath,
     future,


### PR DESCRIPTION
Since it's technically a breaking change to start processing non-bundled CSS files differently, this PR provides an opt-out for those who want Remix to ignore the presence of `postcss.config.js`/`tailwindcss` and instead keep their existing PostCSS/Tailwind setup.