### PR TITLE
docs:  Update of Placeholder Avatar Image on Tutorial Page

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -625,3 +625,4 @@
 - signed
 - souredoutlook
 - tmcw
+- moelzanaty3

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -170,7 +170,7 @@ export default function Contact() {
   const contact = {
     first: "Your",
     last: "Name",
-    avatar: "https://placekitten.com/g/200/200",
+    avatar: "https://i.pravatar.cc/200/200",
     twitter: "your_handle",
     notes: "Some notes",
     favorite: true,


### PR DESCRIPTION
I identified an issue with the placeholder `avatar` image on the tutorial page, originally sourced from `https://placekitten.com`. The `contact` avatar was appearing as a broken image, potentially causing confusion for users following the tutorial. 

To ensure clarity and maintain the quality of our tutorial experience, I have replaced the broken image with an alternative placeholder avatar. 

This minor yet important change involves updating the URL to a new, reliable placeholder image, enhancing the user experience and avoiding any misunderstandings.