### PR TITLE
fix(template/express): chokidar watch path

### DIFF
--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -13,13 +13,12 @@ import sourceMapSupport from "source-map-support";
 sourceMapSupport.install();
 installGlobals();
 
-const BUILD_PATH = url.pathToFileURL(
-  path.join(process.cwd(), "build", "index.js")
-);
+const BUILD_PATH = path.join(process.cwd(), "build", "index.js");
+const BUILD_PATH_URL = url.pathToFileURL(BUILD_PATH);
 /**
  * @type { import('@remix-run/node').ServerBuild | Promise<import('@remix-run/node').ServerBuild> }
  */
-let build = await import(BUILD_PATH);
+let build = await import(BUILD_PATH_URL);
 
 const app = express();
 
@@ -65,7 +64,7 @@ function createDevRequestHandler() {
   watcher.on("all", async () => {
     // 1. purge require cache && load updated server build
     const stat = fs.statSync(BUILD_PATH);
-    build = import(BUILD_PATH + "?t=" + stat.mtimeMs);
+    build = import(BUILD_PATH_URL + "?t=" + stat.mtimeMs);
     // 2. tell dev server that this app server is now ready
     broadcastDevReady(await build);
   });


### PR DESCRIPTION
chokidar wants a path and not a fileURL


```log
/Users/logan/my-remix-app/node_modules/.pnpm/chokidar@3.5.3/node_modules/chokidar/index.js:96
    throw new TypeError(`Non-string provided as watch path: ${paths}`);
          ^
TypeError: Non-string provided as watch path: file:///Users/logan/my-remix-app/build/index.js
    at unifyPaths (/Users/logan/my-remix-app/node_modules/.pnpm/chokidar@3.5.3/node_modules/chokidar/index.js:96:11)
    at FSWatcher.add (/Users/logan/my-remix-app/node_modules/.pnpm/chokidar@3.5.3/node_modules/chokidar/index.js:411:15)
    at Object.watch (/Users/logan/my-remix-app/node_modules/.pnpm/chokidar@3.5.3/node_modules/chokidar/index.js:969:11)
    at createDevRequestHandler (file:///Users/logan/my-remix-app/server.js:63:28)
    at file:///Users/logan/my-remix-app/server.js:46:7
```

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
