### PR TITLE
fix(serve): explicitly bust `require` cache for cjs compatibility

### DIFF
--- a/.changeset/forty-needles-pretend.md
+++ b/.changeset/forty-needles-pretend.md
@@ -1,0 +1,8 @@
+---
+"@remix-run/serve": patch
+---
+
+Fix HMR for CJS projects using `remix-serve` and manual mode (`remix dev --manual`)
+
+By explicitly busting the `require` cache, `remix-serve` now correctly reimports new server changes in CJS.
+ESM projects were already working correctly and are not affected by this.

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -45,6 +45,12 @@ async function run() {
   let versionPath = path.resolve(buildPath, "..", "version.txt");
 
   async function reimportServer() {
+    Object.keys(require.cache).forEach((key) => {
+      if (key.startsWith(buildPath)) {
+        delete require.cache[key];
+      }
+    });
+
     let stat = fs.statSync(buildPath);
 
     // use a timestamp query parameter to bust the import cache


### PR DESCRIPTION
Testing Strategy:

Tested locally (via `LOCAL_BUILD_DIRECTORY`) with both ESM and CJS project using the `remix` template
