### PR TITLE
fix: include set-cookie headers from bubbled thrown responses

### DIFF
--- a/.changeset/bubbled-response-cookies.md
+++ b/.changeset/bubbled-response-cookies.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+Automatically include set-cookie headers from bubbled thrown responses


### PR DESCRIPTION
Now that we're bubbling/exposing `errorHeaders` (#6425), we should also automatically prepend the cookies from any bubbled thrown Responses.

Closes #3157