### PR TITLE
chore: fix `deduplicate-yarn` workflow

### DIFF
--- a/.github/workflows/deduplicate-yarn.yml
+++ b/.github/workflows/deduplicate-yarn.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   deduplicate:
     if: github.repository == 'remix-run/remix'


### PR DESCRIPTION
This should fix the workflow normally 🙏

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs