### PR TITLE
feat(remix-netlify): show deprecation warning on usage

### DIFF
--- a/.changeset/many-cars-jump.md
+++ b/.changeset/many-cars-jump.md
@@ -2,4 +2,4 @@
 "@remix-run/netlify": patch
 ---
 
-Show deprecation warning on `@remix-run/netlify` usage, which is deprecared in favor of `@netlify/remix-adapter`
+Show deprecation warning on `@remix-run/netlify` usage, which is deprecated in favor of `@netlify/remix-adapter`

--- a/.changeset/many-cars-jump.md
+++ b/.changeset/many-cars-jump.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/netlify": patch
+---
+
+Show deprecation warning on `@remix-run/netlify` usage, which is deprecared in favor of `@netlify/remix-adapter`

--- a/packages/remix-netlify/index.ts
+++ b/packages/remix-netlify/index.ts
@@ -1,4 +1,23 @@
 import "./globals";
 
+const alreadyWarned: Record<string, boolean> = {};
+const warnOnce = (message: string, key = message) => {
+  if (!alreadyWarned[key]) {
+    alreadyWarned[key] = true;
+    console.warn(message);
+  }
+};
+
+warnOnce(
+  "⚠️ REMIX FUTURE CHANGE: The `@remix-run/netlify` runtime adapter " +
+    "has been deprecated in favor of `@netlify/remix-adapter` and will be " +
+    "removed in Remix v2. Please update your code by changing all " +
+    "`@remix-run/netlify` imports to `@netlify/remix-adapter`.\n Keep in " +
+    "mind that `@netlify/remix-adapter` requires `@netlify/functions@^1.0.0`, " +
+    "which is a breaking change compared to the current supported " +
+    "`@netlify/functions` versions in `@remix-run/netlify`." +
+    "official-netlify-adapter"
+);
+
 export type { GetLoadContextFunction, RequestHandler } from "./server";
 export { createRequestHandler } from "./server";


### PR DESCRIPTION
Just like we did with the Vercel adapter

We should probably release this as `1.19.2` so people still get this warning before v2 🤔