### PR TITLE
feat(remix-react): make RouteMatch a generic type

### DIFF
--- a/.changeset/stale-moles-cheat.md
+++ b/.changeset/stale-moles-cheat.md
@@ -1,0 +1,7 @@
+---
+"@remix-run/react": minor
+---
+
+Make `RouteMatch` a generic type
+
+Now the `RouteMatch` type is a generic type that supports type inference. So just as you can do `useLoaderData<typeof loader>()`, now you can also do `RouteMatch<typeof loader>`.

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -976,7 +976,7 @@ function dedupe(array: any[]) {
 }
 
 // TODO: Can this be re-exported from RR?
-export interface RouteMatch {
+export interface RouteMatch<T = AppData> {
   /**
    * The id of the matched route
    */
@@ -994,7 +994,7 @@ export interface RouteMatch {
   /**
    * Any route data associated with the matched route
    */
-  data: any;
+  data: SerializeFrom<T>;
   /**
    * The exported `handle` object of the matched route.
    *


### PR DESCRIPTION
Now the `RouteMatch` type is a generic type that supports type inference. So just as you can do `useLoaderData<typeof loader>()`, now you can also do `RouteMatch<typeof loader>`.

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
