### PR TITLE
docs(remix-config): Update default `serverModuleFormat`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -582,3 +582,4 @@
 - robbtraister
 - TrySound
 - rogepi
+- jvzaniolo

--- a/docs/file-conventions/remix-config.md
+++ b/docs/file-conventions/remix-config.md
@@ -168,7 +168,7 @@ Whether to minify the server build in production or not. Defaults to `false`.
 ## serverModuleFormat
 
 The output format of the server build, which can either be `"cjs"` or `"esm"`.
-Defaults to `"cjs"`.
+Defaults to `"esm"`.
 
 ## serverNodeBuiltinsPolyfill
 


### PR DESCRIPTION
As mentioned in the release notes for v2:

> - Changed the default [serverModuleFormat](https://remix.run/docs/en/main/start/v2#servermoduleformat) from `cjs` to `esm` (https://github.com/remix-run/remix/pull/6949)

This PR updates the docs accordingly.