### PR TITLE
fix: move `@types/*` to devDependencies

### DIFF
--- a/packages/remix-architect/package.json
+++ b/packages/remix-architect/package.json
@@ -15,10 +15,10 @@
   "typings": "dist/index.d.ts",
   "dependencies": {
     "@architect/functions": "^5.2.0",
-    "@remix-run/node": "1.15.0",
-    "@types/aws-lambda": "^8.10.82"
+    "@remix-run/node": "1.15.0"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.82",
     "@types/lambda-tester": "^3.6.1",
     "lambda-tester": "^4.0.1"
   },

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -17,8 +17,6 @@
   "module": "dist/esm/index.js",
   "dependencies": {
     "@remix-run/router": "1.5.0",
-    "@types/cookie": "^0.4.0",
-    "@types/react": "^18.0.15",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie": "^0.4.1",
     "set-cookie-parser": "^2.4.8",
@@ -26,6 +24,8 @@
   },
   "devDependencies": {
     "@remix-run/web-file": "^3.0.2",
+    "@types/cookie": "^0.4.0",
+    "@types/react": "^18.0.15",
     "@types/set-cookie-parser": "^2.4.1"
   },
   "engines": {


### PR DESCRIPTION
https://canary.discord.com/channels/770287896669978684/940264701785423992/1095463978722918460
https://canary.discord.com/channels/770287896669978684/940264701785423992/1095464105680322560

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
