### PR TITLE
Add information about exporting ErrorBoundary from Resource Routes

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -585,3 +585,4 @@
 - robbtraister
 - TrySound
 - rogepi
+- kasprownik

--- a/docs/guides/resource-routes.md
+++ b/docs/guides/resource-routes.md
@@ -65,8 +65,8 @@ When the user clicks the link from the UI route, they will navigate to the PDF.
 Resource Route will change its behavior when you export `ErrorBoundary` along with the loader. 
 Remix will process it as a classic layout-less container route.
 
-An example use case would be a layout-less route providing shared data for the child routes, accessible by `useRouteLoaderData`. 
-Errors from the loader can be handled by the exported ErrorBoundary instead of bubbling higher.
+An example use case would be a layout-less route providing shared data for the child routes. 
+In this case, errors from the loader would be handled by the exported ErrorBoundary instead of bubbling higher.
 
 If you export `ErrorBoundary` from a resource route by mistake, the response from the loader will be ignored, Remix will render partent route with empty `<Outlet>`, and you get a message:
 

--- a/docs/guides/resource-routes.md
+++ b/docs/guides/resource-routes.md
@@ -60,6 +60,21 @@ export async function loader({
 
 When the user clicks the link from the UI route, they will navigate to the PDF.
 
+## Resource Routes and ErrorBoundary
+
+Resource Route will change its behavior when you export `ErrorBoundary` along with the loader. 
+Remix will process it as a classic layout-less container route.
+
+An example use case would be a layout-less route providing shared data for the child routes, accessible by `useRouteLoaderData`. 
+Errors from the loader can be handled by the exported ErrorBoundary instead of bubbling higher.
+
+If you export `ErrorBoundary` from a resource route by mistake, the response from the loader will be ignored, Remix will render partent route with empty `<Outlet>`, and you get a message:
+
+```sh
+Matched leaf route at location "/path/to/resource/" does not have an element or Component. 
+This means it will render an <Outlet /> with a null value by default resulting in an "empty" page.
+```
+
 ## Linking to Resource Routes
 
 <docs-error>It’s imperative that you use <code>reloadDocument</code> on any Links to Resource Routes</docs-error>

--- a/docs/guides/resource-routes.md
+++ b/docs/guides/resource-routes.md
@@ -68,7 +68,7 @@ Remix will process it as a classic layout-less container route, because Resource
 An example use case for this decision would be a layout-less route providing shared data for the child routes. 
 In this case, errors from the Loader would be handled by the exported `ErrorBoundary` instead of bubbling higher.
 
-If you export `ErrorBoundary` from a resource route by mistake, the response from the Loader will be ignored, Remix will render partent route with empty `<Outlet>`, and you get a message:
+If you export `ErrorBoundary` from a resource route by mistake, the response from the Loader will be ignored, Remix will render parent route with an empty `<Outlet>`, and you get a message:
 
 ```sh
 Matched leaf route at location "/path/to/resource/" does not have an element or Component. 

--- a/docs/guides/resource-routes.md
+++ b/docs/guides/resource-routes.md
@@ -62,7 +62,7 @@ When the user clicks the link from the UI route, they will navigate to the PDF.
 
 ## Resource Routes and ErrorBoundary
 
-Resource Route will change its behavior when you export `ErrorBoundary` along with the loader. 
+Resource Route will change its behavior when you export `ErrorBoundary` along with the Loader. 
 Remix will process it as a classic layout-less container route, because Resource Route should not contain any UI-related exports.
 
 An example use case for this decision would be a layout-less route providing shared data for the child routes. 

--- a/docs/guides/resource-routes.md
+++ b/docs/guides/resource-routes.md
@@ -66,9 +66,9 @@ Resource Route will change its behavior when you export `ErrorBoundary` along wi
 Remix will process it as a classic layout-less container route.
 
 An example use case would be a layout-less route providing shared data for the child routes. 
-In this case, errors from the loader would be handled by the exported ErrorBoundary instead of bubbling higher.
+In this case, errors from the Loader would be handled by the exported `ErrorBoundary` instead of bubbling higher.
 
-If you export `ErrorBoundary` from a resource route by mistake, the response from the loader will be ignored, Remix will render partent route with empty `<Outlet>`, and you get a message:
+If you export `ErrorBoundary` from a resource route by mistake, the response from the Loader will be ignored, Remix will render partent route with empty `<Outlet>`, and you get a message:
 
 ```sh
 Matched leaf route at location "/path/to/resource/" does not have an element or Component. 

--- a/docs/guides/resource-routes.md
+++ b/docs/guides/resource-routes.md
@@ -63,9 +63,9 @@ When the user clicks the link from the UI route, they will navigate to the PDF.
 ## Resource Routes and ErrorBoundary
 
 Resource Route will change its behavior when you export `ErrorBoundary` along with the loader. 
-Remix will process it as a classic layout-less container route.
+Remix will process it as a classic layout-less container route, because Resource Route should not contain any UI-related exports.
 
-An example use case would be a layout-less route providing shared data for the child routes. 
+An example use case for this decision would be a layout-less route providing shared data for the child routes. 
 In this case, errors from the Loader would be handled by the exported `ErrorBoundary` instead of bubbling higher.
 
 If you export `ErrorBoundary` from a resource route by mistake, the response from the Loader will be ignored, Remix will render partent route with empty `<Outlet>`, and you get a message:


### PR DESCRIPTION
This information would save my team a lot of debugging after upgrading remix, so it would be great to document this for other folks.