### PR TITLE
[Cloudflare Pages] - Remove deletion of the "if-none-match" header

### DIFF
--- a/packages/remix-cloudflare-pages/README.md
+++ b/packages/remix-cloudflare-pages/README.md
@@ -11,3 +11,6 @@ npx create-remix@latest
 Then follow the prompts you see in your terminal.
 
 For more information about Remix, [visit remix.run](https://remix.run)!
+
+## If you are using ETag headers
+Be aware of Cloudflare security features which may modify your headers https://developers.cloudflare.com/cache/reference/etag-headers/

--- a/packages/remix-cloudflare-pages/worker.ts
+++ b/packages/remix-cloudflare-pages/worker.ts
@@ -50,9 +50,6 @@ export function createPagesFunctionHandler<Env = any>({
   let handleFetch = async (context: EventContext<Env, any, any>) => {
     let response: Response | undefined;
 
-    // https://github.com/cloudflare/wrangler2/issues/117
-    context.request.headers.delete("if-none-match");
-
     try {
       response = await context.env.ASSETS.fetch(
         context.request.url,

--- a/packages/remix-cloudflare-workers/README.md
+++ b/packages/remix-cloudflare-workers/README.md
@@ -11,3 +11,6 @@ npx create-remix@latest
 Then follow the prompts you see in your terminal.
 
 For more information about Remix, [visit remix.run](https://remix.run)!
+
+## If you are using ETag headers
+Be aware of Cloudflare security features which may modifying your headers https://developers.cloudflare.com/cache/reference/etag-headers/


### PR DESCRIPTION
[As referenced in a wrangler bug](https://github.com/cloudflare/wrangler2/issues/117) - The `if-none-match` header was not behaving as expected. I believe this original issue is due to default Cloudflare security features modifying the etag. In any case, I cannot repro the bug today.

- [x] Docs - Added reference to Cloudflare warning about potentially modified headers
- [ ] Tests - Still passing?

Testing Strategy tldr;
Repro of etags working here: https://remix-cloudflare-pages-etag-repro.pages.dev
Refresh and you should see a "304" in the network tab

Testing Strategy:
- npx create-remix@latest --template remix-run/remix/templates/cloudflare-pages
- Use patch-package to remove the line that deletes the `if-none-match` header
- Append `remix-etag` to the response. Code sample [here](https://github.com/matthova/remix-cloudflare-pages-etag-repro/blob/main/app/entry.server.tsx#L41)
- Deploy site
- Load site
- Refresh site and verify html is served with a 304 status code

Repro repo code here: https://github.com/matthova/remix-cloudflare-pages-etag-repro