### PR TITLE
docs(tutorials/blog): admin route no longer lives in the `posts` dir

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -543,6 +543,7 @@
 - zachdtaylor
 - zainfathoni
 - zayenz
+- infomiho
 - zhe
 - oscarnewman
 - arifqys

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -558,7 +558,7 @@ Put that anywhere in the component. I stuck it right under the `<h1>`.
 
 <docs-info>Did you notice that the `to` prop is just "admin" and it linked to `/posts/admin`? With Remix, you get relative links.</docs-info>
 
-💿 Create an admin route within the `posts` directory:
+💿 Create an admin route at `app/routes/posts.admin.tsx`:
 
 ```sh
 touch app/routes/posts.admin.tsx


### PR DESCRIPTION
Since the tutorial uses the V2 folder structure, the admin route is no longer created within the `posts` directory.

Closes: (not a reported issue)

- [x] Docs
- [ ] Tests

Testing Strategy:

Went through the tutorial 😄 