### PR TITLE
chore(create-remix): add missing peerDependency of `esbuild-register`

### DIFF
--- a/packages/create-remix/package.json
+++ b/packages/create-remix/package.json
@@ -35,10 +35,11 @@
     "@types/gunzip-maybe": "^1.4.0",
     "@types/node-fetch": "^2.5.7",
     "@types/tar-fs": "^2.0.1",
+    "esbuild": "0.17.6",
+    "esbuild-register": "^3.3.2",
     "fs-extra": "^10.0.0",
     "msw": "^0.39.2",
-    "tiny-invariant": "^1.2.0",
-    "esbuild-register": "^3.3.2"
+    "tiny-invariant": "^1.2.0"
   },
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
Follow-up of @markdalgleish's #6887 