### PR TITLE
docs(manual-mode): add reference to package

### DIFF
--- a/docs/guides/manual-mode.md
+++ b/docs/guides/manual-mode.md
@@ -287,8 +287,11 @@ export const db = singleton(
 );
 ```
 
+Alternatively, you could use [`@epic-web/remember`][@epic-web/remember] which packages this up nicely.
+
 [mental-model]: https://www.youtube.com/watch?v=zTrjaUt9hLo
 [express]: https://expressjs.com/
 [chokidar]: https://github.com/paulmillr/chokidar
 [templates]: https://github.com/remix-run/remix/blob/main/templates/
 [community-examples]: https://github.com/xHomu/remix-v2-server
+[@epic-web/remember]: https://github.com/epicweb-dev/remember


### PR DESCRIPTION
I packaged up the remember utility in case anyone finds it useful.

Closes: #

- [x] Docs
- ~~[ ] Tests~~

Testing Strategy: N/A (docs change)