### PR TITLE
Don't call serverLoader for client-only example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -275,6 +275,7 @@
 - jiahao-c
 - jimniels
 - jinglesthula
+- jkjustjoshing
 - jkup
 - jly36963
 - jmarbutt

--- a/docs/guides/client-data.md
+++ b/docs/guides/client-data.md
@@ -135,7 +135,7 @@ export async function clientLoader({
 clientLoader.hydrate = true;
 
 export function HydrateFallback() {
-  return <p>Skeleton rendered during SSR</p>;
+  return <p>Skeleton rendered during SSR</p>; // (2)
 }
 
 export default function Component() {

--- a/docs/guides/client-data.md
+++ b/docs/guides/client-data.md
@@ -128,7 +128,7 @@ import type { ClientLoaderFunctionArgs } from "@remix-run/react";
 export async function clientLoader({
   request,
 }: ClientLoaderFunctionArgs) {
-  const clientData = await getClientData(request);
+  const clientData = await getClientData(request); // (2)
   return clientData;
 }
 // Note: you do not have to set this explicitly - it is implied if there is no `loader`

--- a/docs/guides/client-data.md
+++ b/docs/guides/client-data.md
@@ -127,22 +127,15 @@ import type { ClientLoaderFunctionArgs } from "@remix-run/react";
 
 export async function clientLoader({
   request,
-  serverLoader,
 }: ClientLoaderFunctionArgs) {
-  const [serverData, clientData] = await Promise.all([
-    serverLoader(),
-    getClientData(request),
-  ]);
-  return {
-    ...serverData, // (4)
-    ...clientData, // (4)
-  };
+  const clientData = await getClientData(request);
+  return clientData;
 }
 // Note: you do not have to set this explicitly - it is implied if there is no `loader`
 clientLoader.hydrate = true;
 
 export function HydrateFallback() {
-  return <p>Skeleton rendered during SSR</p>; // (2)
+  return <p>Skeleton rendered during SSR</p>;
 }
 
 export default function Component() {


### PR DESCRIPTION
I was reading [this page](https://remix.run/docs/en/main/guides/client-data) and noticed an example for

> A route that only depends on a client loader looks like this.

still included a call to `serverLoader()`. This seems wrong, so this PR removes that call.