### PR TITLE
chore(templates/vite): set TS module to ESNext

### DIFF
--- a/templates/unstable-vite-express/tsconfig.json
+++ b/templates/unstable-vite-express/tsconfig.json
@@ -5,6 +5,7 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",
+    "module": "ESNext",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "target": "ES2022",

--- a/templates/unstable-vite/tsconfig.json
+++ b/templates/unstable-vite/tsconfig.json
@@ -5,6 +5,7 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",
+    "module": "ESNext",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "target": "ES2022",


### PR DESCRIPTION
I ran into an issue where TypeScript complained about my use of `import.meta` features because `"module"` wasn't set correctly.