### PR TITLE
chore: update playground template CSS setup

### DIFF
--- a/scripts/playground/template/.gitignore
+++ b/scripts/playground/template/.gitignore
@@ -2,5 +2,3 @@
 
 **/prisma/data.db
 **/prisma/data.db-journal
-
-**/app/styles/tailwind.css

--- a/scripts/playground/template/app/root.tsx
+++ b/scripts/playground/template/app/root.tsx
@@ -8,12 +8,16 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
+import { cssBundleHref } from "@remix-run/css-bundle";
 
 import tailwindStylesheetUrl from "./styles/tailwind.css";
 import { getUser } from "./session.server";
 
 export const links: LinksFunction = () => {
-  return [{ rel: "stylesheet", href: tailwindStylesheetUrl }];
+  return [
+    { rel: "stylesheet", href: tailwindStylesheetUrl },
+    ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),
+  ];
 };
 
 export async function loader({ request }: LoaderArgs) {

--- a/scripts/playground/template/app/styles/tailwind.css
+++ b/scripts/playground/template/app/styles/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/scripts/playground/template/package.json
+++ b/scripts/playground/template/package.json
@@ -3,14 +3,10 @@
   "private": true,
   "sideEffects": false,
   "scripts": {
-    "build": "run-s \"build:*\"",
-    "build:css": "npm run generate:css -- --minify",
-    "build:remix": "node ./node_modules/@remix-run/dev/dist/cli build",
+    "build": "node ./node_modules/@remix-run/dev/dist/cli build",
     "dev": "run-p \"dev:*\"",
-    "dev:css": "cross-env NODE_ENV=development npm run generate:css -- --watch",
     "dev:remix": "cross-env NODE_ENV=development node ./node_modules/@remix-run/dev/dist/cli watch",
     "dev:server": "cross-env NODE_ENV=development node --inspect --require ./node_modules/dotenv/config ./server.js",
-    "generate:css": "tailwindcss -o ./app/styles/tailwind.css",
     "setup": "prisma generate && prisma migrate deploy && prisma db seed",
     "start": "cross-env NODE_ENV=production node --inspect --require ./node_modules/dotenv/config ./server.js"
   },
@@ -21,6 +17,7 @@
   ],
   "dependencies": {
     "@prisma/client": "^3.15.2",
+    "@remix-run/css-bundle": "*",
     "@remix-run/express": "*",
     "@remix-run/node": "*",
     "@remix-run/react": "*",

--- a/scripts/playground/template/remix.config.js
+++ b/scripts/playground/template/remix.config.js
@@ -2,6 +2,7 @@
 module.exports = {
   cacheDirectory: "./node_modules/.cache/remix",
   ignoredRouteFiles: ["**/.*", "**/*.css", "**/*.test.{js,jsx,ts,tsx}"],
+  tailwind: true,
   future: {
     v2_meta: true,
   },


### PR DESCRIPTION
When running `yarn playground:new`, the default template uses Tailwind but doesn't use the new built-in Tailwind support. It also doesn't include the `@remix-run/css-bundle` boilerplate which is a bit of a slowdown if you're wanting to iterate on CSS bundling features.