### PR TITLE
Vite: Validate MDX Rollup plugin order

### DIFF
--- a/.changeset/forty-squids-travel.md
+++ b/.changeset/forty-squids-travel.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: Validate that the MDX Rollup plugin, if present, is placed before Remix in Vite config

--- a/integration/vite-plugin-order-validation-test.ts
+++ b/integration/vite-plugin-order-validation-test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+import dedent from "dedent";
+
+import { createProject, viteBuild } from "./helpers/vite.js";
+
+test.describe(() => {
+  let cwd: string;
+  let buildResult: ReturnType<typeof viteBuild>;
+
+  test.beforeAll(async () => {
+    cwd = await createProject({
+      "vite.config.ts": dedent`
+        import { unstable_vitePlugin as remix } from "@remix-run/dev";
+        import mdx from "@mdx-js/rollup";
+
+        export default {
+          plugins: [
+            remix(),
+            mdx(),
+          ],
+        }
+      `,
+    });
+
+    buildResult = viteBuild({ cwd });
+  });
+
+  test("Vite / plugin order validation / MDX", () => {
+    expect(buildResult.stderr.toString()).toContain(
+      'Error: The "@mdx-js/rollup" plugin should be placed before the Remix plugin in your Vite config file'
+    );
+  });
+});


### PR DESCRIPTION
With the introduction of https://github.com/remix-run/remix/pull/8627, plugin order now matters when using Rollup plugins since only Vite plugins can set `enforce: "pre"`. Most commonly, this is going to cause errors if consumers have added the MDX Rollup plugin after the Remix plugin in their Vite plugins array.

Inspired by [vite-plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc), this PR adds an explicit error message when the MDX plugin is in the wrong order rather than allowing a lower level error message to surface when Remix tries to work with unprocessed MDX files.

I've written the code in a way that makes it easy to add more plugin order checks in the future. I've also added a test to ensure the validation works as expected.