### PR TITLE
docs(quickstart): add cli link/callout to top of quickstart

### DIFF
--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -9,6 +9,8 @@ This guide will get you familiar with the basic plumbing required to run a Remix
 
 When you're ready to get serious about your Remix project, you might consider starting with a community template. They include TypeScript setups, databases, testing harnesses, authentication, and more. You can find a list of community templates on the [Remix Guide Templates][templates] page.
 
+If you prefer to initialize a batteries-included Remix project, you can use the [`create-remix` CLI][create-remix]. This guide will explain all of the different pieces the CLI initializes for you you.
+
 ## Installation
 
 ```shellscript nonumber
@@ -269,6 +271,7 @@ What's next?
 
 - [Tutorial][tutorial]
 
+[create-remix]: ../other-api/create-remix
 [runtimes]: ../discussion/runtimes
 [inspect]: https://nodejs.org/en/docs/guides/debugging-getting-started/
 [tutorial]: ./tutorial

--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -9,7 +9,7 @@ This guide will get you familiar with the basic plumbing required to run a Remix
 
 When you're ready to get serious about your Remix project, you might consider starting with a community template. They include TypeScript setups, databases, testing harnesses, authentication, and more. You can find a list of community templates on the [Remix Guide Templates][templates] page.
 
-If you prefer to initialize a batteries-included Remix project, you can use the [`create-remix` CLI][create-remix]. This guide will explain all of the different pieces the CLI initializes for you you.
+If you prefer to initialize a batteries-included Remix project, you can use the [`create-remix` CLI][create-remix]. This guide will explain all of the different pieces the CLI initializes for you.
 
 ## Installation
 


### PR DESCRIPTION
There was [a discussion in the Discord](https://discord.com/channels/770287896669978684/770287896669978687/1177977705514414191) about the Quickstart and some folks feeling like it was "significantly harder to understand then the 30m tutorial"

I think this is due to expectation setting. While we do have good callouts at the beginning as to what the guide is, per some suggestions I figured it might be good to mention the CLI and link to the page on it.

I specifically tried to avoid adding a `npx create-remix@latest` codeblock, because I was worried for folks who don't read and just look for code they would take it as a command. I also think it's worth reading through and understanding this guide, so I don't want to encourage people taking the "escape hatch", I just want to point it out.

Happy to hear any better suggestions!