### PR TITLE
Add error handling for not found static assets

### DIFF
--- a/docs/future/vite.md
+++ b/docs/future/vite.md
@@ -399,7 +399,12 @@ if (viteDevServer) {
     express.static("build/client/assets", {
       immutable: true,
       maxAge: "1y",
-    })
+      fallthrough: true
+    }),
+    (req, res) => {
+      res.status(404).send('Not found')
+      return
+    }
   );
 }
 app.use(express.static("build/client", { maxAge: "1h" }));


### PR DESCRIPTION
I noticed that without sending an 404 here the request will be handled by Remix and triggers the root loader. As an alternative setting fallthrough=false would also work, but that would show up in logs.

The issue occurs for example when the devtools are open and the browser tries to fetch sourcemaps.

In my case I was committing an CSRF token in the root loader so the CSRF token was not in sync with the client app anymore.

- [x] Docs
- [ ] Tests
