### PR TITLE
fix(vite): fix behind-by-one-render bug for `meta` HMR

### DIFF
--- a/.changeset/fifty-garlics-heal.md
+++ b/.changeset/fifty-garlics-heal.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+fix behind-by-one-render bug for meta hmr

--- a/integration/vite-dev-express-test.ts
+++ b/integration/vite-dev-express-test.ts
@@ -98,6 +98,8 @@ test.beforeAll(async () => {
         // imports
         import { useState, useEffect } from "react";
 
+        export const meta = () => [{ title: "HMR updated title: 0"}]
+
         // loader
 
         export default function IndexRoute() {
@@ -141,6 +143,7 @@ test("Vite custom server HMR & HDR", async ({ page }) => {
 
   // setup: browser state
   let hmrStatus = page.locator("#index [data-hmr]");
+  await expect(page).toHaveTitle("HMR updated title: 0");
   await expect(hmrStatus).toHaveText("HMR updated: 0");
   let input = page.locator("#index input");
   await expect(input).toBeVisible();
@@ -148,9 +151,12 @@ test("Vite custom server HMR & HDR", async ({ page }) => {
 
   // route: HMR
   await edit("app/routes/_index.tsx", (contents) =>
-    contents.replace("HMR updated: 0", "HMR updated: 1")
+    contents
+      .replace("HMR updated title: 0", "HMR updated title: 1")
+      .replace("HMR updated: 0", "HMR updated: 1")
   );
   await page.waitForLoadState("networkidle");
+  await expect(page).toHaveTitle("HMR updated title: 1");
   await expect(hmrStatus).toHaveText("HMR updated: 1");
   await expect(input).toHaveValue("stateful");
 

--- a/integration/vite-dev-express-test.ts
+++ b/integration/vite-dev-express-test.ts
@@ -98,7 +98,7 @@ test.beforeAll(async () => {
         // imports
         import { useState, useEffect } from "react";
 
-        export const meta = () => [{ title: "HMR updated title: 0"}]
+        export const meta = () => [{ title: "HMR updated title: 0" }]
 
         // loader
 

--- a/packages/remix-dev/vite/static/refresh-utils.cjs
+++ b/packages/remix-dev/vite/static/refresh-utils.cjs
@@ -15,7 +15,7 @@ const enqueueUpdate = debounce(async () => {
   if (routeUpdates.size > 0) {
     manifest = JSON.parse(JSON.stringify(__remixManifest));
 
-    routeUpdates.forEach(async (route) => {
+    for (let route of routeUpdates.values()) {
       manifest.routes[route.id] = route;
 
       let imported = await __hmr_import(route.url + "?t=" + Date.now());
@@ -32,7 +32,7 @@ const enqueueUpdate = debounce(async () => {
           : imported.ErrorBoundary,
       };
       window.__remixRouteModules[route.id] = routeModule;
-    });
+    }
 
     let needsRevalidation = new Set(
       Array.from(routeUpdates.values())


### PR DESCRIPTION
and all other non-component Remix exports like `links` too

Fixes #7787