### PR TITLE
Add link to streaming guide in `defer` doc

### DIFF
--- a/docs/utils/defer.md
+++ b/docs/utils/defer.md
@@ -5,6 +5,8 @@ toc: false
 
 # `defer`
 
+To get started with streaming data, check out the [Streaming Guide][streaming_guide].
+
 This is a shortcut for creating a streaming/deferred response. It assumes you are using `utf-8` encoding. From a developer perspective it behaves just like [`json()`][json], but with the ability to transport promises to your UI components.
 
 ```tsx lines=[1,7-10]


### PR DESCRIPTION
[Lee Robinson made a good point](https://twitter.com/leeerob/status/1723115296645361974) that we should probably link back to the Streaming Guide doc in the `defer` API doc

Closes: #

- [x] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
