### PR TITLE
Improve Session API docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,3 +1,4 @@
+- aaronadamsCA
 - aaronpowell96
 - aaronshaf
 - abereghici

--- a/docs/utils/sessions.md
+++ b/docs/utils/sessions.md
@@ -472,7 +472,7 @@ export async function action({
 
 Now we can read the message in a loader.
 
-<docs-info>You must commit the session whenever you read a `flash`. This is different than what you might be used to, where some type of middleware automatically sets the cookie header for you.</docs-info>
+<docs-info>When using `cookieSessionStorage`, you must commit the session after you `session.get()` a flash value. This is different than what you might be used to, where some type of middleware automatically sets the cookie header for you.</docs-info>
 
 ```tsx
 import { json } from "@remix-run/node"; // or cloudflare/deno
@@ -539,7 +539,7 @@ Removes a value from the session.
 session.unset("name");
 ```
 
-<docs-info>When using cookieSessionStorage, you must commit the session whenever you `unset`</docs-info>
+<docs-info>When using `cookieSessionStorage`, you must commit the session after you `session.unset()` a value. This is different than what you might be used to, where some type of middleware automatically sets the cookie header for you.</docs-info>
 
 ```tsx
 export async function loader({ request }: LoaderArgs) {


### PR DESCRIPTION
Better clarify that it's only when using `cookieSessionStorage` that you need to commit a session after reading a flash value or unsetting a value.