### PR TITLE
refactor(vite): handle all future flags

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -334,6 +334,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
         serverBuildPath,
         serverModuleFormat,
         relativeAssetsBuildDirectory,
+        future,
       } = await resolveConfig(config, { rootDirectory });
 
       return {
@@ -347,10 +348,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
         serverBuildPath,
         serverModuleFormat,
         relativeAssetsBuildDirectory,
-        future: {
-          v3_fetcherPersist: options.future?.v3_fetcherPersist === true,
-          v3_relativeSplatPath: options.future?.v3_relativeSplatPath === true,
-        },
+        future,
       };
     };
 
@@ -376,11 +374,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
       export const assetsBuildDirectory = ${JSON.stringify(
         pluginConfig.relativeAssetsBuildDirectory
       )};
-      ${
-        pluginConfig.future
-          ? `export const future = ${JSON.stringify(pluginConfig.future)}`
-          : ""
-      };
+      export const future = ${JSON.stringify(pluginConfig.future)};
       export const publicPath = ${JSON.stringify(pluginConfig.publicPath)};
       export const entry = { module: entryServer };
       export const routes = {


### PR DESCRIPTION
This PR modifies the Vite plugin to pass the entire `future` config object through to the server entry rather than manually adding each value. This ensures that any new future flags don't also need to be added to the Vite plugin, and it also ensures that the types are always correct. If we ever need to add any Vite-specific future flags, we can handle those within the Vite plugin and then forward the rest.