### PR TITLE
feat: bring back simplified types for SerializeFrom

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -6,6 +6,7 @@
 - achinchen
 - adamwathan
 - adicuco
+- afoures
 - ahabhgk
 - ahbruns
 - ahmedeldessouki


### PR DESCRIPTION
just saw that #6736 removed pretty types for SerializeFrom because of circular dependencies and infinitely recursive types.

this is an attempt to fix the infinitely recursive issue without loosing type simplification.

i tested it using the same [Typescript playground](https://tsplay.dev/weaQgw).

there is one issue for circular types, where we loose the type name: in the playground, the name of `Stripe.InvoiceLineItem` is lost.

this happen when `[T] extends [U]` in `type PrettyTransform<T, U> = [T] extends [U] ? T : Pretty<U>;` is evaluated to false, and that is the case when `T` is a infinite circular type, at one point `U` will have the circular property evaluated to `never` because max depth is reached, so `T` and `U` are not the same anymore. i'm not sure how we could fix it.