### PR TITLE
docs(pages/v2): fix typo in `serverBuildDirectory` section

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -86,6 +86,7 @@
 - cloudy9101
 - cmd-johnson
 - codymjarrett
+- colinasquith
 - colinhacks
 - confix
 - coryhouse

--- a/docs/pages/v2.md
+++ b/docs/pages/v2.md
@@ -572,7 +572,7 @@ module.exports = {
 ```js filename=remix.config.js good lines=[3]
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  serverBuildDirectory: "./build/index.js",
+  serverBuildPath: "./build/index.js",
 };
 ```
 


### PR DESCRIPTION
serverBuildDirectory is duplicated in the new example and should be serverBuildPath
