### PR TITLE
fix(react): fix useLoaderData types in Yarn PnP

### DIFF
--- a/.changeset/useloaderdata-types-yarn-pnp.md
+++ b/.changeset/useloaderdata-types-yarn-pnp.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Fix types for `useLoaderData` when using Yarn PnP

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -17,10 +17,10 @@
   "module": "dist/esm/index.js",
   "dependencies": {
     "@remix-run/router": "1.7.2",
+    "@remix-run/server-runtime": "1.19.3",
     "react-router-dom": "6.14.2"
   },
   "devDependencies": {
-    "@remix-run/server-runtime": "1.19.3",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.3.0",
     "@types/react": "^18.0.15",


### PR DESCRIPTION
Fixes #6994

The `useLoaderData` return type depends on access to the `SerializeFrom` type exported by `@remix-run/server-runtime`. Since this package is listed as a dev dependency of `@remix-run/react` rather than a regular dependency, this type isn't currently available to consumers when running Yarn PnP.