### PR TITLE
fix(vite): disable redundant copyPublicDir option

### DIFF
--- a/.changeset/proud-otters-cheat.md
+++ b/.changeset/proud-otters-cheat.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": patch
 ---
 
-Fix redundant copying of assets from `public` directory in Vite build. This ensures that static assets aren't duplicated in `serverBuildDirectory`. This also fixes an issue where the build would break if `assetsBuildDirectory` was deeply nested within the `public` directory.
+Fix redundant copying of assets from `public` directory in Vite build. This ensures that static assets aren't duplicated in the server build directory. This also fixes an issue where the build would break if `assetsBuildDirectory` was deeply nested within the `public` directory.

--- a/.changeset/proud-otters-cheat.md
+++ b/.changeset/proud-otters-cheat.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fix redundant copying of assets from `public` directory in Vite build. This ensures that static assets aren't duplicated in `serverBuildDirectory`. This also fixes an issue where the build would break if `assetsBuildDirectory` was deeply nested within the `public` directory.

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -519,6 +519,13 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
             base: pluginConfig.publicPath,
             build: {
               ...viteUserConfig.build,
+              // By convention Remix builds into a subdirectory within the
+              // public directory ("public/build" by default) so we don't want
+              // to copy the contents of the public directory around. This also
+              // ensures that we don't get caught in an infinite loop when
+              // `assetsBuildDirectory` is nested multiple levels deep within
+              // the public directory, e.g. "public/custom-base-dir/build"
+              copyPublicDir: false,
               ...(!isSsrBuild
                 ? {
                     manifest: true,


### PR DESCRIPTION
Fixes #8023

From the changeset:

> Fix redundant copying of assets from `public` directory in Vite build. This ensures that static assets aren't duplicated in the server build directory. This also fixes an issue where the build would break if `assetsBuildDirectory` was deeply nested within the `public` directory.