### PR TITLE
vite: fix server export dead-code elimination for routes outside of app dir

### DIFF
--- a/.changeset/brave-yaks-vanish.md
+++ b/.changeset/brave-yaks-vanish.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: fix server exports dead-code elimination for routes outside of app directory

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -1674,7 +1674,6 @@ function getRoute(
   file: string
 ): ConfigRoute | undefined {
   let vite = importViteEsmSync();
-  if (!file.startsWith(vite.normalizePath(pluginConfig.appDirectory))) return;
   let routePath = vite.normalizePath(
     path.relative(pluginConfig.appDirectory, file)
   );


### PR DESCRIPTION
Fixes #8790 #6711 