### PR TITLE
fix(remix-react): fix `fetcher.formEncType`

### DIFF
--- a/.changeset/chatty-pears-float.md
+++ b/.changeset/chatty-pears-float.md
@@ -2,4 +2,4 @@
 "@remix-run/react": patch
 ---
 
-Changed the type of formEncType on useFetcher and useFetchers to be FormEncType from react-router-dom instead of strings
+Narrowed the type of `fetcher.formEncType` to use `FormEncType` from `react-router-dom` instead of `string`

--- a/.changeset/chatty-pears-float.md
+++ b/.changeset/chatty-pears-float.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Changed the type of formEncType on useFetcher and useFetchers to be FormEncType from react-router-dom instead of strings

--- a/contributors.yml
+++ b/contributors.yml
@@ -556,3 +556,4 @@
 - tanerijun
 - toufiqnuur
 - ally1002
+- AlemTuzlak

--- a/packages/remix-react/transition.ts
+++ b/packages/remix-react/transition.ts
@@ -1,4 +1,4 @@
-import type { Location } from "react-router-dom";
+import type { Location, FormEncType } from "react-router-dom";
 
 export interface Submission {
   action: string;
@@ -137,7 +137,7 @@ export type FetcherStates<TData = any> = {
     type: "actionSubmission";
     formMethod: FetcherActionSubmission["method"];
     formAction: string;
-    formEncType: string;
+    formEncType: FormEncType;
     submission: FetcherActionSubmission;
     data: TData | undefined;
   } & FetcherSubmissionDataTypes;
@@ -146,7 +146,7 @@ export type FetcherStates<TData = any> = {
     type: "loaderSubmission";
     formMethod: FetcherLoaderSubmission["method"];
     formAction: string;
-    formEncType: string;
+    formEncType: FormEncType;
     submission: FetcherLoaderSubmission;
     data: TData | undefined;
   } & FetcherSubmissionDataTypes;
@@ -155,7 +155,7 @@ export type FetcherStates<TData = any> = {
     type: "actionReload";
     formMethod: FetcherActionSubmission["method"];
     formAction: string;
-    formEncType: string;
+    formEncType: FormEncType;
     submission: FetcherActionSubmission;
     data: TData;
   } & FetcherSubmissionDataTypes;
@@ -164,7 +164,7 @@ export type FetcherStates<TData = any> = {
     type: "actionRedirect";
     formMethod: FetcherActionSubmission["method"];
     formAction: string;
-    formEncType: string;
+    formEncType: FormEncType;
     submission: FetcherActionSubmission;
     data: undefined;
   } & FetcherSubmissionDataTypes;


### PR DESCRIPTION
I believe that there is a typing issue with fetchers where the encType is not typed correctly, I noticed this when using useNavigate where the hook was typed but the fetcher wasn't so I tracked it down and fixed it.

Testing Strategy:

Import useFetcher or useFetchers
The type of formEncType should be FormEncType | undefined instead of string | undefined