### PR TITLE
chore(remix-cloudflare-pages): remove unnecessary typecast

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,9 @@ module.exports = {
     "plugin:markdown/recommended",
   ],
   plugins: ["markdown"],
+  settings: {
+    "import/internal-regex": "^~/",
+  },
   overrides: [
     {
       files: ["**/*.md/**"],
@@ -28,10 +31,29 @@ module.exports = {
       },
     },
     {
-      files: ["templates/**/*.*"],
+      files: [
+        "**/*.md/*.js?(x)",
+        "**/*.md/*.ts?(x)",
+        "integration/helpers/cf-template/**/*.*",
+        "integration/helpers/deno-template/**/*.*",
+        "integration/helpers/node-template/**/*.*",
+        "packages/remix-dev/config/defaults/**/*.*",
+        "templates/**/*.*",
+      ],
       rules: {
         "prefer-let/prefer-let": OFF,
         "prefer-const": WARN,
+
+        "import/order": [
+          WARN,
+          {
+            alphabetize: { caseInsensitive: true, order: "asc" },
+            groups: ["builtin", "external", "internal", "parent", "sibling"],
+            "newlines-between": "always",
+          },
+        ],
+
+        "react/jsx-no-leaked-render": [WARN, { validStrategies: ["ternary"] }],
       },
     },
   ],

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -28,16 +28,15 @@ on:
       TEST_VERCEL_USER_ID:
         required: true
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   arc_deploy:
     name: Architect Deploy
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -72,6 +71,9 @@ jobs:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -107,6 +109,9 @@ jobs:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -143,6 +148,9 @@ jobs:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -182,6 +190,9 @@ jobs:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -217,6 +228,9 @@ jobs:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -249,6 +263,9 @@ jobs:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,16 +6,15 @@ on:
       - main
       - dev
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   format:
     if: github.repository == 'remix-run/remix'
     runs-on: ubuntu-latest
 
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,15 +7,14 @@ on:
       - dev
   pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   lint:
     name: ⬣ Lint
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 

--- a/.github/workflows/merged-pr.yml
+++ b/.github/workflows/merged-pr.yml
@@ -1,0 +1,29 @@
+name: 📦 Merged PR
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - dev
+    paths:
+      - "packages/**"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  merged:
+    name: Add label to merged PR
+    if: github.event.pull_request.merged == true && github.repository == 'remix-run/remix'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          retries: 3
+          script: |
+            await github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: 'awaiting release',
+            })

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,10 +5,6 @@ on:
   schedule:
     - cron: "0 7 * * *" # every day at 12AM PST
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   CI: true
 
@@ -26,6 +22,9 @@ jobs:
       # allows this to be used in the `comment` job below - will be undefined if there's no release necessary
       NEXT_VERSION: ${{ steps.version.outputs.NEXT_VERSION }}
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -17,25 +17,18 @@ jobs:
       - name: 🥺 Handle Ghosting
         uses: actions/stale@v8
         with:
+          days-before-close: 10
           close-issue-message: >
-            This issue has been automatically closed because we didn't hear
-            anything from the original author after the previous notice.
+            This issue has been automatically closed because we haven't received a
+            response from the original author 🙈. This automation helps keep the issue
+            tracker clean from issues that are unactionable. Please reach out if you
+            have more information for us! 🙂
           close-pr-message: >
-            This PR has been automatically closed because we didn't hear
-            anything from the original author after the previous notice.
+            This PR has been automatically closed because we haven't received a
+            response from the original author 🙈. This automation helps keep the issue
+            tracker clean from PRs that are unactionable. Please reach out if you
+            have more information for us! 🙂
+          # don't automatically mark issues/PRs as stale
+          days-before-stale: -1
           stale-issue-label: needs-response
-          stale-issue-message: >
-            This issue has been automatically marked stale because we haven't
-            received a response from the original author in a while 🙈. This
-            automation helps keep the issue tracker clean from issues that are
-            not actionable. Please reach out if you have more information for us
-            or you think this issue shouldn't be closed! 🙂 If you don't do so
-            within 7 days, this issue will be automatically closed.
           stale-pr-label: needs-response
-          stale-pr-message: >
-            This PR has been automatically marked stale because we haven't
-            received a response from the original author in a while 🙈. This
-            automation helps keep the issue tracker clean from issues that are
-            not actionable. Please reach out if you have more information for us
-            or you think this issue shouldn't be closed! 🙂 If you don't do so
-            within 7 days, this PR will be automatically closed.

--- a/.github/workflows/release-comments.yml
+++ b/.github/workflows/release-comments.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: 📝 Comment on related issues and pull requests
-        uses: mcansh/release-comment-action@v0.4
+        uses: mcansh/release-comment-action@v0.4.1
         with:
           DIRECTORY_TO_CHECK: "./packages"
           PACKAGE_NAME: "remix"

--- a/.github/workflows/release-comments.yml
+++ b/.github/workflows/release-comments.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: 📝 Comment on related issues and pull requests
-        uses: mcansh/release-comment-action@v0.4.1
+        uses: remix-run/release-comment-action@v0.4.1
         with:
           DIRECTORY_TO_CHECK: "./packages"
           PACKAGE_NAME: "remix"

--- a/.github/workflows/release-comments.yml
+++ b/.github/workflows/release-comments.yml
@@ -15,7 +15,8 @@ jobs:
           fetch-depth: 0
 
       - name: 📝 Comment on related issues and pull requests
-        uses: mcansh/release-comment-action@v0.3.1
+        uses: mcansh/release-comment-action@v0.4
         with:
           DIRECTORY_TO_CHECK: "./packages"
           PACKAGE_NAME: "remix"
+          PR_LABELS_TO_REMOVE: "awaiting release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,6 @@ on:
       - "!release-manual"
       - "!release-manual-*"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   release:
     name: 🦋 Changesets Release
@@ -28,6 +24,9 @@ jobs:
       published_packages: ${{ steps.changesets.outputs.publishedPackages }}
       published: ${{ steps.changesets.outputs.published }}
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
         with:
@@ -73,6 +72,9 @@ jobs:
     outputs:
       package_version: ${{ steps.find_package_version.outputs.package_version }}
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -10,10 +10,6 @@ on:
         # so we'll need to manually stringify it for now
         type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   CI: true
   CYPRESS_INSTALL_BINARY: 0
@@ -23,6 +19,9 @@ jobs:
     name: ⚙️ Build
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -56,6 +55,9 @@ jobs:
         node: ${{ fromJSON(inputs.node_version) }}
     runs-on: ${{ matrix.os }}
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -91,6 +93,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -125,6 +130,9 @@ jobs:
 
     runs-on: macos-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -159,6 +167,9 @@ jobs:
 
     runs-on: windows-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 

--- a/.github/workflows/stacks.yml
+++ b/.github/workflows/stacks.yml
@@ -7,10 +7,6 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   setup:
     name: Remix Stacks Test
@@ -27,6 +23,9 @@ jobs:
           - repo: "remix-run/grunge-stack"
             name: "grunge"
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
@@ -81,6 +80,9 @@ jobs:
           - repo: "remix-run/grunge-stack"
             name: "grunge"
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: 🗄️ Restore ${{ matrix.stack.name }}
         uses: actions/download-artifact@v3
         with:
@@ -121,6 +123,9 @@ jobs:
           - repo: "remix-run/grunge-stack"
             name: "grunge"
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: 🗄️ Restore ${{ matrix.stack.name }}
         uses: actions/download-artifact@v3
         with:
@@ -161,6 +166,9 @@ jobs:
           - repo: "remix-run/grunge-stack"
             name: "grunge"
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: 🗄️ Restore ${{ matrix.stack.name }}
         uses: actions/download-artifact@v3
         with:
@@ -204,6 +212,9 @@ jobs:
             name: "grunge"
             cypress: "npm run dev"
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - name: 🗄️ Restore ${{ matrix.stack.name }}
         uses: actions/download-artifact@v3
         with:

--- a/contributors.yml
+++ b/contributors.yml
@@ -33,6 +33,7 @@
 - AntoninBeaufort
 - anubra266
 - apeltop
+- appden
 - Aprillion
 - arange
 - archwebio

--- a/contributors.yml
+++ b/contributors.yml
@@ -143,6 +143,7 @@
 - eps1lon
 - esamattis
 - evanwinter
+- everdimension
 - exegeteio
 - F3n67u
 - federicoestevez

--- a/contributors.yml
+++ b/contributors.yml
@@ -118,6 +118,7 @@
 - dima-takoy
 - dmarkow
 - DNLHC
+- dnsbty
 - dogukanakkaya
 - dokeet
 - donavon

--- a/contributors.yml
+++ b/contributors.yml
@@ -536,3 +536,4 @@
 - iamzee
 - TimonVS
 - yudai-nkt
+- TomVance

--- a/contributors.yml
+++ b/contributors.yml
@@ -537,3 +537,4 @@
 - TimonVS
 - yudai-nkt
 - TomVance
+- baby230211

--- a/contributors.yml
+++ b/contributors.yml
@@ -185,6 +185,7 @@
 - hicksy
 - himorishige
 - hjonasson
+- Hirochon
 - hkan
 - hokaccha
 - Holben888

--- a/contributors.yml
+++ b/contributors.yml
@@ -289,6 +289,7 @@
 - lensbart
 - leo
 - leon
+- leovander
 - levippaul
 - LewisArdern
 - lifeiscontent

--- a/contributors.yml
+++ b/contributors.yml
@@ -78,6 +78,7 @@
 - chenc041
 - chenxsan
 - chiangs
+- chimame
 - chipit24
 - chohner
 - christianhg

--- a/docs/file-conventions/root.md
+++ b/docs/file-conventions/root.md
@@ -32,7 +32,7 @@ export const links: LinksFunction = () => {
 export const meta: MetaFunction = () => ({
   charset: "utf-8",
   title: "My Amazing App",
-  viewport: "width=device-width,initial-scale=1",
+  viewport: "width=device-width, initial-scale=1",
 });
 
 export default function App() {

--- a/docs/file-conventions/routes-files.md
+++ b/docs/file-conventions/routes-files.md
@@ -118,7 +118,6 @@ app/
 │   ├── ($lang)/
 │   │   ├── $pid.tsx
 │   │   ├── categories.tsx
-│   │   └── index.tsx
 │   └── index.tsx
 └── root.tsx
 ```

--- a/docs/guides/constraints.md
+++ b/docs/guides/constraints.md
@@ -22,8 +22,8 @@ Consider a route module that exports `loader`, `meta`, and a component:
 import { json } from "@remix-run/node"; // or cloudflare/deno
 import { useLoaderData } from "@remix-run/react";
 
-import PostsView from "../PostsView";
 import { prisma } from "../db";
+import PostsView from "../PostsView";
 
 export async function loader() {
   return json(await prisma.post.findMany());
@@ -80,8 +80,8 @@ Taking our code from earlier, we saw how the compiler can remove the exports and
 import { json } from "@remix-run/node"; // or cloudflare/deno
 import { useLoaderData } from "@remix-run/react";
 
-import PostsView from "../PostsView";
 import { prisma } from "../db";
+import PostsView from "../PostsView";
 
 console.log(prisma);
 
@@ -127,8 +127,8 @@ To fix this, remove the side effect by simply moving the code _into the loader_.
 import { json } from "@remix-run/node"; // or cloudflare/deno
 import { useLoaderData } from "@remix-run/react";
 
-import PostsView from "../PostsView";
 import { prisma } from "../db";
+import PostsView from "../PostsView";
 
 export async function loader() {
   console.log(prisma);

--- a/docs/guides/constraints.md
+++ b/docs/guides/constraints.md
@@ -101,11 +101,11 @@ export default function Posts() {
 
 That `console.log` _does something_. The module is imported and then immediately logs to the console. The compiler won't remove it because it has to run when the module is imported. It will bundle something like this:
 
-```tsx bad lines=[4,6]
+```tsx bad lines=[3,6]
 import { useLoaderData } from "@remix-run/react";
 
-import PostsView from "../PostsView";
 import { prisma } from "../db"; //😬
+import PostsView from "../PostsView";
 
 console.log(prisma); //🥶
 

--- a/docs/guides/migrating-react-router-app.md
+++ b/docs/guides/migrating-react-router-app.md
@@ -47,6 +47,7 @@ Let's start by creating two new files:
 
 ```tsx filename=app/entry.server.tsx
 import { PassThrough } from "stream";
+
 import type { EntryContext } from "@remix-run/node";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
@@ -631,8 +632,8 @@ npm install @remix-run/css-bundle
 Then, import `cssBundleHref` and add it to a link descriptor—most likely in `root.tsx` so that it applies to your entire application.
 
 ```tsx filename=root.tsx lines=[2,6-8]
-import type { LinksFunction } from "@remix-run/node"; // or cloudflare/deno
 import { cssBundleHref } from "@remix-run/css-bundle";
+import type { LinksFunction } from "@remix-run/node"; // or cloudflare/deno
 
 export const links: LinksFunction = () => {
   return [

--- a/docs/guides/not-found.md
+++ b/docs/guides/not-found.md
@@ -24,8 +24,9 @@ export async function loader({ params }: LoaderArgs) {
   });
 
   if (!page) {
-    throw new Response("Not Found", {
+    throw new Response(null, {
       status: 404,
+      statusText: "Not Found",
     });
   }
 
@@ -82,8 +83,9 @@ export async function loader({ params }: LoaderArgs) {
   });
 
   if (!page) {
-    throw new Response("Not Found", {
+    throw new Response(null, {
       status: 404,
+      statusText: "Not Found",
     });
   }
 

--- a/docs/guides/resource-routes.md
+++ b/docs/guides/resource-routes.md
@@ -124,9 +124,10 @@ export const action = async ({ request }: ActionArgs) => {
 Resource routes can be used to handle webhooks. For example, you can create a webhook that receives notifications from GitHub when a new commit is pushed to a repository:
 
 ```tsx
+import crypto from "crypto";
+
 import type { ActionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
-import crypto from "crypto";
 
 export const action = async ({ request }: ActionArgs) => {
   if (request.method !== "POST") {

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -59,6 +59,29 @@ The primary way to define a route is to create a new file in `app/routes/*`. The
 app
 ├── root.jsx
 └── routes
+    ├── _index.jsx
+    ├── accounts.jsx
+    ├── dashboard.jsx
+    ├── expenses.jsx
+    ├── reports.jsx
+    ├── sales._index.jsx
+    ├── sales.customers.jsx
+    ├── sales.deposits.jsx
+    ├── sales.invoices.$invoiceId._index.jsx
+    ├── sales.invoices.$invoiceId.jsx
+    ├── sales.invoices.jsx
+    ├── sales.subscriptions.jsx
+    └── sales.jsx
+```
+
+<details>
+
+<summary>Or if using the v1 routing convention:</summary>
+
+```
+app
+├── root.jsx
+└── routes
     ├── accounts.jsx
     ├── dashboard.jsx
     ├── expenses.jsx
@@ -76,9 +99,11 @@ app
     └── sales.jsx
 ```
 
+</details>
+
 - `root.jsx` is the "root route" that serves as the layout for the entire application. Every route will render inside of its `<Outlet/>`.
-- Note that there are files that match the same name as a folder, this indicates a component layout hierarchy. For example, `sales.jsx` is the **parent route** for all of the **child routes** inside of `app/routes/sales/*`. When a route inside of the sales directory matches, it will render inside of the `sales.jsx` route's `<Outlet>`
-- The `index.jsx` routes will render inside of the parent `<Outlet>` when the url is only as deep as the parent's path (like `example.com/sales` instead of `example.com/sales/customers`)
+- Note that there are files with `.` delimiters. The `.` creates a `/` in the URL for that route, as well as layout nesting with another route that matches the segments before the `.`. For example, `sales.jsx` is the **parent route** for all of the **child routes** that look like `sales.[the nested path].jsx`. The `<Outlet />` in `sales.jsx` will render the matching child route.
+- The `_index.jsx` routes will render inside of the parent `<Outlet>` when the url is only as deep as the parent's path (like `example.com/sales` instead of `example.com/sales/customers`)
 
 ## Rendering Route Layout Hierarchies
 
@@ -86,8 +111,8 @@ Let's consider the URL is `/sales/invoices/102000`. The following routes all mat
 
 - `root.jsx`
 - `routes/sales.jsx`
-- `routes/sales/invoices.jsx`
-- `routes/sales/invoices/$invoiceId.jsx`
+- `routes/sales.invoices.jsx`
+- `routes/sales.invoices.$invoiceId.jsx`
 
 When the user visits this page, Remix will render the components in this hierarchy:
 
@@ -107,10 +132,8 @@ You'll note that the component hierarchy is perfectly mapped to the file system 
 app
 ├── root.jsx
 └── routes
-    ├── sales
-    │   ├── invoices
-    │   │   └── $invoiceId.jsx
-    │   └── invoices.jsx
+    ├── sales.invoices.$invoiceId.jsx
+    ├── sales.invoices.jsx
     └── sales.jsx
 ```
 
@@ -137,7 +160,7 @@ export default function Root() {
 }
 ```
 
-Next up is the sales route, which also renders an outlet for its child routes (all of the routes inside of `app/routes/sales/*.jsx`).
+Next up is the sales route, which also renders an outlet for its child routes (all of the routes matching `app/routes/sales.*.jsx`).
 
 ```tsx filename=app/routes/sales.tsx lines=[8]
 import { Outlet } from "@remix-run/react";
@@ -159,7 +182,7 @@ And so on down the route tree. This is a powerful abstraction that makes somethi
 
 Index routes are often difficult to understand at first. It's easiest to think of them as _the default child route_ for a parent route. When there is no child route to render, we render the index route.
 
-Consider the URL `example.com/sales`. If our app didn't have an index route at `app/routes/sales/index.jsx` the UI would look like this!
+Consider the URL `example.com/sales`. If our app didn't have an index route at `app/routes/sales._index.jsx` the UI would look like this!
 
 <iframe src="/_docs/routing-index" class="w-full aspect-[4/3] rounded-lg overflow-hidden mb-4"></iframe>
 
@@ -169,20 +192,18 @@ And index is the thing you render to fill in that empty space when none of the c
 
 Index routes are "leaf routes". They're the end of the line. If you think you need to add child routes to an index route, that usually means your layout code (like a shared nav) needs to move out of the index route and into the parent route.
 
-This usually comes up when folks are just getting started with Remix and put their global nav in `app/routes/index.jsx`. Move that global nav up into `app/root.jsx`. Everything inside of `app/routes/*` is already a child of `root.tsx`.
+This usually comes up when folks are just getting started with Remix and put their global nav in `app/routes/_index.jsx`. Move that global nav up into `app/root.jsx`. Everything inside of `app/routes/*` is already a child of `root.tsx`.
 
 ### What is the `?index` query param?
 
-You may notice an `?index` query parameter showing up on your URLs from time to time, particularly when you are submitting a `<Form>` from an index route. This is required to differentiate index routes from their parent layout routes. Consider the following structure, where a URL such as `/sales/invoices` would be ambiguous. Is that referring to the `routes/sales/invoices.jsx` file? Or is it referring to the `routes/sales/invoices/index.jsx` file? In order to avoid this ambiguity, Remix uses the `?index` parameter to indicate when a URL refers to the index route instead of the layout route.
+You may notice an `?index` query parameter showing up on your URLs from time to time, particularly when you are submitting a `<Form>` from an index route. This is required to differentiate index routes from their parent layout routes. Consider the following structure, where a URL such as `/sales/invoices` would be ambiguous. Is that referring to the `routes/sales.invoices.jsx` file? Or is it referring to the `routes/sales.invoices._index.jsx` file? In order to avoid this ambiguity, Remix uses the `?index` parameter to indicate when a URL refers to the index route instead of the layout route.
 
 ```
 └── app
     ├── root.jsx
     └── routes
-        ├── sales
-        │   ├── invoices
-        │   │   └── index.jsx   <-- /sales/invoices?index
-        │   └── invoices.jsx    <-- /sales/invoices
+        ├── sales.invoices._index.jsx   <-- /sales/invoices?index
+        ├── sales.invoices.invoices.jsx <-- /sales/invoices
 ```
 
 This is handled automatically for you when you submit from a `<Form>` contained within either the layout route or the index route. But if you are submitting forms to different routes, or using `fetcher.submit`/`fetcher.load` you may need to be aware of this URL pattern so you can target the correct route.
@@ -216,21 +237,19 @@ We want this:
 </Root>
 ```
 
-So, if we want a flat UI hierarchy, we create a flat filename--we use `"."` to create segments instead of folders. This defines URL nesting _without creating component nesting_.
+So, if we want a flat UI hierarchy, we use a `trailing_` underscore to opt-out of layout nesting. This defines URL nesting _without creating component nesting_.
 
 ```
 └── app
     ├── root.jsx
     └── routes
-        ├── sales
-        │   ├── invoices
-        │   │   └── $invoiceId.jsx
-        │   └── invoices.jsx
-        ├── sales.invoices.$invoiceId.edit.jsx 👈 not nested
+        ├── sales.invoices.$invoiceId.jsx
+        ├── sales.invoices.jsx
+        ├── sales_.invoices.$invoiceId.edit.jsx 👈 not nested
         └── sales.jsx
 ```
 
-Just for absolute clarity, if the url is "example.com/sales/invoices/2000/edit", we'll get this UI hierarchy that matches the file system hierarchy:
+So if the url is "example.com/sales/invoices/2000/edit", we'll get this UI hierarchy that matches the file system hierarchy:
 
 ```tsx
 <Root>
@@ -250,10 +269,10 @@ If we remove "edit" from the URL like this: "example.com/sales/invoices/2000", t
 </Root>
 ```
 
-- Nested files: layout nesting + nested urls
-- Flat files: no layout nesting + nested urls
+- Layout Nesting + Nested URLs: happens automatically with `.` delimiters that match parent route names.
+- `trailing_` underscore on the segment matching the parent route opts-out of layout nesting.
 
-You can introduce nesting or non-nesting at any level of your routes, like `app/routes/invoices/$id.edit.js`, which matches the URL `/invoices/123/edit` but does not create nesting inside of `$id.js`.
+You can introduce nesting or non-nesting at any level of your routes, like `app/routes/invoices.$id_.edit.js`, which matches the URL `/invoices/123/edit` but does not create nesting inside of `$id.js`, it would nest with `routes/invoices.jsx` instead.
 
 ## Pathless Layout Routes
 
@@ -275,29 +294,34 @@ At first, you might think to just create an `auth` parent route and put the chil
 app
 ├── root.jsx
 └── routes
-    ├── auth
-    │   ├── login.jsx
-    │   ├── logout.jsx
-    │   └── signup.jsx
+    ├── auth.login.jsx
+    ├── auth.logout.jsx
+    ├── auth.signup.jsx
     └── auth.jsx
 ```
 
 We have the right UI hierarchy, but we probably don't actually want each of the URLs to be prefixed with `/auth` like `/auth/login`. We just want `/login`.
 
-You can remove the URL nesting, but keep the UI nesting, by adding two underscores to the route and folder name:
+You can remove the URL nesting, but keep the UI nesting, by adding an underscore to the auth route segment:
 
 ```
 app
 ├── root.jsx
 └── routes
-    ├── __auth
-    │   ├── login.jsx
-    │   ├── logout.jsx
-    │   └── signup.jsx
-    └── __auth.jsx
+    ├── _auth.login.jsx
+    ├── _auth.logout.jsx
+    ├── _auth.signup.jsx
+    └── _auth.jsx
 ```
 
-And that's it! When the URL matches `/login` the UI hierarchy will be same as before.
+Now when the URL matches `/login` the UI hierarchy will be same as before.
+
+<docs-info>
+
+- `_leading` underscore opts-out of URL nesting
+- `trailing_` underscore opts-out of layout nesting
+
+</docs-info>
 
 ## Dynamic Segments
 
@@ -328,10 +352,8 @@ Route can have multiple params, and params can be folders as well.
 app
 ├── root.jsx
 └── routes
-    ├── projects
-    │   ├── $projectId
-    │   │   └── $taskId.jsx
-    │   └── $projectId.jsx
+    ├── projects.$projectId.jsx
+    ├── projects.$projectId.$taskId.jsx
     └── projects.jsx
 ```
 
@@ -352,10 +374,9 @@ Consider the following routes:
 app
 ├── root.jsx
 └── routes
-    ├── files
-    │   ├── $.jsx
-    │   ├── mine.jsx
-    │   └── recent.jsx
+    ├── files.$.jsx
+    ├── files.mine.jsx
+    ├── files.recent.jsx
     └── files.jsx
 ```
 
@@ -369,7 +390,7 @@ export async function loader({ params }: LoaderArgs) {
 
 You can add splats at any level of your route hierarchy. Any sibling routes will match first (like `/files/mine`).
 
-It's common to add a `routes/$.jsx` file build custom 404 pages with data from a loader (without it, Remix renders your root `CatchBoundary` with no ability to load data for the page when the URL doesn't match any routes).
+It's common to add a `routes/$.jsx` file build custom 404 pages with data from a loader (without it, Remix renders your root `ErrorBoundary` with no ability to load data for the page when the URL doesn't match any routes).
 
 ## Conclusion
 

--- a/docs/guides/streaming.md
+++ b/docs/guides/streaming.md
@@ -80,15 +80,16 @@ Let's take a dive into how to accomplish this.
 
 First, to enable streaming with React 18, you'll update your `entry.server.tsx` file to use `renderToPipeableStream`. Here's a simple (and incomplete) version of that:
 
-```tsx filename=app/entry.server.tsx lines=[1-2,17,24,29,34]
+```tsx filename=app/entry.server.tsx lines=[1,9,18,25,30,35]
 import { PassThrough } from "stream";
-import { renderToPipeableStream } from "react-dom/server";
-import { RemixServer } from "@remix-run/react";
+
 import { Response } from "@remix-run/node"; // or cloudflare/deno
 import type {
   EntryContext,
   Headers,
 } from "@remix-run/node"; // or cloudflare/deno
+import { RemixServer } from "@remix-run/react";
+import { renderToPipeableStream } from "react-dom/server";
 
 export default function handleRequest(
   request: Request,
@@ -259,11 +260,11 @@ With just that in place, you're unlikely to see any significant performance impr
 
 With React streaming set up, now you can start adding `Await` usage for your slow data requests where you'd rather render a fallback UI. Let's do that for our example above:
 
-```tsx lines=[1,3,4,9-11,13-15,24-33,38-40]
-import { Suspense } from "react";
+```tsx lines=[2-4,9-11,13-15,24-33,38-40]
 import type { LoaderArgs } from "@remix-run/node"; // or cloudflare/deno
 import { defer } from "@remix-run/node"; // or cloudflare/deno
 import { Await, useLoaderData } from "@remix-run/react";
+import { Suspense } from "react";
 
 import { getPackageLocation } from "~/models/packages";
 

--- a/docs/guides/streaming.md
+++ b/docs/guides/streaming.md
@@ -336,7 +336,9 @@ export default function PackageRoute() {
 }
 
 function PackageLocation() {
-  const packageLocation = useAsyncValue() as SerializeFrom<typeof loader>["packageLocation"];
+  const packageLocation = useAsyncValue() as SerializeFrom<
+    typeof loader
+  >["packageLocation"];
 
   return (
     <p>

--- a/docs/guides/streaming.md
+++ b/docs/guides/streaming.md
@@ -130,14 +130,15 @@ This handles errors and properly disables streaming for bots which you typically
 
 ```tsx filename=app/entry.server.tsx
 import { PassThrough } from "stream";
-import { renderToPipeableStream } from "react-dom/server";
-import { RemixServer } from "@remix-run/react";
+
 import { Response } from "@remix-run/node"; // or cloudflare/deno
 import type {
   EntryContext,
   Headers,
 } from "@remix-run/node"; // or cloudflare/deno
+import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
+import { renderToPipeableStream } from "react-dom/server";
 
 const ABORT_DELAY = 5000;
 

--- a/docs/guides/streaming.md
+++ b/docs/guides/streaming.md
@@ -311,7 +311,7 @@ export default function PackageRoute() {
 If you're not jazzed about bringing back render props, you can use a hook, but you'll have to break things out into another component:
 
 ```tsx lines=[1,18,26-29]
-import type { SerializedFrom } from "@remix-run/node"; // or cloudflare/deno
+import type { SerializeFrom } from "@remix-run/node"; // or cloudflare/deno
 
 export default function PackageRoute() {
   const data = useLoaderData<typeof loader>();
@@ -336,10 +336,7 @@ export default function PackageRoute() {
 }
 
 function PackageLocation() {
-  const packageLocation =
-    useAsyncValue<
-      SerializedFrom<typeof loader>["packageLocation"]
-    >();
+  const packageLocation = useAsyncValue() as SerializeFrom<typeof loader>["packageLocation"];
 
   return (
     <p>

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -817,7 +817,7 @@ module.exports = {
 [built-in-post-css-support]: #postcss
 [vanilla-extract-2]: #vanilla-extract
 [css-side-effect-imports]: #css-side-effect-imports
-[tailwind-2]: #tailwind
+[tailwind-2]: #tailwind-css
 [post-css]: #postcss
 [css-modules]: #css-modules
 [vanilla-extract-3]: #vanilla-extract

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -606,7 +606,7 @@ Here's some sample code to show how you might use Styled Components with Remix (
 
    export const meta: MetaFunction = () => ({
      charset: "utf-8",
-     viewport: "width=device-width,initial-scale=1",
+     viewport: "width=device-width, initial-scale=1",
    });
 
    export default function App() {

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -256,10 +256,10 @@ import type { LoaderArgs } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
 import { useLoaderData } from "@remix-run/react";
 
-import { TileGrid } from "~/components/tile-grid";
-import { ProductTile } from "~/components/product-tile";
-import { ProductDetails } from "~/components/product-details";
 import { AddFavoriteButton } from "~/components/add-favorite-button";
+import { ProductDetails } from "~/components/product-details";
+import { ProductTile } from "~/components/product-tile";
+import { TileGrid } from "~/components/tile-grid";
 import styles from "~/styles/$category.css";
 
 export function links() {
@@ -293,21 +293,21 @@ The component imports are already there, we just need to surface the assets:
 import type { LinksFunction } from "@remix-run/node"; // or cloudflare/deno
 
 import {
-  TileGrid,
-  links as tileGridLinks,
-} from "~/components/tile-grid";
-import {
-  ProductTile,
-  links as productTileLinks,
-} from "~/components/product-tile";
+  AddFavoriteButton,
+  links as addFavoriteLinks,
+} from "~/components/add-favorite-button";
 import {
   ProductDetails,
   links as productDetailsLinks,
 } from "~/components/product-details";
 import {
-  AddFavoriteButton,
-  links as addFavoriteLinks,
-} from "~/components/add-favorite-button";
+  ProductTile,
+  links as productTileLinks,
+} from "~/components/product-tile";
+import {
+  TileGrid,
+  links as tileGridLinks,
+} from "~/components/tile-grid";
 import styles from "~/styles/$category.css";
 
 export const links: LinksFunction = () => {
@@ -634,9 +634,9 @@ Here's some sample code to show how you might use Styled Components with Remix (
 2. Your `entry.server.tsx` will look something like this:
 
    ```tsx filename=entry.server.tsx lines=[4,12,15-20,22-23]
-   import { renderToString } from "react-dom/server";
-   import { RemixServer } from "@remix-run/react";
    import type { EntryContext } from "@remix-run/node"; // or cloudflare/deno
+   import { RemixServer } from "@remix-run/react";
+   import { renderToString } from "react-dom/server";
    import { ServerStyleSheet } from "styled-components";
 
    export default function handleRequest(

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -206,8 +206,9 @@ And then a `<PrimaryButton>` that extends it:
 }
 ```
 
-```tsx filename=app/components/primary-button/index.js lines=[1,5,12]
+```tsx filename=app/components/primary-button/index.js lines=[1,6,13]
 import { Button, links as buttonLinks } from "../button";
+
 import styles from "./styles.css";
 
 export const links = () => [
@@ -231,12 +232,12 @@ Because these buttons are not routes, and therefore not associated with a URL se
 
 Consider that `routes/index.js` uses the primary button component:
 
-```tsx filename=app/routes/index.js lines=[2-5,9]
-import styles from "~/styles/index.css";
+```tsx filename=app/routes/index.js lines=[1-4,9]
 import {
   PrimaryButton,
   links as primaryButtonLinks,
 } from "~/components/primary-button";
+import styles from "~/styles/index.css";
 
 export function links() {
   return [
@@ -688,9 +689,9 @@ npm install @remix-run/css-bundle
 
 Then, import `cssBundleHref` and add it to a link descriptor—most likely in `root.tsx` so that it applies to your entire application.
 
-```tsx filename=root.tsx lines=[2,6-8]
-import type { LinksFunction } from "@remix-run/node"; // or cloudflare/deno
+```tsx filename=root.tsx lines=[1,6-8]
 import { cssBundleHref } from "@remix-run/css-bundle";
+import type { LinksFunction } from "@remix-run/node"; // or cloudflare/deno
 
 export const links: LinksFunction = () => {
   return [

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ npx create-remix@latest
   <a href="https://github.com/remix-run/examples" aria-label="Remix Examples">
     <docs-card>
       <h4>Remix Examples</h4>
-      <p>Have a look at the various Remix examples made by the community and carefully reviewed by our team.</p>
+      <p>Have a look at the various Remix examples made by the community.</p>
     </docs-card>
   </a>
   <a href="https://rmx.as/discord" aria-label="Remix Discord">

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,25 +15,25 @@ npx create-remix@latest
 ## Getting Started
 
 <docs-cards>
-  <a href="pages/technical-explanation" aria-label="Technical Explanation">
+  <a href="/docs/en/main/pages/technical-explanation" aria-label="Technical Explanation">
     <docs-card>
       <h4>Technical Explanation</h4>
       <p>If you're wondering what Remix is, this is the page for you. Learn how Remix is four primary things: a compiler, an HTTP handler, a server framework, and a browser framework.</p>
     </docs-card>
   </a>
-  <a href="pages/v2" aria-label="Preparing for v2">
+  <a href="/docs/en/main/pages/v2" aria-label="Preparing for v2">
     <docs-card>
       <h4>Preparing for v2</h4> 
       <p>Remix v2 is coming soon! All of the new APIs and behaviors are available already in v1 behind Future Flags. This doc will help you incrementally adopt each one so that when its time to update to v2, you don't have to change a thing.</p>
     </docs-card>
   </a>
-  <a href="tutorials/blog" aria-label="Developer Blog Tutorial">
+  <a href="/docs/en/main/tutorials/blog" aria-label="Developer Blog Tutorial">
     <docs-card>
       <h4>Blog Tutorial</h4>
       <p>Spend your first few minutes with Remix here and let us introduce some of the core features as quickly as possible. After this you can go explore the docs or dive deeper with the other tutorials. We'll build a little markdown blog with data loading, actions, form validation, redirects, and more.</p>
     </docs-card>
   </a>
-  <a href="tutorials/jokes" aria-label="Jokes App Tutorial">
+  <a href="/docs/en/main/tutorials/jokes" aria-label="Jokes App Tutorial">
     <docs-card>
       <h4>Jokes App Deep Dive</h4> 
       <p>Dive deep into Remix and full stack development with this app. It's backed by a SQL database, user authentication and session, and of course some modern UI finishes. You'll learn about nested routes, sessions, data loading, data mutations, progressive enhancement, and more. Get a feel for what a data-backed web app feels like with Remix.</p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,25 +15,25 @@ npx create-remix@latest
 ## Getting Started
 
 <docs-cards>
-  <a href="/docs/en/main/pages/technical-explanation" aria-label="Technical Explanation">
+  <a href="/pages/technical-explanation" aria-label="Technical Explanation">
     <docs-card>
       <h4>Technical Explanation</h4>
       <p>If you're wondering what Remix is, this is the page for you. Learn how Remix is four primary things: a compiler, an HTTP handler, a server framework, and a browser framework.</p>
     </docs-card>
   </a>
-  <a href="/docs/en/main/pages/v2" aria-label="Preparing for v2">
+  <a href="/pages/v2" aria-label="Preparing for v2">
     <docs-card>
       <h4>Preparing for v2</h4> 
       <p>Remix v2 is coming soon! All of the new APIs and behaviors are available already in v1 behind Future Flags. This doc will help you incrementally adopt each one so that when its time to update to v2, you don't have to change a thing.</p>
     </docs-card>
   </a>
-  <a href="/docs/en/main/tutorials/blog" aria-label="Developer Blog Tutorial">
+  <a href="/tutorials/blog" aria-label="Developer Blog Tutorial">
     <docs-card>
       <h4>Blog Tutorial</h4>
       <p>Spend your first few minutes with Remix here and let us introduce some of the core features as quickly as possible. After this you can go explore the docs or dive deeper with the other tutorials. We'll build a little markdown blog with data loading, actions, form validation, redirects, and more.</p>
     </docs-card>
   </a>
-  <a href="/docs/en/main/tutorials/jokes" aria-label="Jokes App Tutorial">
+  <a href="/tutorials/jokes" aria-label="Jokes App Tutorial">
     <docs-card>
       <h4>Jokes App Deep Dive</h4> 
       <p>Dive deep into Remix and full stack development with this app. It's backed by a SQL database, user authentication and session, and of course some modern UI finishes. You'll learn about nested routes, sessions, data loading, data mutations, progressive enhancement, and more. Get a feel for what a data-backed web app feels like with Remix.</p>

--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -46,11 +46,11 @@ createRequestHandler({ build, getLoadContext });
 
 Here's a full example with express:
 
-```ts lines=[2-4,11-22]
-const express = require("express");
+```ts lines=[1-3,11-22]
 const {
   createRequestHandler,
 } = require("@remix-run/express");
+const express = require("express");
 
 const app = express();
 

--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -98,6 +98,7 @@ Here's an example with Netlify:
 
 ```ts
 const path = require("path");
+
 const {
   createRequestHandler,
 } = require("@remix-run/netlify");

--- a/docs/other-api/asset-imports.md
+++ b/docs/other-api/asset-imports.md
@@ -16,8 +16,8 @@ It's most common for stylesheets, but can used for anything.
 ```tsx filename=app/routes/root.tsx
 import type { LinksFunction } from "@remix-run/node"; // or cloudflare/deno
 
-import styles from "./styles/app.css";
 import banner from "./images/banner.jpg";
+import styles from "./styles/app.css";
 
 export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: styles }];

--- a/docs/pages/technical-explanation.md
+++ b/docs/pages/technical-explanation.md
@@ -34,9 +34,9 @@ It's built on the [Web Fetch API][fetch] instead of Node.js. This enables Remix 
 
 This is what Remix looks like when running in an express app:
 
-```ts lines=[2,6-9]
-const express = require("express");
+```ts lines=[1,6-9]
 const remix = require("@remix-run/express");
+const express = require("express");
 
 const app = express();
 

--- a/docs/pages/v2.md
+++ b/docs/pages/v2.md
@@ -379,7 +379,7 @@ function Component() {
     navigation.formMethod != null &&
     navigation.formMethod != "get" &&
     // We had a submission navigation and are loading the submitted location
-    navigation.formAction === navigation.pathname;
+    navigation.formAction === navigation.location.pathname;
 
   // transition.type === "actionRedirect"
   const isActionRedirect =
@@ -387,21 +387,21 @@ function Component() {
     navigation.formMethod != null &&
     navigation.formMethod != "get" &&
     // We had a submission navigation and are now navigating to different location
-    navigation.formAction !== navigation.pathname;
+    navigation.formAction !== navigation.location.pathname;
 
   // transition.type === "loaderSubmission"
   const isLoaderSubmission =
     navigation.state === "loading" &&
     navigation.state.formMethod === "get" &&
     // We had a loader submission and are navigating to the submitted location
-    navigation.formAction === navigation.pathname;
+    navigation.formAction === navigation.location.pathname;
 
   // transition.type === "loaderSubmissionRedirect"
   const isLoaderSubmissionRedirect =
     navigation.state === "loading" &&
     navigation.state.formMethod === "get" &&
     // We had a loader submission and are navigating to a new location
-    navigation.formAction !== navigation.pathname;
+    navigation.formAction !== navigation.location.pathname;
 }
 ```
 

--- a/docs/pages/v2.md
+++ b/docs/pages/v2.md
@@ -696,7 +696,7 @@ In your `remix.config.js`, you should specify either `serverModuleFormat: "cjs"`
 
 ## Dev Server
 
-We are still stabilizing the new dev server that enables HMR and simplifies integration with various servers. You can try it today with `unstable_dev` and referring to the [v1.16 Release Notes](https://github.com/remix-run/remix/releases/tag/remix%401.16.0) to set it up.
+We are still stabilizing the new dev server that enables HMR and simplifies integration with various servers. You can try it today with `unstable_dev` and referring to the [v1.16 Release Notes][v1-16-release-notes] to set it up.
 
 We expect to stabilize in Remix `v1.17.0`. Once that ships, we'll have more instructions here to prepare your app for v2.
 
@@ -706,3 +706,4 @@ We expect to stabilize in Remix `v1.17.0`. Once that ships, we'll have more inst
 [meta-v2]: ../route/meta-v2
 [meta-v2-rfc]: https://github.com/remix-run/remix/discussions/4462
 [meta-v2-matches]: #the-matches-argument
+[v1-16-release-notes]: https://github.com/remix-run/remix/releases/tag/remix%401.16.0

--- a/docs/pages/v2.md
+++ b/docs/pages/v2.md
@@ -696,9 +696,9 @@ In your `remix.config.js`, you should specify either `serverModuleFormat: "cjs"`
 
 ## Dev Server
 
-We are still stabilizing the new dev server that enables HMR, several CSS libraries (CSS Modules, Vanilla Extract, Tailwind, PostCSS) and simplifies integration with various servers.
+We are still stabilizing the new dev server that enables HMR and simplifies integration with various servers. You can try it today with `unstable_dev` and referring to the [v1.16 Release Notes](https://github.com/remix-run/remix/releases/tag/remix%401.16.0) to set it up.
 
-We expect a stable `v2_dev` flag in Remix `v1.16.0`. Once that ships, we'll have more instructions here to prepare your app for v2.
+We expect to stabilize in Remix `v1.17.0`. Once that ships, we'll have more instructions here to prepare your app for v2.
 
 [future-flags]: ./api-development-strategy
 [remix-config]: ../file-conventions/remix-config

--- a/docs/route/headers.md
+++ b/docs/route/headers.md
@@ -92,9 +92,9 @@ All that said, you can avoid this entire problem by _not defining headers in par
 Note that you can also add headers in your `entry.server` file for things that should be global, for example:
 
 ```tsx lines=[16]
-import { renderToString } from "react-dom/server";
-import { RemixServer } from "@remix-run/react";
 import type { EntryContext } from "@remix-run/node"; // or cloudflare/deno
+import { RemixServer } from "@remix-run/react";
+import { renderToString } from "react-dom/server";
 
 export default function handleRequest(
   request: Request,

--- a/docs/route/loader.md
+++ b/docs/route/loader.md
@@ -245,9 +245,9 @@ import { json } from "@remix-run/node"; // or cloudflare/deno
 import type { ThrownResponse } from "@remix-run/react";
 import { useCatch, useLoaderData } from "@remix-run/react";
 
-import { requireUserSession } from "~/http";
 import { getInvoice } from "~/db";
 import type { InvoiceNotFoundResponse } from "~/db";
+import { requireUserSession } from "~/http";
 
 type InvoiceCatchData = {
   invoiceOwnerEmail: string;

--- a/docs/route/meta.md
+++ b/docs/route/meta.md
@@ -53,7 +53,7 @@ export const meta: MetaFunction = () => ({
 
   // name => content
   description: "Delicious shakes", // <meta name="description" content="Delicious shakes">
-  viewport: "width=device-width,initial-scale=1", // <meta name="viewport" content="width=device-width,initial-scale=1">
+  viewport: "width=device-width, initial-scale=1", // <meta name="viewport" content="width=device-width, initial-scale=1">
 
   // <meta {...value}>
   refresh: {

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -498,7 +498,7 @@ Now let's get that markdown parsed and rendered to HTML to the page. There are a
 
 ```sh
 npm add marked
-# if using typescript
+# additionally, if using typescript
 npm add @types/marked -D
 ```
 

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -734,9 +734,7 @@ export default function NewPost() {
         </label>
       </p>
       <p>
-        <label htmlFor="markdown">
-          Markdown:{" "}
-        </label>
+        <label htmlFor="markdown">Markdown: </label>
         <br />
         <textarea
           id="markdown"

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -734,7 +734,9 @@ export default function NewPost() {
         </label>
       </p>
       <p>
-        <label htmlFor="markdown">Markdown:</label>
+        <label htmlFor="markdown">
+          Markdown:{" "}
+        </label>
         <br />
         <textarea
           id="markdown"

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1508,7 +1508,7 @@ npm install --save-dev ts-node tsconfig-paths
 💿 And now we can run our `seed.ts` file with that:
 
 ```sh
-ts-node --require tsconfig-paths/register prisma/seed.ts
+npx ts-node --require tsconfig-paths/register prisma/seed.ts
 ```
 
 Now our database has those jokes in it. No joke!

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -3044,11 +3044,11 @@ So we can now check whether the user is authenticated on the server by reading t
 <summary>app/utils/session.server.ts</summary>
 
 ```ts filename=app/utils/session.server.ts lines=[55-57,59-66,68-81]
-import bcrypt from "bcryptjs";
 import {
   createCookieSessionStorage,
   redirect,
 } from "@remix-run/node";
+import bcrypt from "bcryptjs";
 
 import { db } from "./db.server";
 

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -3851,7 +3851,7 @@ export default function Login() {
             type="hidden"
             name="redirectTo"
             value={
-              searchParams.get("redirectTo") ?? undefined
+              (searchParams.get("redirectTo") as string) ?? undefined
             }
           />
           <fieldset>

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -3851,7 +3851,8 @@ export default function Login() {
             type="hidden"
             name="redirectTo"
             value={
-              (searchParams.get("redirectTo") as string) ?? undefined
+              (searchParams.get("redirectTo") as string) ??
+              undefined
             }
           />
           <fieldset>

--- a/integration/defer-test.ts
+++ b/integration/defer-test.ts
@@ -76,7 +76,7 @@ test.describe("non-aborted", () => {
           export const meta: MetaFunction = () => ({
             charset: "utf-8",
             title: "New Remix App",
-            viewport: "width=device-width,initial-scale=1",
+            viewport: "width=device-width, initial-scale=1",
           });
 
           export const loader = () => defer({
@@ -1105,7 +1105,7 @@ test.describe("aborted", () => {
           export const meta: MetaFunction = () => ({
             charset: "utf-8",
             title: "New Remix App",
-            viewport: "width=device-width,initial-scale=1",
+            viewport: "width=device-width, initial-scale=1",
           });
 
           export const loader = () => defer({

--- a/packages/remix-cloudflare-pages/worker.ts
+++ b/packages/remix-cloudflare-pages/worker.ts
@@ -54,7 +54,7 @@ export function createPagesFunctionHandler<Env = any>({
     context.request.headers.delete("if-none-match");
 
     try {
-      response = await (context.env as any).ASSETS.fetch(
+      response = await context.env.ASSETS.fetch(
         context.request.url,
         context.request.clone()
       );

--- a/packages/remix-css-bundle/README.md
+++ b/packages/remix-css-bundle/README.md
@@ -6,4 +6,4 @@ This package provides access to the `href` of the generated CSS file when using 
 npm install @remix-run/css-bundle
 ```
 
-For more, see the [Remix docs](https://remix.run/docs/).
+For more, see the [Remix docs](https://remix.run/docs).

--- a/packages/remix-dev/__tests__/fixtures/indie-stack/app/root.tsx
+++ b/packages/remix-dev/__tests__/fixtures/indie-stack/app/root.tsx
@@ -11,7 +11,7 @@ import {
 export const meta: MetaFunction = () => ({
   charset: "utf-8",
   title: "New Remix App",
-  viewport: "width=device-width,initial-scale=1",
+  viewport: "width=device-width, initial-scale=1",
 });
 
 export default function App() {

--- a/packages/remix-dev/__tests__/fixtures/replace-remix-magic-imports/app/root.tsx
+++ b/packages/remix-dev/__tests__/fixtures/replace-remix-magic-imports/app/root.tsx
@@ -19,7 +19,7 @@ export const links: LinksFunction = () => {
 export const meta: MetaFunction = () => ({
   charset: "utf-8",
   title: "Remix Notes",
-  viewport: "width=device-width,initial-scale=1",
+  viewport: "width=device-width, initial-scale=1",
 });
 
 type LoaderData = {

--- a/packages/remix-dev/config/defaults/cloudflare/entry.server.react-string.tsx
+++ b/packages/remix-dev/config/defaults/cloudflare/entry.server.react-string.tsx
@@ -1,6 +1,6 @@
 import type { EntryContext } from "@remix-run/cloudflare";
-import { renderToString } from "react-dom/server";
 import { RemixServer } from "@remix-run/react";
+import { renderToString } from "react-dom/server";
 
 export default function handleRequest(
   request: Request,

--- a/packages/remix-dev/config/defaults/deno/entry.server.react-string.tsx
+++ b/packages/remix-dev/config/defaults/deno/entry.server.react-string.tsx
@@ -1,6 +1,6 @@
 import type { EntryContext } from "@remix-run/deno";
-import { renderToString } from "react-dom/server";
 import { RemixServer } from "@remix-run/react";
+import { renderToString } from "react-dom/server";
 
 export default function handleRequest(
   request: Request,

--- a/packages/remix-dev/config/defaults/node/entry.server.react-stream.tsx
+++ b/packages/remix-dev/config/defaults/node/entry.server.react-stream.tsx
@@ -1,4 +1,5 @@
 import { PassThrough } from "stream";
+
 import type { EntryContext } from "@remix-run/node";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";

--- a/packages/remix-dev/config/defaults/node/entry.server.react-string.tsx
+++ b/packages/remix-dev/config/defaults/node/entry.server.react-string.tsx
@@ -1,6 +1,6 @@
 import type { EntryContext } from "@remix-run/node";
-import { renderToString } from "react-dom/server";
 import { RemixServer } from "@remix-run/react";
+import { renderToString } from "react-dom/server";
 
 export default function handleRequest(
   request: Request,

--- a/packages/remix-react/errorBoundaries.tsx
+++ b/packages/remix-react/errorBoundaries.tsx
@@ -77,7 +77,7 @@ export function RemixRootDefaultErrorBoundary({ error }: { error: Error }) {
         <meta charSet="utf-8" />
         <meta
           name="viewport"
-          content="width=device-width,initial-scale=1,viewport-fit=cover"
+          content="width=device-width, initial-scale=1, viewport-fit=cover"
         />
         <title>Application Error!</title>
       </head>
@@ -183,7 +183,7 @@ function RemixRootDefaultCatchBoundaryImpl({
         <meta charSet="utf-8" />
         <meta
           name="viewport"
-          content="width=device-width,initial-scale=1,viewport-fit=cover"
+          content="width=device-width, initial-scale=1, viewport-fit=cover"
         />
         <title>Unhandled Thrown Response!</title>
       </head>

--- a/packages/remix-server-runtime/responses.ts
+++ b/packages/remix-server-runtime/responses.ts
@@ -51,7 +51,7 @@ export const json: JsonFunction = (data, init = {}) => {
 /**
  * This is a shortcut for creating Remix deferred responses
  *
- * @see https://remix.run/docs/utils/defer
+ * @see https://remix.run/utils/defer
  */
 export const defer: DeferFunction = (data, init = {}) => {
   return routerDefer(data, init) as unknown as TypedDeferredData<typeof data>;

--- a/templates/arc/app/entry.client.tsx
+++ b/templates/arc/app/entry.client.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle hydrating your app on the client for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.client
+ * For more information, see https://remix.run/file-conventions/entry.client
  */
 
 import { RemixBrowser } from "@remix-run/react";

--- a/templates/arc/app/entry.server.tsx
+++ b/templates/arc/app/entry.server.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle generating the HTTP Response for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.server
+ * For more information, see https://remix.run/file-conventions/entry.server
  */
 
 import { PassThrough } from "node:stream";

--- a/templates/arc/app/entry.server.tsx
+++ b/templates/arc/app/entry.server.tsx
@@ -5,6 +5,7 @@
  */
 
 import { PassThrough } from "node:stream";
+
 import type { EntryContext } from "@remix-run/node";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";

--- a/templates/arc/app/root.tsx
+++ b/templates/arc/app/root.tsx
@@ -1,3 +1,5 @@
+import { cssBundleHref } from "@remix-run/css-bundle";
+import type { LinksFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -6,8 +8,6 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
-import type { LinksFunction } from "@remix-run/node";
-import { cssBundleHref } from "@remix-run/css-bundle";
 
 export const links: LinksFunction = () => [
   ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),

--- a/templates/arc/server.ts
+++ b/templates/arc/server.ts
@@ -1,6 +1,6 @@
-import { installGlobals } from "@remix-run/node";
 import { createRequestHandler } from "@remix-run/architect";
 import * as build from "@remix-run/dev/server-build";
+import { installGlobals } from "@remix-run/node";
 
 installGlobals();
 

--- a/templates/cloudflare-pages/app/entry.client.tsx
+++ b/templates/cloudflare-pages/app/entry.client.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle hydrating your app on the client for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.client
+ * For more information, see https://remix.run/file-conventions/entry.client
  */
 
 import { RemixBrowser } from "@remix-run/react";

--- a/templates/cloudflare-pages/app/entry.server.tsx
+++ b/templates/cloudflare-pages/app/entry.server.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle generating the HTTP Response for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.server
+ * For more information, see https://remix.run/file-conventions/entry.server
  */
 
 import type { EntryContext } from "@remix-run/cloudflare";

--- a/templates/cloudflare-pages/app/root.tsx
+++ b/templates/cloudflare-pages/app/root.tsx
@@ -1,3 +1,5 @@
+import type { LinksFunction } from "@remix-run/cloudflare";
+import { cssBundleHref } from "@remix-run/css-bundle";
 import {
   Links,
   LiveReload,
@@ -6,8 +8,6 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
-import type { LinksFunction } from "@remix-run/cloudflare";
-import { cssBundleHref } from "@remix-run/css-bundle";
 
 export const links: LinksFunction = () => [
   ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),

--- a/templates/cloudflare-pages/public/_headers
+++ b/templates/cloudflare-pages/public/_headers
@@ -1,2 +1,2 @@
 /build/*
-  Cache-Control: public, max-age=31536000, s-maxage=31536000
+  Cache-Control: public, max-age=31536000, immutable

--- a/templates/cloudflare-workers/app/entry.client.tsx
+++ b/templates/cloudflare-workers/app/entry.client.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle hydrating your app on the client for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.client
+ * For more information, see https://remix.run/file-conventions/entry.client
  */
 
 import { RemixBrowser } from "@remix-run/react";

--- a/templates/cloudflare-workers/app/entry.server.tsx
+++ b/templates/cloudflare-workers/app/entry.server.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle generating the HTTP Response for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.server
+ * For more information, see https://remix.run/file-conventions/entry.server
  */
 
 import type { EntryContext } from "@remix-run/cloudflare";

--- a/templates/cloudflare-workers/app/root.tsx
+++ b/templates/cloudflare-workers/app/root.tsx
@@ -1,3 +1,5 @@
+import type { LinksFunction } from "@remix-run/cloudflare";
+import { cssBundleHref } from "@remix-run/css-bundle";
 import {
   Links,
   LiveReload,
@@ -6,8 +8,6 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
-import type { LinksFunction } from "@remix-run/cloudflare";
-import { cssBundleHref } from "@remix-run/css-bundle";
 
 export const links: LinksFunction = () => [
   ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),

--- a/templates/deno/app/entry.client.tsx
+++ b/templates/deno/app/entry.client.tsx
@@ -13,6 +13,6 @@ startTransition(() => {
     document,
     <StrictMode>
       <RemixBrowser />
-    </StrictMode>
+    </StrictMode>,
   );
 });

--- a/templates/deno/app/entry.client.tsx
+++ b/templates/deno/app/entry.client.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle hydrating your app on the client for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.client
+ * For more information, see https://remix.run/file-conventions/entry.client
  */
 
 import { RemixBrowser } from "@remix-run/react";
@@ -13,6 +13,6 @@ startTransition(() => {
     document,
     <StrictMode>
       <RemixBrowser />
-    </StrictMode>,
+    </StrictMode>
   );
 });

--- a/templates/deno/app/entry.server.tsx
+++ b/templates/deno/app/entry.server.tsx
@@ -13,7 +13,7 @@ export default async function handleRequest(
   request: Request,
   responseStatusCode: number,
   responseHeaders: Headers,
-  remixContext: EntryContext
+  remixContext: EntryContext,
 ) {
   const body = await renderToReadableStream(
     <RemixServer context={remixContext} url={request.url} />,
@@ -23,7 +23,7 @@ export default async function handleRequest(
         console.error(error);
         responseStatusCode = 500;
       },
-    }
+    },
   );
 
   if (isbot(request.headers.get("user-agent"))) {

--- a/templates/deno/app/entry.server.tsx
+++ b/templates/deno/app/entry.server.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle generating the HTTP Response for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.server
+ * For more information, see https://remix.run/file-conventions/entry.server
  */
 
 import type { EntryContext } from "@remix-run/deno";
@@ -13,7 +13,7 @@ export default async function handleRequest(
   request: Request,
   responseStatusCode: number,
   responseHeaders: Headers,
-  remixContext: EntryContext,
+  remixContext: EntryContext
 ) {
   const body = await renderToReadableStream(
     <RemixServer context={remixContext} url={request.url} />,
@@ -23,7 +23,7 @@ export default async function handleRequest(
         console.error(error);
         responseStatusCode = 500;
       },
-    },
+    }
   );
 
   if (isbot(request.headers.get("user-agent"))) {

--- a/templates/express/app/entry.client.tsx
+++ b/templates/express/app/entry.client.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle hydrating your app on the client for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.client
+ * For more information, see https://remix.run/file-conventions/entry.client
  */
 
 import { RemixBrowser } from "@remix-run/react";

--- a/templates/express/app/entry.server.tsx
+++ b/templates/express/app/entry.server.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle generating the HTTP Response for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.server
+ * For more information, see https://remix.run/file-conventions/entry.server
  */
 
 import { PassThrough } from "node:stream";

--- a/templates/express/app/entry.server.tsx
+++ b/templates/express/app/entry.server.tsx
@@ -5,6 +5,7 @@
  */
 
 import { PassThrough } from "node:stream";
+
 import type { EntryContext } from "@remix-run/node";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";

--- a/templates/express/app/root.tsx
+++ b/templates/express/app/root.tsx
@@ -1,3 +1,5 @@
+import { cssBundleHref } from "@remix-run/css-bundle";
+import type { LinksFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -6,8 +8,6 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
-import type { LinksFunction } from "@remix-run/node";
-import { cssBundleHref } from "@remix-run/css-bundle";
 
 export const links: LinksFunction = () => [
   ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -1,9 +1,10 @@
 const path = require("path");
-const express = require("express");
-const compression = require("compression");
-const morgan = require("morgan");
+
 const { createRequestHandler } = require("@remix-run/express");
 const { installGlobals } = require("@remix-run/node");
+const compression = require("compression");
+const express = require("express");
+const morgan = require("morgan");
 
 installGlobals();
 

--- a/templates/fly/app/entry.client.tsx
+++ b/templates/fly/app/entry.client.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle hydrating your app on the client for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.client
+ * For more information, see https://remix.run/file-conventions/entry.client
  */
 
 import { RemixBrowser } from "@remix-run/react";

--- a/templates/fly/app/entry.server.tsx
+++ b/templates/fly/app/entry.server.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle generating the HTTP Response for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.server
+ * For more information, see https://remix.run/file-conventions/entry.server
  */
 
 import { PassThrough } from "node:stream";

--- a/templates/fly/app/entry.server.tsx
+++ b/templates/fly/app/entry.server.tsx
@@ -5,6 +5,7 @@
  */
 
 import { PassThrough } from "node:stream";
+
 import type { EntryContext } from "@remix-run/node";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";

--- a/templates/fly/app/root.tsx
+++ b/templates/fly/app/root.tsx
@@ -1,3 +1,5 @@
+import { cssBundleHref } from "@remix-run/css-bundle";
+import type { LinksFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -6,8 +8,6 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
-import type { LinksFunction } from "@remix-run/node";
-import { cssBundleHref } from "@remix-run/css-bundle";
 
 export const links: LinksFunction = () => [
   ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),

--- a/templates/netlify/app/entry.client.tsx
+++ b/templates/netlify/app/entry.client.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle hydrating your app on the client for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.client
+ * For more information, see https://remix.run/file-conventions/entry.client
  */
 
 import { RemixBrowser } from "@remix-run/react";

--- a/templates/netlify/app/entry.server.tsx
+++ b/templates/netlify/app/entry.server.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle generating the HTTP Response for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.server
+ * For more information, see https://remix.run/file-conventions/entry.server
  */
 
 import { PassThrough } from "node:stream";

--- a/templates/netlify/app/entry.server.tsx
+++ b/templates/netlify/app/entry.server.tsx
@@ -5,6 +5,7 @@
  */
 
 import { PassThrough } from "node:stream";
+
 import type { EntryContext } from "@remix-run/node";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";

--- a/templates/netlify/app/root.tsx
+++ b/templates/netlify/app/root.tsx
@@ -1,3 +1,5 @@
+import { cssBundleHref } from "@remix-run/css-bundle";
+import type { LinksFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -6,8 +8,6 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
-import type { LinksFunction } from "@remix-run/node";
-import { cssBundleHref } from "@remix-run/css-bundle";
 
 export const links: LinksFunction = () => [
   ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),

--- a/templates/netlify/netlify.toml
+++ b/templates/netlify/netlify.toml
@@ -14,4 +14,4 @@
 [[headers]]
   for = "/build/*"
   [headers.values]
-    "Cache-Control" = "public, max-age=31536000, s-maxage=31536000"
+    "Cache-Control" = "public, max-age=31536000, immutable"

--- a/templates/netlify/server.ts
+++ b/templates/netlify/server.ts
@@ -1,6 +1,6 @@
-import { installGlobals } from "@remix-run/node";
-import { createRequestHandler } from "@remix-run/netlify";
 import * as build from "@remix-run/dev/server-build";
+import { createRequestHandler } from "@remix-run/netlify";
+import { installGlobals } from "@remix-run/node";
 
 installGlobals();
 

--- a/templates/remix/app/entry.client.tsx
+++ b/templates/remix/app/entry.client.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle hydrating your app on the client for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.client
+ * For more information, see https://remix.run/file-conventions/entry.client
  */
 
 import { RemixBrowser } from "@remix-run/react";

--- a/templates/remix/app/entry.server.tsx
+++ b/templates/remix/app/entry.server.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle generating the HTTP Response for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.server
+ * For more information, see https://remix.run/file-conventions/entry.server
  */
 
 import { PassThrough } from "node:stream";

--- a/templates/remix/app/entry.server.tsx
+++ b/templates/remix/app/entry.server.tsx
@@ -5,6 +5,7 @@
  */
 
 import { PassThrough } from "node:stream";
+
 import type { EntryContext } from "@remix-run/node";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";

--- a/templates/remix/app/root.tsx
+++ b/templates/remix/app/root.tsx
@@ -1,3 +1,5 @@
+import { cssBundleHref } from "@remix-run/css-bundle";
+import type { LinksFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -6,8 +8,6 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
-import type { LinksFunction } from "@remix-run/node";
-import { cssBundleHref } from "@remix-run/css-bundle";
 
 export const links: LinksFunction = () => [
   ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),

--- a/templates/vercel/app/entry.client.tsx
+++ b/templates/vercel/app/entry.client.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle hydrating your app on the client for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.client
+ * For more information, see https://remix.run/file-conventions/entry.client
  */
 
 import { RemixBrowser } from "@remix-run/react";

--- a/templates/vercel/app/entry.server.tsx
+++ b/templates/vercel/app/entry.server.tsx
@@ -1,7 +1,7 @@
 /**
  * By default, Remix will handle generating the HTTP Response for you.
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/docs/en/main/file-conventions/entry.server
+ * For more information, see https://remix.run/file-conventions/entry.server
  */
 
 import { PassThrough } from "node:stream";

--- a/templates/vercel/app/entry.server.tsx
+++ b/templates/vercel/app/entry.server.tsx
@@ -5,6 +5,7 @@
  */
 
 import { PassThrough } from "node:stream";
+
 import type { EntryContext } from "@remix-run/node";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";

--- a/templates/vercel/app/root.tsx
+++ b/templates/vercel/app/root.tsx
@@ -1,3 +1,5 @@
+import { cssBundleHref } from "@remix-run/css-bundle";
+import type { LinksFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -6,8 +8,6 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
-import type { LinksFunction } from "@remix-run/node";
-import { cssBundleHref } from "@remix-run/css-bundle";
 
 export const links: LinksFunction = () => [
   ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),

--- a/templates/vercel/server.ts
+++ b/templates/vercel/server.ts
@@ -1,6 +1,6 @@
+import * as build from "@remix-run/dev/server-build";
 import { installGlobals } from "@remix-run/node";
 import { createRequestHandler } from "@remix-run/vercel";
-import * as build from "@remix-run/dev/server-build";
 
 installGlobals();
 


### PR DESCRIPTION
As context.env type is defined in [@cloudfare/worker-types](https://github.com/cloudflare/workerd/blob/main/types/defines/pages.d.ts) 
we can somehow remove the annotation `as any` in woker.ts. :)