### PR TITLE
feat(react): export Navigation type

### DIFF
--- a/.changeset/quiet-lemons-fold.md
+++ b/.changeset/quiet-lemons-fold.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": minor
+---
+
+Export the `Navigation` type returned from `useNavigation`

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -8,6 +8,7 @@ export type {
   FormProps,
   Location,
   NavigateFunction,
+  Navigation,
   Params,
   Path,
   ShouldRevalidateFunction,


### PR DESCRIPTION
The `Navigation` type is exported from react-router but wasn't re-exported from Remix. While it's possible for consumers to get the type via `ReturnType<typeof useNavigation>`, this is much more ergonomic and matches the expectation set elsewhere in Remix, e.g. both `useFetcher` and its `Fetcher` return type are exposed.

Fixes #3866