### PR TITLE
Fix bug with pathless layout routes beneath nested path segments

### DIFF
--- a/.changeset/five-zoos-fix.md
+++ b/.changeset/five-zoos-fix.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fix bug with pathless layout routes beneath nested path segments

--- a/packages/remix-dev/__tests__/flat-routes-test.ts
+++ b/packages/remix-dev/__tests__/flat-routes-test.ts
@@ -273,6 +273,31 @@ describe("flatRoutes", () => {
         },
       ],
       [
+        "routes/app._pathless.tsx",
+        {
+          id: "routes/app._pathless",
+          parentId: "routes/app",
+          path: undefined,
+        },
+      ],
+      [
+        "routes/app._pathless._index.tsx",
+        {
+          id: "routes/app._pathless._index",
+          parentId: "routes/app._pathless",
+          index: true,
+          path: undefined,
+        },
+      ],
+      [
+        "routes/app._pathless.child.tsx",
+        {
+          id: "routes/app._pathless.child",
+          parentId: "routes/app._pathless",
+          path: "child",
+        },
+      ],
+      [
         "routes/folder/route.tsx",
         {
           id: "routes/folder",

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -215,6 +215,7 @@ export function flatRoutesUniversal(
     }
 
     if (!config.parentId) config.parentId = "root";
+    config.path = pathname || undefined;
 
     /**
      * We do not try to detect path collisions for pathless layout route
@@ -264,8 +265,6 @@ export function flatRoutesUniversal(
 
     let conflictRouteId = originalPathname + (config.index ? "?index" : "");
     let conflict = uniqueRoutes.get(conflictRouteId);
-
-    config.path = pathname || undefined;
     uniqueRoutes.set(conflictRouteId, config);
 
     if (conflict && (originalPathname || config.index)) {


### PR DESCRIPTION
#4421 added a short circuit for checking for URL conflicts with pathless layout routes, but it is unintentionally also short circuiting the line that updates the route manifest to strip the parent path.  Need to lift that up before the short circuit.  Doesn't impact root pathless layout routes, only those that are nested underneath an existing path segment which we didn't have existing tests for.

Closes #6645