### PR TITLE
fix: avoid circular references and infinitely recursive types

### DIFF
--- a/.changeset/popular-beers-bake.md
+++ b/.changeset/popular-beers-bake.md
@@ -1,0 +1,10 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+Avoid circular references and infinite recursion in types
+
+"Pretty" or simplified Typescript types are evaluated by eagerly resolving types.
+For complex types with circular references, this can cause TS to recurse infinitely.
+
+To fix this, pretty types are reverted as a built-in DX feature of useLoaderData, useActionData, etc...

--- a/packages/remix-server-runtime/serialize.ts
+++ b/packages/remix-server-runtime/serialize.ts
@@ -1,10 +1,6 @@
 import type { AppData } from "./data";
 import type { TypedDeferredData, TypedResponse } from "./responses";
 
-// force Typescript to simplify the type
-type Pretty<T> = { [K in keyof T]: T[K] } & {};
-type PrettyTransform<T, U> = [T] extends [U] ? T : Pretty<U>;
-
 type JsonPrimitive =
   | string
   | number
@@ -29,9 +25,9 @@ type Serialize<T> =
   T extends NonJsonPrimitive ? never :
   T extends { toJSON(): infer U } ? U :
   T extends [] ? [] :
-  T extends [unknown, ...unknown[]] ? PrettyTransform<T, SerializeTuple<T>> :
+  T extends [unknown, ...unknown[]] ? SerializeTuple<T> :
   T extends ReadonlyArray<infer U> ? (U extends NonJsonPrimitive ? null : Serialize<U>)[] :
-  T extends object ? PrettyTransform<T, SerializeObject<UndefinedToOptional<T>>> :
+  T extends object ? SerializeObject<UndefinedToOptional<T>> :
   never
 ;
 


### PR DESCRIPTION
Fixes #6701 , #6693

Reverts "pretty" types for `useLoaderData`, `useActionData`, etc...

Pretty types relied on the ability to eagerly evaluate types, but this can cause infinite recursion or errors with circular referenced types.

Tested in [Typescript playground](https://www.typescriptlang.org/play?target=6&jsx=4&module=1&isolatedModules=true&pretty=false#code/JYWwDg9gTgLgBAbzgKwM4QHZwL5wGZQQhwDkAAlAKYjAAeAtFAK4YD0GEAJpSQFCiRYiOAGUYUYGEo58hYiVTjJPfuGjwkALxkEipTVxIBuXqcq1B8GAE8pcACq3KnAEqVUkDKkoAee3ABeOBYAaw4AdwwAPkC4AHkaGB83D0xvABo4ACI0TCyYgDJEXjgUdAwACgBKAC44AAU5YG8-KJNsE14bOwApcsbQYBhgADdpAJK4AB84RQkMAHNJmYwmEAAjSihluHWICAAbSgBDDB2xeaXSmYA5Nc3t67gAIX2j053Vg4OTbukbzB9TADRKjcbBDDcPDADDOaZwABiLAAxsNMPDUNYNodOqwAFQlPFwAAGp2sxLgzTgMAAFtJMAdrNSnNSacd4MjTnAjvBrBAmHBKABHJjs6TEgAMFPCQxpJIAjMTCaJKNIaTAYGBUDVWKxFMdkSEIGMoHgDhBwgA6ZFEVjHVgAFgAnE6AEwADgAzAA2CWseXOiUSp3ywmsLosgCSqAAghhrK1YhLBbQYJRIag4PK4EV-AB+anMaR1PDHA7eXGsOBgKga4BbejABYcKgRuwiLbAMvATS+ewxCalaNxhP9lNpjOFpjSAtkuA1Sb+cwTziZoEYEFDMFwAv+BelJep9OruAAjDrzfDMY7uCwk3zxfj4+ZpAwCA9ERxG7VOowvBbOAAFUZALYD9wcJ9JwAbQAXRvWCHwPSCTyg0IIgwTJLSwtCLQwWC4ILDsJG7Xt7CYMAjkTcDDxXTM3GOTgGWsGMoCgY4Ez-ADAJiAsKmA5dn1PQF+gkUFrwLL4DnnFViIOHtfG4qoEOo5DMwgdZkEoVEbyIrs5N7OINK0pJAMhShoVhTh7AgOIwDRDAy1aGJwLvLZeFxPEiQ-L9Zk7EjpCgmByKOVAYIqdVNW1XVwhiy0-lQZEJDsg5TgWS1oAWVhGORVBWDZSE9ggEJWFdVh1M01FUEtdUQAOABiIKKMoeh4qqOA8XDP4ZL0+SyKavxVIhMJcNggcIIE6DOKgRFMKwqa4BcGDJgLKDdP8nwESiWbLTW-TKD6yiXCiJbSjqWCPK8z8bl82T5LgcrjMzCoOHgGFkQOJhOBhBY4GOVj2NQNrTk4OB3uOVBvEzDq22kXb5MMiqkhowSHtRMaEEmKCQkpLAQkoPk8Ag8GHCxuCJpPM8L1ErdxNvSh7zqEIYLqOHez8Um2l4DpTHxZUEWgX6sFR+B7EyYBCaGOA2UzOcawgKRYHrTNaXZX6qF+iFgHRGVaRJFgoRhZxiXSZUQGOPHWQgbwcbfe67K1hypLlhXhncHHFBOThLUJZUAFFaGOcAjjqJBjjqOZvvhfXzMNzhcHoegYlDvNw6URZsDDGGgLMiznGs2z7Mc5HJ2F9HJl1BpCBdpkqRejWWAduAdblYlo9zzhjbgPHKDAX7UEbVBMexmEu-xiBCf8Ym29jwb7FJm9XOmxnmZJpn2hzYpSgrxp5a2Gw4AAfWaA-64wRvm5JA3LOJS0VXgYn5cLqSKhGLsSTzYkgchOAqBAY1xWntfWQehaTSAbpgIeONR4EyJpmQBcJyaZjnkzG82M6iLxginOA-t3qfV8JMA8pMTalFKPAzgkxObcyzixdYQw2JQGsEiDAqJG5BAqFhS0f0FjakFtYWCbUAgxBwpEC6ypIwYH-NNby11vC3V7CDTg7JjjMjsLWJgUBLK7CZMo80DEAICwNPZb27U+YC3MIHJq+4iTEi6gAGQgHoqAAARJRsRWaUARHIHwfxx7cgcdwKAUQlTtXDOYSwKjYZ+T2p4ogA1EFwBoXQv6jCUT2TGu4nwj54nsKwlwnhZJ+GBBiPNOITBNRlIITeGM4RjhDGcD4Up5SYAxHiY4KQrh3CeBaPNbilTSigT6dJaptS0ycAaWUsAZSoiVLqMMupYz+y8E5rwbgYN1Z4FSY3Jg3h7GOJcTAY4PhdkBMGok8QySmEsMwFEH83V-IxJAEc-xWxpmmBhGmU0BppD+wsUcTe3JDaRjTCAHhFxlCWnESMCAwBkSUFsYC4FsEuamC6oBWRsQkAORAJQVOlwcArK0ildZmz0QLEoDANFWxbmUumjMMhpgeR+McdmNhAik6TEZYog5IcpaUG+BAOo+zKCZBpCAEAPK6TWFxZHbAmR1gpRpFgiOixMjbK2HUNwQUNFtN8D4wmZKKWyJiLgIICBcDEzJJMNRGiyiYAqFy44VRkVdX2ccFldzoleL1UygJ8ppmMoAMJEE8OmGA7rqhFP+Zy1xQQ1XHK2K67xThfG6N9Tcp1pQHWWnlccGkkws1qu2BnXgjLU1bFdLECNgio3koBbCIF1AWZKCkBCjAUKYVwoRdQDF5qZbxiteS9RWBciVCQHJetwKcBOozi6pRFagjuIeUmqQKbnlQFdP62tQa1CwgwDAedcAq3stKNGg5sQ41rsTd6st67035qUZacdlAG0gE4X-FgMBkUopZOuQIOxlVXHhKsDYbkniFXeGcJ4kkdhICxvjaViwV6-ozk8dc50eZVgALLQGkFQbsigYXBGtpybwdRiTrgpF1NVIMR5cmFlnew7gYA6oxZMPA+w6jrnaCYUta7PSVrZTWqwTG6iMcUCx01vbeEDq1cO8oFRXxManc6lkrr+MLqifJJd16+ObvgNukNe71OHsExjE9taHXnp2ZepRy7KCrscZ6O9maH1pkUJadjEAv28DCeoPu1hmH4BJVgG9EazOgzSPAcxQccXYIDjF1jJC63PuBTwpFpQUM-0HTakdCmUy-OkNgadWdXVuM072bTybCY3r03AAzmBQ0CcjeF09yjY3Wb2bZnTjjnNwCzdFpqj6u0gq-V1AAGhi3YKUlVpx+hnRltA6gTck33aTtBs0pVMLwG0Xh4AJTpGbWImh0pGVRAptjHG4DHYA9ULmVROg7cUD6rYDomvVvC49+AlnJMmFKJ96sf1vCcFK0Efb1BjiWlQMcf89RAeUHtUo+7kxxaHoAIRgDh8Dh9qAmDIlhRDNq4XSjWrk3apADr0FMG+JkLYhAoB1Ax1AIHrrLS04FkVyYxbifZdJ6OvrSiGeY5Zw6mnrFoCU++FO9o23It1eDQ1vdr3WXNcmP977RG4U2YOXZhzASHTps6Nz2Tt4qc-C5kAA)

Also tested locally

<img width="1068" alt="Screenshot 2023-06-30 at 2 15 46 PM" src="https://github.com/remix-run/remix/assets/1477317/c134e314-869f-44aa-9a20-836aab204e3b">

