### PR TITLE
Add an explicit .file extension loader

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -429,6 +429,7 @@
 - ryanflorence
 - ryanjames1729
 - ryankshaw
+- ryanwilsonperkin
 - sandulat
 - sbernheim4
 - schpet

--- a/packages/remix-dev/compiler/utils/loaders.ts
+++ b/packages/remix-dev/compiler/utils/loaders.ts
@@ -8,6 +8,9 @@ export const loaders: { [ext: string]: esbuild.Loader } = {
   ".csv": "file",
   ".eot": "file",
   ".fbx": "file",
+  // Any extension type that isn't explicitly supported here can 
+  // be loaded as a file by using the .file extension
+  ".file": "file",
   ".flac": "file",
   ".gif": "file",
   ".glb": "file",


### PR DESCRIPTION


<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Workaround for https://github.com/remix-run/remix/discussions/4549

As a shortcut around the proposal to use custom import assertions (https://github.com/remix-run/remix/discussions/4549) we can use a .file extension in the list of loaders to allow people to load whatever file types they'd like by adding a `.file` suffix on their file name

