### PR TITLE
refactor(remix-server-runtime): expose `SessionStorage`'s methods as arrow functions

### DIFF
--- a/.changeset/polite-garlics-invite.md
+++ b/.changeset/polite-garlics-invite.md
@@ -2,4 +2,4 @@
 "@remix-run/server-runtime": patch
 ---
 
-Added `this: void` to functions in the `SessionStorage` and `SessionIdStorageStrategy` interfaces so destructuring is correctly part of the contract.
+Expose methods in the `SessionStorage` interface as arrow functions so destructuring is correctly part of the contract.

--- a/.changeset/polite-garlics-invite.md
+++ b/.changeset/polite-garlics-invite.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": minor
+---
+
+Added `this: void` to functions in the `SessionStorage` and `SessionIdStorageStrategy` interfaces so destructuring is correctly part of the contract.

--- a/.changeset/polite-garlics-invite.md
+++ b/.changeset/polite-garlics-invite.md
@@ -1,5 +1,5 @@
 ---
-"@remix-run/server-runtime": minor
+"@remix-run/server-runtime": patch
 ---
 
 Added `this: void` to functions in the `SessionStorage` and `SessionIdStorageStrategy` interfaces so destructuring is correctly part of the contract.

--- a/contributors.yml
+++ b/contributors.yml
@@ -371,6 +371,7 @@
 - nareshbhatia
 - navid-kalaei
 - nexxeln
+- ngbrown
 - ni554n
 - nicholaschiang
 - nicksrandall

--- a/packages/remix-server-runtime/sessions.ts
+++ b/packages/remix-server-runtime/sessions.ts
@@ -174,31 +174,28 @@ export interface SessionStorage<Data = SessionData, FlashData = Data> {
    * Session. If there is no session associated with the cookie, this will
    * return a new Session with no data.
    */
-  getSession(
-    this: void,
+  getSession: (
     cookieHeader?: string | null,
     options?: CookieParseOptions
-  ): Promise<Session<Data, FlashData>>;
+  ) => Promise<Session<Data, FlashData>>;
 
   /**
    * Stores all data in the Session and returns the Set-Cookie header to be
    * used in the HTTP response.
    */
-  commitSession(
-    this: void,
+  commitSession: (
     session: Session<Data, FlashData>,
     options?: CookieSerializeOptions
-  ): Promise<string>;
+  ) => Promise<string>;
 
   /**
    * Deletes all data associated with the Session and returns the Set-Cookie
    * header to be used in the HTTP response.
    */
-  destroySession(
-    this: void,
+  destroySession: (
     session: Session<Data, FlashData>,
     options?: CookieSerializeOptions
-  ): Promise<string>;
+  ) => Promise<string>;
 }
 
 /**
@@ -224,7 +221,6 @@ export interface SessionIdStorageStrategy<
    * Creates a new record with the given data and returns the session id.
    */
   createData: (
-    this: void,
     data: FlashSessionData<Data, FlashData>,
     expires?: Date
   ) => Promise<string>;
@@ -232,16 +228,12 @@ export interface SessionIdStorageStrategy<
   /**
    * Returns data for a given session id, or `null` if there isn't any.
    */
-  readData: (
-    this: void,
-    id: string
-  ) => Promise<FlashSessionData<Data, FlashData> | null>;
+  readData: (id: string) => Promise<FlashSessionData<Data, FlashData> | null>;
 
   /**
    * Updates data for the given session id.
    */
   updateData: (
-    this: void,
     id: string,
     data: FlashSessionData<Data, FlashData>,
     expires?: Date
@@ -250,7 +242,7 @@ export interface SessionIdStorageStrategy<
   /**
    * Deletes data for a given session id from the data store.
    */
-  deleteData: (this: void, id: string) => Promise<void>;
+  deleteData: (id: string) => Promise<void>;
 }
 
 export type CreateSessionStorageFunction = <

--- a/packages/remix-server-runtime/sessions.ts
+++ b/packages/remix-server-runtime/sessions.ts
@@ -175,6 +175,7 @@ export interface SessionStorage<Data = SessionData, FlashData = Data> {
    * return a new Session with no data.
    */
   getSession(
+    this: void,
     cookieHeader?: string | null,
     options?: CookieParseOptions
   ): Promise<Session<Data, FlashData>>;
@@ -184,6 +185,7 @@ export interface SessionStorage<Data = SessionData, FlashData = Data> {
    * used in the HTTP response.
    */
   commitSession(
+    this: void,
     session: Session<Data, FlashData>,
     options?: CookieSerializeOptions
   ): Promise<string>;
@@ -193,6 +195,7 @@ export interface SessionStorage<Data = SessionData, FlashData = Data> {
    * header to be used in the HTTP response.
    */
   destroySession(
+    this: void,
     session: Session<Data, FlashData>,
     options?: CookieSerializeOptions
   ): Promise<string>;
@@ -221,6 +224,7 @@ export interface SessionIdStorageStrategy<
    * Creates a new record with the given data and returns the session id.
    */
   createData: (
+    this: void,
     data: FlashSessionData<Data, FlashData>,
     expires?: Date
   ) => Promise<string>;
@@ -228,12 +232,16 @@ export interface SessionIdStorageStrategy<
   /**
    * Returns data for a given session id, or `null` if there isn't any.
    */
-  readData: (id: string) => Promise<FlashSessionData<Data, FlashData> | null>;
+  readData: (
+    this: void,
+    id: string
+  ) => Promise<FlashSessionData<Data, FlashData> | null>;
 
   /**
    * Updates data for the given session id.
    */
   updateData: (
+    this: void,
     id: string,
     data: FlashSessionData<Data, FlashData>,
     expires?: Date
@@ -242,7 +250,7 @@ export interface SessionIdStorageStrategy<
   /**
    * Deletes data for a given session id from the data store.
    */
-  deleteData: (id: string) => Promise<void>;
+  deleteData: (this: void, id: string) => Promise<void>;
 }
 
 export type CreateSessionStorageFunction = <


### PR DESCRIPTION
## Summary of changes

This is just the relevant parts of the code changes from #6325 instead of also tackling eslint-config changes.

- Expose methods in the `SessionStorage` interface as arrow functions so destructuring is correctly part of the contract.

## Details

I attempted to add the typescript-eslint rules contained in ["plugin:@typescript-eslint/recommended-requiring-type-checking"](https://typescript-eslint.io/linting/configs#recommended-requiring-type-checking) to a Remix based project and came across two common code issues:

```js
const { pipe, abort } = renderToPipeableStream();
```

and then on:

```js
const { getSession, commitSession, destroySession } = createDatabaseSessionStorage();
```

Both of these cause an `unbound-method` error:

> error  Avoid referencing unbound methods which may cause unintentional scoping of `this`.
> 
> If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead @typescript-eslint/unbound-method

This error needed to be taken care of by the type definitions provided by the libraries.

`@types/react-dom` [v18.2.4](https://www.npmjs.com/package/@types/react-dom/v/18.2.4) now includes `this: void` in the functions returned from `renderToPipeableStream()`, so the first half is solved.

This pull request is to address the changes needed in Remix.

This could subtly change the contract for external libraries returning `SessionStorage`, so it would be good to get this in before Remix v2.

Testing Strategy:

> I opened up my windows machine and ran this script:
>
> ```
> yarn test:primary
> npx playwrite install
> yarn test
> yarn build --tsc
> ```

Also tested on a Remix project with eslint and ["plugin:@typescript-eslint/recommended-requiring-type-checking"](https://typescript-eslint.io/linting/configs#recommended-requiring-type-checking) enabled.