### PR TITLE
fix(remix-dev/vite): validate server bundle IDs

### DIFF
--- a/.changeset/cyan-dingos-care.md
+++ b/.changeset/cyan-dingos-care.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: Validate IDs returned from the `serverBundles` function to ensure they only contain alphanumeric characters, hyphens and underscores

--- a/packages/remix-dev/vite/build.ts
+++ b/packages/remix-dev/vite/build.ts
@@ -155,6 +155,11 @@ async function getServerBuilds(ctx: RemixPluginContext): Promise<{
       if (typeof serverBundleId !== "string") {
         throw new Error(`The "serverBundles" function must return a string`);
       }
+      if (!/^[a-zA-Z0-9-_]+$/.test(serverBundleId)) {
+        throw new Error(
+          `The "serverBundles" function must only return strings containing alphanumeric characters, hyphens and underscores.`
+        );
+      }
       buildManifest.routeIdToServerBundleId[route.id] = serverBundleId;
 
       let relativeServerBundleDirectory = path.relative(


### PR DESCRIPTION
Since server bundle IDs are used as folder names and we're also currently considering using ID as part of filenames (e.g. a manifest file like `server-${serverBundleId}-manifest.json`), we want to ensure that the character set is limited.