### PR TITLE
fix(vite-plugin): remove directoy check on route file

### DIFF
--- a/.changeset/cyan-fans-sleep.md
+++ b/.changeset/cyan-fans-sleep.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Remove directory check to allow the usage of defined routes outside of the app directory

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -1674,7 +1674,6 @@ function getRoute(
   file: string
 ): ConfigRoute | undefined {
   let vite = importViteEsmSync();
-  if (!file.startsWith(vite.normalizePath(pluginConfig.appDirectory))) return;
   let routePath = vite.normalizePath(
     path.relative(pluginConfig.appDirectory, file)
   );


### PR DESCRIPTION
This PR tries to solve [this issue](https://github.com/remix-run/remix/issues/8790)

What I did was to remove the check against the `appDirectory`, the change look safe on the test I run which is based in the reproduction case submitted in the issue. But I don't have the background to know if that check is really needed.
Let me know and I can update the PR 😄 