### PR TITLE
feat!: stop passing `isTypeScript` to `remix.init` script

### DIFF
--- a/.changeset/kind-grapes-clap.md
+++ b/.changeset/kind-grapes-clap.md
@@ -1,0 +1,6 @@
+---
+"create-remix": major
+"@remix-run/dev": major
+---
+
+Stop passing `isTypeScript` to `remix.init` script

--- a/packages/create-remix/index.ts
+++ b/packages/create-remix/index.ts
@@ -491,7 +491,6 @@ async function runInitScriptStep(ctx: Context) {
 
   let initScriptDir = path.dirname(ctx.initScriptPath);
   let initPackageJson = path.resolve(initScriptDir, "package.json");
-  let isTypeScript = fs.existsSync(path.join(ctx.cwd, "tsconfig.json"));
   let packageManager = ctx.pkgManager;
 
   try {
@@ -525,7 +524,7 @@ async function runInitScriptStep(ctx: Context) {
       throw new Error("remix.init script doesn't export a function.");
     }
     let rootDirectory = path.resolve(ctx.cwd);
-    await initFn({ isTypeScript, packageManager, rootDirectory });
+    await initFn({ packageManager, rootDirectory });
   } catch (err) {
     error("Oh no!", "Template's remix.init script failed");
     throw err;

--- a/packages/remix-dev/cli/commands.ts
+++ b/packages/remix-dev/cli/commands.ts
@@ -36,7 +36,6 @@ export async function init(
   }
 
   let initPackageJson = path.resolve(initScriptDir, "package.json");
-  let isTypeScript = fse.existsSync(path.join(projectDir, "tsconfig.json"));
   let packageManager = detectPackageManager() ?? "npm";
 
   if (await fse.pathExists(initPackageJson)) {
@@ -51,7 +50,7 @@ export async function init(
     initFn = initFn.default;
   }
   try {
-    await initFn({ isTypeScript, packageManager, rootDirectory: projectDir });
+    await initFn({ packageManager, rootDirectory: projectDir });
 
     if (deleteScript) {
       await fse.remove(initScriptDir);


### PR DESCRIPTION
Follow-up of @markdalgleish's #6887