### PR TITLE
fix(vite): support JSX in .jsx files without React import

### DIFF
--- a/.changeset/clever-months-swim.md
+++ b/.changeset/clever-months-swim.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Support JSX usage in `.jsx` files without manual `React` import in Vite

--- a/contributors.yml
+++ b/contributors.yml
@@ -195,6 +195,7 @@
 - harmony7
 - helderburato
 - HenryVogt
+- hi-ogawa
 - hicksy
 - himorishige
 - Hirochon

--- a/integration/vite-dev-test.ts
+++ b/integration/vite-dev-test.ts
@@ -34,9 +34,6 @@ test.describe("Vite dev", () => {
               strictPort: true,
             },
             plugins: [remix()],
-            esbuild: {
-              jsx: "automatic",
-            }
           });
         `,
         "app/root.tsx": js`

--- a/integration/vite-dev-test.ts
+++ b/integration/vite-dev-test.ts
@@ -136,10 +136,10 @@ test.describe("Vite dev", () => {
             );
           }
         `,
-        "app/routes/non-ts.jsx": js`
-          export default function Page() {
+        "app/routes/jsx.jsx": js`
+          export default function JsxRoute() {
             return (
-              <div id="non-ts">
+              <div id="jsx">
                 <p data-hmr>HMR updated: no</p>
               </div>
             );
@@ -238,31 +238,32 @@ test.describe("Vite dev", () => {
     );
   });
 
-  test("handle non-typescript jsx file", async ({ page }) => {
+  test("handles JSX in .jsx file without React import", async ({ page }) => {
     let pageErrors: unknown[] = [];
     page.on("pageerror", (error) => pageErrors.push(error));
 
-    await page.goto(`http://localhost:${devPort}/non-ts`, {
+    await page.goto(`http://localhost:${devPort}/jsx`, {
       waitUntil: "networkidle",
     });
     expect(pageErrors).toEqual([]);
 
-    let hmrStatus = page.locator("#non-ts [data-hmr]");
+    let hmrStatus = page.locator("#jsx [data-hmr]");
     await expect(hmrStatus).toHaveText("HMR updated: no");
 
     let indexRouteContents = await fs.readFile(
-      path.join(projectDir, "app/routes/non-ts.jsx"),
+      path.join(projectDir, "app/routes/jsx.jsx"),
       "utf8"
     );
     await fs.writeFile(
-      path.join(projectDir, "app/routes/non-ts.jsx"),
+      path.join(projectDir, "app/routes/jsx.jsx"),
       indexRouteContents.replace("HMR updated: no", "HMR updated: yes"),
       "utf8"
     );
     await page.waitForLoadState("networkidle");
     await expect(hmrStatus).toHaveText("HMR updated: yes");
+
     expect(pageErrors).toEqual([]);
-  })
+  });
 });
 
 let bufferize = (stream: Readable): (() => string) => {

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -432,9 +432,9 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
               "react-dom/client",
             ],
           },
-          // for server module, JSX transpilation is done by vite's esbuild
           esbuild: {
-            jsx: 'automatic',
+            jsx: "automatic",
+            jsxDev: viteCommand !== "build",
           },
           resolve: {
             // https://react.dev/warnings/invalid-hook-call-warning#duplicate-react

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -432,6 +432,10 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
               "react-dom/client",
             ],
           },
+          // for server module, JSX transpilation is done by vite's esbuild
+          esbuild: {
+            jsx: 'automatic',
+          },
           resolve: {
             // https://react.dev/warnings/invalid-hook-call-warning#duplicate-react
             dedupe: ["react", "react-dom"],


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: https://github.com/remix-run/remix/issues/7885

It seems explicitly setting vite's esbuild option is necessarily to make jsx transpilation work for `.jsx` file.
This change also aligns with what vite-plugin-react does here
- https://github.com/vitejs/vite-plugin-react/blob/b255776f75ced38e9ae8d0ba2f9113e697159a73/packages/plugin-react/src/index.ts#L130-L131

--- 

(The rest of the comment is some extra note from my investigation. It might not be accurate...)

My guess was that JSX transpilation for server module (i.e. transform done via `ssrLoadModule`) is done by vite's esbuild, which reads local `tsconfig.json` to configure certain transform options.
These are relevant docs:
- https://vitejs.dev/guide/features.html#other-compiler-options-affecting-the-build-result
- https://esbuild.github.io/api/#jsx
- https://esbuild.github.io/api/#tsconfig-raw

But, for some reason, this might not the case for `.jsx` file transpilation.
I also tested with updating `tsconfig.json` to include `**/*.jsx` but this doesn't seem to have any effect.

<details><summary>reveal tsconfig.json</summary>

```json5
{
  "include": ["env.d.ts", "**/*.ts", "**/*.tsx", "**/*.jsx"],
  "compilerOptions": {
    "checkJs": true,
    "lib": ["DOM", "DOM.Iterable", "ES2022"],
    "isolatedModules": true,
    "esModuleInterop": true,
    "jsx": "react-jsx",
    "module": "ESNext",
    "moduleResolution": "Bundler",
    "resolveJsonModule": true,
    "target": "ES2022",
    "strict": true,
    "allowJs": true,
    "forceConsistentCasingInFileNames": true,
    "baseUrl": ".",
    "paths": {
      "~/*": ["./app/*"]
    },

    // Remix takes care of building everything in `remix build`.
    "noEmit": true
  }
}
```

</details>

---

- [ ] Docs
- [x] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
