### PR TITLE
chore(templates/arc): node 18

### DIFF
--- a/templates/arc/app.arc
+++ b/templates/arc/app.arc
@@ -2,7 +2,7 @@
 remix-architect-app
 
 @aws
-runtime nodejs16.x
+runtime nodejs18.x
 # concurrency 1
 # memory 1152
 # profile default


### PR DESCRIPTION
arc docs don't mention it, but node 18 is supported

https://github.com/mcansh/remix-arc-node-18
https://cl2vu5dvj5.execute-api.us-west-2.amazonaws.com

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
