### PR TITLE
docs(tutorials/blog): Fix markdown label spacing

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -184,6 +184,7 @@
 - HenryVogt
 - hicksy
 - himorishige
+- Hirochon
 - hkan
 - hokaccha
 - Holben888

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -734,7 +734,9 @@ export default function NewPost() {
         </label>
       </p>
       <p>
-        <label htmlFor="markdown">Markdown:</label>
+        <label htmlFor="markdown">
+          Markdown:{" "}
+        </label>
         <br />
         <textarea
           id="markdown"


### PR DESCRIPTION
Hi! 

This PR adds a whitespace character to the label of the Markdown input field in the create post form, in line with a similar change made in a later step of the tutorial.

The original code did not have a whitespace character after the colon, which caused a visual inconsistency with the other labels in a later step that was corrected by adding the whitespace character. This PR adds the whitespace character to the earlier step for consistency.

- [x] Docs
