### PR TITLE
Fix templates eslint issue when using ~ alias

### DIFF
--- a/templates/arc/.eslintrc.cjs
+++ b/templates/arc/.eslintrc.cjs
@@ -43,6 +43,9 @@ module.exports = {
           { name: "Link", linkAttribute: "to" },
           { name: "NavLink", linkAttribute: "to" },
         ],
+        "import/resolver": {
+          typescript: {},
+        },
       },
     },
 

--- a/templates/arc/package.json
+++ b/templates/arc/package.json
@@ -29,6 +29,7 @@
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "eslint": "^8.38.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.33.2",

--- a/templates/cloudflare-pages/.eslintrc.cjs
+++ b/templates/cloudflare-pages/.eslintrc.cjs
@@ -43,6 +43,9 @@ module.exports = {
           { name: "Link", linkAttribute: "to" },
           { name: "NavLink", linkAttribute: "to" },
         ],
+        "import/resolver": {
+          typescript: {},
+        },
       },
     },
 

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -26,6 +26,7 @@
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "eslint": "^8.38.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.33.2",

--- a/templates/cloudflare-workers/.eslintrc.cjs
+++ b/templates/cloudflare-workers/.eslintrc.cjs
@@ -43,6 +43,9 @@ module.exports = {
           { name: "Link", linkAttribute: "to" },
           { name: "NavLink", linkAttribute: "to" },
         ],
+        "import/resolver": {
+          typescript: {},
+        },
       },
     },
 

--- a/templates/express/.eslintrc.cjs
+++ b/templates/express/.eslintrc.cjs
@@ -43,6 +43,9 @@ module.exports = {
           { name: "Link", linkAttribute: "to" },
           { name: "NavLink", linkAttribute: "to" },
         ],
+        "import/resolver": {
+          typescript: {},
+        },
       },
     },
 

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -35,6 +35,7 @@
     "chokidar": "^3.5.3",
     "eslint": "^8.38.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.33.2",

--- a/templates/fly/.eslintrc.cjs
+++ b/templates/fly/.eslintrc.cjs
@@ -43,6 +43,9 @@ module.exports = {
           { name: "Link", linkAttribute: "to" },
           { name: "NavLink", linkAttribute: "to" },
         ],
+        "import/resolver": {
+          typescript: {},
+        },
       },
     },
 

--- a/templates/fly/package.json
+++ b/templates/fly/package.json
@@ -26,6 +26,7 @@
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "eslint": "^8.38.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.33.2",

--- a/templates/remix-tutorial/.eslintrc.js
+++ b/templates/remix-tutorial/.eslintrc.js
@@ -43,6 +43,9 @@ module.exports = {
           { name: "Link", linkAttribute: "to" },
           { name: "NavLink", linkAttribute: "to" },
         ],
+        "import/resolver": {
+          typescript: {},
+        },
       },
     },
 

--- a/templates/remix-tutorial/package.json
+++ b/templates/remix-tutorial/package.json
@@ -26,6 +26,7 @@
     "@typescript-eslint/eslint-plugin": "^6.13.0",
     "@typescript-eslint/parser": "^6.13.0",
     "eslint": "^8.47.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-react": "^7.33.2",

--- a/templates/remix/.eslintrc.cjs
+++ b/templates/remix/.eslintrc.cjs
@@ -43,6 +43,9 @@ module.exports = {
           { name: "Link", linkAttribute: "to" },
           { name: "NavLink", linkAttribute: "to" },
         ],
+        "import/resolver": {
+          typescript: {},
+        },
       },
     },
 

--- a/templates/remix/package.json
+++ b/templates/remix/package.json
@@ -25,6 +25,7 @@
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "eslint": "^8.38.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.33.2",

--- a/templates/unstable-vite-express/.eslintrc.cjs
+++ b/templates/unstable-vite-express/.eslintrc.cjs
@@ -43,6 +43,9 @@ module.exports = {
           { name: "Link", linkAttribute: "to" },
           { name: "NavLink", linkAttribute: "to" },
         ],
+        "import/resolver": {
+          typescript: {},
+        },
       },
     },
 

--- a/templates/unstable-vite/.eslintrc.cjs
+++ b/templates/unstable-vite/.eslintrc.cjs
@@ -43,6 +43,9 @@ module.exports = {
           { name: "Link", linkAttribute: "to" },
           { name: "NavLink", linkAttribute: "to" },
         ],
+        "import/resolver": {
+          typescript: {},
+        },
       },
     },
 


### PR DESCRIPTION
Fix issues with templates lint configs when adding path aliases.  

* Adding the package as a dependency fixes the ability to import CSS files
* Adding the setting to the config allows path aliases to be used

Closes #8336 
Supersedes #8337 and #8435