### PR TITLE
Remove redundant `--watch` argument

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -481,6 +481,7 @@
 - ryanjames1729
 - ryankshaw
 - sarahse
+- sambostock
 - sandulat
 - sandstone991
 - sbernheim4

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "remix build",
-    "dev": "remix dev --manual -c \"node --watch-path server.js --watch server.js\"",
+    "dev": "remix dev --manual -c \"node --watch-path server.js server.js\"",
     "start": "cross-env NODE_ENV=production node ./server.js",
     "typecheck": "tsc"
   },


### PR DESCRIPTION
This removes `--watch` from the `dev` script in the Express template.

The docs for `--watch-path` show it used without `--watch`, and explicitly say that it "starts Node.js in watch mode and specifies what paths to watch." Therefore, since we're already explicitly passing `server.js` as a `--watch-path`, we don't need to specify `--watch`, as Node.js will already be put into watch mode.

See https://nodejs.org/api/cli.html#--watch-path