### PR TITLE
feat(remix-dev): log build times for compilation steps

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -136,6 +136,32 @@ LOCAL_BUILD_DIRECTORY=../my-remix-app yarn watch
 
 Now - any time you make changes in the Remix repository, they will be written out to the appropriate locations in `../my-remix-app/node_modules` and you can restart the `npm run dev` command to pick them up 🎉.
 
+**`DEBUG`**
+
+Adding `DEBUG=1` when building your app will enable more logs during the build process, including CSS JIT and compiler build times.
+
+```sh
+DEBUG=1 yarn run dev
+...
+  Source path: ./blog-tutorial/app/tailwind.css
+  Setting up new context...
+  Finding changed files: 4.53ms
+  Reading changed files: 8.2ms
+  Sorting candidates: 0.504ms
+  Generate rules: 20.772ms
+  Build stylesheet: 0.869ms
+  Potential classes:  897
+  Active contexts:  1
+  JIT TOTAL: 119.014ms
+
+  debug  ⏳ esbuild css compiled (173ms)
+  debug  ⏳ esbuild js compiled (250ms)
+  debug  ⏳ Manifest created (1ms)
+  debug  ⏳ esbuild server compiled (2ms)
+
+  💿 Rebuilt in 534ms
+```
+
 ### Transition Manager Flows
 
 The transition manager is a complex and heavily async bit of logic that is foundational to Remix's ability to manage data loading, submission, error handling, and interruptions. Due to the user-driven nature of interruptions we don't quite believe it can be modeled as a finite state machine, however we have modeled some of the happy path flows below for clarity.

--- a/contributors.yml
+++ b/contributors.yml
@@ -110,6 +110,7 @@
 - dan-gamble
 - danielfgray
 - danielweinmann
+- daniloteodoro
 - davecalnan
 - davecranwell-vocovo
 - DavidHollins6

--- a/packages/remix-dev/tux/logger.ts
+++ b/packages/remix-dev/tux/logger.ts
@@ -1,7 +1,10 @@
+import prettyMs from 'pretty-ms';
 import pc from "picocolors";
 import type { Formatter } from "picocolors/types";
 
 import { format } from "./format";
+
+const DEBUG_MODE = !!process.env.DEBUG;
 
 type Log = (
   message: string,
@@ -13,6 +16,7 @@ export type Logger = {
   info: Log;
   warn: Log;
   error: Log;
+  time<T>(label: string): (result: T) => T;
 };
 
 type LogArgs = {
@@ -57,4 +61,11 @@ export let logger: Logger = {
     color: pc.red,
     dest: process.stderr,
   }),
+  time: (label) => {
+    let start = Date.now();
+    return (result) => {
+      if (DEBUG_MODE) logger.debug(`${label} (${prettyMs(Date.now() - start)})`);
+      return result;
+    };
+  },
 };


### PR DESCRIPTION
Closes: https://github.com/remix-run/remix/discussions/6671

- [x] Docs
- [ ] Tests

Testing Strategy:

* Created a new Remix project with `npx create-remix@latest`
* Ran `yarn install`
* Compiled my Remix branch into the newly created project's dir: `REMIX_LOCAL_BUILD_DIRECTORY=../my-remix-app yarn build`
* Ran `DEBUG=1 yarn run dev` and got:
<img width="545" alt="image" src="https://github.com/remix-run/remix/assets/22015949/1111d504-94fa-4522-a4b3-bd664fcc328e">

For bigger projects these numbers obviously go up a lot.