### PR TITLE
chore: add `deduplicate-yarn` workflow

### DIFF
--- a/.github/workflows/deduplicate-yarn.yml
+++ b/.github/workflows/deduplicate-yarn.yml
@@ -1,0 +1,44 @@
+name: ⚙️ Deduplicate yarn.lock
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - ./yarn.lock
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    if: github.repository == 'remix-run/remix'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          cache: "yarn"
+
+      - name: ️️⚙️ Dedupe yarn.lock
+        run: npx yarn-deduplicate && rm -rf ./node_modules && yarn
+
+      - name: 💪 Commit
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+          git add .
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "💿 no deduplication needed"
+            exit 0
+          fi
+          git commit -m "chore: deduplicate `yarn.lock`"
+          git push
+          echo "💿 https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"


### PR DESCRIPTION
This is a re-submission of @mcansh's #6109, which should have gone to `main` I think #7035 (see a07ae176),
#7100 (see e6b4ab70), #7101 (see c6b70a61) & #7102 (see ef74be9e) didn't trigger the workflow while they should have and I think that's because the workflow should always be on `main` first before it can be triggered