### PR TITLE
docs: fix links in v2 upgrade doc

### DIFF
--- a/docs/start/v2.md
+++ b/docs/start/v2.md
@@ -997,7 +997,7 @@ module.exports = {
 [future-flags]: ./future-flags
 [remix-config]: ../file-conventions/remix-config
 [flat-routes]: https://github.com/remix-run/remix/discussions/4482
-[meta-v2]: ../route/meta-v2
+[meta-v2]: ../route/meta
 [meta-v2-rfc]: https://github.com/remix-run/remix/discussions/4462
 [meta-v2-matches]: #the-matches-argument
 [v1-16-release-notes]: https://github.com/remix-run/remix/releases/tag/remix%401.16.0


### PR DESCRIPTION
Couple of broken links in the upgrade docs, 2 right at the top 😬 