### PR TITLE
fix (remix-serve): fallback to default path if source maps aren't available when building stack trace

### DIFF
--- a/.changeset/dry-books-hug.md
+++ b/.changeset/dry-books-hug.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/serve": minor
+---
+
+Allow remix-serve CLI to fallback to default stack trace if source maps are not available

--- a/.changeset/dry-books-hug.md
+++ b/.changeset/dry-books-hug.md
@@ -1,5 +1,5 @@
 ---
-"@remix-run/serve": minor
+"@remix-run/serve": patch
 ---
 
-Allow remix-serve CLI to fallback to default stack trace if source maps are not available
+Don't try to load sourcemaps if they don't exist on disk

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -20,14 +20,16 @@ process.env.NODE_ENV = process.env.NODE_ENV ?? "production";
 
 sourceMapSupport.install({
   retrieveSourceMap: function (source) {
-    // get source file with the `file://` prefix
-    let match = source.match(/^file:\/\/(.*)$/);
+    let match = source.startsWith("file://");
     if (match) {
       let filePath = url.fileURLToPath(source);
-      return {
-        url: source,
-        map: fs.readFileSync(`${filePath}.map`, "utf8"),
-      };
+      let sourceMapPath = `${filePath}.map`;
+      if (fs.existsSync(sourceMapPath)) {
+        return {
+          url: source,
+          map: fs.readFileSync(sourceMapPath, "utf8"),
+        };
+      }
     }
     return null;
   },

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -11,14 +11,16 @@ import sourceMapSupport from "source-map-support";
 
 sourceMapSupport.install({
   retrieveSourceMap: function (source) {
-    // get source file with the `file://` prefix
-    const match = source.match(/^file:\/\/(.*)$/);
+    const match = source.startsWith("file://");
     if (match) {
       const filePath = url.fileURLToPath(source);
-      return {
-        url: source,
-        map: fs.readFileSync(`${filePath}.map`, "utf8"),
-      };
+      const sourceMapPath = `${filePath}.map`;
+      if (fs.existsSync(sourceMapPath)) {
+        return {
+          url: source,
+          map: fs.readFileSync(sourceMapPath, "utf8"),
+        };
+      }
     }
     return null;
   },


### PR DESCRIPTION
Another update to source map loading. This should resolve issues where people reported getting server crashes when they had source maps disabled or when errors were being thrown by 3rd party packages (since source maps aren't available for those). All this does really is check that the file exists before loading it, and returning null if it doesn't (using the original path as a fallback). Mostly based on the patch suggested here: https://github.com/remix-run/remix/issues/8309#issuecomment-1868374521

Testing:

**3rd party error (tiny-invariant)**
![image](https://github.com/remix-run/remix/assets/46335285/2fb83eea-358c-4593-ba18-e3bdc6b89def)

**generic error**
![image](https://github.com/remix-run/remix/assets/46335285/54604013-2eab-444c-9981-8ed7d7662b13)

**generic error after manually deleting source map**
![image](https://github.com/remix-run/remix/assets/46335285/f19608bc-43ea-4e2e-a83c-dd88e9f2eaa5)

Closes: #8309
