### PR TITLE
docs: update msw example to msw@2.x version + add ESM related details

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -614,3 +614,4 @@
 - mrkstwrt
 - AltanS
 - fayez-nazzal
+- mccuna

--- a/docs/other-api/dev.md
+++ b/docs/other-api/dev.md
@@ -200,7 +200,7 @@ For example, you can use `NODE_OPTIONS` to set Node's `--require` flag when runn
 Next, you can use `REMIX_DEV_ORIGIN` to let MSW forward internal "dev ready" messages on `/ping`:
 
 ```ts
-import { rest } from "msw";
+import { http, passthrough } from "msw";
 
 const REMIX_DEV_PING = new URL(
   process.env.REMIX_DEV_ORIGIN
@@ -208,7 +208,7 @@ const REMIX_DEV_PING = new URL(
 REMIX_DEV_PING.pathname = "/ping";
 
 export const server = setupServer(
-  rest.post(REMIX_DEV_PING.href, (req) => req.passthrough())
+  http.post(REMIX_DEV_PING.href, () => passthrough())
   // ... other request handlers go here ...
 );
 ```

--- a/docs/other-api/dev.md
+++ b/docs/other-api/dev.md
@@ -197,6 +197,17 @@ For example, you can use `NODE_OPTIONS` to set Node's `--require` flag when runn
 }
 ```
 
+If you're using ESM as the default module system you will need to set the `--import` flag instead of `--require`:
+
+```json filename=package.json
+{
+  "scripts": {
+    "dev": "remix dev -c \"npm run dev:app\"",
+    "dev:app": "cross-env NODE_OPTIONS=\"--import ./mocks/index.js\" remix-serve ./build/index.js"
+  }
+}
+```
+
 Next, you can use `REMIX_DEV_ORIGIN` to let MSW forward internal "dev ready" messages on `/ping`:
 
 ```ts


### PR DESCRIPTION
I've updated the msw example based on the breaking changes they introduced in v2. Also, considering that Kent's epic-stack uses ESM by default I've added a few details regarding ESM modules to the msw example (might be useful for people using epic-stack as a reference).