### PR TITLE
fix(dev): fix MDX types when using pnpm

### DIFF
--- a/.changeset/fix-mdx-types-for-pnpm.md
+++ b/.changeset/fix-mdx-types-for-pnpm.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fix types for MDX files when using pnpm

--- a/packages/remix-dev/modules.ts
+++ b/packages/remix-dev/modules.ts
@@ -69,12 +69,12 @@ declare module "*.jpg" {
   export default asset;
 }
 declare module "*.md" {
-  import "mdx/types";
+  import "mdx";
   export let attributes: any;
   export let filename: string;
 }
 declare module "*.mdx" {
-  import "mdx/types";
+  import "mdx";
   export let attributes: any;
   export let filename: string;
 }


### PR DESCRIPTION
Fixes #7448

This issue doesn't surface when `@types/mdx` is hoisted to the top-level in `node_modules`, which is the behaviour of the official npm client, but pnpm is stricter about transitive dependencies and ensures that packages aren't hoisted to the top-level by default. This means that Remix consumers don't automatically get the global `*.md`/`*.mdx` types from `@types/mdx` in their app code and only see our augmented `attributes` and `filename` exports. To fix this, we now explicitly import the global types as part of the augmentation.

I've tested this change against a real app running both npm and pnpm to ensure this works across both, and I've confirmed that this change fixed the repro shared in the linked issue.