### PR TITLE
[WIP] add scss and scss modules support

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -546,6 +546,7 @@
 - wilcoschoneveld
 - willhack
 - willin
+- wingleung
 - wizardlyhel
 - wKovacs64
 - wladiston

--- a/packages/remix-dev/compiler/css/compiler.ts
+++ b/packages/remix-dev/compiler/css/compiler.ts
@@ -9,6 +9,7 @@ import { mdxPlugin } from "../plugins/mdx";
 import { externalPlugin } from "../plugins/external";
 import { cssModulesPlugin } from "../plugins/cssModuleImports";
 import { cssSideEffectImportsPlugin } from "../plugins/cssSideEffectImports";
+import { scssFilePlugin } from "../plugins/scssImports";
 import { vanillaExtractPlugin } from "../plugins/vanillaExtract";
 import {
   cssBundleEntryModulePlugin,
@@ -57,6 +58,7 @@ const createEsbuildConfig = (ctx: Context): esbuild.BuildOptions => {
       vanillaExtractPlugin(ctx, { outputCss: true }),
       cssSideEffectImportsPlugin(ctx),
       cssFilePlugin(ctx),
+      scssFilePlugin(ctx),
       absoluteCssUrlsPlugin(),
       externalPlugin(/^https?:\/\//, { sideEffects: false }),
       mdxPlugin(ctx),

--- a/packages/remix-dev/compiler/plugins/scssImports.ts
+++ b/packages/remix-dev/compiler/plugins/scssImports.ts
@@ -1,0 +1,30 @@
+import type { Plugin } from "esbuild";
+
+import type { Context } from "../context";
+
+export function scssFilePlugin({ config }: Context): Plugin {
+  return {
+    name: "scss-file",
+
+    async setup(build) {
+      if (!config?.future?.scss) {
+        return
+      }
+
+      let sassPlugin
+
+      try {
+        let { sassPlugin: importedSassPlugin } = await import("esbuild-sass-plugin");
+        sassPlugin = importedSassPlugin
+      } catch (error) {
+        console.warn("Detected a 'scssImports' plugin enabled without having 'esbuild-sass-plugin' installed. Please install 'esbuild-sass-plugin' package.");
+
+        return
+      }
+
+      sassPlugin({
+        filter: /\.scss$/
+      }).setup(build)
+    },
+  };
+}

--- a/packages/remix-dev/compiler/utils/loaders.ts
+++ b/packages/remix-dev/compiler/utils/loaders.ts
@@ -5,6 +5,7 @@ export const loaders: { [ext: string]: esbuild.Loader } = {
   ".aac": "file",
   ".avif": "file",
   ".css": "file",
+  ".scss": "file",
   ".csv": "file",
   ".eot": "file",
   ".fbx": "file",

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -33,7 +33,9 @@ type Dev = {
   tlsCert?: string;
 };
 
-interface FutureConfig {}
+interface FutureConfig {
+  scss: boolean;
+}
 
 type NodeBuiltinsPolyfillOptions = Pick<
   EsbuildPluginsNodeModulesPolyfillOptions,
@@ -557,7 +559,9 @@ export async function readConfig(
   // list below, so we can let folks know if they have obsolete flags in their
   // config.  If we ever convert remix.config.js to a TS file, so we get proper
   // typings this won't be necessary anymore.
-  let future: FutureConfig = {};
+  let future: FutureConfig = {
+    scss: appConfig.future?.scss ?? false,
+  };
 
   if (appConfig.future) {
     let userFlags = appConfig.future;

--- a/packages/remix-dev/modules.ts
+++ b/packages/remix-dev/modules.ts
@@ -16,6 +16,12 @@ declare module "*.css" {
   let asset: string;
   export default asset;
 }
+declare module "*.module.scss" {
+  let styles: {
+    readonly [key: string]: string;
+  };
+  export default styles;
+}
 declare module "*.csv" {
   let asset: string;
   export default asset;

--- a/packages/remix-dev/modules.ts
+++ b/packages/remix-dev/modules.ts
@@ -17,10 +17,12 @@ declare module "*.css" {
   export default asset;
 }
 declare module "*.module.scss" {
-  let styles: {
-    readonly [key: string]: string;
-  };
+  let styles: { readonly [key: string]: string };
   export default styles;
+}
+declare module "*.scss" {
+  let asset: string;
+  export default asset;
 }
 declare module "*.csv" {
   let asset: string;


### PR DESCRIPTION
Proof of concept to add **optional** support for SCSS and SCSS modules to remix.

### SCSS modules
Updated the existing CSS Module plugin to allow processing SCSS modules with the help of sass. If a SCSS file is detected, sass will dynamically be imported. However if sass was not installed, the user gets a warning.

### SCSS
Added a new `scssImports` plugin that will try and use `esbuild-sass-plugin` when installed. If not, the user gets a warning

### future flag
Added a new future flag `scss` to opt into the SCSS and SCSS modules features

```javascript
// remix.config.js

/** @type {import('@remix-run/dev').AppConfig} */
export default {
  ignoredRouteFiles: ["**/.*"],
  // appDirectory: "app",
  // assetsBuildDirectory: "public/build",
  // publicPath: "/build/",
  // serverBuildPath: "build/index.js",
  future: {
    scss: true
  }
};
```

### Discussions

- https://github.com/remix-run/remix/discussions/5432
- https://github.com/remix-run/remix/discussions/6282
- https://github.com/remix-run/remix/discussions/5579

---

- [ ] Docs
- [ ] Tests

Testing Strategy:

- create a playground project
- enable `future.scss` flag in `remix.config.js`
- install `sass` and `esbuild-sass-plugin` (note: esbuild-sass-plugin already has sass as dependency)
- setup various test scenarios
- example playground project, to add to the `/playground` folder in the remix repo 👉 https://github.com/wingleung/remix-scss-modules