### PR TITLE
fix(remix-dev/vite): keep code-split JS files in SSR build

### DIFF
--- a/.changeset/modern-pans-happen.md
+++ b/.changeset/modern-pans-happen.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": patch
 ---
 
-Keep code-split js files from ssr build and delete only unnecessary assets
+Keep code-split JS files in Vite server build and only delete static assets and CSS files

--- a/.changeset/modern-pans-happen.md
+++ b/.changeset/modern-pans-happen.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": patch
 ---
 
-Keep code-split JS files in Vite server build and only delete static assets and CSS files
+Ensure code-split JS files in the server build's assets directory aren't cleaned up after Vite build

--- a/.changeset/modern-pans-happen.md
+++ b/.changeset/modern-pans-happen.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Keep SSR build assets directory to support code-split js files (e.g. due to dynamic import)

--- a/.changeset/modern-pans-happen.md
+++ b/.changeset/modern-pans-happen.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": patch
 ---
 
-Keep SSR build assets directory to support code-split js files (e.g. due to dynamic import)
+Keep code-split js files from ssr build and delete only unnecessary assets

--- a/integration/vite-build-test.ts
+++ b/integration/vite-build-test.ts
@@ -368,4 +368,11 @@ test.describe("Vite build", () => {
 
     expect(pageErrors).toEqual([]);
   });
+
+  test("keep only code-split js files in ssr build asssets", async () => {
+    let assetFiles = glob.sync("*", {
+      cwd: path.join(fixture.projectDir, "build/assets"),
+    });
+    expect(assetFiles).toEqual(["ssr-code-split-lib-l8BW9uKL.js"]);
+  });
 });

--- a/integration/vite-build-test.ts
+++ b/integration/vite-build-test.ts
@@ -331,7 +331,7 @@ test.describe("Vite build", () => {
     expect(pageErrors).toEqual([]);
   });
 
-  test("removes assets and CSS files from SSR build", async () => {
+  test("removes assets (other than code-split JS) and CSS files from SSR build", async () => {
     let assetFiles = glob.sync("*", {
       cwd: path.join(fixture.projectDir, "build/assets"),
     });

--- a/integration/vite-build-test.ts
+++ b/integration/vite-build-test.ts
@@ -373,6 +373,7 @@ test.describe("Vite build", () => {
     let assetFiles = glob.sync("*", {
       cwd: path.join(fixture.projectDir, "build/assets"),
     });
-    expect(assetFiles).toEqual(["ssr-code-split-lib-l8BW9uKL.js"]);
+    expect(assetFiles.length).toEqual(1);
+    expect(assetFiles[0]).toMatch(/ssr-code-split-lib-.*\.js/);
   });
 });

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -535,9 +535,9 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
                     },
                   }
                 : {
-                    // We move SSR-only assets to client assets.
+                    // We copy SSR-only assets to client assets.
                     // Note that ssr build can also emit code-split js files (e.g. by dynamic import)
-                    // under the same assets directory (regardless of ssrEmitAssets option),
+                    // under the same assets directory regardless of "ssrEmitAssets" option,
                     // but such js files have to be kept as is.
                     ssrEmitAssets: true,
                     manifest: true, // We need the manifest to detect SSR-only assets
@@ -793,7 +793,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
             Array.from(ssrOnlyAssetPaths).map(async (ssrAssetPath) => {
               let src = path.join(serverBuildDir, ssrAssetPath);
               let dest = path.join(assetsBuildDirectory, ssrAssetPath);
-              await fse.move(src, dest);
+              await fse.copy(src, dest);
               return dest;
             })
           );

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -795,10 +795,9 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
             )
           );
 
+          // Only move assets that aren't in the client build, otherwise remove them
           let movedAssetPaths: string[] = [];
           for (let ssrAssetPath of ssrAssetPaths) {
-            // Only move assets that aren't in the client build
-            // otherwise remove a file
             let src = path.join(serverBuildDir, ssrAssetPath);
             if (!clientAssetPaths.has(ssrAssetPath)) {
               let dest = path.join(assetsBuildDirectory, ssrAssetPath);
@@ -809,7 +808,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
             }
           }
 
-          // we assume css from server build is unncessary and delete them for cleaner build output
+          // we assume css from server build is unncessary and remove them for cleaner build output
           let ssrCssPaths = Object.values(ssrViteManifest).flatMap(
             (chunk) => chunk.css ?? []
           );

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -537,7 +537,8 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
                 : {
                     // We move SSR-only assets to client assets.
                     // Note that ssr build can also emit code-split js files (e.g. by dynamic import)
-                    // under the same assets directory, but such js files have to be kept as is.
+                    // under the same assets directory (regardless of ssrEmitAssets option),
+                    // but such js files have to be kept as is.
                     ssrEmitAssets: true,
                     manifest: true, // We need the manifest to detect SSR-only assets
                     outDir: path.dirname(pluginConfig.serverBuildPath),

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -784,19 +784,18 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
           let clientViteManifest = await loadViteManifest(assetsBuildDirectory);
 
           let clientAssetPaths = new Set(
-            Object.values(clientViteManifest).flatMap((chunk) => [
-              ...(chunk.assets ?? []),
-            ])
+            Object.values(clientViteManifest).flatMap(
+              (chunk) => chunk.assets ?? []
+            )
           );
 
           let ssrAssetPaths = new Set(
-            Object.values(ssrViteManifest).flatMap((chunk) => [
-              ...(chunk.assets ?? []),
-            ])
+            Object.values(ssrViteManifest).flatMap(
+              (chunk) => chunk.assets ?? []
+            )
           );
 
           let movedAssetPaths: string[] = [];
-
           for (let ssrAssetPath of ssrAssetPaths) {
             // Only move assets that aren't in the client build
             // otherwise remove a file

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -535,7 +535,10 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
                     },
                   }
                 : {
-                    ssrEmitAssets: true, // We move SSR-only assets to client assets and clean the rest
+                    // We move SSR-only assets to client assets.
+                    // Note that ssr build can also emit code-split js files (e.g. by dynamic import)
+                    // under the same assets directory, but such js files have to be kept as is.
+                    ssrEmitAssets: true,
                     manifest: true, // We need the manifest to detect SSR-only assets
                     outDir: path.dirname(pluginConfig.serverBuildPath),
                     rollupOptions: {
@@ -809,15 +812,6 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
                 "",
               ].join("\n")
             );
-          }
-
-          let ssrAssetsDir = path.join(
-            resolvedViteConfig.build.outDir,
-            resolvedViteConfig.build.assetsDir
-          );
-
-          if (fse.existsSync(ssrAssetsDir)) {
-            await fse.remove(ssrAssetsDir);
           }
         },
       },


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: https://github.com/remix-run/remix/issues/8041
Follow up for https://github.com/remix-run/remix/pull/7892

EDIT: following comment is for initial approach. Now it's written to remove only unnecessary files based on the suggestion in  https://github.com/remix-run/remix/pull/8042#issuecomment-1817261780

---

Instead of keeping whole `assets` directory, maybe we could probe vite manifest and keep only `isDynamicEntry`.
(EDIT: I further extended reproduction https://github.com/hi-ogawa/remix-reproduction-8041 and I found that `isDynamicEntry` is not a right way to detect this)

For example, vite manifest from ssr build for `vite-build-test.ts` looks like this:

<details><summary>reveal build/.vite/manifest.json</summary>

(here `assets/test2-LxNzCzR4.txt` is server-only assets, so it's moved to client assets directory. `assets/test1-eT52RzBS.txt` and `assets/_virtual_server-entry-119NVDiu.css` are unnecessary files to keep.)

```json
{
  "app/assets/test1.txt": {
    "file": "assets/test1-eT52RzBS.txt",
    "src": "app/assets/test1.txt"
  },
  "app/assets/test2.txt": {
    "file": "assets/test2-LxNzCzR4.txt",
    "src": "app/assets/test2.txt"
  },
  "app/ssr-code-split-lib.ts": {
    "file": "assets/ssr-code-split-lib-l8BW9uKL.js",
    "isDynamicEntry": true,
    "src": "app/ssr-code-split-lib.ts"
  },
  "virtual:server-entry": {
    "assets": [
      "assets/test1-eT52RzBS.txt",
      "assets/test2-LxNzCzR4.txt"
    ],
    "css": [
      "assets/_virtual_server-entry-119NVDiu.css"
    ],
    "dynamicImports": [
      "app/ssr-code-split-lib.ts"
    ],
    "file": "index.js",
    "isEntry": true,
    "src": "virtual:server-entry"
  }
}
```

</details>

However, I don't think it's so important to clean up the rest so strictly (and also I'm not entirely sure if there could be more edge cases which I'm not aware of). So, I chose to keep the directory as is.
Please let me know what you think!