### PR TITLE
chore: update `esbuild`

### DIFF
--- a/packages/create-remix/package.json
+++ b/packages/create-remix/package.json
@@ -35,7 +35,7 @@
     "@types/gunzip-maybe": "^1.4.0",
     "@types/node-fetch": "^2.5.7",
     "@types/tar-fs": "^2.0.1",
-    "esbuild": "0.17.6",
+    "esbuild": "^0.17.19",
     "esbuild-register": "^3.3.2",
     "fs-extra": "^10.0.0",
     "msw": "^1.2.3",

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -36,7 +36,7 @@
     "chalk": "^4.1.2",
     "chokidar": "^3.5.1",
     "dotenv": "^16.0.0",
-    "esbuild": "0.17.6",
+    "esbuild": "^0.17.19",
     "esbuild-plugins-node-modules-polyfill": "^1.3.0",
     "execa": "5.1.1",
     "exit-hook": "2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5098,7 +5098,7 @@ esbuild@0.17.6:
     "@esbuild/win32-ia32" "0.17.6"
     "@esbuild/win32-x64" "0.17.6"
 
-esbuild@^0.17.5:
+esbuild@^0.17.19, esbuild@^0.17.5:
   version "0.17.19"
   resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz#087a727e98299f0462a3d0bcdd9cd7ff100bd955"
   integrity sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==


### PR DESCRIPTION
This should trigger the `deduplicate-yarn` workflow and the `yarn.lock` file should be deduplicated now