### PR TITLE
fix(remix-dev/vite): fix websocket double `handleUpgrade` error with custom vite server config

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -609,11 +609,11 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
           ...viteUserConfig,
           mode: viteConfig.mode,
           server: {
-            ...viteUserConfig.server,
             // when parent compiler runs in middleware mode to support
             // custom servers, we don't want the child compiler also
             // run in middleware mode as that will cause websocket port conflicts
             middlewareMode: false,
+            hmr: false,
           },
           configFile: false,
           envFile: false,
@@ -635,15 +635,16 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
                   plugin.name !== "remix" &&
                   plugin.name !== "remix-hmr-updates"
               ),
-            {
-              name: "no-hmr",
-              handleHotUpdate() {
-                // parent vite server is already sending HMR updates
-                // do not send duplicate HMR updates from child server
-                // which log confusing "page reloaded" messages that aren't true
-                return [];
-              },
-            },
+            // TODO: can remove this if `hmr: false`?
+            // {
+            //   name: "no-hmr",
+            //   handleHotUpdate() {
+            //     // parent vite server is already sending HMR updates
+            //     // do not send duplicate HMR updates from child server
+            //     // which log confusing "page reloaded" messages that aren't true
+            //     return [];
+            //   },
+            // },
           ],
         });
         await viteChildCompiler.pluginContainer.buildStart({});


### PR DESCRIPTION


<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: https://github.com/remix-run/remix/issues/7953

Thanks to @Mordred's comment https://github.com/remix-run/remix/issues/7953#issuecomment-1821212710, it turns out this is a general issue when using custom vite server config.

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
