### PR TITLE
Add some clarity to the new create-remix CLI + templates option

### DIFF
--- a/docs/guides/templates.md
+++ b/docs/guides/templates.md
@@ -72,11 +72,14 @@ npx create-remix@latest --template :username/:repo
 
 For a less opinionated starting point, you can also just use a regular template.
 
-The Remix repo provides a set of [templates for different environments.][official-templates]
+The Remix repo provides a set of [templates for different environments.][official-templates]. You can use these templates by passing a GitHub shorthand to the `--template` option:
 
-We also provide a [community-driven examples repository,][examples] with each example showcasing different Remix features, patterns, tools, hosting providers, etc.
+```sh
+npx create-remix@latest --template remix-run/remix/templates/remix-javascript
+npx create-remix@latest --template remix-run/remix/templates/express
+```
 
-You can use these templates and examples by passing a GitHub shorthand to the `--template` option when running `create-remix`, for example:
+We also provide a [community-driven examples repository,][examples] with each example showcasing different Remix features, patterns, tools, hosting providers, etc. You can use these in a similar manner:
 
 ```sh
 npx create-remix@latest --template remix-run/examples/basic

--- a/docs/other-api/create-remix.md
+++ b/docs/other-api/create-remix.md
@@ -10,10 +10,16 @@ The `create-remix` CLI will create a new Remix project. Without passing argument
 npx create-remix@latest
 ```
 
-Optionally you can pass the desired directory path as an argument and a starter template with the `--template` flag.
+Optionally you can pass the desired directory path as an argument:
 
 ```sh
 npx create-remix@latest <projectDir>
+```
+
+The default application is a TypeScript app using the built in [Remix App Server][remix-app-server]. If you wish to create your application based on a different setup, you can use the [`--template`][template-flag-hash-link] flag:
+
+```sh
+npx create-remix@latest --template <templateUrl>
 ```
 
 To get a full list of available commands and flags, run:
@@ -77,3 +83,5 @@ To create a new project from a template in a private GitHub repo, pass the `--to
 If `create-remix` detects any file collisions between the template and the directory you are creating your app in, it will prompt you for confirmation that it's OK to overwrite those files with the template versions. You may skip this prompt with the `--overwrite` CLI flag.
 
 [templates]: ../pages/templates
+[remix-app-server]: ./serve
+[template-flag-hash-link]: #create-remix---template


### PR DESCRIPTION
I've seen some confusion with the removal of the `create-remix` dropdown (i.e., how do I create an express app).  Tried to clarify some of the new usage in the docs.