### PR TITLE
docs(quickstart): Minor fixes to commands

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -65,6 +65,7 @@
 - bogas04
 - BogdanDevBst
 - bolchowka
+- brookslybrand
 - brophdawg11
 - bruno-oliveira
 - bsharrow

--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -19,7 +19,7 @@ cd my-remix-app
 npm i @remix-run/node @remix-run/react @remix-run/serve isbot react react-dom
 
 # install dev dependencies
-npm i -D @remix-run/dev typescript
+npm i -D @remix-run/dev typescript @types/react
 ```
 
 ## The Root Route
@@ -66,7 +66,7 @@ export default function App() {
 First build the app for production:
 
 ```shellscript nonumber
-remix build
+npx remix build
 ```
 
 You should now see a `build/` folder (the server version of your app) and `public/build` folder (the browser version) with some build artifacts in them. (This is all [configurable][remix-config].)
@@ -75,7 +75,7 @@ You should now see a `build/` folder (the server version of your app) and `publi
 
 ```shellscript nonumber
 # note the dash!
-remix-serve build/index.js
+npx remix-serve build/index.js
 ```
 
 You should be able to open up [http://localhost:3000][http-localhost-3000] and see the "hello world" page.
@@ -233,7 +233,7 @@ Now you can work on your app with immediate feedback. Give it a shot, change the
 There are default magic files Remix is using that most apps don't need to mess with, but if you want to customize Remix's entry points to the server and browser you can run `remix reveal` and they'll get dumped into your project.
 
 ```shellscript nonumber
-remix reveal
+npx remix reveal
 ```
 
 ```
@@ -248,7 +248,7 @@ Congrats, you can add Remix to your resume! Summing things up, we've learned:
 - `remix build` and `remix dev` compile your app into two things:
   - A request handler that you add to your own JavaScript server
   - A pile of static assets in your public directory for the browser
-- You can bring your own server with adapters to deploy anywhere.
+- You can bring your own server with adapters to deploy anywhere
 - You can set up a development workflow with HMR built-in
 
 In general, Remix is a bit "guts out". A few minutes of boilerplate but now you own your stack.

--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -73,6 +73,17 @@ You should now see a `build/` folder (the server version of your app) and `publi
 
 💿 **Run the app with `remix-serve`**
 
+First you will need to specify the type in `package.json` as module so that `remix-serve` can run your app.
+
+```jsonc filename=package.json lines=[2] nocopy
+{
+  "type": "module"
+  // ...
+}
+```
+
+Now you can run your app with `remix-serve`:
+
 ```shellscript nonumber
 # note the dash!
 npx remix-serve build/index.js

--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -19,19 +19,19 @@ cd my-remix-app
 npm i @remix-run/node @remix-run/react @remix-run/serve isbot react react-dom
 
 # install dev dependencies
-npm i -D @remix-run/dev typescript @types/react
+npm i -D @remix-run/dev
 ```
 
 ## The Root Route
 
 ```shellscript nonumber
 mkdir app
-touch app/root.tsx
+touch app/root.jsx
 ```
 
 `app/root.jsx` is what we call the "Root Route". It's the root layout of your entire app. Here's the basic set of elements you'll need for any project:
 
-```tsx filename=app/root.tsx
+```jsx filename=app/root.jsx
 import {
   Links,
   Meta,
@@ -199,7 +199,7 @@ app.listen(3000, () => {
 
 And finally, let's connect your UI in the browser to receive those broadcasts:
 
-```tsx filename=app/root.tsx lines=[3,25]
+```jsx filename=app/root.jsx lines=[3,25]
 import {
   Links,
   LiveReload,
@@ -237,7 +237,7 @@ export default function App() {
 npm run dev
 ```
 
-Now you can work on your app with immediate feedback. Give it a shot, change the text in `root.tsx` and watch!
+Now you can work on your app with immediate feedback. Give it a shot, change the text in `root.jsx` and watch!
 
 ## Controlling Server and Browser Entries
 


### PR DESCRIPTION
Some really minor changes to the [quickstart docs on dev](https://remix.run/docs/en/dev/start/quickstart)

Two issues not addressed in the code:
1. There is no `tsconfig.json` file, yet we're using `.tsx` files. Should we include a step to add a `tsconfig.json` file such as [this one](https://github.com/remix-run/remix/blob/30bcd9e9dfbeda1707329da017f9ceccfac21521/docs/guides/typescript.md?plain=1#L49-L70). If so, I can add that instruction
2. When running `remix-serve build/index.js` (or rather `npx remix-serve build/index.js`) I get a syntax error due to the `import` statements. A simple `"type": "module"` in the `package.json` fixes this, but I wasn't sure if there's a more preferred recommendation for the quick start