### PR TITLE
Move `@types/aws-lambda` from devDependencies to dependencies

### DIFF
--- a/packages/remix-architect/package.json
+++ b/packages/remix-architect/package.json
@@ -15,10 +15,10 @@
   "typings": "dist/index.d.ts",
   "dependencies": {
     "@architect/functions": "^5.2.0",
-    "@remix-run/node": "1.17.0"
+    "@remix-run/node": "1.17.0",
+    "@types/aws-lambda": "^8.10.82"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.82",
     "@types/lambda-tester": "^3.6.1",
     "lambda-tester": "^4.0.1"
   },


### PR DESCRIPTION
The `@remix-run/architect` package exports types that depend upon `@types/aws-lambda`, so it needs to depend (not devDepend) on it.

This will fix the following error that occurs on a freshly bootstrapped Architect project generated with create-remix:

```
$ npm run typecheck

> typecheck
> tsc

node_modules/@remix-run/architect/dist/server.d.ts:3:135 - error TS2307: Cannot find module 'aws-lambda' or its corresponding type declarations.

3 import type { APIGatewayProxyEventHeaders, APIGatewayProxyEventV2, APIGatewayProxyHandlerV2, APIGatewayProxyStructuredResultV2 } from "aws-lambda";
                                                                                                                                        ~~~~~~~~~~~~
```

See https://stackoverflow.com/a/46011417/167694.

Addresses part of #6296.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
