### PR TITLE
Set the default value of NODE_ENV to production when building with Vite

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -132,6 +132,7 @@
 - DNLHC
 - dnsbty
 - dogukanakkaya
+- doinki
 - dokeet
 - donavon
 - Drew-Daniels

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -202,6 +202,7 @@ export async function run(argv: string[] = process.argv.slice(2)) {
       await commands.build(input[1], process.env.NODE_ENV, flags.sourcemap);
       break;
     case "vite:build":
+      if (!process.env.NODE_ENV) process.env.NODE_ENV = "production";
       await commands.viteBuild(input[1], flags);
       break;
     case "watch":


### PR DESCRIPTION
Closes: #8364

When building using ```remix vite:build``` in v2.4.1, NODE_ENV is set to development, increasing the build size.
So, I modified the default value of NODE_ENV to be production when building with vite.

<img width="686" alt="1" src="https://github.com/remix-run/remix/assets/90969158/c30fc55a-d72d-4718-8807-599c9c33e0ae" />

<img width="686" alt="2" src="https://github.com/remix-run/remix/assets/90969158/7b2d518f-c13f-4e2a-8980-b1e97824695c" />
