### PR TITLE
Update wrangler to v3 in `cloudflare-pages` template

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -202,6 +202,7 @@
 - itsMapleLeaf
 - izznatsir
 - jacargentina
+- Jackardios
 - jacob-ebey
 - JacobParis
 - jakeginnivan

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "scripts": {
     "build": "remix build",
-    "dev": "remix dev --no-restart -c \"wrangler pages dev ./public\"",
-    "start": "wrangler pages dev ./public",
+    "dev": "remix dev --no-restart -c \"npm run start\"",
+    "start": "wrangler pages dev ./public --compatibility-date 2023-05-12",
     "typecheck": "tsc"
   },
   "dependencies": {
@@ -25,7 +25,7 @@
     "@types/react-dom": "^18.0.11",
     "eslint": "^8.38.0",
     "typescript": "^5.0.4",
-    "wrangler": "^2.17.0"
+    "wrangler": "^3.0.0"
   },
   "engines": {
     "node": ">=16.13"

--- a/templates/cloudflare-pages/wrangler.toml
+++ b/templates/cloudflare-pages/wrangler.toml
@@ -1,2 +1,0 @@
-compatibility_date = "2022-04-05"
-compatibility_flags = ["streams_enable_constructors"]


### PR DESCRIPTION
Closes: #6415

In addition to updating wrangler to v3, I also removed `wrangler.toml` (since it is not supported by `wrangler pages dev`) and added the latest compatibility-date as an option to invoke the `wrangler pages dev` command
