### PR TITLE
wip: debugging info for compiler perf

### DIFF
--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -148,14 +148,13 @@ export async function routes(
 
 export async function build(
   remixRoot: string,
-  modeArg?: string,
-  sourcemap: boolean = false
+  { rawMode = "production", sourcemap = false, perfDebug = false } = {}
 ): Promise<void> {
-  let mode = parseMode(modeArg) ?? "production";
+  let mode = parseMode(rawMode) ?? "production";
 
   logger.info(`building...` + pc.gray(` (NODE_ENV=${mode})`));
 
-  if (modeArg === "production" && sourcemap) {
+  if (mode === "production" && sourcemap) {
     logger.warn("🚨  source maps enabled in production", {
       details: [
         "You are using `--sourcemap` to enable source maps in production,",
@@ -172,6 +171,7 @@ export async function build(
   let options: Options = {
     mode,
     sourcemap,
+    perfDebug,
   };
   if (mode === "development" && config.future.v2_dev) {
     let origin = await resolveDevOrigin(config);
@@ -512,6 +512,7 @@ type DevServeFlags = DevOrigin & {
   restart: boolean;
   tlsKey?: string;
   tlsCert?: string;
+  perfDebug: boolean;
 };
 let resolveDevServe = async (
   config: RemixConfig,
@@ -535,11 +536,14 @@ let resolveDevServe = async (
   let tlsCert = flags.tlsCert ?? (dev === true ? undefined : dev.tlsCert);
   if (tlsCert) tlsCert = path.resolve(tlsCert);
 
+  let perfDebug = flags.perfDebug ?? false;
+
   return {
     command,
     ...origin,
     restart,
     tlsKey,
     tlsCert,
+    perfDebug,
   };
 };

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -190,6 +190,8 @@ export async function run(argv: string[] = process.argv.slice(2)) {
       "--no-restart": Boolean,
       "--tls-key": String,
       "--tls-cert": String,
+
+      "--perf-debug": Boolean,
     },
     {
       argv,
@@ -221,6 +223,11 @@ export async function run(argv: string[] = process.argv.slice(2)) {
   if (flags["tls-cert"]) {
     flags.tlsCert = flags["tls-cert"];
     delete flags["tls-cert"];
+  }
+
+  if (flags["perf-debug"]) {
+    flags.perfDebug = true;
+    delete flags["perf-debug"];
   }
 
   if (args["--no-delete"]) {
@@ -494,7 +501,11 @@ export async function run(argv: string[] = process.argv.slice(2)) {
       break;
     case "build":
       if (!process.env.NODE_ENV) process.env.NODE_ENV = "production";
-      await commands.build(input[1], process.env.NODE_ENV, flags.sourcemap);
+      await commands.build(input[1], {
+        rawMode: process.env.NODE_ENV,
+        sourcemap: flags.sourcemap,
+        perfDebug: flags.perfDebug,
+      });
       break;
     case "watch":
       if (!process.env.NODE_ENV) process.env.NODE_ENV = "development";

--- a/packages/remix-dev/compiler/options.ts
+++ b/packages/remix-dev/compiler/options.ts
@@ -3,6 +3,7 @@ type Mode = "development" | "production" | "test";
 export type Options = {
   mode: Mode;
   sourcemap: boolean;
+  perfDebug: boolean;
 
   // TODO: required in v2
   devOrigin?: {

--- a/packages/remix-dev/devServer/liveReload.ts
+++ b/packages/remix-dev/devServer/liveReload.ts
@@ -47,6 +47,7 @@ export async function liveReload(config: RemixConfig) {
       options: {
         mode: "development",
         sourcemap: true,
+        perfDebug: false,
       },
       fileWatchCache,
       logger,

--- a/packages/remix-dev/devServer_unstable/index.ts
+++ b/packages/remix-dev/devServer_unstable/index.ts
@@ -52,6 +52,7 @@ export let serve = async (
     restart: boolean;
     tlsKey?: string;
     tlsCert?: string;
+    perfDebug: boolean;
   }
 ) => {
   await loadEnv(initialConfig.rootDirectory);
@@ -177,6 +178,7 @@ export let serve = async (
       options: {
         mode: "development",
         sourcemap: true,
+        perfDebug: options.perfDebug,
         devOrigin: origin,
       },
       fileWatchCache,


### PR DESCRIPTION
Adds a `--perf-debug` flag to `remix build` and `remix dev`. When debugging perf, subcompilations are run in series (not concurrently and not in parallel) so that each can be timed independently.

## remix build --perf-debug

<img width="812" alt="Screenshot 2023-06-17 at 4 27 27 PM" src="https://github.com/remix-run/remix/assets/1477317/7d94e1bb-698c-4730-8da1-947aac3a3c3a">

## remix dev --perf-debug

<img width="854" alt="Screenshot 2023-06-17 at 4 27 41 PM" src="https://github.com/remix-run/remix/assets/1477317/245fc62f-3101-44c4-a7e8-4f9d467ea007">
