### PR TITLE
docs(utils/cookies): remove `domain` cookie option

### DIFF
--- a/docs/utils/cookies.md
+++ b/docs/utils/cookies.md
@@ -99,7 +99,6 @@ Cookies have [several attributes][cookie-attrs] that control when they expire, h
 ```ts
 const cookie = createCookie("user-prefs", {
   // These are defaults for this cookie.
-  domain: "remix.run",
   path: "/",
   sameSite: "lax",
   httpOnly: true,
@@ -165,7 +164,6 @@ import { createCookie } from "@remix-run/node"; // or cloudflare/deno
 
 const cookie = createCookie("cookie-name", {
   // all of these are optional defaults that can be overridden at runtime
-  domain: "remix.run",
   expires: new Date(Date.now() + 60_000),
   httpOnly: true,
   maxAge: 60,


### PR DESCRIPTION
I'd recommend leaving the domain out of these examples
- it makes them less copy pastable, as it's one more thing folks have to read through and change
- domains are optional

When you don't specify a cookie domain, it automatically assigns itself to the host's domain plus any subdomains (such as www). This is expected behavior for most people.

If folks assume the domain is mandatory, it leads to complicated environment variable checks to work on localhost and staging and prod.

If the Domain field is set incorrectly, "restrict cookie to specific subdomain" is a much more googlable problem than "cookie returned in response but doesn't set", and for that reason I propose we default to the less restrictive empty value. 

This PR is prompted from a help thread in Discord on the issue https://discord.com/channels/770287896669978684/1140638236390211664

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
