### PR TITLE
Bug: cannot navigate to route using <Link> only with <a>

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -593,3 +593,4 @@
 - TrySound
 - rogepi
 - fredericoo
+- marcioluis


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->


- [ ] Docs
- [x] Tests

Testing Strategy:

I cannot navigate to route through <Link> if route has a dependency on a *.server.ts file.
If navigating using <a> element works fine.

`npx yarn bug-report-test`


<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
