### PR TITLE
fix(dev): dev server listens for updated build hash before writing server files

### DIFF
--- a/.changeset/poor-nails-warn.md
+++ b/.changeset/poor-nails-warn.md
@@ -1,0 +1,8 @@
+---
+"@remix-run/dev": patch
+---
+
+fix race where app server responds with updated manifest version _before_ dev server is listening for it
+
+dev server now listens for updated versions _before_ writing the server changes, guaranteeing that it is listening
+before the app server gets a chance to send its 'ready' message

--- a/packages/remix-dev/compiler/compiler.ts
+++ b/packages/remix-dev/compiler/compiler.ts
@@ -10,7 +10,9 @@ import { create as createManifest, write as writeManifest } from "./manifest";
 import { err, ok } from "../result";
 
 type Compiler = {
-  compile: () => Promise<Manifest>;
+  compile: (options?: {
+    onManifest?: (manifest: Manifest) => void;
+  }) => Promise<Manifest>;
   cancel: () => Promise<void>;
   dispose: () => Promise<void>;
 };
@@ -43,7 +45,9 @@ export let create = async (ctx: Context): Promise<Compiler> => {
     ]);
   };
 
-  let compile = async () => {
+  let compile = async (
+    options: { onManifest?: (manifest: Manifest) => void } = {}
+  ) => {
     let error: unknown | undefined = undefined;
     let errCancel = (thrown: unknown) => {
       if (error === undefined) {
@@ -102,6 +106,7 @@ export let create = async (ctx: Context): Promise<Compiler> => {
       hmr,
     });
     channels.manifest.ok(manifest);
+    options.onManifest?.(manifest);
     writes.manifest = writeManifest(ctx.config, manifest);
 
     // server compilation


### PR DESCRIPTION

previously there was a race where the app server could respond with the updated manifest version (aka build hash) _before_ the dev server was listening for that version.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
