### PR TITLE
docs(tutorials/jokes): Use npx when calling ts-node

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -117,6 +117,7 @@
 - dima-takoy
 - dmarkow
 - DNLHC
+- dnsbty
 - dogukanakkaya
 - dokeet
 - donavon

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1508,7 +1508,7 @@ npm install --save-dev ts-node tsconfig-paths
 💿 And now we can run our `seed.ts` file with that:
 
 ```sh
-ts-node --require tsconfig-paths/register prisma/seed.ts
+npx ts-node --require tsconfig-paths/register prisma/seed.ts
 ```
 
 Now our database has those jokes in it. No joke!


### PR DESCRIPTION
Simple docs change

The jokes tutorial tells the reader to install ts-node to the project dependencies, but then to run the seed script as though it's installed globally. This just adds `npx` before the ts-node seed script command because that's needed for users (like me) who don't have ts-node installed globally. This will probably be especially helpful for those coming from a non-frontend background.