### PR TITLE
vite: reduce network calls for route modules during HMR

### DIFF
--- a/.changeset/thin-rings-eat.md
+++ b/.changeset/thin-rings-eat.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: reduce network calls for route modules during HMR

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -1472,11 +1472,11 @@ function addRefreshWrapper(
         ]
       : [];
   return (
-    REACT_REFRESH_HEADER.replace("__SOURCE__", JSON.stringify(id)) +
+    REACT_REFRESH_HEADER.replaceAll("__SOURCE__", JSON.stringify(id)) +
     code +
-    REACT_REFRESH_FOOTER.replace("__SOURCE__", JSON.stringify(id))
-      .replace("__ACCEPT_EXPORTS__", JSON.stringify(acceptExports))
-      .replaceAll("__ROUTE_ID__", JSON.stringify(route && route.id))
+    REACT_REFRESH_FOOTER.replaceAll("__SOURCE__", JSON.stringify(id))
+      .replaceAll("__ACCEPT_EXPORTS__", JSON.stringify(acceptExports))
+      .replaceAll("__ROUTE_ID__", JSON.stringify(route?.id))
   );
 }
 

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -1455,29 +1455,28 @@ function isEqualJson(v1: unknown, v2: unknown) {
 }
 
 function addRefreshWrapper(
-  pluginConfig: ResolvedVitePluginConfig,
+  remixConfig: ResolvedVitePluginConfig,
   code: string,
   id: string
 ): string {
-  let isRoute =
-    id.endsWith(CLIENT_ROUTE_QUERY_STRING) || getRoute(pluginConfig, id);
-  let acceptExports = isRoute
-    ? [
-        "clientAction",
-        "clientLoader",
-        "handle",
-        "meta",
-        "links",
-        "shouldRevalidate",
-      ]
-    : [];
+  let route = getRoute(remixConfig, id);
+  let acceptExports =
+    route || id.endsWith(CLIENT_ROUTE_QUERY_STRING)
+      ? [
+          "clientAction",
+          "clientLoader",
+          "handle",
+          "meta",
+          "links",
+          "shouldRevalidate",
+        ]
+      : [];
   return (
     REACT_REFRESH_HEADER.replace("__SOURCE__", JSON.stringify(id)) +
     code +
-    REACT_REFRESH_FOOTER.replace("__SOURCE__", JSON.stringify(id)).replace(
-      "__ACCEPT_EXPORTS__",
-      JSON.stringify(acceptExports)
-    )
+    REACT_REFRESH_FOOTER.replace("__SOURCE__", JSON.stringify(id))
+      .replace("__ACCEPT_EXPORTS__", JSON.stringify(acceptExports))
+      .replaceAll("__ROUTE_ID__", JSON.stringify(route && route.id))
   );
 }
 
@@ -1511,6 +1510,7 @@ if (import.meta.hot && !inWebWorker && window.__remixLiveReloadEnabled) {
     RefreshRuntime.registerExportsForReactRefresh(__SOURCE__, currentExports);
     import.meta.hot.accept((nextExports) => {
       if (!nextExports) return;
+      __ROUTE_ID__ && window.__remixRouteModuleUpdates.set(__ROUTE_ID__, nextExports);
       const invalidateMessage = RefreshRuntime.validateRefreshBoundaryAndEnqueueUpdate(currentExports, nextExports, __ACCEPT_EXPORTS__);
       if (invalidateMessage) import.meta.hot.invalidate(invalidateMessage);
     });

--- a/packages/remix-dev/vite/static/refresh-utils.cjs
+++ b/packages/remix-dev/vite/static/refresh-utils.cjs
@@ -17,9 +17,10 @@ const enqueueUpdate = debounce(async () => {
 
     for (let route of routeUpdates.values()) {
       manifest.routes[route.id] = route;
-      let imported =
-        window.__remixRouteModuleUpdates.get(route.id) ??
-        (await __hmr_import(route.url + "?t=" + Date.now()));
+      let imported = window.__remixRouteModuleUpdates.get(route.id);
+      if (!imported) {
+        throw Error(`[remix:hmr] No module update found for route ${route.id}`);
+      }
       let routeModule = {
         ...imported,
         // react-refresh takes care of updating these in-place,

--- a/packages/remix-dev/vite/static/refresh-utils.cjs
+++ b/packages/remix-dev/vite/static/refresh-utils.cjs
@@ -17,8 +17,9 @@ const enqueueUpdate = debounce(async () => {
 
     for (let route of routeUpdates.values()) {
       manifest.routes[route.id] = route;
-
-      let imported = await __hmr_import(route.url + "?t=" + Date.now());
+      let imported =
+        window.__remixRouteModuleUpdates.get(route.id) ??
+        (await __hmr_import(route.url + "?t=" + Date.now()));
       let routeModule = {
         ...imported,
         // react-refresh takes care of updating these in-place,
@@ -53,6 +54,7 @@ const enqueueUpdate = debounce(async () => {
     );
     __remixRouter._internalSetRoutes(routes);
     routeUpdates.clear();
+    window.__remixRouteModuleUpdates.clear();
   }
 
   await revalidate();
@@ -138,6 +140,7 @@ function __hmr_import(module) {
 }
 
 const routeUpdates = new Map();
+window.__remixRouteModuleUpdates = new Map();
 
 async function revalidate() {
   let { promise, resolve } = channel();


### PR DESCRIPTION
## BEFORE

<img width="1280" alt="Screenshot 2024-01-24 at 12 01 46 PM" src="https://github.com/remix-run/remix/assets/1477317/c6f7ffb1-c794-40e0-b99a-228ba0a8dde4">

👆 The `?import&t=` request is redundant. Same module as the `?t=` request (both are 8.1kb)

## AFTER

<img width="1226" alt="Screenshot 2024-01-24 at 12 02 47 PM" src="https://github.com/remix-run/remix/assets/1477317/97b53cb2-6366-4e5c-a187-bb832e654e2e">
