### PR TITLE
fix(dev): remove unused css-bundle path resolution

### DIFF
--- a/packages/remix-dev/compiler/plugins/cssBundlePlugin.ts
+++ b/packages/remix-dev/compiler/plugins/cssBundlePlugin.ts
@@ -16,23 +16,9 @@ export function cssBundlePlugin(refs: {
   return {
     name: pluginName,
     async setup(build) {
-      let preventInfiniteLoop = {};
       build.onResolve({ filter: /^@remix-run\/css-bundle$/ }, async (args) => {
-        // Prevent plugin from infinitely trying to resolve itself
-        if (args.pluginData === preventInfiniteLoop) {
-          return null;
-        }
-
-        let resolvedPath = (
-          await build.resolve(args.path, {
-            resolveDir: args.resolveDir,
-            kind: args.kind,
-            pluginData: preventInfiniteLoop,
-          })
-        ).path;
-
         return {
-          path: resolvedPath,
+          path: args.path,
           namespace,
         };
       });


### PR DESCRIPTION
The resolved path for `@remix-run/css-bundle` became redundant due to https://github.com/remix-run/remix/pull/6982 since we don't read the package contents anymore.