### PR TITLE
template(vite): Improve vite-express template to match official express template server behavior

### DIFF
--- a/templates/unstable-vite-express/.eslintrc.cjs
+++ b/templates/unstable-vite-express/.eslintrc.cjs
@@ -74,7 +74,7 @@ module.exports = {
 
     // Node
     {
-      files: [".eslintrc.js"],
+      files: [".eslintrc.js", "server.mjs"],
       env: {
         node: true,
       },

--- a/templates/unstable-vite-express/package.json
+++ b/templates/unstable-vite-express/package.json
@@ -13,14 +13,18 @@
     "@remix-run/express": "*",
     "@remix-run/node": "*",
     "@remix-run/react": "*",
+    "compression": "^1.7.4",
     "express": "^4.18.2",
     "isbot": "^4.1.0",
+    "morgan": "^1.10.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@remix-run/dev": "*",
+    "@types/compression": "^1.7.5",
     "@types/express": "^4.17.20",
+    "@types/morgan": "^1.9.9",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.7.4",


### PR DESCRIPTION
- Set eslint node environment for server.mjs
- Use compression and disable x-powered-by in express
- Use morgan for logging requests
- Make port configurable by environment variable

These changes make the express server behavior more like the normal express from the official template: https://github.com/remix-run/remix/tree/main/templates/express 

Testing Strategy:

I made these changes after running `create-remix` with the `remix-run/remix/templates/unstable-vite-express` template. I tested both `dev` and `buld`/`start` modes.

After updating the source, I then ran the following:

```ps1
npx create-remix@latest --template /dev/OSS/remix/templates/unstable-vite-express
```

And again the install worked along with the `dev`, `build`, and `start` commands.