### PR TITLE
chore(templates/cloudflare-pages): ignore .dev.vars instead of .env

### DIFF
--- a/templates/cloudflare-pages/.gitignore
+++ b/templates/cloudflare-pages/.gitignore
@@ -4,4 +4,4 @@ node_modules
 /functions/\[\[path\]\].js
 /functions/\[\[path\]\].js.map
 /public/build
-.env
+.dev.vars


### PR DESCRIPTION
This isn't a simple docs change but is still a small change in template, so I deleted the PR form you prepared. Let me know if that is inconvenient for you.

As is documented [here](https://remix.run/docs/en/1.15.0/guides/envvars), Cloudflare Pages uses `.dev.vars` for storing environment variables instead of `.env`. So ignoring `.env` isn't really helpful for Pages template.