### PR TITLE
Migrate Playwright fixture to Vite by default

### DIFF
--- a/integration/action-test.ts
+++ b/integration/action-test.ts
@@ -228,11 +228,7 @@ test.describe("single fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/routes/urlencoded.tsx": js`
             import { Form, useActionData } from "@remix-run/react";

--- a/integration/catch-boundary-data-test.ts
+++ b/integration/catch-boundary-data-test.ts
@@ -256,11 +256,7 @@ test.describe("single fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/root.tsx": js`
             import { json } from "@remix-run/node";

--- a/integration/catch-boundary-test.ts
+++ b/integration/catch-boundary-test.ts
@@ -389,11 +389,7 @@ test.describe("single fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/root.tsx": js`
               import { json } from "@remix-run/node";

--- a/integration/cf-compiler-test.ts
+++ b/integration/cf-compiler-test.ts
@@ -28,6 +28,7 @@ test.describe("cloudflare compiler", () => {
 
   test.beforeAll(async () => {
     projectDir = await createFixtureProject({
+      compiler: "remix",
       template: "cf-template",
       files: {
         "package.json": json({

--- a/integration/client-data-test.ts
+++ b/integration/client-data-test.ts
@@ -1422,11 +1422,7 @@ test.describe("single fetch", () => {
       return createFixture(
         {
           ...init,
-          config: {
-            future: {
-              unstable_singleFetch: true,
-            },
-          },
+          singleFetch: true,
         },
         serverMode
       );

--- a/integration/compiler-mjs-cjs-output-test.ts
+++ b/integration/compiler-mjs-cjs-output-test.ts
@@ -11,6 +11,7 @@ test.describe("", () => {
   ]) {
     test(`can write .${serverModuleExt} server output module`, async () => {
       let projectDir = await createFixtureProject({
+        compiler: "remix",
         files: {
           // Ensure the config is valid ESM
           "remix.config.js": js`

--- a/integration/compiler-test.ts
+++ b/integration/compiler-test.ts
@@ -18,6 +18,7 @@ test.describe("compiler", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      compiler: "remix",
       files: {
         // We need a custom config file here to test usage of `getDependenciesToBundle`
         // since this can't be serialized from the fixture object.

--- a/integration/css-modules-test.ts
+++ b/integration/css-modules-test.ts
@@ -19,6 +19,7 @@ test.describe("CSS Modules", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      compiler: "remix",
       files: {
         "app/root.tsx": js`
           import { Links, Outlet } from "@remix-run/react";

--- a/integration/css-side-effect-imports-test.ts
+++ b/integration/css-side-effect-imports-test.ts
@@ -18,6 +18,7 @@ test.describe("CSS side-effect imports", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      compiler: "remix",
       config: {
         serverDependenciesToBundle: ["react", /@test-package/],
       },

--- a/integration/defer-loader-test.ts
+++ b/integration/defer-loader-test.ts
@@ -106,11 +106,7 @@ test.describe("single fetch", () => {
   test.describe("deferred loaders", () => {
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/routes/_index.tsx": js`
             import { useLoaderData, Link } from "@remix-run/react";

--- a/integration/defer-test.ts
+++ b/integration/defer-test.ts
@@ -1324,11 +1324,7 @@ test.describe("single fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/components/counter.tsx": js`
             import { useState } from "react";
@@ -2287,11 +2283,7 @@ test.describe("single fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/entry.server.tsx": js`
             import { PassThrough } from "node:stream";

--- a/integration/deno-compiler-test.ts
+++ b/integration/deno-compiler-test.ts
@@ -34,6 +34,7 @@ const searchFiles = async (pattern: string | RegExp, files: string[]) => {
 
 test.beforeAll(async () => {
   projectDir = await createFixtureProject({
+    compiler: "remix",
     template: "deno-template",
     files: {
       "package.json": json({

--- a/integration/deterministic-build-output-test.ts
+++ b/integration/deterministic-build-output-test.ts
@@ -26,6 +26,7 @@ test("builds deterministically under different paths", async () => {
   //  * serverRouteModulesPlugin (implicitly tested by build)
   //  * vanillaExtractPlugin (via app/routes/foo.tsx' .css.ts file import)
   let init: FixtureInit = {
+    compiler: "remix",
     files: {
       "postcss.config.js": js`
         export default {

--- a/integration/error-boundary-test.ts
+++ b/integration/error-boundary-test.ts
@@ -1371,11 +1371,7 @@ test.describe("single fetch", () => {
       console.error = () => {};
       fixture = await createFixture(
         {
-          config: {
-            future: {
-              unstable_singleFetch: true,
-            },
-          },
+          singleFetch: true,
           files: {
             "app/root.tsx": js`
                 import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
@@ -1833,11 +1829,7 @@ test.describe("single fetch", () => {
 
       test.beforeAll(async () => {
         fixture = await createFixture({
-          config: {
-            future: {
-              unstable_singleFetch: true,
-            },
-          },
+          singleFetch: true,
           files: {
             "app/root.tsx": js`
                 import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
@@ -2014,11 +2006,7 @@ test.describe("single fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/root.tsx": js`
               import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
@@ -2377,11 +2365,7 @@ test.describe("single fetch", () => {
       test.beforeAll(async () => {
         fixture = await createFixture(
           {
-            config: {
-              future: {
-                unstable_singleFetch: true,
-              },
-            },
+            singleFetch: true,
             files: getFiles({ includeRootErrorBoundary: false }),
           },
           ServerMode.Development
@@ -2453,11 +2437,7 @@ test.describe("single fetch", () => {
       test.beforeAll(async () => {
         fixture = await createFixture(
           {
-            config: {
-              future: {
-                unstable_singleFetch: true,
-              },
-            },
+            singleFetch: true,
             files: getFiles({ includeRootErrorBoundary: true }),
           },
           ServerMode.Development
@@ -2523,11 +2503,7 @@ test.describe("single fetch", () => {
     test.describe("When the root route has a boundary but it also throws 😦", () => {
       test.beforeAll(async () => {
         fixture = await createFixture({
-          config: {
-            future: {
-              unstable_singleFetch: true,
-            },
-          },
+          singleFetch: true,
           files: getFiles({
             includeRootErrorBoundary: true,
             rootErrorBoundaryThrows: true,
@@ -2612,11 +2588,7 @@ test.describe("single fetch", () => {
     console.error = () => {};
 
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         "app/root.tsx": js`
             import { Links, Meta, Outlet, Scripts, useRouteError } from "@remix-run/react";

--- a/integration/error-boundary-v2-test.ts
+++ b/integration/error-boundary-v2-test.ts
@@ -251,11 +251,7 @@ test.describe("single fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/root.tsx": js`
             import { Links, Meta, Outlet, Scripts } from "@remix-run/react";

--- a/integration/error-data-request-test.ts
+++ b/integration/error-data-request-test.ts
@@ -189,11 +189,7 @@ test.describe("single fetch", () => {
       console.error = (v) => errorLogs.push(v);
 
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/root.tsx": js`
             import { Links, Meta, Outlet, Scripts } from "@remix-run/react";

--- a/integration/error-sanitization-test.ts
+++ b/integration/error-sanitization-test.ts
@@ -678,11 +678,7 @@ test.describe("single fetch", () => {
       test.beforeAll(async () => {
         fixture = await createFixture(
           {
-            config: {
-              future: {
-                unstable_singleFetch: true,
-              },
-            },
+            singleFetch: true,
             files: routeFiles,
           },
           ServerMode.Production
@@ -855,11 +851,7 @@ test.describe("single fetch", () => {
       test.beforeAll(async () => {
         fixture = await createFixture(
           {
-            config: {
-              future: {
-                unstable_singleFetch: true,
-              },
-            },
+            singleFetch: true,
             files: routeFiles,
           },
           ServerMode.Development
@@ -1036,11 +1028,7 @@ test.describe("single fetch", () => {
       test.beforeAll(async () => {
         fixture = await createFixture(
           {
-            config: {
-              future: {
-                unstable_singleFetch: true,
-              },
-            },
+            singleFetch: true,
             files: {
               "app/entry.server.tsx": js`
                 import { PassThrough } from "node:stream";

--- a/integration/fetcher-layout-test.ts
+++ b/integration/fetcher-layout-test.ts
@@ -288,11 +288,7 @@ test.describe("multi fetch", () => {
 test.describe("single fetch", () => {
   test.beforeAll(async () => {
     fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         "app/routes/layout-action.tsx": js`
           import { json } from "@remix-run/node";

--- a/integration/fetcher-test.ts
+++ b/integration/fetcher-test.ts
@@ -544,11 +544,7 @@ test.describe("single fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/routes/resource-route-action-only.ts": js`
             import { json } from "@remix-run/node";
@@ -963,11 +959,7 @@ test.describe("single fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/routes/_index.tsx": js`
             import * as React from "react";

--- a/integration/file-uploads-test.ts
+++ b/integration/file-uploads-test.ts
@@ -17,6 +17,7 @@ test.describe("file-uploads", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      useRemixServe: true, // To support usage of process.cwd() in fileUploadHandler.ts
       files: {
         "app/fileUploadHandler.ts": js`
           import * as path from "node:path";
@@ -27,10 +28,9 @@ test.describe("file-uploads", () => {
             unstable_createMemoryUploadHandler as createMemoryUploadHandler,
           } from "@remix-run/node";
 
-          const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
           export let uploadHandler = composeUploadHandlers(
             createFileUploadHandler({
-              directory: path.resolve(__dirname, "..", "uploads"),
+              directory: path.resolve(process.cwd(), "uploads"),
               maxPartSize: 10_000, // 10kb
               // you probably want to avoid conflicts in production
               // do not set to false or passthrough filename in real
@@ -155,11 +155,7 @@ test.describe("single fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/fileUploadHandler.ts": js`
             import * as path from "node:path";

--- a/integration/file-uploads-test.ts
+++ b/integration/file-uploads-test.ts
@@ -117,9 +117,7 @@ test.describe("file-uploads", () => {
 >`);
 
     let written = await fs.readFile(
-      url.pathToFileURL(
-        path.join(fixture.projectDir, "uploads/underLimit.txt")
-      ),
+      url.pathToFileURL(path.join(process.cwd(), "uploads/underLimit.txt")),
       "utf8"
     );
     expect(written).toBe(uploadData);
@@ -166,10 +164,9 @@ test.describe("single fetch", () => {
               unstable_createMemoryUploadHandler as createMemoryUploadHandler,
             } from "@remix-run/node";
 
-            const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
             export let uploadHandler = composeUploadHandlers(
               createFileUploadHandler({
-                directory: path.resolve(__dirname, "..", "uploads"),
+                directory: path.resolve(process.cwd(), "uploads"),
                 maxPartSize: 10_000, // 10kb
                 // you probably want to avoid conflicts in production
                 // do not set to false or passthrough filename in real
@@ -256,9 +253,7 @@ test.describe("single fetch", () => {
 >`);
 
       let written = await fs.readFile(
-        url.pathToFileURL(
-          path.join(fixture.projectDir, "uploads/underLimit.txt")
-        ),
+        url.pathToFileURL(path.join(process.cwd(), "uploads/underLimit.txt")),
         "utf8"
       );
       expect(written).toBe(uploadData);

--- a/integration/flat-routes-test.ts
+++ b/integration/flat-routes-test.ts
@@ -14,13 +14,20 @@ let fixture: Fixture;
 let appFixture: AppFixture;
 
 test.describe("flat routes", () => {
-  let IGNORED_ROUTE = "/ignore-me-pls";
+  let IGNORED_ROUTE = "ignore-me-pls";
   test.beforeAll(async () => {
     fixture = await createFixture({
-      config: {
-        ignoredRouteFiles: [IGNORED_ROUTE],
-      },
       files: {
+        "vite.config.js": `
+          import { defineConfig } from "vite";
+          import { vitePlugin as remix } from "@remix-run/dev";
+
+          export default defineConfig({
+            plugins: [remix({
+              ignoredRouteFiles: [${JSON.stringify(`**/${IGNORED_ROUTE}.*`)}],
+            })],
+          });
+        `,
         "app/root.tsx": js`
           import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
 
@@ -185,9 +192,9 @@ test.describe("flat routes", () => {
   }
 
   test("allows ignoredRouteFiles to be configured", async () => {
-    let routeIds = Object.keys(fixture.build!.routes);
+    let response = await fixture.requestDocument("/" + IGNORED_ROUTE);
 
-    expect(routeIds).not.toContain(IGNORED_ROUTE);
+    expect(response.status).toBe(404);
   });
 });
 

--- a/integration/form-data-test.ts
+++ b/integration/form-data-test.ts
@@ -66,11 +66,7 @@ test.describe("multi fetch", () => {
 test.describe("single fetch", () => {
   test.beforeAll(async () => {
     fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         "app/routes/_index.tsx": js`
           import { json } from "@remix-run/node";

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -1192,11 +1192,7 @@ test.describe("single fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/routes/get-submission.tsx": js`
             import { useLoaderData, Form } from "@remix-run/react";

--- a/integration/helpers/create-fixture.ts
+++ b/integration/helpers/create-fixture.ts
@@ -414,6 +414,7 @@ function build(
   // force the mode to be production for ESM configs when runtime mode is
   // tested.
   mode = mode === ServerMode.Test ? ServerMode.Production : mode;
+  compiler = compiler ?? "vite";
 
   let remixBin = "node_modules/@remix-run/dev/dist/cli.js";
 

--- a/integration/helpers/create-fixture.ts
+++ b/integration/helpers/create-fixture.ts
@@ -17,6 +17,7 @@ import { createRequestHandler } from "../../build/node_modules/@remix-run/server
 import { createRequestHandler as createExpressHandler } from "../../build/node_modules/@remix-run/express/dist/index.js";
 import { installGlobals } from "../../build/node_modules/@remix-run/node/dist/index.js";
 import { decodeViaTurboStream } from "../../build/node_modules/@remix-run/react/dist/single-fetch.js";
+import { viteConfig } from "./vite.js";
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 const root = path.join(__dirname, "../..");
@@ -27,10 +28,13 @@ export interface FixtureInit {
   sourcemap?: boolean;
   files?: { [filename: string]: string };
   template?: "cf-template" | "deno-template" | "node-template";
+  // @deprecated The 'config' option isn't supported by the Vite compiler option
   config?: Partial<AppConfig>;
   useRemixServe?: boolean;
   compiler?: "remix" | "vite";
   spaMode?: boolean;
+  singleFetch?: boolean;
+  port?: number;
 }
 
 export type Fixture = Awaited<ReturnType<typeof createFixture>>;
@@ -45,7 +49,10 @@ export function json(value: JsonObject) {
 
 export async function createFixture(init: FixtureInit, mode?: ServerMode) {
   installGlobals();
-  let compiler = init.compiler ?? "remix";
+
+  init.compiler ||= "vite";
+  let compiler = init.compiler;
+
   let projectDir = await createFixtureProject(init, mode);
   let buildPath = url.pathToFileURL(
     path.join(
@@ -189,7 +196,7 @@ export async function createAppFixture(fixture: Fixture, mode?: ServerMode) {
           [
             "node_modules/@remix-run/serve/dist/cli.js",
             fixture.compiler === "vite"
-              ? "server/build/index.js"
+              ? "build/server/index.js"
               : "build/index.js",
           ],
           {
@@ -315,7 +322,8 @@ export async function createFixtureProject(
   let integrationTemplateDir = path.resolve(__dirname, template);
   let projectName = `remix-${template}-${Math.random().toString(32).slice(2)}`;
   let projectDir = path.join(TMP_DIR, projectName);
-  let compiler = init.compiler ?? "remix";
+  let compiler = init.compiler;
+  let port = init.port ?? (await getPort());
 
   await fse.ensureDir(projectDir);
   await fse.copy(integrationTemplateDir, projectDir);
@@ -339,7 +347,27 @@ export async function createFixtureProject(
   //   path.join(projectDir, "node_modules/.bin/remix-serve")
   // );
 
-  await writeTestFiles(init, projectDir);
+  let hasViteConfig = Object.keys(init.files ?? {}).some((filename) =>
+    filename.startsWith("vite.config.")
+  );
+
+  let { singleFetch, spaMode } = init;
+
+  await writeTestFiles(
+    {
+      ...(hasViteConfig
+        ? {}
+        : {
+            "vite.config.js": await viteConfig.basic({
+              port,
+              singleFetch,
+              spaMode,
+            }),
+          }),
+      ...init.files,
+    },
+    projectDir
+  );
 
   // We update the config file *after* writing test files so that tests can provide a custom
   // `remix.config.js` file while still supporting the type-checked `config`
@@ -421,12 +449,15 @@ function build(
   }
 }
 
-async function writeTestFiles(init: FixtureInit, dir: string) {
+async function writeTestFiles(
+  files: Record<string, string> | undefined,
+  dir: string
+) {
   await Promise.all(
-    Object.keys(init.files ?? {}).map(async (filename) => {
+    Object.keys(files ?? {}).map(async (filename) => {
       let filePath = path.join(dir, filename);
       await fse.ensureDir(path.dirname(filePath));
-      let file = init.files![filename];
+      let file = files![filename];
 
       await fse.writeFile(filePath, stripIndent(file));
     })

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -12,6 +12,7 @@ import glob from "glob";
 import dedent from "dedent";
 import type { Page } from "@playwright/test";
 import { test as base, expect } from "@playwright/test";
+import type { VitePluginConfig } from "@remix-run/dev";
 
 const remixBin = "node_modules/@remix-run/dev/dist/cli.js";
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
@@ -32,14 +33,32 @@ export const viteConfig = {
     `;
     return text;
   },
-  basic: async (args: { port: number; fsAllow?: string[] }) => {
+  basic: async (args: {
+    port: number;
+    fsAllow?: string[];
+    singleFetch?: boolean;
+    spaMode?: boolean;
+  }) => {
+    let remixPluginOptions: VitePluginConfig = {
+      ssr: !args.spaMode,
+      future: {
+        unstable_singleFetch: args.singleFetch,
+      },
+    };
+
     return dedent`
       import { vitePlugin as remix } from "@remix-run/dev";
+      import envOnly from "vite-env-only";
+      import tsconfigPaths from "vite-tsconfig-paths";
 
       export default {
         ${await viteConfig.server(args)}
-        plugins: [remix()]
-      }
+        plugins: [
+          remix(${JSON.stringify(remixPluginOptions)}),
+          envOnly(),
+          tsconfigPaths()
+        ],
+      };
     `;
   },
 };

--- a/integration/hmr-test.ts
+++ b/integration/hmr-test.ts
@@ -272,6 +272,7 @@ async function dev(
   let options = getOptions(appPort);
 
   let fixture: FixtureInit = {
+    compiler: "remix",
     config: {
       dev: {
         port: devPort,

--- a/integration/js-routes-test.ts
+++ b/integration/js-routes-test.ts
@@ -14,6 +14,7 @@ test.describe(".js route files", () => {
   test.beforeAll(async () => {
     appFixture = await createAppFixture(
       await createFixture({
+        compiler: "remix",
         files: {
           "app/routes/js.js": js`
             export default () => <div data-testid="route-js">Rendered with .js ext</div>;

--- a/integration/link-test.ts
+++ b/integration/link-test.ts
@@ -89,8 +89,8 @@ test.describe("route module link export", () => {
             useRouteError,
             isRouteErrorResponse
           } from "@remix-run/react";
-          import resetHref from "./reset.css";
-          import stylesHref from "./app.css";
+          import resetHref from "./reset.css?url";
+          import stylesHref from "./app.css?url";
           import favicon from "./favicon.ico";
 
           export function links() {
@@ -227,8 +227,8 @@ test.describe("route module link export", () => {
 
         "app/routes/links.tsx": js`
           import { useLoaderData, Link } from "@remix-run/react";
-          import redTextHref from "~/redText.css";
-          import blueTextHref from "~/blueText.css";
+          import redTextHref from "~/redText.css?url";
+          import blueTextHref from "~/blueText.css?url";
           import guitar from "~/guitar.jpg";
           export async function loader() {
             return [
@@ -310,7 +310,7 @@ test.describe("route module link export", () => {
         "app/routes/gists.tsx": js`
           import { json } from "@remix-run/node";
           import { Link, Outlet, useLoaderData, useNavigation } from "@remix-run/react";
-          import stylesHref from "~/gists.css";
+          import stylesHref from "~/gists.css?url";
           export function links() {
             return [{ rel: "stylesheet", href: stylesHref }];
           }
@@ -604,7 +604,7 @@ test.describe("route module link export", () => {
       expect(await moduleScript.getAttribute("type")).toBe("module");
       let moduleScriptText = await moduleScript.innerText();
       expect(
-        Array.from(moduleScriptText.matchAll(/import "\/build\/manifest-/g)),
+        Array.from(moduleScriptText.matchAll(/import "\/assets\/manifest-/g)),
         "invalid build manifest"
       ).toHaveLength(1);
       expect(

--- a/integration/loader-test.ts
+++ b/integration/loader-test.ts
@@ -149,11 +149,7 @@ test.describe("single fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/root.tsx": js`
             import { json } from "@remix-run/node";
@@ -211,11 +207,7 @@ test.describe("single fetch", () => {
     test.beforeAll(async () => {
       appFixture = await createAppFixture(
         await createFixture({
-          config: {
-            future: {
-              unstable_singleFetch: true,
-            },
-          },
+          singleFetch: true,
           files: {
             "app/root.tsx": js`
             import { Outlet } from '@remix-run/react'

--- a/integration/mdx-test.ts
+++ b/integration/mdx-test.ts
@@ -16,6 +16,7 @@ test.describe("mdx", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      compiler: "remix",
       files: {
         "app/root.tsx": js`
           import { Links, Meta, Outlet, Scripts } from "@remix-run/react";

--- a/integration/navigation-state-test.ts
+++ b/integration/navigation-state-test.ts
@@ -482,11 +482,7 @@ test.describe("single fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/root.tsx": js`
             import { useMemo, useRef } from "react";

--- a/integration/path-mapping-test.ts
+++ b/integration/path-mapping-test.ts
@@ -7,6 +7,7 @@ let fixture: Fixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    compiler: "remix",
     files: {
       "app/components/my-lib/index.ts": js`
         export const pizza = "this is a pizza";

--- a/integration/postcss-test.ts
+++ b/integration/postcss-test.ts
@@ -34,6 +34,7 @@ test.describe("PostCSS enabled", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      compiler: "remix",
       files: {
         "package.json": json({
           name: "remix-template-remix",
@@ -378,6 +379,7 @@ test.describe("PostCSS disabled", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      compiler: "remix",
       config: {
         postcss: false,
       },

--- a/integration/prefetch-test.ts
+++ b/integration/prefetch-test.ts
@@ -18,6 +18,7 @@ test.describe("multi fetch", () => {
   // Generate the test app using the given prefetch mode
   function fixtureFactory(mode: RemixLinkProps["prefetch"]): FixtureInit {
     return {
+      compiler: "remix",
       files: {
         "app/root.tsx": js`
           import {
@@ -281,6 +282,7 @@ test.describe("multi fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
+        compiler: "remix",
         files: {
           "app/routes/_index.tsx": js`
             import { Link } from "@remix-run/react";
@@ -355,6 +357,7 @@ test.describe("multi fetch", () => {
       page,
     }) => {
       fixture = await createFixture({
+        compiler: "remix",
         files: {
           "app/root.tsx": js`
               import { Links, Meta, Scripts, useFetcher } from "@remix-run/react";
@@ -433,6 +436,7 @@ test.describe("multi fetch", () => {
 
     test("dedupes prefetch tags", async ({ page }) => {
       fixture = await createFixture({
+        compiler: "remix",
         files: {
           "app/root.tsx": js`
             import {
@@ -575,6 +579,7 @@ test.describe("single fetch", () => {
   // Generate the test app using the given prefetch mode
   function fixtureFactory(mode: RemixLinkProps["prefetch"]): FixtureInit {
     return {
+      compiler: "remix",
       config: {
         future: {
           unstable_singleFetch: true,
@@ -843,6 +848,7 @@ test.describe("single fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
+        compiler: "remix",
         config: {
           future: {
             unstable_singleFetch: true,
@@ -922,6 +928,7 @@ test.describe("single fetch", () => {
       page,
     }) => {
       fixture = await createFixture({
+        compiler: "remix",
         config: {
           future: {
             unstable_singleFetch: true,
@@ -1005,6 +1012,7 @@ test.describe("single fetch", () => {
 
     test("dedupes prefetch tags", async ({ page }) => {
       fixture = await createFixture({
+        compiler: "remix",
         config: {
           future: {
             unstable_singleFetch: true,

--- a/integration/redirects-test.ts
+++ b/integration/redirects-test.ts
@@ -154,11 +154,7 @@ test.describe("single fetch", () => {
 
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/routes/absolute.tsx": js`
             import * as React from 'react';

--- a/integration/resource-routes-test.ts
+++ b/integration/resource-routes-test.ts
@@ -168,14 +168,6 @@ test.describe("loader in an app", async () => {
       expect(await page.content()).toContain('{"hello":"world"}');
     });
 
-    test("writes imported asset to `assetDirectory`", async ({ page }) => {
-      new PlaywrightFixture(appFixture, page);
-      let data = await fixture.getBrowserAsset(
-        "build/_assets/icon-W7PJN5PS.svg"
-      );
-      expect(data).toBe(SVG_CONTENTS);
-    });
-
     test("should handle errors thrown from resource routes", async ({
       page,
     }) => {

--- a/integration/revalidate-test.ts
+++ b/integration/revalidate-test.ts
@@ -303,11 +303,7 @@ test.describe("single fetch", () => {
     test.beforeAll(async () => {
       appFixture = await createAppFixture(
         await createFixture({
-          config: {
-            future: {
-              unstable_singleFetch: true,
-            },
-          },
+          singleFetch: true,
           files: {
             "app/root.tsx": js`
               import { Link, Outlet, Scripts, useNavigation } from "@remix-run/react";

--- a/integration/server-code-in-browser-message-test.ts
+++ b/integration/server-code-in-browser-message-test.ts
@@ -14,6 +14,7 @@ let appFixture: AppFixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    compiler: "remix",
     files: {
       "node_modules/has-side-effects/package.json": json({
         name: "has-side-effects",

--- a/integration/server-source-maps-test.ts
+++ b/integration/server-source-maps-test.ts
@@ -9,6 +9,7 @@ let fixture: Fixture;
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    compiler: "remix",
     sourcemap: true,
     files: {
       "app/routes/_index.tsx": js`

--- a/integration/set-cookie-revalidation-test.ts
+++ b/integration/set-cookie-revalidation-test.ts
@@ -141,11 +141,7 @@ test.describe("single fetch", () => {
   test.describe("set-cookie revalidation", () => {
     test.beforeAll(async () => {
       fixture = await createFixture({
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           "app/session.server.ts": js`
             import { createCookieSessionStorage } from "@remix-run/node";

--- a/integration/shared-route-imports-test.ts
+++ b/integration/shared-route-imports-test.ts
@@ -14,6 +14,7 @@ let appFixture: AppFixture;
 test.describe("v1 compiler", () => {
   test.beforeAll(async () => {
     fixture = await createFixture({
+      compiler: "remix",
       files: {
         "app/routes/parent.tsx": js`
           import { createContext, useContext } from "react";
@@ -101,6 +102,7 @@ export function UseParentContext() {
 test.describe("v2 compiler", () => {
   test.beforeAll(async () => {
     fixture = await createFixture({
+      compiler: "remix",
       files: {
         "app/routes/parent.tsx": js`
           import { createContext, useContext } from "react";

--- a/integration/single-fetch-test.ts
+++ b/integration/single-fetch-test.ts
@@ -99,11 +99,7 @@ test.describe("single-fetch", () => {
   test("loads proper data on single fetch loader requests", async () => {
     let fixture = await createFixture(
       {
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files,
       },
       ServerMode.Development
@@ -141,11 +137,7 @@ test.describe("single-fetch", () => {
 
     let fixture = await createFixture(
       {
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files,
       },
       ServerMode.Development
@@ -169,11 +161,7 @@ test.describe("single-fetch", () => {
   test("loads proper data on single fetch action requests", async () => {
     let fixture = await createFixture(
       {
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files,
       },
       ServerMode.Development
@@ -193,11 +181,7 @@ test.describe("single-fetch", () => {
 
   test("loads proper data on document request", async ({ page }) => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files,
     });
     let appFixture = await createAppFixture(fixture);
@@ -210,11 +194,7 @@ test.describe("single-fetch", () => {
 
   test("loads proper data on client side navigation", async ({ page }) => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files,
     });
     let appFixture = await createAppFixture(fixture);
@@ -231,11 +211,7 @@ test.describe("single-fetch", () => {
     page,
   }) => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files,
     });
     let appFixture = await createAppFixture(fixture);
@@ -251,11 +227,7 @@ test.describe("single-fetch", () => {
 
   test("allows fine-grained revalidation", async ({ page }) => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         ...files,
         "app/routes/no-revalidate.tsx": js`
@@ -324,11 +296,7 @@ test.describe("single-fetch", () => {
 
   test("does not revalidate on 4xx/5xx action responses", async ({ page }) => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         ...files,
         "app/routes/action.tsx": js`
@@ -428,11 +396,7 @@ test.describe("single-fetch", () => {
 
   test("returns headers correctly for singular loader and action calls", async () => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         ...files,
         "app/routes/headers.tsx": js`
@@ -502,11 +466,7 @@ test.describe("single-fetch", () => {
 
   test("merges headers from nested routes", async () => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         ...files,
         "app/routes/a.tsx": js`
@@ -661,11 +621,7 @@ test.describe("single-fetch", () => {
 
   test("merges status codes from nested routes", async () => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         ...files,
         "app/routes/a.tsx": js`
@@ -763,11 +719,7 @@ test.describe("single-fetch", () => {
 
   test("merges headers from nested routes when raw Responses are returned", async () => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         ...files,
         "app/routes/a.tsx": js`
@@ -869,11 +821,7 @@ test.describe("single-fetch", () => {
 
   test("merges status codes from nested routes when raw Responses are used", async () => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         ...files,
         "app/routes/a.tsx": js`
@@ -969,11 +917,7 @@ test.describe("single-fetch", () => {
     page,
   }) => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         ...files,
         "app/routes/data.tsx": js`
@@ -1014,11 +958,7 @@ test.describe("single-fetch", () => {
     page,
   }) => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         ...files,
         "app/routes/data.tsx": js`
@@ -1055,11 +995,7 @@ test.describe("single-fetch", () => {
 
   test("processes thrown loader redirects via Response", async ({ page }) => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         ...files,
         "app/routes/data.tsx": js`
@@ -1096,11 +1032,7 @@ test.describe("single-fetch", () => {
 
   test("processes returned loader redirects via Response", async ({ page }) => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         ...files,
         "app/routes/data.tsx": js`
@@ -1137,11 +1069,7 @@ test.describe("single-fetch", () => {
   }) => {
     let fixture = await createFixture(
       {
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           ...files,
           "app/routes/data.tsx": js`
@@ -1188,11 +1116,7 @@ test.describe("single-fetch", () => {
   }) => {
     let fixture = await createFixture(
       {
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           ...files,
           "app/routes/data.tsx": js`
@@ -1235,11 +1159,7 @@ test.describe("single-fetch", () => {
   test("processes thrown action redirects via Response", async ({ page }) => {
     let fixture = await createFixture(
       {
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           ...files,
           "app/routes/data.tsx": js`
@@ -1282,11 +1202,7 @@ test.describe("single-fetch", () => {
   test("processes returned action redirects via Response", async ({ page }) => {
     let fixture = await createFixture(
       {
-        config: {
-          future: {
-            unstable_singleFetch: true,
-          },
-        },
+        singleFetch: true,
         files: {
           ...files,
           "app/routes/data.tsx": js`
@@ -1328,11 +1244,7 @@ test.describe("single-fetch", () => {
     page,
   }) => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         ...files,
         "app/entry.server.tsx": js`
@@ -1416,11 +1328,7 @@ test.describe("single-fetch", () => {
     page,
   }) => {
     let fixture = await createFixture({
-      config: {
-        future: {
-          unstable_singleFetch: true,
-        },
-      },
+      singleFetch: true,
       files: {
         ...files,
         "app/entry.server.tsx": js`
@@ -1504,11 +1412,7 @@ test.describe("single-fetch", () => {
     test("when no routes have client loaders", async ({ page }) => {
       let fixture = await createFixture(
         {
-          config: {
-            future: {
-              unstable_singleFetch: true,
-            },
-          },
+          singleFetch: true,
           files: {
             ...files,
             "app/routes/a.tsx": js`
@@ -1592,11 +1496,7 @@ test.describe("single-fetch", () => {
     test("when one route has a client loader", async ({ page }) => {
       let fixture = await createFixture(
         {
-          config: {
-            future: {
-              unstable_singleFetch: true,
-            },
-          },
+          singleFetch: true,
           files: {
             ...files,
             "app/routes/a.tsx": js`
@@ -1692,11 +1592,7 @@ test.describe("single-fetch", () => {
     test("when multiple routes have client loaders", async ({ page }) => {
       let fixture = await createFixture(
         {
-          config: {
-            future: {
-              unstable_singleFetch: true,
-            },
-          },
+          singleFetch: true,
           files: {
             ...files,
             "app/routes/a.tsx": js`
@@ -1799,11 +1695,7 @@ test.describe("single-fetch", () => {
     test("when all routes have client loaders", async ({ page }) => {
       let fixture = await createFixture(
         {
-          config: {
-            future: {
-              unstable_singleFetch: true,
-            },
-          },
+          singleFetch: true,
           files: {
             ...files,
             "app/routes/a.tsx": js`
@@ -1914,11 +1806,7 @@ test.describe("single-fetch", () => {
     test("when no routes have client loaders", async ({ page }) => {
       let fixture = await createFixture(
         {
-          config: {
-            future: {
-              unstable_singleFetch: true,
-            },
-          },
+          singleFetch: true,
           files: {
             ...files,
             "app/routes/_index.tsx": js`
@@ -2004,11 +1892,7 @@ test.describe("single-fetch", () => {
     test("when one route has a client loader", async ({ page }) => {
       let fixture = await createFixture(
         {
-          config: {
-            future: {
-              unstable_singleFetch: true,
-            },
-          },
+          singleFetch: true,
           files: {
             ...files,
             "app/routes/_index.tsx": js`
@@ -2100,11 +1984,7 @@ test.describe("single-fetch", () => {
     test("when multiple routes have client loaders", async ({ page }) => {
       let fixture = await createFixture(
         {
-          config: {
-            future: {
-              unstable_singleFetch: true,
-            },
-          },
+          singleFetch: true,
           files: {
             ...files,
             "app/routes/_index.tsx": js`
@@ -2201,11 +2081,7 @@ test.describe("single-fetch", () => {
     test("when all routes have client loaders", async ({ page }) => {
       let fixture = await createFixture(
         {
-          config: {
-            future: {
-              unstable_singleFetch: true,
-            },
-          },
+          singleFetch: true,
           files: {
             ...files,
             "app/routes/_index.tsx": js`

--- a/integration/svg-in-node-modules-test.ts
+++ b/integration/svg-in-node-modules-test.ts
@@ -20,6 +20,7 @@ test.beforeEach(async ({ context }) => {
 
 test.beforeAll(async () => {
   fixture = await createFixture({
+    compiler: "remix",
     files: {
       "app/routes/_index.tsx": js`
         import imgSrc from "getos/imgs/logo.svg";

--- a/integration/tailwind-test.ts
+++ b/integration/tailwind-test.ts
@@ -44,6 +44,7 @@ function runTests(ext: typeof extensions[number]) {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      compiler: "remix",
       files: {
         "package.json": json({
           name: "remix-template-remix",
@@ -358,6 +359,7 @@ test.describe("Tailwind disabled", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      compiler: "remix",
       config: {
         tailwind: false,
       },

--- a/integration/upload-test.ts
+++ b/integration/upload-test.ts
@@ -17,13 +17,6 @@ const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
 test.beforeAll(async () => {
   fixture = await createFixture({
-    config: {
-      browserNodeBuiltinsPolyfill: {
-        modules: {
-          url: true,
-        },
-      },
-    },
     files: {
       "app/routes/file-upload-handler.tsx": js`
         import * as path from "node:path";

--- a/integration/vanilla-extract-test.ts
+++ b/integration/vanilla-extract-test.ts
@@ -17,6 +17,7 @@ test.describe("Vanilla Extract", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
+      compiler: "remix",
       files: {
         "package.json": json({
           name: "remix-template-remix",

--- a/integration/vite-dev-custom-entry-test.ts
+++ b/integration/vite-dev-custom-entry-test.ts
@@ -15,7 +15,6 @@ test.describe("Vite custom entry dev", () => {
   test.beforeAll(async () => {
     devPort = await getPort();
     projectDir = await createFixtureProject({
-      compiler: "vite",
       files: {
         "remix.config.js": js`
           throw new Error("Remix should not access remix.config.js when using Vite");

--- a/integration/vite-dev-test.ts
+++ b/integration/vite-dev-test.ts
@@ -17,7 +17,6 @@ test.describe("Vite dev", () => {
   test.beforeAll(async () => {
     devPort = await getPort();
     projectDir = await createFixtureProject({
-      compiler: "vite",
       files: {
         "remix.config.js": js`
           throw new Error("Remix should not access remix.config.js when using Vite");

--- a/integration/vite-spa-mode-test.ts
+++ b/integration/vite-spa-mode-test.ts
@@ -178,7 +178,6 @@ test.describe("SPA Mode", () => {
 
     test("prepends DOCTYPE to HTML in the default entry.server.tsx", async () => {
       let fixture = await createFixture({
-        compiler: "vite",
         spaMode: true,
         files: {
           "vite.config.ts": js`
@@ -224,7 +223,6 @@ test.describe("SPA Mode", () => {
 
     test("works when combined with a basename", async ({ page }) => {
       fixture = await createFixture({
-        compiler: "vite",
         spaMode: true,
         files: {
           "vite.config.ts": js`
@@ -303,7 +301,6 @@ test.describe("SPA Mode", () => {
 
     test("can be used to hydrate only a div", async ({ page }) => {
       fixture = await createFixture({
-        compiler: "vite",
         spaMode: true,
         files: {
           "vite.config.ts": js`
@@ -436,7 +433,6 @@ test.describe("SPA Mode", () => {
       page,
     }) => {
       fixture = await createFixture({
-        compiler: "vite",
         spaMode: true,
         files: {
           "vite.config.ts": js`
@@ -520,7 +516,6 @@ test.describe("SPA Mode", () => {
       page,
     }) => {
       fixture = await createFixture({
-        compiler: "vite",
         spaMode: true,
         files: {
           "vite.config.ts": js`
@@ -591,7 +586,6 @@ test.describe("SPA Mode", () => {
   test.describe("normal apps", () => {
     test.beforeAll(async () => {
       fixture = await createFixture({
-        compiler: "vite",
         spaMode: true,
         files: {
           "vite.config.ts": js`

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "unist-util-remove": "^3.1.0",
     "unist-util-visit": "^4.1.1",
     "vite": "5.1.3",
+    "vite-env-only": "^2.0.0",
     "vite-tsconfig-paths": "^4.2.2",
     "wait-on": "^7.0.1",
     "wrangler": "^3.24.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       vite:
         specifier: 5.1.3
         version: 5.1.3(@types/node@18.17.1)
+      vite-env-only:
+        specifier: ^2.0.0
+        version: 2.2.0
       vite-tsconfig-paths:
         specifier: ^4.2.2
         version: 4.3.1(typescript@5.1.6)(vite@5.1.3)
@@ -14800,7 +14803,6 @@ packages:
       '@babel/types': 7.23.6
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /vite-node@1.2.2(@types/node@18.17.1):
     resolution: {integrity: sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==}


### PR DESCRIPTION
This changes the default `compiler` option for `createFixture` to be `"vite"` and provides a basic Vite config by default. To support this, we've deprecated the `config` option on `createFixture` since it's coupled to the old `remix.config.js` format, which also means we've added a dedicated `singleFetch` flag.