### PR TITLE
docs(jokes.md):  fix code snippet order

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -150,6 +150,7 @@
 - exegeteio
 - F3n67u
 - federicoestevez
+- femincan
 - fergusmeiklejohn
 - fernandojbf
 - fgiuliani

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -1978,6 +1978,23 @@ But if there's an error, you can return an object with the error messages and th
 
 <details>
 
+<summary>app/utils/request.server.ts</summary>
+
+```ts filename=app/utils/request.server.ts
+import { json } from "@remix-run/node";
+
+/**
+ * This helper function helps us to return the accurate HTTP status,
+ * 400 Bad Request, to the client.
+ */
+export const badRequest = <T>(data: T) =>
+  json<T>(data, { status: 400 });
+```
+
+</details>
+
+<details>
+
 <summary>app/routes/jokes.new.tsx</summary>
 
 ```tsx filename=app/routes/jokes.new.tsx lines=[3,6,8-12,14-18,28-32,35-38,40-46,53,63,66-73,76-84,90,92-99,102-110,113-120]
@@ -2109,23 +2126,6 @@ export default function NewJokeRoute() {
     </div>
   );
 }
-```
-
-</details>
-
-<details>
-
-<summary>app/utils/request.server.ts</summary>
-
-```ts filename=app/utils/request.server.ts
-import { json } from "@remix-run/node";
-
-/**
- * This helper function helps us to return the accurate HTTP status,
- * 400 Bad Request, to the client.
- */
-export const badRequest = <T>(data: T) =>
-  json<T>(data, { status: 400 });
 ```
 
 </details>


### PR DESCRIPTION
In the `Mutations` section of the `App Tutorial (Long)` page, I rearranged the order of the code snippets. The code snippet of `app/routes/jokes.new.tsx` now comes after the code snippet of `app/utils/request.server.ts`. Because the first file utilizes the function exported from the second file. Therefore, I reversed the order.