### PR TITLE
fix (remix-serve): convert file url to path when loading source maps

### DIFF
--- a/.changeset/angry-poets-accept.md
+++ b/.changeset/angry-poets-accept.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/serve": patch
+---
+
+Use node `fileURLToPath` to convert source map URL to path

--- a/contributors.yml
+++ b/contributors.yml
@@ -623,3 +623,4 @@
 - timkraut
 - alexanderson1993
 - signed
+- VHall1

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -20,12 +20,13 @@ process.env.NODE_ENV = process.env.NODE_ENV ?? "production";
 
 sourceMapSupport.install({
   retrieveSourceMap: function (source) {
-    // get source file without the `file://` prefix or `?t=...` suffix
-    let match = source.match(/^file:\/\/(.*)\?t=[.\d]+$/);
+    // get source file with the `file://` prefix
+    let match = source.match(/^file:\/\/(.*)$/);
     if (match) {
+      let filePath = url.fileURLToPath(source);
       return {
         url: source,
-        map: fs.readFileSync(`${match[1]}.map`, "utf8"),
+        map: fs.readFileSync(`${filePath}.map`, "utf8"),
       };
     }
     return null;

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -11,12 +11,13 @@ import sourceMapSupport from "source-map-support";
 
 sourceMapSupport.install({
   retrieveSourceMap: function (source) {
-    // get source file without the `file://` prefix or `?t=...` suffix
-    const match = source.match(/^file:\/\/(.*)\?t=[.\d]+$/);
+    // get source file with the `file://` prefix
+    const match = source.match(/^file:\/\/(.*)$/);
     if (match) {
+      const filePath = url.fileURLToPath(source);
       return {
         url: source,
-        map: fs.readFileSync(`${match[1]}.map`, "utf8"),
+        map: fs.readFileSync(`${filePath}.map`, "utf8"),
       };
     }
     return null;


### PR DESCRIPTION
This PR fixes an issue where the leading slash on source map paths would cause remix-serve to crash when an error gets thrown on Windows.

Tested both on Windows and Mac.

Closes: [8309](https://github.com/remix-run/remix/issues/8309)
