### PR TITLE
docs(vite) use server.ts as file name, not server.tsx

### DIFF
--- a/docs/future/vite.md
+++ b/docs/future/vite.md
@@ -283,7 +283,7 @@ If you prefer, you can instead author your custom server in TypeScript.
 You could then use tools like [`tsx`][tsx] or [`tsm`][tsm] to run your custom server:
 
 ```shellscript nonumber
-tsx ./server.tsx
+tsx ./server.ts
 node --loader tsm ./server.ts
 ```
 


### PR DESCRIPTION
The docs mention using `tsx server.tsx`, but the `.tsx` extension is for React related [TypeScript XML](https://www.typescriptlang.org/docs/handbook/jsx.html) files, which isn't relevant to the server file.

[`tsx`](https://github.com/privatenumber/tsx#readme-ov-file) is a `node` CLI replacement to run TypeScript & ESM files. There is a [note](https://github.com/privatenumber/tsx#why-is-it-named-tsx) in their documentation about the unfortunate naming overlap.