### PR TITLE
Add missing fields to EntryRoute

### DIFF
--- a/.changeset/short-mayflies-stare.md
+++ b/.changeset/short-mayflies-stare.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+[REMOVE] Add missing `hasClientAction`/`hasClientLoader` to `EntryRoute` type

--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -27,6 +27,8 @@ export interface Route {
 export interface EntryRoute extends Route {
   hasAction: boolean;
   hasLoader: boolean;
+  hasClientAction: boolean;
+  hasClientLoader: boolean;
   hasErrorBoundary: boolean;
   imports?: string[];
   css?: string[];


### PR DESCRIPTION
Discovered in https://github.com/remix-run/remix-website/pull/143.  These only got added to the `@remix-run/react` `EntryRoute` originally