### PR TITLE
chore(remix-dev): stop ignoring missing `react-dom/client` for React 17

### DIFF
--- a/packages/remix-dev/config/defaults/entry.dev.ts
+++ b/packages/remix-dev/config/defaults/entry.dev.ts
@@ -6,7 +6,7 @@ export default () => {
   import("react/jsx-dev-runtime");
   import("react/jsx-runtime");
   import("react-dom");
-  import("react-dom/client").catch();
+  import("react-dom/client");
   import("react-refresh/runtime");
   import("@remix-run/react");
   import("remix:hmr");


### PR DESCRIPTION
This basically reverts @pcattori's #6725 now that we only support React 18

Should have been part of #7121