### PR TITLE
Fix TS error in entry-server - make Passthrough a ReadableStream

### DIFF
--- a/.changeset/lovely-suits-appear.md
+++ b/.changeset/lovely-suits-appear.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+[REMOVE] Fix TS error in entry.server.tsx to make PassThrough body a ReadableStream

--- a/docs/guides/migrating-react-router-app.md
+++ b/docs/guides/migrating-react-router-app.md
@@ -97,17 +97,16 @@ function handleBotRequest(
       {
         onAllReady() {
           const body = new PassThrough();
+          const stream =
+            createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(
-              createReadableStreamFromReadable(body),
-              {
-                headers: responseHeaders,
-                status: responseStatusCode,
-              }
-            )
+            new Response(stream, {
+              headers: responseHeaders,
+              status: responseStatusCode,
+            })
           );
 
           pipe(body);
@@ -142,17 +141,16 @@ function handleBrowserRequest(
       {
         onShellReady() {
           const body = new PassThrough();
+          const stream =
+            createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(
-              createReadableStreamFromReadable(body),
-              {
-                headers: responseHeaders,
-                status: responseStatusCode,
-              }
-            )
+            new Response(stream, {
+              headers: responseHeaders,
+              status: responseStatusCode,
+            })
           );
 
           pipe(body);

--- a/docs/guides/migrating-react-router-app.md
+++ b/docs/guides/migrating-react-router-app.md
@@ -46,12 +46,13 @@ Let's start by creating two new files:
 <docs-info>All of your app code in Remix will live in an `app` directory by convention. If your existing app uses a directory with the same name, rename it to something like `src` or `old-app` to differentiate as we migrate to Remix.</docs-info>
 
 ```tsx filename=app/entry.server.tsx
-import { Readable, PassThrough } from "node:stream";
+import { PassThrough } from "node:stream";
 
 import type {
   AppLoadContext,
   EntryContext,
 } from "@remix-run/node";
+import { createReadableStreamFromReadable } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";
@@ -96,17 +97,17 @@ function handleBotRequest(
       {
         onAllReady() {
           const body = new PassThrough();
-          const webBody = Readable.toWeb(
-            body
-          ) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(webBody, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(body),
+              {
+                headers: responseHeaders,
+                status: responseStatusCode,
+              }
+            )
           );
 
           pipe(body);
@@ -141,17 +142,17 @@ function handleBrowserRequest(
       {
         onShellReady() {
           const body = new PassThrough();
-          const webBody = Readable.toWeb(
-            body
-          ) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(webBody, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(body),
+              {
+                headers: responseHeaders,
+                status: responseStatusCode,
+              }
+            )
           );
 
           pipe(body);

--- a/docs/guides/migrating-react-router-app.md
+++ b/docs/guides/migrating-react-router-app.md
@@ -46,7 +46,7 @@ Let's start by creating two new files:
 <docs-info>All of your app code in Remix will live in an `app` directory by convention. If your existing app uses a directory with the same name, rename it to something like `src` or `old-app` to differentiate as we migrate to Remix.</docs-info>
 
 ```tsx filename=app/entry.server.tsx
-import { PassThrough } from "node:stream";
+import { Readable, PassThrough } from "node:stream";
 
 import type {
   AppLoadContext,
@@ -96,11 +96,14 @@ function handleBotRequest(
       {
         onAllReady() {
           const body = new PassThrough();
+          const webBody = Readable.toWeb(
+            body
+          ) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(webBody, {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -138,11 +141,14 @@ function handleBrowserRequest(
       {
         onShellReady() {
           const body = new PassThrough();
+          const webBody = Readable.toWeb(
+            body
+          ) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(webBody, {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/integration/defer-test.ts
+++ b/integration/defer-test.ts
@@ -981,7 +981,7 @@ test.describe("aborted", () => {
     fixture = await createFixture({
       files: {
         "app/entry.server.tsx": js`
-          import { PassThrough } from "node:stream";
+          import { PassThrough, Readable } from "node:stream";
           import type { AppLoadContext, EntryContext } from "@remix-run/node";
           import { RemixServer } from "@remix-run/react";
           import isbot from "isbot";
@@ -1029,11 +1029,12 @@ test.describe("aborted", () => {
                 {
                   onAllReady() {
                     let body = new PassThrough();
+                    let webBody = Readable.toWeb(body);
 
                     responseHeaders.set("Content-Type", "text/html");
 
                     resolve(
-                      new Response(body, {
+                      new Response(webBody, {
                         headers: responseHeaders,
                         status: didError ? 500 : responseStatusCode,
                       })
@@ -1074,11 +1075,12 @@ test.describe("aborted", () => {
                 {
                   onShellReady() {
                     let body = new PassThrough();
+                    let webBody = Readable.toWeb(body);
 
                     responseHeaders.set("Content-Type", "text/html");
 
                     resolve(
-                      new Response(body, {
+                      new Response(webBody, {
                         headers: responseHeaders,
                         status: didError ? 500 : responseStatusCode,
                       })

--- a/integration/defer-test.ts
+++ b/integration/defer-test.ts
@@ -981,8 +981,9 @@ test.describe("aborted", () => {
     fixture = await createFixture({
       files: {
         "app/entry.server.tsx": js`
-          import { PassThrough, Readable } from "node:stream";
+          import { PassThrough } from "node:stream";
           import type { AppLoadContext, EntryContext } from "@remix-run/node";
+          import { createReadableStreamFromReadable } from "@remix-run/node";
           import { RemixServer } from "@remix-run/react";
           import isbot from "isbot";
           import { renderToPipeableStream } from "react-dom/server";
@@ -1029,12 +1030,12 @@ test.describe("aborted", () => {
                 {
                   onAllReady() {
                     let body = new PassThrough();
-                    let webBody = Readable.toWeb(body);
+                    let stream = createReadableStreamFromReadable(body);
 
                     responseHeaders.set("Content-Type", "text/html");
 
                     resolve(
-                      new Response(webBody, {
+                      new Response(stream, {
                         headers: responseHeaders,
                         status: didError ? 500 : responseStatusCode,
                       })
@@ -1075,12 +1076,12 @@ test.describe("aborted", () => {
                 {
                   onShellReady() {
                     let body = new PassThrough();
-                    let webBody = Readable.toWeb(body);
+                    let stream = createReadableStreamFromReadable(body);
 
                     responseHeaders.set("Content-Type", "text/html");
 
                     resolve(
-                      new Response(webBody, {
+                      new Response(stream, {
                         headers: responseHeaders,
                         status: didError ? 500 : responseStatusCode,
                       })

--- a/packages/remix-dev/config/defaults/entry.server.node.tsx
+++ b/packages/remix-dev/config/defaults/entry.server.node.tsx
@@ -48,11 +48,12 @@ function handleBotRequest(
         onAllReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(createReadableStreamFromReadable(body), {
+            new Response(stream, {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -97,11 +98,12 @@ function handleBrowserRequest(
         onShellReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(createReadableStreamFromReadable(body), {
+            new Response(stream, {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/packages/remix-dev/config/defaults/entry.server.node.tsx
+++ b/packages/remix-dev/config/defaults/entry.server.node.tsx
@@ -1,6 +1,7 @@
-import { Readable, PassThrough } from "node:stream";
+import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
+import { createReadableStreamFromReadable } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";
@@ -47,12 +48,11 @@ function handleBotRequest(
         onAllReady() {
           shellRendered = true;
           const body = new PassThrough();
-          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(webBody, {
+            new Response(createReadableStreamFromReadable(body), {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -97,12 +97,11 @@ function handleBrowserRequest(
         onShellReady() {
           shellRendered = true;
           const body = new PassThrough();
-          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(webBody, {
+            new Response(createReadableStreamFromReadable(body), {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/packages/remix-dev/config/defaults/entry.server.node.tsx
+++ b/packages/remix-dev/config/defaults/entry.server.node.tsx
@@ -1,4 +1,4 @@
-import { PassThrough } from "node:stream";
+import { Readable, PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
@@ -47,11 +47,12 @@ function handleBotRequest(
         onAllReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(webBody, {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -96,11 +97,12 @@ function handleBrowserRequest(
         onShellReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(webBody, {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/packages/remix-express/__tests__/server-test.ts
+++ b/packages/remix-express/__tests__/server-test.ts
@@ -1,5 +1,8 @@
 import { Readable } from "node:stream";
-import { createRequestHandler as createRemixRequestHandler } from "@remix-run/node";
+import {
+  createReadableStreamFromReadable,
+  createRequestHandler as createRemixRequestHandler,
+} from "@remix-run/node";
 import express from "express";
 import { createRequest, createResponse } from "node-mocks-http";
 import supertest from "supertest";
@@ -99,9 +102,9 @@ describe("express createRequestHandler", () => {
     // https://github.com/node-fetch/node-fetch/blob/4ae35388b078bddda238277142bf091898ce6fda/test/response.js#L142-L148
     it("handles body as stream", async () => {
       mockedCreateRequestHandler.mockImplementation(() => async () => {
-        let stream = Readable.from("hello world");
-        let webStream = Readable.toWeb(stream);
-        return new Response(webStream as ReadableStream, { status: 200 });
+        let readable = Readable.from("hello world");
+        let stream = createReadableStreamFromReadable(readable);
+        return new Response(stream, { status: 200 });
       });
 
       let request = supertest(createApp());

--- a/scripts/playground/template/app/entry.server.tsx
+++ b/scripts/playground/template/app/entry.server.tsx
@@ -30,11 +30,12 @@ export default function handleRequest(
       {
         [callbackName]: () => {
           let body = new PassThrough();
+          let stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(createReadableStreamFromReadable(body), {
+            new Response(stream, {
               headers: responseHeaders,
               status: didError ? 500 : responseStatusCode,
             })

--- a/scripts/playground/template/app/entry.server.tsx
+++ b/scripts/playground/template/app/entry.server.tsx
@@ -1,4 +1,4 @@
-import { PassThrough } from "node:stream";
+import { Readable, PassThrough } from "node:stream";
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
@@ -29,11 +29,12 @@ export default function handleRequest(
       {
         [callbackName]: () => {
           let body = new PassThrough();
+          let webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(webBody, {
               headers: responseHeaders,
               status: didError ? 500 : responseStatusCode,
             })

--- a/scripts/playground/template/app/entry.server.tsx
+++ b/scripts/playground/template/app/entry.server.tsx
@@ -1,5 +1,6 @@
-import { Readable, PassThrough } from "node:stream";
+import { PassThrough } from "node:stream";
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
+import { createReadableStreamFromReadable } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";
@@ -29,12 +30,11 @@ export default function handleRequest(
       {
         [callbackName]: () => {
           let body = new PassThrough();
-          let webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(webBody, {
+            new Response(createReadableStreamFromReadable(body), {
               headers: responseHeaders,
               status: didError ? 500 : responseStatusCode,
             })

--- a/templates/arc/app/entry.server.tsx
+++ b/templates/arc/app/entry.server.tsx
@@ -54,11 +54,12 @@ function handleBotRequest(
         onAllReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(createReadableStreamFromReadable(body), {
+            new Response(stream, {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -103,11 +104,12 @@ function handleBrowserRequest(
         onShellReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(createReadableStreamFromReadable(body), {
+            new Response(stream, {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/templates/arc/app/entry.server.tsx
+++ b/templates/arc/app/entry.server.tsx
@@ -4,7 +4,7 @@
  * For more information, see https://remix.run/file-conventions/entry.server
  */
 
-import { PassThrough } from "node:stream";
+import { Readable, PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
@@ -53,11 +53,12 @@ function handleBotRequest(
         onAllReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(webBody, {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -102,11 +103,12 @@ function handleBrowserRequest(
         onShellReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(webBody, {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/templates/arc/app/entry.server.tsx
+++ b/templates/arc/app/entry.server.tsx
@@ -4,9 +4,10 @@
  * For more information, see https://remix.run/file-conventions/entry.server
  */
 
-import { Readable, PassThrough } from "node:stream";
+import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
+import { createReadableStreamFromReadable } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";
@@ -53,12 +54,11 @@ function handleBotRequest(
         onAllReady() {
           shellRendered = true;
           const body = new PassThrough();
-          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(webBody, {
+            new Response(createReadableStreamFromReadable(body), {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -103,12 +103,11 @@ function handleBrowserRequest(
         onShellReady() {
           shellRendered = true;
           const body = new PassThrough();
-          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(webBody, {
+            new Response(createReadableStreamFromReadable(body), {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/templates/express/app/entry.server.tsx
+++ b/templates/express/app/entry.server.tsx
@@ -54,11 +54,12 @@ function handleBotRequest(
         onAllReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(createReadableStreamFromReadable(body), {
+            new Response(stream, {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -103,11 +104,12 @@ function handleBrowserRequest(
         onShellReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(createReadableStreamFromReadable(body), {
+            new Response(stream, {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/templates/express/app/entry.server.tsx
+++ b/templates/express/app/entry.server.tsx
@@ -4,7 +4,7 @@
  * For more information, see https://remix.run/file-conventions/entry.server
  */
 
-import { PassThrough } from "node:stream";
+import { Readable, PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
@@ -53,11 +53,12 @@ function handleBotRequest(
         onAllReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(webBody, {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -102,11 +103,12 @@ function handleBrowserRequest(
         onShellReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(webBody, {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/templates/express/app/entry.server.tsx
+++ b/templates/express/app/entry.server.tsx
@@ -4,9 +4,10 @@
  * For more information, see https://remix.run/file-conventions/entry.server
  */
 
-import { Readable, PassThrough } from "node:stream";
+import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
+import { createReadableStreamFromReadable } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";
@@ -53,12 +54,11 @@ function handleBotRequest(
         onAllReady() {
           shellRendered = true;
           const body = new PassThrough();
-          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(webBody, {
+            new Response(createReadableStreamFromReadable(body), {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -103,12 +103,11 @@ function handleBrowserRequest(
         onShellReady() {
           shellRendered = true;
           const body = new PassThrough();
-          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(webBody, {
+            new Response(createReadableStreamFromReadable(body), {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/templates/fly/app/entry.server.tsx
+++ b/templates/fly/app/entry.server.tsx
@@ -54,11 +54,12 @@ function handleBotRequest(
         onAllReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(createReadableStreamFromReadable(body), {
+            new Response(stream, {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -103,11 +104,12 @@ function handleBrowserRequest(
         onShellReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(createReadableStreamFromReadable(body), {
+            new Response(stream, {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/templates/fly/app/entry.server.tsx
+++ b/templates/fly/app/entry.server.tsx
@@ -4,7 +4,7 @@
  * For more information, see https://remix.run/file-conventions/entry.server
  */
 
-import { PassThrough } from "node:stream";
+import { Readable, PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
@@ -53,11 +53,12 @@ function handleBotRequest(
         onAllReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(webBody, {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -102,11 +103,12 @@ function handleBrowserRequest(
         onShellReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(webBody, {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/templates/fly/app/entry.server.tsx
+++ b/templates/fly/app/entry.server.tsx
@@ -4,9 +4,10 @@
  * For more information, see https://remix.run/file-conventions/entry.server
  */
 
-import { Readable, PassThrough } from "node:stream";
+import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
+import { createReadableStreamFromReadable } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";
@@ -53,12 +54,11 @@ function handleBotRequest(
         onAllReady() {
           shellRendered = true;
           const body = new PassThrough();
-          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(webBody, {
+            new Response(createReadableStreamFromReadable(body), {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -103,12 +103,11 @@ function handleBrowserRequest(
         onShellReady() {
           shellRendered = true;
           const body = new PassThrough();
-          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(webBody, {
+            new Response(createReadableStreamFromReadable(body), {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/templates/remix-javascript/app/entry.server.jsx
+++ b/templates/remix-javascript/app/entry.server.jsx
@@ -50,11 +50,12 @@ function handleBotRequest(
       {
         onAllReady() {
           const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(createReadableStreamFromReadable(body), {
+            new Response(stream, {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -92,12 +93,12 @@ function handleBrowserRequest(
       {
         onShellReady() {
           const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            // eslint-disable-next-line no-undef
-            new Response(createReadableStreamFromReadable(body), {
+            new Response(stream, {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/templates/remix-javascript/app/entry.server.jsx
+++ b/templates/remix-javascript/app/entry.server.jsx
@@ -4,7 +4,7 @@
  * For more information, see https://remix.run/docs/en/main/file-conventions/entry.server
  */
 
-import { PassThrough } from "node:stream";
+import { Readable, PassThrough } from "node:stream";
 
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
@@ -49,11 +49,12 @@ function handleBotRequest(
       {
         onAllReady() {
           const body = new PassThrough();
+          const webBody = Readable.toWeb(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(webBody, {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -91,11 +92,12 @@ function handleBrowserRequest(
       {
         onShellReady() {
           const body = new PassThrough();
+          const webBody = Readable.toWeb(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(webBody, {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/templates/remix-javascript/app/entry.server.jsx
+++ b/templates/remix-javascript/app/entry.server.jsx
@@ -4,8 +4,9 @@
  * For more information, see https://remix.run/docs/en/main/file-conventions/entry.server
  */
 
-import { Readable, PassThrough } from "node:stream";
+import { PassThrough } from "node:stream";
 
+import { createReadableStreamFromReadable } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";
@@ -49,12 +50,11 @@ function handleBotRequest(
       {
         onAllReady() {
           const body = new PassThrough();
-          const webBody = Readable.toWeb(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(webBody, {
+            new Response(createReadableStreamFromReadable(body), {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -92,12 +92,12 @@ function handleBrowserRequest(
       {
         onShellReady() {
           const body = new PassThrough();
-          const webBody = Readable.toWeb(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(webBody, {
+            // eslint-disable-next-line no-undef
+            new Response(createReadableStreamFromReadable(body), {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/templates/remix/app/entry.server.tsx
+++ b/templates/remix/app/entry.server.tsx
@@ -54,11 +54,12 @@ function handleBotRequest(
         onAllReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(createReadableStreamFromReadable(body), {
+            new Response(stream, {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -103,11 +104,12 @@ function handleBrowserRequest(
         onShellReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(createReadableStreamFromReadable(body), {
+            new Response(stream, {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/templates/remix/app/entry.server.tsx
+++ b/templates/remix/app/entry.server.tsx
@@ -4,7 +4,7 @@
  * For more information, see https://remix.run/file-conventions/entry.server
  */
 
-import { PassThrough } from "node:stream";
+import { Readable, PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
@@ -53,11 +53,12 @@ function handleBotRequest(
         onAllReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(webBody, {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -102,11 +103,12 @@ function handleBrowserRequest(
         onShellReady() {
           shellRendered = true;
           const body = new PassThrough();
+          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(webBody, {
               headers: responseHeaders,
               status: responseStatusCode,
             })

--- a/templates/remix/app/entry.server.tsx
+++ b/templates/remix/app/entry.server.tsx
@@ -4,9 +4,10 @@
  * For more information, see https://remix.run/file-conventions/entry.server
  */
 
-import { Readable, PassThrough } from "node:stream";
+import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
+import { createReadableStreamFromReadable } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";
@@ -53,12 +54,11 @@ function handleBotRequest(
         onAllReady() {
           shellRendered = true;
           const body = new PassThrough();
-          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(webBody, {
+            new Response(createReadableStreamFromReadable(body), {
               headers: responseHeaders,
               status: responseStatusCode,
             })
@@ -103,12 +103,11 @@ function handleBrowserRequest(
         onShellReady() {
           shellRendered = true;
           const body = new PassThrough();
-          const webBody = Readable.toWeb(body) as ReadableStream;
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(webBody, {
+            new Response(createReadableStreamFromReadable(body), {
               headers: responseHeaders,
               status: responseStatusCode,
             })


### PR DESCRIPTION
Now that we're strictly using web fetch/streams and we no longer export the `fetch` API out through `@remix-run/node` (https://github.com/remix-run/remix/pull/7293), we are also using the globally available `Response` constructor in `entry.server.tsx` (https://github.com/remix-run/remix/pull/7271).  TS doesn't allow a node `PassThrough` stream to be passed directly, so we need to convert it to a web stream using node's `Readable.toWeb()` utility.

Closes: #7357 