### PR TITLE
vite: no `enforce: "post"`

### DIFF
--- a/.changeset/green-baboons-punch.md
+++ b/.changeset/green-baboons-punch.md
@@ -1,0 +1,30 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: rely on Vite plugin ordering
+
+**This is a breaking change for projects using the unstable Vite plugin.**
+
+The Remix plugin expects to process JavaScript or TypeScript files, so any transpilation from other languages must be done first.
+For example, that means putting the MDX plugin _before_ the Remix plugin:
+
+```diff
+  import mdx from "@mdx-js/rollup";
+  import { unstable_vitePlugin as remix } from "@remix-run/dev";
+  import { defineConfig } from "vite";
+
+  export default defineConfig({
+    plugins: [
++     mdx(),
+      remix()
+-     mdx(),
+    ],
+  });
+```
+
+Previously, the Remix plugin misused `enforce: "post"` from Vite's plugin API to ensure that it ran last.
+However, this caused other unforeseen issues.
+Instead, we now rely on standard Vite semantics for plugin ordering.
+
+The official [Vite React SWC plugin](https://github.com/vitejs/vite-plugin-react-swc/blob/main/src/index.ts#L97-L116) also relies on plugin ordering for MDX.

--- a/docs/future/vite.md
+++ b/docs/future/vite.md
@@ -661,6 +661,13 @@ If you're using [MDX][mdx], since Vite's plugin API is an extension of the [Roll
 npm install -D @mdx-js/rollup
 ```
 
+<docs-info>
+
+The Remix plugin expects to process JavaScript or TypeScript files, so any transpilation from other languages — like MDX — must be done first.
+In this case, that means putting the MDX plugin _before_ the Remix plugin.
+
+</docs-info>
+
 👉 **Add the MDX Rollup plugin to your Vite config**
 
 ```ts filename=vite.config.ts lines=[1,6]
@@ -669,7 +676,7 @@ import { unstable_vitePlugin as remix } from "@remix-run/dev";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [remix(), mdx()],
+  plugins: [mdx(), remix()],
 });
 ```
 
@@ -694,13 +701,13 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [
-    remix(),
     mdx({
       remarkPlugins: [
         remarkFrontmatter,
         remarkMdxFrontmatter,
       ],
     }),
+    remix(),
   ],
 });
 ```

--- a/integration/vite-build-test.ts
+++ b/integration/vite-build-test.ts
@@ -37,8 +37,8 @@ test.describe("Vite build", () => {
               assetsInlineLimit: 0,
             },
             plugins: [
-              remix(),
               mdx(),
+              remix(),
             ],
           });
         `,

--- a/integration/vite-dev-test.ts
+++ b/integration/vite-dev-test.ts
@@ -34,8 +34,8 @@ test.describe("Vite dev", () => {
               strictPort: true,
             },
             plugins: [
-              remix(),
               mdx(),
+              remix(),
             ],
           });
         `,

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -1229,7 +1229,6 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
     },
     {
       name: "remix-dot-client",
-      enforce: "post",
       async transform(code, id, options) {
         if (!options?.ssr) return;
         let clientFileRE = /\.client(\.[cm]?[jt]sx?)?$/;
@@ -1251,7 +1250,6 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
     },
     {
       name: "remix-route-exports",
-      enforce: "post", // Ensure we're operating on the transformed code to support MDX etc.
       async transform(code, id, options) {
         if (options?.ssr) return;
 
@@ -1294,7 +1292,6 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
     },
     {
       name: "remix-remix-react-proxy",
-      enforce: "post", // Ensure we're operating on the transformed code to support MDX etc.
       resolveId(id) {
         if (id === remixReactProxyId) {
           return VirtualModule.resolve(remixReactProxyId);
@@ -1389,7 +1386,6 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
     },
     {
       name: "remix-react-refresh-babel",
-      enforce: "post", // jsx and typescript (in ts, jsx, tsx files) are already transpiled by vite
       async transform(code, id, options) {
         if (viteCommand !== "serve") return;
         if (id.includes("/node_modules/")) return;


### PR DESCRIPTION
tl;dr: we were abusing `enforce: "post"` so that `mdx` plugin could be place after `remix` plugin. Instead, we should either expect plugins like `mdx` to self-declare as `pre` or rely on Vite plugin ordering.

"Post" plugins are meant primarily for build analysis. Previously we were relying on `enforce: "post"` to ensure that plugins that transpile other languages to JS/TS ran before the Remix plugin. However, it should be the responsability of _those_ plugins to declare themselves with `enforce: "pre"`. In the case of MDX, the canonical plugin is not a Vite plugin, but rather a Rollup plugin so it cannot set `enforce` as that is a Vite-only API.

Ideally, someone would wrap the MDX Rollup plugin and declare it as `enforce: "pre"`. This can also be done in userland through a simple object spread.

That said, its simpler to place the MDX plugin before the Remix plugin in the Vite plugins array. Order is semantically meaningful for Vite plugins anyway.

The official [Vite React SWC plugin](https://github.com/vitejs/vite-plugin-react-swc/blob/main/src/index.ts#L97-L116) also relies on plugin ordering for MDX.
