### PR TITLE
Update vite-configuration link to vite-config where linked to in docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -455,6 +455,7 @@
 - msutkowski
 - mthenw
 - mtt87
+- muhammadjalabi
 - mush159
 - n8agrin
 - na2hiro

--- a/docs/discussion/server-vs-client.md
+++ b/docs/discussion/server-vs-client.md
@@ -183,7 +183,7 @@ export const PostPreview = ({ title, description }) => {
 [file_convention_server]: ../file-conventions/-server
 [window_global]: https://developer.mozilla.org/en-US/docs/Web/API/Window/window
 [server-bundles]: ../future/server-bundles
-[vite-config]: ../file-conventions/vite-configuration
+[vite-config]: ../file-conventions/vite-config
 [vite-env-only]: https://github.com/pcattori/vite-env-only
 [classic-remix-compiler]: ../future/vite#classic-remix-compiler-vs-remix-vite
 [remix-vite]: ../future/vite

--- a/docs/file-conventions/remix-config.md
+++ b/docs/file-conventions/remix-config.md
@@ -287,4 +287,4 @@ There are a few conventions that Remix uses you should be aware of.
 [relativesplatpath]: https://reactrouter.com/en/main/hooks/use-resolved-path#splat-paths
 [classic-remix-compiler]: ../future/vite#classic-remix-compiler-vs-remix-vite
 [remix-vite]: ../future/vite
-[vite-config]: ./vite-configuration
+[vite-config]: ./vite-config


### PR DESCRIPTION
- [x] Docs


Fixed link to vite-config where it had been linked to in the docs as vite-configuration
