### PR TITLE
feat: express template outputs ESM for build

### DIFF
--- a/.changeset/express-template-esm.md
+++ b/.changeset/express-template-esm.md
@@ -1,0 +1,5 @@
+---
+"create-remix": patch
+---
+
+update express template to output ESM and use the new dev command

--- a/templates/express/.eslintrc.cjs
+++ b/templates/express/.eslintrc.cjs
@@ -1,4 +1,4 @@
 /** @type {import('eslint').Linter.Config} */
-export default {
+module.exports = {
   extends: ["@remix-run/eslint-config", "@remix-run/eslint-config/node"],
 };

--- a/templates/express/.eslintrc.js
+++ b/templates/express/.eslintrc.js
@@ -1,4 +1,4 @@
 /** @type {import('eslint').Linter.Config} */
-module.exports = {
+export default {
   extends: ["@remix-run/eslint-config", "@remix-run/eslint-config/node"],
 };

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -1,11 +1,10 @@
 {
   "private": true,
   "sideEffects": false,
+  "type": "module",
   "scripts": {
     "build": "remix build",
-    "dev": "npm-run-all build --parallel \"dev:*\"",
-    "dev:node": "cross-env NODE_ENV=development nodemon --require dotenv/config ./server.js --watch ./server.js",
-    "dev:remix": "remix watch",
+    "dev": "cross-env NODE_ENV=development remix dev -c \"node ./server.js\"",
     "start": "cross-env NODE_ENV=production node ./server.js",
     "typecheck": "tsc"
   },
@@ -29,8 +28,6 @@
     "@types/react-dom": "^18.0.8",
     "dotenv": "^16.0.3",
     "eslint": "^8.27.0",
-    "nodemon": "^2.0.20",
-    "npm-run-all": "^4.1.5",
     "typescript": "^5.0.4"
   },
   "engines": {

--- a/templates/express/remix.config.js
+++ b/templates/express/remix.config.js
@@ -1,11 +1,13 @@
 /** @type {import('@remix-run/dev').AppConfig} */
-module.exports = {
+export default {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
+  serverModuleFormat: "esm",
   future: {
+    unstable_dev: true,
     v2_errorBoundary: true,
     v2_meta: true,
     v2_normalizeFormMethod: true,

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -1,10 +1,12 @@
-const path = require("path");
-const express = require("express");
-const compression = require("compression");
-const morgan = require("morgan");
-const { createRequestHandler } = require("@remix-run/express");
+import express from "express";
+import compression from "compression";
+import morgan from "morgan";
+import { createRequestHandler } from "@remix-run/express";
+import { installGlobals } from "@remix-run/node";
 
-const BUILD_DIR = path.join(process.cwd(), "build");
+import * as build from "./build/index.js";
+
+installGlobals();
 
 const app = express();
 
@@ -25,37 +27,18 @@ app.use(express.static("public", { maxAge: "1h" }));
 
 app.use(morgan("tiny"));
 
+const MODE = process.env.NODE_ENV;
 app.all(
   "*",
-  process.env.NODE_ENV === "development"
-    ? (req, res, next) => {
-        purgeRequireCache();
-
-        return createRequestHandler({
-          build: require(BUILD_DIR),
-          mode: process.env.NODE_ENV,
-        })(req, res, next);
-      }
-    : createRequestHandler({
-        build: require(BUILD_DIR),
-        mode: process.env.NODE_ENV,
-      })
+  createRequestHandler({ build, mode: MODE })
 );
+
 const port = process.env.PORT || 3000;
+app.listen(port, async () => {
+  console.log(`✅ Express server listening on port ${port}`);
 
-app.listen(port, () => {
-  console.log(`Express server listening on port ${port}`);
-});
-
-function purgeRequireCache() {
-  // purge require cache on requests for "server side HMR" this won't let
-  // you have in-memory objects between requests in development,
-  // alternatively you can set up nodemon/pm2-dev to restart the server on
-  // file changes, but then you'll have to reconnect to databases/etc on each
-  // change. We prefer the DX of this, so we've included it for you by default
-  for (const key in require.cache) {
-    if (key.startsWith(BUILD_DIR)) {
-      delete require.cache[key];
-    }
+  if (process.env.NODE_ENV === "development") {
+    const { devReady } = await import("@remix-run/node");
+    devReady(build);
   }
-}
+});


### PR DESCRIPTION
feat: express template server entry is now ESM
feat: express template uses new dev command

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
