### PR TITLE
docs(pages/v2): Fix navigation formAction in v2 documentation page

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -77,6 +77,7 @@
 - chenc041
 - chenxsan
 - chiangs
+- chimame
 - chipit24
 - chohner
 - christianhg

--- a/docs/pages/v2.md
+++ b/docs/pages/v2.md
@@ -379,7 +379,7 @@ function Component() {
     navigation.formMethod != null &&
     navigation.formMethod != "get" &&
     // We had a submission navigation and are loading the submitted location
-    navigation.formAction === navigation.pathname;
+    navigation.formAction === navigation.location.pathname;
 
   // transition.type === "actionRedirect"
   let isActionRedirect =
@@ -387,21 +387,21 @@ function Component() {
     navigation.formMethod != null &&
     navigation.formMethod != "get" &&
     // We had a submission navigation and are now navigating to different location
-    navigation.formAction !== navigation.pathname;
+    navigation.formAction !== navigation.location.pathname;
 
   // transition.type === "loaderSubmission"
   let isLoaderSubmission =
     navigation.state === "loading" &&
     navigation.state.formMethod === "get" &&
     // We had a loader submission and are navigating to the submitted location
-    navigation.formAction === navigation.pathname;
+    navigation.formAction === navigation.location.pathname;
 
   // transition.type === "loaderSubmissionRedirect"
   let isLoaderSubmissionRedirect =
     navigation.state === "loading" &&
     navigation.state.formMethod === "get" &&
     // We had a loader submission and are navigating to a new location
-    navigation.formAction !== navigation.pathname;
+    navigation.formAction !== navigation.location.pathname;
 }
 ```
 


### PR DESCRIPTION
I corrected the method for obtaining the `pathname` from `useNavigation`