### PR TITLE
templates(vite): remove `css-bundle`

### DIFF
--- a/templates/unstable-vite-express/app/root.tsx
+++ b/templates/unstable-vite-express/app/root.tsx
@@ -1,5 +1,3 @@
-import { cssBundleHref } from "@remix-run/css-bundle";
-import type { LinksFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -8,10 +6,6 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
-
-export const links: LinksFunction = () => [
-  ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),
-];
 
 export default function App() {
   return (

--- a/templates/unstable-vite-express/package.json
+++ b/templates/unstable-vite-express/package.json
@@ -9,7 +9,6 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@remix-run/css-bundle": "*",
     "@remix-run/express": "*",
     "@remix-run/node": "*",
     "@remix-run/react": "*",

--- a/templates/unstable-vite/app/root.tsx
+++ b/templates/unstable-vite/app/root.tsx
@@ -1,5 +1,3 @@
-import { cssBundleHref } from "@remix-run/css-bundle";
-import type { LinksFunction } from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -8,10 +6,6 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
-
-export const links: LinksFunction = () => [
-  ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),
-];
 
 export default function App() {
   return (

--- a/templates/unstable-vite/package.json
+++ b/templates/unstable-vite/package.json
@@ -9,7 +9,6 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@remix-run/css-bundle": "*",
     "@remix-run/node": "*",
     "@remix-run/react": "*",
     "@remix-run/serve": "*",


### PR DESCRIPTION
The `css-bundle` boilerplate is redundant in the Vite templates because `cssBundleHref` will always resolve to `undefined`.