### PR TITLE
fix(remix-dev/vite): fix `react-refresh/babel` plugin resolution

### DIFF
--- a/.changeset/brown-panthers-lay.md
+++ b/.changeset/brown-panthers-lay.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+fix: fix "react-refresh/babel" resolution for custom server with pnpm

--- a/.changeset/brown-panthers-lay.md
+++ b/.changeset/brown-panthers-lay.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": patch
 ---
 
-fix: fix "react-refresh/babel" resolution for custom server with pnpm
+fix(vite): fix "react-refresh/babel" resolution for custom server with pnpm

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -788,7 +788,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
             allowAwaitOutsideFunction: true,
             plugins: ["jsx", "typescript"],
           },
-          plugins: ["react-refresh/babel"],
+          plugins: [require("react-refresh/babel")],
           sourceMaps: true,
         });
         if (result === null) return;


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: https://github.com/remix-run/remix/issues/7905

I think this error is caused by the combination of:
- babel does its own resolution when `plugins` option is passed as a string (not sure what rule exactly...)
- when running custom server (by `node ./server.mjs`), the base of such resolution becomes user's root directory.
- `react-refresh` package (transitive dependency of `@remix-run/dev`) is not visible from root directory when using pnpm's non-flat `node_modules`, 

Looking at `vite-plugin-react`, they indeed resolve plugin library on its own then pass to `plugins` option of `babel.transformAsync` (see "additional notes" below).
So this PR align with it in  a similar way by directly calling `require("react-refresh/babel")` within `@remix-run/dev`.

I think the reason why this issue doesn't manifest when running a server via `remix` cli is that, in that case, the babel plugin resolution starts from `@remix-run/dev` package directory and `node_modules/react-refresh` dependency is visible from that directory.

(Additional notes)

`vite-plugin-react` currently does dynamic `import` with own caching to resolve babel plugin https://github.com/vitejs/vite-plugin-react/blob/b255776f75ced38e9ae8d0ba2f9113e697159a73/packages/plugin-react/src/index.ts#L197, but they were also using `require("react-refresh/babel")` before package migration done in https://github.com/vitejs/vite-plugin-react/commit/e999b236b8b312dc44aa7db8b0d1bcea2f6734e7 (see the deleted file `packages/plugin-react/src/index.js`).

## Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->

I verified this fix the issue on pnpm by applying a patch in the reproduction example via `pnpm patch / patch-commit`:

```diff
diff --git a/dist/vite/plugin.js b/dist/vite/plugin.js
index 3f025ab178692932a2c3b6527d5d82a60021f8b6..129c83032a14cf35a815141d7e1666cc6a14ef0d 100644
--- a/dist/vite/plugin.js
+++ b/dist/vite/plugin.js
@@ -551,7 +551,7 @@ const remixVitePlugin = (options = {}) => {
           allowAwaitOutsideFunction: true,
           plugins: ["jsx", "typescript"]
         },
-        plugins: ["react-refresh/babel"],
+        plugins: [require("react-refresh/babel")],
         sourceMaps: true
       });
       if (result === null) return;
```