### PR TITLE
fix(remix-dev/vite): bundle CSS from client entry

### DIFF
--- a/.changeset/brown-hotels-rush.md
+++ b/.changeset/brown-hotels-rush.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Bundle CSS imported in client entry file in Vite plugin

--- a/integration/vite-css-build-test.ts
+++ b/integration/vite-css-build-test.ts
@@ -50,6 +50,22 @@ test.describe("Vite CSS build", () => {
             ],
           });
         `,
+        "app/entry.client.tsx": js`
+          import "./entry.client.css";
+        
+          import { RemixBrowser } from "@remix-run/react";
+          import { startTransition, StrictMode } from "react";
+          import { hydrateRoot } from "react-dom/client";
+
+          startTransition(() => {
+            hydrateRoot(
+              document,
+              <StrictMode>
+                <RemixBrowser />
+              </StrictMode>
+            );
+          });
+        `,
         "app/root.tsx": js`
           import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
 
@@ -68,6 +84,12 @@ test.describe("Vite CSS build", () => {
                 </body>
               </html>
             );
+          }
+        `,
+        "app/entry.client.css": css`
+          .client-entry {
+            background: pink;
+            padding: ${TEST_PADDING_VALUE};
           }
         `,
         "app/routes/_index/styles-bundled.css": css`
@@ -118,12 +140,14 @@ test.describe("Vite CSS build", () => {
           export default function IndexRoute() {
             return (
               <div id="index">
-                <div data-css-modules className={cssModulesStyles.index}>
-                  <div data-css-linked className="index_linked">
-                    <div data-css-bundled className="index_bundled">
-                      <div data-css-vanilla-global className="index_vanilla_global">
-                        <div data-css-vanilla-local className={stylesVanillaLocal.index}>
-                          <h2>CSS test</h2>
+                <div data-client-entry className="client-entry">
+                  <div data-css-modules className={cssModulesStyles.index}>
+                    <div data-css-linked className="index_linked">
+                      <div data-css-bundled className="index_bundled">
+                        <div data-css-vanilla-global className="index_vanilla_global">
+                          <div data-css-vanilla-local className={stylesVanillaLocal.index}>
+                            <h2>CSS test</h2>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -146,6 +170,10 @@ test.describe("Vite CSS build", () => {
   test("renders styles", async ({ page }) => {
     let app = new PlaywrightFixture(appFixture, page);
     await app.goto("/");
+    await expect(page.locator("#index [data-client-entry]")).toHaveCSS(
+      "padding",
+      TEST_PADDING_VALUE
+    );
     await expect(page.locator("#index [data-css-modules]")).toHaveCSS(
       "padding",
       TEST_PADDING_VALUE

--- a/integration/vite-css-dev-test.ts
+++ b/integration/vite-css-dev-test.ts
@@ -335,7 +335,7 @@ test.describe("Vite CSS dev", () => {
       // Ensure CSS updates were handled by HMR
       await expect(input).toHaveValue("stateful");
 
-      // The following change triggers a full page reload, so we check it after the HMR changes
+      // The following change triggers a full page reload, so we check it after all the checks for HMR state preservation
       let clientEntryCssContents = await fs.readFile(
         path.join(projectDir, "app/entry.client.css"),
         "utf8"

--- a/integration/vite-css-dev-test.ts
+++ b/integration/vite-css-dev-test.ts
@@ -222,8 +222,8 @@ test.describe("Vite CSS dev", () => {
 
   test.describe("with JS", () => {
     test.use({ javaScriptEnabled: true });
-    test("updates CSS", async ({ page }) => {
-      let pageErrors: unknown[] = [];
+    test("updates CSS", async ({ page, browserName }) => {
+      let pageErrors: Error[] = [];
       page.on("pageerror", (error) => pageErrors.push(error));
 
       await page.goto(`http://localhost:${devPort}/`, {
@@ -335,6 +335,7 @@ test.describe("Vite CSS dev", () => {
       // Ensure CSS updates were handled by HMR
       await expect(input).toHaveValue("stateful");
 
+      // The following change triggers a full page reload, so we check it after the HMR changes
       let clientEntryCssContents = await fs.readFile(
         path.join(projectDir, "app/entry.client.css"),
         "utf8"
@@ -352,9 +353,6 @@ test.describe("Vite CSS dev", () => {
         "padding",
         UPDATED_TEST_PADDING_VALUE
       );
-
-      // Changes to the client entry fall back to a full page reload
-      await expect(input).toHaveValue("");
 
       expect(pageErrors).toEqual([]);
     });

--- a/integration/vite-css-dev-test.ts
+++ b/integration/vite-css-dev-test.ts
@@ -43,6 +43,22 @@ test.describe("Vite CSS dev", () => {
             ],
           });
         `,
+        "app/entry.client.tsx": js`
+          import "./entry.client.css";
+        
+          import { RemixBrowser } from "@remix-run/react";
+          import { startTransition, StrictMode } from "react";
+          import { hydrateRoot } from "react-dom/client";
+
+          startTransition(() => {
+            hydrateRoot(
+              document,
+              <StrictMode>
+                <RemixBrowser />
+              </StrictMode>
+            );
+          });
+        `,
         "app/root.tsx": js`
           import { Links, Meta, Outlet, Scripts, LiveReload } from "@remix-run/react";
 
@@ -62,6 +78,12 @@ test.describe("Vite CSS dev", () => {
                 </body>
               </html>
             );
+          }
+        `,
+        "app/entry.client.css": css`
+          .client-entry {
+            background: pink;
+            padding: ${TEST_PADDING_VALUE};
           }
         `,
         "app/styles-bundled.css": css`
@@ -113,12 +135,14 @@ test.describe("Vite CSS dev", () => {
             return (
               <div id="index">
                 <input />
-                <div data-css-modules className={cssModulesStyles.index}>
-                  <div data-css-linked className="index_linked">
-                    <div data-css-bundled className="index_bundled">
-                      <div data-css-vanilla-global className="index_vanilla_global">
-                        <div data-css-vanilla-local className={stylesVanillaLocal.index}>
-                          <h2>CSS test</h2>
+                <div data-client-entry className="client-entry">
+                  <div data-css-modules className={cssModulesStyles.index}>
+                    <div data-css-linked className="index_linked">
+                      <div data-css-bundled className="index_bundled">
+                        <div data-css-vanilla-global className="index_vanilla_global">
+                          <div data-css-vanilla-local className={stylesVanillaLocal.index}>
+                            <h2>CSS test</h2>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -169,6 +193,10 @@ test.describe("Vite CSS dev", () => {
       await page.goto(`http://localhost:${devPort}/`, {
         waitUntil: "networkidle",
       });
+      await expect(page.locator("#index [data-client-entry]")).toHaveCSS(
+        "padding",
+        TEST_PADDING_VALUE
+      );
       await expect(page.locator("#index [data-css-modules]")).toHaveCSS(
         "padding",
         TEST_PADDING_VALUE
@@ -205,6 +233,10 @@ test.describe("Vite CSS dev", () => {
       // Ensure no errors on page load
       expect(pageErrors).toEqual([]);
 
+      await expect(page.locator("#index [data-client-entry]")).toHaveCSS(
+        "padding",
+        TEST_PADDING_VALUE
+      );
       await expect(page.locator("#index [data-css-modules]")).toHaveCSS(
         "padding",
         TEST_PADDING_VALUE
@@ -230,6 +262,19 @@ test.describe("Vite CSS dev", () => {
       await expect(input).toBeVisible();
       await input.type("stateful");
       await expect(input).toHaveValue("stateful");
+
+      let clientEntryCssContents = await fs.readFile(
+        path.join(projectDir, "app/entry.client.css"),
+        "utf8"
+      );
+      await fs.writeFile(
+        path.join(projectDir, "app/entry.client.css"),
+        clientEntryCssContents.replace(
+          TEST_PADDING_VALUE,
+          UPDATED_TEST_PADDING_VALUE
+        ),
+        "utf8"
+      );
 
       let bundledCssContents = await fs.readFile(
         path.join(projectDir, "app/styles-bundled.css"),
@@ -277,6 +322,11 @@ test.describe("Vite CSS dev", () => {
       await editFile(
         path.join(projectDir, "app/styles-vanilla-local.css.ts"),
         (data) => data.replace(TEST_PADDING_VALUE, UPDATED_TEST_PADDING_VALUE)
+      );
+
+      await expect(page.locator("#index [data-client-entry]")).toHaveCSS(
+        "padding",
+        UPDATED_TEST_PADDING_VALUE
       );
 
       await expect(page.locator("#index [data-css-modules]")).toHaveCSS(

--- a/integration/vite-css-dev-test.ts
+++ b/integration/vite-css-dev-test.ts
@@ -263,19 +263,6 @@ test.describe("Vite CSS dev", () => {
       await input.type("stateful");
       await expect(input).toHaveValue("stateful");
 
-      let clientEntryCssContents = await fs.readFile(
-        path.join(projectDir, "app/entry.client.css"),
-        "utf8"
-      );
-      await fs.writeFile(
-        path.join(projectDir, "app/entry.client.css"),
-        clientEntryCssContents.replace(
-          TEST_PADDING_VALUE,
-          UPDATED_TEST_PADDING_VALUE
-        ),
-        "utf8"
-      );
-
       let bundledCssContents = await fs.readFile(
         path.join(projectDir, "app/styles-bundled.css"),
         "utf8"
@@ -324,11 +311,6 @@ test.describe("Vite CSS dev", () => {
         (data) => data.replace(TEST_PADDING_VALUE, UPDATED_TEST_PADDING_VALUE)
       );
 
-      await expect(page.locator("#index [data-client-entry]")).toHaveCSS(
-        "padding",
-        UPDATED_TEST_PADDING_VALUE
-      );
-
       await expect(page.locator("#index [data-css-modules]")).toHaveCSS(
         "padding",
         UPDATED_TEST_PADDING_VALUE
@@ -350,7 +332,29 @@ test.describe("Vite CSS dev", () => {
         UPDATED_TEST_PADDING_VALUE
       );
 
+      // Ensure CSS updates were handled by HMR
       await expect(input).toHaveValue("stateful");
+
+      let clientEntryCssContents = await fs.readFile(
+        path.join(projectDir, "app/entry.client.css"),
+        "utf8"
+      );
+      await fs.writeFile(
+        path.join(projectDir, "app/entry.client.css"),
+        clientEntryCssContents.replace(
+          TEST_PADDING_VALUE,
+          UPDATED_TEST_PADDING_VALUE
+        ),
+        "utf8"
+      );
+
+      await expect(page.locator("#index [data-client-entry]")).toHaveCSS(
+        "padding",
+        UPDATED_TEST_PADDING_VALUE
+      );
+
+      // Changes to the client entry fall back to a full page reload
+      await expect(input).toHaveValue("");
 
       expect(pageErrors).toEqual([]);
     });

--- a/integration/vite-css-dev-test.ts
+++ b/integration/vite-css-dev-test.ts
@@ -222,8 +222,8 @@ test.describe("Vite CSS dev", () => {
 
   test.describe("with JS", () => {
     test.use({ javaScriptEnabled: true });
-    test("updates CSS", async ({ page, browserName }) => {
-      let pageErrors: Error[] = [];
+    test("updates CSS", async ({ page }) => {
+      let pageErrors: unknown[] = [];
       page.on("pageerror", (error) => pageErrors.push(error));
 
       await page.goto(`http://localhost:${devPort}/`, {

--- a/packages/remix-dev/vite/import-vite-esm-sync.ts
+++ b/packages/remix-dev/vite/import-vite-esm-sync.ts
@@ -1,0 +1,21 @@
+// This file is used to avoid CJS deprecation warnings in Vite 5 since
+// @remix-run/dev currently compiles to CJS. By using this interface, we only
+// ever access the Vite package via a dynamic import which forces the ESM build.
+// "importViteAsync" is expected be called up-front in the first async plugin
+// hook, which then unlocks "importViteEsmSync" for use anywhere in the plugin
+// and its utils. This file won't be needed when this package is ESM only.
+
+import invariant from "../invariant";
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+type Vite = typeof import("vite");
+let vite: Vite | undefined;
+
+export async function preloadViteEsm(): Promise<void> {
+  vite = await import("vite");
+}
+
+export function importViteEsmSync(): Vite {
+  invariant(vite, "importViteEsmSync() called before preloadViteEsm()");
+  return vite;
+}

--- a/packages/remix-dev/vite/resolve-file-url.ts
+++ b/packages/remix-dev/vite/resolve-file-url.ts
@@ -1,11 +1,12 @@
 import * as path from "node:path";
 
+import { importViteEsmSync } from "./import-vite-esm-sync";
+
 export const resolveFileUrl = (
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  vite: typeof import("vite"),
   { rootDirectory }: { rootDirectory: string },
   filePath: string
 ) => {
+  let vite = importViteEsmSync();
   let relativePath = path.relative(rootDirectory, filePath);
   let isWithinRoot =
     !relativePath.startsWith("..") && !path.isAbsolute(relativePath);

--- a/packages/remix-dev/vite/resolve-file-url.ts
+++ b/packages/remix-dev/vite/resolve-file-url.ts
@@ -1,0 +1,21 @@
+import * as path from "node:path";
+
+export const resolveFileUrl = (
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  vite: typeof import("vite"),
+  { rootDirectory }: { rootDirectory: string },
+  filePath: string
+) => {
+  let relativePath = path.relative(rootDirectory, filePath);
+  let isWithinRoot =
+    !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
+
+  if (!isWithinRoot) {
+    // Vite will prevent serving files outside of the workspace
+    // unless user explictly opts in with `server.fs.allow`
+    // https://vitejs.dev/config/server-options.html#server-fs-allow
+    return path.posix.join("/@fs", vite.normalizePath(filePath));
+  }
+
+  return "/" + vite.normalizePath(relativePath);
+};

--- a/packages/remix-dev/vite/styles.ts
+++ b/packages/remix-dev/vite/styles.ts
@@ -22,8 +22,6 @@ const isCssFile = (file: string) => cssFileRegExp.test(file);
 export const isCssModulesFile = (file: string) => cssModulesRegExp.test(file);
 
 const getStylesForFiles = async (
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  vite: typeof import("vite"),
   viteDevServer: ViteDevServer,
   config: { rootDirectory: string },
   cssModulesManifest: Record<string, string>,
@@ -43,7 +41,7 @@ const getStylesForFiles = async (
       if (!node) {
         try {
           await viteDevServer.transformRequest(
-            resolveFileUrl(vite, config, normalizedPath)
+            resolveFileUrl(config, normalizedPath)
           );
         } catch (err) {
           console.error(err);
@@ -52,14 +50,8 @@ const getStylesForFiles = async (
       }
 
       if (!node) {
-        let absolutePath = path.resolve(file);
-        await viteDevServer.ssrLoadModule(absolutePath);
-        node = await viteDevServer.moduleGraph.getModuleByUrl(absolutePath);
-
-        if (!node) {
-          console.log(`Could not resolve module for file: ${file}`);
-          continue;
-        }
+        console.log(`Could not resolve module for file: ${file}`);
+        continue;
       }
 
       await findDeps(viteDevServer, node, deps);
@@ -175,8 +167,6 @@ const createRoutes = (
 };
 
 export const getStylesForUrl = async (
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  vite: typeof import("vite"),
   viteDevServer: ViteDevServer,
   config: Pick<
     ResolvedRemixConfig,
@@ -198,7 +188,6 @@ export const getStylesForUrl = async (
     ) ?? [];
 
   let styles = await getStylesForFiles(
-    vite,
     viteDevServer,
     config,
     cssModulesManifest,


### PR DESCRIPTION
Without this fix, CSS from the client entry appears to work in dev (after a flash of unstyled content), but the styles are then missing in the production build.

This PR ensures that:
- In dev, CSS from the client entry is included in the string of critical CSS to avoid FOUC.
- In production, any bundled CSS from the client entry is included with the root route.

To test this, CSS imported from the client entry has been added to Vite CSS tests for both dev and build.