### PR TITLE
Reproduce bug where Remix adds trailing slash to the route URL in case there is a public dir with the same name

### DIFF
--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -58,30 +58,12 @@ test.beforeAll(async () => {
     // `createFixture` will make an app and run your tests against it.
     ////////////////////////////////////////////////////////////////////////////
     files: {
-      "app/routes/_index.tsx": js`
-        import { json } from "@remix-run/node";
-        import { useLoaderData, Link } from "@remix-run/react";
-
-        export function loader() {
-          return json("pizza");
-        }
-
+      "app/routes/about.tsx": js`
         export default function Index() {
-          let data = useLoaderData();
-          return (
-            <div>
-              {data}
-              <Link to="/burgers">Other Route</Link>
-            </div>
-          )
+          return <div>about</div>;
         }
       `,
-
-      "app/routes/burgers.tsx": js`
-        export default function Index() {
-          return <div>cheeseburger</div>;
-        }
-      `,
+      "public/about/file.txt": "placeholder",
     },
   });
 
@@ -98,22 +80,13 @@ test.afterAll(() => {
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("[description of what you expect it to do]", async ({ page }) => {
+test("route should not have trailing slash despite public dir having the same name", async ({
+  page,
+}) => {
   let app = new PlaywrightFixture(appFixture, page);
-  // You can test any request your app might get using `fixture`.
-  let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch("pizza");
-
-  // If you need to test interactivity use the `app`
-  await app.goto("/");
-  await app.clickLink("/burgers");
-  await page.waitForSelector("text=cheeseburger");
-
-  // If you're not sure what's going on, you can "poke" the app, it'll
-  // automatically open up in your browser for 20 seconds, so be quick!
-  // await app.poke(20);
-
-  // Go check out the other tests to see what else you can do.
+  await app.goto("/about");
+  let { origin } = new URL(page.url());
+  await expect(page).toHaveURL(`${origin}/about`, { timeout: 1 });
 });
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Reproduces #7529, i.e. the root issue, I believe.

I wasn't aware this issue has been opened yet, I just realized that one of my routes, `/literature.tsx`, had an infinite redirect loop, it took me quite a while to realize that it's because I have a `public/literature` directory as well. The reason for the redirect loop was because I was removing trailing slashes, and this particular page wouldn't budge. (As a workaround I renamed my `public/literature` directory.)

I can add simulate the exact infinite redirect loop in the test if that makes it better.