### PR TITLE
Update wrangler version

### DIFF
--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "typescript": "^5.1.0",
-    "wrangler": "3.8.0"
+    "wrangler": "^3.20.0"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Because the HMR bug is solved in wrangler v3.19.0 (https://github.com/cloudflare/workers-sdk/issues/4318#issuecomment-1840232207), we can now pin the wrangler version to "^3.20.0".