### PR TITLE
feat(remix-react): export `PrefetchBehavior` type

### DIFF
--- a/.changeset/sixty-insects-tell.md
+++ b/.changeset/sixty-insects-tell.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": minor
+---
+
+Export `PrefetchBehavior` type

--- a/contributors.yml
+++ b/contributors.yml
@@ -574,3 +574,4 @@
 - AlemTuzlak
 - ledniy
 - TrySound
+- kinxori

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -141,8 +141,9 @@ export function RemixRouteError({ id }: { id: string }) {
  * - "intent": Fetched when the user focuses or hovers the link
  * - "render": Fetched when the link is rendered
  * - "none": Never fetched
+ * - "viewport": Fetches while the link is in the viewport
  */
-type PrefetchBehavior = "intent" | "render" | "none" | "viewport";
+export type PrefetchBehavior = "intent" | "render" | "none" | "viewport";
 
 export interface RemixLinkProps extends LinkProps {
   prefetch?: PrefetchBehavior;

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -53,6 +53,7 @@ export {
 
 export type {
   AwaitProps,
+  PrefetchBehavior,
   RouteMatch,
   RemixNavLinkProps as NavLinkProps,
   RemixLinkProps as LinkProps,


### PR DESCRIPTION
…om ./components and ./index

<!--

Hey! ✌️ This is my first contribution as a developer. I think I messed up with the naming of the branch 😅.

(I added my name to the contributors.yml 👀 at line 573)

👉  Issue:

This PR is about importing/exporting the right Type for the attribute "prefetch" used un <Link/>. As for the current version of Remix, to add types you would have to do something like this:

`import { Link } from "@remix-run/react" 

export default function LinkComponent({ 
to, 
prefetch 
}:{ 
to?: string; 
prefetch?: "none" | "intent" | "render" | "viewport" | undefined 
} ){

return <Link to={to} prefetch={prefetch} > Hello world! </Link>

}
`
Typescript sends a message telling me to use "PrefetchBehavior" type instead but is not exported to actually use it.

👉 Solution: 

To solve this, I added a few words to 2 files. 

1. packages > remix-react > components.tsx

In this file, I added the line 204 which complements with the documentation of the usage of prefetch="viewport" and  in line 206 I added the word "export" at the beginning of the `type PrefetchBehavior = "intent" | "render" | "none" | "viewport"; `

This will export the PrefetchBehavior.

2. packages > remix-react > index.tsx 

In this file I added the "PrefetchBehavior" to the exportation of types in line 55.

This way the type is exported to use it as intended. 

👉  Testing Strategy:

In the Remix Discord server I was given permission to omit the testing due to the very small change. 

Either way I tried to test this in a very simple way with a local project. 

Basically I applied the same changes above to my node_modules. Then test the importation/exportation and It worked! 🥳

If you guys need anything more to simplify things out, let me know! 

Regards! ✌️

-->
