### PR TITLE
templates(cloudflare-pages): add cf (IncomingRequestCfProperties) to context

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -555,6 +555,7 @@
 - sjparsons
 - skube
 - smathson
+- smcstewart
 - smeijer
 - sndrem
 - sobrinho

--- a/templates/cloudflare-pages/README.md
+++ b/templates/cloudflare-pages/README.md
@@ -13,6 +13,10 @@ npm run dev
 
 Open up [http://127.0.0.1:8788](http://127.0.0.1:8788) and you should be ready to go!
 
+### IncomingRequestCfProperties
+
+Cloudflare Pages has access to the same [`IncomingRequestCfProperties`](https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties) object as Cloudflare Workers. However, in a Remix project (using this template), it is available on the `context` object as `context.cf`, not `request.cf` as per [Cloudflare Workers documentation](https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties).
+
 ## Deployment
 
 Cloudflare Pages are currently only deployable through their Git provider integrations.

--- a/templates/cloudflare-pages/server.ts
+++ b/templates/cloudflare-pages/server.ts
@@ -8,6 +8,6 @@ if (process.env.NODE_ENV === "development") {
 
 export const onRequest = createPagesFunctionHandler({
   build,
-  getLoadContext: (context) => ({ env: context.env }),
+  getLoadContext: (context) => ({ env: context.env, cf: context.request?.cf }),
   mode: build.mode,
 });


### PR DESCRIPTION
Testing Strategy:

Opened a terminal window and ran:
1. Ran `create-remix` from the updated template locally:

```
pnpm dlx create-remix@2.5.1 my-remix-app --template file:///src/remix/templates/cloudflare-pages
cd my-remix-app
pnpm run dev
```

2. Verified that the Remix dev server started up.
3. Opened another terminal window, verifying `GET / 200 OK` appeared in the logs upon the following:

```
http http://localhost:8788
```

4. Then added a loader to the `/app/routes/_index.tsx`:

```
export const loader = async ({ context }) => {
  console.log(JSON.stringify(context, null, 2));
  return null;
}
```

5. And run the dev server again in one window, and the `http` command in another:

```
pnpm run dev
```

```
http http://localhost:8788
```

6. Verified that the `context.cf` object appeared in the logs.
7. Finally, deployed to Cloudflare Pages, and verified the same.