### PR TITLE
docs(guides/routing): fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -427,6 +427,7 @@
 - reggie3
 - reichhartd
 - remix-run-bot
+- richardhunghhw
 - riencoertjens
 - rkulinski
 - rlfarman

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -203,7 +203,7 @@ You may notice an `?index` query parameter showing up on your URLs from time to 
     ├── root.tsx
     └── routes
         ├── sales.invoices._index.tsx   <-- /sales/invoices?index
-        ├── sales.invoices.invoices.tsx <-- /sales/invoices
+        ├── sales.invoices.tsx <-- /sales/invoices
 ```
 
 This is handled automatically for you when you submit from a `<Form>` contained within either the layout route or the index route. But if you are submitting forms to different routes, or using `fetcher.submit`/`fetcher.load` you may need to be aware of this URL pattern, so you can target the correct route.

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -203,7 +203,7 @@ You may notice an `?index` query parameter showing up on your URLs from time to 
     ├── root.tsx
     └── routes
         ├── sales.invoices._index.tsx   <-- /sales/invoices?index
-        ├── sales.invoices.tsx <-- /sales/invoices
+        └── sales.invoices.tsx <-- /sales/invoices
 ```
 
 This is handled automatically for you when you submit from a `<Form>` contained within either the layout route or the index route. But if you are submitting forms to different routes, or using `fetcher.submit`/`fetcher.load` you may need to be aware of this URL pattern, so you can target the correct route.


### PR DESCRIPTION
Routing guide seems to have a typo in it. URL `/sales/invoices` should only match to `routes/sales.invoices.tsx` or `routes/sales.invoices._index.tsx`. This is inline with the paragraph above the example as well. 

- [x] Docs
- [ ] Tests

