### PR TITLE
fix(remix-dev): normalize path before testing if it is a route entry

### DIFF
--- a/.changeset/light-bikes-exercise.md
+++ b/.changeset/light-bikes-exercise.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/dev": patch
+---
+
+normalize file paths before testing if a changed file is a route entry

--- a/packages/remix-dev/compiler/watch.ts
+++ b/packages/remix-dev/compiler/watch.ts
@@ -8,6 +8,7 @@ import { type Manifest } from "../manifest";
 import * as Compiler from "./compiler";
 import type { Context } from "./context";
 import { logThrown } from "./utils/log";
+import { normalizeSlashes } from "../config/routes";
 
 function isEntryPoint(config: RemixConfig, file: string): boolean {
   let appFile = path.relative(config.appDirectory, file);
@@ -16,7 +17,8 @@ function isEntryPoint(config: RemixConfig, file: string): boolean {
     config.entryServerFile,
     ...Object.values(config.routes).map((route) => route.file),
   ];
-  return entryPoints.includes(appFile);
+  let normalized = normalizeSlashes(appFile);
+  return entryPoints.includes(normalized);
 }
 
 export type WatchOptions = {


### PR DESCRIPTION
before this, `entryPoints` were normalized to use unix path separators (`/`) where `file` and `appFile` were using windows path separators (`\\`)

commit was done in parallels on windows 11 where i don't have gpg set up, sue me

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #5247 

- [ ] Docs
- [ ] Tests

Testing Strategy: local testing on windows

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
