### PR TITLE
Vite | Build | Client/SSR Duplicate Asset Error 

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -505,6 +505,7 @@
 - pmbanugo
 - prasook-jain
 - pratikdevdas
+- prescottjrynewicz
 - princerajroy
 - prvnbist
 - ptitFicus

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -1399,8 +1399,8 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
           let movedAssetPaths: string[] = [];
           for (let ssrAssetPath of ssrAssetPaths) {
             let src = path.join(serverBuildDirectory, ssrAssetPath);
-            if (!clientAssetPaths.has(ssrAssetPath)) {
-              let dest = path.join(clientBuildDirectory, ssrAssetPath);
+            let dest = path.join(clientBuildDirectory, ssrAssetPath);
+            if (!clientAssetPaths.has(ssrAssetPath) && !fse.existsSync(dest)) {
               await fse.move(src, dest);
               movedAssetPaths.push(dest);
             } else {


### PR DESCRIPTION
## Description

When migrating from esbuild to Vite, I encountered a small issue when creating the Vite production builds. Even though dev was working as expected, there was an error during the `writeBundle` step of the SSR build. 

After debugging locally, I found a quick check that should resolve the issue I was facing. 

### Expected Behavior
Vite builds for production once the development server is working.

### Actual Behavior 
The client bundle builds appropriately, but the SSR bundle fails with this error

```
x Build failed in 2.07s
Error: [remix] dest already exists.
    at doRename (/workspaces/superbud-ecomm/node_modules/fs-extra/lib/move/move-sync.js:32:34)
    at Object.moveSync (/workspaces/superbud-ecomm/node_modules/fs-extra/lib/move/move-sync.js:17:10)
    at Object.handler (/workspaces/superbud-ecomm/node_modules/@remix-run/dev/dist/vite/plugin.js:875:28)
    at async Promise.all (index 0)
    at async PluginDriver.hookParallel (file:///workspaces/superbud-ecomm/node_modules/rollup/dist/es/shared/node-entry.js:19525:9)
    at async file:///workspaces/superbud-ecomm/node_modules/rollup/dist/es/shared/node-entry.js:20521:13
    at async catchUnfinishedHookActions (file:///workspaces/superbud-ecomm/node_modules/rollup/dist/es/shared/node-entry.js:19942:16)
    at async Module.build (file:///workspaces/superbud-ecomm/node_modules/vite/dist/node/chunks/dep-whKeNLxG.js:67445:22)
    at async viteBuild (/workspaces/superbud-ecomm/node_modules/@remix-run/dev/dist/vite/build.js:212:5)
    at async Promise.all (index 0)
    at async build (/workspaces/superbud-ecomm/node_modules/@remix-run/dev/dist/vite/build.js:245:3)
    at async Object.viteBuild (/workspaces/superbud-ecomm/node_modules/@remix-run/dev/dist/cli/commands.js:183:5)
    at async Object.run (/workspaces/superbud-ecomm/node_modules/@remix-run/dev/dist/cli/run.js:252:7) {
  code: 'PLUGIN_ERROR',
  plugin: 'remix',
  hook: 'writeBundle'
}
```

This error was thrown on `writeBundle` step, when a server asset was trying to be moved to the client asset directory, even though the client asset already existed. 

## Root Cause
This could also mean there is an issue with the `getViteManifestAssetPaths` or the `clientViteManifest`, because the manifest doesn't appear to have all the assets listed that actually exist in the assets folder.

### Testing
I didn't see any tests for the `plugin` file, so I didn't include any here. This is also a two line change 
