### PR TITLE
feat: re-export `redirectDocument` from RR

### DIFF
--- a/.changeset/friendly-fireants-report.md
+++ b/.changeset/friendly-fireants-report.md
@@ -1,0 +1,6 @@
+---
+"@remix-run/react": minor
+"@remix-run/server-runtime": minor
+---
+
+[REMOVE] Update to experimental react router version with Remix back compat code removed

--- a/.changeset/wicked-points-unite.md
+++ b/.changeset/wicked-points-unite.md
@@ -1,0 +1,8 @@
+---
+"@remix-run/cloudflare": minor
+"@remix-run/deno": minor
+"@remix-run/node": minor
+"@remix-run/server-runtime": minor
+---
+
+Re-export new `redirectDocument` method from React Router

--- a/docs/utils/redirectDocument.md
+++ b/docs/utils/redirectDocument.md
@@ -1,0 +1,41 @@
+---
+title: redirectDocument
+toc: false
+---
+
+# `redirectDocument`
+
+This is a small wrapper around [`redirect`][redirect] that will trigger a document-level redirect to the new location instead of a client-side navigation.
+
+This is most useful when you have a Remix app living next to a non-Remix app on the same domain and need to redirect from the Remix app to the non-Remix app:
+
+```tsx lines=[1,7]
+import { redirect } from "@remix-run/node"; // or cloudflare/deno
+
+export const action = async () => {
+  const userSession = await getUserSessionOrWhatever();
+
+  if (!userSession) {
+    return redirect("/login");
+  }
+
+  return json({ ok: true });
+};
+```
+
+Just like [`redirect`][redirect], it accepts a status code or a `ResponseInit` as the second parameter:
+
+```
+redirectDocument(path, 301);
+redirectDocument(path, 303);
+```
+
+```ts
+redirectDocument(path, {
+  headers: {
+    "Set-Cookie": await commitSession(session),
+  },
+});
+```
+
+[redirect]: ./redirect

--- a/integration/navigation-state-test.ts
+++ b/integration/navigation-state-test.ts
@@ -456,7 +456,6 @@ test.describe("navigation states", () => {
           search: "?redirected",
           hash: "",
           state: {
-            _isFetchActionRedirect: true,
             _isRedirect: true,
           },
           key: expect.any(String),

--- a/packages/remix-cloudflare/index.ts
+++ b/packages/remix-cloudflare/index.ts
@@ -20,6 +20,7 @@ export {
   json,
   MaxPartSizeExceededError,
   redirect,
+  redirectDocument,
   unstable_composeUploadHandlers,
   unstable_createMemoryUploadHandler,
   unstable_parseMultipartFormData,

--- a/packages/remix-deno/index.ts
+++ b/packages/remix-deno/index.ts
@@ -23,6 +23,7 @@ export {
   logDevReady,
   MaxPartSizeExceededError,
   redirect,
+  redirectDocument,
   unstable_composeUploadHandlers,
   unstable_createMemoryUploadHandler,
   unstable_parseMultipartFormData,

--- a/packages/remix-node/index.ts
+++ b/packages/remix-node/index.ts
@@ -40,6 +40,7 @@ export {
   json,
   MaxPartSizeExceededError,
   redirect,
+  redirectDocument,
   unstable_composeUploadHandlers,
   unstable_createMemoryUploadHandler,
   unstable_parseMultipartFormData,

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -16,8 +16,8 @@
   "typings": "dist/index.d.ts",
   "module": "dist/esm/index.js",
   "dependencies": {
-    "@remix-run/router": "1.7.2",
-    "react-router-dom": "6.14.2"
+    "@remix-run/router": "0.0.0-experimental-ad6954b7",
+    "react-router-dom": "0.0.0-experimental-ad6954b7"
   },
   "devDependencies": {
     "@remix-run/server-runtime": "1.19.3",

--- a/packages/remix-server-runtime/index.ts
+++ b/packages/remix-server-runtime/index.ts
@@ -4,7 +4,7 @@ export {
   composeUploadHandlers as unstable_composeUploadHandlers,
   parseMultipartFormData as unstable_parseMultipartFormData,
 } from "./formData";
-export { defer, json, redirect } from "./responses";
+export { defer, json, redirect, redirectDocument } from "./responses";
 export { createRequestHandler } from "./server";
 export {
   createSession,

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -16,7 +16,7 @@
   "typings": "dist/index.d.ts",
   "module": "dist/esm/index.js",
   "dependencies": {
-    "@remix-run/router": "1.7.2",
+    "@remix-run/router": "0.0.0-experimental-ad6954b7",
     "@types/cookie": "^0.4.1",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie": "^0.4.1",

--- a/packages/remix-server-runtime/responses.ts
+++ b/packages/remix-server-runtime/responses.ts
@@ -2,6 +2,7 @@ import {
   defer as routerDefer,
   json as routerJson,
   redirect as routerRedirect,
+  redirectDocument as routerRedirectDocument,
   type UNSAFE_DeferredData as DeferredData,
   type TrackedPromise,
 } from "@remix-run/router";
@@ -67,6 +68,17 @@ export type RedirectFunction = (
  */
 export const redirect: RedirectFunction = (url, init = 302) => {
   return routerRedirect(url, init) as TypedResponse<never>;
+};
+
+/**
+ * A redirect response that will force a document reload to the new location.
+ * Sets the status code and the `Location` header.
+ * Defaults to "302 Found".
+ *
+ * @see https://remix.run/utils/redirect
+ */
+export const redirectDocument: RedirectFunction = (url, init = 302) => {
+  return routerRedirectDocument(url, init) as TypedResponse<never>;
 };
 
 export function isDeferredData(value: any): value is DeferredData {

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "@remix-run/node": "1.19.3",
     "@remix-run/react": "1.19.3",
-    "@remix-run/router": "1.7.2",
-    "react-router-dom": "6.14.2"
+    "@remix-run/router": "0.0.0-experimental-ad6954b7",
+    "react-router-dom": "0.0.0-experimental-ad6954b7"
   },
   "devDependencies": {
     "@types/node": "^18.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,10 +2091,10 @@
     "@changesets/types" "^5.0.0"
     dotenv "^8.1.0"
 
-"@remix-run/router@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.7.2.tgz#cba1cf0a04bc04cb66027c51fa600e9cbc388bc8"
-  integrity sha512-7Lcn7IqGMV+vizMPoEl5F0XDshcdDYtMI6uJLQdQz5CfZAwy3vvGKYSUk789qndt5dEC4HfSjviSYlSoHGL2+A==
+"@remix-run/router@0.0.0-experimental-ad6954b7":
+  version "0.0.0-experimental-ad6954b7"
+  resolved "https://registry.npmjs.org/@remix-run/router/-/router-0.0.0-experimental-ad6954b7.tgz#fd4f658db8f081f7bf188715dd2de792186279af"
+  integrity sha512-1YjdLJkQIWDB/4rQX2tjnx+svhD9eoIggjaAV1gYr/Yc2wxUzzXaaatdaKHo+rSsFWrLvRyQqJOh7ulkOFyJZg==
 
 "@remix-run/web-blob@^3.0.5":
   version "3.0.5"
@@ -10027,20 +10027,20 @@ react-refresh@^0.14.0:
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
 
-react-router-dom@6.14.2:
-  version "6.14.2"
-  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.14.2.tgz#88f520118b91aa60233bd08dbd3fdcaea3a68488"
-  integrity sha512-5pWX0jdKR48XFZBuJqHosX3AAHjRAzygouMTyimnBPOLdY3WjzUSKhus2FVMihUFWzeLebDgr4r8UeQFAct7Bg==
+react-router-dom@0.0.0-experimental-ad6954b7:
+  version "0.0.0-experimental-ad6954b7"
+  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-0.0.0-experimental-ad6954b7.tgz#9ae496b137345268cc23568e1ca82e9fd1c516d2"
+  integrity sha512-1HpuTm18dgYTk916/mrGTDZjUFHWqbobYCLqcfdwwgrh5y/AHAPgbx3mp7iokoRWPr3C9n4hlT+OHCpNwPm1Lg==
   dependencies:
-    "@remix-run/router" "1.7.2"
-    react-router "6.14.2"
+    "@remix-run/router" "0.0.0-experimental-ad6954b7"
+    react-router "0.0.0-experimental-ad6954b7"
 
-react-router@6.14.2:
-  version "6.14.2"
-  resolved "https://registry.npmjs.org/react-router/-/react-router-6.14.2.tgz#1f60994d8c369de7b8ba7a78d8f7ec23df76b300"
-  integrity sha512-09Zss2dE2z+T1D03IheqAFtK4UzQyX8nFPWx6jkwdYzGLXd5ie06A6ezS2fO6zJfEb/SpG6UocN2O1hfD+2urQ==
+react-router@0.0.0-experimental-ad6954b7:
+  version "0.0.0-experimental-ad6954b7"
+  resolved "https://registry.npmjs.org/react-router/-/react-router-0.0.0-experimental-ad6954b7.tgz#3bfdfc90088a9db1d3c3c584793b8c0161a5d801"
+  integrity sha512-xyxVY635/ZH3XqC1KynvtcCzDpgYgoqBmxnb7ekcjtZfNXgtLOfm5X98ZTLvVl5bRaDTp06ddI9TeqzSh5ituQ==
   dependencies:
-    "@remix-run/router" "1.7.2"
+    "@remix-run/router" "0.0.0-experimental-ad6954b7"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
Re-export `redirectDocument` from https://github.com/remix-run/react-router/pull/10705.

This will fail CI until we cut the next react router release and can point Remix to it.

Closes https://github.com/remix-run/react-router/discussions/9859