### PR TITLE
docs(guide/styles): Fix anchor for tailwind css

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -533,3 +533,4 @@
 - iamzee
 - TimonVS
 - yudai-nkt
+- TomVance

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -817,7 +817,7 @@ module.exports = {
 [built-in-post-css-support]: #postcss
 [vanilla-extract-2]: #vanilla-extract
 [css-side-effect-imports]: #css-side-effect-imports
-[tailwind-2]: #tailwind
+[tailwind-2]: #tailwind-css
 [post-css]: #postcss
 [css-modules]: #css-modules
 [vanilla-extract-3]: #vanilla-extract


### PR DESCRIPTION
Corrects the fragment for the tailwind css docs, from #tailwind to #tailwind-css