### PR TITLE
docs: fix link in `remix-config.md`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -325,6 +325,7 @@
 - leon
 - leothorp
 - leovander
+- leoweigand
 - levippaul
 - LewisArdern
 - lifeiscontent

--- a/docs/file-conventions/remix-config.md
+++ b/docs/file-conventions/remix-config.md
@@ -272,7 +272,7 @@ There are a few conventions that Remix uses you should be aware of.
 [esbuild_plugins_node_modules_polyfill]: https://npm.im/esbuild-plugins-node-modules-polyfill
 [browser-node-builtins-polyfill]: #browsernodebuiltinspolyfill
 [server-node-builtins-polyfill]: #servernodebuiltinspolyfill
-[future-flags]: ../start/future-flags.md
+[future-flags]: ../start/future-flags
 [fetcherpersist-rfc]: https://github.com/remix-run/remix/discussions/7698
 [use-fetchers]: ../hooks/use-fetchers
 [use-fetcher]: ../hooks/use-fetcher


### PR DESCRIPTION
Because of the `.md` extension, this link didn't work on the website, only GitHub. Thanks!