### PR TITLE
templates: install `source-map-support`

### DIFF
--- a/docs/pages/v2.md
+++ b/docs/pages/v2.md
@@ -874,6 +874,30 @@ remix dev --manual -c 'node ./server.js'
 
 Check out the [manual mode guide][manual-mode] for more details.
 
+## `installGlobals`
+
+For preparation of using Node's built in fetch implementation, installing the fetch globals is now a responsibility of the app server. If you are using `remix-serve`, nothing is required. If you are using your own app server, you will need to install the globals yourself.
+
+```ts filename=server.ts
+import { installGlobals } from "@remix-run/node";
+
+installGlobals();
+```
+
+## `source-map-support`
+
+Source map support is now a responsibility of the app server. If you are using `remix-serve`, nothing is required. If you are using your own app server, you will need to install [`source-map-support`](https://www.npmjs.com/package/source-map-support) yourself.
+
+```sh
+npm i source-map-support
+```
+
+```ts filename=server.ts
+import sourceMapSupport from "source-map-support";
+
+sourceMapSupport.install();
+```
+
 ## Built-in PostCSS/Tailwind support
 
 In v2, these tools will be automatically used within the Remix compiler if PostCSS and/or Tailwind configuration files are present in your project.

--- a/templates/arc/package.json
+++ b/templates/arc/package.json
@@ -16,7 +16,8 @@
     "cross-env": "^7.0.3",
     "isbot": "^3.6.8",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "source-map-support": "^0.5.21"
   },
   "devDependencies": {
     "@architect/architect": "^10.12.1",
@@ -24,6 +25,7 @@
     "@remix-run/eslint-config": "*",
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",
+    "@types/source-map-support": "^0.5.6",
     "eslint": "^8.38.0",
     "typescript": "^5.0.4"
   },

--- a/templates/arc/server.ts
+++ b/templates/arc/server.ts
@@ -1,7 +1,9 @@
 import { createRequestHandler } from "@remix-run/architect";
 import * as build from "@remix-run/dev/server-build";
 import { installGlobals } from "@remix-run/node";
+import sourceMapSupport from "source-map-support";
 
+sourceMapSupport.install();
 installGlobals();
 
 export const handler = createRequestHandler({

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -19,7 +19,8 @@
     "isbot": "^3.6.8",
     "morgan": "^1.10.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "source-map-support": "^0.5.21"
   },
   "devDependencies": {
     "@remix-run/dev": "*",
@@ -29,6 +30,7 @@
     "@types/morgan": "^1.9.4",
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",
+    "@types/source-map-support": "^0.5.6",
     "chokidar": "^3.5.3",
     "eslint": "^8.38.0",
     "typescript": "^5.0.4"

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -6,7 +6,9 @@ import chokidar from "chokidar";
 import compression from "compression";
 import express from "express";
 import morgan from "morgan";
+import sourceMapSupport from "source-map-support";
 
+sourceMapSupport.install();
 installGlobals();
 
 const BUILD_PATH = "./build/index.js";

--- a/templates/netlify/package.json
+++ b/templates/netlify/package.json
@@ -16,7 +16,8 @@
     "cross-env": "^7.0.3",
     "isbot": "^3.6.8",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "source-map-support": "^0.5.21"
   },
   "devDependencies": {
     "@remix-run/dev": "*",
@@ -24,6 +25,7 @@
     "@remix-run/serve": "*",
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",
+    "@types/source-map-support": "^0.5.6",
     "eslint": "^8.38.0",
     "typescript": "^5.0.4"
   },

--- a/templates/netlify/server.ts
+++ b/templates/netlify/server.ts
@@ -1,7 +1,9 @@
 import * as build from "@remix-run/dev/server-build";
 import { createRequestHandler } from "@remix-run/netlify";
 import { installGlobals } from "@remix-run/node";
+import sourceMapSupport from "source-map-support";
 
+sourceMapSupport.install();
 installGlobals();
 
 export const handler = createRequestHandler({

--- a/templates/vercel/package.json
+++ b/templates/vercel/package.json
@@ -14,7 +14,8 @@
     "@vercel/node": "^2.10.3",
     "isbot": "^3.6.8",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "source-map-support": "^0.5.21"
   },
   "devDependencies": {
     "@remix-run/dev": "*",
@@ -22,6 +23,7 @@
     "@remix-run/serve": "*",
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",
+    "@types/source-map-support": "^0.5.6",
     "eslint": "^8.38.0",
     "typescript": "^5.0.4"
   },

--- a/templates/vercel/server.ts
+++ b/templates/vercel/server.ts
@@ -1,7 +1,9 @@
 import * as build from "@remix-run/dev/server-build";
 import { installGlobals } from "@remix-run/node";
 import { createRequestHandler } from "@remix-run/vercel";
+import sourceMapSupport from "source-map-support";
 
+sourceMapSupport.install();
 installGlobals();
 
 export default createRequestHandler({ build, mode: process.env.NODE_ENV });


### PR DESCRIPTION
@jacob-ebey's changes from #7009 against `main`, so new projects already have this + docs are already updated for people

We still need to release the changes Jacob made for `@remix-run/serve` in a patch release so all other Node-templates (Fly & Remix) have these changes as well