### PR TITLE
fix(dev): scope Vanilla Extract detection to root

### DIFF
--- a/packages/remix-dev/compiler/plugins/vanillaExtract.ts
+++ b/packages/remix-dev/compiler/plugins/vanillaExtract.ts
@@ -61,7 +61,9 @@ export function vanillaExtractPlugin(
     name: pluginName,
     async setup(build) {
       try {
-        require.resolve("@vanilla-extract/css");
+        require.resolve("@vanilla-extract/css", {
+          paths: [config.rootDirectory],
+        });
       } catch (_) {
         // If Vanilla Extract isn't installed, skip this plugin.
         return;


### PR DESCRIPTION
This `require.resolve` call to detect whether `@vanilla-extract/css` is installed needs to be scoped to the project's root directory since the _consumer_ needs to have this package available. The existing detection code hasn't been released yet so it's already covered by an existing changeset.

Note that `@vanilla-extract/css` may still be detected depending on how node_modules is structured since it's a dependency of `@vanilla-extract/integration` which Remix depends on. This PR is still useful to at least ensure that Vanilla Extract is available to app code before attempting to use it. To cover false positives where consumers still want to opt-out, I've also opened #6400.