### PR TITLE
docs(fix): Fix typo in create-remix.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -34,6 +34,7 @@
 - anishpras
 - anmolm96
 - anmonteiro
+- anshuman71
 - AntoninBeaufort
 - anubra266
 - apeltop

--- a/docs/other-api/create-remix.md
+++ b/docs/other-api/create-remix.md
@@ -33,11 +33,11 @@ npx create-remix@latest --help
 `create-remix` can also be invoked using various package managers, allowing you to choose between npm, Yarn, pnpm, and Bun for managing the install process.
 
 ```sh
-npm create remix@latest <projectDir>
+npm create-remix@latest <projectDir>
 # or
-yarn create remix <projectDir>
+yarn create-remix <projectDir>
 # or
-pnpm create remix <projectDir>
+pnpm create-remix <projectDir>
 # or
 bunx create-remix <projectDir>
 ```


### PR DESCRIPTION
I was reading the docs and found these typos.

- [x] Docs
- [ ] Tests


