### PR TITLE
Pin Playwright to Node 20.5.1 to fix hanging tests

### DIFF
--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -45,7 +45,7 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "ubuntu-latest"
-      node_version: "[18, 20]"
+      node_version: '[18, "20.5.1"]'
       browser: '["chromium", "firefox"]'
 
   integration-windows:
@@ -54,7 +54,7 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "windows-latest"
-      node_version: "[18, 20]"
+      node_version: '[18, "20.5.1"]'
       browser: '["msedge"]'
 
   integration-macos:
@@ -63,5 +63,5 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "macos-latest"
-      node_version: "[18, 20]"
+      node_version: '[18, "20.5.1"]'
       browser: '["webkit"]'


### PR DESCRIPTION
This PR is a temporary fix to unblock CI.

Playwright tests are hanging in CI when running against Node 20, currently 20.11.1. I've narrowed it down to this line that's hanging indefinitely: https://github.com/remix-run/remix/blob/cc4dcf1e9f244341d4c73cfc614dd082ac95c65b/integration/helpers/create-fixture.ts#L94

If I try to import the server build file directly within Node, everything works fine. I tried commenting out the contents of the server build to further narrow it down and found that it only hangs when importing Remix packages. I'm not sure why this is happening since the move to pnpm, but this import statement doesn't hang in Node 20.5.1, so I'm updating our workflows to use this version until we can properly fix it.