### PR TITLE
Add helpful pointer for how to read uploaded files

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -624,3 +624,4 @@
 - alexanderson1993
 - signed
 - souredoutlook
+- tmcw

--- a/docs/utils/parse-multipart-form-data.md
+++ b/docs/utils/parse-multipart-form-data.md
@@ -49,6 +49,8 @@ export default function AvatarUploadRoute() {
 }
 ```
 
+To read the contents of an uploaded file, use one of the methods it inherits from [the Blob API][the-blob-api]. For example, `.text()` asynchronously returns the text contents of the file, and `.arrayBuffer()` returns the binary contents.
+
 ### `uploadHandler`
 
 The `uploadHandler` is the key to the whole thing. It's responsible for what happens to the multipart/form-data parts as they are being streamed from the client. You can save it to disk, store it in memory, or act as a proxy to send it somewhere else (like a file storage provider).
@@ -61,3 +63,4 @@ Remix has two utilities to create `uploadHandler`s for you:
 These are fully featured utilities for handling fairly simple use cases. It's not recommended to load anything but quite small files into memory. Saving files to disk is a reasonable solution for many use cases. But if you want to upload the file to a file hosting provider, then you'll need to write your own.
 
 [the-browser-file-api]: https://developer.mozilla.org/en-US/docs/Web/API/File
+[the-blob-api]: https://developer.mozilla.org/en-US/docs/Web/API/Blob


### PR DESCRIPTION
Since the only link was to the `File` API, I didn't realize that the methods from `Blob` were available too - those of us who dealt with files in the bad old days are likely to try using `FileReader` before reaching for convenient methods like `.text()`

For the grumpy background behind this PR, my [discussion topic](https://github.com/remix-run/remix/discussions/8278) of the journey of figuring out the way to read a file 😆 