### PR TITLE
fix(remix-dev/vite): preload Vite ESM build in CLI

### DIFF
--- a/packages/remix-dev/vite/build.ts
+++ b/packages/remix-dev/vite/build.ts
@@ -1,6 +1,7 @@
 import type * as Vite from "vite";
 import colors from "picocolors";
 
+import { preloadViteEsm } from "./import-vite-esm-sync";
 import type { ResolvedRemixVitePluginConfig } from "./plugin";
 
 async function extractRemixPluginConfig({
@@ -56,6 +57,10 @@ export async function build(
     mode,
   }: ViteBuildOptions
 ) {
+  // Ensure Vite's ESM build is preloaded at the start of the process
+  // so it can be accessed synchronously via `importViteEsmSync`
+  await preloadViteEsm();
+
   // For now we just use this function to validate that the Vite config is
   // targeting Remix, but in the future the return value can be used to
   // configure the entire multi-step build process.

--- a/packages/remix-dev/vite/dev.ts
+++ b/packages/remix-dev/vite/dev.ts
@@ -1,6 +1,8 @@
 import type * as Vite from "vite";
 import colors from "picocolors";
 
+import { preloadViteEsm } from "./import-vite-esm-sync";
+
 export interface ViteDevOptions {
   clearScreen?: boolean;
   config?: string;
@@ -29,6 +31,10 @@ export async function dev(
     strictPort,
   }: ViteDevOptions
 ) {
+  // Ensure Vite's ESM build is preloaded at the start of the process
+  // so it can be accessed synchronously via `importViteEsmSync`
+  await preloadViteEsm();
+
   let vite = await import("vite");
   let server = await vite.createServer({
     root,


### PR DESCRIPTION
Now that we've introduced Vite-specific CLI commands, we have two new entrypoints into a Vite context. We need to call our `preloadViteEsm` function at the top of these commands to ensure any calls to `loadViteEsmSync` don't fail.