### PR TITLE
Add missing eslint dependencies to templates/remix-tutorial

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -391,6 +391,7 @@
 - michaelgmcd
 - michaelhelvey
 - michaseel
+- mikechabot
 - mikeybinnswebdesign
 - mirzafaizan
 - mitchelldirt

--- a/templates/remix-tutorial/package.json
+++ b/templates/remix-tutorial/package.json
@@ -26,7 +26,10 @@
     "@typescript-eslint/eslint-plugin": "^6.13.0",
     "@typescript-eslint/parser": "^6.13.0",
     "eslint": "^8.47.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "typescript": "^5.1.6"
   },
   "engines": {


### PR DESCRIPTION
The `.eslintrc.js` configuration in `templates/remix-tutorial` contains references to plugins that aren't included in the existing `package.json`. Add these missing dependencies to satisfy eslint:

  - `eslint-plugin-import`
  - `eslint-plugin-jsx-a11y`
  - `eslint-plugin-react-hooks`

See Ryan F request: https://twitter.com/ryanflorence/status/1737890101194293405