### PR TITLE
fix(dev): detect Vanilla Extract in package.json

### DIFF
--- a/integration/helpers/node-template/package.json
+++ b/integration/helpers/node-template/package.json
@@ -19,6 +19,7 @@
     "@remix-run/dev": "0.0.0-local-version",
     "@types/react": "0.0.0-local-version",
     "@types/react-dom": "0.0.0-local-version",
+    "@vanilla-extract/css": "^1.10.0",
     "typescript": "0.0.0-local-version"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@types/retry": "^0.12.0",
     "@types/semver": "^7.3.4",
     "@types/ssri": "^7.1.0",
-    "@vanilla-extract/css": "^1.1.0",
+    "@vanilla-extract/css": "^1.10.0",
     "abort-controller": "^3.0.0",
     "abortcontroller-polyfill": "^1.7.3",
     "babel-jest": "^27.5.1",

--- a/packages/remix-dev/compiler/plugins/vanillaExtract.ts
+++ b/packages/remix-dev/compiler/plugins/vanillaExtract.ts
@@ -7,6 +7,7 @@ import type { Options } from "../options";
 import { loaders } from "../utils/loaders";
 import { getPostcssProcessor } from "../utils/postcss";
 import type { Context } from "../context";
+import { getAppDependencies } from "../../dependencies";
 
 const pluginName = "vanilla-extract-plugin";
 const namespace = `${pluginName}-ns`;
@@ -60,10 +61,8 @@ export function vanillaExtractPlugin(
   return {
     name: pluginName,
     async setup(build) {
-      try {
-        require.resolve("@vanilla-extract/css");
-      } catch (_) {
-        // If Vanilla Extract isn't installed, skip this plugin.
+      let appDependencies = getAppDependencies(config, true);
+      if (!appDependencies["@vanilla-extract/css"]) {
         return;
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3663,7 +3663,7 @@
   dependencies:
     "@babel/core" "^7.20.7"
 
-"@vanilla-extract/css@^1.1.0", "@vanilla-extract/css@^1.10.0":
+"@vanilla-extract/css@^1.10.0":
   version "1.10.0"
   resolved "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.10.0.tgz#4ed13c89c5f4e452f306440415d4591bba8ac01b"
   integrity sha512-s/EFfLDKbU1c2jnELNl+l14AufvIyryDh09ZZxRRqKjRKitiKvEjoiUy964pGKmfHngc9O0mkbzqrbhWaH+96Q==


### PR DESCRIPTION
Closes #6314.

This fixes an issue with our (currently unreleased) Vanilla Extract detection logic which is intended to disable Vanilla Extract support for consumers who aren't using it.

Because we're using `require.resolve` to check for the presence of the `@vanilla-extract/css` package, in the case of a flattened node_modules directory, some consumers can get false positives. This is because Remix depends on `@vanilla-extract/integration` to manage the esbuild integration, but that package depends on `@vanilla-extract/css`. I've seen this myself where `npx create-remix@latest` using npm to install dependencies results in `@vanilla-extract/css` being requirable from my app.

Instead, we now check the app's package.json to ensure that they have a direct dependency on `@vanilla-extract/css`.