### PR TITLE
docs(guides/not-found): fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -13,6 +13,7 @@
 - airjp73
 - airondumael
 - aissa-bouguern
+- ajtorres9
 - akamfoad
 - alanhoskins
 - Alarid

--- a/docs/guides/not-found.md
+++ b/docs/guides/not-found.md
@@ -4,7 +4,7 @@ title: Not Found Handling
 
 # Not Found (404) Handling
 
-When a document isn't found on a web server, it should send a [404 status code][404-status-code]. This indicates to machines that the document is not there: search engines won't index it, CDNS won't cache it, etc. Most SPAs today just serve everything as 200 whether the page exists or not, but for you that stops today!
+When a document isn't found on a web server, it should send a [404 status code][404-status-code]. This indicates to machines that the document is not there: search engines won't index it, CDNs won't cache it, etc. Most SPAs today just serve everything as 200 whether the page exists or not, but for you that stops today!
 
 There are two primary cases where a Remix site should send a 404:
 


### PR DESCRIPTION
I believe `CDNS` is meant to be `CDNs`, the plural of CDN. 🙂 