### PR TITLE
template(vite-express): align with express template

### DIFF
--- a/templates/express/.eslintrc.cjs
+++ b/templates/express/.eslintrc.cjs
@@ -74,7 +74,7 @@ module.exports = {
 
     // Node
     {
-      files: [".eslintrc.js", "server.js"],
+      files: [".eslintrc.cjs", "server.js"],
       env: {
         node: true,
       },

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -64,7 +64,7 @@ app.all("*", remixHandler);
 
 const port = process.env.PORT || 3000;
 app.listen(port, async () => {
-  console.log(`Express server listening on port ${port}`);
+  console.log(`Express server listening at http://localhost:${port}`);
 
   if (process.env.NODE_ENV === "development") {
     broadcastDevReady(initialBuild);

--- a/templates/unstable-vite-express/.eslintrc.cjs
+++ b/templates/unstable-vite-express/.eslintrc.cjs
@@ -74,7 +74,7 @@ module.exports = {
 
     // Node
     {
-      files: [".eslintrc.js", "server.mjs"],
+      files: [".eslintrc.cjs", "server.js"],
       env: {
         node: true,
       },

--- a/templates/unstable-vite-express/package.json
+++ b/templates/unstable-vite-express/package.json
@@ -4,9 +4,9 @@
   "type": "module",
   "scripts": {
     "build": "remix vite:build",
-    "dev": "node ./server.mjs",
+    "dev": "node ./server.js",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
-    "start": "cross-env NODE_ENV=production node ./server.mjs",
+    "start": "cross-env NODE_ENV=production node ./server.js",
     "typecheck": "tsc"
   },
   "dependencies": {


### PR DESCRIPTION
This is a follow-up to #8564. This further aligns with the `express` template:

- Renamed `server.mjs` to `server.js` since it's an ESM project.
- Extracted the Remix request handler into a `remixHandler` variable.
- Fixed the asset fingerprint comment to reference Vite rather than Remix (i.e. the Remix compiler).

As part of the alignment, the following have been fixed across both `express` and `vite-express` templates:
- Fixed the `".eslintrc.cjs"` path within the ESLint config itself.
- Added a full localhost URL to the console log for quick access during local dev in the `express` template.