### PR TITLE
ci: re-add merged pr workflow 

### DIFF
--- a/.github/workflows/merged-pr.yml
+++ b/.github/workflows/merged-pr.yml
@@ -1,0 +1,29 @@
+name: 📦 Merged PR
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - dev
+    paths:
+      - "packages/**"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  merged:
+    name: Add label to merged PR
+    if: github.event.pull_request.merged == true && github.repository == 'remix-run/remix'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          retries: 3
+          script: |
+            await github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: 'awaiting release',
+            })

--- a/.github/workflows/release-comments.yml
+++ b/.github/workflows/release-comments.yml
@@ -15,7 +15,8 @@ jobs:
           fetch-depth: 0
 
       - name: 📝 Comment on related issues and pull requests
-        uses: mcansh/release-comment-action@v0.3.1
+        uses: mcansh/release-comment-action@v0.4
         with:
           DIRECTORY_TO_CHECK: "./packages"
           PACKAGE_NAME: "remix"
+          PR_LABELS_TO_REMOVE: "awaiting release"


### PR DESCRIPTION
re-adds the `merged-pr` workflow that applies the `awaiting release` and properly checks that it's being run on this repo.

also bumps `mcansh/release-comment-action` to 0.4 so we can remove the label when the comment workflow runs https://github.com/mcansh/release-comment-action/pull/8

✅ edit! need to check for stable over in `mcansh/release-comment-action` before we remove the label. one sec https://github.com/mcansh/release-comment-action/pull/9