### PR TITLE
Add caching around resolvePluginConfig() and only invalidate virtual modules when necessary

### DIFF
--- a/.changeset/gentle-ghosts-wait.md
+++ b/.changeset/gentle-ghosts-wait.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Cache resolution of Remix Vite plugin options

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -222,6 +222,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
     | { isSsrBuild: true; getManifest: () => Promise<Manifest> };
 
   let viteChildCompiler: ViteDevServer | null = null;
+  let cachedPluginConfig: ResolvedRemixVitePluginConfig | undefined;
 
   let resolvePluginConfig =
     async (): Promise<ResolvedRemixVitePluginConfig> => {
@@ -417,6 +418,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
         viteCommand = viteConfigEnv.command;
 
         let pluginConfig = await resolvePluginConfig();
+        cachedPluginConfig = pluginConfig;
 
         return {
           appType: "custom",
@@ -541,27 +543,38 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
         vite.httpServer?.on("listening", () => {
           setTimeout(showUnstableWarning, 50);
         });
+        // We cache the pluginConfig here to make sure we're only invalidating virtual modules when necessary.
+        // This requires a separate cache from `cachedPluginConfig`, which is updated by remix-hmr-updates. If
+        // we shared the cache, it would already be refreshed by remix-hmr-updates at this point, and we'd
+        // have no way of comparing against the cache to know if the virtual modules need to be invalidated.
+        let localCachedPluginConfig: ResolvedRemixVitePluginConfig | undefined;
+
         // Let user servers handle SSR requests in middleware mode
         if (vite.config.server.middlewareMode) return;
         return () => {
           vite.middlewares.use(async (req, res, next) => {
             try {
-              // Invalidate all virtual modules
-              vmods.forEach((vmod) => {
-                let mod = vite.moduleGraph.getModuleById(
-                  VirtualModule.resolve(vmod)
-                );
+              let pluginConfig = await resolvePluginConfig();
+              if (
+                JSON.stringify(localCachedPluginConfig) !==
+                JSON.stringify(pluginConfig)
+              ) {
+                // Invalidate all virtual modules
+                localCachedPluginConfig = pluginConfig;
+                vmods.forEach((vmod) => {
+                  let mod = vite.moduleGraph.getModuleById(
+                    VirtualModule.resolve(vmod)
+                  );
 
-                if (mod) {
-                  vite.moduleGraph.invalidateModule(mod);
-                }
-              });
-
+                  if (mod) {
+                    vite.moduleGraph.invalidateModule(mod);
+                  }
+                });
+              }
               let { url } = req;
-              let [pluginConfig, build] = await Promise.all([
-                resolvePluginConfig(),
-                vite.ssrLoadModule(serverEntryId) as Promise<ServerBuild>,
-              ]);
+              let build = await (vite.ssrLoadModule(
+                serverEntryId
+              ) as Promise<ServerBuild>);
 
               let handle = createRequestHandler(build, {
                 mode: "development",
@@ -643,7 +656,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
       async transform(code, id, options) {
         if (options?.ssr) return;
 
-        let pluginConfig = await resolvePluginConfig();
+        let pluginConfig = cachedPluginConfig || (await resolvePluginConfig());
 
         let route = getRoute(pluginConfig, id);
         if (!route) return;
@@ -780,7 +793,8 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
         code = result.code!;
         let refreshContentRE = /\$Refresh(?:Reg|Sig)\$\(/;
         if (refreshContentRE.test(code)) {
-          let pluginConfig = await resolvePluginConfig();
+          let pluginConfig =
+            cachedPluginConfig || (await resolvePluginConfig());
           code = addRefreshWrapper(pluginConfig, code, id);
         }
         return { code, map: result.map };
@@ -790,6 +804,8 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
       name: "remix-hmr-updates",
       async handleHotUpdate({ server, file, modules }) {
         let pluginConfig = await resolvePluginConfig();
+        // Update the config cache any time there is a file change
+        cachedPluginConfig = pluginConfig;
         let route = getRoute(pluginConfig, file);
 
         server.ws.send({


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #7868. This adds caching around `resolvePluginConfig()` to avoid recalculating routes hundreds of times on startup. There is one cache used for `remix-react-refresh-babel` and `remix-remove-server-exports`, and another used in the middleware to determine if the virtual modules need to be invalidated.

I was unable to get a single cache working, as the cache would get updated in one of the other plugin transforms so there was no way to tell if it was stale for the route request by the time the middleware ran.

- [ ] Docs
- [x] Tests: All existing Vite integration tests are passing with these changes

Testing Strategy:

Discussion with @pcattori, "we have pretty good tests for this sort of thing in integration/vite-dev-express-test so if those pass with your changes I'd be reasonably confident about it"

Also used this in developing our app the last couple of days, which included changing  #and adding new routes and lots of HMR/HDR. I didn't run into a single stale cache issue with HMR/HDR, and performance was a ton better than 2.2.0 as released.

### Benchmarking

On 2.2.0, my app startup took 24 seconds, HMR took 2+ seconds when there was a loader, and basic site navigation took around 2 seconds.

With the patch, app startup is just under 12 seconds and HMR with loaders and site nav are both around 400ms. (Note that some, but not all, of this improvement is due to the LiveReload logic fix added since 2.2.0).

Not profiled below, but my `vite build && vite build --ssr` times dropped from a combined 129 seconds to 24 seconds.

2.2.0:

![CleanShot 2023-11-04 at 09 13 44@2x](https://github.com/remix-run/remix/assets/8009/e79ca7ea-2d3a-4843-b9a1-013315422f40)
![CleanShot 2023-11-04 at 09 14 12@2x](https://github.com/remix-run/remix/assets/8009/7022c4f0-82e9-437c-8471-0771e493a2d0)
![CleanShot 2023-11-04 at 09 14 35@2x](https://github.com/remix-run/remix/assets/8009/5b89052a-3e37-4a2b-b12d-9642270e8440)

Patched:

![CleanShot 2023-11-04 at 09 14 53@2x](https://github.com/remix-run/remix/assets/8009/012a4c2e-9357-4375-ad7d-46ec560639ea)
![CleanShot 2023-11-04 at 09 15 09@2x](https://github.com/remix-run/remix/assets/8009/f76a489d-e1b7-48e3-8c2a-e909e3efebe2)
![CleanShot 2023-11-04 at 09 15 21@2x](https://github.com/remix-run/remix/assets/8009/ea6bae13-9053-45b8-a272-a480b7d71597)

