### PR TITLE
Express template wasn't restarting when server.js changes

### DIFF
--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "remix build",
-    "dev": "remix dev --manual -c \"node server.js\"",
+    "dev": "remix dev --manual -c \"node --watch-path server.js --watch server.js\"",
     "start": "cross-env NODE_ENV=production node ./server.js",
     "typecheck": "tsc"
   },


### PR DESCRIPTION
Add node --watch flag. 

Would trigger an experimental warning for using the Node 18 --watch flag, alternative is use nodemon again. 