### PR TITLE
feat(remix-server-runtime): use `type-fest`'s `Jsonify` type in `Serialize`

### DIFF
--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -21,7 +21,8 @@
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie": "^0.4.1",
     "set-cookie-parser": "^2.4.8",
-    "source-map": "^0.7.3"
+    "source-map": "^0.7.3",
+    "type-fest": "^4.0.0"
   },
   "devDependencies": {
     "@remix-run/web-file": "^3.0.3",

--- a/packages/remix-server-runtime/serialize.ts
+++ b/packages/remix-server-runtime/serialize.ts
@@ -1,76 +1,27 @@
+import type { Jsonify } from "type-fest";
+
 import type { AppData } from "./data";
 import type { TypedDeferredData, TypedResponse } from "./responses";
 
-type JsonPrimitive =
-  | string
-  | number
-  | boolean
-  | String
-  | Number
-  | Boolean
-  | null;
-type NonJsonPrimitive = undefined | Function | symbol;
+// Note: The return value has to be `any` and not `unknown` so it can match `void`.
+type ArbitraryFunction = (...args: any[]) => any;
+type NotJsonable = ArbitraryFunction | undefined | symbol;
 
-/*
- * `any` is the only type that can let you equate `0` with `1`
- * See https://stackoverflow.com/a/49928360/1490091
- */
-type IsAny<T> = 0 extends 1 & T ? true : false;
-
-// prettier-ignore
-type Serialize<T> =
-  IsAny<T> extends true ? any :
-  T extends TypedDeferredData<infer U> ? SerializeDeferred<U> :
-  T extends JsonPrimitive ? T :
-  T extends NonJsonPrimitive ? never :
-  T extends { toJSON(): infer U } ? U :
-  T extends [] ? [] :
-  T extends [unknown, ...unknown[]] ? SerializeTuple<T> :
-  T extends ReadonlyArray<infer U> ? (U extends NonJsonPrimitive ? null : Serialize<U>)[] :
-  T extends object ? SerializeObject<UndefinedToOptional<T>> :
-  never
-;
-
-/** JSON serialize [tuples](https://www.typescriptlang.org/docs/handbook/2/objects.html#tuple-types) */
-type SerializeTuple<T extends unknown[]> = T extends [infer F, ...infer R]
-  ? [Serialize<F>, ...SerializeTuple<R>]
-  : [];
-
-/** JSON serialize objects (not including arrays) and classes */
-type SerializeObject<T extends object> = {
-  [k in keyof T as T[k] extends NonJsonPrimitive ? never : k]: Serialize<T[k]>;
-};
+type Serialize<T> = T extends TypedDeferredData<infer U>
+  ? SerializeDeferred<U>
+  : Jsonify<T>;
 
 // prettier-ignore
 type SerializeDeferred<T extends Record<string, unknown>> = {
   [k in keyof T as
     T[k] extends Promise<unknown> ? k :
-    T[k] extends NonJsonPrimitive ? never :
+    T[k] extends NotJsonable ? never :
     k
   ]:
     T[k] extends Promise<infer U>
     ? Promise<Serialize<U>> extends never ? "wtf" : Promise<Serialize<U>>
     : Serialize<T[k]>  extends never ? k : Serialize<T[k]>;
 };
-
-/*
- * For an object T, if it has any properties that are a union with `undefined`,
- * make those into optional properties instead.
- *
- * Example: { a: string | undefined} --> { a?: string}
- */
-type UndefinedToOptional<T extends object> = {
-  // Property is not a union with `undefined`, keep as-is
-  [k in keyof T as undefined extends T[k] ? never : k]: T[k];
-} & {
-  // Property _is_ a union with `defined`. Set as optional (via `?`) and remove `undefined` from the union
-  [k in keyof T as undefined extends T[k] ? k : never]?: Exclude<
-    T[k],
-    undefined
-  >;
-};
-
-type ArbitraryFunction = (...args: any[]) => unknown;
 
 /**
  * Infer JSON serialized data type returned by a loader or action.


### PR DESCRIPTION
- Extracted `Jsonify` so that it's easier to switch to `type-fest` at a later stage
- Added cases for positive/negative infinity, `Boolean`, `Number`, `String`, `Map` & `Set`
- Added more deep grained type for objects that have a `toJSON` function
- Update `UndefinedToOptional` type
- Renamed some generics so they're more in line with the `type-fest` codebase
  - `NonJsonPrimitive` -> `NotJsonable`
    - Also replaced `Function` with `(...arguments_: any[]) => any`
  - `SerializeTuple` -> `JsonifyList`
    - Also updated this
  - `SerializeObject` -> `JsonifyObject`
    - Also updated this

This is mainly taking over @sachinraja's awesome work from https://github.com/sindresorhus/type-fest/pull/519, thanks for that! 🙏