### PR TITLE
Update Vite dev dep to 5.1.0-beta.7

### DIFF
--- a/integration/helpers/vite-template/package.json
+++ b/integration/helpers/vite-template/package.json
@@ -23,7 +23,7 @@
     "@types/react-dom": "^18.2.7",
     "eslint": "^8.38.0",
     "typescript": "^5.1.6",
-    "vite": "5.1.0-beta.6",
+    "vite": "5.1.0-beta.7",
     "vite-tsconfig-paths": "^4.2.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "unified": "^10.1.2",
     "unist-util-remove": "^3.1.0",
     "unist-util-visit": "^4.1.1",
-    "vite": "5.1.0-beta.6",
+    "vite": "5.1.0-beta.7",
     "wait-on": "^7.0.1"
   },
   "engines": {

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -91,7 +91,7 @@
     "msw": "^1.2.3",
     "strip-ansi": "^6.0.1",
     "tiny-invariant": "^1.2.0",
-    "vite": "5.1.0-beta.6"
+    "vite": "5.1.0-beta.7"
   },
   "peerDependencies": {
     "@remix-run/serve": "^2.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13479,10 +13479,10 @@ vite-tsconfig-paths@^4.2.2:
     globrex "^0.1.2"
     tsconfck "^2.1.0"
 
-vite@5.1.0-beta.6:
-  version "5.1.0-beta.6"
-  resolved "https://registry.npmjs.org/vite/-/vite-5.1.0-beta.6.tgz#2fd554818ec3cc888d336d24d5f0994153a06523"
-  integrity sha512-Tnham+O97w9GAQfeYyh1wZF2iePQdr/MgU+8k23O8aa+DtUbAPTmg09CsFgIi4eMta2utRa0pOjSqtYIMcUKbQ==
+vite@5.1.0-beta.7:
+  version "5.1.0-beta.7"
+  resolved "https://registry.npmjs.org/vite/-/vite-5.1.0-beta.7.tgz#9d3e5577059f8546483fdecf0a828d0238a7718c"
+  integrity sha512-bj+s7ILvR+rAJqRRfNy7JwQNPzMal6bS4aKdiGDDZzXofcvEuuuu9MGSc6qqfmt3nfvqFtALSBzpoVlueYAPJQ==
   dependencies:
     esbuild "^0.19.3"
     postcss "^8.4.33"


### PR DESCRIPTION
Just ensuring our tests are passing against the latest beta ahead of Vite's 5.1.0 release.