### PR TITLE
[BUG] Using defer, `Expected a Response to be returned from queryRoute`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -402,6 +402,7 @@
 - Mattinton
 - mattmazzola
 - mattstobbs
+- Mause
 - maxprilutskiy
 - maxschwarzmueller
 - mbarto


### PR DESCRIPTION
I hope this method of reporting a bug is correct? This looks related to https://github.com/remix-run/remix/issues/4741 but not identical, and feels like a really basic case, so I'm not sure what's going wrong here

When running the submitted test, I get:


```
The following error is a bug in Remix; please open an issue! https://github.com/remix-run/remix/issues/new
Error: Expected a Response to be returned from queryRoute
    at Object.invariant [as default] (/home/me/remix/build/node_modules/@remix-run/server-runtime/dist/invariant.js:18:11)
    at handleResourceRequestRR (/home/me/remix/build/node_modules/@remix-run/server-runtime/dist/server.js:297:25)
    at requestHandler (/home/me/remix/build/node_modules/@remix-run/server-runtime/dist/server.js:103:18)
    at file:///home/me/remix/integration/bug-report-test.ts:116:18
    at /home/me/remix/node_modules/@playwright/test/lib/worker/workerMain.js:351:9
    at TestInfoImpl._runAndFailOnError (/home/me/remix/node_modules/@playwright/test/lib/worker/testInfo.js:156:7)
    at /home/me/remix/node_modules/@playwright/test/lib/worker/workerMain.js:347:7
    at TimeoutRunner.run (/home/me/remix/node_modules/playwright-core/lib/utils/timeoutRunner.js:46:14)
    at TimeoutManager.runWithTimeout (/home/me/remix/node_modules/@playwright/test/lib/worker/timeoutManager.js:62:7)
    at TestInfoImpl._runWithTimeout (/home/me/remix/node_modules/@playwright/test/lib/worker/testInfo.js:143:26)
    at WorkerMain._runTest (/home/me/remix/node_modules/@playwright/test/lib/worker/workerMain.js:285:5)
    at WorkerMain.runTestGroup (/home/me/remix/node_modules/@playwright/test/lib/worker/workerMain.js:209:11)
    at process.<anonymous> (/home/me/remix/node_modules/@playwright/test/lib/common/process.js:88:22)
```