### PR TITLE
fix(dev): avoid Cloudflare manifest import warning

### DIFF
--- a/.changeset/silence-cloudfare-manifest-warnings.md
+++ b/.changeset/silence-cloudfare-manifest-warnings.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Silence warnings when importing Cloudflare's built-in `__STATIC_CONTENT_MANIFEST` module

--- a/packages/remix-dev/compiler/server/plugins/bareImports.ts
+++ b/packages/remix-dev/compiler/server/plugins/bareImports.ts
@@ -92,6 +92,9 @@ export function serverBareModulesPlugin(ctx: Context): Plugin {
         if (
           !isNodeBuiltIn(packageName) &&
           !/\bnode_modules\b/.test(importer) &&
+          // Silence spurious warnings when importing Cloudflare's built-in
+          // static content manifest module
+          packageName !== "__STATIC_CONTENT_MANIFEST" &&
           // Silence spurious warnings when using Yarn PnP. Yarn PnP doesn’t use
           // a `node_modules` folder to keep its dependencies, so the above check
           // will always fail.


### PR DESCRIPTION
Consumers can avoid bundling Cloudflare's built-in `__STATIC_CONTENT_MANIFEST` module with the following Remix config which is part of the Cloudflare Workers template:

```ts
  serverDependenciesToBundle: [
    /^(?!.*\b__STATIC_CONTENT_MANIFEST\b).*$/,
  ],
```

However, they still receive a warning in the terminal telling them that they didn't install it because `require.resolve` can't find it. In the same way that we ignore Node built-in modules, this PR extends our logic to ignore this Cloudflare built-in module.