### PR TITLE
POC of Library Mode for Remix SPAs

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -951,6 +951,9 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
             serverBuildDirectory,
             serverBuildFile,
             rootDirectory,
+            future,
+            isSpaMode,
+            libraryName,
           } = pluginConfig;
 
           let ssrViteManifest = await loadViteManifest(serverBuildDirectory);
@@ -1012,16 +1015,16 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
             );
           }
 
-          if (pluginConfig.isSpaMode) {
+          if (isSpaMode) {
             await handleSpaMode(
               // TODO: Is this readily available anywhere?
               await ssrBuildContext.getManifest(),
-              cachedPluginConfig.future,
+              future,
               path.join(rootDirectory, serverBuildDirectory),
               serverBuildFile,
               assetsBuildDirectory,
               viteConfig,
-              cachedPluginConfig.libraryName
+              libraryName
             );
           }
         },

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -1496,33 +1496,45 @@ async function handleSpaMode(
   let { createRequestHandler: createHandler } = await import("@remix-run/node");
   let handler = createHandler(build, viteConfig.mode);
   let response = await handler(new Request("http://localhost/"));
-  let html = await response.text();
+  let text = await response.text();
+
   if (response.status !== 200) {
     throw new Error(
       `SPA Mode: Received a ${response.status} status code from ` +
-        `\`entry.server.tsx\` while generating the \`index.html\` file.\n${html}`
+        `\`entry.server.tsx\` while generating the \`index.html\` file.\n${text}`
     );
   }
 
-  if (
-    !html.includes("window.__remixContext =") ||
-    !html.includes("window.__remixRouteModules =")
+  if (response.headers.get("Content-Type") === "application/javascript") {
+    let jsDir = path.join(assetsBuildDirectory, "assets");
+    let jsPath = path.join(jsDir, "index.js");
+    await fse.writeFile(jsPath, text);
+
+    viteConfig.logger.info(
+      "SPA Mode: index.js has been written to your " +
+        colors.bold(path.relative(process.cwd(), jsDir)) +
+        " directory"
+    );
+  } else if (
+    !text.includes("window.__remixContext =") ||
+    !text.includes("window.__remixRouteModules =")
   ) {
     throw new Error(
       "SPA Mode: Did you forget to include <Scripts/> in your `root.tsx` " +
         "`HydrateFallback` component?  Your `index.html` file cannot hydrate " +
         "into a SPA without `<Scripts />`."
     );
+  } else {
+    // Write out the index.html file for the SPA
+    let htmlPath = path.join(assetsBuildDirectory, "index.html");
+    await fse.writeFile(htmlPath, await response.text());
+
+    viteConfig.logger.info(
+      "SPA Mode: index.html has been written to your " +
+        colors.bold(path.relative(process.cwd(), assetsBuildDirectory)) +
+        " directory"
+    );
   }
-
-  // Write out the index.html file for the SPA
-  await fse.writeFile(path.join(assetsBuildDirectory, "index.html"), html);
-
-  viteConfig.logger.info(
-    "SPA Mode: index.html has been written to your " +
-      colors.bold(path.relative(process.cwd(), assetsBuildDirectory)) +
-      " directory"
-  );
 
   // Cleanup - we no longer need the server build assets
   fse.removeSync(serverBuildDirectoryPath);

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -455,9 +455,9 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
         serverBundles: unstable_serverBundles,
         serverModuleFormat,
         isSpaMode,
+        libraryName: pluginConfig.unstable_library,
         relativeAssetsBuildDirectory,
         future,
-        libraryName: pluginConfig.unstable_library,
       };
     };
 
@@ -1558,7 +1558,7 @@ async function handleSpaMode(
 
     // Write out the index.html file for the SPA
     let htmlPath = path.join(assetsBuildDirectory, "index.html");
-    await fse.writeFile(htmlPath, await response.text());
+    await fse.writeFile(htmlPath, html);
 
     viteConfig.logger.info(
       `SPA Mode: created ${colors.bold(path.relative(process.cwd(), htmlPath))}`

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -145,10 +145,10 @@ export type ResolvedRemixVitePluginConfig = Pick<
   | "serverModuleFormat"
 > & {
   isSpaMode: boolean;
+  libraryName: string | undefined;
   serverBuildDirectory: string;
   serverBuildFile: string;
   serverBundles?: ServerBundlesFunction;
-  libraryName: string | undefined;
 };
 
 export type ServerBuildConfig = {

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -1512,9 +1512,13 @@ async function handleSpaMode(
   if (libraryName) {
     let jsDir = path.join(assetsBuildDirectory, "assets");
     let jsPath = path.join(jsDir, libraryName);
+    invariant(manifest.url, "manifest.url required for SPA mode");
     let js = remixEntryJsString(
-      // @ts-expect-error
-      manifest,
+      // This way TS knows the URL is defined
+      {
+        ...manifest,
+        url: manifest.url,
+      },
       ["root"],
       createServerHandoffString({
         state: {},

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -81,7 +81,6 @@ export {
   useActionData,
   useMatches,
   RemixContext as UNSAFE_RemixContext,
-  UNSAFE_remixSpaModeLibraryJs,
 } from "./components";
 
 export type { HtmlLinkDescriptor } from "./links";

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -81,6 +81,7 @@ export {
   useActionData,
   useMatches,
   RemixContext as UNSAFE_RemixContext,
+  UNSAFE_remixSpaModeLibraryJs,
 } from "./components";
 
 export type { HtmlLinkDescriptor } from "./links";

--- a/packages/remix-server-runtime/entry.ts
+++ b/packages/remix-server-runtime/entry.ts
@@ -28,7 +28,10 @@ export interface AssetsManifest {
   routes: RouteManifest<EntryRoute>;
   url: string;
   version: string;
-  hmrRuntime?: string;
+  hmr?: {
+    timestamp?: number;
+    runtime: string;
+  };
 }
 
 export function createEntryRouteModules(

--- a/packages/remix-server-runtime/index.ts
+++ b/packages/remix-server-runtime/index.ts
@@ -7,6 +7,11 @@ export {
 export { defer, json, redirect, redirectDocument } from "./responses";
 export { createRequestHandler } from "./server";
 export {
+  createServerHandoffString as UNSAFE_createServerHandoffString,
+  remixContextJsString as UNSAFE_remixContextJsString,
+  remixEntryJsString as UNSAFE_remixEntryJsString,
+} from "./serverHandoff";
+export {
   createSession,
   createSessionStorageFactory,
   isSession,

--- a/packages/remix-server-runtime/serverHandoff.ts
+++ b/packages/remix-server-runtime/serverHandoff.ts
@@ -1,6 +1,6 @@
 import type { HydrationState } from "@remix-run/router";
 
-import type { FutureConfig } from "./entry";
+import type { AssetsManifest, FutureConfig } from "./entry";
 import { escapeHtml } from "./markup";
 
 type ValidateShape<T, Shape> =
@@ -27,4 +27,32 @@ export function createServerHandoffString<T>(serverHandoff: {
   // Uses faster alternative of jsesc to escape data returned from the loaders.
   // This string is inserted directly into the HTML in the `<Scripts>` element.
   return escapeHtml(JSON.stringify(serverHandoff));
+}
+
+export function remixContextJsString(handoff: string) {
+  return `window.__remixContext = ${handoff};`;
+}
+
+export function remixEntryJsString(
+  manifest: AssetsManifest,
+  routeIds: string[],
+  handoff?: string
+) {
+  let str = JSON.stringify;
+  return [
+    manifest.hmrRuntime ? `import ${str(manifest.hmrRuntime)};` : "",
+    `import ${JSON.stringify(manifest.url)};`,
+    ...routeIds.map(
+      (id, i) =>
+        `import * as route${i} from ${str(manifest.routes[id].module)};`
+    ),
+    // If we got a handoff, insert it after the imports (used for SPA mode library mode)
+    handoff ? remixContextJsString(handoff) : "",
+    `window.__remixRouteModules = {${routeIds
+      .map((id, index) => `${str(id)}:route${index}`)
+      .join(",")}}`,
+    `import(${str(manifest.entry.module)});`,
+  ]
+    .filter((l) => l)
+    .join("\n");
 }

--- a/packages/remix-server-runtime/serverHandoff.ts
+++ b/packages/remix-server-runtime/serverHandoff.ts
@@ -40,7 +40,7 @@ export function remixEntryJsString(
 ) {
   let str = JSON.stringify;
   return [
-    manifest.hmrRuntime ? `import ${str(manifest.hmrRuntime)};` : "",
+    manifest.hmr?.runtime ? `import ${str(manifest.hmr?.runtime)};` : "",
     `import ${JSON.stringify(manifest.url)};`,
     ...routeIds.map(
       (id, i) =>


### PR DESCRIPTION
This is a POC of what it might look like to add support for https://github.com/remix-run/remix/discussions/7638#discussioncomment-7912638 which would allow Remix SPA's to be built as embeddable JS files instead of full HTML documents.

I don't think we can rely on Vite's `library` config directly here since once you set that it changes up the Vite output pretty significantly.