### PR TITLE
feat(remix-vercel): remove `@vercel/node` from `peerDependencies`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -519,3 +519,4 @@
 - iamzee
 - TimonVS
 - yudai-nkt
+- TrySound

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "yarn@1.22.19",
   "name": "remix-monorepo",
   "private": true,
   "license": "MIT",

--- a/packages/remix-vercel/package.json
+++ b/packages/remix-vercel/package.json
@@ -23,9 +23,6 @@
     "node-mocks-http": "^1.10.1",
     "supertest": "^6.1.5"
   },
-  "peerDependencies": {
-    "@vercel/node": "^1.8.3 || ^2.4.0"
-  },
   "engines": {
     "node": ">=14"
   },

--- a/packages/remix-vercel/server.ts
+++ b/packages/remix-vercel/server.ts
@@ -1,4 +1,7 @@
-import type { VercelRequest, VercelResponse } from "@vercel/node";
+import type {
+  IncomingMessage as VercelRequest,
+  ServerResponse as VercelResponse,
+} from "node:http";
 import type {
   AppLoadContext,
   ServerBuild,


### PR DESCRIPTION
@vercel/node is a huge and quite overloaded library. It includes stale typescript version, old esbuild and own edge-runtime which is not need for most remix users.

You can see here install size https://packagephobia.com/result?p=%40vercel%2Fnode

And `@remix/vercel` use it only to import two types which are compatible with builtin node types.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy: CI should pass

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
