### PR TITLE
fix(dev): skip unused Node polyfills in CSS build

### DIFF
--- a/.changeset/css-bundle-skip-node-polyfills.md
+++ b/.changeset/css-bundle-skip-node-polyfills.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Improve CSS bundle build performance by skipping unused Node polyfills

--- a/packages/remix-dev/compiler/css/compiler.ts
+++ b/packages/remix-dev/compiler/css/compiler.ts
@@ -1,6 +1,5 @@
 import { builtinModules as nodeBuiltins } from "module";
 import * as esbuild from "esbuild";
-import { nodeModulesPolyfillPlugin } from "esbuild-plugins-node-modules-polyfill";
 
 import type { RemixConfig } from "../../config";
 import { getAppDependencies } from "../../dependencies";
@@ -81,7 +80,6 @@ const createEsbuildConfig = (ctx: Context): esbuild.BuildOptions => {
       externalPlugin(/^https?:\/\//, { sideEffects: false }),
       mdxPlugin(ctx),
       emptyModulesPlugin(ctx, /\.server(\.[jt]sx?)?$/),
-      nodeModulesPolyfillPlugin(),
       externalPlugin(/^node:.*/, { sideEffects: false }),
     ],
     supported: {


### PR DESCRIPTION
Since the JavaScript from the CSS bundle build is never executed and we only use the bundled CSS, there's no need to inject Node polyfills.