### PR TITLE
Custom error instances are eaten by error catching

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -370,6 +370,7 @@
 - michaelgmcd
 - michaelhelvey
 - michaseel
+- mikeybinns
 - mikeybinnswebdesign
 - mirzafaizan
 - mitchelldirt


### PR DESCRIPTION
This adds a failing bug test which shows that custom error instances are being eaten by the error boundary or useRouteError.

Ideally, Remix should pass through an error instance as-is (as long as it's still an instance of Error), and it would fall to the user to check "Is this error an instance of custom error".

This change would not affect existing code because as the test shows, custom errors are also instances of Error.