### PR TITLE
docs(pages/v2): remove default values from `serverBuildTarget` section

### DIFF
--- a/docs/pages/v2.md
+++ b/docs/pages/v2.md
@@ -14,7 +14,7 @@ All v2 APIs and behaviors are available in v1 with [Future Flags][future-flags].
 
 You can keep using the old convention with `@remix-run/v1-route-convention` even after upgrading to v2 if you don't want to make the change right now (or ever, it's just a convention and you can use whatever file organization you prefer).
 
-```shellscript
+```sh
 npm i @remix-run/v1-route-convention
 ```
 
@@ -49,29 +49,29 @@ A routes folder that looks like this in v1:
 ```txt bad
 routes
 ├── __auth
-│   ├── login.tsx
-│   ├── logout.tsx
-│   └── signup.tsx
+│   ├── login.tsx
+│   ├── logout.tsx
+│   └── signup.tsx
 ├── __public
-│   ├── about-us.tsx
-│   ├── contact.tsx
-│   └── index.tsx
+│   ├── about-us.tsx
+│   ├── contact.tsx
+│   └── index.tsx
 ├── dashboard
-│   ├── calendar
-│   │   ├── $day.tsx
-│   │   └── index.tsx
-│   ├── projects
-│   │   ├── $projectId
-│   │   │   ├── collaborators.tsx
-│   │   │   ├── edit.tsx
-│   │   │   ├── index.tsx
-│   │   │   ├── settings.tsx
-│   │   │   └── tasks.$taskId.tsx
-│   │   ├── $projectId.tsx
-│   │   └── new.tsx
-│   ├── calendar.tsx
-│   ├── index.tsx
-│   └── projects.tsx
+│   ├── calendar
+│   │   ├── $day.tsx
+│   │   └── index.tsx
+│   ├── projects
+│   │   ├── $projectId
+│   │   │   ├── collaborators.tsx
+│   │   │   ├── edit.tsx
+│   │   │   ├── index.tsx
+│   │   │   ├── settings.tsx
+│   │   │   └── tasks.$taskId.tsx
+│   │   ├── $projectId.tsx
+│   │   └── new.tsx
+│   ├── calendar.tsx
+│   ├── index.tsx
+│   └── projects.tsx
 ├── __auth.tsx
 ├── __public.tsx
 └── dashboard.calendar.$projectId.print.tsx
@@ -114,9 +114,9 @@ For example, we can move `_public.tsx` to `_public/route.tsx` and then co-locate
 routes
 ├── _auth.tsx
 ├── _public
-│   ├── footer.tsx
-│   ├── header.tsx
-│   └── route.tsx
+│   ├── footer.tsx
+│   ├── header.tsx
+│   └── route.tsx
 ├── _public._index.tsx
 ├── _public.about-us.tsx
 └── etc.
@@ -591,10 +591,10 @@ The following configurations should replace your current `serverBuildTarget`:
 module.exports = {
   publicPath: "/_static/build/",
   serverBuildPath: "server/index.js",
-  serverMainFields: ["main", "module"],
-  serverModuleFormat: "cjs",
-  serverPlatform: "node",
-  serverMinify: false,
+  serverMainFields: ["main", "module"], // default value, can be removed
+  serverMinify: false, // default value, can be removed
+  serverModuleFormat: "cjs", // default value, can be removed
+  serverPlatform: "node", // default value, can be removed
 };
 ```
 
@@ -603,14 +603,14 @@ module.exports = {
 ```js filename=remix.config.js
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  publicPath: "/build/",
+  publicPath: "/build/", // default value, can be removed
   serverBuildPath: "functions/[[path]].js",
   serverConditions: ["worker"],
+  serverDependenciesToBundle: "all",
   serverMainFields: ["browser", "module", "main"],
+  serverMinify: true,
   serverModuleFormat: "esm",
   serverPlatform: "neutral",
-  serverDependenciesToBundle: "all",
-  serverMinify: true,
 };
 ```
 
@@ -619,14 +619,14 @@ module.exports = {
 ```js filename=remix.config.js
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  publicPath: "/build/",
-  serverBuildPath: "build/index.js",
+  publicPath: "/build/", // default value, can be removed
+  serverBuildPath: "build/index.js", // default value, can be removed
   serverConditions: ["worker"],
+  serverDependenciesToBundle: "all",
   serverMainFields: ["browser", "module", "main"],
+  serverMinify: true,
   serverModuleFormat: "esm",
   serverPlatform: "neutral",
-  serverDependenciesToBundle: "all",
-  serverMinify: true,
 };
 ```
 
@@ -635,14 +635,14 @@ module.exports = {
 ```js filename=remix.config.js
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  publicPath: "/build/",
-  serverBuildPath: "build/index.js",
+  publicPath: "/build/", // default value, can be removed
+  serverBuildPath: "build/index.js", // default value, can be removed
   serverConditions: ["deno", "worker"],
+  serverDependenciesToBundle: "all",
   serverMainFields: ["module", "main"],
+  serverMinify: false, // default value, can be removed
   serverModuleFormat: "esm",
   serverPlatform: "neutral",
-  serverDependenciesToBundle: "all",
-  serverMinify: false,
 };
 ```
 
@@ -651,13 +651,12 @@ module.exports = {
 ```js filename=remix.config.js
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  publicPath: "/build/",
+  publicPath: "/build/", // default value, can be removed
   serverBuildPath: ".netlify/functions-internal/server.js",
-  serverConditions: ["deno", "worker"],
-  serverMainFields: ["main", "module"],
-  serverModuleFormat: "cjs",
-  serverPlatform: "node",
-  serverMinify: false,
+  serverMainFields: ["main", "module"], // default value, can be removed
+  serverMinify: false, // default value, can be removed
+  serverModuleFormat: "cjs", // default value, can be removed
+  serverPlatform: "node", // default value, can be removed
 };
 ```
 
@@ -666,12 +665,12 @@ module.exports = {
 ```js filename=remix.config.js
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  publicPath: "/build/",
-  serverBuildPath: "build/index.js",
-  serverMainFields: ["main", "module"],
-  serverModuleFormat: "cjs",
-  serverPlatform: "node",
-  serverMinify: false,
+  publicPath: "/build/", // default value, can be removed
+  serverBuildPath: "build/index.js", // default value, can be removed
+  serverMainFields: ["main", "module"], // default value, can be removed
+  serverMinify: false, // default value, can be removed
+  serverModuleFormat: "cjs", // default value, can be removed
+  serverPlatform: "node", // default value, can be removed
 };
 ```
 
@@ -680,12 +679,12 @@ module.exports = {
 ```js filename=remix.config.js
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  publicPath: "/build/",
+  publicPath: "/build/", // default value, can be removed
   serverBuildPath: "api/index.js",
-  serverMainFields: ["main", "module"],
-  serverModuleFormat: "cjs",
-  serverPlatform: "node",
-  serverMinify: false,
+  serverMainFields: ["main", "module"], // default value, can be removed
+  serverMinify: false, // default value, can be removed
+  serverModuleFormat: "cjs", // default value, can be removed
+  serverPlatform: "node", // default value, can be removed
 };
 ```
 


### PR DESCRIPTION
Follow-up of #5934

Since we're talking about replacement, I figured that we don't need to specify the default values in here in order to make it work as expected