### PR TITLE
refactor: simplify `V2_MetaArgs` & `V2_ServerRuntimeMetaArgs` types

### DIFF
--- a/packages/remix-react/routeModules.ts
+++ b/packages/remix-react/routeModules.ts
@@ -117,9 +117,7 @@ export interface V2_MetaArgs<
   Loader extends LoaderFunction | unknown = unknown,
   MatchLoaders extends Record<string, unknown> = Record<string, unknown>
 > {
-  data:
-    | (Loader extends LoaderFunction ? SerializeFrom<Loader> : AppData)
-    | undefined;
+  data?: Loader extends LoaderFunction ? SerializeFrom<Loader> : AppData;
   params: Params;
   location: Location;
   matches: V2_MetaMatches<MatchLoaders>;

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -200,9 +200,7 @@ export interface V2_ServerRuntimeMetaArgs<
   Loader extends LoaderFunction | unknown = unknown,
   MatchLoaders extends Record<string, unknown> = Record<string, unknown>
 > {
-  data:
-    | (Loader extends LoaderFunction ? SerializeFrom<Loader> : AppData)
-    | undefined;
+  data?: Loader extends LoaderFunction ? SerializeFrom<Loader> : AppData;
   params: Params;
   location: Location;
   matches: V2_ServerRuntimeMetaMatches<MatchLoaders>;


### PR DESCRIPTION
This is a simplification of @machour's #6231