### PR TITLE
fix(remix-server-runtime): make `DataFunctionArgs` a type alias

### DIFF
--- a/.changeset/small-impalas-invent.md
+++ b/.changeset/small-impalas-invent.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+[REMOVE] make `DataFunctionArgs` a type alias

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -17,13 +17,10 @@ export interface RouteModules<RouteModule> {
 }
 
 // Context is always provided in Remix, and typed for module augmentation support.
-// RR also doesn't export DataFunctionArgs so we extend the two interfaces here
+// RR also doesn't export DataFunctionArgs, so we extend the two interfaces here
 // even tough they're identical under the hood
-export interface DataFunctionArgs
-  extends RRActionFunctionArgs,
-    RRLoaderFunctionArgs {
-  context: AppLoadContext;
-}
+export type DataFunctionArgs = RRActionFunctionArgs<AppLoadContext> &
+  RRLoaderFunctionArgs<AppLoadContext>;
 
 /**
  * A function that handles data mutations for a route.


### PR DESCRIPTION
Follow-up of @brophdawg11's #7360

I don't think we want people to override `DataFunctionArgs` as they can already override `AppLoadContext`