### PR TITLE
docs: update `ActionArgs`/`LoaderArgs` references

### DIFF
--- a/docs/discussion/concurrency.md
+++ b/docs/discussion/concurrency.md
@@ -72,7 +72,7 @@ The user is now looking at different data than what is on the server. Note that 
 In UI components like combo boxes, each keystroke can trigger a network request. Managing such rapid, consecutive requests can be tricky, especially when ensuring that the displayed results match the most recent query. However, with Remix, this challenge is automatically handled, ensuring that users see the correct results without developers having to micromanage the network.
 
 ```tsx filename=app/routes/city-search.tsx
-import type { LoaderArgs } from "@remix-run/node"; // or cloudflare/deno
+import type { LoaderFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
 
 export async function loader({

--- a/docs/discussion/data-flow.md
+++ b/docs/discussion/data-flow.md
@@ -36,10 +36,10 @@ export async function action() {
 Route files can export a [`loader`][loader] function that provides data to the route component. When the user navigates to a matching route, the data is first loaded and then the page is rendered.
 
 ```tsx filename=routes/account.tsx lines=[1-2,4-10]
-import type { LoaderArgs } from "@remix-run/node"; // or cloudflare/deno
+import type { LoaderFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
 
-export async function loader({ request }: LoaderArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const user = await getUser(request);
   return json({
     displayName: user.displayName,
@@ -61,11 +61,11 @@ export async function action() {
 The default export of the route file is the component that renders. It reads the loader data with [`useLoaderData`][use_loader_data]:
 
 ```tsx lines=[3,13-28]
-import type { LoaderArgs } from "@remix-run/node"; // or cloudflare/deno
+import type { LoaderFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
 import { useLoaderData } from "@remix-run/react";
 
-export async function loader({ request }: LoaderArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const user = await getUser(request);
   return json({
     displayName: user.displayName,
@@ -101,13 +101,13 @@ Finally, the action on the route matching the form's action attribute is called 
 
 ```tsx lines=[2,33-42]
 import type {
-  ActionArgs,
-  LoaderArgs,
+  ActionFunctionArgs,
+  LoaderFunctionArgs,
 } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
 import { useLoaderData } from "@remix-run/react";
 
-export async function loader({ request }: LoaderArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const user = await getUser(request);
   return json({
     displayName: user.displayName,
@@ -132,7 +132,7 @@ export default function Component() {
   );
 }
 
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
   const user = await getUser(request);
 

--- a/docs/discussion/form-vs-fetcher.md
+++ b/docs/discussion/form-vs-fetcher.md
@@ -68,7 +68,7 @@ As you can see, the two sets of APIs have a lot of similarities:
 ### Creating a New Record
 
 ```tsx filename=app/routes/recipes/new.tsx lines=[16,20-21,26]
-import type { ActionArgs } from "@remix-run/node"; // or cloudflare/deno
+import type { ActionFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { redirect } from "@remix-run/node"; // or cloudflare/deno
 import {
   Form,
@@ -76,7 +76,7 @@ import {
   useNavigation,
 } from "@remix-run/react";
 
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
   const errors = await validateRecipeFormData(formData);
   if (errors) {
@@ -135,11 +135,11 @@ Now consider we're looking at a list of recipes that have delete buttons on each
 First consider the basic route setup to get a list of recipes on the page:
 
 ```tsx filename=app/routes/recipes/_index.tsx
-import type { LoaderArgs } from "@remix-run/node"; // or cloudflare/deno
+import type { LoaderFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
 import { useLoaderData } from "@remix-run/react";
 
-export async function loader({ request }: LoaderArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   return json({
     recipes: await db.recipes.findAll({ limit: 30 }),
   });
@@ -160,7 +160,7 @@ export function Recipes() {
 Now we'll look at the action that deletes a recipe and the component that renders each recipe in the list.
 
 ```tsx filename=app/routes/recipes/_index.tsx lines=[5,11,17]
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
   const id = formData.get("id");
   await db.recipes.delete(id);

--- a/docs/discussion/pending-ui.md
+++ b/docs/discussion/pending-ui.md
@@ -108,11 +108,11 @@ While localized indicators on links are nice, they are incomplete. There are man
 **Busy Indicator**: It's typically best to wait for a record to be created instead of using optimistic UI since things like IDs and other fields are unknown until it completes. Also note this action redirects to the new record from the action.
 
 ```tsx filename=app/routes/create-project.tsx lines=[2,11,19-20,24,33]
-import type { ActionArgs } from "@remix-run/node"; // or cloudflare/deno
+import type { ActionFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { redirect } from "@remix-run/node"; // or cloudflare/deno
 import { useNavigation } from "@remix-run/react";
 
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
   const project = await createRecord({
     name: formData.get("name"),
@@ -203,12 +203,12 @@ function ProjectListItem({ project }) {
 **Skeleton Fallback**: When data is deferred, you can add fallbacks with [`<Suspense>`][suspense_component]. This allows the UI to render without waiting for the data to load, speeding up the perceived and actual performance of the application.
 
 ```tsx lines=[9-12,21-25]
-import type { LoaderArgs } from "@remix-run/node"; // or cloudflare/deno
+import type { LoaderFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { defer } from "@remix-run/node"; // or cloudflare/deno
 import { Await } from "@remix-run/react";
 import { Suspense } from "react";
 
-export async function loader({ params }: LoaderArgs) {
+export async function loader({ params }: LoaderFunctionArgs) {
   const reviewsPromise = getReviews(params.productId);
   const product = await getProduct(params.productId);
   return defer({

--- a/docs/discussion/server-vs-client.md
+++ b/docs/discussion/server-vs-client.md
@@ -19,9 +19,9 @@ Consider this route module from the last section:
 
 ```tsx filename=routes/settings.tsx
 import type {
-  ActionArgs,
+  ActionFunctionArgs,
   HeadersFunction,
-  LoaderArgs,
+  LoaderFunctionArgs,
 } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
 import { useLoaderData } from "@remix-run/react";
@@ -32,7 +32,7 @@ export const headers: HeadersFunction = () => ({
   "Cache-Control": "max-age=300, s-maxage=3600",
 });
 
-export async function loader({ request }: LoaderArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const user = await getUser(request);
   return json({
     displayName: user.displayName,
@@ -57,7 +57,7 @@ export default function Component() {
   );
 }
 
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const user = await getUser(request);
 
   await updateUser(user.id, {

--- a/docs/discussion/state-management.md
+++ b/docs/discussion/state-management.md
@@ -264,22 +264,22 @@ Next we set up the server action and loader to read and write the cookie:
 
 ```tsx
 import type {
-  ActionArgs,
-  LoaderArgs,
+  ActionFunctionArgs,
+  LoaderFunctionArgs,
 } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
 
 import { prefs } from "./prefs-cookie";
 
 // read the state from the cookie
-export async function loader({ request }: LoaderArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const cookieHeader = request.headers.get("Cookie");
   const cookie = await prefs.parse(cookieHeader);
   return json({ sidebarIsOpen: cookie.sidebarIsOpen });
 }
 
 // write the state to the cookie
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const cookieHeader = request.headers.get("Cookie");
   const cookie = await prefs.parse(cookieHeader);
   const formData = await request.formData();
@@ -451,14 +451,14 @@ export async function signupHandler(request: Request) {
 Now, let's contrast this with a Remix-based implementation. The action remains consistent, but the component is vastly simplified due to the direct utilization of server state via [`useActionData`][use_action_data], and leveraging the network state that Remix inherently manages.
 
 ```tsx filename=app/routes/signup.tsx good lines=[21-23]
-import type { ActionArgs } from "@remix-run/node"; // or cloudflare/deno
+import type { ActionFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
 import {
   useActionData,
   useNavigation,
 } from "@remix-run/react";
 
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const errors = await validateSignupRequest(request);
   if (errors) {
     return json({ ok: false, errors: errors });

--- a/docs/file-conventions/routes.md
+++ b/docs/file-conventions/routes.md
@@ -282,7 +282,7 @@ While [dynamic segments][dynamic_segments] match a single path segment (the stuf
 Similar to dynamic route parameters, you can access the value of the matched path on the splat route's `params` with the `"*"` key.
 
 ```tsx filename=app/routes/files.$.tsx
-export async function loader({ params }: LoaderArgs) {
+export async function loader({ params }: LoaderFunctionArgs) {
   const filePath = params["*"];
   return fake.getFileInfo(filePath);
 }

--- a/docs/guides/form-validation.md
+++ b/docs/guides/form-validation.md
@@ -35,7 +35,7 @@ export default function Signup() {
 In this step, we'll define a server `action` in the same file as our `Signup` component. Note that the aim here is to provide a broad overview of the mechanics involved rather than digging deep into form validation rules or error object structures. We'll use rudimentary checks for the email and password to demonstrate the core concepts.
 
 ```tsx filename=app/routes/signup.tsx
-import type { ActionArgs } from "@remix-run/node"; // or cloudflare/deno
+import type { ActionFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
 import { Form, redirect } from "@remix-run/react";
 
@@ -43,7 +43,7 @@ export default function Signup() {
   // omitted for brevity
 }
 
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
   const email = String(formData.get("email"));
   const password = String(formData.get("password"));
@@ -75,7 +75,7 @@ If any validation errors are found, they are returned from the `action` to the c
 Finally, we'll modify the `Signup` component to display validation errors, if any. We'll use [`useActionData`][use_action_data] to access and display these errors.
 
 ```tsx filename=app/routes/signup.tsx lines=[6,10,16,21]
-import type { ActionArgs } from "@remix-run/node"; // or cloudflare/deno
+import type { ActionFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
 import {
   Form,
@@ -105,7 +105,7 @@ export default function Signup() {
   );
 }
 
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   // omitted for brevity
 }
 ```

--- a/docs/guides/streaming.md
+++ b/docs/guides/streaming.md
@@ -31,11 +31,11 @@ There are three steps to streaming data:
 A route module without streaming might look like this:
 
 ```tsx
-import type { LoaderArgs } from "@remix-run/node"; // or cloudflare/deno
+import type { LoaderFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
 import { useLoaderData } from "@remix-run/react";
 
-export async function loader({ params }: LoaderArgs) {
+export async function loader({ params }: LoaderFunctionArgs) {
   const [product, reviews] = await Promise.all([
     db.getProduct(params.productId),
     db.getReviews(params.productId),
@@ -59,14 +59,14 @@ export default function Product() {
 In order to render streamed data, you need to use [`<Suspense>`][suspense_component] from React and [`<Await>`][await_component] from Remix. It's a bit of boilerplate, but straightforward:
 
 ```tsx lines=[3-4,18-22]
-import type { LoaderArgs } from "@remix-run/node"; // or cloudflare/deno
+import type { LoaderFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
 import { Await, useLoaderData } from "@remix-run/react";
 import { Suspense } from "react";
 
 import { ReviewsSkeleton } from "./reviews-skeleton";
 
-export async function loader({ params }: LoaderArgs) {
+export async function loader({ params }: LoaderFunctionArgs) {
   // existing code
 }
 
@@ -95,14 +95,14 @@ Now that our project and route component are set up stream data, we can start de
 Note the change in the async promise code.
 
 ```tsx lines=[2,9-17]
-import type { LoaderArgs } from "@remix-run/node"; // or cloudflare/deno
+import type { LoaderFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { defer } from "@remix-run/node"; // or cloudflare/deno
 import { Await, useLoaderData } from "@remix-run/react";
 import { Suspense } from "react";
 
 import { ReviewsSkeleton } from "./reviews-skeleton";
 
-export async function loader({ params }: LoaderArgs) {
+export async function loader({ params }: LoaderFunctionArgs) {
   // 👇 note this promise is not awaited
   const reviewsPromise = db.getReviews(params.productId);
   // 👇 but this one is
@@ -130,7 +130,7 @@ That's it! You should now be streaming data to the browser.
 It's important to initiate promises for deferred data _before_ you await any other promises, otherwise you won't get the full benefit of streaming. Note the difference with this less efficient code example:
 
 ```tsx bad
-export async function loader({ params }: LoaderArgs) {
+export async function loader({ params }: LoaderFunctionArgs) {
   const product = await db.getProduct(params.productId);
   // 👇 this won't initiate loading until `product` is done
   const reviewsPromise = db.getReviews(params.productId);


### PR DESCRIPTION
Responding to #7600, I noticed the published docs still refer to `ActionArgs`/`LoaderArgs` in some places. Looks like it came from some docs that were updated after #7426 was merged. This replaces all of them to `ActionFunctionArgs`/`LoaderFunctionArgs`. 