### PR TITLE
fix: reload page when routeModules doesn't contain module for current route

### DIFF
--- a/.changeset/dual-forward-bug.md
+++ b/.changeset/dual-forward-bug.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Detect mismatches between the initially loaded URL and the URL at the time we hydrate and trigger a hard reload if they do not match. This is an edge-case that can happen when the network is slowish and the user clicks forward into a Remix app and then clicks forward again while the initial JS chunks are loading.

--- a/integration/browser-entry-test.ts
+++ b/integration/browser-entry-test.ts
@@ -1,4 +1,3 @@
-import type { Request } from "@playwright/test";
 import { test, expect } from "@playwright/test";
 
 import type { AppFixture, Fixture } from "./helpers/create-fixture";
@@ -25,11 +24,8 @@ test.beforeAll(async () => {
       `,
 
       "app/routes/burgers.jsx": js`
-
         export default function Index() {
-          return (
-            <div id="cheeseburger">cheeseburger</div>
-          );
+          return <div id="cheeseburger">cheeseburger</div>;
         }
       `,
     },
@@ -41,61 +37,48 @@ test.beforeAll(async () => {
 
 test.afterAll(() => appFixture.close());
 
-// This test generally fails without the corresponding fix in browser.tsx,
-// but sometimes manages to pass. With the fix, it always passes.
-test(`expect to be able to browse backward out of a remix app, 
-      then forward in history and have pages render correctly`, async ({
-  page,
-  browserName,
-}) => {
-  test.skip(
-    browserName === "firefox",
-    "FireFox doesn't support browsing to an empty page (aka about:blank)"
-  );
+test(
+  "expect to be able to browse backward out of a remix app, then forward " +
+    "twice in history and have pages render correctly",
+  async ({ page, browserName }) => {
+    test.skip(
+      browserName === "firefox",
+      "FireFox doesn't support browsing to an empty page (aka about:blank)"
+    );
 
-  let app = new PlaywrightFixture(appFixture, page);
+    let app = new PlaywrightFixture(appFixture, page);
 
-  // This sets up the Remix modules cache in memory, priming the error case.
-  await app.goto("/");
-  await app.clickLink("/burgers");
-  expect(await page.content()).toContain("cheeseburger");
+    // Slow down the entry chunk on the second load so the bug surfaces
+    let isSecondLoad = false;
+    await page.route(/entry/, async (route) => {
+      if (isSecondLoad) {
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+      route.continue();
+    });
 
-  let retry = 4;
-  for (let i = 0; i < retry; i++) {
-    // Back to /
+    // This sets up the Remix modules cache in memory, priming the error case.
+    await app.goto("/");
+    await app.clickLink("/burgers");
+    expect(await page.content()).toContain("cheeseburger");
     await page.goBack();
-
     await page.waitForSelector("#pizza");
     expect(await app.getHtml()).toContain("pizza");
 
-    // Takes the browser to an empty state.
-    // This doesn't seem to work in headless Firefox.
+    // Takes the browser out of the Remix app
     await page.goBack();
     expect(page.url()).toContain("about:blank");
 
-    // This attempts to watch for the request for the entry.client.js chunk
-    // and redirect before it is finished loading.
-    let redirectOnEntryChunk = async (request: Request) => {
-      if (request.url().includes("entry")) {
-        page.off("request", redirectOnEntryChunk);
-        await page.goForward();
-      }
-    };
-
-    page.on("request", redirectOnEntryChunk);
-
-    // Forward to /
-    // This initiates a request for the entry.client.js chunk
+    // Forward to / and immediately again to /burgers.  This will trigger the
+    // error since we'll load __routeModules for / but then try to hydrate /burgers
+    isSecondLoad = true;
     await page.goForward();
-    expect(page.url()).toContain("/");
-
-    // The navigation to /burgers happens in `redirectOnEntryChunk`.
-    // Here's an error: the path should be `/burgers`
-    // (this validates correctly and passes)
+    await page.goForward();
     await page.waitForSelector("#cheeseburger");
-    expect(page.url()).toContain("/burgers");
 
-    // but now the content won't contain the string "cheeseburger"
+    // If we resolve the error, we should hard reload and eventually
+    // successfully render /burgers
+    await page.waitForSelector("#cheeseburger");
     expect(await app.getHtml()).toContain("cheeseburger");
   }
-});
+);

--- a/integration/browser-entry-test.ts
+++ b/integration/browser-entry-test.ts
@@ -1,0 +1,100 @@
+import type { Request } from "@playwright/test";
+import { test, expect } from "@playwright/test";
+
+import type { AppFixture, Fixture } from "./helpers/create-fixture";
+import { createFixture, js, createAppFixture } from "./helpers/create-fixture";
+import { PlaywrightFixture } from "./helpers/playwright-fixture";
+
+let fixture: Fixture;
+let appFixture: AppFixture;
+
+test.beforeAll(async () => {
+  fixture = await createFixture({
+    files: {
+      "app/routes/index.jsx": js`
+        import { Link } from "@remix-run/react";
+
+        export default function Index() {
+          return (
+            <div>
+              <div id="pizza">pizza</div>
+              <Link to="/burgers">burger link</Link>
+            </div>
+          )
+        }
+      `,
+
+      "app/routes/burgers.jsx": js`
+
+        export default function Index() {
+          return (
+            <div id="cheeseburger">cheeseburger</div>
+          );
+        }
+      `,
+    },
+  });
+
+  // This creates an interactive app using puppeteer.
+  appFixture = await createAppFixture(fixture);
+});
+
+test.afterAll(() => appFixture.close());
+
+// This test generally fails without the corresponding fix in browser.tsx,
+// but sometimes manages to pass.
+// However, it always passes with the redirect fix applied.
+test(`expect to be able to browse backward out of a remix app, 
+      then forward in history and have pages render correctly`, async ({
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName === "firefox",
+    "FireFox doesn't support browsing to an empty page (aka about:blank)"
+  );
+
+  let app = new PlaywrightFixture(appFixture, page);
+
+  // This sets up the Remix modules cache in memory, priming the error case.
+  await app.goto("/");
+  await app.clickLink("/burgers");
+  expect(await page.content()).toContain("cheeseburger");
+
+  let retry = 4;
+  for (let i = 0; i < retry; i++) {
+    // Back to /
+    await page.goBack();
+
+    await page.waitForSelector("#pizza");
+    expect(await app.getHtml()).toContain("pizza");
+    // Takes the browser to an empty state. This doesn't seem to work in headless Firefox
+    await page.goBack();
+    expect(page.url()).toContain("about:blank");
+
+    // This attempts to watch for the request for the entry.client.js chunk
+    // and redirect before it is finished loading. This is the source of the race.
+    let redirectOnEntryChunk = async (request: Request) => {
+      if (request.url().includes("entry")) {
+        page.off("request", redirectOnEntryChunk);
+        await page.goForward();
+      }
+    };
+
+    page.on("request", redirectOnEntryChunk);
+
+    // Forward to /
+    // This initiates a request for the entry.client.js chunk
+    await page.goForward();
+    expect(page.url()).toContain("/");
+
+    // The navigation to /burgers happens in `redirectOnEntryChunk`.
+    // Here's an error: the path should be `/burgers`
+    // (this validates correctly and passes)
+    await page.waitForSelector("#cheeseburger");
+    expect(page.url()).toContain("/burgers");
+
+    // but now the content won't contain the string "cheeseburger"
+    expect(await app.getHtml()).toContain("cheeseburger");
+  }
+});

--- a/integration/browser-entry-test.ts
+++ b/integration/browser-entry-test.ts
@@ -42,8 +42,7 @@ test.beforeAll(async () => {
 test.afterAll(() => appFixture.close());
 
 // This test generally fails without the corresponding fix in browser.tsx,
-// but sometimes manages to pass.
-// However, it always passes with the redirect fix applied.
+// but sometimes manages to pass. With the fix, it always passes.
 test(`expect to be able to browse backward out of a remix app, 
       then forward in history and have pages render correctly`, async ({
   page,
@@ -68,12 +67,14 @@ test(`expect to be able to browse backward out of a remix app,
 
     await page.waitForSelector("#pizza");
     expect(await app.getHtml()).toContain("pizza");
-    // Takes the browser to an empty state. This doesn't seem to work in headless Firefox
+
+    // Takes the browser to an empty state.
+    // This doesn't seem to work in headless Firefox.
     await page.goBack();
     expect(page.url()).toContain("about:blank");
 
     // This attempts to watch for the request for the entry.client.js chunk
-    // and redirect before it is finished loading. This is the source of the race.
+    // and redirect before it is finished loading.
     let redirectOnEntryChunk = async (request: Request) => {
       if (request.url().includes("entry")) {
         page.off("request", redirectOnEntryChunk);

--- a/packages/remix-react/browser.tsx
+++ b/packages/remix-react/browser.tsx
@@ -189,6 +189,17 @@ export function RemixBrowser(_props: RemixBrowserProps): ReactElement {
     });
   }, [location]);
 
+  // Check if __remixRouteModules is missing the module for the current route
+  // and if so, load it.
+  for (let match of router.state.matches) {
+    if (!window.__remixRouteModules[match.route.id]) {
+      window.location.reload();
+      // `reload` executes asynchronously, meaning the error will still flash.
+      // To get around that we return an empty div here.
+      return <div></div>;
+    }
+  }
+
   // We need to include a wrapper RemixErrorBoundary here in case the root error
   // boundary also throws and we need to bubble up outside of the router entirely.
   // Then we need a stateful location here so the user can back-button navigate

--- a/packages/remix-react/browser.tsx
+++ b/packages/remix-react/browser.tsx
@@ -196,7 +196,7 @@ export function RemixBrowser(_props: RemixBrowserProps): ReactElement {
       window.location.reload();
       // `reload` executes asynchronously, meaning the error will still flash.
       // To get around that we return an empty div.
-      return <div></div>;
+      return <div/>;
     }
   }
 

--- a/packages/remix-react/browser.tsx
+++ b/packages/remix-react/browser.tsx
@@ -195,7 +195,7 @@ export function RemixBrowser(_props: RemixBrowserProps): ReactElement {
     if (!window.__remixRouteModules[match.route.id]) {
       window.location.reload();
       // `reload` executes asynchronously, meaning the error will still flash.
-      // To get around that we return an empty div here.
+      // To get around that we return an empty div.
       return <div></div>;
     }
   }

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -264,6 +264,7 @@ async function handleDocumentRequestRR(
     routeModules: createEntryRouteModules(build.routes),
     staticHandlerContext: context,
     serverHandoffString: createServerHandoffString({
+      url: context.location.pathname + context.location.search,
       state: {
         loaderData: context.loaderData,
         actionData: context.actionData,
@@ -307,6 +308,7 @@ async function handleDocumentRequestRR(
       ...entryContext,
       staticHandlerContext: context,
       serverHandoffString: createServerHandoffString({
+        url: context.location.pathname + context.location.search,
         state: {
           loaderData: context.loaderData,
           actionData: context.actionData,

--- a/packages/remix-server-runtime/serverHandoff.ts
+++ b/packages/remix-server-runtime/serverHandoff.ts
@@ -19,6 +19,7 @@ export function createServerHandoffString<T>(serverHandoff: {
   // Don't allow StaticHandlerContext to be passed in verbatim, since then
   // we'd end up including duplicate info
   state: ValidateShape<T, HydrationState>;
+  url: string;
   future: FutureConfig;
   dev?: { websocketPort: number };
 }): string {


### PR DESCRIPTION
This can happen when entry.client.ts isn't fully loaded before a route change occurs.

The fix is to validate the route's module is loaded, and if not, simply reload the page. Credit to @brophdawg11 who suggested this approach here: https://github.com/remix-run/remix/issues/1757#issuecomment-1401023829

See https://github.com/remix-run/remix/issues/1757 for more info.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #1757

- [x] Docs
- [x] Tests

Testing Strategy:

- added a new test (included in this PR) named browser-entry-test.ts

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->


