### PR TITLE
chore: fix copy-build-to-dist script on Windows

### DIFF
--- a/scripts/copy-build-to-dist.mjs
+++ b/scripts/copy-build-to-dist.mjs
@@ -141,9 +141,9 @@ async function getPackageBuildPaths(moduleRootDir) {
       if (path.basename(moduleDir) === "@remix-run") {
         packageBuilds.push(...(await getPackageBuildPaths(moduleDir)));
       } else if (
-        /node_modules\/@remix-run\//.test(moduleDir) ||
-        /node_modules\/create-remix/.test(moduleDir) ||
-        /node_modules\/remix/.test(moduleDir)
+        /node_modules[/\\]@remix-run[/\\]/.test(moduleDir) ||
+        /node_modules[/\\]create-remix/.test(moduleDir) ||
+        /node_modules[/\\]remix/.test(moduleDir)
       ) {
         packageBuilds.push(moduleDir);
       }


### PR DESCRIPTION
I ran into this issue while working on #6509 which resulted in tests failing on Windows in CI. Since that PR is now closed, I've pulled out this fix into its own PR.