### PR TITLE
Revert back to latest versions of node in CI

### DIFF
--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/shared-test-unit.yml
     with:
       os: "ubuntu-latest"
-      node_version: "['18', '20.5']"
+      node_version: "[18, 20]"
 
   unit-windows:
     name: "🧪 Unit Test"
@@ -37,7 +37,7 @@ jobs:
     uses: ./.github/workflows/shared-test-unit.yml
     with:
       os: "windows-latest"
-      node_version: "['18', '20.5']"
+      node_version: "[18, 20]"
 
   integration-ubuntu:
     name: "👀 Integration Test"
@@ -45,7 +45,7 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "ubuntu-latest"
-      node_version: "['18', '20.5']"
+      node_version: "[18, 20]"
       browser: '["chromium", "firefox"]'
 
   integration-windows:
@@ -54,7 +54,7 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "windows-latest"
-      node_version: "['18', '20.5']"
+      node_version: "[18, 20]"
       browser: '["msedge"]'
 
   integration-macos:
@@ -63,5 +63,5 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "macos-latest"
-      node_version: "['18', '20.5']"
+      node_version: "[18, 20]"
       browser: '["webkit"]'

--- a/.github/workflows/test-pr-ubuntu.yml
+++ b/.github/workflows/test-pr-ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/shared-test-unit.yml
     with:
       os: "ubuntu-latest"
-      node_version: '["20.5.1"]'
+      node_version: '["latest"]'
 
   integration-chromium:
     name: "👀 Integration Test"
@@ -34,5 +34,5 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "ubuntu-latest"
-      node_version: '["20.5.1"]'
+      node_version: '["latest"]'
       browser: '["chromium"]'

--- a/.github/workflows/test-pr-windows-macos.yml
+++ b/.github/workflows/test-pr-windows-macos.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/shared-test-unit.yml
     with:
       os: "windows-latest"
-      node_version: '["20.5.1"]'
+      node_version: '["latest"]'
 
   integration-firefox:
     name: "👀 Integration Test"
@@ -28,7 +28,7 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "ubuntu-latest"
-      node_version: '["20.5.1"]'
+      node_version: '["latest"]'
       browser: '["firefox"]'
 
   integration-msedge:
@@ -37,7 +37,7 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "windows-latest"
-      node_version: '["20.5.1"]'
+      node_version: '["latest"]'
       browser: '["msedge"]'
 
   integration-webkit:
@@ -46,5 +46,5 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "macos-latest"
-      node_version: '["20.5.1"]'
+      node_version: '["latest"]'
       browser: '["webkit"]'


### PR DESCRIPTION
Node 20.6.1 is released which should fix https://github.com/shelljs/shelljs/issues/1133, so we should be bable to go back to `latest` versions of node in CI