### PR TITLE
Revalidate loader data prefetch cache after action

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1182,7 +1182,7 @@ function mergeRefs<T = any>(
 
 // WIP: I'm sure there's a better way to listen for submit complete internally?
 // If this is the only solution, then this will need to also handle state changes
-// returned from `useFetches`
+// returned from `useFetchers`
 const useSubmitCompleteEffect = (callback: () => unknown) => {
   let navigation = useNavigation();
   let ref = React.useRef(navigation.state);

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -421,7 +421,6 @@ function PrefetchPageLinksImpl({
       <React.Fragment key={dataLinksKey}>
         {dataHrefs.map((href) => (
           <link
-            data-key={dataLinksKey}
             key={href}
             rel="prefetch"
             as="fetch"


### PR DESCRIPTION
This PR demonstrates a potential fix for stale data in the prefetch cache after form submissions https://github.com/remix-run/remix/discussions/7898.

I'm not sure the concept is foolproof:
1. The revalidation won't currently run if the prefetch tags are no longer rendered (due to `usePrefetchBehaviour` logic or even just the user navigating to another page)
2. I'm not sure all browsers will re-exec the prefetch if it's already in the cache? (although Chrome does)

I can add tests if you're interested in this fix.
