### PR TITLE
fix(remix-dev/vite): import hmr runtime from main script to ensure script ordering

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -407,6 +407,10 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
         imports: [],
       },
       routes,
+      hmr: {
+        runtime: VirtualModule.url(injectHmrRuntimeId),
+        timestamp: -1, // not used for vite hmr
+      }
     };
   };
 
@@ -707,12 +711,13 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
           return [
             'import { createElement } from "react";',
             'export * from "@remix-run/react";',
-            'export const LiveReload = process.env.NODE_ENV !== "development" ? () => null : ',
-            '() => createElement("script", {',
-            ' type: "module",',
-            " async: true,",
-            ` src: "${VirtualModule.url(injectHmrRuntimeId)}"`,
-            "});",
+            'export const LiveReload = () => null;',
+            // 'export const LiveReload = process.env.NODE_ENV !== "development" ? () => null : ',
+            // '() => createElement("script", {',
+            // ' type: "module",',
+            // " async: true,",
+            // ` src: "${VirtualModule.url(injectHmrRuntimeId)}"`,
+            // "});",
           ].join("\n");
         }
       },


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: https://github.com/remix-run/remix/issues/7863

I saw that this issue seems to be addressed by https://github.com/remix-run/remix/pull/7842, but I still observed `@vitejs/plugin-react can't detect preamble` after reloading repeatedly like 10 or 20 times (see reproduction in https://github.com/remix-run/remix/issues/7863#issuecomment-1793748142), so it might be that "async" attribute doesn't necessarily guarantee execution order.

I was looking at the code and it seems pre-vite HMR had already some logic to inject extra `import` in `<Scripts />` before running client entry, so I was wondering if there is any downside to use this for vite plugin as well:

https://github.com/remix-run/remix/blob/06856da8f1d2f215e55b5adbe66dfcbf07c94e3a/packages/remix-react/components.tsx#L776-L777

One clear difference is that this would setup HMR regardless of `LiveReload`, but currently if users didn't include `LiveReload` then they will get the same error `@vitejs/plugin-react can't detect preamble` anyway, so it seems this won't do any harm at least (though it may not be ideal eventually).

Testing Strategy:

Using the local build of this branch in https://github.com/hi-ogawa/test-remix-vite-hmr-runtime/pull/2, I verified the same error doesn't happen on CI anymore (testing 1000 times reload).

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
