### PR TITLE
Support custom Vite `build.assetsDir` option

### DIFF
--- a/.changeset/tender-keys-develop.md
+++ b/.changeset/tender-keys-develop.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Support custom Vite `build.assetsDir` option

--- a/contributors.yml
+++ b/contributors.yml
@@ -171,6 +171,7 @@
 - emzoumpo
 - enbonnet
 - eps1lon
+- ericchernuka
 - esamattis
 - evanwinter
 - everdimension

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -774,15 +774,12 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
     return new Set([...cssUrlPaths, ...chunkAssetPaths]);
   };
 
-  let getClientBuildAssetsDirectory = () => {
-    invariant(viteConfig);
-    return viteConfig.build.assetsDir;
-  };
-
   let generateRemixManifestsForBuild = async (): Promise<{
     remixBrowserManifest: RemixManifest;
     remixServerManifest: RemixManifest;
   }> => {
+    invariant(viteConfig);
+
     let viteManifest = await loadViteManifest(
       getClientBuildDirectory(ctx.remixConfig)
     );
@@ -838,8 +835,8 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
 
     let fingerprintedValues = { entry, routes: browserRoutes };
     let version = getHash(JSON.stringify(fingerprintedValues), 8);
-    let manifestPath = path.join(
-      getClientBuildAssetsDirectory(),
+    let manifestPath = path.posix.join(
+      viteConfig.build.assetsDir,
       `manifest-${version}.js`
     );
     let url = `${ctx.remixConfig.publicPath}${manifestPath}`;

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -774,6 +774,11 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
     return new Set([...cssUrlPaths, ...chunkAssetPaths]);
   };
 
+  let getClientBuildAssetsDirectory = () => {
+    invariant(viteConfig);
+    return viteConfig.build.assetsDir;
+  };
+
   let createBrowserManifestForBuild = async (): Promise<BrowserManifest> => {
     let viteManifest = await loadViteManifest(
       getClientBuildDirectory(ctx.remixConfig)
@@ -819,10 +824,12 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
         ),
       };
     }
-
     let fingerprintedValues = { entry, routes };
     let version = getHash(JSON.stringify(fingerprintedValues), 8);
-    let manifestPath = `assets/manifest-${version}.js`;
+    let manifestPath = path.join(
+      getClientBuildAssetsDirectory(),
+      `manifest-${version}.js`
+    );
     let url = `${ctx.remixConfig.publicPath}${manifestPath}`;
     let nonFingerprintedValues = { url, version };
 


### PR DESCRIPTION
I was in need of having the assets directory in a different location due to a proxy. Leveraging Vite's `build#assetsDir`, I was able to achieve most of what I needed, but there was a straggler file at `build/client/assets/manifest-{hash}.js` even though the configuration of the asset was set to a different directory. To ensure this file adheres to the Vite configuration, I've added handling to build the path from the Vite configuration.

Testing Strategy:
I wasn't able to find any test regarding the Vite plugin functionality so I ended up utilizing manual testing using the playground. To recreate this, I leveraged the `template.local` feature of the `scripts/playground` directory.
1. Run the following from the project root `npx create-remix@latest ./scripts/playground/template.local --template remix-run/remix/templates/vite-cloudflare`
2. Update package.json references for `@remix/*` to all reference `*` to match existing base template
3. Run `yarn build` to build fresh version with the changes in this PR
4. Run `yarn playground:new` to create a fresh template
5. Install dependencies for this new playground
6. Run `yarn build`
7. The result should be a build directory with `client` and `server` directories. The `client` directory should be a subdirectory named `assets,` which includes a `manifest-{hash}.js.`
8. Update vite.config.ts to match the following:
```typescript
export default defineConfig({
  plugins: [remixCloudflareDevProxy(), remix(), tsconfigPaths()],
  build: {
    assetsDir: "assets-remix"
  }
});
```
9. From the new playground root, run `yarn build`. The result should be a build directory with two directories, `client` and `server`. Within the `client` directory, there should no longer be an `assets` directory containing `manifest-{hash}.js`, and it should now be part of the `assets-remix` directory.