### PR TITLE
Remove AppData/RouteHandle types

### DIFF
--- a/.changeset/chilled-horses-look.md
+++ b/.changeset/chilled-horses-look.md
@@ -1,0 +1,8 @@
+---
+"@remix-run/cloudflare": major
+"@remix-run/deno": major
+"@remix-run/node": major
+"@remix-run/server-runtime": major
+---
+
+Remove `AppData`/`RouteHandle` types which are just aliases for `unknown`

--- a/packages/remix-cloudflare/index.ts
+++ b/packages/remix-cloudflare/index.ts
@@ -29,7 +29,6 @@ export {
 export type {
   ActionFunction,
   ActionFunctionArgs,
-  AppData,
   AppLoadContext,
   Cookie,
   CookieOptions,
@@ -54,7 +53,6 @@ export type {
   HandleErrorFunction,
   PageLinkDescriptor,
   RequestHandler,
-  RouteHandle,
   SerializeFrom,
   ServerBuild,
   ServerEntryModule,

--- a/packages/remix-deno/index.ts
+++ b/packages/remix-deno/index.ts
@@ -32,7 +32,6 @@ export {
 export type {
   ActionFunction,
   ActionFunctionArgs,
-  AppData,
   AppLoadContext,
   Cookie,
   CookieOptions,
@@ -57,7 +56,6 @@ export type {
   MemoryUploadHandlerOptions,
   PageLinkDescriptor,
   RequestHandler,
-  RouteHandle,
   SerializeFrom,
   ServerBuild,
   ServerEntryModule,

--- a/packages/remix-node/index.ts
+++ b/packages/remix-node/index.ts
@@ -49,7 +49,6 @@ export {
 export type {
   ActionFunction,
   ActionFunctionArgs,
-  AppData,
   AppLoadContext,
   Cookie,
   CookieOptions,
@@ -74,7 +73,6 @@ export type {
   HandleErrorFunction,
   PageLinkDescriptor,
   RequestHandler,
-  RouteHandle,
   SerializeFrom,
   ServerBuild,
   ServerEntryModule,

--- a/packages/remix-server-runtime/index.ts
+++ b/packages/remix-server-runtime/index.ts
@@ -35,7 +35,6 @@ export type {
 export type {
   ActionFunction,
   ActionFunctionArgs,
-  AppData,
   AppLoadContext,
   Cookie,
   CookieOptions,
@@ -60,7 +59,6 @@ export type {
   HandleErrorFunction,
   PageLinkDescriptor,
   RequestHandler,
-  RouteHandle,
   SerializeFrom,
   ServerBuild,
   ServerEntryModule,

--- a/packages/remix-server-runtime/reexport.ts
+++ b/packages/remix-server-runtime/reexport.ts
@@ -24,7 +24,7 @@ export type {
 
 export type { SignFunction, UnsignFunction } from "./crypto";
 
-export type { AppLoadContext, AppData } from "./data";
+export type { AppLoadContext } from "./data";
 
 export type { EntryContext } from "./entry";
 
@@ -45,7 +45,6 @@ export type {
   LinksFunction,
   LoaderFunction,
   LoaderFunctionArgs,
-  RouteHandle,
   ServerRuntimeMetaArgs,
   ServerRuntimeMetaDescriptor,
   ServerRuntimeMetaFunction,


### PR DESCRIPTION
Removing types which are just aliases for unknown.

I left `AppLoadContext` in for now since it's used in the adapters but I could be convinced to just hardcode `unknown` in those and remove that as well.

Follow up of https://github.com/remix-run/remix/pull/7319#discussion_r1316373471