### PR TITLE
fix(vite): fix HMR preamble race condition

### DIFF
--- a/.changeset/afraid-suns-yawn.md
+++ b/.changeset/afraid-suns-yawn.md
@@ -1,0 +1,6 @@
+---
+"@remix-run/dev": patch
+"@remix-run/react": patch
+---
+
+Support rendering of `LiveReload` component after `Scripts` in Vite dev

--- a/.changeset/early-trees-walk.md
+++ b/.changeset/early-trees-walk.md
@@ -1,0 +1,6 @@
+---
+"@remix-run/dev": patch
+"@remix-run/react": patch
+---
+
+Support optional rendering of `LiveReload` component in Vite dev

--- a/docs/future/vite.md
+++ b/docs/future/vite.md
@@ -127,43 +127,6 @@ Vite handles imports for all sorts of different file types, sometimes in ways th
 + "include": ["env.d.ts", "**/*.ts", "**/*.tsx"],
 ```
 
-#### `LiveReload` before `Scripts`
-
-<docs-info>
-  This is a temporary workaround for a limitation that will be removed in the future.
-</docs-info>
-
-For React Fast Refresh to work, it [needs to be initialized before any app code is run][rfr-preamble].
-That means it needs to come _before_ your `<Scripts />` element that loads your app code.
-
-We're working on a better API that would eliminate issues with ordering scripts.
-But for now, you can work around this limitation by manually moving `<LiveReload />` before `<Scripts />`.
-If your app doesn't the `Scripts` component, you can safely ignore this step.
-
-👉 **Ensure `<LiveReload />` comes _before_ `<Scripts />`**
-
-```diff filename=app/root.tsx
-export default function App() {
-  return (
-    <html lang="en">
-      <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <Meta />
-        <Links />
-      </head>
-      <body>
-        <Outlet />
-        <ScrollRestoration />
-+        <LiveReload />
-        <Scripts />
--        <LiveReload />
-      </body>
-    </html>
-  );
-}
-```
-
 #### Migrating from Remix App Server
 
 If you were using `remix-serve` in development (or `remix dev` without the `-c` flag), you'll need to switch to the new minimal dev server.
@@ -656,7 +619,6 @@ We're definitely late to the Vite party, but we're excited to be here now!
 [solidstart]: https://start.solidjs.com/getting-started/what-is-solidstart
 [sveltekit]: https://kit.svelte.dev/
 [supported-with-some-deprecations]: #mdx
-[rfr-preamble]: https://github.com/facebook/react/issues/16604#issuecomment-528663101
 [component-keys]: #component-keys
 [issues-vite]: https://github.com/remix-run/remix/labels/vite
 [hmr]: ../discussion/hot-module-replacement

--- a/integration/vite-css-dev-test.ts
+++ b/integration/vite-css-dev-test.ts
@@ -56,8 +56,8 @@ test.describe("Vite CSS dev", () => {
                   <div id="content">
                     <Outlet />
                   </div>
-                  <LiveReload />
                   <Scripts />
+                  <LiveReload />
                 </body>
               </html>
             );

--- a/integration/vite-dev-express-test.ts
+++ b/integration/vite-dev-express-test.ts
@@ -87,8 +87,8 @@ test.beforeAll(async () => {
                   <h1>Root</h1>
                   <Outlet />
                 </div>
-                <LiveReload />
                 <Scripts />
+                <LiveReload />
               </body>
             </html>
           );

--- a/integration/vite-dev-test.ts
+++ b/integration/vite-dev-test.ts
@@ -54,8 +54,8 @@ test.describe("Vite dev", () => {
                     <h1>Root</h1>
                     <Outlet />
                   </div>
-                  <LiveReload />
                   <Scripts />
+                  <LiveReload />
                 </body>
               </html>
             );

--- a/packages/remix-dev/manifest.ts
+++ b/packages/remix-dev/manifest.ts
@@ -20,7 +20,7 @@ export type Manifest = {
     };
   };
   hmr?: {
-    timestamp: number;
+    timestamp?: number;
     runtime: string;
   };
 };

--- a/packages/remix-react/entry.ts
+++ b/packages/remix-react/entry.ts
@@ -38,7 +38,7 @@ export interface AssetsManifest {
   url: string;
   version: string;
   hmr?: {
-    timestamp: number;
+    timestamp?: number;
     runtime: string;
   };
 }

--- a/templates/unstable-vite-express/app/root.tsx
+++ b/templates/unstable-vite-express/app/root.tsx
@@ -25,8 +25,8 @@ export default function App() {
       <body>
         <Outlet />
         <ScrollRestoration />
-        <LiveReload />
         <Scripts />
+        <LiveReload />
       </body>
     </html>
   );

--- a/templates/unstable-vite/app/root.tsx
+++ b/templates/unstable-vite/app/root.tsx
@@ -25,8 +25,8 @@ export default function App() {
       <body>
         <Outlet />
         <ScrollRestoration />
-        <LiveReload />
         <Scripts />
+        <LiveReload />
       </body>
     </html>
   );


### PR DESCRIPTION
Closes #7863.

This PR fixes a couple issues:

- Resolves a race condition between the React Refresh preamble script and the app code by ensuring that the preamble is imported first in the same script tag as the app code.
- Allows the `LiveReload` component to behave the same as the existing Remix compiler from a consumer perspective. You can now choose _not_ to render it, forcing you to perform a full refresh to see changes, and you can also render it after `Scripts`. I've updated the ordering of `LiveReload` and `Scripts` in the Vite tests to show this is the case.