### PR TITLE
docs(guides/streaming): remove text about AWS Lambda not supporting streaming

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -185,6 +185,7 @@
 - houmark
 - humphd
 - hzhu
+- harshmangalam
 - IAmLuisJ
 - ianduvall
 - ikarus-akhil

--- a/docs/guides/streaming.md
+++ b/docs/guides/streaming.md
@@ -7,7 +7,7 @@ description: When, why, and how to stream with React 18 and Remix's deferred API
 
 Remix supports the [web streaming API][web-streaming-api] as a first-class citizen. Additionally, JavaScript server runtimes have support for streaming responses to the client.
 
-<docs-warning>NOTE: Deferred UX goals rely on streaming responses. Some popular hosts do not support streaming responses. In general, any host built around AWS Lambda does not support streaming and any bare metal / VM provider will. Make sure your hosting platform supports before using this API.</docs-warning>
+<docs-warning>NOTE: Deferred UX goals rely on streaming responses. Some popular hosts do not support streaming responses. In general, any bare metal / VM provider will support streaming. Make sure your hosting platform supports before using this API.</docs-warning>
 
 ## The problem
 


### PR DESCRIPTION
https://aws.amazon.com/blogs/compute/introducing-aws-lambda-response-streaming