### PR TITLE
feat(remix-cloudflare-pages)!: use type aliases instead of interfaces

### DIFF
--- a/.changeset/healthy-apples-agree.md
+++ b/.changeset/healthy-apples-agree.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/cloudflare-pages": major
+---
+
+Renamed `createPagesFunctionHandlerParams` type to `CreatePagesFunctionHandlerParams`

--- a/.changeset/lucky-carrots-lick.md
+++ b/.changeset/lucky-carrots-lick.md
@@ -1,0 +1,7 @@
+---
+"@remix-run/cloudflare-pages": major
+---
+
+The following types are now exported as type aliases instead of interfaces:
+
+- `CreatePagesFunctionHandlerParams`

--- a/packages/remix-cloudflare-pages/index.ts
+++ b/packages/remix-cloudflare-pages/index.ts
@@ -1,5 +1,5 @@
 export type {
-  createPagesFunctionHandlerParams,
+  CreatePagesFunctionHandlerParams,
   GetLoadContextFunction,
   RequestHandler,
 } from "./worker";

--- a/packages/remix-cloudflare-pages/worker.ts
+++ b/packages/remix-cloudflare-pages/worker.ts
@@ -14,17 +14,17 @@ export type GetLoadContextFunction<Env = unknown> = (
 
 export type RequestHandler<Env = any> = PagesFunction<Env>;
 
-export interface createPagesFunctionHandlerParams<Env = any> {
+export type CreatePagesFunctionHandlerParams<Env = any> = {
   build: ServerBuild;
   getLoadContext?: GetLoadContextFunction<Env>;
   mode?: string;
-}
+};
 
 export function createRequestHandler<Env = any>({
   build,
   getLoadContext,
   mode,
-}: createPagesFunctionHandlerParams<Env>): RequestHandler<Env> {
+}: CreatePagesFunctionHandlerParams<Env>): RequestHandler<Env> {
   let handleRequest = createRemixRequestHandler(build, mode);
 
   return async (context) => {
@@ -40,7 +40,7 @@ export function createPagesFunctionHandler<Env = any>({
   build,
   getLoadContext,
   mode,
-}: createPagesFunctionHandlerParams<Env>) {
+}: CreatePagesFunctionHandlerParams<Env>) {
   let handleRequest = createRequestHandler<Env>({
     build,
     getLoadContext,


### PR DESCRIPTION
Just like I did in #7363

To transition more smoothly, we can start with exporting these public types with a `V3_` prefix

This would be something like
```ts
export interface CreatePagesFunctionHandlerParams {
  // ...
}
export type V3_CreatePagesFunctionHandlerParams = CreatePagesFunctionHandlerParams;
```