### PR TITLE
fix(remix-dev/vite): remove http2 pseudo headers from internal request

### DIFF
--- a/.changeset/good-pandas-burn.md
+++ b/.changeset/good-pandas-burn.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fix validation error due to http2 pseudo headers

--- a/packages/remix-dev/vite/node/adapter.ts
+++ b/packages/remix-dev/vite/node/adapter.ts
@@ -67,6 +67,11 @@ function createHeaders(requestHeaders) {
   let headers = new Headers();
 
   for (let [key, values] of Object.entries(requestHeaders)) {
+    // skip http2 pseudo headers since it would cause validation error
+    // in @remix-run/web-fetch's Headers polyfill
+    if (key.startsWith(":")) {
+      continue;
+    }
     if (values) {
       if (Array.isArray(values)) {
         for (let value of values) {


### PR DESCRIPTION
Closes: https://github.com/remix-run/remix/issues/7867

I'm thinking this PR could help as a short term workaround for `@remix-run/web-fetch` Headers validation error.
This might not be a mandatory since there is a simple user side workaround by setting `server: { proxy: {} }` in vite config.

Also as I wrote in https://github.com/remix-run/remix/issues/7867#issuecomment-1817366255, the removal of `@remix-run/web-fetch` polyfill would also make this workaround obsolete, so if remix team has a plan to remove automatic polyfills for newer node versions (this could be related? https://github.com/remix-run/remix/discussions/7823), then this change will not be necessary.

Please let me know if there's any concern with this approach.

### Testing Strategy:
I verified the same patch fixes my reproduction https://github.com/hi-ogawa/remix-reproduction-7867/pull/2