### PR TITLE
feat(remix-react)!: use type aliases instead of interfaces

### DIFF
--- a/.changeset/hot-turkeys-battle.md
+++ b/.changeset/hot-turkeys-battle.md
@@ -1,0 +1,25 @@
+---
+"@remix-run/react": major
+---
+
+The following types are now exported as type aliases instead of interfaces:
+
+- `AwaitProps`
+- `FormProps`
+- `LinkProps`
+- `Location`
+- `MetaArgs`
+- `MetaFunction`
+- `NavLinkProps`
+- `NavigateFunction`
+- `Path`
+- `RemixBrowserProps`
+- `RemixServerProps`
+- `RouteMatch`
+- `ShouldRevalidateFunction`
+- `SubmitFunction`
+- `SubmitOptions`
+- `UNSAFE_FutureConfig`
+- `UNSAFE_RemixContextObject`
+- `UNSAFE_RouteManifest`
+- `UNSAFE_RouteModules`

--- a/packages/remix-react/CHANGELOG.md
+++ b/packages/remix-react/CHANGELOG.md
@@ -338,7 +338,7 @@ No significant changes to this package were made in this release. [See the relea
 
 - Remove duplicate manifest imports ([#5534](https://github.com/remix-run/remix/pull/5534))
 - Ensure types for fetchers always include `form*` submission fields ([#5476](https://github.com/remix-run/remix/pull/5476))
-- Sync `FutureConfig` interface between packages ([#5398](https://github.com/remix-run/remix/pull/5398))
+- Sync `FutureConfig` type between packages ([#5398](https://github.com/remix-run/remix/pull/5398))
 - Updated dependencies:
   - `@remix-run/router@1.3.3`
   - `react-router-dom@8.6.2`

--- a/packages/remix-react/browser.tsx
+++ b/packages/remix-react/browser.tsx
@@ -35,7 +35,7 @@ declare global {
 }
 /* eslint-enable prefer-let/prefer-let */
 
-export interface RemixBrowserProps {}
+export type RemixBrowserProps = {};
 
 declare global {
   interface ImportMeta {

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -97,21 +97,21 @@ function useRemixContext(): RemixContextObject {
  */
 type PrefetchBehavior = "intent" | "render" | "none" | "viewport";
 
-export interface RemixLinkProps extends LinkProps {
+export type RemixLinkProps = LinkProps & {
   prefetch?: PrefetchBehavior;
-}
+};
 
-export interface RemixNavLinkProps extends NavLinkProps {
+export type RemixNavLinkProps = NavLinkProps & {
   prefetch?: PrefetchBehavior;
-}
+};
 
-interface PrefetchHandlers {
+type PrefetchHandlers = {
   onFocus?: FocusEventHandler;
   onBlur?: FocusEventHandler;
   onMouseEnter?: MouseEventHandler;
   onMouseLeave?: MouseEventHandler;
   onTouchStart?: TouchEventHandler;
-}
+};
 
 function usePrefetchBehavior<T extends HTMLAnchorElement>(
   prefetch: PrefetchBehavior,
@@ -561,11 +561,11 @@ function isValidMetaTag(tagName: unknown): tagName is "meta" | "link" {
   return typeof tagName === "string" && /^(meta|link)$/.test(tagName);
 }
 
-export interface AwaitProps<Resolve> {
+export type AwaitProps<Resolve> = {
   children: React.ReactNode | ((value: Awaited<Resolve>) => React.ReactNode);
   errorElement?: React.ReactNode;
   resolve: Resolve;
-}
+};
 
 export function Await<Resolve>(props: AwaitProps<Resolve>) {
   return <AwaitRR {...props} />;
@@ -976,7 +976,7 @@ function dedupe(array: any[]) {
 }
 
 // TODO: Can this be re-exported from RR?
-export interface RouteMatch {
+export type RouteMatch = {
   /**
    * The id of the matched route
    */
@@ -1001,7 +1001,7 @@ export interface RouteMatch {
    * @see https://remix.run/route/handle
    */
   handle: undefined | { [key: string]: any };
-}
+};
 
 /**
  * Returns the JSON parsed data from the current route's `loader`.

--- a/packages/remix-react/entry.ts
+++ b/packages/remix-react/entry.ts
@@ -9,24 +9,24 @@ type SerializedError = {
   message: string;
   stack?: string;
 };
-export interface RemixContextObject {
+export type RemixContextObject = {
   manifest: AssetsManifest;
   routeModules: RouteModules;
   serverHandoffString?: string;
   future: FutureConfig;
   abortDelay?: number;
   serializeError?(error: Error): SerializedError;
-}
+};
 
 // Additional React-Router information needed at runtime, but not hydrated
 // through RemixContext
-export interface EntryContext extends RemixContextObject {
+export type EntryContext = RemixContextObject & {
   staticHandlerContext: StaticHandlerContext;
-}
+};
 
-export interface FutureConfig {}
+export type FutureConfig = {};
 
-export interface AssetsManifest {
+export type AssetsManifest = {
   entry: {
     imports: string[];
     module: string;
@@ -38,4 +38,4 @@ export interface AssetsManifest {
     timestamp: number;
     runtime: string;
   };
-}
+};

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -1,3 +1,13 @@
+import type {
+  FormProps as RRFormProps,
+  Location as RRLocation,
+  NavigateFunction as RRNavigateFunction,
+  Path as RRPath,
+  ShouldRevalidateFunction as RRShouldRevalidateFunction,
+  SubmitFunction as RRSubmitFunction,
+  SubmitOptions as RRSubmitOptions,
+} from "react-router-dom";
+
 export type { RemixBrowserProps } from "./browser";
 export { RemixBrowser } from "./browser";
 export type {
@@ -6,18 +16,18 @@ export type {
   FetcherWithComponents,
   FormEncType,
   FormMethod,
-  FormProps,
-  Location,
-  NavigateFunction,
   Navigation,
   Params,
-  Path,
-  ShouldRevalidateFunction,
-  SubmitFunction,
-  SubmitOptions,
   unstable_Blocker,
   unstable_BlockerFunction,
 } from "react-router-dom";
+export type FormProps = RRFormProps;
+export type Location = RRLocation;
+export type NavigateFunction = RRNavigateFunction;
+export type Path = RRPath;
+export type ShouldRevalidateFunction = RRShouldRevalidateFunction;
+export type SubmitFunction = RRSubmitFunction;
+export type SubmitOptions = RRSubmitOptions;
 export {
   createPath,
   generatePath,

--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -12,7 +12,7 @@ type LiteralUnion<LiteralType, BaseType extends Primitive> =
   | LiteralType
   | (BaseType & Record<never, never>);
 
-interface HtmlLinkProps {
+type HtmlLinkProps = {
   /**
    * Address of the hyperlink
    */
@@ -135,9 +135,9 @@ interface HtmlLinkProps {
    * Image sizes for different page layouts (for rel="preload")
    */
   imageSizes?: string;
-}
+};
 
-interface HtmlLinkPreloadImage extends HtmlLinkProps {
+type HtmlLinkPreloadImage = HtmlLinkProps & {
   /**
    * Relationship between the document containing the hyperlink and the destination resource
    */
@@ -163,7 +163,7 @@ interface HtmlLinkPreloadImage extends HtmlLinkProps {
    * Image sizes for different page layouts (for rel="preload")
    */
   imageSizes?: string;
-}
+};
 
 /**
  * Represents a `<link>` element.
@@ -178,24 +178,23 @@ export type HtmlLinkDescriptor =
   | (HtmlLinkPreloadImage &
       Pick<Required<HtmlLinkPreloadImage>, "href"> & { imageSizes?: never });
 
-export interface PrefetchPageDescriptor
-  extends Omit<
-    HtmlLinkDescriptor,
-    | "href"
-    | "rel"
-    | "type"
-    | "sizes"
-    | "imageSrcSet"
-    | "imageSizes"
-    | "as"
-    | "color"
-    | "title"
-  > {
+export type PrefetchPageDescriptor = Omit<
+  HtmlLinkDescriptor,
+  | "href"
+  | "rel"
+  | "type"
+  | "sizes"
+  | "imageSrcSet"
+  | "imageSizes"
+  | "as"
+  | "color"
+  | "title"
+> & {
   /**
    * The absolute path of the page to prefetch.
    */
   page: string;
-}
+};
 
 export type LinkDescriptor = HtmlLinkDescriptor | PrefetchPageDescriptor;
 

--- a/packages/remix-react/markup.ts
+++ b/packages/remix-react/markup.ts
@@ -18,9 +18,9 @@ export function escapeHtml(html: string) {
   return html.replace(ESCAPE_REGEX, (match) => ESCAPE_LOOKUP[match]);
 }
 
-export interface SafeHtml {
+export type SafeHtml = {
   __html: string;
-}
+};
 
 export function createHtml(html: string): SafeHtml {
   return { __html: html };

--- a/packages/remix-react/routeModules.ts
+++ b/packages/remix-react/routeModules.ts
@@ -11,18 +11,18 @@ import type { AppData } from "./data";
 import type { LinkDescriptor } from "./links";
 import type { EntryRoute } from "./routes";
 
-export interface RouteModules {
+export type RouteModules = {
   [routeId: string]: RouteModule;
-}
+};
 
-export interface RouteModule {
+export type RouteModule = {
   ErrorBoundary?: ErrorBoundaryComponent;
   default: RouteComponent;
   handle?: RouteHandle;
   links?: LinksFunction;
   meta?: MetaFunction;
   shouldRevalidate?: ShouldRevalidateFunction;
-}
+};
 
 /**
  * V2 version of the ErrorBoundary that eliminates the distinction between
@@ -37,14 +37,12 @@ export type ErrorBoundaryComponent = ComponentType;
  *
  * @see https://remix.run/route/meta
  */
-export interface LinksFunction {
-  (): LinkDescriptor[];
-}
+export type LinksFunction = () => LinkDescriptor[];
 
-export interface MetaMatch<
+export type MetaMatch<
   RouteId extends string = string,
   Loader extends LoaderFunction | unknown = unknown
-> {
+> = {
   id: RouteId;
   pathname: DataRouteMatch["pathname"];
   data: Loader extends LoaderFunction ? SerializeFrom<Loader> : unknown;
@@ -52,7 +50,7 @@ export interface MetaMatch<
   params: DataRouteMatch["params"];
   meta: MetaDescriptor[];
   error?: unknown;
-}
+};
 
 export type MetaMatches<
   MatchLoaders extends Record<string, LoaderFunction | unknown> = Record<
@@ -68,13 +66,13 @@ export type MetaMatches<
   }[keyof MatchLoaders]
 >;
 
-export interface MetaArgs<
+export type MetaArgs<
   Loader extends LoaderFunction | unknown = unknown,
   MatchLoaders extends Record<string, LoaderFunction | unknown> = Record<
     string,
     unknown
   >
-> {
+> = {
   data:
     | (Loader extends LoaderFunction ? SerializeFrom<Loader> : AppData)
     | undefined;
@@ -82,17 +80,15 @@ export interface MetaArgs<
   location: Location;
   matches: MetaMatches<MatchLoaders>;
   error?: unknown;
-}
+};
 
-export interface MetaFunction<
+export type MetaFunction<
   Loader extends LoaderFunction | unknown = unknown,
   MatchLoaders extends Record<string, LoaderFunction | unknown> = Record<
     string,
     unknown
   >
-> {
-  (args: MetaArgs<Loader, MatchLoaders>): MetaDescriptor[] | undefined;
-}
+> = (args: MetaArgs<Loader, MatchLoaders>) => MetaDescriptor[] | undefined;
 
 export type MetaDescriptor =
   | { charSet: "utf-8" }

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -18,28 +18,28 @@ import type { FutureConfig } from "./entry";
 import { prefetchStyleLinks } from "./links";
 import { RemixRootDefaultErrorBoundary } from "./errorBoundaries";
 
-export interface RouteManifest<Route> {
+export type RouteManifest<Route> = {
   [routeId: string]: Route;
-}
+};
 
 // NOTE: make sure to change the Route in server-runtime if you change this
-interface Route {
+type Route = {
   index?: boolean;
   caseSensitive?: boolean;
   id: string;
   parentId?: string;
   path?: string;
-}
+};
 
 // NOTE: make sure to change the EntryRoute in server-runtime if you change this
-export interface EntryRoute extends Route {
+export type EntryRoute = Route & {
   hasAction: boolean;
   hasLoader: boolean;
   hasErrorBoundary: boolean;
   imports?: string[];
   module: string;
   parentId?: string;
-}
+};
 
 // Create a map of routes by parentId to use recursively instead of
 // repeatedly filtering the manifest.

--- a/packages/remix-react/server.tsx
+++ b/packages/remix-react/server.tsx
@@ -10,11 +10,11 @@ import type { EntryContext } from "./entry";
 import { RemixErrorBoundary } from "./errorBoundaries";
 import { createServerRoutes } from "./routes";
 
-export interface RemixServerProps {
+export type RemixServerProps = {
   context: EntryContext;
   url: string | URL;
   abortDelay?: number;
-}
+};
 
 /**
  * The entry point for a Remix app when it is rendered on the server (in


### PR DESCRIPTION
Just like I did in #7363, #7366 & #7367

To transition more smoothly, we can start with exporting these public types with a `V3_` prefix

This would be something like
```ts
export interface AwaitProps {
  // ...
}
export type V3_AwaitProps = AwaitProps;
```