### PR TITLE
templates(cloudflare-pages,cloudflare-workers): adjust `serverConditions`

### DIFF
--- a/templates/cloudflare-pages/remix.config.js
+++ b/templates/cloudflare-pages/remix.config.js
@@ -4,7 +4,7 @@ export default {
   ignoredRouteFiles: ["**/.*"],
   server: "./server.ts",
   serverBuildPath: "functions/[[path]].js",
-  serverConditions: ["worker"],
+  serverConditions: ['workerd', 'worker', 'browser'],
   serverDependenciesToBundle: "all",
   serverMainFields: ["browser", "module", "main"],
   serverMinify: true,

--- a/templates/cloudflare-workers/remix.config.js
+++ b/templates/cloudflare-workers/remix.config.js
@@ -2,7 +2,7 @@
 export default {
   ignoredRouteFiles: ["**/.*"],
   server: "./server.ts",
-  serverConditions: ["worker"],
+  serverConditions: ['workerd', 'worker', 'browser'],
   serverDependenciesToBundle: [
     // bundle verything except the virtual module for the static content manifest provided by wrangler
     /^(?!.*\b__STATIC_CONTENT_MANIFEST\b).*$/,


### PR DESCRIPTION
The change for the `serverConditions` of the templates of `cloudflare-pages` and `cloudflare-workers` was mentioned here by @huw:
- https://github.com/remix-run/remix/pull/6229#discussion_r1181993844
- https://github.com/remix-run/remix/pull/6650#discussion_r1240184974

Unfortunately, however, this was not addressed. Therefore I would like to have clarity whether it is recommended to adjust the `serverConditions` or to leave them at `worker`.



> I think this should be `["workerd", "worker", "browser"]`:
> 
> * `workerd` is the new standard for Cloudflare Workers and could have slightly different code, usually optimised for edge runtimes. This is being adopted by React [with a different bundle from their browser bundle](https://github.com/facebook/react/blob/559e83aebb2026035d47aa0ebf842f78d4cd6757/packages/react-dom/package.json#L52-L58).
> * `worker` should remain, because it’ll usually work and rely on less code than the browser bundle.
> * `browser` lets us fall back to browser code in packages that don’t have one of the other builds. Anecdotally, some of my code breaks without adding this condition. I’d argue this is more likely to happen than the inverse (a user imports a code that relies on browser-specific globals that Workers doesn’t have).

from https://github.com/remix-run/remix/pull/6229#discussion_r1181993844
