### PR TITLE
fix(remix-run/react): fix import.meta.hot type clash

### DIFF
--- a/.changeset/ninety-ducks-sin.md
+++ b/.changeset/ninety-ducks-sin.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Vite: Fix type conflict with `import.meta.hot` from the existing Remix compiler

--- a/packages/remix-react/browser.tsx
+++ b/packages/remix-react/browser.tsx
@@ -48,12 +48,6 @@ declare global {
 
 export interface RemixBrowserProps {}
 
-declare global {
-  interface ImportMeta {
-    hot: any;
-  }
-}
-
 let router: Router;
 let routerInitialized = false;
 let hmrAbortController: AbortController | undefined;
@@ -75,7 +69,9 @@ type CriticalCssReducer = () => typeof window.__remixContext.criticalCss;
 // The critical CSS can only be cleared, so the reducer always returns undefined
 let criticalCssReducer: CriticalCssReducer = () => undefined;
 
+// @ts-expect-error
 if (import.meta && import.meta.hot) {
+  // @ts-expect-error
   import.meta.hot.accept(
     "remix:manifest",
     async ({

--- a/packages/remix-react/routeModules.ts
+++ b/packages/remix-react/routeModules.ts
@@ -183,6 +183,7 @@ export async function loadRouteModule(
     // assets, the manifest path, but not the documents 😬
     if (
       window.__remixContext.isSpaMode &&
+      // @ts-expect-error
       typeof import.meta.hot !== "undefined"
     ) {
       // In SPA Mode (which implies vite) we don't want to perform a hard reload


### PR DESCRIPTION
This PR is another fix related to #8443.

The global `import.meta.hot` types defined in `@remix-run/react` are clashing with the types provided by Vite. Since these types were not intended for consumers, I've opted to simplify and just use `@ts-expect-error` directives in the two spots that we use `import.meta.hot` (which was typed as `any` anyway).