### PR TITLE
refactor(remix-dev): clean resolved config

### DIFF
--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -39,7 +39,6 @@ describe("readConfig", () => {
           "v3_fetcherPersist": false,
           "v3_relativeSplatPath": false,
         },
-        "isSpaMode": false,
         "mdx": undefined,
         "postcss": true,
         "publicPath": "/build/",

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -339,14 +339,6 @@ export interface RemixConfig {
   serverPlatform: ServerPlatform;
 
   /**
-   * Enable SPA Mode.  Default's to `false`.
-   *
-   * This is the inverse of the user-level `unstable_ssr` config and used throughout
-   * the codebase to avoid confusion with Vite's `ssr` config
-   */
-  isSpaMode: boolean;
-
-  /**
    * Whether to support Tailwind functions and directives in CSS files if `tailwindcss` is installed.
    * Defaults to `true`.
    */
@@ -667,7 +659,6 @@ export async function resolveConfig(
     serverMode,
     serverModuleFormat,
     serverNodeBuiltinsPolyfill,
-    isSpaMode,
     browserNodeBuiltinsPolyfill,
     serverPlatform,
     mdx,

--- a/packages/remix-dev/vite/build.ts
+++ b/packages/remix-dev/vite/build.ts
@@ -260,22 +260,14 @@ export async function build(
     );
   }
 
-  let {
-    isSpaMode,
-    assetsBuildDirectory,
-    serverBuildDirectory,
-    serverBuildFile,
-  } = remixConfig;
+  let { assetsBuildDirectory, serverBuildDirectory, serverBuildFile, ssr } =
+    remixConfig;
 
   await remixConfig.adapter?.buildEnd?.({
-    // Since this is public API, these properties need to mirror the options
-    // passed to the Remix plugin. This means we need to translate our internal
-    // names back to their original public counterparts. It's probably worth
-    // aligning these internally so we don't need this translation layer.
     assetsBuildDirectory,
     serverBuildDirectory,
     serverBuildFile,
     unstable_serverBundlesManifest: serverBundlesManifest,
-    unstable_ssr: !isSpaMode,
+    unstable_ssr: ssr,
   });
 }

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -543,7 +543,7 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
         )
       )};
       export const future = ${JSON.stringify(remixConfig.future)};
-      export const isSpaMode = ${remixConfig.ssr === false};
+      export const isSpaMode = ${!remixConfig.ssr};
       export const publicPath = ${JSON.stringify(remixConfig.publicPath)};
       export const entry = { module: entryServer };
       export const routes = {

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -452,6 +452,7 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
       viteUserConfig.root ?? process.env.REMIX_ROOT ?? process.cwd();
 
     let ssr = resolvedRemixUserConfig.unstable_ssr !== false;
+    let isSpaMode = !ssr;
 
     // Only select the Remix esbuild config options that the Vite plugin uses
     let {
@@ -465,7 +466,7 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
       serverModuleFormat,
     } = await resolveRemixEsbuildConfig(
       pick(resolvedRemixUserConfig, supportedRemixEsbuildConfigKeys),
-      { rootDirectory, isSpaMode: !ssr }
+      { rootDirectory, isSpaMode }
     );
 
     let serverBuildDirectory = path.resolve(
@@ -477,7 +478,7 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
       resolvedRemixUserConfig;
 
     // Log warning for incompatible vite config flags
-    if (serverBundles && !ssr) {
+    if (isSpaMode && serverBundles) {
       console.warn(
         colors.yellow(
           colors.bold("⚠️  SPA Mode: ") +


### PR DESCRIPTION
This PR cleans up the resolved config objects a little. The goal is to make the resolved Vite plugin config suitable to be exposed via public APIs, e.g. the new adapter `buildEnd` hook.

For the resolved Vite plugin config, I've replaced `isSpaMode` with `ssr` and removed `relativeAssetsBuildDirectory` so that the object mirrors what was passed in.

I also removed `isSpaMode` from the resolved config for the old compiler since it's unused in that context.