### PR TITLE
fix: account for presence of Layout in default error boundary

### DIFF
--- a/.changeset/layout-error-boundary.md
+++ b/.changeset/layout-error-boundary.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+account for presence of Layout in default error boundary

--- a/integration/root-route-test.ts
+++ b/integration/root-route-test.ts
@@ -112,4 +112,44 @@ test.describe("root route", () => {
 
     console.error = oldConsoleError;
   });
+
+  test("renders the Layout around the default ErrorBoundary", async ({ page }) => {
+    let oldConsoleError;
+    oldConsoleError = console.error;
+    console.error = () => {};
+
+    fixture = await createFixture(
+      {
+        files: {
+          "app/root.tsx": js`
+          export function Layout({ children }) {
+            return (
+              <html>
+                <head>
+                  <title>Layout Title</title>
+                </head>
+                <body>
+                  {children}
+                </body>
+              </html>
+            );
+          }
+          export default function Root() {
+            throw new Error('broken render')
+          }
+        `,
+        },
+      },
+      ServerMode.Development
+    );
+    appFixture = await createAppFixture(fixture, ServerMode.Development);
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/");
+    await page.waitForSelector("h1");
+    console.log(await app.getHtml())
+    expect(await app.getHtml("title")).toMatch("Layout Title");
+    expect(await app.getHtml("h1")).toMatch("Application Error");
+
+    console.error = oldConsoleError;
+  });
 });

--- a/packages/remix-react/errorBoundaries.tsx
+++ b/packages/remix-react/errorBoundaries.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import type { Location } from "@remix-run/router";
 import { isRouteErrorResponse } from "react-router-dom";
 
+import { useRemixContext } from "./components"
+
 type RemixErrorBoundaryProps = React.PropsWithChildren<{
   location: Location;
   error?: Error;
@@ -67,9 +69,11 @@ export function RemixRootDefaultErrorBoundary({ error }: { error: unknown }) {
   if (isRouteErrorResponse(error)) {
     return (
       <BoundaryShell title="Unhandled Thrown Response!">
-        <h1 style={{ fontFamily: "system-ui, sans-serif", padding: "2rem" }}>
-          {error.status} {error.statusText}
-        </h1>
+        <main style={{ fontFamily: "system-ui, sans-serif", padding: "2rem" }}>
+          <h1 style={{ fontSize: "24px" }}>
+            {error.status} {error.statusText}
+          </h1>
+        </main>
       </BoundaryShell>
     );
   }
@@ -113,6 +117,27 @@ function BoundaryShell({
   title: string;
   children: React.ReactNode;
 }) {
+  let { routeModules } = useRemixContext();
+
+  let contents = (
+    <>
+      {children}
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `
+              console.log(
+                "💿 Hey developer 👋. You can provide a way better UX than this when your app throws errors. Check out https://remix.run/guides/errors for more information."
+              );
+            `,
+        }}
+      />
+    </>
+  );
+
+  if (routeModules.root?.Layout) {
+    return contents;
+  }
+
   return (
     <html lang="en">
       <head>
@@ -124,16 +149,7 @@ function BoundaryShell({
         <title>{title}</title>
       </head>
       <body>
-        {children}
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-              console.log(
-                "💿 Hey developer 👋. You can provide a way better UX than this when your app throws errors. Check out https://remix.run/guides/errors for more information."
-              );
-            `,
-          }}
-        />
+        {contents}
       </body>
     </html>
   );


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
