### PR TITLE
makes it possible to run remix on subfolder by changing config files

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -593,3 +593,4 @@
 - TrySound
 - rogepi
 - fredericoo
+- marimax

--- a/packages/remix-react/browser.tsx
+++ b/packages/remix-react/browser.tsx
@@ -35,7 +35,9 @@ declare global {
 }
 /* eslint-enable prefer-let/prefer-let */
 
-export interface RemixBrowserProps {}
+export interface RemixBrowserProps {
+  routerBasename?: string
+}
 
 declare global {
   interface ImportMeta {
@@ -167,7 +169,7 @@ if (import.meta && import.meta.hot) {
  * `app/entry.client.js`). This component is used by React to hydrate the HTML
  * that was received from the server.
  */
-export function RemixBrowser(_props: RemixBrowserProps): ReactElement {
+export function RemixBrowser(props: RemixBrowserProps): ReactElement {
   if (!router) {
     // Hard reload if the path we tried to load is not the current path.
     // This is usually the result of 2 rapid back/forward clicks from an
@@ -205,6 +207,7 @@ export function RemixBrowser(_props: RemixBrowserProps): ReactElement {
 
     router = createBrowserRouter(routes, {
       hydrationData,
+      basename: props.routerBasename,
       future: {
         v7_normalizeFormMethod: true,
       },


### PR DESCRIPTION
I can setup server to work with subfolder, but cannot do the same for client part, this will allow to pass basename for router as a property for <RemixBrowser />

