### PR TITLE
test(remix-server-runtime): remove polyfill references

### DIFF
--- a/packages/remix-server-runtime/__tests__/formData-test.ts
+++ b/packages/remix-server-runtime/__tests__/formData-test.ts
@@ -1,9 +1,3 @@
-import {
-  Request as NodeRequest,
-  FormData as NodeFormData,
-} from "@remix-run/web-fetch";
-import { Blob, File } from "@remix-run/web-file";
-
 import { parseMultipartFormData } from "../formData";
 
 class CustomError extends Error {
@@ -14,12 +8,12 @@ class CustomError extends Error {
 
 describe("parseMultipartFormData", () => {
   it("can use a custom upload handler", async () => {
-    let formData = new NodeFormData();
+    let formData = new FormData();
     formData.set("a", "value");
     formData.set("blob", new Blob(["blob".repeat(1000)]), "blob.txt");
     formData.set("file", new File(["file".repeat(1000)], "file.txt"));
 
-    let req = new NodeRequest("https://test.com", {
+    let req = new Request("https://test.com", {
       method: "post",
       body: formData,
     });
@@ -48,12 +42,12 @@ describe("parseMultipartFormData", () => {
   });
 
   it("can return undefined", async () => {
-    let formData = new NodeFormData();
+    let formData = new FormData();
     formData.set("a", "value");
     formData.set("blob", new Blob(["blob".repeat(1000)]), "blob.txt");
     formData.set("file", new File(["file".repeat(1000)], "file.txt"));
 
-    let req = new NodeRequest("https://test.com", {
+    let req = new Request("https://test.com", {
       method: "post",
       body: formData,
     });
@@ -69,10 +63,10 @@ describe("parseMultipartFormData", () => {
   });
 
   it("can throw errors in upload handlers", async () => {
-    let formData = new NodeFormData();
+    let formData = new FormData();
     formData.set("blob", new Blob(["blob"]), "blob.txt");
 
-    let req = new NodeRequest("https://test.com", {
+    let req = new Request("https://test.com", {
       method: "post",
       body: formData,
     });
@@ -92,12 +86,12 @@ describe("parseMultipartFormData", () => {
 
   describe("stream should propagate events", () => {
     it("when controller errors", async () => {
-      let formData = new NodeFormData();
+      let formData = new FormData();
       formData.set("a", "value");
       formData.set("blob", new Blob(["blob".repeat(1000)]), "blob.txt");
       formData.set("file", new File(["file".repeat(1000)], "file.txt"));
 
-      let underlyingRequest = new NodeRequest("https://test.com", {
+      let underlyingRequest = new Request("https://test.com", {
         method: "post",
         body: formData,
       });
@@ -113,7 +107,7 @@ describe("parseMultipartFormData", () => {
         },
       });
 
-      let req = new NodeRequest("https://test.com", {
+      let req = new Request("https://test.com", {
         method: "post",
         body,
         headers: underlyingRequest.headers,
@@ -132,12 +126,12 @@ describe("parseMultipartFormData", () => {
     });
 
     it("when controller is closed", async () => {
-      let formData = new NodeFormData();
+      let formData = new FormData();
       formData.set("a", "value");
       formData.set("blob", new Blob(["blob".repeat(1000)]), "blob.txt");
       formData.set("file", new File(["file".repeat(1000)], "file.txt"));
 
-      let underlyingRequest = new NodeRequest("https://test.com", {
+      let underlyingRequest = new Request("https://test.com", {
         method: "post",
         body: formData,
       });
@@ -153,7 +147,7 @@ describe("parseMultipartFormData", () => {
         },
       });
 
-      let req = new NodeRequest("https://test.com", {
+      let req = new Request("https://test.com", {
         method: "post",
         body,
         headers: underlyingRequest.headers,

--- a/packages/remix-server-runtime/__tests__/setup.ts
+++ b/packages/remix-server-runtime/__tests__/setup.ts
@@ -1,2 +1,3 @@
 import { installGlobals } from "@remix-run/node";
+
 installGlobals();

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -25,7 +25,6 @@
     "type-fest": "^4.0.0"
   },
   "devDependencies": {
-    "@remix-run/web-file": "^3.0.3",
     "@types/set-cookie-parser": "^2.4.1",
     "typescript": "^5.1.6"
   },


### PR DESCRIPTION
Just like we did in @jacob-ebey's #7230
We can do this because we call `installGlobals` for our tests
https://github.com/remix-run/remix/blob/6b6bb39185b6be73eaf8d0aa7ddd0fd39a17e3cf/packages/remix-server-runtime/__tests__/setup.ts#L2