### PR TITLE
feat: use undici as fetch polyfill

### DIFF
--- a/jest/jest.config.shared.js
+++ b/jest/jest.config.shared.js
@@ -9,11 +9,6 @@ const ignorePatterns = [
 /** @type {import('jest').Config} */
 module.exports = {
   moduleNameMapper: {
-    "^@remix-run/web-blob$": require.resolve("@remix-run/web-blob"),
-    "^@remix-run/web-fetch$": require.resolve("@remix-run/web-fetch"),
-    "^@remix-run/web-file": require.resolve("@remix-run/web-file"),
-    "^@remix-run/web-form-data$": require.resolve("@remix-run/web-form-data"),
-    "^@remix-run/web-stream$": require.resolve("@remix-run/web-stream"),
     "^@web3-storage/multipart-parser$": require.resolve(
       "@web3-storage/multipart-parser"
     ),

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@remix-run/css-bundle": "workspace:*",
     "@remix-run/dev": "workspace:*",
     "@remix-run/node": "workspace:*",
-    "@remix-run/web-fetch": "^4.4.2",
     "@remix-run/react": "workspace:*",
     "@remix-run/testing": "workspace:*",
     "@rollup/plugin-babel": "^5.2.2",

--- a/packages/remix-architect/__tests__/server-test.ts
+++ b/packages/remix-architect/__tests__/server-test.ts
@@ -217,7 +217,7 @@ describe("architect createRemixHeaders", () => {
         "x-foo": "bar, baz",
         "x-bar": "baz",
       });
-      expect(headers.getAll("x-foo")).toEqual(["bar, baz"]);
+      expect(headers.get("x-foo")).toEqual("bar, baz");
       expect(headers.get("x-bar")).toBe("baz");
     });
 
@@ -226,9 +226,9 @@ describe("architect createRemixHeaders", () => {
         "__session=some_value",
         "__other=some_other_value",
       ]);
-      expect(headers.getAll("cookie")).toEqual([
-        "__session=some_value; __other=some_other_value",
-      ]);
+      expect(headers.get("cookie")).toEqual(
+        "__session=some_value; __other=some_other_value"
+      );
     });
   });
 });

--- a/packages/remix-architect/server.ts
+++ b/packages/remix-architect/server.ts
@@ -88,7 +88,9 @@ export function createRemixHeaders(
   }
 
   if (requestCookies) {
-    headers.append("Cookie", requestCookies.join("; "));
+    for (let cookie of requestCookies) {
+      headers.append("Cookie", cookie);
+    }
   }
 
   return headers;

--- a/packages/remix-express/__tests__/server-test.ts
+++ b/packages/remix-express/__tests__/server-test.ts
@@ -178,7 +178,7 @@ describe("express createRemixHeaders", () => {
         "x-foo": ["bar", "baz"],
         "x-bar": "baz",
       });
-      expect(headers.getAll("x-foo")).toEqual(["bar", "baz"]);
+      expect(headers.get("x-foo")).toEqual("bar, baz");
       expect(headers.get("x-bar")).toBe("baz");
     });
 
@@ -189,7 +189,7 @@ describe("express createRemixHeaders", () => {
           "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
         ],
       });
-      expect(headers.getAll("set-cookie")).toEqual([
+      expect(headers.getSetCookie()).toEqual([
         "__session=some_value; Path=/; Secure; HttpOnly; MaxAge=7200; SameSite=Lax",
         "__other=some_other_value; Path=/; Secure; HttpOnly; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax",
       ]);

--- a/packages/remix-node/__tests__/fileUploadHandler-test.ts
+++ b/packages/remix-node/__tests__/fileUploadHandler-test.ts
@@ -1,13 +1,8 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { ReadableStream } from "@remix-run/web-stream";
 
 import { NodeOnDiskFile } from "../upload/fileUploadHandler";
 import { readableStreamToString } from "../stream";
-
-beforeAll(() => {
-  global.ReadableStream = ReadableStream;
-});
 
 describe("NodeOnDiskFile", () => {
   let filepath = path.resolve(__dirname, "assets/test.txt");

--- a/packages/remix-node/globals.ts
+++ b/packages/remix-node/globals.ts
@@ -1,19 +1,4 @@
 import {
-  ByteLengthQueuingStrategy as NodeByteLengthQueuingStrategy,
-  CountQueuingStrategy as NodeCountQueuingStrategy,
-  ReadableByteStreamController as NodeReadableByteStreamController,
-  ReadableStream as NodeReadableStream,
-  ReadableStreamBYOBReader as NodeReadableStreamBYOBReader,
-  ReadableStreamBYOBRequest as NodeReadableStreamBYOBRequest,
-  ReadableStreamDefaultController as NodeReadableStreamDefaultController,
-  ReadableStreamDefaultReader as NodeReadableStreamDefaultReader,
-  TransformStream as NodeTransformStream,
-  TransformStreamDefaultController as NodeTransformStreamDefaultController,
-  WritableStream as NodeWritableStream,
-  WritableStreamDefaultController as NodeWritableStreamDefaultController,
-  WritableStreamDefaultWriter as NodeWritableStreamDefaultWriter,
-} from "node:stream/web";
-import {
   File as NodeFile,
   fetch as nodeFetch,
   FormData as NodeFormData,
@@ -60,26 +45,4 @@ export function installGlobals() {
   global.fetch = nodeFetch;
   // @ts-expect-error - overriding globals
   global.FormData = NodeFormData;
-
-  // Export everything from https://developer.mozilla.org/en-US/docs/Web/API/Streams_API
-  global.ByteLengthQueuingStrategy = NodeByteLengthQueuingStrategy;
-  global.CountQueuingStrategy = NodeCountQueuingStrategy;
-  // @ts-expect-error - overriding globals
-  global.ReadableByteStreamController = NodeReadableByteStreamController;
-  // @ts-expect-error - overriding globals
-  global.ReadableStream = NodeReadableStream;
-  global.ReadableStreamBYOBReader = NodeReadableStreamBYOBReader;
-  global.ReadableStreamBYOBRequest = NodeReadableStreamBYOBRequest;
-  global.ReadableStreamDefaultController = NodeReadableStreamDefaultController;
-  // @ts-expect-error - overriding globals
-  global.ReadableStreamDefaultReader = NodeReadableStreamDefaultReader;
-  // @ts-expect-error - overriding globals
-  global.TransformStream = NodeTransformStream;
-  global.TransformStreamDefaultController =
-    NodeTransformStreamDefaultController;
-  // @ts-expect-error - overriding globals
-  global.WritableStream = NodeWritableStream;
-  // @ts-expect-error - overriding globals
-  global.WritableStreamDefaultController = NodeWritableStreamDefaultController;
-  global.WritableStreamDefaultWriter = NodeWritableStreamDefaultWriter;
 }

--- a/packages/remix-node/globals.ts
+++ b/packages/remix-node/globals.ts
@@ -1,12 +1,4 @@
 import {
-  File as NodeFile,
-  fetch as nodeFetch,
-  FormData as NodeFormData,
-  Headers as NodeHeaders,
-  Request as NodeRequest,
-  Response as NodeResponse,
-} from "@remix-run/web-fetch";
-import {
   ByteLengthQueuingStrategy as NodeByteLengthQueuingStrategy,
   CountQueuingStrategy as NodeCountQueuingStrategy,
   ReadableByteStreamController as NodeReadableByteStreamController,
@@ -20,7 +12,15 @@ import {
   WritableStream as NodeWritableStream,
   WritableStreamDefaultController as NodeWritableStreamDefaultController,
   WritableStreamDefaultWriter as NodeWritableStreamDefaultWriter,
-} from "@remix-run/web-stream";
+} from "node:stream/web";
+import {
+  File as NodeFile,
+  fetch as nodeFetch,
+  FormData as NodeFormData,
+  Headers as NodeHeaders,
+  Request as NodeRequest,
+  Response as NodeResponse,
+} from "undici";
 
 declare global {
   namespace NodeJS {
@@ -41,30 +41,45 @@ declare global {
       WritableStream: typeof WritableStream;
     }
   }
+
+  interface RequestInit {
+    duplex?: "half";
+  }
 }
 
 export function installGlobals() {
-  global.File = NodeFile;
+  global.File = NodeFile as unknown as typeof File;
 
-  global.Headers = NodeHeaders as typeof Headers;
-  global.Request = NodeRequest as typeof Request;
-  global.Response = NodeResponse as unknown as typeof Response;
-  global.fetch = nodeFetch as typeof fetch;
+  // @ts-expect-error - overriding globals
+  global.Headers = NodeHeaders;
+  // @ts-expect-error - overriding globals
+  global.Request = NodeRequest;
+  // @ts-expect-error - overriding globals
+  global.Response = NodeResponse;
+  // @ts-expect-error - overriding globals
+  global.fetch = nodeFetch;
+  // @ts-expect-error - overriding globals
   global.FormData = NodeFormData;
 
   // Export everything from https://developer.mozilla.org/en-US/docs/Web/API/Streams_API
   global.ByteLengthQueuingStrategy = NodeByteLengthQueuingStrategy;
   global.CountQueuingStrategy = NodeCountQueuingStrategy;
+  // @ts-expect-error - overriding globals
   global.ReadableByteStreamController = NodeReadableByteStreamController;
+  // @ts-expect-error - overriding globals
   global.ReadableStream = NodeReadableStream;
   global.ReadableStreamBYOBReader = NodeReadableStreamBYOBReader;
   global.ReadableStreamBYOBRequest = NodeReadableStreamBYOBRequest;
   global.ReadableStreamDefaultController = NodeReadableStreamDefaultController;
+  // @ts-expect-error - overriding globals
   global.ReadableStreamDefaultReader = NodeReadableStreamDefaultReader;
+  // @ts-expect-error - overriding globals
   global.TransformStream = NodeTransformStream;
   global.TransformStreamDefaultController =
     NodeTransformStreamDefaultController;
+  // @ts-expect-error - overriding globals
   global.WritableStream = NodeWritableStream;
+  // @ts-expect-error - overriding globals
   global.WritableStreamDefaultController = NodeWritableStreamDefaultController;
   global.WritableStreamDefaultWriter = NodeWritableStreamDefaultWriter;
 }

--- a/packages/remix-node/package.json
+++ b/packages/remix-node/package.json
@@ -21,13 +21,11 @@
   },
   "dependencies": {
     "@remix-run/server-runtime": "workspace:*",
-    "@remix-run/web-fetch": "^4.4.2",
-    "@remix-run/web-file": "^3.1.0",
-    "@remix-run/web-stream": "^1.1.0",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie-signature": "^1.1.0",
     "source-map-support": "^0.5.21",
-    "stream-slice": "^0.1.2"
+    "stream-slice": "^0.1.2",
+    "undici": "^6.10.1"
   },
   "devDependencies": {
     "@types/cookie-signature": "^1.0.3",

--- a/packages/remix-react/__tests__/setup.ts
+++ b/packages/remix-react/__tests__/setup.ts
@@ -1,3 +1,8 @@
-import { installGlobals } from "@remix-run/node";
+const JSDOMFormData = global.FormData;
+global.TextDecoder = require("util").TextDecoder;
+global.TextEncoder = require("util").TextEncoder;
+global.ReadableStream = require("stream/web").ReadableStream;
+global.WritableStream = require("stream/web").WritableStream;
 
-installGlobals();
+require("@remix-run/node").installGlobals();
+global.FormData = JSDOMFormData;

--- a/packages/remix-server-runtime/__tests__/formData-test.ts
+++ b/packages/remix-server-runtime/__tests__/formData-test.ts
@@ -1,5 +1,11 @@
 import { parseMultipartFormData } from "../formData";
 
+declare global {
+  interface RequestInit {
+    duplex?: "half";
+  }
+}
+
 class CustomError extends Error {
   constructor() {
     super("test error");
@@ -21,7 +27,7 @@ describe("parseMultipartFormData", () => {
     let parsedFormData = await parseMultipartFormData(
       req,
       async ({ filename, data, contentType }) => {
-        let chunks = [];
+        let chunks: Uint8Array[] = [];
         for await (let chunk of data) {
           chunks.push(chunk);
         }
@@ -111,6 +117,7 @@ describe("parseMultipartFormData", () => {
         method: "post",
         body,
         headers: underlyingRequest.headers,
+        duplex: "half",
       });
 
       let error: Error;
@@ -151,6 +158,7 @@ describe("parseMultipartFormData", () => {
         method: "post",
         body,
         headers: underlyingRequest.headers,
+        duplex: "half",
       });
 
       let error: Error;

--- a/packages/remix-testing/jest.setup.js
+++ b/packages/remix-testing/jest.setup.js
@@ -1,3 +1,8 @@
-import { installGlobals } from "@remix-run/node";
+const JSDOMFormData = global.FormData;
+global.TextDecoder = require("util").TextDecoder;
+global.TextEncoder = require("util").TextEncoder;
+global.ReadableStream = require("stream/web").ReadableStream;
+global.WritableStream = require("stream/web").WritableStream;
 
-installGlobals();
+require("@remix-run/node").installGlobals();
+global.FormData = JSDOMFormData;

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^18.17.1",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
-    "jest-environment-jsdom": "^29.6.4",
+    "jest-environment-jsdom": "^29.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.1.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,9 +91,6 @@ importers:
       '@remix-run/testing':
         specifier: workspace:*
         version: link:packages/remix-testing
-      '@remix-run/web-fetch':
-        specifier: ^4.4.2
-        version: 4.4.2
       '@rollup/plugin-babel':
         specifier: ^5.2.2
         version: 5.3.1(@babel/core@7.23.7)(rollup@2.75.7)
@@ -1185,15 +1182,6 @@ importers:
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../remix-server-runtime
-      '@remix-run/web-fetch':
-        specifier: ^4.4.2
-        version: 4.4.2
-      '@remix-run/web-file':
-        specifier: ^3.1.0
-        version: 3.1.0
-      '@remix-run/web-stream':
-        specifier: ^1.1.0
-        version: 1.1.0
       '@web3-storage/multipart-parser':
         specifier: ^1.0.0
         version: 1.0.0
@@ -1206,6 +1194,9 @@ importers:
       stream-slice:
         specifier: ^0.1.2
         version: 0.1.2
+      undici:
+        specifier: ^6.10.1
+        version: 6.10.1
     devDependencies:
       '@types/cookie-signature':
         specifier: ^1.0.3
@@ -1365,7 +1356,7 @@ importers:
         specifier: ^18.2.7
         version: 18.2.7
       jest-environment-jsdom:
-        specifier: ^29.6.4
+        specifier: ^29.7.0
         version: 29.7.0
       react:
         specifier: ^18.2.0
@@ -4225,7 +4216,7 @@ packages:
       '@web3-storage/multipart-parser': 1.0.0
       abort-controller: 3.0.0
       data-uri-to-buffer: 3.0.1
-      mrmime: 1.0.0
+      mrmime: 1.0.1
     dev: false
 
   /@remix-run/web-file@3.1.0:
@@ -11637,8 +11628,8 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /mrmime@1.0.0:
-    resolution: {integrity: sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ==}
+  /mrmime@1.0.1:
+    resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
     engines: {node: '>=10'}
     dev: false
 
@@ -14461,6 +14452,11 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       '@fastify/busboy': 2.1.0
+
+  /undici@6.10.1:
+    resolution: {integrity: sha512-kSzmWrOx3XBKTgPm4Tal8Hyl3yf+hzlA00SAf4goxv8LZYafKmS6gJD/7Fe5HH/DMNiFTRXvkwhLo7mUn5fuQQ==}
+    engines: {node: '>=18.0'}
+    dev: false
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}

--- a/scripts/bump-fetch-versions.sh
+++ b/scripts/bump-fetch-versions.sh
@@ -7,7 +7,7 @@ if [ "${VERSION}" == "" ]; then
 fi
 
 
-echo "Updating the web-std-io dependencies to version '${VERSION}'"
+echo "Updating the undici dependencies to version '${VERSION}'"
 echo ""
 
 if [ ! -d "packages/remix-node" ]; then
@@ -18,7 +18,7 @@ fi
 set -x
 
 cd packages/remix-node
-pnpm add @remix-run/web-fetch@${VERSION} @remix-run/web-file@${VERSION} @remix-run/web-stream@${VERSION}
+pnpm add undici@${VERSION}
 cd ../..
 
 set +x

--- a/scripts/deployment-test/_shared.mjs
+++ b/scripts/deployment-test/_shared.mjs
@@ -5,8 +5,8 @@ import crypto from "node:crypto";
 import { sync as spawnSync } from "cross-spawn";
 import PackageJson from "@npmcli/package-json";
 import jsonfile from "jsonfile";
-import { fetch } from "@remix-run/web-fetch";
 import retry from "fetch-retry";
+import { fetch } from "undici";
 
 let fetchRetry = retry(fetch);
 

--- a/scripts/deployment-test/cf-pages.mjs
+++ b/scripts/deployment-test/cf-pages.mjs
@@ -1,8 +1,8 @@
 import path from "node:path";
 import { sync as spawnSync } from "cross-spawn";
 import fse from "fs-extra";
-import { fetch } from "@remix-run/web-fetch";
 import PackageJson from "@npmcli/package-json";
+import { fetch } from "undici";
 
 import {
   addCypress,

--- a/scripts/deployment-test/cf-workers.mjs
+++ b/scripts/deployment-test/cf-workers.mjs
@@ -2,8 +2,8 @@ import path from "node:path";
 import { sync as spawnSync } from "cross-spawn";
 import fse from "fs-extra";
 import toml from "@iarna/toml";
-import { fetch } from "@remix-run/web-fetch";
 import PackageJson from "@npmcli/package-json";
+import { fetch } from "undici";
 
 import {
   addCypress,


### PR DESCRIPTION
Use undici as our fetch polyfill going forward. This will allow us to firstly (and my my favorite part), stop maintaining our own, and secondly and arguably more important, will allow us to smoothly upgrade our users to the Node.js fetch when they are on a node 20+ as they will already be using it via the polyfill. Undici is the node fetch implementation, and now all our installGlobals() will be doing is giving you the latest version regardless of your node version, and I think that's pretty sweet.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
