### PR TITLE
chore: remove `abort-controller` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,8 +87,6 @@
     "@types/serialize-javascript": "^5.0.2",
     "@types/ssri": "^7.1.0",
     "@vanilla-extract/css": "^1.10.0",
-    "abort-controller": "^3.0.0",
-    "abortcontroller-polyfill": "^1.7.3",
     "babel-jest": "^27.5.1",
     "babel-plugin-transform-remove-console": "^6.9.4",
     "chalk": "^4.1.2",

--- a/packages/remix-architect/package.json
+++ b/packages/remix-architect/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@types/lambda-tester": "^3.6.1",
+    "@types/node": "^18.17.1",
     "lambda-tester": "^4.0.1",
     "typescript": "^5.1.0"
   },

--- a/packages/remix-architect/server.ts
+++ b/packages/remix-architect/server.ts
@@ -1,11 +1,9 @@
 import type {
   AppLoadContext,
   ServerBuild,
-  RequestInit as NodeRequestInit,
   Response as NodeResponse,
 } from "@remix-run/node";
 import {
-  AbortController as NodeAbortController,
   Headers as NodeHeaders,
   Request as NodeRequest,
   createRequestHandler as createRemixRequestHandler,
@@ -67,15 +65,13 @@ export function createRemixRequest(event: APIGatewayProxyEventV2): NodeRequest {
     "multipart/form-data"
   );
   // Note: No current way to abort these for Architect, but our router expects
-  // requests to contain a signal so it can detect aborted requests
-  let controller = new NodeAbortController();
+  // requests to contain a signal, so it can detect aborted requests
+  let controller = new AbortController();
 
   return new NodeRequest(url.href, {
     method: event.requestContext.http.method,
     headers: createRemixHeaders(event.headers, event.cookies),
-    // Cast until reason/throwIfAborted added
-    // https://github.com/mysticatea/abort-controller/issues/36
-    signal: controller.signal as NodeRequestInit["signal"],
+    signal: controller.signal,
     body:
       event.body && event.isBase64Encoded
         ? isFormData

--- a/packages/remix-express/package.json
+++ b/packages/remix-express/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.9",
+    "@types/node": "^18.17.1",
     "@types/supertest": "^2.0.10",
     "express": "^4.17.1",
     "node-mocks-http": "^1.10.1",

--- a/packages/remix-express/server.ts
+++ b/packages/remix-express/server.ts
@@ -6,7 +6,6 @@ import type {
   Response as NodeResponse,
 } from "@remix-run/node";
 import {
-  AbortController as NodeAbortController,
   createRequestHandler as createRemixRequestHandler,
   Headers as NodeHeaders,
   Request as NodeRequest,
@@ -96,15 +95,13 @@ export function createRemixRequest(
   let url = new URL(`${req.protocol}://${req.get("host")}${req.url}`);
 
   // Abort action/loaders once we can no longer write a response
-  let controller = new NodeAbortController();
+  let controller = new AbortController();
   res.on("close", () => controller.abort());
 
   let init: NodeRequestInit = {
     method: req.method,
     headers: createRemixHeaders(req.headers),
-    // Cast until reason/throwIfAborted added
-    // https://github.com/mysticatea/abort-controller/issues/36
-    signal: controller.signal as NodeRequestInit["signal"],
+    signal: controller.signal,
   };
 
   if (req.method !== "GET" && req.method !== "HEAD") {

--- a/packages/remix-netlify/package.json
+++ b/packages/remix-netlify/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@netlify/functions": "^1.0.0",
+    "@types/node": "^18.17.1",
     "typescript": "^5.1.0"
   },
   "peerDependencies": {

--- a/packages/remix-netlify/server.ts
+++ b/packages/remix-netlify/server.ts
@@ -5,7 +5,6 @@ import type {
   Response as NodeResponse,
 } from "@remix-run/node";
 import {
-  AbortController as NodeAbortController,
   createRequestHandler as createRemixRequestHandler,
   Headers as NodeHeaders,
   Request as NodeRequest,
@@ -67,15 +66,13 @@ export function createRemixRequest(event: HandlerEvent): NodeRequest {
   }
 
   // Note: No current way to abort these for Netlify, but our router expects
-  // requests to contain a signal so it can detect aborted requests
-  let controller = new NodeAbortController();
+  // requests to contain a signal, so it can detect aborted requests
+  let controller = new AbortController();
 
   let init: NodeRequestInit = {
     method: event.httpMethod,
     headers: createRemixHeaders(event.multiValueHeaders),
-    // Cast until reason/throwIfAborted added
-    // https://github.com/mysticatea/abort-controller/issues/36
-    signal: controller.signal as NodeRequestInit["signal"],
+    signal: controller.signal,
   };
 
   if (event.httpMethod !== "GET" && event.httpMethod !== "HEAD" && event.body) {

--- a/packages/remix-node/globals.ts
+++ b/packages/remix-node/globals.ts
@@ -2,7 +2,6 @@ import {
   ReadableStream as NodeReadableStream,
   WritableStream as NodeWritableStream,
 } from "@remix-run/web-stream";
-import { AbortController as NodeAbortController } from "abort-controller";
 
 import { atob, btoa } from "./base64";
 import {
@@ -36,8 +35,6 @@ declare global {
 
       ReadableStream: typeof ReadableStream;
       WritableStream: typeof WritableStream;
-
-      AbortController: typeof AbortController;
     }
   }
 }
@@ -57,6 +54,4 @@ export function installGlobals() {
 
   global.ReadableStream = NodeReadableStream;
   global.WritableStream = NodeWritableStream;
-
-  global.AbortController = global.AbortController || NodeAbortController;
 }

--- a/packages/remix-node/index.ts
+++ b/packages/remix-node/index.ts
@@ -1,5 +1,3 @@
-export { AbortController } from "abort-controller";
-
 export type {
   HeadersInit,
   RequestInfo,

--- a/packages/remix-node/package.json
+++ b/packages/remix-node/package.json
@@ -22,7 +22,6 @@
     "@remix-run/web-file": "^3.0.3",
     "@remix-run/web-stream": "^1.0.4",
     "@web3-storage/multipart-parser": "^1.0.0",
-    "abort-controller": "^3.0.0",
     "cookie-signature": "^1.1.0",
     "source-map-support": "^0.5.21",
     "stream-slice": "^0.1.2"

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -24,7 +24,6 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^13.3.0",
     "@types/react": "^18.0.15",
-    "abort-controller": "^3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.1.0"

--- a/packages/remix-vercel/package.json
+++ b/packages/remix-vercel/package.json
@@ -17,6 +17,7 @@
     "@remix-run/node": "1.19.2"
   },
   "devDependencies": {
+    "@types/node": "^18.17.1",
     "@types/supertest": "^2.0.10",
     "@vercel/node": "^2.12.0",
     "node-mocks-http": "^1.10.1",

--- a/packages/remix-vercel/server.ts
+++ b/packages/remix-vercel/server.ts
@@ -6,7 +6,6 @@ import type {
   Response as NodeResponse,
 } from "@remix-run/node";
 import {
-  AbortController as NodeAbortController,
   createRequestHandler as createRemixRequestHandler,
   Headers as NodeHeaders,
   Request as NodeRequest,
@@ -85,15 +84,13 @@ export function createRemixRequest(
   let url = new URL(`${protocol}://${host}${req.url}`);
 
   // Abort action/loaders once we can no longer write a response
-  let controller = new NodeAbortController();
+  let controller = new AbortController();
   res.on("close", () => controller.abort());
 
   let init: NodeRequestInit = {
     method: req.method,
     headers: createRemixHeaders(req.headers),
-    // Cast until reason/throwIfAborted added
-    // https://github.com/mysticatea/abort-controller/issues/36
-    signal: controller.signal as NodeRequestInit["signal"],
+    signal: controller.signal,
   };
 
   if (req.method !== "GET" && req.method !== "HEAD") {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3155,11 +3155,6 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-abortcontroller-polyfill@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz"
-  integrity sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==
-
 accepts@^1.3.7, accepts@~1.3.5, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz"


### PR DESCRIPTION
`AbortSignal` is stable as of Node v15.4

https://nodejs.org/api/globals.html#class-abortcontroller

---

This PR is relying on #6108, so that one needs to be merged first