### PR TITLE
docs: update references to CSS bundling

### DIFF
--- a/docs/guides/migrating-react-router-app.md
+++ b/docs/guides/migrating-react-router-app.md
@@ -451,7 +451,7 @@ Create React App and many other build tools support importing CSS in your compon
 
 ### Route `links` exports
 
-In Remix, stylesheets can be loaded from route component files. Importing them does not do anything magical with your styles, rather it returns a URL that can be used to load the stylesheet as you see fit. You can render the stylesheet directly in your component or use our [`links` export][see-our-docs-on-route-links-for-more-information].
+In Remix, regular stylesheets can be loaded from route component files. Importing them does not do anything magical with your styles, rather it returns a URL that can be used to load the stylesheet as you see fit. You can render the stylesheet directly in your component or use our [`links` export][see-our-docs-on-route-links-for-more-information].
 
 Let's move our app's stylesheet and a few other assets to the `links` function in our root route:
 

--- a/docs/guides/migrating-react-router-app.md
+++ b/docs/guides/migrating-react-router-app.md
@@ -387,7 +387,7 @@ If you are using TypeScript, you also need to create the `remix.env.d.ts` file i
 
 ### A note about non-standard imports
 
-At this point, you _might_ be able to run your app with no changes. If you are using Create React App or a highly-configured Webpack app, you likely use `import` to include non-JavaScript modules like stylesheets and images.
+At this point, you _might_ be able to run your app with no changes. If you are using Create React App or a highly-configured bundler setup, you likely use `import` to include non-JavaScript modules like stylesheets and images.
 
 Remix does not support most non-standard imports, and we think for good reason. Below is a non-exhaustive list of some of the differences you'll encounter in Remix, and how to refactor as you migrate.
 
@@ -407,7 +407,7 @@ In Remix, this works basically the same way. For assets like fonts that are load
 
 #### SVG imports
 
-Create React App and some Webpack plugins allow you to import SVG files as a React component. This is a common use case for SVG files, but it's not supported by default in Remix.
+Create React App and some other build tools allow you to import SVG files as a React component. This is a common use case for SVG files, but it's not supported by default in Remix.
 
 ```js bad nocopy
 // This will not work in Remix!
@@ -447,58 +447,11 @@ export default function Icon() {
 
 #### CSS imports
 
-Create React App and many Webpack plugins support importing CSS in your components in many ways. While this is common practice in the React ecosystem, it's not supported the same way in Remix for a few different reasons. We'll discuss this in depth in the next section, but for now just know that you need to import your stylesheets in route modules. Importing stylesheets directly in non-route components is not currently supported.
-
-[Read more about route styles and why Remix does things a bit differently.][read-more-about-route-styles-and-why-remix-does-things-a-bit-differently]
-
-### Route styles
-
-Let's talk a bit more about styles. Remix does not handle CSS imports the same way your bundler likely does, and we think that's for a good reason.
-
-Assume you have a plain CSS import in your `App` component:
-
-```jsx filename=app.jsx lines=[5]
-import { Outlet } from "react-router-dom";
-
-import Logo from "./logo";
-import SiteNav from "./site-nav";
-import "./styles.css";
-
-export default function App() {
-  return (
-    <div>
-      <header>
-        <Logo />
-        <SiteNav />
-      </header>
-      <main>
-        <Outlet />
-      </main>
-      <footer>&copy; Remix Software</footer>
-    </div>
-  );
-}
-```
-
-While this is a convenient API, consider a few questions:
-
-- How do the styles actually end up on the page? Do you get a `<link />` or an inline `<style />` in the `<head>`?
-- If other components also import CSS, where do they end up in relation other component styles? This has important implications on how the styles are applied due to the cascading nature of CSS.
-- As the styles are static assets, are we caching them? Can they be preloaded or lazy loaded?
-
-The answer to all of these questions is up to your bundler, _not you_. We think there's a better way, and it's one that happens to be as old as HTML2: `<link rel="stylesheet" />`.
-
-<docs-info>
-
-**Note:** Remix does not currently support CSS processing directly. If you use preprocessors like Sass, Less, or PostCSS, you can run those as a separate process in development.
-
-We do process [CSS Modules][css-modules], but support is currently [opt-in behind a feature flag][css-modules].
-
-</docs-info>
+Create React App and many other build tools support importing CSS in your components in various ways. Remix supports importing regular CSS files along with several popular CSS bundling solutions described below.
 
 ### Route `links` exports
 
-In Remix, stylesheets can only be loaded from route component files. Importing them does not do anything magical with your styles, rather it returns a URL that can be used to load the stylesheet as you see fit. You can render the stylesheet directly in your component or use our [`links` export][see-our-docs-on-route-links-for-more-information].
+In Remix, stylesheets can be loaded from route component files. Importing them does not do anything magical with your styles, rather it returns a URL that can be used to load the stylesheet as you see fit. You can render the stylesheet directly in your component or use our [`links` export][see-our-docs-on-route-links-for-more-information].
 
 Let's move our app's stylesheet and a few other assets to the `links` function in our root route:
 
@@ -547,6 +500,53 @@ export default function Root() {
 You'll notice on line 32 that we've rendered a `<Links />` component that replaced all of our individual `<link />` components. This is inconsequential if we only ever use links in the root route, but all child routes may export their own links that will also be rendered here. The `links` function can also return a [`PageLinkDescriptor` object][page-link-descriptor-object] that allows you to prefetch the resources for a page the user is likely to navigate to.
 
 If you currently inject `<link />` tags into your page client-side in your existing route components, either directly or via an abstraction like [`react-helmet`][react-helmet], you can stop doing that and instead use the `links` export. You get to delete a lot of code and possibly a dependency or two!
+
+### PostCSS
+
+To enable [PostCSS] support, set the `postcss` option to `true` in `remix.config.js`. Remix will then automatically process your styles with PostCSS if a `postcss.config.js` file is present.
+
+```js filename=remix.config.js
+/** @type {import('@remix-run/dev').AppConfig} */
+module.exports = {
+  postcss: true,
+  // ...
+};
+```
+
+
+### CSS bundling
+
+Remix has built-in support for [CSS Modules][css-modules], [Vanilla Extract][vanilla-extract] and [CSS side-effect imports][css-side-effect-imports]. In order to make use of these features, you'll need to set up CSS bundling in your application.
+
+First, to get access to the generated CSS bundle, install the `@remix-run/css-bundle` package.
+
+```sh
+npm install @remix-run/css-bundle
+```
+
+Then, import `cssBundleHref` and add it to a link descriptor—most likely in `root.tsx` so that it applies to your entire application.
+
+```tsx filename=root.tsx lines=[2,6-8]
+import type { LinksFunction } from "@remix-run/node"; // or cloudflare/deno
+import { cssBundleHref } from "@remix-run/css-bundle";
+
+export const links: LinksFunction = () => {
+  return [
+    ...(cssBundleHref
+      ? [{ rel: "stylesheet", href: cssBundleHref }]
+      : []),
+    // ...
+  ];
+};
+```
+
+[See our docs on CSS bundling for more information.][css-bundling]
+
+<docs-info>
+
+**Note:** Remix does not currently support Sass/Less processing directly, but you can still run those as a separate process to generate CSS files that can then be imported into your Remix app.
+
+</docs-info>
 
 ### Rendering components in `<head>`
 
@@ -633,7 +633,6 @@ Now then, go off and _remix your app_. We think you'll like what you build along
 [react-svgr]: https://react-svgr.com
 [command-line]: https://react-svgr.com/docs/cli
 [online-playground]: https://react-svgr.com/playground
-[read-more-about-route-styles-and-why-remix-does-things-a-bit-differently]: #route-stylesheets
 [page-link-descriptor-object]: ../route/links#pagelinkdescriptor
 [react-helmet]: https://www.npmjs.com/package/react-helmet
 [remix-philosophy]: ../pages/philosophy
@@ -643,4 +642,8 @@ Now then, go off and _remix your app_. We think you'll like what you build along
 [styling-in-remix]: ./styling
 [frequently-asked-questions]: ../pages/faq
 [common-gotchas]: ../pages/currently
+[postcss]: ./styling#postcss
 [css-modules]: ./styling#css-modules
+[vanilla-extract]: ./styling#vanilla-extract
+[css-side-effect-imports]: ./styling#css-side-effect-imports
+[css-bundling]: ./styling#css-bundling

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -52,15 +52,16 @@ export function links() {
 }
 ```
 
+Remix also has built-in support for the following:
+- [Tailwind](#tailwind)
+- [PostCSS](#postcss)
+- [CSS Modules](#css-modules)
+- [Vanilla Extract](#vanilla-extract)
+- [CSS side-effect imports](#css-side-effect-imports)
+
 ## CSS Ecosystem and Performance
 
-<docs-info>We are still researching how best to support, and be supported by, the various styling libraries without sacrificing the user's network tab or creating a maintenance burden for Remix.</docs-info>
 
-In today's ecosystem there are dozens of approaches and frameworks for styling. Remix supports many of them out of the box, but the frameworks that require direct integration with our compiler and expect Remix to automatically inject styles onto the page don't work right now.
-
-We recognize that not being able to use your favorite CSS framework is a bummer. If yours isn't supported right now, we hope you'll find some of the approaches in this document equally as productive. We also recognize that supporting a variety of tools is critical for migration paths to Remix.
-
-Here's some background on where we're at.
 
 In general, stylesheets added to the page with `<link>` tend to provide the best user experience:
 
@@ -71,11 +72,7 @@ In general, stylesheets added to the page with `<link>` tend to provide the best
 - Changes to components don't break the cache for the styles
 - Changes to the styles don't break the cache for the JavaScript
 
-Therefore, CSS support in Remix boils down to one thing: it needs to create a CSS file you can add to the page with `<link rel="stylesheet">`. This seems like a reasonable request of a CSS framework--to generate a CSS file. Remix isn't against the frameworks that can't do this, it's just too early for us to add extension points to the compiler. Additionally, adding support directly inside of Remix is not tenable with the vast number of libraries out there.
-
 Remix also supports "runtime" frameworks like styled components where styles are evaluated at runtime but don't require any kind of bundler integration--though we would prefer your stylesheets had a URL instead of being injected into style tags.
-
-All this is to say that **we're still researching how best to integrate and work with the frameworks that require compiler integration**. With Remix's unique ability to prefetch, add, and remove CSS for partial UI on the page, we anticipate CSS frameworks will have some new ideas on how to support building actual CSS files to better support Remix and the performance of websites using them.
 
 The two most popular approaches in the Remix community are route-based stylesheets and [Tailwind][tailwind]. Both have exceptional performance characteristics. In this document, we'll show how to use these two approaches as well as a few more.
 
@@ -531,7 +528,7 @@ module.exports = (ctx) => {
 
 You can use CSS preprocessors like LESS and SASS. Doing so requires running an additional build process to convert these files to CSS files. This can be done via the command line tools provided by the preprocessor or any equivalent tool.
 
-Once converted to CSS by the preprocessor, the generated CSS files can be imported into your components via the [Route Module `links` export][route-module-links] function, just like any other CSS file in Remix.
+Once converted to CSS by the preprocessor, the generated CSS files can be imported into your components via the [Route Module `links` export][route-module-links] function, or included via [side-effect imports][css-side-effect-imports] when using [CSS bundling][css-bundling], just like any other CSS file in Remix.
 
 To ease development with CSS preprocessors you can add npm scripts to your `package.json` that generate CSS files from your SASS or LESS files. These scripts can be run in parallel alongside any other npm scripts that you run for developing a Remix application.
 
@@ -814,3 +811,4 @@ module.exports = {
 [sprinkles]: https://vanilla-extract.style/documentation/packages/sprinkles
 [built-in-post-css-support]: #postcss
 [vanilla-extract-2]: #vanilla-extract
+[css-side-effect-imports]: #css-side-effect-imports


### PR DESCRIPTION
This PR removes all references to the _lack_ of CSS bundling and adds CSS bundling docs to the React Router migration guide now that these features have been stabilized.