### PR TITLE
templates(vite): enable skipLibCheck in tsconfig

### DIFF
--- a/docs/future/vite.md
+++ b/docs/future/vite.md
@@ -134,6 +134,8 @@ export default defineConfig({
 
 Vite handles imports for all sorts of different file types, sometimes in ways that differ from the existing Remix compiler, so let's reference Vite's types from `vite/client` instead of the obsolete types from `@remix-run/dev`.
 
+Since the module types provided by `vite/client` are not compatible with the module types implicitly included with `@remix-run/dev`, you'll also need to enable the `skipLibCheck` flag in your TypeScript config. Remix won't require this flag in the future once the Vite plugin is the default compiler.
+
 👉 **Rename `remix.env.d.ts` to `env.d.ts`**
 
 ```diff nonumber
@@ -154,6 +156,12 @@ Vite handles imports for all sorts of different file types, sometimes in ways th
 ```diff filename=tsconfig.json
 - "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
 + "include": ["env.d.ts", "**/*.ts", "**/*.tsx"],
+```
+
+👉 **Ensure `skipLibCheck` is enabled in `tsconfig.json`**
+
+```json filename=tsconfig.json
+"skipLibCheck": true,
 ```
 
 👉 **Ensure `module` and `moduleResolution` fields are set correctly in `tsconfig.json`**

--- a/templates/unstable-vite-express/tsconfig.json
+++ b/templates/unstable-vite-express/tsconfig.json
@@ -11,20 +11,12 @@
     "target": "ES2022",
     "strict": true,
     "allowJs": true,
+    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
       "~/*": ["./app/*"]
     },
-
-    // The `skipLibCheck` flag is enabled in Remix's Vite templates due to a
-    // clash between the module types from `vite/client` and the old module
-    // types from `@remix-run/dev` which were intended for use with Remix's
-    // esbuild compiler. When `@remix-run/dev` no longer implicitly includes
-    // these module types, the Remix Vite templates will no longer enable this
-    // flag. This will most likely happen in a future major release when the
-    // esbuild compiler is removed in favor of the Vite plugin.
-    "skipLibCheck": true,
 
     // Vite takes care of building everything, not tsc.
     "noEmit": true

--- a/templates/unstable-vite-express/tsconfig.json
+++ b/templates/unstable-vite-express/tsconfig.json
@@ -17,7 +17,16 @@
       "~/*": ["./app/*"]
     },
 
-    // Remix takes care of building everything in `remix build`.
+    // The `skipLibCheck` flag is enabled in Remix's Vite templates due to a
+    // clash between the module types from `vite/client` and the old module
+    // types from `@remix-run/dev` which were intended for use with Remix's
+    // esbuild compiler. When `@remix-run/dev` no longer implicitly includes
+    // these module types, the Remix Vite templates will no longer enable this
+    // flag. This will most likely happen in a future major release when the
+    // esbuild compiler is removed in favor of the Vite plugin.
+    "skipLibCheck": true,
+
+    // Vite takes care of building everything, not tsc.
     "noEmit": true
   }
 }

--- a/templates/unstable-vite/tsconfig.json
+++ b/templates/unstable-vite/tsconfig.json
@@ -11,20 +11,12 @@
     "target": "ES2022",
     "strict": true,
     "allowJs": true,
+    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
       "~/*": ["./app/*"]
     },
-
-    // The `skipLibCheck` flag is enabled in Remix's Vite templates due to a
-    // clash between the module types from `vite/client` and the old module
-    // types from `@remix-run/dev` which were intended for use with Remix's
-    // esbuild compiler. When `@remix-run/dev` no longer implicitly includes
-    // these module types, the Remix Vite templates will no longer enable this
-    // flag. This will most likely happen in a future major release when the
-    // esbuild compiler is removed in favor of the Vite plugin.
-    "skipLibCheck": true,
 
     // Vite takes care of building everything, not tsc.
     "noEmit": true

--- a/templates/unstable-vite/tsconfig.json
+++ b/templates/unstable-vite/tsconfig.json
@@ -17,7 +17,16 @@
       "~/*": ["./app/*"]
     },
 
-    // Remix takes care of building everything in `remix build`.
+    // The `skipLibCheck` flag is enabled in Remix's Vite templates due to a
+    // clash between the module types from `vite/client` and the old module
+    // types from `@remix-run/dev` which were intended for use with Remix's
+    // esbuild compiler. When `@remix-run/dev` no longer implicitly includes
+    // these module types, the Remix Vite templates will no longer enable this
+    // flag. This will most likely happen in a future major release when the
+    // esbuild compiler is removed in favor of the Vite plugin.
+    "skipLibCheck": true,
+
+    // Vite takes care of building everything, not tsc.
     "noEmit": true
   }
 }


### PR DESCRIPTION
Closes #8443

As discussed in the linked issue, there are type clashes between the module types coming from `@remix-run/dev` and `vite/client` due to the fact that they both register types for files like `"*.css"`, `"*.mdx"` etc.

Even though we've removed `/// <reference types="@remix-run/dev" />` from the Vite templates' `env.d.ts` files, it turns out the global module types are still included implicitly because `@remix-run/dev/dist/index.d.ts` imports from `modules.d.ts` as a top-level side effect. This means that it's currently impossible to avoid including the modules types from the old compiler. These type errors slipped through because this doesn't raise a type error in your editor, only when running `tsc`.

We could fix this by decoupling `modules.d.ts` from `@remix-run/dev/dist/index.d.ts`, but this would be a breaking change since all consumers of the current compiler would need to update their `remix-env.d.ts` file to include a reference to this file. So, rather than forcing a breaking change on all consumers of the current esbuild-based Remix compiler, I'm opting to enable the `skipLibCheck` flag in templates for Vite consumers. Re can revisit the status of this flag in the future once Vite has become the default compiler.

- [x] Docs
- [ ] Tests

Testing Strategy:

Ran `create-remix` with both `unstable-vite` and `unstable-vite-express` templates. Confirmed that `npm run typecheck` fails for both templates and that enabling `skipLibCheck` suppresses these type errors.