### PR TITLE
Bump router

### DIFF
--- a/.changeset/chatty-birds-sing.md
+++ b/.changeset/chatty-birds-sing.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Bump router 6.14.0-pre.1

--- a/integration/helpers/playwright-fixture.ts
+++ b/integration/helpers/playwright-fixture.ts
@@ -298,7 +298,7 @@ async function doAndWait(
   //     locator resolved to hidden <div id="root-boundary">ROOT_BOUNDARY_TEXT</div>
   //     ... and so on until the test times out
   let userAgent = await page.evaluate(() => navigator.userAgent);
-  if (/Safari/i.test(userAgent)) {
+  if (/Safari\//i.test(userAgent) && !/Chrome\//i.test(userAgent)) {
     await page.evaluate(() => new Promise((r) => requestAnimationFrame(r)));
   }
 

--- a/integration/helpers/playwright-fixture.ts
+++ b/integration/helpers/playwright-fixture.ts
@@ -285,8 +285,9 @@ async function doAndWait(
   // I wish I knew why but Safari seems to get all screwed up without this.
   // When you run doAndWait (via clicking a blink or submitting a form) and
   // then waitForSelector().  It finds the selector element but thinks it's
-  // hidden for some unknown reason.  It's intermittent, but delaying slightly
-  // before the waitForSelector() calls seems to fix it 🤷‍♂️
+  // hidden for some unknown reason.  It's intermittent, but waiting for the
+  // next animation frame delaying slightly before the waitForSelector() calls
+  // seems to fix it 🤷‍♂️
   //
   //   Test timeout of 30000ms exceeded.
   //
@@ -298,9 +299,7 @@ async function doAndWait(
   //     ... and so on until the test times out
   let userAgent = await page.evaluate(() => navigator.userAgent);
   if (/Safari/i.test(userAgent)) {
-    // 10ms seemed to be the sweet spot.  5ms still had failures and
-    // requestAnimationFrame() is undefined
-    await new Promise((r) => setTimeout(r, 10));
+    await page.evaluate(() => new Promise((r) => requestAnimationFrame(r)));
   }
 
   if (DEBUG) {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@octokit/graphql": "^4.8.0",
     "@octokit/plugin-paginate-rest": "^2.17.0",
     "@octokit/rest": "^18.12.0",
-    "@playwright/test": "^1.35.1",
+    "@playwright/test": "1.28.1",
     "@remix-run/changelog-github": "^0.0.5",
     "@rollup/plugin-babel": "^5.2.2",
     "@rollup/plugin-json": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@octokit/graphql": "^4.8.0",
     "@octokit/plugin-paginate-rest": "^2.17.0",
     "@octokit/rest": "^18.12.0",
-    "@playwright/test": "1.28.1",
+    "@playwright/test": "1.33.0",
     "@remix-run/changelog-github": "^0.0.5",
     "@rollup/plugin-babel": "^5.2.2",
     "@rollup/plugin-json": "^4.1.0",

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -17,7 +17,7 @@
   "module": "dist/esm/index.js",
   "dependencies": {
     "@remix-run/router": "1.7.0-pre.0",
-    "react-router-dom": "6.14.0-pre.0"
+    "react-router-dom": "6.14.0-pre.1"
   },
   "devDependencies": {
     "@remix-run/server-runtime": "1.18.0-pre.0",

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -19,7 +19,7 @@
     "@remix-run/node": "1.18.0-pre.0",
     "@remix-run/react": "1.18.0-pre.0",
     "@remix-run/router": "1.7.0-pre.0",
-    "react-router-dom": "6.14.0-pre.0"
+    "react-router-dom": "6.14.0-pre.1"
   },
   "devDependencies": {
     "@types/node": "^18.11.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11437,18 +11437,18 @@ react-refresh@^0.14.0:
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
 
-react-router-dom@6.14.0-pre.0:
-  version "6.14.0-pre.0"
-  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.14.0-pre.0.tgz#8e106739c776f48c0d3710aae69bac42ddf09a3f"
-  integrity sha512-NndsLa0FHP8BDUePOnpiQqunDaoY1e0PljjqTQDxHMeCZqf1148S8hl54ZF6rXoA4EuACszVSrURIrAhZ++ljg==
+react-router-dom@6.14.0-pre.1:
+  version "6.14.0-pre.1"
+  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.14.0-pre.1.tgz#7d88b8d2547f74780d8b84fe17d92866655b3409"
+  integrity sha512-BJb1N+NOOSt9Wr+wFnXGsQhgWgA5fbEbvqNGJjdwDqlfkdCpgLE6V2DdS4klvvBYlSSZwV/xMbXEtN4rwTyydQ==
   dependencies:
     "@remix-run/router" "1.7.0-pre.0"
-    react-router "6.14.0-pre.0"
+    react-router "6.14.0-pre.1"
 
-react-router@6.14.0-pre.0:
-  version "6.14.0-pre.0"
-  resolved "https://registry.npmjs.org/react-router/-/react-router-6.14.0-pre.0.tgz#38d8ace45232b5d6cbcaf8b68d6af76a584f5e02"
-  integrity sha512-xNXcEDQ7pjKpw4ueFhmbksnVaRuyXng4OXXBg9RsM16FyJDSUUKXruygjrDiVeyGeAGjIiDDNUX/G6EwF3aS9w==
+react-router@6.14.0-pre.1:
+  version "6.14.0-pre.1"
+  resolved "https://registry.npmjs.org/react-router/-/react-router-6.14.0-pre.1.tgz#e14b217c0b445c2f42a1ed556ee9c820ae6a86bc"
+  integrity sha512-ZXGINPC0OgunHSqgiUjJqQh+TmPHT+kEO03WacCaYgEZWLDjL9FowXSqvdBUFU20sDnMdN5QmqPLHIK+v3B2BA==
   dependencies:
     "@remix-run/router" "1.7.0-pre.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2569,15 +2569,13 @@
     tiny-glob "^0.2.9"
     tslib "^2.4.0"
 
-"@playwright/test@^1.35.1":
-  version "1.35.1"
-  resolved "https://registry.npmjs.org/@playwright/test/-/test-1.35.1.tgz#a596b61e15b980716696f149cc7a2002f003580c"
-  integrity sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==
+"@playwright/test@1.28.1":
+  version "1.28.1"
+  resolved "https://registry.npmjs.org/@playwright/test/-/test-1.28.1.tgz#e5be297e024a3256610cac2baaa9347fd57c7860"
+  integrity sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.35.1"
-  optionalDependencies:
-    fsevents "2.3.2"
+    playwright-core "1.28.1"
 
 "@remix-run/changelog-github@^0.0.5":
   version "0.0.5"
@@ -7169,7 +7167,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@2.3.2, fsevents@^2.3.2, fsevents@~2.3.2:
+fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -10983,10 +10981,10 @@ pkg-types@^1.0.1:
     mlly "^1.0.0"
     pathe "^1.0.0"
 
-playwright-core@1.35.1:
-  version "1.35.1"
-  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.1.tgz#52c1e6ffaa6a8c29de1a5bdf8cce0ce290ffb81d"
-  integrity sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==
+playwright-core@1.28.1:
+  version "1.28.1"
+  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.1.tgz#8400be9f4a8d1c0489abdb9e75a4cc0ffc3c00cb"
+  integrity sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==
 
 pointer-symbol@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2569,13 +2569,15 @@
     tiny-glob "^0.2.9"
     tslib "^2.4.0"
 
-"@playwright/test@1.28.1":
-  version "1.28.1"
-  resolved "https://registry.npmjs.org/@playwright/test/-/test-1.28.1.tgz#e5be297e024a3256610cac2baaa9347fd57c7860"
-  integrity sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==
+"@playwright/test@1.33.0":
+  version "1.33.0"
+  resolved "https://registry.npmjs.org/@playwright/test/-/test-1.33.0.tgz#669ef859efb81b143dfc624eef99d1dd92a81b67"
+  integrity sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.28.1"
+    playwright-core "1.33.0"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 "@remix-run/changelog-github@^0.0.5":
   version "0.0.5"
@@ -7167,7 +7169,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^2.3.2, fsevents@~2.3.2:
+fsevents@2.3.2, fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -10981,10 +10983,10 @@ pkg-types@^1.0.1:
     mlly "^1.0.0"
     pathe "^1.0.0"
 
-playwright-core@1.28.1:
-  version "1.28.1"
-  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.1.tgz#8400be9f4a8d1c0489abdb9e75a4cc0ffc3c00cb"
-  integrity sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==
+playwright-core@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz#269efe29a927cd6d144d05f3c2d2f72bd72447a1"
+  integrity sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==
 
 pointer-symbol@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Bump to `react-router-dom@6.14.0-pre.1` to include https://github.com/remix-run/react-router/pull/10627 which was why we were originally failing E2E tests on playwright 1.28 (older version of Chrome)