### PR TITLE
chore: gitignore playwright-report dirs anywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ tsconfig.tsbuildinfo
 /fixtures/test
 /fixtures/my-remix-app
 /fixtures/deno-app
-/playwright-report
+playwright-report
 /test-results
 /uploads
 


### PR DESCRIPTION
Running the integration tests results in the directory /integration/playwright-report, which should be ignored.