### PR TITLE
fix(dev): do not clear screen when dev server starts

### DIFF
--- a/.changeset/tasty-bats-turn.md
+++ b/.changeset/tasty-bats-turn.md
@@ -1,0 +1,11 @@
+---
+"@remix-run/dev": patch
+---
+
+Do not clear screen when dev server starts
+
+On some terminal emulators, "clearing" only scrolls the next line to the
+top. on others, it erases the scrollback.
+
+Instead, let users call `clear` themselves (`clear && remix dev`) if
+they want to clear.

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -223,8 +223,6 @@ export async function dev(
     tlsCert?: string;
   } = {}
 ) {
-  // clear screen
-  process.stdout.write("\x1Bc");
   console.log(`\n 💿  remix dev\n`);
 
   if (process.env.NODE_ENV && process.env.NODE_ENV !== "development") {


### PR DESCRIPTION
Fixes #6709

on some terminal emulators, "clearing" only scrolls the next line to the top. on others, it erases the scrollback.

instead, let users call `clear` themselves (`clear && remix dev`) if they want to clear

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
