### PR TITLE
docs(tutorial): fix typo escape char in shellscript

### DIFF
--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -361,7 +361,7 @@ Instead of creating a route for every single one of our posts, we can use a "dyn
 💿 Create a dynamic route at `app/routes/posts.$slug.tsx`
 
 ```shellscript nonumber
-touch app/routes/posts.$slug.tsx
+touch app/routes/posts.\$slug.tsx
 ```
 
 ```tsx filename=app/routes/posts.$slug.tsx


### PR DESCRIPTION

Closes: #

- [x] Docs

Added backslash to escape the dollar sign, so that it is not treated as the start of a variable or special expression

```shellscript nonumber
touch app/routes/posts.$slug.tsx
```
->
```shellscript nonumber
touch app/routes/posts.\$slug.tsx
```