### PR TITLE
Unstable Vite: dedupe and optimize react deps

### DIFF
--- a/integration/vite-css-dev-test.ts
+++ b/integration/vite-css-dev-test.ts
@@ -32,9 +32,6 @@ test.describe("Vite CSS dev", () => {
           import { unstable_vitePlugin as remix } from "@remix-run/dev";
 
           export default defineConfig({
-            optimizeDeps: {
-              include: ["react", "react-dom/client"],
-            },
             server: {
               port: ${devPort},
               strictPort: true,

--- a/integration/vite-dev-test.ts
+++ b/integration/vite-dev-test.ts
@@ -29,9 +29,6 @@ test.describe("Vite dev", () => {
           import { unstable_vitePlugin as remix } from "@remix-run/dev";
 
           export default defineConfig({
-            optimizeDeps: {
-              include: ["react", "react-dom/client"],
-            },
             server: {
               port: ${devPort},
               strictPort: true,

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -404,6 +404,21 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
         return {
           appType: "custom",
           experimental: { hmrPartialAccept: true },
+          optimizeDeps: {
+            include: [
+              // pre-bundle React dependencies to avoid React duplicates,
+              // even if React dependencies are not direct dependencies
+              // https://react.dev/warnings/invalid-hook-call-warning#duplicate-react
+              "react",
+              `react/jsx-runtime`,
+              `react/jsx-dev-runtime`,
+              "react-dom/client",
+            ],
+          },
+          resolve: {
+            // https://react.dev/warnings/invalid-hook-call-warning#duplicate-react
+            dedupe: ["react", "react-dom"],
+          },
           ...(viteCommand === "build" && {
             base: pluginConfig.publicPath,
             build: {


### PR DESCRIPTION
Currently, we require [userland config](https://github.com/pcattori/remix-template-vite/blob/main/vite.config.ts#L6-L8) to do this. We should just do it for the user automatically when the Vite plugin for Remix is used. Then the userland vite config can be simplified by omitting the `optimizeDeps` and `resolve` entries.

See [vite-plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/src/index.ts#L267-L275) for a reference implementation.