### PR TITLE
chore: use type aliases instead of interfaces

### DIFF
--- a/integration/helpers/create-fixture.ts
+++ b/integration/helpers/create-fixture.ts
@@ -21,14 +21,14 @@ import { installGlobals } from "../../build/node_modules/@remix-run/node/dist/in
 const TMP_DIR = path.join(process.cwd(), ".tmp", "integration");
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
-export interface FixtureInit {
+export type FixtureInit = {
   buildStdio?: Writable;
   sourcemap?: boolean;
   files?: { [filename: string]: string };
   template?: "cf-template" | "deno-template" | "node-template";
   config?: Partial<AppConfig>;
   useRemixServe?: boolean;
-}
+};
 
 export type Fixture = Awaited<ReturnType<typeof createFixture>>;
 export type AppFixture = Awaited<ReturnType<typeof createAppFixture>>;

--- a/packages/remix-architect/sessions/arcTableSessionStorage.ts
+++ b/packages/remix-architect/sessions/arcTableSessionStorage.ts
@@ -8,7 +8,7 @@ import { createSessionStorage } from "@remix-run/node";
 import arc from "@architect/functions";
 import type { ArcTable } from "@architect/functions/types/tables";
 
-interface ArcTableSessionStorageOptions {
+type ArcTableSessionStorageOptions = {
   /**
    * The Cookie used to store the session id on the client, or options used
    * to automatically create one.
@@ -32,7 +32,7 @@ interface ArcTableSessionStorageOptions {
    * If absent, then no TTL will be stored and session records will not expire.
    */
   ttl?: string;
-}
+};
 
 /**
  * Session storage using a DynamoDB table managed by Architect.

--- a/packages/remix-cloudflare/sessions/workersKVStorage.ts
+++ b/packages/remix-cloudflare/sessions/workersKVStorage.ts
@@ -6,7 +6,7 @@ import type {
 
 import { createSessionStorage } from "../implementations";
 
-interface WorkersKVSessionStorageOptions {
+type WorkersKVSessionStorageOptions = {
   /**
    * The Cookie used to store the session id on the client, or options used
    * to automatically create one.
@@ -17,7 +17,7 @@ interface WorkersKVSessionStorageOptions {
    * The KVNamespace used to store the sessions.
    */
   kv: KVNamespace;
-}
+};
 
 /**
  * Creates a SessionStorage that stores session data in the Clouldflare KV Store.

--- a/packages/remix-deno/sessions/fileStorage.ts
+++ b/packages/remix-deno/sessions/fileStorage.ts
@@ -7,7 +7,7 @@ import type {
 } from "@remix-run/server-runtime";
 import { createSessionStorage } from "../implementations.ts";
 
-interface FileSessionStorageOptions {
+type FileSessionStorageOptions = {
   /**
    * The Cookie used to store the session id on the client, or options used
    * to automatically create one.
@@ -18,7 +18,7 @@ interface FileSessionStorageOptions {
    * The directory to use to store session files.
    */
   dir: string;
-}
+};
 
 /**
  * Creates a SessionStorage that stores session data on a filesystem.
@@ -55,7 +55,7 @@ export function createFileSessionStorage<Data = SessionData, FlashData = Data>({
           if (exists) continue;
 
           await Deno.mkdir(path.dirname(file), { recursive: true }).catch(
-            () => {},
+            () => {}
           );
           await Deno.writeFile(file, new TextEncoder().encode(content));
 
@@ -70,9 +70,10 @@ export function createFileSessionStorage<Data = SessionData, FlashData = Data>({
         const file = getFile(dir, id);
         const content = JSON.parse(await Deno.readTextFile(file));
         const data = content.data;
-        const expires = typeof content.expires === "string"
-          ? new Date(content.expires)
-          : null;
+        const expires =
+          typeof content.expires === "string"
+            ? new Date(content.expires)
+            : null;
 
         if (!expires || expires > new Date()) {
           return data;

--- a/packages/remix-node/sessions/fileStorage.ts
+++ b/packages/remix-node/sessions/fileStorage.ts
@@ -9,7 +9,7 @@ import type {
 
 import { createSessionStorage } from "../implementations";
 
-interface FileSessionStorageOptions {
+type FileSessionStorageOptions = {
   /**
    * The Cookie used to store the session id on the client, or options used
    * to automatically create one.
@@ -20,7 +20,7 @@ interface FileSessionStorageOptions {
    * The directory to use to store session files.
    */
   dir: string;
-}
+};
 
 /**
  * Creates a SessionStorage that stores session data on a filesystem.

--- a/packages/remix-serve/CHANGELOG.md
+++ b/packages/remix-serve/CHANGELOG.md
@@ -132,7 +132,7 @@
 ### Patch Changes
 
 - Allow configurable `NODE_ENV` with `remix-serve` ([#5540](https://github.com/remix-run/remix/pull/5540))
-- Sync `FutureConfig` interface between packages ([#5398](https://github.com/remix-run/remix/pull/5398))
+- Sync `FutureConfig` type between packages ([#5398](https://github.com/remix-run/remix/pull/5398))
 - Updated dependencies:
   - `@remix-run/express@1.14.0`
 

--- a/scripts/unist.d.ts
+++ b/scripts/unist.d.ts
@@ -2,10 +2,10 @@ import type { Parent, Literal } from "unist";
 
 export type Node = FlowNode | PhrasingNode | RootNode;
 
-export interface RootNode extends Parent {
+export type RootNode = Parent & {
   type: "root";
   children: FlowNode[];
-}
+};
 
 export type PhrasingNode = TextNode | EmphasisNode;
 
@@ -17,46 +17,46 @@ export type FlowNode =
   | PreNode
   | CodeNode;
 
-export interface BlockquoteNode extends Parent {
+export type BlockquoteNode = Parent & {
   type: "blockquote";
   children: FlowNode[];
-}
+};
 
-export interface HeadingNode extends Parent {
+export type HeadingNode = Parent & {
   type: "heading";
   depth: number;
   children: PhrasingNode[];
-}
+};
 
-export interface ParagraphNode extends Parent {
+export type ParagraphNode = Parent & {
   type: "paragraph";
   children: PhrasingNode[];
-}
+};
 
-export interface PreNode extends Parent {
+export type PreNode = Parent & {
   type: "pre";
   children: PhrasingNode[];
-}
+};
 
-export interface CodeNode extends Parent {
+export type CodeNode = Parent & {
   type: "code";
   children: PhrasingNode[];
   value?: string;
   meta?: string | string[];
-}
+};
 
-export interface EmphasisNode extends Parent {
+export type EmphasisNode = Parent & {
   type: "emphasis";
   children: PhrasingNode[];
-}
+};
 
-export interface LinkNode extends Parent {
+export type LinkNode = Parent & {
   type: "link";
   children: FlowNode[];
   url?: string;
-}
+};
 
-export interface TextNode extends Literal {
+export type TextNode = Literal & {
   type: "text";
   value: string;
-}
+};


### PR DESCRIPTION
Just like I did in #7363, #7366, #7367, #7368, #7369 & #7370

These are all internal types, so we can just merge it as-is