### PR TITLE
fix(dev): switch to JEST_WORKER_ID environment variable

### DIFF
--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -409,7 +409,7 @@ export async function readConfig(
     try {
       // shout out to next
       // https://github.com/vercel/next.js/blob/b15a976e11bf1dc867c241a4c1734757427d609c/packages/next/server/config.ts#L748-L765
-      if (process.env.NODE_ENV === "test") {
+      if (process.env.JEST_WORKER_ID) {
         // dynamic import does not currently work inside of vm which
         // jest relies on so we fall back to require for this case
         // https://github.com/nodejs/node/issues/35889


### PR DESCRIPTION
Apparently, ESLint sets the NODE_ENV to test and if you are using a eslint plugin that relies on this code you'll end up requiring when you should be importing.

Because this block is for Jest specifically, we'll instead use a known environment variable in a Jest environment.

- ~~[ ] Docs~~
- ~~[ ] Tests~~

Testing Strategy: Run CI. I also verified this solves my use case with a local patch.