### PR TITLE
Fix bug in create-remix git repo path collisions

### DIFF
--- a/packages/create-remix/copy-template.ts
+++ b/packages/create-remix/copy-template.ts
@@ -312,7 +312,15 @@ async function downloadAndExtractTarball(
           header.name = header.name.replace(`${originalDirName}/`, "");
 
           if (filePath) {
-            if (header.name.startsWith(filePath)) {
+            // Include trailing slash on startsWith when filePath doesn't include
+            // it so something like `templates/remix` doesn't inadvertently
+            // include `templates/remix-javascript/*` files
+            if (
+              (filePath.endsWith(path.posix.sep) &&
+                header.name.startsWith(filePath)) ||
+              (!filePath.endsWith(path.posix.sep) &&
+                header.name.startsWith(filePath + path.posix.sep))
+            ) {
               filePathHasFiles = true;
               header.name = header.name.replace(filePath, "");
             } else {


### PR DESCRIPTION
```
npx create-remix@nightly --template https://github.com/remix-run/remix/tree/dev/templates/remix
```

this was inadvertently extracting stuff from `templates/remix-javascript` into a `-javascript/` folder due to the `startsWith` check passing