### PR TITLE
docs: remove version from yarn/pnpm create

### DIFF
--- a/docs/other-api/create-remix.md
+++ b/docs/other-api/create-remix.md
@@ -29,9 +29,9 @@ npx create-remix@latest --help
 ```sh
 npm create remix@latest <projectDir>
 # or
-yarn create remix@latest <projectDir>
+yarn create remix <projectDir>
 # or
-pnpm create remix@latest <projectDir>
+pnpm create remix <projectDir>
 ```
 
 ### `create-remix --template`


### PR DESCRIPTION
Yarn doesn't support specific versions for `yarn create`, and it's redundant for `pnpm create`.