### PR TITLE
Update remix file conventions demo to v2 link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -488,6 +488,7 @@
 - sergiocarneiro
 - sergiodxa
 - shairez
+- shamsup
 - shashankboosi
 - shininglovestar
 - shubhaguha

--- a/docs/file-conventions/remix-config.md
+++ b/docs/file-conventions/remix-config.md
@@ -235,7 +235,7 @@ There are a few conventions that Remix uses you should be aware of.
 
 [minimatch]: https://npm.im/minimatch
 [dilum_sanjaya]: https://twitter.com/DilumSanjaya
-[an_awesome_visualization]: https://remix-routing-demo.netlify.app
+[an_awesome_visualization]: https://interactive-remix-routing-v2.netlify.app
 [remix_dev]: ../other-api/dev#remix-dev
 [app_directory]: #appDirectory
 [css_side_effect_imports]: ../styling/css-imports


### PR DESCRIPTION
Small docs change to link to the v2 version of the interactive demo of remix's file conventions for routing rather than the v1 routing version in the File Conventions > remix.config.js page. The link is already updated on the Route File Naming page