### PR TITLE
docs(guides/form-validation): fix `ActionArgs` references

### DIFF
--- a/docs/guides/form-validation.md
+++ b/docs/guides/form-validation.md
@@ -35,7 +35,7 @@ export default function Signup() {
 In this step, we'll define a server `action` in the same file as our `Signup` component. Note that the aim here is to provide a broad overview of the mechanics involved rather than digging deep into form validation rules or error object structures. We'll use rudimentary checks for the email and password to demonstrate the core concepts.
 
 ```tsx filename=app/routes/signup.tsx
-import type { ActionArgs } from "@remix-run/node"; // or cloudflare/deno
+import type { ActionFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
 import { Form, redirect } from "@remix-run/react";
 
@@ -43,7 +43,7 @@ export default function Signup() {
   // omitted for brevity
 }
 
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
   const email = String(formData.get("email"));
   const password = String(formData.get("password"));
@@ -75,7 +75,7 @@ If any validation errors are found, they are returned from the `action` to the c
 Finally, we'll modify the `Signup` component to display validation errors, if any. We'll use [`useActionData`][use_action_data] to access and display these errors.
 
 ```tsx filename=app/routes/signup.tsx lines=[6,10,16,21]
-import type { ActionArgs } from "@remix-run/node"; // or cloudflare/deno
+import type { ActionFunctionArgs } from "@remix-run/node"; // or cloudflare/deno
 import { json } from "@remix-run/node"; // or cloudflare/deno
 import {
   Form,
@@ -107,7 +107,7 @@ export default function Signup() {
   );
 }
 
-export async function action({ request }: ActionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   // omitted for brevity
 }
 ```


### PR DESCRIPTION
Correcting `ActionArgs` to `ActionFunctionArgs` which is the correct type. The current document was referencing the wrong type. 

Closes: #

- [X] Docs
- [ ] Tests

