### PR TITLE
vite: Enable use of `vite preview` to preview built SPA sites

### DIFF
--- a/.changeset/tender-pens-tan.md
+++ b/.changeset/tender-pens-tan.md
@@ -1,0 +1,8 @@
+---
+"@remix-run/dev": patch
+---
+
+vite: Enable use of `vite preview` to preview built SPA sites
+
+In the SPA template, `start` script (`npm run start`) has been renamed to `preview` (`npm run preview`).
+In the SPA template, `npm run preview` uses `vite preview` for serving built SPA sites.

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -897,7 +897,12 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
 
         return {
           __remixPluginContext: ctx,
-          appType: "custom",
+          appType:
+            viteCommand === "serve" &&
+            viteConfigEnv.mode === "production" &&
+            ctx.remixConfig.unstable_ssr === false
+              ? "spa"
+              : "custom",
           optimizeDeps: {
             include: [
               // Pre-bundle React dependencies to avoid React duplicates,
@@ -979,6 +984,14 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
                           },
                         },
                       }),
+                },
+              }
+            : viteCommand === "serve" && ctx.remixConfig.unstable_ssr === false
+            ? {
+                base: ctx.remixConfig.publicPath,
+                build: {
+                  manifest: true,
+                  outDir: getClientBuildDirectory(ctx.remixConfig),
                 },
               }
             : undefined),

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -938,48 +938,50 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
             ],
           },
           base: viteUserConfig.base,
-          ...(viteCommand === "build" && {
-            build: {
-              cssMinify: viteUserConfig.build?.cssMinify ?? true,
-              ...(!viteConfigEnv.isSsrBuild
-                ? {
-                    manifest: true,
-                    outDir: getClientBuildDirectory(ctx.remixConfig),
-                    rollupOptions: {
-                      preserveEntrySignatures: "exports-only",
-                      input: [
-                        ctx.entryClientFilePath,
-                        ...Object.values(ctx.remixConfig.routes).map(
-                          (route) =>
-                            `${path.resolve(
-                              ctx.remixConfig.appDirectory,
-                              route.file
-                            )}${CLIENT_ROUTE_QUERY_STRING}`
-                        ),
-                      ],
-                    },
-                  }
-                : {
-                    // We move SSR-only assets to client assets. Note that the
-                    // SSR build can also emit code-split JS files (e.g. by
-                    // dynamic import) under the same assets directory
-                    // regardless of "ssrEmitAssets" option, so we also need to
-                    // keep these JS files have to be kept as-is.
-                    ssrEmitAssets: true,
-                    copyPublicDir: false, // Assets in the public directory are only used by the client
-                    manifest: true, // We need the manifest to detect SSR-only assets
-                    outDir: getServerBuildDirectory(ctx),
-                    rollupOptions: {
-                      preserveEntrySignatures: "exports-only",
-                      input: serverBuildId,
-                      output: {
-                        entryFileNames: ctx.remixConfig.serverBuildFile,
-                        format: ctx.remixConfig.serverModuleFormat,
-                      },
-                    },
-                  }),
-            },
-          }),
+          ...(viteCommand === "build"
+            ? {
+                build: {
+                  cssMinify: viteUserConfig.build?.cssMinify ?? true,
+                  ...(!viteConfigEnv.isSsrBuild
+                    ? {
+                        manifest: true,
+                        outDir: getClientBuildDirectory(ctx.remixConfig),
+                        rollupOptions: {
+                          preserveEntrySignatures: "exports-only",
+                          input: [
+                            ctx.entryClientFilePath,
+                            ...Object.values(ctx.remixConfig.routes).map(
+                              (route) =>
+                                `${path.resolve(
+                                  ctx.remixConfig.appDirectory,
+                                  route.file
+                                )}${CLIENT_ROUTE_QUERY_STRING}`
+                            ),
+                          ],
+                        },
+                      }
+                    : {
+                        // We move SSR-only assets to client assets. Note that the
+                        // SSR build can also emit code-split JS files (e.g. by
+                        // dynamic import) under the same assets directory
+                        // regardless of "ssrEmitAssets" option, so we also need to
+                        // keep these JS files have to be kept as-is.
+                        ssrEmitAssets: true,
+                        copyPublicDir: false, // Assets in the public directory are only used by the client
+                        manifest: true, // We need the manifest to detect SSR-only assets
+                        outDir: getServerBuildDirectory(ctx),
+                        rollupOptions: {
+                          preserveEntrySignatures: "exports-only",
+                          input: serverBuildId,
+                          output: {
+                            entryFileNames: ctx.remixConfig.serverBuildFile,
+                            format: ctx.remixConfig.serverModuleFormat,
+                          },
+                        },
+                      }),
+                },
+              }
+            : undefined),
         };
       },
       async configResolved(resolvedViteConfig) {

--- a/templates/spa/README.md
+++ b/templates/spa/README.md
@@ -34,7 +34,9 @@ Preview build locally with [vite preview](https://vitejs.dev/guide/cli#vite-prev
 npm run preview
 ```
 
-You can serve this from any server of your choosing. The server should support SPA fallback. For a simple example, you could use [sirv-cli](https://www.npmjs.com/package/sirv-cli):
+You can serve this from any server of your choosing. The server should be configured to serve multiple paths from a single root `/index.html` file (commonly called "SPA fallback"). Other steps may be required if the host doesn't directly support this functionality.
+
+For a simple example, you could use [sirv-cli](https://www.npmjs.com/package/sirv-cli):
 
 ```shellscript
 npx sirv-cli build/client/ --single --ignores "^/assets/"

--- a/templates/spa/README.md
+++ b/templates/spa/README.md
@@ -22,16 +22,16 @@ npm run dev
 
 ## Production
 
-When you are ready yo build a production version of your app, `npm run build` will generate your assets and an `index.html` for the SPA.
+When you are ready to build a production version of your app, `npm run build` will generate your assets and an `index.html` for the SPA.
 
 ```shellscript
 npm run build
 ```
 
-You can serve this from any server of your choosing, for a simple example, you could use [http-server](https://www.npmjs.com/package/http-server):
+You can serve this from any server of your choosing. The server should support SPA fallback. For a simple example, you could use [sirv-cli](https://www.npmjs.com/package/sirv-cli):
 
 ```shellscript
-npx http-server build/client/
+npx sirv-cli build/client/ --single --ignores "^/assets/"
 ```
 
 [remix-vite-docs]: https://remix.run/docs/en/main/future/vite

--- a/templates/spa/README.md
+++ b/templates/spa/README.md
@@ -28,6 +28,12 @@ When you are ready to build a production version of your app, `npm run build` wi
 npm run build
 ```
 
+Preview build locally with [vite preview](https://vitejs.dev/guide/cli#vite-preview) to serve all routes via the single `index.html` file. Do not use this as a production server as it's not designed for it:
+
+```shellscript
+npm run preview
+```
+
 You can serve this from any server of your choosing. The server should support SPA fallback. For a simple example, you could use [sirv-cli](https://www.npmjs.com/package/sirv-cli):
 
 ```shellscript

--- a/templates/spa/package.json
+++ b/templates/spa/package.json
@@ -6,13 +6,12 @@
     "build": "remix vite:build",
     "dev": "remix vite:dev",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
-    "start": "http-server build/client/",
+    "preview": "vite preview",
     "typecheck": "tsc"
   },
   "dependencies": {
     "@remix-run/node": "*",
     "@remix-run/react": "*",
-    "http-server": "^14.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
This enables use of `vite preview` for serving built SPA sites. This works better than `http-server` because it correctly supports the SPA fallback (i.e. serving a statically deployed site with all routes being served from a root `/index.html`).

This is more than a template change because the Remix Vite plugin was setting `appType: "custom"`, preventing `vite preview` from working in `"spa"` mode. The patch also sets the `build.outDir` when previewing so additional command line options aren't needed.

The SPA template has been updated to use `npm run preview` (or `yarn preview`) to preview the built site. The `start` script (`npm run start`) has been removed from the SPA template because it isn't something that should be used in production.

Closes: #8623

- [x] Docs (template/spa/README.md)

<!--
- [ ] Tests (manual)
-->

Testing Strategy:

I opened up my windows machine and ran this script (PowerShell):

```ps1
Remove-Item -Recurse .\scripts\playground\template.local\
Copy-Item -Recurse .\templates\spa .\scripts\playground\template.local
yarn playground:new
cd .\playground\playground-1706546017969 # use directory name produced by previous command
echo "export default function Hello() { return <>Hello</>; }" | Out-File ./app/routes/hello.tsx -Encoding utf8
echo "import { Link } from `"@remix-run/react`";`n`nexport default function Index() { return <Link to=`"/hello`">Navigate</Link>; }" | Out-File ./app/routes/_index.tsx  -Encoding utf8
npm run dev
npm run build
npm run preview
```

Open browser to link provided by `vite preview` and click on the "Navigate" link to arrive at `http://localhost:4173/hello` (port may differ). Refresh the page (e.g. `F5`), and the page should load without a 404. Also try navigating directly to that URL in a new tab.