### PR TITLE
Add "eslint-import-resolver-typescript" to the remix template

### DIFF
--- a/templates/remix/package.json
+++ b/templates/remix/package.json
@@ -25,6 +25,7 @@
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "eslint": "^8.38.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.33.2",


### PR DESCRIPTION
When creating a new project with `create-remix@latest`, if you attempt to import a `*.css` file (for instance, when using Tailwind), eslint complains about the resolver:

<img width="887" alt="image" src="https://github.com/remix-run/remix/assets/96213/1fcd9009-a633-4b7c-84cf-081dd0ea26b5">



The fix is to run `npm install -D eslint-import-resolver-typescript`, after which eslint will no longer complain about the wrong interface or the `*.css` file.