### PR TITLE
Fix highlighting in Vite MDX docs

### DIFF
--- a/docs/future/vite.md
+++ b/docs/future/vite.md
@@ -803,7 +803,7 @@ npm install -D remark-frontmatter remark-mdx-frontmatter
 
 👉 **Pass the Remark frontmatter plugins to the MDX Rollup plugin**
 
-```ts filename=vite.config.ts lines=[3-4,10-15]
+```ts filename=vite.config.ts lines=[3-4,9-14]
 import mdx from "@mdx-js/rollup";
 import { unstable_vitePlugin as remix } from "@remix-run/dev";
 import remarkFrontmatter from "remark-frontmatter";


### PR DESCRIPTION
The line highlighting in the Vite MDX docs got out of sync when we removed our usage of `enfore: 'pre'` from the Remix Vite plugin and made it so that the MDX plugin needs to come before Remix.