### PR TITLE
Bump Router prerelease

### DIFF
--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -29,7 +29,7 @@
     "@mdx-js/mdx": "^2.3.0",
     "@npmcli/package-json": "^4.0.1",
     "@remix-run/node": "2.7.2",
-    "@remix-run/router": "1.15.1",
+    "@remix-run/router": "1.15.2-pre.0",
     "@remix-run/server-runtime": "2.7.2",
     "@types/mdx": "^2.0.5",
     "@vanilla-extract/integration": "^6.2.0",

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -16,10 +16,10 @@
   "typings": "dist/index.d.ts",
   "module": "dist/esm/index.js",
   "dependencies": {
-    "@remix-run/router": "1.15.1",
+    "@remix-run/router": "1.15.2-pre.0",
     "@remix-run/server-runtime": "2.7.2",
-    "react-router": "6.22.1",
-    "react-router-dom": "6.22.1"
+    "react-router": "6.22.2-pre.0",
+    "react-router-dom": "6.22.2-pre.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.17.0",

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -16,7 +16,7 @@
   "typings": "dist/index.d.ts",
   "module": "dist/esm/index.js",
   "dependencies": {
-    "@remix-run/router": "1.15.1",
+    "@remix-run/router": "1.15.2-pre.0",
     "@types/cookie": "^0.6.0",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie": "^0.6.0",

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "@remix-run/node": "2.7.2",
     "@remix-run/react": "2.7.2",
-    "@remix-run/router": "1.15.1",
-    "react-router-dom": "6.22.1"
+    "@remix-run/router": "1.15.2-pre.0",
+    "react-router-dom": "6.22.2-pre.0"
   },
   "devDependencies": {
     "@types/node": "^18.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2482,10 +2482,10 @@
     "@changesets/types" "^5.0.0"
     dotenv "^8.1.0"
 
-"@remix-run/router@1.15.1":
-  version "1.15.1"
-  resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.15.1.tgz#221fd31a65186b9bc027b74573485fb3226dff7f"
-  integrity sha512-zcU0gM3z+3iqj8UX45AmWY810l3oUmXM7uH4dt5xtzvMhRtYVhKGOmgOd1877dOPPepfCjUv57w+syamWIYe7w==
+"@remix-run/router@1.15.2-pre.0":
+  version "1.15.2-pre.0"
+  resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.15.2-pre.0.tgz#7c045fa57c7eeb64306a92c0611949b5d3bebfe5"
+  integrity sha512-87zTVzkwSWTlaHH5vLziaQkyYWTEy8tTs/XPkwKlDfIZVdvnVtuDuwMCsCyzccJw8FxPvS2xoOeExeaQIlhacQ==
 
 "@remix-run/web-blob@^3.1.0":
   version "3.1.0"
@@ -11300,20 +11300,20 @@ react-refresh@^0.14.0:
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
 
-react-router-dom@6.22.1:
-  version "6.22.1"
-  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.1.tgz#cfa109d4b6b0a4d00bac179bc0ad2a6469455282"
-  integrity sha512-iwMyyyrbL7zkKY7MRjOVRy+TMnS/OPusaFVxM2P11x9dzSzGmLsebkCvYirGq0DWB9K9hOspHYYtDz33gE5Duw==
+react-router-dom@6.22.2-pre.0:
+  version "6.22.2-pre.0"
+  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.2-pre.0.tgz#9892bc8bcb15e25b1bc2050fb9f3b80646264d59"
+  integrity sha512-37KoToqJmM8Di0WPojcLQvywjfN8fDUKtRgCxASzjnXnUr2AY55FWMYImBC6/zgwgVCZP8wodKoNysAiBEst8w==
   dependencies:
-    "@remix-run/router" "1.15.1"
-    react-router "6.22.1"
+    "@remix-run/router" "1.15.2-pre.0"
+    react-router "6.22.2-pre.0"
 
-react-router@6.22.1:
-  version "6.22.1"
-  resolved "https://registry.npmjs.org/react-router/-/react-router-6.22.1.tgz#a5ff849bfe709438f7e139421bb28138209662c7"
-  integrity sha512-0pdoRGwLtemnJqn1K0XHUbnKiX0S4X8CgvVVmHGOWmofESj31msHo/1YiqcJWK7Wxfq2a4uvvtS01KAQyWK/CQ==
+react-router@6.22.2-pre.0:
+  version "6.22.2-pre.0"
+  resolved "https://registry.npmjs.org/react-router/-/react-router-6.22.2-pre.0.tgz#2b82e32367b28e962a7f8539c96e8d2bf4efb864"
+  integrity sha512-bVT5azwFuWqfarpI7JV/NdejUR8/2A0N6YTA8X8hhuxYnJZlD/XdWAiErFL8Rfe2emhlJ7Zf3qZTHF+6yLf4fg==
   dependencies:
-    "@remix-run/router" "1.15.1"
+    "@remix-run/router" "1.15.2-pre.0"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
Bump router to latest prerelease and add an integration test for https://github.com/remix-run/remix/issues/8889 which is fixed in RR 6.22.2