### PR TITLE
Docs Tutorial: params.slug could be undefined

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -19,6 +19,7 @@
 - Alarid
 - alex-ketch
 - alexmgrant
+- alexmuzenhardt
 - alextes
 - alexuxui
 - alireza-bonab

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -388,7 +388,9 @@ import { json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 
 export const loader = async ({ params }: LoaderArgs) => {
-  return json({ slug: params.slug });
+  if(params?.slug) {
+    return json({post: await getPost(params.slug)});
+  }
 };
 
 export default function PostSlug() {


### PR DESCRIPTION
Typescripts complains that params.slug could be string | undefined. A check would change this.
I also put the await getPost(params.slug) directly inside the object of the json-function. In the previous example we did this too and this would increase consistency.