### PR TITLE
test: refactor vite config templates

### DIFF
--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -37,32 +37,6 @@ export const viteConfig = {
   },
 };
 
-export const VITE_CONFIG = async (args: {
-  port: number;
-  pluginOptions?: string;
-  viteManifest?: boolean;
-}) => {
-  let hmrPort = await getPort();
-  return String.raw`
-    import { defineConfig } from "vite";
-    import { unstable_vitePlugin as remix } from "@remix-run/dev";
-
-    export default defineConfig({
-      server: {
-        port: ${args.port},
-        strictPort: true,
-        hmr: {
-          port: ${hmrPort}
-        }
-      },
-      build: {
-        manifest: ${String(args.viteManifest ?? false)},
-      },
-      plugins: [remix(${args.pluginOptions})],
-    });
-  `;
-};
-
 export const EXPRESS_SERVER = (args: {
   port: number;
   loadContext?: Record<string, unknown>;

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -15,9 +15,6 @@ const remixBin = "node_modules/@remix-run/dev/dist/cli.js";
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
 export const viteConfig = {
-  imports: dedent`
-    import { unstable_vitePlugin as remix } from "@remix-run/dev";
-  `,
   server: async (args: { port: number }) => {
     let hmrPort = await getPort();
     let text = dedent`
@@ -27,7 +24,7 @@ export const viteConfig = {
   },
   basic: async (args: { port: number }) => {
     return dedent`
-      ${viteConfig.imports}
+      import { unstable_vitePlugin as remix } from "@remix-run/dev";
 
       export default {
         ${await viteConfig.server(args)}

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -40,7 +40,6 @@ export const viteConfig = {
 export const VITE_CONFIG = async (args: {
   port: number;
   pluginOptions?: string;
-  vitePlugins?: string;
   viteManifest?: boolean;
 }) => {
   let hmrPort = await getPort();
@@ -59,7 +58,7 @@ export const VITE_CONFIG = async (args: {
       build: {
         manifest: ${String(args.viteManifest ?? false)},
       },
-      plugins: [remix(${args.pluginOptions}),${args.vitePlugins ?? ""}],
+      plugins: [remix(${args.pluginOptions})],
     });
   `;
 };

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -14,13 +14,6 @@ import dedent from "dedent";
 const remixBin = "node_modules/@remix-run/dev/dist/cli.js";
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
-const indent = (text: string, indentation: number): string => {
-  return text
-    .split("\n")
-    .map((line, i) => (i === 0 ? line : "  ".repeat(indentation) + line))
-    .join("\n");
-};
-
 export const viteConfig = {
   imports: dedent`
     import { unstable_vitePlugin as remix } from "@remix-run/dev";
@@ -28,15 +21,9 @@ export const viteConfig = {
   server: async (args: { port: number }) => {
     let hmrPort = await getPort();
     let text = dedent`
-      server: {
-        port: ${args.port},
-        strictPort: true,
-        hmr: {
-          port: ${hmrPort}
-        }
-      },
+      server: { port: ${args.port}, strictPort: true, hmr: { port: ${hmrPort} } },
     `;
-    return indent(text, 1);
+    return text;
   },
   basic: async (args: { port: number }) => {
     return dedent`
@@ -55,7 +42,6 @@ export const VITE_CONFIG = async (args: {
   pluginOptions?: string;
   vitePlugins?: string;
   viteManifest?: boolean;
-  viteSsrResolveExternalConditions?: string[];
 }) => {
   let hmrPort = await getPort();
   return String.raw`
@@ -63,13 +49,6 @@ export const VITE_CONFIG = async (args: {
     import { unstable_vitePlugin as remix } from "@remix-run/dev";
 
     export default defineConfig({
-      ssr: {
-        resolve: {
-          externalConditions: ${JSON.stringify(
-            args.viteSsrResolveExternalConditions ?? []
-          )},
-        },
-      },
       server: {
         port: ${args.port},
         strictPort: true,

--- a/integration/vite-cloudflare-test.ts
+++ b/integration/vite-cloudflare-test.ts
@@ -51,8 +51,10 @@ test.describe("Vite / cloudflare", async () => {
         2
       ),
       "vite.config.ts": dedent`
-        ${viteConfig.imports}
-        import { unstable_cloudflarePreset as cloudflare } from "@remix-run/dev";
+        import {
+          unstable_vitePlugin as remix,
+          unstable_cloudflarePreset as cloudflare,
+        } from "@remix-run/dev";
 
         export default {
           ${await viteConfig.server({ port })}

--- a/integration/vite-cloudflare-test.ts
+++ b/integration/vite-cloudflare-test.ts
@@ -1,7 +1,8 @@
 import { test, expect } from "@playwright/test";
 import getPort from "get-port";
+import dedent from "dedent";
 
-import { VITE_CONFIG, createProject, using, viteDev } from "./helpers/vite.js";
+import { viteConfig, createProject, using, viteDev } from "./helpers/vite.js";
 
 test.describe("Vite / cloudflare", async () => {
   let port: number;
@@ -49,17 +50,28 @@ test.describe("Vite / cloudflare", async () => {
         null,
         2
       ),
-      "vite.config.ts": await VITE_CONFIG({
-        port,
-        viteSsrResolveExternalConditions: ["workerd", "worker"],
-        pluginOptions: `{
-          presets: [
-            (await import("@remix-run/dev")).unstable_cloudflarePreset({
-              getRemixDevLoadContext: (ctx) => ({ ...ctx, extra: "stuff" })
+      "vite.config.ts": dedent`
+        ${viteConfig.imports}
+        import { unstable_cloudflarePreset as cloudflare } from "@remix-run/dev";
+
+        export default {
+          ${await viteConfig.server({ port })}
+          ssr: {
+            resolve: {
+              externalConditions: ["workerd", "worker"],
+            },
+          },
+          plugins: [
+            remix({
+              presets: [
+                cloudflare({
+                  getRemixDevLoadContext: (ctx) => ({ ...ctx, extra: "stuff" })
+                })
+              ]
             })
-          ]
-        }`,
-      }),
+          ],
+        }
+      `,
       "functions/[[page]].ts": `
         import { createPagesFunctionHandler } from "@remix-run/cloudflare-pages";
 

--- a/integration/vite-css-test.ts
+++ b/integration/vite-css-test.ts
@@ -151,7 +151,7 @@ const files = {
 };
 
 const VITE_CONFIG = async (port: number) => dedent`
-  ${viteConfig.imports}
+  import { unstable_vitePlugin as remix } from "@remix-run/dev";
   import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
 
   export default {

--- a/integration/vite-css-test.ts
+++ b/integration/vite-css-test.ts
@@ -1,6 +1,7 @@
 import type { Page } from "@playwright/test";
 import { test, expect } from "@playwright/test";
 import getPort from "get-port";
+import dedent from "dedent";
 
 import {
   createProject,
@@ -9,8 +10,8 @@ import {
   viteBuild,
   viteRemixServe,
   customDev,
-  VITE_CONFIG,
   EXPRESS_SERVER,
+  viteConfig,
 } from "./helpers/vite.js";
 
 const js = String.raw;
@@ -149,8 +150,15 @@ const files = {
   `,
 };
 
-const vitePlugins =
-  '(await import("@vanilla-extract/vite-plugin")).vanillaExtractPlugin()';
+const VITE_CONFIG = async (port: number) => dedent`
+  ${viteConfig.imports}
+  import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
+
+  export default {
+    ${await viteConfig.server({ port })}
+    plugins: [remix(), vanillaExtractPlugin()],
+  }
+`;
 
 test.describe(() => {
   test.describe(async () => {
@@ -161,7 +169,7 @@ test.describe(() => {
     test.beforeAll(async () => {
       port = await getPort();
       cwd = await createProject({
-        "vite.config.ts": await VITE_CONFIG({ port, vitePlugins }),
+        "vite.config.ts": await VITE_CONFIG(port),
         ...files,
       });
       stop = await viteDev({ cwd, port });
@@ -192,7 +200,7 @@ test.describe(() => {
     test.beforeAll(async () => {
       port = await getPort();
       cwd = await createProject({
-        "vite.config.ts": await VITE_CONFIG({ port, vitePlugins }),
+        "vite.config.ts": await VITE_CONFIG(port),
         "server.mjs": EXPRESS_SERVER({ port }),
         ...files,
       });
@@ -224,7 +232,7 @@ test.describe(() => {
     test.beforeAll(async () => {
       port = await getPort();
       cwd = await createProject({
-        "vite.config.ts": await VITE_CONFIG({ port, vitePlugins }),
+        "vite.config.ts": await VITE_CONFIG(port),
         ...files,
       });
 

--- a/integration/vite-dot-server-test.ts
+++ b/integration/vite-dot-server-test.ts
@@ -2,13 +2,14 @@ import * as path from "node:path";
 import { test, expect } from "@playwright/test";
 import stripAnsi from "strip-ansi";
 import getPort from "get-port";
+import dedent from "dedent";
 
 import {
-  VITE_CONFIG,
   createProject,
   grep,
   using,
   viteBuild,
+  viteConfig,
   viteDev,
   viteRemixServe,
 } from "./helpers/vite.js";
@@ -222,11 +223,16 @@ test.describe("Vite / server-only escape hatch", async () => {
   test.beforeAll(async () => {
     port = await getPort();
     cwd = await createProject({
-      "vite.config.ts": await VITE_CONFIG({
-        port,
-        vitePlugins:
-          '(await import("vite-env-only")).default(), (await import("vite-tsconfig-paths")).default()',
-      }),
+      "vite.config.ts": dedent`
+        ${viteConfig.imports}
+        import envOnly from "vite-env-only";
+        import tsconfigPaths from "vite-tsconfig-paths";
+
+        export default {
+          ${await viteConfig.server({ port })}
+          plugins: [remix(), envOnly(), tsconfigPaths()],
+        }
+      `,
       "app/utils.server.ts": serverOnlyModule,
       "app/.server/utils.ts": serverOnlyModule,
       "app/routes/_index.tsx": String.raw`

--- a/integration/vite-dot-server-test.ts
+++ b/integration/vite-dot-server-test.ts
@@ -224,7 +224,7 @@ test.describe("Vite / server-only escape hatch", async () => {
     port = await getPort();
     cwd = await createProject({
       "vite.config.ts": dedent`
-        ${viteConfig.imports}
+        import { unstable_vitePlugin as remix } from "@remix-run/dev";
         import envOnly from "vite-env-only";
         import tsconfigPaths from "vite-tsconfig-paths";
 

--- a/integration/vite-dotenv-test.ts
+++ b/integration/vite-dotenv-test.ts
@@ -5,7 +5,7 @@ import {
   createProject,
   customDev,
   EXPRESS_SERVER,
-  VITE_CONFIG,
+  viteConfig,
 } from "./helpers/vite.js";
 
 let files = {
@@ -51,7 +51,7 @@ test.describe(async () => {
   test.beforeAll(async () => {
     port = await getPort();
     cwd = await createProject({
-      "vite.config.js": await VITE_CONFIG({ port }),
+      "vite.config.js": await viteConfig.basic({ port }),
       "server.mjs": EXPRESS_SERVER({ port }),
       ...files,
     });

--- a/integration/vite-hmr-hdr-test.ts
+++ b/integration/vite-hmr-hdr-test.ts
@@ -9,8 +9,8 @@ import {
   createEditor,
   viteDev,
   customDev,
-  VITE_CONFIG,
   EXPRESS_SERVER,
+  viteConfig,
 } from "./helpers/vite.js";
 
 const files = {
@@ -50,7 +50,7 @@ test.describe(async () => {
   test.beforeAll(async () => {
     port = await getPort();
     cwd = await createProject({
-      "vite.config.js": await VITE_CONFIG({ port }),
+      "vite.config.js": await viteConfig.basic({ port }),
       ...files,
     });
     stop = await viteDev({ cwd, port });
@@ -70,7 +70,7 @@ test.describe(async () => {
   test.beforeAll(async () => {
     port = await getPort();
     cwd = await createProject({
-      "vite.config.js": await VITE_CONFIG({ port }),
+      "vite.config.js": await viteConfig.basic({ port }),
       "server.mjs": EXPRESS_SERVER({ port }),
       ...files,
     });

--- a/integration/vite-loader-context-test.ts
+++ b/integration/vite-loader-context-test.ts
@@ -5,7 +5,7 @@ import {
   createProject,
   customDev,
   EXPRESS_SERVER,
-  VITE_CONFIG,
+  viteConfig,
 } from "./helpers/vite.js";
 
 let port: number;
@@ -15,7 +15,7 @@ let stop: () => void;
 test.beforeAll(async () => {
   port = await getPort();
   cwd = await createProject({
-    "vite.config.js": await VITE_CONFIG({ port }),
+    "vite.config.js": await viteConfig.basic({ port }),
     "server.mjs": EXPRESS_SERVER({ port, loadContext: { value: "value" } }),
     "app/routes/_index.tsx": String.raw`
       import { json } from "@remix-run/node";

--- a/integration/vite-manifests-test.ts
+++ b/integration/vite-manifests-test.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 import { test, expect } from "@playwright/test";
 import getPort from "get-port";
 
-import { createProject, viteBuild, VITE_CONFIG } from "./helpers/vite.js";
+import {
+  createProject,
+  viteBuild,
+  VITE_CONFIG,
+  viteConfig,
+} from "./helpers/vite.js";
 
 function createRoute(path: string) {
   return {
@@ -106,10 +111,11 @@ test.describe(() => {
 
   test.beforeAll(async () => {
     cwd = await createProject({
-      "vite.config.ts": await VITE_CONFIG({ port: await getPort() }),
+      "vite.config.ts": await viteConfig.basic({ port: await getPort() }),
       ...files,
     });
 
+    // TODO
     await viteBuild({ cwd });
   });
 

--- a/integration/vite-manifests-test.ts
+++ b/integration/vite-manifests-test.ts
@@ -2,13 +2,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { test, expect } from "@playwright/test";
 import getPort from "get-port";
+import dedent from "dedent";
 
-import {
-  createProject,
-  viteBuild,
-  VITE_CONFIG,
-  viteConfig,
-} from "./helpers/vite.js";
+import { createProject, viteBuild, viteConfig } from "./helpers/vite.js";
 
 function createRoute(path: string) {
   return {
@@ -54,11 +50,15 @@ test.describe(() => {
 
   test.beforeAll(async () => {
     cwd = await createProject({
-      "vite.config.ts": await VITE_CONFIG({
-        port: await getPort(),
-        pluginOptions: "{ manifest: true }",
-        viteManifest: true,
-      }),
+      "vite.config.ts": dedent`
+        ${viteConfig.imports}
+
+        export default {
+          ${await viteConfig.server({ port: await getPort() })}
+          build: { manifest: true },
+          plugins: [remix({ manifest: true })],
+        }
+      `,
       ...files,
     });
 

--- a/integration/vite-manifests-test.ts
+++ b/integration/vite-manifests-test.ts
@@ -54,7 +54,6 @@ test.describe(() => {
         import { unstable_vitePlugin as remix } from "@remix-run/dev";
 
         export default {
-          ${await viteConfig.server({ port: await getPort() })}
           build: { manifest: true },
           plugins: [remix({ manifest: true })],
         }

--- a/integration/vite-manifests-test.ts
+++ b/integration/vite-manifests-test.ts
@@ -62,7 +62,7 @@ test.describe(() => {
       ...files,
     });
 
-    await viteBuild({ cwd });
+    viteBuild({ cwd });
   });
 
   test("Vite / manifests enabled / Vite manifests", () => {
@@ -115,8 +115,7 @@ test.describe(() => {
       ...files,
     });
 
-    // TODO
-    await viteBuild({ cwd });
+    viteBuild({ cwd });
   });
 
   test("Vite / manifest disabled / Vite manifests", () => {

--- a/integration/vite-manifests-test.ts
+++ b/integration/vite-manifests-test.ts
@@ -51,7 +51,7 @@ test.describe(() => {
   test.beforeAll(async () => {
     cwd = await createProject({
       "vite.config.ts": dedent`
-        ${viteConfig.imports}
+        import { unstable_vitePlugin as remix } from "@remix-run/dev";
 
         export default {
           ${await viteConfig.server({ port: await getPort() })}

--- a/integration/vite-node-env-test.ts
+++ b/integration/vite-node-env-test.ts
@@ -6,7 +6,7 @@ import {
   viteDev,
   viteBuild,
   viteRemixServe,
-  VITE_CONFIG,
+  viteConfig,
 } from "./helpers/vite.js";
 
 let files = {
@@ -18,21 +18,21 @@ let files = {
 };
 
 test.describe(async () => {
-  let devPort: number;
+  let port: number;
   let cwd: string;
   let stop: () => void;
 
   test.beforeAll(async () => {
-    devPort = await getPort();
+    port = await getPort();
     cwd = await createProject({
-      "vite.config.js": await VITE_CONFIG({ port: devPort }),
+      "vite.config.js": await viteConfig.basic({ port: port }),
       ...files,
     });
   });
 
   test.describe(() => {
     test.beforeAll(async () => {
-      stop = await viteDev({ cwd, port: devPort });
+      stop = await viteDev({ cwd, port });
     });
     test.afterAll(() => stop());
 
@@ -40,7 +40,7 @@ test.describe(async () => {
       let pageErrors: unknown[] = [];
       page.on("pageerror", (error) => pageErrors.push(error));
 
-      await page.goto(`http://localhost:${devPort}/node_env`, {
+      await page.goto(`http://localhost:${port}/node_env`, {
         waitUntil: "networkidle",
       });
       expect(pageErrors).toEqual([]);

--- a/integration/vite-presets-test.ts
+++ b/integration/vite-presets-test.ts
@@ -4,15 +4,99 @@ import URL from "node:url";
 import { test, expect } from "@playwright/test";
 import { normalizePath } from "vite";
 import getPort from "get-port";
+import dedent from "dedent";
 
 import {
   createProject,
   viteDev,
   viteBuild,
-  VITE_CONFIG,
+  viteConfig,
 } from "./helpers/vite.js";
 
-const js = String.raw;
+const VITE_CONFIG = async (port: number) => dedent`
+  ${viteConfig.imports}
+  import fs from "node:fs/promises";
+  import serializeJs from "serialize-javascript";
+
+  export default {
+    ${await viteConfig.server({ port })}
+    plugins: [remix({
+      presets: [
+        // Ensure preset config takes lower precedence than user config
+        {
+          name: "test-preset",
+          remixConfig: async () => ({
+            appDirectory: "INCORRECT_APP_DIR", // This is overridden by the user config further down this file
+          }),
+        },
+        {
+          name: "test-preset",
+          remixConfigResolved: async ({ remixConfig }) => {
+            if (remixConfig.appDirectory.includes("INCORRECT_APP_DIR")) {
+              throw new Error("Remix preset config wasn't overridden with user config");
+            }
+          }
+        },
+
+        // Ensure config presets are merged in the correct order
+        {
+          name: "test-preset",
+          remixConfig: async () => ({
+            buildDirectory: "INCORRECT_BUILD_DIR",
+          }),
+        },
+        {
+          name: "test-preset",
+          remixConfig: async () => ({
+            buildDirectory: "build",
+          }),
+        },
+
+        // Ensure remixConfigResolved is called with a frozen Remix config
+        {
+          name: "test-preset",
+          remixConfigResolved: async ({ remixConfig }) => {
+            let isDeepFrozen = (obj: any) =>
+              Object.isFrozen(obj) &&
+              Object.keys(obj).every(
+                prop => typeof obj[prop] !== 'object' || isDeepFrozen(obj[prop])
+              );
+
+            await fs.writeFile("PRESET_REMIX_CONFIG_RESOLVED_META.json", JSON.stringify({
+              remixConfigFrozen: isDeepFrozen(remixConfig),
+            }), "utf-8");
+          }
+        },
+
+        // Ensure presets can set serverBundles option (this is critical for Vercel support)
+        {
+          name: "test-preset",
+          remixConfig: async () => ({
+            serverBundles() {
+              return "preset-server-bundle-id";
+            },
+          }),
+        },
+
+        // Ensure presets can set buildEnd option (this is critical for Vercel support)
+        {
+          name: "test-preset",
+          remixConfig: async () => ({
+            async buildEnd(buildEndArgs) {
+              await fs.writeFile(
+                "BUILD_END_ARGS.js",
+                "export default " + serializeJs(buildEndArgs, { space: 2, unsafe: true }),
+                "utf-8"
+              );
+            },
+          }),
+        },
+      ],
+      // Ensure user config takes precedence over preset config
+      appDirectory: "app",
+    })],
+  }
+`;
 
 test.describe(async () => {
   let port: number;
@@ -29,93 +113,7 @@ test.describe(async () => {
 
   test.beforeAll(async () => {
     port = await getPort();
-    cwd = await createProject({
-      "vite.config.ts": await VITE_CONFIG({
-        port,
-        pluginOptions: js`
-          {
-            presets: [
-              // Ensure preset config takes lower precedence than user config
-              {
-                name: "test-preset",
-                remixConfig: async () => ({
-                  appDirectory: "INCORRECT_APP_DIR", // This is overridden by the user config further down this file
-                }),
-              },
-              {
-                name: "test-preset",
-                remixConfigResolved: async ({ remixConfig }) => {
-                  if (remixConfig.appDirectory.includes("INCORRECT_APP_DIR")) {
-                    throw new Error("Remix preset config wasn't overridden with user config");
-                  }
-                }
-              },
-
-              // Ensure config presets are merged in the correct order
-              {
-                name: "test-preset",
-                remixConfig: async () => ({
-                  buildDirectory: "INCORRECT_BUILD_DIR",
-                }),
-              },
-              {
-                name: "test-preset",
-                remixConfig: async () => ({
-                  buildDirectory: "build",
-                }),
-              },
-
-              // Ensure remixConfigResolved is called with a frozen Remix config
-              {
-                name: "test-preset",
-                remixConfigResolved: async ({ remixConfig }) => {
-                  let isDeepFrozen = (obj: any) =>
-                    Object.isFrozen(obj) &&
-                    Object.keys(obj).every(
-                      prop => typeof obj[prop] !== 'object' || isDeepFrozen(obj[prop])
-                    );
-
-                  let fs = await import("node:fs/promises");
-                  await fs.writeFile("PRESET_REMIX_CONFIG_RESOLVED_META.json", JSON.stringify({
-                    remixConfigFrozen: isDeepFrozen(remixConfig),
-                  }), "utf-8");
-                }
-              },
-
-              // Ensure presets can set serverBundles option (this is critical for Vercel support)
-              {
-                name: "test-preset",
-                remixConfig: async () => ({
-                  serverBundles() {
-                    return "preset-server-bundle-id";
-                  },
-                }),
-              },
-
-              // Ensure presets can set buildEnd option (this is critical for Vercel support)
-              {
-                name: "test-preset",
-                remixConfig: async () => ({
-                  async buildEnd(buildEndArgs) {
-                    let fs = await import("node:fs/promises");
-                    let serializeJs = (await import("serialize-javascript")).default;
-
-                    await fs.writeFile(
-                      "BUILD_END_ARGS.js",
-                      "export default " + serializeJs(buildEndArgs, { space: 2, unsafe: true }),
-                      "utf-8"
-                    );
-                  },
-                }),
-              },
-            ],
-
-            // Ensure user config takes precedence over preset config
-            appDirectory: "app",
-          },
-        `,
-      }),
-    });
+    cwd = await createProject({ "vite.config.ts": await VITE_CONFIG(port) });
     stop = await viteDev({ cwd, port });
   });
   test.afterAll(() => stop());

--- a/integration/vite-presets-test.ts
+++ b/integration/vite-presets-test.ts
@@ -14,7 +14,7 @@ import {
 } from "./helpers/vite.js";
 
 const VITE_CONFIG = async (port: number) => dedent`
-  ${viteConfig.imports}
+  import { unstable_vitePlugin as remix } from "@remix-run/dev";
   import fs from "node:fs/promises";
   import serializeJs from "serialize-javascript";
 

--- a/integration/vite-route-added-test.ts
+++ b/integration/vite-route-added-test.ts
@@ -36,8 +36,7 @@ test.describe(async () => {
     });
     stop = await viteDev({ cwd, port });
   });
-  // TODO
-  test.afterAll(async () => await stop());
+  test.afterAll(() => stop());
 
   test("Vite / dev / route added", async ({ page }) => {
     let pageErrors: Error[] = [];

--- a/integration/vite-route-added-test.ts
+++ b/integration/vite-route-added-test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { test, expect } from "@playwright/test";
 import getPort from "get-port";
 
-import { createProject, viteDev, VITE_CONFIG } from "./helpers/vite.js";
+import { createProject, viteDev, viteConfig } from "./helpers/vite.js";
 
 const files = {
   "app/routes/_index.tsx": String.raw`
@@ -31,11 +31,12 @@ test.describe(async () => {
   test.beforeAll(async () => {
     port = await getPort();
     cwd = await createProject({
-      "vite.config.js": await VITE_CONFIG({ port }),
+      "vite.config.js": await viteConfig.basic({ port }),
       ...files,
     });
     stop = await viteDev({ cwd, port });
   });
+  // TODO
   test.afterAll(async () => await stop());
 
   test("Vite / dev / route added", async ({ page }) => {

--- a/integration/vite-route-exports-modified-offscreen-test.ts
+++ b/integration/vite-route-exports-modified-offscreen-test.ts
@@ -5,7 +5,7 @@ import {
   createProject,
   createEditor,
   viteDev,
-  VITE_CONFIG,
+  viteConfig,
 } from "./helpers/vite.js";
 
 const files = {
@@ -49,7 +49,7 @@ test.describe(async () => {
   test.beforeAll(async () => {
     port = await getPort();
     cwd = await createProject({
-      "vite.config.js": await VITE_CONFIG({ port }),
+      "vite.config.js": await viteConfig.basic({ port }),
       ...files,
     });
     stop = await viteDev({ cwd, port });

--- a/integration/vite-server-bundles-test.ts
+++ b/integration/vite-server-bundles-test.ts
@@ -119,7 +119,7 @@ test.describe(() => {
     port = await getPort();
     cwd = await createProject({
       "vite.config.ts": dedent`
-        ${viteConfig.imports}
+        import { unstable_vitePlugin as remix } from "@remix-run/dev";
 
         export default {
           ${await viteConfig.server({ port })}

--- a/integration/vite-server-bundles-test.ts
+++ b/integration/vite-server-bundles-test.ts
@@ -2,13 +2,14 @@ import fs from "node:fs";
 import path from "node:path";
 import { type Page, test, expect } from "@playwright/test";
 import getPort from "get-port";
+import dedent from "dedent";
 
 import {
   createProject,
   viteDev,
   viteBuild,
   viteRemixServe,
-  VITE_CONFIG,
+  viteConfig,
 } from "./helpers/vite.js";
 
 const withBundleServer = async (
@@ -112,48 +113,52 @@ const expectRenderedRoutes = async (page: Page, routeFiles: string[]) => {
 
 test.describe(() => {
   let cwd: string;
-  let devPort: number;
+  let port: number;
 
   test.beforeAll(async () => {
-    devPort = await getPort();
+    port = await getPort();
     cwd = await createProject({
-      "vite.config.ts": await VITE_CONFIG({
-        port: devPort,
-        viteManifest: true,
-        pluginOptions: `{
-          manifest: true,
-          serverBundles: async ({ branch }) => {
-            // Smoke test to ensure we can read the route files via 'route.file'
-            await Promise.all(branch.map(async (route) => {
-              const fs = await import("node:fs/promises");
-              const routeFileContents = await fs.readFile(route.file, "utf8");
-              if (!routeFileContents.includes(${JSON.stringify(
-                ROUTE_FILE_COMMENT
-              )})) {
-                throw new Error("Couldn't file route file test comment");
+      "vite.config.ts": dedent`
+        ${viteConfig.imports}
+
+        export default {
+          ${await viteConfig.server({ port })}
+          build: { manifest: true },
+          plugins: [remix({
+            manifest: true,
+            serverBundles: async ({ branch }) => {
+              // Smoke test to ensure we can read the route files via 'route.file'
+              await Promise.all(branch.map(async (route) => {
+                const fs = await import("node:fs/promises");
+                const routeFileContents = await fs.readFile(route.file, "utf8");
+                if (!routeFileContents.includes(${JSON.stringify(
+                  ROUTE_FILE_COMMENT
+                )})) {
+                  throw new Error("Couldn't file route file test comment");
+                }
+              }));
+
+              if (branch.some((route) => route.id === "routes/_index")) {
+                return "root";
               }
-            }));
 
-            if (branch.some((route) => route.id === "routes/_index")) {
-              return "root";
+              if (branch.some((route) => route.id === "routes/bundle-a")) {
+                return "bundle-a";
+              }
+
+              if (branch.some((route) => route.id === "routes/bundle-b")) {
+                return "bundle-b";
+              }
+
+              if (branch.some((route) => route.id === "routes/_pathless.bundle-c")) {
+                return "bundle-c";
+              }
+
+              throw new Error("No bundle defined for route " + branch[branch.length - 1].id);
             }
-
-            if (branch.some((route) => route.id === "routes/bundle-a")) {
-              return "bundle-a";
-            }
-
-            if (branch.some((route) => route.id === "routes/bundle-b")) {
-              return "bundle-b";
-            }
-
-            if (branch.some((route) => route.id === "routes/_pathless.bundle-c")) {
-              return "bundle-c";
-            }
-
-            throw new Error("No bundle defined for route " + branch[branch.length - 1].id);
-          }
-        }`,
-      }),
+          })]
+        }
+      `,
       ...files,
     });
   });
@@ -161,7 +166,7 @@ test.describe(() => {
   test.describe(() => {
     let stop: () => void;
     test.beforeAll(async () => {
-      stop = await viteDev({ cwd, port: devPort });
+      stop = await viteDev({ cwd, port });
     });
 
     test.afterAll(() => stop());
@@ -172,16 +177,16 @@ test.describe(() => {
       let pageErrors: Error[] = [];
       page.on("pageerror", (error) => pageErrors.push(error));
 
-      await page.goto(`http://localhost:${devPort}/`);
+      await page.goto(`http://localhost:${port}/`);
       await expectRenderedRoutes(page, ["_index.tsx"]);
 
-      await page.goto(`http://localhost:${devPort}/bundle-a`);
+      await page.goto(`http://localhost:${port}/bundle-a`);
       await expectRenderedRoutes(page, ["bundle-a.tsx", "bundle-a._index.tsx"]);
 
-      await page.goto(`http://localhost:${devPort}/bundle-b`);
+      await page.goto(`http://localhost:${port}/bundle-b`);
       await expectRenderedRoutes(page, ["bundle-b.tsx"]);
 
-      await page.goto(`http://localhost:${devPort}/bundle-c`);
+      await page.goto(`http://localhost:${port}/bundle-c`);
       await expectRenderedRoutes(page, [
         "_pathless.tsx",
         "_pathless.bundle-c.tsx",


### PR DESCRIPTION
Our `VITE_CONFIG` template helper incentivized test fixture code to use tricks like dynamic imports that are not representative of user code. The API for `VITE_CONFIG` has grown complex and inconsistent. This PR breaks down `VITE_CONFIG` into two pieces:
- `viteConfig.basic` as a convenience method to quickly configure Vite for our integration tests without any fluff
- `viteConfig.server` helper to construct _just_ the `server` field while letting the test define a custom `vite.config.ts`