### PR TITLE
fix(dev): ensure build dir exists when writing metafiles

### DIFF
--- a/packages/remix-dev/compiler/analysis.ts
+++ b/packages/remix-dev/compiler/analysis.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs";
+import fs from "fs-extra";
 import path from "node:path";
 import type { Metafile } from "esbuild";
 
@@ -10,8 +10,5 @@ export let writeMetafile = (
   metafile: Metafile
 ) => {
   let buildDir = path.dirname(ctx.config.serverBuildPath);
-  if (!fs.existsSync(buildDir)) {
-    fs.mkdirSync(buildDir, { recursive: true });
-  }
-  fs.writeFileSync(path.join(buildDir, filename), JSON.stringify(metafile));
+  fs.outputFileSync(path.join(buildDir, filename), JSON.stringify(metafile));
 };


### PR DESCRIPTION
also avoids any race conditions when checking for existence of dirs/file

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
