### PR TITLE
docs(discussion/form-vs-fetcher): fix user avatar details popup example filename

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -98,6 +98,7 @@
 - confix
 - coryhouse
 - courtyenn
+- craigayre
 - craigglennie
 - crismali
 - CSFlorin

--- a/docs/discussion/form-vs-fetcher.md
+++ b/docs/discussion/form-vs-fetcher.md
@@ -222,7 +222,7 @@ function useMarkAsRead({ articleId, userId }) {
 
 Anytime you show the user avatar, you could put a hover effect that fetches data from a loader and displays it in a popup.
 
-```tsx filename=app/routes/user.$id.details.tsx
+```tsx filename=app/routes/users.$id.details.tsx
 export async function loader({
   params,
 }: LoaderFunctionArgs) {


### PR DESCRIPTION
Update `docs/discussions/form-vs-fetcher.md` user avatar details popup example route filename to match the one referenced in the code.