### PR TITLE
Fix Vite critical CSS resolution when cwd differs from project root

### DIFF
--- a/.changeset/nice-jobs-boil.md
+++ b/.changeset/nice-jobs-boil.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: Fix issue resolving critical CSS during development when the current working directory differs from the project root

--- a/packages/remix-dev/vite/styles.ts
+++ b/packages/remix-dev/vite/styles.ts
@@ -37,7 +37,7 @@ const getStylesForFiles = async ({
 
   try {
     for (let file of files) {
-      let normalizedPath = path.resolve(file).replace(/\\/g, "/");
+      let normalizedPath = path.resolve(rootDirectory, file).replace(/\\/g, "/");
       let node = await viteDevServer.moduleGraph.getModuleById(normalizedPath);
 
       // If the module is only present in the client module graph, the module

--- a/packages/remix-dev/vite/styles.ts
+++ b/packages/remix-dev/vite/styles.ts
@@ -37,7 +37,9 @@ const getStylesForFiles = async ({
 
   try {
     for (let file of files) {
-      let normalizedPath = path.resolve(rootDirectory, file).replace(/\\/g, "/");
+      let normalizedPath = path
+        .resolve(rootDirectory, file)
+        .replace(/\\/g, "/");
       let node = await viteDevServer.moduleGraph.getModuleById(normalizedPath);
 
       // If the module is only present in the client module graph, the module


### PR DESCRIPTION
Hi 👋 

While integrating Remix<>Hydrogen in workerd, I found a weird issue with path resolution when applying critical CSS. Turns out it was resolving `app/entry.client.tsx` using `process.cwd()` (by omission) instead of `rootDirectory`, which can be different in some situations.