### PR TITLE
fix(remix-node): relax typings for createReadableStreamFromReadable

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -149,6 +149,7 @@
 - emzoumpo
 - eps1lon
 - esamattis
+- estyrke
 - evanwinter
 - everdimension
 - exegeteio

--- a/packages/remix-node/stream.ts
+++ b/packages/remix-node/stream.ts
@@ -64,7 +64,13 @@ export async function readableStreamToString(
 }
 
 export const createReadableStreamFromReadable = (
-  source: Readable & { readableHighWaterMark?: number }
+  source: Stream & {
+    readableHighWaterMark?: number;
+    readable?: boolean;
+    resume?: () => void;
+    pause?: () => void;
+    destroy?: (error?: Error) => void;
+  }
 ) => {
   let pump = new StreamPump(source);
   let stream = new ReadableStream(pump, pump);


### PR DESCRIPTION
This enables NodeJS.ReadWriteStream to be used with it.

- [ ] Docs
- [ ] Tests

Testing Strategy:

This allows the Chakra UI example at https://github.com/remix-run/examples/blob/main/chakra-ui/ to be converted to v2 according to https://remix.run/docs/en/main/start/v2#removal-of-exported-polyfills

That said, I have only tested this by copy/pasting the code into my local entry.server.tsx.

