### PR TITLE
Fix Playwright hanging in Node 20.5.2+

### DIFF
--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -45,7 +45,7 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "ubuntu-latest"
-      node_version: '[18, "20.5.1"]'
+      node_version: "[18, 20]"
       browser: '["chromium", "firefox"]'
 
   integration-windows:
@@ -54,7 +54,7 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "windows-latest"
-      node_version: '[18, "20.5.1"]'
+      node_version: "[18, 20]"
       browser: '["msedge"]'
 
   integration-macos:
@@ -63,5 +63,5 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "macos-latest"
-      node_version: '[18, "20.5.1"]'
+      node_version: "[18, 20]"
       browser: '["webkit"]'

--- a/.github/workflows/test-pr-ubuntu.yml
+++ b/.github/workflows/test-pr-ubuntu.yml
@@ -27,7 +27,7 @@ jobs:
     uses: ./.github/workflows/shared-test-unit.yml
     with:
       os: "ubuntu-latest"
-      node_version: '["20.5.1"]'
+      node_version: "[20]"
 
   integration-chromium:
     name: "👀 Integration Test"
@@ -35,5 +35,5 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "ubuntu-latest"
-      node_version: '["20.5.1"]'
+      node_version: "[20]"
       browser: '["chromium"]'

--- a/.github/workflows/test-pr-windows-macos.yml
+++ b/.github/workflows/test-pr-windows-macos.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/shared-test-unit.yml
     with:
       os: "windows-latest"
-      node_version: '["20.5.1"]'
+      node_version: "[20]"
 
   integration-firefox:
     name: "👀 Integration Test"
@@ -28,7 +28,7 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "ubuntu-latest"
-      node_version: '["20.5.1"]'
+      node_version: "[20]"
       browser: '["firefox"]'
 
   integration-msedge:
@@ -37,7 +37,7 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "windows-latest"
-      node_version: '["20.5.1"]'
+      node_version: "[20]"
       browser: '["msedge"]'
 
   integration-webkit:
@@ -46,5 +46,5 @@ jobs:
     uses: ./.github/workflows/shared-test-integration.yml
     with:
       os: "macos-latest"
-      node_version: '["20.5.1"]'
+      node_version: "[20]"
       browser: '["webkit"]'

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -4,6 +4,11 @@ import { devices } from "@playwright/test";
 const config: PlaywrightTestConfig = {
   testDir: ".",
   testMatch: ["**/*-test.ts"],
+  // Playwright treats our workspace packages as internal by default. If we
+  // don't mark them as external, tests hang in Node 20.5.2+
+  build: {
+    external: ["**/packages/**/*"],
+  },
   /* Maximum time one test can run for. */
   timeout: process.platform === "win32" ? 60_000 : 30_000,
   fullyParallel: true,


### PR DESCRIPTION
This reverts https://github.com/remix-run/remix/pull/9000.

Since moving to pnpm, we've had issues with Playwright tests hanging in Node 20.5.2+. I was able to narrow it down to workspace package imports being the cause. With pnpm, our built code no longer resides in a `node_modules` directory but is linked to the `packages` directory instead which means that Playwright no longer treats it as external. If we mark the packages dir as external, the tests don't hang anymore.