### PR TITLE
fix(tests): use external process to get ports for tests to avoid race…

### DIFF
--- a/integration/fetcher-state-test.ts
+++ b/integration/fetcher-state-test.ts
@@ -165,7 +165,11 @@ test.describe("fetcher states", () => {
     await app.goto("/page", true);
     await app.clickElement(`#${TYPES.actionSubmission}`);
     await page.waitForSelector("#loading", { state: "hidden" });
-    let text = (await app.getElement("#states")).text();
+    let text = await (
+      await page.waitForSelector("#states:has-text('done')")
+    ).textContent();
+    if (!text) throw new Error("states not found");
+
     expect(JSON.parse(text)).toEqual([
       {
         state: "submitting",
@@ -213,7 +217,11 @@ test.describe("fetcher states", () => {
     await app.goto("/page", true);
     await app.clickElement(`#${TYPES.loaderSubmission}`);
     await page.waitForSelector("#loading", { state: "hidden" });
-    let text = (await app.getElement("#states")).text();
+    let text = await (
+      await page.waitForSelector("#states:has-text('done')")
+    ).textContent();
+    if (!text) throw new Error("states not found");
+
     expect(JSON.parse(text)).toEqual([
       {
         state: "submitting",
@@ -247,7 +255,10 @@ test.describe("fetcher states", () => {
     await app.goto("/page", true);
     await app.clickElement(`#${TYPES.actionRedirect}`);
     await page.waitForSelector("#loading", { state: "hidden" });
-    let text = (await app.getElement("#states")).text();
+    let text = await (
+      await page.waitForSelector("#states:has-text('done')")
+    ).textContent();
+    if (!text) throw new Error("states not found");
     expect(JSON.parse(text)).toEqual([
       {
         state: "submitting",
@@ -289,7 +300,10 @@ test.describe("fetcher states", () => {
     await app.goto("/page", true);
     await app.clickElement(`#${TYPES.normalLoad}`);
     await page.waitForSelector("#loading", { state: "hidden" });
-    let text = (await app.getElement("#states")).text();
+    let text = await (
+      await page.waitForSelector("#states:has-text('done')")
+    ).textContent();
+    if (!text) throw new Error("states not found");
     expect(JSON.parse(text)).toEqual([
       {
         state: "loading",

--- a/integration/get-port-process.mjs
+++ b/integration/get-port-process.mjs
@@ -1,0 +1,14 @@
+import { createServer } from "node:http";
+import getPort from "get-port";
+
+createServer(async (req, res) => {
+  try {
+    res.end(`${await getPort()}`);
+  } catch (error) {
+    console.error(error);
+    res.statusCode = 500;
+    res.end();
+  }
+}).listen(9000, () => {
+  console.log(`GetPort server listening on port 9000`);
+});

--- a/integration/helpers/create-fixture.ts
+++ b/integration/helpers/create-fixture.ts
@@ -2,7 +2,6 @@ import type { Writable } from "node:stream";
 import path from "node:path";
 import fse from "fs-extra";
 import express from "express";
-import getPort from "get-port";
 import dedent from "dedent";
 import stripIndent from "strip-indent";
 import serializeJavaScript from "serialize-javascript";
@@ -14,6 +13,7 @@ import { ServerMode } from "@remix-run/server-runtime/mode";
 import type { ServerBuild } from "../../build/node_modules/@remix-run/server-runtime";
 import { createRequestHandler } from "../../build/node_modules/@remix-run/server-runtime";
 import { createRequestHandler as createExpressHandler } from "../../build/node_modules/@remix-run/express";
+import { getPort } from "./get-port";
 
 const TMP_DIR = path.join(process.cwd(), ".tmp", "integration");
 

--- a/integration/helpers/get-port.ts
+++ b/integration/helpers/get-port.ts
@@ -1,0 +1,6 @@
+export async function getPort() {
+  let response = await fetch("http://localhost:9000");
+  if (response.status !== 200) throw new Error("Failed to get port");
+  let port = await response.json();
+  return port;
+}

--- a/integration/hmr-log-test.ts
+++ b/integration/hmr-log-test.ts
@@ -245,7 +245,7 @@ let expectConsoleError = (
   };
 };
 
-let HMR_TIMEOUT_MS = 10_000;
+let HMR_TIMEOUT_MS = 15_000;
 
 test("HMR", async ({ page, browserName }) => {
   // uncomment for debugging
@@ -272,7 +272,7 @@ test("HMR", async ({ page, browserName }) => {
         if (dev.exitCode) throw Error("Dev server exited early");
         return /✅ app ready: /.test(devStdout());
       },
-      { timeoutMs: 10_000 }
+      { timeoutMs: HMR_TIMEOUT_MS }
     );
 
     await page.goto(`http://localhost:${appPort}`, {

--- a/integration/hmr-log-test.ts
+++ b/integration/hmr-log-test.ts
@@ -3,10 +3,10 @@ import execa from "execa";
 import fs from "node:fs";
 import path from "node:path";
 import type { Readable } from "node:stream";
-import getPort, { makeRange } from "get-port";
 
 import type { FixtureInit } from "./helpers/create-fixture";
 import { createFixtureProject, css, js, json } from "./helpers/create-fixture";
+import { getPort } from "./helpers/get-port";
 
 test.setTimeout(120_000);
 
@@ -259,9 +259,7 @@ test("HMR", async ({ page, browserName }) => {
     }
   });
 
-  let portRange = makeRange(4080, 4099);
-  let appPort = await getPort({ port: portRange });
-  let devPort = await getPort({ port: portRange });
+  let [appPort, devPort] = await Promise.all([getPort(), getPort()]);
   let projectDir = await createFixtureProject(fixture({ appPort, devPort }));
 
   // spin up dev server

--- a/integration/hmr-test.ts
+++ b/integration/hmr-test.ts
@@ -3,10 +3,10 @@ import execa from "execa";
 import fs from "node:fs";
 import path from "node:path";
 import type { Readable } from "node:stream";
-import getPort, { makeRange } from "get-port";
 
 import type { FixtureInit } from "./helpers/create-fixture";
 import { createFixtureProject, css, js, json } from "./helpers/create-fixture";
+import { getPort } from "./helpers/get-port";
 
 test.setTimeout(120_000);
 
@@ -279,9 +279,7 @@ test("HMR", async ({ page, browserName }) => {
     }
   });
 
-  let portRange = makeRange(3080, 3099);
-  let appPort = await getPort({ port: portRange });
-  let devPort = await getPort({ port: portRange });
+  let [appPort, devPort] = await Promise.all([getPort(), getPort()]);
   let projectDir = await createFixtureProject(fixture({ appPort, devPort }));
 
   // spin up dev server

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -15,6 +15,11 @@ const config: PlaywrightTestConfig = {
   retries: process.env.CI ? 3 : 0,
   reporter: process.env.CI ? "dot" : [["html", { open: "never" }]],
   use: { actionTimeout: 0 },
+  webServer: {
+    reuseExistingServer: true,
+    port: 9000,
+    command: "node ./get-port-process.mjs"
+  },
 
   projects: [
     {


### PR DESCRIPTION
… condition between workers picking ports

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
