### PR TITLE
fix(templates): bump the wrangler version up in the cloudflare templates

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -121,6 +121,7 @@
 - dan-gamble
 - danielfgray
 - danielweinmann
+- dario-piotrowicz
 - davecalnan
 - davecranwell-vocovo
 - DavidHollins6

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "typescript": "^5.1.0",
-    "wrangler": "3.8.0"
+    "wrangler": "^3.24.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "typescript": "^5.1.6",
-    "wrangler": "3.8.0"
+    "wrangler": "^3.24.0"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
bump the wrangler version present in the cloudflare template's dev dependency from 3.8.0 to ^3.24.0, this matches the peer dependency present in remix-dev (without this change the current template would not work with the current remix-dev package becuase of the wrangler version missmatch)

____

To manually test the changes, run `create-remix` and pass to it the official repo's cloudflare-pages template:
```sh
npx create-remix@latest --template https://github.com/remix-run/remix/tree/main/templates/cloudflare-pages
```
and notice that create-remix fails when trying to install the npm dependencies:
![Screenshot 2024-02-02 at 15 48 08](https://github.com/remix-run/remix/assets/61631103/1817be36-b38e-43c2-b1e1-206eb904cddd)

Then try running `create-remix` with the template from this PR's branch:
```sh
npx create-remix@latest --template https://github.com/dario-piotrowicz/remix/tree/cloudflare-templates-bump-wrangler/templates/cloudflare-pages
```
and notice that now the npm installation works as expected:
![Screenshot 2024-02-02 at 15 49 03](https://github.com/remix-run/remix/assets/61631103/09de75ca-e6f5-44d3-b76f-8beeaf0def90)
