### PR TITLE
docs(tutorials/jokes): fix code highlighting

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -544,3 +544,4 @@
 - TomVance
 - amir-ziaei
 - mrkhosravian
+- tanerijun

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1980,7 +1980,7 @@ But if there's an error, you can return an object with the error messages and th
 
 <summary>app/routes/jokes.new.tsx</summary>
 
-```tsx filename=app/routes/jokes.new.tsx lines=[3,6,8-12,14-18,28-32,35-38,40-46,53,63,66-73,76-84,90,92-99,102-110,115-122]
+```tsx filename=app/routes/jokes.new.tsx lines=[3,6,8-12,14-18,28-32,35-38,40-46,53,63,66-73,76-84,90,92-99,102-110,113-120]
 import type { ActionArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 import { useActionData } from "@remix-run/react";


### PR DESCRIPTION
Fixed syntax highlight for the final code example in tutorials/jokes/mutation which is shifted forward by 2 lines