### PR TITLE
feat(remix-node): use built-in `atob` & `btoa`

### DIFF
--- a/.changeset/early-trains-fold.md
+++ b/.changeset/early-trains-fold.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/node": patch
+---
+
+Remove `atob`/`btoa` polyfills in favor of built-in versions

--- a/packages/remix-node/base64.ts
+++ b/packages/remix-node/base64.ts
@@ -1,7 +1,0 @@
-export function atob(a: string): string {
-  return Buffer.from(a, "base64").toString("binary");
-}
-
-export function btoa(b: string): string {
-  return Buffer.from(b, "binary").toString("base64");
-}

--- a/packages/remix-node/globals.ts
+++ b/packages/remix-node/globals.ts
@@ -14,7 +14,6 @@ import {
   WritableStreamDefaultWriter as NodeWritableStreamDefaultWriter,
 } from "@remix-run/web-stream";
 
-import { atob, btoa } from "./base64";
 import {
   Blob as NodeBlob,
   File as NodeFile,
@@ -32,9 +31,6 @@ declare global {
     }
 
     interface Global {
-      atob: typeof atob;
-      btoa: typeof btoa;
-
       Blob: typeof Blob;
       File: typeof File;
 
@@ -51,9 +47,6 @@ declare global {
 }
 
 export function installGlobals() {
-  global.atob = atob;
-  global.btoa = btoa;
-
   global.Blob = NodeBlob;
   global.File = NodeFile;
 


### PR DESCRIPTION
- https://nodejs.org/dist/latest-v20.x/docs/api/globals.html#atobdata
- https://nodejs.org/dist/latest-v20.x/docs/api/globals.html#btoadata