### PR TITLE
Fix typo in data flow docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -126,6 +126,7 @@
 - danielfgray
 - danielweinmann
 - dario-piotrowicz
+- danielshamburger
 - davecalnan
 - davecranwell-vocovo
 - DavidHollins6

--- a/docs/discussion/data-flow.md
+++ b/docs/discussion/data-flow.md
@@ -172,7 +172,7 @@ When you send HTML from the server, it's best to have it work even before JavaSc
 When the user submits the form before JavaScript loads:
 
 1. The browser submits the form to the action (instead of `fetch`) and the browsers pending states activate (spinning favicon)
-2. After the action complets, loaders are called
+2. After the action completes, loaders are called
 3. Remix renders the page and sends HTML to the browser
 
 [loader]: ../route/loader


### PR DESCRIPTION
Quick typo fix of `complets` --> `completes`.

Cheers!