### PR TITLE
feat(remix-serve): install `source-map-support`

### DIFF
--- a/.changeset/lucky-kangaroos-develop.md
+++ b/.changeset/lucky-kangaroos-develop.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/serve": patch
+---
+
+Install `source-map-support`

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -1,9 +1,13 @@
 import "./env";
 import path from "path";
 import os from "os";
-import { broadcastDevReady } from "@remix-run/node";
+import { broadcastDevReady, installGlobals } from "@remix-run/node";
+import sourceMapSupport from "source-map-support";
 
 import { createApp } from "./index";
+
+sourceMapSupport.install();
+installGlobals();
 
 let port = process.env.PORT ? Number(process.env.PORT) : 3000;
 if (Number.isNaN(port)) port = 3000;

--- a/packages/remix-serve/package.json
+++ b/packages/remix-serve/package.json
@@ -21,12 +21,14 @@
     "@remix-run/node": "1.19.2-pre.1",
     "compression": "^1.7.4",
     "express": "^4.17.1",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "source-map-support": "^0.5.21"
   },
   "devDependencies": {
     "@types/compression": "^1.7.0",
     "@types/express": "^4.17.9",
-    "@types/morgan": "^1.9.2"
+    "@types/morgan": "^1.9.2",
+    "@types/source-map-support": "^0.5.6"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3406,10 +3406,10 @@
   resolved "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz"
   integrity sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==
 
-"@types/source-map-support@^0.5.4":
-  version "0.5.4"
-  resolved "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.4.tgz"
-  integrity sha512-9zGujX1sOPg32XLyfgEB/0G9ZnrjthL/Iv1ZfuAjj8LEilHZEpQSQs1scpRXPhHzGYgWiLz9ldF1cI8JhL+yMw==
+"@types/source-map-support@^0.5.4", "@types/source-map-support@^0.5.6":
+  version "0.5.6"
+  resolved "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.6.tgz#aa4a8c98ec73a1f1f30a813573a9b2154a6eb39a"
+  integrity sha512-b2nJ9YyXmkhGaa2b8VLM0kJ04xxwNyijcq12/kDoomCt43qbHBeK2SLNJ9iJmETaAj+bKUT05PQUu3Q66GvLhQ==
   dependencies:
     source-map "^0.6.0"
 


### PR DESCRIPTION
Follow-up of ##7009 & #7010

This should be in a patch release