### PR TITLE
Fix add labels workflow for merged PRs

### DIFF
--- a/.github/workflows/merged-pr.yml
+++ b/.github/workflows/merged-pr.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           retries: 3
           script: |
-            await github.issues.addLabels({
+            await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              labels: 'awaiting release',
+              labels: ['awaiting release'],
             })


### PR DESCRIPTION
This approach was added in https://github.com/remix-run/remix/pull/6277, but I've gotten a few notifications that it failed on recently merged PRs of mine:  https://github.com/remix-run/remix/actions/workflows/merged-pr.yml.

```
Run actions/github-script@v6
  ...
TypeError: Cannot read properties of undefined (reading 'addLabels')
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:1514[3](https://github.com/remix-run/remix/actions/runs/5060206394/jobs/9082772469#step:2:3):16), <anonymous>:3:21)
...
Error: Unhandled error: TypeError: Cannot read properties of undefined (reading 'addLabels')
```

It seems the last successful run was using a different workflow entirely.  I think we might just have a bad script based on what the docs show for this same example: https://github.com/actions/github-script#apply-a-label-to-an-issue