### PR TITLE
templates: add version.txt to .gitignore

### DIFF
--- a/templates/arc/.gitignore
+++ b/templates/arc/.gitignore
@@ -5,6 +5,7 @@ node_modules
 /server/index.mjs
 /server/index.mjs.map
 /server/metafile.*
+/server/version.txt
 preferences.arc
 sam.json
 sam.yaml

--- a/templates/cloudflare-pages/.gitignore
+++ b/templates/cloudflare-pages/.gitignore
@@ -4,5 +4,6 @@ node_modules
 /functions/\[\[path\]\].js
 /functions/\[\[path\]\].js.map
 /functions/metafile.*
+/functions/version.txt
 /public/build
 .dev.vars


### PR DESCRIPTION
Thank you for developing this wonderful framework, Remix.

I have updated to v2 and tried using it and noticed that v2 outputs a `version.txt` when I do a build. However, I believe this is what Remix outputs at build time and not a file that should be included in git.

So I added it to gitignore.