### PR TITLE
chore(remix-node): bump `@remix-run/web-fetch` to latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
     if: github.repository == 'remix-run/remix'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      node_version: '["19"]'
+      node_version: '["latest"]'

--- a/integration/error-data-request-test.ts
+++ b/integration/error-data-request-test.ts
@@ -129,17 +129,13 @@ test.describe("ErrorBoundary", () => {
   });
 
   test("returns a 405 x-remix-error on a data fetch with a bad method", async () => {
-    let response = await fixture.requestData(
-      `/loader-return-json`,
-      "routes/loader-return-json",
-      {
+    expect(() =>
+      fixture.requestData("/loader-return-json", "routes/loader-return-json", {
         method: "TRACE",
-      }
+      })
+    ).rejects.toThrowError(
+      `Failed to construct 'Request': 'TRACE' HTTP method is unsupported.`
     );
-    expect(response.status).toBe(405);
-    expect(response.headers.get("X-Remix-Error")).toBe("yes");
-    expect(await response.text()).toMatch("Unexpected Server Error");
-    assertConsoleError('Error: Invalid request method "TRACE"');
   });
 
   test("returns a 403 x-remix-error on a data fetch GET to a bad path", async () => {

--- a/packages/remix-architect/__tests__/server-test.ts
+++ b/packages/remix-architect/__tests__/server-test.ts
@@ -242,45 +242,8 @@ describe("architect createRemixRequest", () => {
       createMockEvent({ cookies: ["__session=value"] })
     );
 
-    expect(remixRequest).toMatchInlineSnapshot(`
-      NodeRequest {
-        "agent": undefined,
-        "compress": true,
-        "counter": 0,
-        "follow": 20,
-        "highWaterMark": 16384,
-        "insecureHTTPParser": false,
-        "size": 0,
-        Symbol(Body internals): Object {
-          "body": null,
-          "boundary": null,
-          "disturbed": false,
-          "error": null,
-          "size": 0,
-          "type": null,
-        },
-        Symbol(Request internals): Object {
-          "credentials": "same-origin",
-          "headers": Headers {},
-          "method": "GET",
-          "parsedURL": "https://localhost:3333/",
-          "redirect": "follow",
-          "signal": AbortSignal {},
-        },
-      }
-    `);
-
-    expect(remixRequest.headers.get("accept")).toBe(
-      "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
-    );
-    expect(remixRequest.headers.get("accept-encoding")).toBe("gzip, deflate");
-    expect(remixRequest.headers.get("accept-language")).toBe("en-US,en;q=0.9");
+    expect(remixRequest.method).toBe("GET");
     expect(remixRequest.headers.get("cookie")).toBe("__session=value");
-    expect(remixRequest.headers.get("host")).toBe("localhost:3333");
-    expect(remixRequest.headers.get("upgrade-insecure-requests")).toBe("1");
-    expect(remixRequest.headers.get("user-agent")).toBe(
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15"
-    );
   });
 });
 

--- a/packages/remix-architect/__tests__/server-test.ts
+++ b/packages/remix-architect/__tests__/server-test.ts
@@ -3,10 +3,6 @@ import path from "path";
 import lambdaTester from "lambda-tester";
 import type { APIGatewayProxyEventV2 } from "aws-lambda";
 import {
-  // This has been added as a global in node 15+, but we expose it here while we
-  // support Node 14
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  AbortController,
   createRequestHandler as createRemixRequestHandler,
   Response as NodeResponse,
 } from "@remix-run/node";
@@ -210,52 +206,22 @@ describe("architect createRemixHeaders", () => {
 
     it("handles simple headers", () => {
       let headers = createRemixHeaders({ "x-foo": "bar" });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "x-foo": Array [
-            "bar",
-          ],
-        }
-      `);
+      expect(headers.get("x-foo")).toBe("bar");
     });
 
     it("handles multiple headers", () => {
       let headers = createRemixHeaders({ "x-foo": "bar", "x-bar": "baz" });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "x-bar": Array [
-            "baz",
-          ],
-          "x-foo": Array [
-            "bar",
-          ],
-        }
-      `);
+      expect(headers.get("x-foo")).toBe("bar");
+      expect(headers.get("x-bar")).toBe("baz");
     });
 
     it("handles headers with multiple values", () => {
-      let headers = createRemixHeaders({ "x-foo": "bar, baz" });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "x-foo": Array [
-            "bar, baz",
-          ],
-        }
-      `);
-    });
-
-    it("handles headers with multiple values and multiple headers", () => {
-      let headers = createRemixHeaders({ "x-foo": "bar, baz", "x-bar": "baz" });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "x-bar": Array [
-            "baz",
-          ],
-          "x-foo": Array [
-            "bar, baz",
-          ],
-        }
-      `);
+      let headers = createRemixHeaders({
+        "x-foo": "bar, baz",
+        "x-bar": "baz",
+      });
+      expect(headers.getAll("x-foo")).toEqual(["bar, baz"]);
+      expect(headers.get("x-bar")).toBe("baz");
     });
 
     it("handles multiple request cookies", () => {
@@ -263,13 +229,9 @@ describe("architect createRemixHeaders", () => {
         "__session=some_value",
         "__other=some_other_value",
       ]);
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "cookie": Array [
-            "__session=some_value; __other=some_other_value",
-          ],
-        }
-      `);
+      expect(headers.getAll("cookie")).toEqual([
+        "__session=some_value; __other=some_other_value",
+      ]);
     });
   });
 });
@@ -308,31 +270,17 @@ describe("architect createRemixRequest", () => {
       }
     `);
 
-    expect(remixRequest.headers.raw()).toMatchInlineSnapshot(`
-      Object {
-        "accept": Array [
-          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        ],
-        "accept-encoding": Array [
-          "gzip, deflate",
-        ],
-        "accept-language": Array [
-          "en-US,en;q=0.9",
-        ],
-        "cookie": Array [
-          "__session=value",
-        ],
-        "host": Array [
-          "localhost:3333",
-        ],
-        "upgrade-insecure-requests": Array [
-          "1",
-        ],
-        "user-agent": Array [
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15",
-        ],
-      }
-    `);
+    expect(remixRequest.headers.get("accept")).toBe(
+      "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+    );
+    expect(remixRequest.headers.get("accept-encoding")).toBe("gzip, deflate");
+    expect(remixRequest.headers.get("accept-language")).toBe("en-US,en;q=0.9");
+    expect(remixRequest.headers.get("cookie")).toBe("__session=value");
+    expect(remixRequest.headers.get("host")).toBe("localhost:3333");
+    expect(remixRequest.headers.get("upgrade-insecure-requests")).toBe("1");
+    expect(remixRequest.headers.get("user-agent")).toBe(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15"
+    );
   });
 });
 

--- a/packages/remix-architect/__tests__/server-test.ts
+++ b/packages/remix-architect/__tests__/server-test.ts
@@ -204,86 +204,70 @@ describe("architect createRequestHandler", () => {
 describe("architect createRemixHeaders", () => {
   describe("creates fetch headers from architect headers", () => {
     it("handles empty headers", () => {
-      expect(createRemixHeaders({}, undefined)).toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [],
-          Symbol(context): null,
-        }
-      `);
+      let headers = createRemixHeaders({});
+      expect(headers.raw()).toMatchInlineSnapshot(`Object {}`);
     });
 
     it("handles simple headers", () => {
-      expect(createRemixHeaders({ "x-foo": "bar" }, undefined))
-        .toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
+      let headers = createRemixHeaders({ "x-foo": "bar" });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "x-foo": Array [
             "bar",
           ],
-          Symbol(context): null,
         }
       `);
     });
 
     it("handles multiple headers", () => {
-      expect(createRemixHeaders({ "x-foo": "bar", "x-bar": "baz" }, undefined))
-        .toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
-            "bar",
-            "x-bar",
+      let headers = createRemixHeaders({ "x-foo": "bar", "x-bar": "baz" });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "x-bar": Array [
             "baz",
           ],
-          Symbol(context): null,
+          "x-foo": Array [
+            "bar",
+          ],
         }
       `);
     });
 
     it("handles headers with multiple values", () => {
-      expect(createRemixHeaders({ "x-foo": "bar, baz" }, undefined))
-        .toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
+      let headers = createRemixHeaders({ "x-foo": "bar, baz" });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "x-foo": Array [
             "bar, baz",
           ],
-          Symbol(context): null,
         }
       `);
     });
 
     it("handles headers with multiple values and multiple headers", () => {
-      expect(
-        createRemixHeaders({ "x-foo": "bar, baz", "x-bar": "baz" }, undefined)
-      ).toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
-            "bar, baz",
-            "x-bar",
+      let headers = createRemixHeaders({ "x-foo": "bar, baz", "x-bar": "baz" });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "x-bar": Array [
             "baz",
           ],
-          Symbol(context): null,
+          "x-foo": Array [
+            "bar, baz",
+          ],
         }
       `);
     });
 
-    it("handles cookies", () => {
-      expect(
-        createRemixHeaders({ "x-something-else": "true" }, [
-          "__session=some_value",
-          "__other=some_other_value",
-        ])
-      ).toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-something-else",
-            "true",
-            "cookie",
+    it("handles multiple request cookies", () => {
+      let headers = createRemixHeaders({}, [
+        "__session=some_value",
+        "__other=some_other_value",
+      ]);
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "cookie": Array [
             "__session=some_value; __other=some_other_value",
           ],
-          Symbol(context): null,
         }
       `);
     });
@@ -292,13 +276,11 @@ describe("architect createRemixHeaders", () => {
 
 describe("architect createRemixRequest", () => {
   it("creates a request with the correct headers", () => {
-    expect(
-      createRemixRequest(
-        createMockEvent({
-          cookies: ["__session=value"],
-        })
-      )
-    ).toMatchInlineSnapshot(`
+    let remixRequest = createRemixRequest(
+      createMockEvent({ cookies: ["__session=value"] })
+    );
+
+    expect(remixRequest).toMatchInlineSnapshot(`
       NodeRequest {
         "agent": undefined,
         "compress": true,
@@ -317,30 +299,38 @@ describe("architect createRemixRequest", () => {
         },
         Symbol(Request internals): Object {
           "credentials": "same-origin",
-          "headers": Headers {
-            Symbol(query): Array [
-              "accept",
-              "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-              "accept-encoding",
-              "gzip, deflate",
-              "accept-language",
-              "en-US,en;q=0.9",
-              "cookie",
-              "__session=value",
-              "host",
-              "localhost:3333",
-              "upgrade-insecure-requests",
-              "1",
-              "user-agent",
-              "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15",
-            ],
-            Symbol(context): null,
-          },
+          "headers": Headers {},
           "method": "GET",
           "parsedURL": "https://localhost:3333/",
           "redirect": "follow",
           "signal": AbortSignal {},
         },
+      }
+    `);
+
+    expect(remixRequest.headers.raw()).toMatchInlineSnapshot(`
+      Object {
+        "accept": Array [
+          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        ],
+        "accept-encoding": Array [
+          "gzip, deflate",
+        ],
+        "accept-language": Array [
+          "en-US,en;q=0.9",
+        ],
+        "cookie": Array [
+          "__session=value",
+        ],
+        "host": Array [
+          "localhost:3333",
+        ],
+        "upgrade-insecure-requests": Array [
+          "1",
+        ],
+        "user-agent": Array [
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15",
+        ],
       }
     `);
   });

--- a/packages/remix-express/__tests__/server-test.ts
+++ b/packages/remix-express/__tests__/server-test.ts
@@ -163,43 +163,22 @@ describe("express createRemixHeaders", () => {
 
     it("handles simple headers", () => {
       let headers = createRemixHeaders({ "x-foo": "bar" });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "x-foo": Array [
-            "bar",
-          ],
-        }
-      `);
+      expect(headers.get("x-foo")).toBe("bar");
     });
 
     it("handles multiple headers", () => {
       let headers = createRemixHeaders({ "x-foo": "bar", "x-bar": "baz" });
-      expect(headers).toMatchInlineSnapshot(`Headers {}`);
+      expect(headers.get("x-foo")).toBe("bar");
+      expect(headers.get("x-bar")).toBe("baz");
     });
 
     it("handles headers with multiple values", () => {
-      let headers = createRemixHeaders({ "x-foo": "bar, baz" });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "x-foo": Array [
-            "bar, baz",
-          ],
-        }
-      `);
-    });
-
-    it("handles headers with multiple values and multiple headers", () => {
-      let headers = createRemixHeaders({ "x-foo": "bar, baz", "x-bar": "baz" });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "x-bar": Array [
-            "baz",
-          ],
-          "x-foo": Array [
-            "bar, baz",
-          ],
-        }
-      `);
+      let headers = createRemixHeaders({
+        "x-foo": ["bar", "baz"],
+        "x-bar": "baz",
+      });
+      expect(headers.getAll("x-foo")).toEqual(["bar", "baz"]);
+      expect(headers.get("x-bar")).toBe("baz");
     });
 
     it("handles multiple set-cookie headers", () => {
@@ -209,14 +188,10 @@ describe("express createRemixHeaders", () => {
           "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
         ],
       });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "set-cookie": Array [
-            "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
-            "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
-          ],
-        }
-      `);
+      expect(headers.getAll("set-cookie")).toEqual([
+        "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
+        "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
+      ]);
     });
   });
 });
@@ -265,15 +240,9 @@ describe("express createRemixRequest", () => {
       }
     `);
 
-    expect(remixRequest.headers.raw()).toMatchInlineSnapshot(`
-      Object {
-        "cache-control": Array [
-          "max-age=300, s-maxage=3600",
-        ],
-        "host": Array [
-          "localhost:3000",
-        ],
-      }
-    `);
+    expect(remixRequest.headers.get("cache-control")).toBe(
+      "max-age=300, s-maxage=3600"
+    );
+    expect(remixRequest.headers.get("host")).toBe("localhost:3000");
   });
 });

--- a/packages/remix-express/__tests__/server-test.ts
+++ b/packages/remix-express/__tests__/server-test.ts
@@ -107,9 +107,7 @@ describe("express createRequestHandler", () => {
       });
 
       let request = supertest(createApp());
-      // note: vercel's createServerWithHelpers requires a x-now-bridge-request-id
-      let res = await request.get("/").set({ "x-now-bridge-request-id": "2" });
-
+      let res = await request.get("/");
       expect(res.status).toBe(200);
       expect(res.text).toBe("hello world");
     });
@@ -159,86 +157,64 @@ describe("express createRequestHandler", () => {
 describe("express createRemixHeaders", () => {
   describe("creates fetch headers from express headers", () => {
     it("handles empty headers", () => {
-      expect(createRemixHeaders({})).toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [],
-          Symbol(context): null,
-        }
-      `);
+      let headers = createRemixHeaders({});
+      expect(headers.raw()).toMatchInlineSnapshot(`Object {}`);
     });
 
     it("handles simple headers", () => {
-      expect(createRemixHeaders({ "x-foo": "bar" })).toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
+      let headers = createRemixHeaders({ "x-foo": "bar" });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "x-foo": Array [
             "bar",
           ],
-          Symbol(context): null,
         }
       `);
     });
 
     it("handles multiple headers", () => {
-      expect(createRemixHeaders({ "x-foo": "bar", "x-bar": "baz" }))
-        .toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
-            "bar",
-            "x-bar",
-            "baz",
-          ],
-          Symbol(context): null,
-        }
-      `);
+      let headers = createRemixHeaders({ "x-foo": "bar", "x-bar": "baz" });
+      expect(headers).toMatchInlineSnapshot(`Headers {}`);
     });
 
     it("handles headers with multiple values", () => {
-      expect(createRemixHeaders({ "x-foo": "bar, baz" }))
-        .toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
+      let headers = createRemixHeaders({ "x-foo": "bar, baz" });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "x-foo": Array [
             "bar, baz",
           ],
-          Symbol(context): null,
         }
       `);
     });
 
     it("handles headers with multiple values and multiple headers", () => {
-      expect(createRemixHeaders({ "x-foo": "bar, baz", "x-bar": "baz" }))
-        .toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
-            "bar, baz",
-            "x-bar",
+      let headers = createRemixHeaders({ "x-foo": "bar, baz", "x-bar": "baz" });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "x-bar": Array [
             "baz",
           ],
-          Symbol(context): null,
+          "x-foo": Array [
+            "bar, baz",
+          ],
         }
       `);
     });
 
     it("handles multiple set-cookie headers", () => {
-      expect(
-        createRemixHeaders({
-          "set-cookie": [
+      let headers = createRemixHeaders({
+        "set-cookie": [
+          "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
+          "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
+        ],
+      });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "set-cookie": Array [
             "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
-            "__other=some_other_value; Path=/; Secure; HttpOnly; MaxAge=3600; SameSite=Lax",
+            "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
           ],
-        })
-      ).toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "set-cookie",
-            "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
-            "set-cookie",
-            "__other=some_other_value; Path=/; Secure; HttpOnly; MaxAge=3600; SameSite=Lax",
-          ],
-          Symbol(context): null,
         }
       `);
     });
@@ -259,8 +235,9 @@ describe("express createRemixRequest", () => {
     });
     let expressResponse = createResponse();
 
-    expect(createRemixRequest(expressRequest, expressResponse))
-      .toMatchInlineSnapshot(`
+    let remixRequest = createRemixRequest(expressRequest, expressResponse);
+
+    expect(remixRequest).toMatchInlineSnapshot(`
       NodeRequest {
         "agent": undefined,
         "compress": true,
@@ -279,20 +256,23 @@ describe("express createRemixRequest", () => {
         },
         Symbol(Request internals): Object {
           "credentials": "same-origin",
-          "headers": Headers {
-            Symbol(query): Array [
-              "cache-control",
-              "max-age=300, s-maxage=3600",
-              "host",
-              "localhost:3000",
-            ],
-            Symbol(context): null,
-          },
+          "headers": Headers {},
           "method": "GET",
           "parsedURL": "http://localhost:3000/foo/bar",
           "redirect": "follow",
           "signal": AbortSignal {},
         },
+      }
+    `);
+
+    expect(remixRequest.headers.raw()).toMatchInlineSnapshot(`
+      Object {
+        "cache-control": Array [
+          "max-age=300, s-maxage=3600",
+        ],
+        "host": Array [
+          "localhost:3000",
+        ],
       }
     `);
   });

--- a/packages/remix-express/__tests__/server-test.ts
+++ b/packages/remix-express/__tests__/server-test.ts
@@ -212,34 +212,7 @@ describe("express createRemixRequest", () => {
 
     let remixRequest = createRemixRequest(expressRequest, expressResponse);
 
-    expect(remixRequest).toMatchInlineSnapshot(`
-      NodeRequest {
-        "agent": undefined,
-        "compress": true,
-        "counter": 0,
-        "follow": 20,
-        "highWaterMark": 16384,
-        "insecureHTTPParser": false,
-        "size": 0,
-        Symbol(Body internals): Object {
-          "body": null,
-          "boundary": null,
-          "disturbed": false,
-          "error": null,
-          "size": 0,
-          "type": null,
-        },
-        Symbol(Request internals): Object {
-          "credentials": "same-origin",
-          "headers": Headers {},
-          "method": "GET",
-          "parsedURL": "http://localhost:3000/foo/bar",
-          "redirect": "follow",
-          "signal": AbortSignal {},
-        },
-      }
-    `);
-
+    expect(remixRequest.method).toBe("GET");
     expect(remixRequest.headers.get("cache-control")).toBe(
       "max-age=300, s-maxage=3600"
     );

--- a/packages/remix-netlify/__tests__/server-test.ts
+++ b/packages/remix-netlify/__tests__/server-test.ts
@@ -266,34 +266,7 @@ describe("netlify createRemixRequest", () => {
       createMockEvent({ multiValueHeaders: { Cookie: ["__session=value"] } })
     );
 
-    expect(remixRequest).toMatchInlineSnapshot(`
-      NodeRequest {
-        "agent": undefined,
-        "compress": true,
-        "counter": 0,
-        "follow": 20,
-        "highWaterMark": 16384,
-        "insecureHTTPParser": false,
-        "size": 0,
-        Symbol(Body internals): Object {
-          "body": null,
-          "boundary": null,
-          "disturbed": false,
-          "error": null,
-          "size": 0,
-          "type": null,
-        },
-        Symbol(Request internals): Object {
-          "credentials": "same-origin",
-          "headers": Headers {},
-          "method": "GET",
-          "parsedURL": "http://localhost:3000/",
-          "redirect": "follow",
-          "signal": AbortSignal {},
-        },
-      }
-    `);
-
+    expect(remixRequest.method).toBe("GET");
     expect(remixRequest.headers.get("cookie")).toBe("__session=value");
   });
 });

--- a/packages/remix-netlify/__tests__/server-test.ts
+++ b/packages/remix-netlify/__tests__/server-test.ts
@@ -221,94 +221,78 @@ describe("netlify createRequestHandler", () => {
 describe("netlify createRemixHeaders", () => {
   describe("creates fetch headers from netlify headers", () => {
     it("handles empty headers", () => {
-      expect(createRemixHeaders({})).toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [],
-          Symbol(context): null,
-        }
-      `);
+      let headers = createRemixHeaders({});
+      expect(headers.raw()).toMatchInlineSnapshot(`Object {}`);
     });
 
     it("handles simple headers", () => {
-      expect(createRemixHeaders({ "x-foo": ["bar"] })).toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
+      let headers = createRemixHeaders({ "x-foo": ["bar"] });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "x-foo": Array [
             "bar",
           ],
-          Symbol(context): null,
         }
       `);
     });
 
     it("handles multiple headers", () => {
-      expect(createRemixHeaders({ "x-foo": ["bar"], "x-bar": ["baz"] }))
-        .toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
-            "bar",
-            "x-bar",
+      let headers = createRemixHeaders({ "x-foo": ["bar"], "x-bar": ["baz"] });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "x-bar": Array [
             "baz",
           ],
-          Symbol(context): null,
+          "x-foo": Array [
+            "bar",
+          ],
         }
       `);
     });
 
     it("handles headers with multiple values", () => {
-      expect(createRemixHeaders({ "x-foo": ["bar", "baz"] }))
-        .toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
+      let headers = createRemixHeaders({ "x-foo": ["bar", "baz"] });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "x-foo": Array [
             "bar",
-            "x-foo",
             "baz",
           ],
-          Symbol(context): null,
         }
       `);
     });
 
     it("handles headers with multiple values and multiple headers", () => {
-      expect(createRemixHeaders({ "x-foo": ["bar", "baz"], "x-bar": ["baz"] }))
-        .toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
-            "bar",
-            "x-foo",
-            "baz",
-            "x-bar",
+      let headers = createRemixHeaders({
+        "x-foo": ["bar", "baz"],
+        "x-bar": ["baz"],
+      });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "x-bar": Array [
             "baz",
           ],
-          Symbol(context): null,
+          "x-foo": Array [
+            "bar",
+            "baz",
+          ],
         }
       `);
     });
 
-    it("handles cookies", () => {
-      expect(
-        createRemixHeaders({
-          Cookie: [
+    it("handles multiple set-cookie headers", () => {
+      let headers = createRemixHeaders({
+        "set-cookie": [
+          "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
+          "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
+        ],
+      });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "set-cookie": Array [
             "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
             "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
           ],
-
-          "x-something-else": ["true"],
-        })
-      ).toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "cookie",
-            "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
-            "cookie",
-            "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
-            "x-something-else",
-            "true",
-          ],
-          Symbol(context): null,
         }
       `);
     });
@@ -317,15 +301,14 @@ describe("netlify createRemixHeaders", () => {
 
 describe("netlify createRemixRequest", () => {
   it("creates a request with the correct headers", () => {
-    expect(
-      createRemixRequest(
-        createMockEvent({
-          multiValueHeaders: {
-            Cookie: ["__session=value", "__other=value"],
-          },
-        })
-      )
-    ).toMatchInlineSnapshot(`
+    let remixRequest = createRemixRequest(
+      createMockEvent({
+        multiValueHeaders: {
+          Cookie: ["__session=value", "__other=value"],
+        },
+      })
+    );
+    expect(remixRequest).toMatchInlineSnapshot(`
       NodeRequest {
         "agent": undefined,
         "compress": true,
@@ -344,20 +327,20 @@ describe("netlify createRemixRequest", () => {
         },
         Symbol(Request internals): Object {
           "credentials": "same-origin",
-          "headers": Headers {
-            Symbol(query): Array [
-              "cookie",
-              "__session=value",
-              "cookie",
-              "__other=value",
-            ],
-            Symbol(context): null,
-          },
+          "headers": Headers {},
           "method": "GET",
           "parsedURL": "http://localhost:3000/",
           "redirect": "follow",
           "signal": AbortSignal {},
         },
+      }
+    `);
+    expect(remixRequest.headers.raw()).toMatchInlineSnapshot(`
+      Object {
+        "cookie": Array [
+          "__session=value",
+          "__other=value",
+        ],
       }
     `);
   });

--- a/packages/remix-netlify/__tests__/server-test.ts
+++ b/packages/remix-netlify/__tests__/server-test.ts
@@ -227,57 +227,22 @@ describe("netlify createRemixHeaders", () => {
 
     it("handles simple headers", () => {
       let headers = createRemixHeaders({ "x-foo": ["bar"] });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "x-foo": Array [
-            "bar",
-          ],
-        }
-      `);
+      expect(headers.get("x-foo")).toBe("bar");
     });
 
     it("handles multiple headers", () => {
       let headers = createRemixHeaders({ "x-foo": ["bar"], "x-bar": ["baz"] });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "x-bar": Array [
-            "baz",
-          ],
-          "x-foo": Array [
-            "bar",
-          ],
-        }
-      `);
+      expect(headers.get("x-foo")).toBe("bar");
+      expect(headers.get("x-bar")).toBe("baz");
     });
 
     it("handles headers with multiple values", () => {
-      let headers = createRemixHeaders({ "x-foo": ["bar", "baz"] });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "x-foo": Array [
-            "bar",
-            "baz",
-          ],
-        }
-      `);
-    });
-
-    it("handles headers with multiple values and multiple headers", () => {
       let headers = createRemixHeaders({
         "x-foo": ["bar", "baz"],
         "x-bar": ["baz"],
       });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "x-bar": Array [
-            "baz",
-          ],
-          "x-foo": Array [
-            "bar",
-            "baz",
-          ],
-        }
-      `);
+      expect(headers.getAll("x-foo")).toEqual(["bar", "baz"]);
+      expect(headers.get("x-bar")).toBe("baz");
     });
 
     it("handles multiple set-cookie headers", () => {
@@ -287,14 +252,10 @@ describe("netlify createRemixHeaders", () => {
           "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
         ],
       });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "set-cookie": Array [
-            "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
-            "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
-          ],
-        }
-      `);
+      expect(headers.getAll("set-cookie")).toEqual([
+        "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
+        "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
+      ]);
     });
   });
 });
@@ -302,12 +263,9 @@ describe("netlify createRemixHeaders", () => {
 describe("netlify createRemixRequest", () => {
   it("creates a request with the correct headers", () => {
     let remixRequest = createRemixRequest(
-      createMockEvent({
-        multiValueHeaders: {
-          Cookie: ["__session=value", "__other=value"],
-        },
-      })
+      createMockEvent({ multiValueHeaders: { Cookie: ["__session=value"] } })
     );
+
     expect(remixRequest).toMatchInlineSnapshot(`
       NodeRequest {
         "agent": undefined,
@@ -335,14 +293,8 @@ describe("netlify createRemixRequest", () => {
         },
       }
     `);
-    expect(remixRequest.headers.raw()).toMatchInlineSnapshot(`
-      Object {
-        "cookie": Array [
-          "__session=value",
-          "__other=value",
-        ],
-      }
-    `);
+
+    expect(remixRequest.headers.get("cookie")).toBe("__session=value");
   });
 });
 

--- a/packages/remix-node/package.json
+++ b/packages/remix-node/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "@remix-run/server-runtime": "1.15.0",
-    "@remix-run/web-fetch": "^4.3.2",
+    "@remix-run/web-fetch": "^4.3.4",
     "@remix-run/web-file": "^3.0.2",
     "@remix-run/web-stream": "^1.0.3",
     "@web3-storage/multipart-parser": "^1.0.0",

--- a/packages/remix-vercel/__tests__/server-test.ts
+++ b/packages/remix-vercel/__tests__/server-test.ts
@@ -224,34 +224,7 @@ describe("vercel createRemixRequest", () => {
 
     let remixRequest = createRemixRequest(request, response);
 
-    expect(remixRequest).toMatchInlineSnapshot(`
-      NodeRequest {
-        "agent": undefined,
-        "compress": true,
-        "counter": 0,
-        "follow": 20,
-        "highWaterMark": 16384,
-        "insecureHTTPParser": false,
-        "size": 0,
-        Symbol(Body internals): Object {
-          "body": null,
-          "boundary": null,
-          "disturbed": false,
-          "error": null,
-          "size": 0,
-          "type": null,
-        },
-        Symbol(Request internals): Object {
-          "credentials": "same-origin",
-          "headers": Headers {},
-          "method": "GET",
-          "parsedURL": "http://localhost:3000/foo/bar",
-          "redirect": "follow",
-          "signal": AbortSignal {},
-        },
-      }
-    `);
-
+    expect(remixRequest.method).toBe("GET");
     expect(remixRequest.headers.get("cache-control")).toBe(
       "max-age=300, s-maxage=3600"
     );

--- a/packages/remix-vercel/__tests__/server-test.ts
+++ b/packages/remix-vercel/__tests__/server-test.ts
@@ -170,86 +170,73 @@ describe("vercel createRequestHandler", () => {
 describe("vercel createRemixHeaders", () => {
   describe("creates fetch headers from vercel headers", () => {
     it("handles empty headers", () => {
-      expect(createRemixHeaders({})).toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [],
-          Symbol(context): null,
-        }
-      `);
+      let headers = createRemixHeaders({});
+      expect(headers.raw()).toMatchInlineSnapshot(`Object {}`);
     });
 
     it("handles simple headers", () => {
-      expect(createRemixHeaders({ "x-foo": "bar" })).toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
+      let headers = createRemixHeaders({ "x-foo": "bar" });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "x-foo": Array [
             "bar",
           ],
-          Symbol(context): null,
         }
       `);
     });
 
     it("handles multiple headers", () => {
-      expect(createRemixHeaders({ "x-foo": "bar", "x-bar": "baz" }))
-        .toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
-            "bar",
-            "x-bar",
+      let headers = createRemixHeaders({ "x-foo": "bar", "x-bar": "baz" });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "x-bar": Array [
             "baz",
           ],
-          Symbol(context): null,
+          "x-foo": Array [
+            "bar",
+          ],
         }
       `);
     });
 
     it("handles headers with multiple values", () => {
-      expect(createRemixHeaders({ "x-foo": "bar, baz" }))
-        .toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
+      let headers = createRemixHeaders({ "x-foo": "bar, baz" });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "x-foo": Array [
             "bar, baz",
           ],
-          Symbol(context): null,
         }
       `);
     });
 
     it("handles headers with multiple values and multiple headers", () => {
-      expect(createRemixHeaders({ "x-foo": "bar, baz", "x-bar": "baz" }))
-        .toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "x-foo",
-            "bar, baz",
-            "x-bar",
+      let headers = createRemixHeaders({ "x-foo": "bar, baz", "x-bar": "baz" });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "x-bar": Array [
             "baz",
           ],
-          Symbol(context): null,
+          "x-foo": Array [
+            "bar, baz",
+          ],
         }
       `);
     });
 
     it("handles multiple set-cookie headers", () => {
-      expect(
-        createRemixHeaders({
-          "set-cookie": [
+      let headers = createRemixHeaders({
+        "set-cookie": [
+          "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
+          "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
+        ],
+      });
+      expect(headers.raw()).toMatchInlineSnapshot(`
+        Object {
+          "set-cookie": Array [
             "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
-            "__other=some_other_value; Path=/; Secure; HttpOnly; MaxAge=3600; SameSite=Lax",
+            "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
           ],
-        })
-      ).toMatchInlineSnapshot(`
-        Headers {
-          Symbol(query): Array [
-            "set-cookie",
-            "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
-            "set-cookie",
-            "__other=some_other_value; Path=/; Secure; HttpOnly; MaxAge=3600; SameSite=Lax",
-          ],
-          Symbol(context): null,
         }
       `);
     });
@@ -269,7 +256,9 @@ describe("vercel createRemixRequest", () => {
     }) as VercelRequest;
     let response = createResponse() as unknown as VercelResponse;
 
-    expect(createRemixRequest(request, response)).toMatchInlineSnapshot(`
+    let remixRequest = createRemixRequest(request, response);
+
+    expect(remixRequest).toMatchInlineSnapshot(`
       NodeRequest {
         "agent": undefined,
         "compress": true,
@@ -288,22 +277,26 @@ describe("vercel createRemixRequest", () => {
         },
         Symbol(Request internals): Object {
           "credentials": "same-origin",
-          "headers": Headers {
-            Symbol(query): Array [
-              "cache-control",
-              "max-age=300, s-maxage=3600",
-              "x-forwarded-host",
-              "localhost:3000",
-              "x-forwarded-proto",
-              "http",
-            ],
-            Symbol(context): null,
-          },
+          "headers": Headers {},
           "method": "GET",
           "parsedURL": "http://localhost:3000/foo/bar",
           "redirect": "follow",
           "signal": AbortSignal {},
         },
+      }
+    `);
+
+    expect(remixRequest.headers.raw()).toMatchInlineSnapshot(`
+      Object {
+        "cache-control": Array [
+          "max-age=300, s-maxage=3600",
+        ],
+        "x-forwarded-host": Array [
+          "localhost:3000",
+        ],
+        "x-forwarded-proto": Array [
+          "http",
+        ],
       }
     `);
   });

--- a/packages/remix-vercel/__tests__/server-test.ts
+++ b/packages/remix-vercel/__tests__/server-test.ts
@@ -176,52 +176,22 @@ describe("vercel createRemixHeaders", () => {
 
     it("handles simple headers", () => {
       let headers = createRemixHeaders({ "x-foo": "bar" });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "x-foo": Array [
-            "bar",
-          ],
-        }
-      `);
+      expect(headers.get("x-foo")).toBe("bar");
     });
 
     it("handles multiple headers", () => {
       let headers = createRemixHeaders({ "x-foo": "bar", "x-bar": "baz" });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "x-bar": Array [
-            "baz",
-          ],
-          "x-foo": Array [
-            "bar",
-          ],
-        }
-      `);
+      expect(headers.get("x-foo")).toBe("bar");
+      expect(headers.get("x-bar")).toBe("baz");
     });
 
     it("handles headers with multiple values", () => {
-      let headers = createRemixHeaders({ "x-foo": "bar, baz" });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "x-foo": Array [
-            "bar, baz",
-          ],
-        }
-      `);
-    });
-
-    it("handles headers with multiple values and multiple headers", () => {
-      let headers = createRemixHeaders({ "x-foo": "bar, baz", "x-bar": "baz" });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "x-bar": Array [
-            "baz",
-          ],
-          "x-foo": Array [
-            "bar, baz",
-          ],
-        }
-      `);
+      let headers = createRemixHeaders({
+        "x-foo": ["bar", "baz"],
+        "x-bar": "baz",
+      });
+      expect(headers.getAll("x-foo")).toEqual(["bar", "baz"]);
+      expect(headers.getAll("x-bar")).toEqual(["baz"]);
     });
 
     it("handles multiple set-cookie headers", () => {
@@ -231,14 +201,10 @@ describe("vercel createRemixHeaders", () => {
           "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
         ],
       });
-      expect(headers.raw()).toMatchInlineSnapshot(`
-        Object {
-          "set-cookie": Array [
-            "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
-            "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
-          ],
-        }
-      `);
+      expect(headers.getAll("set-cookie")).toEqual([
+        "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
+        "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
+      ]);
     });
   });
 });
@@ -286,18 +252,10 @@ describe("vercel createRemixRequest", () => {
       }
     `);
 
-    expect(remixRequest.headers.raw()).toMatchInlineSnapshot(`
-      Object {
-        "cache-control": Array [
-          "max-age=300, s-maxage=3600",
-        ],
-        "x-forwarded-host": Array [
-          "localhost:3000",
-        ],
-        "x-forwarded-proto": Array [
-          "http",
-        ],
-      }
-    `);
+    expect(remixRequest.headers.get("cache-control")).toBe(
+      "max-age=300, s-maxage=3600"
+    );
+    expect(remixRequest.headers.get("x-forwarded-host")).toBe("localhost:3000");
+    expect(remixRequest.headers.get("x-forwarded-proto")).toBe("http");
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2480,10 +2480,10 @@
     "@remix-run/web-stream" "^1.0.0"
     web-encoding "1.1.5"
 
-"@remix-run/web-fetch@^4.3.2":
-  version "4.3.2"
-  resolved "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.3.2.tgz"
-  integrity sha512-aRNaaa0Fhyegv/GkJ/qsxMhXvyWGjPNgCKrStCvAvV1XXphntZI0nQO/Fl02LIQg3cGL8lDiOXOS1gzqDOlG5w==
+"@remix-run/web-fetch@^4.3.4":
+  version "4.3.4"
+  resolved "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.3.4.tgz#6149582fa2199b8e2a35d4e653ba05772bd0e675"
+  integrity sha512-AUM1XBa4hcgeNt2CD86OlB5aDLlqdMl0uJ+89R8dPGx07I5BwMXnbopCaPAkvSBIoHeT/IoLWIuZrLi7RvXS+Q==
   dependencies:
     "@remix-run/web-blob" "^3.0.4"
     "@remix-run/web-form-data" "^3.0.3"


### PR DESCRIPTION
fixes `TypeError: Value of "this" must be of type URLSearchParams` on Node 20

looks like node 20 also changes how our Headers polyfill is rendered via jest's `toMatchInlineSnapshot` as this is the result of tests
```diff
- "headers": Headers {
-   Symbol(query): Array [
-     "cache-control",
-     "max-age=300, s-maxage=3600",
-     "x-forwarded-host",
-     "localhost:3000",
-     "x-forwarded-proto",
-     "http",
-   ],
-   Symbol(context): null,
- },
+ "headers": Headers {},
```

<details>
<img width="300px" src="https://user-images.githubusercontent.com/11698668/234115621-e0ff827a-f200-4658-848c-ed4dc929e0a2.jpeg" />
<img width="300px" src="https://user-images.githubusercontent.com/11698668/234116355-67cd7b2e-6bd5-49b0-bb83-757825ab7a90.jpeg" />
</details>

---

Closes #6118