### PR TITLE
perf(vite): fix LiveReload proxy bailout logic

### DIFF
--- a/.changeset/nervous-fans-do.md
+++ b/.changeset/nervous-fans-do.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Improve performance of LiveReload proxy in Vite dev

--- a/integration/vite-css-dev-test.ts
+++ b/integration/vite-css-dev-test.ts
@@ -36,6 +36,9 @@ test.describe("Vite CSS dev", () => {
               port: ${devPort},
               strictPort: true,
             },
+            optimizeDeps: {
+              include: ["react", "react-dom/client", "@remix-run/react"],
+            },
             plugins: [remix()],
           });
         `,
@@ -60,28 +63,28 @@ test.describe("Vite CSS dev", () => {
             );
           }
         `,
-        "app/routes/_index/styles-bundled.css": css`
+        "app/styles-bundled.css": css`
           .index_bundled {
             background: papayawhip;
             padding: ${TEST_PADDING_VALUE};
           }
         `,
-        "app/routes/_index/styles-linked.css": css`
+        "app/styles-linked.css": css`
           .index_linked {
             background: salmon;
             padding: ${TEST_PADDING_VALUE};
           }
         `,
-        "app/routes/_index/styles.module.css": css`
+        "app/styles.module.css": css`
           .index {
             background: peachpuff;
             padding: ${TEST_PADDING_VALUE};
           }
         `,
-        "app/routes/_index/route.tsx": js`
-          import "./styles-bundled.css";
-          import linkedStyles from "./styles-linked.css?url";
-          import cssModulesStyles from "./styles.module.css";
+        "app/routes/_index.tsx": js`
+          import "../styles-bundled.css";
+          import linkedStyles from "../styles-linked.css?url";
+          import cssModulesStyles from "../styles.module.css";
 
           export function links() {
             return [{ rel: "stylesheet", href: linkedStyles }];
@@ -160,9 +163,16 @@ test.describe("Vite CSS dev", () => {
   test.describe("with JS", () => {
     test.use({ javaScriptEnabled: true });
     test("updates CSS", async ({ page }) => {
+      let pageErrors: unknown[] = [];
+      page.on("pageerror", (error) => pageErrors.push(error));
+
       await page.goto(`http://localhost:${devPort}/`, {
         waitUntil: "networkidle",
       });
+
+      // Ensure no errors on page load
+      expect(pageErrors).toEqual([]);
+
       await expect(page.locator("#index [data-css-modules]")).toHaveCSS(
         "padding",
         TEST_PADDING_VALUE
@@ -177,11 +187,11 @@ test.describe("Vite CSS dev", () => {
       );
 
       let bundledCssContents = await fs.readFile(
-        path.join(projectDir, "app/routes/_index/styles-bundled.css"),
+        path.join(projectDir, "app/styles-bundled.css"),
         "utf8"
       );
       await fs.writeFile(
-        path.join(projectDir, "app/routes/_index/styles-bundled.css"),
+        path.join(projectDir, "app/styles-bundled.css"),
         bundledCssContents.replace(
           TEST_PADDING_VALUE,
           UPDATED_TEST_PADDING_VALUE
@@ -190,11 +200,11 @@ test.describe("Vite CSS dev", () => {
       );
 
       let linkedCssContents = await fs.readFile(
-        path.join(projectDir, "app/routes/_index/styles-linked.css"),
+        path.join(projectDir, "app/styles-linked.css"),
         "utf8"
       );
       await fs.writeFile(
-        path.join(projectDir, "app/routes/_index/styles-linked.css"),
+        path.join(projectDir, "app/styles-linked.css"),
         linkedCssContents.replace(
           TEST_PADDING_VALUE,
           UPDATED_TEST_PADDING_VALUE
@@ -203,11 +213,11 @@ test.describe("Vite CSS dev", () => {
       );
 
       let cssModuleContents = await fs.readFile(
-        path.join(projectDir, "app/routes/_index/styles.module.css"),
+        path.join(projectDir, "app/styles.module.css"),
         "utf8"
       );
       await fs.writeFile(
-        path.join(projectDir, "app/routes/_index/styles.module.css"),
+        path.join(projectDir, "app/styles.module.css"),
         cssModuleContents.replace(
           TEST_PADDING_VALUE,
           UPDATED_TEST_PADDING_VALUE

--- a/integration/vite-dev-express-test.ts
+++ b/integration/vite-dev-express-test.ts
@@ -24,9 +24,9 @@ test.beforeAll(async () => {
             hmr: {
               port: ${hmrPort}
             }
-          },
+          },          
           optimizeDeps: {
-            include: ["react", "react-dom/client"],
+            include: ["react", "react-dom/client", "@remix-run/react"],
           },
           plugins: [remix()],
         });

--- a/integration/vite-dev-test.ts
+++ b/integration/vite-dev-test.ts
@@ -33,6 +33,9 @@ test.describe("Vite dev", () => {
               port: ${devPort},
               strictPort: true,
             },
+            optimizeDeps: {
+              include: ["react", "react-dom/client", "@remix-run/react"],
+            },
             plugins: [remix()],
           });
         `,

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -666,11 +666,11 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
           return;
         }
 
+        let referencesLiveReload =
+          code.includes("@remix-run/react") && code.includes("LiveReload");
+
         // Don't transform files that don't need the proxy
-        if (
-          !code.includes("@remix-run/react") &&
-          !code.includes("LiveReload")
-        ) {
+        if (!referencesLiveReload) {
           return;
         }
 

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -666,11 +666,11 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
           return;
         }
 
-        let referencesLiveReload =
-          code.includes("@remix-run/react") && code.includes("LiveReload");
+        let hasLiveReloadHints =
+          code.includes("LiveReload") && code.includes("@remix-run/react");
 
         // Don't transform files that don't need the proxy
-        if (!referencesLiveReload) {
+        if (!hasLiveReloadHints) {
           return;
         }
 


### PR DESCRIPTION
This fixes an issue raised by @dmarkow in https://github.com/remix-run/remix/issues/7868#issuecomment-1791470740.

In the Vite dev server, we use a Babel transform to replace usage of `@remix-run/react` with a proxy module so that we can replace the `LiveReload` component with a Vite-specific implementation. Since this transformation doesn't come for free, we first check whether the file contains references to `@remix-run/react` and `LiveReload`. This should mean that, even if the transformation could be faster, it's only applied to a single file in your app.

However, there was an error in the boolean logic for this check that meant we were processing any file containing `@remix-run/react`, even if it was missing a reference to `LiveReload`. This PR fixes the logic so that both strings need to be present, as intended.