### PR TITLE
Re-export response helpers through react package

### DIFF
--- a/.changeset/twelve-cars-work.md
+++ b/.changeset/twelve-cars-work.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Export `Response` helpers (`defer`/`json`/`redirect`/`redirectDocument`) through `@remix-run/react` for use in `clientLoader`/`clientAction`

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -1,5 +1,3 @@
-export type { RemixBrowserProps } from "./browser";
-export { RemixBrowser } from "./browser";
 export type {
   ErrorResponse,
   Fetcher,
@@ -52,7 +50,16 @@ export {
   unstable_usePrompt,
   unstable_useViewTransitionState,
 } from "react-router-dom";
+export {
+  // For use in clientLoader/clientAction
+  defer,
+  json,
+  redirect,
+  redirectDocument,
+} from "@remix-run/server-runtime";
 
+export type { RemixBrowserProps } from "./browser";
+export { RemixBrowser } from "./browser";
 export type {
   AwaitProps,
   RemixNavLinkProps as NavLinkProps,


### PR DESCRIPTION
Export these from the react package for use in `clientLoader`/`clientAction` since users cannot use them from `@remix-run/node` in client bundles.  right now, the workaround is to import from `@remix-run/server-runtime`.

See: https://github.com/remix-run/remix/discussions/7634#discussioncomment-7867885