### PR TITLE
docs(other-api/adapters): fix link remix-azure-functions to adapters

### DIFF
--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -32,7 +32,7 @@ Each adapter has the same API. In the future we may have helpers specific to the
 - [`@vercel/remix`][vercel-remix] - For [Vercel][vercel].
 - [`remix-google-cloud-functions`][remix-google-cloud-functions] - For [Google Cloud][google-cloud-functions] and [Firebase][firebase-functions] functions.
 - [`partymix`][partymix] - For [PartyKit][partykit].
-- [`@scandinavianairlines/remix-azure-functions`][remix-azure-functions]: For [Azure Functions][azure-functions] and \[Azure Static Web Apps]\[azure-static-web-apps].
+- [`@scandinavianairlines/remix-azure-functions`][remix-azure-functions]: For [Azure Functions][azure-functions] and [Azure Static Web Apps][azure-static-web-apps].
 
 ## Creating an Adapter
 
@@ -155,4 +155,4 @@ addEventListener("fetch", (event) => {
 [partymix]: https://github.com/partykit/partykit/tree/main/packages/partymix
 [remix-azure-functions]: https://github.com/scandinavianairlines/remix-azure-functions
 [azure-functions]: https://azure.microsoft.com/en-us/products/functions/
-[azure-staticwebapps]: https://azure.microsoft.com/en-us/products/app-service/static
+[azure-static-web-apps]: https://azure.microsoft.com/en-us/products/app-service/static


### PR DESCRIPTION
Fixes the broken link `azure-staticwebapps` and `azure-statuc-web-apps` to `azure-statuc-web-apps`