### PR TITLE
[Bug] Test failing when loading api route

### DIFF
--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -42,20 +42,18 @@ let appFixture: AppFixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
-    future: { v2_routeConvention: true },
     ////////////////////////////////////////////////////////////////////////////
     // 💿 Next, add files to this object, just like files in a real app,
     // `createFixture` will make an app and run your tests against it.
     ////////////////////////////////////////////////////////////////////////////
     files: {
+
       "app/routes/_index.jsx": js`
         import { json } from "@remix-run/node";
         import { useLoaderData, Link } from "@remix-run/react";
-
         export function loader() {
           return json("pizza");
         }
-
         export default function Index() {
           let data = useLoaderData();
           return (
@@ -66,9 +64,31 @@ test.beforeAll(async () => {
           )
         }
       `,
+      "app/routes/pizza.jsx": js`
+        import { json } from "@remix-run/node";
+        
+        export function loader() {
+          return json("pizza");
+        }
+      `,
 
       "app/routes/burgers.jsx": js`
+        import * as React from "react";
+        import { useFetcher, useSearchParams} from "@remix-run/react";
         export default function Index() {
+          let [searchParams,setSearchParams] = useSearchParams();
+          const fetcher = useFetcher();
+          React.useEffect(() => {
+            
+            fetcher.load("/pizza");
+          }, []);
+
+          React.useEffect(() => {
+            if (!searchParams.has("channel")) {
+            setSearchParams({channel: "whatever"})
+            }
+          }, [searchParams]);
+          
           return <div>cheeseburger</div>;
         }
       `,
@@ -88,22 +108,14 @@ test.afterAll(() => {
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("[description of what you expect it to do]", async ({ page }) => {
+test("[Successfully set searchParams without errors]", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);
-  // You can test any request your app might get using `fixture`.
-  let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch("pizza");
-
-  // If you need to test interactivity use the `app`
-  await app.goto("/");
-  await app.clickLink("/burgers");
+  await app.goto("/burgers", true);  
   expect(await app.getHtml()).toMatch("cheeseburger");
+  expect(await app.page.url()).toMatch("/burgers?channel=whatever");
 
-  // If you're not sure what's going on, you can "poke" the app, it'll
-  // automatically open up in your browser for 20 seconds, so be quick!
-  // await app.poke(20);
 
-  // Go check out the other tests to see what else you can do.
+
 });
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ x] Tests

Testing Strategy:

The test describes an issue with loader revalidation that has come up in recent versions. This is the stack trace of the error:

```
Uncaught (in promise) Error: Expected route module to be loaded for routes/pizza
    at invariant2 (invariant.js:13:11)
    at Object.shouldRevalidate (routes.js:89:5)
    at shouldRevalidateLoader (router.ts:3383:41)
    at router.ts:3318:28
    at Map.forEach (<anonymous>)
    at getMatchesToLoad (router.ts:3278:20)
    at handleLoaders (router.ts:1458:49)
    at startNavigation (router.ts:1291:56)
    at Object.navigate (router.ts:1134:18)
    at hooks.tsx:965:16
```

It seems to be caused by using setSearchParams from the useSearchParams hook on a route where a useEffect uses a fetcher to load data from an api route.

In the test, if you comment out `fetcher.load("/pizza")` the test passes.
Also, if you poke the app and go to /burgers and look at the console you'll find the aforementioned error.
