### PR TITLE
Fix express template to use re-loaded build in requests

### DIFF
--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -37,18 +37,15 @@ app.use(express.static("public", { maxAge: "1h" }));
 
 app.use(morgan("tiny"));
 
-app.all("*", async (...args) => {
-  if (process.env.NODE_ENV === "development") {
-    const handler = await createDevRequestHandler(initialBuild);
-    return handler(...args);
-  }
-
-  const handler = createRequestHandler({
-    build: initialBuild,
-    mode: initialBuild.mode,
-  });
-  return handler(...args);
-});
+app.all(
+  "*",
+  process.env.NODE_ENV === "development"
+    ? await createDevRequestHandler(initialBuild)
+    : createRequestHandler({
+        build: initialBuild,
+        mode: initialBuild.mode,
+      })
+);
 
 const port = process.env.PORT || 3000;
 app.listen(port, async () => {
@@ -74,7 +71,7 @@ async function reimportServer() {
 
 /**
  * @param {ServerBuild} initialBuild
- * @returns {import('@remix-run/express').RequestHandler}
+ * @returns {Promise<import('@remix-run/express').RequestHandler>}
  */
 async function createDevRequestHandler(initialBuild) {
   let build = initialBuild;

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -16,7 +16,15 @@ installGlobals();
 
 const BUILD_PATH = path.resolve("build/index.js");
 const VERSION_PATH = path.resolve("build/version.txt");
+
 const initialBuild = await reimportServer();
+const remixHandler =
+  process.env.NODE_ENV === "development"
+    ? await createDevRequestHandler(initialBuild)
+    : createRequestHandler({
+        build: initialBuild,
+        mode: initialBuild.mode,
+      });
 
 const app = express();
 
@@ -37,15 +45,7 @@ app.use(express.static("public", { maxAge: "1h" }));
 
 app.use(morgan("tiny"));
 
-app.all(
-  "*",
-  process.env.NODE_ENV === "development"
-    ? await createDevRequestHandler(initialBuild)
-    : createRequestHandler({
-        build: initialBuild,
-        mode: initialBuild.mode,
-      })
-);
+app.all("*", remixHandler);
 
 const port = process.env.PORT || 3000;
 app.listen(port, async () => {


### PR DESCRIPTION
Closes: #7542

The template was re-importing the `initialBuild` on every request, so HMR would appear to work after changes, but any full request would not update. Actions would also not update.

The documentation for [Manual Mode](https://remix.run/docs/en/main/guides/manual-mode) is not affected because it wasn't trying to dynamically import `chokidar` (so it can be a dev dependency).

This is against the `main` branch because templates usage is pulled directly from the repo and not released as packages.

**Testing Strategy:**

I opened my windows machine and ran this script:

```
npx create-remix@latest --template remix-run/remix/templates/express
```

I updated the `server.js` with these changes and then ran:

```
cd my-test
npm run dev
```