### PR TITLE
fix(types): Add missing type def for isSpaMode in @remix-run/dev/server-build

### DIFF
--- a/.changeset/new-clouds-pull.md
+++ b/.changeset/new-clouds-pull.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Added a missing type definition for the Remix config `isSpaMode` option to the `@remix-run/dev/server-build` virtual module

--- a/contributors.yml
+++ b/contributors.yml
@@ -5,6 +5,7 @@
 - abotsi
 - accidentaldeveloper
 - achinchen
+- acusti
 - adamwathan
 - adicuco
 - ahabhgk

--- a/packages/remix-dev/server-build.ts
+++ b/packages/remix-dev/server-build.ts
@@ -11,6 +11,7 @@ export const assets: ServerBuild["assets"] = undefined!;
 export const entry: ServerBuild["entry"] = undefined!;
 export const routes: ServerBuild["routes"] = undefined!;
 export const future: ServerBuild["future"] = undefined!;
+export const isSpaMode: ServerBuild["isSpaMode"] = undefined!;
 export const publicPath: ServerBuild["publicPath"] = undefined!;
 // prettier-ignore
 export const assetsBuildDirectory: ServerBuild["assetsBuildDirectory"] = undefined!;


### PR DESCRIPTION
using remix v2.5.0, my `server.ts` file, which starts:

```ts
import { getAssetFromKV } from '@cloudflare/kv-asset-handler';
import { createRequestHandler, logDevReady } from '@remix-run/cloudflare';
import type { AppLoadContext } from '@remix-run/cloudflare';
import * as build from '@remix-run/dev/server-build';
import __STATIC_CONTENT_MANIFEST from '__STATIC_CONTENT_MANIFEST'; // eslint-disable-line import/no-unresolved

const MANIFEST = JSON.parse(__STATIC_CONTENT_MANIFEST);
const handleRemixRequest = createRequestHandler(build, process.env.NODE_ENV);

if (process.env.NODE_ENV === 'development') {
    logDevReady(build);
}
```

triggers the following type error:

```
server.ts:8:49 - error TS2345: Argument of type 'typeof import("/path/to/project/node_modules/@remix-run/dev/server-build")' is not assignable to parameter of type 'ServerBuild | (() => Promise<ServerBuild>)'.
  Property 'isSpaMode' is missing in type 'typeof import("/path/to/project/node_modules/@remix-run/dev/server-build")' but required in type 'ServerBuild'.

8 const handleRemixRequest = createRequestHandler(build, process.env.NODE_ENV);
                                                  ~~~~~

  node_modules/@remix-run/server-runtime/dist/build.d.ts:18:5
    18     isSpaMode: boolean;
           ~~~~~~~~~
    'isSpaMode' is declared here.

server.ts:11:17 - error TS2345: Argument of type 'typeof import("/path/to/project/node_modules/@remix-run/dev/server-build")' is not assignable to parameter of type 'ServerBuild'.

11     logDevReady(build);
                   ~~~~~


Found 2 errors in the same file, starting at: server.ts:8
```

looking at `packages/remix-dev/server-build.ts` and [similar issues](#4766) from the past, it seems like the new `isSpaMode` option just needs to be added as an export to that file to provide the type definition for the virtual module provided by the Remix compiler at build time. this is the same fix as d7a6fb5 (#4771) but for `isSpaMode`. as such, this PR is opened against `main` (like that PR), but if it should be against `dev`, i’m happy to update it.


### Testing Strategy:

i manually edited `node_modules/@remix-run/dev/server-build.d.ts` like so:

```diff
--- node_modules/@remix-run/dev/server-build_unmodified.d.ts	2024-01-14 11:05:45
+++ node_modules/@remix-run/dev/server-build.d.ts	2024-01-14 11:05:56
@@ -4,5 +4,6 @@
 export declare const entry: ServerBuild["entry"];
 export declare const routes: ServerBuild["routes"];
 export declare const future: ServerBuild["future"];
+export declare const isSpaMode: ServerBuild["isSpaMode"];
 export declare const publicPath: ServerBuild["publicPath"];
 export declare const assetsBuildDirectory: ServerBuild["assetsBuildDirectory"];
```

and i manually edited `node_modules/@remix-run/dev/server-build.js` like so (shouldn’t make any different to tsc, i just wanted to be thorough with my testing):

```diff
--- node_modules/@remix-run/dev/server-build_unmodified.js	2024-01-14 11:06:01
+++ node_modules/@remix-run/dev/server-build.js	2024-01-14 11:06:07
@@ -19,6 +19,7 @@
 const entry = undefined;
 const routes = undefined;
 const future = undefined;
+const isSpaMode = undefined;
 const publicPath = undefined;
 // prettier-ignore
 const assetsBuildDirectory = undefined;
```

with those changes, the typescript errors were resolved.