### PR TITLE
cloudflare: update types to > 4.0

### DIFF
--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^3.19.0",
+    "@cloudflare/workers-types": "^4.0",
     "@remix-run/dev": "*",
     "@remix-run/eslint-config": "*",
     "@types/react": "^18.0.35",


### PR DESCRIPTION
This PR updates `@remix/cloudflare` to use the latest `@cloudflare/workers-types` versions defined in https://github.com/cloudflare/workerd/tree/main/types/defines - vs. the (since deprecated) https://github.com/cloudflare/workers-types repository.

* The new source is published as `@cloudflare/workers-types`, but starts at `4.x` - e.g. `4.20230419.0`
* The version selectors updated in this PR allow any > 4.0 version to be used