### PR TITLE
fix(remix-dev): fix unstable dev server hang on Windows

### DIFF
--- a/packages/remix-dev/devServer_unstable/index.ts
+++ b/packages/remix-dev/devServer_unstable/index.ts
@@ -107,7 +107,8 @@ export let serve = async (
     console.log(`> ${cmd}`);
     let newAppServer = execa
       .command(cmd, {
-        stdio: "pipe",
+        stdio: ['ignore', 'inherit', 'inherit'],
+        shell: true,
         env: {
           NODE_ENV: "development",
           PATH:

--- a/packages/remix-dev/devServer_unstable/index.ts
+++ b/packages/remix-dev/devServer_unstable/index.ts
@@ -108,7 +108,6 @@ export let serve = async (
     let newAppServer = execa
       .command(cmd, {
         stdio: ['ignore', 'inherit', 'inherit'],
-        shell: true,
         env: {
           NODE_ENV: "development",
           PATH:


### PR DESCRIPTION
## Closes: #6504 


This is an issue noted on Epic Stack as well, forcing a patch with `execa`:

* https://github.com/epicweb-dev/epic-stack/blob/main/server/dev-server.js#L9
* https://github.com/epicweb-dev/epic-stack/issues/136

