### PR TITLE
Export correct Remix useMatches wrapper

### DIFF
--- a/.changeset/use-matches-type.md
+++ b/.changeset/use-matches-type.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Export the proper Remix `useMatches` wrapper to fix `UIMatch` typings

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -37,7 +37,6 @@ export {
   useHref,
   useLocation,
   useMatch,
-  useMatches,
   useNavigate,
   useNavigation,
   useNavigationType,
@@ -72,6 +71,7 @@ export {
   useLoaderData,
   useRouteLoaderData,
   useActionData,
+  useMatches,
   RemixContext as UNSAFE_RemixContext,
 } from "./components";
 


### PR DESCRIPTION
We're re-exporting the RR version, not the Remix wrapper, so types are messed up

Closes #7518