### PR TITLE
feat(remix-dev): add `serverBundles` config option

### DIFF
--- a/.changeset/angry-gorillas-battle.md
+++ b/.changeset/angry-gorillas-battle.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": minor
+---
+
+Add support for new `serverBundles` configuration to generate multiple server bundles.

--- a/contributors.yml
+++ b/contributors.yml
@@ -512,6 +512,7 @@
 - tombyrer
 - TomerAberbach
 - tomer-yechiel
+- TooTallNate
 - toyozaki
 - turkerdev
 - tvanantwerp

--- a/packages/remix-dev/compiler/compiler.ts
+++ b/packages/remix-dev/compiler/compiler.ts
@@ -30,10 +30,23 @@ export let create = async (ctx: Context): Promise<Compiler> => {
     manifestChannel: undefined as unknown as Channel.Type<Manifest>,
   };
 
+  let serverBundles = Array.isArray(ctx.config.serverBundles)
+    ? ctx.config.serverBundles
+    : [
+        {
+          serverBuildPath: ctx.config.serverBuildPath,
+          routes: ctx.config.routes,
+        },
+      ];
+
   let subcompiler = {
     css: await CSS.createCompiler(ctx),
     js: await JS.createCompiler(ctx, refs),
-    server: await Server.createCompiler(ctx, refs),
+    serverBundles: await Promise.all(
+      serverBundles.map(({ routes, serverBuildPath }) =>
+        Server.createCompiler(ctx, routes, serverBuildPath, refs)
+      )
+    ),
   };
   let cancel = async () => {
     // resolve channels with error so that downstream tasks don't hang waiting for results from upstream tasks
@@ -44,7 +57,7 @@ export let create = async (ctx: Context): Promise<Compiler> => {
     await Promise.all([
       subcompiler.css.cancel(),
       subcompiler.js.cancel(),
-      subcompiler.server.cancel(),
+      ...subcompiler.serverBundles.map((server) => server.cancel()),
     ]);
   };
 
@@ -61,11 +74,7 @@ export let create = async (ctx: Context): Promise<Compiler> => {
     };
 
     // keep track of manually written artifacts
-    let writes: {
-      cssBundle?: Promise<void>;
-      manifest?: Promise<void>;
-      server?: Promise<void>;
-    } = {};
+    let writes: Promise<void>[] = [];
 
     // reset refs for this compilation
     refs.manifestChannel = Channel.create();
@@ -74,7 +83,7 @@ export let create = async (ctx: Context): Promise<Compiler> => {
         let { bundleOutputFile, outputFiles } = await subcompiler.css.compile();
 
         if (bundleOutputFile) {
-          writes.cssBundle = CSS.writeBundle(ctx, outputFiles);
+          writes.push(CSS.writeBundle(ctx, outputFiles));
         }
 
         return (
@@ -94,7 +103,9 @@ export let create = async (ctx: Context): Promise<Compiler> => {
     // kickoff compilations in parallel
     let tasks = {
       js: subcompiler.js.compile().then(ok, errCancel),
-      server: subcompiler.server.compile().then(ok, errCancel),
+      serverBundles: subcompiler.serverBundles.map((server) =>
+        server.compile().then(ok, errCancel)
+      ),
     };
 
     // js compilation (implicitly writes artifacts/js)
@@ -111,22 +122,31 @@ export let create = async (ctx: Context): Promise<Compiler> => {
     });
     refs.manifestChannel.ok(manifest);
     options.onManifest?.(manifest);
-    writes.manifest = writeManifest(ctx.config, manifest);
+    writes.push(writeManifest(ctx.config, manifest));
 
     // server compilation
-    let server = await tasks.server;
-    if (!server.ok) throw error ?? server.error;
-    // artifacts/server
-    writes.server = Server.write(ctx.config, server.value);
+    await Promise.all(
+      tasks.serverBundles.map(async (promise, i) => {
+        let server = await promise;
+        if (!server.ok) throw error ?? server.error;
+        // artifacts/server
+        let { serverBuildPath } = serverBundles[i];
+        writes.push(Server.write(ctx.config, serverBuildPath, server.value));
+      })
+    );
 
-    await Promise.all(Object.values(writes));
+    await Promise.all(writes);
     return manifest;
   };
   return {
     compile,
     cancel,
     dispose: async () => {
-      await Promise.all(Object.values(subcompiler).map((sub) => sub.dispose()));
+      await Promise.all([
+        subcompiler.css.dispose(),
+        subcompiler.js.dispose(),
+        ...subcompiler.serverBundles.map((server) => server.dispose()),
+      ]);
     },
   };
 };

--- a/packages/remix-dev/compiler/server/plugins/entry.ts
+++ b/packages/remix-dev/compiler/server/plugins/entry.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from "esbuild";
 
 import type { Context } from "../../context";
+import type { RouteManifest } from "../../../config/routes";
 import {
   serverBuildVirtualModule,
   assetsManifestVirtualModule,
@@ -12,7 +13,10 @@ import {
  * for you to consume the build in a custom server entry that is also fed through
  * the compiler.
  */
-export function serverEntryModulePlugin({ config, options }: Context): Plugin {
+export function serverEntryModulePlugin(
+  { config, options }: Context,
+  routes: RouteManifest
+): Plugin {
   let filter = serverBuildVirtualModule.filter;
 
   return {
@@ -31,11 +35,11 @@ export function serverEntryModulePlugin({ config, options }: Context): Plugin {
           loader: "js",
           contents: `
 import * as entryServer from ${JSON.stringify(config.entryServerFilePath)};
-${Object.keys(config.routes)
+${Object.keys(routes)
   .map((key, index) => {
     // IMPORTANT: Any values exported from this generated module must also be
     // typed in `packages/remix-dev/server-build.ts` to avoid tsc errors.
-    let route = config.routes[key];
+    let route = routes[key];
     return `import * as route${index} from ${JSON.stringify(
       `./${route.file}`
     )};`;
@@ -52,9 +56,9 @@ ${Object.keys(config.routes)
   export const publicPath = ${JSON.stringify(config.publicPath)};
   export const entry = { module: entryServer };
   export const routes = {
-    ${Object.keys(config.routes)
+    ${Object.keys(routes)
       .map((key, index) => {
-        let route = config.routes[key];
+        let route = routes[key];
         return `${JSON.stringify(key)}: {
       id: ${JSON.stringify(route.id)},
       parentId: ${JSON.stringify(route.parentId)},

--- a/packages/remix-dev/compiler/server/plugins/manifest.ts
+++ b/packages/remix-dev/compiler/server/plugins/manifest.ts
@@ -2,6 +2,7 @@ import type { Plugin } from "esbuild";
 import jsesc from "jsesc";
 
 import type * as Channel from "../../../channel";
+import type { RouteManifest } from "../../../config/routes";
 import { type Manifest } from "../../../manifest";
 import { assetsManifestVirtualModule } from "../virtualModules";
 import { Cancel } from "../../cancel";
@@ -13,7 +14,9 @@ import { Cancel } from "../../cancel";
  */
 export function serverAssetsManifestPlugin(refs: {
   manifestChannel: Channel.Type<Manifest>;
-}): Plugin {
+},
+  routes: RouteManifest
+): Plugin {
   let filter = assetsManifestVirtualModule.filter;
 
   return {
@@ -29,8 +32,19 @@ export function serverAssetsManifestPlugin(refs: {
       build.onLoad({ filter }, async () => {
         let manifest = await refs.manifestChannel.result;
         if (!manifest.ok) throw new Cancel("server");
+
+        // Filter out the routes that are not in this bundle
+        let manifestWithRoutes = { ...manifest.value };
+        let manifestRoutes = { ...manifest.value.routes };
+        for (let id in manifestRoutes) {
+          if (!(id in routes)) {
+            delete manifestRoutes[id];
+          }
+        }
+        manifestWithRoutes.routes = manifestRoutes;
+
         return {
-          contents: `export default ${jsesc(manifest.value, {
+          contents: `export default ${jsesc(manifestWithRoutes, {
             es6: true,
           })};`,
           loader: "js",

--- a/packages/remix-dev/compiler/server/plugins/routes.ts
+++ b/packages/remix-dev/compiler/server/plugins/routes.ts
@@ -4,18 +4,22 @@ import type esbuild from "esbuild";
 
 import { getLoaderForFile } from "../../utils/loaders";
 import type { Context } from "../../context";
+import type { RouteManifest } from "../../../config/routes";
 
 /**
  * This plugin loads route modules for the server build and prevents errors
  * while adding new files in development mode.
  */
-export function serverRouteModulesPlugin({ config }: Context): esbuild.Plugin {
+export function serverRouteModulesPlugin(
+  { config }: Context,
+  routes: RouteManifest
+): esbuild.Plugin {
   return {
     name: "server-route-modules",
     setup(build) {
       let routeFiles = new Set(
-        Object.keys(config.routes).map((key) =>
-          path.resolve(config.appDirectory, config.routes[key].file)
+        Object.keys(routes).map((key) =>
+          path.resolve(config.appDirectory, routes[key].file)
         )
       );
 

--- a/packages/remix-dev/compiler/server/write.ts
+++ b/packages/remix-dev/compiler/server/write.ts
@@ -6,9 +6,10 @@ import type { RemixConfig } from "../../config";
 
 export async function write(
   config: RemixConfig,
+  serverBuildPath: string,
   outputFiles: esbuild.OutputFile[]
 ) {
-  await fse.ensureDir(path.dirname(config.serverBuildPath));
+  await fse.ensureDir(path.dirname(serverBuildPath));
 
   for (let file of outputFiles) {
     if (file.path.endsWith(".js") || file.path.endsWith(".mjs")) {
@@ -32,7 +33,7 @@ export async function write(
     } else {
       let assetPath = path.join(
         config.assetsBuildDirectory,
-        file.path.replace(path.dirname(config.serverBuildPath), "")
+        file.path.replace(path.dirname(serverBuildPath), "")
       );
 
       // Don't write CSS bundle from server build to browser assets directory,


### PR DESCRIPTION
This adds the ability to split up the server-side build into multiple bundles via a new config property: `serverBundles`.

Example:

```js
  serverBundles: [
    { serverBuildPath: 'build/build1.js', routes: ['routes/index', 'routes/about'] },
    { serverBuildPath: 'build/build2.js', routes: ['routes/generate', 'routes/error'] }
  ],
```

When `serverBundles` is defined, it takes precedence over the top-level `serverBuildPath` property, since each "bundle" entry can define its output file path.

Related to Discussion: [#5405](https://github.com/remix-run/remix/discussions/5405#discussioncomment-4990250)

- [ ] Docs
- [ ] Tests

I will add docs / tests if this proposal is agreed upon.

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
