### PR TITLE
update deno to use built in http server

### DIFF
--- a/templates/classic-remix-compiler/deno/server.ts
+++ b/templates/classic-remix-compiler/deno/server.ts
@@ -1,7 +1,6 @@
 import { createRequestHandlerWithStaticFiles } from "@remix-run/deno";
 // Import path interpreted by the Remix compiler
 import * as build from "@remix-run/dev/server-build";
-import { serve } from "https://deno.land/std@0.128.0/http/server.ts";
 
 const remixHandler = createRequestHandlerWithStaticFiles({
   build,
@@ -9,5 +8,4 @@ const remixHandler = createRequestHandlerWithStaticFiles({
 });
 
 const port = Number(Deno.env.get("PORT")) || 8000;
-console.log(`Listening on http://localhost:${port}`);
-serve(remixHandler, { port });
+Deno.serve({ port }, remixHandler);


### PR DESCRIPTION
deno std http server is marked as deprecated, and `Deno.serve` is the preferred api to use. 

https://deno.land/std@0.221.0/http/server.ts
https://docs.deno.com/runtime/manual/runtime/http_server_apis