### PR TITLE
fix(dev): use `;` for joining PATHs in windows

### DIFF
--- a/packages/remix-dev/devServer_unstable/index.ts
+++ b/packages/remix-dev/devServer_unstable/index.ts
@@ -70,7 +70,8 @@ export let serve = async (
       stdio: "pipe",
       env: {
         NODE_ENV: "development",
-        PATH: `${bin}:${process.env.PATH}`,
+        PATH:
+          bin + (process.platform === "win32" ? ";" : ":") + process.env.PATH,
         REMIX_DEV_HTTP_ORIGIN: stringifyOrigin(httpOrigin),
       },
     });


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
