### PR TITLE
refactor: clean flags in remix-javascript template

### DIFF
--- a/templates/remix-javascript/remix.config.js
+++ b/templates/remix-javascript/remix.config.js
@@ -7,9 +7,7 @@ module.exports = {
   // publicPath: "/build/",
   serverModuleFormat: "cjs",
   future: {
-    v2_errorBoundary: true,
     v2_meta: true,
-    v2_normalizeFormMethod: true,
     v2_routeConvention: true,
   },
 };


### PR DESCRIPTION
These flags have already been removed but were still in the newly-added `remix-javascript` template introduced as part of the new `create-remix` CLI.