### PR TITLE
feat(vite): support adding plugin config via env var

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -367,9 +367,16 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
         unstable_ssr: true,
       } as const satisfies Partial<RemixVitePluginOptions>;
 
+      let extraConfig: Partial<RemixVitePluginOptions> = {};
+      let extraConfigPath = process.env.REMIX_VITE_EXTRA_CONFIG;
+      if (extraConfigPath) {
+        extraConfig = (await import(extraConfigPath)).default;
+      }
+
       let pluginConfig = {
         ...defaults,
         ...options,
+        ...extraConfig,
       };
 
       let rootDirectory =


### PR DESCRIPTION
Extra Vite plugin configuration may be supplied by importing the file specified by the `REMIX_VITE_EXTRA_CONFIG` env var. This allows for additional configuration values to be specified at build-time without modifying the `vite.config` file.
