### PR TITLE
fix(dev): improve minified CSS compatibility

### DIFF
--- a/.changeset/improve-minified-css-compatibility.md
+++ b/.changeset/improve-minified-css-compatibility.md
@@ -1,0 +1,7 @@
+---
+"@remix-run/dev": patch
+---
+
+Improve browser compatibility of minified CSS
+
+We now minify CSS targeting the Remix browser support baseline (i.e. anything that supports [ES module scripts](https://caniuse.com/es6-module)), whereas previously CSS was minified using esbuild's default "esnext" target. This meant that CSS in the production build could be using properties that are unsupported in some browsers. This change also means you now have more control over CSS transformations using the built-in PostCSS support since they won't be reversed by esbuild's minification.

--- a/packages/remix-dev/compiler/css/bundle.ts
+++ b/packages/remix-dev/compiler/css/bundle.ts
@@ -6,9 +6,9 @@ import postcssDiscardDuplicates from "postcss-discard-duplicates";
 
 import type { Context } from "../context";
 
-export let write = async (ctx: Context, outputFiles: esbuild.OutputFile[]) => {
+export async function write(ctx: Context, outputFiles: esbuild.OutputFile[]) {
   let cssBundleFile = outputFiles.find((outputFile) =>
-    isBundle(ctx, outputFile, ".css")
+    isCssBundleFile(ctx, outputFile, ".css")
   );
   if (!cssBundleFile) return;
 
@@ -23,7 +23,7 @@ export let write = async (ctx: Context, outputFiles: esbuild.OutputFile[]) => {
     to: cssBundlePath,
     map: ctx.options.sourcemap && {
       prev: outputFiles.find((outputFile) =>
-        isBundle(ctx, outputFile, ".css.map")
+        isCssBundleFile(ctx, outputFile, ".css.map")
       )?.text,
       inline: false,
       annotation: false,
@@ -45,16 +45,45 @@ export let write = async (ctx: Context, outputFiles: esbuild.OutputFile[]) => {
         await fse.writeFile(asset.path, asset.contents);
       }),
   ]);
-};
+}
 
-export let isBundle = (
+function isCssBundleFile(
   ctx: Context,
   outputFile: esbuild.OutputFile,
   extension: ".css" | ".css.map"
-): boolean => {
+): boolean {
   return (
     path.dirname(outputFile.path) === ctx.config.assetsBuildDirectory &&
     path.basename(outputFile.path).startsWith("css-bundle") &&
     outputFile.path.endsWith(extension)
   );
-};
+}
+
+interface GroupedCssBundleFiles {
+  css?: esbuild.OutputFile;
+  sourceMap?: esbuild.OutputFile;
+  assets: esbuild.OutputFile[];
+}
+
+export function groupCssBundleFiles(
+  ctx: Context,
+  files: esbuild.OutputFile[]
+): GroupedCssBundleFiles {
+  let groupedFiles: GroupedCssBundleFiles = {
+    css: undefined,
+    sourceMap: undefined,
+    assets: [],
+  };
+
+  for (let file of files) {
+    if (isCssBundleFile(ctx, file, ".css")) {
+      groupedFiles.css = file;
+    } else if (isCssBundleFile(ctx, file, ".css.map")) {
+      groupedFiles.sourceMap = file;
+    } else {
+      groupedFiles.assets.push(file);
+    }
+  }
+
+  return groupedFiles;
+}

--- a/packages/remix-dev/compiler/css/bundle.ts
+++ b/packages/remix-dev/compiler/css/bundle.ts
@@ -59,7 +59,7 @@ function isCssBundleFile(
   );
 }
 
-interface GroupedCssBundleFiles {
+type GroupedCssBundleFiles = {
   css?: esbuild.OutputFile;
   sourceMap?: esbuild.OutputFile;
   assets: esbuild.OutputFile[];

--- a/packages/remix-dev/compiler/css/compiler.ts
+++ b/packages/remix-dev/compiler/css/compiler.ts
@@ -4,6 +4,7 @@ import * as esbuild from "esbuild";
 import type { RemixConfig } from "../../config";
 import { getAppDependencies } from "../../dependencies";
 import { loaders } from "../utils/loaders";
+import { cssTarget } from "../utils/cssTarget";
 import { cssFilePlugin } from "../plugins/cssImports";
 import { absoluteCssUrlsPlugin } from "../plugins/absoluteCssUrlsPlugin";
 import { emptyModulesPlugin } from "../plugins/emptyModules";
@@ -17,7 +18,7 @@ import {
   cssBundleEntryModuleId,
 } from "./plugins/bundleEntry";
 import type { Context } from "../context";
-import { isBundle } from "./bundle";
+import { groupCssBundleFiles } from "./bundle";
 import { writeMetafile } from "../analysis";
 
 const getExternals = (config: RemixConfig): string[] => {
@@ -39,7 +40,7 @@ const getExternals = (config: RemixConfig): string[] => {
   return nodeBuiltins.filter((mod) => !dependencies.includes(mod));
 };
 
-const createEsbuildConfig = (ctx: Context): esbuild.BuildOptions => {
+const createCompilerEsbuildConfig = (ctx: Context): esbuild.BuildOptions => {
   return {
     entryPoints: {
       "css-bundle": cssBundleEntryModuleId,
@@ -58,7 +59,17 @@ const createEsbuildConfig = (ctx: Context): esbuild.BuildOptions => {
     tsconfig: ctx.config.tsconfigPath,
     mainFields: ["browser", "module", "main"],
     treeShaking: true,
-    minify: ctx.options.mode === "production",
+    // Minification is handled via a separate esbuild pass. This is because CSS
+    // minification takes into account the "target" option (e.g. the CSS
+    // properties top/bottom/left/right when used as a set will be minified to
+    // shorthand of "inset" if supported by the target browsers), but this
+    // option affects all code in the build, not just CSS. If we set the target
+    // too low, we get build errors when esbuild detects JS features that can't
+    // be transpiled for the specified target. By separating the minification of
+    // CSS files from the compilation of the entire module graph, we're better
+    // able to target the Remix browser support baseline, i.e. anything that
+    // supports ES module scripts: https://caniuse.com/es6-module
+    minify: false,
     entryNames: "[dir]/[name]-[hash]",
     chunkNames: "_shared/[name]-[hash]",
     assetNames: "_assets/[name]-[hash]",
@@ -90,19 +101,102 @@ const createEsbuildConfig = (ctx: Context): esbuild.BuildOptions => {
   };
 };
 
+const createCssProcessorEsbuildConfig = ({
+  ctx,
+  cssContents,
+  sourceMapContents,
+}: {
+  ctx: Context;
+  cssContents: string;
+  sourceMapContents: string | null;
+}): esbuild.BuildOptions => {
+  let sourceMapString = sourceMapContents
+    ? `/*# sourceMappingURL=data:application/json;base64,${Buffer.from(
+        sourceMapContents
+      ).toString("base64")} */`
+    : null;
+
+  let cssProcessorEntryId = ":contents"; // Could be anything, but this makes the output CSS comment look nicer - /* css-bundle::contents */
+  let cssProcessorEntryFilter = new RegExp(`^${cssProcessorEntryId}$`);
+
+  return {
+    entryPoints: { "css-bundle": cssProcessorEntryId }, // This ensures the generated file name starts with "css-bundle"
+    outdir: ctx.config.assetsBuildDirectory,
+    bundle: true,
+    // We only want to process the CSS bundle contents so anything else is external
+    external: ["*"],
+    logLevel: "silent",
+    sourcemap: ctx.options.sourcemap,
+    // As pointed out by https://github.com/evanw/esbuild/issues/2440, when tsconfig is set to
+    // `undefined`, esbuild will keep looking for a tsconfig.json recursively up. This unwanted
+    // behavior can only be avoided by creating an empty tsconfig file in the root directory.
+    tsconfig: ctx.config.tsconfigPath,
+    minify: ctx.options.mode === "production",
+    target: cssTarget,
+    entryNames: "[dir]/[name]-[hash]",
+    chunkNames: "_shared/[name]-[hash]",
+    assetNames: "_assets/[name]-[hash]",
+    publicPath: ctx.config.publicPath,
+    plugins: [
+      {
+        name: "css-processor-input",
+        setup(build) {
+          build.onResolve({ filter: cssProcessorEntryFilter }, ({ path }) => {
+            return {
+              path,
+              namespace: "css-bundle",
+            };
+          });
+
+          build.onLoad({ filter: cssProcessorEntryFilter }, async () => {
+            return {
+              loader: "css",
+              contents: [cssContents, sourceMapString]
+                .filter(Boolean)
+                .join("\n"),
+            };
+          });
+        },
+      },
+    ],
+  };
+};
+
 export let create = async (ctx: Context) => {
   let compiler = await esbuild.context({
-    ...createEsbuildConfig(ctx),
+    ...createCompilerEsbuildConfig(ctx),
     write: false,
     metafile: true,
   });
+
   let compile = async () => {
-    let { outputFiles, metafile } = await compiler.rebuild();
-    writeMetafile(ctx, "metafile.css.json", metafile);
-    let bundleOutputFile = outputFiles.find((outputFile) =>
-      isBundle(ctx, outputFile, ".css")
-    );
-    return { bundleOutputFile, outputFiles };
+    let rawResult = await compiler.rebuild();
+    writeMetafile(ctx, "metafile.css.json", rawResult.metafile);
+
+    let rawFiles = groupCssBundleFiles(ctx, rawResult.outputFiles);
+
+    // We hand the result to a 2nd esbuild pass to optionally handle CSS
+    // minification with its own "target" separate from the JS build. This
+    // happens in dev mode to keep dev and production builds as close as
+    // possible even though it's not strictly required.
+    let processedResult = rawFiles.css?.text
+      ? await esbuild.build({
+          ...createCssProcessorEsbuildConfig({
+            ctx,
+            cssContents: rawFiles.css.text,
+            sourceMapContents: rawFiles.sourceMap?.text ?? null,
+          }),
+          write: false,
+          metafile: false,
+        })
+      : null;
+
+    let processedFiles = processedResult?.outputFiles ?? [];
+
+    return {
+      bundleOutputFile: groupCssBundleFiles(ctx, processedFiles).css,
+      outputFiles: [...processedFiles, ...rawFiles.assets],
+    };
   };
   return {
     compile,

--- a/packages/remix-dev/compiler/plugins/cssImports.ts
+++ b/packages/remix-dev/compiler/plugins/cssImports.ts
@@ -8,6 +8,7 @@ import {
   getPostcssProcessor,
   populateDependenciesFromMessages,
 } from "../utils/postcss";
+import { cssTarget } from "../utils/cssTarget";
 import { absoluteCssUrlsPlugin } from "./absoluteCssUrlsPlugin";
 
 const isExtendedLengthPath = /^\\\\\?\\/;
@@ -74,7 +75,7 @@ export function cssFilePlugin(ctx: Context): esbuild.Plugin {
               platform,
               publicPath,
               sourceRoot,
-              target,
+              target: cssTarget,
               treeShaking,
               tsconfig,
               minify: ctx.options.mode === "production",

--- a/packages/remix-dev/compiler/plugins/cssImports.ts
+++ b/packages/remix-dev/compiler/plugins/cssImports.ts
@@ -42,7 +42,6 @@ export function cssFilePlugin(ctx: Context): esbuild.Plugin {
         nodePaths,
         platform,
         publicPath,
-        target,
       } = build.initialOptions;
 
       // eslint-disable-next-line prefer-let/prefer-let -- Avoid needing to repeatedly check for null since const can't be reassigned

--- a/packages/remix-dev/compiler/utils/cssTarget.ts
+++ b/packages/remix-dev/compiler/utils/cssTarget.ts
@@ -1,0 +1,13 @@
+// We use this as our CSS target to maximize compatibility during minification.
+// This is the minimum set of browsers that Remix supports due to their support
+// for ES module scripts: https://caniuse.com/es6-module
+import type { BuildOptions } from "esbuild";
+
+export const cssTarget: BuildOptions["target"] = [
+  "chrome61",
+  "edge16",
+  "safari10.1",
+  "ios11",
+  "firefox60",
+  "opera48",
+];


### PR DESCRIPTION
Fixes #6114

As the changeset says, we now minify CSS targeting the Remix browser support baseline (i.e. anything that supports [ES module scripts](https://caniuse.com/es6-module)), whereas previously CSS was minified using esbuild's default "esnext" target. This meant that CSS in the production build could be using properties that are unsupported in some browsers.

This change also means you now have more control over CSS transformations using the built-in PostCSS support since they won't be reversed by esbuild's minification.