### PR TITLE
Add min. version notes to vite

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -578,6 +578,7 @@
 - squidpunch
 - staylor
 - stephanerangaya
+- stephencweiss
 - stephenwade
 - SufianBabri
 - supachaidev

--- a/docs/future/vite.md
+++ b/docs/future/vite.md
@@ -6,6 +6,8 @@ title: Vite
 
 [Vite][vite] is a powerful, performant and extensible development environment for JavaScript projects. In order to improve and extend Remix's bundling capabilities, we now support Vite as an alternative compiler. In the future, Vite will become the default compiler for Remix.
 
+The Vite plugin was stabilized as of Remix 2.7.0.
+
 ## Getting started
 
 We've got a few different Vite-based templates to get you started.
@@ -337,6 +339,8 @@ npm install -D vite
 ```
 
 Remix is now just a Vite plugin, so you'll need to hook it up to Vite.
+
+**Note**: Remix requires a minimum Vite version of 5.0.0 to work properly.
 
 👉 **Replace `remix.config.js` with `vite.config.ts` at the root of your Remix app**
 


### PR DESCRIPTION
Providing guidance to readers on minimum versions required can help - particularly in the case of migrating an existing application where they may already have `vite` installed, but it's of a version that is incompatible with the plugin.

I determined 2.7.0 as the minimum version based on the changelog note that that's when the Vite plugin was stablized.

For Vite, I determined that 5.0.0 was the minimum version because of the use of `bindCLIShortcuts`. Looking at the version code for vite on NPM for [5.0.0](https://www.npmjs.com/package/vite/v/5.0.0?activeTab=code)), 5.0.0 was the first time I saw `bindCLIShortcuts` present. The previous release that I could find, [4.5.2](https://www.npmjs.com/package/vite/v/4.5.2?activeTab=code), used `bindShortcuts` instead.

Previously i was on a 4.x version of `vite` and received this error:
```
TypeError: server.bindCLIShortcuts is not a function
    at dev (/Users/stephenweiss/code/plated/node_modules/@remix-run/dev/dist/vite/dev.js:75:10)
    at async Object.viteDev (/Users/stephenweiss/code/plated/node_modules/@remix-run/dev/dist/cli/commands.js:213:3)
    at async Object.run (/Users/stephenweiss/code/plated/node_modules/@remix-run/dev/dist/cli/run.js:226:7)
```