### PR TITLE
test: remove polyfill references from Node adapters

### DIFF
--- a/packages/remix-architect/__tests__/server-test.ts
+++ b/packages/remix-architect/__tests__/server-test.ts
@@ -1,11 +1,8 @@
 import fsp from "node:fs/promises";
 import path from "node:path";
-import lambdaTester from "lambda-tester";
+import { createRequestHandler as createRemixRequestHandler } from "@remix-run/node";
 import type { APIGatewayProxyEventV2 } from "aws-lambda";
-import {
-  createRequestHandler as createRemixRequestHandler,
-  Response as NodeResponse,
-} from "@remix-run/node";
+import lambdaTester from "lambda-tester";
 
 import {
   createRequestHandler,
@@ -249,14 +246,14 @@ describe("architect createRemixRequest", () => {
 
 describe("sendRemixResponse", () => {
   it("handles regular responses", async () => {
-    let response = new NodeResponse("anything");
+    let response = new Response("anything");
     let result = await sendRemixResponse(response);
     expect(result.body).toBe("anything");
   });
 
   it("handles resource routes with regular data", async () => {
     let json = JSON.stringify({ foo: "bar" });
-    let response = new NodeResponse(json, {
+    let response = new Response(json, {
       headers: {
         "Content-Type": "application/json",
         "content-length": json.length.toString(),
@@ -271,7 +268,7 @@ describe("sendRemixResponse", () => {
   it("handles resource routes with binary data", async () => {
     let image = await fsp.readFile(path.join(__dirname, "554828.jpeg"));
 
-    let response = new NodeResponse(image, {
+    let response = new Response(image, {
       headers: {
         "content-type": "image/jpeg",
         "content-length": image.length.toString(),

--- a/packages/remix-express/__tests__/server-test.ts
+++ b/packages/remix-express/__tests__/server-test.ts
@@ -1,11 +1,8 @@
-import express from "express";
-import supertest from "supertest";
-import { createRequest, createResponse } from "node-mocks-http";
-import {
-  createRequestHandler as createRemixRequestHandler,
-  Response as NodeResponse,
-} from "@remix-run/node";
 import { Readable } from "node:stream";
+import { createRequestHandler as createRemixRequestHandler } from "@remix-run/node";
+import express from "express";
+import { createRequest, createResponse } from "node-mocks-http";
+import supertest from "supertest";
 
 import {
   createRemixHeaders,
@@ -103,7 +100,7 @@ describe("express createRequestHandler", () => {
     it("handles body as stream", async () => {
       mockedCreateRequestHandler.mockImplementation(() => async () => {
         let stream = Readable.from("hello world");
-        return new NodeResponse(stream, { status: 200 }) as unknown as Response;
+        return new Response(stream, { status: 200 }) as unknown as Response;
       });
 
       let request = supertest(createApp());


### PR DESCRIPTION
Follow-up of #7205 & especially @jacob-ebey's #7230

It's remove from the codebase, so why keep it in the tests? 🤷‍♂️