### PR TITLE
Warn users about obsolete future flags in remix.config.js

### DIFF
--- a/.changeset/brown-seals-look.md
+++ b/.changeset/brown-seals-look.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": minor
+---
+
+Warn users about obsolete future flags in remix.config.js

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -608,7 +608,38 @@ export async function readConfig(
     tsconfigPath = rootJsConfig;
   }
 
+  // Note: When a future flag is removed from here, it should be added to the
+  // list below so we can let folks know if they have obsolete flags in their
+  // config.  If we ever convert remix.config.js to a TS file so we get proper
+  // typings this won't be necessary anymore.
   let future: FutureConfig = {};
+
+  if (appConfig.future) {
+    let userFlags = appConfig.future;
+    let deprecatedFlags = [
+      "unstable_cssModules",
+      "unstable_cssSideEffectImports",
+      "unstable_dev",
+      "unstable_postcss",
+      "unstable_tailwind",
+      "unstable_vanillaExtract",
+      "v2_dev",
+      "v2_errorBoundary",
+      "v2_headers",
+      "v2_meta",
+      "v2_normalizeFormMethod",
+      "v2_routeConvention",
+    ] as const;
+
+    let obsoleteFlags = deprecatedFlags.filter((f) => f in userFlags);
+    if (obsoleteFlags.length > 0) {
+      logger.warn(
+        `⚠️ REMIX FUTURE CHANGE: the following Remix future flags are now obsolete ` +
+          `and can be removed from your remix.config.js file:\n` +
+          obsoleteFlags.map((f) => `- ${f}\n`).join("")
+      );
+    }
+  }
 
   return {
     appDirectory,

--- a/packages/remix-dev/warnOnce.ts
+++ b/packages/remix-dev/warnOnce.ts
@@ -1,8 +1,0 @@
-const alreadyWarned: { [message: string]: boolean } = {};
-
-export function warnOnce(message: string, key = message): void {
-  if (!alreadyWarned[key]) {
-    alreadyWarned[key] = true;
-    console.warn(message);
-  }
-}


### PR DESCRIPTION
Recreation of https://github.com/remix-run/remix/pull/6211 against `dev`

Run against my playground app which has all flags turned on + latest `nightly`:

<img width="926" alt="Screenshot 2023-08-03 at 10 06 16 AM" src="https://github.com/remix-run/remix/assets/1609022/230340a9-4417-424d-93a7-f1df9aeb4578">
