### PR TITLE
chore: add packageManager field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "watch": "rollup -c --watch --watch.onEnd=\"node scripts/copy-build-to-dist.mjs\"",
     "postinstall": "patch-package"
   },
+  "packageManager": "yarn@1.22.21",
   "resolutions": {
     "jsdom": "^22.0.0"
   },


### PR DESCRIPTION
This field is being added to support [vite-ecosystem-ci](https://github.com/vitejs/vite-ecosystem-ci) since they use Corepack to manage package managers across the various consumer repos. I've added the version of Yarn that's running in CI.