### PR TITLE
docs(tutorials/blog): fix code highlighting

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -422,6 +422,7 @@
 - plastic041
 - plondon
 - pmbanugo
+- prasook-jain
 - pratikdevdas
 - princerajroy
 - prvnbist

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -856,7 +856,7 @@ Notice we don't return a redirect this time, we actually return the errors. Thes
 
 💿 Add validation messages to the UI
 
-```tsx filename=app/routes/posts.admin.new.tsx lines=[3,10,17-19,26-28,35-39]
+```tsx filename=app/routes/posts.admin.new.tsx lines=[3,11,18-20,27-29,36-40]
 import type { ActionArgs } from "@remix-run/node";
 import { redirect, json } from "@remix-run/node";
 import { Form, useActionData } from "@remix-run/react";


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->
At present the diff highlighted in the blog docs is incorrect and confusing, I have updated the line number to show the correct highlighted diff:

<img width="1512" alt="Screenshot 2023-08-12 at 11 00 52 PM" src="https://github.com/remix-run/remix/assets/5060226/62ff92c9-226c-4e14-a367-9f405c115571">

page link: [second last code block in actions section](https://remix.run/docs/en/main/tutorials/blog#actions)

Closes: #

- [x] Docs
- [ ] Tests


