### PR TITLE
docs(pages/v2): typo heirarchy -> hierarchy

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -431,6 +431,7 @@
 - ryanflorence
 - ryanjames1729
 - ryankshaw
+- sarahse
 - sandulat
 - sbernheim4
 - schpet

--- a/docs/pages/v2.md
+++ b/docs/pages/v2.md
@@ -162,7 +162,7 @@ export function meta(args) {
 }
 ```
 
-It's important to note that this function will _not_ merge meta across the entire heirarchy by default. This is because you may have some routes that return an array of objects directly without the `metaV1` function and this could result in unpredictable behavior. If you want to merge meta across the entire heirarchy, use the `metaV1` function for all of your route's meta exports.
+It's important to note that this function will _not_ merge meta across the entire hierarchy by default. This is because you may have some routes that return an array of objects directly without the `metaV1` function and this could result in unpredictable behavior. If you want to merge meta across the entire hierarchy, use the `metaV1` function for all of your route's meta exports.
 
 #### The `parentsData` argument
 


### PR DESCRIPTION
Simple typo I noticed while reading the documentation for v2. This updates `heirarchy` to the correct spelling `hierarchy`.