### PR TITLE
Fix incorrect `MetaFunction` import in vite-cloudflare template

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -639,6 +639,7 @@
 - wladiston
 - wtlin1228
 - wxh06
+- xanderberkein
 - xdivby0
 - xHomu
 - XiNiHa

--- a/templates/vite-cloudflare/app/routes/_index.tsx
+++ b/templates/vite-cloudflare/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "@remix-run/node";
+import type { MetaFunction } from "@remix-run/cloudflare";
 
 export const meta: MetaFunction = () => {
   return [


### PR DESCRIPTION
The vite-cloudflare template imports from `@remix-run/node` instead of `@remix-run/cloudflare` in `_index.tsx`. This PR updates the import statement.