### PR TITLE
fix(vite): css file paths when cwd is not the root directory

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -339,6 +339,7 @@
 - knowler
 - konradkalemba
 - krolebord
+- ksjogo
 - kubaprzetakiewicz
 - kuldar
 - kumard3

--- a/packages/remix-dev/vite/styles.ts
+++ b/packages/remix-dev/vite/styles.ts
@@ -205,7 +205,7 @@ export const getStylesForUrl = async ({
     cssModulesManifest,
     files: [
       // Always include the client entry file when crawling the module graph for CSS
-      path.relative(rootDirectory, entryClientFilePath),
+      path.join(rootDirectory, path.relative(rootDirectory, entryClientFilePath)),
       // Then include any styles from the matched routes
       ...documentRouteFiles,
     ],


### PR DESCRIPTION
Currently the getStylesForUrl functionality is broken when using vite if the current working directory (cwd) is not the rootDirectory.

The issue is that a relative path to the root directory is created and passed to getStylesForFiles.
getStylesForFiles is accessing files by generating a normalized path, this path is normalized on the CWD and not the root directory though.
So if there is a difference between CWD and root, it will miss that path difference.

Testing Strategy:
I did test it with our new remix vite setup.
First remix contribution though, so I am not aware of further conventions here, please advise which tests would help.