### PR TITLE
templates: ignore `metafile.*` files

### DIFF
--- a/templates/arc/.gitignore
+++ b/templates/arc/.gitignore
@@ -1,10 +1,10 @@
-.DS_Store
 node_modules
 
 /.cache
+/public/build
 /server/index.mjs
 /server/index.mjs.map
-/public/build
+/server/metafile.*
 preferences.arc
 sam.json
 sam.yaml

--- a/templates/arc/app.arc
+++ b/templates/arc/app.arc
@@ -1,18 +1,21 @@
 @app
 remix-architect-app
 
+@aws
+runtime nodejs16.x
+# concurrency 1
+# memory 1152
+# profile default
+# region us-west-1
+# timeout 30
+
 @http
 /*
   method any
   src server
 
-@static
-
 @plugins
 plugin-remix
   src plugin-remix.js
 
-# @aws
-# profile default
-# region us-west-1
-  
+@static

--- a/templates/arc/server/config.arc
+++ b/templates/arc/server/config.arc
@@ -1,5 +1,0 @@
-@aws
-runtime nodejs16.x
-# memory 1152
-# timeout 30
-# concurrency 1

--- a/templates/cloudflare-pages/.gitignore
+++ b/templates/cloudflare-pages/.gitignore
@@ -1,8 +1,8 @@
-.DS_Store
 node_modules
 
 /.cache
 /functions/\[\[path\]\].js
 /functions/\[\[path\]\].js.map
+/functions/metafile.*
 /public/build
 .dev.vars

--- a/templates/express/.gitignore
+++ b/templates/express/.gitignore
@@ -1,4 +1,3 @@
-.DS_Store
 node_modules
 
 /.cache

--- a/templates/netlify/.gitignore
+++ b/templates/netlify/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 
 /.cache
-/public/build
 /.netlify
+/public/build
 .env

--- a/templates/vercel/.gitignore
+++ b/templates/vercel/.gitignore
@@ -1,11 +1,11 @@
 node_modules
 
-.cache
-.env
-.vercel
-.output
-
-/build/
-/public/build
+/.cache
+/.output
+/.vercel
 /api/index.js
 /api/index.js.map
+/api/metafile.*
+/build
+/public/build
+.env


### PR DESCRIPTION
I originally just wanted to ignore the `metafile.*` files, but since the entire build directory is generated I figured it would be better to ignore it entirely 🤷‍♂️

---

Supersedes #7090