### PR TITLE
fix(docs): entry server defaults broken links

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -585,3 +585,4 @@
 - robbtraister
 - TrySound
 - rogepi
+- fredericoo

--- a/docs/file-conventions/entry.server.md
+++ b/docs/file-conventions/entry.server.md
@@ -57,5 +57,5 @@ Note that this does not handle thrown `Response` instances from your `loader`/`a
 [browser-entry-module]: ./entry.client
 [rendertopipeablestream]: https://react.dev/reference/react-dom/server/renderToPipeableStream
 [rendertoreadablestream]: https://react.dev/reference/react-dom/server/renderToReadableStream
-[node-streaming-entry-server]: https://github.com/remix-run/remix/blob/main/packages/remix-dev/config/defaults/node/entry.server.react-stream.tsx
-[cloudflare-streaming-entry-server]: https://github.com/remix-run/remix/blob/main/packages/remix-dev/config/defaults/cloudflare/entry.server.react-stream.tsx
+[node-streaming-entry-server]: https://github.com/remix-run/remix/blob/main/packages/remix-dev/config/defaults/entry.server.node.tsx
+[cloudflare-streaming-entry-server]: https://github.com/remix-run/remix/blob/main/packages/remix-dev/config/defaults/entry.server.cloudflare.tsx


### PR DESCRIPTION
Broken links for default entry.server files ◡̈ 