### PR TITLE
docs(spa-mode): fix typo in route-based code-splitting

### DIFF
--- a/docs/future/spa-mode.md
+++ b/docs/future/spa-mode.md
@@ -21,7 +21,7 @@ That's why we added support for **SPA Mode** in [2.5.0][2.5.0] ([RFC][rfc]), whi
 SPA Mode is basically what you'd get if you had your own [React Router + Vite][rr-setup] setup using `createBrowserRouter`/`RouterProvider`, but along with some extra Remix goodies:
 
 - File-based routing (or config-based via [`routes()`][routes-config])
-- Automatic route-based code-spitting via [`route.lazy`][route-lazy]
+- Automatic route-based code-splitting via [`route.lazy`][route-lazy]
 - `<Link prefetch>` support to eagerly prefetch route modules
 - `<head>` management via Remix [`<Meta>`][meta]/[`<Links>`][links] APIs if you choose to hydrate the full `document`
 


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

- [x] Docs
- [ ] Tests

In spa-mode.md, I found the description "Automatic route-based code-spitting via [`route.lazy`](https://reactrouter.com/en/main/route/lazy)", but I confirmed that the page of [`route.lazy`](https://reactrouter.com/en/main/route/lazy) describes "route-based code-splitting".

I have never seen the word `"code-spitting"`, and I have confirmed that the word `"code-splitting"` is used on the page of [`route.lazy`](https://reactrouter.com/en/main/route/lazy), so I judged that the description in spa-mode.md is incorrect and corrected it.

