### PR TITLE
chore(ci/no-response): Don't automatically mark issues/PRs as stale

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -23,19 +23,6 @@ jobs:
           close-pr-message: >
             This PR has been automatically closed because we didn't hear
             anything from the original author after the previous notice.
-          stale-issue-label: needs-response
-          stale-issue-message: >
-            This issue has been automatically marked stale because we haven't
-            received a response from the original author in a while 🙈. This
-            automation helps keep the issue tracker clean from issues that are
-            not actionable. Please reach out if you have more information for us
-            or you think this issue shouldn't be closed! 🙂 If you don't do so
-            within 7 days, this issue will be automatically closed.
-          stale-pr-label: needs-response
-          stale-pr-message: >
-            This PR has been automatically marked stale because we haven't
-            received a response from the original author in a while 🙈. This
-            automation helps keep the issue tracker clean from issues that are
-            not actionable. Please reach out if you have more information for us
-            or you think this issue shouldn't be closed! 🙂 If you don't do so
-            within 7 days, this PR will be automatically closed.
+          days-before-close: 10
+          days-before-stale: -1
+          only-labels: needs-response


### PR DESCRIPTION
Discussed with @ryanflorence on Discord.

Let's leave that to the team discretion. 
Workflow will only close stale issues after 10 days
