### PR TITLE
docs(file-conventions/remix-config): fix `serverModuleFormat`'s default value

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -392,6 +392,7 @@
 - n8agrin
 - na2hiro
 - nareshbhatia
+- natac13
 - navid-kalaei
 - nexxeln
 - ngbrown

--- a/docs/file-conventions/remix-config.md
+++ b/docs/file-conventions/remix-config.md
@@ -168,7 +168,7 @@ Whether to minify the server build in production or not. Defaults to `false`.
 ## serverModuleFormat
 
 The output format of the server build, which can either be `"cjs"` or `"esm"`.
-Defaults to `"cjs"`.
+Defaults to `"esm"`.
 
 ## serverNodeBuiltinsPolyfill
 

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -137,7 +137,7 @@ export interface AppConfig {
   serverMinify?: boolean;
 
   /**
-   * The output format of the server build. Defaults to "cjs".
+   * The output format of the server build. Defaults to "esm".
    */
   serverModuleFormat?: ServerModuleFormat;
 
@@ -310,7 +310,7 @@ export interface RemixConfig {
   serverMode: ServerMode;
 
   /**
-   * The output format of the server build. Defaults to "cjs".
+   * The output format of the server build. Defaults to "esm".
    */
   serverModuleFormat: ServerModuleFormat;
 


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

Simple Doc change for the default `serverModuleFormat` as well as JS doc