### PR TITLE
chore(remix-dev): remove `@babel/preset-env` from dependencies

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -573,3 +573,4 @@
 - defjosiah
 - AlemTuzlak
 - ledniy
+- TrySound

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -23,7 +23,6 @@
     "@babel/parser": "^7.21.8",
     "@babel/plugin-syntax-jsx": "^7.21.4",
     "@babel/plugin-syntax-typescript": "^7.21.4",
-    "@babel/preset-env": "^7.21.5",
     "@babel/preset-typescript": "^7.21.5",
     "@babel/traverse": "^7.21.5",
     "@babel/types": "^7.21.5",


### PR DESCRIPTION
Looks like preset env was added by accident or was not removed while refactoring. Now it is not referenced anywhere except root config and remix rely on esbuild for transpiling.

Preset env depends on many other packages which makes installing slower especially with bad internet connection.