### PR TITLE
templates: remove polyfill references

### DIFF
--- a/docs/guides/migrating-react-router-app.md
+++ b/docs/guides/migrating-react-router-app.md
@@ -52,7 +52,6 @@ import type {
   AppLoadContext,
   EntryContext,
 } from "@remix-run/node";
-import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";

--- a/integration/defer-test.ts
+++ b/integration/defer-test.ts
@@ -979,15 +979,10 @@ test.describe("aborted", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
-      ////////////////////////////////////////////////////////////////////////////
-      // 💿 Next, add files to this object, just like files in a real app,
-      // `createFixture` will make an app and run your tests against it.
-      ////////////////////////////////////////////////////////////////////////////
       files: {
         "app/entry.server.tsx": js`
           import { PassThrough } from "node:stream";
           import type { AppLoadContext, EntryContext } from "@remix-run/node";
-          import { Response } from "@remix-run/node";
           import { RemixServer } from "@remix-run/react";
           import isbot from "isbot";
           import { renderToPipeableStream } from "react-dom/server";

--- a/packages/remix-dev/config/defaults/entry.server.node.tsx
+++ b/packages/remix-dev/config/defaults/entry.server.node.tsx
@@ -1,7 +1,6 @@
 import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
-import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";

--- a/scripts/playground/template/app/entry.server.tsx
+++ b/scripts/playground/template/app/entry.server.tsx
@@ -1,6 +1,5 @@
 import { PassThrough } from "node:stream";
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
-import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";

--- a/templates/arc/app/entry.server.tsx
+++ b/templates/arc/app/entry.server.tsx
@@ -7,7 +7,6 @@
 import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
-import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";

--- a/templates/express/app/entry.server.tsx
+++ b/templates/express/app/entry.server.tsx
@@ -7,7 +7,6 @@
 import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
-import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";

--- a/templates/fly/app/entry.server.tsx
+++ b/templates/fly/app/entry.server.tsx
@@ -7,7 +7,6 @@
 import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
-import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";

--- a/templates/remix-javascript/app/entry.server.jsx
+++ b/templates/remix-javascript/app/entry.server.jsx
@@ -5,7 +5,7 @@
  */
 
 import { PassThrough } from "node:stream";
-import { Response } from "@remix-run/node";
+
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";

--- a/templates/remix/app/entry.server.tsx
+++ b/templates/remix/app/entry.server.tsx
@@ -7,7 +7,6 @@
 import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
-import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";


### PR DESCRIPTION
Follow-up of #7205 & @jacob-ebey's #7230

Templates are either calling `installGlobals` themselves _or_ if they're using `@remix-run/serve` (`fly`, `remix` & `remix-javascript`), that already called `installGlobals` as well

https://github.com/remix-run/remix/blob/c28c3cc6a577653a857f3f38a3d93eefa091f102/templates/arc/server.ts#L7
https://github.com/remix-run/remix/blob/c28c3cc6a577653a857f3f38a3d93eefa091f102/templates/express/server.js#L14
https://github.com/remix-run/remix/blob/c28c3cc6a577653a857f3f38a3d93eefa091f102/packages/remix-serve/cli.ts#L21