### PR TITLE
docs(playground): clarify README

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -461,6 +461,7 @@
 - supachaidev
 - Synvox
 - tagraves
+- takagimeow
 - tascord
 - TheRealAstoo
 - t-dub

--- a/scripts/playground/template/README.md
+++ b/scripts/playground/template/README.md
@@ -2,4 +2,4 @@
 
 This project has everything set up for you to play around with the local Remix packages in a real app environment.
 
-To create a new project within the `playground` directory (which is ignored by `.gitignore`), execute the command `yarn playground:new <?name>`. For more details, please refer to the contributing guidelines.
+To create a new project within the `playground` directory (which is ignored by `.gitignore`), execute the command `yarn playground:new <?name>`. For more details, please refer to [the contributing guidelines](https://remix.run/pages/contributing).

--- a/scripts/playground/template/README.md
+++ b/scripts/playground/template/README.md
@@ -2,4 +2,4 @@
 
 This project has everything set up for you to play around with the local Remix packages in a real app environment.
 
-To generate a project in the `.gitignore`-d `playground` directory, run `yarn playground:new <?name>`. Read more in [the contributing guidelines](https://remix.run/pages/contributing).
+To create a new project within the `playground` directory (which is ignored by `.gitignore`), execute the command `yarn playground:new <?name>`. For more details, please refer to the contributing guidelines.


### PR DESCRIPTION
For non-native English-speaking developers like myself, it took some time to understand the meaning of the expression "`.gitignore` -d" when I first encountered it. 

To make it more accessible for developers who may not be fluent in English, I've updated the wording to a clearer English expression.



