### PR TITLE
docs: update `*.server.tsx` to `*.server.ts`

### DIFF
--- a/docs/discussion/server-vs-client.md
+++ b/docs/discussion/server-vs-client.md
@@ -99,13 +99,13 @@ export default function Component() {
 
 ## Forcing Code Out of the Browser or Server Builds
 
-You can force code out of either the client or the server with the [`*.client.tsx`][file_convention_client] and [`*.server.tsx`][file_convention_server] conventions.
+You can force code out of either the client or the server with the [`*.client.ts`][file_convention_client] and [`*.server.ts`][file_convention_server] conventions.
 
-While rare, sometimes server code makes it to client bundles because of how the compiler determines the dependencies of a route module, or because you accidentally try to use it in code that needs to ship to the client. You can force it out by adding `*.server.tsx` on the end of the file name.
+While rare, sometimes server code makes it to client bundles because of how the compiler determines the dependencies of a route module, or because you accidentally try to use it in code that needs to ship to the client. You can force it out by adding `*.server.ts` on the end of the file name.
 
 For example, we could name a module `app/user.server.ts` instead of `app/user.ts` to ensure that the code in that module is never bundled into the client — even if you try to use it in the component.
 
-Additionally, you may depend on client libraries that are unsafe to even bundle on the server — maybe it tries to access [`window`][window_global] by simply being imported. You can likewise remove these modules from the server build by appending `*.client.tsx` to the file name.
+Additionally, you may depend on client libraries that are unsafe to even bundle on the server — maybe it tries to access [`window`][window_global] by simply being imported. You can likewise remove these modules from the server build by appending `*.client.ts` to the file name.
 
 [action]: ../route/action
 [headers]: ../route/headers

--- a/docs/file-conventions/routes.md
+++ b/docs/file-conventions/routes.md
@@ -333,7 +333,7 @@ app/
 │   │   └── scroll-experience.tsx
 │   ├── _landing.about/
 │   │   ├── employee-profile-card.tsx
-│   │   ├── get-employee-data.server.tsx
+│   │   ├── get-employee-data.server.ts
 │   │   ├── route.tsx
 │   │   └── team-photo.jpg
 │   ├── _landing/
@@ -344,7 +344,7 @@ app/
 │   │   ├── route.tsx
 │   │   └── stats.tsx
 │   ├── app.projects/
-│   │   ├── get-projects.server.tsx
+│   │   ├── get-projects.server.ts
 │   │   ├── project-buttons.tsx
 │   │   ├── project-card.tsx
 │   │   └── route.tsx
@@ -355,7 +355,7 @@ app/
 │   ├── app_.projects.$id.roadmap/
 │   │   ├── chart.tsx
 │   │   ├── route.tsx
-│   │   └── update-timeline.server.tsx
+│   │   └── update-timeline.server.ts
 │   └── contact-us.tsx
 └── root.tsx
 ```

--- a/docs/guides/file-uploads.md
+++ b/docs/guides/file-uploads.md
@@ -101,7 +101,7 @@ Your job is to do whatever you need with the `data` and return a value that's a 
 
 We have the built-in `unstable_createFileUploadHandler` and `unstable_createMemoryUploadHandler` and we also expect more upload handler utilities to be developed in the future. If you have a form that needs to use different upload handlers, you can compose them together with a custom handler, here's a theoretical example:
 
-```tsx filename=file-upload-handler.server.ts
+```ts filename=file-upload-handler.server.ts
 import type { UploadHandler } from "@remix-run/node"; // or cloudflare/deno
 import { unstable_createFileUploadHandler } from "@remix-run/node"; // or cloudflare/deno
 import { createCloudinaryUploadHandler } from "some-handy-remix-util";

--- a/docs/guides/file-uploads.md
+++ b/docs/guides/file-uploads.md
@@ -101,7 +101,7 @@ Your job is to do whatever you need with the `data` and return a value that's a 
 
 We have the built-in `unstable_createFileUploadHandler` and `unstable_createMemoryUploadHandler` and we also expect more upload handler utilities to be developed in the future. If you have a form that needs to use different upload handlers, you can compose them together with a custom handler, here's a theoretical example:
 
-```tsx filename=file-upload-handler.server.tsx
+```tsx filename=file-upload-handler.server.ts
 import type { UploadHandler } from "@remix-run/node"; // or cloudflare/deno
 import { unstable_createFileUploadHandler } from "@remix-run/node"; // or cloudflare/deno
 import { createCloudinaryUploadHandler } from "some-handy-remix-util";


### PR DESCRIPTION
- [x] Docs

# Description

While reading the [Route File Naming docs](https://remix.run/docs/en/main/file-conventions/routes#folders-for-organization) , I got confused by the route examples `.server.tsx`. The names of the files implie no JSX return, so I guess it should be a `.server.ts` file instead.

Even more, if you read the [docs](https://remix.run/docs/en/main/file-conventions/-server) for `*.server.ts`, it doesn't mention the `tsx` extension.

While it seems that both `.tsx` and `.ts` work (haven't thoroughly checked tho), I think those examples should be a `.ts` extension to reinforce the idea of extract colocating logic next to components, like Ryan brilliantly explained in [this video](https://www.youtube.com/watch?v=xEl8OCMOf_I).

## Note
I also changed `.client.tsx` to `.client.ts` in the `server-vs-client.md` file as I thought it would be even more confusing to have `*.client.tsx` and `*.server.ts` in the same paragraph. 

Should we add some more details in the `file_convention` docs regarding the extensions? 