### PR TITLE
feat!: set minimum TS version to 5.1

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -33,7 +33,7 @@ The Remix compiler will not do any type checking (it simply removes the types). 
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
     "eslint": "^8.23.1",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "tailwindcss": "^3.3.0",
     "to-vfile": "7.2.3",
     "type-fest": "^2.16.0",
-    "typescript": "^5.0.4",
+    "typescript": "^5.1.0",
     "unified": "^10.1.2",
     "unist-util-remove": "^3.1.0",
     "unist-util-visit": "^4.1.1"

--- a/packages/remix-architect/package.json
+++ b/packages/remix-architect/package.json
@@ -20,7 +20,16 @@
   },
   "devDependencies": {
     "@types/lambda-tester": "^3.6.1",
-    "lambda-tester": "^4.0.1"
+    "lambda-tester": "^4.0.1",
+    "typescript": "^5.1.0"
+  },
+  "peerDependencies": {
+    "typescript": "^5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/remix-cloudflare-pages/package.json
+++ b/packages/remix-cloudflare-pages/package.json
@@ -19,10 +19,17 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230518.0",
-    "@types/mime": "^2.0.3"
+    "@types/mime": "^2.0.3",
+    "typescript": "^5.1.0"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^4.0.0"
+    "@cloudflare/workers-types": "^4.0.0",
+    "typescript": "^5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/remix-cloudflare-workers/package.json
+++ b/packages/remix-cloudflare-workers/package.json
@@ -19,10 +19,17 @@
     "@remix-run/cloudflare": "1.19.1"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20230518.0"
+    "@cloudflare/workers-types": "^4.20230518.0",
+    "typescript": "^5.1.0"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^4.0.0"
+    "@cloudflare/workers-types": "^4.0.0",
+    "typescript": "^5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/remix-cloudflare/package.json
+++ b/packages/remix-cloudflare/package.json
@@ -18,10 +18,17 @@
     "@remix-run/server-runtime": "1.19.1"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20230518.0"
+    "@cloudflare/workers-types": "^4.20230518.0",
+    "typescript": "^5.1.0"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^4.0.0"
+    "@cloudflare/workers-types": "^4.0.0",
+    "typescript": "^5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/remix-deno/package.json
+++ b/packages/remix-deno/package.json
@@ -18,6 +18,14 @@
     "@remix-run/server-runtime": "1.19.1",
     "mime": "^3.0.0"
   },
+  "peerDependencies": {
+    "typescript": "^5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=18.0.0"
   }

--- a/packages/remix-dev/__tests__/fixtures/cloudflare/package.json
+++ b/packages/remix-dev/__tests__/fixtures/cloudflare/package.json
@@ -27,7 +27,7 @@
     "@types/react-dom": "^18.0.8",
     "eslint": "^8.27.0",
     "npm-run-all": "^4.1.5",
-    "typescript": "^5.0.4",
+    "typescript": "^5.1.0",
     "wrangler": "^2.2.1"
   },
   "engines": {

--- a/packages/remix-dev/__tests__/fixtures/indie-stack/package.json
+++ b/packages/remix-dev/__tests__/fixtures/indie-stack/package.json
@@ -16,7 +16,7 @@
     "@types/node": "^17.0.35",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/remix-dev/__tests__/fixtures/node/package.json
+++ b/packages/remix-dev/__tests__/fixtures/node/package.json
@@ -21,7 +21,7 @@
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
     "eslint": "^8.27.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/remix-dev/index.ts
+++ b/packages/remix-dev/index.ts
@@ -4,5 +4,5 @@ export type { AppConfig, RemixConfig as ResolvedRemixConfig } from "./config";
 
 export * as cli from "./cli/index";
 
-export { type Manifest as AssetsManifest } from "./manifest";
+export type { Manifest as AssetsManifest } from "./manifest";
 export { getDependenciesToBundle } from "./dependencies";

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -91,10 +91,14 @@
     "type-fest": "^2.16.0"
   },
   "peerDependencies": {
-    "@remix-run/serve": "^1.19.1"
+    "@remix-run/serve": "^1.19.1",
+    "typescript": "^5.1.0"
   },
   "peerDependenciesMeta": {
     "@remix-run/serve": {
+      "optional": true
+    },
+    "typescript": {
       "optional": true
     }
   },

--- a/packages/remix-eslint-config/package.json
+++ b/packages/remix-eslint-config/package.json
@@ -45,12 +45,12 @@
     "eslint": "^8.37.0",
     "jest": "^27.5.1",
     "react": "^18.2.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.0"
   },
   "peerDependencies": {
     "eslint": "^8.0.0",
     "react": "^17.0.0 || ^18.0.0",
-    "typescript": "^4.0.0 || ^5.0.0"
+    "typescript": "^5.1.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/remix-express/package.json
+++ b/packages/remix-express/package.json
@@ -21,10 +21,17 @@
     "@types/supertest": "^2.0.10",
     "express": "^4.17.1",
     "node-mocks-http": "^1.10.1",
-    "supertest": "^6.1.5"
+    "supertest": "^6.1.5",
+    "typescript": "^5.1.0"
   },
   "peerDependencies": {
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "typescript": "^5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/remix-netlify/package.json
+++ b/packages/remix-netlify/package.json
@@ -17,10 +17,17 @@
     "@remix-run/node": "1.19.1"
   },
   "devDependencies": {
-    "@netlify/functions": "^1.0.0"
+    "@netlify/functions": "^1.0.0",
+    "typescript": "^5.1.0"
   },
   "peerDependencies": {
-    "@netlify/functions": "^1.0.0"
+    "@netlify/functions": "^1.0.0",
+    "typescript": "^5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/remix-node/package.json
+++ b/packages/remix-node/package.json
@@ -29,7 +29,16 @@
   },
   "devDependencies": {
     "@types/cookie-signature": "^1.0.3",
-    "@types/source-map-support": "^0.5.4"
+    "@types/source-map-support": "^0.5.4",
+    "typescript": "^5.1.0"
+  },
+  "peerDependencies": {
+    "typescript": "^5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -26,11 +26,18 @@
     "@types/react": "^18.0.15",
     "abort-controller": "^3.0.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "typescript": "^5.1.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "react-dom": ">=16.8.0",
+    "typescript": "^5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -25,7 +25,16 @@
   },
   "devDependencies": {
     "@remix-run/web-file": "^3.0.2",
-    "@types/set-cookie-parser": "^2.4.1"
+    "@types/set-cookie-parser": "^2.4.1",
+    "typescript": "^5.1.0"
+  },
+  "peerDependencies": {
+    "typescript": "^5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -27,10 +27,16 @@
     "@types/react-dom": "^18.0.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.0"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "typescript": "^5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/remix-vercel/package.json
+++ b/packages/remix-vercel/package.json
@@ -20,10 +20,17 @@
     "@types/supertest": "^2.0.10",
     "@vercel/node": "^2.12.0",
     "node-mocks-http": "^1.10.1",
-    "supertest": "^6.1.5"
+    "supertest": "^6.1.5",
+    "typescript": "^5.1.0"
   },
   "peerDependencies": {
-    "@vercel/node": "^2.4.0"
+    "@vercel/node": "^2.4.0",
+    "typescript": "^5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18.0.0"

--- a/scripts/playground/template/package.json
+++ b/scripts/playground/template/package.json
@@ -47,7 +47,7 @@
     "tailwindcss": "^3.1.8",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.1.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/templates/arc/package.json
+++ b/templates/arc/package.json
@@ -25,7 +25,7 @@
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",
     "eslint": "^8.38.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -24,7 +24,7 @@
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",
     "eslint": "^8.38.0",
-    "typescript": "^5.0.4",
+    "typescript": "^5.1.0",
     "wrangler": "^3.1.1"
   },
   "engines": {

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -24,7 +24,7 @@
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",
     "eslint": "^8.38.0",
-    "typescript": "^5.0.4",
+    "typescript": "^5.1.0",
     "wrangler": "^3.1.1"
   },
   "engines": {

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -31,7 +31,7 @@
     "@types/react-dom": "^18.0.11",
     "chokidar": "^3.5.3",
     "eslint": "^8.38.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/templates/fly/package.json
+++ b/templates/fly/package.json
@@ -23,7 +23,7 @@
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",
     "eslint": "^8.38.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/templates/netlify/package.json
+++ b/templates/netlify/package.json
@@ -25,7 +25,7 @@
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",
     "eslint": "^8.38.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/templates/remix/package.json
+++ b/templates/remix/package.json
@@ -22,7 +22,7 @@
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",
     "eslint": "^8.38.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/templates/vercel/package.json
+++ b/templates/vercel/package.json
@@ -23,7 +23,7 @@
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",
     "eslint": "^8.38.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13233,10 +13233,10 @@ typescript@4.3.4:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz"
   integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
-typescript@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@^5.1.0:
+  version "5.1.6"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
+  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
 
 ufo@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Since we want to use latest version of `type-fest` for simplifying some of our own types, we need at least TS 5.1

https://github.com/sindresorhus/type-fest/releases/tag/v4.0.0