### PR TITLE
liveReload: add hearbeat for keepalive

### DIFF
--- a/packages/remix-dev/devServer/liveReload.ts
+++ b/packages/remix-dev/devServer/liveReload.ts
@@ -76,9 +76,12 @@ export async function liveReload(config: RemixConfig) {
     }
   );
 
+  const heartbeat = setInterval(broadcast, 60000, { type: "PING" });
+
   exitHook(() => clean(config));
   return async () => {
     wss.close();
+    clearInterval(heartbeat);
     await dispose();
   };
 }


### PR DESCRIPTION
This prevents the WebSocket connection from being closed due to inactivity when using a proxy like Cloudflare.

Testing Strategy:

Run a remix app in dev mode and load it via a [Cloudflare tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/):

```sh
npm run dev & cloudflared tunnel --url http://localhost:57763
```

Now open the tunnel URL and wait 100 seconds. The socket connection will be closed and the page will reload.
