### PR TITLE
fix(remix-dev/vite): default NODE_ENV in build

### DIFF
--- a/.changeset/fair-bobcats-walk.md
+++ b/.changeset/fair-bobcats-walk.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: Default `NODE_ENV` to `"production"` when running `remix vite:build` command

--- a/integration/vite-node-env-test.ts
+++ b/integration/vite-node-env-test.ts
@@ -1,0 +1,79 @@
+import { test, expect } from "@playwright/test";
+import getPort from "get-port";
+
+import {
+  createProject,
+  viteDev,
+  viteBuild,
+  viteRemixServe,
+  VITE_CONFIG,
+} from "./helpers/vite.js";
+
+let files = {
+  "app/routes/node_env.tsx": String.raw`
+    export default function NodeEnvRoute() {
+      return <div data-node-env>{process.env.NODE_ENV}</div>
+    }
+  `,
+};
+
+test.describe(async () => {
+  let devPort: number;
+  let cwd: string;
+  let stop: () => Promise<void> | void;
+
+  test.beforeAll(async () => {
+    devPort = await getPort();
+    cwd = await createProject({
+      "vite.config.js": await VITE_CONFIG({ port: devPort }),
+      ...files,
+    });
+  });
+
+  test.describe(() => {
+    test.beforeAll(async () => {
+      stop = await viteDev({ cwd, port: devPort });
+    });
+    test.afterAll(async () => await stop());
+
+    test("Vite / NODE_ENV / dev", async ({ page }) => {
+      let pageErrors: unknown[] = [];
+      page.on("pageerror", (error) => pageErrors.push(error));
+
+      await page.goto(`http://localhost:${devPort}/node_env`, {
+        waitUntil: "networkidle",
+      });
+      expect(pageErrors).toEqual([]);
+
+      let nodeEnvContent = page.locator("[data-node-env]");
+      await expect(nodeEnvContent).toHaveText("development");
+
+      expect(pageErrors).toEqual([]);
+    });
+  });
+
+  test.describe(() => {
+    let buildPort: number;
+    test.beforeAll(async () => {
+      await viteBuild({ cwd });
+      buildPort = await getPort();
+      stop = await viteRemixServe({ cwd, port: buildPort });
+    });
+    test.afterAll(async () => await stop());
+
+    test("Vite / NODE_ENV / build", async ({ page }) => {
+      let pageErrors: unknown[] = [];
+      page.on("pageerror", (error) => pageErrors.push(error));
+
+      await page.goto(`http://localhost:${buildPort}/node_env`, {
+        waitUntil: "networkidle",
+      });
+      expect(pageErrors).toEqual([]);
+
+      let nodeEnvContent = page.locator("[data-node-env]");
+      await expect(nodeEnvContent).toHaveText("production");
+
+      expect(pageErrors).toEqual([]);
+    });
+  });
+});

--- a/packages/remix-dev/vite/build.ts
+++ b/packages/remix-dev/vite/build.ts
@@ -27,7 +27,9 @@ async function extractConfig({
   // process so we don't need to have a separate Remix config
   let viteConfig = await vite.resolveConfig(
     { mode, configFile, root },
-    "build"
+    "build", // command
+    "production", // default mode
+    "production" // default NODE_ENV
   );
 
   let pluginConfig = viteConfig[


### PR DESCRIPTION
Fixes #8364.

This PR implements the fix suggested here: https://github.com/remix-run/remix/pull/8365#issuecomment-1868309373

I've also added a test and ensured that it fails without the provided fix.