### PR TITLE
set node env to production in start script in vite template

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,3 +1,4 @@
+- aarbi
 - aaronpowell96
 - aaronshaf
 - AbePlays

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -6,7 +6,7 @@
     "build": "remix vite:build",
     "dev": "remix vite:dev",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
-    "start": "remix-serve ./build/server/index.js",
+    "start": "cross-env NODE_ENV=production remix-serve ./build/server/index.js",
     "typecheck": "tsc"
   },
   "dependencies": {
@@ -22,7 +22,8 @@
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.7.4",
-    "@typescript-eslint/parser": "^6.7.4",
+    "@typescript-eslint/parser": "^6.7.4",    
+    "cross-env": "^7.0.3",
     "eslint": "^8.38.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->

* fresh remix installation using `vite` template: npx create-remix@latest --template remix-run/remix/templates/vite
* npm run build
* npm start
previously this was throwing an error:
```
  if (!origin) throw Error("Dev server origin not set");
                     ^
Error: Dev server origin not set
    at Object.broadcastDevReady (/Users/aarbi/Batcave/jsnodes/remix/vite/node_modules/.pnpm/@remix-run+server-runtime@2.8.1_typescript@5.4.2/node_modules/@remix-run/server-runtime/dist/dev.js:17:22)
    at Server.onListen (/Users/aarbi/Batcave/jsnodes/remix/vite/node_modules/.pnpm/@remix-run+serve@2.8.1_typescript@5.4.2/node_modules/@remix-run/serve/dist/cli.js:123:17)
    at Object.onceWrapper (node:events:632:28)
    at Server.emit (node:events:530:35)
    at emitListeningNT (node:net:1906:10)
    at processTicksAndRejections (node:internal/process/task_queues:81:21)
```
We should not see this error anymore