### PR TITLE
fix(remix-dev/vite): use `ssrEmitAssets` to support assets referenced by server-only code

### DIFF
--- a/.changeset/tricky-frogs-film.md
+++ b/.changeset/tricky-frogs-film.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": patch
 ---
 
-fix(vite): emit asset files references only by server-only file
+fix(vite): emit asset files referenced only by server-only file

--- a/.changeset/tricky-frogs-film.md
+++ b/.changeset/tricky-frogs-film.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+fix(vite): emit asset files references only by server-only file

--- a/.changeset/tricky-frogs-film.md
+++ b/.changeset/tricky-frogs-film.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": patch
 ---
 
-fix(vite): emit asset files referenced only by server-only file
+Emit assets that were only referenced in the server build into the client assets directory in Vite build

--- a/integration/vite-build-test.ts
+++ b/integration/vite-build-test.ts
@@ -33,7 +33,7 @@ test.describe("Vite build", () => {
 
           export default defineConfig({
             build: {
-              // force emitting asset files instead of inline as data-url
+              // force emitting asset files instead of inlined as data-url
               assetsInlineLimit: 0,
             },
             plugins: [

--- a/integration/vite-build-test.ts
+++ b/integration/vite-build-test.ts
@@ -258,21 +258,6 @@ test.describe("Vite build", () => {
     );
   });
 
-  test("emit ssr assets", async ({ page }) => {
-    let app = new PlaywrightFixture(appFixture, page);
-    await app.goto("/ssr-assets");
-
-    // verify asset files are emitted and served correctly
-    await page.getByRole("link", { name: "url1" }).click();
-    await page.waitForURL("**/build/assets/test1-*.txt");
-    await page.getByText("test1").click();
-    await page.goBack();
-
-    await page.getByRole("link", { name: "url2" }).click();
-    await page.waitForURL("**/build/assets/test2-*.txt");
-    await page.getByText("test2").click();
-  });
-
   test("server renders matching MDX routes", async ({ page }) => {
     let res = await fixture.requestDocument("/mdx");
     expect(res.status).toBe(200);
@@ -292,6 +277,21 @@ test.describe("Vite build", () => {
     );
 
     expect(pageErrors).toEqual([]);
+  });
+
+  test("emits SSR assets to the client assets directory", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/ssr-assets");
+
+    // verify asset files are emitted and served correctly
+    await page.getByRole("link", { name: "url1" }).click();
+    await page.waitForURL("**/build/assets/test1-*.txt");
+    await page.getByText("test1").click();
+    await page.goBack();
+
+    await page.getByRole("link", { name: "url2" }).click();
+    await page.waitForURL("**/build/assets/test2-*.txt");
+    await page.getByText("test2").click();
   });
 
   test("supports code-split css", async ({ page }) => {

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -806,6 +806,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
                 ...movedAssetPaths.map((movedAssetPath) =>
                   colors.dim(path.relative(rootDirectory, movedAssetPath))
                 ),
+                "",
               ].join("\n")
             );
           }

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -3,7 +3,7 @@
 import type * as Vite from "vite";
 import { type BinaryLike, createHash } from "node:crypto";
 import * as path from "node:path";
-import * as fs from "node:fs/promises";
+import * as fse from "fs-extra";
 import babel from "@babel/core";
 import { type ServerBuild } from "@remix-run/server-runtime";
 import {
@@ -182,8 +182,8 @@ function dedupe<T>(array: T[]): T[] {
 }
 
 const writeFileSafe = async (file: string, contents: string): Promise<void> => {
-  await fs.mkdir(path.dirname(file), { recursive: true });
-  await fs.writeFile(file, contents);
+  await fse.ensureDir(path.dirname(file));
+  await fse.writeFile(file, contents);
 };
 
 const getRouteModuleExports = async (
@@ -213,7 +213,7 @@ const getRouteModuleExports = async (
 
   let [id, code] = await Promise.all([
     resolveId(),
-    fs.readFile(routePath, "utf-8"),
+    fse.readFile(routePath, "utf-8"),
     // pluginContainer.transform(...) fails if we don't do this first:
     moduleGraph.ensureEntryFromUrl(url, ssr),
   ]);
@@ -244,6 +244,8 @@ export type RemixVitePlugin = (
 export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
   let viteCommand: Vite.ResolvedConfig["command"];
   let viteUserConfig: Vite.UserConfig;
+  let resolvedViteConfig: Vite.ResolvedConfig | undefined;
+
   let isViteV4 = getViteMajorVersion() === 4;
 
   let cssModulesManifest: Record<string, string> = {};
@@ -338,19 +340,23 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
       };`;
   };
 
+  let loadViteManifest = async (directory: string) => {
+    let manifestPath = isViteV4
+      ? "manifest.json"
+      : path.join(".vite", "manifest.json");
+    let manifestContents = await fse.readFile(
+      path.resolve(directory, manifestPath),
+      "utf-8"
+    );
+    return JSON.parse(manifestContents) as Vite.Manifest;
+  };
+
   let createBuildManifest = async (): Promise<Manifest> => {
     let pluginConfig = await resolvePluginConfig();
 
-    let viteManifestPath = isViteV4
-      ? "manifest.json"
-      : path.join(".vite", "manifest.json");
-
-    let viteManifest = JSON.parse(
-      await fs.readFile(
-        path.resolve(pluginConfig.assetsBuildDirectory, viteManifestPath),
-        "utf-8"
-      )
-    ) as Vite.Manifest;
+    let viteManifest = await loadViteManifest(
+      pluginConfig.assetsBuildDirectory
+    );
 
     let entry: Manifest["entry"] = resolveBuildAssetPaths(
       pluginConfig,
@@ -529,8 +535,8 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
                     },
                   }
                 : {
-                    // unstable option? https://github.com/vitejs/vite/discussions/13808
-                    ssrEmitAssets: true,
+                    ssrEmitAssets: true, // We move SSR-only assets to client assets and clean the rest
+                    manifest: true, // We need the manifest to detect SSR-only assets
                     outDir: path.dirname(pluginConfig.serverBuildPath),
                     rollupOptions: {
                       ...viteUserConfig.build?.rollupOptions,
@@ -548,30 +554,10 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
           }),
         };
       },
-      // after ssr asset generation, move them to client assets directory
-      // https://rollupjs.org/plugin-development/#writebundle
-      // we could intercept during `generateBundle` and write files directly
-      // but that would lose file name/size logging by rollup
-      // https://rollupjs.org/plugin-development/#generatebundle
-      writeBundle: {
-        async handler(options, bundle) {
-          if (!ssrBuildContext.isSsrBuild) {
-            return;
-          }
-          let pluginConfig = await resolvePluginConfig();
-          for (const entry of Object.values(bundle)) {
-            if (entry.type === "asset") {
-              // TODO: when is "dir" undefined?
-              await fs.rename(
-                path.join(options.dir!, entry.fileName),
-                path.join(pluginConfig.assetsBuildDirectory, entry.fileName)
-              );
-            }
-          }
-        },
-      },
       async configResolved(viteConfig) {
         await initEsModuleLexer;
+
+        resolvedViteConfig = viteConfig;
 
         ssrBuildContext =
           viteConfig.build.ssr && viteCommand === "build"
@@ -761,6 +747,88 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
           }
         };
       },
+      writeBundle: {
+        // After the SSR build is finished, we inspect the Vite manifest for
+        // the SSR build and move all server assets to client assets directory
+        async handler() {
+          if (!ssrBuildContext.isSsrBuild) {
+            return;
+          }
+
+          invariant(
+            cachedPluginConfig,
+            "Expected plugin config to be cached when writeBundle hook is called"
+          );
+
+          invariant(
+            resolvedViteConfig,
+            "Expected resolvedViteConfig to exist when writeBundle hook is called"
+          );
+
+          let { assetsBuildDirectory, serverBuildPath, rootDirectory } =
+            cachedPluginConfig;
+          let serverBuildDir = path.dirname(serverBuildPath);
+
+          let ssrViteManifest = await loadViteManifest(serverBuildDir);
+          let clientViteManifest = await loadViteManifest(assetsBuildDirectory);
+
+          let clientAssetPaths = new Set(
+            Object.values(clientViteManifest).flatMap(
+              (chunk) => chunk.assets ?? []
+            )
+          );
+
+          let ssrOnlyAssetPaths = new Set(
+            Object.values(ssrViteManifest)
+              .flatMap((chunk) => chunk.assets ?? [])
+              // Only move assets that aren't in the client build
+              .filter((asset) => !clientAssetPaths.has(asset))
+          );
+
+          let movedAssetPaths = await Promise.all(
+            Array.from(ssrOnlyAssetPaths).map(async (ssrAssetPath) => {
+              let src = path.join(serverBuildDir, ssrAssetPath);
+              let dest = path.join(assetsBuildDirectory, ssrAssetPath);
+              await fse.move(src, dest);
+              return dest;
+            })
+          );
+
+          let logger = vite.createLogger();
+
+          if (movedAssetPaths.length) {
+            logger.info(
+              [
+                "",
+                `${colors.green("✓")} ${movedAssetPaths.length} asset${
+                  movedAssetPaths.length > 1 ? "s" : ""
+                } moved from Remix server build to client assets.`,
+                ...movedAssetPaths.map((movedAssetPath) =>
+                  colors.dim(path.relative(rootDirectory, movedAssetPath))
+                ),
+              ].join("\n")
+            );
+          }
+
+          let ssrAssetsDir = path.join(
+            resolvedViteConfig.build.outDir,
+            resolvedViteConfig.build.assetsDir
+          );
+
+          if (fse.existsSync(ssrAssetsDir)) {
+            await fse.remove(ssrAssetsDir);
+            logger.info(
+              [
+                "",
+                colors.dim(
+                  `${colors.green("✓")} Cleaned Remix server assets directory.`
+                ),
+                colors.dim(path.relative(rootDirectory, ssrAssetsDir)),
+              ].join("\n")
+            );
+          }
+        },
+      },
       async buildEnd() {
         await viteChildCompiler?.close();
       },
@@ -921,8 +989,8 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
 
         return [
           "const exports = {}",
-          await fs.readFile(reactRefreshRuntimePath, "utf8"),
-          await fs.readFile(
+          await fse.readFile(reactRefreshRuntimePath, "utf8"),
+          await fse.readFile(
             require.resolve("./static/refresh-utils.cjs"),
             "utf8"
           ),

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -794,7 +794,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
             })
           );
 
-          let logger = vite.createLogger();
+          let logger = resolvedViteConfig.logger;
 
           if (movedAssetPaths.length) {
             logger.info(
@@ -817,15 +817,6 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
 
           if (fse.existsSync(ssrAssetsDir)) {
             await fse.remove(ssrAssetsDir);
-            logger.info(
-              [
-                "",
-                colors.dim(
-                  `${colors.green("✓")} Cleaned Remix server assets directory.`
-                ),
-                colors.dim(path.relative(rootDirectory, ssrAssetsDir)),
-              ].join("\n")
-            );
           }
         },
       },


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: https://github.com/remix-run/remix/issues/7847 

I'm not so sure how robust this change is (especially `writeBundle` plugin hook), but it think it should achieve mostly same thing as what sveltekit did in https://github.com/sveltejs/kit/pull/9073. 
See this comment https://github.com/remix-run/remix/issues/7847#issuecomment-1792110139 for more references (especially vite's "stabilizing" discussion https://github.com/vitejs/vite/discussions/13808).

I added a test only for `build` case. I think this is not relevant for `dev` since vite serves assets files directly without moving or renaming file name with content hash etc..., so I didn't add a test.
Please let me know if there are others cases to be covered by tests.

- [ ] Docs
- [x] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
