### PR TITLE
docs(tutorials/blog): improve wording

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -532,3 +532,4 @@
 - iamzee
 - TimonVS
 - yudai-nkt
+- lkrbalci

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -859,7 +859,7 @@ export const action = async ({ request }: ActionArgs) => {
 // ...
 ```
 
-Notice we don't return a redirect this time, we actually return the errors. These errors are available to the component via `useActionData`. It's just like `useLoaderData` but the data comes from the action after a form POST.
+Notice we don't return a redirect if any of the input is empty (so if we have any error), we actually return the errors. These errors are available to the component via `useActionData`. It's just like `useLoaderData` but the data comes from the action after a form POST.
 
 💿 Add validation messages to the UI
 


### PR DESCRIPTION
as action returns redirect if the error object is empty, I think it would be better to be specific to avoid confusion.

