### PR TITLE
Update server-bundles.md (fix broken link)

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -139,6 +139,7 @@
 - dhmacs
 - dima-takoy
 - dmarkow
+- dmillar
 - DNLHC
 - dnsbty
 - dogukanakkaya

--- a/docs/future/server-bundles.md
+++ b/docs/future/server-bundles.md
@@ -48,5 +48,5 @@ When the build is complete, Remix will generate a `bundles.json` manifest file i
 - `routeIdToServerBundleId` — An object that maps route IDs to its server bundle ID.
 - `routes` — A route manifest that maps route IDs to route metadata. This can be used to drive a custom routing layer in front of your Remix request handlers.
 
-[remix-vite]: ./vite.md
+[remix-vite]: ./vite
 [pathless-layout-route]: ../file-conventions/routes#nested-layouts-without-nested-urls


### PR DESCRIPTION
Fixing url to remix vite plugin. Linking to .md file and therefore being incorrectly routed.