### PR TITLE
in manual mode, watch for changes to version.txt instead of server build

### DIFF
--- a/.changeset/four-spies-draw.md
+++ b/.changeset/four-spies-draw.md
@@ -1,0 +1,7 @@
+---
+"@remix-run/serve": patch
+---
+
+Fix error caused by partially written server build
+
+Previously, it was possible to trigger a reimport of the app server code before the new server build had completely been written. Reimporting the partially written server build caused issues related to `build.assets` being undefined and crashing when reading `build.assets.version`.

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -42,6 +42,7 @@ async function run() {
   }
 
   let buildPath = path.resolve(buildPathArg);
+  let versionPath = path.resolve(buildPath, "..", "version.txt");
 
   async function reimportServer() {
     let stat = fs.statSync(buildPath);
@@ -60,7 +61,7 @@ async function run() {
     }
 
     chokidar
-      .watch(buildPath, { ignoreInitial: true })
+      .watch(versionPath, { ignoreInitial: true })
       .on("add", handleServerUpdate)
       .on("change", handleServerUpdate);
 


### PR DESCRIPTION
to avoid race conditions caused by partially written server build

Tried HMR updates on a fresh install w/ these changes added in via `LOCAL_BUILD_DIRECTORY`
