### PR TITLE
Vite: Pass `remixUserConfig` to preset config hook

### DIFF
--- a/.changeset/mighty-carpets-lie.md
+++ b/.changeset/mighty-carpets-lie.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: Pass `remixUserConfig` to preset `remixConfig` hook

--- a/docs/future/presets.md
+++ b/docs/future/presets.md
@@ -21,9 +21,9 @@ Presets conform to the following `Preset` type:
 type Preset = {
   name: string;
 
-  remixConfig?: () =>
-    | RemixConfigPreset
-    | Promise<RemixConfigPreset>;
+  remixConfig?: (args: {
+    remixUserConfig: VitePluginConfig;
+  }) => RemixConfigPreset | Promise<RemixConfigPreset>;
 
   remixConfigResolved?: (args: {
     remixConfig: ResolvedVitePluginConfig;

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -118,7 +118,9 @@ type RemixConfigPreset = Omit<VitePluginConfig, ExcludedRemixConfigPresetKey>;
 
 export type Preset = {
   name: string;
-  remixConfig?: () => RemixConfigPreset | Promise<RemixConfigPreset>;
+  remixConfig?: (args: {
+    remixUserConfig: VitePluginConfig;
+  }) => RemixConfigPreset | Promise<RemixConfigPreset>;
   remixConfigResolved?: (args: {
     remixConfig: ResolvedVitePluginConfig;
   }) => void | Promise<void>;
@@ -527,6 +529,9 @@ let deepFreeze = (o: any) => {
 
 export type RemixVitePlugin = (config?: VitePluginConfig) => Vite.Plugin[];
 export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
+  // Prevent mutations to the user config
+  remixUserConfig = deepFreeze(remixUserConfig);
+
   let viteCommand: Vite.ResolvedConfig["command"];
   let viteUserConfig: Vite.UserConfig;
   let viteConfigEnv: Vite.ConfigEnv;
@@ -556,7 +561,7 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
           }
 
           let remixConfigPreset: VitePluginConfig = omit(
-            await preset.remixConfig(),
+            await preset.remixConfig({ remixUserConfig }),
             excludedRemixConfigPresetKeys
           );
 


### PR DESCRIPTION
This change allows presets to configure Remix differently based on the user config.

The use case driving this change is to allow Vercel to avoid setting `serverBundles` when consumers have enabled SPA mode, otherwise Vercel preset consumers get the following warning and there's no way to avoid it:

> ⚠️  SPA Mode: the serverBundles config is invalid with unstable_ssr:false and will be ignored