### PR TITLE
fix(create-remix): only update "*" versions for Remix dependencies

### DIFF
--- a/.changeset/wicked-suits-heal.md
+++ b/.changeset/wicked-suits-heal.md
@@ -1,0 +1,5 @@
+---
+"create-remix": patch
+---
+
+Only update `*` versions for `@remix-run/*` dependencies

--- a/.changeset/wicked-suits-heal.md
+++ b/.changeset/wicked-suits-heal.md
@@ -2,4 +2,4 @@
 "create-remix": patch
 ---
 
-Only update `*` versions for `@remix-run/*` dependencies
+Only update `*` versions for Remix dependencies

--- a/contributors.yml
+++ b/contributors.yml
@@ -10,6 +10,7 @@
 - ahabhgk
 - ahbruns
 - ahmedeldessouki
+- ahuth
 - aiji42
 - airjp73
 - airondumael

--- a/packages/create-remix/__tests__/create-remix-test.ts
+++ b/packages/create-remix/__tests__/create-remix-test.ts
@@ -989,8 +989,9 @@ describe("create-remix CLI", () => {
 
     expect(dependencies).toMatchObject({
       "@remix-run/react": expect.any(String),
+      remix: expect.any(String),
       "not-remix": "*",
-    })
+    });
   });
 
   describe("when project directory contains files", () => {

--- a/packages/create-remix/__tests__/create-remix-test.ts
+++ b/packages/create-remix/__tests__/create-remix-test.ts
@@ -968,6 +968,31 @@ describe("create-remix CLI", () => {
     }
   });
 
+  it("changes star dependencies for only Remix packages", async () => {
+    let projectDir = getProjectDir("local-directory");
+
+    let { status } = await execCreateRemix({
+      args: [
+        projectDir,
+        "--template",
+        path.join(__dirname, "fixtures", "stack"),
+        "--no-git-init",
+        "--no-install",
+      ],
+    });
+
+    expect(status).toBe(0);
+
+    let packageJsonPath = path.join(projectDir, "package.json");
+    let packageJson = JSON.parse(String(fse.readFileSync(packageJsonPath)));
+    let dependencies = packageJson.dependencies;
+
+    expect(dependencies).toMatchObject({
+      "@remix-run/react": expect.any(String),
+      "not-remix": "*",
+    })
+  });
+
   describe("when project directory contains files", () => {
     describe("interactive shell", () => {
       let interactive = true;

--- a/packages/create-remix/__tests__/fixtures/stack/package.json
+++ b/packages/create-remix/__tests__/fixtures/stack/package.json
@@ -7,7 +7,10 @@
     "dev": "remix dev",
     "start": "remix-serve build/index.js"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@remix-run/react": "*",
+    "not-remix": "*"
+  },
   "devDependencies": {},
   "engines": {
     "node": ">=18.0.0"

--- a/packages/create-remix/__tests__/fixtures/stack/package.json
+++ b/packages/create-remix/__tests__/fixtures/stack/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "@remix-run/react": "*",
-    "not-remix": "*"
+    "not-remix": "*",
+    "remix": "*"
   },
   "devDependencies": {},
   "engines": {

--- a/packages/create-remix/index.ts
+++ b/packages/create-remix/index.ts
@@ -720,7 +720,10 @@ async function updatePackageJSON(ctx: Context) {
 
     for (let dependency in dependencies) {
       let version = dependencies[dependency];
-      if (dependency.startsWith("@remix-run") && version === "*") {
+      if (
+        (dependency.startsWith("@remix-run/") || dependency === "remix") &&
+        version === "*"
+      ) {
         dependencies[dependency] = semver.prerelease(ctx.remixVersion)
           ? // Templates created from prereleases should pin to a specific version
             ctx.remixVersion

--- a/packages/create-remix/index.ts
+++ b/packages/create-remix/index.ts
@@ -720,7 +720,7 @@ async function updatePackageJSON(ctx: Context) {
 
     for (let dependency in dependencies) {
       let version = dependencies[dependency];
-      if (version === "*") {
+      if (dependency.startsWith("@remix-run") && version === "*") {
         dependencies[dependency] = semver.prerelease(ctx.remixVersion)
           ? // Templates created from prereleases should pin to a specific version
             ctx.remixVersion


### PR DESCRIPTION
This PR updates `create-remix` so that it only updates "*" dependencies for `@remix-run/*` packages.

For example, when create-remix runs, we currently get this change

```diff
"dependencies": {
-  "@remix-run/react": "*",
+  "@remix-run/react": "^2.4.1",
```

Unfortunately, this also affects non-Remix dependencies, such as:

```diff
"dependencies": {
-  "@remix-run/react": "*",
+  "@remix-run/react": "^2.4.1",
-  "@myorg/some-random-dep": "*"
+  "@myorg/some-random-dep": "^2.4.1"
```

which breaks when version 2.4.1 (or whatever the current Remix release is) doesn't exist.

Closes: # n/a

- [ ] Docs
- [x] Tests

Testing Strategy:

Unit test
