### PR TITLE
fix(remix-dev/cli): remove `AWS Lamba` copy

### DIFF
--- a/.changeset/chilly-shoes-scream.md
+++ b/.changeset/chilly-shoes-scream.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Rename `Architect (AWS Lambda)` -> `Architect` in the `create-remix` CLI to avoid confusion for other methods of deploying to AWS (i.e., SST)

--- a/contributors.yml
+++ b/contributors.yml
@@ -159,6 +159,7 @@
 - freeman
 - frontsideair
 - furkanakkurt1335
+- fwang
 - fx109138
 - gabimor
 - garand

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -130,7 +130,7 @@ ${colors.logoBlue("R")} ${colors.logoGreen("E")} ${colors.logoYellow(
 const templateChoices = [
   { name: "Remix App Server", value: "remix" },
   { name: "Express Server", value: "express" },
-  { name: "Architect (AWS Lambda)", value: "arc" },
+  { name: "Architect", value: "arc" },
   { name: "Fly.io", value: "fly" },
   { name: "Netlify", value: "netlify" },
   { name: "Vercel", value: "vercel" },


### PR DESCRIPTION
Hi team, I'm a maintainer of SST. SST helps Remix users [deploy their Remix apps to AWS](https://docs.sst.dev/start/remix).

We've received feedback indicating that the `Architect (AWS Lambda)` option in the `create-remix` flow is causing some confusion. SST wraps around the default `Remix App Server` inside a Lambda handler, but we've noticed several users mistakenly selecting the `Architect (AWS Lambda)` deployment target. (please see the attached screenshot for reference)

This PR removed the `AWS Lambda` copy from the `Architect` deployment target to alleviate this confusion.

<img width="1072" alt="bootstrap-remix-3406f4a372963a16dc8f5ae4b75de387" src="https://github.com/remix-run/remix/assets/83515/4227d202-5d04-4edd-8ea8-b978abde5a15">
