### PR TITLE
remove unused experimental flag `hmrPartialAccept`

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -750,7 +750,6 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
         let defaults = {
           __remixPluginContext: ctx,
           appType: "custom",
-          experimental: { hmrPartialAccept: true },
           optimizeDeps: {
             include: [
               // Pre-bundle React dependencies to avoid React duplicates,


### PR DESCRIPTION
instead, we pass a list of special Remix exports to accept during HMR and invalidate when any other non-component exports are encountered
