### PR TITLE
feat(remix-dev/vite): support HMR for MDX

### DIFF
--- a/.changeset/four-bottles-bathe.md
+++ b/.changeset/four-bottles-bathe.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+feat: support HMR for MDX

--- a/integration/vite-dev-test.ts
+++ b/integration/vite-dev-test.ts
@@ -164,6 +164,10 @@ test.describe("Vite dev", () => {
           ## MDX Route
 
           <MdxComponent />
+
+          ### HMR updated: no
+
+          <input />
         `,
       },
     });
@@ -296,6 +300,23 @@ test.describe("Vite dev", () => {
 
     let mdxContent = page.locator("[data-mdx-route]");
     await expect(mdxContent).toHaveText("MDX route content from loader");
+
+    // verify HMR
+    let hmrStatus = page.locator("h3");
+    await expect(hmrStatus).toHaveText("HMR updated: no");
+
+    let input = page.locator("input");
+    await input.type("stateful");
+
+    let filepath = path.join(projectDir, "app/routes/mdx.mdx");
+    let src = await fs.readFile(filepath, "utf8");
+    await fs.writeFile(
+      filepath,
+      src.replace("HMR updated: no", "HMR updated: yes"),
+      "utf8"
+    );
+    await expect(hmrStatus).toHaveText("HMR updated: yes");
+    await expect(input).toHaveValue("stateful");
 
     expect(pageErrors).toEqual([]);
   });

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -835,7 +835,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
         if (id.includes("/node_modules/")) return;
 
         let [filepath] = id.split("?");
-        if (!/.[tj]sx?$/.test(filepath)) return;
+        if (!/\.(mdx|[tj]sx?)$/.test(filepath)) return;
 
         let devRuntime = "react/jsx-dev-runtime";
         let ssr = options?.ssr === true;


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: https://github.com/remix-run/remix/issues/7788

I went over some relevant discussions and other implementations regarding HMR-ing MDX:

- https://github.com/vitejs/vite-plugin-react/issues/38
- https://github.com/cyco130/vite-plugin-mdx/blob/main/packages/vite-plugin-mdx/src/index.ts#L84
- https://github.com/mdx-js/mdx/blob/main/packages/rollup/lib/index.js

and my conclusion is that HMR should just work as long as MDX files goes through "react-refresh/babel" transform.
Currently `remix-react-refresh-babel` already `enforce: "post"` and `@mdx-js/rollup` has no `enforce`, so simply tweaking regex filter to allow `.mdx` seems to be enough.

However, as it's already mentioned, mdx uses `export` for local variable and also for `frontmatter` plugin, so this unfortunately forces full-reload when mdx includes frontmatter, but I think this might be okay for starter.
Please let me know if it's desired to improve more HMR feature for MDX (for example, maybe extend HMR `acceptExports` trick to cover `frontmatter` in some way? or improve "Could not Fast Refresh" message for `frontmatter`?).
Thanks!

---

- [ ] Docs
- [x] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
