### PR TITLE
chore: fix Windows path normalization in Vite

### DIFF
--- a/.changeset/long-walls-rescue.md
+++ b/.changeset/long-walls-rescue.md
@@ -1,0 +1,7 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: reliably detect non-root routes in Windows
+
+Sometimes route `file` will be unnormalized Windows path with `\` instead of `/`.

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -1693,7 +1693,7 @@ function getRoute(
     path.relative(pluginConfig.appDirectory, file)
   );
   let route = Object.values(pluginConfig.routes).find(
-    (r) => r.file === routePath
+    (r) => vite.normalizePath(r.file) === routePath
   );
   return route;
 }


### PR DESCRIPTION
Closes: #8805

Testing Strategy:

I've used the reproduction in the linked issue to test that this works and the errors went away. 