### PR TITLE
Fix markdown/html nesting

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -278,6 +278,7 @@
 - KenanYusuf
 - kentcdodds
 - kevinrambaud
+- keul
 - kevlened
 - kgregory
 - kiancross

--- a/docs/tutorials/jokes.md
+++ b/docs/tutorials/jokes.md
@@ -2353,7 +2353,7 @@ We're going to create a login page, and I've got some CSS for you to use on that
 
 <details>
 
-<summary>💿 Copy this CSS into `app/styles/login.css`</summary>
+<summary>💿 Copy this CSS into app/styles/login.css</summary>
 
 ```css
 /*


### PR DESCRIPTION
Fixing nesting of markdown into `summary` section.

This was leading to raw backticks displayed instead