### PR TITLE
Avoid re-prefetching stylesheets for active routes during a revalidation

### DIFF
--- a/.changeset/stylesheet-re-prefetch.md
+++ b/.changeset/stylesheet-re-prefetch.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Avoid re-prefetching stylesheets for active routes during a revalidation

--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -239,6 +239,7 @@ export function getLinksForMatches(
 export async function prefetchStyleLinks(
   routeModule: RouteModule
 ): Promise<void> {
+  debugger;
   if (!routeModule.links) return;
   let descriptors = routeModule.links();
   if (!descriptors) return;
@@ -254,9 +255,14 @@ export async function prefetchStyleLinks(
     }
   }
 
-  // don't block for non-matching media queries
+  // don't block for non-matching media queries, or for stylesheets that are
+  // already in the DOM (active route revalidations)
   let matchingLinks = styleLinks.filter(
-    (link) => !link.media || window.matchMedia(link.media).matches
+    (link) =>
+      (!link.media || window.matchMedia(link.media).matches) &&
+      document.querySelector(
+        `head link[rel="stylesheet"][href="${link.href}"]`
+      ) != null
   );
 
   await Promise.all(matchingLinks.map(prefetchStyleLink));

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -203,6 +203,7 @@ async function loadRouteModuleWithBlockingLinks(
   routeModules: RouteModules
 ) {
   let routeModule = await loadRouteModule(route, routeModules);
+  // Should we not call this is the route is already active?
   await prefetchStyleLinks(routeModule);
   return routeModule;
 }


### PR DESCRIPTION
**TODO**
* [ ] See if there's any way to short circuit any earlier in the flow?  Might not be since `links()` could return new stuff
* [ ] Tests

Closes #5448