### PR TITLE
Remove `node` type from Vite template tsconfigs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -628,6 +628,7 @@
 - vm
 - vmosyaykin
 - vorcigernix
+- wahyubucil
 - wangbinyq
 - weavdale
 - wilcoschoneveld

--- a/templates/vite-express/tsconfig.json
+++ b/templates/vite-express/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["**/*.ts", "**/*.tsx"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "types": ["@remix-run/node", "node", "vite/client"],
+    "types": ["@remix-run/node", "vite/client"],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",

--- a/templates/vite/tsconfig.json
+++ b/templates/vite/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["**/*.ts", "**/*.tsx"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "types": ["@remix-run/node", "node", "vite/client"],
+    "types": ["@remix-run/node", "vite/client"],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
On `vite` and `vite-express` template. We don't need the `node` type because we already have the `@remix-run/node` type.

This PR is created based on this feedback: https://github.com/remix-run/remix/pull/8899#pullrequestreview-1902442836, which is related to issue #8898.