### PR TITLE
fix (templates): Add source map retrieval fix to Express template

### DIFF
--- a/.changeset/sour-stingrays-roll.md
+++ b/.changeset/sour-stingrays-roll.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/serve": patch
+---
+
+Fix source map loading when file has ?t=timestamp suffix (rebuilds)

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -18,7 +18,19 @@ import getPort from "get-port";
 
 process.env.NODE_ENV = process.env.NODE_ENV ?? "production";
 
-sourceMapSupport.install();
+sourceMapSupport.install({
+  retrieveSourceMap: function (source) {
+    // get source file without the `file://` prefix or `?t=...` suffix
+    let match = source.match(/^file:\/\/(.*)\?t=[.\d]+$/);
+    if (match) {
+      return {
+        url: source,
+        map: fs.readFileSync(`${match[1]}.map`, "utf8"),
+      };
+    }
+    return null;
+  },
+});
 installGlobals();
 
 run();

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -9,7 +9,19 @@ import express from "express";
 import morgan from "morgan";
 import sourceMapSupport from "source-map-support";
 
-sourceMapSupport.install();
+sourceMapSupport.install({
+  retrieveSourceMap: function (source) {
+    // get source file without the `file://` prefix or `?t=...` suffix
+    const match = source.match(/^file:\/\/(.*)\?t=[.\d]+$/);
+    if (match) {
+      return {
+        url: source,
+        map: fs.readFileSync(`${match[1]}.map`, "utf8"),
+      };
+    }
+    return null;
+  },
+});
 installGlobals();
 
 /** @typedef {import('@remix-run/node').ServerBuild} ServerBuild */


### PR DESCRIPTION
This PR updates the the Express template and fixes the issue where source maps are not getting used. This was traced to how the map file is loaded when HMR reloads the server file with the `?t=timestamp` suffix.

This causes the source map to not be found and therefore not used.

Adding the hook for `retrieveSourceMap`, this strips out the unexpected characters from the filename and properly returns the source map.
