### PR TITLE
feat(remix-dev): add deprecation warning about `devServerBroadcastDelay` & `devServerPort`

### DIFF
--- a/.changeset/moody-seals-fetch.md
+++ b/.changeset/moody-seals-fetch.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Show deprecation warning when using `devServerBroadcastDelay` and `devServerPort` config options

--- a/docs/file-conventions/remix-config.md
+++ b/docs/file-conventions/remix-config.md
@@ -45,18 +45,22 @@ The path to the browser build, relative to remix.config.js. Defaults to
 The path to a directory Remix can use for caching things in development,
 relative to `remix.config.js`. Defaults to `".cache"`.
 
-## devServerBroadcastDelay (deprecated)
+## devServerBroadcastDelay
+
+<docs-warning>This option is deprecated and will likely be removed in a future
+stable release. Enable `v2_dev` to eliminate the race conditions that necessitated
+this option.</docs-warning>
 
 The delay, in milliseconds, before the dev server broadcasts a reload event.
 There is no delay by default.
 
-For `v2_dev`, the race conditions that necesitated this option have been eliminated.
+## devServerPort
 
-## devServerPort (deprecated)
+<docs-warning>This option is deprecated and will likely be removed in a future
+stable release. Enable `v2_dev` and use [`--port` / `v2_dev.port` option][port]
+instead.</docs-warning>
 
 The port number to use for the dev websocket server. Defaults to 8002.
-
-For `v2_dev`, use [`--port` / `v2_dev.port` option][port].
 
 ## ignoredRouteFiles
 
@@ -316,4 +320,4 @@ There are a few conventions that Remix uses you should be aware of.
 [tailwind-functions-and-directives]: https://tailwindcss.com/docs/functions-and-directives
 [jspm]: https://github.com/jspm/jspm-core
 [esbuild-plugins-node-modules-polyfill]: https://www.npmjs.com/package/esbuild-plugins-node-modules-polyfill
-[port]: ../other-api/dev-v2#option-1
+[port]: ../other-api/dev-v2#options-1

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -117,12 +117,17 @@ export interface AppConfig {
 
   /**
    * The port number to use for the dev server. Defaults to 8002.
+   *
+   * @deprecated Use {@link AppConfig.future.v2_dev.port} instead.
    */
   devServerPort?: number;
 
   /**
    * The delay, in milliseconds, before the dev server broadcasts a reload
    * event. There is no delay by default.
+   *
+   * @deprecated Enable {@link AppConfig.future.v2_dev} to eliminate the race
+   * conditions that necessitated this option.
    */
   devServerBroadcastDelay?: number;
 
@@ -296,11 +301,16 @@ export interface RemixConfig {
 
   /**
    * The port number to use for the dev (asset) server.
+   *
+   * @deprecated Use {@link RemixConfig.future.v2_dev.port} instead.
    */
   devServerPort: number;
 
   /**
    * The delay before the dev (asset) server broadcasts a reload event.
+   *
+   * @deprecated Enable {@link RemixConfig.future.v2_dev} to eliminate the race
+   * conditions that necessitated this option.
    */
   devServerBroadcastDelay: number;
 
@@ -804,6 +814,13 @@ export async function readConfig(
     assetsBuildDirectory
   );
 
+  if (appConfig.devServerPort) {
+    devServerPortWarning();
+  }
+  if (appConfig.devServerBroadcastDelay) {
+    devServerBroadcastDelayWarning();
+  }
+
   let devServerPort =
     Number(process.env.REMIX_DEV_SERVER_WS_PORT) ||
     (await getPort({ port: Number(appConfig.devServerPort) || 8002 }));
@@ -1035,6 +1052,27 @@ let browserBuildDirectoryWarning = () =>
       key: "browserBuildDirectoryWarning",
     }
   );
+
+let devServerBroadcastDelayWarning = () =>
+  logger.warn(
+    "The `devServerBroadcastDelay` config option will be removed in v2",
+    {
+      details: [
+        "Enable `v2_dev` to eliminate the race conditions that necessitated this option.",
+        "-> https://remix.run/docs/en/v1.19.3/pages/v2#devserverbroadcastdelay",
+      ],
+      key: "devServerBroadcastDelayWarning",
+    }
+  );
+
+let devServerPortWarning = () =>
+  logger.warn("The `devServerPort` config option will be removed in v2", {
+    details: [
+      "Enable `v2_dev` and use `--port` / `v2_dev.port` option instead.",
+      "-> https://remix.run/docs/en/v1.19.3/pages/v2#devserverport",
+    ],
+    key: "devServerPortWarning",
+  });
 
 let serverBuildDirectoryWarning = () =>
   logger.warn(


### PR DESCRIPTION
This should be released in a patch release

Docs pointed to in the warnings will be implemented by #7023 & #7057