### PR TITLE
fix(dev): tracking of prev build even when rebuilds are interrupted

### DIFF
--- a/packages/remix-dev/devServer_unstable/index.ts
+++ b/packages/remix-dev/devServer_unstable/index.ts
@@ -113,6 +113,8 @@ export let serve = async (
           (state.prevManifest ? "Rebuilt" : "Built") +
             ` in ${prettyMs(durationMs)}`
         );
+        let prevManifest = state.prevManifest;
+        state.prevManifest = manifest;
         state.latestBuildHash = manifest.version;
         state.buildHashChannel = Channel.create();
 
@@ -130,17 +132,16 @@ export let serve = async (
         if (!ok) return;
         console.log(`App server took ${prettyMs(Date.now() - start)}`);
 
-        if (manifest.hmr && state.prevManifest) {
-          let updates = HMR.updates(ctx.config, manifest, state.prevManifest);
+        if (manifest.hmr && prevManifest) {
+          let updates = HMR.updates(ctx.config, manifest, prevManifest);
           websocket.hmr(manifest, updates);
 
           let hdr = updates.some((u) => u.revalidate);
           console.log("> HMR" + (hdr ? " + HDR" : ""));
-        } else if (state.prevManifest !== undefined) {
+        } else if (prevManifest !== undefined) {
           websocket.reload();
           console.log("> Live reload");
         }
-        state.prevManifest = manifest;
       },
       onFileCreated: (file) =>
         websocket.log(`File created: ${relativePath(file)}`),


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
