### PR TITLE
Fix wrong file path in headers.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -621,6 +621,7 @@
 - twhitbeck
 - tylerbrostrom
 - udasitharani
+- uerkw
 - uhoh-itsmaciek
 - unhackit
 - UsamaHameed

--- a/docs/route/headers.md
+++ b/docs/route/headers.md
@@ -60,7 +60,7 @@ If a user is looking at `/users/123/profile` and `users.$userId.profile.tsx` doe
 
 If all three define `headers`, the deepest module wins, in this case `users.$userId.profile.tsx`. However, if your `users.$userId.profile.tsx`'s `loader` threw and bubbled to a boundary in `users.userId.tsx` - then `users.userId.tsx`'s `headers` function would be used as it is the leaf rendered route.
 
-We don't want surprise headers in your responses, so it's your job to merge them if you'd like. Remix passes in the `parentHeaders` to your `headers` function. So `users.$userId.users.tsx` headers get passed to `users.$userId.tsx`, and then `users.$userId.tsx`'s `headers` are passed to `users.$userId.profile.tsx`'s `headers`.
+We don't want surprise headers in your responses, so it's your job to merge them if you'd like. Remix passes in the `parentHeaders` to your `headers` function. So `users.tsx` headers get passed to `users.$userId.tsx`, and then `users.$userId.tsx`'s `headers` are passed to `users.$userId.profile.tsx`'s `headers`.
 
 That is all to say that Remix has given you a very large gun with which to shoot your foot. You need to be careful not to send a `Cache-Control` from a child route module that is more aggressive than a parent route. Here's some code that picks the least aggressive caching in these cases:
 


### PR DESCRIPTION
The current example uses `users.userId.users.tsx` when it is previously defined and expected that the parent `users.tsx` will pass headers down to the nested/lead routes. This change clears up an otherwise rather confusing example. The changes should read very clearly now to anyone familiar with the headers control system in Remix. 

