### PR TITLE
fix(serve): update usage error to support ESM

### DIFF
--- a/.changeset/remix-serve-esm-usage-error.md
+++ b/.changeset/remix-serve-esm-usage-error.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/serve": patch
+---
+
+Update remix-serve usage error message to support ESM projects

--- a/docs/file-conventions/remix-config.md
+++ b/docs/file-conventions/remix-config.md
@@ -112,15 +112,6 @@ main module. If specified, Remix will compile this file along with your
 application into a single file to be deployed to your server. This file can use
 either a `.js` or `.ts` file extension.
 
-## serverBuildDirectory
-
-<docs-warning>This option is deprecated and will likely be removed in a future
-stable release. Use [`serverBuildPath`][server-build-path]
-instead.</docs-warning>
-
-The path to the server build, relative to `remix.config.js`. Defaults to
-"build". This needs to be deployed to your server.
-
 ## serverBuildPath
 
 The path to the server build file, relative to `remix.config.js`. This file
@@ -150,7 +141,7 @@ module.exports = {
   appDirectory: "app",
   assetsBuildDirectory: "public/build",
   publicPath: "/build/",
-  serverBuildDirectory: "build",
+  serverBuildPath: "build/index.js",
   ignoredRouteFiles: ["**/.*"],
   serverDependenciesToBundle: [
     /^rehype.*/,

--- a/docs/guides/migrating-react-router-app.md
+++ b/docs/guides/migrating-react-router-app.md
@@ -302,7 +302,7 @@ In your `package.json` file, update your scripts to use `remix` commands instead
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "start": "remix-serve build",
+    "start": "remix-serve build/index.js",
     "typecheck": "tsc"
   }
 }

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -17,7 +17,7 @@ The Remix compiler will not do any type checking (it simply removes the types). 
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "start": "remix-serve build",
+    "start": "remix-serve build/index.js",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/docs/other-api/dev.md
+++ b/docs/other-api/dev.md
@@ -155,7 +155,7 @@ For example, you may have it hardcoded in your `server.js` file.
 If you are using `remix-serve` as your app server, you can use its `--port` flag to set the app server port:
 
 ```sh
-remix dev -c "remix-serve --port 8000 ./build"
+remix dev -c "remix-serve --port 8000 ./build/index.js"
 ```
 
 In contrast, the `remix dev --port` option is an escape-hatch for users who need fine-grain control of network ports.

--- a/docs/other-api/serve.md
+++ b/docs/other-api/serve.md
@@ -9,6 +9,8 @@ Remix is designed for you to own your server, but if you don't want to set one u
 
 ```sh
 remix-serve <server-build-path>
+# e.g.
+remix-serve build/index.js
 ```
 
 ## `PORT` environment variable
@@ -16,7 +18,7 @@ remix-serve <server-build-path>
 You can change the port of the server with an environment variable.
 
 ```sh
-PORT=4000 npx remix-serve <server-build-path>
+PORT=4000 npx remix-serve build/index.js
 ```
 
 ## `HOST` environment variable
@@ -24,14 +26,14 @@ PORT=4000 npx remix-serve <server-build-path>
 You can configure the hostname for your Express app via `process.env.HOST` and that value will be passed to the internal [`app.listen`][express-listen] method when starting the server.
 
 ```sh
-HOST=127.0.0.1 npx remix-serve build/
+HOST=127.0.0.1 npx remix-serve build/index.js
 ```
 
 ## Development Environment
 
 Depending on `process.env.NODE_ENV`, the server will boot in development or production mode.
 
-The `server-build-path` needs to point to the `serverBuildDirectory` defined in `remix.config.js`.
+The `server-build-path` needs to point to the `serverBuildPath` defined in `remix.config.js`.
 
 Because only the build artifacts (`build/`, `public/build/`) need to be deployed to production, the `remix.config.js` is not guaranteed to be available in production, so you need to tell Remix where your server build is with this option.
 

--- a/packages/create-remix/__tests__/fixtures/stack/package.json
+++ b/packages/create-remix/__tests__/fixtures/stack/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "start": "remix-serve build"
+    "start": "remix-serve build/index.js"
   },
   "dependencies": {},
   "devDependencies": {},

--- a/packages/remix-dev/__tests__/fixtures/node/package.json
+++ b/packages/remix-dev/__tests__/fixtures/node/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "start": "remix-serve build",
+    "start": "remix-serve build/index.js",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/packages/remix-dev/__tests__/fixtures/stack/package.json
+++ b/packages/remix-dev/__tests__/fixtures/stack/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "start": "remix-serve build"
+    "start": "remix-serve build/index.js"
   },
   "dependencies": {},
   "devDependencies": {},

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -37,7 +37,7 @@ async function run() {
 
   if (!buildPathArg) {
     console.error(`
-  Usage: remix-serve <build-dir>`);
+  Usage: remix-serve <server-build-path> - e.g. remix-serve build/index.js`);
     process.exit(1);
   }
 


### PR DESCRIPTION
Since `remix-serve build` doesn't work in ESM projects (it needs to be the file path, e.g. `remix-serve build/index.js`), I've updated all `remix-serve` usage docs to use the `serverBuildPath` format instead.

This notably includes a code change in `remix-serve` in one of its error messages which was incorrectly telling consumers to provide the server build directory rather than the server build path.

This also cleans up references in the docs to the now-removed `serverBuildDirectory` option since it was referenced in the remix-serve docs.