### PR TITLE
Update nightly release to use pnpm since it checks out the dev branch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,14 +34,17 @@ jobs:
           token: ${{ secrets.NIGHTLY_PAT }}
           fetch-depth: 0
 
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v3.0.0
+
       - name: ⎔ Setup node
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
-          cache: "yarn"
+          cache: "pnpm"
 
       - name: 📥 Install deps
-        run: yarn --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: 🕵️ Check for changes
         id: version
@@ -74,12 +77,12 @@ jobs:
           git config --local user.email "hello@remix.run"
           git config --local user.name "Remix Run Bot"
           git checkout -b nightly/${{ steps.version.outputs.NEXT_VERSION }}
-          yarn run version ${{steps.version.outputs.NEXT_VERSION}} --skip-prompt
+          pnpm run version ${{steps.version.outputs.NEXT_VERSION}} --skip-prompt
           git push origin --tags
 
       - name: 🏗 Build
         if: steps.version.outputs.NEXT_VERSION
-        run: yarn build
+        run: pnpm build
 
       - name: 🔐 Setup npm auth
         if: steps.version.outputs.NEXT_VERSION


### PR DESCRIPTION
It looks like your nightly releases [broke](https://github.com/remix-run/remix/actions/workflows/nightly.yml) with the `pnpm` switch.  Since the nightly workflow runs on a cron job, it always uses the workflow file from `main`, even though it checks out the source code from `dev` - per this comment I found when I went to check out the workflow 🤣 

```
# HEADS UP! this "nightly" job will only ever run on the `main` branch due to it being a cron job,
# and the last commit on main will be what github shows as the trigger
# however in the checkout below we specify the `dev` branch, so all the scripts
# in this job will be ran from that, confusing i know, so in some cases we'll need to create
# multiple PRs when modifying nightly release processes
```

This copies the updated file from `dev` down to `main` and hopefully tonights nightly release will pass 🤞 
