### PR TITLE
Ignore Babel config for `react-refresh` transform

### DIFF
--- a/.changeset/tame-otters-clap.md
+++ b/.changeset/tame-otters-clap.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Ensure Babel config files are not referenced when applying the `react-refresh` Babel transform within the Remix Vite plugin

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -1700,6 +1700,8 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
         }
 
         let result = await babel.transformAsync(code, {
+          configFile: false,
+          babelrc: false,
           filename: id,
           sourceFileName: filepath,
           parserOpts: {


### PR DESCRIPTION
Since `configFile` and `babelrc` options weren't disabled when running `babel.transformAsync`, we were inadvertently picking up Babel config files from consumers' projects when applying the dev-only `react-refresh` Babel transform.