### PR TITLE
docs: fix links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see [our guide to contributing](docs/pages/contributing.md).
+Please see [our guide to contributing](docs/guides/contributing.md).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The documentation is automatically generated on each release from the files in
 
 ## Contributing
 
-If you're interested in contributing code and/or documentation, please see [our guide to contributing](docs/pages/contributing.md).
+If you're interested in contributing code and/or documentation, please see [our guide to contributing](docs/guides/contributing.md).
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ We are happy you're here!
 
 [Remix](https://remix.run) is a full stack web framework that lets you focus on the user interface and work back through web fundamentals to deliver a fast, slick, and resilient user experience that deploys to any Node.js server and even non-Node.js environments at the edge like Cloudflare Workers.
 
-Want to know more? Read the [Technical Explanation of Remix](https://remix.run/pages/technical-explanation)
-
 This repository contains the Remix source code. This repo is a work in progress, so we appreciate your patience as we figure things out.
 
 ## Documentation

--- a/contributors.yml
+++ b/contributors.yml
@@ -581,3 +581,4 @@
 - robbtraister
 - TrySound
 - rogepi
+- antonkri97

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -239,7 +239,7 @@ There may be other branches for various features and experimentation, but all of
 
 ## How do nightly releases work?
 
-Nightly releases will run the action files from the `main` branch as scheduled workflows will always use the latest commit to the default branch, signified by [this comment on the nightly action file][nightly-action-comment] and the explicit branch appended to the reusable workflows in the [postrelease action][postrelease-action], however they checkout the `dev` branch during their set up as that's where we want our nightly releases to be cut from. From there, we check if the git SHA is the same and only cut a new nightly if something has changed.
+Nightly releases will run the action files from the `main` branch as scheduled workflows will always use the latest commit to the default branch, signified by [this comment on the nightly action file][nightly-action-comment] and the explicit branch appended to the reusable workflows in the postrelease action, however they checkout the `dev` branch during their set up as that's where we want our nightly releases to be cut from. From there, we check if the git SHA is the same and only cut a new nightly if something has changed.
 
 ## End to end testing
 
@@ -259,6 +259,5 @@ For every release of Remix (stable, experimental, nightly, and pre-releases), we
 [yarn-workspaces]: https://classic.yarnpkg.com/en/docs/workspaces
 [vscode-playwright]: https://playwright.dev/docs/intro#using-the-vs-code-extension
 [nightly-action-comment]: https://github.com/remix-run/remix/blob/main/.github/workflows/nightly.yml#L8-L12
-[postrelease-action]: https://github.com/remix-run/remix/blob/main/.github/workflows/postrelease.yml
-[templates]: /templates
+[templates]: https://github.com/remix-run/remix/tree/main/templates
 [https-remix-new]: https://remix.new


### PR DESCRIPTION
Hey everyone!

This pull request only about doc links. 

1. I removed incorrect links leading to non-existent resources
2. I removed block about tech explanation since I did not find  tech explanation in main branch
3. I set proper links to existent resources