### PR TITLE
Vite: Fix `server.fs.allow` with default entry

### DIFF
--- a/.changeset/tall-frogs-visit.md
+++ b/.changeset/tall-frogs-visit.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: Fix error when using Vite's `server.fs.allow` option without a client entry file

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -17,14 +17,20 @@ const remixBin = "node_modules/@remix-run/dev/dist/cli.js";
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
 export const viteConfig = {
-  server: async (args: { port: number }) => {
+  server: async (args: { port: number; fsAllow?: string[] }) => {
+    let { port, fsAllow } = args;
     let hmrPort = await getPort();
     let text = dedent`
-      server: { port: ${args.port}, strictPort: true, hmr: { port: ${hmrPort} } },
+      server: {
+        port: ${port},
+        strictPort: true,
+        hmr: { port: ${hmrPort} },
+        fs: { allow: ${fsAllow ? JSON.stringify(fsAllow) : "undefined"} }
+      },
     `;
     return text;
   },
-  basic: async (args: { port: number }) => {
+  basic: async (args: { port: number; fsAllow?: string[] }) => {
     return dedent`
       import { vitePlugin as remix } from "@remix-run/dev";
 

--- a/integration/vite-server-fs-allow-test.ts
+++ b/integration/vite-server-fs-allow-test.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+import getPort from "get-port";
+
+import {
+  createProject,
+  customDev,
+  EXPRESS_SERVER,
+  viteConfig,
+} from "./helpers/vite.js";
+
+let files = {
+  "app/routes/test-route.tsx": String.raw`
+    export default function IndexRoute() {
+      return <div id="test">Hello world</div>
+    }
+  `,
+};
+
+test.describe(async () => {
+  let port: number;
+  let cwd: string;
+  let stop: () => void;
+
+  test.beforeAll(async () => {
+    port = await getPort();
+    cwd = await createProject({
+      "vite.config.ts": await viteConfig.basic({ port, fsAllow: ["app"] }),
+      "server.mjs": EXPRESS_SERVER({ port }),
+      ...files,
+    });
+    stop = await customDev({ cwd, port });
+  });
+  test.afterAll(() => stop());
+
+  test("Vite / server.fs.allow / works with basic allow list", async ({
+    page,
+  }) => {
+    let pageErrors: unknown[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error));
+
+    await page.goto(`http://localhost:${port}/test-route`, {
+      waitUntil: "networkidle",
+    });
+    expect(pageErrors).toEqual([]);
+
+    let testContent = page.locator("#test");
+    await expect(testContent).toBeAttached();
+
+    expect(pageErrors).toEqual([]);
+  });
+});


### PR DESCRIPTION
When using Vite's `server.fs.allow` option (https://vitejs.dev/config/server-options#server-fs-allow), the default client entry file throws an error when used because it's not in the allow list. To fix this, we detect whether `server.fs.allow` has been defined, and if so, we ensure that all default entry files are included in the allow list.

I've included a test case that fails when the fix hasn't been applied.