### PR TITLE
fix(remix-dev/vite): rename bundles manifest key

### DIFF
--- a/integration/vite-server-bundles-test.ts
+++ b/integration/vite-server-bundles-test.ts
@@ -272,7 +272,7 @@ test.describe(() => {
           file: "build/server/root/index.js",
         },
       },
-      routeIdToBundleId: {
+      routeIdToServerBundleId: {
         "routes/_pathless.bundle-c.route-a": "bundle-c",
         "routes/_pathless.bundle-c.route-b": "bundle-c",
         "routes/_pathless.bundle-c": "bundle-c",

--- a/packages/remix-dev/vite/build.ts
+++ b/packages/remix-dev/vite/build.ts
@@ -88,7 +88,7 @@ export type ServerBundlesManifest = {
       file: string;
     };
   };
-  routeIdToBundleId: Record<string, string>;
+  routeIdToServerBundleId: Record<string, string>;
   routes: RouteManifest;
 };
 
@@ -122,7 +122,7 @@ async function getServerBuilds({
 
   let serverBundlesManifest: ServerBundlesManifest = {
     serverBundles: {},
-    routeIdToBundleId: {},
+    routeIdToServerBundleId: {},
     routes: rootRelativeRoutes,
   };
 
@@ -145,7 +145,7 @@ async function getServerBuilds({
           `The "unstable_serverBundles" function must return a string`
         );
       }
-      serverBundlesManifest.routeIdToBundleId[route.id] = bundleId;
+      serverBundlesManifest.routeIdToServerBundleId[route.id] = bundleId;
 
       let serverBundleDirectory = path.join(serverBuildDirectory, bundleId);
       let serverBuildConfig = serverBuildConfigByBundleId.get(bundleId);


### PR DESCRIPTION
I'd renamed `routeIdToBundleId` to `routeIdToServerBundleId` in the docs but hadn't updated it in the code.