### PR TITLE
fix(dev): pass script props to deferred inline script tags

### DIFF
--- a/packages/remix-react/__tests__/deferred-scripts-test.tsx
+++ b/packages/remix-react/__tests__/deferred-scripts-test.tsx
@@ -1,0 +1,102 @@
+import * as React from "react";
+import { createMemoryRouter } from "react-router-dom";
+import { defer } from "react-router-dom";
+import { StaticRouterProvider } from "react-router-dom/server";
+import { prettyDOM, render } from "@testing-library/react";
+import type { EntryContext } from "@remix-run/server-runtime";
+
+import { Scripts, RemixContext } from "../components";
+
+import "@testing-library/jest-dom/extend-expect";
+
+/**
+ * Don't try to add additional tests for <Scripts /> to this file!
+ *
+ * <Scripts /> gates most of its functionality on the **unexported**
+ * variable isHydrated, defined inside ../components, and it sets that
+ * variable the first time it is rendered. This means that subsequent
+ * calls to <Scripts /> will skip writing actual script tags.
+ *
+ * Using jest.resetModules() or .isolateModules() won't help here as
+ * we'd need to re-import or re-require [1]. Re-importing would need new
+ * packages to work [2] and re-requiring has problems with React [3].
+ *
+ * [1]: https://github.com/jestjs/jest/issues/3236
+ * [2]: https://github.com/jestjs/jest/issues/3236#issuecomment-698271251
+ * [3]: https://github.com/jestjs/jest/issues/11471
+ */
+
+describe("<Scripts /> with activeDeferreds", () => {
+  it("should pass custom props", () => {
+    let context: EntryContext = {
+      routeModules: { root: { default: () => null } },
+      manifest: {
+        routes: {
+          root: {
+            hasLoader: false,
+            hasAction: false,
+            hasCatchBoundary: false,
+            hasErrorBoundary: false,
+            id: "root",
+            module: "root.js",
+          },
+        },
+        entry: { imports: [], module: "" },
+        url: "",
+        version: "",
+      },
+      // @ts-expect-error
+      // Enumerating all flags just to set them to false is overly brittle;
+      // we allow an empty object as a shortcut.
+      future: {},
+      // @ts-expect-error
+      // Similarly, we have no interest in the rest of the static handler
+      // context. We're not trying to write a test for React Router, we
+      // just want to trick <Scripts /> into thinking there's a need for
+      // deferred scripts. We'll look for "key with a promise" to check that
+      // this isn't being ignored.
+      staticHandlerContext: {
+        activeDeferreds: {
+          "/": defer({
+            "key with a promise": new Promise((resolve) => resolve("value")),
+          }),
+        },
+      },
+    };
+
+    let router = createMemoryRouter([
+      {
+        id: "root",
+        path: "/",
+        element: <Scripts nonce="some nonce" />,
+      },
+    ]);
+
+    let { container } = render(
+      <RemixContext.Provider value={context}>
+        <StaticRouterProvider
+          router={router}
+          context={context.staticHandlerContext}
+          // We're testing <Scripts />, but <StaticRouterProvider /> can insert
+          // its own script tags too, so we pass it the same nonce prop so our
+          // check for "do all script tags have the nonce prop" still works.
+          nonce="some nonce"
+        />
+      </RemixContext.Provider>
+    );
+
+    let scriptElements = Array.from(container.getElementsByTagName("script"));
+
+    // Confirm that activeDeferreds is being handled
+    expect(
+      scriptElements.filter((elem) =>
+        elem.innerHTML.includes("key with a promise")
+      ).length
+    ).toBeGreaterThan(0);
+
+    // Test that all script tags have the additional nonce prop
+    scriptElements.forEach((elem) =>
+      expect(elem).toHaveAttribute("nonce", "some nonce")
+    );
+  });
+});

--- a/packages/remix-react/__tests__/deferred-scripts-test.tsx
+++ b/packages/remix-react/__tests__/deferred-scripts-test.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { createMemoryRouter } from "react-router-dom";
 import { defer } from "react-router-dom";
 import { StaticRouterProvider } from "react-router-dom/server";
-import { prettyDOM, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import type { EntryContext } from "@remix-run/server-runtime";
 
 import { Scripts, RemixContext } from "../components";

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -960,6 +960,7 @@ export function Scripts(props: ScriptProps) {
                       deferredData={deferredData}
                       routeId={routeId}
                       dataKey={key}
+                      scriptProps={props}
                     />
                   );
 
@@ -1058,7 +1059,7 @@ import(${JSON.stringify(manifest.entry.module)});`;
 
   if (!isStatic && typeof __remixContext === "object" && __remixContext.a) {
     for (let i = 0; i < __remixContext.a; i++) {
-      deferredScripts.push(<DeferredHydrationScript key={i} />);
+      deferredScripts.push(<DeferredHydrationScript key={i} scriptProps={props} />);
     }
   }
 
@@ -1117,10 +1118,12 @@ function DeferredHydrationScript({
   dataKey,
   deferredData,
   routeId,
+  scriptProps,
 }: {
   dataKey?: string;
   deferredData?: DeferredData;
   routeId?: string;
+  scriptProps?: ScriptProps;
 }) {
   if (typeof document === "undefined" && deferredData && dataKey && routeId) {
     invariant(
@@ -1140,6 +1143,7 @@ function DeferredHydrationScript({
         dataKey &&
         routeId ? null : (
           <script
+            {...scriptProps}
             async
             suppressHydrationWarning
             dangerouslySetInnerHTML={{ __html: " " }}
@@ -1151,10 +1155,11 @@ function DeferredHydrationScript({
         <Await
           resolve={deferredData.data[dataKey]}
           errorElement={
-            <ErrorDeferredHydrationScript dataKey={dataKey} routeId={routeId} />
+            <ErrorDeferredHydrationScript dataKey={dataKey} routeId={routeId} scriptProps={scriptProps} />
           }
           children={(data) => (
             <script
+              {...scriptProps}
               async
               suppressHydrationWarning
               dangerouslySetInnerHTML={{
@@ -1169,6 +1174,7 @@ function DeferredHydrationScript({
         />
       ) : (
         <script
+          {...scriptProps}
           async
           suppressHydrationWarning
           dangerouslySetInnerHTML={{ __html: " " }}
@@ -1181,9 +1187,11 @@ function DeferredHydrationScript({
 function ErrorDeferredHydrationScript({
   dataKey,
   routeId,
+  scriptProps,
 }: {
   dataKey: string;
   routeId: string;
+  scriptProps?: ScriptProps;
 }) {
   let error = useAsyncError() as Error;
   let toSerialize: { message: string; stack?: string } =
@@ -1199,6 +1207,7 @@ function ErrorDeferredHydrationScript({
 
   return (
     <script
+      {...scriptProps}
       suppressHydrationWarning
       dangerouslySetInnerHTML={{
         __html: `__remixContext.r(${JSON.stringify(routeId)}, ${JSON.stringify(


### PR DESCRIPTION
Closes: #5156 and #5539

If you pass a nonce or some other prop to `<Scripts />`, it doesn't get added to all of the script tags that might be written — the ones that handle deferred data won't get it. This PR just passes the props all the way down (see [`b2be332`](https://github.com/remix-run/remix/commit/b2be3324ae885d1b068743d5c60cad76244ea8d5)).

- [ ] Docs

> Don't think there's doc changes needed — this is a bug fix aligning with what's already documented at the bottom of [this page](https://remix.run/docs/en/1.16.0/file-conventions/root#root-route).

- [x] Tests

Testing Strategy: I added a test in [`fe7d61e`](https://github.com/remix-run/remix/commit/fe7d61edefe9e6cd5e06ac72489884cda10906df).

> Testing this was really tricky, the entire `<Scripts />` component seemed untested. Happy for feedback:
> - `<Scripts />` gates most of its behavior behind a un-exported global `isHydrated` variable that Jest can't clean up, so we get one clean call to RTL's `render` per file (subsequent ones skip all script tags)
> - There's deferred script behavior conditional on `document` being undefined, but RTL uses `document` internally, so there's some cases I'm fixing that I wasn't able to test
> - I didn't want to tightly couple this test to the data loading implementation details of Remix / React Router (not really what we're looking to test here), so I thought that allowing some type errors in the Remix `EntryContext` would strike the right balance
