### PR TITLE
docs(file-conventions/route-files-v2): fix code highlighting

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -540,3 +540,4 @@
 - yudai-nkt
 - baby230211
 - TomVance
+- mrkhosravian

--- a/docs/file-conventions/route-files-v2.md
+++ b/docs/file-conventions/route-files-v2.md
@@ -84,7 +84,7 @@ Note that these routes will be rendered in the outlet of `app/root.tsx` because 
 Adding a `.` to a route filename will create a `/` in the URL.
 
 <!-- prettier-ignore -->
-```markdown lines=[4-6]
+```markdown lines=[5-7]
 app/
 ├── routes/
 │   ├── _index.tsx


### PR DESCRIPTION
fix: change wrong code lines highlight

There is a wrong line highlighting in [Dot Delimiters](https://remix.run/docs/en/main/file-conventions/route-files-v2#dot-delimiters) section that this commit will fix it.
