### PR TITLE
Revert AppLoadContext back to an interface for module augmentation su…

### DIFF
--- a/.changeset/align-rr-types.md
+++ b/.changeset/align-rr-types.md
@@ -15,6 +15,5 @@ Remove/align Remix types with those used in React Router
   * `useFetcher().data`
   * `MetaMatch.handle`
 * `useMatches()[i].handle` type changed from `{ [k: string]: any }` to `unknown`
-* `AppLoadContext` type changed from `{ [k: string]: unknown }` to `unknown`
 * Rename the `useMatches()` return type from `RouteMatch` to `UIMatch`
-* Rename `LoaderArgs`/`ActionArgs` to `LoaderFunctionArgs`/`ActionFunctionArgs` and add a generic to accept a `context` type
+* Rename `LoaderArgs`/`ActionArgs` to `LoaderFunctionArgs`/`ActionFunctionArgs`

--- a/.changeset/lemon-dodos-crash.md
+++ b/.changeset/lemon-dodos-crash.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+[REMOVE] Revert AppLoadContext back to an interface for use with module augmentation

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -1,5 +1,3 @@
-import type { ActionFunction, LoaderFunction } from "@remix-run/router";
-
 import {
   redirect,
   json,
@@ -7,13 +5,21 @@ import {
   isResponse,
   isRedirectStatusCode,
 } from "./responses";
-import type { DataFunctionArgs } from "./routeModules";
+import type {
+  ActionFunction,
+  DataFunctionArgs,
+  LoaderFunction,
+} from "./routeModules";
 
 /**
- * An unknown type for route loaders and actions provided by the server's
- * `getLoadContext()` function.
+ * An object of unknown type for route loaders and actions provided by the
+ * server's `getLoadContext()` function.  This is defined as an empty interface
+ * specifically so apps can leverage declaration merging to augment this type
+ * globally: https://www.typescriptlang.org/docs/handbook/declaration-merging.html
  */
-export type AppLoadContext = unknown;
+export interface AppLoadContext {
+  [key: string]: unknown;
+}
 
 /**
  * Data for a route that was returned from a `loader()`.

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -8,7 +8,7 @@ import type {
   Params,
 } from "@remix-run/router";
 
-import type { AppData } from "./data";
+import type { AppData, AppLoadContext } from "./data";
 import type { LinkDescriptor } from "./links";
 import type { SerializeFrom } from "./serialize";
 
@@ -16,11 +16,32 @@ export interface RouteModules<RouteModule> {
   [routeId: string]: RouteModule;
 }
 
-export type ActionFunctionArgs = RRActionFunctionArgs<unknown>;
-export type ActionFunction = RRActionFunction<unknown>;
-export type LoaderFunctionArgs = RRLoaderFunctionArgs<unknown>;
-export type LoaderFunction = RRLoaderFunction<unknown>;
-export type DataFunctionArgs = LoaderFunctionArgs | ActionFunctionArgs;
+// Context is always provided in Remix, and typed for module augmentation support.
+// RR also doesn't export DataFunctionArgs so we extend the two interfaces here
+// even tough they're identical under the hood
+export interface DataFunctionArgs
+  extends RRActionFunctionArgs,
+    RRLoaderFunctionArgs {
+  context: AppLoadContext;
+}
+
+/**
+ * A function that handles data mutations for a route.
+ */
+export type ActionFunction = (
+  args: DataFunctionArgs
+) => ReturnType<RRActionFunction>;
+
+export type ActionFunctionArgs = DataFunctionArgs;
+
+/**
+ * A function that loads data for a route.
+ */
+export type LoaderFunction = (
+  args: DataFunctionArgs
+) => ReturnType<RRLoaderFunction>;
+
+export type LoaderFunctionArgs = DataFunctionArgs;
 
 export type HeadersArgs = {
   loaderHeaders: Headers;

--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -1,12 +1,12 @@
-import type { AgnosticDataRouteObject } from "@remix-run/router";
+import type {
+  AgnosticDataRouteObject,
+  LoaderFunctionArgs as RRLoaderFunctionArgs,
+  ActionFunctionArgs as RRActionFunctionArgs,
+} from "@remix-run/router";
 
 import { callRouteActionRR, callRouteLoaderRR } from "./data";
 import type { FutureConfig } from "./entry";
-import type {
-  ServerRouteModule,
-  ActionFunctionArgs,
-  LoaderFunctionArgs,
-} from "./routeModules";
+import type { ServerRouteModule } from "./routeModules";
 
 export interface RouteManifest<Route> {
   [routeId: string]: Route;
@@ -87,7 +87,9 @@ export function createStaticHandlerDataRoutes(
       id: route.id,
       path: route.path,
       loader: route.module.loader
-        ? (args: LoaderFunctionArgs) =>
+        ? // Need to use RR's version here to permit the optional context even
+          // though we know it'll always be provided in remix
+          (args: RRLoaderFunctionArgs) =>
             callRouteLoaderRR({
               request: args.request,
               params: args.params,
@@ -97,7 +99,7 @@ export function createStaticHandlerDataRoutes(
             })
         : undefined,
       action: route.module.action
-        ? (args: ActionFunctionArgs) =>
+        ? (args: RRActionFunctionArgs) =>
             callRouteActionRR({
               request: args.request,
               params: args.params,

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -4,6 +4,8 @@ import {
   type HydrationState,
   type InitialEntry,
   type Router,
+  type ActionFunctionArgs as RRActionFunctionArgs,
+  type LoaderFunctionArgs as RRLoaderFunctionArgs,
 } from "@remix-run/router";
 import { UNSAFE_RemixContext as RemixContext } from "@remix-run/react";
 import type {
@@ -22,11 +24,9 @@ import type {
 import { createMemoryRouter, Outlet, RouterProvider } from "react-router-dom";
 import type {
   ActionFunction,
-  ActionFunctionArgs,
   AppLoadContext,
   LinksFunction,
   LoaderFunction,
-  LoaderFunctionArgs,
 } from "@remix-run/server-runtime";
 
 interface StubIndexRouteObject
@@ -160,10 +160,10 @@ function processRoutes(
       Component: route.Component,
       ErrorBoundary: route.ErrorBoundary,
       action: action
-        ? (args: ActionFunctionArgs) => action!({ ...args, context })
+        ? (args: RRActionFunctionArgs) => action!({ ...args, context })
         : undefined,
       loader: loader
-        ? (args: LoaderFunctionArgs) => loader!({ ...args, context })
+        ? (args: RRLoaderFunctionArgs) => loader!({ ...args, context })
         : undefined,
       handle: route.handle,
       shouldRevalidate: route.shouldRevalidate,


### PR DESCRIPTION
Reverting the `AppLoadContext` portion of https://github.com/remix-run/remix/pull/7319 as we didn't realize folks use module augmentation to define that in v1 and changing it to `unknown` breaks that ability (this feature was originally added in https://github.com/remix-run/remix/pull/1876).  

This PR brings back the limitation of needing to return an object from `getLoadContext` (and thus prevents using something like a `Map` or a custom `class`), but this is a less-invasive change for v2 - and we can revisit a change to allow those in the future if the need arises.