### PR TITLE
Clean `?client-route=1` in build manifest

### DIFF
--- a/.changeset/sour-houses-fly.md
+++ b/.changeset/sour-houses-fly.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Clean up redundant client route query strings on route JavaScript files in production builds

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -347,7 +347,7 @@ const resolveChunk = (
   return entryChunk;
 };
 
-const resolveBuildAssetPaths = (
+const getRemixManifestBuildAssets = (
   ctx: RemixPluginContext,
   viteManifest: Vite.Manifest,
   entryFilePath: string,
@@ -366,7 +366,7 @@ const resolveBuildAssetPaths = (
   ]);
 
   return {
-    module: `${ctx.remixConfig.publicPath}${entryChunk.file}${CLIENT_ROUTE_QUERY_STRING}`,
+    module: `${ctx.remixConfig.publicPath}${entryChunk.file}`,
     imports:
       dedupe(chunks.flatMap((e) => e.imports ?? [])).map((imported) => {
         return `${ctx.remixConfig.publicPath}${viteManifest[imported].file}`;
@@ -856,7 +856,7 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
       getClientBuildDirectory(ctx.remixConfig)
     );
 
-    let entry = resolveBuildAssetPaths(
+    let entry = getRemixManifestBuildAssets(
       ctx,
       viteManifest,
       ctx.entryClientFilePath
@@ -886,7 +886,7 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
         hasClientAction: sourceExports.includes("clientAction"),
         hasClientLoader: sourceExports.includes("clientLoader"),
         hasErrorBoundary: sourceExports.includes("ErrorBoundary"),
-        ...resolveBuildAssetPaths(
+        ...getRemixManifestBuildAssets(
           ctx,
           viteManifest,
           routeFilePath,


### PR DESCRIPTION
These query strings are only relevant during dev and build but were accidentally included in the production manifest.

Before:

<img width="302" alt="Screenshot 2024-03-05 at 7 31 33 am" src="https://github.com/remix-run/remix/assets/696693/60b34c96-4078-4001-95b1-f76876f420e0">


After:

<img width="302" alt="Screenshot 2024-03-05 at 7 31 52 am" src="https://github.com/remix-run/remix/assets/696693/819dcacd-a0ae-4d5f-964f-8b54f0a5e40f">
