### PR TITLE
fix(remix-dev): remove `sort-package-json`

### DIFF
--- a/.changeset/metal-horses-camp.md
+++ b/.changeset/metal-horses-camp.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+REMOVE: removed dependency that caused TS error

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "rollup-plugin-copy": "^3.3.0",
     "semver": "^7.3.7",
     "simple-git": "^3.16.0",
-    "sort-package-json": "^1.55.0",
     "to-vfile": "7.2.3",
     "typescript": "^5.1.0",
     "unified": "^10.1.2",

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -63,7 +63,6 @@
     "remark-frontmatter": "4.0.1",
     "remark-mdx-frontmatter": "^1.0.1",
     "semver": "^7.3.7",
-    "sort-package-json": "^1.55.0",
     "tar-fs": "^2.1.1",
     "tsconfig-paths": "^4.0.0",
     "ws": "^7.4.5"


### PR DESCRIPTION
When running `npx run typecheck` on a newly installed project, I get the following errors

```sh
node_modules/@types/glob/index.d.ts:29:42 - error TS2694: Namespace '"/Users/michaeldeboey/Downloads/my-remix-app/node_modules/minimatch/dist/mjs/index"' has no exported member 'IOptions'.

29     interface IOptions extends minimatch.IOptions {
                                            ~~~~~~~~

node_modules/@types/glob/index.d.ts:74:30 - error TS2724: '"/Users/michaeldeboey/Downloads/my-remix-app/node_modules/minimatch/dist/mjs/index"' has no exported member named 'IMinimatch'. Did you mean 'Minimatch'?

74         minimatch: minimatch.IMinimatch;
                                ~~~~~~~~~~
```

Running `npm ls @types/glob` to figure out where the dependency comes from, show us that it's a dependency of `sort-package-json`, which is a dependency of `@remix-run/dev`

```sh
my-remix-app@ [REDACTED]/my-remix-app
└─┬ @remix-run/dev@2.0.0-pre.4
  └─┬ sort-package-json@1.57.0
    └─┬ globby@10.0.0
      └── @types/glob@7.2.0
```

Since the `create-remix` change, we don't need `sort-package-json` in `@remix-run/dev` anymore so removed it from it's dependencies + also from the root

---

Closes #6620
Closes #6708