### PR TITLE
fix(remix-dev/vite): instantiate plugins independently for child vite compiler

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -547,9 +547,12 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
       async configResolved(viteConfig) {
         await initEsModuleLexer;
 
-        // load same config file again for child compiler so that each parent/child compiler plugins have independent state.
-        // reusing `viteUserConfig.plugins` for child compiler would lead to mutating single plugin instance in an unexpected way.
-        // (for example, when `vite build`, `config` plugin hook is called with `command = "build"` by parent and then `command = "serve"` by child)
+        // load same config file again for child compiler so that
+        // parent and child compiler's plugins have independent state.
+        // note that reusing `viteUserConfig.plugins` for child compiler would lead
+        // to mutating single plugin instance in an unexpected way,
+        // for example, during `vite build`, `configResolved` plugin hook would called
+        // with `command = "build"` by parent and then `command = "serve"` by child.
         let childConfig = await loadConfigFromFile(
           {
             command: viteConfig.command,
@@ -572,23 +575,6 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
           configFile: false,
           envFile: false,
           plugins: [
-            // ...(viteUserConfig.plugins ?? [])
-            //   .flat()
-            //   // Exclude this plugin from the child compiler to prevent an
-            //   // infinite loop (plugin creates a child compiler with the same
-            //   // plugin that creates another child compiler, repeat ad
-            //   // infinitum), and to prevent the manifest from being written to
-            //   // disk from the child compiler. This is important in the
-            //   // production build because the child compiler is a Vite dev
-            //   // server and will generate incorrect manifests.
-            //   .filter(
-            //     (plugin) =>
-            //       typeof plugin === "object" &&
-            //       plugin !== null &&
-            //       "name" in plugin &&
-            //       plugin.name !== "remix" &&
-            //       plugin.name !== "remix-hmr-updates"
-            //   ),
             ...(childConfig?.config.plugins ?? [])
               .flat()
               // Exclude this plugin from the child compiler to prevent an


### PR DESCRIPTION
Closes: https://github.com/remix-run/remix/issues/7989

The same issue is already indicated in https://github.com/remix-run/remix/pull/7911#issue-1977584283 but this time, `@vanilla-extract/vite-plugin` is affected by the issue since it makes use of `config.command = "server" or "build"` to switch plugin behavior.
Specifically, the plugin uses this pattern:

```tsx
export function vanillaExtractPlugin({
  ...
}: Options = {}): Plugin {
  let config: ResolvedConfig;
  ...

  return {
    name: 'vanilla-extract',
    ...
    async configResolved(resolvedConfig) {
      config = resolvedConfig;
      ...
    }

   // ... in later hooks (e.g. transform), it uses `config.command === 'build'` check to switch behavior ...
```

During `vite build`, child compiler calls `configResolved` 2nd time with `config.command: "serve"`, so it forces parent compiler to also behave in the same way.

This PR fixes this issue by loading user vite config file independently for child compiler (via `loadConfigFromFile`), which will ensure that plugin states won't be mixed between parent and child even though they still have different `confg.command`.

One issue with this approach is that it also "doubles" remix's own plugin as well, which might cause some issues (or at least negative perf impact). For example, the child compiler is going to have independent `resolvePluginConfig` cache etc... as it's used for `"remix-remove-server-exports"` and `"remix-react-refresh-babel"` plugins which are not removed for child compiler.

## Testing Strategy

This PR is tested on reproduction repository https://github.com/mrm007/remix-vite-vanilla-repro/pull/1.
I'll also add a playwright test here.
