### PR TITLE
fix(dev): wait until all app server descendants have been killed

### DIFF
--- a/.changeset/blue-dots-glow.md
+++ b/.changeset/blue-dots-glow.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+fix `remix dev -c`: kill all descendant processes of specified command when restarting

--- a/packages/remix-dev/devServer_unstable/proc.ts
+++ b/packages/remix-dev/devServer_unstable/proc.ts
@@ -1,0 +1,48 @@
+import execa from "execa";
+import pidtree from "pidtree";
+
+let isWindows = process.platform === "win32";
+
+export let kill = async (pid: number) => {
+  try {
+    let cmd = isWindows
+      ? ["taskkill", "/F", "/PID", pid.toString()]
+      : ["kill", "-9", pid.toString()];
+    await execa(cmd[0], cmd.slice(1));
+  } catch (error) {
+    throw new Error(`Failed to kill process ${pid}: ${error}`);
+  }
+};
+
+let isAlive = (pid: number) => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+export let killtree = async (pid: number) => {
+  let descendants = await pidtree(pid);
+  let pids = [pid, ...descendants];
+
+  await Promise.all(pids.map(kill));
+
+  return new Promise<void>((resolve, reject) => {
+    let check = setInterval(() => {
+      let alive = pids.filter(isAlive);
+      if (alive.length === 0) {
+        clearInterval(check);
+        resolve();
+      }
+    }, 50);
+
+    setTimeout(() => {
+      clearInterval(check);
+      reject(
+        new Error("Timeout: Processes did not exit within the specified time.")
+      );
+    }, 2000);
+  });
+};

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -54,6 +54,7 @@
     "ora": "^5.4.1",
     "picocolors": "^1.0.0",
     "picomatch": "^2.3.1",
+    "pidtree": "^0.6.0",
     "postcss": "^8.4.19",
     "postcss-discard-duplicates": "^5.1.0",
     "postcss-load-config": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10947,6 +10947,11 @@ pidtree@^0.3.0:
   resolved "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz"
   integrity sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==
 
+pidtree@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
+  integrity sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==
+
 pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"


### PR DESCRIPTION
Previously, only the immediate child process run via `-c` was killed. When that child spawned its own subprocesses (e.g. using `binode` for MSW support), _those_ descendants stuck around, causing port conflicts and other errors.

## Testing

Existing HMR tests cover this. Also tested locally with Indie Stack + MSW
