### PR TITLE
Set `ignoredRouteFiles` in Vite templates

### DIFF
--- a/templates/vite-cloudflare/vite.config.ts
+++ b/templates/vite-cloudflare/vite.config.ts
@@ -6,5 +6,11 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [remixCloudflareDevProxy(), remix(), tsconfigPaths()],
+  plugins: [
+    remixCloudflareDevProxy(),
+    remix({
+      ignoredRouteFiles: ["**/.*"],
+    }),
+    tsconfigPaths(),
+  ],
 });

--- a/templates/vite-express/vite.config.ts
+++ b/templates/vite-express/vite.config.ts
@@ -3,5 +3,10 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [remix(), tsconfigPaths()],
+  plugins: [
+    remix({
+      ignoredRouteFiles: ["**/.*"],
+    }),
+    tsconfigPaths(),
+  ],
 });

--- a/templates/vite/vite.config.ts
+++ b/templates/vite/vite.config.ts
@@ -3,5 +3,10 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [remix(), tsconfigPaths()],
+  plugins: [
+    remix({
+      ignoredRouteFiles: ["**/.*"],
+    }),
+    tsconfigPaths(),
+  ],
 });


### PR DESCRIPTION
All non-Vite templates set `ignoredRouteFiles` to `["**/.*"]` so this gets the Vite templates to parity.

This came up in the context of this issue: https://github.com/remix-run/remix/issues/8744