### PR TITLE
Update UIMatch type to cover cases where loaderData is undefined

### DIFF
--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -986,7 +986,7 @@ function dedupe(array: any[]) {
 }
 
 export type UIMatch<D = AppData, H = RouteHandle> = UIMatchRR<
-  SerializeFrom<D>,
+  SerializeFrom<D> | undefined,
   H
 >;
 


### PR DESCRIPTION
when using a UIMatch loaderData may be undefined in the scenario that the loader failed, so this makes the types a bit more safe making sure that consumers of the UIMatch type check for `undefined`

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
