### PR TITLE
docs(file-conventions/route-files-v2): fix matched route with optional segment

### DIFF
--- a/docs/file-conventions/route-files-v2.md
+++ b/docs/file-conventions/route-files-v2.md
@@ -254,7 +254,7 @@ app/
 | `/categories`              | `($lang).categories.tsx` |
 | `/en/categories`           | `($lang).categories.tsx` |
 | `/fr/categories`           | `($lang).categories.tsx` |
-| `/american-flag-speedo`    | `($lang).$productId.tsx` |
+| `/american-flag-speedo`    | `($lang)._index.tsx`     |
 | `/en/american-flag-speedo` | `($lang).$productId.tsx` |
 | `/fr/american-flag-speedo` | `($lang).$productId.tsx` |
 


### PR DESCRIPTION
As outlined in the following issues, this route is not matched as stated in the documentation.

Whether this is a bug with remix instead of a documentation error still seems up for discussion.

I think this should actually work as currently documented, but it doesn't and this seems known for a while, so this change is just reflecting the current implementation.

https://github.com/remix-run/remix/issues/6021
https://github.com/remix-run/remix/issues/6317
https://github.com/remix-run/remix/issues/6426