### PR TITLE
template(cloudflare): Update remix cloudflare template to latest package versions

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -7,6 +7,7 @@
 - achinchen
 - adamwathan
 - adicuco
+- AdiRishi
 - ahabhgk
 - ahbruns
 - ahmedeldessouki

--- a/templates/cloudflare/package.json
+++ b/templates/cloudflare/package.json
@@ -16,12 +16,12 @@
     "@remix-run/cloudflare-pages": "*",
     "@remix-run/react": "*",
     "isbot": "^4.1.0",
-    "miniflare": "^3.20231030.4",
+    "miniflare": "^3.20240404.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20230518.0",
+    "@cloudflare/workers-types": "^4.20240405.0",
     "@remix-run/dev": "*",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
@@ -37,7 +37,7 @@
     "typescript": "^5.1.6",
     "vite": "^5.1.0",
     "vite-tsconfig-paths": "^4.2.1",
-    "wrangler": "^3.24.0"
+    "wrangler": "^3.48.0"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
### Rationale

The template `remix-run/remix/templates/cloudflare` has fallen major versions behind some packages. Moreover, it is quite far behind in terms of `wrangler` which has gone through a large amount of updates recently.

This PR aims to bring the package versions up to the their respective latest versions
Edit: As per review request, only Cloudflare related packages have been bumped.
```
@cloudflare/workers-types         ^4.20230518.0  →  ^4.20240405.0
miniflare                         ^3.20231030.4  →  ^3.20240404.0
wrangler                                ^3.24.0  →        ^3.48.0
```

### How has this been tested

Local testing by creating a brand new remix app using `npx create-remix@latest --template ~/personal/forks/remix/templates/cloudflare` (pointed at the local versions with changes)

Once the local test app has been made, I ran the following checks
- Build the app locally and confirm it can be run using wrangler (using `npm start`)
- Run lint to confirm that the major updates for eslint cause no breaking changes
- Run `npm run typecheck` to ensure tsc works fine
- Deploy the built version of the app to Cloudflare and ensure that process works fine. The deployed app can be found [at this URL](https://test-remix-bmk.pages.dev/).