### PR TITLE
Render loop when revalidating a page that has Suspense/Await Elements on it

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -664,3 +664,4 @@
 - zainfathoni
 - zayenz
 - zhe
+- lauhon


### PR DESCRIPTION
When using the useRevalidator hook on a page that renders an async value with Suspense/Await. The component will render infinitely.

The test in the PR will actually go through, as I did not know how to accurately assert this. When you check the browser tab that gets opened through `app.poke` you will see a huge number of renders and the counter rising in the logs.

 
