### PR TITLE
Update blog.md to create a migration without deleting your database

### DIFF
--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -266,10 +266,10 @@ model Post {
 }
 ```
 
-💿 Now let's tell Prisma to update our local database and TypeScript definitions to match this schema change:
+💿 Let's generate a migration file for our schema changes, which will be required if you deploy your application rather than just running in dev mode locally.  This will also update our local database and TypeScript definitions to match the schema change.
 
 ```sh
-npx prisma db push
+npx prisma migrate dev
 ```
 
 💿 Let's seed our database with a couple posts. Open `prisma/seed.ts` and add this to the end of the seed functionality (right before the `console.log`):
@@ -327,12 +327,6 @@ Great, let's get those posts into the database with the seed script:
 
 ```
 npx prisma db seed
-```
-
-💿 Let's generate a migration file for our schema changes - which will be required if you deploy your application rather than just running in dev mode locally.
-
-```sh
-npx prisma migrate dev
 ```
 
 <docs-warning>You'll get the ability to name the migration name, ideally you can refer back to what the changes you made are, so I'd suggest `create-post-model` for the name.</docs-warning>
@@ -1020,7 +1014,7 @@ That's it for today! Here are some bits of homework to implement if you want to 
 
 **Optimistic UI:** You know how when you favorite a tweet, the heart goes red instantly and if the tweet is deleted it reverts back to empty? That's Optimistic UI: assume the request will succeed, and render what the user will see if it does. So your homework is to make it so when you hit "Create" it renders the post in the left nav and renders the "Create a New Post" link (or if you add update/delete do it for those too). You'll find this ends up being easier than you think even if it takes you a second to arrive there (and if you've implemented this pattern in the past, you'll find Remix makes this much easier). Learn more from [the Optimistic UI guide][the-optimistic-ui-guide].
 
-**Authenticated users only:** Another cool bit of homework you could do is make it so only authenticated users can create posts. You've already got authentication all set up for you thanks to the Indie Stack. Tip, if you want to make it, so you're the only one who can make posts, then simply check the user's email in your loaders and actions and if it's not yours redirect them [somewhere][somewhere] 😈
+**Authenticated users only:** Another cool bit of homework you could do is make it so only authenticated users can create posts. You've already got authentication all set up for you thanks to the Indie Stack. Tip: if you want to make it so you're the only one who can make posts, simply check the user's email in your loaders and actions and if it's not yours redirect them [somewhere][somewhere] 😈
 
 **Customize the app:** If you're happy with Tailwind CSS, keep it around, otherwise, check [the styling guide][the-styling-guide] to learn of other options. Remove the `Notes` model and routes, etc. Whatever you want to make this thing yours.
 


### PR DESCRIPTION
The original instructions tell you to generate a migration after you've already done `prisma db push`.  This will prompt you to delete your database, which is not ideal, and then you'd need to seed it again anyway.  It would be better to just generate the migration instead of using `prisma db push` at all, since those commands are largely interchangeable.  I assume the existing migration instructions were hastily added in response to [this issue](https://github.com/remix-run/remix/issues/3246).

Also fixed some punctuation later.