### PR TITLE
fix(remix-dev/vite): skip "vanilla-extract" plugin in child compiler

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -573,6 +573,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
                   typeof plugin === "object" &&
                   plugin !== null &&
                   "name" in plugin &&
+                  plugin.name !== "vanilla-extract" &&
                   plugin.name !== "remix" &&
                   plugin.name !== "remix-hmr-updates"
               ),


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: https://github.com/remix-run/remix/issues/7989

This is less general approach of fixing the issue, but for the specific case of `vanilla-extract`, this could be a reasonable workaround.
My assumption is that `vanilla-extract` works on top of standard typescript/javascript (i.e not extending any syntactic feature), so probably applying this plugin for child compiler is not necessary.

Testing Strategy:

The reproduction fix is verified with same patch https://github.com/mrm007/remix-vite-vanilla-repro/pull/2
