### PR TITLE
fix(remix-dev/vite): attach CSS from shared chunks to routes

### DIFF
--- a/.changeset/itchy-rabbits-fly.md
+++ b/.changeset/itchy-rabbits-fly.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+fix: include css from code-split assets when "build"

--- a/.changeset/itchy-rabbits-fly.md
+++ b/.changeset/itchy-rabbits-fly.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": patch
 ---
 
-fix: include css from code-split assets when "build"
+Attach CSS from shared chunks to routes in Vite build

--- a/integration/vite-build-test.ts
+++ b/integration/vite-build-test.ts
@@ -233,7 +233,7 @@ test.describe("Vite build", () => {
     expect(pageErrors).toEqual([]);
   });
 
-  test.only("supports code-split css", async ({ page }) => {
+  test("supports code-split css", async ({ page }) => {
     let pageErrors: unknown[] = [];
     page.on("pageerror", (error) => pageErrors.push(error));
 

--- a/integration/vite-build-test.ts
+++ b/integration/vite-build-test.ts
@@ -107,7 +107,7 @@ test.describe("Vite build", () => {
           import { useEffect, useState } from "react";
           import { json } from "@remix-run/node";
           import { useLoaderData } from "@remix-run/react";
-          
+
           import { serverOnly1, serverOnly2 } from "../utils.server";
 
           export const loader = () => {
@@ -137,6 +137,32 @@ test.describe("Vite build", () => {
           ## MDX Route
 
           <MdxComponent />
+        `,
+        "app/routes/code-split1.tsx": js`
+          import { CodeSplitComponent } from "../code-split-component";
+
+          export default function CodeSplit1Route() {
+            return <div id="code-split1"><CodeSplitComponent /></div>;
+          }
+        `,
+        "app/routes/code-split2.tsx": js`
+          import { CodeSplitComponent } from "../code-split-component";
+
+          export default function CodeSplit2Route() {
+            return <div id="code-split2"><CodeSplitComponent /></div>;
+          }
+        `,
+        "app/code-split-component.tsx": js`
+          import classes from "./code-split.module.css";
+
+          export function CodeSplitComponent() {
+            return <span className={classes.test}>ok</span>
+          }
+        `,
+        "app/code-split.module.css": js`
+          .test {
+            background-color: rgb(255, 170, 0);
+          }
         `,
       },
     });
@@ -203,6 +229,28 @@ test.describe("Vite build", () => {
     await expect(page.locator("[data-mdx-route]")).toContainText(
       "MDX route content from loader: mounted"
     );
+
+    expect(pageErrors).toEqual([]);
+  });
+
+  test.only("supports code-split css", async ({ page }) => {
+    let pageErrors: unknown[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error));
+
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/code-split1");
+    expect(
+      await page
+        .locator("#code-split1 span")
+        .evaluate((e) => window.getComputedStyle(e).backgroundColor)
+    ).toBe("rgb(255, 170, 0)");
+
+    await app.goto("/code-split2");
+    expect(
+      await page
+        .locator("#code-split2 span")
+        .evaluate((e) => window.getComputedStyle(e).backgroundColor)
+    ).toBe("rgb(255, 170, 0)");
 
     expect(pageErrors).toEqual([]);
   });


### PR DESCRIPTION
Closes: https://github.com/remix-run/remix/issues/7941

I think the issue was due to asset resolution not taking account for code-split common assets.
I made a reproduction repo here https://github.com/hi-ogawa/test-remix-vite-css-split and this is my observation.
I attached vite manifest and remix manifest generated by `build ` currently.
In vite manifest, `_test-206a75ed.js` entry has reference to `assets/test-ef980167.css`, but there's no direct css dependency neither from `app/root.tsx` or `app/routes/_index.tsx`, so remix manifest ends up with no css.

<details><summary>build/manifest.json (vite manifest)</summary>

```js
{
  "_components-be9f5b54.js": {
    "file": "assets/components-be9f5b54.js",
    "imports": [
      "_jsx-runtime-26afeca0.js"
    ]
  },
  "_jsx-runtime-26afeca0.js": {
    "file": "assets/jsx-runtime-26afeca0.js"
  },
  "_test-206a75ed.js": {
    "css": [
      "assets/test-ef980167.css"
    ],
    "file": "assets/test-206a75ed.js",
    "imports": [
      "_jsx-runtime-26afeca0.js"
    ]
  },
  "app/root.tsx": {
    "file": "assets/root-42156807.js",
    "imports": [
      "_jsx-runtime-26afeca0.js",
      "_test-206a75ed.js",
      "_components-be9f5b54.js"
    ],
    "isEntry": true,
    "src": "app/root.tsx"
  },
  "app/routes/_index.tsx": {
    "file": "assets/_index-01b79c10.js",
    "imports": [
      "_jsx-runtime-26afeca0.js",
      "_test-206a75ed.js"
    ],
    "isEntry": true,
    "src": "app/routes/_index.tsx"
  },
  "node_modules/.pnpm/@remix-run+dev@0.0.0-nightly-8543efe-20231108_@remix-run+serve@0.0.0-nightly-8543efe-20231108_fetfjcoiwibmio4yfoqtdictta/node_modules/@remix-run/dev/dist/config/defaults/entry.client.tsx": {
    "file": "assets/entry.client-b45bdf04.js",
    "imports": [
      "_jsx-runtime-26afeca0.js",
      "_components-be9f5b54.js"
    ],
    "isEntry": true,
    "src": "node_modules/.pnpm/@remix-run+dev@0.0.0-nightly-8543efe-20231108_@remix-run+serve@0.0.0-nightly-8543efe-20231108_fetfjcoiwibmio4yfoqtdictta/node_modules/@remix-run/dev/dist/config/defaults/entry.client.tsx"
  },
  "test.css": {
    "file": "assets/test-ef980167.css",
    "src": "test.css"
  }
}
```

</details>

<details><summary>build/manifest-(hash).js (remix manifest)</summary>

```js
window.__remixManifest = {
  entry: {
    module: "/build/assets/entry.client-b45bdf04.js",
    imports: [
      "/build/assets/jsx-runtime-26afeca0.js",
      "/build/assets/components-be9f5b54.js",
    ],
    css: [],
  },
  routes: {
    root: {
      id: "root",
      path: "",
      hasAction: false,
      hasLoader: false,
      hasErrorBoundary: false,
      module: "/build/assets/root-42156807.js",
      imports: [
        "/build/assets/jsx-runtime-26afeca0.js",
        "/build/assets/test-206a75ed.js",
        "/build/assets/components-be9f5b54.js",
      ],
      css: [],
    },
    "routes/_index": {
      id: "routes/_index",
      parentId: "root",
      index: true,
      hasAction: false,
      hasLoader: false,
      hasErrorBoundary: false,
      module: "/build/assets/_index-01b79c10.js",
      imports: [
        "/build/assets/jsx-runtime-26afeca0.js",
        "/build/assets/test-206a75ed.js",
      ],
      css: [],
    },
  },
  url: "/build/manifest-04ec219c.js",
  version: "04ec219c",
};

```

</details>

I fixed the issue by traversing `ViteManifest[key].imports` to collect depending assets of given route entry.
(I had similar issue when I was experimenting my own plugin, so the code is roughly based on https://github.com/hi-ogawa/vite-plugins/blob/0591f50b53ebd6027653a0902b50a492820fbbab/packages/vite-glob-routes/src/react-router/features/preload/shared.ts#L50-L59)

I locally verified that this PR fixed my reproduction https://github.com/hi-ogawa/test-remix-vite-css-split/pull/1 and also added a new test case for `vite-build-test.ts`.

- [ ] Docs
- [x] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
