### PR TITLE
docs(hooks/use-fetcher): add notice about index routes in `load` section

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -558,6 +558,7 @@
 - ptitFicus
 - pwbriggs
 - pyr0gan
+- rachaelmcq
 - ramiroazar
 - RATIU5
 - raulfdm

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -112,7 +112,7 @@ fetcher.submit(
 
 Loads data from a route loader. While multiple nested routes can match a URL, only the leaf route will be called. 
 
-Note that when calling `load` on an index route's loader, you [must include](https://remix.run/docs/en/1.19.3/guides/routing#what-is-the-index-query-param) a `?index` query parameter in order to disambiguate between the `index.tsx` layout and the `root.tsx` route.
+Note that when calling `load` on an index route's loader, you must include an [`?index` query param](../guides/index-query-param) in order to disambiguate between the `index.tsx` layout and the `root.tsx` route.
 
 ```ts
 fetcher.load("/some/route");

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -110,7 +110,9 @@ fetcher.submit(
 
 ### `fetcher.load(href, options)`
 
-Loads data from a route loader. While multiple nested routes can match a URL, only the leaf route will be called.
+Loads data from a route loader. While multiple nested routes can match a URL, only the leaf route will be called. 
+
+Note that when calling `load` on an index route's loader, you [must include](https://remix.run/docs/en/1.19.3/guides/routing#what-is-the-index-query-param) a `?index` query parameter in order to disambiguate between the `index.tsx` layout and the `root.tsx` route.
 
 ```ts
 fetcher.load("/some/route");


### PR DESCRIPTION
Adds additional doc to clarify how to use `load` on index routes. It was a bummer to find [this excellent explanation](https://github.com/remix-run/remix/discussions/3494#discussioncomment-2966946) of our problem buried in a discussion rather than in the docs themselves.