### PR TITLE
chore(remix-cloudflare-pages): remove unnecessary typecast 

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -530,3 +530,4 @@
 - iamzee
 - TimonVS
 - yudai-nkt
+- baby230211

--- a/packages/remix-cloudflare-pages/worker.ts
+++ b/packages/remix-cloudflare-pages/worker.ts
@@ -54,7 +54,7 @@ export function createPagesFunctionHandler<Env = any>({
     context.request.headers.delete("if-none-match");
 
     try {
-      response = await (context.env as any).ASSETS.fetch(
+      response = await context.env.ASSETS.fetch(
         context.request.url,
         context.request.clone()
       );


### PR DESCRIPTION
As context.env type is defined in [@cloudfare/worker-types](https://github.com/cloudflare/workerd/blob/main/types/defines/pages.d.ts)
we can somehow remove the annotation as any in woker.ts. :)

menthioned in #6341 , As this change is touching package, move this to dev branch