### PR TITLE
Add support for json/text submissions

### DIFF
--- a/.changeset/json-text-encoding.md
+++ b/.changeset/json-text-encoding.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": minor
+---
+
+Support `application/json` and `text/plain` submission encodings in `useSubmit`/`fetcher.submit`

--- a/integration/hook-useSubmit-test.ts
+++ b/integration/hook-useSubmit-test.ts
@@ -15,34 +15,78 @@ test.describe("`useSubmit()` returned function", () => {
       },
       files: {
         "app/routes/_index.jsx": js`
-        import { useLoaderData, useSubmit } from "@remix-run/react";
+          import { useLoaderData, useSubmit } from "@remix-run/react";
 
-        export function loader({ request }) {
-          let url = new URL(request.url);
-          return url.searchParams.toString()
-        }
-
-        export default function Index() {
-          let submit = useSubmit();
-          let handleClick = event => {
-            event.preventDefault()
-            submit(event.nativeEvent.submitter || event.currentTarget)
+          export function loader({ request }) {
+            let url = new URL(request.url);
+            return url.searchParams.toString()
           }
-          let data = useLoaderData();
-          return (
-            <form>
-              <input type="text" name="tasks" defaultValue="first" />
-              <input type="text" name="tasks" defaultValue="second" />
 
-              <button onClick={handleClick} name="tasks" value="third">
-                Prepare Third Task
-              </button>
+          export default function Index() {
+            let submit = useSubmit();
+            let handleClick = event => {
+              event.preventDefault()
+              submit(event.nativeEvent.submitter || event.currentTarget)
+            }
+            let data = useLoaderData();
+            return (
+              <form>
+                <input type="text" name="tasks" defaultValue="first" />
+                <input type="text" name="tasks" defaultValue="second" />
 
-              <pre>{data}</pre>
-            </form>
-          )
-        }
-      `,
+                <button onClick={handleClick} name="tasks" value="third">
+                  Prepare Third Task
+                </button>
+
+                <pre>{data}</pre>
+              </form>
+            )
+          }
+        `,
+        "app/routes/action.jsx": js`
+          import { json } from "@remix-run/node";
+          import { useActionData, useSubmit } from "@remix-run/react";
+
+          export async function action({ request }) {
+            let contentType = request.headers.get('Content-Type');
+            if (contentType.includes('application/json')) {
+              return json({ value: await request.json() });
+            }
+            if (contentType.includes('text/plain')) {
+              return json({ value: await request.text() });
+            }
+            let fd = await request.formData();
+            return json({ value: new URLSearchParams(fd.entries()).toString() })
+          }
+
+          export default function Component() {
+            let submit = useSubmit();
+            let data = useActionData();
+            return (
+              <>
+                <button id="submit-json" onClick={() => submit(
+                  { key: 'value' },
+                  { method: 'post', encType: 'application/json' },
+                )}>
+                  Submit JSON
+                </button>
+                <button id="submit-text" onClick={() => submit(
+                  "raw text",
+                  { method: 'post', encType: 'text/plain' },
+                )}>
+                  Submit Text
+                </button>
+                <button id="submit-formData" onClick={() => submit(
+                  { key: 'value' },
+                  { method: 'post' },
+                )}>
+                  Submit FrmData
+                </button>
+                {data ? <p id="action-data">data: {JSON.stringify(data)}</p> : null}
+              </>
+            );
+          }
+        `,
       },
     });
 
@@ -63,5 +107,29 @@ test.describe("`useSubmit()` returned function", () => {
     expect(await app.getHtml("pre")).toBe(
       `<pre>tasks=first&amp;tasks=second&amp;tasks=third</pre>`
     );
+  });
+
+  test("submits json data", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/action", true);
+    await app.clickElement("#submit-json");
+    await page.waitForSelector("#action-data");
+    expect(await app.getHtml()).toMatch('data: {"value":{"key":"value"}}');
+  });
+
+  test("submits text data", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/action", true);
+    await app.clickElement("#submit-text");
+    await page.waitForSelector("#action-data");
+    expect(await app.getHtml()).toMatch('data: {"value":"raw text"}');
+  });
+
+  test("submits form data", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/action", true);
+    await app.clickElement("#submit-formData");
+    await page.waitForSelector("#action-data");
+    expect(await app.getHtml()).toMatch('data: {"value":"key=value"}');
   });
 });

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1456,8 +1456,10 @@ export function useFetchers(): Fetcher[] {
       data: f.data,
       formMethod: f.formMethod,
       formAction: f.formAction,
-      formData: f.formData,
       formEncType: f.formEncType,
+      formData: f.formData,
+      json: f.json,
+      text: f.text,
       " _hasFetcherDoneAnything ": f[" _hasFetcherDoneAnything "],
     });
     addFetcherDeprecationWarnings(fetcher);
@@ -1490,8 +1492,10 @@ export function useFetcher<TData = any>(): FetcherWithComponents<
       data: fetcherRR.data,
       formMethod: fetcherRR.formMethod,
       formAction: fetcherRR.formAction,
-      formData: fetcherRR.formData,
       formEncType: fetcherRR.formEncType,
+      formData: fetcherRR.formData,
+      json: fetcherRR.json,
+      text: fetcherRR.text,
       " _hasFetcherDoneAnything ": fetcherRR[" _hasFetcherDoneAnything "],
     });
     let fetcherWithComponents = {
@@ -1542,8 +1546,16 @@ function addFetcherDeprecationWarnings(fetcher: Fetcher) {
 function convertRouterFetcherToRemixFetcher(
   fetcherRR: Omit<ReturnType<typeof useFetcherRR>, "load" | "submit" | "Form">
 ): Fetcher {
-  let { state, formMethod, formAction, formEncType, formData, data } =
-    fetcherRR;
+  let {
+    state,
+    formMethod,
+    formAction,
+    formEncType,
+    formData,
+    json,
+    text,
+    data,
+  } = fetcherRR;
 
   let isActionSubmission =
     formMethod != null &&
@@ -1556,8 +1568,10 @@ function convertRouterFetcherToRemixFetcher(
         type: "done",
         formMethod: undefined,
         formAction: undefined,
-        formData: undefined,
         formEncType: undefined,
+        formData: undefined,
+        json: undefined,
+        text: undefined,
         submission: undefined,
         data,
       };
@@ -1573,7 +1587,7 @@ function convertRouterFetcherToRemixFetcher(
     formMethod &&
     formAction &&
     formEncType &&
-    formData
+    (formData || json || text)
   ) {
     if (isActionSubmission) {
       // Actively submitting to an action
@@ -1581,14 +1595,21 @@ function convertRouterFetcherToRemixFetcher(
         state,
         type: "actionSubmission",
         formMethod: formMethod.toUpperCase() as ActionSubmission["method"],
-        formAction: formAction,
-        formEncType: formEncType,
-        formData: formData,
+        formAction,
+        formEncType,
+        formData,
+        json,
+        text,
+        // @ts-expect-error formData/json/text are mutually exclusive in the type,
+        // so TS can't be sure these meet that criteria, but as a straight
+        // assignment from the RR fetcher we know they will
         submission: {
           method: formMethod.toUpperCase() as ActionSubmission["method"],
           action: formAction,
           encType: formEncType,
-          formData: formData,
+          formData,
+          json,
+          text,
           key: "",
         },
         data,
@@ -1604,7 +1625,7 @@ function convertRouterFetcherToRemixFetcher(
   }
 
   if (state === "loading") {
-    if (formMethod && formAction && formEncType && formData) {
+    if (formMethod && formAction && formEncType) {
       if (isActionSubmission) {
         if (data) {
           // In a loading state but we have data - must be an actionReload
@@ -1612,14 +1633,21 @@ function convertRouterFetcherToRemixFetcher(
             state,
             type: "actionReload",
             formMethod: formMethod.toUpperCase() as ActionSubmission["method"],
-            formAction: formAction,
-            formEncType: formEncType,
-            formData: formData,
+            formAction,
+            formEncType,
+            formData,
+            json,
+            text,
+            // @ts-expect-error formData/json/text are mutually exclusive in the type,
+            // so TS can't be sure these meet that criteria, but as a straight
+            // assignment from the RR fetcher we know they will
             submission: {
               method: formMethod.toUpperCase() as ActionSubmission["method"],
               action: formAction,
               encType: formEncType,
-              formData: formData,
+              formData,
+              json,
+              text,
               key: "",
             },
             data,
@@ -1630,14 +1658,21 @@ function convertRouterFetcherToRemixFetcher(
             state,
             type: "actionRedirect",
             formMethod: formMethod.toUpperCase() as ActionSubmission["method"],
-            formAction: formAction,
-            formEncType: formEncType,
-            formData: formData,
+            formAction,
+            formEncType,
+            formData,
+            json,
+            text,
+            // @ts-expect-error formData/json/text are mutually exclusive in the type,
+            // so TS can't be sure these meet that criteria, but as a straight
+            // assignment from the RR fetcher we know they will
             submission: {
               method: formMethod.toUpperCase() as ActionSubmission["method"],
               action: formAction,
               encType: formEncType,
-              formData: formData,
+              formData,
+              json,
+              text,
               key: "",
             },
             data: undefined,
@@ -1651,27 +1686,36 @@ function convertRouterFetcherToRemixFetcher(
         // will fix this bug.
         let url = new URL(formAction, window.location.origin);
 
-        // This typing override should be safe since this is only running for
-        // GET submissions and over in @remix-run/router we have an invariant
-        // if you have any non-string values in your FormData when we attempt
-        // to convert them to URLSearchParams
-        url.search = new URLSearchParams(
-          formData.entries() as unknown as [string, string][]
-        ).toString();
+        if (formData) {
+          // This typing override should be safe since this is only running for
+          // GET submissions and over in @remix-run/router we have an invariant
+          // if you have any non-string values in your FormData when we attempt
+          // to convert them to URLSearchParams
+          url.search = new URLSearchParams(
+            formData.entries() as unknown as [string, string][]
+          ).toString();
+        }
 
         // Actively "submitting" to a loader
         let fetcher: FetcherStates["SubmittingLoader"] = {
           state: "submitting",
           type: "loaderSubmission",
           formMethod: formMethod.toUpperCase() as LoaderSubmission["method"],
-          formAction: formAction,
-          formEncType: formEncType,
-          formData: formData,
+          formAction,
+          formEncType,
+          formData,
+          json,
+          text,
+          // @ts-expect-error formData/json/text are mutually exclusive in the type,
+          // so TS can't be sure these meet that criteria, but as a straight
+          // assignment from the RR fetcher we know they will
           submission: {
             method: formMethod.toUpperCase() as LoaderSubmission["method"],
             action: url.pathname + url.search,
             encType: formEncType,
-            formData: formData,
+            formData,
+            json,
+            text,
             key: "",
           },
           data,
@@ -1688,6 +1732,8 @@ function convertRouterFetcherToRemixFetcher(
     formMethod: undefined,
     formAction: undefined,
     formData: undefined,
+    json: undefined,
+    text: undefined,
     formEncType: undefined,
     submission: undefined,
     data,

--- a/packages/remix-react/data.ts
+++ b/packages/remix-react/data.ts
@@ -40,12 +40,23 @@ export async function fetchData(
     init.method = request.method;
 
     let contentType = request.headers.get("Content-Type");
-    init.body =
-      // Check between word boundaries instead of startsWith() due to the last
-      // paragraph of https://httpwg.org/specs/rfc9110.html#field.content-type
-      contentType && /\bapplication\/x-www-form-urlencoded\b/.test(contentType)
-        ? new URLSearchParams(await request.text())
-        : await request.formData();
+
+    // Check between word boundaries instead of startsWith() due to the last
+    // paragraph of https://httpwg.org/specs/rfc9110.html#field.content-type
+    if (contentType && /\bapplication\/json\b/.test(contentType)) {
+      init.headers = { "Content-Type": contentType };
+      init.body = JSON.stringify(await request.json());
+    } else if (contentType && /\btext\/plain\b/.test(contentType)) {
+      init.headers = { "Content-Type": contentType };
+      init.body = await request.text();
+    } else if (
+      contentType &&
+      /\bapplication\/x-www-form-urlencoded\b/.test(contentType)
+    ) {
+      init.body = new URLSearchParams(await request.text());
+    } else {
+      init.body = await request.formData();
+    }
   }
 
   if (retry > 0) {

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -75,6 +75,49 @@ export type TransitionStates = {
 
 export type Transition = TransitionStates[keyof TransitionStates];
 
+// Thanks https://github.com/sindresorhus/type-fest!
+type JsonObject = { [Key in string]: JsonValue } & {
+  [Key in string]?: JsonValue | undefined;
+};
+type JsonArray = JsonValue[] | readonly JsonValue[];
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonObject | JsonArray;
+
+// Fetchers need a separate set of types to reflect the json/text submission
+// support in react-router.  We do not carry that into useTransition since
+// it's deprecated
+type FetcherSubmissionDataTypes =
+  | {
+      formData: FormData;
+      json: undefined;
+      text: undefined;
+    }
+  | {
+      formData: undefined;
+      json: JsonValue;
+      text: undefined;
+    }
+  | {
+      formData: undefined;
+      json: undefined;
+      text: string;
+    };
+
+export type FetcherSubmission = {
+  action: string;
+  method: string;
+  encType: string;
+  key: string;
+} & FetcherSubmissionDataTypes;
+
+export type FetcherActionSubmission = FetcherSubmission & {
+  method: "POST" | "PUT" | "PATCH" | "DELETE";
+};
+
+export type FetcherLoaderSubmission = FetcherSubmission & {
+  method: "GET";
+};
+
 // TODO: keep data around on resubmission?
 export type FetcherStates<TData = any> = {
   Idle: {
@@ -82,51 +125,49 @@ export type FetcherStates<TData = any> = {
     type: "init";
     formMethod: undefined;
     formAction: undefined;
-    formData: undefined;
     formEncType: undefined;
+    formData: undefined;
+    json: undefined;
+    text: undefined;
     submission: undefined;
     data: undefined;
   };
   SubmittingAction: {
     state: "submitting";
     type: "actionSubmission";
-    formMethod: ActionSubmission["method"];
+    formMethod: FetcherActionSubmission["method"];
     formAction: string;
-    formData: FormData;
     formEncType: string;
-    submission: ActionSubmission;
+    submission: FetcherActionSubmission;
     data: TData | undefined;
-  };
+  } & FetcherSubmissionDataTypes;
   SubmittingLoader: {
     state: "submitting";
     type: "loaderSubmission";
-    formMethod: LoaderSubmission["method"];
+    formMethod: FetcherLoaderSubmission["method"];
     formAction: string;
-    formData: FormData;
     formEncType: string;
-    submission: LoaderSubmission;
+    submission: FetcherLoaderSubmission;
     data: TData | undefined;
-  };
+  } & FetcherSubmissionDataTypes;
   ReloadingAction: {
     state: "loading";
     type: "actionReload";
-    formMethod: ActionSubmission["method"];
+    formMethod: FetcherActionSubmission["method"];
     formAction: string;
-    formData: FormData;
     formEncType: string;
-    submission: ActionSubmission;
+    submission: FetcherActionSubmission;
     data: TData;
-  };
+  } & FetcherSubmissionDataTypes;
   LoadingActionRedirect: {
     state: "loading";
     type: "actionRedirect";
-    formMethod: ActionSubmission["method"];
+    formMethod: FetcherActionSubmission["method"];
     formAction: string;
-    formData: FormData;
     formEncType: string;
-    submission: ActionSubmission;
+    submission: FetcherActionSubmission;
     data: undefined;
-  };
+  } & FetcherSubmissionDataTypes;
   Loading: {
     state: "loading";
     type: "normalLoad";
@@ -134,6 +175,8 @@ export type FetcherStates<TData = any> = {
     formAction: undefined;
     formData: undefined;
     formEncType: undefined;
+    json: undefined;
+    text: undefined;
     submission: undefined;
     data: TData | undefined;
   };
@@ -142,8 +185,10 @@ export type FetcherStates<TData = any> = {
     type: "done";
     formMethod: undefined;
     formAction: undefined;
-    formData: undefined;
     formEncType: undefined;
+    formData: undefined;
+    json: undefined;
+    text: undefined;
     submission: undefined;
     data: TData;
   };
@@ -165,7 +210,9 @@ export const IDLE_FETCHER: FetcherStates["Idle"] = {
   data: undefined,
   formMethod: undefined,
   formAction: undefined,
-  formData: undefined,
   formEncType: undefined,
+  formData: undefined,
+  json: undefined,
+  text: undefined,
   submission: undefined,
 };


### PR DESCRIPTION
Make required changes and add tests for the Remix portion of https://github.com/remix-run/react-router/pull/10413 which adds support for `application/json` and `text/plain` submissions