### PR TITLE
Memoize resolve url during manifest creation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -58,6 +58,7 @@
 - BenMcH
 - benwis
 - bgschiller
+- BillBrower-Shopify
 - binajmen
 - bmarvinb
 - bmontalvo
@@ -94,6 +95,7 @@
 - colinasquith
 - colinhacks
 - confix
+- connorjones13
 - coryhouse
 - craigglennie
 - crismali

--- a/packages/remix-dev/compiler/manifest.ts
+++ b/packages/remix-dev/compiler/manifest.ts
@@ -22,11 +22,17 @@ export async function create({
   hmr?: Manifest["hmr"];
   fileWatchCache: FileWatchCache;
 }): Promise<Manifest> {
+  let outputMap: {[path: string]: string} = {};
+
   function resolveUrl(outputPath: string): string {
-    return createUrl(
-      config.publicPath,
-      path.relative(config.assetsBuildDirectory, path.resolve(outputPath))
-    );
+    let filePath;
+    if (outputMap[outputPath]) {
+      filePath = outputMap[outputPath]
+    } else {
+      filePath = path.relative(config.assetsBuildDirectory, path.resolve(outputPath));
+      outputMap[outputPath] = filePath;
+    }
+    return createUrl(config.publicPath, filePath);
   }
 
   function resolveImports(


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->

Ran the following script and tracked the build and rebuild times when making file changes
```sh
NODE_ENV=development node ./node_modules/@remix-run/dev/dist/cli watch
```

We tested this on an internal app with ~250 manual routes and configuring 300 manual routes with the following in our `remix.config.js` file
```js
  routes: (defineRoutes) => {
    return defineRoutes((route) => {
      let i = 1;
      while (i <= 300) {
        let routePath = `/route_${i}`;
        route(routePath, 'routes/($locale)._index.tsx', {id: routePath});
        i += 1;
      }
    });
  },
```

Here are the results from running against our application with ~250 manual routes pointing to many different route files.
before:
<img width="415" alt="image" src="https://github.com/remix-run/remix/assets/8009598/db7f95b5-3891-476a-bb0d-8ee2ad654794">

after:
<img width="404" alt="image" src="https://github.com/remix-run/remix/assets/8009598/13253538-628b-48cf-8f98-892ee18294e9">

These are the results using the above mock route config where all manual routes point to same route file.
before:
<img width="416" alt="image" src="https://github.com/remix-run/remix/assets/8009598/3eb9b4d8-58b8-4bec-ab80-b95ff30855c8">

after:
<img width="402" alt="image" src="https://github.com/remix-run/remix/assets/8009598/17653f86-d517-48b8-8601-944e44bf258b">


