### PR TITLE
feat(remix-server-runtime)!: use type aliases instead of interfaces

### DIFF
--- a/.changeset/wicked-avocados-play.md
+++ b/.changeset/wicked-avocados-play.md
@@ -1,0 +1,26 @@
+---
+"@remix-run/server-runtime": major
+---
+
+The following types are now exported as type aliases instead of interfaces:
+
+- `Cookie`
+- `CookieParseOptions`
+- `CookieSerializeOptions`
+- `CookieSignatureOptions`
+- `DataFunctionArgs`
+- `EntryContext`
+- `HandleDataRequestFunction`
+- `HandleDocumentRequestFunction`
+- `HandleErrorFunction`
+- `HeadersFunction`
+- `LinksFunction`
+- `PageLinkDescriptor`
+- `ServerBuild`
+- `ServerEntryModule`
+- `ServerRuntimeMetaArgs`
+- `ServerRuntimeMetaFunction`
+- `Session`
+- `SessionData`
+- `SessionIdStorageStrategy`
+- `SessionStorage`

--- a/packages/remix-server-runtime/CHANGELOG.md
+++ b/packages/remix-server-runtime/CHANGELOG.md
@@ -804,7 +804,7 @@ No significant changes to this package were made in this release. [See the relea
 
 ### Patch Changes
 
-- We've added type safety for load context. `AppLoadContext` is now an an interface mapping `string` to `unknown`, allowing users to extend it via module augmentation: ([#1876](https://github.com/remix-run/remix/pull/1876))
+- We've added type safety for load context. `AppLoadContext` is now an interface mapping `string` to `unknown`, allowing users to extend it via module augmentation: ([#1876](https://github.com/remix-run/remix/pull/1876))
 
   ```ts
   declare module "@remix-run/server-runtime" {

--- a/packages/remix-server-runtime/build.ts
+++ b/packages/remix-server-runtime/build.ts
@@ -6,7 +6,7 @@ import type { AppLoadContext } from "./data";
 /**
  * The output of the compiler for the server build.
  */
-export interface ServerBuild {
+export type ServerBuild = {
   mode: string;
   entry: {
     module: ServerEntryModule;
@@ -16,32 +16,32 @@ export interface ServerBuild {
   publicPath: string;
   assetsBuildDirectory: string;
   future: FutureConfig;
-}
+};
 
-export interface HandleDocumentRequestFunction {
-  (
-    request: Request,
-    responseStatusCode: number,
-    responseHeaders: Headers,
-    context: EntryContext,
-    loadContext: AppLoadContext
-  ): Promise<Response> | Response;
-}
+export type HandleDocumentRequestFunction = (
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  context: EntryContext,
+  loadContext: AppLoadContext
+) => Promise<Response> | Response;
 
-export interface HandleDataRequestFunction {
-  (response: Response, args: DataFunctionArgs): Promise<Response> | Response;
-}
+export type HandleDataRequestFunction = (
+  response: Response,
+  args: DataFunctionArgs
+) => Promise<Response> | Response;
 
-export interface HandleErrorFunction {
-  (error: unknown, args: DataFunctionArgs): void;
-}
+export type HandleErrorFunction = (
+  error: unknown,
+  args: DataFunctionArgs
+) => void;
 
 /**
  * A module that serves as the entry point for a Remix app during server
  * rendering.
  */
-export interface ServerEntryModule {
+export type ServerEntryModule = {
   default: HandleDocumentRequestFunction;
   handleDataRequest?: HandleDataRequestFunction;
   handleError?: HandleErrorFunction;
-}
+};

--- a/packages/remix-server-runtime/cookies.ts
+++ b/packages/remix-server-runtime/cookies.ts
@@ -1,12 +1,16 @@
-import type { CookieParseOptions, CookieSerializeOptions } from "cookie";
+import type {
+  CookieParseOptions as RRCookieParseOptions,
+  CookieSerializeOptions as RRCookieSerializeOptions,
+} from "cookie";
 import { parse, serialize } from "cookie";
 
 import type { SignFunction, UnsignFunction } from "./crypto";
 import { warnOnce } from "./warnings";
 
-export type { CookieParseOptions, CookieSerializeOptions };
+export type CookieParseOptions = RRCookieParseOptions;
+export type CookieSerializeOptions = RRCookieSerializeOptions;
 
-export interface CookieSignatureOptions {
+export type CookieSignatureOptions = {
   /**
    * An array of secrets that may be used to sign/unsign the value of a cookie.
    *
@@ -16,7 +20,7 @@ export interface CookieSignatureOptions {
    * cookies that were signed with older secrets still work.
    */
   secrets?: string[];
-}
+};
 
 export type CookieOptions = CookieParseOptions &
   CookieSerializeOptions &
@@ -32,7 +36,7 @@ export type CookieOptions = CookieParseOptions &
  *
  * @see https://remix.run/utils/cookies#cookie-api
  */
-export interface Cookie {
+export type Cookie = {
   /**
    * The name of the cookie, used in the `Cookie` and `Set-Cookie` headers.
    */
@@ -65,7 +69,7 @@ export interface Cookie {
    * header.
    */
   serialize(value: any, options?: CookieSerializeOptions): Promise<string>;
-}
+};
 
 export type CreateCookieFunction = (
   name: string,

--- a/packages/remix-server-runtime/entry.ts
+++ b/packages/remix-server-runtime/entry.ts
@@ -4,18 +4,18 @@ import type { SerializedError } from "./errors";
 import type { RouteManifest, ServerRouteManifest, EntryRoute } from "./routes";
 import type { RouteModules, EntryRouteModule } from "./routeModules";
 
-export interface EntryContext {
+export type EntryContext = {
   manifest: AssetsManifest;
   routeModules: RouteModules<EntryRouteModule>;
   serverHandoffString?: string;
   staticHandlerContext: StaticHandlerContext;
   future: FutureConfig;
   serializeError(error: Error): SerializedError;
-}
+};
 
-export interface FutureConfig {}
+export type FutureConfig = {};
 
-export interface AssetsManifest {
+export type AssetsManifest = {
   entry: {
     imports: string[];
     module: string;
@@ -24,7 +24,7 @@ export interface AssetsManifest {
   url: string;
   version: string;
   hmrRuntime?: string;
-}
+};
 
 export function createEntryRouteModules(
   manifest: ServerRouteManifest

--- a/packages/remix-server-runtime/links.ts
+++ b/packages/remix-server-runtime/links.ts
@@ -4,7 +4,7 @@ type LiteralUnion<LiteralType, BaseType extends Primitive> =
   | LiteralType
   | (BaseType & Record<never, never>);
 
-interface HtmlLinkProps {
+type HtmlLinkProps = {
   /**
    * Address of the hyperlink
    */
@@ -127,9 +127,9 @@ interface HtmlLinkProps {
    * Image sizes for different page layouts (for rel="preload")
    */
   imageSizes?: string;
-}
+};
 
-interface HtmlLinkPreloadImage extends HtmlLinkProps {
+type HtmlLinkPreloadImage = HtmlLinkProps & {
   /**
    * Relationship between the document containing the hyperlink and the destination resource
    */
@@ -155,7 +155,7 @@ interface HtmlLinkPreloadImage extends HtmlLinkProps {
    * Image sizes for different page layouts (for rel="preload")
    */
   imageSizes?: string;
-}
+};
 
 /**
  * Represents a `<link>` element.
@@ -170,23 +170,22 @@ export type HtmlLinkDescriptor =
   | (HtmlLinkPreloadImage &
       Pick<Required<HtmlLinkPreloadImage>, "href"> & { imageSizes?: never });
 
-export interface PageLinkDescriptor
-  extends Omit<
-    HtmlLinkDescriptor,
-    | "href"
-    | "rel"
-    | "type"
-    | "sizes"
-    | "imageSrcSet"
-    | "imageSizes"
-    | "as"
-    | "color"
-    | "title"
-  > {
+export type PageLinkDescriptor = Omit<
+  HtmlLinkDescriptor,
+  | "href"
+  | "rel"
+  | "type"
+  | "sizes"
+  | "imageSrcSet"
+  | "imageSizes"
+  | "as"
+  | "color"
+  | "title"
+> & {
   /**
    * The absolute path of the page to prefetch.
    */
   page: string;
-}
+};
 
 export type LinkDescriptor = HtmlLinkDescriptor | PageLinkDescriptor;

--- a/packages/remix-server-runtime/routeMatching.ts
+++ b/packages/remix-server-runtime/routeMatching.ts
@@ -3,11 +3,11 @@ import { matchRoutes } from "@remix-run/router";
 
 import type { ServerRoute } from "./routes";
 
-export interface RouteMatch<Route> {
+export type RouteMatch<Route> = {
   params: Params;
   pathname: string;
   route: Route;
-}
+};
 
 export function matchServerRoutes(
   routes: ServerRoute[],

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -12,18 +12,15 @@ import type { AppData, AppLoadContext } from "./data";
 import type { LinkDescriptor } from "./links";
 import type { SerializeFrom } from "./serialize";
 
-export interface RouteModules<RouteModule> {
+export type RouteModules<RouteModule> = {
   [routeId: string]: RouteModule;
-}
+};
 
 // Context is always provided in Remix, and typed for module augmentation support.
-// RR also doesn't export DataFunctionArgs so we extend the two interfaces here
+// RR also doesn't export DataFunctionArgs, so we extend the two interfaces here
 // even tough they're identical under the hood
-export interface DataFunctionArgs
-  extends RRActionFunctionArgs,
-    RRLoaderFunctionArgs {
-  context: AppLoadContext;
-}
+export type DataFunctionArgs = RRActionFunctionArgs<AppLoadContext> &
+  RRLoaderFunctionArgs<AppLoadContext>;
 
 /**
  * A function that handles data mutations for a route.
@@ -54,17 +51,13 @@ export type HeadersArgs = {
  * A function that returns HTTP headers to be used for a route. These headers
  * will be merged with (and take precedence over) headers from parent routes.
  */
-export interface HeadersFunction {
-  (args: HeadersArgs): Headers | HeadersInit;
-}
+export type HeadersFunction = (args: HeadersArgs) => Headers | HeadersInit;
 
 /**
  * A function that defines `<link>` tags to be inserted into the `<head>` of
  * the document on route transitions.
  */
-export interface LinksFunction {
-  (): LinkDescriptor[];
-}
+export type LinksFunction = () => LinkDescriptor[];
 
 /**
  * A function that returns an array of data objects to use for rendering
@@ -124,22 +117,20 @@ export interface LinksFunction {
  * }
  * ```
  */
-export interface ServerRuntimeMetaFunction<
+export type ServerRuntimeMetaFunction<
   Loader extends LoaderFunction | unknown = unknown,
   ParentsLoaders extends Record<string, LoaderFunction | unknown> = Record<
     string,
     unknown
   >
-> {
-  (
-    args: ServerRuntimeMetaArgs<Loader, ParentsLoaders>
-  ): ServerRuntimeMetaDescriptor[];
-}
+> = (
+  args: ServerRuntimeMetaArgs<Loader, ParentsLoaders>
+) => ServerRuntimeMetaDescriptor[];
 
-interface ServerRuntimeMetaMatch<
+type ServerRuntimeMetaMatch<
   RouteId extends string = string,
   Loader extends LoaderFunction | unknown = unknown
-> {
+> = {
   id: RouteId;
   pathname: AgnosticRouteMatch["pathname"];
   data: Loader extends LoaderFunction ? SerializeFrom<Loader> : unknown;
@@ -147,7 +138,7 @@ interface ServerRuntimeMetaMatch<
   params: AgnosticRouteMatch["params"];
   meta: ServerRuntimeMetaDescriptor[];
   error?: unknown;
-}
+};
 
 type ServerRuntimeMetaMatches<
   MatchLoaders extends Record<string, LoaderFunction | unknown> = Record<
@@ -163,20 +154,20 @@ type ServerRuntimeMetaMatches<
   }[keyof MatchLoaders]
 >;
 
-export interface ServerRuntimeMetaArgs<
+export type ServerRuntimeMetaArgs<
   Loader extends LoaderFunction | unknown = unknown,
   MatchLoaders extends Record<string, LoaderFunction | unknown> = Record<
     string,
     unknown
   >
-> {
+> = {
   data:
     | (Loader extends LoaderFunction ? SerializeFrom<Loader> : AppData)
     | undefined;
   params: Params;
   location: Location;
   matches: ServerRuntimeMetaMatches<MatchLoaders>;
-}
+};
 
 export type ServerRuntimeMetaDescriptor =
   | { charSet: "utf-8" }
@@ -200,16 +191,16 @@ type LdJsonValue = LdJsonPrimitive | LdJsonObject | LdJsonArray;
  */
 export type RouteHandle = unknown;
 
-export interface EntryRouteModule {
+export type EntryRouteModule = {
   ErrorBoundary?: any; // Weakly typed because server-runtime is not React-aware
   default: any; // Weakly typed because server-runtime is not React-aware
   handle?: RouteHandle;
   links?: LinksFunction;
   meta?: ServerRuntimeMetaFunction;
-}
+};
 
-export interface ServerRouteModule extends EntryRouteModule {
+export type ServerRouteModule = EntryRouteModule & {
   action?: ActionFunction;
   headers?: HeadersFunction | { [name: string]: string };
   loader?: LoaderFunction;
-}
+};

--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -8,35 +8,35 @@ import { callRouteActionRR, callRouteLoaderRR } from "./data";
 import type { FutureConfig } from "./entry";
 import type { ServerRouteModule } from "./routeModules";
 
-export interface RouteManifest<Route> {
+export type RouteManifest<Route> = {
   [routeId: string]: Route;
-}
+};
 
 export type ServerRouteManifest = RouteManifest<Omit<ServerRoute, "children">>;
 
 // NOTE: make sure to change the Route in remix-react if you change this
-export interface Route {
+export type Route = {
   index?: boolean;
   caseSensitive?: boolean;
   id: string;
   parentId?: string;
   path?: string;
-}
+};
 
 // NOTE: make sure to change the EntryRoute in remix-react if you change this
-export interface EntryRoute extends Route {
+export type EntryRoute = Route & {
   hasAction: boolean;
   hasLoader: boolean;
   hasErrorBoundary: boolean;
   imports?: string[];
   module: string;
   parentId?: string;
-}
+};
 
-export interface ServerRoute extends Route {
+export type ServerRoute = Route & {
   children: ServerRoute[];
   module: ServerRouteModule;
-}
+};
 
 function groupRoutesByParentId(manifest: ServerRouteManifest) {
   let routes: Record<string, Omit<ServerRoute, "children">[]> = {};

--- a/packages/remix-server-runtime/sessions.ts
+++ b/packages/remix-server-runtime/sessions.ts
@@ -7,16 +7,16 @@ import { warnOnce } from "./warnings";
 /**
  * An object of name/value pairs to be used in the session.
  */
-export interface SessionData {
+export type SessionData = {
   [name: string]: any;
-}
+};
 
 /**
  * Session persists data across HTTP requests.
  *
  * @see https://remix.run/utils/sessions#session-api
  */
-export interface Session<Data = SessionData, FlashData = Data> {
+export type Session<Data = SessionData, FlashData = Data> = {
   /**
    * A unique identifier for this session.
    *
@@ -67,7 +67,7 @@ export interface Session<Data = SessionData, FlashData = Data> {
    * Removes a value from the session.
    */
   unset(name: keyof Data & string): void;
-}
+};
 
 export type FlashSessionData<Data, FlashData> = Partial<
   Data & {
@@ -168,7 +168,7 @@ export const isSession: IsSessionFunction = (object): object is Session => {
  * A SessionStorage creates Session objects using a `Cookie` header as input.
  * Then, later it generates the `Set-Cookie` header to be used in the response.
  */
-export interface SessionStorage<Data = SessionData, FlashData = Data> {
+export type SessionStorage<Data = SessionData, FlashData = Data> = {
   /**
    * Parses a Cookie header from a HTTP request and returns the associated
    * Session. If there is no session associated with the cookie, this will
@@ -196,7 +196,7 @@ export interface SessionStorage<Data = SessionData, FlashData = Data> {
     session: Session<Data, FlashData>,
     options?: CookieSerializeOptions
   ) => Promise<string>;
-}
+};
 
 /**
  * SessionIdStorageStrategy is designed to allow anyone to easily build their
@@ -207,10 +207,7 @@ export interface SessionStorage<Data = SessionData, FlashData = Data> {
  * database or on disk. A set of create, read, update, and delete operations
  * are provided for managing the session data.
  */
-export interface SessionIdStorageStrategy<
-  Data = SessionData,
-  FlashData = Data
-> {
+export type SessionIdStorageStrategy<Data = SessionData, FlashData = Data> = {
   /**
    * The Cookie used to store the session id, or options used to automatically
    * create one.
@@ -243,7 +240,7 @@ export interface SessionIdStorageStrategy<
    * Deletes data for a given session id from the data store.
    */
   deleteData: (id: string) => Promise<void>;
-}
+};
 
 export type CreateSessionStorageFunction = <
   Data = SessionData,

--- a/packages/remix-server-runtime/sessions/cookieStorage.ts
+++ b/packages/remix-server-runtime/sessions/cookieStorage.ts
@@ -7,13 +7,13 @@ import type {
 } from "../sessions";
 import { warnOnceAboutSigningSessionCookie, createSession } from "../sessions";
 
-interface CookieSessionStorageOptions {
+type CookieSessionStorageOptions = {
   /**
    * The Cookie used to store the session data on the client, or options used
    * to automatically create one.
    */
   cookie?: SessionIdStorageStrategy["cookie"];
-}
+};
 
 export type CreateCookieSessionStorageFunction = <
   Data = SessionData,

--- a/packages/remix-server-runtime/sessions/memoryStorage.ts
+++ b/packages/remix-server-runtime/sessions/memoryStorage.ts
@@ -6,13 +6,13 @@ import type {
   FlashSessionData,
 } from "../sessions";
 
-interface MemorySessionStorageOptions {
+type MemorySessionStorageOptions = {
   /**
    * The Cookie used to store the session id on the client, or options used
    * to automatically create one.
    */
   cookie?: SessionIdStorageStrategy["cookie"];
-}
+};
 
 export type CreateMemorySessionStorageFunction = <
   Data = SessionData,


### PR DESCRIPTION
As requested by @brophdawg11 in https://github.com/remix-run/remix/pull/7362#issuecomment-1710730616, this PR converts all interfaces (both internal + exported) to type aliases