### PR TITLE
fix(dev): skip Vanilla Extract plugin if not installed

### DIFF
--- a/.changeset/slimy-snakes-do.md
+++ b/.changeset/slimy-snakes-do.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Only process .css.ts/js files with Vanilla Extract if `@vanilla-extract/css` is installed

--- a/packages/remix-dev/compiler/plugins/vanillaExtract.ts
+++ b/packages/remix-dev/compiler/plugins/vanillaExtract.ts
@@ -60,6 +60,13 @@ export function vanillaExtractPlugin(
   return {
     name: pluginName,
     async setup(build) {
+      try {
+        require.resolve("@vanilla-extract/css");
+      } catch (_) {
+        // If Vanilla Extract isn't installed, skip this plugin.
+        return;
+      }
+
       let root = config.appDirectory;
 
       let postcssProcessor = await getPostcssProcessor({


### PR DESCRIPTION
Closes: #6314

This ensures that, in the rare case that someone is using a .css.js/ts file extension when _not_ using Vanilla Extract in their app, we don't inadvertently try to process it with the Vanilla Extract plugin.