### PR TITLE
fix(dev): Silence ESM-only warning when building for ESM

### DIFF
--- a/.changeset/nine-toes-provide.md
+++ b/.changeset/nine-toes-provide.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Silence ESM-only package warning when building ESM server modules.

--- a/packages/remix-dev/compiler/server/plugins/bareImports.ts
+++ b/packages/remix-dev/compiler/server/plugins/bareImports.ts
@@ -116,7 +116,8 @@ export function serverBareModulesPlugin(ctx: Context): Plugin {
         if (
           !isNodeBuiltIn(packageName) &&
           kind !== "dynamic-import" &&
-          ctx.config.serverPlatform === "node"
+          ctx.config.serverPlatform === "node" &&
+          ctx.config.serverModuleFormat !== "esm"
         ) {
           warnOnceIfEsmOnlyPackage(ctx, packageName, path, importer);
         }


### PR DESCRIPTION
Closes:  #6766

When targeting ESM module format (like the default Express template does) with the configuration of `serverModuleFormat: "esm"`, there is no need to warn about ESM-only dependencies for the node server build.

The current warning looks like this:

```
[warn] esm-only package: browser-bunyan
┃ browser-bunyan is possibly an ESM-only package.
┃ To bundle it with your server, include it in `serverDependenciesToBundle`
┃ -> https://remix.run/docs/en/main/file-conventions/remix-config#serverdependenciestobundle
┗
```

Testing Strategy:

I tested this change with ESM-only dependencies (`quick-lru` and `browser-bunyan`) on the Remix Express template. There is now no warning output and the ESM-only module still works correctly (when removed from `serverDependenciesToBundle`).