### PR TITLE
fix typo in jokes app tutorial

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -472,6 +472,7 @@
 - sjparsons
 - skube
 - sndrem
+- smeijer
 - sobrinho
 - squidpunch
 - staylor

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -7656,7 +7656,7 @@ Fly generated a few files for us:
 fly secrets set SESSION_SECRET=your-secret-here
 ```
 
-`your-secret-here` can be whatever you want. It's just a string that's used to encrypt the session cookie. Use a password generator if you like.
+`your-secret-here` can be whatever you want. It's just a string that's used to sign the session cookie. Use a password generator if you like.
 
 One other thing we need to do is get Prisma ready to set up our database for the first time. Now that we're happy with our schema, we can create our first migration.
 


### PR DESCRIPTION
The session secrets are used to `sign` the cookie, not to `encrypt` it. This mistake can lead to dangerously wrong assumptions 🙂