### PR TITLE
build(deno): speed up Rollup copy step

### DIFF
--- a/packages/remix-deno/.gitignore
+++ b/packages/remix-deno/.gitignore
@@ -1,2 +1,0 @@
-# This file is needed for the Rollup copy plugin to ignore local node_modules/
-node_modules

--- a/packages/remix-deno/rollup.config.js
+++ b/packages/remix-deno/rollup.config.js
@@ -15,10 +15,15 @@ module.exports = function rollup() {
         copy({
           targets: [
             { src: "LICENSE.md", dest: [outputDir, sourceDir] },
-            { src: `${sourceDir}/**/*`, dest: outputDir },
-            { src: `!${sourceDir}/rollup.config.js`, dest: outputDir },
+            {
+              src: [
+                `${sourceDir}/**/*`,
+                `!${sourceDir}/rollup.config.js`,
+                `!${sourceDir}/node_modules`,
+              ],
+              dest: outputDir,
+            },
           ],
-          gitignore: true,
         }),
         copyToPlaygrounds(),
       ],


### PR DESCRIPTION
On my machine the Rollup build can be quite slow with initial builds taking 30s, but it was more of a papercut since rebuilds were fast. I was able to narrow it down to the usage of the `gitignore: true` option for `rollup-plugin-copy` on the `@remix-run/deno` package which no other package uses. I was able to achieve the same build output while avoiding this option.

Note that the removed `.gitignore` file was only present for `rollup-plugin-copy` to pick up, so with this config change it became redundant.