### PR TITLE
Client side navigation ignores defer with nested route and URL param

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -535,3 +535,4 @@
 - TimonVS
 - yudai-nkt
 - TomVance
+- oscarnewman


### PR DESCRIPTION
This is a PR as a bug report for a weird issue I noticed with defer:

When navigating (client side) from one route with a deferred loader to it's child route, also with a deferred loader, the navigation is blocking (not deferred) IF there is ANY url param present on the child route.

I've put together a small test to reproduce the specific issue, though I haven't yet validated if there's more general cases where this might be triggered.

@jacob-ebey you might have figured this one out already but here's the repro I mentioned to you