### PR TITLE
docs(dev): PORT env var for remix-serve, not --port flag

### DIFF
--- a/docs/other-api/dev-v2.md
+++ b/docs/other-api/dev-v2.md
@@ -179,10 +179,10 @@ The `remix dev --port` option sets the internal port used for hot updates.
 To set your app server port, set it the way you normally would in production.
 For example, you may have it hardcoded in your `server.js` file.
 
-If you are using `remix-serve` as your app server, you can use its `--port` flag to set the app server port:
+If you are using `remix-serve` as your app server, you can use the `PORT` environment variable to set the app server port:
 
 ```
-remix dev -c "remix-serve --port 8000 ./build"
+remix dev -c "PORT=8000 remix-serve ./build"
 ```
 
 In contrast, the `remix dev --port` option is an escape-hatch for users who need fine-grain control of network ports.


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
