### PR TITLE
Remove vite-tsconfig-paths from remix-javascript template

### DIFF
--- a/templates/remix-javascript/vite.config.js
+++ b/templates/remix-javascript/vite.config.js
@@ -1,10 +1,9 @@
 import { vitePlugin as remix } from "@remix-run/dev";
 import { installGlobals } from "@remix-run/node";
 import { defineConfig } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 installGlobals();
 
 export default defineConfig({
-  plugins: [remix(), tsconfigPaths()],
+  plugins: [remix()],
 });


### PR DESCRIPTION
This file wasn't cleaned up when copying from the `remix` template.