### PR TITLE
feat(remix-dev)!: use type aliases instead of interfaces

### DIFF
--- a/.changeset/light-doors-beg.md
+++ b/.changeset/light-doors-beg.md
@@ -1,0 +1,8 @@
+---
+"@remix-run/dev": major
+---
+
+The following types are now exported as type aliases instead of interfaces:
+
+- `AppConfig`
+- `ResolvedRemixConfig`

--- a/packages/remix-dev/compiler/fileWatchCache.ts
+++ b/packages/remix-dev/compiler/fileWatchCache.ts
@@ -8,20 +8,23 @@ type CacheValue<T> = {
   | { fileDependencies: Set<string>; globDependencies?: Set<string> }
 );
 
-export interface FileWatchCache {
-  get(key: string): Promise<CacheValue<unknown>> | undefined;
-  set<T>(key: string, promise: Promise<CacheValue<T>>): Promise<CacheValue<T>>;
+export type FileWatchCache = {
+  get: (key: string) => Promise<CacheValue<unknown>> | undefined;
+  set: <T>(
+    key: string,
+    promise: Promise<CacheValue<T>>
+  ) => Promise<CacheValue<T>>;
   /**
    * #description Get a cache value, or lazily set the value if it doesn't exist
    * and then return the new cache value. This lets you interact with the cache
    * in a single expression.
    */
-  getOrSet<T>(
+  getOrSet: <T>(
     key: string,
     lazySetter: () => Promise<CacheValue<T>>
-  ): Promise<CacheValue<T>>;
-  invalidateFile(path: string): void;
-}
+  ) => Promise<CacheValue<T>>;
+  invalidateFile: (path: string) => void;
+};
 
 const globMatchers = new Map<string, ReturnType<typeof picomatch>>();
 function getGlobMatcher(glob: string) {

--- a/packages/remix-dev/compiler/plugins/cssModuleImports.ts
+++ b/packages/remix-dev/compiler/plugins/cssModuleImports.ts
@@ -16,10 +16,10 @@ const cssModulesFilter = /\.module\.css$/;
 const compiledCssQuery = "?css-modules-plugin-compiled-css";
 const compiledCssFilter = /\?css-modules-plugin-compiled-css$/;
 
-interface PluginData {
+type PluginData = {
   resolveDir: string;
   compiledCss: string;
-}
+};
 
 export const cssModulesPlugin = (
   { config, options, fileWatchCache }: Context,

--- a/packages/remix-dev/compiler/server/virtualModules.ts
+++ b/packages/remix-dev/compiler/server/virtualModules.ts
@@ -1,7 +1,7 @@
-interface VirtualModule {
+type VirtualModule = {
   id: string;
   filter: RegExp;
-}
+};
 
 export const serverBuildVirtualModule: VirtualModule = {
   id: "@remix-run/dev/server-build",

--- a/packages/remix-dev/compiler/utils/postcss.ts
+++ b/packages/remix-dev/compiler/utils/postcss.ts
@@ -10,9 +10,9 @@ import type { Options } from "../options";
 import type { FileWatchCache } from "../fileWatchCache";
 import { findConfig } from "../../config";
 
-interface PostcssContext {
+type PostcssContext = {
   vanillaExtract: boolean;
-}
+};
 
 const defaultPostcssContext: PostcssContext = {
   vanillaExtract: false,

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -13,10 +13,10 @@ import { flatRoutes } from "./config/flat-routes";
 import { detectPackageManager } from "./cli/detectPackageManager";
 import { logger } from "./tux";
 
-export interface RemixMdxConfig {
+export type RemixMdxConfig = {
   rehypePlugins?: any[];
   remarkPlugins?: any[];
-}
+};
 
 export type RemixMdxConfigFunction = (
   filename: string
@@ -33,7 +33,7 @@ type Dev = {
   tlsCert?: string;
 };
 
-interface FutureConfig {}
+type FutureConfig = {};
 
 type ServerNodeBuiltinsPolyfillOptions = Pick<
   EsbuildPluginsNodeModulesPolyfillOptions,
@@ -43,7 +43,7 @@ type ServerNodeBuiltinsPolyfillOptions = Pick<
 /**
  * The user-provided config in `remix.config.js`.
  */
-export interface AppConfig {
+export type AppConfig = {
   /**
    * The path to the `app` directory, relative to `remix.config.js`. Defaults
    * to `"app"`.
@@ -176,12 +176,12 @@ export interface AppConfig {
   future?: Partial<FutureConfig> & {
     [propName: string]: never;
   };
-}
+};
 
 /**
  * Fully resolved configuration object we use throughout Remix.
  */
-export interface RemixConfig {
+export type RemixConfig = {
   /**
    * The absolute path to the root of the Remix project.
    */
@@ -337,7 +337,7 @@ export interface RemixConfig {
   tsconfigPath: string | undefined;
 
   future: FutureConfig;
-}
+};
 
 /**
  * Returns a fully resolved config object from the remix.config.js in the given
@@ -634,33 +634,6 @@ export function findConfig(
   }
 
   return undefined;
-}
-
-// adds types for `Intl.ListFormat` to the global namespace
-// we could also update our `tsconfig.json` to include `lib: ["es2021"]`
-declare namespace Intl {
-  type ListType = "conjunction" | "disjunction";
-
-  interface ListFormatOptions {
-    localeMatcher?: "lookup" | "best fit";
-    type?: ListType;
-    style?: "long" | "short" | "narrow";
-  }
-
-  interface ListFormatPart {
-    type: "element" | "literal";
-    value: string;
-  }
-
-  class ListFormat {
-    constructor(locales?: string | string[], options?: ListFormatOptions);
-    format(values: any[]): string;
-    formatToParts(values: any[]): ListFormatPart[];
-    supportedLocalesOf(
-      locales: string | string[],
-      options?: ListFormatOptions
-    ): string[];
-  }
 }
 
 let disjunctionListFormat = new Intl.ListFormat("en", {

--- a/packages/remix-dev/config/routes.ts
+++ b/packages/remix-dev/config/routes.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
  * A route that was created using `defineRoutes` or created conventionally from
  * looking at the files on the filesystem.
  */
-export interface ConfigRoute {
+export type ConfigRoute = {
   /**
    * The path this route uses to match on the URL pathname.
    */
@@ -37,13 +37,13 @@ export interface ConfigRoute {
    * `config.appDirectory`.
    */
   file: string;
-}
+};
 
-export interface RouteManifest {
+export type RouteManifest = {
   [routeId: string]: ConfigRoute;
-}
+};
 
-export interface DefineRouteOptions {
+export type DefineRouteOptions = {
   /**
    * Should be `true` if the route `path` is case-sensitive. Defaults to
    * `false`.
@@ -60,11 +60,9 @@ export interface DefineRouteOptions {
    * two or more routes with the same route file.
    */
   id?: string;
-}
+};
 
-interface DefineRouteChildren {
-  (): void;
-}
+type DefineRouteChildren = () => void;
 
 /**
  * A function for defining a route that is passed as the argument to the
@@ -80,30 +78,28 @@ interface DefineRouteChildren {
  *     });
  *   });
  */
-export interface DefineRouteFunction {
-  (
-    /**
-     * The path this route uses to match the URL pathname.
-     */
-    path: string | undefined,
+export type DefineRouteFunction = (
+  /**
+   * The path this route uses to match the URL pathname.
+   */
+  path: string | undefined,
 
-    /**
-     * The path to the file that exports the React component rendered by this
-     * route as its default export, relative to the `app` directory.
-     */
-    file: string,
+  /**
+   * The path to the file that exports the React component rendered by this
+   * route as its default export, relative to the `app` directory.
+   */
+  file: string,
 
-    /**
-     * Options for defining routes, or a function for defining child routes.
-     */
-    optionsOrChildren?: DefineRouteOptions | DefineRouteChildren,
+  /**
+   * Options for defining routes, or a function for defining child routes.
+   */
+  optionsOrChildren?: DefineRouteOptions | DefineRouteChildren,
 
-    /**
-     * A function for defining child routes.
-     */
-    children?: DefineRouteChildren
-  ): void;
-}
+  /**
+   * A function for defining child routes.
+   */
+  children?: DefineRouteChildren
+) => void;
 
 export type DefineRoutesFunction = typeof defineRoutes;
 


### PR DESCRIPTION
Just like I did in #7363 & #7366

To transition more smoothly, we can start with exporting these public types with a `V3_` prefix

This would be something like
```ts
export interface AppConfig {
  // ...
}
export type V3_AppConfig = AppConfig;
```