### PR TITLE
docs(tutorials/jokes): remove unnecessary typecast

### DIFF
--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -3851,8 +3851,7 @@ export default function Login() {
             type="hidden"
             name="redirectTo"
             value={
-              (searchParams.get("redirectTo") as string) ??
-              undefined
+              searchParams.get("redirectTo") ?? undefined
             }
           />
           <fieldset>


### PR DESCRIPTION
This reverts @machour's #6209 as `URLSearchParams.get` returns a value of type `string | null`.
https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/get#return_value

The mentioned problem in #5843 was already fixed in #6050