### PR TITLE
fix(vite): clear critical CSS on HMR

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -749,20 +749,17 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
       async handleHotUpdate({ server, file, modules }) {
         let pluginConfig = await resolvePluginConfig();
         let route = getRoute(pluginConfig, file);
-        if (route) {
-          server.ws.send({
-            type: "custom",
-            event: "remix:hmr-route",
-            data: {
-              route: await getRouteMetadata(
-                pluginConfig,
-                viteChildCompiler,
-                route
-              ),
-            },
-          });
-          return modules;
-        }
+
+        server.ws.send({
+          type: "custom",
+          event: "remix:hmr",
+          data: {
+            route: route
+              ? await getRouteMetadata(pluginConfig, viteChildCompiler, route)
+              : null,
+          },
+        });
+
         return modules;
       },
     },

--- a/packages/remix-dev/vite/static/refresh-utils.cjs
+++ b/packages/remix-dev/vite/static/refresh-utils.cjs
@@ -159,8 +159,12 @@ function channel() {
   return { promise, resolve, reject };
 }
 
-import.meta.hot.on("remix:hmr-route", async ({ route }) => {
-  routeUpdates.set(route.id, route);
+import.meta.hot.on("remix:hmr", async ({ route }) => {
+  window.__remixClearCriticalCss();
+
+  if (route) {
+    routeUpdates.set(route.id, route);
+  }
 });
 
 exports.__hmr_import = __hmr_import;


### PR DESCRIPTION
This fixes an issue where stale critical CSS stays in the document after making CSS changes in dev. This issue is most noticeable when removing styles since the old styles will still be applied.