### PR TITLE
fix(remix-vercel): export `EntryContext`

### DIFF
--- a/packages/remix-vercel/index.ts
+++ b/packages/remix-vercel/index.ts
@@ -2,3 +2,4 @@ import "./globals";
 
 export type { GetLoadContextFunction, RequestHandler } from "./server";
 export { createRequestHandler } from "./server";
+export { EntryContext } from "@remix-run/server-runtime";


### PR DESCRIPTION
not sure if this is the right place for it, but based off of this file: https://github.com/remix-run/examples/blob/main/twind/app/entry.server.tsx it looks like EntryContext should be imported from the runtime you're using.