### PR TITLE
fix(remix-dev/vite): remove Vite v4 back compat

### DIFF
--- a/.changeset/great-mice-march.md
+++ b/.changeset/great-mice-march.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: Remove undocumented backwards compatibility layer for Vite v4


### PR DESCRIPTION
Vite v4 is not supported by our peer dependency range, but this backwards compatibility layer was still left in the code temporarily just in case someone was stuck on v4 in the short term. Now that we're getting close to being stable, it's a good time to remove this layer and fully commit to v5 as the new minimum version.