### PR TITLE
Avoid bundling chokidar in production express server

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -422,6 +422,7 @@
 - penx
 - petetnt
 - philandstuff
+- phlipsterit
 - phishy
 - plastic041
 - plondon

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -4,7 +4,9 @@ import * as url from "node:url";
 
 import { createRequestHandler } from "@remix-run/express";
 import { broadcastDevReady, installGlobals } from "@remix-run/node";
-import chokidar from "chokidar";
+// Avoid bundling chokidar in produciton builds since it is a devDependency
+const chokidar =
+  process.env.NODE_ENV === "development" ? await import("chokidar") : null;
 import compression from "compression";
 import express from "express";
 import morgan from "morgan";
@@ -45,9 +47,9 @@ app.all(
   process.env.NODE_ENV === "development"
     ? createDevRequestHandler()
     : createRequestHandler({
-        build,
-        mode: build.mode,
-      })
+      build,
+      mode: build.mode,
+    })
 );
 
 const port = process.env.PORT || 3000;

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -47,9 +47,9 @@ app.all(
   process.env.NODE_ENV === "development"
     ? createDevRequestHandler()
     : createRequestHandler({
-      build,
-      mode: build.mode,
-    })
+        build,
+        mode: build.mode,
+      })
 );
 
 const port = process.env.PORT || 3000;


### PR DESCRIPTION
Make the import statement of chokidar conditional based on the node environment. We don't want to import it in production builds, because chokidar is not needed for production, and it is listed in the devDependencies in package.json.
It's common for deploy scripts to run "npm prune" after a build to remove all development dependencies from node_modules. This will remove chokidar. Running the application with "npm run start" afterward will then fail when server.js tries to import chokidar.

The code change in this PR is based on a suggestion from xHomu in a help-question in the Remix Discord

To reproduce the issue, follow these steps : 

- "npx create-remix"
- Select "Just the basics"
- Select "Express Server"
- Select "Typescript"
- Select yes to "run npm install"
- "cd my-remix-app"
- "npm run build"
- "npm prune --omit=dev" or just "npm prune" when NODE_ENV is set to production
- "npm run start"
- The above command will fail with the error Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'chokidar' imported from my-remix-app\server.js

After the the changes in this PR, the above steps will successfully start the server
