### PR TITLE
chore: enable prettier cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build": "node scripts/build.mjs",
     "clean": "git clean -fdX .",
     "clean:build": "node ./scripts/clean-build.mjs",
-    "format": "prettier --ignore-path .eslintignore --write ./ && npm run lint:fix",
+    "format": "prettier --cache --ignore-path .eslintignore --write ./ && npm run lint:fix",
     "format:deno": "deno fmt integration/helpers/deno-template packages/remix-deno templates/deno --ignore=node_modules,build,public/build",
     "license": "node ./scripts/license.js",
     "lint": "eslint --cache .",


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

I was wondering if there is a specific reason to not enable caching for prettier https://prettier.io/docs/en/cli.html#--cache.
It might not matter if people use some IDE plugins to run linter on file save, but for some reason, I prefer running `yarn format` manually, so this caching would help me a little bit.

Here are quick stats on my PC:

```sh
# first time without cache
$ time yarn format
...
real    0m13.486s
user    0m22.333s
sys     0m1.202s

# 2nd time with cache
$ time yarn format
...
real    0m3.397s
user    0m3.647s
sys     0m0.610s
```