### PR TITLE
Update docs vite.md

### DIFF
--- a/docs/future/vite.md
+++ b/docs/future/vite.md
@@ -1082,6 +1082,23 @@ export default defineConfig({
 });
 ```
 
+Your setup might also need to reinstantiate the react plugin for testing like this:
+
+```ts filename=vite.config.ts lines=[6]
+import { vitePlugin as remix } from "@remix-run/dev";
+import { defineConfig, loadEnv } from "vite";
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [!process.env.VITEST ? remix() : react()],
+  test: {
+    environment: "happy-dom",
+    // Additionally, this is to load ".env.test" during vitest
+    env: loadEnv("test", process.cwd(), ""),
+  },
+});
+```
+
 For Storybook:
 
 ```ts filename=vite.config.ts lines=[7]


### PR DESCRIPTION
Depending on the setup the user might need to re-enable the react plugin when disabling remix for testing.
As otherwise React can be undefined when running vitest.
Might be good to mention this in the docs.