### PR TITLE
fix(dev): surface PostCSS config errors

### DIFF
--- a/.changeset/postcss-surface-errors.md
+++ b/.changeset/postcss-surface-errors.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Surface errors when PostCSS config is invalid

--- a/packages/remix-dev/compiler/plugins/cssImports.ts
+++ b/packages/remix-dev/compiler/plugins/cssImports.ts
@@ -44,9 +44,6 @@ export function cssFilePlugin(ctx: Context): esbuild.Plugin {
         target,
       } = build.initialOptions;
 
-      // eslint-disable-next-line prefer-let/prefer-let -- Avoid needing to repeatedly check for null since const can't be reassigned
-      const postcssProcessor = await getPostcssProcessor(ctx);
-
       build.onLoad({ filter: /\.css$/ }, async (args) => {
         let cacheKey = `css-file:${args.path}`;
         let {
@@ -59,6 +56,9 @@ export function cssFilePlugin(ctx: Context): esbuild.Plugin {
         } = await ctx.fileWatchCache.getOrSet(cacheKey, async () => {
           let fileDependencies = new Set([args.path]);
           let globDependencies = new Set<string>();
+
+          // eslint-disable-next-line prefer-let/prefer-let -- Avoid needing to repeatedly check for null since const can't be reassigned
+          const postcssProcessor = await getPostcssProcessor(ctx);
 
           let { metafile, outputFiles, warnings, errors } = await esbuild.build(
             {

--- a/packages/remix-dev/compiler/plugins/cssModuleImports.ts
+++ b/packages/remix-dev/compiler/plugins/cssModuleImports.ts
@@ -28,8 +28,6 @@ export const cssModulesPlugin = (
   return {
     name: pluginName,
     setup: async (build: PluginBuild) => {
-      let postcssPlugins = await loadPostcssPlugins({ config });
-
       build.onResolve(
         { filter: cssModulesFilter, namespace: "file" },
         async (args) => {
@@ -59,6 +57,8 @@ export const cssModulesPlugin = (
 
             let fileDependencies = new Set<string>([absolutePath]);
             let globDependencies = new Set<string>();
+
+            let postcssPlugins = await loadPostcssPlugins({ config });
 
             let { css: compiledCss, messages } = await postcss([
               ...postcssPlugins,

--- a/packages/remix-dev/compiler/plugins/cssSideEffectImports.ts
+++ b/packages/remix-dev/compiler/plugins/cssSideEffectImports.ts
@@ -50,8 +50,6 @@ export const cssSideEffectImportsPlugin = (
   return {
     name: pluginName,
     setup: async (build) => {
-      let postcssProcessor = await getCachedPostcssProcessor(ctx);
-
       build.onLoad(
         { filter: allJsFilesFilter, namespace: "file" },
         async (args) => {
@@ -131,6 +129,8 @@ export const cssSideEffectImportsPlugin = (
 
       build.onLoad({ filter: /\.css$/, namespace }, async (args) => {
         let absolutePath = path.resolve(ctx.config.rootDirectory, args.path);
+        let postcssProcessor = await getCachedPostcssProcessor(ctx);
+
         return {
           contents: postcssProcessor
             ? await postcssProcessor({ path: absolutePath })

--- a/packages/remix-dev/compiler/plugins/vanillaExtract.ts
+++ b/packages/remix-dev/compiler/plugins/vanillaExtract.ts
@@ -68,11 +68,6 @@ export function vanillaExtractPlugin(
 
       let root = config.appDirectory;
 
-      let postcssProcessor = await getPostcssProcessor({
-        config,
-        postcssContext: { vanillaExtract: true },
-      });
-
       // Resolve virtual CSS files first to avoid resolving the same
       // file multiple times since this filter is more specific and
       // doesn't require a file system lookup.
@@ -120,6 +115,11 @@ export function vanillaExtractPlugin(
           let compiler = getCompiler(root, options.mode);
           let { css, filePath } = compiler.getCssForFile(relativeFilePath);
           let resolveDir = dirname(resolve(root, filePath));
+
+          let postcssProcessor = await getPostcssProcessor({
+            config,
+            postcssContext: { vanillaExtract: true },
+          });
 
           if (postcssProcessor) {
             css = (

--- a/packages/remix-dev/compiler/utils/postcss.ts
+++ b/packages/remix-dev/compiler/utils/postcss.ts
@@ -64,7 +64,14 @@ export async function loadPostcssPlugins({
 
       plugins.push(...postcssConfig.plugins);
     } catch (err) {
-      // If they don't have a PostCSS config, just ignore it.
+      // If they don't have a PostCSS config, just ignore it,
+      // otherwise rethrow the error.
+      if (
+        err instanceof Error &&
+        !/No PostCSS Config found/i.test(err.message)
+      ) {
+        throw err;
+      }
     }
   }
 


### PR DESCRIPTION
We were swallowing errors when loading PostCSS config so that it didn't break the build for those without a PostCSS config, but this suppresses real errors for PostCSS consumers when there's a problem with their config.

This PR updates the logic so that we only swallow the missing config error and ensure that all other errors are thrown.

I've also refactored all CSS plugins so that the PostCSS config is loaded lazily rather than up-front in the `setup` hook. Without this change, consumers see the error coming from the first plugin that happens to be instantiated which is confusing if they're not using the feature, e.g. the error comes from the CSS Modules plugin when they're not using CSS Modules.