### PR TITLE
fix(vite): await new route module import on hot update

### DIFF
--- a/.changeset/little-bikes-teach.md
+++ b/.changeset/little-bikes-teach.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+fix: fix hot update delay of "meta" export

--- a/contributors.yml
+++ b/contributors.yml
@@ -195,6 +195,7 @@
 - harmony7
 - helderburato
 - HenryVogt
+- hi-ogawa
 - hicksy
 - himorishige
 - Hirochon

--- a/integration/vite-dev-test.ts
+++ b/integration/vite-dev-test.ts
@@ -61,6 +61,8 @@ test.describe("Vite dev", () => {
         "app/routes/_index.tsx": js`
           import { useState, useEffect } from "react";
 
+          export const meta = () => [{ title: "Hello" }];
+
           export default function IndexRoute() {
             const [mounted, setMounted] = useState(false);
             useEffect(() => {
@@ -132,14 +134,27 @@ test.describe("Vite dev", () => {
       path.join(projectDir, "app/routes/_index.tsx"),
       "utf8"
     );
+    indexRouteContents = indexRouteContents.replace("HMR updated: no", "HMR updated: yes")
     await fs.writeFile(
       path.join(projectDir, "app/routes/_index.tsx"),
-      indexRouteContents.replace("HMR updated: no", "HMR updated: yes"),
+      indexRouteContents,
       "utf8"
     );
     await page.waitForLoadState("networkidle");
     await expect(hmrStatus).toHaveText("HMR updated: yes");
     await expect(input).toHaveValue("stateful");
+
+    // verify meta title hmr
+    await page.pause();
+    await expect(page).toHaveTitle("Hello");
+    indexRouteContents = indexRouteContents.replace(`{ title: "Hello" }`, `{ title: "Goodbye" }`)
+    await fs.writeFile(
+      path.join(projectDir, "app/routes/_index.tsx"),
+      indexRouteContents,
+      "utf8"
+    );
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveTitle("Goodbye");
   });
 });
 

--- a/packages/remix-dev/vite/static/refresh-utils.cjs
+++ b/packages/remix-dev/vite/static/refresh-utils.cjs
@@ -15,7 +15,7 @@ const enqueueUpdate = debounce(async () => {
   if (routeUpdates.size > 0) {
     manifest = JSON.parse(JSON.stringify(__remixManifest));
 
-    routeUpdates.forEach(async (route) => {
+    for (const route of routeUpdates.values()) {
       manifest.routes[route.id] = route;
 
       let imported = await __hmr_import(route.url + "?t=" + Date.now());
@@ -32,7 +32,7 @@ const enqueueUpdate = debounce(async () => {
           : imported.ErrorBoundary,
       };
       window.__remixRouteModules[route.id] = routeModule;
-    });
+    }
 
     let needsRevalidation = new Set(
       Array.from(routeUpdates.values())


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: https://github.com/remix-run/remix/issues/7787

I wasn't sure if the code here was intentionally hanging async/promise, but this change seems to fix router state update being one hot update delayed.
Since vite is unstable/experimental feature, core team might not want external contribution yet, so if that's the case, please feel free to  close it.
I was very excited about remix's vite integration and was exploring some code, so either way, it was great opportunity to setup local dev to explore further and play with vite feature.
Thanks for the review!

- [ ] Docs
- [x] Tests

Testing Strategy:

In addition to expanding integration test, I also setup local playground to experiment with the change.


<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
