### PR TITLE
docs(future/vite): bring in line with template

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -315,6 +315,7 @@
 - juwiragiye
 - jveldridge
 - jvnm-dev
+- jwaltz
 - jwnx
 - kalch
 - kamtugeza

--- a/docs/future/vite.md
+++ b/docs/future/vite.md
@@ -168,6 +168,14 @@ you should export a `getLoadContext` function from a shared module so that **loa
 import { type AppLoadContext } from "@remix-run/cloudflare";
 import { type PlatformProxy } from "wrangler";
 
+// When using `wrangler.toml` to configure bindings,
+// `wrangler types` will generate types for those bindings
+// into the global `Env` interface.
+// Need this empty interface so that typechecking passes
+// even if no `wrangler.toml` exists.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface Env {}
+
 type Cloudflare = Omit<PlatformProxy<Env>, "dispose">;
 
 declare module "@remix-run/cloudflare" {


### PR DESCRIPTION
This pull request updates the Cloudflare documentation for Vite regarding [augmenting load context](https://remix.run/docs/en/main/future/vite#augmenting-load-context) to include a global declaration of the `Env` type, matching the `vite-cloudflare` template [here](https://github.com/remix-run/remix/blob/main/templates/vite-cloudflare/load-context.ts#L3-L9). The current documentation does not define `Env`.