### PR TITLE
docs: add `to` prop to link, rename `To` to `Path`.

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -178,6 +178,7 @@
 - fayez-nazzal
 - fede
 - federicoestevez
+- feelixe
 - fergusmeiklejohn
 - fernandocanizo
 - fernandojbf

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -16,6 +16,24 @@ import { Link } from "@remix-run/react";
 
 ## Props
 
+### `to: string`
+The most basic usage takes an href string:
+```tsx
+<Link to="/some/path" />
+```
+
+### `to: Path`
+You can also pass a `Path` value:
+```tsx
+<Link
+  to={{
+    pathname: '/some/path',
+    search: '?query=string',
+    hash: '#hash',
+  }}
+/>
+```
+
 ### `prefetch`
 
 Defines the data and module prefetching behavior for the link.

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -22,8 +22,8 @@ The most basic usage takes an href string:
 <Link to="/some/path" />
 ```
 
-### `to: Path`
-You can also pass a `Path` value:
+### `to: Partial<Path>`
+You can also pass a `Partial<Path>` value:
 ```tsx
 <Link
   to={{

--- a/docs/hooks/use-navigate.md
+++ b/docs/hooks/use-navigate.md
@@ -42,9 +42,9 @@ navigate("../other/path");
 
 <docs-info>Please see the [Splat Paths][relativesplatpath] section on the `useResolvedPath` docs for a note on the behavior of the `future.v3_relativeSplatPath` future flag for relative `useNavigate()` behavior within splat routes</docs-info>
 
-### `to: To`
+### `to: Path`
 
-You can also pass a `To` value:
+You can also pass a `Path` value:
 
 ```tsx
 navigate({

--- a/docs/hooks/use-navigate.md
+++ b/docs/hooks/use-navigate.md
@@ -42,9 +42,9 @@ navigate("../other/path");
 
 <docs-info>Please see the [Splat Paths][relativesplatpath] section on the `useResolvedPath` docs for a note on the behavior of the `future.v3_relativeSplatPath` future flag for relative `useNavigate()` behavior within splat routes</docs-info>
 
-### `to: Path`
+### `to: Partial<Path>`
 
-You can also pass a `Path` value:
+You can also pass a `Partial<Path>` value:
 
 ```tsx
 navigate({


### PR DESCRIPTION
- Add `to` prop to `Link` docs page.
- Also renames prop type `To` in the docs from to `Path` which better matches the typescript type.
  - I believe this is a better name because `To` is defined as `export type To = string | Partial<Path>;` and the docs are referring to the `Path` part of that type.