### PR TITLE
Revert "chore: remove `styfle/cancel-workflow-action` usage"

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -28,16 +28,15 @@ on:
       TEST_VERCEL_USER_ID:
         required: true
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   arc_deploy:
     name: Architect Deploy
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -72,6 +71,9 @@ jobs:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -107,6 +109,9 @@ jobs:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -143,6 +148,9 @@ jobs:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -182,6 +190,9 @@ jobs:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -217,6 +228,9 @@ jobs:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -249,6 +263,9 @@ jobs:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,16 +6,15 @@ on:
       - main
       - dev
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   format:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
 
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,15 +7,14 @@ on:
       - dev
   pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   lint:
     name: ⬣ Lint
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,10 +5,6 @@ on:
   schedule:
     - cron: "0 7 * * *" # every day at 12AM PST
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   CI: true
 
@@ -26,6 +22,9 @@ jobs:
       # allows this to be used in the `comment` job below - will be undefined if there's no release necessary
       NEXT_VERSION: ${{ steps.version.outputs.NEXT_VERSION }}
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,6 @@ on:
       - "!release-manual"
       - "!release-manual-*"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   release:
     name: 🦋 Changesets Release
@@ -28,6 +24,9 @@ jobs:
       published_packages: ${{ steps.changesets.outputs.publishedPackages }}
       published: ${{ steps.changesets.outputs.published }}
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
         with:
@@ -73,6 +72,9 @@ jobs:
     outputs:
       package_version: ${{ steps.find_package_version.outputs.package_version }}
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -10,10 +10,6 @@ on:
         # so we'll need to manually stringify it for now
         type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   CI: true
   CYPRESS_INSTALL_BINARY: 0
@@ -23,6 +19,9 @@ jobs:
     name: ⚙️ Build
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -56,6 +55,9 @@ jobs:
         node: ${{ fromJSON(inputs.node_version) }}
     runs-on: ${{ matrix.os }}
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -91,6 +93,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -125,6 +130,9 @@ jobs:
 
     runs-on: macos-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -159,6 +167,9 @@ jobs:
 
     runs-on: windows-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 

--- a/.github/workflows/stacks.yml
+++ b/.github/workflows/stacks.yml
@@ -7,10 +7,6 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   setup:
     name: Remix Stacks Test
@@ -27,6 +23,9 @@ jobs:
           - repo: "remix-run/grunge-stack"
             name: "grunge"
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
@@ -81,6 +80,9 @@ jobs:
           - repo: "remix-run/grunge-stack"
             name: "grunge"
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: 🗄️ Restore ${{ matrix.stack.name }}
         uses: actions/download-artifact@v3
         with:
@@ -121,6 +123,9 @@ jobs:
           - repo: "remix-run/grunge-stack"
             name: "grunge"
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: 🗄️ Restore ${{ matrix.stack.name }}
         uses: actions/download-artifact@v3
         with:
@@ -161,6 +166,9 @@ jobs:
           - repo: "remix-run/grunge-stack"
             name: "grunge"
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: 🗄️ Restore ${{ matrix.stack.name }}
         uses: actions/download-artifact@v3
         with:
@@ -204,6 +212,9 @@ jobs:
             name: "grunge"
             cypress: "npm run dev"
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: 🗄️ Restore ${{ matrix.stack.name }}
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Reverts remix-run/remix#6178

it's currently cancelling the comment, deploy tests, and stack tests for nightly and changeset releases https://github.com/remix-run/remix/actions/runs/4843033118, https://github.com/remix-run/remix/actions/runs/4833273314