### PR TITLE
docs(pages/v2): fix typo in `useFetcher` section

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -467,6 +467,7 @@
 - therealflyingcoder
 - thomasheyenbrock
 - thomasrettig
+- thomasverleye
 - tjefferson08
 - tombiju
 - tombyrer

--- a/docs/pages/v2.md
+++ b/docs/pages/v2.md
@@ -413,7 +413,7 @@ Like `useNavigation`, `useFetcher` has flattened the `submission` and removed th
 import { useFetcher } from "@remix-run/react";
 
 function SomeComponent() {
-  let fetcher = useTransition();
+  let fetcher = useFetcher();
   fetcher.submission.formData;
   fetcher.submission.formMethod;
   fetcher.submission.formAction;

--- a/docs/pages/v2.md
+++ b/docs/pages/v2.md
@@ -422,10 +422,10 @@ function SomeComponent() {
 ```
 
 ```tsx filename=app/routes/v2-route.tsx
-import { useNavigation } from "@remix-run/react";
+import { useFetcher } from "@remix-run/react";
 
 function SomeComponent() {
-  let fetcher = useTransition();
+  let fetcher = useFetcher();
 
   // these keys are flattened
   fetcher.formData;


### PR DESCRIPTION
Also see #5968 but this PR is more complete as the import on the second example is also incorrect :-)