### PR TITLE
Replace broken placekitten avatar with picsum in tutorial

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -186,6 +186,7 @@
 - gonzoscript
 - graham42
 - GregBrimble
+- gregdingle
 - GSt4r
 - guatedude2
 - guerra08

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -170,7 +170,7 @@ export default function Contact() {
   const contact = {
     first: "Your",
     last: "Name",
-    avatar: "https://placekitten.com/g/200/200",
+    avatar: "https://picsum.photos/id/237/200/200",
     twitter: "your_handle",
     notes: "Some notes",
     favorite: true,


### PR DESCRIPTION
This is nearly a simple docs change. 

I was just doing the remix-tutorial and I noticed an image was broken. It looks like `placekitten.com` is simply no longer. With a quick web search, I found `picsum.photos` and a photo on there which seems to serve the same purpose. But feel free to swap in something else. 

I'm not looking to take sides on dogs vs cats 🙂 

**Before**

![CleanShot 2023-12-16 at 16 28 40](https://github.com/remix-run/remix/assets/28797/c3203adf-b516-48b1-a41c-056707efe6be)


**After**

![CleanShot 2023-12-16 at 16 28 56](https://github.com/remix-run/remix/assets/28797/a8a78c2f-e2ff-4f9a-a49d-674c4b168d2c)
