### PR TITLE
Fix Vite client route requests with pre-processed search params

### DIFF
--- a/.changeset/vite-whatwg-querystring.md
+++ b/.changeset/vite-whatwg-querystring.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": minor
 ---
 
-Vite: Add support for client route query string that has been processed by WHATWG url parser/serializer which adds a `=` to query params without a value.
+Vite: Fix issue where client route file requests fail if search params have been processed before reaching the Remix Vite plugin

--- a/.changeset/vite-whatwg-querystring.md
+++ b/.changeset/vite-whatwg-querystring.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": minor
 ---
 
-Vite: Fix issue where client route file requests fail if search params have been processed before reaching the Remix Vite plugin
+Vite: Fix issue where client route file requests fail if search params have been parsed and serialized before reaching the Remix Vite plugin

--- a/.changeset/vite-whatwg-querystring.md
+++ b/.changeset/vite-whatwg-querystring.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": minor
+---
+
+Vite: Add support for client route query string that has been processed by WHATWG url parser/serializer which adds a `=` to query params without a value.

--- a/contributors.yml
+++ b/contributors.yml
@@ -114,6 +114,7 @@
 - crismali
 - CSFlorin
 - cysp
+- cythrawll
 - d4vsanchez
 - dabdine
 - daganomri


### PR DESCRIPTION
Issue if you have middleware that pass query string through any processing. anything WHATWG compatible will render a query param without a value ending with `=` this breaks matching in the vite plugin.

Included code so that vite plugin will match against the supported query string if it ends in '='.

another solution would just change the query string to something a bit more compatible like `?client-route=1` Would be willing to open a PR for that. I went for this one due to it being compatible with current solution.

Testing Strategy:

Tested on a custom express server  that had a searchParams filter that parses the query string that transforms `?client-route` into `?client-route=` because of how WhatWG URL serializes searchParams.

the middleware mock basically looks like this (with 'http-hook' package installed): 
```ts
process.on('httpHooks:request', (req) => {
  const url = new URL(req.url, `http://localhost:3000`);
  const searchParams = url.searchParams;
  req.url = `${url.pathname}?${url.searchParams}`;
});
```

see stackblitz: https://stackblitz.com/edit/remix-run-remix-xzvnld?file=server.ts

Came across this because I have some security hooks/middleware that process the query string.