### PR TITLE
Copy latest docs updates into release-next

### DIFF
--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -4,7 +4,7 @@ title: Form
 
 # `<Form>`
 
-The `<Form>` component is a declarative way to perform data mutations: creating, updating, and deleting data. While it might be a mind-shift to think about these tasks as "navigation", it's how the web has handled mutations since before JavaScript was created!
+A progressively enhanced HTML `<form>` wrapper, useful for submissions that should also change the URL or otherwise add an entry to the browser history stack. For forms that shouldn't manipulate the browser history stack, use [`<fetcher.Form>`](../hooks/use-fetcher).
 
 ```tsx
 import { Form } from "@remix-run/react";
@@ -19,22 +19,55 @@ function NewEvent() {
 }
 ```
 
-- Whether JavaScript is on the page or not, your data interactions created with `<Form>` and `action` will work.
-- After a `<Form>` submission, all the loaders on the page will be reloaded. This ensures that any updates to your data are reflected in the UI.
-- `<Form>` automatically serializes your form's values (identically to the browser when not using JavaScript).
-- You can build "optimistic UI" and pending indicators with [`useNavigation`][usenavigation].
-
 ## Props
 
 ### `action`
 
-Most of the time you can omit this prop. Forms without an action prop (`<Form method="post">`) will automatically post to the same route within which they are rendered. This makes collocating your component, your data reads, and your data writes a snap.
+The URL to submit the form data to.
 
-If you need to post to a different route, then add an action prop:
+If `undefined`, the action defaults to the closest route in context. If a parent route renders a `<Form>` but the URL matches deeper child routes, the form will post to the parent route. Likewise, a form inside the child route will post to the child route. This differs from a native `<form>` that will always point to the full URL.
+
+### `method`
+
+This determines the [HTTP verb][http-verb] to be used: get, post, put, patch, delete. The default is "get".
 
 ```tsx
-<Form action="/projects/new" method="post" />
+<Form method="post" />
 ```
+
+Native `<form>` only supports GET and POST, so you should avoid the other verbs if you'd like to support [progressive enhancement](../discussion/06-progressive-enhancement)
+
+### `encType`
+
+The encoding type to use for the form submission.
+
+```tsx
+<Form encType="multipart/form-data" />
+```
+
+Defaults to `application/x-www-form-urlencoded`, use `multipart/form-data` for file uploads.
+
+### `replace`
+
+Replaces the current entry in the history stack, instead of pushing the new entry.
+
+```tsx
+<Form replace />
+```
+
+### `reloadDocument`
+
+If true, it will submit the form with the browser instead of client side routing. The same as a native `<form>`.
+
+```tsx
+<Form reloadDocument />
+```
+
+This is recommended over `<form />`. When the `action` prop is omitted, `<Form>` and `<form>` will sometimes call different actions depending on what the current URL is since `<form>` uses the current URL as the default, but `<Form>` uses the URL for the route the form is rendered in.
+
+## Notes
+
+### `?index`
 
 Because index routes and their parent route share the same URL, the `?index` param is used to differentiate between them.
 
@@ -50,44 +83,6 @@ Because index routes and their parent route share the same URL, the `?index` par
 See also:
 
 - [`?index` query param][index query param]
-
-### `method`
-
-This determines the [HTTP verb][http-verb] to be used: get, post, put, patch, delete. The default is "get".
-
-```tsx
-<Form method="post" />
-```
-
-Native `<form>` only supports get and post, so if you want your form to work with JavaScript on or off the page you'll need to stick with those two.
-
-Without JavaScript, Remix will turn non-get requests into "post", but you'll still need to instruct your server with a hidden input like `<input type="hidden" name="_method" value="delete" />`. If you always include JavaScript, you don't need to worry about this.
-
-We generally recommend sticking with "get" and "post" because the other verbs are not supported by HTML.
-
-### `encType`
-
-Defaults to `application/x-www-form-urlencoded`, use `multipart/form-data` for file uploads.
-
-### `replace`
-
-```tsx
-<Form replace />
-```
-
-Instructs the form to replace the current entry in the history stack, instead of pushing the new entry. If you expect a form to be submitted multiple times you may not want the user to have to click "back" for every submission to get to the previous page.
-
-This has no effect without JavaScript on the page.
-
-### `reloadDocument`
-
-If true, it will submit the form with the browser instead of JavaScript, even if JavaScript is on the page, the same as a native `<form>`.
-
-```tsx
-<Form reloadDocument />
-```
-
-This is recommended over `<form />`. When the `action` prop is omitted, `<Form>` and `<form>` will sometimes call different actions depending on what the current URL is since `<form>` uses the current URL as the default, but `<Form>` uses the URL for the route the form is rendered in.
 
 ## Additional Resources
 

--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -4,7 +4,7 @@ title: Form
 
 # `<Form>`
 
-A progressively enhanced HTML `<form>` wrapper, useful for submissions that should also change the URL or otherwise add an entry to the browser history stack. For forms that shouldn't manipulate the browser history stack, use [`<fetcher.Form>`](../hooks/use-fetcher).
+A progressively enhanced HTML `<form>` wrapper, useful for submissions that should also change the URL or otherwise add an entry to the browser history stack. For forms that shouldn't manipulate the browser history stack, use [`<fetcher.Form>`][fetcher-form].
 
 ```tsx
 import { Form } from "@remix-run/react";
@@ -35,7 +35,7 @@ This determines the [HTTP verb][http-verb] to be used: get, post, put, patch, de
 <Form method="post" />
 ```
 
-Native `<form>` only supports GET and POST, so you should avoid the other verbs if you'd like to support [progressive enhancement](../discussion/06-progressive-enhancement)
+Native `<form>` only supports GET and POST, so you should avoid the other verbs if you'd like to support [progressive enhancement][progressive-enhancement]
 
 ### `encType`
 
@@ -116,3 +116,5 @@ See also:
 [fullstack-data-flow]: ../discussion/03-data-flow
 [pending-ui]: ../discussion/07-pending-ui
 [form-vs-fetcher]: ../discussion/10-form-vs-fetcher
+[fetcher-form]: ../hooks/use-fetcher
+[progressive-enhancement]: ../discussion/06-progressive-enhancement

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -12,7 +12,9 @@ import { Link } from "@remix-run/react";
 <Link to="/dashboard">Dashboard</Link>;
 ```
 
-## `prefetch`
+## Props
+
+### `prefetch`
 
 Defines the data and module prefetching behavior for the link.
 
@@ -43,7 +45,7 @@ Prefetching is done with HTML `<link rel="prefetch">` tags. They are inserted af
 
 Because of this, if you are using `nav :last-child` you will need to use `nav :last-of-type` so the styles don't conditionally fall off your last link (and any other similar selectors).
 
-## `preventScrollReset`
+### `preventScrollReset`
 
 If you are using [`<ScrollRestoration>`][scroll-restoration], this lets you prevent the scroll position from being reset to the top of the window when the link is clicked.
 
@@ -85,7 +87,7 @@ An example when you might want this behavior is a list of tabs that manipulate t
 
 </details>
 
-## `relative`
+### `relative`
 
 Defines the relative path behavior for the link.
 
@@ -98,7 +100,7 @@ Defines the relative path behavior for the link.
 - **route** - default, relative to the route hierarchy so `..` will remove all URL segments of the current route pattern
 - **path** - relative to the path so `..` will remove one URL segment
 
-## `reloadDocument`
+### `reloadDocument`
 
 Will use document navigation instead of client side routing when the link is clicked, the browser will handle the transition normally (as if it were an `<a href>`).
 
@@ -106,7 +108,7 @@ Will use document navigation instead of client side routing when the link is cli
 <Link to="/logout" reloadDocument />
 ```
 
-## `replace`
+### `replace`
 
 The `replace` prop will replace the current entry in the history stack instead of pushing a new one onto it.
 
@@ -125,7 +127,7 @@ A -> B -> C
 A -> C
 ```
 
-## `state`
+### `state`
 
 Adds persistent client side routing state to the next location.
 

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -45,7 +45,7 @@ Because of this, if you are using `nav :last-child` you will need to use `nav :l
 
 ## `preventScrollReset`
 
-If you are using [`<ScrollRestoration>`](./scroll-restoration), this lets you prevent the scroll position from being reset to the top of the window when the link is clicked.
+If you are using [`<ScrollRestoration>`][scroll-restoration], this lets you prevent the scroll position from being reset to the top of the window when the link is clicked.
 
 ```tsx
 <Link to="?tab=one" preventScrollReset />
@@ -142,6 +142,8 @@ function SomeComp() {
 }
 ```
 
-This state is inaccessible on the server as it is implemented on top of [`history.state`](https://developer.mozilla.org/en-US/docs/Web/API/History/state).
+This state is inaccessible on the server as it is implemented on top of [`history.state`][history-state].
 
 [rr-link]: https://reactrouter.com/en/main/components/link
+[scroll-restoration]: ./scroll-restoration
+[history-state]: https://developer.mozilla.org/en-US/docs/Web/API/History/state

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -4,25 +4,17 @@ title: Link
 
 # `<Link>`
 
-This component renders an anchor tag and is the primary way the user will navigate around your website. Anywhere you would have used `<a href="...">` you should now use `<Link to="..."/>` to get all the performance benefits of client-side routing in Remix.
+A `<a href>` wrapper to enable navigation with client-side routing.
 
 ```tsx
 import { Link } from "@remix-run/react";
 
-export default function GlobalNav() {
-  return (
-    <nav>
-      <Link to="/dashboard">Dashboard</Link>{" "}
-      <Link to="/account">Account</Link>{" "}
-      <Link to="/support">Support</Link>
-    </nav>
-  );
-}
+<Link to="/dashboard">Dashboard</Link>;
 ```
 
 ## `prefetch`
 
-In the effort to remove all loading states from your UI, `Link` can automatically prefetch all the resources the next page needs: JavaScript modules, stylesheets, and data. This prop controls if and when that happens.
+Defines the data and module prefetching behavior for the link.
 
 ```tsx
 <>
@@ -34,17 +26,122 @@ In the effort to remove all loading states from your UI, `Link` can automaticall
 </>
 ```
 
-- **"none"** - Default behavior. This will prevent any prefetching from happening. This is recommended when linking to pages that require a user session that the browser won't be able to prefetch anyway.
-- **"intent"** - Recommended if you want to prefetch. Fetches when Remix thinks the user intends to visit the link. Right now the behavior is simple: if they hover or focus the link it will prefetch the resources. In the future we hope to make this even smarter. Links with large click areas/padding get a bit of a head start. It is worth noting that when using `prefetch="intent"`, `<link rel="prefetch">` elements will be inserted on hover/focus and removed if the `<Link>` loses hover/focus. Without proper `cache-control` headers on your loaders, this could result in repeated prefetch loads if a user continually hovers on and off a link.
-- **"render"** - Fetches when the link is rendered.
-- **"viewport"** - Fetches while the link is in the viewport
+- **none** - default, no prefetching
+- **intent** - prefetches when the user hovers or focuses the link
+- **render** - prefetches when the link renders
+- **viewport** - prefetches when the link is in the viewport, very useful for mobile
 
-<docs-error>You may need to use the <code>:last-of-type</code> selector instead of <code>:last-child</code> when styling child elements inside of your links</docs-error>
+Prefetching is done with HTML `<link rel="prefetch">` tags. They are inserted after the link.
 
-Remix uses the browser's cache for prefetching with HTML `<link rel="prefetch"/>` tags, which provides a lot of subtle benefits (like respecting HTTP cache headers, doing the work in browser idle time, using a different thread than your app, etc.) but the implementation might mess with your CSS since the link tags are rendered inside of your anchor tag. This means `a *:last-child {}` style selectors won't work. You'll need to change them to `a *:last-of-type {}` and you should be good. We will eventually get rid of this limitation.
+```tsx
+<nav>
+  <a href="..." />
+  <a href="..." />
+  <link rel="prefetch" /> {/* might conditionally render */}
+</nav>
+```
 
-## React Router `<Link/>`
+Because of this, if you are using `nav :last-child` you will need to use `nav :last-of-type` so the styles don't conditionally fall off your last link (and any other similar selectors).
 
-This component is a wrapper around [React Router `<Link/>`][rr-link]. It has the same API except for Remix's `prefetch` addition. For more information and advanced usage, refer to the [React Router docs][rr-link].
+## `preventScrollReset`
+
+If you are using [`<ScrollRestoration>`](./scroll-restoration), this lets you prevent the scroll position from being reset to the top of the window when the link is clicked.
+
+```tsx
+<Link to="?tab=one" preventScrollReset />
+```
+
+This does not prevent the scroll position from being restored when the user comes back to the location with the back/forward buttons, it just prevents the reset when the user clicks the link.
+
+<details>
+<summary>Discussion</summary>
+
+An example when you might want this behavior is a list of tabs that manipulate the url search params that aren't at the top of the page. You wouldn't want the scroll position to jump up to the top because it might scroll the toggled content out of the viewport!
+
+```
+      ┌─────────────────────────┐
+      │                         ├──┐
+      │                         │  │
+      │                         │  │ scrolled
+      │                         │  │ out of view
+      │                         │  │
+      │                         │ ◄┘
+    ┌─┴─────────────────────────┴─┐
+    │                             ├─┐
+    │                             │ │ viewport
+    │   ┌─────────────────────┐   │ │
+    │   │  tab   tab   tab    │   │ │
+    │   ├─────────────────────┤   │ │
+    │   │                     │   │ │
+    │   │                     │   │ │
+    │   │ content             │   │ │
+    │   │                     │   │ │
+    │   │                     │   │ │
+    │   └─────────────────────┘   │ │
+    │                             │◄┘
+    └─────────────────────────────┘
+
+```
+
+</details>
+
+## `relative`
+
+Defines the relative path behavior for the link.
+
+```tsx
+<Link to=".." />; // default: "route"
+<Link relative="route" />;
+<Link relative="path" />;
+```
+
+- **route** - default, relative to the route hierarchy so `..` will remove all URL segments of the current route pattern
+- **path** - relative to the path so `..` will remove one URL segment
+
+## `reloadDocument`
+
+Will use document navigation instead of client side routing when the link is clicked, the browser will handle the transition normally (as if it were an `<a href>`).
+
+```tsx
+<Link to="/logout" reloadDocument />
+```
+
+## `replace`
+
+The `replace` prop will replace the current entry in the history stack instead of pushing a new one onto it.
+
+```tsx
+<Link replace />
+```
+
+```
+# with a history stack like this
+A -> B
+
+# normal link click pushes a new entry
+A -> B -> C
+
+# but with `replace`, B is replaced by C
+A -> C
+```
+
+## `state`
+
+Adds persistent client side routing state to the next location.
+
+```tsx
+<Link to="/somewhere/else" state={{ some: "value" }} />
+```
+
+The location state is accessed from the `location`.
+
+```ts
+function SomeComp() {
+  const location = useLocation();
+  location.state; // { some: "value" }
+}
+```
+
+This state is inaccessible on the server as it is implemented on top of [`history.state`](https://developer.mozilla.org/en-US/docs/Web/API/History/state).
 
 [rr-link]: https://reactrouter.com/en/main/components/link

--- a/docs/components/nav-link.md
+++ b/docs/components/nav-link.md
@@ -5,7 +5,7 @@ toc: false
 
 # `<NavLink>`
 
-A `<NavLink>` is a special kind of [`<Link>`][link] that knows whether or not it is "active" or "pending". This is useful when building a navigation menu, such as a breadcrumb or a set of tabs where you'd like to show which of them is currently selected. It also provides useful context for assistive technology like screen readers.
+Wraps [`<Link>`](./link) with additional props for styling active and pending states.
 
 ```tsx
 import { NavLink } from "@remix-run/react";
@@ -20,25 +20,31 @@ import { NavLink } from "@remix-run/react";
 </NavLink>;
 ```
 
-## Default `active` class
+## Automatic Attributes
 
-By default, an `active` class is added to a `<NavLink>` component when it is active so you can use CSS to style it.
+### `.active`
+
+An `active` class is added to a `<NavLink>` component when it is active so you can use CSS to style it.
 
 ```tsx
-<nav id="sidebar">
-  <NavLink to="/messages" />
-</nav>
+<NavLink to="/messages" />
 ```
 
 ```css
-#sidebar a.active {
+a.active {
   color: red;
 }
 ```
 
-## `className`
+### `aria-current`
 
-The `className` prop works like a normal className, but you can also pass it a function to customize the classNames applied based on the active and pending state of the link.
+When a `NavLink` is active it will automatically apply `<a aria-current="page">` to the underlying anchor tag. See [aria-current][aria-current] on MDN.
+
+## Props
+
+### `className` callback
+
+Calls back with the active and pending states to allow customizing the class names applied.
 
 ```tsx
 <NavLink
@@ -51,9 +57,9 @@ The `className` prop works like a normal className, but you can also pass it a f
 </NavLink>
 ```
 
-## `style`
+### `style` callback
 
-The `style` prop works like a normal style prop, but you can also pass it a function to customize the styles applied based on the active and pending state of the link.
+Calls back with the active and pending states to allow customizing the styles applied.
 
 ```tsx
 <NavLink
@@ -69,9 +75,9 @@ The `style` prop works like a normal style prop, but you can also pass it a func
 </NavLink>
 ```
 
-## `children`
+### `children` callback
 
-You can pass a render prop as children to customize the content of the `<NavLink>` based on the active and pending state, which is useful to change styles on internal elements.
+Calls back with the active and pending states to allow customizing the content of the `<NavLink>`.
 
 ```tsx
 <NavLink to="/tasks">
@@ -81,7 +87,7 @@ You can pass a render prop as children to customize the content of the `<NavLink
 </NavLink>
 ```
 
-## `end`
+### `end`
 
 The `end` prop changes the matching logic for the `active` and `pending` states to only match to the "end" of the NavLinks's `to` path. If the URL is longer than `to`, it will no longer be considered active.
 
@@ -92,11 +98,9 @@ The `end` prop changes the matching logic for the `active` and `pending` states 
 | `<NavLink to="/tasks" end />` | `/tasks`     | true     |
 | `<NavLink to="/tasks" end />` | `/tasks/123` | false    |
 
-**A note on links to the root route**
-
 `<NavLink to="/">` is an exceptional case because _every_ URL matches `/`. To avoid this matching every single route by default, it effectively ignores the `end` prop and only matches when you're at the root route.
 
-## `caseSensitive`
+### `caseSensitive`
 
 Adding the `caseSensitive` prop changes the matching logic to make it case sensitive.
 
@@ -105,9 +109,9 @@ Adding the `caseSensitive` prop changes the matching logic to make it case sensi
 | `<NavLink to="/SpOnGe-bOB" />`               | `/sponge-bob` | true     |
 | `<NavLink to="/SpOnGe-bOB" caseSensitive />` | `/sponge-bob` | false    |
 
-## `aria-current`
+### `<Link>` props
 
-When a `NavLink` is active it will automatically apply `<a aria-current="page">` to the underlying anchor tag. See [aria-current][aria-current] on MDN.
+All other props of [`<Link>`][link] are supported.
 
 [aria-current]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current
-[link]: ./link.md
+[link]: ./link

--- a/docs/components/nav-link.md
+++ b/docs/components/nav-link.md
@@ -5,7 +5,7 @@ toc: false
 
 # `<NavLink>`
 
-Wraps [`<Link>`](./link) with additional props for styling active and pending states.
+Wraps [`<Link>`][link-2] with additional props for styling active and pending states.
 
 ```tsx
 import { NavLink } from "@remix-run/react";
@@ -115,3 +115,4 @@ All other props of [`<Link>`][link] are supported.
 
 [aria-current]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current
 [link]: ./link
+[link-2]: ./link

--- a/docs/components/outlet.md
+++ b/docs/components/outlet.md
@@ -5,6 +5,18 @@ toc: false
 
 # `<Outlet>`
 
-<docs-info>This component is simply a re-export of [React Router's `Outlet`][rr-outlet].</docs-info>
+Renders the matching child route of a parent route.
 
-[rr-outlet]: https://reactrouter.com/components/outlet
+```tsx
+import { Outlet } from "@remix-run/react";
+
+export function SomeParent() {
+  return (
+    <div>
+      <h1>Parent Content</h1>
+
+      <Outlet />
+    </div>
+  );
+}
+```

--- a/docs/components/scripts.md
+++ b/docs/components/scripts.md
@@ -22,6 +22,6 @@ export default function Root() {
 }
 ```
 
-If you don't render the `<Scripts/>` component, your app will still work like a traditional web app without JavaScript, relying solely on HTML and browser behaviors. That's cool, but we personally have bigger goals than spinning favicons, so we recommend adding JavaScript to your app 😎
+If you don't render the `<Scripts/>` component, your app will still work like a traditional web app without JavaScript, relying solely on HTML and browser behaviors.
 
 [meta]: ../route/meta

--- a/docs/components/scroll-restoration.md
+++ b/docs/components/scroll-restoration.md
@@ -27,10 +27,90 @@ export default function Root() {
 }
 ```
 
-## React Router `<ScrollRestoration/>`
+## Props
 
-This is a wrapper around [React Router `<ScrollRestoration>`][rr-scrollrestoration]. Because Remix server renders your app's HTML, it can restore scroll positions before JavaScript even loads, avoiding the janky "scroll jump" typically found in SPAs. Other than that, it is identical to the React Router version.
+### `getKey`
 
-For advanced usage, see the [React Router ScrollRestoration docs][rr-scrollrestoration].
+Optional. Defines the key used to restore scroll positions.
 
-[rr-scrollrestoration]: https://reactrouter.com/en/main/components/scroll-restoration
+```tsx
+<ScrollRestoration
+  getKey={(location, matches) => {
+    // default behavior
+    return location.key;
+  }}
+/>
+```
+
+<details>
+<summary>Discussion</summary>
+
+Using `location.key` emulates the browser's default behavior. The user can navigate to the same URL multiple times in the stack and each entry gets its own scroll position to restore.
+
+Some apps may want to override this behavior and restore position based on something else. Consider a social app that has four primary pages:
+
+- "/home"
+- "/messages"
+- "/notifications"
+- "/search"
+
+If the user starts at "/home", scrolls down a bit, clicks "messages" in the navigation menu, then clicks "home" in the navigation menu (not the back button!) there will be three entries in the history stack:
+
+```
+1. /home
+2. /messages
+3. /home
+```
+
+By default, React Router (and the browser) will have two different scroll positions stored for `1` and `3` even though they have the same URL. That means as the user navigated from `2` → `3` the scroll position goes to the top instead of restoring to where it was in `1`.
+
+A solid product decision here is to keep the users scroll position on the home feed no matter how they got there (back button or new link clicks). For this, you'd want to use the `location.pathname` as the key.
+
+```tsx
+<ScrollRestoration
+  getKey={(location, matches) => {
+    return location.pathname;
+  }}
+/>
+```
+
+Or you may want to only use the pathname for some paths, and use the normal behavior for everything else:
+
+```tsx
+<ScrollRestoration
+  getKey={(location, matches) => {
+    const paths = ["/home", "/notifications"];
+    return paths.includes(location.pathname)
+      ? // home and notifications restore by pathname
+        location.pathname
+      : // everything else by location like the browser
+        location.key;
+  }}
+/>
+```
+
+</details>
+
+### `nonce`
+
+`<ScrollRestoration>` renders an inline `<script>` to prevent scroll flashing. The `nonce` prop will be passed down to the script tag to allow CSP nonce usage.
+
+```tsx
+<ScrollRestoration nonce={cspNonce} />
+```
+
+## Preventing Scroll Reset
+
+When navigating to new locations, the scroll position is reset to the top of the page. You can prevent the "scroll to top" behavior from your links and forms:
+
+```tsx
+<Link preventScrollReset={true} />;
+<Form preventScrollReset={true} />;
+```
+
+See also: [`<Link preventScrollReset>`][preventscrollreset], [`<Form preventScrollReset>`][form-preventscrollreset]
+
+[remix]: https://remix.run
+[preventscrollreset]: ../components/link#preventscrollreset
+[form-preventscrollreset]: ../components/form#preventscrollreset
+[pickingarouter]: ../routers/picking-a-router

--- a/docs/discussion/10-form-vs-fetcher.md
+++ b/docs/discussion/10-form-vs-fetcher.md
@@ -23,7 +23,7 @@ The primary criterion when choosing among these tools is whether you want the UR
 
   - **Expected Behavior**: In many cases, when users hit the back button, they should be taken to the previous page. Other times the history entry may be replaced but the URL change is important nonetheless.
 
-- **No URL Change Desired**: For actions that don't significantly change the context or primary content of the current view. This might include updating individual fields or minor data manipulations that don't warrant a new URL or page reload.
+- **No URL Change Desired**: For actions that don't significantly change the context or primary content of the current view. This might include updating individual fields or minor data manipulations that don't warrant a new URL or page reload. This also applies to loading data with fetchers for things like popovers, comboboxes, etc.
 
 ### Specific Use Cases
 
@@ -46,6 +46,8 @@ These actions are generally more subtle and don't require a context switch for t
 - **Deleting a Record from a List**: In a list view, if a user deletes an item, they likely expect to remain on the list view, with that item simply disappearing.
 
 - **Creating a Record in a List View**: When adding a new item to a list, it often makes sense for the user to remain in that context, seeing their new item added to the list without a full page transition.
+
+- **Loading Data for a Popover or Combobox**: When loading data for a popover or combobox, the user's context remains unchanged. The data is loaded in the background and displayed in a small, self-contained UI element.
 
 For such actions, `useFetcher` is the go-to API. It's versatile, combining functionalities of the other four APIs, and is perfectly suited for tasks where the URL should remain unchanged.
 
@@ -186,6 +188,69 @@ The key advantage here is the maintenance of context. The user stays on the list
 Furthermore, with each fetcher having the autonomy to manage its own state, operations on individual list items become independent, ensuring that actions on one item don't affect the others (though revalidation of the page data is a shared concern that is covered in [Network Concurrency Management][network-concurrency-management]).
 
 In essence, useFetcher offers a seamless mechanism for actions that don't necessitate a change in the URL or navigation, enhancing the user experience by providing real-time feedback and context preservation.
+
+### Mark Article as Read
+
+Imagine you want to mark that an article has been read by the current user, after they've been on the page for a while and scrolled to the bottom. You could make a hook that looks something like this:
+
+```tsx
+function useMarkAsRead({ articleId, userId }) {
+  const marker = useFetcher();
+
+  useSpentSomeTimeHereAndScrolledToTheBottom(() => {
+    marker.submit(
+      { userId },
+      {
+        method: "post",
+        action: `/article/${articleID}/mark-as-read`,
+      }
+    );
+  });
+}
+```
+
+### User Avatar Details Popup
+
+Anytime you show the user avatar, you could put a hover effect that fetches data from a loader and displays it in a popup.
+
+```tsx filename=app/routes/user.$id.details.tsx
+export async function loader({ params }: LoaderArgs) {
+  return json(
+    await fakeDb.user.find({ where: { id: params.id } })
+  );
+}
+
+function UserAvatar({ partialUser }) {
+  const userDetails = useFetcher<typeof loader>();
+  const [showDetails, setShowDetails] = useState(false);
+
+  useEffect(() => {
+    if (
+      showDetails &&
+      userDetails.state === "idle" &&
+      !userDetails.data
+    ) {
+      userDetails.load(`/users/${user.id}/details`);
+    }
+  }, [showDetails, userDetails]);
+
+  return (
+    <div
+      onMouseEnter={() => setShowDetails(true)}
+      onMouseLeave={() => setShowDetails(false)}
+    >
+      <img src={partialUser.profileImageUrl} />
+      {showDetails ? (
+        userDetails.state === "idle" && userDetails.data ? (
+          <UserPopup user={userDetails.data} />
+        ) : (
+          <UserPopupLoading />
+        )
+      ) : null}
+    </div>
+  );
+}
+```
 
 ## Conclusion
 

--- a/docs/discussion/resubmissions.md
+++ b/docs/discussion/resubmissions.md
@@ -58,10 +58,15 @@ It's advisable to implement a redirect from the action to avoid unintended resub
 
 **Guides**
 
-- [Form Validation](../guides/form-validation)
+- [Form Validation][form-validation]
 
 **API**
 
-- [`<Form>`](../components/form)
-- [`useActionData`](../hooks/use-action-data)
-- [`redirect`](../utils/redirect)
+- [`<Form>`][form]
+- [`useActionData`][use-action-data]
+- [`redirect`][redirect]
+
+[form-validation]: ../guides/form-validation
+[form]: ../components/form
+[use-action-data]: ../hooks/use-action-data
+[redirect]: ../utils/redirect

--- a/docs/discussion/resubmissions.md
+++ b/docs/discussion/resubmissions.md
@@ -1,0 +1,67 @@
+---
+title: Form Resubmissions
+---
+
+# Form Resubmissions
+
+When you use `<Form method="post">` in Remix, as opposed to using the native HTML `<form method="post">`, Remix does not adhere to the default browser behavior for resubmitting forms during navigation events like clicking back, forward, or refreshing.
+
+## The Browser's Default Behavior
+
+In a standard browser environment, form submissions are navigation events. This means that when a user clicks the back button, the browser will typically resubmit the form. For example:
+
+1. User visits `/buy`
+2. Submits a form to `/checkout`
+3. Navigates to `/order/123`
+
+The browser history stack would look like this:
+
+```
+GET /buy > POST /checkout > *GET /order/123
+```
+
+If the user clicks the back button, the history becomes:
+
+```
+GET /buy - *POST /checkout < GET /order/123
+```
+
+In this situation, the browser resubmits the form data, which could lead to issues such as charging a credit card twice.
+
+## Redirecting from Actions
+
+A common practice to avoid this issue is to issue a redirect after the POST request. This removes the POST action from the browser's history. The history stack would then look like this:
+
+```
+GET /buy > POST /checkout, Redirect > GET /order/123
+```
+
+With this approach, clicking the back button would not resubmit the form:
+
+```
+GET /buy - *GET /order/123
+```
+
+## Specific Scenarios to Consider
+
+While accidental resubmissions generally don't happen in Remix, there are specific scenarios where they might.
+
+- You used `<form>` instead of `<Form>`
+- You used `<Form reloadDocument>`
+- You are not rendering `<Scripts/>`
+- JavaScript is disabled by the user
+- JavaScript had not loaded when the form was submitted
+
+It's advisable to implement a redirect from the action to avoid unintended resubmissions.
+
+## Additional Resources
+
+**Guides**
+
+- [Form Validation](../guides/form-validation)
+
+**API**
+
+- [`<Form>`](../components/form)
+- [`useActionData`](../hooks/use-action-data)
+- [`redirect`](../utils/redirect)

--- a/docs/guides/form-validation.md
+++ b/docs/guides/form-validation.md
@@ -1,0 +1,109 @@
+---
+title: Form Validation
+---
+
+# Form Validation
+
+This guide walks you through implementing form validation for a simple signup form in Remix. Here, we focus on capturing the fundamentals to help you understand the essential elements of form validation in Remix, including actions, action data, and rendering errors.
+
+## Step 1: Setting Up the Signup Form
+
+We'll start by creating a basic signup form using the `Form` component from Remix.
+
+```tsx filename=app/routes/signup.tsx
+import { Form } from "@remix-run/react";
+
+export default function Signup() {
+  return (
+    <Form method="post">
+      <p>
+        <input type="email" name="email" />
+      </p>
+
+      <p>
+        <input type="password" name="password" />
+      </p>
+
+      <button type="submit">Sign Up</button>
+    </Form>
+  );
+}
+```
+
+## Step 2: Defining the Action
+
+In this step, we'll define a server action in the same file as our Signup component. Note that the aim here is to provide a broad overview of the mechanics involved rather than digging deep into form validation rules or error object structures. We'll use rudimentary checks for the email and password to demonstrate the core concepts.
+
+```tsx filename=app/routes/signup.jsx
+import { Form, redirect } from "@remix-run/react";
+
+export default function Signup() {
+  // omitted for brevity
+}
+
+export function action({ request }) {
+  const formData = await request.formData();
+  const email = String(formData.get("email"));
+  const password = String(formData.get("password"));
+
+  const errors = {};
+
+  if (!email.includes("@")) {
+    errors.email = "Invalid email address";
+  }
+
+  if (password.length < 12) {
+    errors.password =
+      "Password should be at least 12 characters";
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return errors;
+  }
+
+  // Redirect to dashboard if validation is successful
+  return redirect("/dashboard");
+}
+```
+
+If any validation errors are found, they are returned from the action to the client. This is our way of signaling to the UI that something needs to be corrected, otherwise the user will be redirected to the dashboard.
+
+## Step 3: Displaying Validation Errors
+
+Finally, we'll modify the Signup component to display validation errors, if any. We'll use `useActionData` to access and display these errors.
+
+```tsx filename=app/routes/signup.jsx
+import {
+  Form,
+  redirect,
+  useActionData,
+} from "@remix-run/react";
+
+export default function Signup() {
+  const errors = useActionData();
+
+  return (
+    <Form method="post">
+      <p>
+        <input type="email" name="email" />
+        {errors?.email && <em>{errors.email}</em>}
+      </p>
+
+      <p>
+        <input type="password" name="password" />
+        {errors?.password && <em>{errors.password}</em>}
+      </p>
+
+      <button type="submit">Sign Up</button>
+    </Form>
+  );
+}
+
+export function action({ request }) {
+  // omitted for brevity
+}
+```
+
+## Conclusion
+
+And there you have it! You've successfully set up a basic form validation flow in Remix. The beauty of this approach is that the errors will automatically display based on the action data, and they will be updated each time the user re-submits the form. This reduces the amount of boilerplate code you have to write, making your development process more efficient.

--- a/docs/hooks/use-action-data.md
+++ b/docs/hooks/use-action-data.md
@@ -5,161 +5,43 @@ toc: false
 
 # `useActionData`
 
-<docs-info>This hook is simply a re-export of [React Router's `useActionData`][rr-useactiondata].</docs-info>
+Returns the serialized data from the most recent route action or undefined if there isn't one.
 
-This hook returns the JSON parsed data from your route action. It returns `undefined` if there hasn't been a submission at the current location yet.
-
-```tsx lines=[3,12,21]
-import type { ActionArgs } from "@remix-run/node"; // or cloudflare/deno
-import { json } from "@remix-run/node"; // or cloudflare/deno
+```tsx lines=[7,11]
+import type { ActionArgs } from "@remix-run/node";
 import { Form, useActionData } from "@remix-run/react";
 
 export async function action({ request }: ActionArgs) {
   const body = await request.formData();
   const name = body.get("visitorsName");
-  return json({ message: `Hello, ${name}` });
+  return { message: `Hello, ${name}` };
 }
 
 export default function Invoices() {
   const data = useActionData<typeof action>();
   return (
     <Form method="post">
-      <p>
-        <label>
-          What is your name?
-          <input type="text" name="visitorsName" />
-        </label>
-      </p>
-      <p>{data ? data.message : "Waiting..."}</p>
+      <input type="text" name="visitorsName" />
+      {data ? data.message : "Waiting..."}
     </Form>
   );
 }
 ```
 
-The most common use-case for this hook is form validation errors. If the form isn't right, you can simply return the errors and let the user try again (instead of pushing all the errors into sessions and back out of the loader).
+## Additional Resources
 
-```tsx lines=[23,32,40-42,46-48]
-import type { ActionArgs } from "@remix-run/node"; // or cloudflare/deno
-import { json, redirect } from "@remix-run/node"; // or cloudflare/deno
-import { Form, useActionData } from "@remix-run/react";
+**Guides**
 
-export async function action({ request }: ActionArgs) {
-  const form = await request.formData();
-  const email = form.get("email");
-  const password = form.get("password");
-  const errors = {};
+- [Form Validation](../guides/form-validation)
 
-  // validate the fields
-  if (typeof email !== "string" || !email.includes("@")) {
-    errors.email =
-      "That doesn't look like an email address";
-  }
-
-  if (typeof password !== "string" || password.length < 6) {
-    errors.password = "Password must be > 6 characters";
-  }
-
-  // return data if we have errors
-  if (Object.keys(errors).length) {
-    return json(errors, { status: 422 });
-  }
-
-  // otherwise create the user and redirect
-  await createUser(form);
-  return redirect("/dashboard");
-}
-
-export default function Signup() {
-  const errors = useActionData<typeof action>();
-
-  return (
-    <>
-      <h1>Signup</h1>
-      <Form method="post">
-        <p>
-          <input type="text" name="email" />
-          {errors?.email ? (
-            <span>{errors.email}</span>
-          ) : null}
-        </p>
-        <p>
-          <input type="text" name="password" />
-          {errors?.password ? (
-            <span>{errors.password}</span>
-          ) : null}
-        </p>
-        <p>
-          <button type="submit">Sign up</button>
-        </p>
-      </Form>
-    </>
-  );
-}
-```
-
-#### Notes about resubmissions
-
-When using `<Form>` (instead of `<form>` or `<Form reloadDocument>`), Remix _does not_ follow the browser's behavior of resubmitting forms when the user clicks back, forward, or refreshes into the location.
-
-<docs-info>Remix client-side navigation does not resubmit forms on pop events like browsers.</docs-info>
-
-Form submissions are navigation events in browsers (and Remix), which means users can click the back button into a location that had a form submission _and the browser will resubmit the form_. You usually don't want this to happen.
-
-For example, consider this user flow:
-
-1. The user lands at `/buy`
-2. They submit a form to `/checkout`
-3. They click a link to `/order/123`
-
-The history stack looks like this, where "\*" is the current entry:
-
-```
-GET /buy > POST /checkout > *GET /order/123
-```
-
-Now consider the user clicks the back button 😨
-
-```
-GET /buy - *POST /checkout < GET /order/123
-```
-
-The browser will repost the same information and likely charge their credit card again. You usually don't want this.
-
-The decades-old best practice is to redirect in the POST request. This way the location disappears from the browser's history stack and the user can't "back into it" anymore.
-
-```
-GET /buy > POST /checkout, Redirect > GET /order/123
-```
-
-This results in a history stack that looks like this:
-
-```
-GET /buy - *GET /order/123
-```
-
-Now the user can click back without resubmitting the form.
-
-**When you should worry about this**
-
-Usually your actions will either return validation issues or redirect, and then your data and your user's are safe no matter how the form is submitted. But to go into further detail, if you're using:
-
-- `<form>`
-- `<Form reloadDocument>`
-- You're not rendering `<Scripts/>`
-- The user has JavaScript disabled
-
-The browser will resubmit the form in these situations unless you redirect from the action. If these are cases you want to support, we recommend you follow the age-old best practice of redirecting from actions.
-
-If you're using `<Form>` and don't care to support the cases above, you don't need to redirect from your actions. However, if you don't redirect from an action, make sure reposting the same information isn't dangerous to your data or your visitors because you can't control if they have JavaScript enabled or not.
-
-<docs-info>In general, if the form validation fails, return data from the action and render it in the component. But, once you actually change data (in your database, or otherwise), you should redirect.</docs-info>
-
-<docs-info>For more information and usage, please refer to the [React Router `useActionData` docs][rr-useactiondata].</docs-info>
-
-See also:
+**Related API**
 
 - [`action`][action]
 - [`useNavigation`][usenavigation]
+
+**Discussions**
+
+- [Fullstack Data Flow](../discussion/03-data-flow)
 
 [action]: ../route/action
 [usenavigation]: ../hooks/use-navigation

--- a/docs/hooks/use-action-data.md
+++ b/docs/hooks/use-action-data.md
@@ -32,7 +32,7 @@ export default function Invoices() {
 
 **Guides**
 
-- [Form Validation](../guides/form-validation)
+- [Form Validation][form-validation]
 
 **Related API**
 
@@ -41,8 +41,10 @@ export default function Invoices() {
 
 **Discussions**
 
-- [Fullstack Data Flow](../discussion/03-data-flow)
+- [Fullstack Data Flow][fullstack-data-flow]
 
 [action]: ../route/action
 [usenavigation]: ../hooks/use-navigation
 [rr-useactiondata]: https://reactrouter.com/hooks/use-action-data
+[form-validation]: ../guides/form-validation
+[fullstack-data-flow]: ../discussion/03-data-flow

--- a/docs/hooks/use-async-error.md
+++ b/docs/hooks/use-async-error.md
@@ -1,10 +1,38 @@
 ---
 title: useAsyncError
-toc: false
+new: true
 ---
 
 # `useAsyncError`
 
-<docs-info>This hook is simply a re-export of [React Router's `useAsyncError`][rr-useassyncerror].</docs-info>
+Returns the rejection value from the closest [`<Await>`][await] component.
 
-[rr-useassyncerror]: https://reactrouter.com/hooks/use-async-error
+```tsx [4,12]
+import { useAsyncError, Await } from "react-router-dom";
+
+function ErrorElement() {
+  const error = useAsyncError();
+  return (
+    <p>Uh Oh, something went wrong! {error.message}</p>
+  );
+}
+
+<Await
+  resolve={promiseThatRejects}
+  errorElement={<ErrorElement />}
+/>;
+```
+
+## Additional Resources
+
+**Guides**
+
+- [Streaming](../guides/streaming)
+
+**API**
+
+- [`<Await/>`][await]
+- [`useAsyncValue()`][use_async_value]
+
+[await]: ../components/await
+[use_async_value]: ../hooks/use-async-value

--- a/docs/hooks/use-async-error.md
+++ b/docs/hooks/use-async-error.md
@@ -27,7 +27,7 @@ function ErrorElement() {
 
 **Guides**
 
-- [Streaming](../guides/streaming)
+- [Streaming][streaming]
 
 **API**
 
@@ -36,3 +36,4 @@ function ErrorElement() {
 
 [await]: ../components/await
 [use_async_value]: ../hooks/use-async-value
+[streaming]: ../guides/streaming

--- a/docs/hooks/use-async-value.md
+++ b/docs/hooks/use-async-value.md
@@ -24,7 +24,7 @@ function SomeDescendant() {
 
 **Guides**
 
-- [Streaming](../guides/streaming)
+- [Streaming][streaming]
 
 **API**
 
@@ -33,3 +33,4 @@ function SomeDescendant() {
 
 [await]: ../components/await
 [use_async_error]: ../hooks/use-async-error
+[streaming]: ../guides/streaming

--- a/docs/hooks/use-async-value.md
+++ b/docs/hooks/use-async-value.md
@@ -1,10 +1,35 @@
 ---
 title: useAsyncValue
-toc: false
+new: true
 ---
 
 # `useAsyncValue`
 
-<docs-info>This hook is simply a re-export of [React Router's `useAsyncValue`][rr-useassyncvalue].</docs-info>
+Returns the resolved data from the closest `<Await>` ancestor component.
 
-[rr-useassyncvalue]: https://reactrouter.com/hooks/use-async-value
+```tsx
+function SomeDescendant() {
+  const value = useAsyncValue();
+  // ...
+}
+```
+
+```tsx
+<Await resolve={somePromise}>
+  <SomeDescendant />
+</Await>
+```
+
+## Additional Resources
+
+**Guides**
+
+- [Streaming](../guides/streaming)
+
+**API**
+
+- [`<Await/>`][await]
+- [`useAsyncError`][use_async_error]
+
+[await]: ../components/await
+[use_async_error]: ../hooks/use-async-error

--- a/docs/hooks/use-before-unload.md
+++ b/docs/hooks/use-before-unload.md
@@ -5,8 +5,6 @@ toc: false
 
 # `useBeforeUnload`
 
-<docs-info>This hook is simply a re-export of [React Router's `useBeforeUnload`][rr-usebeforeunload].</docs-info>
-
 This hook is just a helper around `window.onbeforeunload`.
 
 When users click links to pages they haven't visited yet, Remix loads the code-split modules for that page. If you deploy in the middle of a user's session, and you or your host removes the old files from the server (many do 😭), then Remix's requests for those modules will fail. Remix recovers by automatically reloading the browser at the new URL. This should start over from the server with the latest version of your application. Most of the time this works out great, and user doesn't even know anything happened.
@@ -38,7 +36,3 @@ function SomeForm() {
   return <>{/*... */}</>;
 }
 ```
-
-<docs-info>For more information and usage, please refer to the [React Router `useBeforeUnload` docs][rr-usebeforeunload].</docs-info>
-
-[rr-usebeforeunload]: https://reactrouter.com/hooks/use-before-unload

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -82,6 +82,18 @@ You can know the state of the fetcher with `fetcher.state`. It will be one of:
 
 The returned response data from your loader or action is stored here. Once the data is set, it persists on the fetcher even through reloads and resubmissions (like calling `fetcher.load()` again after having already read the data).
 
+### `fetcher.formData`
+
+The `FormData` instance that was submitted to the server is stored here. This is useful for optimistic UIs.
+
+### `fetcher.formAction`
+
+The URL of the submission.
+
+### `fetcher.formMethod`
+
+The form method of the submission.
+
 ## Additional Resources
 
 **Discussions**

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -4,107 +4,20 @@ title: useFetcher
 
 # `useFetcher`
 
-<docs-success>Watch the <a href="https://www.youtube.com/playlist?list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">📼 Remix Singles</a>: <a href="https://www.youtube.com/watch?v=vTzNpiOk668&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Concurrent Mutations w/ useFetcher</a> and <a href="https://www.youtube.com/watch?v=EdB_nj01C80&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Optimistic UI</a></docs-success>
-
-In HTML/HTTP, data mutations and loads are modeled with navigation: `<a href>` and `<form action>`. Both cause a navigation in the browser. The Remix equivalents are `<Link>` and `<Form>`.
-
-But sometimes you want to call a loader outside of navigation, or call an action (and get the routes to reload) but you don't want the URL to change. Many interactions with the server aren't navigation events. This hook lets you plug your UI into your actions and loaders without navigating.
-
-This is useful when you need to:
-
-- fetch data not associated with UI routes (popovers, dynamic forms, etc.)
-- submit data to actions without navigating (shared components like a newsletter sign ups)
-- handle multiple concurrent submissions in a list (typical "todo app" list where you can click multiple buttons and all be pending at the same time)
-- infinite scroll containers
-- and more!
-
-It is common for Remix newcomers to see this hook and think it is the primary way to interact with the server for data loading and updates--because it looks like what you might have done outside of Remix. If your use case can be modeled as "navigation", it's recommended you use one of the core data APIs before reaching for `useFetcher`:
-
-- [`useLoaderData`][useloaderdata]
-- [`Form`][form]
-- [`useActionData`][useactiondata]
-- [`useNavigation`][usenavigation]
-
-If you're building a highly interactive, "app-like" user interface, you will use `useFetcher` often.
+A hook for interacting with the server outside of navigation.
 
 ```tsx
 import { useFetcher } from "@remix-run/react";
 
-function SomeComponent() {
+export function SomeComponent() {
   const fetcher = useFetcher();
-
-  // trigger the fetch with these
-  <fetcher.Form {...formOptions} />;
-
-  useEffect(() => {
-    fetcher.submit(data, options);
-    fetcher.load(href);
-  }, [fetcher]);
-
-  // build UI with these
-  fetcher.state;
-  fetcher.formMethod;
-  fetcher.formAction;
-  fetcher.formData;
-  fetcher.formEncType;
-  fetcher.data;
+  // ...
 }
 ```
 
-Notes about how it works:
+## Components
 
-- Automatically handles cancellation of the fetch at the browser level
-- When submitting with POST, PUT, PATCH, DELETE, the action is called first
-  - After the action completes, the loaders on the page are reloaded to capture any mutations that may have happened, automatically keeping your UI in sync with your server state
-- When multiple fetchers are inflight at once, it will
-  - commit the freshest available data as they each land
-  - ensure no stale loads override fresher data, no matter which order the responses return
-- Handles uncaught errors by rendering the nearest `ErrorBoundary` (just like a normal navigation from `<Link>` or `<Form>`)
-- Will redirect the app if your action/loader being called returns a redirect (just like a normal navigation from `<Link>` or `<Form>`)
-
-## `fetcher.state`
-
-You can know the state of the fetcher with `fetcher.state`. It will be one of:
-
-- **idle** - Nothing is being fetched.
-- **submitting** - A form has been submitted. If the method is GET, then the route loader is being called. If POST, PUT, PATCH, or DELETE, then the route action is being called.
-- **loading** - The loaders for the routes are being reloaded after an action submission.
-
-## `fetcher.type`
-
-<docs-warning>`fetcher.type` will be removed in v2. For instructions on preparing for this change see the [v2 guide][v2guide].</docs-warning>
-
-This is the type of state the fetcher is in. It's like `fetcher.state`, but more granular. Depending on the fetcher's state, the types can be the following:
-
-- `state === "idle"`
-
-  - **init** - The fetcher isn't doing anything currently and hasn't done anything yet.
-  - **done** - The fetcher isn't doing anything currently, but it has completed a fetch and you can safely read the `fetcher.data`.
-
-- `state === "submitting"`
-
-  - **actionSubmission** - A form has been submitted with POST, PUT, PATCH, or DELETE, and the action is being called.
-  - **loaderSubmission** - A form has been submitted with GET and the loader is being called.
-
-- `state === "loading"`
-
-  - **actionReload** - The action from an "actionSubmission" returned data and the loaders on the page are being reloaded.
-  - **actionRedirect** - The action from an "actionSubmission" returned a redirect and the page is navigating to the new location.
-  - **normalLoad** - A route's loader is being called without a submission (`fetcher.load()`).
-
-## `fetcher.submission`
-
-<docs-warning>`fetcher.submission` will be flattened into the fetcher object itself in v2. For instructions on preparing for this change see the [v2 guide][v2guide].</docs-warning>
-
-When using `<fetcher.Form>` or `fetcher.submit()`, the form submission is available to build optimistic UI.
-
-It is not available when the fetcher state is "idle" or "loading".
-
-## `fetcher.data`
-
-The returned response data from your loader or action is stored here. Once the data is set, it persists on the fetcher even through reloads and resubmissions (like calling `fetcher.load()` again after having already read the data).
-
-## `fetcher.Form`
+### `fetcher.Form`
 
 Just like `<Form>` except it doesn't cause a navigation.
 
@@ -119,323 +32,64 @@ function SomeComponent() {
 }
 ```
 
-## `fetcher.submit()`
+## Methods
 
-Just like `useSubmit` except it doesn't cause a navigation.
+### `fetcher.submit(formData, options)`
 
-```tsx
-function SomeComponent() {
-  const fetcher = useFetcher();
+Submits form data to a route. While multiple nested routes can match a URL, only the leaf route will be called.
 
-  const onClick = () =>
-    fetcher.submit({ some: "values" }, { method: "post" });
+The `formData` can be multiple types:
 
-  // ...
-}
-```
+- `FormData` - A `FormData` instance.
+- `HTMLFormElement` - A `<form>` DOM element.
+- `Object` - An object of key/value pairs that will be converted to a `FormData` instance.
 
-Although a URL matches multiple Routes in a remix router hierarchy, a `fetcher.submit()` call will only call the action on the deepest matching route, unless the deepest matching route is an "index route". In this case, it will post to the parent route of the index route (because they share the same URL).
-
-If you want to submit to an index route use `?index` in the URL:
+If the method is GET, then the route loader is being called and with the formData serialized to the url as URLSearchParams. If POST, PUT, PATCH, or DELETE, then the route action is being called with FormData as the body.
 
 ```tsx
+fetcher.submit(event.currentTarget.form, {
+  method: "POST",
+});
+
 fetcher.submit(
-  { some: "values" },
-  { method: "post", action: "/accounts?index" }
+  { serialized: "values" },
+  { method: "POST" }
 );
+
+fetcher.submit(formData);
 ```
 
-See also:
+## `fetcher.load(href)`
 
-- [`?index` query param][index query param]
-
-## `fetcher.load()`
-
-Loads data from a route loader.
-
-```tsx
-function SomeComponent() {
-  const fetcher = useFetcher();
-
-  useEffect(() => {
-    if (fetcher.state === "idle" && fetcher.data == null) {
-      fetcher.load("/some/route");
-    }
-  }, [fetcher]);
-
-  fetcher.data; // the data from the loader
-}
-```
-
-Although a URL matches multiple Routes in a remix router hierarchy, a `fetcher.load()` call will only call the loader on the deepest matching route, unless the deepest matching route is an "index route". In this case, it will load the parent route of the index route (because they share the same URL).
-
-If you want to load an index route use `?index` in the URL:
+Loads data from a route loader. While multiple nested routes can match a URL, only the leaf route will be called.
 
 ```ts
-fetcher.load("/some/route?index");
+fetcher.load("/some/route");
+fetcher.load("/some/route?foo=bar");
 ```
 
-See also:
+## Properties
 
-- [`?index` query param][index query param]
+### `fetcher.state`
 
-## Examples
+You can know the state of the fetcher with `fetcher.state`. It will be one of:
 
-<docs-success>Watch the <a href="https://www.youtube.com/playlist?list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">📼 Remix Single</a>: <a href="https://www.youtube.com/watch?v=jd_bin5HPrw&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Remix Newsletter Signup Form</a></docs-success>
+- **idle** - Nothing is being fetched.
+- **submitting** - A form has been submitted. If the method is GET, then the route loader is being called. If POST, PUT, PATCH, or DELETE, then the route action is being called.
+- **loading** - The loaders for the routes are being reloaded after an action submission.
 
-**Newsletter Signup Form**
+### `fetcher.data`
 
-Perhaps you have a persistent newsletter signup at the bottom of every page on your site. This is not a navigation event, so `useFetcher` is perfect for the job. First, you create a Resource Route:
+The returned response data from your loader or action is stored here. Once the data is set, it persists on the fetcher even through reloads and resubmissions (like calling `fetcher.load()` again after having already read the data).
 
-```tsx filename=app/routes/newsletter.subscribe.tsx
-export async function action({ request }: ActionArgs) {
-  const email = (await request.formData()).get("email");
-  try {
-    await subscribe(email);
-    return json({ error: null, ok: true });
-  } catch (error) {
-    return json({ error: error.message, ok: false });
-  }
-}
-```
+## Additional Resources
 
-Then, somewhere else in your app (your root layout in this example), you render the following component:
+**Discussions**
 
-```tsx filename=app/routes/root.tsx
-// ...
+- [Form vs. Fetcher](../discussion/10-form-vs-fetcher)
+- [Network Concurrency Management](../discussion/09-concurrency)
 
-function NewsletterSignup() {
-  const newsletter = useFetcher();
-  const ref = useRef();
+**Videos**
 
-  useEffect(() => {
-    if (
-      newsletter.state === "idle" &&
-      newsletter.data?.ok
-    ) {
-      ref.current.reset();
-    }
-  }, [newsletter]);
-
-  return (
-    <newsletter.Form
-      ref={ref}
-      method="post"
-      action="/newsletter/subscribe"
-    >
-      <p>
-        <input type="text" name="email" />{" "}
-        <button
-          type="submit"
-          disabled={newsletter.state === "submitting"}
-        >
-          Subscribe
-        </button>
-      </p>
-
-      {newsletter.state === "idle" && newsletter.data ? (
-        newsletter.data.ok ? (
-          <p>Thanks for subscribing!</p>
-        ) : newsletter.data.error ? (
-          <p data-error>{newsletter.data.error}</p>
-        ) : null
-      ) : null}
-    </newsletter.Form>
-  );
-}
-```
-
-<docs-info>You can still provide a no-JavaScript experience</docs-info>
-
-Because `useFetcher` doesn't cause a navigation, it won't automatically work if there is no JavaScript on the page like a normal Remix `<Form>` will, because the browser will still navigate to the form's action.
-
-If you want to support a no JavaScript experience, just export a component from the route with the action.
-
-```tsx filename=app/routes/newsletter.subscribe.tsx
-export async function action({ request }: ActionArgs) {
-  // just like before
-}
-
-export default function NewsletterSignupRoute() {
-  const newsletter = useActionData<typeof action>();
-  return (
-    <Form method="post" action="/newsletter/subscribe">
-      <p>
-        <input type="text" name="email" />{" "}
-        <button type="submit">Subscribe</button>
-      </p>
-
-      {newsletter.data.ok ? (
-        <p>Thanks for subscribing!</p>
-      ) : newsletter.data.error ? (
-        <p data-error>{newsletter.data.error}</p>
-      ) : null}
-    </Form>
-  );
-}
-```
-
-- When JS is on the page, the user will subscribe to the newsletter and the page won't change, they'll just get a solid, dynamic experience.
-- When JS is not on the page, they'll be navigated to the signup page by the browser.
-
-You could even refactor the component to take props from the hooks and reuse it:
-
-```tsx filename=app/routes/newsletter.subscribe.tsx
-import { Form, useFetcher } from "@remix-run/react";
-
-// used in the footer
-export function NewsletterSignup() {
-  const newsletter = useFetcher();
-  return (
-    <NewsletterForm
-      Form={newsletter.Form}
-      data={newsletter.data}
-      state={newsletter.state}
-    />
-  );
-}
-
-// used here and in the route
-export function NewsletterForm({ Form, data, state }) {
-  // refactor a bit in here, just read from props instead of useFetcher
-}
-```
-
-And now you could reuse the same form, but it gets data from a different hook for the no-js experience:
-
-```tsx filename=app/routes/newsletter.subscribe.tsx
-import { Form } from "@remix-run/react";
-
-import { NewsletterForm } from "~/NewsletterSignup";
-
-export default function NewsletterSignupRoute() {
-  const data = useActionData<typeof action>();
-  return (
-    <NewsletterForm Form={Form} data={data} state="idle" />
-  );
-}
-```
-
-**Mark Article as Read**
-
-Imagine you want to mark that an article has been read by the current user, after they've been on the page for a while and scrolled to the bottom. You could make a hook that looks something like this:
-
-```tsx
-function useMarkAsRead({ articleId, userId }) {
-  const marker = useFetcher();
-
-  useSpentSomeTimeHereAndScrolledToTheBottom(() => {
-    marker.submit(
-      { userId },
-      {
-        method: "post",
-        action: `/article/${articleID}/mark-as-read`,
-      }
-    );
-  });
-}
-```
-
-**User Avatar Details Popup**
-
-Anytime you show the user avatar, you could put a hover effect that fetches data from a loader and displays it in a popup.
-
-```tsx filename=app/routes/user.$id.details.tsx
-export async function loader({ params }: LoaderArgs) {
-  return json(
-    await fakeDb.user.find({ where: { id: params.id } })
-  );
-}
-
-function UserAvatar({ partialUser }) {
-  const userDetails = useFetcher<typeof loader>();
-  const [showDetails, setShowDetails] = useState(false);
-
-  useEffect(() => {
-    if (
-      showDetails &&
-      userDetails.state === "idle" &&
-      !userDetails.data
-    ) {
-      userDetails.load(`/users/${user.id}/details`);
-    }
-  }, [showDetails, userDetails]);
-
-  return (
-    <div
-      onMouseEnter={() => setShowDetails(true)}
-      onMouseLeave={() => setShowDetails(false)}
-    >
-      <img src={partialUser.profileImageUrl} />
-      {showDetails ? (
-        userDetails.state === "idle" && userDetails.data ? (
-          <UserPopup user={userDetails.data} />
-        ) : (
-          <UserPopupLoading />
-        )
-      ) : null}
-    </div>
-  );
-}
-```
-
-**Async Reach UI Combobox**
-
-If the user needs to select a city, you could have a loader that returns a list of cities based on a query and plug it into a Reach UI combobox:
-
-```tsx filename=app/routes/city-search.tsx
-export async function loader({ request }: LoaderArgs) {
-  const url = new URL(request.url);
-  return json(
-    await searchCities(url.searchParams.get("city-query"))
-  );
-}
-
-function CitySearchCombobox() {
-  const cities = useFetcher<typeof loader>();
-
-  return (
-    <cities.Form method="get" action="/city-search">
-      <Combobox aria-label="Cities">
-        <div>
-          <ComboboxInput
-            name="city-query"
-            onChange={(event) =>
-              cities.submit(event.target.form)
-            }
-          />
-          {cities.state === "submitting" ? (
-            <Spinner />
-          ) : null}
-        </div>
-
-        {cities.data ? (
-          <ComboboxPopover className="shadow-popup">
-            {cities.data.error ? (
-              <p>Failed to load cities :(</p>
-            ) : cities.data.length ? (
-              <ComboboxList>
-                {cities.data.map((city) => (
-                  <ComboboxOption
-                    key={city.id}
-                    value={city.name}
-                  />
-                ))}
-              </ComboboxList>
-            ) : (
-              <span>No results found</span>
-            )}
-          </ComboboxPopover>
-        ) : null}
-      </Combobox>
-    </cities.Form>
-  );
-}
-```
-
-[form]: ../components/form
-[index query param]: ../guides/routing#what-is-the-index-query-param
-[usenavigation]: ./use-navigation
-[useactiondata]: ./use-action-data
-[useloaderdata]: ./use-loader-data
-[v2guide]: ../pages/v2#usefetcher
+- [Concurrent Mutations w/ useFetcher](https://www.youtube.com/watch?v=vTzNpiOk668&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6)
+- [Optimistic UI](https://www.youtube.com/watch?v=EdB_nj01C80&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6)

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -86,10 +86,15 @@ The returned response data from your loader or action is stored here. Once the d
 
 **Discussions**
 
-- [Form vs. Fetcher](../discussion/10-form-vs-fetcher)
-- [Network Concurrency Management](../discussion/09-concurrency)
+- [Form vs. Fetcher][form-vs-fetcher]
+- [Network Concurrency Management][network-concurrency-management]
 
 **Videos**
 
-- [Concurrent Mutations w/ useFetcher](https://www.youtube.com/watch?v=vTzNpiOk668&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6)
-- [Optimistic UI](https://www.youtube.com/watch?v=EdB_nj01C80&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6)
+- [Concurrent Mutations w/ useFetcher][concurrent-mutations-w-use-fetcher]
+- [Optimistic UI][optimistic-ui]
+
+[form-vs-fetcher]: ../discussion/10-form-vs-fetcher
+[network-concurrency-management]: ../discussion/09-concurrency
+[concurrent-mutations-w-use-fetcher]: https://www.youtube.com/watch?v=vTzNpiOk668&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6
+[optimistic-ui]: https://www.youtube.com/watch?v=EdB_nj01C80&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6

--- a/docs/hooks/use-fetchers.md
+++ b/docs/hooks/use-fetchers.md
@@ -5,126 +5,28 @@ toc: false
 
 # `useFetchers`
 
-Returns an array of all inflight fetchers.
-
-This is useful for components throughout the app that didn't create the fetchers but want to use their submissions to participate in optimistic UI.
-
-For example, imagine a UI where the sidebar lists projects, and the main view displays a list of checkboxes for the current project. The sidebar could display the number of completed and total tasks for each project.
-
-```
-+-----------------+----------------------------+
-|                 |                            |
-|   Soccer  (8/9) | [x] Do the dishes          |
-|                 |                            |
-| > Home    (2/4) | [x] Fold laundry           |
-|                 |                            |
-|                 | [ ] Replace battery in the |
-|                 |     smoke alarm            |
-|                 |                            |
-|                 | [ ] Change lights in kids  |
-|                 |     bathroom               |
-|                 |                            |
-+-----------------+----------------------------┘
-```
-
-When the user clicks a checkbox, the submission goes to the action to change the state of the task. Instead of creating a "loading state" we want to create an "optimistic UI" that will **immediately** update the checkbox to appear checked even though the server hasn't processed it yet. In the checkbox component, we can use `fetcher.formData`:
+Returns an array of all inflight fetchers. This is useful for components throughout the app that didn't create the fetchers but want to use their submissions to participate in optimistic UI.
 
 ```tsx
-function Task({ task }) {
-  const toggle = useFetcher();
-  const checked = toggle.formData
-    ? // use the optimistic version
-      Boolean(toggle.formData.get("complete"))
-    : // use the normal version
-      task.complete;
+import { useFetchers } from "@remix-run/react";
 
-  const { projectId, id } = task;
-  return (
-    <toggle.Form
-      method="put"
-      action={`/project/${projectId}/tasks/${id}`}
-    >
-      <label>
-        <input
-          type="checkbox"
-          checked={checked}
-          onChange={(e) => toggle.submit(e.target.form)}
-        />
-      </label>
-    </toggle.Form>
-  );
-}
-```
-
-This is awesome for the checkbox, but the sidebar will say 2/4 while the checkboxes show 3/4 when the user clicks one of them!
-
-```
-+-----------------+----------------------------+
-|                 |                            |
-|   Soccer  (8/9) | [x] Do the dishes          |
-|                 |                            |
-| > Home    (2/4) | [x] Fold laundry           |
-|                 |                            |
-|          CLICK!-->[x] Replace battery in the |
-|                 |     smoke alarm            |
-|                 |                            |
-|                 | [ ] Change lights in kids  |
-|                 |     bathroom               |
-|                 |                            |
-+-----------------+----------------------------┘
-```
-
-Because Remix will automatically reload the routes, the sidebar will quickly update and be correct. But for a moment, it's going to feel a little funny.
-
-This is where `useFetchers` comes in. Up in the sidebar, we can access all the inflight fetcher states from the checkboxes - even though it's not the component that created them.
-
-The strategy has three steps:
-
-1. Find the submissions for tasks in a specific project
-2. Use the `fetcher.formData` to immediately update the count
-3. Use the normal task's state if it's not inflight
-
-Here's some sample code:
-
-```tsx
-function ProjectTaskCount({ project }) {
+function SomeComponent() {
   const fetchers = useFetchers();
-  let completedTasks = 0;
-
-  // 1) Find my task's submissions
-  const myFetchers = new Map();
-  for (const f of fetchers) {
-    if (
-      f.formAction &&
-      f.formAction.startsWith(
-        `/projects/${project.id}/task`
-      )
-    ) {
-      const taskId = f.formData.get("id");
-      myFetchers.set(
-        parseInt(taskId),
-        f.formData.get("complete") === "on"
-      );
-    }
-  }
-
-  for (const task of project.tasks) {
-    // 2) use the optimistic version
-    if (myFetchers.has(task.id)) {
-      if (myFetchers.get(task.id)) {
-        completedTasks++;
-      }
-    }
-    // 3) use the normal version
-    else if (task.complete) {
-      completedTasks++;
-    }
-  }
-
-  return (
-    <small>
-      {completedTasks}/{project.tasks.length}
-    </small>
-  );
+  fetchers[0].formData; // FormData
+  fetchers[0].state; // etc.
+  // ...
 }
 ```
+
+The fetchers don't contain `fetcher.Form`, `fetcher.submit`, or `fetcher.load`, only the states like `fetcher.formData`, `fetcher.state`, etc.
+
+## Additional Resources
+
+**Discussions**
+
+- [Form vs. Fetcher](../discussion/10-form-vs-fetcher)
+- [Pending, Optimistic UI](../discussion/07-pending-ui)
+
+**API**
+
+- [`useFetcher`](./use-fetcher)

--- a/docs/hooks/use-fetchers.md
+++ b/docs/hooks/use-fetchers.md
@@ -24,9 +24,13 @@ The fetchers don't contain `fetcher.Form`, `fetcher.submit`, or `fetcher.load`, 
 
 **Discussions**
 
-- [Form vs. Fetcher](../discussion/10-form-vs-fetcher)
-- [Pending, Optimistic UI](../discussion/07-pending-ui)
+- [Form vs. Fetcher][form-vs-fetcher]
+- [Pending, Optimistic UI][pending-optimistic-ui]
 
 **API**
 
-- [`useFetcher`](./use-fetcher)
+- [`useFetcher`][use-fetcher]
+
+[form-vs-fetcher]: ../discussion/10-form-vs-fetcher
+[pending-optimistic-ui]: ../discussion/07-pending-ui
+[use-fetcher]: ./use-fetcher

--- a/docs/hooks/use-form-action.md
+++ b/docs/hooks/use-form-action.md
@@ -4,25 +4,34 @@ title: useFormAction
 
 # `useFormAction`
 
-<docs-info>This hook is simply a re-export of [React Router's `useFormAction`][rr-useformaction].</docs-info>
+Resolves the URL to the closest route in the component hierarchy instead of the current URL of the app.
 
-Resolves the value of a `<form action>` attribute using React Router's relative paths. This can be useful when computing the correct action for a `<button formAction>`, for example, when a `<button>` changes the action of its `<form>`.
+This is used internally by `<Form>` to resolve the action to the closest route, but can be used generically as well.
 
 ```tsx
+import { useFormAction } from "@remix-run/react";
 function SomeComponent() {
-  return (
-    <button
-      formAction={useFormAction("destroy")}
-      formMethod="post"
-    >
-      Delete
-    </button>
-  );
+  // closest route URL
+  const action = useFormAction();
+
+  // closest route URL + "destroy"
+  const destroyAction = useFormAction("destroy");
 }
 ```
 
-(Yes, HTML buttons can change the action of their form!)
+## Signature
 
-<docs-info>For more information and usage, please refer to the [React Router `useFormAction` docs][rr-useformaction].</docs-info>
+```
+useFormAction(action, options)
+```
 
-[rr-useformaction]: https://reactrouter.com/hooks/use-form-action
+### `action`
+
+Optional. The action to append to the closest route URL.
+
+### `options`
+
+The only option is `{ relative: "route" | "path"}`.
+
+- **route** default - relative to the route hierarchy, not the URL
+- **path** - makes the action relative to the URL paths, so `..` will remove one URL segment.

--- a/docs/hooks/use-href.md
+++ b/docs/hooks/use-href.md
@@ -5,6 +5,29 @@ toc: false
 
 # `useHref`
 
-<docs-info>This hook is simply a re-export of [React Router's `useHref`][rr-usehref].</docs-info>
+Resolves a full URL to be used as an href to a link. If a relative path is supplied, it will resolve to a full URL.
 
-[rr-usehref]: https://reactrouter.com/hooks/use-href
+```tsx
+import { useHref } from "@remix-run/react";
+function SomeComponent() {
+  const href = useHref();
+  // ...
+}
+```
+
+## Signature
+
+```
+useHref(to, options)
+```
+
+### `to`
+
+Optional. The path to append to the resolved URL.
+
+### `options`
+
+The only option is `{ relative: "route" | "path"}`, which defines the behavior when resolving relative URLs.
+
+- **route** default - relative to the route hierarchy, not the URL
+- **path** - makes the action relative to the URL paths, so `..` will remove one URL segment.

--- a/docs/hooks/use-loader-data.md
+++ b/docs/hooks/use-loader-data.md
@@ -24,10 +24,15 @@ export default function Invoices() {
 
 **Discussions**
 
-- [Fullstack Data Flow](../discussion/03-data-flow)
-- [State Management](../discussion/08-state-management)
+- [Fullstack Data Flow][fullstack-data-flow]
+- [State Management][state-management]
 
 **API**
 
-- [`loader`](../route/loader)
-- [`useFetcher`](./use-fetcher)
+- [`loader`][loader]
+- [`useFetcher`][use-fetcher]
+
+[fullstack-data-flow]: ../discussion/03-data-flow
+[state-management]: ../discussion/08-state-management
+[loader]: ../route/loader
+[use-fetcher]: ./use-fetcher

--- a/docs/hooks/use-loader-data.md
+++ b/docs/hooks/use-loader-data.md
@@ -5,18 +5,13 @@ toc: false
 
 # `useLoaderData`
 
-<docs-info>This hook is simply a re-export of [React Router's `useLoaderData`][rr-useloaderdata].</docs-info>
+Returns the serialized data from the closest route loader.
 
-<docs-success>Watch the <a href="https://www.youtube.com/playlist?list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">📼 Remix Single</a>: <a href="https://www.youtube.com/watch?v=NXqEP_PsPNc&list=PLXoynULbYuEDG2wBFSZ66b85EIspy3fy6">Loading data into components</a></docs-success>
-
-This hook returns the JSON parsed data from your route loader function.
-
-```tsx lines=[2,9]
-import { json } from "@remix-run/node"; // or cloudflare/deno
+```tsx lines=[1,8]
 import { useLoaderData } from "@remix-run/react";
 
 export async function loader() {
-  return json(await fakeDb.invoices.findAll());
+  return fakeDb.invoices.findAll();
 }
 
 export default function Invoices() {
@@ -25,6 +20,14 @@ export default function Invoices() {
 }
 ```
 
-<docs-info>For more information and usage, please refer to the [React Router `useLoaderData` docs][rr-useloaderdata].</docs-info>
+## Additional Resources
 
-[rr-useloaderdata]: https://reactrouter.com/hooks/use-loader-data
+**Discussions**
+
+- [Fullstack Data Flow](../discussion/03-data-flow)
+- [State Management](../discussion/08-state-management)
+
+**API**
+
+- [`loader`](../route/loader)
+- [`useFetcher`](./use-fetcher)

--- a/docs/hooks/use-location.md
+++ b/docs/hooks/use-location.md
@@ -5,6 +5,35 @@ toc: false
 
 # `useLocation`
 
-<docs-info>This hook is simply a re-export of [React Router's `useLocation`][rr-uselocation].</docs-info>
+Returns the current location object.
 
-[rr-uselocation]: https://reactrouter.com/hooks/use-location
+```tsx
+import { useLocation } from "@remix-run/react";
+
+function SomeComponent() {
+  const location = useLocation();
+  // ...
+}
+```
+
+## Properties
+
+### `location.hash`
+
+The hash of the current URL.
+
+### `location.key`
+
+The unique key of this location.
+
+### `location.pathname`
+
+The path of the current URL.
+
+### `location.search`
+
+The query string of the current URL.
+
+### `location.state`
+
+The state value of the location created by [`<Link state>`](../components/link) or [`navigate`](./use-navigate).

--- a/docs/hooks/use-location.md
+++ b/docs/hooks/use-location.md
@@ -36,4 +36,7 @@ The query string of the current URL.
 
 ### `location.state`
 
-The state value of the location created by [`<Link state>`](../components/link) or [`navigate`](./use-navigate).
+The state value of the location created by [`<Link state>`][link-state] or [`navigate`][navigate].
+
+[link-state]: ../components/link
+[navigate]: ./use-navigate


### PR DESCRIPTION
Grabbing all the latest docs updates from Ryan on `dev` into `release-next` so they merge to `main` with v2 stable.

Here's the list of commits on `dev` not in `release-next`: https://github.com/remix-run/remix/compare/release-next...dev

Thankfully all of his are sequential, so this was just a matter of:

```
 git cherry-pick 4892a0d^..481f73e
```
