### PR TITLE
fix(remix-cloudflare-pages): fix `GetLoadContextFunction` type

### DIFF
--- a/packages/remix-cloudflare-pages/worker.ts
+++ b/packages/remix-cloudflare-pages/worker.ts
@@ -8,8 +8,8 @@ import { createRequestHandler as createRemixRequestHandler } from "@remix-run/cl
  * You can think of this as an escape hatch that allows you to pass
  * environment/platform-specific values through to your loader/action.
  */
-export type GetLoadContextFunction<Env = any> = (
-  context: EventContext<Env, any, any>
+export type GetLoadContextFunction<Env = unknown> = (
+  context: Parameters<PagesFunction<Env>>[0]
 ) => AppLoadContext;
 
 export type RequestHandler<Env = any> = PagesFunction<Env>;


### PR DESCRIPTION
Due to @mcansh's remark in https://github.com/remix-run/remix/pull/5822#discussion_r1163230868, I noticed that the CP adapter's `GetLoadContextFunction` was wrong

With this PR, we derive `context` from `@cloudflare/workers-types`' `PagesFunction`