### PR TITLE
test(vite): fix firefox expected error detection

### DIFF
--- a/integration/vite-hmr-hdr-test.ts
+++ b/integration/vite-hmr-hdr-test.ts
@@ -172,7 +172,7 @@ async function workflow({
           "Cannot destructure property 'message' of 'useLoaderData(...)' as it is null.";
       let firefox =
         browserName === "firefox" &&
-        error.message === "TypeError: (intermediate value)() is null";
+        error.message === "(intermediate value)() is null";
       let webkit =
         browserName === "webkit" &&
         error.message === "Right side of assignment cannot be destructured";


### PR DESCRIPTION
Ran this locally with:

```sh
yarn test:integration --project=firefox -g "vite-hmr"
```