### PR TITLE
feat(dev): add `vanillaExtract` option for opt-out

### DIFF
--- a/.changeset/vanilla-extract-flag.md
+++ b/.changeset/vanilla-extract-flag.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": minor
+---
+
+Add `vanillaExtract` config option to allow explicit opt-out of Vanilla Extract support

--- a/docs/file-conventions/remix-config.md
+++ b/docs/file-conventions/remix-config.md
@@ -200,6 +200,10 @@ The platform the server build is targeting, which can either be `"neutral"` or
 
 Whether to support [Tailwind functions and directives][tailwind-functions-and-directives] in CSS files if `tailwindcss` is installed. Defaults to `false`.
 
+## vanillaExtract
+
+Whether to process `.css.ts`/`.css.js` files using [Vanilla Extract][vanilla-extract] if `@vanilla-extract/css` is installed. Defaults to `true`.
+
 ## watchPaths
 
 An array, string, or async function that defines custom directories, relative to the project root, to watch while running [remix dev][remix-dev]. These directories are in addition to [`appDirectory`][app-directory].
@@ -241,4 +245,5 @@ There are a few conventions that Remix uses you should be aware of.
 [app-directory]: #appDirectory
 [css-side-effect-imports]: ../guides/styling#css-side-effect-imports
 [postcss]: https://postcss.org
+[vanilla-extract]: https://vanilla-extract.style
 [tailwind-functions-and-directives]: https://tailwindcss.com/docs/functions-and-directives

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -87,6 +87,7 @@ describe("readConfig", () => {
         "serverPlatform": "node",
         "tailwind": false,
         "tsconfigPath": Any<String>,
+        "vanillaExtract": true,
         "watchPaths": Array [],
       }
     `

--- a/packages/remix-dev/compiler/plugins/vanillaExtract.ts
+++ b/packages/remix-dev/compiler/plugins/vanillaExtract.ts
@@ -60,6 +60,10 @@ export function vanillaExtractPlugin(
   return {
     name: pluginName,
     async setup(build) {
+      if (!config.vanillaExtract) {
+        return;
+      }
+
       try {
         require.resolve("@vanilla-extract/css");
       } catch (_) {

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -202,6 +202,12 @@ export interface AppConfig {
   tailwind?: boolean;
 
   /**
+   * Whether to process `.css.ts`/`.css.js` files using Vanilla Extract if `@vanilla-extract/css` is installed.
+   * Defaults to `true`.
+   */
+  vanillaExtract?: boolean;
+
+  /**
    * A list of filenames or a glob patterns to match files in the `app/routes`
    * directory that Remix will ignore. Matching files will not be recognized as
    * routes.
@@ -373,6 +379,12 @@ export interface RemixConfig {
   tailwind: boolean;
 
   /**
+   * Whether to process `.css.ts`/`.css.js` files using Vanilla Extract if `@vanilla-extract/css` is installed.
+   * Defaults to `true`.
+   */
+  vanillaExtract: boolean;
+
+  /**
    * A list of directories to watch.
    */
   watchPaths: string[];
@@ -520,6 +532,7 @@ export async function readConfig(
     appConfig.postcss ?? appConfig.future?.unstable_postcss === true;
   let tailwind =
     appConfig.tailwind ?? appConfig.future?.unstable_tailwind === true;
+  let vanillaExtract = appConfig.vanillaExtract ?? true;
 
   let appDirectory = path.resolve(
     rootDirectory,
@@ -771,6 +784,7 @@ export async function readConfig(
     mdx,
     postcss,
     tailwind,
+    vanillaExtract,
     watchPaths,
     tsconfigPath,
     future,


### PR DESCRIPTION
Closes #6314.

This allows consumers to explicitly opt-out of Vanilla Extract support, even if the `@vanilla-extract/css` package is requirable. This is important in cases where node_modules has been flattened and consumers inadvertently still have access to this package (since Remix depends on `@vanilla-extract/integration`, which depends on `@vanilla-extract/css`).