### PR TITLE
perf(remix-dev/vite): extract route module exports in parallel for route manifest generation + use `transformRequest` to utilize vite's transform cache

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -219,7 +219,7 @@ const getRouteModuleExports = async (
   let url = resolveFileUrl(pluginConfig, routePath);
 
   let transformed = await viteChildCompiler.transformRequest(url, { ssr });
-  invariant(transformed);
+  invariant(transformed); // TODO: what if failed? syntax error?
 
   let [, exports] = esModuleLexer(transformed.code);
   let exportNames = exports.map((e) => e.n);
@@ -630,7 +630,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
           envFile: false,
           experimental: {
             // ssrTransform transforms "import" into "__vite_ssr_import__"
-            // which would export extraction based on es-module-lexer
+            // which would break es-module-lexer-based route exports extraction.
             // https://github.com/vitejs/vite/discussions/13812
             // TODO: instead of relying on this, child compiler can run transformRequest with `ssr: false`? (and can remove all "remix-..." plugins?)
             skipSsrTransform: true,


### PR DESCRIPTION
(These two ideas are independent, so we can evaluate separately. For initial testing, I pushed in one PR, but I'll create two PRs separately later)

## 1st idea

Not properly tested or benchmarked yet, but it seems doing `await getRouteModuleExports(...)` in for loop slow down server start up, so I'm experimenting with doing `Promise.all` instead.
(Regarding this, I was initially looking at `server.warmup` option https://vitejs.dev/config/server-options#server-warmup, but what it does is more-or-less just triggering `transformRequest` in parallel ([code](https://github.com/vitejs/vite/blob/0654d1b52448db4d7a9b69aee6aad9e015481452/packages/vite/src/node/server/warmup.ts#L21-L25)) and actually `server.warmup` won't be triggered for child compiler use cases, so I didn't think further about this option.)

## 2nd idea

Also, while looking at `getRouteModuleExports`, I thought it might be beneficial to use `ViteDevServer.transformRequest` API instead of manually transforming code via `PluginContainer` API. Currently, I needed `experimental.skipSsrTransform` to make it work, but I also have another idea to not rely on that (see TODO in the code).
Again I haven't tested properly yet, but I'm hoping this might allow utilizing vite's cache (+ auto invalidation?) to save unnecessary transform.
If this idea is sound, then remix's own caching introduced in https://github.com/remix-run/remix/pull/7908 to reduce virtual entry invalidation might not be necessary since I think the bottleneck is `getDevManifest` transforming all route files to extract all exports.

---

To be able to analyze and evaluate perf ideas more systematically, I'm thinking to prepare dummy remix app with many routes and components. For example, It would be something like remix-equivalent of these benchmarks:
- https://github.com/vitejs/vite-benchmark
- https://github.com/yArna/parcel-vs-vite-vs-turbopack-hmr
