### PR TITLE
Surface thrown response headers to ancestor boundaries

### DIFF
--- a/.changeset/expose-error-headers.md
+++ b/.changeset/expose-error-headers.md
@@ -2,4 +2,4 @@
 "@remix-run/server-runtime": minor
 ---
 
-Add `errorHeaders` parameter to `headers()` functions to expose headers from thrown responses that bubble up to ancestor route boundaries.  If the throwing route contains the boundary, then `errorHeaders` will be the same object from `loaderHeaders`/`actionHeaders` for that route.
+Add `errorHeaders` parameter to the leaf `headers()` function to expose headers from thrown responses that bubble up to ancestor route boundaries.  If the throwing route contains the boundary, then `errorHeaders` will be the same object as `loaderHeaders`/`actionHeaders` for that route.

--- a/.changeset/expose-error-headers.md
+++ b/.changeset/expose-error-headers.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": minor
+---
+
+Add `errorHeaders` parameter to `headers()` functions to expose headers from thrown responses that bubble up to ancestor route boundaries.  If the throwing route contains the boundary, then `errorHeaders` will be the same object from `loaderHeaders`/`actionHeaders` for that route.

--- a/packages/remix-server-runtime/headers.ts
+++ b/packages/remix-server-runtime/headers.ts
@@ -44,7 +44,10 @@ export function getDocumentHeadersRR(
               loaderHeaders,
               parentHeaders,
               actionHeaders,
-              errorHeaders,
+              // Only expose errorHeaders to the leaf headers() function to
+              // avoid duplication via parentHeaders
+              errorHeaders:
+                idx === matches.length - 1 ? errorHeaders : undefined,
             })
           : routeModule.headers
         : undefined

--- a/packages/remix-server-runtime/headers.ts
+++ b/packages/remix-server-runtime/headers.ts
@@ -32,7 +32,7 @@ export function getDocumentHeadersRR(
     });
   }
 
-  return matches.reduce((parentHeaders, match) => {
+  return matches.reduce((parentHeaders, match, idx) => {
     let { id } = match.route;
     let routeModule = build.routes[id].module;
     let loaderHeaders = context.loaderHeaders[id] || new Headers();

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -70,6 +70,7 @@ export type HeadersArgs = {
   loaderHeaders: Headers;
   parentHeaders: Headers;
   actionHeaders: Headers;
+  errorHeaders: Headers | undefined;
 };
 
 /**


### PR DESCRIPTION
We have a gap in the API currently where you cannot access headers from child-route-thrown-responses because we only run `headers()` from "renderable" matches (which means root down to the boundary).  So if you `throw new Response()` from `/parent/child` and catch it in `/parent` - you have no way to send any child headers back from the `/parent` `headers()` function.

This PR adds a new `errorHeaders` parameter to `headers()` that holds the headers from any thrown Response triggering the error boundary.

If the route that throws the response is also the boundary route, then `errorHeaders` will be the same as what's already passed as `loaderHeaders`/`actionHeaders`.

We also only expose the `errorHeaders` to the leaf renderable match `headers()` function to avoid duplicating the header value through `parentHeaders`.

Closes #5356 

