### PR TITLE
fix(vite): disable `server.watch` for child compiler during build

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -680,6 +680,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
           ...viteUserConfig,
           mode: viteConfig.mode,
           server: {
+            watch: viteConfig.command === "build" ? null : undefined,
             preTransformRequests: false,
             hmr: false,
           },


### PR DESCRIPTION
Closes: https://github.com/remix-run/remix/issues/8313

Vite introduced `server.watch: null` in https://github.com/vitejs/vite/pull/14208. Initial use case was for Vitest, but reading the thread there, it looks like Astro also had such use case.
I think disabling `server.watch` during dev might be also fine since currently child compiler doesn't make use of Vite's caching/invalidation so watcher might not be necessary as well. But for now, disabling for build seems obvious, so I only did that here.

## testing

I cannot think of a way to verify the change exactly... Maybe better to ask the issue author to verify this by patching it locally.