### PR TITLE
fix: propagate NODE_ENV to application in arc sandbox mode

### DIFF
--- a/templates/arc/plugin-remix.js
+++ b/templates/arc/plugin-remix.js
@@ -35,4 +35,11 @@ export default {
       }, 300);
     },
   },
+  set: {
+    env() {
+      // `arc sandbox` does not automatically pass `NODE_ENV` from its
+      // environment to the application.
+      return { testing: { NODE_ENV: 'development' } };
+    },
+  },
 };


### PR DESCRIPTION
Fixes #198.

Testing Strategy:

I ran `npx create-remix@latest`, created a new Architect project, and ran `npm run dev`. I opened a browser, turned on developer tools, and showed the JavaScript console. Here are screen shots before and after this patch, showing that the #198 is fixed.

# Before

![Screenshot 2023-07-02 at 10 31 54](https://github.com/remix-run/remix/assets/728407/caec9053-0ade-410f-841e-60ee56fd8478)

# After

![Screenshot 2023-07-02 at 10 32 19](https://github.com/remix-run/remix/assets/728407/fe4db1d0-3083-4622-92cd-57ce5198891f)