### PR TITLE
fix(dev): include `cssBundleHref` in manifest hash

### DIFF
--- a/.changeset/fix-css-bundle-server-client-mismatch.md
+++ b/.changeset/fix-css-bundle-server-client-mismatch.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fix `cssBundleHref` server/client mismatch on change

--- a/.changeset/fix-css-bundle-server-client-mismatch.md
+++ b/.changeset/fix-css-bundle-server-client-mismatch.md
@@ -1,5 +1,0 @@
----
-"@remix-run/dev": patch
----
-
-Fix `cssBundleHref` server/client mismatch on change

--- a/.changeset/include-css-bundle-in-manifest-hash.md
+++ b/.changeset/include-css-bundle-in-manifest-hash.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Ensure CSS bundle changes result in a new manifest hash

--- a/packages/remix-dev/compiler/manifest.ts
+++ b/packages/remix-dev/compiler/manifest.ts
@@ -93,7 +93,14 @@ export async function create({
   invariant(entry, `Missing output for entry point`);
 
   optimizeRoutes(routes, entry.imports);
-  let version = getHash(JSON.stringify({ entry, routes })).slice(0, 8);
+
+  let version = getHash(
+    JSON.stringify({
+      entry,
+      routes,
+      cssBundleHref,
+    })
+  ).slice(0, 8);
 
   return { version, entry, routes, cssBundleHref, hmr };
 }

--- a/packages/remix-dev/compiler/manifest.ts
+++ b/packages/remix-dev/compiler/manifest.ts
@@ -94,15 +94,23 @@ export async function create({
 
   optimizeRoutes(routes, entry.imports);
 
-  let version = getHash(
-    JSON.stringify({
-      entry,
-      routes,
-      cssBundleHref,
-    })
-  ).slice(0, 8);
+  let fingerprintedValues = {
+    entry,
+    routes,
+    cssBundleHref,
+  };
 
-  return { version, entry, routes, cssBundleHref, hmr };
+  let version = getHash(JSON.stringify(fingerprintedValues)).slice(0, 8);
+
+  let nonFingerprintedValues = {
+    version,
+    hmr,
+  };
+
+  return {
+    ...fingerprintedValues,
+    ...nonFingerprintedValues,
+  };
 }
 
 export const write = async (config: RemixConfig, assetsManifest: Manifest) => {


### PR DESCRIPTION
Fixes #6369

The `cssBundleHref` value wasn't being included in the hash in the manifest file name. This means that CSS bundle changes weren't busting the manifest cache. I've also refactored the code to try to avoid this issue coming back when further changes are made to the manifest structure.