### PR TITLE
feat(remix-dev)!: set `esbuild`'s `target` to `'node18'`

### DIFF
--- a/.changeset/plenty-maps-wink.md
+++ b/.changeset/plenty-maps-wink.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": major
+---
+
+Set `esbuild`'s `target` to `'node18'`

--- a/packages/remix-dev/compiler/server/compiler.ts
+++ b/packages/remix-dev/compiler/server/compiler.ts
@@ -93,7 +93,7 @@ const createEsbuildConfig = (
     minifySyntax: true,
     minify: ctx.options.mode === "production" && ctx.config.serverMinify,
     mainFields: ctx.config.serverMainFields,
-    target: "node14",
+    target: "node18",
     loader: loaders,
     bundle: true,
     logLevel: "silent",


### PR DESCRIPTION
Fixes #5203