### PR TITLE
feat(remix-dev/vite): add `serverBuildEntry` option and resolve `@remix-run/dev/server-build` virtual module

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -494,7 +494,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
               "@remix-run/react",
             ],
             // prevent virtual modules (e.g. @remix-run/dev/server-build) from being optimized
-            // (note that optimization would make this vite plugin's transform to be skipped)
+            // (note that optimization would skip custom resolution/transformation by vite plugins)
             exclude: ["@remix-run/dev"],
           },
           ssr: {

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -55,6 +55,7 @@ export type RemixVitePluginOptions = Pick<
   SupportedRemixConfigKey
 > & {
   legacyCssImports?: boolean;
+  serverBuildEntry?: string;
 };
 
 type ResolvedRemixVitePluginConfig = Pick<
@@ -530,7 +531,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
                     rollupOptions: {
                       ...viteUserConfig.build?.rollupOptions,
                       preserveEntrySignatures: "exports-only",
-                      input: serverEntryId,
+                      input: options.serverBuildEntry ?? serverEntryId,
                       output: {
                         entryFileNames: path.basename(
                           pluginConfig.serverBuildPath
@@ -647,7 +648,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
               }
               let { url } = req;
               let build = await (vite.ssrLoadModule(
-                serverEntryId
+                options.serverBuildEntry ?? serverEntryId
               ) as Promise<ServerBuild>);
 
               let criticalCss = await getStylesForUrl(


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

I was thinking how I could support cloudflare workers (and possibly other runtime/deployment) for both dev and build.
After some experiment, allowing to customize server build entry seems to give a nice flexibility to achieve this.
(EDIT: Initially I forgot to mention that just supporting such option is not enough. This essentially also requires down-stream code to directly consume `import * as remixBuild from "virtual:server-entry"`, which is similar to what `"@remix-run/dev/server-build"` provides.)

I made a small demo in https://github.com/hi-ogawa/demo-remix-unstable-vite-cloudflare-workers.
The idea is a mix of:
- `@vavite/connect` plugin's `handlerEntry` option https://github.com/cyco130/vavite/blob/main/packages/connect/readme.md#handlerentry-string--handler
- `@hono/vite-dev-server` plugin's use of `Miniflare` to provide cloudflare-workers-like runtime within vite dev server https://github.com/honojs/vite-plugins/blob/b67a7c279f31c6c37b2dd71fbbd85e6486feb043/packages/dev-server/src/dev-server.ts#L55

One fundamental difference from current (pre-vite) remix's cloudflare workers support is that, during dev, the server runtime is not genuine workerd runtime (provided by `wrangler dev`), but it's nothing but nodejs mimicking workerd runtime via miniflare.
This could be a deal breaker because of potential dev/build inconsistency, but this approach can still allow using `wrangler dev` for local preview build to test it out, so it might be acceptable. My demo repository includes tests for both `vite dev` and `wrangler dev`.

Please let me know what you think about exposing this API.
Thanks!

## plans

- [x] resolve `@remix-run/dev/server-build` as `virtual:server-entry`?
- [ ] test
- [ ] discuss API
- [ ] create `unstable-vite-cloudflare-workers` template?
- [ ] rewrite `unstable-vite-express` template using `@remix-run/dev/server-build`?
  - output `handler.js` for custom server use cases? (cf. https://kit.svelte.dev/docs/adapter-node#custom-server)