### PR TITLE
chore: name remixDevServerMiddleware and make it a standalone plugin

### DIFF
--- a/.changeset/flat-badgers-pay.md
+++ b/.changeset/flat-badgers-pay.md
@@ -1,0 +1,6 @@
+---
+"remix": patch
+"@remix-run/dev": patch
+---
+
+Name remixDevServerMiddleware and make it a standalone plugin giving subsequent Vite plugins a means to remove the dev server plugin, or the middleware it adds from the dev server.


### PR DESCRIPTION
Name remixDevServerMiddleware and make it a standalone plugin giving subsequent Vite plugins a means to remove the dev server plugin, or the middleware it adds from the dev server.