### PR TITLE
Fix resource routes being loaded through route.lazy

### DIFF
--- a/.changeset/route-lazy-resource-route.md
+++ b/.changeset/route-lazy-resource-route.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Fix resource routes being loaded through `route.lazy`

--- a/packages/remix-dev/compiler/js/plugins/routes.ts
+++ b/packages/remix-dev/compiler/js/plugins/routes.ts
@@ -8,6 +8,8 @@ import type { Context } from "../../context";
 
 type Route = RemixConfig["routes"][string];
 
+// If you change this, make sure you update loadRouteModuleWithBlockingLinks in
+// remix-react/routes.ts
 const browserSafeRouteExports: { [name: string]: boolean } = {
   ErrorBoundary: true,
   default: true,

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -226,7 +226,7 @@ async function loadRouteModuleWithBlockingLinks(
   // ignore those when setting the Component
   let defaultExportIsEmptyObject =
     typeof routeModule.default === "object" &&
-    Object.keys(routeModule.default).length === 0;
+    Object.keys(routeModule.default || {}).length === 0;
 
   // Include all `browserSafeRouteExports` fields
   return {

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -226,7 +226,7 @@ async function loadRouteModuleWithBlockingLinks(
   // ignore those when setting the Component
   let hasComponent =
     typeof routeModule.default === "object" &&
-    Object.keys(routeModule.default).length === 0;
+    Object.keys(routeModule.default).length > 0;
 
   // Include all `browserSafeRouteExports` fields
   return {

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -224,13 +224,15 @@ async function loadRouteModuleWithBlockingLinks(
 
   // Resource routes are built with an empty object as the default export -
   // ignore those when setting the Component
-  let hasComponent =
+  let defaultExportIsEmptyObject =
     typeof routeModule.default === "object" &&
-    Object.keys(routeModule.default).length > 0;
+    Object.keys(routeModule.default).length === 0;
 
   // Include all `browserSafeRouteExports` fields
   return {
-    ...(hasComponent ? { Component: routeModule.default } : {}),
+    ...(routeModule.default != null && !defaultExportIsEmptyObject
+      ? { Component: routeModule.default }
+      : {}),
     ErrorBoundary: routeModule.ErrorBoundary,
     handle: routeModule.handle,
     links: routeModule.links,

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -221,16 +221,21 @@ async function loadRouteModuleWithBlockingLinks(
 ) {
   let routeModule = await loadRouteModule(route, routeModules);
   await prefetchStyleLinks(routeModule);
+
+  // Resource routes are built with an empty object as the default export -
+  // ignore those when setting the Component
+  let hasComponent =
+    typeof routeModule.default === "object" &&
+    Object.keys(routeModule.default).length === 0;
+
+  // Include all `browserSafeRouteExports` fields
   return {
-    ...routeModule,
-    default: undefined,
-    // Resource routes are built with an empty object as the default export -
-    // ignore those when setting the Component
-    Component:
-      typeof routeModule.default === "object" &&
-      Object.keys(routeModule.default).length === 0
-        ? undefined
-        : routeModule.default,
+    ...(hasComponent ? { Component: routeModule.default } : {}),
+    ErrorBoundary: routeModule.ErrorBoundary,
+    handle: routeModule.handle,
+    links: routeModule.links,
+    meta: routeModule.meta,
+    shouldRevalidate: routeModule.shouldRevalidate,
   };
 }
 

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -224,7 +224,13 @@ async function loadRouteModuleWithBlockingLinks(
   return {
     ...routeModule,
     default: undefined,
-    Component: routeModule.default,
+    // Resource routes are built with an empty object as the default export -
+    // ignore those when setting the Component
+    Component:
+      typeof routeModule.default === "object" &&
+      Object.keys(routeModule.default).length === 0
+        ? undefined
+        : routeModule.default,
   };
 }
 


### PR DESCRIPTION
Resource routes are compiled with a default export of `{}`, so we need to ignore those empty objects when assigning `Component` via `route.lazy`

Closes #7497