### PR TITLE
feat(remix-testing)!: use type aliases instead of interfaces

### DIFF
--- a/.changeset/cool-bears-collect.md
+++ b/.changeset/cool-bears-collect.md
@@ -1,0 +1,7 @@
+---
+"@remix-run/testing": major
+---
+
+The following types are now exported as type aliases instead of interfaces:
+
+- `RemixStubProps`

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -29,33 +29,31 @@ import type {
   LoaderFunction,
 } from "@remix-run/server-runtime";
 
-interface StubIndexRouteObject
-  extends Omit<
-    IndexRouteObject,
-    "loader" | "action" | "element" | "errorElement" | "children"
-  > {
+type StubIndexRouteObject = Omit<
+  IndexRouteObject,
+  "loader" | "action" | "element" | "errorElement" | "children"
+> & {
   loader?: LoaderFunction;
   action?: ActionFunction;
   children?: StubRouteObject[];
   meta?: MetaFunction;
   links?: LinksFunction;
-}
+};
 
-interface StubNonIndexRouteObject
-  extends Omit<
-    NonIndexRouteObject,
-    "loader" | "action" | "element" | "errorElement" | "children"
-  > {
+type StubNonIndexRouteObject = Omit<
+  NonIndexRouteObject,
+  "loader" | "action" | "element" | "errorElement" | "children"
+> & {
   loader?: LoaderFunction;
   action?: ActionFunction;
   children?: StubRouteObject[];
   meta?: MetaFunction;
   links?: LinksFunction;
-}
+};
 
 type StubRouteObject = StubIndexRouteObject | StubNonIndexRouteObject;
 
-export interface RemixStubProps {
+export type RemixStubProps = {
   /**
    *  The initial entries in the history stack. This allows you to start a test with
    *  multiple locations already in the history stack (for testing a back navigation, etc.)
@@ -86,7 +84,7 @@ export interface RemixStubProps {
    * Future flags mimicking the settings in remix.config.js
    */
   remixConfigFuture?: Partial<FutureConfig>;
-}
+};
 
 export function createRemixStub(
   routes: StubRouteObject[],


### PR DESCRIPTION
Just like I did in #7363, #7366, #7367 & #7368

To transition more smoothly, we can start with exporting these public types with a `V3_` prefix

This would be something like
```ts
export interface RemixStubProps {
  // ...
}
export type V3_RemixStubProps = RemixStubProps;
```