### PR TITLE
Add `pnpm-lock.yaml` to `.eslintignore`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,7 @@
 **/tests/__snapshots/
 **/node_modules/
 .tmp
+pnpm-lock.yaml
 /playground
 **/__tests__/fixtures
 **/__tests__/**/*/fixtures


### PR DESCRIPTION
`pnpm format` is currently formatting `pnpm-lock.yaml` because it's using `.eslintignore` as the ignore file.