### PR TITLE
fix(vite): fix errors for non-existent `index.html` importer

### DIFF
--- a/.changeset/curly-coats-reflect.md
+++ b/.changeset/curly-coats-reflect.md
@@ -1,0 +1,6 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: Fix errors for non-existent `index.html` importer
+

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -947,7 +947,13 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
           serverFileRE.test(resolved!.id) || serverDirRE.test(resolved!.id);
         if (!isDotServer) return;
 
-        if (!importer) throw Error(`Importer not found: ${id}`);
+        if (!importer) return;
+        if (viteCommand !== "build" && importer.endsWith(".html")) {
+          // Vite has a special `index.html` importer for `resolveId` within `transformRequest`
+          // https://github.com/vitejs/vite/blob/5684fcd8d27110d098b3e1c19d851f44251588f1/packages/vite/src/node/server/transformRequest.ts#L158
+          // https://github.com/vitejs/vite/blob/5684fcd8d27110d098b3e1c19d851f44251588f1/packages/vite/src/node/server/pluginContainer.ts#L668
+          return;
+        }
 
         let vite = importViteEsmSync();
         let pluginConfig = await resolvePluginConfig();


### PR DESCRIPTION
Testing strategy:

Tried it locally with `LOCAL_BUILD_DIRECTORY` on a simple express + vite app that was having the same error before.