### PR TITLE
Add `server.fs.allow` to Vite templates

### DIFF
--- a/templates/spa/vite.config.ts
+++ b/templates/spa/vite.config.ts
@@ -3,13 +3,29 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [remix({ ssr: false }), tsconfigPaths()],
+  plugins: [
+    remix({
+      ssr: false,
+    }),
+    tsconfigPaths(),
+  ],
   ssr: {
-    // Bundle all dependencies during the server build by default to avoid
-    // most ESM/CJS issues.  This may slow down your build a bit -- if so, you
-    // can try removing this option, or switching to a more targeted array
-    // containing the specific dependencies you wish to bundle.
-    // See https://vitejs.dev/config/ssr-options#ssr-noexternal for more information
+    // Bundle all dependencies during the server build by default to avoid most
+    // ESM/CJS issues.  This may slow down your build a bit -- if so, you can
+    // try removing this option, or switching to a more targeted array
+    // containing the specific dependencies you wish to bundle. See more:
+    // https://vitejs.dev/config/ssr-options#ssr-noexternal
     noExternal: true,
+  },
+  server: {
+    fs: {
+      // Restrict files that could be served by Vite's dev server.  Accessing
+      // files outside this directory list that aren't imported from an allowed
+      // file will result in a 403.  Both directories and files can be provided.
+      // If you're comfortable with Vite's dev server making any file within the
+      // project root available, you can remove this option.  See more:
+      // https://vitejs.dev/config/server-options.html#server-fs-allow
+      allow: ["app"],
+    },
   },
 });

--- a/templates/vite-cloudflare/vite.config.ts
+++ b/templates/vite-cloudflare/vite.config.ts
@@ -7,4 +7,15 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [remixCloudflareDevProxy(), remix(), tsconfigPaths()],
+  server: {
+    fs: {
+      // Restrict files that could be served by Vite's dev server.  Accessing
+      // files outside this directory list that aren't imported from an allowed
+      // file will result in a 403.  Both directories and files can be provided.
+      // If you're comfortable with Vite's dev server making any file within the
+      // project root available, you can remove this option.  See more:
+      // https://vitejs.dev/config/server-options.html#server-fs-allow
+      allow: ["app"],
+    },
+  },
 });

--- a/templates/vite-express/vite.config.ts
+++ b/templates/vite-express/vite.config.ts
@@ -4,4 +4,15 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [remix(), tsconfigPaths()],
+  server: {
+    fs: {
+      // Restrict files that could be served by Vite's dev server.  Accessing
+      // files outside this directory list that aren't imported from an allowed
+      // file will result in a 403.  Both directories and files can be provided.
+      // If you're comfortable with Vite's dev server making any file within the
+      // project root available, you can remove this option.  See more:
+      // https://vitejs.dev/config/server-options.html#server-fs-allow
+      allow: ["app"],
+    },
+  },
 });

--- a/templates/vite/vite.config.ts
+++ b/templates/vite/vite.config.ts
@@ -7,4 +7,15 @@ installGlobals();
 
 export default defineConfig({
   plugins: [remix(), tsconfigPaths()],
+  server: {
+    fs: {
+      // Restrict files that could be served by Vite's dev server.  Accessing
+      // files outside this directory list that aren't imported from an allowed
+      // file will result in a 403.  Both directories and files can be provided.
+      // If you're comfortable with Vite's dev server making any file within the
+      // project root available, you can remove this option.  See more:
+      // https://vitejs.dev/config/server-options.html#server-fs-allow
+      allow: ["app"],
+    },
+  },
 });


### PR DESCRIPTION
This gives consumers a more locked-down dev server by default without forcing it on every plugin consumer. We may want to revisit this, but this is a safe first step since consumers can always modify/delete it if it's causing trouble.

https://vitejs.dev/config/server-options.html#server-fs-allow