### PR TITLE
docs(tutorials/blog): fix code highlight

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -258,6 +258,7 @@
 - jrf0110
 - jrubins
 - jsbmg
+- jsparkdev
 - jssisodiya
 - jstafman
 - juhanakristian

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -852,7 +852,7 @@ Notice we don't return a redirect this time, we actually return the errors. Thes
 
 💿 Add validation messages to the UI
 
-```tsx filename=app/routes/posts.admin.new.tsx lines=[3,11,18-20,27-29,36-40]
+```tsx filename=app/routes/posts.admin.new.tsx lines=[3,11,19-21,28-30,37-41]
 import type { ActionArgs } from "@remix-run/node";
 import { redirect, json } from "@remix-run/node";
 import { Form, useActionData } from "@remix-run/react";


### PR DESCRIPTION
Fixed incorrect code highlighting.

Closes: #

- [x] Docs
- ~~[ ] Tests~~

Testing Strategy: N/A (docs change)

Current code highlighting is below:

![fe](https://github.com/remix-run/remix/assets/39112954/c2a7359e-a17c-44fd-8794-a80eb4a09ef4)

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 --template remix my-test
> cd my-test
> npm run dev
> ```
-->
