### PR TITLE
refactor!(docs,dev,server-runtime): remove deprecated REMIX_DEV_HTTP_…

### DIFF
--- a/.changeset/cuddly-rings-mate.md
+++ b/.changeset/cuddly-rings-mate.md
@@ -1,0 +1,8 @@
+---
+"@remix-run/dev": major
+"@remix-run/server-runtime": major
+---
+
+Remove deprecated REMIX_DEV_HTTP_ORIGIN env var.
+
+Use REMIX_DEV_ORIGIN instead.

--- a/docs/other-api/dev-v2.md
+++ b/docs/other-api/dev-v2.md
@@ -212,7 +212,7 @@ To use [Mock Service Worker][msw] in development, you'll need to:
 1. Run MSW as part of your app server
 2. Configure MSW to not mock internal "dev ready" messages to the Remix compiler
 
-Make sure that you are setting up your mocks for your _app server_ within the `-c` flag so that the `REMIX_DEV_HTTP_ORIGIN` environment variable is available to your mocks.
+Make sure that you are setting up your mocks for your _app server_ within the `-c` flag so that the `REMIX_DEV_ORIGIN` environment variable is available to your mocks.
 For example, you can use `NODE_OPTIONS` to set Node's `--require` flag when running `remix-serve`:
 
 ```json filename=package.json

--- a/packages/remix-dev/compiler/server/compiler.ts
+++ b/packages/remix-dev/compiler/server/compiler.ts
@@ -115,10 +115,6 @@ const createEsbuildConfig = (
       "process.env.REMIX_DEV_ORIGIN": JSON.stringify(
         ctx.options.REMIX_DEV_ORIGIN ?? ""
       ),
-      // TODO: remove in v2
-      "process.env.REMIX_DEV_HTTP_ORIGIN": JSON.stringify(
-        ctx.options.REMIX_DEV_ORIGIN ?? ""
-      ),
     },
     jsx: "automatic",
     jsxDev: ctx.options.mode !== "production",

--- a/packages/remix-dev/devServer_unstable/index.ts
+++ b/packages/remix-dev/devServer_unstable/index.ts
@@ -99,7 +99,6 @@ export let serve = async (
           PATH:
             bin + (process.platform === "win32" ? ";" : ":") + process.env.PATH,
           REMIX_DEV_ORIGIN: options.REMIX_DEV_ORIGIN.href,
-          REMIX_DEV_HTTP_ORIGIN: options.REMIX_DEV_ORIGIN.href, // TODO: remove in v2
           FORCE_COLOR: process.env.NO_COLOR === undefined ? "1" : "0",
         },
         // https://github.com/sindresorhus/execa/issues/433

--- a/packages/remix-server-runtime/dev.ts
+++ b/packages/remix-server-runtime/dev.ts
@@ -1,7 +1,7 @@
 import type { ServerBuild } from "./build";
 
 export async function broadcastDevReady(build: ServerBuild, origin?: string) {
-  origin ??= process.env.REMIX_DEV_HTTP_ORIGIN;
+  origin ??= process.env.REMIX_DEV_ORIGIN;
   if (!origin) throw Error("Dev server origin not set");
   let url = new URL(origin);
   url.pathname = "ping";


### PR DESCRIPTION
…ORIGIN env var

use REMIX_DEV_ORIGIN instead

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
