### PR TITLE
templates(express): use `watcher.on("add").on("change")`

### DIFF
--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -75,7 +75,11 @@ function createDevRequestHandler() {
   }
 
   chokidar
-    .watch(BUILD_PATH, { ignoreInitial: true })
+    .watch(BUILD_PATH, {
+      // Chokidar settings to avoid certain race condition issues #6831
+      ignoreInitial: true,
+      awaitWriteFinish: { stabilityThreshold: 200 },
+   })
     .on("add", handleServerUpdate)
     .on("change", handleServerUpdate);
 

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -2,20 +2,26 @@ import * as fs from "node:fs";
 
 import { createRequestHandler } from "@remix-run/express";
 import { broadcastDevReady, installGlobals } from "@remix-run/node";
-import chokidar from "chokidar";
 import compression from "compression";
 import express from "express";
 import morgan from "morgan";
 
+// We'll make chokidar a dev dependency so it doesn't get bundled in production.
+const chokidar =
+  process.env.NODE_ENV === "development" ? await import("chokidar") : null;
+// Swap in this if using Remix in CJS mode
+// const chokidar =
+//   process.env.NODE_ENV === "development" ? require("chokidar") : null;
+
 installGlobals();
+
 
 const BUILD_PATH = "./build/index.js";
 /**
  * @type { import('@remix-run/node').ServerBuild | Promise<import('@remix-run/node').ServerBuild> }
  */
 let build = await import(BUILD_PATH);
-
-//Swap in this if using Remix in CJS mode
+// Swap in this if using Remix in CJS mode
 // let build = require(BUILD_PATH);
 
 const app = express();
@@ -97,7 +103,6 @@ function createDevRequestHandler() {
 }
 
 // ESM import cache busting
-// Swap this out for the CJS require cache below if you switch to serverModuleFormat: "cjs" in remix.config
 /**
  * @type {() => Promise<ServerBuild>}
  */
@@ -108,7 +113,7 @@ async function reimportServer() {
   return import(BUILD_PATH + "?t=" + stat.mtimeMs);
 }
 
-
+// Swap in this if using Remix in CJS mode
 // // CJS require cache busting
 // /**
 //  * @type {() => Promise<ServerBuild>}


### PR DESCRIPTION
Also add in comments on what to change for CJS

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Does not close #6919 but the debugger might help with bug tracking.

- [x] Docs

This actually get the express template in line with existing v2 dev doc changes.


Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
