### PR TITLE
chore: update `@types/cacache`

### DIFF
--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@remix-run/serve": "1.19.3",
-    "@types/cacache": "^15.0.0",
+    "@types/cacache": "^17.0.0",
     "@types/gunzip-maybe": "^1.4.0",
     "@types/jsesc": "^3.0.1",
     "@types/lodash.debounce": "^4.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2340,10 +2340,10 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/cacache@^15.0.0":
-  version "15.0.1"
-  resolved "https://registry.npmjs.org/@types/cacache/-/cacache-15.0.1.tgz"
-  integrity sha512-JhL2GFJuHMx4RMg4z0XfXB4ZkKdyiOaOLpjoYMXcyKfrkF3IBXNZBj6/Peo9zX/7PPHyfI63NWVD589cI2YTzg==
+"@types/cacache@^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.npmjs.org/@types/cacache/-/cacache-17.0.0.tgz#6e3badad0e7e7e674f3479d55bca83db4d683f91"
+  integrity sha512-4BfoYFzkHdmINTyUIX9MSbKUkntVPR082FRnNc+5KlvvebrcxWWhfP3MRQ28QgfFncP3fTKCuemDYJqFjmWEAA==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
This should trigger the `deduplicate-yarn` workflow and the `yarn.lock` file should be deduplicated now