### PR TITLE
feat(remix-dev): add support for `mdx`' `providerImportSource` config

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -530,4 +530,4 @@
 - iamzee
 - TimonVS
 - yudai-nkt
-- Jpkcy
+- Jokcy

--- a/contributors.yml
+++ b/contributors.yml
@@ -530,3 +530,4 @@
 - iamzee
 - TimonVS
 - yudai-nkt
+- Jpkcy

--- a/packages/remix-dev/compiler/plugins/mdx.ts
+++ b/packages/remix-dev/compiler/plugins/mdx.ts
@@ -76,17 +76,20 @@ export async function processMDX(
       remarkFrontmatter,
       [remarkMdxFrontmatter, { name: "attributes" }],
     ];
+    let providerImportSource: string | undefined = ''
 
     switch (typeof config.mdx) {
       case "object":
         rehypePlugins.push(...(config.mdx.rehypePlugins || []));
         remarkPlugins.push(...(config.mdx.remarkPlugins || []));
+        providerImportSource = config.mdx.providerImportSource
 
         break;
       case "function":
         let mdxConfig = await config.mdx(argsPath);
         rehypePlugins.push(...(mdxConfig?.rehypePlugins || []));
         remarkPlugins.push(...(mdxConfig?.remarkPlugins || []));
+        providerImportSource = mdxConfig?.providerImportSource
         break;
     }
 
@@ -102,6 +105,7 @@ export const handle = typeof attributes !== "undefined" && attributes.handle;
       jsxRuntime: "automatic",
       rehypePlugins,
       remarkPlugins,
+      ...(providerImportSource ? { providerImportSource } : {})
     });
 
     let contents = `

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -18,6 +18,7 @@ import { warnOnce } from "./warnOnce";
 export interface RemixMdxConfig {
   rehypePlugins?: any[];
   remarkPlugins?: any[];
+  providerImportSource?: string;
 }
 
 export type RemixMdxConfigFunction = (


### PR DESCRIPTION
- [ ] Docs
- [ ] Tests

Testing Strategy:

I directly modify my remix project node_modules

```js
let compiled = await xdm.compile(fileContents, {
      jsx: true,
      jsxRuntime: "automatic",
      rehypePlugins,
      remarkPlugins,
      providerImportSource: '@mdx-js/react'
    });
```

It work fine and MDXProvider worked.

I did not find tests file for this plugin, if unit tests is required I will try to add then.
