### PR TITLE
Change dev and build commands to use npm scripts to allow remix cli

### DIFF
--- a/docs/future/spa-mode.md
+++ b/docs/future/spa-mode.md
@@ -58,7 +58,7 @@ export default defineConfig({
 In SPA Mode, you develop the same way you would for a traditional Remix SSR app, and you actually use a running Remix dev server in order to enable HMR/HDR:
 
 ```sh
-remix vite:dev
+npm run dev
 ```
 
 ### Production
@@ -66,7 +66,7 @@ remix vite:dev
 When you build your app in SPA Mode, Remix will call the server handler for the `/` route and save the rendered HTML in an `index.html` file alongside your client side assets (by default `build/client/index.html`).
 
 ```sh
-remix vite:build
+npm run build
 ```
 
 #### Preview


### PR DESCRIPTION
## Issue

The existing docs suggest using commands `remix dev` or `remix build`; the direct use of `remix` will fail (I believe unless this package is installed globally)

```
D:\repos\universe-timeline-remix [master]> remix vite:dev
remix: The term 'remix' is not recognized as a name of a cmdlet, function, script file, or executable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```

## Solution

Invoke the same commands through NPM scripts, which makes all the binary packages from the current project available

`package.json` of new SPA project
```
...
  "scripts": {
    "build": "remix vite:build",
    "dev": "remix vite:dev",
    "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
    "preview": "vite preview",
    "typecheck": "tsc"
  }
...
```

```
npm run dev
```
```
npm run build
```

## Closes: N/A

- [x] Docs
- [ ] Tests

## Testing Strategy:

Run commands on new SPA project verify successful execution


