### PR TITLE
Handle disabled preload config in firefox

### DIFF
--- a/.changeset/disabled-link-preload.md
+++ b/.changeset/disabled-link-preload.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Add `<link rel="preload">` timeout counter and disabling logic in case preloading is disabled by the user in Firefox.  This prevents us from hanging on client-side navigations when we try to preload stylesheets and never receive a `load`/`error` event on the `link` tag.

--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -230,10 +230,7 @@ export async function prefetchStyleLinks(
   if (!routeModule.links) return;
   let descriptors = routeModule.links();
   if (!descriptors) return;
-
-  if (isPreloadDisabled) {
-    return;
-  }
+  if (isPreloadDisabled) return;
 
   // If we've hit our timeout 3 times, we may be in firefox with the
   // `network.preload` config disabled and we'll _never_ get onload/onerror

--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -288,6 +288,7 @@ async function prefetchStyleLink(
   return new Promise((resolve) => {
     let link = document.createElement("link");
     Object.assign(link, descriptor);
+
     function removeLink() {
       // if a navigation interrupts this prefetch React will update the <head>
       // and remove the link we put in there manually, so we check if it's still
@@ -314,6 +315,7 @@ async function prefetchStyleLink(
     document.head.appendChild(link);
   });
 }
+
 ////////////////////////////////////////////////////////////////////////////////
 export function isPageLinkDescriptor(
   object: any


### PR DESCRIPTION
I'm not sure we _want_ this, but it's a POC for a potential fix for https://github.com/remix-run/remix/issues/2619

This adds some client-side detection of preload timeouts (after 3s) and once 3 stylesheet preloads timeout, we try to force a preload `link.onerror`.  If that also times out - we deduce that preload is not supported by the browser (or disabled by the user) and we stop trying to inject preloads for stylesheets on client side navigations.

Closes #2619