### PR TITLE
docs(node): update link to node releases

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -503,6 +503,7 @@
 - sitek94
 - sjparsons
 - skube
+- smathson
 - sndrem
 - smeijer
 - sobrinho

--- a/docs/other-api/node.md
+++ b/docs/other-api/node.md
@@ -27,4 +27,4 @@ installGlobals();
 
 Remix officially supports **Active** and **Maintenance** [Node LTS versions][node-releases] at any given point in time. Dropped support for End of Life Node versions is done in a Remix Minor release.
 
-[node-releases]: https://nodejs.dev/en/about/releases
+[node-releases]: https://nodejs.org/en/about/previous-releases


### PR DESCRIPTION
The current link to https://nodejs.dev/en/about/releases 404s. Updates the link to the current nodejs.org page that documents which releases are currently LTS Active and LTS Maintenance.