### PR TITLE
tests(remix-vercel): remove `@vercel/node-bridge` usage

### DIFF
--- a/packages/remix-vercel/package.json
+++ b/packages/remix-vercel/package.json
@@ -18,8 +18,7 @@
   },
   "devDependencies": {
     "@types/supertest": "^2.0.10",
-    "@vercel/node": "^2.10.3",
-    "@vercel/node-bridge": "^4.0.1",
+    "@vercel/node": "^2.12.0",
     "node-mocks-http": "^1.10.1",
     "supertest": "^6.1.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1622,15 +1622,20 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@edge-runtime/format@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@edge-runtime/format/-/format-1.1.0.tgz#5a209221a8bae7791d6e465c480f146249d1e15f"
-  integrity sha512-MkLDDtPhXZIMx83NykdFmOpF7gVWIdd6GBHYb8V/E+PKWvD2pK/qWx9B30oN1iDJ2XBm0SGDjz02S8nDHI9lMQ==
+"@edge-runtime/format@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/@edge-runtime/format/-/format-2.0.1.tgz#765295809ff6a0938da739e13ef327d95a418395"
+  integrity sha512-aE+9DtBvQyg349srixtXEUNauWtIv5HTKPy8Q9dvG1NvpldVIvvhcDBI+SuvDVM8kQl8phbYnp2NTNloBCn/Yg==
 
 "@edge-runtime/primitives@2.0.0":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-2.0.0.tgz#b4bf44f9cab36aee3027fe4c3ff3cc1d5713e155"
   integrity sha512-AXqUq1zruTJAICrllUvZcgciIcEGHdF6KJ3r6FM0n4k8LpFxZ62tPWVIJ9HKm+xt+ncTBUZxwgUaQ73QMUQEKw==
+
+"@edge-runtime/primitives@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-2.1.2.tgz#8ff657f12a7f8c7fc4e3a0c10ec19356ef2d656d"
+  integrity sha512-SR04SMDybALlhIYIi0hiuEUwIl0b7Sn+RKwQkX6hydg4+AKMzBNDFhj2nqHDD1+xkHArV9EhmJIb6iGjShwSzg==
 
 "@edge-runtime/vm@2.0.0":
   version "2.0.0"
@@ -1638,6 +1643,13 @@
   integrity sha512-BOLrAX8IWHRXu1siZocwLguKJPEUv7cr+rG8tI4hvHgMdIsBWHJlLeB8EjuUVnIURFrUiM49lVKn8DRrECmngw==
   dependencies:
     "@edge-runtime/primitives" "2.0.0"
+
+"@edge-runtime/vm@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/@edge-runtime/vm/-/vm-2.1.2.tgz#d760ce27b659c17c470b23453321769c08d213f5"
+  integrity sha512-j4H5S26NJhYOyjVMN8T/YJuwwslfnEX1P0j6N2Rq1FaubgNowdYunA9nlO7lg8Rgjv6dqJ2zKuM7GD1HFtNSGw==
+  dependencies:
+    "@edge-runtime/primitives" "2.1.2"
 
 "@emotion/hash@^0.9.0":
   version "0.9.0"
@@ -3541,32 +3553,41 @@
   resolved "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-6.7.1.tgz#94bccb959d9f2dcdecb7744c939b546073902373"
   integrity sha512-Ecc9oQBSVwk1suENcRcj1L6gQrUt4+0XA9oPFxrUpoFEk04lP/ZV3qAQPk+ex08N+vfUulYdqb+cmVTnwqsmqw==
 
-"@vercel/node-bridge@4.0.1", "@vercel/node-bridge@^4.0.1":
+"@vercel/error-utils@1.0.8":
+  version "1.0.8"
+  resolved "https://registry.npmjs.org/@vercel/error-utils/-/error-utils-1.0.8.tgz#5cefc4142820846d011cf048ddfb0afda81d484b"
+  integrity sha512-s+f7jP2oH1koICbQ8e3K9hOpOeUct7rbCnF9qsNwXemq850wAh2e90tp9R6oYBM0BNpiLRRm+oG5zD2sCIm3HQ==
+
+"@vercel/node-bridge@4.0.1":
   version "4.0.1"
   resolved "https://registry.npmjs.org/@vercel/node-bridge/-/node-bridge-4.0.1.tgz#e4f41188f61d9cd4e7c44de31d436dd447e1978c"
   integrity sha512-XEfKfnLGzlIBpad7eGNPql1HnMhoSTv9q3uDNC4axdaAC/kI5yvl8kXjuCPAXYvpbJnVQPpcSUC5/r5ap8F3jA==
 
-"@vercel/node@^2.10.3":
-  version "2.10.3"
-  resolved "https://registry.npmjs.org/@vercel/node/-/node-2.10.3.tgz#24a65d9f7e69161762c85df630601f3852308c26"
-  integrity sha512-R6YwD7YTV4OPEjXnthTP2Zn96ZF2TAjmBhGKfYC9ZuqlmFzSxqyuHn+RUSkknkKBO46b4OzaNdi5XVnAdJizLA==
+"@vercel/node@^2.12.0":
+  version "2.12.0"
+  resolved "https://registry.npmjs.org/@vercel/node/-/node-2.12.0.tgz#2eff4ffb04ae3ca19a7fd7e49e4f376791284abb"
+  integrity sha512-QItQ4DjKrHqTMk/hmtX64V5RfDdp+fDoFzbSbPUICkIOHK3EBCJ5c/392Iv05AwSv+mJIALZUGRQz5o4HKvs6A==
   dependencies:
     "@edge-runtime/vm" "2.0.0"
     "@types/node" "14.18.33"
     "@vercel/build-utils" "6.7.1"
+    "@vercel/error-utils" "1.0.8"
     "@vercel/node-bridge" "4.0.1"
-    "@vercel/static-config" "2.0.15"
-    edge-runtime "2.0.0"
+    "@vercel/static-config" "2.0.16"
+    async-listen "1.2.0"
+    edge-runtime "2.1.4"
     esbuild "0.14.47"
     exit-hook "2.2.1"
     node-fetch "2.6.7"
+    path-to-regexp "6.2.1"
+    ts-morph "12.0.0"
     ts-node "10.9.1"
     typescript "4.3.4"
 
-"@vercel/static-config@2.0.15":
-  version "2.0.15"
-  resolved "https://registry.npmjs.org/@vercel/static-config/-/static-config-2.0.15.tgz#a1e4d052e50cb9493071aaa2b4ca5e05c054fada"
-  integrity sha512-A/N3ZGiOOMql9JArwBTIfhFngFtmVC7ndKQKp0FoFq8MO79AS5qBBtdpILS5QA71M5v+9CPjVkHxN6QweU55Xg==
+"@vercel/static-config@2.0.16":
+  version "2.0.16"
+  resolved "https://registry.npmjs.org/@vercel/static-config/-/static-config-2.0.16.tgz#2495325056e62b94925d8432b703bbf5625b06e5"
+  integrity sha512-lULo+NWBMpTJb9kR4AwYYK/2e7wknTJO2iFxgYYOkG5i12WHgPhMnXDKrEOcotxctd0yPKx3TsWVGEXniNm63g==
   dependencies:
     ajv "8.6.3"
     json-schema-to-ts "1.6.4"
@@ -4177,6 +4198,16 @@ astring@^1.6.0:
   version "1.7.5"
   resolved "https://registry.npmjs.org/astring/-/astring-1.7.5.tgz"
   integrity sha512-lobf6RWXb8c4uZ7Mdq0U12efYmpD1UFnyOWVJPTa3ukqZrMopav+2hdNu0hgBF0JIBFK9QgrBDfwYvh3DFJDAA==
+
+async-listen@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/async-listen/-/async-listen-1.2.0.tgz#861ab6f92e1703ba54498b10ddb9b5da7b69f363"
+  integrity sha512-CcEtRh/oc9Jc4uWeUwdpG/+Mb2YUHKmdaTf0gUr7Wa+bfp4xx70HOb3RuSTJMvqKNB1TkdTfjLdrcz2X4rkkZA==
+
+async-listen@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/async-listen/-/async-listen-2.0.3.tgz#be1be5a1b15e6007123e67275450fc4e84955e61"
+  integrity sha512-WVLi/FGIQaXyfYyNvmkwKT1RZbkzszLLnmW/gFCc5lbVvN/0QQCWpBwRBk2OWSdkkmKRBc8yD6BrKsjA3XKaSw==
 
 async@^3.2.0:
   version "3.2.3"
@@ -5612,15 +5643,15 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-edge-runtime@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.0.0.tgz#4739e1c8f4237db8ad8a16db5f0e28cc6de16aab"
-  integrity sha512-TmRJhKi4mlM1e+zgF4CSzVU5gJ1sWj7ia+XhVgZ8PYyYUxk4PPjJU8qScpSLsAbdSxoBghLxdMuwuCzdYLd1sQ==
+edge-runtime@2.1.4:
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.1.4.tgz#aea4e103897f451f98a9094df26b07c4d1eb75b3"
+  integrity sha512-SertKByzAmjm+MkLbFl1q0ko+/90V24dhZgQM8fcdguQaDYVEVtb6okEBGeg8IQgL1/JUP8oSlUIxSI/bvsVRQ==
   dependencies:
-    "@edge-runtime/format" "1.1.0"
-    "@edge-runtime/vm" "2.0.0"
+    "@edge-runtime/format" "2.0.1"
+    "@edge-runtime/vm" "2.1.2"
+    async-listen "2.0.3"
     exit-hook "2.2.1"
-    http-status "1.5.3"
     mri "1.2.0"
     picocolors "1.0.0"
     pretty-bytes "5.6.0"
@@ -7449,11 +7480,6 @@ http-signature@~1.3.6:
     assert-plus "^1.0.0"
     jsprim "^2.0.2"
     sshpk "^1.14.1"
-
-http-status@1.5.3:
-  version "1.5.3"
-  resolved "https://registry.npmjs.org/http-status/-/http-status-1.5.3.tgz#9d1f6adcd1a609f535679f6e1b82811b96c3306e"
-  integrity sha512-jCClqdnnwigYslmtfb28vPplOgoiZ0siP2Z8C5Ua+3UKbx410v+c+jT+jh1bbI4TvcEySuX0vd/CfFZFbDkJeQ==
 
 http2-wrapper@^1.0.0-beta.5.2:
   version "1.0.3"
@@ -10648,6 +10674,11 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
+  integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
 
 path-to-regexp@^6.2.0:
   version "6.2.0"


### PR DESCRIPTION
As noted by @TooTallNate in https://github.com/vercel/vercel/pull/9745#issuecomment-1519196324, we can replace `@vercel/node-bridge` with `http`