### PR TITLE
fix(vite): apply `normalizePath` to default entry file outside of project directory

### DIFF
--- a/.changeset/green-balloons-promise.md
+++ b/.changeset/green-balloons-promise.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fix out-of-tree default client entry import url on Window

--- a/.changeset/green-balloons-promise.md
+++ b/.changeset/green-balloons-promise.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": patch
 ---
 
-Fix out-of-tree default client entry import url on Window
+Vite: fix access to default `entry.{client,server}.tsx` within pnpm workspace on Windows

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -91,7 +91,7 @@ const resolveFileUrl = (
   // Vite will prevent serving files outside of the workspace
   // unless user explictly opts in with `server.fs.allow`
   // https://vitejs.dev/config/server-options.html#server-fs-allow
-  if (!isWithinRoot) return `/@fs` + filePath;
+  if (!isWithinRoot) return `/@fs` + normalizePath(filePath);
 
   return `/${normalizePath(relativePath)}`;
 };

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -91,7 +91,7 @@ const resolveFileUrl = (
   // Vite will prevent serving files outside of the workspace
   // unless user explictly opts in with `server.fs.allow`
   // https://vitejs.dev/config/server-options.html#server-fs-allow
-  if (!isWithinRoot) return `/@fs` + normalizePath(filePath);
+  if (!isWithinRoot) return path.posix.join(`/@fs`, normalizePath(filePath));
 
   return `/${normalizePath(relativePath)}`;
 };

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -75,11 +75,6 @@ let remixReactProxyId = VirtualModule.id("remix-react-proxy");
 let hmrRuntimeId = VirtualModule.id("hmr-runtime");
 let injectHmrRuntimeId = VirtualModule.id("inject-hmr-runtime");
 
-const normalizePath = (p: string) => {
-  let unixPath = p.replace(/[\\/]+/g, "/").replace(/^([a-zA-Z]+:|\.\/)/, "");
-  return vite.normalizePath(unixPath);
-};
-
 const resolveFileUrl = (
   { rootDirectory }: Pick<ResolvedRemixVitePluginConfig, "rootDirectory">,
   filePath: string
@@ -88,12 +83,14 @@ const resolveFileUrl = (
   let isWithinRoot =
     !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
 
-  // Vite will prevent serving files outside of the workspace
-  // unless user explictly opts in with `server.fs.allow`
-  // https://vitejs.dev/config/server-options.html#server-fs-allow
-  if (!isWithinRoot) return path.posix.join(`/@fs`, normalizePath(filePath));
+  if (!isWithinRoot) {
+    // Vite will prevent serving files outside of the workspace
+    // unless user explictly opts in with `server.fs.allow`
+    // https://vitejs.dev/config/server-options.html#server-fs-allow
+    return path.posix.join("/@fs", vite.normalizePath(filePath));
+  }
 
-  return `/${normalizePath(relativePath)}`;
+  return "/" + vite.normalizePath(relativePath);
 };
 
 const isJsFile = (filePath: string) => /\.[cm]?[jt]sx?$/i.test(filePath);
@@ -106,7 +103,7 @@ const resolveRelativeRouteFilePath = (
   let file = route.file;
   let fullPath = path.resolve(pluginConfig.appDirectory, file);
 
-  return normalizePath(fullPath);
+  return vite.normalizePath(fullPath);
 };
 
 let vmods = [serverEntryId, serverManifestId, browserManifestId];
@@ -125,7 +122,7 @@ const resolveBuildAssetPaths = (
     pluginConfig.rootDirectory,
     absoluteFilePath
   );
-  let manifestKey = normalizePath(rootRelativeFilePath);
+  let manifestKey = vite.normalizePath(rootRelativeFilePath);
   let entryChunk = viteManifest[manifestKey];
 
   if (!entryChunk) {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: https://github.com/remix-run/remix/issues/7722#issuecomment-1810263774 (follow up of https://github.com/remix-run/remix/pull/7913)

I think this issue is because of the lack of `normalizePath`.

---

In https://github.com/hi-ogawa/remix/pull/1/files, I'm trying to verify this works on Windows, but it seems there is still something wrong.
I see `SyntaxError: Unexpected token '<'` in https://github.com/hi-ogawa/remix/actions/runs/6919035654/job/18821929935#step:7:328 which indicates transform not being run for client entry.