### PR TITLE
Don't run Build/Test CI on PR's that only touch templates

### DIFF
--- a/.github/workflows/test-pr-ubuntu.yml
+++ b/.github/workflows/test-pr-ubuntu.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths-ignore:
       - "docs/**"
+      - "templates/**"
       - "scripts/**"
       - "contributors.yml"
       - "**/*.md"


### PR DESCRIPTION
None of our CI Build/Unit/E2E test stuff checks any `templates` I don't think?