### PR TITLE
Fix quirks mode warning for SPA template

### DIFF
--- a/.changeset/wild-timers-impress.md
+++ b/.changeset/wild-timers-impress.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": patch
 ---
 
-Fix quirks mode warning for SPA template and default server entry
+Automatically prepend `<!DOCTYPE html>` if not present to fix quirks mode warnings for SPA template

--- a/.changeset/wild-timers-impress.md
+++ b/.changeset/wild-timers-impress.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fix quirks mode warning for SPA template and default server entry

--- a/contributors.yml
+++ b/contributors.yml
@@ -424,6 +424,7 @@
 - morinokami
 - mrkhosravian
 - mrkstwrt
+- mrm007
 - mskoroglu
 - msutkowski
 - mtt87

--- a/integration/helpers/create-fixture.ts
+++ b/integration/helpers/create-fixture.ts
@@ -29,6 +29,7 @@ export interface FixtureInit {
   config?: Partial<AppConfig>;
   useRemixServe?: boolean;
   compiler?: "remix" | "vite";
+  spaMode?: boolean;
 }
 
 export type Fixture = Awaited<ReturnType<typeof createFixture>>;
@@ -59,19 +60,26 @@ export async function createFixture(init: FixtureInit, mode?: ServerMode) {
     );
   };
 
-  let isSpaMode =
-    compiler === "vite" &&
-    fse.existsSync(path.join(projectDir, "build/client/index.html"));
+  let isSpaMode = compiler === "vite" && init.spaMode;
 
   if (isSpaMode) {
+    let requestDocument = () => {
+      let html = fse.readFileSync(
+        path.join(projectDir, "build/client/index.html")
+      );
+      return new Response(html, {
+        headers: {
+          "Content-Type": "text/html",
+        },
+      });
+    };
+
     return {
       projectDir,
       build: null,
       isSpaMode,
       compiler,
-      requestDocument: () => {
-        throw new Error("Cannot requestDocument in SPA Mode tests");
-      },
+      requestDocument,
       requestData: () => {
         throw new Error("Cannot requestData in SPA Mode tests");
       },

--- a/integration/spa-mode-test.ts
+++ b/integration/spa-mode-test.ts
@@ -540,7 +540,9 @@ test.describe("SPA Mode", () => {
         },
       });
       let res = await fixture.requestDocument("/");
-      expect(await res.text()).not.toMatch(/<!DOCTYPE html>/);
+      let html = await res.text();
+      expect(html).toMatch(/^<div>/);
+      expect(html).not.toMatch(/<!DOCTYPE html>/);
     });
   });
 });

--- a/integration/spa-mode-test.ts
+++ b/integration/spa-mode-test.ts
@@ -19,6 +19,7 @@ test.describe("SPA Mode", () => {
   test.beforeAll(async () => {
     fixture = await createFixture({
       compiler: "vite",
+      spaMode: true,
       files: {
         "vite.config.ts": js`
           import { defineConfig } from "vite";
@@ -454,6 +455,92 @@ test.describe("SPA Mode", () => {
       expect(await page.locator("[data-error]").textContent()).toBe(
         'Error: You cannot call serverAction() in SPA Mode (routeId: "routes/error")'
       );
+    });
+
+    test("prepends DOCTYPE to <html> documents if not present", async () => {
+      let fixture = await createFixture({
+        compiler: "vite",
+        spaMode: true,
+        files: {
+          "vite.config.ts": js`
+            import { defineConfig } from "vite";
+            import { unstable_vitePlugin as remix } from "@remix-run/dev";
+
+            export default defineConfig({
+              plugins: [remix({ unstable_ssr: false })],
+            });
+          `,
+          "app/root.tsx": js`
+            import { Outlet, Scripts } from "@remix-run/react";
+
+            export default function Root() {
+              return (
+                <html lang="en">
+                  <head></head>
+                  <body>
+                    <h1 data-root>Root</h1>
+                    <Scripts />
+                  </body>
+                </html>
+              );
+            }
+
+            export function HydrateFallback() {
+              return (
+                <html lang="en">
+                  <head></head>
+                  <body>
+                    <h1 data-loading>Loading SPA...</h1>
+                    <Scripts />
+                  </body>
+                </html>
+              );
+            }
+          `,
+        },
+      });
+      let res = await fixture.requestDocument("/");
+      expect(await res.text()).toMatch(/^<!DOCTYPE html>\n<html lang="en">/);
+    });
+
+    test("does not prepend DOCTYPE if user is not hydrating the document", async () => {
+      let fixture = await createFixture({
+        compiler: "vite",
+        spaMode: true,
+        files: {
+          "vite.config.ts": js`
+            import { defineConfig } from "vite";
+            import { unstable_vitePlugin as remix } from "@remix-run/dev";
+
+            export default defineConfig({
+              plugins: [remix({ unstable_ssr: false })],
+            });
+          `,
+          "app/root.tsx": js`
+            import { Outlet, Scripts } from "@remix-run/react";
+
+            export default function Root() {
+              return (
+                <div>
+                  <h1 data-root>Root</h1>
+                  <Scripts />
+                </div>
+              );
+            }
+
+            export function HydrateFallback() {
+              return (
+                <div>
+                  <h1>Loading SPA...</h1>
+                  <Scripts />
+                </div>
+              );
+            }
+          `,
+        },
+      });
+      let res = await fixture.requestDocument("/");
+      expect(await res.text()).not.toMatch(/<!DOCTYPE html>/);
     });
   });
 });

--- a/packages/remix-dev/config/defaults/entry.server.spa.tsx
+++ b/packages/remix-dev/config/defaults/entry.server.spa.tsx
@@ -9,9 +9,9 @@ export default function handleRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  let html = renderToString(
-    <RemixServer context={remixContext} url={request.url} />
-  );
+  let html =
+    "<!DOCTYPE html>\n" +
+    renderToString(<RemixServer context={remixContext} url={request.url} />);
   return new Response(html, {
     headers: { "Content-Type": "text/html" },
     status: responseStatusCode,

--- a/packages/remix-dev/config/defaults/entry.server.spa.tsx
+++ b/packages/remix-dev/config/defaults/entry.server.spa.tsx
@@ -1,4 +1,4 @@
-import type { AppLoadContext, EntryContext } from "@remix-run/node";
+import type { EntryContext } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import * as React from "react";
 import { renderToString } from "react-dom/server";
@@ -9,9 +9,12 @@ export default function handleRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  let html =
-    "<!DOCTYPE html>\n" +
-    renderToString(<RemixServer context={remixContext} url={request.url} />);
+  let html = renderToString(
+    <RemixServer context={remixContext} url={request.url} />
+  );
+  if (html.startsWith("<html")) {
+    html = "<!DOCTYPE html>\n" + html;
+  }
   return new Response(html, {
     headers: { "Content-Type": "text/html" },
     status: responseStatusCode,

--- a/templates/spa/app/entry.server.tsx
+++ b/templates/spa/app/entry.server.tsx
@@ -8,9 +8,9 @@ export default function handleRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  const html = renderToString(
-    <RemixServer context={remixContext} url={request.url} />
-  );
+  const html =
+    "<!DOCTYPE html>\n" +
+    renderToString(<RemixServer context={remixContext} url={request.url} />);
   return new Response(html, {
     headers: { "Content-Type": "text/html" },
     status: responseStatusCode,

--- a/templates/spa/app/entry.server.tsx
+++ b/templates/spa/app/entry.server.tsx
@@ -8,9 +8,12 @@ export default function handleRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  const html =
-    "<!DOCTYPE html>\n" +
-    renderToString(<RemixServer context={remixContext} url={request.url} />);
+  let html = renderToString(
+    <RemixServer context={remixContext} url={request.url} />
+  );
+  if (html.startsWith("<html")) {
+    html = "<!DOCTYPE html>\n" + html;
+  }
   return new Response(html, {
     headers: { "Content-Type": "text/html" },
     status: responseStatusCode,


### PR DESCRIPTION
1. Set up a new Remix app using the instructions for [SPA Mode](https://remix.run/docs/en/main/future/spa-mode#usage)
1. Start the dev server with `remix vite:dev`
1. Open Firefox Dev Tools and observe the warning:

```
This page is in Quirks Mode. Page layout may be impacted. For Standards Mode use “<!DOCTYPE html>”
```