### PR TITLE
docs(pages/gotchas): add 'Minimizing Bundle Size' section

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -64,6 +64,7 @@
 - bogas04
 - BogdanDevBst
 - bolchowka
+- Brocktho
 - brophdawg11
 - bruno-oliveira
 - bsharrow


### PR DESCRIPTION
I created a [discussion](https://github.com/remix-run/remix/discussions/6990#esbuild-bundle) around minimizing build time and bundle size, wanted to add this to gotchas for the Remix docs since it can be easy to include very large packages or polyfills by accident. I tagged along at the end of the gotcha page a section on tree shaking larger packages, and ensuring server only files aren't having polyfills added to your client bundle mistakenly.

- [x] Docs

Please let me know any revisions or what else I should do to help get this through as I believe it could be really useful to developers both as they start to develop with Remix and as their application becomes larger and build times increase.