### PR TITLE
docs(start/tutorial): small updates

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -121,6 +121,7 @@
 - developit
 - devongovett
 - dgurns
+- dg1234uk
 - dhargitai
 - dhmacs
 - dima-takoy

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -484,7 +484,6 @@ export const loader = async ({ params }) => {
 };
 
 export default function Contact() {
-  // Replace `const contact = { ... }` with this:
   const { contact } = useLoaderData<typeof loader>();
 
   // existing code

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -268,7 +268,7 @@ Since Remix is built on top of React Router, it supports nested routing. In orde
 
 👉 **Render an [`<Outlet />`][outlet-component]**
 
-```tsx filename=app/root.tsx lines=[7,20-22]
+```tsx filename=app/root.tsx lines=[7,22-24]
 // existing imports
 import {
   Form,


### PR DESCRIPTION
- [ x ] Docs

Three changes to the `tutorial.md` doc:

1. Renamed `Root()` to `App()` to match the tutorial code created from `npx create-remix@latest --template ryanflorence/remix-tutorial-template`. 
2. Added more detail to the code example to help the reader determine where to place the `<div id="detail">`
3. Comment added to remind reader to delete/replace existing `const contact = { ... }` with `const contact = await getContact(params.contactId);` in `contacts.$contactId.tsx`