### PR TITLE
fix(dev): cache CSS side-effects transform for HMR

### DIFF
--- a/.changeset/css-side-effect-imports-hmr-cache.md
+++ b/.changeset/css-side-effect-imports-hmr-cache.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Cache CSS side-effect imports transform when using HMR

--- a/packages/remix-dev/compiler/plugins/cssSideEffectImports.ts
+++ b/packages/remix-dev/compiler/plugins/cssSideEffectImports.ts
@@ -63,6 +63,7 @@ export const cssSideEffectImportsPlugin = (
 
               let code = await fse.readFile(args.path, "utf8");
 
+              // Don't process file if it doesn't contain any references to CSS files
               if (!code.includes(".css")) {
                 return {
                   fileDependencies,

--- a/packages/remix-dev/compiler/plugins/cssSideEffectImports.ts
+++ b/packages/remix-dev/compiler/plugins/cssSideEffectImports.ts
@@ -1,7 +1,6 @@
 import path from "path";
 import type { Plugin } from "esbuild";
 import fse from "fs-extra";
-import LRUCache from "lru-cache";
 import { parse, type ParserOptions } from "@babel/parser";
 import traverse from "@babel/traverse";
 import generate from "@babel/generator";
@@ -56,28 +55,51 @@ export const cssSideEffectImportsPlugin = (
       build.onLoad(
         { filter: allJsFilesFilter, namespace: "file" },
         async (args) => {
-          let code = await fse.readFile(args.path, "utf8");
+          let cacheKey = `css-side-effect-imports-plugin:${args.path}`;
+          let { cacheValue } = await ctx.fileWatchCache.getOrSet(
+            cacheKey,
+            async () => {
+              let fileDependencies = new Set([args.path]);
 
-          // Don't process file if it doesn't contain any references to CSS files
-          if (!code.includes(".css")) {
+              let code = await fse.readFile(args.path, "utf8");
+
+              if (!code.includes(".css")) {
+                return {
+                  fileDependencies,
+                  cacheValue: null,
+                };
+              }
+
+              let loader =
+                loaderForExtension[path.extname(args.path) as Extension];
+              let contents = addSuffixToCssSideEffectImports(loader, code);
+
+              if (args.path.startsWith(ctx.config.appDirectory) && hmr) {
+                contents = await applyHMR(
+                  contents,
+                  args,
+                  ctx.config,
+                  !!build.initialOptions.sourcemap
+                );
+              }
+
+              return {
+                fileDependencies,
+                cacheValue: {
+                  contents,
+                  loader,
+                },
+              };
+            }
+          );
+
+          if (!cacheValue) {
             return null;
           }
 
-          let loader = loaderForExtension[path.extname(args.path) as Extension];
-          let contents = addSuffixToCssSideEffectImports(loader, code);
-
-          if (args.path.startsWith(ctx.config.appDirectory) && hmr) {
-            contents = await applyHMR(
-              contents,
-              args,
-              ctx.config,
-              !!build.initialOptions.sourcemap
-            );
-          }
-
           return {
-            contents,
-            loader,
+            contents: cacheValue.contents,
+            loader: cacheValue.loader,
           };
         }
       );
@@ -129,20 +151,10 @@ const babelPluginsForLoader: Record<Loader, ParserOptions["plugins"]> = {
   tsx: ["typescript", "jsx", ...additionalLanguageFeatures],
 };
 
-const cache = new LRUCache<string, string>({ max: 1000 });
-const getCacheKey = (loader: Loader, code: string) => `${loader}:${code}`;
-
 export function addSuffixToCssSideEffectImports(
   loader: Loader,
   code: string
 ): string {
-  let cacheKey = getCacheKey(loader, code);
-  let cachedResult = cache.get(cacheKey);
-
-  if (cachedResult) {
-    return cachedResult;
-  }
-
   let ast = parse(code, {
     sourceType: "module",
     plugins: babelPluginsForLoader[loader],
@@ -191,8 +203,6 @@ export function addSuffixToCssSideEffectImports(
     retainLines: true,
     compact: false,
   }).code;
-
-  cache.set(cacheKey, result);
 
   return result;
 }

--- a/packages/remix-dev/compiler/plugins/cssSideEffectImports.ts
+++ b/packages/remix-dev/compiler/plugins/cssSideEffectImports.ts
@@ -55,7 +55,7 @@ export const cssSideEffectImportsPlugin = (
       build.onLoad(
         { filter: allJsFilesFilter, namespace: "file" },
         async (args) => {
-          let cacheKey = `css-side-effect-imports-plugin:${args.path}`;
+          let cacheKey = `css-side-effect-imports-plugin:${args.path}&hmr=${hmr}`;
           let { cacheValue } = await ctx.fileWatchCache.getOrSet(
             cacheKey,
             async () => {

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -49,7 +49,6 @@
     "json5": "^2.2.2",
     "lodash": "^4.17.21",
     "lodash.debounce": "^4.0.8",
-    "lru-cache": "^7.14.1",
     "minimatch": "^9.0.0",
     "node-fetch": "^2.6.9",
     "ora": "^5.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9487,11 +9487,6 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lru-cache@^7.14.1:
-  version "7.14.1"
-  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz"
-  integrity sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==
-
 lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz"


### PR DESCRIPTION
This `addSuffixToCssSideEffectImports` function used internally within `cssSideEffectImportsPlugin` had its own cache, but this caching mechanism didn't factor in the newly added HMR work.

This PR replaces the custom caching mechanism with our new `fileWatchCache`, allowing us to more easily capture all plugin logic (including the HMR transform) in the cache.