### PR TITLE
refactor(vite): rename Vite dev server variable

### DIFF
--- a/docs/future/vite.md
+++ b/docs/future/vite.md
@@ -231,22 +231,20 @@ import express from "express";
 
 installGlobals();
 
-const vite =
+const viteDevServer =
   process.env.NODE_ENV === "production"
     ? undefined
-    : await import("vite").then(({ createServer }) =>
-        createServer({
-          server: {
-            middlewareMode: true,
-          },
+    : await import("vite").then((vite) =>
+        vite.createServer({
+          server: { middlewareMode: true },
         })
       );
 
 const app = express();
 
 // handle asset requests
-if (vite) {
-  app.use(vite.middlewares);
+if (viteDevServer) {
+  app.use(viteDevServer.middlewares);
 } else {
   app.use(
     "/assets",
@@ -262,9 +260,11 @@ app.use(express.static("build/client", { maxAge: "1h" }));
 app.all(
   "*",
   createRequestHandler({
-    build: vite
+    build: viteDevServer
       ? () =>
-          vite.ssrLoadModule("virtual:remix/server-build")
+          viteDevServer.ssrLoadModule(
+            "virtual:remix/server-build"
+          )
       : await import("./build/server/index.js"),
   })
 );

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -47,19 +47,19 @@ export const EXPRESS_SERVER = (args: {
 
     installGlobals();
 
-    let vite =
+    let viteDevServer =
       process.env.NODE_ENV === "production"
         ? undefined
-        : await import("vite").then(({ createServer }) =>
-            createServer({
+        : await import("vite").then((vite) =>
+            vite.createServer({
               server: { middlewareMode: true },
             })
           );
 
     const app = express();
 
-    if (vite) {
-      app.use(vite.middlewares);
+    if (viteDevServer) {
+      app.use(viteDevServer.middlewares);
     } else {
       app.use(
         "/assets",
@@ -71,8 +71,8 @@ export const EXPRESS_SERVER = (args: {
     app.all(
       "*",
       createRequestHandler({
-        build: vite
-          ? () => vite.ssrLoadModule("virtual:remix/server-build")
+        build: viteDevServer
+          ? () => viteDevServer.ssrLoadModule("virtual:remix/server-build")
           : await import("./build/index.js"),
         getLoadContext: () => (${JSON.stringify(args.loadContext ?? {})}),
       })

--- a/templates/unstable-vite-express/server.mjs
+++ b/templates/unstable-vite-express/server.mjs
@@ -4,22 +4,20 @@ import express from "express";
 
 installGlobals();
 
-const vite =
+const viteDevServer =
   process.env.NODE_ENV === "production"
     ? undefined
-    : await import("vite").then(({ createServer }) =>
-        createServer({
-          server: {
-            middlewareMode: true,
-          },
+    : await import("vite").then((vite) =>
+        vite.createServer({
+          server: { middlewareMode: true },
         })
       );
 
 const app = express();
 
 // handle asset requests
-if (vite) {
-  app.use(vite.middlewares);
+if (viteDevServer) {
+  app.use(viteDevServer.middlewares);
 } else {
   app.use(
     "/assets",
@@ -32,8 +30,8 @@ app.use(express.static("build/client", { maxAge: "1h" }));
 app.all(
   "*",
   createRequestHandler({
-    build: vite
-      ? () => vite.ssrLoadModule("virtual:remix/server-build")
+    build: viteDevServer
+      ? () => viteDevServer.ssrLoadModule("virtual:remix/server-build")
       : await import("./build/server/index.js"),
   })
 );


### PR DESCRIPTION
This renames the `vite` variable to `viteDevServer`, which also frees up the `vite` variable name for dynamic imports of Vite itself.