### PR TITLE
Vite: Fix `build.sourcemap` config support

### DIFF
--- a/.changeset/little-turtles-applaud.md
+++ b/.changeset/little-turtles-applaud.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: Fix support for `build.sourcemap` option in Vite config

--- a/packages/remix-dev/vite/build.ts
+++ b/packages/remix-dev/vite/build.ts
@@ -237,8 +237,8 @@ export async function build(
     logLevel,
     minify,
     mode,
-    sourcemapClient = false,
-    sourcemapServer = false,
+    sourcemapClient,
+    sourcemapServer,
   }: ViteBuildOptions
 ) {
   // Ensure Vite's ESM build is preloaded at the start of the process


### PR DESCRIPTION
Fixes #8935

The Remix CLI was defaulting `build.sourcemap` to `false` in the inline Vite config object passed to `vite.build`, but this was taking higher precedence than `build.sourcemap` in the user's Vite config. This meant that the only way to generate sourcemaps was via the `--sourcemapServer` and `--sourcemapClient` CLI flags. To avoid this, we need to default the values for these options to `undefined` rather than `false`.