### PR TITLE
feat(remix-react) allow specifying custom origin on LiveReload component

### DIFF
--- a/docs/components/live-reload.md
+++ b/docs/components/live-reload.md
@@ -21,3 +21,19 @@ export default function Root() {
   );
 }
 ```
+
+## Props
+
+### `origin`
+
+Specify a custom origin for the Live Reload protocol. The url provided should use the `http` protocol, that will be upgraded to `ws` protocol internally. This is useful when using a reverse proxy in front of the Remix dev server. The default value is the `REMIX_DEV_ORIGIN` environment variable, or `window.location.origin` only if `REMIX_DEV_ORIGIN` is not set.
+
+
+### `port`
+
+Specify a custom port for the Live Reload protocol. The default value is the port derived from `REMIX_DEV_ORIGIN` environment variable, or `8002` only if `REMIX_DEV_ORIGIN` is not set.
+
+
+### `timeoutMs`
+
+The `timeoutMs` prop allows specifying a custom timeout for the Live Reload protocol, in milliseconds. This is the delay before trying to reconnect if the Web Socket connection is lost. The default value is `1000`.

--- a/packages/remix-react/__tests__/components-test.tsx
+++ b/packages/remix-react/__tests__/components-test.tsx
@@ -43,6 +43,25 @@ describe("<LiveReload />", () => {
       jest.resetModules();
     });
 
+    it("defaults the origin to REMIX_DEV_ORIGIN env variable", () => {
+      let origin = "http://test-origin";
+      LiveReload = require("../components").LiveReload;
+      process.env = { ...oldEnv, REMIX_DEV_ORIGIN: origin };
+      let { container } = render(<LiveReload />);
+      expect(container.querySelector("script")).toHaveTextContent(
+        `let LIVE_RELOAD_ORIGIN = ${JSON.stringify(origin)};`
+      );
+    });
+
+    it("can set the origin explicitly", () => {
+      let origin = "http://test-origin";
+      LiveReload = require("../components").LiveReload;
+      let { container } = render(<LiveReload origin={origin} />);
+      expect(container.querySelector("script")).toHaveTextContent(
+        `let LIVE_RELOAD_ORIGIN = ${JSON.stringify(origin)};`
+      );
+    });
+
     it("defaults the port to 8002", () => {
       LiveReload = require("../components").LiveReload;
       let { container } = render(<LiveReload />);

--- a/packages/remix-react/__tests__/components-test.tsx
+++ b/packages/remix-react/__tests__/components-test.tsx
@@ -47,14 +47,14 @@ describe("<LiveReload />", () => {
       LiveReload = require("../components").LiveReload;
       let { container } = render(<LiveReload />);
       expect(container.querySelector("script")).toHaveTextContent(
-        "url.port = undefined || (REMIX_DEV_ORIGIN ? new URL(REMIX_DEV_ORIGIN).port : 8002);"
+        "url.port = undefined || (LIVE_RELOAD_ORIGIN ? new URL(LIVE_RELOAD_ORIGIN).port : 8002);"
       );
     });
 
     it("can set the port explicitly", () => {
       let { container } = render(<LiveReload port={4321} />);
       expect(container.querySelector("script")).toHaveTextContent(
-        "url.port = 4321 || (REMIX_DEV_ORIGIN ? new URL(REMIX_DEV_ORIGIN).port : 8002);"
+        "url.port = 4321 || (LIVE_RELOAD_ORIGIN ? new URL(LIVE_RELOAD_ORIGIN).port : 8002);"
       );
     });
 

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1039,10 +1039,12 @@ export const LiveReload =
   process.env.NODE_ENV !== "development"
     ? () => null
     : function LiveReload({
+        origin = process.env.REMIX_DEV_ORIGIN,
         port,
         timeoutMs = 1000,
         nonce = undefined,
       }: {
+        origin?: string;
         port?: number;
         timeoutMs?: number;
         nonce?: string;
@@ -1055,18 +1057,16 @@ export const LiveReload =
             dangerouslySetInnerHTML={{
               __html: js`
                 function remixLiveReloadConnect(config) {
-                  let REMIX_DEV_ORIGIN = ${JSON.stringify(
-                    process.env.REMIX_DEV_ORIGIN
-                  )};
+                  let LIVE_RELOAD_ORIGIN = ${JSON.stringify(origin)};
                   let protocol =
-                    REMIX_DEV_ORIGIN ? new URL(REMIX_DEV_ORIGIN).protocol.replace(/^http/, "ws") :
+                    LIVE_RELOAD_ORIGIN ? new URL(LIVE_RELOAD_ORIGIN).protocol.replace(/^http/, "ws") :
                     location.protocol === "https:" ? "wss:" : "ws:"; // remove in v2?
-                  let hostname = REMIX_DEV_ORIGIN ? new URL(REMIX_DEV_ORIGIN).hostname : location.hostname;
+                  let hostname = LIVE_RELOAD_ORIGIN ? new URL(LIVE_RELOAD_ORIGIN).hostname : location.hostname;
                   let url = new URL(protocol + "//" + hostname + "/socket");
 
                   url.port =
                     ${port} ||
-                    (REMIX_DEV_ORIGIN ? new URL(REMIX_DEV_ORIGIN).port : 8002);
+                    (LIVE_RELOAD_ORIGIN ? new URL(LIVE_RELOAD_ORIGIN).port : 8002);
 
                   let ws = new WebSocket(url.href);
                   ws.onmessage = async (message) => {


### PR DESCRIPTION
Closes: #7540

Changes:

- Add `origin` props to the `LiveReload` component in addition to the `port` prop, to address use cases described in #7540

- [x] Docs
- [x] Tests

How to reproduce issue:

- Open https://codesandbox.io/p/sandbox/remix-live-reload-issue-3c3n6f?file=%2Fapp%2Froot.tsx%3A6%2C10
- This is a default `bun create remix` app
- The sandbox cannot connect live reload protocol, web socket is constantly getting 101 code
- The app constantly reloads itself

Expected behavior:

- Open https://codesandbox.io/p/sandbox/bun-remix-v2-j7f6nx?file=%2Fapp%2FPatchedLiveReload.tsx%3A12%2C23
- This is a default `bun create remix` app
- The sandbox contains a `PatchedLiveReload` component, as suggested workaround in the ticket (with logic similar to this PR solution)
- The app works as expected: 
  - Live reload protocol works
  - The app does not reload constantly

Testing Strategy:

- Added scripts for the new`origin` prop like for the `port` prop
- Ran `yarn test` in the `remix-react` dir

