### PR TITLE
create-remix: high-contrast fg/bg for header colors

### DIFF
--- a/.changeset/breezy-cows-battle.md
+++ b/.changeset/breezy-cows-battle.md
@@ -1,0 +1,8 @@
+---
+"create-remix": patch
+---
+
+create-remix: high-contrast fg/bg for header colors
+
+`bgWhite` and `whiteBright` are the same color in many terminal colorthemes,
+which was causing it to render as illegible white-on-white

--- a/packages/create-remix/index.ts
+++ b/packages/create-remix/index.ts
@@ -201,7 +201,7 @@ interface Context {
 
 async function introStep(ctx: Context) {
   log(
-    `\n${color.bgWhite(` ${color.whiteBright("remix")} `)}  ${color.green(
+    `\n${color.bgWhite(` ${color.black("remix")} `)}  ${color.green(
       color.bold(`v${ctx.remixVersion}`)
     )} ${color.bold("💿 Let's build a better website...")}`
   );
@@ -757,7 +757,7 @@ async function loadingIndicator(args: {
 }
 
 function title(text: string) {
-  return align(color.bgWhite(` ${color.whiteBright(text)} `), "end", 7) + " ";
+  return align(color.bgWhite(` ${color.black(text)} `), "end", 7) + " ";
 }
 
 function printHelp(ctx: Context) {


### PR DESCRIPTION
`bgWhite` and `whiteBright` are the same color in many terminal colorthemes, which was causing it to render as illegible white-on-white.

For some reason the `done` section was already `bgWhite`/`black` and was working properly 🤷

## BEFORE

<img width="936" alt="Screenshot 2024-01-12 at 1 01 24 PM" src="https://github.com/remix-run/remix/assets/1477317/feffa51b-465c-42b8-ae77-ea25ac56e914">

## AFTER

<img width="935" alt="Screenshot 2024-01-12 at 12 56 56 PM" src="https://github.com/remix-run/remix/assets/1477317/2e017025-1d81-4bbe-abf1-1bdf87fbbc8d">

