### PR TITLE
Unify Fastly Compute product name in docs

### DIFF
--- a/docs/discussion/runtimes.md
+++ b/docs/discussion/runtimes.md
@@ -20,7 +20,7 @@ Let's talk about what each part does.
 
 ## JavaScript Runtimes
 
-Remix can be deployed to any JavaScript runtime like Node.js, Shopify Oxygen, Cloudflare Workers/Pages, Fastly Functions, Deno, Bun, etc.
+Remix can be deployed to any JavaScript runtime like Node.js, Shopify Oxygen, Cloudflare Workers/Pages, Fastly Compute, Deno, Bun, etc.
 
 Each runtime has varying support for the standard Web APIs that Remix is built on, so Remix runtime package is required to polyfill any missing features of the runtime. These polyfills include web standard APIs like Request, Response, crypto, and more. This allows you to use the same APIs on the server as in the browser.
 

--- a/docs/other-api/adapter.md
+++ b/docs/other-api/adapter.md
@@ -24,7 +24,7 @@ Each adapter has the same API. In the future we may have helpers specific to the
 
 ## Community Adapters
 
-- [`@fastly/remix-server-adapter`][fastly-remix-server-adapter] - For [Fastly Compute@Edge][fastly-compute-at-edge].
+- [`@fastly/remix-server-adapter`][fastly-remix-server-adapter] - For [Fastly Compute][fastly-compute].
 - [`@mcansh/remix-fastify`][remix-fastify] - For [Fastify][fastify].
 - [`@mcansh/remix-raw-http`][remix-raw-http] - For a good old bare bones Node server.
 - [`@netlify/remix-adapter`][netlify-remix-adapter] - For [Netlify][netlify].
@@ -139,7 +139,7 @@ addEventListener("fetch", (event) => {
 
 [web-fetch-api]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
 [fastly-remix-server-adapter]: https://github.com/fastly/remix-compute-js/tree/main/packages/remix-server-adapter
-[fastly-compute-at-edge]: https://developer.fastly.com/learning/compute/
+[fastly-compute]: https://developer.fastly.com/learning/compute/
 [remix-google-cloud-functions]: https://github.com/penx/remix-google-cloud-functions
 [google-cloud-functions]: https://cloud.google.com/functions
 [firebase-functions]: https://firebase.google.com/docs/functions


### PR DESCRIPTION
At Fastly, we have unified our branding for edge computing with the name "Fastly Compute".
This pull request updates references in the docs to our product to this name.

These are docs-only, so it's been branched from the main branch.
