### PR TITLE
fix(dev): ignore errors when killing already dead processes

### DIFF
--- a/.changeset/kind-coins-attack.md
+++ b/.changeset/kind-coins-attack.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+ignore errors when killing already dead processes


### PR DESCRIPTION
Fixes #6421 , #6768