### PR TITLE
Properly handle in-flight network errors on _data requests

### DIFF
--- a/.changeset/handle-network-errors.md
+++ b/.changeset/handle-network-errors.md
@@ -1,0 +1,6 @@
+---
+"@remix-run/react": patch
+"@remix-run/server-runtime": patch
+---
+
+Properly handle `?_data` HTTP/Network errors that don't reach the Remix server and ensure they bubble to the `ErrorBoundary`

--- a/packages/remix-react/data.ts
+++ b/packages/remix-react/data.ts
@@ -18,12 +18,41 @@ export function isErrorResponse(response: any): response is Response {
   return response.headers.get("X-Remix-Error") != null;
 }
 
+export function isNetworkErrorResponse(response: any): response is Response {
+  // If we reach the Remix server, we can safely identify response types via the
+  // X-Remix-Error/X-Remix-Catch headers.  However, if we never reach the Remix
+  // server, and instead receive a 4xx/5xx from somewhere in between (like
+  // Cloudflare), then we get a false negative n the isErrorResponse check and
+  // we incorrectly assume that the user returns the 4xx/5xx response and
+  // consider it successful.  To alleviate this, we add X-Remix-Response to any
+  // non-Error/non-Catch responses coming back from the server.  If we don't
+  // see this, we can conclude that a 4xx/5xx response never actually reached
+  // the Remix server and we can bubble it up as an error.
+  return (
+    isResponse(response) &&
+    response.status >= 400 &&
+    response.headers.get("X-Remix-Error") == null &&
+    response.headers.get("X-Remix-Catch") == null &&
+    response.headers.get("X-Remix-Response") == null
+  );
+}
+
 export function isRedirectResponse(response: Response): boolean {
   return response.headers.get("X-Remix-Redirect") != null;
 }
 
 export function isDeferredResponse(response: Response): boolean {
   return !!response.headers.get("Content-Type")?.match(/text\/remix-deferred/);
+}
+
+function isResponse(value: any): value is Response {
+  return (
+    value != null &&
+    typeof value.status === "number" &&
+    typeof value.statusText === "string" &&
+    typeof value.headers === "object" &&
+    typeof value.body !== "undefined"
+  );
 }
 
 export async function fetchData(
@@ -82,6 +111,13 @@ export async function fetchData(
     let data = await response.json();
     let error = new Error(data.message);
     error.stack = data.stack;
+    return error;
+  }
+
+  if (isNetworkErrorResponse(response)) {
+    let text = await response.text();
+    let error = new Error(text);
+    error.stack = undefined;
     return error;
   }
 

--- a/packages/remix-server-runtime/__tests__/data-test.ts
+++ b/packages/remix-server-runtime/__tests__/data-test.ts
@@ -1,4 +1,5 @@
 import type { ServerBuild } from "../build";
+import { defer } from "../responses";
 import { createRequestHandler } from "../server";
 
 describe("loaders", () => {
@@ -39,7 +40,133 @@ describe("loaders", () => {
     expect(await res.json()).toMatchInlineSnapshot(`"?foo=bar"`);
   });
 
-  it("sets header for throw responses", async () => {
+  it("sets X-Remix-Response header for returned 2xx response", async () => {
+    let routeId = "routes/random";
+    let build = {
+      routes: {
+        [routeId]: {
+          id: routeId,
+          path: "/random",
+          module: {
+            async loader() {
+              return new Response("text", {
+                status: 200,
+                headers: { "Content-Type": "text/plain" },
+              });
+            },
+          },
+        },
+      },
+      entry: {
+        module: {
+          handleError() {},
+        },
+      },
+      future: {},
+    } as unknown as ServerBuild;
+
+    let handler = createRequestHandler(build);
+
+    let request = new Request(
+      "http://example.com/random?_data=routes/random&foo=bar",
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+    let res = await handler(request);
+    expect(res.headers.get("X-Remix-Response")).toBeTruthy();
+    expect(res.headers.get("X-Remix-Error")).toBeNull();
+    expect(res.headers.get("X-Remix-Catch")).toBeNull();
+    expect(res.headers.get("X-Remix-Redirect")).toBeNull();
+  });
+
+  it("sets X-Remix-Response header for returned 2xx defer response", async () => {
+    let routeId = "routes/random";
+    let build = {
+      routes: {
+        [routeId]: {
+          id: routeId,
+          path: "/random",
+          module: {
+            async loader() {
+              return defer({ lazy: Promise.resolve("hey!") });
+            },
+          },
+        },
+      },
+      entry: {
+        module: {
+          handleError() {},
+        },
+      },
+      future: {},
+    } as unknown as ServerBuild;
+
+    let handler = createRequestHandler(build);
+
+    let request = new Request(
+      "http://example.com/random?_data=routes/random&foo=bar",
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+    let res = await handler(request);
+    expect(res.headers.get("X-Remix-Response")).toBeTruthy();
+    expect(res.headers.get("X-Remix-Error")).toBeNull();
+    expect(res.headers.get("X-Remix-Catch")).toBeNull();
+    expect(res.headers.get("X-Remix-Redirect")).toBeNull();
+  });
+
+  it("sets X-Remix-Redirect header for returned 3xx redirect", async () => {
+    let routeId = "routes/random";
+    let build = {
+      routes: {
+        [routeId]: {
+          id: routeId,
+          path: "/random",
+          module: {
+            async loader() {
+              return new Response("text", {
+                status: 302,
+                headers: { Location: "https://remix.run" },
+              });
+            },
+          },
+        },
+      },
+      entry: {
+        module: {
+          handleError() {},
+        },
+      },
+      future: {},
+    } as unknown as ServerBuild;
+
+    let handler = createRequestHandler(build);
+
+    let request = new Request(
+      "http://example.com/random?_data=routes/random&foo=bar",
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+    let res = await handler(request);
+    expect(res.headers.get("X-Remix-Redirect")).toBeTruthy();
+    expect(res.headers.get("X-Remix-Error")).toBeNull();
+    expect(res.headers.get("X-Remix-Catch")).toBeNull();
+    expect(res.headers.get("X-Remix-Response")).toBeNull();
+  });
+
+  it("sets X-Remix-Catch header for throw responses", async () => {
     let loader = async ({ request }) => {
       throw new Response("null", {
         headers: {
@@ -75,7 +202,50 @@ describe("loaders", () => {
     );
 
     let res = await handler(request);
-    expect(await res.headers.get("X-Remix-Catch")).toBeTruthy();
+    expect(res.headers.get("X-Remix-Catch")).toBeTruthy();
+    expect(res.headers.get("X-Remix-Error")).toBeNull();
+    expect(res.headers.get("X-Remix-Redirect")).toBeNull();
+    expect(res.headers.get("X-Remix-Response")).toBeNull();
+  });
+
+  it("sets X-Remix-Error header for throw error", async () => {
+    let routeId = "routes/random";
+    let build = {
+      routes: {
+        [routeId]: {
+          id: routeId,
+          path: "/random",
+          module: {
+            async loader() {
+              throw new Error("broke!");
+            },
+          },
+        },
+      },
+      entry: {
+        module: {
+          handleError() {},
+        },
+      },
+      future: {},
+    } as unknown as ServerBuild;
+
+    let handler = createRequestHandler(build);
+
+    let request = new Request(
+      "http://example.com/random?_data=routes/random&foo=bar",
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+    let res = await handler(request);
+    expect(res.headers.get("X-Remix-Error")).toBeTruthy();
+    expect(res.headers.get("X-Remix-Catch")).toBeNull();
+    expect(res.headers.get("X-Remix-Redirect")).toBeNull();
+    expect(res.headers.get("X-Remix-Response")).toBeNull();
   });
 
   it("removes index from request.url", async () => {

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -166,10 +166,16 @@ async function handleDataRequestRR(
       let init = deferredData.init || {};
       let headers = new Headers(init.headers);
       headers.set("Content-Type", "text/remix-deferred");
+      // Mark successful responses with a header so we can identify in-flight
+      // network errors that are missing this header
+      headers.set("X-Remix-Response", "yes");
       init.headers = headers;
       return new Response(body, init);
     }
 
+    // Mark all successful responses with a header so we can identify in-flight
+    // network errors that are missing this header
+    response.headers.set("X-Remix-Response", "yes");
     return response;
   } catch (error: unknown) {
     if (isResponse(error)) {


### PR DESCRIPTION
If we make a `?_data` `fetch` and it never actually reaches the Remix server, and instead we get a 4xx/5xx response back from a CDN/Proxy/Load Balancer, etc., then we currently incorrectly think it's a returned response from a `loader`/`action` since it's perfectly valid to:

```js
export function loader() {
  return json({ isTeapot: true }, { status: 418 });
}
```

This PR adds an `X-Remix-Response: yes` header to successful responses for `?_data` requests so we can differentiate responses that reached the Remix server from those that did not - and we can treat CDN/Proxy errors as real errors and surface them to the `ErrorBoundary`.

Closes #5418 