### PR TITLE
Fix build errors with Vite `.css?url` imports

### DIFF
--- a/.changeset/cold-suns-notice.md
+++ b/.changeset/cold-suns-notice.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: Fix error when building projects with `.css?url` imports

--- a/integration/helpers/vite-template/package.json
+++ b/integration/helpers/vite-template/package.json
@@ -23,7 +23,7 @@
     "@types/react-dom": "^18.2.7",
     "eslint": "^8.38.0",
     "typescript": "^5.1.6",
-    "vite": "5.1.0",
+    "vite": "5.1.3",
     "vite-tsconfig-paths": "^4.2.1"
   },
   "engines": {

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -111,12 +111,21 @@ export async function createProject(files: Record<string, string> = {}) {
   return projectDir;
 }
 
-export const viteBuild = ({ cwd }: { cwd: string }) => {
+export const viteBuild = ({
+  cwd,
+  env = {},
+}: {
+  cwd: string;
+  env?: Record<string, string>;
+}) => {
   let nodeBin = process.argv[0];
 
   return spawnSync(nodeBin, [remixBin, "vite:build"], {
     cwd,
-    env: { ...process.env },
+    env: {
+      ...process.env,
+      ...env,
+    },
   });
 };
 

--- a/integration/vite-css-test.ts
+++ b/integration/vite-css-test.ts
@@ -241,7 +241,15 @@ test.describe(() => {
         contents.replace('"sideEffects": false', '"sideEffects": ["*.css.ts"]')
       );
 
-      viteBuild({ cwd });
+      let { stderr, status } = viteBuild({
+        cwd,
+        env: {
+          // Vanilla Extract uses Vite's CJS build which emits a warning to stderr
+          VITE_CJS_IGNORE_WARNING: "true",
+        },
+      });
+      expect(stderr.toString()).toBeFalsy();
+      expect(status).toBe(0);
       stop = await viteRemixServe({ cwd, port });
     });
     test.afterAll(() => stop());

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "unified": "^10.1.2",
     "unist-util-remove": "^3.1.0",
     "unist-util-visit": "^4.1.1",
-    "vite": "5.1.0",
+    "vite": "5.1.3",
     "wait-on": "^7.0.1"
   },
   "engines": {

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -91,7 +91,7 @@
     "msw": "^1.2.3",
     "strip-ansi": "^6.0.1",
     "tiny-invariant": "^1.2.0",
-    "vite": "5.1.0",
+    "vite": "5.1.3",
     "wrangler": "^3.28.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13472,10 +13472,10 @@ vite-tsconfig-paths@^4.2.2:
     globrex "^0.1.2"
     tsconfck "^2.1.0"
 
-vite@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.npmjs.org/vite/-/vite-5.1.0.tgz#4510394f48b942ecc6843025f4b926ba99a2fb8c"
-  integrity sha512-STmSFzhY4ljuhz14bg9LkMTk3d98IO6DIArnTY6MeBwiD1Za2StcQtz7fzOUnRCqrHSD5+OS2reg4HOz1eoLnw==
+vite@5.1.3:
+  version "5.1.3"
+  resolved "https://registry.npmjs.org/vite/-/vite-5.1.3.tgz#dd072653a80225702265550a4700561740dfde55"
+  integrity sha512-UfmUD36DKkqhi/F75RrxvPpry+9+tTkrXfMNZD+SboZqBCMsxKtO52XeGzzuh7ioz+Eo/SYDBbdb0Z7vgcDJew==
   dependencies:
     esbuild "^0.19.3"
     postcss "^8.4.35"


### PR DESCRIPTION
Fixes #8813

The linked issue was introduced in #8796 but slipped through because the Vite CSS test didn't assert the build command succeeded without any output to `stderr`. The test still managed to pass because the build output still worked if you ignored the error message which meant all of our assertions still passed. I've updated the test to catch this issue along with the fix.