### PR TITLE
feat(remix-dev/vite): remove unstable prefix from serverBundles

### DIFF
--- a/.changeset/two-pumpkins-vanish.md
+++ b/.changeset/two-pumpkins-vanish.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: Remove `unstable` prefix from `serverBundles` option.

--- a/docs/future/server-bundles.md
+++ b/docs/future/server-bundles.md
@@ -4,11 +4,11 @@ title: Server Bundles (Unstable)
 
 # Server Bundles (Unstable)
 
-<docs-warning>This is an advanced feature designed for hosting provider integrations. When compiling your app into multiple server bundles, there will need to be a custom routing layer in front of your app directing requests to the correct bundle. This feature is currently unstable and only designed to gather early feedback.</docs-warning>
+<docs-warning>This is an advanced feature designed for hosting provider integrations. When compiling your app into multiple server bundles, there will need to be a custom routing layer in front of your app directing requests to the correct bundle.</docs-warning>
 
-Remix typically builds your server code into a bundle that exposes a single request handler function. However, there are some scenarios where you might want to split your route tree into multiple server bundles that expose a request handler function for a subset of routes. To provide this level of flexibility, the [Remix Vite plugin][remix-vite] supports an `unstable_serverBundles` option which is a function for assigning routes to different server bundles.
+Remix typically builds your server code into a bundle that exposes a single request handler function. However, there are some scenarios where you might want to split your route tree into multiple server bundles that expose a request handler function for a subset of routes. To provide this level of flexibility, the [Remix Vite plugin][remix-vite] supports an `serverBundles` option which is a function for assigning routes to different server bundles.
 
-The provided `unstable_serverBundles` function is called for each route in the tree (except for routes that aren't addressable, e.g. pathless layout routes) and returns a server bundle ID that you'd like to assign it to. These bundle IDs will be used as directory names in your server build directory.
+The provided `serverBundles` function is called for each route in the tree (except for routes that aren't addressable, e.g. pathless layout routes) and returns a server bundle ID that you'd like to assign it to. These bundle IDs will be used as directory names in your server build directory.
 
 For each route, this function is passed an array of routes leading to and including that route, referred to as the route `branch`. This allows you to create server bundles for different portions of the route tree. For example, you could use this to create a separate server bundle containing all routes within a particular layout route:
 
@@ -19,7 +19,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   plugins: [
     remix({
-      unstable_serverBundles: ({ branch }) => {
+      serverBundles: ({ branch }) => {
         const isAuthenticatedRoute = branch.some(
           (route) => route.id === "routes/_authenticated"
         );

--- a/docs/future/vite.md
+++ b/docs/future/vite.md
@@ -74,7 +74,7 @@ Whether to write a `manifest.json` file to the build directory. Defaults to `fal
 
 The name of the server file generated in the server build directory. Defaults to `"index.js"`.
 
-#### unstable_serverBundles
+#### serverBundles
 
 A function for assigning addressable routes to [server bundles][server-bundles].
 

--- a/integration/vite-adapter-test.ts
+++ b/integration/vite-adapter-test.ts
@@ -32,9 +32,9 @@ test.describe(async () => {
         pluginOptions: `
           {
             adapter: async ({ remixConfig }) => ({
-              unstable_serverBundles(...args) {
+              serverBundles(...args) {
                 // This lets us assert that user options are passed to adapter options hook
-                return remixConfig.unstable_serverBundles?.(...args) + "--adapter-options";
+                return remixConfig.serverBundles?.(...args) + "--adapter-options";
               },
               async buildEnd(args) {
                 let fs = await import("node:fs/promises");
@@ -53,7 +53,7 @@ test.describe(async () => {
               }
             }),
             
-            unstable_serverBundles() {
+            serverBundles() {
               return "user-options";
             }
           },
@@ -64,7 +64,7 @@ test.describe(async () => {
   });
   test.afterAll(() => stop());
 
-  test("Vite / adapter / unstable_serverBundles and buildEnd hooks", async () => {
+  test("Vite / adapter / serverBundles and buildEnd hooks", async () => {
     let { status } = viteBuild({ cwd });
     expect(status).toBe(0);
 

--- a/integration/vite-server-bundles-test.ts
+++ b/integration/vite-server-bundles-test.ts
@@ -122,7 +122,7 @@ test.describe(() => {
         port: devPort,
         pluginOptions: `{
           manifest: true,
-          unstable_serverBundles: async ({ branch }) => {
+          serverBundles: async ({ branch }) => {
             // Smoke test to ensure we can read the route files via 'route.file'
             await Promise.all(branch.map(async (route) => {
               const fs = await import("node:fs/promises");

--- a/packages/remix-dev/vite/build.ts
+++ b/packages/remix-dev/vite/build.ts
@@ -153,9 +153,7 @@ async function getServerBuilds(ctx: RemixPluginContext): Promise<{
         ),
       });
       if (typeof serverBundleId !== "string") {
-        throw new Error(
-          `The "unstable_serverBundles" function must return a string`
-        );
+        throw new Error(`The "serverBundles" function must return a string`);
       }
       buildManifest.routeIdToServerBundleId[route.id] = serverBundleId;
 

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -112,7 +112,7 @@ export type ServerBundlesBuildManifest = BaseBuildManifest & {
 export type BuildManifest = DefaultBuildManifest | ServerBundlesBuildManifest;
 
 const adapterRemixConfigOverrideKeys = [
-  "unstable_serverBundles",
+  "serverBundles",
 ] as const satisfies ReadonlyArray<keyof VitePluginConfig>;
 
 type AdapterRemixConfigOverrideKey =
@@ -164,7 +164,7 @@ export type VitePluginConfig = RemixEsbuildUserConfigJsdocOverrides &
      * function should return a server bundle ID which will be used as the
      * bundle's directory name within the server build directory.
      */
-    unstable_serverBundles?: ServerBundlesFunction;
+    serverBundles?: ServerBundlesFunction;
     /**
      * Enable server-side rendering for your application. Disable to use Remix in
      * "SPA Mode", which will request the `/` path at build-time and save it as
@@ -492,15 +492,14 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
       resolvedRemixUserConfig.buildDirectory
     );
 
-    let { serverBuildFile, unstable_serverBundles: serverBundles } =
-      resolvedRemixUserConfig;
+    let { serverBuildFile, serverBundles } = resolvedRemixUserConfig;
 
     // Log warning for incompatible vite config flags
     if (isSpaMode && serverBundles) {
       console.warn(
         colors.yellow(
           colors.bold("⚠️  SPA Mode: ") +
-            "the `unstable_serverBundles` config is invalid with " +
+            "the `serverBundles` config is invalid with " +
             "`unstable_ssr:false` and will be ignored`"
         )
       );


### PR DESCRIPTION
Since this option is being used for hosting provider integrations, we want to ensure that it's relatively stable within the context of the Vite plugin.

At this moment it's still technically considered unstable because the entire Vite plugin is unstable, but we can't see this API changing any more than the other plugin options, if at all.