### PR TITLE
Only use active matches in meta/links during SPA mode SSR/hydration

### DIFF
--- a/.changeset/calm-geckos-refuse.md
+++ b/.changeset/calm-geckos-refuse.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Only use active matches in meta/links in SPA mode

--- a/integration/spa-mode-test.ts
+++ b/integration/spa-mode-test.ts
@@ -9,19 +9,15 @@ import type { Fixture, AppFixture } from "./helpers/create-fixture.js";
 import { PlaywrightFixture } from "./helpers/playwright-fixture.js";
 import { createProject, viteBuild } from "./helpers/vite.js";
 
-// SSR'd useId value we can assert against pre- and post-hydration
-const USE_ID_VALUE = ":R1:";
-
 test.describe("SPA Mode", () => {
   let fixture: Fixture;
   let appFixture: AppFixture;
 
-  test.beforeAll(async () => {
-    fixture = await createFixture({
-      compiler: "vite",
-      spaMode: true,
-      files: {
-        "vite.config.ts": js`
+  test.describe("custom builds", () => {
+    test.describe("build errors", () => {
+      test("errors on server-only exports", async () => {
+        let cwd = await createProject({
+          "vite.config.ts": js`
           import { defineConfig } from "vite";
           import { unstable_vitePlugin as remix } from "@remix-run/dev";
 
@@ -29,175 +25,7 @@ test.describe("SPA Mode", () => {
             plugins: [remix({ unstable_ssr: false })],
           });
         `,
-        "app/root.tsx": js`
-          import * as React from "react";
-          import { Form, Link, Links, Meta, Outlet, Scripts } from "@remix-run/react";
-
-          export default function Root() {
-            let id = React.useId();
-            return (
-              <html lang="en">
-                <head>
-                  <Meta />
-                  <Links />
-                </head>
-                <body>
-                    <h1 data-root>Root</h1>
-                    <pre data-use-id>{id}</pre>
-                    <nav>
-                      <Link to="/about">/about</Link>
-                      <br/>
-
-                      <Form method="post" action="/about">
-                        <button type="submit">
-                          Submit /about
-                        </button>
-                      </Form>
-                      <br/>
-
-                      <Link to="/error">/error</Link>
-                      <br/>
-
-                      <Form method="post" action="/error">
-                        <button type="submit">
-                          Submit /error
-                        </button>
-                      </Form>
-                      <br/>
-                     </nav>
-                    <Outlet />
-                  <Scripts />
-                </body>
-              </html>
-            );
-          }
-
-          export function HydrateFallback() {
-            const id = React.useId();
-            const [hydrated, setHydrated] = React.useState(false);
-            React.useEffect(() => setHydrated(true), []);
-
-            return (
-              <html lang="en">
-                <head>
-                  <Meta />
-                  <Links />
-                </head>
-                <body>
-                  <h1 data-loading>Loading SPA...</h1>
-                  <pre data-use-id>{id}</pre>
-                  {hydrated ? <h3 data-hydrated>Hydrated</h3> : null}
-                  <Scripts />
-                </body>
-              </html>
-            );
-          }
-        `,
-        "app/routes/_index.tsx": js`
-          import * as React  from "react";
-          import { useLoaderData } from "@remix-run/react";
-
-          export function meta({ data }) {
-            return [{
-              title: "Index Title: " + data
-            }];
-          }
-
-          export async function clientLoader({ request }) {
-            if (new URL(request.url).searchParams.has('slow')) {
-              await new Promise(r => setTimeout(r, 500));
-            }
-            return "Index Loader Data";
-          }
-
-          export default function Component() {
-            let data = useLoaderData();
-            const [mounted, setMounted] = React.useState(false);
-            React.useEffect(() => setMounted(true), []);
-
-            return (
-              <>
-                <h2 data-route>Index</h2>
-                <p data-loader-data>{data}</p>
-                {!mounted ? <h3>Unmounted</h3> : <h3 data-mounted>Mounted</h3>}
-              </>
-            );
-          }
-        `,
-        "app/routes/about.tsx": js`
-          import { useActionData, useLoaderData } from "@remix-run/react";
-
-          export function meta({ data }) {
-            return [{
-              title: "About Title: " + data
-            }];
-          }
-
-          export function clientLoader() {
-            return "About Loader Data";
-          }
-
-          export function clientAction() {
-            return "About Action Data";
-          }
-
-          export default function Component() {
-            let data = useLoaderData();
-            let actionData = useActionData();
-
-            return (
-              <>
-                <h2 data-route>About</h2>
-                <p data-loader-data>{data}</p>
-                <p data-action-data>{actionData}</p>
-              </>
-            );
-          }
-        `,
-        "app/routes/error.tsx": js`
-          import { useRouteError } from "@remix-run/react";
-
-          export async function clientLoader({ serverLoader }) {
-            await serverLoader();
-            return null;
-          }
-
-          export async function clientAction({ serverAction }) {
-            await serverAction();
-            return null;
-          }
-
-          export default function Component() {
-            return <h2>Error</h2>;
-          }
-
-          export function ErrorBoundary() {
-            let error = useRouteError();
-            return <pre data-error>{error.data}</pre>
-          }
-        `,
-      },
-    });
-
-    appFixture = await createAppFixture(fixture);
-  });
-
-  test.afterAll(() => {
-    appFixture.close();
-  });
-
-  test.describe("builds", () => {
-    test("errors on server-only exports", async () => {
-      let cwd = await createProject({
-        "vite.config.ts": js`
-          import { defineConfig } from "vite";
-          import { unstable_vitePlugin as remix } from "@remix-run/dev";
-
-          export default defineConfig({
-            plugins: [remix({ unstable_ssr: false })],
-          });
-        `,
-        "app/routes/invalid-exports.tsx": String.raw`
+          "app/routes/invalid-exports.tsx": String.raw`
           // Invalid exports
           export function headers() {}
           export function loader() {}
@@ -208,19 +36,19 @@ test.describe("SPA Mode", () => {
           export function clientAction() {}
           export default function Component() {}
         `,
+        });
+        let result = viteBuild({ cwd });
+        let stderr = result.stderr.toString("utf8");
+        expect(stderr).toMatch(
+          "SPA Mode: 3 invalid route export(s) in `routes/invalid-exports.tsx`: " +
+            "`headers`, `loader`, `action`. See https://remix.run/future/spa-mode " +
+            "for more information."
+        );
       });
-      let result = viteBuild({ cwd });
-      let stderr = result.stderr.toString("utf8");
-      expect(stderr).toMatch(
-        "SPA Mode: 3 invalid route export(s) in `routes/invalid-exports.tsx`: " +
-          "`headers`, `loader`, `action`. See https://remix.run/future/spa-mode " +
-          "for more information."
-      );
-    });
 
-    test("errors on HydrateFallback export from non-root route", async () => {
-      let cwd = await createProject({
-        "vite.config.ts": js`
+      test("errors on HydrateFallback export from non-root route", async () => {
+        let cwd = await createProject({
+          "vite.config.ts": js`
           import { defineConfig } from "vite";
           import { unstable_vitePlugin as remix } from "@remix-run/dev";
 
@@ -228,7 +56,7 @@ test.describe("SPA Mode", () => {
             plugins: [remix({ unstable_ssr: false })],
           });
         `,
-        "app/routes/invalid-exports.tsx": String.raw`
+          "app/routes/invalid-exports.tsx": String.raw`
           // Invalid exports
           export function HydrateFallback() {}
 
@@ -237,19 +65,19 @@ test.describe("SPA Mode", () => {
           export function clientAction() {}
           export default function Component() {}
         `,
+        });
+        let result = viteBuild({ cwd });
+        let stderr = result.stderr.toString("utf8");
+        expect(stderr).toMatch(
+          "SPA Mode: Invalid `HydrateFallback` export found in `routes/invalid-exports.tsx`. " +
+            "`HydrateFallback` is only permitted on the root route in SPA Mode. " +
+            "See https://remix.run/future/spa-mode for more information."
+        );
       });
-      let result = viteBuild({ cwd });
-      let stderr = result.stderr.toString("utf8");
-      expect(stderr).toMatch(
-        "SPA Mode: Invalid `HydrateFallback` export found in `routes/invalid-exports.tsx`. " +
-          "`HydrateFallback` is only permitted on the root route in SPA Mode. " +
-          "See https://remix.run/future/spa-mode for more information."
-      );
-    });
 
-    test("errors on a non-200 status from entry.server.tsx", async () => {
-      let cwd = await createProject({
-        "vite.config.ts": js`
+      test("errors on a non-200 status from entry.server.tsx", async () => {
+        let cwd = await createProject({
+          "vite.config.ts": js`
           import { defineConfig } from "vite";
           import { unstable_vitePlugin as remix } from "@remix-run/dev";
 
@@ -257,7 +85,7 @@ test.describe("SPA Mode", () => {
             plugins: [remix({ unstable_ssr: false })],
           });
         `,
-        "app/entry.server.tsx": js`
+          "app/entry.server.tsx": js`
           import { RemixServer } from "@remix-run/react";
           import { renderToString } from "react-dom/server";
 
@@ -276,7 +104,7 @@ test.describe("SPA Mode", () => {
             });
           }
         `,
-        "app/root.tsx": js`
+          "app/root.tsx": js`
           import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
 
           export default function Root() {
@@ -309,19 +137,19 @@ test.describe("SPA Mode", () => {
             );
           }
         `,
+        });
+        let result = viteBuild({ cwd });
+        let stderr = result.stderr.toString("utf8");
+        expect(stderr).toMatch(
+          "SPA Mode: Received a 500 status code from `entry.server.tsx` while " +
+            "generating the `index.html` file."
+        );
+        expect(stderr).toMatch("<h1>Loading...</h1>");
       });
-      let result = viteBuild({ cwd });
-      let stderr = result.stderr.toString("utf8");
-      expect(stderr).toMatch(
-        "SPA Mode: Received a 500 status code from `entry.server.tsx` while " +
-          "generating the `index.html` file."
-      );
-      expect(stderr).toMatch("<h1>Loading...</h1>");
-    });
 
-    test("errors if you do not include <Scripts> in your root <HydrateFallback>", async () => {
-      let cwd = await createProject({
-        "vite.config.ts": js`
+      test("errors if you do not include <Scripts> in your root <HydrateFallback>", async () => {
+        let cwd = await createProject({
+          "vite.config.ts": js`
           import { defineConfig } from "vite";
           import { unstable_vitePlugin as remix } from "@remix-run/dev";
 
@@ -329,132 +157,20 @@ test.describe("SPA Mode", () => {
             plugins: [remix({ unstable_ssr: false })],
           });
         `,
-        "app/root.tsx": String.raw`
+          "app/root.tsx": String.raw`
           export function HydrateFallback() {
             return <h1>Loading</h1>
           }
         `,
+        });
+        let result = viteBuild({ cwd });
+        let stderr = result.stderr.toString("utf8");
+        expect(stderr).toMatch(
+          "SPA Mode: Did you forget to include <Scripts/> in your `root.tsx` " +
+            "`HydrateFallback` component?  Your `index.html` file cannot hydrate " +
+            "into a SPA without `<Scripts />`."
+        );
       });
-      let result = viteBuild({ cwd });
-      let stderr = result.stderr.toString("utf8");
-      expect(stderr).toMatch(
-        "SPA Mode: Did you forget to include <Scripts/> in your `root.tsx` " +
-          "`HydrateFallback` component?  Your `index.html` file cannot hydrate " +
-          "into a SPA without `<Scripts />`."
-      );
-    });
-  });
-
-  test.describe("javascript disabled", () => {
-    test.use({ javaScriptEnabled: false });
-
-    test("renders the root HydrateFallback", async ({ page }) => {
-      let app = new PlaywrightFixture(appFixture, page);
-      await app.goto("/");
-      expect(await page.locator("[data-loading]").textContent()).toBe(
-        "Loading SPA..."
-      );
-      expect(await page.locator("[data-use-id]").textContent()).toBe(
-        USE_ID_VALUE
-      );
-      expect(await page.locator("title").textContent()).toBe(
-        "Index Title: undefined"
-      );
-    });
-  });
-
-  test.describe("javascript enabled", () => {
-    test("hydrates", async ({ page }) => {
-      let app = new PlaywrightFixture(appFixture, page);
-      await app.goto("/");
-      expect(await page.locator("[data-route]").textContent()).toBe("Index");
-      expect(await page.locator("[data-loader-data]").textContent()).toBe(
-        "Index Loader Data"
-      );
-      expect(await page.locator("[data-mounted]").textContent()).toBe(
-        "Mounted"
-      );
-      expect(await page.locator("title").textContent()).toBe(
-        "Index Title: Index Loader Data"
-      );
-    });
-
-    test("hydrates a proper useId value", async ({ page }) => {
-      let app = new PlaywrightFixture(appFixture, page);
-      await app.goto("/?slow");
-
-      // We should hydrate the same useId value in HydrateFallback that we
-      // rendered on the server above
-      await page.waitForSelector("[data-hydrated]");
-      expect(await page.locator("[data-use-id]").textContent()).toBe(
-        USE_ID_VALUE
-      );
-
-      // Once hydrated, we should get a different useId value from the root component
-      await page.waitForSelector("[data-route]");
-      expect(await page.locator("[data-route]").textContent()).toBe("Index");
-      expect(await page.locator("[data-use-id]").textContent()).not.toBe(
-        USE_ID_VALUE
-      );
-    });
-
-    test("navigates and calls loaders", async ({ page }) => {
-      let app = new PlaywrightFixture(appFixture, page);
-      await app.goto("/");
-      expect(await page.locator("[data-route]").textContent()).toBe("Index");
-
-      await app.clickLink("/about");
-      await page.waitForSelector('[data-route]:has-text("About")');
-      expect(await page.locator("[data-route]").textContent()).toBe("About");
-      expect(await page.locator("[data-loader-data]").textContent()).toBe(
-        "About Loader Data"
-      );
-      expect(await page.locator("title").textContent()).toBe(
-        "About Title: About Loader Data"
-      );
-    });
-
-    test("navigates and calls actions/loaders", async ({ page }) => {
-      let app = new PlaywrightFixture(appFixture, page);
-      await app.goto("/");
-      expect(await page.locator("[data-route]").textContent()).toBe("Index");
-
-      await app.clickSubmitButton("/about");
-      await page.waitForSelector('[data-route]:has-text("About")');
-      expect(await page.locator("[data-route]").textContent()).toBe("About");
-      expect(await page.locator("[data-action-data]").textContent()).toBe(
-        "About Action Data"
-      );
-      expect(await page.locator("[data-loader-data]").textContent()).toBe(
-        "About Loader Data"
-      );
-      expect(await page.locator("title").textContent()).toBe(
-        "About Title: About Loader Data"
-      );
-    });
-
-    test("errors if you call serverLoader", async ({ page }) => {
-      let app = new PlaywrightFixture(appFixture, page);
-      await app.goto("/");
-      expect(await page.locator("[data-route]").textContent()).toBe("Index");
-
-      await app.clickLink("/error");
-      await page.waitForSelector("[data-error]");
-      expect(await page.locator("[data-error]").textContent()).toBe(
-        'Error: You cannot call serverLoader() in SPA Mode (routeId: "routes/error")'
-      );
-    });
-
-    test("errors if you call serverAction", async ({ page }) => {
-      let app = new PlaywrightFixture(appFixture, page);
-      await app.goto("/");
-      expect(await page.locator("[data-route]").textContent()).toBe("Index");
-
-      await app.clickSubmitButton("/error");
-      await page.waitForSelector("[data-error]");
-      expect(await page.locator("[data-error]").textContent()).toBe(
-        'Error: You cannot call serverAction() in SPA Mode (routeId: "routes/error")'
-      );
     });
 
     test("prepends DOCTYPE to <html> documents if not present", async () => {
@@ -543,6 +259,284 @@ test.describe("SPA Mode", () => {
       let html = await res.text();
       expect(html).toMatch(/^<div>/);
       expect(html).not.toMatch(/<!DOCTYPE html>/);
+    });
+  });
+
+  test.describe("normal apps", () => {
+    test.beforeAll(async () => {
+      fixture = await createFixture({
+        compiler: "vite",
+        spaMode: true,
+        files: {
+          "vite.config.ts": js`
+            import { defineConfig } from "vite";
+            import { unstable_vitePlugin as remix } from "@remix-run/dev";
+
+            export default defineConfig({
+              plugins: [remix({ unstable_ssr: false })],
+            });
+          `,
+          "app/root.tsx": js`
+            import * as React from "react";
+            import { Form, Link, Links, Meta, Outlet, Scripts } from "@remix-run/react";
+
+            export default function Root() {
+              let id = React.useId();
+              return (
+                <html lang="en">
+                  <head>
+                    <Meta />
+                    <Links />
+                  </head>
+                  <body>
+                      <h1 data-root>Root</h1>
+                      <pre data-use-id>{id}</pre>
+                      <nav>
+                        <Link to="/about">/about</Link>
+                        <br/>
+
+                        <Form method="post" action="/about">
+                          <button type="submit">
+                            Submit /about
+                          </button>
+                        </Form>
+                        <br/>
+
+                        <Link to="/error">/error</Link>
+                        <br/>
+
+                        <Form method="post" action="/error">
+                          <button type="submit">
+                            Submit /error
+                          </button>
+                        </Form>
+                        <br/>
+                       </nav>
+                      <Outlet />
+                    <Scripts />
+                  </body>
+                </html>
+              );
+            }
+
+            export function HydrateFallback() {
+              const id = React.useId();
+              const [hydrated, setHydrated] = React.useState(false);
+              React.useEffect(() => setHydrated(true), []);
+
+              return (
+                <html lang="en">
+                  <head>
+                    <Meta />
+                    <Links />
+                  </head>
+                  <body>
+                    <h1 data-loading>Loading SPA...</h1>
+                    <pre data-use-id>{id}</pre>
+                    {hydrated ? <h3 data-hydrated>Hydrated</h3> : null}
+                    <Scripts />
+                  </body>
+                </html>
+              );
+            }
+          `,
+          "app/routes/_index.tsx": js`
+            import * as React  from "react";
+            import { useLoaderData } from "@remix-run/react";
+
+            export function meta({ data }) {
+              return [{
+                title: "Index Title: " + data
+              }];
+            }
+
+            export async function clientLoader({ request }) {
+              if (new URL(request.url).searchParams.has('slow')) {
+                await new Promise(r => setTimeout(r, 500));
+              }
+              return "Index Loader Data";
+            }
+
+            export default function Component() {
+              let data = useLoaderData();
+              const [mounted, setMounted] = React.useState(false);
+              React.useEffect(() => setMounted(true), []);
+
+              return (
+                <>
+                  <h2 data-route>Index</h2>
+                  <p data-loader-data>{data}</p>
+                  {!mounted ? <h3>Unmounted</h3> : <h3 data-mounted>Mounted</h3>}
+                </>
+              );
+            }
+          `,
+          "app/routes/about.tsx": js`
+            import { useActionData, useLoaderData } from "@remix-run/react";
+
+            export function meta({ data }) {
+              return [{
+                title: "About Title: " + data
+              }];
+            }
+
+            export function clientLoader() {
+              return "About Loader Data";
+            }
+
+            export function clientAction() {
+              return "About Action Data";
+            }
+
+            export default function Component() {
+              let data = useLoaderData();
+              let actionData = useActionData();
+
+              return (
+                <>
+                  <h2 data-route>About</h2>
+                  <p data-loader-data>{data}</p>
+                  <p data-action-data>{actionData}</p>
+                </>
+              );
+            }
+          `,
+          "app/routes/error.tsx": js`
+            import { useRouteError } from "@remix-run/react";
+
+            export async function clientLoader({ serverLoader }) {
+              await serverLoader();
+              return null;
+            }
+
+            export async function clientAction({ serverAction }) {
+              await serverAction();
+              return null;
+            }
+
+            export default function Component() {
+              return <h2>Error</h2>;
+            }
+
+            export function ErrorBoundary() {
+              let error = useRouteError();
+              return <pre data-error>{error.data}</pre>
+            }
+          `,
+        },
+      });
+
+      appFixture = await createAppFixture(fixture);
+    });
+
+    test.afterAll(() => {
+      appFixture.close();
+    });
+
+    test("renders the root HydrateFallback initially", async ({ page }) => {
+      let res = await fixture.requestDocument("/");
+      let html = await res.text();
+      expect(html).toMatch("<title>Index Title: undefined</title>");
+      expect(html).toMatch('<h1 data-loading="true">Loading SPA...</h1>');
+    });
+
+    test("hydrates", async ({ page }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/");
+      expect(await page.locator("[data-route]").textContent()).toBe("Index");
+      expect(await page.locator("[data-loader-data]").textContent()).toBe(
+        "Index Loader Data"
+      );
+      expect(await page.locator("[data-mounted]").textContent()).toBe(
+        "Mounted"
+      );
+      expect(await page.locator("title").textContent()).toBe(
+        "Index Title: Index Loader Data"
+      );
+    });
+
+    test("hydrates a proper useId value", async ({ page }) => {
+      // SSR'd useId value we can assert against pre- and post-hydration
+      let USE_ID_VALUE = ":R1:";
+
+      // Ensure we SSR a proper useId value
+      let res = await fixture.requestDocument("/");
+      let html = await res.text();
+      expect(html).toMatch(`<pre data-use-id="true">${USE_ID_VALUE}</pre>`);
+
+      // We should hydrate the same useId value in HydrateFallback
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/?slow");
+      await page.waitForSelector("[data-hydrated]");
+      expect(await page.locator("[data-use-id]").textContent()).toBe(
+        USE_ID_VALUE
+      );
+
+      // Once hydrated, we should get a different useId value from the root Component
+      await page.waitForSelector("[data-route]");
+      expect(await page.locator("[data-route]").textContent()).toBe("Index");
+      expect(await page.locator("[data-use-id]").textContent()).not.toBe(
+        USE_ID_VALUE
+      );
+    });
+
+    test("navigates and calls loaders", async ({ page }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/");
+      expect(await page.locator("[data-route]").textContent()).toBe("Index");
+
+      await app.clickLink("/about");
+      await page.waitForSelector('[data-route]:has-text("About")');
+      expect(await page.locator("[data-route]").textContent()).toBe("About");
+      expect(await page.locator("[data-loader-data]").textContent()).toBe(
+        "About Loader Data"
+      );
+      expect(await page.locator("title").textContent()).toBe(
+        "About Title: About Loader Data"
+      );
+    });
+
+    test("navigates and calls actions/loaders", async ({ page }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/");
+      expect(await page.locator("[data-route]").textContent()).toBe("Index");
+
+      await app.clickSubmitButton("/about");
+      await page.waitForSelector('[data-route]:has-text("About")');
+      expect(await page.locator("[data-route]").textContent()).toBe("About");
+      expect(await page.locator("[data-action-data]").textContent()).toBe(
+        "About Action Data"
+      );
+      expect(await page.locator("[data-loader-data]").textContent()).toBe(
+        "About Loader Data"
+      );
+      expect(await page.locator("title").textContent()).toBe(
+        "About Title: About Loader Data"
+      );
+    });
+
+    test("errors if you call serverLoader", async ({ page }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/");
+      expect(await page.locator("[data-route]").textContent()).toBe("Index");
+
+      await app.clickLink("/error");
+      await page.waitForSelector("[data-error]");
+      expect(await page.locator("[data-error]").textContent()).toBe(
+        'Error: You cannot call serverLoader() in SPA Mode (routeId: "routes/error")'
+      );
+    });
+
+    test("errors if you call serverAction", async ({ page }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/");
+      expect(await page.locator("[data-route]").textContent()).toBe("Index");
+
+      await app.clickSubmitButton("/error");
+      await page.waitForSelector("[data-error]");
+      expect(await page.locator("[data-error]").textContent()).toBe(
+        'Error: You cannot call serverAction() in SPA Mode (routeId: "routes/error")'
+      );
     });
   });
 });


### PR DESCRIPTION
We do this for `Scripts` but not for `Meta`/`Links` so if you have `meta`/`links` in your `index.html` they incorrectly get SSR'd into the `index.html` file - causing a hydration issue since we only hydrate the root route.

* fa9e138 can be ignored - it was a test reorg before adding the failing test
* 0abe524 has all of the functional changes

Closes #8536