### PR TITLE
do not use built-in, minimal SSR in middleware mode

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -520,6 +520,8 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
         vite.httpServer?.on("listening", () => {
           setTimeout(showUnstableWarning, 50);
         });
+        // Let user servers handle SSR requests in middleware mode
+        if (vite.config.server.middlewareMode) return;
         return () => {
           vite.middlewares.use(async (req, res, next) => {
             try {


### PR DESCRIPTION
to allow userland servers to handle SSR requests via createRequestHandler

Previously, `vite.middlewares` included the middleware within `configureServer` that handles SSR for minimal dev server, which prevented userland `createRequestHandler` from ever being used.
