### PR TITLE
Heartbeat: implement in both live-reload servers

### DIFF
--- a/packages/remix-dev/devServer/liveReload.ts
+++ b/packages/remix-dev/devServer/liveReload.ts
@@ -76,7 +76,7 @@ export async function liveReload(config: RemixConfig) {
     }
   );
 
-  const heartbeat = setInterval(broadcast, 60000, { type: "PING" });
+  let heartbeat = setInterval(broadcast, 60000, { type: "PING" });
 
   exitHook(() => clean(config));
   return async () => {

--- a/packages/remix-dev/devServer_unstable/socket.ts
+++ b/packages/remix-dev/devServer_unstable/socket.ts
@@ -37,5 +37,12 @@ export let serve = (server: HTTPServer) => {
     broadcast({ type: "HMR", assetsManifest, updates });
   };
 
-  return { log, reload, hmr, close: wss.close };
+  let heartbeat = setInterval(broadcast, 60000, { type: "PING" });
+
+  let close = () => {
+    clearInterval(heartbeat);
+    return wss.close();
+  };
+
+  return { log, reload, hmr, close };
 };


### PR DESCRIPTION
This updates #6904 to apply the heartbeat to both version of the live-reload server.

- [ ] Docs
- [ ] Tests

Testing Strategy:

Run a remix app in dev mode and load it via a [Cloudflare tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/):

```sh
npm run dev & cloudflared tunnel --url http://localhost:57763
```

Now open the tunnel URL and wait 100 seconds. The socket connection will be closed and the page will reload.
