### PR TITLE
add codeblock tag

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -622,3 +622,4 @@
 - mccuna
 - alexanderson1993
 - signed
+- souredoutlook

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -1004,7 +1004,7 @@ When a route has children, and you're at the parent route's path, the `<Outlet>`
 
 👉 **Create an index route for the root route**
 
-```
+``` shellscript nonumber
 touch app/routes/_index.tsx
 ```
 

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -1004,7 +1004,7 @@ When a route has children, and you're at the parent route's path, the `<Outlet>`
 
 👉 **Create an index route for the root route**
 
-``` shellscript nonumber
+```shellscript nonumber
 touch app/routes/_index.tsx
 ```
 


### PR DESCRIPTION
The shell script code block is missing the `shellscript nonumber` tag in the index route step of the tutorial 
