### PR TITLE
docs(testing): remove redundant usage of `waitFor`

### DIFF
--- a/docs/other-api/testing.md
+++ b/docs/other-api/testing.md
@@ -30,9 +30,7 @@ Then you can render the `<RemixStub />` component and assert against it:
 
 ```tsx
 render(<RemixStub />);
-await waitFor(() =>
-  screen.findByText("Some rendered text")
-);
+await screen.findByText("Some rendered text");
 ```
 
 ## Example


### PR DESCRIPTION
This is a simple docs change. Wrapping a `find*` query in `waitFor` is unnecessary since that's what it's doing anyway.