### PR TITLE
Fix incorrect useFunction example in Preparing for v2 doc

### DIFF
--- a/docs/pages/v2.md
+++ b/docs/pages/v2.md
@@ -413,7 +413,7 @@ Like `useNavigation`, `useFetcher` has flattened the `submission` and removed th
 import { useFetcher } from "@remix-run/react";
 
 function SomeComponent() {
-  let fetcher = useTransition();
+  let fetcher = useFetcher();
   fetcher.submission.formData;
   fetcher.submission.formMethod;
   fetcher.submission.formAction;
@@ -425,7 +425,7 @@ function SomeComponent() {
 import { useNavigation } from "@remix-run/react";
 
 function SomeComponent() {
-  let fetcher = useTransition();
+  let fetcher = useFetcher();
 
   // these keys are flattened
   fetcher.formData;


### PR DESCRIPTION
Looks like the example was copied from `useTransition`/`useNavigation`, but wasn't fully replaced with `useFetcher` calls