### PR TITLE
test(dev): fix CLI test

### DIFF
--- a/packages/remix-dev/__tests__/cli-test.ts
+++ b/packages/remix-dev/__tests__/cli-test.ts
@@ -230,7 +230,7 @@ describe("remix CLI", () => {
       await interactWithShell(proc, [
         { question: /Where.*create.*app/i, type: [projectDir, ENTER] },
         { question: /What type of app/i, answer: /basics/i },
-        { question: /Where.*deploy/i, answer: /express/i },
+        { question: /Where.*deploy/i, answer: /remix/i },
         { question: /typescript or javascript/i, answer: /typescript/i },
         { question: /install/i, type: ["n", ENTER] },
       ]);
@@ -255,7 +255,7 @@ describe("remix CLI", () => {
       await interactWithShell(proc, [
         { question: /Where.*create.*app/i, type: [projectDir, ENTER] },
         { question: /What type of app/i, answer: /basics/i },
-        { question: /Where.*deploy/i, answer: /express/i },
+        { question: /Where.*deploy/i, answer: /remix/i },
         { question: /typescript or javascript/i, answer: /javascript/i },
         { question: /install/i, type: ["n", ENTER] },
       ]);


### PR DESCRIPTION
The `express` template in main now uses ESM which crashes this test. This is because the code in `@remix-run/dev` that reads the config makes a special case when `NODE_ENV` is `"test"` and attempts to `require` the config rather than importing it, so this is not an issue impacting consumers. As a quick fix, this PR switches to the CJS `remix` template which still passes this test suite since it only asserts the presence of a couple of key files.