### PR TITLE
feat: cloudflare websocket proxy

### DIFF
--- a/packages/remix-dev/vite/cloudflare-proxy-plugin.ts
+++ b/packages/remix-dev/vite/cloudflare-proxy-plugin.ts
@@ -1,10 +1,13 @@
+import { Server } from "node:http";
+
 import { createRequestHandler } from "@remix-run/server-runtime";
 import {
   type AppLoadContext,
   type ServerBuild,
 } from "@remix-run/server-runtime";
-import { type Plugin } from "vite";
+import { type Connect, type Plugin } from "vite";
 import { type GetPlatformProxyOptions, type PlatformProxy } from "wrangler";
+import { Server as WebSocketServer } from "ws";
 
 import { fromNodeRequest, toNodeRequest } from "./node-adapter";
 
@@ -40,6 +43,13 @@ export const cloudflareDevProxyVitePlugin = <Env, Cf extends CfProperties>({
   return {
     name: NAME,
     config: () => ({
+      server: {
+        hmr: {
+          // HMR must be served on a different port than the dev server
+          // so non-HMR WebSocket upgrade request is handled by the WebSocket proxy
+          port: 4173,
+        },
+      },
       ssr: {
         resolve: {
           externalConditions: ["workerd", "worker"],
@@ -61,6 +71,83 @@ export const cloudflareDevProxyVitePlugin = <Env, Cf extends CfProperties>({
       // Do not include `dispose` in Cloudflare context
       let { dispose, ...cloudflare } = await getPlatformProxy<Env, Cf>(options);
       let context = { cloudflare };
+
+      // Create WebSocket proxy for Durable Object WebSocket
+      if (viteDevServer.httpServer instanceof Server) {
+        let wsServer = new WebSocketServer({
+          server: viteDevServer.httpServer,
+        });
+
+        wsServer.on("connection", async (nodeWs, nodeReq) => {
+          // Patch Node IncomingMessage to be compatible with Connect.IncomingMessage
+          (nodeReq as Connect.IncomingMessage).originalUrl = nodeReq.url;
+
+          let build = (await viteDevServer.ssrLoadModule(
+            serverBuildId
+          )) as ServerBuild;
+
+          let handler = createRequestHandler(build, "development");
+          let req = fromNodeRequest(nodeReq);
+          let loadContext = getLoadContext
+            ? await getLoadContext({ request: req, context })
+            : context;
+
+          let request = fromNodeRequest(nodeReq);
+          let response = (await handler(request, loadContext)) as unknown as {
+            status: number;
+            webSocket?: import("@cloudflare/workers-types").WebSocket;
+          };
+
+          if (response.status !== 101 || response.webSocket === undefined) {
+            nodeWs.close();
+            return;
+          }
+
+          let doWs = response.webSocket;
+          doWs.accept();
+
+          let closedByClient = false;
+          let closedByWorkerd = false;
+
+          nodeWs.on("close", () => {
+            if (closedByWorkerd) {
+              closedByWorkerd = false;
+              viteDevServer.hot.send({
+                type: "full-reload",
+              });
+              return;
+            }
+
+            closedByClient = true;
+            doWs.close();
+          });
+
+          nodeWs.on("message", (data) => {
+            if (Array.isArray(data)) {
+              for (let datum of data) {
+                doWs.send(datum);
+              }
+            } else {
+              doWs.send(data);
+            }
+          });
+
+          doWs.addEventListener("close", () => {
+            if (closedByClient) {
+              closedByClient = false;
+              return;
+            }
+
+            closedByWorkerd = true;
+            nodeWs.close();
+          });
+
+          doWs.addEventListener("message", (e) => {
+            nodeWs.send(e.data);
+          });
+        });
+      }
+
       return () => {
         if (!viteDevServer.config.server.middlewareMode) {
           viteDevServer.middlewares.use(async (nodeReq, nodeRes, next) => {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->
WebSocket proxy for Cloudflare Durable Object based WebSocket.

- [ ] Docs
- [ ] Tests

Testing Strategy:

Has been tested by running an echo room via Durable Object based WebSocket in separate service locally. Must be in separate service as Cloudflare Pages Functions (non advanced mode) [does not support inlined Durable Object](https://developers.cloudflare.com/pages/functions/bindings/#interact-with-your-durable-object-namespaces-locally). Will try to add an integration test later. 

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
