### PR TITLE
fix(templates/express): dynamically import `chokidar` so it doesn't crash production

### DIFF
--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -4,7 +4,6 @@ import * as url from "node:url";
 
 import { createRequestHandler } from "@remix-run/express";
 import { broadcastDevReady, installGlobals } from "@remix-run/node";
-import chokidar from "chokidar";
 import compression from "compression";
 import express from "express";
 import morgan from "morgan";
@@ -38,15 +37,18 @@ app.use(express.static("public", { maxAge: "1h" }));
 
 app.use(morgan("tiny"));
 
-app.all(
-  "*",
-  process.env.NODE_ENV === "development"
-    ? createDevRequestHandler(initialBuild)
-    : createRequestHandler({
-        build: initialBuild,
-        mode: initialBuild.mode,
-      })
-);
+app.all("*", async (...args) => {
+  if (process.env.NODE_ENV === "development") {
+    const handler = await createDevRequestHandler(initialBuild);
+    return handler(...args);
+  }
+
+  const handler = createRequestHandler({
+    build: initialBuild,
+    mode: initialBuild.mode,
+  });
+  return handler(...args);
+});
 
 const port = process.env.PORT || 3000;
 app.listen(port, async () => {
@@ -74,7 +76,7 @@ async function reimportServer() {
  * @param {ServerBuild} initialBuild
  * @returns {import('@remix-run/express').RequestHandler}
  */
-function createDevRequestHandler(initialBuild) {
+async function createDevRequestHandler(initialBuild) {
   let build = initialBuild;
   async function handleServerUpdate() {
     // 1. re-import the server build
@@ -82,6 +84,7 @@ function createDevRequestHandler(initialBuild) {
     // 2. tell Remix that this app server is now up-to-date and ready
     broadcastDevReady(build);
   }
+  const chokidar = await import("chokidar");
   chokidar
     .watch(VERSION_PATH, { ignoreInitial: true })
     .on("add", handleServerUpdate)


### PR DESCRIPTION
prior to this change if you built the remix app, pruned dev only dependencies and attempted to `npm start` the server would bail as it tried to import chokidar

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
