### PR TITLE
Simplify implementation

### DIFF
--- a/.changeset/popular-adults-remain.md
+++ b/.changeset/popular-adults-remain.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+[REMOVE] Remove RR flags and impement via dataStrategy

--- a/.changeset/popular-adults-remain.md
+++ b/.changeset/popular-adults-remain.md
@@ -2,4 +2,4 @@
 "@remix-run/server-runtime": patch
 ---
 
-[REMOVE] Remove RR flags and impement via dataStrategy
+[REMOVE] Remove RR flags and implement via dataStrategy

--- a/integration/package.json
+++ b/integration/package.json
@@ -14,7 +14,7 @@
     "@remix-run/dev": "workspace:*",
     "@remix-run/express": "workspace:*",
     "@remix-run/node": "workspace:*",
-    "@remix-run/router": "1.16.0-pre.0",
+    "@remix-run/router": "1.16.0-pre.1",
     "@remix-run/server-runtime": "workspace:*",
     "@types/express": "^4.17.9",
     "@vanilla-extract/css": "^1.10.0",

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -32,7 +32,7 @@
     "@mdx-js/mdx": "^2.3.0",
     "@npmcli/package-json": "^4.0.1",
     "@remix-run/node": "workspace:*",
-    "@remix-run/router": "1.16.0-pre.0",
+    "@remix-run/router": "1.16.0-pre.1",
     "@remix-run/server-runtime": "workspace:*",
     "@types/mdx": "^2.0.5",
     "@vanilla-extract/integration": "^6.2.0",

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -19,10 +19,10 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@remix-run/router": "1.16.0-pre.0",
+    "@remix-run/router": "1.16.0-pre.1",
     "@remix-run/server-runtime": "workspace:*",
-    "react-router": "6.23.0-pre.0",
-    "react-router-dom": "6.23.0-pre.0",
+    "react-router": "6.23.0-pre.1",
+    "react-router-dom": "6.23.0-pre.1",
     "turbo-stream": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -19,7 +19,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@remix-run/router": "1.16.0-pre.0",
+    "@remix-run/router": "1.16.0-pre.1",
     "@types/cookie": "^0.6.0",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie": "^0.6.0",

--- a/packages/remix-server-runtime/single-fetch.ts
+++ b/packages/remix-server-runtime/single-fetch.ts
@@ -1,7 +1,6 @@
 import type {
   StaticHandler,
   unstable_DataStrategyFunctionArgs as DataStrategyFunctionArgs,
-  unstable_HandlerResult as HandlerResult,
   StaticHandlerContext,
 } from "@remix-run/router";
 import {

--- a/packages/remix-server-runtime/single-fetch.ts
+++ b/packages/remix-server-runtime/single-fetch.ts
@@ -131,7 +131,9 @@ export async function singleFetchAction(
     let context = result;
 
     let singleFetchResult: SingleFetchResult;
-    let { statusCode, headers } = mergeResponseStubs(context, responseStubs);
+    let { statusCode, headers } = mergeResponseStubs(context, responseStubs, {
+      isActionDataRequest: true,
+    });
 
     if (isRedirectStatusCode(statusCode) && headers.has("Location")) {
       return {
@@ -215,9 +217,7 @@ export async function singleFetchLoaders(
 
     let context = result;
 
-    let { statusCode, headers } = mergeResponseStubs(context, responseStubs, {
-      isActionDataRequest: true,
-    });
+    let { statusCode, headers } = mergeResponseStubs(context, responseStubs);
 
     if (isRedirectStatusCode(statusCode) && headers.has("Location")) {
       return {

--- a/packages/remix-server-runtime/single-fetch.ts
+++ b/packages/remix-server-runtime/single-fetch.ts
@@ -1,6 +1,7 @@
 import type {
   StaticHandler,
   unstable_DataStrategyFunctionArgs as DataStrategyFunctionArgs,
+  unstable_HandlerResult as HandlerResult,
   StaticHandlerContext,
 } from "@remix-run/router";
 import {
@@ -36,9 +37,22 @@ export type SingleFetchResults = {
 };
 
 export function getSingleFetchDataStrategy(
-  responseStubs: ReturnType<typeof getResponseStubs>
+  responseStubs: ReturnType<typeof getResponseStubs>,
+  {
+    isActionDataRequest,
+    loadRouteIds,
+  }: { isActionDataRequest?: boolean; loadRouteIds?: string[] } = {}
 ) {
   return async ({ request, matches }: DataStrategyFunctionArgs) => {
+    // Don't call loaders on action data requests
+    if (isActionDataRequest && request.method === "GET") {
+      return await Promise.all(
+        matches.map((m) =>
+          m.resolve(async () => ({ type: "data", result: null }))
+        )
+      );
+    }
+
     let results = await Promise.all(
       matches.map(async (match) => {
         let responseStub: ResponseStub | undefined;
@@ -49,7 +63,11 @@ export function getSingleFetchDataStrategy(
         }
 
         let result = await match.resolve(async (handler) => {
-          let data = await handler({ response: responseStub });
+          // Only run opt-in loaders when fine-grained revalidation is enabled
+          let data =
+            loadRouteIds && !loadRouteIds.includes(match.route.id)
+              ? null
+              : await handler({ response: responseStub });
           return { type: "data", result: data };
         });
 
@@ -96,8 +114,9 @@ export async function singleFetchAction(
     let result = await staticHandler.query(handlerRequest, {
       requestContext: loadContext,
       skipLoaderErrorBubbling: true,
-      skipLoaders: true,
-      unstable_dataStrategy: getSingleFetchDataStrategy(responseStubs),
+      unstable_dataStrategy: getSingleFetchDataStrategy(responseStubs, {
+        isActionDataRequest: true,
+      }),
     });
 
     // Unlike `handleDataRequest`, when singleFetch is enabled, queryRoute does
@@ -176,9 +195,10 @@ export async function singleFetchLoaders(
     let responseStubs = getResponseStubs();
     let result = await staticHandler.query(handlerRequest, {
       requestContext: loadContext,
-      loadRouteIds,
       skipLoaderErrorBubbling: true,
-      unstable_dataStrategy: getSingleFetchDataStrategy(responseStubs),
+      unstable_dataStrategy: getSingleFetchDataStrategy(responseStubs, {
+        loadRouteIds,
+      }),
     });
 
     if (isResponse(result)) {
@@ -196,7 +216,9 @@ export async function singleFetchLoaders(
 
     let context = result;
 
-    let { statusCode, headers } = mergeResponseStubs(context, responseStubs);
+    let { statusCode, headers } = mergeResponseStubs(context, responseStubs, {
+      isActionDataRequest: true,
+    });
 
     if (isRedirectStatusCode(statusCode) && headers.has("Location")) {
       return {
@@ -323,17 +345,20 @@ function proxyResponseToResponseStub(
 
 export function mergeResponseStubs(
   context: StaticHandlerContext,
-  responseStubs: ReturnType<typeof getResponseStubs>
+  responseStubs: ReturnType<typeof getResponseStubs>,
+  { isActionDataRequest }: { isActionDataRequest?: boolean } = {}
 ) {
   let statusCode: number | undefined = undefined;
   let headers = new Headers();
 
   // Action followed by top-down loaders
   let actionStub = responseStubs[ResponseStubActionSymbol];
-  let stubs = [
-    actionStub,
-    ...context.matches.map((m) => responseStubs[m.route.id]),
-  ];
+  let stubs = [actionStub];
+
+  // Nothing to merge at the route level on action data requests
+  if (!isActionDataRequest) {
+    stubs.push(...context.matches.map((m) => responseStubs[m.route.id]));
+  }
 
   for (let stub of stubs) {
     // Take the highest error/redirect, or the lowest success value - preferring

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@remix-run/node": "workspace:*",
     "@remix-run/react": "workspace:*",
-    "@remix-run/router": "1.16.0-pre.0",
-    "react-router-dom": "6.23.0-pre.0"
+    "@remix-run/router": "1.16.0-pre.1",
+    "react-router-dom": "6.23.0-pre.1"
   },
   "devDependencies": {
     "@remix-run/server-runtime": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,8 +320,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/remix-node
       '@remix-run/router':
-        specifier: 1.16.0-pre.0
-        version: 1.16.0-pre.0
+        specifier: 1.16.0-pre.1
+        version: 1.16.0-pre.1
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../packages/remix-server-runtime
@@ -868,8 +868,8 @@ importers:
         specifier: ^2.9.0-pre.0
         version: link:../remix-react
       '@remix-run/router':
-        specifier: 1.16.0-pre.0
-        version: 1.16.0-pre.0
+        specifier: 1.16.0-pre.1
+        version: 1.16.0-pre.1
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../remix-server-runtime
@@ -1211,17 +1211,17 @@ importers:
   packages/remix-react:
     dependencies:
       '@remix-run/router':
-        specifier: 1.16.0-pre.0
-        version: 1.16.0-pre.0
+        specifier: 1.16.0-pre.1
+        version: 1.16.0-pre.1
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../remix-server-runtime
       react-router:
-        specifier: 6.23.0-pre.0
-        version: 6.23.0-pre.0(react@18.2.0)
+        specifier: 6.23.0-pre.1
+        version: 6.23.0-pre.1(react@18.2.0)
       react-router-dom:
-        specifier: 6.23.0-pre.0
-        version: 6.23.0-pre.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: 6.23.0-pre.1
+        version: 6.23.0-pre.1(react-dom@18.2.0)(react@18.2.0)
       turbo-stream:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1297,8 +1297,8 @@ importers:
   packages/remix-server-runtime:
     dependencies:
       '@remix-run/router':
-        specifier: 1.16.0-pre.0
-        version: 1.16.0-pre.0
+        specifier: 1.16.0-pre.1
+        version: 1.16.0-pre.1
       '@types/cookie':
         specifier: ^0.6.0
         version: 0.6.0
@@ -1334,11 +1334,11 @@ importers:
         specifier: workspace:*
         version: link:../remix-react
       '@remix-run/router':
-        specifier: 1.16.0-pre.0
-        version: 1.16.0-pre.0
+        specifier: 1.16.0-pre.1
+        version: 1.16.0-pre.1
       react-router-dom:
-        specifier: 6.23.0-pre.0
-        version: 6.23.0-pre.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: 6.23.0-pre.1
+        version: 6.23.0-pre.1(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@remix-run/server-runtime':
         specifier: workspace:*
@@ -4193,8 +4193,8 @@ packages:
       - encoding
     dev: false
 
-  /@remix-run/router@1.16.0-pre.0:
-    resolution: {integrity: sha512-4KYbcmBcjX1HO/sLPZIcY87YWTF3e5qs9KTTieXE0HNukV2m199yTkMIjcmzTNL6w0wDj5YYc2YiXxm4W9qsTw==}
+  /@remix-run/router@1.16.0-pre.1:
+    resolution: {integrity: sha512-zmaT9ICBPTMyoerhGgydSZVdBbEysM7SHan4pJUBIPe66ofscEv60OCjPyX+ZcH2ihjspj3tN2/ZnYAIZmEzjA==}
     engines: {node: '>=14.0.0'}
     dev: false
 
@@ -12784,26 +12784,26 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /react-router-dom@6.23.0-pre.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-TDEljjV6XwOEb9gp6FFNquAB0yY490lhSZRo4YNDPI8+QEA0n3yJ2VfIZLmxR70ljnFBwYOnWmNl94EHom/JjQ==}
+  /react-router-dom@6.23.0-pre.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-iZnPPBGCvg/gGzzKCqaXoPJjdVQwjJ4aJj2UTatJvzIQq6c586BS7u8WzpHy2pmbri58btGj4eLIgF7jv1Fgvw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.16.0-pre.0
+      '@remix-run/router': 1.16.0-pre.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-router: 6.23.0-pre.0(react@18.2.0)
+      react-router: 6.23.0-pre.1(react@18.2.0)
     dev: false
 
-  /react-router@6.23.0-pre.0(react@18.2.0):
-    resolution: {integrity: sha512-GawzByLrAoOr4Sc0ybAuYBTJmtysK8I7p3VuBQCzDCqXzu10uAP7tu0Iy+mv0SGkmzKpPXg4PUO26UQ9bBH7bg==}
+  /react-router@6.23.0-pre.1(react@18.2.0):
+    resolution: {integrity: sha512-lijdeB51mv3Cxij+ymI/NcGCb0D9KjXPuvqFXxeUIyMtevHh6i1viDD/0U+gknla1ZfawhWKfwkn4XAD2T7KTA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.16.0-pre.0
+      '@remix-run/router': 1.16.0-pre.1
       react: 18.2.0
     dev: false
 


### PR DESCRIPTION
Move `skipLoaders`/`loadRouteIds` logic to `dataStrategy` now that it's request specific so we can remove them from the router API: https://github.com/remix-run/react-router/pull/11384