### PR TITLE
fix(server-runtime): mark critical CSS arg private

### DIFF
--- a/packages/remix-dev/vite/node/adapter.ts
+++ b/packages/remix-dev/vite/node/adapter.ts
@@ -199,7 +199,7 @@ export let createRequestHandler = (
   let handler = createBaseRequestHandler(build, mode);
   return async (req: IncomingMessage, res: ServerResponse) => {
     let request = createRequest(req);
-    let response = await handler(request, {}, { criticalCss });
+    let response = await handler(request, {}, { __criticalCss: criticalCss });
     handleNodeResponse(response, res);
   };
 };

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -32,7 +32,12 @@ import { createServerHandoffString } from "./serverHandoff";
 export type RequestHandler = (
   request: Request,
   loadContext?: AppLoadContext,
-  args?: { criticalCss?: string }
+  args?: {
+    /**
+     * @private This is an internal API intended for use by the Remix Vite plugin in dev mode
+     */
+    __criticalCss?: string;
+  }
 ) => Promise<Response>;
 
 export type CreateRequestHandlerFunction = (
@@ -78,7 +83,7 @@ export const createRequestHandler: CreateRequestHandlerFunction = (
   return async function requestHandler(
     request,
     loadContext = {},
-    { criticalCss } = {}
+    { __criticalCss: criticalCss } = {}
   ) {
     _build = typeof build === "function" ? await build() : build;
     if (typeof build === "function") {


### PR DESCRIPTION
Since this arg hasn't been designed with public usage in mind, we're marking it as private in case the API changes in the future.