### PR TITLE
Support `bun` package manager in create-remix

### DIFF
--- a/packages/remix-dev/cli/create.ts
+++ b/packages/remix-dev/cli/create.ts
@@ -210,12 +210,16 @@ export async function createApp({
   if (installDeps) {
     let packageManager = detectPackageManager() ?? "npm";
 
+    // bun does not have an npm-compatible `config` command
     let npmConfig = execSync(
-      `${packageManager} config get @remix-run:registry`,
+      `${
+        packageManager === "bun" ? "npm" : packageManager
+      } config get @remix-run:registry`,
       {
         encoding: "utf8",
       }
     );
+
     if (npmConfig?.startsWith("https://npm.remix.run")) {
       throw Error(
         "🚨 Oops! You still have the private Remix registry configured. Please " +

--- a/packages/remix-dev/cli/detectPackageManager.ts
+++ b/packages/remix-dev/cli/detectPackageManager.ts
@@ -1,4 +1,4 @@
-type PackageManager = "npm" | "pnpm" | "yarn";
+type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
 
 /**
  * Determine which package manager the user prefers.
@@ -15,6 +15,7 @@ export const detectPackageManager = (): PackageManager | undefined => {
     if (pkgManager === "npm") return "npm";
     if (pkgManager === "pnpm") return "pnpm";
     if (pkgManager === "yarn") return "yarn";
+    if (pkgManager === "bun") return "bun";
     return undefined;
   } catch {
     return undefined;

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -142,6 +142,7 @@ const npxInterop = {
   npm: "npx",
   yarn: "yarn",
   pnpm: "pnpm exec",
+  bun: "bunx",
 };
 
 /**
@@ -446,7 +447,11 @@ export async function run(argv: string[] = process.argv.slice(2)) {
                 "🚨 Your terminal doesn't support interactivity; using default " +
                   "configuration.\n\n" +
                   "If you'd like to use different settings, try passing them " +
-                  `as arguments. Run \`${packageManager} create remix@latest --help\` to see ` +
+                  `as arguments. Run \`${
+                    packageManager === "bun"
+                      ? "bunx create-remix"
+                      : `${packageManager} create remix`
+                  }@latest --help\` to see ` +
                   "available options."
               )
             );

--- a/packages/remix-dev/devServer_unstable/index.ts
+++ b/packages/remix-dev/devServer_unstable/index.ts
@@ -31,6 +31,10 @@ let detectBin = async (): Promise<string> => {
     let { stdout } = await execa(pkgManager, ["prefix"]);
     return path.join(stdout.trim(), "node_modules", ".bin");
   }
+  if (pkgManager === "bun") {
+    let { stdout } = await execa(pkgManager, ["pm", "bin"]);
+    return stdout.trim();
+  }
   let { stdout } = await execa(pkgManager, ["bin"]);
   return stdout.trim();
 };


### PR DESCRIPTION
This adds support for `bun` to the `create-remix` package manager detection system. Bun sets the value of `npm_config_user_agent` when executing a script with `bun run`/`bunx`. When a Bun user runs `bunx create-remix`, they will be prompted to use `bun install` to install dependencies.

## Testing

After building the CLI with `yarn build` I ran the `create-remix` script with the `npm_config_user_agent` set appropriately. It detected the variable and ran `bun install` as expected.

```sh
$ npm_config_user_agent=bun/1.0 node build/node_modules/create-remix/dist/cli.js
? Where would you like to create your app? ./my-remix-app
? What type of app do you want to create? Just the basics
? Where do you want to deploy? Choose Remix App Server if you're unsure; it's easy to change deployment targets. Remix App Server
? TypeScript or JavaScript? TypeScript
? Do you want me to run `bun install`? Yes
⠼ Creating your app…bun install v0.7.1 (53cc4df1)
 + @remix-run/dev@1.19.2
 + @remix-run/eslint-config@1.19.2
 + @types/react@18.2.18
 + @types/react-dom@18.2.7
 + eslint@8.46.0
 + typescript@5.1.6
 + @remix-run/css-bundle@1.19.2
 + @remix-run/node@1.19.2
 + @remix-run/react@1.19.2
 + @remix-run/serve@1.19.2
 + isbot@3.6.13
 + react@18.2.0
 + react-dom@18.2.0

 914 packages installed [1.68s]
💿 That's it! `cd` into "/Users/colinmcd94/Documents/repos/remix/my-remix-app" and check the README for development and deploy instructions!
```

