### PR TITLE
fix(remix-dev/vite): start SSR build within plugin

### DIFF
--- a/.changeset/flat-pants-act.md
+++ b/.changeset/flat-pants-act.md
@@ -1,0 +1,17 @@
+---
+"@remix-run/dev": patch
+---
+
+Automatically run `vite build --ssr` as a sub-process of the `vite build` command.
+
+This means you no longer need to manually run `vite build --ssr` after `vite build`.
+
+```diff
+{
+  "scripts": {
+    "dev": "vite dev",
+-    "build": "vite build && vite build --ssr"
++    "build": "vite build"
+  }
+}
+```

--- a/docs/future/vite.md
+++ b/docs/future/vite.md
@@ -175,7 +175,7 @@ You'll also need to update to the new build output paths, which are `build/serve
 ```json filename=package.json lines=[3-4]
 {
   "scripts": {
-    "build": "vite build && vite build --ssr",
+    "build": "vite build",
     "dev": "vite dev",
     "start": "remix-serve ./build/server/index.js"
   }
@@ -272,7 +272,7 @@ app.listen(port, () =>
 ```json filename=package.json
 {
   "scripts": {
-    "build": "vite build && vite build --ssr",
+    "build": "vite build",
     "dev": "node ./server.mjs",
     "start": "cross-env NODE_ENV=production node ./server.mjs"
   }

--- a/integration/helpers/create-fixture.ts
+++ b/integration/helpers/create-fixture.ts
@@ -315,43 +315,36 @@ function build(
 
   let remixBin = "node_modules/@remix-run/dev/dist/cli.js";
 
-  let commands: string[][] =
+  let buildArgs: string[] =
     compiler === "vite"
-      ? [
-          [viteBin, "build"],
-          [viteBin, "build", "--ssr"],
-        ]
-      : [[remixBin, "build", ...(sourcemap ? ["--sourcemap"] : [])]];
+      ? [viteBin, "build"]
+      : [remixBin, "build", ...(sourcemap ? ["--sourcemap"] : [])];
 
-  commands.forEach((buildArgs) => {
-    let buildSpawn = spawnSync("node", buildArgs, {
-      cwd: projectDir,
-      env: {
-        ...process.env,
-        NODE_ENV: mode || ServerMode.Production,
-      },
-    });
-
-    // These logs are helpful for debugging. Remove comments if needed.
-    // console.log("spawning node " + buildArgs.join(" ") + ":\n");
-    // console.log("  STDOUT:");
-    // console.log("  " + buildSpawn.stdout.toString("utf-8"));
-    // console.log("  STDERR:");
-    // console.log("  " + buildSpawn.stderr.toString("utf-8"));
-
-    if (buildStdio) {
-      buildStdio.write(buildSpawn.stdout.toString("utf-8"));
-      buildStdio.write(buildSpawn.stderr.toString("utf-8"));
-      buildStdio.end();
-    }
-
-    if (buildSpawn.error || buildSpawn.status) {
-      console.error(buildSpawn.stderr.toString("utf-8"));
-      throw (
-        buildSpawn.error || new Error(`Build failed, check the output above`)
-      );
-    }
+  let buildSpawn = spawnSync("node", buildArgs, {
+    cwd: projectDir,
+    env: {
+      ...process.env,
+      NODE_ENV: mode || ServerMode.Production,
+    },
   });
+
+  // These logs are helpful for debugging. Remove comments if needed.
+  // console.log("spawning node " + buildArgs.join(" ") + ":\n");
+  // console.log("  STDOUT:");
+  // console.log("  " + buildSpawn.stdout.toString("utf-8"));
+  // console.log("  STDERR:");
+  // console.log("  " + buildSpawn.stderr.toString("utf-8"));
+
+  if (buildStdio) {
+    buildStdio.write(buildSpawn.stdout.toString("utf-8"));
+    buildStdio.write(buildSpawn.stderr.toString("utf-8"));
+    buildStdio.end();
+  }
+
+  if (buildSpawn.error || buildSpawn.status) {
+    console.error(buildSpawn.stderr.toString("utf-8"));
+    throw buildSpawn.error || new Error(`Build failed, check the output above`);
+  }
 }
 
 async function writeTestFiles(init: FixtureInit, dir: string) {

--- a/integration/helpers/vite-template/package.json
+++ b/integration/helpers/vite-template/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && vite build --ssr",
+    "build": "vite build",
     "start": "remix-serve ./build/server/index.js",
     "typecheck": "tsc"
   },

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -128,19 +128,10 @@ const createDev =
 export const viteBuild = ({ cwd }: { cwd: string }) => {
   let nodeBin = process.argv[0];
   let viteBin = resolveBin.sync("vite");
-  let commands = [
-    [viteBin, "build"],
-    [viteBin, "build", "--ssr"],
-  ];
-  let results = [];
-  for (let command of commands) {
-    let result = spawnSync(nodeBin, command, {
-      cwd,
-      env: { ...process.env },
-    });
-    results.push(result);
-  }
-  return results;
+  return spawnSync(nodeBin, [viteBin, "build"], {
+    cwd,
+    env: { ...process.env },
+  });
 };
 
 export const viteRemixServe = async ({

--- a/integration/vite-dot-client-test.ts
+++ b/integration/vite-dot-client-test.ts
@@ -37,9 +37,8 @@ test("Vite / client code excluded from server bundle", async () => {
       }
     `,
   });
-  let [client, server] = viteBuild({ cwd });
-  expect(client.status).toBe(0);
-  expect(server.status).toBe(0);
+  let { status } = viteBuild({ cwd });
+  expect(status).toBe(0);
   let lines = grep(
     path.join(cwd, "build/server"),
     /CLIENT_ONLY_FILE|CLIENT_ONLY_DIR/

--- a/integration/vite-dot-server-test.ts
+++ b/integration/vite-dot-server-test.ts
@@ -26,8 +26,8 @@ test("Vite / .server file / named import in client fails with expected error", a
       }
     `,
   });
-  let client = viteBuild({ cwd })[0];
-  let stderr = client.stderr.toString("utf8");
+  let result = viteBuild({ cwd });
+  let stderr = result.stderr.toString("utf8");
   expect(stderr).toMatch(
     `"dotServerFile" is not exported by "app/utils.server.ts"`
   );
@@ -45,8 +45,8 @@ test("Vite / .server file / namespace import in client fails with expected error
       }
     `,
   });
-  let client = viteBuild({ cwd })[0];
-  let stderr = client.stderr.toString("utf8");
+  let result = viteBuild({ cwd });
+  let stderr = result.stderr.toString("utf8");
   expect(stderr).toMatch(
     `"dotServerFile" is not exported by "app/utils.server.ts"`
   );
@@ -64,8 +64,8 @@ test("Vite / .server file / default import in client fails with expected error",
       }
     `,
   });
-  let client = viteBuild({ cwd })[0];
-  let stderr = client.stderr.toString("utf8");
+  let result = viteBuild({ cwd });
+  let stderr = result.stderr.toString("utf8");
   expect(stderr).toMatch(`"default" is not exported by "app/utils.server.ts"`);
 });
 
@@ -81,8 +81,8 @@ test("Vite / .server dir / named import in client fails with expected error", as
       }
     `,
   });
-  let client = viteBuild({ cwd })[0];
-  let stderr = client.stderr.toString("utf8");
+  let result = viteBuild({ cwd });
+  let stderr = result.stderr.toString("utf8");
   expect(stderr).toMatch(
     `"dotServerDir" is not exported by "app/.server/utils.ts"`
   );
@@ -100,8 +100,8 @@ test("Vite / .server dir / namespace import in client fails with expected error"
       }
     `,
   });
-  let client = viteBuild({ cwd })[0];
-  let stderr = client.stderr.toString("utf8");
+  let result = viteBuild({ cwd });
+  let stderr = result.stderr.toString("utf8");
   expect(stderr).toMatch(
     `"dotServerDir" is not exported by "app/.server/utils.ts"`
   );
@@ -119,8 +119,8 @@ test("Vite / .server dir / default import in client fails with expected error", 
       }
     `,
   });
-  let client = viteBuild({ cwd })[0];
-  let stderr = client.stderr.toString("utf8");
+  let result = viteBuild({ cwd });
+  let stderr = result.stderr.toString("utf8");
   expect(stderr).toMatch(`"default" is not exported by "app/.server/utils.ts"`);
 });
 
@@ -142,9 +142,8 @@ test("Vite / `handle` with dynamic imports as an escape hatch for server-only co
       }
     `,
   });
-  let [client, server] = viteBuild({ cwd });
-  expect(client.status).toBe(0);
-  expect(server.status).toBe(0);
+  let { status } = viteBuild({ cwd });
+  expect(status).toBe(0);
 
   let lines = grep(
     path.join(cwd, "build/client"),
@@ -186,9 +185,8 @@ test("Vite / dead-code elimination for server exports", async () => {
       }
     `,
   });
-  let [client, server] = viteBuild({ cwd });
-  expect(client.status).toBe(0);
-  expect(server.status).toBe(0);
+  let { status } = viteBuild({ cwd });
+  expect(status).toBe(0);
 
   let lines = grep(
     path.join(cwd, "build/client"),

--- a/integration/vite-route-exports-test.ts
+++ b/integration/vite-route-exports-test.ts
@@ -21,8 +21,8 @@ test("Vite / invalid route exports / expected build error", async () => {
       export const invalid2 = 2;
     `,
   });
-  let client = viteBuild({ cwd })[0];
-  let stderr = client.stderr.toString("utf8");
+  let result = viteBuild({ cwd });
+  let stderr = result.stderr.toString("utf8");
   expect(stderr).toMatch(
     "2 invalid route exports in `routes/fail-non-remix-exports.tsx`:\n  - `invalid1`\n  - `invalid2`"
   );
@@ -64,7 +64,6 @@ test("Vite / invalid route exports / ignore in mdx", async () => {
       # Hello World
     `,
   });
-  let [client, server] = viteBuild({ cwd });
-  expect(client.status).toBe(0);
-  expect(server.status).toBe(0);
+  let { status } = viteBuild({ cwd });
+  expect(status).toBe(0);
 });

--- a/templates/unstable-vite-express/package.json
+++ b/templates/unstable-vite-express/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "node ./server.mjs",
-    "build": "vite build && vite build --ssr",
+    "build": "vite build",
     "start": "cross-env NODE_ENV=production node ./server.mjs",
     "typecheck": "tsc"
   },

--- a/templates/unstable-vite/package.json
+++ b/templates/unstable-vite/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && vite build --ssr",
+    "build": "vite build",
     "start": "remix-serve ./build/server/index.js",
     "typecheck": "tsc"
   },


### PR DESCRIPTION
tl;dr: You only need to run `vite build` now, not `vite build && vite build --ssr` 🎉

Since we're trying to stabilise the Vite API, I realised that consumers need to stop co-ordinating multiple Vite builds as they're doing today. This is because we're looking at adding support for server bundle shredding (i.e. multiple request handlers, not  just one) and RSC, and both of these would mean that we won't know how many builds there will be ahead of time. To handle both of these scenarios, this PR adds a queue where we can push subsequent Vite build processes from within the initial `vite build` pass.

By the way, after this change I tried running `vite build && vite build --ssr` and it still works, it's just slower due to the double SSR build.

An alternative approach to this would be to wrap Vite in the Remix CLI (`remix vite:build` etc., or something similar), but that introduces its own set of complexity since we'd need to forward everything from our CLI to Vite, manage args parsing and validation, keep up to date with Vite CLI API changes etc. I initially went down this road and it started feeling too heavy, so I pivoted to the approach in this PR instead to see how we felt about it. It's nice that we get to continue being "just a Vite plugin", but it's a bit non-standard the way we're achieving it. I'm keen to get some feedback on it.

Todo:
- [ ] Confirm that CLI args are passed to the child SSR build (e.g. `vite build --assetsInlineLimit <number>`)

UPDATE: While this solution is clever, it has some major drawbacks that I'm referring to as the "uncanny valley effect", one example of which is the question @mmachatschek raised below, but this is certainly not the only issue. I've opened another PR with a more traditional solution that addresses these tradeoffs: #8211.