### PR TITLE
refactor: use native `Blob` class

### DIFF
--- a/.changeset/use-native-blob.md
+++ b/.changeset/use-native-blob.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/node": patch
+---
+
+Use native `Blob` cleass instead of polyfill

--- a/packages/remix-node/fetch.ts
+++ b/packages/remix-node/fetch.ts
@@ -7,7 +7,7 @@ import {
 } from "@remix-run/web-fetch";
 export { FormData } from "@remix-run/web-fetch";
 // @ts-ignore
-export { File, Blob } from "@remix-run/web-file";
+export { File } from "@remix-run/web-file";
 
 type NodeHeadersInit = ConstructorParameters<typeof WebHeaders>[0];
 type NodeResponseInfo = ConstructorParameters<typeof WebResponse>[0];

--- a/packages/remix-node/globals.ts
+++ b/packages/remix-node/globals.ts
@@ -5,7 +5,6 @@ import {
 
 import { atob, btoa } from "./base64";
 import {
-  Blob as NodeBlob,
   File as NodeFile,
   FormData as NodeFormData,
   Headers as NodeHeaders,
@@ -24,7 +23,6 @@ declare global {
       atob: typeof atob;
       btoa: typeof btoa;
 
-      Blob: typeof Blob;
       File: typeof File;
 
       Headers: typeof Headers;
@@ -43,7 +41,6 @@ export function installGlobals() {
   global.atob = atob;
   global.btoa = btoa;
 
-  global.Blob = NodeBlob;
   global.File = NodeFile;
 
   global.Headers = NodeHeaders as typeof Headers;


### PR DESCRIPTION
https://nodejs.org/dist/latest-v20.x/docs/api/globals.html#class-blob

Unfortunately I couldn't get rid of `File` usage as that's only added in Node v20: https://nodejs.org/dist/latest-v20.x/docs/api/globals.html#class-file