### PR TITLE
fix(remix-dev): allow emitting `serverBuildPath` as cjs

### DIFF
--- a/packages/remix-dev/compiler/server/write.ts
+++ b/packages/remix-dev/compiler/server/write.ts
@@ -4,6 +4,8 @@ import * as fse from "fs-extra";
 
 import type { RemixConfig } from "../../config";
 
+let outputExtensions = [".js", ".mjs", ".cjs"];
+
 export async function write(
   config: RemixConfig,
   outputFiles: esbuild.OutputFile[]
@@ -11,7 +13,8 @@ export async function write(
   await fse.ensureDir(path.dirname(config.serverBuildPath));
 
   for (let file of outputFiles) {
-    if (file.path.endsWith(".js") || file.path.endsWith(".mjs")) {
+    let extension = path.extname(file.path);
+    if (outputExtensions.includes(extension)) {
       // fix sourceMappingURL to be relative to current path instead of /build
       let filename = file.path.substring(file.path.lastIndexOf(path.sep) + 1);
       let escapedFilename = filename.replace(/\./g, "\\.");


### PR DESCRIPTION
Signed-off-by: Logan McAnsh <logan@mcan.sh>
(cherry picked from commit 63b5e5de2862a29a3a027c05e38a2fdd3ed4dc29)

same as https://github.com/remix-run/remix/pull/7348 but pointed to main

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
