### PR TITLE
Fix sync `routes` config type error

### DIFF
--- a/.changeset/quiet-cups-attack.md
+++ b/.changeset/quiet-cups-attack.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fix type error in Remix config for synchronous `routes` function

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -67,7 +67,9 @@ export interface AppConfig {
    */
   routes?: (
     defineRoutes: DefineRoutesFunction
-  ) => Promise<ReturnType<DefineRoutesFunction>>;
+  ) =>
+    | ReturnType<DefineRoutesFunction>
+    | Promise<ReturnType<DefineRoutesFunction>>;
 
   /**
    * The path to the browser build, relative to `remix.config.js`. Defaults to


### PR DESCRIPTION
Remix config options are type checked in Vite when using `vite.config.ts`. This has highlighted a gap in our config types where a sync `routes` function is a type error even though it works fine.

A good example of this is when using the [v1 route convention package](https://github.com/remix-run/v1-compat-utils/tree/main/packages/v1-route-convention) which is sync. From the readme:

```ts
// remix.config.js
const { createRoutesFromFolders } = require("@remix-run/v1-route-convention");

/** @type {import('@remix-run/dev').AppConfig} */
module.exports = {
  // Tell Remix to ignore everything in the routes directory.
  // We'll let `createRoutesFromFolders` take care of that.
  ignoredRouteFiles: ["**/*"],
  routes: (defineRoutes) => {
    // `createRoutesFromFolders` will create routes for all files in the
    // routes directory using the same default conventions as Remix v1.
    return createRoutesFromFolders(defineRoutes, {
      // If you're already using `ignoredRouteFiles` in your Remix config,
      // you can move them to `ignoredFilePatterns` in the plugin's options.
      ignoredFilePatterns: ["**/.*", "**/*.css"],
    });
  },
};
```