### PR TITLE
Fix `V2_MetaFunction` type import in templates

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -516,3 +516,4 @@
 - zhe
 - arifqys
 - iamzee
+- TimonVS

--- a/templates/arc/app/routes/_index.tsx
+++ b/templates/arc/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import type { V2_MetaFunction } from "@remix-run/node";
+import type { V2_MetaFunction } from "@remix-run/react";
 
 export const meta: V2_MetaFunction = () => {
   return [{ title: "New Remix App" }];

--- a/templates/cloudflare-pages/app/routes/_index.tsx
+++ b/templates/cloudflare-pages/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import type { V2_MetaFunction } from "@remix-run/node";
+import type { V2_MetaFunction } from "@remix-run/react";
 
 export const meta: V2_MetaFunction = () => {
   return [{ title: "New Remix App" }];

--- a/templates/cloudflare-workers/app/routes/_index.tsx
+++ b/templates/cloudflare-workers/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import type { V2_MetaFunction } from "@remix-run/node";
+import type { V2_MetaFunction } from "@remix-run/react";
 
 export const meta: V2_MetaFunction = () => {
   return [{ title: "New Remix App" }];

--- a/templates/deno/app/routes/_index.tsx
+++ b/templates/deno/app/routes/_index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import type { V2_MetaFunction } from "@remix-run/node";
+import type { V2_MetaFunction } from "@remix-run/react";
 
 export const meta: V2_MetaFunction = () => {
   return [{ title: "New Remix App" }];

--- a/templates/express/app/routes/_index.tsx
+++ b/templates/express/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import type { V2_MetaFunction } from "@remix-run/node";
+import type { V2_MetaFunction } from "@remix-run/react";
 
 export const meta: V2_MetaFunction = () => {
   return [{ title: "New Remix App" }];

--- a/templates/fly/app/routes/_index.tsx
+++ b/templates/fly/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import type { V2_MetaFunction } from "@remix-run/node";
+import type { V2_MetaFunction } from "@remix-run/react";
 
 export const meta: V2_MetaFunction = () => {
   return [{ title: "New Remix App" }];

--- a/templates/netlify/app/routes/_index.tsx
+++ b/templates/netlify/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import type { V2_MetaFunction } from "@remix-run/node";
+import type { V2_MetaFunction } from "@remix-run/react";
 
 export const meta: V2_MetaFunction = () => {
   return [{ title: "New Remix App" }];

--- a/templates/remix/app/routes/_index.tsx
+++ b/templates/remix/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import type { V2_MetaFunction } from "@remix-run/node";
+import type { V2_MetaFunction } from "@remix-run/react";
 
 export const meta: V2_MetaFunction = () => {
   return [{ title: "New Remix App" }];

--- a/templates/vercel/app/routes/_index.tsx
+++ b/templates/vercel/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import type { V2_MetaFunction } from "@remix-run/node";
+import type { V2_MetaFunction } from "@remix-run/react";
 
 export const meta: V2_MetaFunction = () => {
   return [{ title: "New Remix App" }];


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

When I bootstrapped a new Remix project a few days ago, I noticed the type `V2_MetaFunction` was imported from the Node adapter `@remix-run/node`, which isn't installed because I chose to deploy to Cloudflare Pages. This is present in all templates. I also noticed that this type can be imported both from the adapter, and from `@remix-run/react`. I wasn't sure which is the correct one, maybe the adapter specific version is more correct, but I couldn't from a brief glance I didn't notice any difference in the types.