### PR TITLE
refactor(remix-dev/vite): resolve absolute serverBuildDirectory

### DIFF
--- a/packages/remix-dev/vite/build.ts
+++ b/packages/remix-dev/vite/build.ts
@@ -139,18 +139,21 @@ async function getServerBuilds({
       }
       serverBundlesManifest.routeIdToServerBundleId[route.id] = bundleId;
 
-      let serverBundleDirectory = path.join(serverBuildDirectory, bundleId);
+      let relativeServerBundleDirectory = path.relative(
+        rootDirectory,
+        path.join(serverBuildDirectory, bundleId)
+      );
       let serverBuildConfig = serverBuildConfigByBundleId.get(bundleId);
       if (!serverBuildConfig) {
         serverBundlesManifest.serverBundles[bundleId] = {
           id: bundleId,
           file: normalizePath(
-            path.join(serverBundleDirectory, serverBuildFile)
+            path.join(relativeServerBundleDirectory, serverBuildFile)
           ),
         };
         serverBuildConfig = {
           routes: {},
-          serverBuildDirectory: serverBundleDirectory,
+          serverBuildDirectory: relativeServerBundleDirectory,
         };
         serverBuildConfigByBundleId.set(bundleId, serverBuildConfig);
       }
@@ -263,10 +266,6 @@ export async function build(
     serverBuildDirectory,
     serverBuildFile,
   } = remixConfig;
-
-  // Should this already be absolute on the resolved config object?
-  // In the meantime, we make it absolute before passing to adapter hooks
-  serverBuildDirectory = path.resolve(root, serverBuildDirectory);
 
   await remixConfig.adapter?.buildEnd?.({
     // Since this is public API, these properties need to mirror the options

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -21,8 +21,8 @@ import colors from "picocolors";
 
 import { type ConfigRoute, type RouteManifest } from "../config/routes";
 import {
-  type AppConfig as RemixUserConfig,
-  type RemixConfig as ResolvedRemixConfig,
+  type AppConfig as RemixEsbuildUserConfig,
+  type RemixConfig as ResolvedRemixEsbuildConfig,
   resolveConfig as resolveRemixEsbuildConfig,
 } from "../config";
 import { type Manifest } from "../manifest";
@@ -43,9 +43,9 @@ const supportedRemixEsbuildConfigKeys = [
   "publicPath",
   "routes",
   "serverModuleFormat",
-] as const satisfies ReadonlyArray<keyof RemixUserConfig>;
-type SupportedRemixEsbuildConfig = Pick<
-  RemixUserConfig,
+] as const satisfies ReadonlyArray<keyof RemixEsbuildUserConfig>;
+type SupportedRemixEsbuildUserConfig = Pick<
+  RemixEsbuildUserConfig,
   typeof supportedRemixEsbuildConfigKeys[number]
 >;
 
@@ -66,17 +66,17 @@ const CLIENT_ROUTE_QUERY_STRING = "?client-route";
 
 // We need to provide different JSDoc comments in some cases due to differences
 // between the Remix config and the Vite plugin.
-type RemixEsbuildConfigJsdocOverrides = {
+type RemixEsbuildUserConfigJsdocOverrides = {
   /**
    * The path to the browser build, relative to the project root. Defaults to
    * `"build/client"`.
    */
-  assetsBuildDirectory?: SupportedRemixEsbuildConfig["assetsBuildDirectory"];
+  assetsBuildDirectory?: SupportedRemixEsbuildUserConfig["assetsBuildDirectory"];
   /**
    * The URL prefix of the browser build with a trailing slash. Defaults to
    * `"/"`. This is the path the browser will use to find assets.
    */
-  publicPath?: SupportedRemixEsbuildConfig["publicPath"];
+  publicPath?: SupportedRemixEsbuildUserConfig["publicPath"];
 };
 
 // Only expose a subset of route properties to the "serverBundles" function
@@ -124,8 +124,11 @@ export type VitePluginAdapter = (args: {
   remixConfig: VitePluginConfig;
 }) => Adapter | Promise<Adapter>;
 
-export type VitePluginConfig = RemixEsbuildConfigJsdocOverrides &
-  Omit<SupportedRemixEsbuildConfig, keyof RemixEsbuildConfigJsdocOverrides> & {
+export type VitePluginConfig = RemixEsbuildUserConfigJsdocOverrides &
+  Omit<
+    SupportedRemixEsbuildUserConfig,
+    keyof RemixEsbuildUserConfigJsdocOverrides
+  > & {
     /**
      * A function for adapting the build output and/or development environment
      * for different hosting providers.
@@ -168,7 +171,7 @@ type BuildEndArgs = Pick<
 type BuildEndHook = (args: BuildEndArgs) => void | Promise<void>;
 
 export type ResolvedVitePluginConfig = Pick<
-  ResolvedRemixConfig,
+  ResolvedRemixEsbuildConfig,
   | "appDirectory"
   | "rootDirectory"
   | "assetsBuildDirectory"

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -23,7 +23,7 @@ import { type ConfigRoute, type RouteManifest } from "../config/routes";
 import {
   type AppConfig as RemixUserConfig,
   type RemixConfig as ResolvedRemixConfig,
-  resolveConfig,
+  resolveConfig as resolveRemixEsbuildConfig,
 } from "../config";
 import { type Manifest } from "../manifest";
 import invariant from "../invariant";
@@ -35,7 +35,7 @@ import { removeExports } from "./remove-exports";
 import { replaceImportSpecifier } from "./replace-import-specifier";
 import { importViteEsmSync, preloadViteEsm } from "./import-vite-esm-sync";
 
-const supportedRemixConfigKeys = [
+const supportedRemixEsbuildConfigKeys = [
   "appDirectory",
   "assetsBuildDirectory",
   "future",
@@ -44,8 +44,10 @@ const supportedRemixConfigKeys = [
   "routes",
   "serverModuleFormat",
 ] as const satisfies ReadonlyArray<keyof RemixUserConfig>;
-type SupportedRemixConfigKey = typeof supportedRemixConfigKeys[number];
-type SupportedRemixConfig = Pick<RemixUserConfig, SupportedRemixConfigKey>;
+type SupportedRemixEsbuildConfig = Pick<
+  RemixUserConfig,
+  typeof supportedRemixEsbuildConfigKeys[number]
+>;
 
 const SERVER_ONLY_ROUTE_EXPORTS = ["loader", "action", "headers"];
 const CLIENT_ROUTE_EXPORTS = [
@@ -64,17 +66,17 @@ const CLIENT_ROUTE_QUERY_STRING = "?client-route";
 
 // We need to provide different JSDoc comments in some cases due to differences
 // between the Remix config and the Vite plugin.
-type RemixConfigJsdocOverrides = {
+type RemixEsbuildConfigJsdocOverrides = {
   /**
    * The path to the browser build, relative to the project root. Defaults to
    * `"build/client"`.
    */
-  assetsBuildDirectory?: SupportedRemixConfig["assetsBuildDirectory"];
+  assetsBuildDirectory?: SupportedRemixEsbuildConfig["assetsBuildDirectory"];
   /**
    * The URL prefix of the browser build with a trailing slash. Defaults to
    * `"/"`. This is the path the browser will use to find assets.
    */
-  publicPath?: SupportedRemixConfig["publicPath"];
+  publicPath?: SupportedRemixEsbuildConfig["publicPath"];
 };
 
 // Only expose a subset of route properties to the "serverBundles" function
@@ -122,8 +124,8 @@ export type VitePluginAdapter = (args: {
   remixConfig: VitePluginConfig;
 }) => Adapter | Promise<Adapter>;
 
-export type VitePluginConfig = RemixConfigJsdocOverrides &
-  Omit<SupportedRemixConfig, keyof RemixConfigJsdocOverrides> & {
+export type VitePluginConfig = RemixEsbuildConfigJsdocOverrides &
+  Omit<SupportedRemixEsbuildConfig, keyof RemixEsbuildConfigJsdocOverrides> & {
     /**
      * A function for adapting the build output and/or development environment
      * for different hosting providers.
@@ -453,13 +455,18 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
 
     let isSpaMode = mergedRemixConfig.unstable_ssr === false;
 
-    let resolvedRemixConfig = await resolveConfig(
-      pick(mergedRemixConfig, supportedRemixConfigKeys),
-      {
-        rootDirectory,
-        isSpaMode,
-      }
+    let resolvedRemixEsbuildConfig = await resolveRemixEsbuildConfig(
+      pick(mergedRemixConfig, supportedRemixEsbuildConfigKeys),
+      { rootDirectory, isSpaMode }
     );
+
+    let resolvedRemixConfig = {
+      ...resolvedRemixEsbuildConfig,
+      serverBuildDirectory: path.resolve(
+        rootDirectory,
+        mergedRemixConfig.serverBuildDirectory
+      ),
+    };
 
     // Only select the Remix config options that the Vite plugin uses
     let {
@@ -1063,7 +1070,7 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
 
           if (remixConfig.isSpaMode) {
             await handleSpaMode(
-              path.join(rootDirectory, serverBuildDirectory),
+              serverBuildDirectory,
               serverBuildFile,
               assetsBuildDirectory,
               viteConfig


### PR DESCRIPTION
All paths on the resolved Remix config should be absolute but `serverBuildDirectory` was root-relative which made it awkward for any consuming code.

Since we're now resolving options from the Vite plugin, I've refactored the code to make it clearer that we're only calling `resolveConfig` for options that are compatible with the Remix esbuild compiler.