### PR TITLE
templates(arc): remove `preferences.arc` instructions

### DIFF
--- a/templates/arc/README.md
+++ b/templates/arc/README.md
@@ -4,18 +4,6 @@
 
 ## Development
 
-Create a `preferences.arc` file in the root with the following contents:
-
-```
-@sandbox
-livereload false
-
-# NODE_ENV development is required when running the dev server
-@env
-testing
-  NODE_ENV development
-```
-
 The following command will run two processes during development when using Architect as your server.
 
 - Your Architect server sandbox


### PR DESCRIPTION
Thanks to #6757 and #6781, these are no longer needed.

See https://github.com/remix-run/grunge-stack/pull/154#issuecomment-1626080936.