### PR TITLE
docs(other-api/adapter): add PartyMix to community adapters

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -501,6 +501,7 @@
 - takagimeow
 - tascord
 - TheRealAstoo
+- threepointone
 - t-dub
 - therealflyingcoder
 - thomasheyenbrock

--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -30,7 +30,7 @@ Each adapter has the same API. In the future we may have helpers specific to the
 - [`@mcansh/remix-fastify`][remix-fastify] - For [Fastify][fastify].
 - [`@mcansh/remix-raw-http`][remix-raw-http] - For a good ol barebones Node server.
 - [`remix-google-cloud-functions`][remix-google-cloud-functions] - For [Google Cloud][google-cloud-functions] and [Firebase][firebase-functions] functions.
-- [`partymix`](https://github.com/partykit/partykit/blob/main/packages/partymix/) - For [PartyKit](https://partykit.io).
+- [`PartyMix`][partymix] - For [PartyKit][partykit].
 
 ## Creating an Adapter
 
@@ -190,3 +190,5 @@ addEventListener("fetch", (event) => {
 [remix-fastify]: https://github.com/mcansh/remix-fastify
 [fastify]: https://www.fastify.io
 [remix-raw-http]: https://github.com/mcansh/remix-node-http-server
+[partykit]: https://partykit.io
+[partymix]: https://github.com/partykit/partykit/tree/main/packages/partymix

--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -30,6 +30,7 @@ Each adapter has the same API. In the future we may have helpers specific to the
 - [`@mcansh/remix-fastify`][remix-fastify] - For [Fastify][fastify].
 - [`@mcansh/remix-raw-http`][remix-raw-http] - For a good ol barebones Node server.
 - [`remix-google-cloud-functions`][remix-google-cloud-functions] - For [Google Cloud][google-cloud-functions] and [Firebase][firebase-functions] functions.
+- [`partymix`](https://github.com/partykit/partykit/blob/main/packages/partymix/) - For [PartyKit](https://partykit.io).
 
 ## Creating an Adapter
 

--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -30,7 +30,7 @@ Each adapter has the same API. In the future we may have helpers specific to the
 - [`@mcansh/remix-fastify`][remix-fastify] - For [Fastify][fastify].
 - [`@mcansh/remix-raw-http`][remix-raw-http] - For a good ol barebones Node server.
 - [`remix-google-cloud-functions`][remix-google-cloud-functions] - For [Google Cloud][google-cloud-functions] and [Firebase][firebase-functions] functions.
-- [`PartyMix`][partymix] - For [PartyKit][partykit].
+- [`partymix`][partymix] - For [PartyKit][partykit].
 
 ## Creating an Adapter
 


### PR DESCRIPTION
Like the title says! You can now deploy full remix applications to PartyKit. Additionally, there's a new starter template at https://github.com/partykit/remix-starter/ powered by partymix