### PR TITLE
chore(docs,templates): lint with same rules as examples/stacks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,9 @@ module.exports = {
     "plugin:markdown/recommended",
   ],
   plugins: ["markdown"],
+  settings: {
+    "import/internal-regex": "^~/",
+  },
   overrides: [
     {
       files: ["**/*.md/**"],
@@ -28,10 +31,29 @@ module.exports = {
       },
     },
     {
-      files: ["templates/**/*.*"],
+      files: [
+        "**/*.md/*.js?(x)",
+        "**/*.md/*.ts?(x)",
+        "integration/helpers/cf-template/**/*.*",
+        "integration/helpers/deno-template/**/*.*",
+        "integration/helpers/node-template/**/*.*",
+        "packages/remix-dev/config/defaults/**/*.*",
+        "templates/**/*.*",
+      ],
       rules: {
         "prefer-let/prefer-let": OFF,
         "prefer-const": WARN,
+
+        "import/order": [
+          WARN,
+          {
+            alphabetize: { caseInsensitive: true, order: "asc" },
+            groups: ["builtin", "external", "internal", "parent", "sibling"],
+            "newlines-between": "always",
+          },
+        ],
+
+        "react/jsx-no-leaked-render": [WARN, { validStrategies: ["ternary"] }],
       },
     },
   ],

--- a/docs/guides/constraints.md
+++ b/docs/guides/constraints.md
@@ -101,11 +101,11 @@ export default function Posts() {
 
 That `console.log` _does something_. The module is imported and then immediately logs to the console. The compiler won't remove it because it has to run when the module is imported. It will bundle something like this:
 
-```tsx bad lines=[4,6]
+```tsx bad lines=[3,6]
 import { useLoaderData } from "@remix-run/react";
 
-import PostsView from "../PostsView";
 import { prisma } from "../db"; //😬
+import PostsView from "../PostsView";
 
 console.log(prisma); //🥶
 

--- a/docs/guides/streaming.md
+++ b/docs/guides/streaming.md
@@ -80,15 +80,16 @@ Let's take a dive into how to accomplish this.
 
 First, to enable streaming with React 18, you'll update your `entry.server.tsx` file to use `renderToPipeableStream`. Here's a simple (and incomplete) version of that:
 
-```tsx filename=app/entry.server.tsx lines=[1-2,17,24,29,34]
+```tsx filename=app/entry.server.tsx lines=[1,9,18,25,30,35]
 import { PassThrough } from "stream";
-import { renderToPipeableStream } from "react-dom/server";
-import { RemixServer } from "@remix-run/react";
+
 import { Response } from "@remix-run/node"; // or cloudflare/deno
 import type {
   EntryContext,
   Headers,
 } from "@remix-run/node"; // or cloudflare/deno
+import { RemixServer } from "@remix-run/react";
+import { renderToPipeableStream } from "react-dom/server";
 
 export default function handleRequest(
   request: Request,
@@ -259,11 +260,11 @@ With just that in place, you're unlikely to see any significant performance impr
 
 With React streaming set up, now you can start adding `Await` usage for your slow data requests where you'd rather render a fallback UI. Let's do that for our example above:
 
-```tsx lines=[1,3,4,9-11,13-15,24-33,38-40]
-import { Suspense } from "react";
+```tsx lines=[2-4,9-11,13-15,24-33,38-40]
 import type { LoaderArgs } from "@remix-run/node"; // or cloudflare/deno
 import { defer } from "@remix-run/node"; // or cloudflare/deno
 import { Await, useLoaderData } from "@remix-run/react";
+import { Suspense } from "react";
 
 import { getPackageLocation } from "~/models/packages";
 

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -210,8 +210,9 @@ And then a `<PrimaryButton>` that extends it:
 }
 ```
 
-```tsx filename=app/components/primary-button/index.js lines=[1,5,12]
+```tsx filename=app/components/primary-button/index.js lines=[1,6,13]
 import { Button, links as buttonLinks } from "../button";
+
 import styles from "./styles.css";
 
 export const links = () => [
@@ -235,12 +236,12 @@ Because these buttons are not routes, and therefore not associated with a URL se
 
 Consider that `routes/index.js` uses the primary button component:
 
-```tsx filename=app/routes/index.js lines=[2-5,9]
-import styles from "~/styles/index.css";
+```tsx filename=app/routes/index.js lines=[1-4,9]
 import {
   PrimaryButton,
   links as primaryButtonLinks,
 } from "~/components/primary-button";
+import styles from "~/styles/index.css";
 
 export function links() {
   return [
@@ -920,9 +921,9 @@ npm install @remix-run/css-bundle
 
 Then, import `cssBundleHref` and add it to a link descriptor—most likely in `root.tsx` so that it applies to your entire application.
 
-```tsx filename=root.tsx lines=[2,6-8]
-import type { LinksFunction } from "@remix-run/node"; // or cloudflare/deno
+```tsx filename=root.tsx lines=[1,6-8]
 import { cssBundleHref } from "@remix-run/css-bundle";
+import type { LinksFunction } from "@remix-run/node"; // or cloudflare/deno
 
 export const links: LinksFunction = () => {
   return [

--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -46,11 +46,11 @@ createRequestHandler({ build, getLoadContext });
 
 Here's a full example with express:
 
-```ts lines=[2-4,11-22]
-const express = require("express");
+```ts lines=[1-3,11-22]
 const {
   createRequestHandler,
 } = require("@remix-run/express");
+const express = require("express");
 
 const app = express();
 

--- a/docs/pages/technical-explanation.md
+++ b/docs/pages/technical-explanation.md
@@ -34,9 +34,9 @@ It's built on the [Web Fetch API][fetch] instead of Node.js. This enables Remix 
 
 This is what Remix looks like when running in an express app:
 
-```ts lines=[2,6-9]
-const express = require("express");
+```ts lines=[1,6-9]
 const remix = require("@remix-run/express");
+const express = require("express");
 
 const app = express();
 

--- a/packages/remix-dev/config/defaults/cloudflare/entry.server.react-string.tsx
+++ b/packages/remix-dev/config/defaults/cloudflare/entry.server.react-string.tsx
@@ -1,6 +1,6 @@
 import type { EntryContext } from "@remix-run/cloudflare";
-import { renderToString } from "react-dom/server";
 import { RemixServer } from "@remix-run/react";
+import { renderToString } from "react-dom/server";
 
 export default function handleRequest(
   request: Request,

--- a/packages/remix-dev/config/defaults/deno/entry.server.react-string.tsx
+++ b/packages/remix-dev/config/defaults/deno/entry.server.react-string.tsx
@@ -1,6 +1,6 @@
 import type { EntryContext } from "@remix-run/deno";
-import { renderToString } from "react-dom/server";
 import { RemixServer } from "@remix-run/react";
+import { renderToString } from "react-dom/server";
 
 export default function handleRequest(
   request: Request,

--- a/packages/remix-dev/config/defaults/node/entry.server.react-stream.tsx
+++ b/packages/remix-dev/config/defaults/node/entry.server.react-stream.tsx
@@ -1,4 +1,5 @@
 import { PassThrough } from "stream";
+
 import type { EntryContext } from "@remix-run/node";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";

--- a/packages/remix-dev/config/defaults/node/entry.server.react-string.tsx
+++ b/packages/remix-dev/config/defaults/node/entry.server.react-string.tsx
@@ -1,6 +1,6 @@
 import type { EntryContext } from "@remix-run/node";
-import { renderToString } from "react-dom/server";
 import { RemixServer } from "@remix-run/react";
+import { renderToString } from "react-dom/server";
 
 export default function handleRequest(
   request: Request,

--- a/templates/arc/app/entry.server.tsx
+++ b/templates/arc/app/entry.server.tsx
@@ -5,6 +5,7 @@
  */
 
 import { PassThrough } from "node:stream";
+
 import type { EntryContext } from "@remix-run/node";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";

--- a/templates/arc/server.ts
+++ b/templates/arc/server.ts
@@ -1,6 +1,6 @@
-import { installGlobals } from "@remix-run/node";
 import { createRequestHandler } from "@remix-run/architect";
 import * as build from "@remix-run/dev/server-build";
+import { installGlobals } from "@remix-run/node";
 
 installGlobals();
 

--- a/templates/express/app/entry.server.tsx
+++ b/templates/express/app/entry.server.tsx
@@ -5,6 +5,7 @@
  */
 
 import { PassThrough } from "node:stream";
+
 import type { EntryContext } from "@remix-run/node";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";

--- a/templates/fly/app/entry.server.tsx
+++ b/templates/fly/app/entry.server.tsx
@@ -5,6 +5,7 @@
  */
 
 import { PassThrough } from "node:stream";
+
 import type { EntryContext } from "@remix-run/node";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";

--- a/templates/netlify/app/entry.server.tsx
+++ b/templates/netlify/app/entry.server.tsx
@@ -5,6 +5,7 @@
  */
 
 import { PassThrough } from "node:stream";
+
 import type { EntryContext } from "@remix-run/node";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";

--- a/templates/netlify/server.ts
+++ b/templates/netlify/server.ts
@@ -1,6 +1,6 @@
-import { installGlobals } from "@remix-run/node";
-import { createRequestHandler } from "@remix-run/netlify";
 import * as build from "@remix-run/dev/server-build";
+import { createRequestHandler } from "@remix-run/netlify";
+import { installGlobals } from "@remix-run/node";
 
 installGlobals();
 

--- a/templates/remix/app/entry.server.tsx
+++ b/templates/remix/app/entry.server.tsx
@@ -5,6 +5,7 @@
  */
 
 import { PassThrough } from "node:stream";
+
 import type { EntryContext } from "@remix-run/node";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";

--- a/templates/vercel/app/entry.server.tsx
+++ b/templates/vercel/app/entry.server.tsx
@@ -5,6 +5,7 @@
  */
 
 import { PassThrough } from "node:stream";
+
 import type { EntryContext } from "@remix-run/node";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";

--- a/templates/vercel/server.ts
+++ b/templates/vercel/server.ts
@@ -1,6 +1,6 @@
+import * as build from "@remix-run/dev/server-build";
 import { installGlobals } from "@remix-run/node";
 import { createRequestHandler } from "@remix-run/vercel";
-import * as build from "@remix-run/dev/server-build";
 
 installGlobals();
 


### PR DESCRIPTION
Using the same rules as we do in the `examples` & stack repos

https://github.com/remix-run/examples/blob/main/.eslintrc.js
https://github.com/remix-run/indie-stack/blob/main/.eslintrc.repo.js
https://github.com/remix-run/blues-stack/blob/main/.eslintrc.repo.js
https://github.com/remix-run/grunge-stack/blob/main/.eslintrc.repo.js

---

Follow-up of https://github.com/remix-run/indie-stack/pull/223, https://github.com/remix-run/blues-stack/pull/176 & https://github.com/remix-run/grunge-stack/pull/142