### PR TITLE
feat(create-remix)!: use type aliases instead of interfaces

### DIFF
--- a/.changeset/giant-forks-jog.md
+++ b/.changeset/giant-forks-jog.md
@@ -1,0 +1,7 @@
+---
+"create-remix": major
+---
+
+The following types are now exported as type aliases instead of interfaces:
+
+- `Context`

--- a/packages/create-remix/__tests__/create-remix-test.ts
+++ b/packages/create-remix/__tests__/create-remix-test.ts
@@ -1303,11 +1303,11 @@ async function execCreateRemix({
   return await interactWithShell(proc, interactions);
 }
 
-interface ShellResult {
+type ShellResult = {
   status: number | "timeout" | null;
   stdout: string;
   stderr: string;
-}
+};
 
 type ShellInteractions = Array<
   | { question: RegExp; type: Array<String>; answer?: never }

--- a/packages/create-remix/copy-template.ts
+++ b/packages/create-remix/copy-template.ts
@@ -72,12 +72,12 @@ export async function copyTemplate(
   }
 }
 
-interface CopyTemplateOptions {
+type CopyTemplateOptions = {
   debug?: boolean;
   token?: string;
   onError(error: unknown): any;
   log?(message: string): any;
-}
+};
 
 function isLocalFilePath(input: string): boolean {
   try {
@@ -172,11 +172,11 @@ async function extractLocalTarball(
   }
 }
 
-interface TarballDownloadOptions {
+type TarballDownloadOptions = {
   debug?: boolean;
   filePath?: string | null;
   token?: string;
-}
+};
 
 async function downloadAndExtractRepoTarball(
   repo: RepoInfo,
@@ -207,10 +207,10 @@ async function downloadAndExtractRepoTarball(
   });
 }
 
-interface DownloadAndExtractTarballOptions {
+type DownloadAndExtractTarballOptions = {
   token?: string;
   filePath?: string | null;
-}
+};
 
 async function downloadAndExtractTarball(
   downloadPath: string,
@@ -466,15 +466,15 @@ export class CopyTemplateError extends Error {
   }
 }
 
-interface RepoInfo {
+type RepoInfo = {
   owner: string;
   name: string;
   branch?: string | null;
   filePath?: string | null;
-}
+};
 
 // https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#get-a-release-asset
-interface GitHubApiReleaseAsset {
+type GitHubApiReleaseAsset = {
   url: string;
   browser_download_url: string;
   id: number;
@@ -488,9 +488,9 @@ interface GitHubApiReleaseAsset {
   created_at: string;
   updated_at: string;
   uploader: null | GitHubApiUploader;
-}
+};
 
-interface GitHubApiUploader {
+type GitHubApiUploader = {
   name: string | null;
   email: string | null;
   login: string;
@@ -512,15 +512,15 @@ interface GitHubApiUploader {
   type: string;
   site_admin: boolean;
   starred_at: string;
-}
+};
 
-interface ReleaseAssetInfo {
+type ReleaseAssetInfo = {
   browserUrl: string;
   owner: string;
   name: string;
   asset: string;
   tag: string;
-}
+};
 
 type GithubUrlString =
   | `https://github.com/${string}/${string}`

--- a/packages/create-remix/index.ts
+++ b/packages/create-remix/index.ts
@@ -177,7 +177,7 @@ async function getContext(argv: string[]): Promise<Context> {
   return context;
 }
 
-interface Context {
+type Context = {
   tempDir: string;
   cwd: string;
   interactive: boolean;
@@ -199,7 +199,7 @@ interface Context {
   token?: string;
   versionRequested?: boolean;
   overwrite?: boolean;
-}
+};
 
 async function introStep(ctx: Context) {
   log(

--- a/packages/create-remix/prompt.ts
+++ b/packages/create-remix/prompt.ts
@@ -109,37 +109,36 @@ type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
   ? I
   : never;
 
-interface BasePromptType {
+type BasePromptType = {
   name: string;
-}
+};
 
-interface TextPromptType extends BasePromptType {
+type TextPromptType = BasePromptType & {
   type: "text";
-}
+};
 
-interface ConfirmPromptType extends BasePromptType {
+type ConfirmPromptType = BasePromptType & {
   type: "confirm";
-}
+};
 
-interface SelectPromptType<
-  Choices extends Readonly<Readonly<SelectChoiceType>[]>
-> extends BasePromptType {
-  type: "select";
-  choices: Choices;
-}
+type SelectPromptType<Choices extends Readonly<Readonly<SelectChoiceType>[]>> =
+  BasePromptType & {
+    type: "select";
+    choices: Choices;
+  };
 
-interface MultiSelectPromptType<
+type MultiSelectPromptType<
   Choices extends Readonly<Readonly<SelectChoiceType>[]>
-> extends BasePromptType {
+> = BasePromptType & {
   type: "multiselect";
   choices: Choices;
-}
+};
 
-interface SelectChoiceType {
+type SelectChoiceType = {
   value: unknown;
   label: string;
   hint?: string;
-}
+};
 
 type PromptType<
   Choices extends Readonly<SelectChoiceType[]> = Readonly<SelectChoiceType[]>
@@ -178,10 +177,10 @@ type Answers<
   ? UnionToIntersection<Answers<T[number]>>
   : never;
 
-interface PromptTypeOptions<
+type PromptTypeOptions<
   T extends PromptType<any>,
   Choices extends Readonly<SelectChoiceType[]> = PromptChoices<T>
-> {
+> = {
   onSubmit?(
     question: T | Readonly<T>,
     answer: Answer<T, Choices>,
@@ -190,4 +189,4 @@ interface PromptTypeOptions<
   onCancel?(question: T | Readonly<T>, answers: Answers<T>): any;
   stdin?: NodeJS.ReadStream;
   stdout?: NodeJS.WriteStream;
-}
+};

--- a/packages/create-remix/prompts-confirm.ts
+++ b/packages/create-remix/prompts-confirm.ts
@@ -7,14 +7,14 @@ import { cursor, erase } from "sisteransi";
 import { Prompt, type PromptOptions } from "./prompts-prompt-base";
 import { color, strip, clear, type ActionKey } from "./utils";
 
-export interface ConfirmPromptOptions extends PromptOptions {
+export type ConfirmPromptOptions = PromptOptions & {
   label: string;
   message: string;
   initial?: boolean;
   hint?: string;
   validate?: (v: any) => boolean;
   error?: string;
-}
+};
 
 export type ConfirmPromptChoices = [
   { value: true; label: string },

--- a/packages/create-remix/prompts-multi-select.ts
+++ b/packages/create-remix/prompts-multi-select.ts
@@ -8,9 +8,9 @@ import { Prompt, type PromptOptions } from "./prompts-prompt-base";
 import { type SelectChoice } from "./prompts-select";
 import { color, strip, clear, type ActionKey } from "./utils";
 
-export interface MultiSelectPromptOptions<
+export type MultiSelectPromptOptions<
   Choices extends Readonly<Readonly<SelectChoice>[]>
-> extends PromptOptions {
+> = PromptOptions & {
   hint?: string;
   message: string;
   label: string;
@@ -18,7 +18,7 @@ export interface MultiSelectPromptOptions<
   validate?: (v: any) => boolean;
   error?: string;
   choices: Choices;
-}
+};
 
 export class MultiSelectPrompt<
   Choices extends Readonly<Readonly<SelectChoice>[]>

--- a/packages/create-remix/prompts-prompt-base.ts
+++ b/packages/create-remix/prompts-prompt-base.ts
@@ -93,7 +93,7 @@ export class Prompt extends EventEmitter {
   }
 }
 
-export interface PromptOptions {
+export type PromptOptions = {
   stdin?: typeof process.stdin;
   stdout?: typeof process.stdout;
   onRender?(render: (...text: unknown[]) => string): void;
@@ -112,4 +112,4 @@ export interface PromptOptions {
   onState?(
     v: any
   ): void | undefined | boolean | Promise<void | undefined | boolean>;
-}
+};

--- a/packages/create-remix/prompts-select.ts
+++ b/packages/create-remix/prompts-select.ts
@@ -7,15 +7,15 @@ import { cursor, erase } from "sisteransi";
 import { Prompt, type PromptOptions } from "./prompts-prompt-base";
 import { color, strip, clear, shouldUseAscii, type ActionKey } from "./utils";
 
-export interface SelectChoice {
+export type SelectChoice = {
   value: unknown;
   label: string;
   hint?: string;
-}
+};
 
-export interface SelectPromptOptions<
+export type SelectPromptOptions<
   Choices extends Readonly<Readonly<SelectChoice>[]>
-> extends PromptOptions {
+> = PromptOptions & {
   hint?: string;
   message: string;
   label: string;
@@ -23,7 +23,7 @@ export interface SelectPromptOptions<
   validate?: (v: any) => boolean;
   error?: string;
   choices: Choices;
-}
+};
 
 export class SelectPrompt<
   Choices extends Readonly<Readonly<SelectChoice>[]>

--- a/packages/create-remix/prompts-text.ts
+++ b/packages/create-remix/prompts-text.ts
@@ -14,7 +14,7 @@ import {
   type ActionKey,
 } from "./utils";
 
-export interface TextPromptOptions extends PromptOptions {
+export type TextPromptOptions = PromptOptions & {
   label: string;
   message: string;
   initial?: string;
@@ -22,7 +22,7 @@ export interface TextPromptOptions extends PromptOptions {
   validate?: (v: any) => v is string;
   error?: string;
   hint?: string;
-}
+};
 
 export class TextPrompt extends Prompt {
   transform: { render: (v: string) => any; scale: number };


### PR DESCRIPTION
Just like I did in #7363, #7366, #7367, #7368 & #7369

To transition more smoothly, we can start with exporting these public types with a `V3_` prefix

This would be something like
```ts
export interface Context {
  // ...
}
export type V3_Context = Context;
```