### PR TITLE
docs(file-conventions/entry.server): add note about aborted requests in `handleError` section

### DIFF
--- a/docs/file-conventions/entry.server.md
+++ b/docs/file-conventions/entry.server.md
@@ -32,10 +32,14 @@ export function handleError(
   error: unknown,
   { request, params, context }: DataFunctionArgs
 ) {
-  sendErrorToErrorReportingService(error);
-  console.error(formatErrorForJsonLogging(error));
+  if (!request.signal.aborted) {
+    sendErrorToErrorReportingService(error);
+    console.error(formatErrorForJsonLogging(error));
+  }
 }
 ```
+
+_Note that you generally want to avoid logging when the request was aborted, since Remix's cancellation and race-condition handling can cause a lot of requests to be aborted._
 
 ### Streaming Rendering Errors
 


### PR DESCRIPTION
Added some clarity for a scenario that comes up a lot with `handleError` and aborted requests