### PR TITLE
docs(discussion/routes#manual-route-configuration): fix code example

### DIFF
--- a/docs/discussion/routes.md
+++ b/docs/discussion/routes.md
@@ -133,7 +133,7 @@ export default {
       route("/", "home/route.tsx", { index: true });
       route("about", "about/route.tsx");
       route("concerts", "concerts/layout.tsx", () => {
-        route("/", "concerts/home.tsx", { index: true });
+        route("", "concerts/home.tsx", { index: true });
         route("trending", "concerts/trending.tsx");
         route(":city", "concerts/city.tsx");
       });


### PR DESCRIPTION
The provided example results in the following error:

```
Error: Absolute route path "/" nested under path "/concerts" is not valid. An absolute child route path must start with the combined path of all its parent routes.
```