### PR TITLE
Use `REMIX_DEV_ORIGIN` for the live reload hostname

### DIFF
--- a/.changeset/fluffy-fishes-lay.md
+++ b/.changeset/fluffy-fishes-lay.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Use the hostname from `REMIX_DEV_ORIGIN` to connect to the live reload socket

--- a/contributors.yml
+++ b/contributors.yml
@@ -199,6 +199,7 @@
 - Hopsken
 - houmark
 - humphd
+- huw
 - huyb1991
 - hzhu
 - harshmangalam

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1302,7 +1302,7 @@ export const LiveReload =
                   let protocol =
                     REMIX_DEV_ORIGIN ? new URL(REMIX_DEV_ORIGIN).protocol.replace(/^http/, "ws") :
                     location.protocol === "https:" ? "wss:" : "ws:"; // remove in v2?
-                  let hostname = location.hostname;
+                  let hostname = REMIX_DEV_ORIGIN ? new URL(REMIX_DEV_ORIGIN).hostname : location.hostname;
                   let url = new URL(protocol + "//" + hostname + "/socket");
 
                   url.port =


### PR DESCRIPTION
Discussed with @pcattori [on Discord](https://discord.com/channels/770287896669978684/940264701785423992/1131949671896584322).

For live reloading, we currently use the protocol and port from the `REMIX_DEV_ORIGIN` variable, but use the hostname from `window.location`. This PR also uses the hostname from `REMIX_DEV_ORIGIN` (when provided).

This also means that we can support use cases where the development server is on a different hostname from the static assets. This is the case, for example, with GitHub Codespaces, which proxies separate ports through HTTPS on different subdomains. For example:

- `https://<CODESPACE_NAME>-3000.app.github.dev` for the static assets
- `https://<CODESPACE_NAME>-3001.app.github.dev` for the websocket

(If for whatever reason you’re a Codespaces user seeing this, I set `REMIX_DEV_ORIGIN` to `https://${process.env.CODESPACE_NAME}-3001.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN]}` when I launch the development server)