### PR TITLE
template(spa): Provide example of server that can handle SPA routes

### DIFF
--- a/templates/spa/README.md
+++ b/templates/spa/README.md
@@ -22,16 +22,20 @@ npm run dev
 
 ## Production
 
-When you are ready yo build a production version of your app, `npm run build` will generate your assets and an `index.html` for the SPA.
+When you are ready to build a production version of your app, `npm run build` will generate your assets and an `index.html` for the SPA.
 
 ```shellscript
 npm run build
 ```
 
-You can serve this from any server of your choosing, for a simple example, you could use [http-server](https://www.npmjs.com/package/http-server):
+### Deployment
+
+You can then serve your app from any HTTP server of your choosing. The server should be configured to serve multiple paths from a single root `/index.html` file (commonly called "SPA fallback"). Other steps may be required if the server doesn't directly support this functionality.
+
+For a simple example, you could use [sirv-cli](https://www.npmjs.com/package/sirv-cli):
 
 ```shellscript
-npx http-server build/client/
+npx sirv-cli build/client/ --single
 ```
 
 [remix-vite-docs]: https://remix.run/docs/en/main/future/vite


### PR DESCRIPTION
Because this also fixes the typo of "yo" -> "to" this pull request supersedes #8639.

Because `http-server` isn't able to serve the `index.html` file as a fallback for what would otherwise be 404 routes (see #8624) it is best to suggest a different server to preview or run a built SPA application. This change doesn't change how the `start` script in `package.json` uses `http-server` because that is not specifically addressed in the `README.md`.

This change includes part of the `README.md` updates from #8624, but without the changes to `packages/remix-dev/vite/plugin.ts` needed to support `vite preview`.
