### PR TITLE
Remove @remix-run/eslint-config references from unit test fixtures

### DIFF
--- a/packages/remix-dev/__tests__/fixtures/cloudflare/.eslintrc.cjs
+++ b/packages/remix-dev/__tests__/fixtures/cloudflare/.eslintrc.cjs
@@ -1,4 +1,0 @@
-/** @type {import('eslint').Linter.Config} */
-module.exports = {
-  extends: ["@remix-run/eslint-config", "@remix-run/eslint-config/node"],
-};

--- a/packages/remix-dev/__tests__/fixtures/cloudflare/package.json
+++ b/packages/remix-dev/__tests__/fixtures/cloudflare/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230518.0",
     "@remix-run/dev": "*",
-    "@remix-run/eslint-config": "*",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "eslint": "^8.38.0",

--- a/packages/remix-dev/__tests__/fixtures/node/.eslintrc.js
+++ b/packages/remix-dev/__tests__/fixtures/node/.eslintrc.js
@@ -1,4 +1,0 @@
-/** @type {import('eslint').Linter.Config} */
-module.exports = {
-  extends: ["@remix-run/eslint-config", "@remix-run/eslint-config/node"],
-};

--- a/packages/remix-dev/__tests__/fixtures/node/package.json
+++ b/packages/remix-dev/__tests__/fixtures/node/package.json
@@ -19,7 +19,6 @@
   },
   "devDependencies": {
     "@remix-run/dev": "*",
-    "@remix-run/eslint-config": "*",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "eslint": "^8.38.0",


### PR DESCRIPTION
Forked off from #7597 since this touches unit tests so should technically merge to `dev`.  The unit tests are testing `remix dev` behavior so linting is irrelevant in the fixtures