### PR TITLE
fix: sourcemap takes into account special chars in output file

### DIFF
--- a/.changeset/fix-cf-sourcemaps.md
+++ b/.changeset/fix-cf-sourcemaps.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+sourcemap takes into account special chars in output file

--- a/packages/remix-dev/compiler/server/write.ts
+++ b/packages/remix-dev/compiler/server/write.ts
@@ -14,7 +14,7 @@ export async function write(
     if ([".js", ".cjs", ".mjs"].some((ext) => file.path.endsWith(ext))) {
       // fix sourceMappingURL to be relative to current path instead of /build
       let filename = file.path.substring(file.path.lastIndexOf(path.sep) + 1);
-      let escapedFilename = filename.replace(/\./g, "\\.");
+      let escapedFilename = filename.replace(/([.[\]])/g, "\\$1");
       let pattern = `(//# sourceMappingURL=)(.*)${escapedFilename}`;
       let contents = Buffer.from(file.contents).toString("utf-8");
       contents = contents.replace(new RegExp(pattern), `$1${filename}`);


### PR DESCRIPTION
Closes: https://github.com/remix-run/remix/issues/3768

- [ ] Docs
- [ ] Tests

Testing Strategy:

Initialized a new CF Pages template and built Remix into it. Ran the project, connected a debugger, threw an error in a loader and sourcemaps brought me back to the correct line in the source `.ts` route.