### PR TITLE
fix(remix-dev/vite): use `/@fs/` path to support default server/client entry outside of app root

### DIFF
--- a/.changeset/nasty-waves-whisper.md
+++ b/.changeset/nasty-waves-whisper.md
@@ -2,4 +2,11 @@
 "@remix-run/dev": patch
 ---
 
-fix(vite): use `/@fs/` path to support default server/client entry outside of app root
+fix(vite): Let Vite handle serving files outside of project root via `/@fs`
+
+This fixes errors when using default client entry or server entry in a pnpm project
+where those files may be outside of the project root, but within the workspace root.
+
+By default, Vite prevents access to files outside the workspace root
+(when using workspaces) or outside of the project root (when not using
+workspaces) unless user explicitly opts into it via Vite's `server.fs.allow`.

--- a/.changeset/nasty-waves-whisper.md
+++ b/.changeset/nasty-waves-whisper.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+fix(vite): use `/@fs/` path to support default server/client entry outside of app root

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -84,6 +84,17 @@ const resolveFileUrl = (
   { rootDirectory }: Pick<ResolvedRemixVitePluginConfig, "rootDirectory">,
   filePath: string
 ) => {
+  if (filePath.includes("/node_modules/")) {
+    // use "/@fs/" url to workaround the case where remix client/server default entry files live outside of app root,
+    // for example, when using pnpm, the structure becomes:
+    //   (workspace-root)
+    //   |- node_modules/.pnpm/@remix-run+dev@xxx/node_modules/@remix-run/dev/dist/config/defaults/entry.client.tsx
+    //   |- packages/remix-app/vite.config.ts
+    // note that, by default, vite allows serving files from workspace root.
+    // https://vitejs.dev/config/server-options.html#server-fs-allow
+    return `/@fs` + filePath;
+  }
+
   let relativePath = path.relative(rootDirectory, filePath);
 
   if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: https://github.com/remix-run/remix/issues/7722

While looking at devtools network tab, I just spotted vite itself seems to be using `/@fs/` url to define globals (the url is something like `http://localhost:5173/@fs/home/hiroshi/code/tmp/remix-pnpm-workspace/node_modules/.pnpm/vite@4.5.0/node_modules/vite/dist/client/env.mjs` cf. https://github.com/vitejs/vite/pull/12471).
So, I came to this idea of doing something similar to support default entries outside of remix app root.

- [ ] Docs
- [ ] Tests

Testing Strategy:

I created a simpler reproduction in https://github.com/hi-ogawa/demo-remix-vite-pnpm-workspace and verified this fix using `pnpm patch` https://github.com/hi-ogawa/demo-remix-vite-pnpm-workspace/commit/6d18e91ab1a242c3624d8b20d274b356fad6f848

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
