### PR TITLE
s/ "Dependencies installing..." / "Installing dependencies..."

### DIFF
--- a/.changeset/itchy-years-allow.md
+++ b/.changeset/itchy-years-allow.md
@@ -1,0 +1,5 @@
+---
+"create-remix": patch
+---
+
+s/ "Dependencies installing..." / "Installing dependencies..."

--- a/packages/create-remix/index.ts
+++ b/packages/create-remix/index.ts
@@ -454,7 +454,7 @@ async function installDependenciesStep(ctx: Context) {
 
   if (showInstallOutput) {
     log("");
-    info(`Install`, `Dependencies installing with ${pkgManager}...`);
+    info(`Install`, `Installing dependencies with ${pkgManager}...`);
     log("");
     await runInstall();
     log("");
@@ -463,8 +463,8 @@ async function installDependenciesStep(ctx: Context) {
 
   log("");
   await loadingIndicator({
-    start: `Dependencies installing with ${pkgManager}...`,
-    end: "Dependencies installed",
+    start: `Installing dependencies with ${pkgManager}...`,
+    end: "Installed dependencies",
     while: runInstall,
     ctx,
   });


### PR DESCRIPTION
This reads a little better imo.

(Not a docs change, but I didn't test it because it's just a wording change)