### PR TITLE
fix(vite): vite v5 compat

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -200,10 +200,18 @@ const showUnstableWarning = () => {
   );
 };
 
+const getViteMajor = () => {
+  let vitePkg = require("vite/package.json");
+
+  return parseInt(vitePkg.version.split(".")[0]!);
+};
+
 export type RemixVitePlugin = (
   options?: RemixVitePluginOptions
 ) => VitePlugin[];
 export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
+  let isViteV5 = getViteMajor() === 5;
+
   let viteCommand: ResolvedViteConfig["command"];
   let viteUserConfig: ViteUserConfig;
 
@@ -300,9 +308,14 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
 
   let createBuildManifest = async (): Promise<Manifest> => {
     let pluginConfig = await resolvePluginConfig();
+
+    let viteManifestPath = isViteV5
+      ? path.join(".vite", "manifest.json")
+      : "manifest.json";
+
     let viteManifest = JSON.parse(
       await fs.readFile(
-        path.resolve(pluginConfig.assetsBuildDirectory, "manifest.json"),
+        path.resolve(pluginConfig.assetsBuildDirectory, viteManifestPath),
         "utf-8"
       )
     ) as ViteManifest;

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -210,7 +210,7 @@ export type RemixVitePlugin = (
   options?: RemixVitePluginOptions
 ) => VitePlugin[];
 export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
-  let isViteV5 = getViteMajor() === 5;
+  let isViteGTEv5 = getViteMajor() >= 5;
 
   let viteCommand: ResolvedViteConfig["command"];
   let viteUserConfig: ViteUserConfig;
@@ -309,7 +309,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
   let createBuildManifest = async (): Promise<Manifest> => {
     let pluginConfig = await resolvePluginConfig();
 
-    let viteManifestPath = isViteV5
+    let viteManifestPath = isViteGTEv5
       ? path.join(".vite", "manifest.json")
       : "manifest.json";
 


### PR DESCRIPTION
Vite v5 build output places the `manifest.json` file inside of a `.vite` folder (https://main.vitejs.dev/guide/migration#manifest-files-are-now-generated-in-vite-directory-by-default).

This PR tweaks the build process to find the correct vite manifest depending on if vite version >= v5 or not.

Manually tested `build` + `start` is working OK with the `unstable-vite` template, with Vite `v4.5` and Vite `v5.0.0-beta.14`.