### PR TITLE
Update form-vs-fetcher.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -595,3 +595,4 @@
 - TrySound
 - rogepi
 - fredericoo
+- SeanGroff

--- a/docs/discussion/form-vs-fetcher.md
+++ b/docs/discussion/form-vs-fetcher.md
@@ -43,7 +43,7 @@ These actions are generally more subtle and don't require a context switch for t
 
 - **Updating a Single Field**: Maybe a user wants to change the name of an item in a list or update a specific property of a record. This action is minor and doesn't necessitate a new page or URL.
 
-- **Deleting a Record from a List**: In a list view, if a user deletes an item, they likely expect to remain on the list view, while warning the user of the destructive action.
+- **Deleting a Record from a List**: In a list view, if a user deletes an item, they likely expect to remain on the list view, with that item no longer in the list.
 
 - **Creating a Record in a List View**: When adding a new item to a list, it often makes sense for the user to remain in that context, seeing their new item added to the list without a full page transition.
 

--- a/docs/discussion/form-vs-fetcher.md
+++ b/docs/discussion/form-vs-fetcher.md
@@ -43,7 +43,7 @@ These actions are generally more subtle and don't require a context switch for t
 
 - **Updating a Single Field**: Maybe a user wants to change the name of an item in a list or update a specific property of a record. This action is minor and doesn't necessitate a new page or URL.
 
-- **Deleting a Record from a List**: In a list view, if a user deletes an item, they likely expect to remain on the list view, with that item simply disappearing.
+- **Deleting a Record from a List**: In a list view, if a user deletes an item, they likely expect to remain on the list view, while warning the user of the destructive action.
 
 - **Creating a Record in a List View**: When adding a new item to a list, it often makes sense for the user to remain in that context, seeing their new item added to the list without a full page transition.
 


### PR DESCRIPTION
I know modals are frowned upon by the Remix team, but the act of performing a destructive action should always warn the user before confirming the destructive action. Usually this involves showing a :gasp: confirmation modal.
I'm not keen on my verbiage as I tried to provide a generic answer. Feel free to modify. I just wanted to bring this to light.

Unrelated, thanks for adding this article to the docs. My team has found it so helpful in clearing up confusion they've had over the past few months that i've pinned it in our internal slack.