### PR TITLE
chore: update CSS bundling changesets

### DIFF
--- a/.changeset/postcss-enabled-by-default.md
+++ b/.changeset/postcss-enabled-by-default.md
@@ -1,0 +1,50 @@
+---
+"@remix-run/dev": major
+"@remix-run/react": major
+"@remix-run/server-runtime": major
+---
+
+PostCSS support is now enabled by default if a `postcss.config.js` file is present at the root of your project.
+
+If you already have a custom PostCSS setup that you'd like to maintain, you can disable this behavior by setting the `postcss` option to `false` in `remix.config.js`.
+
+Otherwise, if you followed the original PostCSS setup guide for Remix and want to make use of this feature, you may have a folder structure that looks like this, separating your source files from its processed output:
+
+```
+.
+├── app
+│   └── styles (processed files)
+│       ├── app.css
+│       └── routes
+│           └── index.css
+└── styles (source files)
+    ├── app.css
+    └── routes
+        └── index.css
+```
+
+With the new built-in PostCSS support, you can delete the processed files from `app/styles` folder and move your source files from `styles` to `app/styles`:
+
+```
+.
+├── app
+│   └── styles (source files)
+│       ├── app.css
+│       └── routes
+│           └── index.css
+```
+
+You should then remove `app/styles` from your `.gitignore` file since it now contains source files rather than processed output.
+
+You can then update your `package.json` scripts to remove any usage of `postcss` since Remix handles this automatically. For example, if you had followed the original setup guide:
+
+```diff
+{
+  "scripts": {
+-    "dev:css": "postcss styles --base styles --dir app/styles -w",
+-    "build:css": "postcss styles --base styles --dir app/styles --env production",
+-    "dev": "concurrently \"npm run dev:css\" \"remix dev\""
++    "dev": "remix dev"
+  }
+}
+```

--- a/.changeset/remove-unstable-css-modules.md
+++ b/.changeset/remove-unstable-css-modules.md
@@ -1,8 +1,0 @@
----
-"@remix-run/dev": major
-"@remix-run/react": major
-"@remix-run/server-runtime": major
-"@remix-run/testing": major
----
-
-Remove `unstable_cssModules` option. CSS Modules is now supported automatically.

--- a/.changeset/remove-unstable-css-side-effect-imports.md
+++ b/.changeset/remove-unstable-css-side-effect-imports.md
@@ -1,8 +1,0 @@
----
-"@remix-run/dev": major
-"@remix-run/react": major
-"@remix-run/server-runtime": major
-"@remix-run/testing": major
----
-
-Remove `unstable_cssSideEffectImports` option. CSS side-effect imports are now supported automatically.

--- a/.changeset/remove-unstable-postcss.md
+++ b/.changeset/remove-unstable-postcss.md
@@ -1,8 +1,0 @@
----
-"@remix-run/dev": major
-"@remix-run/react": major
-"@remix-run/server-runtime": major
-"@remix-run/testing": major
----
-
-Remove `unstable_postcss` option. CSS files are now automatically processed using PostCSS if `postcss.config.js` is present. If needed, this feature can be disabled by setting the `postcss` option to `false` in `remix.config.js`.

--- a/.changeset/remove-unstable-tailwind.md
+++ b/.changeset/remove-unstable-tailwind.md
@@ -1,8 +1,0 @@
----
-"@remix-run/dev": major
-"@remix-run/react": major
-"@remix-run/server-runtime": major
-"@remix-run/testing": major
----
-
-Remove `unstable_tailwind` option. Tailwind functions and directives are now automatically supported in CSS files if `tailwindcss` is installed. If needed, this feature can be disabled by setting the `tailwind` option to `false` in `remix.config.js`.

--- a/.changeset/remove-unstable-vanilla-extract.md
+++ b/.changeset/remove-unstable-vanilla-extract.md
@@ -1,8 +1,0 @@
----
-"@remix-run/dev": major
-"@remix-run/react": major
-"@remix-run/server-runtime": major
-"@remix-run/testing": major
----
-
-Remove `unstable_vanillaExtract` option. Vanilla Extract is now supported automatically.

--- a/.changeset/tailwind-enabled-by-default.md
+++ b/.changeset/tailwind-enabled-by-default.md
@@ -1,0 +1,49 @@
+---
+"@remix-run/dev": major
+"@remix-run/react": major
+"@remix-run/server-runtime": major
+---
+
+Tailwind support is now enabled by default if a Tailwind config file is present at the root of your project.
+
+If you already have a custom Tailwind setup that you'd like to maintain, you can disable this behavior by setting the `tailwind` option to `false` in `remix.config.js`.
+
+Otherwise, if you followed the original Tailwind setup guide for Remix and want to make use of this feature, you should first delete the generated `app/tailwind.css`.
+
+Then, if you have a `styles/tailwind.css` file, you should move it to `app/tailwind.css`.
+
+```sh
+rm app/tailwind.css
+mv styles/tailwind.css app/tailwind.css
+```
+
+If you don't already have an `app/tailwind.css` file, you should create one with the following contents:
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+You should then remove `/app/tailwind.css` from your `.gitignore` file since it now contains source code rather than processed output.
+
+You can then update your `package.json` scripts to remove any usage of `tailwindcss` since Remix handles this automatically. For example, if you had followed the original setup guide:
+
+```diff
+{
+  // ...
+  "scripts": {
+-    "build": "run-s \"build:*\"",
++    "build": "remix build",
+-    "build:css": "npm run generate:css -- --minify",
+-    "build:remix": "remix build",
+-    "dev": "run-p \"dev:*\"",
++    "dev": "remix dev",
+-    "dev:css": "npm run generate:css -- --watch",
+-    "dev:remix": "remix dev",
+-    "generate:css": "npx tailwindcss -o ./app/tailwind.css",
+    "start": "remix-serve build"
+  }
+  // ...
+}
+```


### PR DESCRIPTION
This PR updates the v2 changests to reflect changes made in v1 — namely that the `postcss` and `tailwind` options are being added (disabled by default) and that CSS bundling features are being enabled.