### PR TITLE
Update crossOrigin value used in links documentation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -61,6 +61,7 @@
 - benwis
 - bgschiller
 - binajmen
+- bmac
 - bmarvinb
 - bmontalvo
 - bogas04

--- a/docs/route/links.md
+++ b/docs/route/links.md
@@ -58,7 +58,7 @@ export const links: LinksFunction = () => {
     {
       rel: "stylesheet",
       href: "https://example.com/some/styles.css",
-      crossOrigin: "true",
+      crossOrigin: "anonymous",
     },
 
     // add a local stylesheet, remix will fingerprint the file name for


### PR DESCRIPTION
Valid values are "anonymous" | "use-credentials". https://github.com/remix-run/remix/blob/43387828b3079d7f1f839b6bafa02e911f2be421/packages/remix-server-runtime/links.ts#L16

