### PR TITLE
chore: let `@typescript-eslint/no-floating-promises` ESLint rule pass

### DIFF
--- a/packages/remix-dev/__tests__/utils/withApp.ts
+++ b/packages/remix-dev/__tests__/utils/withApp.ts
@@ -36,6 +36,6 @@ export default async <Result>(
     // errors when attempting to removing the temporary directory.
     // Retrying a couple times seems to get it to succeed.
     // See https://github.com/jprichardson/node-fs-extra/issues?q=EBUSY%3A+resource+busy+or+locked%2C+rmdir
-    retry(async () => await fse.remove(TEMP_DIR), 3, 200);
+    await retry(async () => await fse.remove(TEMP_DIR), 3, 200);
   }
 };

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -147,7 +147,7 @@ export async function watch(
       : await readConfig(remixRootOrConfig);
 
   let resolved = await resolveDev(config);
-  devServer.liveReload(config, resolved);
+  void devServer.liveReload(config, resolved);
   return await new Promise(() => {});
 }
 

--- a/packages/remix-dev/compiler/compiler.ts
+++ b/packages/remix-dev/compiler/compiler.ts
@@ -56,7 +56,7 @@ export let create = async (ctx: Context): Promise<Compiler> => {
       if (error === undefined) {
         error = thrown;
       }
-      cancel();
+      void cancel();
       return err(thrown);
     };
 

--- a/packages/remix-dev/compiler/fileWatchCache.ts
+++ b/packages/remix-dev/compiler/fileWatchCache.ts
@@ -111,7 +111,7 @@ export function createFileWatchCache(): FileWatchCache {
   ): Promise<CacheValue<T>> {
     promiseForCacheKey.set(key, promise);
 
-    promise
+    void promise
       .catch(() => {
         // Swallow errors to prevent the build from crashing and remove the
         // rejected promise from the cache so consumers can retry

--- a/packages/remix-dev/compiler/watch.ts
+++ b/packages/remix-dev/compiler/watch.ts
@@ -58,7 +58,7 @@ export async function watch(
 
   let restart = debounce(async () => {
     let start = Date.now();
-    compiler.dispose();
+    void compiler.dispose();
 
     try {
       ctx.config = await reloadConfig(ctx.config.rootDirectory);
@@ -130,6 +130,6 @@ export async function watch(
 
   return async () => {
     await watcher.close().catch(() => undefined);
-    compiler.dispose();
+    void compiler.dispose();
   };
 }

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -412,11 +412,13 @@ function useKeyedPrefetchLinks(matches: AgnosticDataRouteMatch[]) {
   React.useEffect(() => {
     let interrupted: boolean = false;
 
-    getKeyedPrefetchLinks(matches, manifest, routeModules).then((links) => {
-      if (!interrupted) {
-        setKeyedPrefetchLinks(links);
+    void getKeyedPrefetchLinks(matches, manifest, routeModules).then(
+      (links) => {
+        if (!interrupted) {
+          setKeyedPrefetchLinks(links);
+        }
       }
-    });
+    );
 
     return () => {
       interrupted = true;

--- a/packages/remix-react/data.ts
+++ b/packages/remix-react/data.ts
@@ -175,7 +175,7 @@ export async function parseDeferredReadableStream(
     }
 
     // Read the rest of the stream and resolve deferred promises
-    (async () => {
+    void (async () => {
       try {
         for await (let section of sectionReader) {
           // Determine event type and data

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -38,7 +38,7 @@ let onListen = () => {
     );
   }
   if (process.env.NODE_ENV === "development") {
-    broadcastDevReady(build);
+    void broadcastDevReady(build);
   }
 };
 


### PR DESCRIPTION
## Summary of changes

This is just the relevant parts of the code changes from #6325 instead of also tackling eslint-config changes.

- Added [`void` operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void) to Promises that are not being awaited. Used `await` on finally retry in test.

## Details

When enabling the typescript-eslint rules contained in ["plugin:@typescript-eslint/recommended-requiring-type-checking"](https://typescript-eslint.io/linting/configs#recommended-requiring-type-checking) I tried to improve code quality by addressing some of the issues raised when enabling the type checked linting rules.

This change specifically resolves issues raised with the typescript-eslint error: [`no-floating-promises`](https://typescript-eslint.io/rules/no-floating-promises).

> error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises


Testing Strategy:

> I opened up my windows machine and ran this script (with the additional eslint rules enabled from #6325):
>
> ```
> yarn lint
> yarn test:primary
> npx playwrite install
> yarn test
> yarn build --tsc
> ```

The specific rule configuration was:

```js
  "@typescript-eslint/no-floating-promises": [
    "error",
    { ignoreVoid: true, ignoreIIFE: true },
  ],
```
