### PR TITLE
warn that `future.v2_dev` should be moved to `dev` in v2

### DIFF
--- a/.changeset/odd-bananas-teach.md
+++ b/.changeset/odd-bananas-teach.md
@@ -1,0 +1,7 @@
+---
+"@remix-run/dev": patch
+---
+
+Warn if `future.v2_dev` is set
+
+Prompt user to delete it if its set to `true` or move it to `dev` if its an object.

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -568,18 +568,29 @@ export async function readConfig(
       "unstable_postcss",
       "unstable_tailwind",
       "unstable_vanillaExtract",
-      "v2_dev",
       "v2_errorBoundary",
       "v2_headers",
       "v2_meta",
       "v2_normalizeFormMethod",
       "v2_routeConvention",
-    ] as const;
+    ];
+
+    if ("v2_dev" in userFlags) {
+      if (userFlags.v2_dev === true) {
+        deprecatedFlags.push("v2_dev");
+      } else {
+        logger.warn("The `v2_dev` future flag is obsolete.", {
+          details: [
+            "Move your dev options from `future.v2_dev` to `dev` within your `remix.config.js` file",
+          ],
+        });
+      }
+    }
 
     let obsoleteFlags = deprecatedFlags.filter((f) => f in userFlags);
     if (obsoleteFlags.length > 0) {
       logger.warn(
-        `⚠️ REMIX FUTURE CHANGE: the following Remix future flags are now obsolete ` +
+        `The following Remix future flags are now obsolete ` +
           `and can be removed from your remix.config.js file:\n` +
           obsoleteFlags.map((f) => `- ${f}\n`).join("")
       );


### PR DESCRIPTION
## If `future.v2_dev` is `true`

<img width="1200" alt="Screenshot 2023-09-15 at 1 00 05 PM" src="https://github.com/remix-run/remix/assets/1477317/e8a26800-a1c6-4ca7-980f-714b24256e6a">

## If `future.v2_dev` is an object

<img width="1188" alt="Screenshot 2023-09-15 at 12 59 10 PM" src="https://github.com/remix-run/remix/assets/1477317/43ee8a2b-9079-473d-a062-ece873cbddd9">
