### PR TITLE
Remove `ssr.noExternal` from SPA template

### DIFF
--- a/templates/spa/vite.config.ts
+++ b/templates/spa/vite.config.ts
@@ -9,14 +9,6 @@ export default defineConfig({
     }),
     tsconfigPaths(),
   ],
-  ssr: {
-    // Bundle all dependencies during the server build by default to avoid most
-    // ESM/CJS issues.  This may slow down your build a bit -- if so, you can
-    // try removing this option, or switching to a more targeted array
-    // containing the specific dependencies you wish to bundle. See more:
-    // https://vitejs.dev/config/ssr-options#ssr-noexternal
-    noExternal: true,
-  },
   server: {
     fs: {
       // Restrict files that could be served by Vite's dev server.  Accessing


### PR DESCRIPTION
The SPA template is currently broken due to this setting. In dev mode, I get the following error:

```
[vite] Internal server error: module is not defined
      at eval (/path/to/project/node_modules/react/jsx-dev-runtime.js:8:3)
      at instantiateModule (file:///path/to/project/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:54725:15)
```

During the build I also see this:

```
x Build failed in 124ms
Error [RollupError]: [commonjs--resolver] Cannot bundle Node.js built-in "stream" imported from "node_modules/react-dom/cjs/react-dom-server-legacy.node.production.min.js". Consider disabling ssr.noExternal or remove the built-in dependency.
file: /path/to/project/node_modules/react-dom/server.node.js
```

Rather than simply removing `ssr.noExternal`, I tried to fix it by also setting `ssr.external` to avoid bundling troublesome dependencies. I was able to fix it with the following config:

```ts
ssr: {
  noExternal: true,
  external: [
    "react",
    "react-dom",
    "@remix-run/server-runtime",
  ],
}
```

I thought this might be good enough, but I decided to try introducing `react-bootstrap` since this was package that originally triggered this change due to Rollup build errors. I then received the following error due to other package issues:

```
[vite] Internal server error: window is not defined
      at eval (/path/to/project/node_modules/classnames/index.js:77:3)
      at eval (/path/to/project/node_modules/classnames/index.js:79:2)
      at instantiateModule (file:///path/to/project/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:54725:15)
```

I can fix this in dev by adding `react-bootstrap` to the `ssr.external` array, but then we're back where we started with a broken build. Instead, I had to add the lower-level offending packages to get both dev and build to work:

```ts
ssr: {
  noExternal: true,
  external: [
    "react",
    "react-dom",
    "@remix-run/server-runtime",
    "classnames",
    "@restart/ui",
  ],
}
```

So taking a step back, this felt like we had replaced one problem with a worse one, since the original issue with `react-bootstrap` can be fixed more succinctly and directly like this:

```ts
ssr: {
  noExternal: ["react-bootstrap"],
}
```

So I think ultimately it's a safer bet for us to leave this area unconfigured for now unless we can find a better way to avoid these sorts of issues.

Either way, this PR can be thought of as a hotfix to get the template back to a working state.