### PR TITLE
fix(dev): wait until app server is killed before starting a new app server

### DIFF
--- a/.changeset/good-laws-marry.md
+++ b/.changeset/good-laws-marry.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+wait until app server is killed before starting a new app server


### PR DESCRIPTION
Fixes #6283

Testing: Added a `setTimeout` locally to artificially delay `p.kill` to simulate a slow-to-kill process for the app server. Confirmed that this code was resilient and waited for process to be killed before proceeding to spin up new app server instance and that `EADDRINUSE` was not encountered.