### PR TITLE
feat: specify where project will be created in create remix cli

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -666,3 +666,4 @@
 - zainfathoni
 - zayenz
 - zhe
+- jonmejia

--- a/packages/create-remix/index.ts
+++ b/packages/create-remix/index.ts
@@ -237,7 +237,7 @@ async function projectNameStep(ctx: Context) {
       name: "name",
       type: "text",
       label: title("dir"),
-      message: "Where should we create your new project?",
+      message: "Where should we create your new project? (Will be relative to current directory)",
       initial: "./my-remix-app",
     });
     ctx.cwd = name!;


### PR DESCRIPTION
Hi, I was trying out remix for the first time and was extremely pleased with the cli, but there was only one issue I came across. When asked where I wanted to create my remix dir, I did not know it would all be inside of my current dir, and I input `~/Repositories` which in my head, should have gone to the Repositories directory in my home holder, but instead created a directory called `~/` inside of the directory I was in at the time. To remove it I tried `rm -rf ~/` and you can imagine what happened next. 

I think it would be nice if there was just a little tool tip to tell the user the directory they are creating will be relative to the path of their current working directory and it will not be as if they were interacting with the terminal itself. 