### PR TITLE
templates(deno): fix `V2_MetaFunction` import

### DIFF
--- a/templates/deno/app/routes/_index.tsx
+++ b/templates/deno/app/routes/_index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import type { V2_MetaFunction } from "@remix-run/node";
+import type { V2_MetaFunction } from "@remix-run/deno";
 
 export const meta: V2_MetaFunction = () => {
   return [{ title: "New Remix App" }];


### PR DESCRIPTION
This template depends on `@remix-run/deno`, not `@remix-run/node`. Noticed this while adding the `css-bundle` boilerplate.