### PR TITLE
refactor(remix-dev/vite): remove redundant `jsx` and `typescript` babel plugins + remove `remix-react-refresh-babel` plugin from child vite compiler

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -908,7 +908,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
     },
     {
       name: "remix-react-refresh-babel",
-      enforce: "post",
+      enforce: "post", // jsx and typescript (in ts, jsx, tsx files) are already transpiled by vite
       async transform(code, id, options) {
         if (viteCommand !== "serve") return;
         if (id.includes("/node_modules/")) return;
@@ -928,7 +928,6 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
           parserOpts: {
             sourceType: "module",
             allowAwaitOutsideFunction: true,
-            plugins: ["jsx", "typescript"],
           },
           plugins: [[require("react-refresh/babel"), { skipEnvCheck: true }]],
           sourceMaps: true,

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -611,6 +611,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
                   plugin !== null &&
                   "name" in plugin &&
                   plugin.name !== "remix" &&
+                  plugin.name !== "remix-react-refresh-babel" &&
                   plugin.name !== "remix-hmr-updates"
               ),
             {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

While investigating mdx hmr in https://github.com/remix-run/remix/pull/7954, I noticed that `"remix-react-refresh-babel"` plugin's `transform` is receiving already transpiled plain js file, so I think we don't need to add `plugins: ["jsx", "typescript"]` for bebel transform.

One thing to note is that this is a different from `@vitejs/plugin-react`, which uses `enforce: "pre"`. In their case, they are intercepting before vite's internal transform, so jsx/typescript handling is required:
https://github.com/vitejs/vite-plugin-react/blob/0cd00a5bf59fe1b326c667efb9c340732c6b0630/packages/plugin-react/src/index.ts#L119-L120

Assuming this first idea is valid,  I think remix can then remove `remix-react-refresh-babel` plugin from child vite compiler since the purpose of child compiler is currently only for extracting exports of route file by `getRouteModuleExports` and injecting HMR-related code is not necessary as long as code is transformed to plain js.
This could help perf by reducing unnecessary babel transform (though it might not be a significant gain).

## Testing Strategy

I think existing tests should be enough to verify the correctness of this idea.
