### PR TITLE
Rename --no-restart to --manual in docs and templates

### DIFF
--- a/docs/pages/v2.md
+++ b/docs/pages/v2.md
@@ -857,7 +857,7 @@ app.listen(port, async () => {
 If you were relying on `require` cache purging, you can keep doing so by using the `--manual` flag:
 
 ```sh
-remix dev --no-restart -c 'node ./server.js'
+remix dev --manual -c 'node ./server.js'
 ```
 
 Check out the [manual mode guide][manual-mode] for more details.

--- a/templates/arc/package.json
+++ b/templates/arc/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "remix build",
-    "dev": "remix dev --no-restart -c \"arc sandbox -e testing\"",
+    "dev": "remix dev --manual -c \"arc sandbox -e testing\"",
     "start": "cross-env NODE_ENV=production arc sandbox",
     "typecheck": "tsc"
   },

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "remix build",
-    "dev": "remix dev --no-restart -c \"npm run start\"",
+    "dev": "remix dev --manual -c \"npm run start\"",
     "start": "wrangler pages dev --compatibility-date=2023-06-21 ./public",
     "typecheck": "tsc"
   },

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "remix build",
     "deploy": "remix build && wrangler publish",
-    "dev": "remix dev --no-restart -c \"npm start\"",
+    "dev": "remix dev --manual -c \"npm start\"",
     "start": "wrangler dev ./build/index.js",
     "typecheck": "tsc"
   },

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "remix build",
-    "dev": "remix dev --no-restart -c \"node server.js\"",
+    "dev": "remix dev --manual -c \"node server.js\"",
     "start": "cross-env NODE_ENV=production node ./server.js",
     "typecheck": "tsc"
   },


### PR DESCRIPTION
The `--no-restart` flag is deprecated and replaced with `--manual`. We forgot to update it in one place in the docs and in several of the templates.