### PR TITLE
Update single fetch logic when clientLoaders are present

### DIFF
--- a/.changeset/single-fetch-client-loaders.md
+++ b/.changeset/single-fetch-client-loaders.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Update single fetch implementation to avoid over-fetching when clientLoader's exist

--- a/integration/single-fetch-test.ts
+++ b/integration/single-fetch-test.ts
@@ -488,58 +488,58 @@ test.describe("single-fetch", () => {
           files: {
             ...files,
             "app/routes/a.tsx": js`
-          import { Outlet, useLoaderData } from '@remix-run/react';
+              import { Outlet, useLoaderData } from '@remix-run/react';
 
-          export function loader() {
-            return { message: "A server loader" };
-          }
+              export function loader() {
+                return { message: "A server loader" };
+              }
 
-          export default function Comp() {
-            let data = useLoaderData();
-            return (
-              <>
-                <h1>A</h1>
-                <p id="a-data">{data.message}</p>
-                <Outlet/>
-              </>
-            );
-          }
-        `,
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>A</h1>
+                    <p id="a-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
             "app/routes/a.b.tsx": js`
-          import { Outlet, useLoaderData } from '@remix-run/react';
+              import { Outlet, useLoaderData } from '@remix-run/react';
 
-          export function loader() {
-            return { message: "B server loader" };
-          }
+              export function loader() {
+                return { message: "B server loader" };
+              }
 
-          export default function Comp() {
-            let data = useLoaderData();
-            return (
-              <>
-                <h1>B</h1>
-                <p id="b-data">{data.message}</p>
-                <Outlet/>
-              </>
-            );
-          }
-        `,
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>B</h1>
+                    <p id="b-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
             "app/routes/a.b.c.tsx": js`
-          import { useLoaderData } from '@remix-run/react';
+              import { useLoaderData } from '@remix-run/react';
 
-          export function  loader() {
-            return { message: "C server loader" };
-          }
+              export function  loader() {
+                return { message: "C server loader" };
+              }
 
-          export default function Comp() {
-            let data = useLoaderData();
-            return (
-              <>
-                <h1>C</h1>
-                <p id="c-data">{data.message}</p>
-              </>
-            );
-          }
-        `,
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>C</h1>
+                    <p id="c-data">{data.message}</p>
+                  </>
+                );
+              }
+            `,
           },
         },
         ServerMode.Development
@@ -560,7 +560,9 @@ test.describe("single-fetch", () => {
       expect(await app.getHtml("#a-data")).toContain("A server loader");
       expect(await app.getHtml("#b-data")).toContain("B server loader");
       expect(await app.getHtml("#c-data")).toContain("C server loader");
-      expect(urls).toEqual([expect.stringMatching(/\/a\/b\/c.data$/)]);
+
+      // No clientLoaders so we can make a single parameter-less fetch
+      expect(urls).toEqual([expect.stringMatching(/\/a\/b\/c\.data$/)]);
     });
 
     test("when one route has a client loader", async ({ page }) => {
@@ -574,63 +576,63 @@ test.describe("single-fetch", () => {
           files: {
             ...files,
             "app/routes/a.tsx": js`
-          import { Outlet, useLoaderData } from '@remix-run/react';
+              import { Outlet, useLoaderData } from '@remix-run/react';
 
-          export function loader() {
-            return { message: "A server loader" };
-          }
+              export function loader() {
+                return { message: "A server loader" };
+              }
 
-          export default function Comp() {
-            let data = useLoaderData();
-            return (
-              <>
-                <h1>A</h1>
-                <p id="a-data">{data.message}</p>
-                <Outlet/>
-              </>
-            );
-          }
-        `,
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>A</h1>
+                    <p id="a-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
             "app/routes/a.b.tsx": js`
-          import { Outlet, useLoaderData } from '@remix-run/react';
+              import { Outlet, useLoaderData } from '@remix-run/react';
 
-          export function loader() {
-            return { message: "B server loader" };
-          }
+              export function loader() {
+                return { message: "B server loader" };
+              }
 
-          export default function Comp() {
-            let data = useLoaderData();
-            return (
-              <>
-                <h1>B</h1>
-                <p id="b-data">{data.message}</p>
-                <Outlet/>
-              </>
-            );
-          }
-        `,
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>B</h1>
+                    <p id="b-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
             "app/routes/a.b.c.tsx": js`
-          import { useLoaderData } from '@remix-run/react';
+              import { useLoaderData } from '@remix-run/react';
 
-          export function  loader() {
-            return { message: "C server loader" };
-          }
+              export function  loader() {
+                return { message: "C server loader" };
+              }
 
-          export async function clientLoader({ serverLoader }) {
-            let data = await serverLoader();
-            return { message: data.message + " (C client loader)" };
-          }
+              export async function clientLoader({ serverLoader }) {
+                let data = await serverLoader();
+                return { message: data.message + " (C client loader)" };
+              }
 
-          export default function Comp() {
-            let data = useLoaderData();
-            return (
-              <>
-                <h1>C</h1>
-                <p id="c-data">{data.message}</p>
-              </>
-            );
-          }
-        `,
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>C</h1>
+                    <p id="c-data">{data.message}</p>
+                  </>
+                );
+              }
+            `,
           },
         },
         ServerMode.Development
@@ -653,11 +655,13 @@ test.describe("single-fetch", () => {
       expect(await app.getHtml("#c-data")).toContain(
         "C server loader (C client loader)"
       );
+
+      // A/B can be loaded together, C needs it's own call due to it's clientLoader
       expect(urls.sort()).toEqual([
         expect.stringMatching(
-          /\/a\/b\/c.data\?_routes=routes%2Fa%2Croutes%2Fa.b$/
+          /\/a\/b\/c\.data\?_routes=routes%2Fa%2Croutes%2Fa\.b$/
         ),
-        expect.stringMatching(/\/a\/b\/c.data\?_routes=routes%2Fa.b.c$/),
+        expect.stringMatching(/\/a\/b\/c\.data\?_routes=routes%2Fa\.b\.c$/),
       ]);
     });
 
@@ -672,68 +676,68 @@ test.describe("single-fetch", () => {
           files: {
             ...files,
             "app/routes/a.tsx": js`
-          import { Outlet, useLoaderData } from '@remix-run/react';
+              import { Outlet, useLoaderData } from '@remix-run/react';
 
-          export function loader() {
-            return { message: "A server loader" };
-          }
+              export function loader() {
+                return { message: "A server loader" };
+              }
 
-          export default function Comp() {
-            let data = useLoaderData();
-            return (
-              <>
-                <h1>A</h1>
-                <p id="a-data">{data.message}</p>
-                <Outlet/>
-              </>
-            );
-          }
-        `,
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>A</h1>
+                    <p id="a-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
             "app/routes/a.b.tsx": js`
-          import { Outlet, useLoaderData } from '@remix-run/react';
+              import { Outlet, useLoaderData } from '@remix-run/react';
 
-          export function loader() {
-            return { message: "B server loader" };
-          }
+              export function loader() {
+                return { message: "B server loader" };
+              }
 
-          export async function clientLoader({ serverLoader }) {
-            let data = await serverLoader();
-            return { message: data.message + " (B client loader)" };
-          }
+              export async function clientLoader({ serverLoader }) {
+                let data = await serverLoader();
+                return { message: data.message + " (B client loader)" };
+              }
 
-          export default function Comp() {
-            let data = useLoaderData();
-            return (
-              <>
-                <h1>B</h1>
-                <p id="b-data">{data.message}</p>
-                <Outlet/>
-              </>
-            );
-          }
-        `,
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>B</h1>
+                    <p id="b-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
             "app/routes/a.b.c.tsx": js`
-          import { useLoaderData } from '@remix-run/react';
+              import { useLoaderData } from '@remix-run/react';
 
-          export function  loader() {
-            return { message: "C server loader" };
-          }
+              export function  loader() {
+                return { message: "C server loader" };
+              }
 
-          export async function clientLoader({ serverLoader }) {
-            let data = await serverLoader();
-            return { message: data.message + " (C client loader)" };
-          }
+              export async function clientLoader({ serverLoader }) {
+                let data = await serverLoader();
+                return { message: data.message + " (C client loader)" };
+              }
 
-          export default function Comp() {
-            let data = useLoaderData();
-            return (
-              <>
-                <h1>C</h1>
-                <p id="c-data">{data.message}</p>
-              </>
-            );
-          }
-        `,
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>C</h1>
+                    <p id="c-data">{data.message}</p>
+                  </>
+                );
+              }
+            `,
           },
         },
         ServerMode.Development
@@ -758,10 +762,13 @@ test.describe("single-fetch", () => {
       expect(await app.getHtml("#c-data")).toContain(
         "C server loader (C client loader)"
       );
+
+      // B/C have client loaders so they get individual calls, which leaves A
+      // getting it's own "individual" since it's the last route standing
       expect(urls.sort()).toEqual([
-        expect.stringMatching(/\/a\/b\/c.data\?_routes=routes%2Fa$/),
-        expect.stringMatching(/\/a\/b\/c.data\?_routes=routes%2Fa.b$/),
-        expect.stringMatching(/\/a\/b\/c.data\?_routes=routes%2Fa.b.c$/),
+        expect.stringMatching(/\/a\/b\/c\.data\?_routes=routes%2Fa$/),
+        expect.stringMatching(/\/a\/b\/c\.data\?_routes=routes%2Fa\.b$/),
+        expect.stringMatching(/\/a\/b\/c\.data\?_routes=routes%2Fa\.b\.c$/),
       ]);
     });
 
@@ -776,73 +783,73 @@ test.describe("single-fetch", () => {
           files: {
             ...files,
             "app/routes/a.tsx": js`
-          import { Outlet, useLoaderData } from '@remix-run/react';
+              import { Outlet, useLoaderData } from '@remix-run/react';
 
-          export function loader() {
-            return { message: "A server loader" };
-          }
+              export function loader() {
+                return { message: "A server loader" };
+              }
 
-          export async function clientLoader({ serverLoader }) {
-            let data = await serverLoader();
-            return { message: data.message + " (A client loader)" };
-          }
+              export async function clientLoader({ serverLoader }) {
+                let data = await serverLoader();
+                return { message: data.message + " (A client loader)" };
+              }
 
-          export default function Comp() {
-            let data = useLoaderData();
-            return (
-              <>
-                <h1>A</h1>
-                <p id="a-data">{data.message}</p>
-                <Outlet/>
-              </>
-            );
-          }
-        `,
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>A</h1>
+                    <p id="a-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
             "app/routes/a.b.tsx": js`
-          import { Outlet, useLoaderData } from '@remix-run/react';
+              import { Outlet, useLoaderData } from '@remix-run/react';
 
-          export function loader() {
-            return { message: "B server loader" };
-          }
+              export function loader() {
+                return { message: "B server loader" };
+              }
 
-          export async function clientLoader({ serverLoader }) {
-            let data = await serverLoader();
-            return { message: data.message + " (B client loader)" };
-          }
+              export async function clientLoader({ serverLoader }) {
+                let data = await serverLoader();
+                return { message: data.message + " (B client loader)" };
+              }
 
-          export default function Comp() {
-            let data = useLoaderData();
-            return (
-              <>
-                <h1>B</h1>
-                <p id="b-data">{data.message}</p>
-                <Outlet/>
-              </>
-            );
-          }
-        `,
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>B</h1>
+                    <p id="b-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
             "app/routes/a.b.c.tsx": js`
-          import { useLoaderData } from '@remix-run/react';
+              import { useLoaderData } from '@remix-run/react';
 
-          export function  loader() {
-            return { message: "C server loader" };
-          }
+              export function  loader() {
+                return { message: "C server loader" };
+              }
 
-          export async function clientLoader({ serverLoader }) {
-            let data = await serverLoader();
-            return { message: data.message + " (C client loader)" };
-          }
+              export async function clientLoader({ serverLoader }) {
+                let data = await serverLoader();
+                return { message: data.message + " (C client loader)" };
+              }
 
-          export default function Comp() {
-            let data = useLoaderData();
-            return (
-              <>
-                <h1>C</h1>
-                <p id="c-data">{data.message}</p>
-              </>
-            );
-          }
-        `,
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>C</h1>
+                    <p id="c-data">{data.message}</p>
+                  </>
+                );
+              }
+            `,
           },
         },
         ServerMode.Development
@@ -869,11 +876,410 @@ test.describe("single-fetch", () => {
       expect(await app.getHtml("#c-data")).toContain(
         "C server loader (C client loader)"
       );
+
+      // A/B/C all have client loaders so they get individual calls
       expect(urls.sort()).toEqual([
         expect.stringMatching(/\/a\/b\/c.data\?_routes=routes%2Fa$/),
         expect.stringMatching(/\/a\/b\/c.data\?_routes=routes%2Fa.b$/),
         expect.stringMatching(/\/a\/b\/c.data\?_routes=routes%2Fa.b.c$/),
       ]);
+    });
+  });
+
+  test.describe("prefetching", () => {
+    test("when no routes have client loaders", async ({ page }) => {
+      let fixture = await createFixture(
+        {
+          config: {
+            future: {
+              unstable_singleFetch: true,
+            },
+          },
+          files: {
+            ...files,
+            "app/routes/_index.tsx": js`
+              import {  Link } from "@remix-run/react";
+
+              export default function Index() {
+                return <Link to="/a/b/c" prefetch="render">/a/b/c</Link>
+              }
+            `,
+            "app/routes/a.tsx": js`
+              import { Outlet, useLoaderData } from '@remix-run/react';
+
+              export function loader() {
+                return { message: "A server loader" };
+              }
+
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>A</h1>
+                    <p id="a-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
+            "app/routes/a.b.tsx": js`
+              import { Outlet, useLoaderData } from '@remix-run/react';
+
+              export function loader() {
+                return { message: "B server loader" };
+              }
+
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>B</h1>
+                    <p id="b-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
+            "app/routes/a.b.c.tsx": js`
+              import { useLoaderData } from '@remix-run/react';
+
+              export function  loader() {
+                return { message: "C server loader" };
+              }
+
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>C</h1>
+                    <p id="c-data">{data.message}</p>
+                  </>
+                );
+              }
+            `,
+          },
+        },
+        ServerMode.Development
+      );
+
+      let urls: string[] = [];
+      page.on("request", (req) => {
+        if (req.method() === "GET" && req.url().includes(".data")) {
+          urls.push(req.url());
+        }
+      });
+
+      let appFixture = await createAppFixture(fixture, ServerMode.Development);
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/", true);
+      // No clientLoaders so we can make a single parameter-less fetch
+      expect(urls).toEqual([expect.stringMatching(/\/a\/b\/c\.data$/)]);
+    });
+
+    test("when one route has a client loader", async ({ page }) => {
+      let fixture = await createFixture(
+        {
+          config: {
+            future: {
+              unstable_singleFetch: true,
+            },
+          },
+          files: {
+            ...files,
+            "app/routes/_index.tsx": js`
+              import {  Link } from "@remix-run/react";
+
+              export default function Index() {
+                return <Link to="/a/b/c" prefetch="render">/a/b/c</Link>
+              }
+            `,
+            "app/routes/a.tsx": js`
+              import { Outlet, useLoaderData } from '@remix-run/react';
+
+              export function loader() {
+                return { message: "A server loader" };
+              }
+
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>A</h1>
+                    <p id="a-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
+            "app/routes/a.b.tsx": js`
+              import { Outlet, useLoaderData } from '@remix-run/react';
+
+              export function loader() {
+                return { message: "B server loader" };
+              }
+
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>B</h1>
+                    <p id="b-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
+            "app/routes/a.b.c.tsx": js`
+              import { useLoaderData } from '@remix-run/react';
+
+              export function  loader() {
+                return { message: "C server loader" };
+              }
+
+              export async function clientLoader({ serverLoader }) {
+                let data = await serverLoader();
+                return { message: data.message + " (C client loader)" };
+              }
+
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>C</h1>
+                    <p id="c-data">{data.message}</p>
+                  </>
+                );
+              }
+            `,
+          },
+        },
+        ServerMode.Development
+      );
+
+      let urls: string[] = [];
+      page.on("request", (req) => {
+        if (req.method() === "GET" && req.url().includes(".data")) {
+          urls.push(req.url());
+        }
+      });
+
+      let appFixture = await createAppFixture(fixture, ServerMode.Development);
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/", true);
+
+      // A/B can be prefetched, C doesn't get prefetched due to its `clientLoader`
+      expect(urls.sort()).toEqual([
+        expect.stringMatching(
+          /\/a\/b\/c\.data\?_routes=routes%2Fa%2Croutes%2Fa\.b$/
+        ),
+      ]);
+    });
+
+    test("when multiple routes have client loaders", async ({ page }) => {
+      let fixture = await createFixture(
+        {
+          config: {
+            future: {
+              unstable_singleFetch: true,
+            },
+          },
+          files: {
+            ...files,
+            "app/routes/_index.tsx": js`
+              import {  Link } from "@remix-run/react";
+
+              export default function Index() {
+                return <Link to="/a/b/c" prefetch="render">/a/b/c</Link>
+              }
+            `,
+            "app/routes/a.tsx": js`
+              import { Outlet, useLoaderData } from '@remix-run/react';
+
+              export function loader() {
+                return { message: "A server loader" };
+              }
+
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>A</h1>
+                    <p id="a-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
+            "app/routes/a.b.tsx": js`
+              import { Outlet, useLoaderData } from '@remix-run/react';
+
+              export function loader() {
+                return { message: "B server loader" };
+              }
+
+              export async function clientLoader({ serverLoader }) {
+                let data = await serverLoader();
+                return { message: data.message + " (B client loader)" };
+              }
+
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>B</h1>
+                    <p id="b-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
+            "app/routes/a.b.c.tsx": js`
+              import { useLoaderData } from '@remix-run/react';
+
+              export function  loader() {
+                return { message: "C server loader" };
+              }
+
+              export async function clientLoader({ serverLoader }) {
+                let data = await serverLoader();
+                return { message: data.message + " (C client loader)" };
+              }
+
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>C</h1>
+                    <p id="c-data">{data.message}</p>
+                  </>
+                );
+              }
+            `,
+          },
+        },
+        ServerMode.Development
+      );
+
+      let urls: string[] = [];
+      page.on("request", (req) => {
+        if (req.method() === "GET" && req.url().includes(".data")) {
+          urls.push(req.url());
+        }
+      });
+
+      let appFixture = await createAppFixture(fixture, ServerMode.Development);
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/", true);
+
+      // Only A can get prefetched, B/C can't due to `clientLoader`
+      expect(urls.sort()).toEqual([
+        expect.stringMatching(/\/a\/b\/c\.data\?_routes=routes%2Fa$/),
+      ]);
+    });
+
+    test("when all routes have client loaders", async ({ page }) => {
+      let fixture = await createFixture(
+        {
+          config: {
+            future: {
+              unstable_singleFetch: true,
+            },
+          },
+          files: {
+            ...files,
+            "app/routes/_index.tsx": js`
+              import {  Link } from "@remix-run/react";
+
+              export default function Index() {
+                return <Link to="/a/b/c" prefetch="render">/a/b/c</Link>
+              }
+            `,
+            "app/routes/a.tsx": js`
+              import { Outlet, useLoaderData } from '@remix-run/react';
+
+              export function loader() {
+                return { message: "A server loader" };
+              }
+
+              export async function clientLoader({ serverLoader }) {
+                let data = await serverLoader();
+                return { message: data.message + " (A client loader)" };
+              }
+
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>A</h1>
+                    <p id="a-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
+            "app/routes/a.b.tsx": js`
+              import { Outlet, useLoaderData } from '@remix-run/react';
+
+              export function loader() {
+                return { message: "B server loader" };
+              }
+
+              export async function clientLoader({ serverLoader }) {
+                let data = await serverLoader();
+                return { message: data.message + " (B client loader)" };
+              }
+
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>B</h1>
+                    <p id="b-data">{data.message}</p>
+                    <Outlet/>
+                  </>
+                );
+              }
+            `,
+            "app/routes/a.b.c.tsx": js`
+              import { useLoaderData } from '@remix-run/react';
+
+              export function  loader() {
+                return { message: "C server loader" };
+              }
+
+              export async function clientLoader({ serverLoader }) {
+                let data = await serverLoader();
+                return { message: data.message + " (C client loader)" };
+              }
+
+              export default function Comp() {
+                let data = useLoaderData();
+                return (
+                  <>
+                    <h1>C</h1>
+                    <p id="c-data">{data.message}</p>
+                  </>
+                );
+              }
+            `,
+          },
+        },
+        ServerMode.Development
+      );
+
+      let urls: string[] = [];
+      page.on("request", (req) => {
+        if (req.method() === "GET" && req.url().includes(".data")) {
+          urls.push(req.url());
+        }
+      });
+
+      let appFixture = await createAppFixture(fixture, ServerMode.Development);
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/", true);
+
+      // No prefetching due to clientLoaders
+      expect(urls.sort()).toEqual([]);
     });
   });
 });

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -434,7 +434,7 @@ function PrefetchPageLinksImpl({
     let url = addRevalidationParam(
       manifest,
       routeModules,
-      matches.map((m) => m.route),
+      nextMatches.map((m) => m.route),
       newMatchesForData.map((m) => m.route),
       singleFetchUrl(page)
     );

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -429,8 +429,14 @@ function PrefetchPageLinksImpl({
   // just the manifest like the other links in here.
   let keyedPrefetchLinks = useKeyedPrefetchLinks(newMatchesForAssets);
 
-  let singleFetchHref: string | undefined;
-  if (future.unstable_singleFetch && newMatchesForData.length > 0) {
+  let linksToRender: React.ReactNode | React.ReactNode[] | null = null;
+  if (!future.unstable_singleFetch) {
+    // Non-single-fetch prefetching
+    linksToRender = dataHrefs.map((href) => (
+      <link key={href} rel="prefetch" as="fetch" href={href} {...linkProps} />
+    ));
+  } else if (newMatchesForData.length > 0) {
+    // Single-fetch with routes that require data
     let url = addRevalidationParam(
       manifest,
       routeModules,
@@ -438,30 +444,26 @@ function PrefetchPageLinksImpl({
       newMatchesForData.map((m) => m.route),
       singleFetchUrl(page)
     );
-    singleFetchHref = url.pathname + url.search;
+    if (url.searchParams.get("_routes") !== "") {
+      linksToRender = (
+        <link
+          key={url.pathname + url.search}
+          rel="prefetch"
+          as="fetch"
+          href={url.pathname + url.search}
+          {...linkProps}
+        />
+      );
+    } else {
+      // No single-fetch prefetching if _routes param is empty due to `clientLoader`'s
+    }
+  } else {
+    // No single-fetch prefetching if there are no new matches for data
   }
 
   return (
     <>
-      {singleFetchHref ? (
-        <link
-          key={singleFetchHref}
-          rel="prefetch"
-          as="fetch"
-          href={singleFetchHref}
-          {...linkProps}
-        />
-      ) : (
-        dataHrefs.map((href) => (
-          <link
-            key={href}
-            rel="prefetch"
-            as="fetch"
-            href={href}
-            {...linkProps}
-          />
-        ))
-      )}
+      {linksToRender}
       {moduleHrefs.map((href) => (
         <link key={href} rel="modulepreload" href={href} {...linkProps} />
       ))}

--- a/packages/remix-react/single-fetch.tsx
+++ b/packages/remix-react/single-fetch.tsx
@@ -158,10 +158,11 @@ function singleFetchLoaderStrategy(
     matches.map(async (m) =>
       m.resolve(async (handler): Promise<HandlerResult> => {
         let result: unknown;
+        let url = stripIndexParam(singleFetchUrl(request.url));
+
         // When a route has a client loader, it calls it's singular server loader
         if (manifest.routes[m.route.id].hasClientLoader) {
           result = await handler(async () => {
-            let url = stripIndexParam(singleFetchUrl(request.url));
             url.searchParams.set("_routes", m.route.id);
             let { data } = await fetchAndDecode(url);
             return unwrapSingleFetchResults(
@@ -173,12 +174,12 @@ function singleFetchLoaderStrategy(
           result = await handler(async () => {
             // Otherwise we let multiple routes hook onto the same promise
             if (!singleFetchPromise) {
-              let url = addRevalidationParam(
+              url = addRevalidationParam(
                 manifest,
                 routeModules,
                 matches.map((m) => m.route),
                 matches.filter((m) => m.shouldLoad).map((m) => m.route),
-                stripIndexParam(singleFetchUrl(request.url))
+                url
               );
               singleFetchPromise = fetchAndDecode(url).then(
                 ({ data }) => data as SingleFetchResults

--- a/packages/remix-react/single-fetch.tsx
+++ b/packages/remix-react/single-fetch.tsx
@@ -113,9 +113,6 @@ export function getSingleFetchDataStrategy(
   manifest: AssetsManifest,
   routeModules: RouteModules
 ): DataStrategyFunction {
-  let genRouteIds = (arr: string[]) =>
-    arr.filter((id) => manifest.routes[id].hasLoader).join(",");
-
   return async ({ request, matches }: DataStrategyFunctionArgs) => {
     // This function is the way for a loader/action to "talk" to the server
     let singleFetch: (routeId: string) => Promise<unknown>;

--- a/packages/remix-react/single-fetch.tsx
+++ b/packages/remix-react/single-fetch.tsx
@@ -153,7 +153,7 @@ function singleFetchLoaderStrategy(
   request: Request,
   matches: DataStrategyFunctionArgs["matches"]
 ) {
-  let singleFetchPromise: Promise<SingleFetchResults>;
+  let singleFetchPromise: Promise<SingleFetchResults> | undefined;
   return Promise.all(
     matches.map(async (m) =>
       m.resolve(async (handler): Promise<HandlerResult> => {


### PR DESCRIPTION
Change the logic for `serverLoader` calls from `clientLoader`'s in single fetch mode so we're not over-fetching on the server if a `clientLoader` never calls `serverLoader`.

Todo:
* [x] Update prefetching logic to align