### PR TITLE
Add mode field into generated vite server build

### DIFF
--- a/.changeset/tender-cherries-taste.md
+++ b/.changeset/tender-cherries-taste.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": patch
 ---
 
-Add `mode` field into generated serber build for vite
+Vite: Add `mode` field into generated server build

--- a/.changeset/tender-cherries-taste.md
+++ b/.changeset/tender-cherries-taste.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Add `mode` field into generated serber build for vite

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -452,6 +452,12 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
 
   let getServerEntry = async () => {
     invariant(viteConfig, "viteconfig required to generate the server entry");
+
+    // v3 TODO:
+    // - Deprecate `ServerBuild.mode` once we officially stabilize vite and
+    //   mark the old compiler as deprecated
+    // - Remove `ServerBuild.mode` in v3
+
     return `
     import * as entryServer from ${JSON.stringify(
       resolveFileUrl(pluginConfig, pluginConfig.entryServerFilePath)
@@ -467,6 +473,10 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
         )};`;
       })
       .join("\n")}
+      /**
+       * \`mode\` is only relevant for the old Remix compiler but
+       * is included here to satisfy the \`ServerBuild\` typings.
+       */
       export const mode = ${JSON.stringify(viteConfig.mode)};
       export { default as assets } from ${JSON.stringify(serverManifestId)};
       export const assetsBuildDirectory = ${JSON.stringify(

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -451,6 +451,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
     };
 
   let getServerEntry = async () => {
+    invariant(viteConfig, "viteconfig required to generate the server entry");
     return `
     import * as entryServer from ${JSON.stringify(
       resolveFileUrl(pluginConfig, pluginConfig.entryServerFilePath)
@@ -466,6 +467,7 @@ export const remixVitePlugin: RemixVitePlugin = (options = {}) => {
         )};`;
       })
       .join("\n")}
+      export const mode = ${JSON.stringify(viteConfig.mode)};
       export { default as assets } from ${JSON.stringify(serverManifestId)};
       export const assetsBuildDirectory = ${JSON.stringify(
         pluginConfig.relativeAssetsBuildDirectory

--- a/packages/remix-server-runtime/build.ts
+++ b/packages/remix-server-runtime/build.ts
@@ -7,6 +7,9 @@ import type { AppLoadContext } from "./data";
  * The output of the compiler for the server build.
  */
 export interface ServerBuild {
+  // v3 TODO:
+  // - Deprecate when we deprecate the old compiler
+  // - Remove in v3
   mode: string;
   entry: {
     module: ServerEntryModule;


### PR DESCRIPTION
Reported in discord - TS was throwing an error in the vite express template if you use a `server.ts`