### PR TITLE
chore(templates): remove future flags

### DIFF
--- a/templates/arc/remix.config.js
+++ b/templates/arc/remix.config.js
@@ -7,7 +7,4 @@ export default {
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   serverModuleFormat: "esm",
-  future: {
-    v2_dev: true,
-  },
 };

--- a/templates/cloudflare-pages/remix.config.js
+++ b/templates/cloudflare-pages/remix.config.js
@@ -13,7 +13,4 @@ export default {
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // publicPath: "/build/",
-  future: {
-    v2_dev: true,
-  },
 };

--- a/templates/cloudflare-workers/remix.config.js
+++ b/templates/cloudflare-workers/remix.config.js
@@ -15,7 +15,4 @@ export default {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
-  future: {
-    v2_dev: true,
-  },
 };

--- a/templates/express/remix.config.js
+++ b/templates/express/remix.config.js
@@ -6,7 +6,4 @@ export default {
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
   serverModuleFormat: "esm",
-  future: {
-    v2_dev: true,
-  },
 };

--- a/templates/fly/remix.config.js
+++ b/templates/fly/remix.config.js
@@ -6,7 +6,4 @@ module.exports = {
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
   serverModuleFormat: "cjs",
-  future: {
-    v2_dev: true,
-  },
 };

--- a/templates/netlify/remix.config.js
+++ b/templates/netlify/remix.config.js
@@ -10,7 +10,4 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // publicPath: "/build/",
   serverModuleFormat: "cjs",
-  future: {
-    v2_dev: true,
-  },
 };

--- a/templates/remix/remix.config.js
+++ b/templates/remix/remix.config.js
@@ -6,7 +6,4 @@ module.exports = {
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
   serverModuleFormat: "cjs",
-  future: {
-    v2_dev: true,
-  },
 };

--- a/templates/vercel/remix.config.js
+++ b/templates/vercel/remix.config.js
@@ -10,7 +10,4 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // publicPath: "/build/",
   serverModuleFormat: "cjs",
-  future: {
-    v2_dev: true,
-  },
 };


### PR DESCRIPTION
Since all future flags have been removed, these templates can now be cleaned up to remove all future flag config.