### PR TITLE
docs(vite): remove outdated serverBuildPath docs

### DIFF
--- a/docs/future/vite.md
+++ b/docs/future/vite.md
@@ -54,7 +54,6 @@ The following subset of Remix config options are supported:
 - [ignoredRouteFiles][ignored-route-files]
 - [publicPath][public-path]
 - [routes][routes]
-- [serverBuildPath][server-build-path]
 - [serverModuleFormat][server-module-format]
 
 The Vite plugin also accepts the following additional options:


### PR DESCRIPTION
The `serverBuildPath` option from `remix.config.js` has been replaced with `serverBuildFile` in the Vite plugin so that we can support server bundles.