### PR TITLE
Type check `.server`/`.client` dirs in Vite templates

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -628,6 +628,7 @@
 - vm
 - vmosyaykin
 - vorcigernix
+- wahyubucil
 - wangbinyq
 - weavdale
 - wilcoschoneveld

--- a/templates/vite-cloudflare/tsconfig.json
+++ b/templates/vite-cloudflare/tsconfig.json
@@ -1,5 +1,12 @@
 {
-  "include": ["**/*.ts", "**/*.tsx", "**/.server/**/*.ts"],
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "**/.server/**/*.ts",
+    "**/.server/**/*.tsx",
+    "**/.client/**/*.ts",
+    "**/.client/**/*.tsx"
+  ],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["@remix-run/cloudflare", "vite/client"],

--- a/templates/vite-cloudflare/tsconfig.json
+++ b/templates/vite-cloudflare/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["**/*.ts", "**/*.tsx"],
+  "include": ["**/*.ts", "**/*.tsx", "**/.server/**/*.ts"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["@remix-run/cloudflare", "vite/client"],

--- a/templates/vite-express/tsconfig.json
+++ b/templates/vite-express/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["**/*.ts", "**/*.tsx", "**/.server/**/*.ts"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "types": ["@remix-run/node", "vite/client"],
+    "types": ["@remix-run/node", "node", "vite/client"],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",

--- a/templates/vite-express/tsconfig.json
+++ b/templates/vite-express/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["**/*.ts", "**/*.tsx"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "types": ["@remix-run/node", "node", "vite/client"],
+    "types": ["@remix-run/node", "vite/client"],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",

--- a/templates/vite-express/tsconfig.json
+++ b/templates/vite-express/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["**/*.ts", "**/*.tsx"],
+  "include": ["**/*.ts", "**/*.tsx", "**/.server/**/*.ts"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["@remix-run/node", "vite/client"],

--- a/templates/vite-express/tsconfig.json
+++ b/templates/vite-express/tsconfig.json
@@ -1,5 +1,12 @@
 {
-  "include": ["**/*.ts", "**/*.tsx", "**/.server/**/*.ts"],
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "**/.server/**/*.ts",
+    "**/.server/**/*.tsx",
+    "**/.client/**/*.ts",
+    "**/.client/**/*.tsx"
+  ],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["@remix-run/node", "node", "vite/client"],

--- a/templates/vite/tsconfig.json
+++ b/templates/vite/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["**/*.ts", "**/*.tsx", "**/.server/**/*.ts"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "types": ["@remix-run/node", "vite/client"],
+    "types": ["@remix-run/node", "node", "vite/client"],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",

--- a/templates/vite/tsconfig.json
+++ b/templates/vite/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["**/*.ts", "**/*.tsx"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "types": ["@remix-run/node", "node", "vite/client"],
+    "types": ["@remix-run/node", "vite/client"],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",

--- a/templates/vite/tsconfig.json
+++ b/templates/vite/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["**/*.ts", "**/*.tsx"],
+  "include": ["**/*.ts", "**/*.tsx", "**/.server/**/*.ts"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["@remix-run/node", "vite/client"],

--- a/templates/vite/tsconfig.json
+++ b/templates/vite/tsconfig.json
@@ -1,5 +1,12 @@
 {
-  "include": ["**/*.ts", "**/*.tsx", "**/.server/**/*.ts"],
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "**/.server/**/*.ts",
+    "**/.server/**/*.tsx",
+    "**/.client/**/*.ts",
+    "**/.client/**/*.tsx"
+  ],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["@remix-run/node", "node", "vite/client"],


### PR DESCRIPTION
Closes: #8898 

Testing Strategy:
I edited the provided StackBlitz link on the issue with the new `tsconfig.json` on this PR.

Note:
1. For the `node` type, I'm not sure if we still need it or not. If we need it, then I will put it back and install the `@types/node` on the `devDependencies`.
2. For the `include` field, I only added `.ts` files to detect, let me know if I also need to include `.tsx` files.