### PR TITLE
chore(remix-dev): fix `v2_meta` warning

### DIFF
--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -904,7 +904,7 @@ export const formMethodWarning =
   "https://remix.run/docs/en/v1.15.0/pages/v2#formMethod";
 
 export const metaWarning =
-  "⚠️ REMIX FUTURE CHANGE: The route `meta` export signature is changing in v2" +
+  "⚠️ REMIX FUTURE CHANGE: The route `meta` export signature is changing in v2. " +
   "You can prepare for this change at your convenience with the `v2_meta` future flag. " +
   "For instructions on making this change see " +
   "https://remix.run/docs/en/v1.15.0/pages/v2#meta";


### PR DESCRIPTION
* Meta export notice does not match the format all the other V2 Future change notes

Prior to change the text doesn't properly terminate the sentence in the console notice
![image](https://user-images.githubusercontent.com/682263/231301722-2eb0e5aa-83e8-4cb9-94aa-e645f422fc8a.png)
