### PR TITLE
docs(discussion/server-vs-client) Add missing `formData` to `action` example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -490,6 +490,7 @@
 - sandulat
 - sandstone991
 - sarahse
+- sathvik-k
 - sbernheim4
 - schpet
 - scottybrown

--- a/docs/discussion/server-vs-client.md
+++ b/docs/discussion/server-vs-client.md
@@ -62,6 +62,7 @@ export default function Component() {
 export async function action({
   request,
 }: ActionFunctionArgs) {
+  const formData = await request.formData();
   const user = await getUser(request);
 
   await updateUser(user.id, {


### PR DESCRIPTION
The `Server vs. Client Code Execution` example was missing the `formData` variable initialization in the `action`
