### PR TITLE
Deprecate DataFunctionArgs

### DIFF
--- a/.changeset/data-function-args.md
+++ b/.changeset/data-function-args.md
@@ -1,0 +1,8 @@
+---
+"@remix-run/server-runtime": minor
+"@remix-run/server-node": minor
+"@remix-run/server-cloudflare": minor
+"@remix-run/server-deno": minor
+---
+
+Deprecate `DataFunctionArgs` in favor of `LoaderFunctionArgs`/`ActionFunctionArgs`.  This is aimed at keeping the types aligned across server/client loaders/actions now that we have `serverLoader`/`serverAction` parameters which differentiate `ClientLoaderFunctionArgs`/`ClientActionFunctionArgs`.

--- a/docs/file-conventions/entry.server.md
+++ b/docs/file-conventions/entry.server.md
@@ -16,7 +16,11 @@ You can export an optional `handleDataRequest` function that will allow you to m
 ```tsx
 export function handleDataRequest(
   response: Response,
-  { request, params, context }: DataFunctionArgs
+  {
+    request,
+    params,
+    context,
+  }: LoaderFunctionArgs | ActionFunctionArgs
 ) {
   response.headers.set("X-Custom-Header", "value");
   return response;
@@ -30,7 +34,11 @@ By default, Remix will log encountered server-side errors to the console. If you
 ```tsx
 export function handleError(
   error: unknown,
-  { request, params, context }: DataFunctionArgs
+  {
+    request,
+    params,
+    context,
+  }: LoaderFunctionArgs | ActionFunctionArgs
 ) {
   if (!request.signal.aborted) {
     sendErrorToErrorReportingService(error);

--- a/packages/remix-server-runtime/build.ts
+++ b/packages/remix-server-runtime/build.ts
@@ -1,4 +1,4 @@
-import type { DataFunctionArgs } from "./routeModules";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "./routeModules";
 import type { AssetsManifest, EntryContext, FutureConfig } from "./entry";
 import type { ServerRouteManifest } from "./routes";
 import type { AppLoadContext } from "./data";
@@ -29,11 +29,13 @@ export interface HandleDocumentRequestFunction {
 }
 
 export interface HandleDataRequestFunction {
-  (response: Response, args: DataFunctionArgs): Promise<Response> | Response;
+  (response: Response, args: LoaderFunctionArgs | ActionFunctionArgs):
+    | Promise<Response>
+    | Response;
 }
 
 export interface HandleErrorFunction {
-  (error: unknown, args: DataFunctionArgs): void;
+  (error: unknown, args: LoaderFunctionArgs | ActionFunctionArgs): void;
 }
 
 /**

--- a/packages/remix-server-runtime/data.ts
+++ b/packages/remix-server-runtime/data.ts
@@ -7,8 +7,9 @@ import {
 } from "./responses";
 import type {
   ActionFunction,
-  DataFunctionArgs,
+  ActionFunctionArgs,
   LoaderFunction,
+  LoaderFunctionArgs,
 } from "./routeModules";
 
 /**
@@ -35,7 +36,7 @@ export async function callRouteActionRR({
 }: {
   request: Request;
   action: ActionFunction;
-  params: DataFunctionArgs["params"];
+  params: ActionFunctionArgs["params"];
   loadContext: AppLoadContext;
   routeId: string;
 }) {
@@ -64,7 +65,7 @@ export async function callRouteLoaderRR({
 }: {
   request: Request;
   loader: LoaderFunction;
-  params: DataFunctionArgs["params"];
+  params: LoaderFunctionArgs["params"];
   loadContext: AppLoadContext;
   routeId: string;
 }) {

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -16,11 +16,14 @@ export interface RouteModules<RouteModule> {
   [routeId: string]: RouteModule;
 }
 
-// Context is always provided in Remix, and typed for module augmentation support.
-// RR also doesn't export DataFunctionArgs, so we extend the two interfaces here
-// even tough they're identical under the hood
+/**
+ * @deprecated Use `LoaderFunctionArgs`/`ActionFunctionArgs` instead
+ */
 export type DataFunctionArgs = RRActionFunctionArgs<AppLoadContext> &
   RRLoaderFunctionArgs<AppLoadContext> & {
+    // Context is always provided in Remix, and typed for module augmentation support.
+    // RR also doesn't export DataFunctionArgs, so we extend the two interfaces here
+    // even tough they're identical under the hood
     context: AppLoadContext;
   };
 
@@ -28,19 +31,31 @@ export type DataFunctionArgs = RRActionFunctionArgs<AppLoadContext> &
  * A function that handles data mutations for a route.
  */
 export type ActionFunction = (
-  args: DataFunctionArgs
+  args: ActionFunctionArgs
 ) => ReturnType<RRActionFunction>;
 
-export type ActionFunctionArgs = DataFunctionArgs;
+/**
+ * Arguments passed to a route `action` function
+ */
+export type ActionFunctionArgs = RRActionFunctionArgs<AppLoadContext> & {
+  // Context is always provided in Remix, and typed for module augmentation support.
+  context: AppLoadContext;
+};
 
 /**
  * A function that loads data for a route.
  */
 export type LoaderFunction = (
-  args: DataFunctionArgs
+  args: LoaderFunctionArgs
 ) => ReturnType<RRLoaderFunction>;
 
-export type LoaderFunctionArgs = DataFunctionArgs;
+/**
+ * Arguments passed to a route `loader` function
+ */
+export type LoaderFunctionArgs = RRLoaderFunctionArgs<AppLoadContext> & {
+  // Context is always provided in Remix, and typed for module augmentation support.
+  context: AppLoadContext;
+};
 
 export type HeadersArgs = {
   loaderHeaders: Headers;

--- a/packages/remix-testing/__tests__/stub-test.tsx
+++ b/packages/remix-testing/__tests__/stub-test.tsx
@@ -10,7 +10,7 @@ import {
   useLoaderData,
   useMatches,
 } from "@remix-run/react";
-import type { DataFunctionArgs } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
 
 test("renders a route", () => {
@@ -128,7 +128,7 @@ test("fetchers work", async () => {
 });
 
 test("can pass a predefined loader", () => {
-  async function loader(_args: DataFunctionArgs) {
+  async function loader(_args: LoaderFunctionArgs) {
     return json({ hi: "there" });
   }
 


### PR DESCRIPTION
This is the first of a series of PRs to implement [Client Data](https://github.com/remix-run/remix/discussions/7634) into a `feature/client-data` branch.

When `clientLoader`/`clientAction` come into play, we'll finally have a differentiation between parameters passed to `clientLoader`/`clientAction` since they'll receive a `serverLoader`/`serverAction` function to call the loader/action on the server.

We don't plan to introduce a `ClientDataFunctionArgs` because they will be different, so it will just be `ClientLoaderFunctionArgs`/`ClientActionFunctionArgs`

To keep things consistent across server and client types , this PR deprecates `DataFunctionArgs` so that folks can move to `LoaderFunctionArgs`/`ActionFunctionArgs`
 