### PR TITLE
Fix FOUC on subsequent client-side navigations to route.lazy routes

### DIFF
--- a/.changeset/route-lazy-fouc.md
+++ b/.changeset/route-lazy-fouc.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Fix FOUC on subsequent client-side navigations to route.lazy routes

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -132,10 +132,11 @@ export function createClientRoutes(
       index: route.index,
       path: route.path,
       async loader({ request }) {
-        let routeModulePromise = loadRouteModuleWithBlockingLinks(
-          route,
-          routeModulesCache
-        );
+        // Only prefetch links if we've been loaded into the cache, route.lazy
+        // will handle initial loads
+        let routeModulePromise = routeModulesCache[route.id]
+          ? prefetchStyleLinks(routeModulesCache[route.id])
+          : Promise.resolve();
         try {
           if (!route.hasLoader) return null;
           return fetchServerHandler(request, route);
@@ -144,10 +145,11 @@ export function createClientRoutes(
         }
       },
       async action({ request }) {
-        let routeModulePromise = loadRouteModuleWithBlockingLinks(
-          route,
-          routeModulesCache
-        );
+        // Only prefetch links if we've been loaded into the cache, route.lazy
+        // will handle initial loads
+        let routeModulePromise = routeModulesCache[route.id]
+          ? prefetchStyleLinks(routeModulesCache[route.id])
+          : Promise.resolve();
         try {
           if (!route.hasAction) {
             let msg =

--- a/packages/remix-react/routes.tsx
+++ b/packages/remix-react/routes.tsx
@@ -131,22 +131,38 @@ export function createClientRoutes(
       id: route.id,
       index: route.index,
       path: route.path,
-      loader({ request }) {
-        if (!route.hasLoader) return null;
-        return fetchServerHandler(request, route);
-      },
-      action({ request }) {
-        if (!route.hasAction) {
-          let msg =
-            `Route "${route.id}" does not have an action, but you are trying ` +
-            `to submit to it. To fix this, please add an \`action\` function to the route`;
-          console.error(msg);
-          return Promise.reject(
-            new ErrorResponse(405, "Method Not Allowed", new Error(msg), true)
-          );
+      async loader({ request }) {
+        let routeModulePromise = loadRouteModuleWithBlockingLinks(
+          route,
+          routeModulesCache
+        );
+        try {
+          if (!route.hasLoader) return null;
+          return fetchServerHandler(request, route);
+        } finally {
+          await routeModulePromise;
         }
+      },
+      async action({ request }) {
+        let routeModulePromise = loadRouteModuleWithBlockingLinks(
+          route,
+          routeModulesCache
+        );
+        try {
+          if (!route.hasAction) {
+            let msg =
+              `Route "${route.id}" does not have an action, but you are trying ` +
+              `to submit to it. To fix this, please add an \`action\` function to the route`;
+            console.error(msg);
+            return Promise.reject(
+              new ErrorResponse(405, "Method Not Allowed", new Error(msg), true)
+            );
+          }
 
-        return fetchServerHandler(request, route);
+          return fetchServerHandler(request, route);
+        } finally {
+          await routeModulePromise;
+        }
       },
       ...(routeModule
         ? // Use critical path modules directly


### PR DESCRIPTION
Fixes a regression from the switch to `route.lazy`.  `loadRouteModulesWithBlockingLinks` happens on the initial route to a `route.lazy` route, but then was not included in the subsequent `loader`/`action` executions once we remove `.lazy`.

[View with whitespace changes hidden](https://github.com/remix-run/remix/pull/7576/files?diff=unified&w=1)

Closes #7516