### PR TITLE
Always ignore route files starting with `.`

### DIFF
--- a/.changeset/shy-gifts-ring.md
+++ b/.changeset/shy-gifts-ring.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Always ignore route files starting with `.`

--- a/docs/file-conventions/remix-config.md
+++ b/docs/file-conventions/remix-config.md
@@ -14,7 +14,7 @@ module.exports = {
   future: {
     /* any enabled future flags */
   },
-  ignoredRouteFiles: ["**/.*"],
+  ignoredRouteFiles: ["**/*.css"],
   publicPath: "/build/",
   routes(defineRoutes) {
     return defineRoutes((route) => {
@@ -84,7 +84,7 @@ The `future` config lets you opt-into future breaking changes via [Future Flags]
 This is an array of globs (via [minimatch][minimatch]) that Remix will match to
 files while reading your `app/routes` directory. If a file matches, it will be
 ignored rather than treated like a route module. This is useful for ignoring
-dotfiles (like `.DS_Store` files) or CSS/test files you wish to colocate.
+CSS/test files you wish to colocate.
 
 ## publicPath
 
@@ -181,7 +181,7 @@ module.exports = {
   assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildPath: "build/index.js",
-  ignoredRouteFiles: ["**/.*"],
+  ignoredRouteFiles: ["**/*.css"],
   serverDependenciesToBundle: [
     /^rehype.*/,
     /^remark.*/,

--- a/docs/future/vite.md
+++ b/docs/future/vite.md
@@ -36,7 +36,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   plugins: [
     remix({
-      ignoredRouteFiles: ["**/.*"],
+      ignoredRouteFiles: ["**/*.css"],
     }),
   ],
 });
@@ -348,7 +348,7 @@ The subset of [supported Remix config options][supported-remix-config-options] s
 export default defineConfig({
   plugins: [
     remix({
-      ignoredRouteFiles: ["**/.*"],
+      ignoredRouteFiles: ["**/*.css"],
     }),
   ],
 });

--- a/docs/guides/migrating-react-router-app.md
+++ b/docs/guides/migrating-react-router-app.md
@@ -445,7 +445,7 @@ Every Remix app accepts a `remix.config.js` file in the project root. While its 
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   appDirectory: "app",
-  ignoredRouteFiles: ["**/.*"],
+  ignoredRouteFiles: ["**/*.css"],
   assetsBuildDirectory: "public/build",
 };
 ```

--- a/integration/flat-routes-test.ts
+++ b/integration/flat-routes-test.ts
@@ -67,6 +67,20 @@ test.describe("flat routes", () => {
           }
         `,
 
+        "app/routes/.dotfile": `
+          DOTFILE SHOULD BE IGNORED
+        `,
+
+        "app/routes/.route-with-unescaped-leading-dot.tsx": js`
+          throw new Error("This file should be ignored as a route");
+        `,
+
+        "app/routes/[.]route-with-escaped-leading-dot.tsx": js`
+          export default function () {
+            return <h2>Route With Escaped Leading Dot</h2>;
+          }
+        `,
+
         "app/routes/dashboard/route.tsx": js`
           import { Outlet } from "@remix-run/react";
 
@@ -145,6 +159,17 @@ test.describe("flat routes", () => {
       expect(await app.getHtml("#content")).toBe(`<div id="content">
   <h1>Root</h1>
   <h2>Flat File</h2>
+</div>`);
+    });
+
+    test("renders matching routes (route with escaped leading dot)", async ({
+      page,
+    }) => {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/.route-with-escaped-leading-dot");
+      expect(await app.getHtml("#content")).toBe(`<div id="content">
+  <h1>Root</h1>
+  <h2>Route With Escaped Leading Dot</h2>
 </div>`);
     });
 

--- a/integration/helpers/cf-template/remix.config.js
+++ b/integration/helpers/cf-template/remix.config.js
@@ -1,6 +1,5 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {
-  ignoredRouteFiles: ["**/.*"],
   server: "./server.ts",
   serverConditions: ["workerd", "worker", "browser"],
   serverDependenciesToBundle: [

--- a/integration/helpers/deno-template/remix.config.js
+++ b/integration/helpers/deno-template/remix.config.js
@@ -1,6 +1,5 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  ignoredRouteFiles: ["**/.*"],
   server: "./server.ts",
   serverConditions: ["deno", "worker"],
   serverDependenciesToBundle: "all",

--- a/integration/helpers/node-template/remix.config.js
+++ b/integration/helpers/node-template/remix.config.js
@@ -1,6 +1,5 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {
-  ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // publicPath: "/build/",

--- a/packages/create-remix/__tests__/fixtures/stack/remix.config.js
+++ b/packages/create-remix/__tests__/fixtures/stack/remix.config.js
@@ -1,7 +1,6 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   serverBuildTarget: "node-cjs",
-  ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",

--- a/packages/remix-dev/__tests__/fixtures/cloudflare/remix.config.js
+++ b/packages/remix-dev/__tests__/fixtures/cloudflare/remix.config.js
@@ -1,6 +1,5 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {
-  ignoredRouteFiles: ["**/.*"],
   server: "./server.ts",
   serverBuildPath: "functions/[[path]].js",
   serverConditions: ["workerd", "worker", "browser"],

--- a/packages/remix-dev/__tests__/fixtures/deno/remix.config.js
+++ b/packages/remix-dev/__tests__/fixtures/deno/remix.config.js
@@ -1,6 +1,5 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  ignoredRouteFiles: ["**/.*"],
   server: "./server.ts",
   serverConditions: ["deno", "worker"],
   serverDependenciesToBundle: "all",

--- a/packages/remix-dev/__tests__/fixtures/node/remix.config.js
+++ b/packages/remix-dev/__tests__/fixtures/node/remix.config.js
@@ -1,6 +1,5 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {
-  ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // publicPath: "/build/",

--- a/packages/remix-dev/__tests__/fixtures/stack/remix.config.js
+++ b/packages/remix-dev/__tests__/fixtures/stack/remix.config.js
@@ -1,6 +1,5 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -77,7 +77,7 @@ export function flatRoutes(
   ignoredFilePatterns: string[] = [],
   prefix = "routes"
 ) {
-  let ignoredFileRegex = ignoredFilePatterns
+  let ignoredFileRegex = Array.from(new Set(["**/.*", ...ignoredFilePatterns]))
     .map((re) => makeRe(re))
     .filter((re: any): re is RegExp => !!re);
   let routesDir = path.join(appDirectory, prefix);

--- a/packages/remix-dev/config/flat-routes.ts
+++ b/packages/remix-dev/config/flat-routes.ts
@@ -104,7 +104,7 @@ export function flatRoutes(
 
   let routes: string[] = [];
   for (let entry of entries) {
-    let filepath = path.join(routesDir, entry.name);
+    let filepath = normalizeSlashes(path.join(routesDir, entry.name));
 
     let route: string | null = null;
     // If it's a directory, don't recurse into it, instead just look for a route module
@@ -302,7 +302,7 @@ function findRouteModuleForFile(
   filepath: string,
   ignoredFileRegex: RegExp[]
 ): string | null {
-  let relativePath = path.relative(appDirectory, filepath);
+  let relativePath = normalizeSlashes(path.relative(appDirectory, filepath));
   let isIgnored = ignoredFileRegex.some((regex) => regex.test(relativePath));
   if (isIgnored) return null;
   return filepath;

--- a/scripts/playground/template/remix.config.js
+++ b/scripts/playground/template/remix.config.js
@@ -1,5 +1,5 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   cacheDirectory: "./node_modules/.cache/remix",
-  ignoredRouteFiles: ["**/.*", "**/*.css", "**/*.test.{js,jsx,ts,tsx}"],
+  ignoredRouteFiles: ["**/*.css", "**/*.test.{js,jsx,ts,tsx}"],
 };

--- a/templates/arc/remix.config.js
+++ b/templates/arc/remix.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {
-  ignoredRouteFiles: ["**/.*"],
+  ignoredRouteFiles: ["**/*.css"],
   publicPath: "/_static/build/",
   server: "server.ts",
   serverBuildPath: "server/index.mjs",

--- a/templates/cloudflare-pages/remix.config.js
+++ b/templates/cloudflare-pages/remix.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {
-  ignoredRouteFiles: ["**/.*"],
+  ignoredRouteFiles: ["**/*.css"],
   server: "./server.ts",
   serverBuildPath: "functions/[[path]].js",
   serverConditions: ["workerd", "worker", "browser"],

--- a/templates/cloudflare-workers/remix.config.js
+++ b/templates/cloudflare-workers/remix.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {
-  ignoredRouteFiles: ["**/.*"],
+  ignoredRouteFiles: ["**/*.css"],
   server: "./server.ts",
   serverConditions: ["workerd", "worker", "browser"],
   serverDependenciesToBundle: [

--- a/templates/deno/remix.config.js
+++ b/templates/deno/remix.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  ignoredRouteFiles: ["**/.*"],
+  ignoredRouteFiles: ["**/*.css"],
   server: "./server.ts",
   serverConditions: ["deno", "worker"],
   serverDependenciesToBundle: "all",

--- a/templates/express/remix.config.js
+++ b/templates/express/remix.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {
-  ignoredRouteFiles: ["**/.*"],
+  ignoredRouteFiles: ["**/*.css"],
   serverModuleFormat: "esm",
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",

--- a/templates/fly/remix.config.js
+++ b/templates/fly/remix.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {
-  ignoredRouteFiles: ["**/.*"],
+  ignoredRouteFiles: ["**/*.css"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // publicPath: "/build/",

--- a/templates/remix-javascript/remix.config.js
+++ b/templates/remix-javascript/remix.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {
-  ignoredRouteFiles: ["**/.*"],
+  ignoredRouteFiles: ["**/*.css"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // publicPath: "/build/",

--- a/templates/remix-tutorial/remix.config.js
+++ b/templates/remix-tutorial/remix.config.js
@@ -1,5 +1,5 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  ignoredRouteFiles: ["**/.*"],
+  ignoredRouteFiles: ["**/*.css"],
   serverModuleFormat: "cjs",
 };

--- a/templates/remix/remix.config.js
+++ b/templates/remix/remix.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {
-  ignoredRouteFiles: ["**/.*"],
+  ignoredRouteFiles: ["**/*.css"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // publicPath: "/build/",


### PR DESCRIPTION
This change is in response to the following issue: #8744

Having dotfiles like `.DS_Store` in the routes directory causes hard-to-debug errors when `"**/.*"` is not configured in `ignoredRouteFiles`. This is particularly notable when using the Vite plugin since we've encourage usage without any config (i.e. `remix()` in the plugins array). Currently none of the Vite templates have `ignoredRouteFiles` set.

Since we've moved to flat routes, it no longer makes sense to have route files starting with a `.` character since it's meant to be a delimiter denoting a `/` in the URL. As a result, rather than doubling down and adding `remix({ ignoredRouteFiles: ["**/.*"] })` to all Vite templates, it makes more sense to always ignore route files starting with `.`.

The bulk of this PR is just updating docs and templates now that it's redundant to add `**/.*` to `ignoredRouteFiles`.