### PR TITLE
docs(api/remix): Fix infinite loop in fetcher.load() example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -456,6 +456,7 @@
 - scottybrown
 - sdavids
 - sean-roberts
+- seanmccann
 - sebz
 - selfish
 - sergiocarneiro

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -161,7 +161,7 @@ function SomeComponent() {
     if (fetcher.state === "idle" && fetcher.data == null) {
       fetcher.load("/some/route");
     }
-  }, [fetcher]);
+  }, []);
 
   fetcher.data; // the data from the loader
 }


### PR DESCRIPTION
Similar to #4386 the example caused an infinite loop, and this change will run on mount.