### PR TITLE
refactor(dev): revert serving assets from dev server

### DIFF
--- a/.changeset/ninety-flies-allow.md
+++ b/.changeset/ninety-flies-allow.md
@@ -1,7 +1,0 @@
----
-"@remix-run/dev": patch
----
-
-- Fix public asset serving for non-Remix assets in the new dev server
-- Add `--public-directory` / `unstable_dev.publicDirectory` option for configuring local directory for serving non-Remix assets like fonts
-- Fix `svg` serving for new dev server

--- a/packages/remix-dev/__tests__/cli-test.ts
+++ b/packages/remix-dev/__tests__/cli-test.ts
@@ -122,7 +122,6 @@ describe("remix CLI", () => {
             --http-host         HTTP(S) host for the dev server. Default: localhost
             --http-port         HTTP(S) port for the dev server. Default: any open port
             --no-restart        Do not restart the app server when rebuilds occur.
-            --public-directory  Path to public assets directory relative to Remix project root. Default: public
             --websocket-port    Websocket port for the dev server. Default: any open port
           \`init\` Options:
             --no-delete         Skip deleting the \`remix.init\` script

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -224,7 +224,6 @@ export async function dev(
     httpHost?: string;
     httpPort?: number;
     restart?: boolean;
-    publicDirectory?: string;
     websocketPort?: number;
   } = {}
 ) {
@@ -516,7 +515,6 @@ let resolveDevBuild = async (
 
 type DevServeFlags = DevBuildFlags & {
   command: string;
-  publicDirectory: string;
   restart: boolean;
 };
 let resolveDevServe = async (
@@ -555,11 +553,6 @@ let resolveDevServe = async (
     }
   }
 
-  let publicDirectory =
-    flags.publicDirectory ??
-    (dev === true ? undefined : dev.publicDirectory) ??
-    "public";
-
   let restart =
     flags.restart ?? (dev === true ? undefined : dev.restart) ?? true;
 
@@ -568,7 +561,6 @@ let resolveDevServe = async (
     httpScheme,
     httpHost,
     httpPort,
-    publicDirectory,
     websocketPort,
     restart,
   };

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -48,7 +48,6 @@ ${colors.logoBlue("R")} ${colors.logoGreen("E")} ${colors.logoYellow(
     --http-host         HTTP(S) host for the dev server. Default: localhost
     --http-port         HTTP(S) port for the dev server. Default: any open port
     --no-restart        Do not restart the app server when rebuilds occur.
-    --public-directory  Path to public assets directory relative to Remix project root. Default: public
     --websocket-port    Websocket port for the dev server. Default: any open port
   \`init\` Options:
     --no-delete         Skip deleting the \`remix.init\` script
@@ -189,7 +188,6 @@ export async function run(argv: string[] = process.argv.slice(2)) {
       "--http-host": String,
       "--http-port": Number,
       "--no-restart": Boolean,
-      "--public-directory": String,
       "--websocket-port": Number,
     },
     {
@@ -226,10 +224,6 @@ export async function run(argv: string[] = process.argv.slice(2)) {
   if (flags["http-port"]) {
     flags.httpPort = flags["http-port"];
     delete flags["http-port"];
-  }
-  if (flags["public-directory"]) {
-    flags.publicDirectory = flags["public-directory"];
-    delete flags["public-directory"];
   }
   if (flags["websocket-port"]) {
     flags.websocketPort = flags["websocket-port"];

--- a/packages/remix-dev/compiler/js/compiler.ts
+++ b/packages/remix-dev/compiler/js/compiler.ts
@@ -202,11 +202,7 @@ const createEsbuildConfig = (
     platform: "browser",
     format: "esm",
     external: getExternals(ctx.config),
-    loader: {
-      ...loaders,
-      // in development, use dataurls for svgs so that `<use href={mysvg} />` works across different origins
-      ".svg": ctx.options.mode === "development" ? "dataurl" : loaders[".svg"],
-    },
+    loader: loaders,
     bundle: true,
     logLevel: "silent",
     splitting: true,


### PR DESCRIPTION
When sending HMR updates, the assumption was that serving assets from dev server would allow those updates to be sent immediately, without waiting for the app server to restart. But this isn't the case (e.g. if you navigate to another page that has a loader and the app server is rebooting, that loader fetch will fail).

---

Idea moving forward is:
1) If you don't mind a bit of downtime from your app server during dev, then you can rely on Remix restarts. but you'll need to wait for app server to reboot before you hard refresh or click buttons that trigger actions, or navigate to different pages that need loaders.

2) if that amount of downtime is too much for you, using chokidar and purgeRequireCache w/ --no-restart and that will keep you zipping along with an always-up server.

Note: during rebuild there is no downtime, its only after rebuild but before app server restart that there is some downtime with (1) 
^not serving assets from dev server also means there's less of a difference b/w dev and prod, which is nice. plus we don't have to use dataurls to handle svgs if we do that.
