### PR TITLE
fix live reload port when explicitly set as a prop

### DIFF
--- a/.changeset/tidy-paws-promise.md
+++ b/.changeset/tidy-paws-promise.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Fix live reload port when set explicitly as a prop

--- a/packages/remix-react/__tests__/components-test.tsx
+++ b/packages/remix-react/__tests__/components-test.tsx
@@ -47,14 +47,14 @@ describe("<LiveReload />", () => {
       LiveReload = require("../components").LiveReload;
       let { container } = render(<LiveReload />);
       expect(container.querySelector("script")).toHaveTextContent(
-        "url.port = undefined || REMIX_DEV_ORIGIN ? new URL(REMIX_DEV_ORIGIN).port : 8002;"
+        "url.port = undefined || (REMIX_DEV_ORIGIN ? new URL(REMIX_DEV_ORIGIN).port : 8002);"
       );
     });
 
     it("can set the port explicitly", () => {
       let { container } = render(<LiveReload port={4321} />);
       expect(container.querySelector("script")).toHaveTextContent(
-        "url.port = 4321 || REMIX_DEV_ORIGIN ? new URL(REMIX_DEV_ORIGIN).port : 8002;"
+        "url.port = 4321 || (REMIX_DEV_ORIGIN ? new URL(REMIX_DEV_ORIGIN).port : 8002);"
       );
     });
 

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1062,8 +1062,7 @@ export const LiveReload =
 
                   url.port =
                     ${port} ||
-                    REMIX_DEV_ORIGIN ? new URL(REMIX_DEV_ORIGIN).port :
-                    8002;
+                    (REMIX_DEV_ORIGIN ? new URL(REMIX_DEV_ORIGIN).port : 8002);
 
                   let ws = new WebSocket(url.href);
                   ws.onmessage = async (message) => {


### PR DESCRIPTION
Previously, `${port} || REMIX_DEV_ORIGIN` was interpreted as the condition for the ternary, which caused `REMIX_DEV_ORIGIN`'s port to be used whenever `port` was defined, even if `REMIX_DEV_ORIGIN` was `undefined`.