### PR TITLE
test: fix integration tests

### DIFF
--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -40,6 +40,13 @@ let appFixture: AppFixture;
 //    ```
 ////////////////////////////////////////////////////////////////////////////////
 
+test.beforeEach(async ({ context }) => {
+  await context.route(/_data/, async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    route.continue();
+  });
+});
+
 test.beforeAll(async () => {
   fixture = await createFixture({
     config: {

--- a/integration/catch-boundary-data-test.ts
+++ b/integration/catch-boundary-data-test.ts
@@ -24,6 +24,13 @@ let HAS_BOUNDARY_NESTED_LOADER = "/yes/loader-self-boundary" as const;
 let ROOT_DATA = "root data";
 let LAYOUT_DATA = "root data";
 
+test.beforeEach(async ({ context }) => {
+  await context.route(/_data/, async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    route.continue();
+  });
+});
+
 test.beforeAll(async () => {
   fixture = await createFixture({
     config: {

--- a/integration/catch-boundary-test.ts
+++ b/integration/catch-boundary-test.ts
@@ -22,6 +22,13 @@ test.describe("CatchBoundary", () => {
 
   let NOT_FOUND_HREF = "/not/found";
 
+  test.beforeEach(async ({ context }) => {
+    await context.route(/_data/, async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      route.continue();
+    });
+  });
+
   test.beforeAll(async () => {
     fixture = await createFixture({
       config: {

--- a/integration/defer-test.ts
+++ b/integration/defer-test.ts
@@ -27,6 +27,13 @@ declare global {
   };
 }
 
+test.beforeEach(async ({ context }) => {
+  await context.route(/_data/, async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    route.continue();
+  });
+});
+
 test.describe("non-aborted", () => {
   let fixture: Fixture;
   let appFixture: AppFixture;

--- a/integration/error-boundary-test.ts
+++ b/integration/error-boundary-test.ts
@@ -37,6 +37,13 @@ test.describe("ErrorBoundary", () => {
   // packages/remix-react/errorBoundaries.tsx
   let INTERNAL_ERROR_BOUNDARY_HEADING = "Application Error";
 
+  test.beforeEach(async ({ context }) => {
+    await context.route(/_data/, async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      route.continue();
+    });
+  });
+
   test.beforeAll(async () => {
     _consoleError = console.error;
     console.error = () => {};

--- a/integration/fetcher-state-test.ts
+++ b/integration/fetcher-state-test.ts
@@ -17,6 +17,13 @@ test.describe("fetcher states", () => {
   let fixture: Fixture;
   let appFixture: AppFixture;
 
+  test.beforeEach(async ({ context }) => {
+    await context.route(/_data/, async (route) => {
+      await new Promise((r) => setTimeout(r, 50));
+      route.continue();
+    });
+  });
+
   test.beforeAll(async () => {
     fixture = await createFixture({
       config: {

--- a/integration/fetcher-state-test.ts
+++ b/integration/fetcher-state-test.ts
@@ -19,7 +19,7 @@ test.describe("fetcher states", () => {
 
   test.beforeEach(async ({ context }) => {
     await context.route(/_data/, async (route) => {
-      await new Promise((r) => setTimeout(r, 50));
+      await new Promise((resolve) => setTimeout(resolve, 50));
       route.continue();
     });
   });

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -49,7 +49,7 @@ test.describe("Forms", () => {
 
   test.beforeEach(async ({ context }) => {
     await context.route(/_data/, async (route) => {
-      await new Promise((r) => setTimeout(r, 50));
+      await new Promise((resolve) => setTimeout(resolve, 50));
       route.continue();
     });
   });

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -47,6 +47,13 @@ test.describe("Forms", () => {
   let SPLAT_ROUTE_PARENT_ACTION = "splat-route-parent";
   let SPLAT_ROUTE_TOO_MANY_DOTS_ACTION = "splat-route-too-many-dots";
 
+  test.beforeEach(async ({ context }) => {
+    await context.route(/_data/, async (route) => {
+      await new Promise((r) => setTimeout(r, 50));
+      route.continue();
+    });
+  });
+
   test.beforeAll(async () => {
     fixture = await createFixture({
       config: {

--- a/integration/hmr-log-test.ts
+++ b/integration/hmr-log-test.ts
@@ -274,7 +274,7 @@ test("HMR", async ({ page, browserName }) => {
         if (dev.exitCode) throw Error("Dev server exited early");
         return /✅ app ready: /.test(devStdout());
       },
-      { timeoutMs: 10_000 }
+      { timeoutMs: HMR_TIMEOUT_MS }
     );
 
     await page.goto(`http://localhost:${appPort}`, {
@@ -369,7 +369,7 @@ test("HMR", async ({ page, browserName }) => {
       }
     `;
     fs.writeFileSync(indexPath, withLoader1);
-    await expect.poll(() => dataRequests).toBe(1);
+    await expect.poll(() => dataRequests, { timeout: HMR_TIMEOUT_MS }).toBe(1);
     await page.waitForLoadState("networkidle");
 
     await page.getByText("Hello, world").waitFor({ timeout: HMR_TIMEOUT_MS });
@@ -399,7 +399,7 @@ test("HMR", async ({ page, browserName }) => {
       }
     `;
     fs.writeFileSync(indexPath, withLoader2);
-    await expect.poll(() => dataRequests).toBe(2);
+    await expect.poll(() => dataRequests, { timeout: HMR_TIMEOUT_MS }).toBe(2);
     await page.waitForLoadState("networkidle");
 
     await page.getByText("Hello, planet").waitFor({ timeout: HMR_TIMEOUT_MS });
@@ -465,11 +465,11 @@ whatsup
 <Component/>
 `;
     fs.writeFileSync(mdxPath, mdx);
-    await expect.poll(() => dataRequests).toBe(4);
+    await expect.poll(() => dataRequests, { timeout: HMR_TIMEOUT_MS }).toBe(4);
     await page.waitForSelector(`#hot`);
 
     fs.writeFileSync(mdxPath, originalMdx);
-    await expect.poll(() => dataRequests).toBe(5);
+    await expect.poll(() => dataRequests, { timeout: HMR_TIMEOUT_MS }).toBe(5);
     await page.waitForSelector(`#crazy`);
 
     // dev server doesn't crash when rebuild fails

--- a/integration/hmr-test.ts
+++ b/integration/hmr-test.ts
@@ -269,7 +269,7 @@ let HMR_TIMEOUT_MS = 10_000;
 
 test.beforeEach(async ({ context }) => {
   await context.route(/_data/, async (route) => {
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((resolve) => setTimeout(resolve, 50));
     route.continue();
   });
 });

--- a/integration/hmr-test.ts
+++ b/integration/hmr-test.ts
@@ -267,6 +267,13 @@ let expectConsoleError = (
 
 let HMR_TIMEOUT_MS = 10_000;
 
+test.beforeEach(async ({ context }) => {
+  await context.route(/_data/, async (route) => {
+    await new Promise((r) => setTimeout(r, 50));
+    route.continue();
+  });
+});
+
 test("HMR", async ({ page, browserName }) => {
   // uncomment for debugging
   // page.on("console", (msg) => console.log(msg.text()));

--- a/integration/hmr-test.ts
+++ b/integration/hmr-test.ts
@@ -267,13 +267,6 @@ let expectConsoleError = (
 
 let HMR_TIMEOUT_MS = 10_000;
 
-test.beforeEach(async ({ context }) => {
-  await context.route(/_data/, async (route) => {
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    route.continue();
-  });
-});
-
 test("HMR", async ({ page, browserName }) => {
   // uncomment for debugging
   // page.on("console", (msg) => console.log(msg.text()));
@@ -301,7 +294,7 @@ test("HMR", async ({ page, browserName }) => {
         if (dev.exitCode) throw Error("Dev server exited early");
         return /✅ app ready: /.test(devStdout());
       },
-      { timeoutMs: 10_000 }
+      { timeoutMs: HMR_TIMEOUT_MS }
     );
 
     await page.goto(`http://localhost:${appPort}`, {

--- a/integration/hmr-test.ts
+++ b/integration/hmr-test.ts
@@ -410,7 +410,7 @@ test("HMR", async ({ page, browserName }) => {
       }
     `;
     fs.writeFileSync(indexPath, withLoader1);
-    await expect.poll(() => dataRequests).toBe(1);
+    await expect.poll(() => dataRequests, { timeout: HMR_TIMEOUT_MS }).toBe(1);
     await page.waitForLoadState("networkidle");
 
     await page.getByText("Hello, world").waitFor({ timeout: HMR_TIMEOUT_MS });
@@ -439,7 +439,7 @@ test("HMR", async ({ page, browserName }) => {
     `;
     fs.writeFileSync(indexPath, withLoader2);
 
-    await expect.poll(() => dataRequests).toBe(2);
+    await expect.poll(() => dataRequests, { timeout: HMR_TIMEOUT_MS }).toBe(2);
 
     await page.waitForLoadState("networkidle");
 
@@ -506,11 +506,11 @@ whatsup
 <Component/>
 `;
     fs.writeFileSync(mdxPath, mdx);
-    await expect.poll(() => dataRequests).toBe(4);
+    await expect.poll(() => dataRequests, { timeout: HMR_TIMEOUT_MS }).toBe(4);
     await page.waitForSelector(`#hot`);
 
     fs.writeFileSync(mdxPath, originalMdx);
-    await expect.poll(() => dataRequests).toBe(5);
+    await expect.poll(() => dataRequests, { timeout: HMR_TIMEOUT_MS }).toBe(5);
     await page.waitForSelector(`#crazy`);
 
     // dev server doesn't crash when rebuild fails

--- a/integration/navigation-state-v2-test.ts
+++ b/integration/navigation-state-v2-test.ts
@@ -27,7 +27,7 @@ test.describe("navigation states", () => {
 
   test.beforeEach(async ({ context }) => {
     await context.route(/_data/, async (route) => {
-      await new Promise((r) => setTimeout(r, 50));
+      await new Promise((resolve) => setTimeout(resolve, 50));
       route.continue();
     });
   });

--- a/integration/navigation-state-v2-test.ts
+++ b/integration/navigation-state-v2-test.ts
@@ -25,6 +25,13 @@ test.describe("navigation states", () => {
   let fixture: Fixture;
   let appFixture: AppFixture;
 
+  test.beforeEach(async ({ context }) => {
+    await context.route(/_data/, async (route) => {
+      await new Promise((r) => setTimeout(r, 50));
+      route.continue();
+    });
+  });
+
   test.beforeAll(async () => {
     fixture = await createFixture({
       config: {

--- a/integration/transition-state-test.ts
+++ b/integration/transition-state-test.ts
@@ -25,7 +25,7 @@ test.describe("rendering", () => {
 
   test.beforeEach(async ({ context }) => {
     await context.route(/_data/, async (route) => {
-      await new Promise((r) => setTimeout(r, 50));
+      await new Promise((resolve) => setTimeout(resolve, 50));
       route.continue();
     });
   });

--- a/integration/transition-state-test.ts
+++ b/integration/transition-state-test.ts
@@ -23,6 +23,13 @@ test.describe("rendering", () => {
   let fixture: Fixture;
   let appFixture: AppFixture;
 
+  test.beforeEach(async ({ context }) => {
+    await context.route(/_data/, async (route) => {
+      await new Promise((r) => setTimeout(r, 50));
+      route.continue();
+    });
+  });
+
   test.beforeAll(async () => {
     fixture = await createFixture({
       config: {


### PR DESCRIPTION
This addresses a couple of issues:
- HMR tests timing out.
- Flaky tests seemingly due to APIs responding faster and more often than the UI updates.

We still have some non-blocking flaky test issues, but the main thing is that the HMR tests are no longer blocking builds in CI due to persistent timeouts.