### PR TITLE
refactor(remix-dev/vite): clean resolved Remix config

### DIFF
--- a/packages/remix-dev/vite/build.ts
+++ b/packages/remix-dev/vite/build.ts
@@ -9,7 +9,7 @@ import {
   type ServerBundleBuildConfig,
   type ServerBundlesBuildManifest,
   configRouteToBranchRoute,
-  getServerBuildRootDirectory,
+  getServerBuildDirectory,
 } from "./plugin";
 import type { ConfigRoute, RouteManifest } from "../config/routes";
 import invariant from "../invariant";
@@ -110,7 +110,7 @@ async function getServerBuilds(buildContext: BuildContext): Promise<{
   // eslint-disable-next-line prefer-let/prefer-let -- Improve type narrowing
   const { routes, serverBuildFile, serverBundles, appDirectory } =
     buildContext.remixConfig;
-  let serverBuildRootDirectory = getServerBuildRootDirectory(buildContext);
+  let serverBuildDirectory = getServerBuildDirectory(buildContext);
   if (!serverBundles) {
     return {
       serverBuilds: [{ ssr: true }],
@@ -160,7 +160,7 @@ async function getServerBuilds(buildContext: BuildContext): Promise<{
 
       let relativeServerBundleDirectory = path.relative(
         rootDirectory,
-        path.join(serverBuildRootDirectory, serverBundleId)
+        path.join(serverBuildDirectory, serverBundleId)
       );
       let serverBuildConfig = serverBundleBuildConfigById.get(serverBundleId);
       if (!serverBuildConfig) {
@@ -198,21 +198,21 @@ async function getServerBuilds(buildContext: BuildContext): Promise<{
   };
 }
 
-async function cleanServerBuildRootDirectory(
+async function cleanServerBuildDirectory(
   viteConfig: Vite.ResolvedConfig,
   buildContext: BuildContext
 ) {
-  let serverBuildRootDirectory = getServerBuildRootDirectory(buildContext);
+  let serverBuildDirectory = getServerBuildDirectory(buildContext);
   let isWithinRoot = () => {
     let relativePath = path.relative(
       buildContext.rootDirectory,
-      serverBuildRootDirectory
+      serverBuildDirectory
     );
     return !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
   };
 
   if (viteConfig.build.emptyOutDir ?? isWithinRoot()) {
-    await fse.remove(serverBuildRootDirectory);
+    await fse.remove(serverBuildDirectory);
   }
 }
 
@@ -273,7 +273,7 @@ export async function build(
   // output directories, we need to clean the root server build directory
   // ourselves rather than relying on Vite to do it, otherwise you can end up
   // with stale server bundle directories in your build output
-  await cleanServerBuildRootDirectory(viteConfig, buildContext);
+  await cleanServerBuildDirectory(viteConfig, buildContext);
 
   // Run the Vite client build first
   await viteBuild({ ssr: false });

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -419,7 +419,7 @@ const getServerBundleBuildConfig = (
   return viteUserConfig.__remixServerBundleBuildConfig as ServerBundleBuildConfig;
 };
 
-let getServerBuildDirectory = (buildContext: BuildContext) =>
+export let getServerBuildDirectory = (buildContext: BuildContext) =>
   path.join(
     buildContext.remixConfig.buildDirectory,
     "server",
@@ -427,9 +427,6 @@ let getServerBuildDirectory = (buildContext: BuildContext) =>
       ? [buildContext.serverBundleId]
       : [])
   );
-
-export let getServerBuildRootDirectory = (buildContext: BuildContext) =>
-  getServerBuildDirectory(buildContext);
 
 let getClientBuildDirectory = (remixConfig: ResolvedVitePluginConfig) =>
   path.join(remixConfig.buildDirectory, "client");

--- a/packages/remix-dev/vite/styles.ts
+++ b/packages/remix-dev/vite/styles.ts
@@ -21,12 +21,17 @@ const cssModulesRegExp = new RegExp(`\\.module${cssFileRegExp.source}`);
 const isCssFile = (file: string) => cssFileRegExp.test(file);
 export const isCssModulesFile = (file: string) => cssModulesRegExp.test(file);
 
-const getStylesForFiles = async (
-  viteDevServer: ViteDevServer,
-  config: { rootDirectory: string },
-  cssModulesManifest: Record<string, string>,
-  files: string[]
-): Promise<string | undefined> => {
+const getStylesForFiles = async ({
+  viteDevServer,
+  rootDirectory,
+  cssModulesManifest,
+  files,
+}: {
+  viteDevServer: ViteDevServer;
+  rootDirectory: string;
+  cssModulesManifest: Record<string, string>;
+  files: string[];
+}): Promise<string | undefined> => {
   let styles: Record<string, string> = {};
   let deps = new Set<ModuleNode>();
 
@@ -41,7 +46,7 @@ const getStylesForFiles = async (
       if (!node) {
         try {
           await viteDevServer.transformRequest(
-            resolveFileUrl(config, normalizedPath)
+            resolveFileUrl({ rootDirectory }, normalizedPath)
           );
         } catch (err) {
           console.error(err);
@@ -166,38 +171,45 @@ const createRoutes = (
   }));
 };
 
-export const getStylesForUrl = async (
-  viteDevServer: ViteDevServer,
-  config: Pick<
-    ResolvedRemixConfig,
-    "appDirectory" | "routes" | "rootDirectory" | "entryClientFilePath"
-  >,
-  cssModulesManifest: Record<string, string>,
-  build: ServerBuild,
-  url: string | undefined
-): Promise<string | undefined> => {
+export const getStylesForUrl = async ({
+  viteDevServer,
+  rootDirectory,
+  remixConfig,
+  entryClientFilePath,
+  cssModulesManifest,
+  build,
+  url,
+}: {
+  viteDevServer: ViteDevServer;
+  rootDirectory: string;
+  remixConfig: Pick<ResolvedRemixConfig, "appDirectory" | "routes">;
+  entryClientFilePath: string;
+  cssModulesManifest: Record<string, string>;
+  build: ServerBuild;
+  url: string | undefined;
+}): Promise<string | undefined> => {
   if (url === undefined || url.includes("?_data=")) {
     return undefined;
   }
 
   let routes = createRoutes(build.routes);
-  let appPath = path.relative(process.cwd(), config.appDirectory);
+  let appPath = path.relative(process.cwd(), remixConfig.appDirectory);
   let documentRouteFiles =
     matchRoutes(routes, url)?.map((match) =>
-      path.join(appPath, config.routes[match.route.id].file)
+      path.join(appPath, remixConfig.routes[match.route.id].file)
     ) ?? [];
 
-  let styles = await getStylesForFiles(
+  let styles = await getStylesForFiles({
     viteDevServer,
-    config,
+    rootDirectory,
     cssModulesManifest,
-    [
+    files: [
       // Always include the client entry file when crawling the module graph for CSS
-      path.relative(config.rootDirectory, config.entryClientFilePath),
+      path.relative(rootDirectory, entryClientFilePath),
       // Then include any styles from the matched routes
       ...documentRouteFiles,
-    ]
-  );
+    ],
+  });
 
   return styles;
 };


### PR DESCRIPTION
This is a follow-up to https://github.com/remix-run/remix/pull/8582, in preparation to expose the resolved Remix config as public API (e.g. via the adapter buildEnd hook).

The only remaining properties on the resolved `remixConfig` object that aren't present in the user-facing config type are `rootDirectory`, `entryClientFilePath` and `entryServerFilePath`. These have now been moved to the `buildContext` object. Since a lot of code assumes these are on `remixConfig`, it required a bit of a refactor to accomodate this.