### PR TITLE
docs(tutorials/jokes): update hydrate link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -550,3 +550,4 @@
 - amir-ziaei
 - mrkhosravian
 - tanerijun
+- ally1002

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -7740,7 +7740,7 @@ Phew! And there we have it. If you made it through this whole thing then I'm rea
 [the-http-api]: https://developer.mozilla.org/en-US/docs/Web/HTTP
 [the-basic-example]: https://codesandbox.io/s/github/remix-run/examples/tree/main/basic
 [express]: https://expressjs.com
-[hydrate]: https://reactjs.org/docs/react-dom.html#hydrate
+[hydrate]: https://react.dev/reference/react-dom/client/hydrateRoot
 [http-localhost-3000]: http://localhost:3000
 [bare-bones-hello-world-app]: /jokes-tutorial/img/bare-bones.png
 [remix-config-js]: ../file-conventions/remix-config


### PR DESCRIPTION
It was redirecting us for a older version `hydrate`, I just adapted to redirect to the right doc for `hydrateRoot`

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #6626 

- [x] Docs
- [ ] Tests

Testing Strategy:

https://remix.run/docs/en/1.17.1/tutorials/jokes#explore-the-project-structure

At this part of the tutorial, it is showing us a link to go into the `hydrate` doc, but this is the old docs of this functions, we're now using `hydrateRoot`, I just adapted the URL using the new docs

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
