### PR TITLE
fix(dev): statically serve built assets from dev server

### DIFF
--- a/packages/remix-dev/__tests__/cli-test.ts
+++ b/packages/remix-dev/__tests__/cli-test.ts
@@ -115,6 +115,14 @@ describe("remix CLI", () => {
           \`dev\` Options:
             --debug             Attach Node.js inspector
             --port, -p          Choose the port from which to run your app
+
+            [unstable_dev]
+            --command, -c       Command used to run your app server
+            --http-scheme       HTTP(S) scheme for the dev server. Default: http
+            --http-host         HTTP(S) host for the dev server. Default: localhost
+            --http-port         HTTP(S) port for the dev server. Default: any open port
+            --no-restart        Do not restart the app server when rebuilds occur.
+            --websocket-port    Websocket port for the dev server. Default: any open port
           \`init\` Options:
             --no-delete         Skip deleting the \`remix.init\` script
           \`routes\` Options:

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -177,7 +177,7 @@ export async function build(
   };
   if (config.future.unstable_dev) {
     let dev = await resolveDev(config.future.unstable_dev);
-    options.devHttpPort = dev.httpPort;
+    options.devHttpOrigin = dev.httpOrigin;
     options.devWebsocketPort = dev.websocketPort;
   }
 
@@ -212,7 +212,11 @@ export async function dev(
   flags: {
     debug?: boolean;
     port?: number; // TODO: remove for v2
+
+    // unstable_dev
     command?: string;
+    httpScheme?: string;
+    httpHost?: string;
     httpPort?: number;
     restart?: boolean;
     websocketPort?: number;
@@ -466,17 +470,27 @@ let resolveDev = async (
   dev: Exclude<RemixConfig["future"]["unstable_dev"], false>,
   flags: {
     command?: string;
+    httpScheme?: string;
+    httpHost?: string;
     httpPort?: number;
     restart?: boolean;
     websocketPort?: number;
   } = {}
 ): Promise<{
   command?: string;
-  httpPort: number;
+  httpOrigin: {
+    scheme: string;
+    host: string;
+    port: number;
+  };
   restart: boolean;
   websocketPort: number;
 }> => {
   let command = flags.command ?? (dev === true ? undefined : dev.command);
+  let httpScheme =
+    flags.httpScheme ?? (dev === true ? undefined : dev.httpScheme) ?? "http";
+  let httpHost =
+    flags.httpHost ?? (dev === true ? undefined : dev.httpHost) ?? "localhost";
   let httpPort =
     flags.httpPort ??
     (dev === true ? undefined : dev.httpPort) ??
@@ -490,7 +504,11 @@ let resolveDev = async (
 
   return {
     command,
-    httpPort,
+    httpOrigin: {
+      scheme: httpScheme,
+      host: httpHost,
+      port: httpPort,
+    },
     websocketPort,
     restart,
   };

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -41,6 +41,14 @@ ${colors.logoBlue("R")} ${colors.logoGreen("E")} ${colors.logoYellow(
   \`dev\` Options:
     --debug             Attach Node.js inspector
     --port, -p          Choose the port from which to run your app
+
+    [unstable_dev]
+    --command, -c       Command used to run your app server
+    --http-scheme       HTTP(S) scheme for the dev server. Default: http
+    --http-host         HTTP(S) host for the dev server. Default: localhost
+    --http-port         HTTP(S) port for the dev server. Default: any open port
+    --no-restart        Do not restart the app server when rebuilds occur.
+    --websocket-port    Websocket port for the dev server. Default: any open port
   \`init\` Options:
     --no-delete         Skip deleting the \`remix.init\` script
   \`routes\` Options:
@@ -151,14 +159,11 @@ export async function run(argv: string[] = process.argv.slice(2)) {
 
   let args = arg(
     {
-      "--command": String,
-      "-c": "--command",
       "--debug": Boolean,
       "--no-delete": Boolean,
       "--dry": Boolean,
       "--force": Boolean,
       "--help": Boolean,
-      "--http-port": Number,
       "-h": "--help",
       "--install": Boolean,
       "--no-install": Boolean,
@@ -168,8 +173,6 @@ export async function run(argv: string[] = process.argv.slice(2)) {
       "--port": Number,
       "-p": "--port",
       "--remix-version": String,
-      "--restart": Boolean,
-      "--no-restart": Boolean,
       "--sourcemap": Boolean,
       "--template": String,
       "--token": String,
@@ -177,6 +180,14 @@ export async function run(argv: string[] = process.argv.slice(2)) {
       "--no-typescript": Boolean,
       "--version": Boolean,
       "-v": "--version",
+
+      // dev server
+      "--command": String,
+      "-c": "--command",
+      "--http-scheme": String,
+      "--http-host": String,
+      "--http-port": Number,
+      "--no-restart": Boolean,
       "--websocket-port": Number,
     },
     {
@@ -202,6 +213,14 @@ export async function run(argv: string[] = process.argv.slice(2)) {
     return;
   }
 
+  if (flags["http-scheme"]) {
+    flags.httpScheme = flags["http-scheme"];
+    delete flags["http-scheme"];
+  }
+  if (flags["http-host"]) {
+    flags.httpHost = flags["http-host"];
+    delete flags["http-host"];
+  }
   if (flags["http-port"]) {
     flags.httpPort = flags["http-port"];
     delete flags["http-port"];

--- a/packages/remix-dev/compiler/options.ts
+++ b/packages/remix-dev/compiler/options.ts
@@ -6,6 +6,10 @@ export type Options = {
   onWarning?: (message: string, key: string) => void;
 
   // TODO: required in v2
-  devHttpPort?: number;
+  devHttpOrigin?: {
+    scheme: string;
+    host: string;
+    port: number;
+  };
   devWebsocketPort?: number;
 };

--- a/packages/remix-dev/compiler/server/compiler.ts
+++ b/packages/remix-dev/compiler/server/compiler.ts
@@ -102,8 +102,8 @@ const createEsbuildConfig = (
       "process.env.REMIX_DEV_SERVER_WS_PORT": JSON.stringify(
         ctx.config.devServerPort
       ),
-      "process.env.REMIX_DEV_HTTP_PORT": JSON.stringify(
-        ctx.options.devHttpPort ?? ""
+      "process.env.REMIX_DEV_HTTP_ORIGIN": JSON.stringify(
+        ctx.options.devHttpOrigin ?? "" // TODO: remove nullish check in v2
       ),
     },
     jsx: "automatic",

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -41,6 +41,8 @@ type Dev = {
   port?: number; // TODO: remove in v2
 
   command?: string;
+  httpScheme?: string;
+  httpHost?: string;
   httpPort?: number;
   websocketPort?: number;
   restart?: boolean;

--- a/packages/remix-dev/devServer_unstable/index.ts
+++ b/packages/remix-dev/devServer_unstable/index.ts
@@ -14,11 +14,18 @@ import * as HMR from "./hmr";
 import { warnOnce } from "../warnOnce";
 import { detectPackageManager } from "../cli/detectPackageManager";
 
+let stringifyOrigin = (o: { scheme: string; host: string; port: number }) =>
+  `${o.scheme}://${o.host}:${o.port}`;
+
 export let serve = async (
   initialConfig: RemixConfig,
   options: {
     command?: string;
-    httpPort: number;
+    httpOrigin: {
+      scheme: string;
+      host: string;
+      port: number;
+    };
     websocketPort: number;
     restart: boolean;
   }
@@ -42,7 +49,7 @@ export let serve = async (
       env: {
         NODE_ENV: "development",
         PATH: `${bin}:${process.env.PATH}`,
-        REMIX_DEV_HTTP_PORT: String(options.httpPort),
+        REMIX_DEV_HTTP_ORIGIN: stringifyOrigin(options.httpOrigin),
       },
     });
   };
@@ -54,7 +61,7 @@ export let serve = async (
         mode: "development",
         sourcemap: true,
         onWarning: warnOnce,
-        devHttpPort: options.httpPort,
+        devHttpOrigin: options.httpOrigin,
         devWebsocketPort: options.websocketPort,
       },
     },
@@ -122,8 +129,8 @@ export let serve = async (
       }
       res.sendStatus(200);
     })
-    .listen(options.httpPort, () => {
-      console.log(`dev server listening on port ${options.httpPort}`);
+    .listen(options.httpOrigin.port, () => {
+      console.log("Remix dev server ready");
     });
 
   return new Promise(() => {}).finally(async () => {

--- a/packages/remix-server-runtime/dev.ts
+++ b/packages/remix-server-runtime/dev.ts
@@ -1,25 +1,17 @@
 import type { ServerBuild } from "./build";
 
-export let devReady = (
-  build: ServerBuild,
-  options: {
-    scheme?: string;
-    host?: string;
-    port?: number;
-  } = {}
-) => {
-  let scheme = options.scheme ?? "http";
-  let host = options.host ?? "localhost";
-  let port = options.port ?? Number(process.env.REMIX_DEV_HTTP_PORT);
-  if (!port) throw Error("Dev server port not set");
-  if (isNaN(port))
-    throw Error(
-      `Dev server port must be a number. Got: ${JSON.stringify(port)}`
-    );
+export let devReady = (build: ServerBuild, origin?: string) => {
+  origin ??= process.env.REMIX_DEV_HTTP_ORIGIN;
+  if (!origin) throw Error("Dev server origin not set");
 
-  fetch(`${scheme}://${host}:${port}/ping`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ buildHash: build.assets.version }),
-  });
+  try {
+    fetch(`${origin}/ping`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ buildHash: build.assets.version }),
+    });
+  } catch (error) {
+    console.error(`Could not reach Remix dev server at ${origin}`);
+    throw error;
+  }
 };


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
