### PR TITLE
Add error type to server runtime meta args

### DIFF
--- a/.changeset/big-cooks-confess.md
+++ b/.changeset/big-cooks-confess.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+Add error to ServerRuntimeMetaArgs type

--- a/.changeset/big-cooks-confess.md
+++ b/.changeset/big-cooks-confess.md
@@ -2,4 +2,4 @@
 "@remix-run/server-runtime": patch
 ---
 
-Add error to ServerRuntimeMetaArgs type
+Add optional `error` to `ServerRuntimeMetaArgs` type to align with `MetaArgs`

--- a/contributors.yml
+++ b/contributors.yml
@@ -619,3 +619,4 @@
 - SeanRoberts
 - yasoob
 - mccuna
+- timkraut

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -224,6 +224,7 @@ export interface ServerRuntimeMetaArgs<
   params: Params;
   location: Location;
   matches: ServerRuntimeMetaMatches<MatchLoaders>;
+  error?: unknown;
 }
 
 export type ServerRuntimeMetaDescriptor =


### PR DESCRIPTION
Closes: There is no issue for this one yet

- [ ] Docs (https://remix.run/docs/en/main/route/meta#error does not mention a specific package to import this from - no changes required)
- [ ] Tests (there is a test "loader errors are passed to meta" in the `meta-test.tsx` file - no changes required)

I have a Remix app on the latest version (`v2.3.1`) and with a lot of debugging, I've found out that the `MetaFunction` type imported from `'@remix-run/node'` differs from the `MetaFunction` from `'@remix-run/react'`. If there is an error thrown in the `loader` with `v.2.3.1`, the `error` is set as expected in JavaScript but the types yelled at me.

## Testing Strategy
- Have a look at the inferred types of the `MetaFunction` imported from `'@remix-run/node'`
- Verify that the `error` property is included
