### PR TITLE
docs(hooks/use-fetcher): update link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -599,3 +599,4 @@
 - fredericoo
 - SeanGroff
 - jmarbutt
+- KarelVerschraegen

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -106,7 +106,7 @@ The form method of the submission.
 - [Concurrent Mutations w/ useFetcher][concurrent_mutations_with_use_fetcher]
 - [Optimistic UI][optimistic_ui]
 
-[form_component]: ../components/Form
+[form_component]: ../components/form
 [form_data]: https://developer.mozilla.org/en-US/docs/Web/API/FormData
 [html_form_element]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement
 [form_element]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form


### PR DESCRIPTION
The url should be `https://remix.run/docs/en/main/components/form` instead of `https://remix.run/docs/en/main/components/Form` as the latter throws a 404



