### PR TITLE
fix(remix-dev/vite): allow custom `NODE_ENV` for `vite dev`

### DIFF
--- a/.changeset/hungry-tables-hang.md
+++ b/.changeset/hungry-tables-hang.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": patch
 ---
 
-fix: allow custom NODE_ENV on vite dev with remix plugin
+Allow `process.env.NODE_ENV` values other than `"development"` in Vite dev

--- a/.changeset/hungry-tables-hang.md
+++ b/.changeset/hungry-tables-hang.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+fix: allow custom NODE_ENV on vite dev with remix plugin

--- a/integration/vite-dev-test.ts
+++ b/integration/vite-dev-test.ts
@@ -204,7 +204,7 @@ test.describe("Vite dev", () => {
     let viteBin = resolveBin.sync("vite");
     devProc = spawn(nodeBin, [viteBin, "dev"], {
       cwd: projectDir,
-      env: { ...process.env, NODE_ENV: "test" },
+      env: process.env,
       stdio: "pipe",
     });
     let devStdout = bufferize(devProc.stdout);

--- a/integration/vite-dev-test.ts
+++ b/integration/vite-dev-test.ts
@@ -204,7 +204,7 @@ test.describe("Vite dev", () => {
     let viteBin = resolveBin.sync("vite");
     devProc = spawn(nodeBin, [viteBin, "dev"], {
       cwd: projectDir,
-      env: process.env,
+      env: { ...process.env, NODE_ENV: "test" },
       stdio: "pipe",
     });
     let devStdout = bufferize(devProc.stdout);

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -896,7 +896,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
             allowAwaitOutsideFunction: true,
             plugins: ["jsx", "typescript"],
           },
-          plugins: [require("react-refresh/babel")],
+          plugins: [[require("react-refresh/babel"), { skipEnvCheck: true }]],
           sourceMaps: true,
         });
         if (result === null) return;

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -815,7 +815,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
           return [
             'import { createElement } from "react";',
             'export * from "@remix-run/react";',
-            'export const LiveReload = process.env.NODE_ENV !== "development" ? () => null : ',
+            `export const LiveReload = ${viteCommand !== "serve"} ? () => null : `,
             '() => createElement("script", {',
             "  dangerouslySetInnerHTML: { ",
             "    __html: `window.__remixLiveReloadEnabled = true`",


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: https://github.com/remix-run/remix/issues/7918

This can be achieved by
- set `skipEnvCheck: true` for `react-refresh/babel` plugin, and
- update `LiveReload` to check `viteCommand = "serve"` instead of `NODE_ENV = "development"`

I initially thought the error `"React Refresh Babel transform should only be enabled in development environment."` only manifests when remix plugin is (unintentionally) loaded on vitest, but I found that this can also happen, for example, when doing `NODE_ENV=test vite dev`.
So, I think it makes sense to disable this check (and also allow HMR) for other NODE_ENV as well since it looks like too-opinionated restriction. Also remix itself applies this transform only on `"serve"` command, so such warning is irrelevant.

Also note that this is yet-another compatibility with `@vitejs/plugin-react`, which also uses `skipEnvCheck: true`:
https://github.com/vitejs/vite-plugin-react/blob/38b3cece51644f3d4ba78e2352717b5077bd4637/packages/plugin-react/src/index.ts#L196-L199

## Testing Strategy:

I didn't add a test case since it felt a little redundant. But, to verify the behavior, I locally checked `vite-dev-test.ts` still passes after manually modifying `NODE_ENV: "test"` here:

https://github.com/remix-run/remix/blob/25181c69623267c0fa0b92c075b2c2eafb6afd18/integration/vite-dev-test.ts#L205-L209

```diff
- env: process.env,
+ env: { ...process.env, NODE_ENV: "test" },
```