### PR TITLE
Update v2.md to specify installing v1 route convention as dev dep

### DIFF
--- a/docs/start/v2.md
+++ b/docs/start/v2.md
@@ -120,7 +120,7 @@ If you are using `v2_dev` config, you'll need to move it to the `dev` config fie
 You can keep using the old convention with `@remix-run/v1-route-convention` even after upgrading to v2 if you don't want to make the change right now (or ever, it's just a convention, and you can use whatever file organization you prefer).
 
 ```shellscript nonumber
-npm i @remix-run/v1-route-convention
+npm i -D @remix-run/v1-route-convention
 ```
 
 ```js filename=remix.config.js


### PR DESCRIPTION
The @remix-run/v1-route-convention package should be installed as a dev dependency so that @remix-run/dev doesn't get pulled into production dependencies. This saved about 100mb on my docker image and removed critical vulnerabilities 🙈 