### PR TITLE
docs(guides/typescript): add punctuation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -197,7 +197,7 @@
 - IshanKBG
 - itsMapleLeaf
 - izznatsir
-oacargentina
+- jacargentina
 - jacob-ebey
 - JacobParis
 - jakeginnivan

--- a/contributors.yml
+++ b/contributors.yml
@@ -197,7 +197,7 @@
 - IshanKBG
 - itsMapleLeaf
 - izznatsir
-- jacargentina
+oacargentina
 - jacob-ebey
 - JacobParis
 - jakeginnivan
@@ -233,6 +233,7 @@
 - johnson444
 - joms
 - joshball
+- JoshuaKGoldberg
 - jrf0110
 - jrubins
 - jsbmg

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -75,6 +75,6 @@ Remix has TypeScript type definitions built-in as well. The starter templates cr
 /// <reference types="@remix-run/node" />
 ```
 
-<docs-info>Note that the types referenced in `remix.env.d.ts` will depend on which environment you're running your app in. For example, there are different globals available in Cloudflare</docs-info>
+<docs-info>Note that the types referenced in `remix.env.d.ts` will depend on which environment you're running your app in. For example, there are different globals available in Cloudflare.</docs-info>
 
 [with-jsx]: https://www.typescriptlang.org/docs/handbook/jsx.html


### PR DESCRIPTION
Please pardon the lack of corresponding issue; I didn't see anything in https://github.com/remix-run/remix/blob/b30a61157d89f21eef1063d4dd8fca2326f9210e/docs/pages/contributing.md about it. 🙂 