### PR TITLE
docs: 10-form-vs-fetcher code blocks formatting

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -577,3 +577,4 @@
 - ledniy
 - robbtraister
 - TrySound
+- KarelVerschraegen

--- a/docs/discussion/10-form-vs-fetcher.md
+++ b/docs/discussion/10-form-vs-fetcher.md
@@ -117,7 +117,7 @@ export function NewRecipe() {
 }
 ```
 
-The example leverages `<Form>`, ` useActionData``, and  `useNavigation\` to facilitate an intuitive record creation process.
+The example leverages `<Form>`, ` useActionData`, and `useNavigation` to facilitate an intuitive record creation process.
 
 Using `<Form>` ensures direct and logical navigation. After creating a record, the user is naturally guided to the new recipe's unique URL, reinforcing the outcome of their action.
 


### PR DESCRIPTION
Error was added in the following commit https://github.com/remix-run/remix/commit/d828b440fd45240dfab00bcfa5c8764d10c6d357

Seems like the formatter bot added an extra slash which is also not needed https://github.com/remix-run/remix/commit/ed12d8d0ca17042c12eddd0b90efe8e16ea39be3

Before
![image](https://github.com/remix-run/remix/assets/11301291/1023aa5d-dbce-4eb4-95f4-95fce25a0baa)


After
![image](https://github.com/remix-run/remix/assets/11301291/5a18cfb1-40e9-45c1-adb1-ada63047e76e)
