### PR TITLE
test(vite): dynamic .server imports are excluded from client

### DIFF
--- a/integration/vite-dot-server-test.ts
+++ b/integration/vite-dot-server-test.ts
@@ -16,7 +16,7 @@ let files = {
   `,
 };
 
-test("Vite /  .server file / named import in client fails with expected error", async () => {
+test("Vite / .server file / named import in client fails with expected error", async () => {
   let cwd = await createProject({
     ...files,
     "app/routes/fail-server-file-in-client.tsx": String.raw`
@@ -35,7 +35,7 @@ test("Vite /  .server file / named import in client fails with expected error", 
   );
 });
 
-test("Vite /  .server file / namespace import in client fails with expected error", async () => {
+test("Vite / .server file / namespace import in client fails with expected error", async () => {
   let cwd = await createProject({
     ...files,
     "app/routes/fail-server-file-in-client.tsx": String.raw`
@@ -147,57 +147,68 @@ test("Vite / `handle` with dynamic imports as an escape hatch for server-only co
   let [client, server] = viteBuild({ cwd });
   expect(client.status).toBe(0);
   expect(server.status).toBe(0);
+
+  let lines = grep(
+    path.join(cwd, "build/client"),
+    /SERVER_ONLY_FILE|SERVER_ONLY_DIR/
+  );
+  expect(lines).toHaveLength(0);
 });
 
 test("Vite / dead-code elimination for server exports", async () => {
   let cwd = await createProject({
     ...files,
     "app/routes/remove-server-exports-and-dce.tsx": String.raw`
-        import fs from "node:fs";
-        import { json } from "@remix-run/node";
-        import { useLoaderData } from "@remix-run/react";
+      import fs from "node:fs";
+      import { json } from "@remix-run/node";
+      import { useLoaderData } from "@remix-run/react";
 
-        import { dotServerFile } from "../utils.server";
-        import { dotServerDir } from "../.server/utils";
+      import { dotServerFile } from "../utils.server";
+      import { dotServerDir } from "../.server/utils";
 
-        export const loader = () => {
-          let contents = fs.readFileSync("blah");
-          let data = dotServerFile + dotServerDir + serverOnly + contents;
-          return json({ data });
-        }
+      export const loader = () => {
+        let contents = fs.readFileSync("blah");
+        let data = dotServerFile + dotServerDir + serverOnly + contents;
+        return json({ data });
+      }
 
-        export const action = () => {
-          console.log(dotServerFile, dotServerDir, serverOnly);
-          return null;
-        }
+      export const action = () => {
+        console.log(dotServerFile, dotServerDir, serverOnly);
+        return null;
+      }
 
-        export default function() {
-          let { data } = useLoaderData<typeof loader>();
-          return (
-            <>
-              <h2>Index</h2>
-              <p>{data}</p>
-            </>
-          );
-        }
-      `,
+      export default function() {
+        let { data } = useLoaderData<typeof loader>();
+        return (
+          <>
+            <h2>Index</h2>
+            <p>{data}</p>
+          </>
+        );
+      }
+    `,
   });
   let [client, server] = viteBuild({ cwd });
   expect(client.status).toBe(0);
   expect(server.status).toBe(0);
 
-  // detect client asset files
+  let lines = grep(
+    path.join(cwd, "build/client"),
+    /SERVER_ONLY_FILE|SERVER_ONLY_DIR|node:fs/
+  );
+  expect(lines).toHaveLength(0);
+});
+
+function grep(cwd: string, pattern: RegExp): string[] {
   let assetFiles = glob.sync("**/*.@(js|jsx|ts|tsx)", {
-    cwd: path.join(cwd, "build/client"),
+    cwd,
     absolute: true,
   });
 
-  // grep for server-only values in client assets
-  let result = shell
-    .grep("-l", /SERVER_ONLY_FILE|SERVER_ONLY_DIR|node:fs/, assetFiles)
+  let lines = shell
+    .grep("-l", pattern, assetFiles)
     .stdout.trim()
     .split("\n")
     .filter((line) => line.length > 0);
-
-  expect(result).toHaveLength(0);
-});
+  return lines;
+}


### PR DESCRIPTION
this was already the case, just adding a test to make it explicitly checked for
