### PR TITLE
fix(remix-dev/vite): expose `@remix-run/dev/server-build` module

### DIFF
--- a/integration/vite-build-test.ts
+++ b/integration/vite-build-test.ts
@@ -232,6 +232,15 @@ test.describe("Vite build", () => {
             return "ssrCodeSplitTest";
           }
         `,
+
+        "app/routes/server-build.tsx": js`
+          import { json } from "@remix-run/server-runtime";
+
+          export const loader = async () => {
+            const build = await import("@remix-run/dev/server-build");
+            return json(build);
+          }
+        `,
       },
     });
 
@@ -376,5 +385,17 @@ test.describe("Vite build", () => {
     );
 
     expect(pageErrors).toEqual([]);
+  });
+
+  test("access server build", async () => {
+    let res = await fixture.requestDocument("/server-build");
+    expect(res.status).toBe(200);
+    let build = await res.json();
+    expect(build).toMatchObject({
+      routes: {
+        root: { path: "" },
+        "routes/server-build": { path: "server-build" },
+      },
+    });
   });
 });

--- a/integration/vite-dev-test.ts
+++ b/integration/vite-dev-test.ts
@@ -260,6 +260,14 @@ test.describe("Vite dev", () => {
             );
           }
         `,
+        "app/routes/server-build.tsx": js`
+          import { json } from "@remix-run/server-runtime";
+
+          export const loader = async () => {
+            const build = await import("@remix-run/dev/server-build");
+            return json(build);
+          }
+        `,
       },
     });
 
@@ -488,6 +496,18 @@ test.describe("Vite dev", () => {
     );
 
     expect(pageErrors).toEqual([]);
+  });
+
+  test("access server build", async ({ request }) => {
+    let res = await request.get(`http://localhost:${devPort}/server-build`);
+    expect(res.status()).toBe(200);
+    let build = await res.json();
+    expect(build).toMatchObject({
+      routes: {
+        root: { path: "" },
+        "routes/server-build": { path: "server-build" },
+      },
+    });
   });
 });
 

--- a/packages/remix-dev/vite/index.ts
+++ b/packages/remix-dev/vite/index.ts
@@ -4,7 +4,7 @@
 import type { ViteDevServer } from "vite";
 
 import type { RemixVitePlugin } from "./plugin";
-import { id } from "./vmod";
+import { serverBuildVirtualModule } from "../compiler/server/virtualModules";
 
 export const unstable_vitePlugin: RemixVitePlugin = (...args) => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
@@ -22,5 +22,5 @@ export const unstable_createViteServer = async () => {
 };
 
 export const unstable_loadViteServerBuild = async (vite: ViteDevServer) => {
-  return vite.ssrLoadModule(id("server-entry"));
+  return vite.ssrLoadModule(serverBuildVirtualModule.id);
 };


### PR DESCRIPTION
Closes: https://github.com/remix-run/remix/issues/8122

This revives a part of the change from a closed PR https://github.com/remix-run/remix/pull/7975.
I wasn't sure if remix team is considering to keep this API, but at least this seems to be a breaking change, so here is my attempt to provide the same experience.
Please let me know if you had a different plan for this.

## Testing Strategy

- Existing tests should ensure no regression.
- I also added tests to consume this module inside the app itself.
  (TODO: it looks like Windows CI is stuck, so such import might still have some problems...)