### PR TITLE
Update arc template's deploy command

### DIFF
--- a/templates/arc/README.md
+++ b/templates/arc/README.md
@@ -35,7 +35,7 @@ If you make it through all of that, you're ready to deploy!
 2. Deploy with `arc`
 
    ```sh
-   arc deploy production
+   npx arc deploy production
    ```
 
 You're in business!


### PR DESCRIPTION
This should help clarify the command for people that takes docs literally (or a bit dull, like me), since `arc` is not a command and you have to add `npx` to it. The full command is documented on [arc's quick start docs](https://arc.codes/docs/en/get-started/quickstart)