### PR TITLE
Remove `server.fs.allow` from Vite templates

### DIFF
--- a/templates/spa/vite.config.ts
+++ b/templates/spa/vite.config.ts
@@ -9,15 +9,4 @@ export default defineConfig({
     }),
     tsconfigPaths(),
   ],
-  server: {
-    fs: {
-      // Restrict files that could be served by Vite's dev server.  Accessing
-      // files outside this directory list that aren't imported from an allowed
-      // file will result in a 403.  Both directories and files can be provided.
-      // If you're comfortable with Vite's dev server making any file within the
-      // project root available, you can remove this option.  See more:
-      // https://vitejs.dev/config/server-options.html#server-fs-allow
-      allow: ["app"],
-    },
-  },
 });

--- a/templates/vite-cloudflare/vite.config.ts
+++ b/templates/vite-cloudflare/vite.config.ts
@@ -7,15 +7,4 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [remixCloudflareDevProxy(), remix(), tsconfigPaths()],
-  server: {
-    fs: {
-      // Restrict files that could be served by Vite's dev server.  Accessing
-      // files outside this directory list that aren't imported from an allowed
-      // file will result in a 403.  Both directories and files can be provided.
-      // If you're comfortable with Vite's dev server making any file within the
-      // project root available, you can remove this option.  See more:
-      // https://vitejs.dev/config/server-options.html#server-fs-allow
-      allow: ["app"],
-    },
-  },
 });

--- a/templates/vite-express/vite.config.ts
+++ b/templates/vite-express/vite.config.ts
@@ -4,15 +4,4 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [remix(), tsconfigPaths()],
-  server: {
-    fs: {
-      // Restrict files that could be served by Vite's dev server.  Accessing
-      // files outside this directory list that aren't imported from an allowed
-      // file will result in a 403.  Both directories and files can be provided.
-      // If you're comfortable with Vite's dev server making any file within the
-      // project root available, you can remove this option.  See more:
-      // https://vitejs.dev/config/server-options.html#server-fs-allow
-      allow: ["app"],
-    },
-  },
 });

--- a/templates/vite/vite.config.ts
+++ b/templates/vite/vite.config.ts
@@ -7,15 +7,4 @@ installGlobals();
 
 export default defineConfig({
   plugins: [remix(), tsconfigPaths()],
-  server: {
-    fs: {
-      // Restrict files that could be served by Vite's dev server.  Accessing
-      // files outside this directory list that aren't imported from an allowed
-      // file will result in a 403.  Both directories and files can be provided.
-      // If you're comfortable with Vite's dev server making any file within the
-      // project root available, you can remove this option.  See more:
-      // https://vitejs.dev/config/server-options.html#server-fs-allow
-      allow: ["app"],
-    },
-  },
 });


### PR DESCRIPTION
This reverts #8950.

Upon further discussion, we think this is overly protective as a default since most consumers don't need this and it's more likely to just cause them issues.