### PR TITLE
Correcting Form Validation Error Handling

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -595,3 +595,4 @@
 - TrySound
 - rogepi
 - fredericoo
+- jmarbutt

--- a/docs/guides/form-validation.md
+++ b/docs/guides/form-validation.md
@@ -84,19 +84,19 @@ import {
 } from "@remix-run/react";
 
 export default function Signup() {
-  const { errors } = useActionData<typeof useAction>();
+  const actionData = useActionData<typeof action>();
 
   return (
     <Form method="post">
       <p>
         <input type="email" name="email" />
-        {errors?.email ? <em>{errors.email}</em> : null}
+        {actionData?.errors?.email ? <em>{actionData?.errors.email}</em> : null}
       </p>
 
       <p>
         <input type="password" name="password" />
-        {errors?.password ? (
-          <em>{errors.password}</em>
+        {actionData?.errors?.password ? (
+          <em>{actionData?.errors.password}</em>
         ) : null}
       </p>
 


### PR DESCRIPTION
The current example did not account for handling undefined returned from `useActionData` in addition to passing the correct type into the generic. This is a simple update to documentation

Closes: #

- [X] Docs
- [ ] Tests
