### PR TITLE
suggest dynamic import() as a viable alternative to importing ESM

### DIFF
--- a/docs/pages/gotchas.md
+++ b/docs/pages/gotchas.md
@@ -116,6 +116,15 @@ module.exports = {
 };
 ```
 
+In rare circumstances, some Node.js packages are ESM-only and does not work properly when bundled. In such cases, you can use dynamic import to import the module. For example:
+
+```js filename=index.js
+export const loader = async (args: LoaderArgs) => {
+  const lib = await import('that-esm-only-lib-that-shall-not-be-bundled')
+  return lib.handleRequest(args.request)
+}
+```
+
 > Why does this happen?
 
 Remix compiles your server build to CJS and doesn't bundle your node modules. CJS modules can't import ESM modules.


### PR DESCRIPTION
- [x] Docs

Some server packages that I use are ESM-only and do not work properly when bundled (and instead gives this very cryptic error).

![image](https://user-images.githubusercontent.com/193136/233850094-ac9f4bb6-2437-4e49-b3d4-4b87b77bb4fc.png)

Moreover, they depend on some 3rd-party polymorphic package. When imported directly inside Node.js it works, but when bundled, it errorneously imported the web implementation instead. I spent hours trying to get the bundling to work without much success. Then I thought, what if I just `import()` this? It works!