### PR TITLE
Update to stable releases of web-std-io and react-router

### DIFF
--- a/.changeset/poor-dolls-nail.md
+++ b/.changeset/poor-dolls-nail.md
@@ -1,0 +1,8 @@
+---
+"@remix-run/node": patch
+"@remix-run/react": patch
+"@remix-run/server-runtime": patch
+"@remix-run/testing": patch
+---
+
+[Remove] Update to stable `web-std-io` and `react-router` releases

--- a/packages/remix-node/package.json
+++ b/packages/remix-node/package.json
@@ -18,9 +18,9 @@
   ],
   "dependencies": {
     "@remix-run/server-runtime": "2.0.0-pre.11",
-    "@remix-run/web-fetch": "^4.4.0-pre.0",
-    "@remix-run/web-file": "^3.1.0-pre.0",
-    "@remix-run/web-stream": "^1.1.0-pre.0",
+    "@remix-run/web-fetch": "^4.4.0",
+    "@remix-run/web-file": "^3.1.0",
+    "@remix-run/web-stream": "^1.1.0",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie-signature": "^1.1.0",
     "source-map-support": "^0.5.21",

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -16,9 +16,9 @@
   "typings": "dist/index.d.ts",
   "module": "dist/esm/index.js",
   "dependencies": {
-    "@remix-run/router": "1.9.0-pre.2",
+    "@remix-run/router": "1.9.0",
     "@remix-run/server-runtime": "2.0.0-pre.11",
-    "react-router-dom": "6.16.0-pre.2"
+    "react-router-dom": "6.15.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.17.0",

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -16,7 +16,7 @@
   "typings": "dist/index.d.ts",
   "module": "dist/esm/index.js",
   "dependencies": {
-    "@remix-run/router": "1.9.0-pre.2",
+    "@remix-run/router": "1.8.0",
     "@types/cookie": "^0.4.1",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie": "^0.4.1",

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "@remix-run/node": "2.0.0-pre.11",
     "@remix-run/react": "2.0.0-pre.11",
-    "@remix-run/router": "1.9.0-pre.2",
-    "react-router-dom": "6.16.0-pre.2"
+    "@remix-run/router": "1.9.0",
+    "react-router-dom": "6.15.0"
   },
   "devDependencies": {
     "@types/node": "^18.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,45 +2137,45 @@
   resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.9.0-pre.2.tgz#60f8d78a6a63734f212a35330a72d256598928ca"
   integrity sha512-SsG5WVdITYKH5VJnsI1yDyNlQjV3TxF9Aeq7ZhrYprCD0x5QqaqvTEbdpuEHybzDbvpU1Ev9eO99RTHoxeHV2w==
 
-"@remix-run/web-blob@^3.1.0-pre.0":
-  version "3.1.0-pre.0"
-  resolved "https://registry.npmjs.org/@remix-run/web-blob/-/web-blob-3.1.0-pre.0.tgz#eae9f36e48395cf483b97becbbb71d40360d9bef"
-  integrity sha512-TcxrfMv1RWSVKdtueh70kvtxTeNeyCsqHQhOZA8EoKhGCEhIoP1fHIGkHWdwxTheoRYJzhncuJi9V3yBiPNlxA==
+"@remix-run/web-blob@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/@remix-run/web-blob/-/web-blob-3.1.0.tgz#e0c669934c1eb6028960047e57a13ed38bbfb434"
+  integrity sha512-owGzFLbqPH9PlKb8KvpNJ0NO74HWE2euAn61eEiyCXX/oteoVzTVSN8mpLgDjaxBf2btj5/nUllSUgpyd6IH6g==
   dependencies:
-    "@remix-run/web-stream" "^1.1.0-pre.0"
+    "@remix-run/web-stream" "^1.1.0"
     web-encoding "1.1.5"
 
-"@remix-run/web-fetch@^4.4.0-pre.0":
-  version "4.4.0-pre.0"
-  resolved "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.4.0-pre.0.tgz#8e9b023983c04a044fe27b2513b7b14fa08abbad"
-  integrity sha512-caqYs9qWZw0fm8Cj8byFADfGyO+oenIOUywNzJ2LAzWsNbuPu0XjTMIuUEijxtMPsOXn3CznV6R1tndpMoaEMQ==
+"@remix-run/web-fetch@^4.4.0":
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.4.0.tgz#23919c0f5a6649d133c42e72f2ca08dad18693c1"
+  integrity sha512-j6vswnGteHd3N5Y2lb5sRKP+NxChVCd1goXRDAanTMFfgxsCV/1ItlJFY8G/F4AESkDydcZ6tz6gAsttkGDiMA==
   dependencies:
-    "@remix-run/web-file" "^3.1.0-pre.0"
-    "@remix-run/web-form-data" "^3.1.0-pre.0"
-    "@remix-run/web-stream" "^1.1.0-pre.0"
+    "@remix-run/web-file" "^3.1.0"
+    "@remix-run/web-form-data" "^3.1.0"
+    "@remix-run/web-stream" "^1.1.0"
     "@web3-storage/multipart-parser" "^1.0.0"
     abort-controller "^3.0.0"
     data-uri-to-buffer "^3.0.1"
     mrmime "^1.0.0"
 
-"@remix-run/web-file@^3.1.0-pre.0":
-  version "3.1.0-pre.0"
-  resolved "https://registry.npmjs.org/@remix-run/web-file/-/web-file-3.1.0-pre.0.tgz#b3e096dadc827e2766b6e5de24e41ce51fd9426c"
-  integrity sha512-5Er4u9fvACp7Ejp9fqjmJHXRHl+1wt897GcJCYd1rAWPkEPp1oPlBeV8SkK3bMJj8oXEJtDuAlyJQ/Q6RcJGBg==
+"@remix-run/web-file@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/@remix-run/web-file/-/web-file-3.1.0.tgz#07219021a2910e90231bc30ca1ce693d0e9d3825"
+  integrity sha512-dW2MNGwoiEYhlspOAXFBasmLeYshyAyhIdrlXBi06Duex5tDr3ut2LFKVj7tyHLmn8nnNwFf1BjNbkQpygC2aQ==
   dependencies:
-    "@remix-run/web-blob" "^3.1.0-pre.0"
+    "@remix-run/web-blob" "^3.1.0"
 
-"@remix-run/web-form-data@^3.1.0-pre.0":
-  version "3.1.0-pre.0"
-  resolved "https://registry.npmjs.org/@remix-run/web-form-data/-/web-form-data-3.1.0-pre.0.tgz#dd067dca1bda403ee994901618e24b2a0f67fffe"
-  integrity sha512-C7Z2Z0uRuNDdMyzvcWV5dcsOaDT4YPeCBEit9+TsLag2ABTDitbcnY2kexPGjpTbounm3Xx+v8668ramIl6yVQ==
+"@remix-run/web-form-data@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/@remix-run/web-form-data/-/web-form-data-3.1.0.tgz#47f9ad8ce8bf1c39ed83eab31e53967fe8e3df6a"
+  integrity sha512-NdeohLMdrb+pHxMQ/Geuzdp0eqPbea+Ieo8M8Jx2lGC6TBHsgHzYcBvr0LyPdPVycNRDEpWpiDdCOdCryo3f9A==
   dependencies:
     web-encoding "1.1.5"
 
-"@remix-run/web-stream@^1.1.0-pre.0":
-  version "1.1.0-pre.0"
-  resolved "https://registry.npmjs.org/@remix-run/web-stream/-/web-stream-1.1.0-pre.0.tgz#970b7a16643e952e8665e6ca26e79724b5c703d9"
-  integrity sha512-wDKocDPORtaBTFkkYfradntGY+yE03twtXCmDEn10/eioTsmVoA8SK1leoFfBdAqToBH7vDAwb3UbIOLIVSmsA==
+"@remix-run/web-stream@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@remix-run/web-stream/-/web-stream-1.1.0.tgz#b93a8f806c2c22204930837c44d81fdedfde079f"
+  integrity sha512-KRJtwrjRV5Bb+pM7zxcTJkhIqWWSy+MYsIxHK+0m5atcznsf15YwUBWHWulZerV2+vvHH1Lp1DD7pw6qKW8SgA==
   dependencies:
     web-streams-polyfill "^3.1.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,10 +2132,15 @@
     "@changesets/types" "^5.0.0"
     dotenv "^8.1.0"
 
-"@remix-run/router@1.9.0-pre.2":
-  version "1.9.0-pre.2"
-  resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.9.0-pre.2.tgz#60f8d78a6a63734f212a35330a72d256598928ca"
-  integrity sha512-SsG5WVdITYKH5VJnsI1yDyNlQjV3TxF9Aeq7ZhrYprCD0x5QqaqvTEbdpuEHybzDbvpU1Ev9eO99RTHoxeHV2w==
+"@remix-run/router@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.8.0.tgz#e848d2f669f601544df15ce2a313955e4bf0bafc"
+  integrity sha512-mrfKqIHnSZRyIzBcanNJmVQELTnX+qagEDlcKO90RgRBVOZGSGvZKeDihTRfWcqoDn5N/NkUcwWTccnpN18Tfg==
+
+"@remix-run/router@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.9.0.tgz#9033238b41c4cbe1e961eccb3f79e2c588328cf6"
+  integrity sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA==
 
 "@remix-run/web-blob@^3.1.0":
   version "3.1.0"
@@ -10128,20 +10133,20 @@ react-refresh@^0.14.0:
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
 
-react-router-dom@6.16.0-pre.2:
-  version "6.16.0-pre.2"
-  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.16.0-pre.2.tgz#331f8a820d984303f65990a2ab9da06f781d1b7e"
-  integrity sha512-ZaYhnNQPeCYOGb9bcVxT3lbSLehZY36xK+j+xnQRw0GeaF+KBi14Hn2HwmhbmwYCbv15d1jHtvE676rFGrQlDg==
+react-router-dom@6.15.0:
+  version "6.15.0"
+  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.15.0.tgz#6da7db61e56797266fbbef0d5e324d6ac443ee40"
+  integrity sha512-aR42t0fs7brintwBGAv2+mGlCtgtFQeOzK0BM1/OiqEzRejOZtpMZepvgkscpMUnKb8YO84G7s3LsHnnDNonbQ==
   dependencies:
-    "@remix-run/router" "1.9.0-pre.2"
-    react-router "6.16.0-pre.2"
+    "@remix-run/router" "1.8.0"
+    react-router "6.15.0"
 
-react-router@6.16.0-pre.2:
-  version "6.16.0-pre.2"
-  resolved "https://registry.npmjs.org/react-router/-/react-router-6.16.0-pre.2.tgz#2a306b77033c2d3110ecb37f5e4446e28916dcf6"
-  integrity sha512-6DVgJNxnBLGOD0SOiv11sPDaZErfrAhAuFUOzTy5OPdMpmagvsTidji6aadUZAnXDjQNYQS053BIaLC7pn5+bg==
+react-router@6.15.0:
+  version "6.15.0"
+  resolved "https://registry.npmjs.org/react-router/-/react-router-6.15.0.tgz#bf2cb5a4a7ed57f074d4ea88db0d95033f39cac8"
+  integrity sha512-NIytlzvzLwJkCQj2HLefmeakxxWHWAP+02EGqWEZy+DgfHHKQMUoBBjUQLOtFInBMhWtb3hiUy6MfFgwLjXhqg==
   dependencies:
-    "@remix-run/router" "1.9.0-pre.2"
+    "@remix-run/router" "1.8.0"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
Update to stable releases of `web-std-io` and `react-router`

https://github.com/remix-run/web-std-io/releases
https://github.com/remix-run/react-router/releases/tag/react-router%406.16.0
