### PR TITLE
Add esbuild `banner` for ESM+NodeJS builds, to work around "dynamic require not supported" issue

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -65,6 +65,7 @@
 - bogas04
 - BogdanDevBst
 - bolchowka
+- brettdh
 - brookslybrand
 - brophdawg11
 - bruno-oliveira

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -6,6 +6,7 @@ import {
   createAppFixture,
   createFixture,
   js,
+  json,
 } from "./helpers/create-fixture.js";
 
 let fixture: Fixture;
@@ -58,6 +59,38 @@ test.beforeAll(async () => {
     // `createFixture` will make an app and run your tests against it.
     ////////////////////////////////////////////////////////////////////////////
     files: {
+      "package.json": json({
+        name: "bug-report-test",
+        private: true,
+        sideEffects: false,
+        type: "module",
+        dependencies: {
+          "@remix-run/css-bundle": "0.0.0-local-version",
+          "@remix-run/node": "0.0.0-local-version",
+          "@remix-run/react": "0.0.0-local-version",
+          "@remix-run/serve": "0.0.0-local-version",
+          isbot: "0.0.0-local-version",
+          react: "0.0.0-local-version",
+          "react-dom": "0.0.0-local-version",
+        },
+        devDependencies: {
+          "@remix-run/dev": "0.0.0-local-version",
+          "@types/react": "0.0.0-local-version",
+          "@types/react-dom": "0.0.0-local-version",
+          typescript: "0.0.0-local-version",
+
+          "@vanilla-extract/css": "0.0.0-local-version",
+          tailwindcss: "0.0.0-local-version",
+        },
+        engines: {
+          node: ">=18.0.0",
+        },
+      }),
+      "remix.config.js": js`
+        export default {
+          serverDependenciesToBundle: "all",
+        };
+      `,
       "app/routes/_index.tsx": js`
         import { json } from "@remix-run/node";
         import { useLoaderData, Link } from "@remix-run/react";
@@ -98,16 +131,13 @@ test.afterAll(() => {
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("[description of what you expect it to do]", async ({ page }) => {
+test("the build succeeds and the app loads", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);
   // You can test any request your app might get using `fixture`.
   let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch("pizza");
 
-  // If you need to test interactivity use the `app`
-  await app.goto("/");
-  await app.clickLink("/burgers");
-  await page.waitForSelector("text=cheeseburger");
+  // We're just testing that the build succeeded and the page loaded;
+  // nothing else to see here.
 
   // If you're not sure what's going on, you can "poke" the app, it'll
   // automatically open up in your browser for 20 seconds, so be quick!


### PR DESCRIPTION
## Bug report and failing test

Having `type: "module"` in `package.json` along with `serverDependenciesToBundle: "all"` in `remix.config.js` causes a build error:

    Error: Dynamic require of "http" is not supported

Oddly, in this integration test, it appears to happen at run time (unless I'm misreading the stack trace), whereas in the description of #7467, the error appears at build time. However, the error did appear at run time in my earlier testing as well, as indicated in the AWS Lambda logs in [my comment](https://github.com/remix-run/remix/issues/7467#issuecomment-1775411138).

## Bug fix

The general `Dynamic require of <pkg> not supported` issue is discussed at length in https://github.com/evanw/esbuild/issues/1921, and it appears that several other projects have had to apply a workaround for this problem. I first attempted to apply [this async IIFE](https://github.com/evanw/esbuild/issues/1921#issuecomment-1439609735) approach, but I realized that Remix already has a similar workaround applied for the `__file` and `__dirname` globals, so I removed those bits.

I'm not confident that this is the "right" fix (or a complete fix), but it makes the new integration test pass, and it doesn't appear to cause any other failures. It may also become irrelevant in the future if the esbuild issue is fixed, or if Remix fully [moves to Vite](https://github.com/remix-run/remix/discussions/7632), but I'm hoping it will at least unblock my current progress.

Closes: #7467 

## Tasks

- [x] Tests
  - [x] Add bugreport test that repros the issue
  - [ ] Move bugreport test to integration test
  - [x] Test this fix using patch-package with a real (proprietary) project where I'm also encountering the issue
- [ ] Docs
  - Not sure what would be appropriate to add here; happy to add something if someone can point me in the right direction
- [ ] Changeset
  - Waiting to see if folks think this looks like the right fix.

## Testing Strategy

Ran all the integration tests several times. Saw some flaky failures, and one not-as-flaky failure:

```
  1) [chromium] › defer-test.ts:823:3 › non-aborted › routes are interactive when deferred promises are suspended and after rejection in subsequent payload

    Test timeout of 30000ms exceeded.

    Error: page.waitForSelector: Target closed
    =========================== logs ===========================
    waiting for locator('#MANUAL_FALLBACK_ID') to be visible
fix: apply workaround for 'dynamic require not supported' error
    ============================================================

      830 |     await page.waitForSelector(`#${ROOT_ID}`);
      831 |     await page.waitForSelector(`#${DEFERRED_ID}`);
    > 832 |     await page.waitForSelector(`#${MANUAL_FALLBACK_ID}`);
          |                ^
      833 |     let idElement = await page.waitForSelector(`#${RESOLVED_DEFERRED_ID}`);
      834 |     let id = await idElement.innerText();
      835 |     expect(id).toBeTruthy();

        at /Users/brhiggins/src/remix/integration/defer-test.ts:832:16

    Pending operations:
      - page.waitForSelector at integration/defer-test.ts:832:16
```

Confirmed that this test also fails (pretty reliably) without my changes.