### PR TITLE
Add second generic to UIMatch for handle field

### DIFF
--- a/.changeset/add-uimatch-handle.md
+++ b/.changeset/add-uimatch-handle.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Add second generic to `UIMatch` for `handle` field

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -52,6 +52,7 @@ import type {
   MetaDescriptor,
   MetaMatch,
   MetaMatches,
+  RouteHandle,
 } from "./routeModules";
 
 function useDataRouterContext() {
@@ -976,7 +977,10 @@ function dedupe(array: any[]) {
   return [...new Set(array)];
 }
 
-export type UIMatch<D = AppData> = UIMatchRR<SerializeFrom<D>>;
+export type UIMatch<D = AppData, H = RouteHandle> = UIMatchRR<
+  SerializeFrom<D>,
+  H
+>;
 
 /**
  * Returns the active route matches, useful for accessing loaderData for


### PR DESCRIPTION
Add second `handle` generic to `UIMatch` to match the React Router version

Closes: https://github.com/remix-run/remix/issues/7438