### PR TITLE
feat(remix-testing): cast types to use Remix type definitions + allow passing context

### DIFF
--- a/.changeset/testing-helper-context-and-types.md
+++ b/.changeset/testing-helper-context-and-types.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/testing": patch
+---
+
+feat(remix-testing): cast types to use Remix type definitions + allow passing context

--- a/packages/remix-testing/__tests__/stub-test.tsx
+++ b/packages/remix-testing/__tests__/stub-test.tsx
@@ -67,22 +67,16 @@ test("loaders work", async () => {
 });
 
 test("can pass a predefined loader", () => {
-  async function loader({ context }: DataFunctionArgs) {
-    if (context.something) {
-      return json({ cya: "later" });
-    }
+  async function loader(_args: DataFunctionArgs) {
     return json({ hi: "there" });
   }
 
-  unstable_createRemixStub(
-    [
-      {
-        path: "/example",
-        loader,
-      },
-    ],
-    { something: true }
-  );
+  unstable_createRemixStub([
+    {
+      path: "/example",
+      loader,
+    },
+  ]);
 });
 
 test("can pass context values", async () => {

--- a/packages/remix-testing/__tests__/stub-test.tsx
+++ b/packages/remix-testing/__tests__/stub-test.tsx
@@ -65,6 +65,33 @@ test("loaders work", async () => {
   );
 });
 
+
+test("can pass context values", async () => {
+  function App() {
+    let data = useLoaderData();
+    return <pre data-testid="data">Context: {data.context}</pre>;
+  }
+
+  let RemixStub = unstable_createRemixStub(
+    [
+      {
+        path: "/",
+        index: true,
+        element: <App />,
+        loader({ context }) {
+          return json(context);
+        },
+      },
+    ],
+    { context: "hello" }
+  );
+
+  render(<RemixStub />);
+
+  expect(await screen.findByTestId("data")).toHaveTextContent(
+    /context: hello/i
+  );
+});
 test("all routes have ids", () => {
   function Home() {
     let matches = useMatches();

--- a/packages/remix-testing/__tests__/stub-test.tsx
+++ b/packages/remix-testing/__tests__/stub-test.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { render, screen } from "@testing-library/react";
 import { unstable_createRemixStub } from "@remix-run/testing";
 import { Outlet, useLoaderData, useMatches } from "@remix-run/react";
+import type { DataFunctionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
 
 test("renders a route", () => {
@@ -65,6 +66,24 @@ test("loaders work", async () => {
   );
 });
 
+test("can pass a predefined loader", () => {
+  async function loader({ context }: DataFunctionArgs) {
+    if (context.something) {
+      return json({ cya: "later" });
+    }
+    return json({ hi: "there" });
+  }
+
+  unstable_createRemixStub(
+    [
+      {
+        path: "/example",
+        loader,
+      },
+    ],
+    { something: true }
+  );
+});
 
 test("can pass context values", async () => {
   function App() {
@@ -92,6 +111,7 @@ test("can pass context values", async () => {
     /context: hello/i
   );
 });
+
 test("all routes have ids", () => {
   function Home() {
     let matches = useMatches();

--- a/packages/remix-testing/__tests__/stub-test.tsx
+++ b/packages/remix-testing/__tests__/stub-test.tsx
@@ -82,26 +82,47 @@ test("can pass a predefined loader", () => {
 test("can pass context values", async () => {
   function App() {
     let data = useLoaderData();
-    return <pre data-testid="data">Context: {data.context}</pre>;
+    return (
+      <div>
+        <pre data-testid="root">Context: {data.context}</pre>;
+        <Outlet />
+      </div>
+    );
+  }
+
+  function Hello() {
+    let data = useLoaderData();
+    return <pre data-testid="hello">Context: {data.context}</pre>;
   }
 
   let RemixStub = unstable_createRemixStub(
     [
       {
         path: "/",
-        index: true,
         element: <App />,
         loader({ context }) {
           return json(context);
         },
+        children: [
+          {
+            path: "hello",
+            element: <Hello />,
+            loader({ context }) {
+              return json(context);
+            },
+          },
+        ],
       },
     ],
     { context: "hello" }
   );
 
-  render(<RemixStub />);
+  render(<RemixStub initialEntries={["/hello"]} />);
 
-  expect(await screen.findByTestId("data")).toHaveTextContent(
+  expect(await screen.findByTestId("root")).toHaveTextContent(
+    /context: hello/i
+  );
+  expect(await screen.findByTestId("hello")).toHaveTextContent(
     /context: hello/i
   );
 });

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -57,13 +57,6 @@ function patchRoutesWithContext(
   context: AppLoadContext
 ): (RouteObject | DataRouteObject)[] {
   return routes.map((route) => {
-    if (route.children) {
-      return {
-        ...route,
-        children: patchRoutesWithContext(route.children, context),
-      };
-    }
-
     if (route.loader) {
       let loader = route.loader;
       route.loader = (args) => loader({ ...args, context });
@@ -72,6 +65,13 @@ function patchRoutesWithContext(
     if (route.action) {
       let action = route.action;
       route.action = (args) => action({ ...args, context });
+    }
+
+    if (route.children) {
+      return {
+        ...route,
+        children: patchRoutesWithContext(route.children, context),
+      };
     }
 
     return route as RouteObject | DataRouteObject;


### PR DESCRIPTION
before if you tried to pass a loader/action directly to the route object it would fail as `context` is optional in RR, but required in Remix (types for each are also different, bug would remain if required), so you would have to manually pass `context: {}`

```ts
import { json, type DataFunctionArgs } from "@remix-run/node";
import { unstable_createRemixStub as createRemixStub } from "@remix-run/testing";

export async function loader(args: DataFunctionArgs) {
  return json({ hi: "there" });
}

createRemixStub([
  {
    path: "/example",
    loader: args => loader({ ...args, context: {} }),
  },
]);
```

now we're using the Remix types for loader/action, but we need to cast them on the way out back to RR for use with `createMemoryRouter`

```ts
import { json, type DataFunctionArgs } from "@remix-run/node";
import { unstable_createRemixStub as createRemixStub } from "@remix-run/testing";

export async function loader(args: DataFunctionArgs) {
  return json({ hi: "there" });
}

createRemixStub([
  {
    path: "/example",
    loader,
  },
]);
```

this PR also introduces the ability to pass `context` to your stubbed loaders/actions via a second argument to `createRemixStub`

```ts
unstable_createRemixStub(
  [
    {
      path: "/",
      index: true,
      element: <App />,
      loader({ context }) {
        return json(context);
      },
    },
  ],
  { context: "hello" }
);
```

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

closes #6054

- [ ] Docs
- [x] Tests

Testing Strategy: new tests

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
