### PR TITLE
Fix comment on default for serverModuleFormat

### DIFF
--- a/docs/start/v2.md
+++ b/docs/start/v2.md
@@ -758,7 +758,7 @@ module.exports = {
   serverBuildPath: "server/index.js",
   serverMainFields: ["main", "module"], // default value, can be removed
   serverMinify: false, // default value, can be removed
-  serverModuleFormat: "cjs", // default value, can be removed
+  serverModuleFormat: "cjs", // default value in 1.x, add before upgrading
   serverPlatform: "node", // default value, can be removed
 };
 ```
@@ -774,7 +774,7 @@ module.exports = {
   serverDependenciesToBundle: "all",
   serverMainFields: ["browser", "module", "main"],
   serverMinify: true,
-  serverModuleFormat: "esm",
+  serverModuleFormat: "esm", // default value in 2.x, can be removed once upgraded
   serverPlatform: "neutral",
 };
 ```
@@ -790,7 +790,7 @@ module.exports = {
   serverDependenciesToBundle: "all",
   serverMainFields: ["browser", "module", "main"],
   serverMinify: true,
-  serverModuleFormat: "esm",
+  serverModuleFormat: "esm", // default value in 2.x, can be removed once upgraded
   serverPlatform: "neutral",
 };
 ```
@@ -806,7 +806,7 @@ module.exports = {
   serverDependenciesToBundle: "all",
   serverMainFields: ["module", "main"],
   serverMinify: false, // default value, can be removed
-  serverModuleFormat: "esm",
+  serverModuleFormat: "esm", // default value in 2.x, can be removed once upgraded
   serverPlatform: "neutral",
 };
 ```
@@ -820,7 +820,7 @@ module.exports = {
   serverBuildPath: "build/index.js", // default value, can be removed
   serverMainFields: ["main", "module"], // default value, can be removed
   serverMinify: false, // default value, can be removed
-  serverModuleFormat: "cjs", // default value, can be removed
+  serverModuleFormat: "cjs", // default value in 1.x, add before upgrading
   serverPlatform: "node", // default value, can be removed
 };
 ```


### PR DESCRIPTION
Since the default for `serverModuleFormat` is now `esm`, the comments in the v2 guide for the different configurations of `serverBuildTarget` were incorrect.

- [x] Docs
