### PR TITLE
fix(remix-dev): fix `FutureConfig` type

### DIFF
--- a/.changeset/two-boxes-dance.md
+++ b/.changeset/two-boxes-dance.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fix `FutureConfig` type

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -180,9 +180,13 @@ export interface AppConfig {
     | string[]
     | (() => Promise<string | string[]> | string | string[]);
 
-  future?: Partial<FutureConfig> & {
-    [propName: string]: never;
-  };
+  /**
+   * Enabled future flags
+   */
+  future?: [keyof FutureConfig] extends [never]
+    ? // Partial<FutureConfig> doesn't work when it's empty so just prevent any keys
+      { [key: string]: never }
+    : Partial<FutureConfig>;
 }
 
 /**


### PR DESCRIPTION
We added a fix in #7261 to disallow unknown/removed future flags but it turns out that fix only worked when `FutureConfig` was empty - which it was at that time since we were preparing to release v2.  Now that we added the first. v3 future flag we found out this isn't the right approach and need to use a conditional type instead.

https://www.typescriptlang.org/play?#code/JYOwLgpgTgZghgYwgAgGIFczqhAwgexBmAHNkBvAKAEgA3AZgH0o4ATVCOLHALmQCN8+ADacQlAL6VKoSLEQoAggAdlBIqQqVkO5DEzYIAfj4BtANYQAnvhhoDOdcRIBdZBAAekEKwDOyUxAIWmg3IwoLaz5fMChQVz4gkKgJZD4ABTgoMGA4YQAeDG48QmcAPklpUTBkBFLNAF4tan1ivipqOiYWdk425Fj0CAAaGjoAJkYAdzAACwgEcz5BkZoJUdTfLmBfYgh-FTV6kmkZcGh4JHtip1JxrSkzuUulVVuSe6pdPQdjM0sbHYioZ3m5PN4-AEkqFkOFyJErNFYvEXIlgtBUhksjk8oVfu8Ko9qrVjvcmh1WoZ2mMGMw2BwuFSBlAhqNOrRJjN5otlizVtR1pJkFscrtgPtkId3uNKEA