### PR TITLE
Add isSpaMode to server build virtual module type

### DIFF
--- a/.changeset/fresh-shoes-drive.md
+++ b/.changeset/fresh-shoes-drive.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Add `isSpaMode` to `@remix-run/dev/server-build` virtual module"

--- a/packages/remix-dev/server-build.ts
+++ b/packages/remix-dev/server-build.ts
@@ -14,3 +14,4 @@ export const future: ServerBuild["future"] = undefined!;
 export const publicPath: ServerBuild["publicPath"] = undefined!;
 // prettier-ignore
 export const assetsBuildDirectory: ServerBuild["assetsBuildDirectory"] = undefined!;
+export const isSpaMode: ServerBuild["isSpaMode"] = undefined!;


### PR DESCRIPTION
Fixes a type error in the cloudflare pages server (and potentially other spots) where the server build is imoprted from the virtual module:

![Screenshot 2024-01-11 at 3 38 21 PM](https://github.com/remix-run/remix/assets/1609022/0008bab9-c2ce-4c94-9820-d0c6a2598c94)

![Screenshot 2024-01-11 at 3 40 11 PM](https://github.com/remix-run/remix/assets/1609022/ff462e40-8bb2-4fa9-bf81-c71bd40c8c4e)
