### PR TITLE
docs(remix-react): add JSDoc to LiveReload component

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -17,6 +17,7 @@
 - akamfoad
 - alanhoskins
 - Alarid
+- alcpereira
 - alex-ketch
 - alexmgrant
 - alextes

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1041,8 +1041,13 @@ export function useFetcher<TData = AppData>(
   return useFetcherRR(opts);
 }
 
-// Dead Code Elimination magic for production builds.
-// This way devs don't have to worry about doing the NODE_ENV check themselves.
+/**
+ * This component connects your app to the Remix asset server and 
+ * automatically reloads the page when files change in development.
+ * In production, it renders null, so you can safely render it always in your root route.
+ * 
+ * @see https://remix.run/docs/components/live-reload
+ */
 export const LiveReload =
   process.env.NODE_ENV !== "development"
     ? () => null

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -1042,13 +1042,15 @@ export function useFetcher<TData = AppData>(
 }
 
 /**
- * This component connects your app to the Remix asset server and 
+ * This component connects your app to the Remix asset server and
  * automatically reloads the page when files change in development.
  * In production, it renders null, so you can safely render it always in your root route.
- * 
+ *
  * @see https://remix.run/docs/components/live-reload
  */
 export const LiveReload =
+  // Dead Code Elimination magic for production builds.
+  // This way devs don't have to worry about doing the NODE_ENV check themselves.
   process.env.NODE_ENV !== "development"
     ? () => null
     : function LiveReload({


### PR DESCRIPTION
`LiveReload` component did not have a proper JSDoc, that might be confusing for new users when seeing this component in the `root.tsx`.