### PR TITLE
chore: cleanup `createFixtureProject` in integration test helpers

### DIFF
--- a/integration/helpers/create-fixture.ts
+++ b/integration/helpers/create-fixture.ts
@@ -327,11 +327,6 @@ async function writeTestFiles(init: FixtureInit, dir: string) {
       let filePath = path.join(dir, filename);
       await fse.ensureDir(path.dirname(filePath));
       let file = init.files![filename];
-      // if we have a jsconfig we don't want the tsconfig to exist
-      if (filename.endsWith("jsconfig.json")) {
-        let parsed = path.parse(filePath);
-        await fse.remove(path.join(parsed.dir, "tsconfig.json"));
-      }
 
       await fse.writeFile(filePath, stripIndent(file));
     })


### PR DESCRIPTION
We don't include any `jsconfig.json` files in our fixtures anymore