### PR TITLE
docs(discussion/04-server-vs-client.md): add `headers`

### DIFF
--- a/docs/discussion/04-server-vs-client.md
+++ b/docs/discussion/04-server-vs-client.md
@@ -21,6 +21,10 @@ import { useLoaderData } from "@remix-run/react";
 
 import { getUser, updateUser } from "../user";
 
+export function headers() {
+  return { "Cache-Control": "max-age=300, s-maxage=3600" }
+}
+
 export function loader({ request }) {
   const user = await getUser(request);
   return {
@@ -58,7 +62,7 @@ export function action({ request }) {
 }
 ```
 
-The server build will contain the entire module in the final bundle. However, the client build will remove the loader and action, along with the dependencies, resulting in this:
+The server build will contain the entire module in the final bundle. However, the client build will remove the headers, loader, and action, along with the dependencies, resulting in this:
 
 ```tsx filename=routes/settings.tsx
 import { useLoaderData } from "@remix-run/react";
@@ -87,6 +91,6 @@ You can force code out of either the client or the server with the `*.client.tsx
 
 While rare, sometimes server code makes it to client bundles because of how the compiler determines the dependencies of a route module, or because you accidentally try to use it in code that needs to ship to the client. You can force it out by adding `*.server.tsx` on the end of the file name.
 
-For example, we could name a module `app/user.server.ts` instead of `app/user.ts` to ensure that the code in that module is never bundled into the client--even if you try to use it in the component.
+For example, we could name a module `app/user.server.ts` instead of `app/user.ts` to ensure that the code in that module is never bundled into the client - even if you try to use it in the component.
 
-Additionally, you may depend on client libraries that are unsafe to even bundle on the server--maybe it tries to access `window` by simply being imported. You can likewise remove these modules from the server build by appending `*.client.tsx` to the file name.
+Additionally, you may depend on client libraries that are unsafe to even bundle on the server - maybe it tries to access `window` by simply being imported. You can likewise remove these modules from the server build by appending `*.client.tsx` to the file name.

--- a/docs/discussion/05-react-router.md
+++ b/docs/discussion/05-react-router.md
@@ -12,7 +12,7 @@ This also means that the 90% of Remix is really just React Router: a very old, v
 
 ## Importing Components and Hooks
 
-Remix Re-exports all of the components and hooks from React Router DOM, so you don't need to install React Router yourself.
+Remix re-exports all of the components and hooks from React Router DOM, so you don't need to install React Router yourself.
 
 🚫 Don't do this:
 


### PR DESCRIPTION
On lines 11-15 of this page, `headers` is listed along with `loader` and `action` so I thought it'd be cool to update the example to add a `headers` export. If that is not desirable, the `headers` item should probably removed from that list.

Also couple lil copy fixes