### PR TITLE
Fix Vite critical CSS resolution for route files with absolute paths

### DIFF
--- a/.changeset/hot-suits-jam.md
+++ b/.changeset/hot-suits-jam.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Vite: Fix issue resolving critical CSS during development when route files are located outside of the app directory.

--- a/packages/remix-dev/vite/styles.ts
+++ b/packages/remix-dev/vite/styles.ts
@@ -198,7 +198,7 @@ export const getStylesForUrl = async ({
   let appPath = path.relative(process.cwd(), remixConfig.appDirectory);
   let documentRouteFiles =
     matchRoutes(routes, url, build.basename)?.map((match) =>
-      path.join(appPath, remixConfig.routes[match.route.id].file)
+      path.resolve(appPath, remixConfig.routes[match.route.id].file)
     ) ?? [];
 
   let styles = await getStylesForFiles({


### PR DESCRIPTION
👋 Hey

I was trying to start using Remix presets to add some dev-only routes we have in Hydrogen, such as `/graphiql`. It mostly works but when it requests the critical CSS, it fails because it only supports files that are within the `app` directory. Our route files come from `node_modules` using absolute paths.

This small change does the trick because `path.resolve` does not modify absolute paths 👍 