### PR TITLE
Fix false-positive resource route identification on doc requests

### DIFF
--- a/.changeset/resource-route-boundary-only.md
+++ b/.changeset/resource-route-boundary-only.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+Fix false-positive resource route classification on document requests for routes that only export an `ErrorBoundary`

--- a/integration/resource-routes-test.ts
+++ b/integration/resource-routes-test.ts
@@ -27,6 +27,7 @@ test.describe("loader in an app", async () => {
           export default () => (
             <>
               <Link to="/redirect">Redirect</Link>
+              <Link to="/some-404-path">404 route</Link>
               <Form action="/redirect-to" method="post">
                 <input name="destination" defaultValue="/redirect-destination" />
                 <button type="submit">Redirect</button>
@@ -109,6 +110,19 @@ test.describe("loader in an app", async () => {
             return json({ ok: true });
           }
         `,
+        "app/routes/$.tsx": js`
+          import { json } from "@remix-run/node";
+          import { useRouteError } from "@remix-run/react";
+          export function loader({ request }) {
+            throw json({ message: new URL(request.url).pathname + ' not found' }, {
+              status: 404
+            });
+          }
+          export function ErrorBoundary() {
+            let error = useRouteError();
+            return <pre>{error.status + ' ' + error.data.message}</pre>;
+          }
+        `,
       },
     });
     appFixture = await createAppFixture(fixture, ServerMode.Test);
@@ -166,6 +180,16 @@ test.describe("loader in an app", async () => {
       expect(await res.text()).toEqual(
         "Unexpected Server Error\n\nError: Oh noes!"
       );
+    });
+
+    test("should let loader throw to it's own boundary without a default export", async ({
+      page,
+    }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/", true);
+      await app.clickLink("/some-404-path");
+      let html = await app.getHtml();
+      expect(html).toMatch("404 /some-404-path not found");
     });
   }
 

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -88,7 +88,8 @@ export const createRequestHandler: CreateRequestHandlerFunction = (
       }
     } else if (
       matches &&
-      matches[matches.length - 1].route.module.default == null
+      matches[matches.length - 1].route.module.default == null &&
+      matches[matches.length - 1].route.module.ErrorBoundary == null
     ) {
       response = await handleResourceRequestRR(
         serverMode,


### PR DESCRIPTION
This adds the corresponding logic from #6125 (closing #6106) for document requests.  A resource route should be a route that exports _no_ UI components, not just one that doesn't export a happy path UI component.

This way it's possible to do a self-contained splat route 404 page.  Previously, the below would be interpreted as a resource route and just return the raw text as a response and ignore the `ErrorBoundary`.

```jsx
// $.jsx
import { useRouteError } from "react-router-dom";

export async function loader({ request }) {
  throw new Response(`${new URL(request.url).pathname} not found`, {
    status: 404,
    statusText: "Not Found",
  });
}

export function ErrorBoundary() {
  let error = useRouteError();
  return (
    <>
      <h1>
        {error.status} {error.statusText}
      </h1>
      <p>{error.data}</p>
    </>
  );
}
```