### PR TITLE
feat: add `prefetch="viewport"` support to `<Link>`

### DIFF
--- a/.changeset/prefetch-viewport.md
+++ b/.changeset/prefetch-viewport.md
@@ -1,0 +1,6 @@
+---
+"remix": minor
+"@remix-run/react": minor
+---
+
+Add support for `<Link prefetch="viewport">` to prefetch links when they enter the viewport via an [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)

--- a/.changeset/tidy-bears-turn.md
+++ b/.changeset/tidy-bears-turn.md
@@ -1,6 +1,0 @@
----
-"remix": patch
-"@remix-run/react": patch
----
-
-adds support for viewport prefetching to `<Link>`. this allows you to prefetch a page when it gets into view via an [intersection observer](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)

--- a/.changeset/tidy-bears-turn.md
+++ b/.changeset/tidy-bears-turn.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/react": patch
+---
+
+adds support for viewport prefetching to `<Link>`. this allows you to prefetch a page when it gets into view via an [intersection observer](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -30,12 +30,14 @@ In the effort to remove all loading states from your UI, `Link` can automaticall
   <Link prefetch="none" />
   <Link prefetch="intent" />
   <Link prefetch="render" />
+  <Link prefetch="viewport" />
 </>
 ```
 
 - **"none"** - Default behavior. This will prevent any prefetching from happening. This is recommended when linking to pages that require a user session that the browser won't be able to prefetch anyway.
 - **"intent"** - Recommended if you want to prefetch. Fetches when Remix thinks the user intends to visit the link. Right now the behavior is simple: if they hover or focus the link it will prefetch the resources. In the future we hope to make this even smarter. Links with large click areas/padding get a bit of a head start. It is worth noting that when using `prefetch="intent"`, `<link rel="prefetch">` elements will be inserted on hover/focus and removed if the `<Link>` loses hover/focus. Without proper `cache-control` headers on your loaders, this could result in repeated prefetch loads if a user continually hovers on and off a link.
 - **"render"** - Fetches when the link is rendered.
+- **"viewport"** - Fetches while the link is in the viewport
 
 <docs-error>You may need to use the <code>:last-of-type</code> selector instead of <code>:last-child</code> when styling child elements inside of your links</docs-error>
 

--- a/docs/components/nav-link.md
+++ b/docs/components/nav-link.md
@@ -5,7 +5,7 @@ toc: false
 
 # `<NavLink>`
 
-A `<NavLink>` is a special kind of `<Link>` that knows whether or not it is "active" or "pending". This is useful when building a navigation menu, such as a breadcrumb or a set of tabs where you'd like to show which of them is currently selected. It also provides useful context for assistive technology like screen readers.
+A `<NavLink>` is a special kind of [`<Link>`][link] that knows whether or not it is "active" or "pending". This is useful when building a navigation menu, such as a breadcrumb or a set of tabs where you'd like to show which of them is currently selected. It also provides useful context for assistive technology like screen readers.
 
 ```tsx
 import { NavLink } from "@remix-run/react";
@@ -122,3 +122,4 @@ Adding the `caseSensitive` prop changes the matching logic to make it case sensi
 When a `NavLink` is active it will automatically apply `<a aria-current="page">` to the underlying anchor tag. See [aria-current][aria-current] on MDN.
 
 [aria-current]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current
+[link]: ./link.md

--- a/integration/prefetch-test.ts
+++ b/integration/prefetch-test.ts
@@ -271,3 +271,74 @@ test.describe("prefetch=intent (focus)", () => {
     expect(await page.locator("#nav link").count()).toBe(1);
   });
 });
+
+test.describe("prefetch=viewport", () => {
+  let fixture: Fixture;
+  let appFixture: AppFixture;
+
+  test.beforeAll(async () => {
+    fixture = await createFixture({
+      config: {
+        future: { v2_routeConvention: true },
+      },
+      files: {
+        "app/routes/_index.jsx": js`
+          import { Link } from "@remix-run/react";
+
+          export default function Component() {
+            return (
+              <>
+                <h1>Index Page - Scroll Down</h1>
+                <div style={{ marginTop: "150vh" }}>
+                  <Link to="/test" prefetch="viewport">Click me!</Link>
+                </div>
+              </>
+            );
+          }
+        `,
+
+        "app/routes/test.jsx": js`
+          export function loader() {
+            return null;
+          }
+          export default function Component() {
+            return <h1>Test Page</h1>;
+          }
+        `,
+      },
+    });
+
+    // This creates an interactive app using puppeteer.
+    appFixture = await createAppFixture(fixture);
+  });
+
+  test.afterAll(() => {
+    appFixture.close();
+  });
+
+  test("should prefetch when the link enters the viewport", async ({
+    page,
+  }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/");
+
+    // No preloads to start
+    await expect(page.locator("div link")).toHaveCount(0);
+
+    // Preloads render on scroll down
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    await page.waitForSelector(
+      "div link[rel='prefetch'][as='fetch'][href='/test?_data=routes%2Ftest']",
+      { state: "attached" }
+    );
+    await page.waitForSelector(
+      "div link[rel='modulepreload'][href^='/build/routes/test-']",
+      { state: "attached" }
+    );
+
+    // Preloads removed on scroll up
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await expect(page.locator("div link")).toHaveCount(0);
+  });
+});

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -222,7 +222,7 @@ interface PrefetchHandlers {
 function usePrefetchBehavior<T extends HTMLAnchorElement>(
   prefetch: PrefetchBehavior,
   theirElementProps: PrefetchHandlers
-): [boolean, React.RefObject<T> | null, Required<PrefetchHandlers>] {
+): [boolean, React.RefObject<T>, Required<PrefetchHandlers>] {
   let [maybePrefetch, setMaybePrefetch] = React.useState(false);
   let [shouldPrefetch, setShouldPrefetch] = React.useState(false);
   let { onFocus, onBlur, onMouseEnter, onMouseLeave, onTouchStart } =
@@ -276,7 +276,7 @@ function usePrefetchBehavior<T extends HTMLAnchorElement>(
 
   return [
     shouldPrefetch,
-    prefetch === "viewport" ? ref : null,
+    ref,
     {
       onFocus: composeEventHandlers(onFocus, setIntent),
       onBlur: composeEventHandlers(onBlur, cancelIntent),
@@ -309,7 +309,7 @@ let NavLink = React.forwardRef<HTMLAnchorElement, RemixNavLinkProps>(
         <RouterNavLink
           {...props}
           {...prefetchHandlers}
-          ref={ref ? mergeRefs(forwardedRef, ref) : forwardedRef}
+          ref={mergeRefs(forwardedRef, ref)}
           to={to}
         />
         {shouldPrefetch && !isAbsolute ? (
@@ -343,7 +343,7 @@ let Link = React.forwardRef<HTMLAnchorElement, RemixLinkProps>(
         <RouterLink
           {...props}
           {...prefetchHandlers}
-          ref={ref ? mergeRefs(forwardedRef, ref) : forwardedRef}
+          ref={mergeRefs(forwardedRef, ref)}
           to={to}
         />
         {shouldPrefetch && !isAbsolute ? (

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -222,7 +222,7 @@ interface PrefetchHandlers {
 function usePrefetchBehavior<T extends HTMLAnchorElement>(
   prefetch: PrefetchBehavior,
   theirElementProps: PrefetchHandlers
-): [boolean, React.RefObject<T>, Required<PrefetchHandlers>] {
+): [boolean, React.RefObject<T> | null, Required<PrefetchHandlers>] {
   let [maybePrefetch, setMaybePrefetch] = React.useState(false);
   let [shouldPrefetch, setShouldPrefetch] = React.useState(false);
   let { onFocus, onBlur, onMouseEnter, onMouseLeave, onTouchStart } =
@@ -276,7 +276,7 @@ function usePrefetchBehavior<T extends HTMLAnchorElement>(
 
   return [
     shouldPrefetch,
-    ref,
+    prefetch === "viewport" ? ref : null,
     {
       onFocus: composeEventHandlers(onFocus, setIntent),
       onBlur: composeEventHandlers(onBlur, cancelIntent),
@@ -309,7 +309,7 @@ let NavLink = React.forwardRef<HTMLAnchorElement, RemixNavLinkProps>(
         <RouterNavLink
           {...props}
           {...prefetchHandlers}
-          ref={mergeRefs(forwardedRef, ref)}
+          ref={ref ? mergeRefs(forwardedRef, ref) : forwardedRef}
           to={to}
         />
         {shouldPrefetch && !isAbsolute ? (
@@ -343,7 +343,7 @@ let Link = React.forwardRef<HTMLAnchorElement, RemixLinkProps>(
         <RouterLink
           {...props}
           {...prefetchHandlers}
-          ref={mergeRefs(forwardedRef, ref)}
+          ref={ref ? mergeRefs(forwardedRef, ref) : forwardedRef}
           to={to}
         />
         {shouldPrefetch && !isAbsolute ? (

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -238,7 +238,7 @@ function usePrefetchBehavior<T extends HTMLAnchorElement>(
     if (prefetch === "viewport") {
       let callback: IntersectionObserverCallback = (entries) => {
         entries.forEach((entry) => {
-          if (entry.isIntersecting) setShouldPrefetch(true);
+          setShouldPrefetch(entry.isIntersecting);
         });
       };
       let observer = new IntersectionObserver(callback, { threshold: 0.5 });

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -237,7 +237,6 @@ function usePrefetchBehavior<T extends HTMLAnchorElement>(
 
     if (prefetch === "viewport") {
       let callback: IntersectionObserverCallback = (entries) => {
-        console.log("entries", entries);
         entries.forEach((entry) => {
           if (entry.isIntersecting) setShouldPrefetch(true);
         });

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -244,7 +244,6 @@ function usePrefetchBehavior<T extends HTMLAnchorElement>(
       };
       let observer = new IntersectionObserver(callback, { threshold: 0.5 });
       if (ref.current) observer.observe(ref.current);
-      else console.warn("No element to observe");
 
       return () => {
         observer.disconnect();
@@ -339,8 +338,6 @@ let Link = React.forwardRef<HTMLAnchorElement, RemixLinkProps>(
       prefetch,
       props
     );
-
-    console.log({ ref: ref.current, forwardedRef });
 
     return (
       <>


### PR DESCRIPTION
Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: https://canary.discord.com/channels/770287896669978684/940264701785423992/1109137291974279239

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
