### PR TITLE
Update root.tsx with meta export

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -38,6 +38,7 @@
 - andrelandgraf
 - andrewbrey
 - AndrewIngram
+- AndrewOt
 - anishpras
 - anmolm96
 - anmonteiro

--- a/templates/vite/app/root.tsx
+++ b/templates/vite/app/root.tsx
@@ -6,12 +6,17 @@ import {
   ScrollRestoration,
 } from "@remix-run/react";
 
+export const meta: MetaFunction = () => {
+  return [
+    { charSet: "utf-8" },
+    { viewport: "width=device-width,initial-scale=1" },
+  ];
+};
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>


### PR DESCRIPTION
Changing the template to use the `meta` export function to do things the "remix" way.

I was using this template to upgrade my vite spa app to remix vite and ran into a hydration issue. After a bit of research and tinkering, I discovered that adding my own meta tags was causing the problem. So I figured I could just use the `meta` export. Then I thought I'd fix the template so no other poor soul would run into a hydration error because of this issue.