### PR TITLE
vite: typesafe server build

### DIFF
--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -41,6 +41,7 @@ export const EXPRESS_SERVER = (args: {
   loadContext?: Record<string, unknown>;
 }) =>
   String.raw`
+    import path from "node:path";
     import { createRequestHandler } from "@remix-run/express";
     import { installGlobals, getServerBuild } from "@remix-run/node";
     import express from "express";
@@ -68,10 +69,12 @@ export const EXPRESS_SERVER = (args: {
     }
     app.use(express.static("build/client", { maxAge: "1h" }));
 
+    const buildPath = path.resolve("./build/server/index.js");
+    const build = await getServerBuild(buildPath, { viteDevServer });
     app.all(
       "*",
       createRequestHandler({
-        build: await getServerBuild("./build/server/index.js", viteDevServer),
+        build,
         getLoadContext: () => (${JSON.stringify(args.loadContext ?? {})}),
       })
     );

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -42,7 +42,7 @@ export const EXPRESS_SERVER = (args: {
 }) =>
   String.raw`
     import { createRequestHandler } from "@remix-run/express";
-    import { installGlobals } from "@remix-run/node";
+    import { installGlobals, getServerBuild } from "@remix-run/node";
     import express from "express";
 
     installGlobals();
@@ -71,9 +71,7 @@ export const EXPRESS_SERVER = (args: {
     app.all(
       "*",
       createRequestHandler({
-        build: viteDevServer
-          ? () => viteDevServer.ssrLoadModule("virtual:remix/server-build")
-          : await import("./build/index.js"),
+        build: await getServerBuild("./build/server/index.js", viteDevServer),
         getLoadContext: () => (${JSON.stringify(args.loadContext ?? {})}),
       })
     );

--- a/integration/vite-basename-test.ts
+++ b/integration/vite-basename-test.ts
@@ -94,6 +94,7 @@ const customServerFile = ({
   basename = basename ?? base;
 
   return String.raw`
+    import path from "node:path";
     import { createRequestHandler } from "@remix-run/express";
     import { installGlobals, getServerBuild } from "@remix-run/node";
     import express from "express";
@@ -112,12 +113,11 @@ const customServerFile = ({
 
     const app = express();
     app.use("${base}", viteDevServer?.middlewares || express.static("build/client"));
-    app.all(
-      "${basename}*",
-      createRequestHandler({
-        build: await getServerBuild("./build/server/index.js", viteDevServer),
-      })
-    );
+
+    const buildPath = path.resolve("./build/server/index.js");
+    console.log({ viteDevServer, mode: process.env.NODE_ENV });
+    const build = await getServerBuild(buildPath, { viteDevServer });
+    app.all("${basename}*", createRequestHandler({ build }));
     app.get("*", (_req, res) => {
       res.setHeader("content-type", "text/html")
       res.end('Remix app is at <a href="${basename}">${basename}</a>');

--- a/integration/vite-basename-test.ts
+++ b/integration/vite-basename-test.ts
@@ -95,7 +95,7 @@ const customServerFile = ({
 
   return String.raw`
     import { createRequestHandler } from "@remix-run/express";
-    import { installGlobals } from "@remix-run/node";
+    import { installGlobals, getServerBuild } from "@remix-run/node";
     import express from "express";
     installGlobals();
 
@@ -115,9 +115,7 @@ const customServerFile = ({
     app.all(
       "${basename}*",
       createRequestHandler({
-        build: viteDevServer
-          ? () => viteDevServer.ssrLoadModule("virtual:remix/server-build")
-          : await import("./build/server/index.js"),
+        build: await getServerBuild("./build/server/index.js", viteDevServer),
       })
     );
     app.get("*", (_req, res) => {

--- a/packages/remix-cloudflare/index.ts
+++ b/packages/remix-cloudflare/index.ts
@@ -15,6 +15,7 @@ export {
   defer,
   broadcastDevReady,
   logDevReady,
+  getServerBuild,
   isCookie,
   isSession,
   json,

--- a/packages/remix-deno/index.ts
+++ b/packages/remix-deno/index.ts
@@ -17,6 +17,7 @@ export {
   broadcastDevReady,
   createSession,
   defer,
+  getServerBuild,
   isCookie,
   isSession,
   json,

--- a/packages/remix-node/index.ts
+++ b/packages/remix-node/index.ts
@@ -27,6 +27,7 @@ export {
   defer,
   broadcastDevReady,
   logDevReady,
+  getServerBuild,
   isCookie,
   isSession,
   json,

--- a/packages/remix-server-runtime/__tests__/build-test.ts
+++ b/packages/remix-server-runtime/__tests__/build-test.ts
@@ -1,0 +1,15 @@
+import { getServerBuild } from "../build";
+
+it("getServerBuild throws when path is relative", async () => {
+  await expect(() => getServerBuild("./build/server/index.js")).rejects.toThrow(
+    "Server build path must be absolute, but received relative path: ./build/server/index.js"
+  );
+});
+
+it("getServerBuild throws when build does not exist", async () => {
+  await expect(() =>
+    getServerBuild("/this/path/doesnt/exist.js")
+  ).rejects.toThrow(
+    "Could not import server build from '/this/path/doesnt/exist.js'. Did you forget to run 'remix vite:build' first?"
+  );
+});

--- a/packages/remix-server-runtime/build.ts
+++ b/packages/remix-server-runtime/build.ts
@@ -8,18 +8,19 @@ import type { AppLoadContext } from "./data";
 
 export async function getServerBuild(
   buildPath: string,
-  {
-    viteDevServer,
-  }: {
+  options: {
     viteDevServer?: ViteDevServer;
   } = {}
 ): Promise<ServerBuild | (() => Promise<ServerBuild>)> {
+  // eslint-disable-next-line prefer-let/prefer-let
+  const { viteDevServer } = options;
   if (viteDevServer) {
     return () =>
       viteDevServer.ssrLoadModule(
         "virtual:remix/server-build"
       ) as Promise<ServerBuild>;
   }
+  console.log({ buildPath, options });
 
   if (!path.isAbsolute(buildPath)) {
     throw new Error(
@@ -28,7 +29,9 @@ export async function getServerBuild(
   }
 
   // Convert file path meant for `import` to URL for Windows compatibility
-  let buildURL = "file:///" + encodeURI(buildPath);
+  let buildURL =
+    "file://" + (buildPath.startsWith("/") ? "" : "/") + encodeURI(buildPath);
+  console.log({ buildURL });
   return import(buildURL).catch(() => {
     throw Error(
       `Could not import server build from '${buildPath}'. Did you forget to run 'remix vite:build' first?`

--- a/packages/remix-server-runtime/index.ts
+++ b/packages/remix-server-runtime/index.ts
@@ -80,3 +80,4 @@ export type {
   UploadHandler,
   UploadHandlerPart,
 } from "./reexport";
+export { getServerBuild } from "./reexport";

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -20,18 +20,24 @@
     "@types/cookie": "^0.6.0",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie": "^0.6.0",
+    "pathe": "^1.1.2",
     "set-cookie-parser": "^2.4.8",
     "source-map": "^0.7.3"
   },
   "devDependencies": {
     "@types/set-cookie-parser": "^2.4.1",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "vite": "^5.1.0"
   },
   "peerDependencies": {
-    "typescript": "^5.1.0"
+    "typescript": "^5.1.0",
+    "vite": "^5.1.0"
   },
   "peerDependenciesMeta": {
     "typescript": {
+      "optional": true
+    },
+    "vite": {
       "optional": true
     }
   },

--- a/packages/remix-server-runtime/reexport.ts
+++ b/packages/remix-server-runtime/reexport.ts
@@ -7,6 +7,7 @@ export type {
   ServerBuild,
   ServerEntryModule,
 } from "./build";
+export { getServerBuild } from "./build";
 
 export type { UploadHandlerPart, UploadHandler } from "./formData";
 export type {

--- a/packages/remix-server-runtime/tsconfig.json
+++ b/packages/remix-server-runtime/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2022"],
     "target": "ES2022",
     "composite": true,
+    "module": "ESNext",
 
     "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10747,6 +10747,11 @@ pathe@^1.0.0, pathe@^1.1.0:
   resolved "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz#e2e13f6c62b31a3289af4ba19886c230f295ec03"
   integrity sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==
 
+pathe@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
+  integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
+
 peek-stream@^1.1.0:
   version "1.1.3"
   resolved "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz"
@@ -13493,6 +13498,17 @@ vite@5.1.3:
     rollup "^3.27.1"
   optionalDependencies:
     fsevents "~2.3.2"
+
+vite@^5.1.0:
+  version "5.1.4"
+  resolved "https://registry.npmjs.org/vite/-/vite-5.1.4.tgz#14e9d3e7a6e488f36284ef13cebe149f060bcfb6"
+  integrity sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==
+  dependencies:
+    esbuild "^0.19.3"
+    postcss "^8.4.35"
+    rollup "^4.2.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 w3c-xmlserializer@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Fixes #8343

```ts
import path from "node:path"
import { getServerBuild } from "@remix-run/node"

const buildPath = path.resolve("./build/server/index.js")
const build = await getServerBuild(buildPath, { viteDevServer })

app.all("*", createRequestHandler({ build }));
```