### PR TITLE
docs(hooks/use-matches): fix code highlighting

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -291,6 +291,7 @@
 - kuldar
 - kumard3
 - lachlanjc
+- larister
 - laughnan
 - lawrencecchen
 - leifarriens

--- a/docs/hooks/use-matches.md
+++ b/docs/hooks/use-matches.md
@@ -58,7 +58,7 @@ You can put whatever you want on a route `handle`. Here we'll use `breadcrumb`. 
 
 3. Now we can put it all together in our root route with `useMatches`.
 
-   ```tsx filename=root.tsx lines=[5,19-30]
+   ```tsx filename=root.tsx lines=[5,9,19-30]
    import {
      Links,
      Scripts,


### PR DESCRIPTION
Noticed that line 9 was missing in the highlighting whilst checking the docs.
