### PR TITLE
Ignore only local env files in Vite templates

### DIFF
--- a/templates/vite-cloudflare/.gitignore
+++ b/templates/vite-cloudflare/.gitignore
@@ -2,6 +2,6 @@ node_modules
 
 /.cache
 /build
-.env
+.env*.local
 
 .wrangler

--- a/templates/vite-express/.gitignore
+++ b/templates/vite-express/.gitignore
@@ -2,4 +2,4 @@ node_modules
 
 /.cache
 /build
-.env
+.env*.local

--- a/templates/vite/.gitignore
+++ b/templates/vite/.gitignore
@@ -2,4 +2,4 @@ node_modules
 
 /.cache
 /build
-.env
+.env*.local


### PR DESCRIPTION
In Vite `.env` files work a bit differently, where `.env` itself is intended to be public, and `.env.local` is the one that should be ignored by Git. But a Vite project can have more `.env` files, like `.env.development`, which is used only in development mode, and overrides values in `.env`, then you can have `.env.development.local` as well and so on.

```sh
.env                # loaded in all cases
.env.local          # loaded in all cases, ignored by git
.env.[mode]         # only loaded in specified mode
.env.[mode].local   # only loaded in specified mode, ignored by git
```

https://vitejs.dev/guide/env-and-mode.html#env-files

It appears that [Vite uses just `*.local` pattern](https://github.com/vitejs/vite/blob/6f8a3206653127a1ca9e20880af117d3a7c4fadc/packages/create-vite/template-vanilla/_gitignore#L13) for their templates, but I'm not comfortable with that 😄 