### PR TITLE
chore: update `@types/node`

### DIFF
--- a/packages/remix-architect/package.json
+++ b/packages/remix-architect/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/lambda-tester": "^3.6.1",
-    "@types/node": "^18.17.1",
+    "@types/node": "^18.19.86",
     "lambda-tester": "^4.0.1",
     "typescript": "^5.1.0"
   },

--- a/packages/remix-cloudflare-pages/package.json
+++ b/packages/remix-cloudflare-pages/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230518.0",
     "@types/mime": "^2.0.3",
-    "@types/node": "^18.17.1",
+    "@types/node": "^18.19.86",
     "typescript": "^5.1.0"
   },
   "peerDependencies": {

--- a/packages/remix-cloudflare-workers/package.json
+++ b/packages/remix-cloudflare-workers/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230518.0",
-    "@types/node": "^18.17.1",
+    "@types/node": "^18.19.86",
     "typescript": "^5.1.6"
   },
   "peerDependencies": {

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -93,7 +93,7 @@
     "@types/gunzip-maybe": "^1.4.0",
     "@types/jsesc": "^3.0.1",
     "@types/lodash.debounce": "^4.0.6",
-    "@types/node": "^18.17.1",
+    "@types/node": "^18.19.86",
     "@types/npmcli__package-json": "^4.0.0",
     "@types/picomatch": "^2.3.0",
     "@types/prettier": "^2.7.3",

--- a/packages/remix-express/package.json
+++ b/packages/remix-express/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.9",
-    "@types/node": "^18.17.1",
+    "@types/node": "^18.19.86",
     "@types/supertest": "^2.0.10",
     "express": "^4.20.0",
     "node-mocks-http": "^1.10.1",

--- a/packages/remix-node/package.json
+++ b/packages/remix-node/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@types/cookie-signature": "^1.0.3",
+    "@types/node": "^18.19.86",
     "@types/source-map-support": "^0.5.4",
     "typescript": "^5.1.6"
   },

--- a/packages/remix-node/upload/fileUploadHandler.ts
+++ b/packages/remix-node/upload/fileUploadHandler.ts
@@ -150,22 +150,14 @@ export function createFileUploadHandler({
       }
     }
 
-    // TODO: remove this typecast once TS fixed File class regression
-    //  https://github.com/microsoft/TypeScript/issues/52166
-    return new NodeOnDiskFile(filepath, contentType) as unknown as File;
+    return new NodeOnDiskFile(filepath, contentType);
   };
 }
 
-// TODO: remove this `Omit` usage once TS fixed File class regression
-//  https://github.com/microsoft/TypeScript/issues/52166
-export class NodeOnDiskFile implements Omit<File, "constructor"> {
+export class NodeOnDiskFile implements File {
   name: string;
   lastModified: number = 0;
   webkitRelativePath: string = "";
-
-  // TODO: remove this property once TS fixed File class regression
-  //  https://github.com/microsoft/TypeScript/issues/52166
-  prototype = File.prototype;
 
   constructor(
     private filepath: string,
@@ -201,9 +193,7 @@ export class NodeOnDiskFile implements Omit<File, "constructor"> {
         start,
         end,
       }
-      // TODO: remove this typecast once TS fixed File class regression
-      //  https://github.com/microsoft/TypeScript/issues/52166
-    ) as unknown as Blob;
+    );
   }
 
   async arrayBuffer(): Promise<ArrayBuffer> {

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@remix-run/server-runtime": "workspace:*",
     "@remix-run/testing": "workspace:*",
-    "@types/node": "^18.17.1",
+    "@types/node": "^18.19.86",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "jest-environment-jsdom": "^29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,7 +291,7 @@ importers:
         version: 4.1.1
       vite:
         specifier: ^6.0.0
-        version: 6.0.6(@types/node@18.17.1)
+        version: 6.0.6(@types/node@18.19.86)
       vite-tsconfig-paths:
         specifier: ^4.2.2
         version: 4.3.1(typescript@5.1.6)(vite@6.0.6)
@@ -616,7 +616,7 @@ importers:
         version: 5.1.6
       vite:
         specifier: 5.1.8
-        version: 5.1.8(@types/node@18.17.1)
+        version: 5.1.8(@types/node@18.19.86)
       vite-env-only:
         specifier: ^2.0.0
         version: 2.2.0
@@ -686,7 +686,7 @@ importers:
         version: 5.1.6
       vite:
         specifier: ^6.0.0
-        version: 6.0.6(@types/node@18.17.1)
+        version: 6.0.6(@types/node@18.19.86)
       vite-env-only:
         specifier: ^2.0.0
         version: 2.2.0
@@ -741,7 +741,7 @@ importers:
         version: 5.1.6
       vite:
         specifier: ^6.0.0
-        version: 6.0.6(@types/node@18.17.1)
+        version: 6.0.6(@types/node@18.19.86)
       vite-tsconfig-paths:
         specifier: ^4.2.1
         version: 4.3.1(typescript@5.1.6)(vite@6.0.6)
@@ -840,8 +840,8 @@ importers:
         specifier: ^3.6.1
         version: 3.6.2
       '@types/node':
-        specifier: ^18.17.1
-        version: 18.17.1
+        specifier: ^18.19.86
+        version: 18.19.86
       lambda-tester:
         specifier: ^4.0.1
         version: 4.0.1
@@ -878,8 +878,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       '@types/node':
-        specifier: ^18.17.1
-        version: 18.17.1
+        specifier: ^18.19.86
+        version: 18.19.86
       typescript:
         specifier: ^5.1.0
         version: 5.1.6
@@ -897,8 +897,8 @@ importers:
         specifier: ^4.20230518.0
         version: 4.20240208.0
       '@types/node':
-        specifier: ^18.17.1
-        version: 18.17.1
+        specifier: ^18.19.86
+        version: 18.19.86
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
@@ -963,7 +963,7 @@ importers:
         version: 2.0.5
       '@vanilla-extract/integration':
         specifier: ^6.2.0
-        version: 6.5.0(@types/node@18.17.1)
+        version: 6.5.0(@types/node@18.19.86)
       arg:
         specifier: ^5.0.1
         version: 5.0.2
@@ -1086,10 +1086,10 @@ importers:
         version: 0.41.0(typescript@5.1.6)
       vite:
         specifier: ^5.1.0 || ^6.0.0
-        version: 6.0.6(@types/node@18.17.1)
+        version: 6.0.6(@types/node@18.19.86)
       vite-node:
         specifier: 3.0.0-beta.2
-        version: 3.0.0-beta.2(@types/node@18.17.1)
+        version: 3.0.0-beta.2(@types/node@18.19.86)
       ws:
         specifier: ^7.5.10
         version: 7.5.10
@@ -1137,8 +1137,8 @@ importers:
         specifier: ^4.0.6
         version: 4.0.9
       '@types/node':
-        specifier: ^18.17.1
-        version: 18.17.1
+        specifier: ^18.19.86
+        version: 18.19.86
       '@types/npmcli__package-json':
         specifier: ^4.0.0
         version: 4.0.4
@@ -1256,8 +1256,8 @@ importers:
         specifier: ^4.17.9
         version: 4.17.21
       '@types/node':
-        specifier: ^18.17.1
-        version: 18.17.1
+        specifier: ^18.19.86
+        version: 18.19.86
       '@types/supertest':
         specifier: ^2.0.10
         version: 2.0.16
@@ -1313,6 +1313,9 @@ importers:
       '@types/cookie-signature':
         specifier: ^1.0.3
         version: 1.1.2
+      '@types/node':
+        specifier: ^18.19.86
+        version: 18.19.86
       '@types/source-map-support':
         specifier: ^0.5.4
         version: 0.5.10
@@ -1383,7 +1386,7 @@ importers:
         version: 5.1.6
       vite:
         specifier: ^6.0.0
-        version: 6.0.6(@types/node@18.17.1)
+        version: 6.0.6(@types/node@18.19.86)
 
   packages/remix-routes-option-adapter:
     devDependencies:
@@ -1490,8 +1493,8 @@ importers:
         specifier: workspace:*
         version: 'link:'
       '@types/node':
-        specifier: ^18.17.1
-        version: 18.17.1
+        specifier: ^18.19.86
+        version: 18.19.86
       '@types/react':
         specifier: ^18.2.20
         version: 18.2.20
@@ -3969,7 +3972,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -3989,14 +3992,14 @@ packages:
       '@jest/test-result': 29.6.4
       '@jest/transform': 29.6.4
       '@jest/types': 29.6.3
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.3.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.6.3
-      jest-config: 29.6.4(@types/node@18.17.1)
+      jest-config: 29.6.4(@types/node@18.19.86)
       jest-haste-map: 29.6.4
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -4023,7 +4026,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       jest-mock: 29.7.0
 
   /@jest/expect-utils@29.6.4:
@@ -4047,7 +4050,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -4078,7 +4081,7 @@ packages:
       '@jest/transform': 29.6.4
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.19
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -4160,7 +4163,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.3
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       '@types/yargs': 17.0.24
       chalk: 4.1.2
 
@@ -4997,12 +5000,12 @@ packages:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
 
   /@types/cacache@17.0.2:
     resolution: {integrity: sha512-IrqHzVX2VRMDQQKa7CtKRnuoCLdRJiLW6hWU+w7i7+AaQ0Ii5bKwJxd5uRK4zBCyrHd3tG6G8zOm2LplxbSfQg==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
     dev: true
 
   /@types/chalk@2.2.0:
@@ -5015,7 +5018,7 @@ packages:
   /@types/cheerio@0.22.30:
     resolution: {integrity: sha512-t7ZVArWZlq3dFa9Yt33qFBQIK4CQd1Q3UJp0V+UhP6vgLWLM6Qug7vZuRSGXg45zXeB1Fm5X2vmBkEX58LV2Tw==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
     dev: false
 
   /@types/compression@1.7.5:
@@ -5027,12 +5030,12 @@ packages:
   /@types/connect@3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
 
   /@types/cookie-signature@1.1.2:
     resolution: {integrity: sha512-2OhrZV2LVnUAXklUFwuYUTokalh/dUb8rqt70OW6ByMSxYpauPZ+kfNLknX3aJyjY5iu8i3cUyoLZP9Fn37tTg==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
     dev: true
 
   /@types/cookie@0.4.1:
@@ -5050,7 +5053,7 @@ packages:
   /@types/cross-spawn@6.0.2:
     resolution: {integrity: sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
 
   /@types/debug@4.1.8:
     resolution: {integrity: sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==}
@@ -5084,7 +5087,7 @@ packages:
   /@types/express-serve-static-core@4.17.43:
     resolution: {integrity: sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       '@types/qs': 6.9.11
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -5100,19 +5103,19 @@ packages:
   /@types/fs-extra@8.1.2:
     resolution: {integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
     dev: false
 
   /@types/glob@7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
 
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
 
   /@types/gunzip-maybe@1.4.2:
     resolution: {integrity: sha512-2uqXZg1jTCKE1Pjbab8qb74+f2+i9h/jz8rQ+jRR+zaNJF75zWwrpbX8/TjF4m56m3KFOg9umHdCJ074KwiVxg==}
@@ -5167,7 +5170,7 @@ packages:
   /@types/jsdom@20.0.1:
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       '@types/tough-cookie': 4.0.5
       parse5: 7.1.2
     dev: true
@@ -5186,7 +5189,7 @@ packages:
   /@types/jsonfile@6.1.0:
     resolution: {integrity: sha512-zQPywzif9EycCkvECjYT9dbbttT0dkk657zcLb/803ZOXHsBA963jzEPF/Jnh1zOdBbgFJvUE8kcvZverAoK1w==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
     dev: false
 
   /@types/lambda-tester@3.6.2:
@@ -5240,7 +5243,7 @@ packages:
   /@types/morgan@1.9.9:
     resolution: {integrity: sha512-iRYSDKVaC6FkGSpEVVIvrRGw0DfJMiQzIn3qr2G5B3C//AWkulhXgaBd7tS9/J79GWSYMTHGs7PfI5b3Y8m+RQ==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
     dev: true
 
   /@types/ms@0.7.31:
@@ -5249,7 +5252,7 @@ packages:
   /@types/node-forge@1.3.11:
     resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
 
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -5261,6 +5264,12 @@ packages:
 
   /@types/node@18.17.1:
     resolution: {integrity: sha512-xlR1jahfizdplZYRU59JlUx9uzF1ARa8jbhM11ccpCJya8kvos5jwdm2ZAgxSCwOl0fq21svP18EVwPBXMQudw==}
+    dev: true
+
+  /@types/node@18.19.86:
+    resolution: {integrity: sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==}
+    dependencies:
+      undici-types: 5.26.5
 
   /@types/node@20.11.17:
     resolution: {integrity: sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==}
@@ -5320,7 +5329,7 @@ packages:
   /@types/resolve@1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
     dev: false
 
   /@types/retry@0.12.1:
@@ -5342,7 +5351,7 @@ packages:
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
 
   /@types/serialize-javascript@5.0.2:
     resolution: {integrity: sha512-BRLlwZzRoZukGaBtcUxkLsZsQfWZpvog6MZk3PWQO9Q6pXmXFzjU5iGzZ+943evp6tkkbN98N1Z31KT0UG1yRw==}
@@ -5353,19 +5362,19 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.4
       '@types/mime': 2.0.3
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
 
   /@types/set-cookie-parser@2.4.7:
     resolution: {integrity: sha512-+ge/loa0oTozxip6zmhRIk8Z/boU51wl9Q6QdLZcokIGMzY5lFXYy/x7Htj2HTC6/KZP1hUbZ1ekx8DYXICvWg==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
     dev: true
 
   /@types/shelljs@0.8.15:
     resolution: {integrity: sha512-vzmnCHl6hViPu9GNLQJ+DZFd6BQI2DBTUeOvYHqkWQLMfKAAQYMb/xAmZkTogZI/vqXHCWkqDRymDI5p0QTi5Q==}
     dependencies:
       '@types/glob': 7.2.0
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
 
   /@types/sinonjs__fake-timers@8.1.1:
     resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
@@ -5384,7 +5393,7 @@ packages:
   /@types/ssri@7.1.1:
     resolution: {integrity: sha512-DPP/jkDaqGiyU75MyMURxLWyYLwKSjnAuGe9ZCsLp9QZOpXmDfuevk769F0BS86TmRuD5krnp06qw9nSoNO+0g==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
     dev: false
 
   /@types/stack-utils@2.0.1:
@@ -5395,7 +5404,7 @@ packages:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
     dev: true
 
   /@types/supertest@2.0.16:
@@ -5414,7 +5423,7 @@ packages:
   /@types/tar-stream@3.1.3:
     resolution: {integrity: sha512-Zbnx4wpkWBMBSu5CytMbrT5ZpMiF55qgM+EpHzR4yIDu7mv52cej8hTkOc6K+LzpkOAbxwn/m7j3iO+/l42YkQ==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
     dev: true
 
   /@types/testing-library__jest-dom@5.14.2:
@@ -5437,13 +5446,13 @@ packages:
   /@types/wait-on@5.3.2:
     resolution: {integrity: sha512-7NBSJs/YvbHlaYCJ7wIUF6t7ct3OMt525NmZ+US73pPlkmpxd9ADwfNxrRAmg8nWlcTMqR0PkhW7aYk3FLlvrQ==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
     dev: false
 
   /@types/ws@7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
     dev: true
 
   /@types/yargs-parser@20.2.1:
@@ -5458,7 +5467,7 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
     dev: false
     optional: true
 
@@ -5617,7 +5626,7 @@ packages:
       modern-ahocorasick: 1.0.1
       outdent: 0.8.0
 
-  /@vanilla-extract/integration@6.5.0(@types/node@18.17.1):
+  /@vanilla-extract/integration@6.5.0(@types/node@18.19.86):
     resolution: {integrity: sha512-E2YcfO8vA+vs+ua+gpvy1HRqvgWbI+MTlUpxA8FvatOvybuNcWAY0CKwQ/Gpj7rswYKtC6C7+xw33emM6/ImdQ==}
     dependencies:
       '@babel/core': 7.23.7
@@ -5631,8 +5640,8 @@ packages:
       lodash: 4.17.21
       mlly: 1.5.0
       outdent: 0.8.0
-      vite: 5.1.8(@types/node@18.17.1)
-      vite-node: 1.6.0(@types/node@18.17.1)
+      vite: 5.1.8(@types/node@18.19.86)
+      vite-node: 1.6.0(@types/node@18.19.86)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -5651,11 +5660,11 @@ packages:
     peerDependencies:
       vite: ^2.2.3 || ^3.0.0 || ^4.0.3 || ^5.0.0
     dependencies:
-      '@vanilla-extract/integration': 6.5.0(@types/node@18.17.1)
+      '@vanilla-extract/integration': 6.5.0(@types/node@18.19.86)
       outdent: 0.8.0
       postcss: 8.4.49
       postcss-load-config: 4.0.2(postcss@8.4.49)
-      vite: 5.1.8(@types/node@18.17.1)
+      vite: 5.1.8(@types/node@18.19.86)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -5672,11 +5681,11 @@ packages:
     peerDependencies:
       vite: ^2.2.3 || ^3.0.0 || ^4.0.3 || ^5.0.0
     dependencies:
-      '@vanilla-extract/integration': 6.5.0(@types/node@18.17.1)
+      '@vanilla-extract/integration': 6.5.0(@types/node@18.19.86)
       outdent: 0.8.0
       postcss: 8.4.49
       postcss-load-config: 4.0.2(postcss@8.4.49)
-      vite: 6.0.6(@types/node@18.17.1)
+      vite: 6.0.6(@types/node@18.19.86)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -8414,7 +8423,7 @@ packages:
     resolution: {integrity: sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==}
     engines: {node: '>= 0.8'}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       require-like: 0.1.2
 
   /event-target-shim@5.0.1:
@@ -9986,7 +9995,7 @@ packages:
       '@jest/expect': 29.6.4
       '@jest/test-result': 29.6.4
       '@jest/types': 29.6.3
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.1
@@ -10023,7 +10032,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.0.2
-      jest-config: 29.6.4(@types/node@18.17.1)
+      jest-config: 29.6.4(@types/node@18.19.86)
       jest-util: 29.7.0
       jest-validate: 29.6.3
       prompts: 2.4.2
@@ -10034,7 +10043,7 @@ packages:
       - supports-color
       - ts-node
 
-  /jest-config@29.6.4(@types/node@18.17.1):
+  /jest-config@29.6.4(@types/node@18.19.86):
     resolution: {integrity: sha512-JWohr3i9m2cVpBumQFv2akMEnFEPVOh+9L2xIBJhJ0zOaci2ZXuKJj0tgMKQCBZAKA09H049IR4HVS/43Qb19A==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -10049,7 +10058,7 @@ packages:
       '@babel/core': 7.23.7
       '@jest/test-sequencer': 29.6.4
       '@jest/types': 29.6.3
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       babel-jest: 29.6.4(@babel/core@7.23.7)
       chalk: 4.1.2
       ci-info: 3.3.2
@@ -10111,7 +10120,7 @@ packages:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 22.1.0
@@ -10128,7 +10137,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -10142,7 +10151,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.6
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.11
@@ -10189,7 +10198,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       jest-util: 29.7.0
 
   /jest-pnp-resolver@1.2.2(jest-resolve@29.6.4):
@@ -10239,7 +10248,7 @@ packages:
       '@jest/test-result': 29.6.4
       '@jest/transform': 29.6.4
       '@jest/types': 29.6.3
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -10269,7 +10278,7 @@ packages:
       '@jest/test-result': 29.6.4
       '@jest/transform': 29.6.4
       '@jest/types': 29.6.3
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
@@ -10319,7 +10328,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       chalk: 4.1.2
       ci-info: 3.3.2
       graceful-fs: 4.2.11
@@ -10366,7 +10375,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.6.4
       '@jest/types': 29.6.3
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -10377,7 +10386,7 @@ packages:
     resolution: {integrity: sha512-6dpvFV4WjcWbDVGgHTWo/aupl8/LbBx2NSKfiwqf79xC/yeJjKHT1+StcKy/2KTmW16hE68ccKVOtXf+WZGz7Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -14890,7 +14899,6 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-    dev: true
 
   /undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
@@ -15267,7 +15275,7 @@ packages:
       - supports-color
     dev: true
 
-  /vite-node@1.6.0(@types/node@18.17.1):
+  /vite-node@1.6.0(@types/node@18.19.86):
     resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -15276,7 +15284,7 @@ packages:
       debug: 4.4.0(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.1.8(@types/node@18.17.1)
+      vite: 5.1.8(@types/node@18.19.86)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15287,7 +15295,7 @@ packages:
       - supports-color
       - terser
 
-  /vite-node@3.0.0-beta.2(@types/node@18.17.1):
+  /vite-node@3.0.0-beta.2(@types/node@18.19.86):
     resolution: {integrity: sha512-ofTf6cfRdL30Wbl9n/BX81EyIR5s4PReLmSurrxQ+koLaWUNOEo8E0lCM53OJkb8vpa2URM2nSrxZsIFyvY1rg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -15296,7 +15304,7 @@ packages:
       debug: 4.4.0(supports-color@8.1.1)
       es-module-lexer: 1.6.0
       pathe: 1.1.2
-      vite: 6.0.6(@types/node@18.17.1)
+      vite: 6.0.6(@types/node@18.19.86)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -15323,7 +15331,7 @@ packages:
       debug: 4.4.0(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 3.0.2(typescript@5.1.6)
-      vite: 5.1.8(@types/node@18.17.1)
+      vite: 5.1.8(@types/node@18.19.86)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -15339,12 +15347,12 @@ packages:
       debug: 4.4.0(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 3.0.2(typescript@5.1.6)
-      vite: 6.0.6(@types/node@18.17.1)
+      vite: 6.0.6(@types/node@18.19.86)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  /vite@5.1.8(@types/node@18.17.1):
+  /vite@5.1.8(@types/node@18.19.86):
     resolution: {integrity: sha512-mB8ToUuSmzODSpENgvpFk2fTiU/YQ1tmcVJJ4WZbq4fPdGJkFNVcmVL5k7iDug6xzWjjuGDKAuSievIsD6H7Xw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -15372,14 +15380,14 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       esbuild: 0.19.12
       postcss: 8.4.49
       rollup: 4.29.1
     optionalDependencies:
       fsevents: 2.3.3
 
-  /vite@6.0.6(@types/node@18.17.1):
+  /vite@6.0.6(@types/node@18.19.86):
     resolution: {integrity: sha512-NSjmUuckPmDU18bHz7QZ+bTYhRR0iA72cs2QAxCqDpafJ0S6qetco0LB3WW2OxlMHS0JmAv+yZ/R3uPmMyGTjQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -15419,7 +15427,7 @@ packages:
       yaml:
         optional: true
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 18.19.86
       esbuild: 0.24.2
       postcss: 8.4.49
       rollup: 4.29.1

--- a/scripts/playground/template/package.json
+++ b/scripts/playground/template/package.json
@@ -36,7 +36,7 @@
     "@faker-js/faker": "^6.3.1",
     "@remix-run/dev": "*",
     "@types/bcryptjs": "^2.4.2",
-    "@types/node": "^18.17.1",
+    "@types/node": "^18.19.86",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "autoprefixer": "^10.4.8",


### PR DESCRIPTION
Type casts can now be removed due to the fix of https://github.com/microsoft/TypeScript/issues/52166 in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67034

Closes #10264