### PR TITLE
Don't allow unknown fields in TS future config

### DIFF
--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -173,7 +173,9 @@ export interface AppConfig {
     | string[]
     | (() => Promise<string | string[]> | string | string[]);
 
-  future?: Partial<FutureConfig>;
+  future?: Partial<FutureConfig> & {
+    [propName: string]: never;
+  };
 }
 
 /**


### PR DESCRIPTION
Closes #7253 

See approach in https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgUQB4EMDG8C+cBmUEIcA5DAJ5gCmAtPtQM4ykDcAUO8AHYzVT4s1OADEArjDFRqAYQjd8wAOaJ2ASABuAZgD6UdABMR1dJOkBGAFxwARhAgAbE93Xa9h46anUATNbuOzuw4nDx8AkJwAIJgYHIKyqpwyQQS3gD81gAK6LDA6A4APOJmsvKKSgB8cABkiADaYERgAHLoINTWzFA8SgC61tzUGvxwISHs1KiQsHAG1IJiDvAI6vhp0tarapq6+kYmpVZwMFBi1AA06po+OgDuMAAW1JgA1tan51dqOFd4jKZgIxFExorF4hV2EA

We could have also used `Exact` from `type-fest` but it felt weird needing 2 args and doing:

```ts
future: Exact<Partial<FutureConfig>, Partial<FutureConfig>>
```

Note this is in addition to the build-time warnings we log for JS config files: https://github.com/remix-run/remix/blob/dev/packages/remix-dev/config.ts#L566