### PR TITLE
fix(vite): add remix-node to optimizeDeps.include

### DIFF
--- a/.changeset/shiny-timers-bake.md
+++ b/.changeset/shiny-timers-bake.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Add `@remix-run/node` to Vite's `optimizeDeps.include` array

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -557,6 +557,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
               // That means that before Vite pre-bundles dependencies (e.g. first time dev server is run)
               // mismatching Remix routers cause `Error: You must render this element inside a <Remix> element`.
               "@remix-run/react",
+              "@remix-run/node",
             ],
           },
           esbuild: {


### PR DESCRIPTION
The integration test named `vite-dotenv-test` was consistently failing for me when testing in Safari locally and in CI. Debugging locally, I was able to see the following errors in the console:

<img width="1000" alt="error" src="https://github.com/remix-run/remix/assets/696693/1bdc1c8b-4825-4be1-a3ed-111b0a1fafea">

The tests even failed when setting `optimizeDeps.force` to `true`. The only way I was able to get it to pass was to ensure that `@remix-run/node` was also included in the `optimizeDeps.include` array.