### PR TITLE
Add back in required AppLoadContext to DataFunctionArgs

### DIFF
--- a/.changeset/cyan-cameras-invite.md
+++ b/.changeset/cyan-cameras-invite.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+[Remove] Fix AppLoadContext

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -20,7 +20,9 @@ export interface RouteModules<RouteModule> {
 // RR also doesn't export DataFunctionArgs, so we extend the two interfaces here
 // even tough they're identical under the hood
 export type DataFunctionArgs = RRActionFunctionArgs<AppLoadContext> &
-  RRLoaderFunctionArgs<AppLoadContext>;
+  RRLoaderFunctionArgs<AppLoadContext> & {
+    context: AppLoadContext;
+  };
 
 /**
  * A function that handles data mutations for a route.


### PR DESCRIPTION
`context` was inadvertently reverted to optional in https://github.com/remix-run/remix/pull/7362