### PR TITLE
fix(react): fix Vite dev CSS hydration errors

### DIFF
--- a/.changeset/kind-pandas-think.md
+++ b/.changeset/kind-pandas-think.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Fix critical CSS hydration errors for Vite dev

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -289,7 +289,9 @@ export function Links() {
 
   return (
     <>
-      {criticalCss ? <style>{criticalCss}</style> : null}
+      {criticalCss ? (
+        <style dangerouslySetInnerHTML={{ __html: criticalCss }} />
+      ) : null}
       {keyedLinks.map(({ key, link }) =>
         isPageLinkDescriptor(link) ? (
           <PrefetchPageLinks key={key} {...link} />


### PR DESCRIPTION
We're seeing hydration errors when the CSS contains characters that get HTML encoded in the server render. This is a short term fix to unblock the release. This method works except for some extreme edge cases.