### PR TITLE
chore: simplify template entry.server files

### DIFF
--- a/integration/headers-test.ts
+++ b/integration/headers-test.ts
@@ -272,7 +272,7 @@ test.describe("headers export", () => {
     let response = await appFixture.requestDocument("/parent");
     expect(JSON.stringify(Array.from(response.headers.entries()))).toBe(
       JSON.stringify([
-        ["content-type", "text/html"],
+        ["content-type", "text/html; charset=utf-8"],
         ["x-parent-loader", "success"],
       ])
     );
@@ -282,7 +282,7 @@ test.describe("headers export", () => {
     let response = await appFixture.requestDocument("/parent/child");
     expect(JSON.stringify(Array.from(response.headers.entries()))).toBe(
       JSON.stringify([
-        ["content-type", "text/html"],
+        ["content-type", "text/html; charset=utf-8"],
         ["x-parent-loader", "success"],
       ])
     );
@@ -295,7 +295,7 @@ test.describe("headers export", () => {
     );
     expect(JSON.stringify(Array.from(response.headers.entries()))).toBe(
       JSON.stringify([
-        ["content-type", "text/html"],
+        ["content-type", "text/html; charset=utf-8"],
         ["x-parent-action", "success"],
         ["x-parent-loader", "success"],
       ])
@@ -309,7 +309,7 @@ test.describe("headers export", () => {
     );
     expect(JSON.stringify(Array.from(response.headers.entries()))).toBe(
       JSON.stringify([
-        ["content-type", "text/html"],
+        ["content-type", "text/html; charset=utf-8"],
         ["x-parent-loader", "success"],
       ])
     );
@@ -319,7 +319,7 @@ test.describe("headers export", () => {
     let response = await appFixture.requestDocument("/parent?throw=parent");
     expect(JSON.stringify(Array.from(response.headers.entries()))).toBe(
       JSON.stringify([
-        ["content-type", "text/html"],
+        ["content-type", "text/html; charset=utf-8"],
         ["x-parent-loader", "error, error"], // Shows up in loaderHeaders and errorHeaders
       ])
     );
@@ -331,7 +331,7 @@ test.describe("headers export", () => {
     );
     expect(JSON.stringify(Array.from(response.headers.entries()))).toBe(
       JSON.stringify([
-        ["content-type", "text/html"],
+        ["content-type", "text/html; charset=utf-8"],
         ["x-child-loader", "error"],
         ["x-parent-loader", "success"],
       ])
@@ -344,7 +344,7 @@ test.describe("headers export", () => {
     );
     expect(JSON.stringify(Array.from(response.headers.entries()))).toBe(
       JSON.stringify([
-        ["content-type", "text/html"],
+        ["content-type", "text/html; charset=utf-8"],
         ["x-parent-loader", "error, error"], // Shows up in loaderHeaders and errorHeaders
       ])
     );
@@ -356,7 +356,7 @@ test.describe("headers export", () => {
     );
     expect(JSON.stringify(Array.from(response.headers.entries()))).toBe(
       JSON.stringify([
-        ["content-type", "text/html"],
+        ["content-type", "text/html; charset=utf-8"],
         ["x-child-loader", "error"],
         ["x-parent-loader", "success"],
       ])
@@ -370,7 +370,7 @@ test.describe("headers export", () => {
     );
     expect(JSON.stringify(Array.from(response.headers.entries()))).toBe(
       JSON.stringify([
-        ["content-type", "text/html"],
+        ["content-type", "text/html; charset=utf-8"],
         ["x-parent-action", "error, error"], // Shows up in actionHeaders and errorHeaders
       ])
     );
@@ -383,7 +383,7 @@ test.describe("headers export", () => {
     );
     expect(JSON.stringify(Array.from(response.headers.entries()))).toBe(
       JSON.stringify([
-        ["content-type", "text/html"],
+        ["content-type", "text/html; charset=utf-8"],
         ["x-child-action", "error"],
       ])
     );
@@ -393,7 +393,7 @@ test.describe("headers export", () => {
     let response = await appFixture.requestDocument("/cookie/child");
     expect(JSON.stringify(Array.from(response.headers.entries()))).toBe(
       JSON.stringify([
-        ["content-type", "text/html"],
+        ["content-type", "text/html; charset=utf-8"],
         ["set-cookie", "normal-cookie=true"],
       ])
     );
@@ -403,7 +403,7 @@ test.describe("headers export", () => {
     let response = await appFixture.requestDocument("/cookie/child?throw");
     expect(JSON.stringify(Array.from(response.headers.entries()))).toBe(
       JSON.stringify([
-        ["content-type", "text/html"],
+        ["content-type", "text/html; charset=utf-8"],
         ["set-cookie", "thrown-cookie=true"],
       ])
     );
@@ -413,7 +413,7 @@ test.describe("headers export", () => {
     let response = await appFixture.requestDocument("/cookie?parent-throw");
     expect(JSON.stringify(Array.from(response.headers.entries()))).toBe(
       JSON.stringify([
-        ["content-type", "text/html"],
+        ["content-type", "text/html; charset=utf-8"],
         ["set-cookie", "parent-thrown-cookie=true"],
       ])
     );

--- a/packages/remix-dev/config/defaults/entry.server.cloudflare.tsx
+++ b/packages/remix-dev/config/defaults/entry.server.cloudflare.tsx
@@ -1,3 +1,9 @@
+/**
+ * By default, Remix will handle generating the HTTP Response for you.
+ * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
+ * For more information, see https://remix.run/file-conventions/entry.server
+ */
+
 import type { AppLoadContext, EntryContext } from "@remix-run/cloudflare";
 import { RemixServer } from "@remix-run/react";
 import * as isbotModule from "isbot";
@@ -8,30 +14,44 @@ export default async function handleRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   remixContext: EntryContext,
+  // This is ignored so we can keep it in the template for visibility.  Feel
+  // free to delete this parameter in your app if you're not using it!
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   loadContext: AppLoadContext
 ) {
+  let status = responseStatusCode;
+  const headers = new Headers(responseHeaders);
+  headers.set("Content-Type", "text/html; charset=utf-8");
+  headers.set("Transfer-Encoding", "chunked");
+
+  let shellRendered = false;
   const body = await renderToReadableStream(
     <RemixServer context={remixContext} url={request.url} />,
     {
       signal: request.signal,
       onError(error: unknown) {
-        // Log streaming rendering errors from inside the shell
-        console.error(error);
-        responseStatusCode = 500;
+        status = 500;
+        // Log streaming rendering errors from inside the shell.  Don't log
+        // errors encountered during initial shell rendering since they'll
+        // reject and get logged in handleDocumentRequest.
+        if (shellRendered) {
+          console.error(error);
+        }
       },
     }
   );
+  shellRendered = true;
 
-  if (isBotRequest(request.headers.get("user-agent"))) {
+  if (isBotRequest(request.headers.get("user-agent") || "")) {
     await body.allReady;
   }
 
-  responseHeaders.set("Content-Type", "text/html");
   return new Response(body, {
-    headers: responseHeaders,
-    status: responseStatusCode,
+    headers,
+    status,
   });
 }
+
 
 // We have some Remix apps in the wild already running with isbot@3 so we need
 // to maintain backwards compatibility even though we want new apps to use

--- a/packages/remix-dev/config/defaults/entry.server.deno.tsx
+++ b/packages/remix-dev/config/defaults/entry.server.deno.tsx
@@ -1,3 +1,9 @@
+/**
+ * By default, Remix will handle generating the HTTP Response for you.
+ * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
+ * For more information, see https://remix.run/file-conventions/entry.server
+ */
+
 import type { AppLoadContext, EntryContext } from "@remix-run/deno";
 import { RemixServer } from "@remix-run/react";
 import * as isbotModule from "isbot";
@@ -8,30 +14,44 @@ export default async function handleRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   remixContext: EntryContext,
+  // This is ignored so we can keep it in the template for visibility.  Feel
+  // free to delete this parameter in your app if you're not using it!
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   loadContext: AppLoadContext
 ) {
+  let status = responseStatusCode;
+  const headers = new Headers(responseHeaders);
+  headers.set("Content-Type", "text/html; charset=utf-8");
+  headers.set("Transfer-Encoding", "chunked");
+
+  let shellRendered = false;
   const body = await renderToReadableStream(
     <RemixServer context={remixContext} url={request.url} />,
     {
       signal: request.signal,
       onError(error: unknown) {
-        // Log streaming rendering errors from inside the shell
-        console.error(error);
-        responseStatusCode = 500;
+        status = 500;
+        // Log streaming rendering errors from inside the shell.  Don't log
+        // errors encountered during initial shell rendering since they'll
+        // reject and get logged in handleDocumentRequest.
+        if (shellRendered) {
+          console.error(error);
+        }
       },
     }
   );
+  shellRendered = true;
 
-  if (isBotRequest(request.headers.get("user-agent"))) {
+  if (isBotRequest(request.headers.get("user-agent") || "")) {
     await body.allReady;
   }
 
-  responseHeaders.set("Content-Type", "text/html");
   return new Response(body, {
-    headers: responseHeaders,
-    status: responseStatusCode,
+    headers,
+    status,
   });
 }
+
 
 // We have some Remix apps in the wild already running with isbot@3 so we need
 // to maintain backwards compatibility even though we want new apps to use

--- a/packages/remix-dev/config/defaults/entry.server.node.tsx
+++ b/packages/remix-dev/config/defaults/entry.server.node.tsx
@@ -1,3 +1,8 @@
+/**
+ * By default, Remix will handle generating the HTTP Response for you.
+ * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
+ * For more information, see https://remix.run/file-conventions/entry.server
+ */
 import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
@@ -13,22 +18,73 @@ export default function handleRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   remixContext: EntryContext,
+  // This is ignored so we can keep it in the template for visibility.  Feel
+  // free to delete this parameter in your app if you're not using it!
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   loadContext: AppLoadContext
 ) {
-  return isBotRequest(request.headers.get("user-agent"))
-    ? handleBotRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      )
-    : handleBrowserRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      );
+  const isBot = isBotRequest(request.headers.get("user-agent") || "");
+
+  let status = responseStatusCode;
+  const headers = new Headers(responseHeaders);
+  headers.set("Content-Type", "text/html; charset=utf-8");
+
+  return new Promise((resolve, reject) => {
+    let shellRendered = false;
+    const { pipe, abort } = renderToPipeableStream(
+      <RemixServer
+        context={remixContext}
+        url={request.url}
+        abortDelay={ABORT_DELAY}
+      />,
+      {
+        onAllReady() {
+          if (!isBot) return;
+
+          resolve(
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
+          );
+        },
+        onShellReady() {
+          shellRendered = true;
+
+          if (isBot) return;
+
+          resolve(
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
+          );
+        },
+        onShellError(error: unknown) {
+          reject(error);
+        },
+        onError(error: unknown) {
+          status = 500;
+          // Log streaming rendering errors from inside the shell.  Don't log
+          // errors encountered during initial shell rendering since they'll
+          // reject and get logged in handleDocumentRequest.
+          if (shellRendered) {
+            console.error(error);
+          }
+        },
+      }
+    );
+
+    setTimeout(abort, ABORT_DELAY);
+  });
 }
+
 
 // We have some Remix apps in the wild already running with isbot@3 so we need
 // to maintain backwards compatibility even though we want new apps to use
@@ -49,104 +105,4 @@ function isBotRequest(userAgent: string | null) {
   }
 
   return false;
-}
-
-function handleBotRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  remixContext: EntryContext
-) {
-  return new Promise((resolve, reject) => {
-    let shellRendered = false;
-    const { pipe, abort } = renderToPipeableStream(
-      <RemixServer
-        context={remixContext}
-        url={request.url}
-        abortDelay={ABORT_DELAY}
-      />,
-      {
-        onAllReady() {
-          shellRendered = true;
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
-
-          responseHeaders.set("Content-Type", "text/html");
-
-          resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
-          );
-
-          pipe(body);
-        },
-        onShellError(error: unknown) {
-          reject(error);
-        },
-        onError(error: unknown) {
-          responseStatusCode = 500;
-          // Log streaming rendering errors from inside the shell.  Don't log
-          // errors encountered during initial shell rendering since they'll
-          // reject and get logged in handleDocumentRequest.
-          if (shellRendered) {
-            console.error(error);
-          }
-        },
-      }
-    );
-
-    setTimeout(abort, ABORT_DELAY);
-  });
-}
-
-function handleBrowserRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  remixContext: EntryContext
-) {
-  return new Promise((resolve, reject) => {
-    let shellRendered = false;
-    const { pipe, abort } = renderToPipeableStream(
-      <RemixServer
-        context={remixContext}
-        url={request.url}
-        abortDelay={ABORT_DELAY}
-      />,
-      {
-        onShellReady() {
-          shellRendered = true;
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
-
-          responseHeaders.set("Content-Type", "text/html");
-
-          resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
-          );
-
-          pipe(body);
-        },
-        onShellError(error: unknown) {
-          reject(error);
-        },
-        onError(error: unknown) {
-          responseStatusCode = 500;
-          // Log streaming rendering errors from inside the shell.  Don't log
-          // errors encountered during initial shell rendering since they'll
-          // reject and get logged in handleDocumentRequest.
-          if (shellRendered) {
-            console.error(error);
-          }
-        },
-      }
-    );
-
-    setTimeout(abort, ABORT_DELAY);
-  });
 }

--- a/templates/arc/app/entry.server.tsx
+++ b/templates/arc/app/entry.server.tsx
@@ -3,7 +3,6 @@
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
  * For more information, see https://remix.run/file-conventions/entry.server
  */
-
 import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
@@ -24,27 +23,12 @@ export default function handleRequest(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   loadContext: AppLoadContext
 ) {
-  return isbot(request.headers.get("user-agent") || "")
-    ? handleBotRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      )
-    : handleBrowserRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      );
-}
+  const isBot = isbot(request.headers.get("user-agent") || "");
 
-function handleBotRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  remixContext: EntryContext
-) {
+  let status = responseStatusCode;
+  const headers = new Headers(responseHeaders);
+  headers.set("Content-Type", "text/html; charset=utf-8");
+
   return new Promise((resolve, reject) => {
     let shellRendered = false;
     const { pipe, abort } = renderToPipeableStream(
@@ -55,76 +39,38 @@ function handleBotRequest(
       />,
       {
         onAllReady() {
-          shellRendered = true;
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
-
-          responseHeaders.set("Content-Type", "text/html");
+          if (!isBot) return;
 
           resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
           );
-
-          pipe(body);
         },
-        onShellError(error: unknown) {
-          reject(error);
-        },
-        onError(error: unknown) {
-          responseStatusCode = 500;
-          // Log streaming rendering errors from inside the shell.  Don't log
-          // errors encountered during initial shell rendering since they'll
-          // reject and get logged in handleDocumentRequest.
-          if (shellRendered) {
-            console.error(error);
-          }
-        },
-      }
-    );
-
-    setTimeout(abort, ABORT_DELAY);
-  });
-}
-
-function handleBrowserRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  remixContext: EntryContext
-) {
-  return new Promise((resolve, reject) => {
-    let shellRendered = false;
-    const { pipe, abort } = renderToPipeableStream(
-      <RemixServer
-        context={remixContext}
-        url={request.url}
-        abortDelay={ABORT_DELAY}
-      />,
-      {
         onShellReady() {
           shellRendered = true;
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
 
-          responseHeaders.set("Content-Type", "text/html");
+          if (isBot) return;
 
           resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
           );
-
-          pipe(body);
         },
         onShellError(error: unknown) {
           reject(error);
         },
         onError(error: unknown) {
-          responseStatusCode = 500;
+          status = 500;
           // Log streaming rendering errors from inside the shell.  Don't log
           // errors encountered during initial shell rendering since they'll
           // reject and get logged in handleDocumentRequest.

--- a/templates/cloudflare-pages/app/entry.server.tsx
+++ b/templates/cloudflare-pages/app/entry.server.tsx
@@ -19,25 +19,35 @@ export default async function handleRequest(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   loadContext: AppLoadContext
 ) {
+  let status = responseStatusCode;
+  const headers = new Headers(responseHeaders);
+  headers.set("Content-Type", "text/html; charset=utf-8");
+  headers.set("Transfer-Encoding", "chunked");
+
+  let shellRendered = false;
   const body = await renderToReadableStream(
     <RemixServer context={remixContext} url={request.url} />,
     {
       signal: request.signal,
       onError(error: unknown) {
-        // Log streaming rendering errors from inside the shell
-        console.error(error);
-        responseStatusCode = 500;
+        status = 500;
+        // Log streaming rendering errors from inside the shell.  Don't log
+        // errors encountered during initial shell rendering since they'll
+        // reject and get logged in handleDocumentRequest.
+        if (shellRendered) {
+          console.error(error);
+        }
       },
     }
   );
+  shellRendered = true;
 
   if (isbot(request.headers.get("user-agent") || "")) {
     await body.allReady;
   }
 
-  responseHeaders.set("Content-Type", "text/html");
   return new Response(body, {
-    headers: responseHeaders,
-    status: responseStatusCode,
+    headers,
+    status,
   });
 }

--- a/templates/cloudflare-workers/app/entry.server.tsx
+++ b/templates/cloudflare-workers/app/entry.server.tsx
@@ -19,25 +19,35 @@ export default async function handleRequest(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   loadContext: AppLoadContext
 ) {
+  let status = responseStatusCode;
+  const headers = new Headers(responseHeaders);
+  headers.set("Content-Type", "text/html; charset=utf-8");
+  headers.set("Transfer-Encoding", "chunked");
+
+  let shellRendered = false;
   const body = await renderToReadableStream(
     <RemixServer context={remixContext} url={request.url} />,
     {
       signal: request.signal,
       onError(error: unknown) {
-        // Log streaming rendering errors from inside the shell
-        console.error(error);
-        responseStatusCode = 500;
+        status = 500;
+        // Log streaming rendering errors from inside the shell.  Don't log
+        // errors encountered during initial shell rendering since they'll
+        // reject and get logged in handleDocumentRequest.
+        if (shellRendered) {
+          console.error(error);
+        }
       },
     }
   );
+  shellRendered = true;
 
   if (isbot(request.headers.get("user-agent") || "")) {
     await body.allReady;
   }
 
-  responseHeaders.set("Content-Type", "text/html");
   return new Response(body, {
-    headers: responseHeaders,
-    status: responseStatusCode,
+    headers,
+    status,
   });
 }

--- a/templates/deno/app/entry.server.tsx
+++ b/templates/deno/app/entry.server.tsx
@@ -17,27 +17,37 @@ export default async function handleRequest(
   // This is ignored so we can keep it in the template for visibility.  Feel
   // free to delete this parameter in your app if you're not using it!
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  loadContext: AppLoadContext,
+  loadContext: AppLoadContext
 ) {
+  let status = responseStatusCode;
+  const headers = new Headers(responseHeaders);
+  headers.set("Content-Type", "text/html; charset=utf-8");
+  headers.set("Transfer-Encoding", "chunked");
+
+  let shellRendered = false;
   const body = await renderToReadableStream(
     <RemixServer context={remixContext} url={request.url} />,
     {
       signal: request.signal,
       onError(error: unknown) {
-        // Log streaming rendering errors from inside the shell
-        console.error(error);
-        responseStatusCode = 500;
+        status = 500;
+        // Log streaming rendering errors from inside the shell.  Don't log
+        // errors encountered during initial shell rendering since they'll
+        // reject and get logged in handleDocumentRequest.
+        if (shellRendered) {
+          console.error(error);
+        }
       },
-    },
+    }
   );
+  shellRendered = true;
 
   if (isbot(request.headers.get("user-agent") || "")) {
     await body.allReady;
   }
 
-  responseHeaders.set("Content-Type", "text/html");
   return new Response(body, {
-    headers: responseHeaders,
-    status: responseStatusCode,
+    headers,
+    status,
   });
 }

--- a/templates/express/app/entry.server.tsx
+++ b/templates/express/app/entry.server.tsx
@@ -3,7 +3,6 @@
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
  * For more information, see https://remix.run/file-conventions/entry.server
  */
-
 import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
@@ -24,27 +23,12 @@ export default function handleRequest(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   loadContext: AppLoadContext
 ) {
-  return isbot(request.headers.get("user-agent") || "")
-    ? handleBotRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      )
-    : handleBrowserRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      );
-}
+  const isBot = isbot(request.headers.get("user-agent") || "");
 
-function handleBotRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  remixContext: EntryContext
-) {
+  let status = responseStatusCode;
+  const headers = new Headers(responseHeaders);
+  headers.set("Content-Type", "text/html; charset=utf-8");
+
   return new Promise((resolve, reject) => {
     let shellRendered = false;
     const { pipe, abort } = renderToPipeableStream(
@@ -55,76 +39,38 @@ function handleBotRequest(
       />,
       {
         onAllReady() {
-          shellRendered = true;
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
-
-          responseHeaders.set("Content-Type", "text/html");
+          if (!isBot) return;
 
           resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
           );
-
-          pipe(body);
         },
-        onShellError(error: unknown) {
-          reject(error);
-        },
-        onError(error: unknown) {
-          responseStatusCode = 500;
-          // Log streaming rendering errors from inside the shell.  Don't log
-          // errors encountered during initial shell rendering since they'll
-          // reject and get logged in handleDocumentRequest.
-          if (shellRendered) {
-            console.error(error);
-          }
-        },
-      }
-    );
-
-    setTimeout(abort, ABORT_DELAY);
-  });
-}
-
-function handleBrowserRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  remixContext: EntryContext
-) {
-  return new Promise((resolve, reject) => {
-    let shellRendered = false;
-    const { pipe, abort } = renderToPipeableStream(
-      <RemixServer
-        context={remixContext}
-        url={request.url}
-        abortDelay={ABORT_DELAY}
-      />,
-      {
         onShellReady() {
           shellRendered = true;
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
 
-          responseHeaders.set("Content-Type", "text/html");
+          if (isBot) return;
 
           resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
           );
-
-          pipe(body);
         },
         onShellError(error: unknown) {
           reject(error);
         },
         onError(error: unknown) {
-          responseStatusCode = 500;
+          status = 500;
           // Log streaming rendering errors from inside the shell.  Don't log
           // errors encountered during initial shell rendering since they'll
           // reject and get logged in handleDocumentRequest.

--- a/templates/fly/app/entry.server.tsx
+++ b/templates/fly/app/entry.server.tsx
@@ -3,7 +3,6 @@
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
  * For more information, see https://remix.run/file-conventions/entry.server
  */
-
 import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
@@ -24,27 +23,12 @@ export default function handleRequest(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   loadContext: AppLoadContext
 ) {
-  return isbot(request.headers.get("user-agent") || "")
-    ? handleBotRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      )
-    : handleBrowserRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      );
-}
+  const isBot = isbot(request.headers.get("user-agent") || "");
 
-function handleBotRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  remixContext: EntryContext
-) {
+  let status = responseStatusCode;
+  const headers = new Headers(responseHeaders);
+  headers.set("Content-Type", "text/html; charset=utf-8");
+
   return new Promise((resolve, reject) => {
     let shellRendered = false;
     const { pipe, abort } = renderToPipeableStream(
@@ -55,76 +39,38 @@ function handleBotRequest(
       />,
       {
         onAllReady() {
-          shellRendered = true;
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
-
-          responseHeaders.set("Content-Type", "text/html");
+          if (!isBot) return;
 
           resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
           );
-
-          pipe(body);
         },
-        onShellError(error: unknown) {
-          reject(error);
-        },
-        onError(error: unknown) {
-          responseStatusCode = 500;
-          // Log streaming rendering errors from inside the shell.  Don't log
-          // errors encountered during initial shell rendering since they'll
-          // reject and get logged in handleDocumentRequest.
-          if (shellRendered) {
-            console.error(error);
-          }
-        },
-      }
-    );
-
-    setTimeout(abort, ABORT_DELAY);
-  });
-}
-
-function handleBrowserRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  remixContext: EntryContext
-) {
-  return new Promise((resolve, reject) => {
-    let shellRendered = false;
-    const { pipe, abort } = renderToPipeableStream(
-      <RemixServer
-        context={remixContext}
-        url={request.url}
-        abortDelay={ABORT_DELAY}
-      />,
-      {
         onShellReady() {
           shellRendered = true;
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
 
-          responseHeaders.set("Content-Type", "text/html");
+          if (isBot) return;
 
           resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
           );
-
-          pipe(body);
         },
         onShellError(error: unknown) {
           reject(error);
         },
         onError(error: unknown) {
-          responseStatusCode = 500;
+          status = 500;
           // Log streaming rendering errors from inside the shell.  Don't log
           // errors encountered during initial shell rendering since they'll
           // reject and get logged in handleDocumentRequest.

--- a/templates/remix-javascript/app/entry.server.jsx
+++ b/templates/remix-javascript/app/entry.server.jsx
@@ -19,7 +19,7 @@ export default function handleRequest(
   remixContext,
   // This is ignored so we can keep it in the template for visibility.  Feel
   // free to delete this parameter in your app if you're not using it!
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line no-unused-vars
   loadContext
 ) {
   const isBot = isbot(request.headers.get("user-agent") || "");

--- a/templates/remix-javascript/app/entry.server.jsx
+++ b/templates/remix-javascript/app/entry.server.jsx
@@ -3,7 +3,6 @@
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
  * For more information, see https://remix.run/file-conventions/entry.server
  */
-
 import { PassThrough } from "node:stream";
 
 import { createReadableStreamFromReadable } from "@remix-run/node";
@@ -17,30 +16,20 @@ export default function handleRequest(
   request,
   responseStatusCode,
   responseHeaders,
-  remixContext
+  remixContext,
+  // This is ignored so we can keep it in the template for visibility.  Feel
+  // free to delete this parameter in your app if you're not using it!
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  loadContext
 ) {
-  return isbot(request.headers.get("user-agent") || "")
-    ? handleBotRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      )
-    : handleBrowserRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      );
-}
+  const isBot = isbot(request.headers.get("user-agent") || "");
 
-function handleBotRequest(
-  request,
-  responseStatusCode,
-  responseHeaders,
-  remixContext
-) {
+  let status = responseStatusCode;
+  const headers = new Headers(responseHeaders);
+  headers.set("Content-Type", "text/html; charset=utf-8");
+
   return new Promise((resolve, reject) => {
+    let shellRendered = false;
     const { pipe, abort } = renderToPipeableStream(
       <RemixServer
         context={remixContext}
@@ -49,69 +38,44 @@ function handleBotRequest(
       />,
       {
         onAllReady() {
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
-
-          responseHeaders.set("Content-Type", "text/html");
+          if (!isBot) return;
 
           resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
           );
-
-          pipe(body);
         },
-        onShellError(error) {
-          reject(error);
-        },
-        onError(error) {
-          responseStatusCode = 500;
-          console.error(error);
-        },
-      }
-    );
-
-    setTimeout(abort, ABORT_DELAY);
-  });
-}
-
-function handleBrowserRequest(
-  request,
-  responseStatusCode,
-  responseHeaders,
-  remixContext
-) {
-  return new Promise((resolve, reject) => {
-    const { pipe, abort } = renderToPipeableStream(
-      <RemixServer
-        context={remixContext}
-        url={request.url}
-        abortDelay={ABORT_DELAY}
-      />,
-      {
         onShellReady() {
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
+          shellRendered = true;
 
-          responseHeaders.set("Content-Type", "text/html");
+          if (isBot) return;
 
           resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
           );
-
-          pipe(body);
         },
         onShellError(error) {
           reject(error);
         },
         onError(error) {
-          console.error(error);
-          responseStatusCode = 500;
+          status = 500;
+          // Log streaming rendering errors from inside the shell.  Don't log
+          // errors encountered during initial shell rendering since they'll
+          // reject and get logged in handleDocumentRequest.
+          if (shellRendered) {
+            console.error(error);
+          }
         },
       }
     );

--- a/templates/remix/app/entry.server.tsx
+++ b/templates/remix/app/entry.server.tsx
@@ -3,7 +3,6 @@
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
  * For more information, see https://remix.run/file-conventions/entry.server
  */
-
 import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
@@ -24,27 +23,12 @@ export default function handleRequest(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   loadContext: AppLoadContext
 ) {
-  return isbot(request.headers.get("user-agent") || "")
-    ? handleBotRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      )
-    : handleBrowserRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      );
-}
+  const isBot = isbot(request.headers.get("user-agent") || "");
 
-function handleBotRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  remixContext: EntryContext
-) {
+  let status = responseStatusCode;
+  const headers = new Headers(responseHeaders);
+  headers.set("Content-Type", "text/html; charset=utf-8");
+
   return new Promise((resolve, reject) => {
     let shellRendered = false;
     const { pipe, abort } = renderToPipeableStream(
@@ -55,76 +39,38 @@ function handleBotRequest(
       />,
       {
         onAllReady() {
-          shellRendered = true;
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
-
-          responseHeaders.set("Content-Type", "text/html");
+          if (!isBot) return;
 
           resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
           );
-
-          pipe(body);
         },
-        onShellError(error: unknown) {
-          reject(error);
-        },
-        onError(error: unknown) {
-          responseStatusCode = 500;
-          // Log streaming rendering errors from inside the shell.  Don't log
-          // errors encountered during initial shell rendering since they'll
-          // reject and get logged in handleDocumentRequest.
-          if (shellRendered) {
-            console.error(error);
-          }
-        },
-      }
-    );
-
-    setTimeout(abort, ABORT_DELAY);
-  });
-}
-
-function handleBrowserRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  remixContext: EntryContext
-) {
-  return new Promise((resolve, reject) => {
-    let shellRendered = false;
-    const { pipe, abort } = renderToPipeableStream(
-      <RemixServer
-        context={remixContext}
-        url={request.url}
-        abortDelay={ABORT_DELAY}
-      />,
-      {
         onShellReady() {
           shellRendered = true;
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
 
-          responseHeaders.set("Content-Type", "text/html");
+          if (isBot) return;
 
           resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
           );
-
-          pipe(body);
         },
         onShellError(error: unknown) {
           reject(error);
         },
         onError(error: unknown) {
-          responseStatusCode = 500;
+          status = 500;
           // Log streaming rendering errors from inside the shell.  Don't log
           // errors encountered during initial shell rendering since they'll
           // reject and get logged in handleDocumentRequest.

--- a/templates/vite-cloudflare/app/entry.server.tsx
+++ b/templates/vite-cloudflare/app/entry.server.tsx
@@ -19,25 +19,35 @@ export default async function handleRequest(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   loadContext: AppLoadContext
 ) {
+  let status = responseStatusCode;
+  const headers = new Headers(responseHeaders);
+  headers.set("Content-Type", "text/html; charset=utf-8");
+  headers.set("Transfer-Encoding", "chunked");
+
+  let shellRendered = false;
   const body = await renderToReadableStream(
     <RemixServer context={remixContext} url={request.url} />,
     {
       signal: request.signal,
       onError(error: unknown) {
-        // Log streaming rendering errors from inside the shell
-        console.error(error);
-        responseStatusCode = 500;
+        status = 500;
+        // Log streaming rendering errors from inside the shell.  Don't log
+        // errors encountered during initial shell rendering since they'll
+        // reject and get logged in handleDocumentRequest.
+        if (shellRendered) {
+          console.error(error);
+        }
       },
     }
   );
+  shellRendered = true;
 
   if (isbot(request.headers.get("user-agent") || "")) {
     await body.allReady;
   }
 
-  responseHeaders.set("Content-Type", "text/html");
   return new Response(body, {
-    headers: responseHeaders,
-    status: responseStatusCode,
+    headers,
+    status,
   });
 }

--- a/templates/vite-express/app/entry.server.tsx
+++ b/templates/vite-express/app/entry.server.tsx
@@ -3,7 +3,6 @@
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
  * For more information, see https://remix.run/file-conventions/entry.server
  */
-
 import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
@@ -24,27 +23,12 @@ export default function handleRequest(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   loadContext: AppLoadContext
 ) {
-  return isbot(request.headers.get("user-agent") || "")
-    ? handleBotRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      )
-    : handleBrowserRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      );
-}
+  const isBot = isbot(request.headers.get("user-agent") || "");
 
-function handleBotRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  remixContext: EntryContext
-) {
+  let status = responseStatusCode;
+  const headers = new Headers(responseHeaders);
+  headers.set("Content-Type", "text/html; charset=utf-8");
+
   return new Promise((resolve, reject) => {
     let shellRendered = false;
     const { pipe, abort } = renderToPipeableStream(
@@ -55,76 +39,38 @@ function handleBotRequest(
       />,
       {
         onAllReady() {
-          shellRendered = true;
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
-
-          responseHeaders.set("Content-Type", "text/html");
+          if (!isBot) return;
 
           resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
           );
-
-          pipe(body);
         },
-        onShellError(error: unknown) {
-          reject(error);
-        },
-        onError(error: unknown) {
-          responseStatusCode = 500;
-          // Log streaming rendering errors from inside the shell.  Don't log
-          // errors encountered during initial shell rendering since they'll
-          // reject and get logged in handleDocumentRequest.
-          if (shellRendered) {
-            console.error(error);
-          }
-        },
-      }
-    );
-
-    setTimeout(abort, ABORT_DELAY);
-  });
-}
-
-function handleBrowserRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  remixContext: EntryContext
-) {
-  return new Promise((resolve, reject) => {
-    let shellRendered = false;
-    const { pipe, abort } = renderToPipeableStream(
-      <RemixServer
-        context={remixContext}
-        url={request.url}
-        abortDelay={ABORT_DELAY}
-      />,
-      {
         onShellReady() {
           shellRendered = true;
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
 
-          responseHeaders.set("Content-Type", "text/html");
+          if (isBot) return;
 
           resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
           );
-
-          pipe(body);
         },
         onShellError(error: unknown) {
           reject(error);
         },
         onError(error: unknown) {
-          responseStatusCode = 500;
+          status = 500;
           // Log streaming rendering errors from inside the shell.  Don't log
           // errors encountered during initial shell rendering since they'll
           // reject and get logged in handleDocumentRequest.

--- a/templates/vite/app/entry.server.tsx
+++ b/templates/vite/app/entry.server.tsx
@@ -3,7 +3,6 @@
  * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
  * For more information, see https://remix.run/file-conventions/entry.server
  */
-
 import { PassThrough } from "node:stream";
 
 import type { AppLoadContext, EntryContext } from "@remix-run/node";
@@ -24,27 +23,12 @@ export default function handleRequest(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   loadContext: AppLoadContext
 ) {
-  return isbot(request.headers.get("user-agent") || "")
-    ? handleBotRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      )
-    : handleBrowserRequest(
-        request,
-        responseStatusCode,
-        responseHeaders,
-        remixContext
-      );
-}
+  const isBot = isbot(request.headers.get("user-agent") || "");
 
-function handleBotRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  remixContext: EntryContext
-) {
+  let status = responseStatusCode;
+  const headers = new Headers(responseHeaders);
+  headers.set("Content-Type", "text/html; charset=utf-8");
+
   return new Promise((resolve, reject) => {
     let shellRendered = false;
     const { pipe, abort } = renderToPipeableStream(
@@ -55,76 +39,38 @@ function handleBotRequest(
       />,
       {
         onAllReady() {
-          shellRendered = true;
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
-
-          responseHeaders.set("Content-Type", "text/html");
+          if (!isBot) return;
 
           resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
           );
-
-          pipe(body);
         },
-        onShellError(error: unknown) {
-          reject(error);
-        },
-        onError(error: unknown) {
-          responseStatusCode = 500;
-          // Log streaming rendering errors from inside the shell.  Don't log
-          // errors encountered during initial shell rendering since they'll
-          // reject and get logged in handleDocumentRequest.
-          if (shellRendered) {
-            console.error(error);
-          }
-        },
-      }
-    );
-
-    setTimeout(abort, ABORT_DELAY);
-  });
-}
-
-function handleBrowserRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  remixContext: EntryContext
-) {
-  return new Promise((resolve, reject) => {
-    let shellRendered = false;
-    const { pipe, abort } = renderToPipeableStream(
-      <RemixServer
-        context={remixContext}
-        url={request.url}
-        abortDelay={ABORT_DELAY}
-      />,
-      {
         onShellReady() {
           shellRendered = true;
-          const body = new PassThrough();
-          const stream = createReadableStreamFromReadable(body);
 
-          responseHeaders.set("Content-Type", "text/html");
+          if (isBot) return;
 
           resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
+            new Response(
+              createReadableStreamFromReadable(pipe(new PassThrough())),
+              {
+                headers,
+                status,
+              }
+            )
           );
-
-          pipe(body);
         },
         onShellError(error: unknown) {
           reject(error);
         },
         onError(error: unknown) {
-          responseStatusCode = 500;
+          status = 500;
           // Log streaming rendering errors from inside the shell.  Don't log
           // errors encountered during initial shell rendering since they'll
           // reject and get logged in handleDocumentRequest.


### PR DESCRIPTION
- properly handle errors in Cloudflare template
- drastically simplify node templates

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
