### PR TITLE
Remove explicit `process.exit(0)` from cli.ts

### DIFF
--- a/.changeset/soft-carrots-smile.md
+++ b/.changeset/soft-carrots-smile.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Stop calling `process.exit(0)` on successful CLI runs to avoid exiting prior to flushing the stdout buffers

--- a/packages/remix-dev/cli.ts
+++ b/packages/remix-dev/cli.ts
@@ -1,11 +1,6 @@
 import { cli } from "./index";
 
-cli.run().then(
-  () => {
-    process.exit(0);
-  },
-  (error: unknown) => {
-    if (error) console.error(error);
-    process.exit(1);
-  }
-);
+cli.run().catch((error: unknown) => {
+  if (error) console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Calling `process.exit(0)` in the successful case is redundant, but also causes problems when wanting to use the CLI commands in any kind of automated capacity, if the output is larger than 8192 bytes. This is because the Promise resolves _before_ the stdout buffers have been flushed, and when `process.exit(0)` is called, the entire process terminates leaving buffered output unsent to the calling process.

This is usually not a problem when running the CLI directly, but can be problematic when invoked via a child process. For instance, @brophdawg11 supplied this sample code in [Discord](https://discord.com/channels/770287896669978684/940264701785423992/1156614372433608734):

```js
// tmp.js
const child_process = require('child_process')
const { matchRoutes } = require("react-router-dom")
const routes = JSON.parse(
  child_process.execSync("npx remix routes --json").toString()
)
const matches = matchRoutes(routes, "/")
```

However, attempting to run this on a project with a large number of routes, resulting in a JSON object larger than 8192 bytes, results in a deserialization error:

```sh
❯ node tmp.js
undefined:160
                "

SyntaxError: Unterminated string in JSON at position 8192
```
The default case for a node script that exits gracefully is an exit code of `0`. So, removing the explicit `process.exit(0)` leaves the process running until all I/O is completed and STDOUT buffers are flushed.

### Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->

I tested this using the following patch on an installed version of `@remix-run/dev`, which resulted in letting the above JS code run successfully and parse the full JSON output (which is larger than 8192 bytes):

```diff
diff --git a/dist/cli.js b/dist/cli.js
index a7df897f9b2e3efee0f8d154dae72fc7450ca937..bd3d4462ebdbaa8ed89d1e9ec8ec0ce46cad7328 100644
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -13,9 +13,7 @@
 
 var index = require('./index');
 
-index.cli.run().then(() => {
-  process.exit(0);
-}, error => {
+index.cli.run().catch(error => {
   if (error) console.error(error);
   process.exit(1);
 });
```
