### PR TITLE
fix(dev): stop remix dev when esbuild is not running

### DIFF
--- a/.changeset/fluffy-bananas-love.md
+++ b/.changeset/fluffy-bananas-love.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+stop remix dev when esbuild is not running

--- a/packages/remix-dev/compiler/watch.ts
+++ b/packages/remix-dev/compiler/watch.ts
@@ -47,6 +47,18 @@ export async function watch(
   let compiler = await Compiler.create(ctx);
   let compile = () =>
     compiler.compile({ onManifest: onBuildManifest }).catch((thrown) => {
+      if (
+        thrown instanceof Error &&
+        thrown.message === "The service is no longer running"
+      ) {
+        ctx.logger.error("esbuild is no longer running", {
+          details: [
+            "Most likely, your machine ran out of memory and killed the esbuild process",
+            "that `remix dev` relies on for builds and rebuilds.",
+          ],
+        });
+        process.exit(1);
+      }
       logThrown(thrown);
       return undefined;
     });


### PR DESCRIPTION
Closes #6782

<img width="859" alt="Screenshot 2023-08-14 at 1 50 07 PM" src="https://github.com/remix-run/remix/assets/1477317/d91c5191-9d95-4b4b-89b8-d1c37f1d2afe">
