### PR TITLE
vite: make getLoadContext optional for cloudflare pages handler

### DIFF
--- a/.changeset/brown-rats-flow.md
+++ b/.changeset/brown-rats-flow.md
@@ -1,0 +1,8 @@
+---
+"@remix-run/cloudflare-pages": minor
+---
+
+Make `getLoadContext` optional for Cloudflare Pages
+
+Defaults to `(context) => ({ env: context })`, which is what we used to have in all the templates.
+This gives parity with the Cloudflare preset for the Remix Vite plugin and keeps our templates leaner.

--- a/docs/guides/envvars.md
+++ b/docs/guides/envvars.md
@@ -48,17 +48,7 @@ export async function loader() {
 
 If you're using the `@remix-run/cloudflare-pages` adapter, env variables work a little differently. Since Cloudflare Pages are powered by Functions, you'll need to define your local environment variables in the [`.dev.vars`][dev-vars] file. It has the same syntax as `.env` example file mentioned above.
 
-Then, you can pass those through via `getLoadContext` in your server file:
-
-```ts
-export const onRequest = createPagesFunctionHandler({
-  build,
-  getLoadContext: (context) => ({ env: context.env }), // Hand-off Cloudflare ENV vars to the Remix `context` object
-  mode: build.mode,
-});
-```
-
-And they'll be available via Remix's `context` in your `loader`/`action` functions:
+Then, they'll be available via Remix's `context.env` in your `loader`/`action` functions:
 
 ```tsx
 export const loader = async ({

--- a/docs/guides/manual-mode.md
+++ b/docs/guides/manual-mode.md
@@ -259,10 +259,7 @@ app.all(
   "*",
   process.env.NODE_ENV === "development"
     ? createDevRequestHandler(initialBuild)
-    : createRequestHandler({
-        build: initialBuild,
-        mode: initialBuild.mode,
-      })
+    : createRequestHandler({ build: initialBuild })
 );
 ```
 

--- a/docs/other-api/dev.md
+++ b/docs/other-api/dev.md
@@ -91,13 +91,7 @@ If not, you can follow these steps to integrate your project with `remix dev`:
 
    // ... code for setting up your express app goes here ...
 
-   app.all(
-     "*",
-     createRequestHandler({
-       build,
-       mode: build.mode,
-     })
-   );
+   app.all("*", createRequestHandler({ build }));
 
    const port = 3000;
    app.listen(port, () => {

--- a/integration/helpers/deno-template/server.ts
+++ b/integration/helpers/deno-template/server.ts
@@ -6,7 +6,6 @@ import * as build from "@remix-run/dev/server-build";
 const remixHandler = createRequestHandlerWithStaticFiles({
   build,
   getLoadContext: () => ({}),
-  mode: build.mode,
 });
 
 const port = Number(Deno.env.get("PORT")) || 8000;

--- a/packages/remix-cloudflare-pages/worker.ts
+++ b/packages/remix-cloudflare-pages/worker.ts
@@ -26,13 +26,13 @@ export interface createPagesFunctionHandlerParams<Env = any> {
 
 export function createRequestHandler<Env = any>({
   build,
-  getLoadContext,
   mode,
+  getLoadContext = (context) => ({ env: context.env }),
 }: createPagesFunctionHandlerParams<Env>): RequestHandler<Env> {
   let handleRequest = createRemixRequestHandler(build, mode);
 
   return async (context) => {
-    let loadContext = await getLoadContext?.(context);
+    let loadContext = await getLoadContext(context);
 
     return handleRequest(context.request, loadContext);
   };

--- a/packages/remix-dev/__tests__/fixtures/cloudflare/server.ts
+++ b/packages/remix-dev/__tests__/fixtures/cloudflare/server.ts
@@ -6,8 +6,4 @@ if (process.env.NODE_ENV === "development") {
   logDevReady(build);
 }
 
-export const onRequest = createPagesFunctionHandler({
-  build,
-  getLoadContext: (context) => ({ env: context.env }),
-  mode: build.mode,
-});
+export const onRequest = createPagesFunctionHandler({ build });

--- a/packages/remix-dev/__tests__/fixtures/deno/server.ts
+++ b/packages/remix-dev/__tests__/fixtures/deno/server.ts
@@ -6,7 +6,6 @@ import * as build from "@remix-run/dev/server-build";
 const remixHandler = createRequestHandlerWithStaticFiles({
   build,
   getLoadContext: () => ({}),
-  mode: build.mode,
 });
 
 const port = Number(Deno.env.get("PORT")) || 8000;

--- a/templates/arc/server.ts
+++ b/templates/arc/server.ts
@@ -6,7 +6,4 @@ import sourceMapSupport from "source-map-support";
 sourceMapSupport.install();
 installGlobals();
 
-export const handler = createRequestHandler({
-  build,
-  mode: build.mode,
-});
+export const handler = createRequestHandler({ build });

--- a/templates/cloudflare-pages/server.ts
+++ b/templates/cloudflare-pages/server.ts
@@ -6,8 +6,4 @@ if (process.env.NODE_ENV === "development") {
   logDevReady(build);
 }
 
-export const onRequest = createPagesFunctionHandler({
-  build,
-  getLoadContext: (context) => ({ env: context.env }),
-  mode: build.mode,
-});
+export const onRequest = createPagesFunctionHandler({ build });

--- a/templates/deno/server.ts
+++ b/templates/deno/server.ts
@@ -1,12 +1,11 @@
-import { serve } from "https://deno.land/std@0.128.0/http/server.ts";
 import { createRequestHandlerWithStaticFiles } from "@remix-run/deno";
 // Import path interpreted by the Remix compiler
 import * as build from "@remix-run/dev/server-build";
+import { serve } from "https://deno.land/std@0.128.0/http/server.ts";
 
 const remixHandler = createRequestHandlerWithStaticFiles({
   build,
   getLoadContext: () => ({}),
-  mode: build.mode,
 });
 
 const port = Number(Deno.env.get("PORT")) || 8000;

--- a/templates/express/server.js
+++ b/templates/express/server.js
@@ -36,10 +36,7 @@ const initialBuild = await reimportServer();
 const remixHandler =
   process.env.NODE_ENV === "development"
     ? await createDevRequestHandler(initialBuild)
-    : createRequestHandler({
-        build: initialBuild,
-        mode: initialBuild.mode,
-      });
+    : createRequestHandler({ build: initialBuild });
 
 const app = express();
 


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
