### PR TITLE
place route updates in manifest.routes, not manifest itself

### DIFF
--- a/packages/remix-dev/vite/static/refresh-utils.cjs
+++ b/packages/remix-dev/vite/static/refresh-utils.cjs
@@ -16,7 +16,7 @@ const enqueueUpdate = debounce(async () => {
     manifest = JSON.parse(JSON.stringify(__remixManifest));
 
     routeUpdates.forEach(async (route) => {
-      manifest[route.id] = route;
+      manifest.routes[route.id] = route;
 
       let imported = await __hmr_import(route.url + "?t=" + Date.now());
       let routeModule = {


### PR DESCRIPTION
fixes useloaderdata destructuring when adding a loader to a route during HMR

```
TypeError: Cannot destructure property 'blah' of `useLoaderData(...)` as it is null.
```

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
