### PR TITLE
chore: move missed changeset to changelog

### DIFF
--- a/.changeset/tricky-frogs-film.md
+++ b/.changeset/tricky-frogs-film.md
@@ -1,5 +1,0 @@
----
-"@remix-run/dev": patch
----
-
-Emit assets that were only referenced in the server build into the client assets directory in Vite build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ function handleClick() {
   - Handle multiple `Set-Cookie` headers in Vite dev server ([#7843](https://github.com/remix-run/remix/pull/7843))
   - Fix flash of unstyled content on initial page load in Vite dev when using a custom Express server ([#7937](https://github.com/remix-run/remix/pull/7937))
   - Populate `process.env` from `.env` files on the server in Vite dev ([#7958](https://github.com/remix-run/remix/pull/7958))
+  - Emit assets that were only referenced in the server build into the client assets directory in Vite build ([#7892](https://github.com/remix-run/remix/pull/7892))
 
 ### Updated Dependencies
 

--- a/packages/remix-dev/CHANGELOG.md
+++ b/packages/remix-dev/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fix flash of unstyled content on initial page load in Vite dev when using a custom Express server ([#7937](https://github.com/remix-run/remix/pull/7937))
 - Emit assets that were only referenced in the server build into the client assets directory in Vite build ([#7892](https://github.com/remix-run/remix/pull/7892), cherry-picked in [`8cd31d65`](https://github.com/remix-run/remix/commit/8cd31d6543ef4c765220fc64dca9bcc9c61ee9eb))
 - Populate `process.env` from `.env` files on the server in Vite dev ([#7958](https://github.com/remix-run/remix/pull/7958))
+- Emit assets that were only referenced in the server build into the client assets directory in Vite build ([#7892](https://github.com/remix-run/remix/pull/7892))
 - Fix `FutureConfig` type ([#7895](https://github.com/remix-run/remix/pull/7895))
 - Updated dependencies:
   - `@remix-run/server-runtime@2.3.0`


### PR DESCRIPTION
This patch went out in v2.3.0 but the changeset didn't get picked up, probably due to the way the commit was cherry-picked into the `release-next` branch. This PR deletes the changeset and adds the missing line to the relevant changelogs. After merging, I'll update the GitHub release too.