### PR TITLE
templates(deno): fix import maps docs link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -390,6 +390,7 @@
 - m0nica
 - m5r
 - machour
+- macklinu
 - maferland
 - manan30
 - manosim

--- a/templates/deno/README.md
+++ b/templates/deno/README.md
@@ -29,7 +29,7 @@ Read about
   import { copy } from "https://deno.land/std@0.138.0/streams/conversion.ts";
   ```
 - ❌ Do not use
-  [import maps](https://deno.land/manual/linking_to_external_code/import_maps).
+  [import maps](https://docs.deno.com/runtime/manual/basics/import_maps).
 
 ## Development
 


### PR DESCRIPTION
- [x] Docs
- [ ] Tests

This PR updates a link to Deno's import maps in the Deno template that was 404ing.