### PR TITLE
fix(templates/vite): remove unnecessary eslint ignore

### DIFF
--- a/templates/unstable-vite-express/vite.config.ts
+++ b/templates/unstable-vite-express/vite.config.ts
@@ -1,8 +1,5 @@
 import { unstable_vitePlugin as remix } from "@remix-run/dev";
 import { defineConfig } from "vite";
-// This is only an issue in the Remix monorepo, this should lint properly once
-// you've created an app from this template and this comment can be removed
-// eslint-disable-next-line import/no-unresolved
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({

--- a/templates/unstable-vite/vite.config.ts
+++ b/templates/unstable-vite/vite.config.ts
@@ -1,9 +1,6 @@
 import { unstable_vitePlugin as remix } from "@remix-run/dev";
 import { installGlobals } from "@remix-run/node";
 import { defineConfig } from "vite";
-// This is only an issue in the Remix monorepo, this should lint properly once
-// you've created an app from this template and this comment can be removed
-// eslint-disable-next-line import/no-unresolved
 import tsconfigPaths from "vite-tsconfig-paths";
 
 installGlobals();


### PR DESCRIPTION
`yarn lint` passes without these eslint ignores