### PR TITLE
Make Cloudflare preset usage consistent

### DIFF
--- a/docs/future/vite.md
+++ b/docs/future/vite.md
@@ -137,6 +137,11 @@ export default defineConfig({
       presets: [cloudflare()],
     }),
   ],
+  ssr: {
+    resolve: {
+      externalConditions: ["workerd", "worker"],
+    },
+  },
 });
 ```
 
@@ -513,10 +518,10 @@ The Remix Vite plugin only officially supports [Cloudflare Pages][cloudflare-pag
 
 </docs-warning>
 
-👉 **In your Vite config, add `"workerd"` and `"worker"` to Vite's
-`ssr.resolve.externalConditions` option and add the Cloudflare Remix preset**
+👉 **In your Vite config, add the Cloudflare Remix preset, and add `"workerd"` and `"worker"` to Vite's
+`ssr.resolve.externalConditions` option.**
 
-```ts filename=vite.config.ts lines=[3,8-12,15]
+```ts filename=vite.config.ts lines=[3,10,13-17]
 import {
   unstable_vitePlugin as remix,
   unstable_cloudflarePreset as cloudflare,
@@ -524,16 +529,16 @@ import {
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  ssr: {
-    resolve: {
-      externalConditions: ["workerd", "worker"],
-    },
-  },
   plugins: [
     remix({
       presets: [cloudflare()],
     }),
   ],
+  ssr: {
+    resolve: {
+      externalConditions: ["workerd", "worker"],
+    },
+  },
 });
 ```
 

--- a/templates/unstable-vite-cloudflare/vite.config.ts
+++ b/templates/unstable-vite-cloudflare/vite.config.ts
@@ -6,15 +6,15 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  ssr: {
-    resolve: {
-      externalConditions: ["workerd", "worker"],
-    },
-  },
   plugins: [
     remix({
       presets: [cloudflare()],
     }),
     tsconfigPaths(),
   ],
+  ssr: {
+    resolve: {
+      externalConditions: ["workerd", "worker"],
+    },
+  },
 });


### PR DESCRIPTION
In the docs, I noticed that Vite's `ssr.resolve.externalConditions` option wasn't being set in our first Cloudflare preset example and that we only mentioned this in the migration guide. While fixing this, I decided it's better to keep the Remix plugin at the top of the Vite config, so I've refactored all examples and the Cloudflare Vite templated to follow this pattern.