### PR TITLE
docs(guides/form-validation): fix code examples

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -6,6 +6,7 @@
 - achinchen
 - adamwathan
 - adicuco
+- agarcher
 - ahabhgk
 - ahbruns
 - ahmedeldessouki

--- a/docs/guides/form-validation.md
+++ b/docs/guides/form-validation.md
@@ -35,15 +35,15 @@ export default function Signup() {
 In this step, we'll define a server `action` in the same file as our `Signup` component. Note that the aim here is to provide a broad overview of the mechanics involved rather than digging deep into form validation rules or error object structures. We'll use rudimentary checks for the email and password to demonstrate the core concepts.
 
 ```tsx filename=app/routes/signup.tsx
-import type { ActionArgs } from "@remix-run/node"; // or cloudflare/deno
-import { json } from "@remix-run/node"; // or cloudflare/deno
-import { Form, redirect } from "@remix-run/react";
+import type { DataFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
+import { json, redirect } from "@remix-run/node"; // or cloudflare/deno
+import { Form } from "@remix-run/react";
 
 export default function Signup() {
   // omitted for brevity
 }
 
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: DataFunctionArgs) {
   const formData = await request.formData();
   const email = String(formData.get("email"));
   const password = String(formData.get("password"));
@@ -75,11 +75,10 @@ If any validation errors are found, they are returned from the `action` to the c
 Finally, we'll modify the `Signup` component to display validation errors, if any. We'll use [`useActionData`][use_action_data] to access and display these errors.
 
 ```tsx filename=app/routes/signup.tsx lines=[6,10,16,21]
-import type { ActionArgs } from "@remix-run/node"; // or cloudflare/deno
-import { json } from "@remix-run/node"; // or cloudflare/deno
+import type { DataFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
+import { json, redirect } from "@remix-run/node"; // or cloudflare/deno
 import {
   Form,
-  redirect,
   useActionData,
 } from "@remix-run/react";
 
@@ -107,7 +106,7 @@ export default function Signup() {
   );
 }
 
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: DataFunctionArgs) {
   // omitted for brevity
 }
 ```


### PR DESCRIPTION
I ran through the [Form Validation guide](https://remix.run/docs/en/main/guides/form-validation) and hit a few errors. Namely:

- There is no `ActionArgs` type exported from `@remix-run/node`
- The `redirect` function is exported from `@remix-run/node` not `@remix-run/react`

I found [this discussion](https://github.com/remix-run/remix/discussions/7600) which pointed me in the right direction on the first point.