### PR TITLE
Fix broken `resolvePath` link in `use-resolved-path` docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -484,9 +484,10 @@
 - ryanflorence
 - ryanjames1729
 - ryankshaw
-- sarahse
+- sambostock
 - sandulat
 - sandstone991
+- sarahse
 - sbernheim4
 - schpet
 - scottybrown

--- a/docs/hooks/use-resolved-path.md
+++ b/docs/hooks/use-resolved-path.md
@@ -22,7 +22,7 @@ This is useful when building links from relative values and used internally for 
 
 ## Additional Resources
 
-- [`resolvePath`][resolve-path]
+- [`resolvePath`][rr-resolve-path]
 
 [nav-link-component]: ../components/nav-link
-[resolve-path]: ../utils/resolve-path
+[rr-resolve-path]: https://reactrouter.com/utils/resolve-path


### PR DESCRIPTION
This fixes a broken link in the docs:

```diff
-https://remix.run/docs/utils/resolve-path
+https://reactrouter.com/utils/resolve-path
```