### PR TITLE
fix(remix-dev/vite): upgrade Vite peer dep to v5

### DIFF
--- a/.changeset/angry-dingos-buy.md
+++ b/.changeset/angry-dingos-buy.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Upgrade Vite peer dependency range to v5

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -98,7 +98,7 @@
   "peerDependencies": {
     "@remix-run/serve": "^2.3.1",
     "typescript": "^5.1.0",
-    "vite": "^4.4.9 || ^5.0.0"
+    "vite": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "@remix-run/serve": {


### PR DESCRIPTION
Before marking the Vite plugin as stable, we want to raise the minimum version of Vite that we support since this will be harder to do later.