### PR TITLE
Add remix.config.js relevance notice to routes discussion page

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -494,6 +494,7 @@
 - pacexy
 - pandaiolo
 - panteliselef
+- pavinduLakshan
 - pcattori
 - penspinner
 - penx

--- a/docs/discussion/routes.md
+++ b/docs/discussion/routes.md
@@ -125,6 +125,8 @@ app/
 
 To configure this structure into the same URLs as the previous examples, you can use the `routes` function in `remix.config.js`:
 
+<docs-warning>`remix.config.js` is only relevant when using the [Classic Remix Compiler][classic-remix-compiler]. When using [Remix Vite][remix-vite], this file should not be present in your project. Instead, Remix configuration should be provided to the Remix plugin in your [Vite config][vite-config].</docs-warning>
+
 ```js filename=remix.config.js
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {


### PR DESCRIPTION
So I wanted to manually configure routes in my Remix app, and decided to add a `remix.config.js` to my vite project, but unfortunately it didn't work.

Later when I was randomly navigating through the docs site, I found out that the `remix.config.js` file is only applicable for the projects that use classic remix compiler[1]. For vite projects, the configs need to go inside remix vite plugin config.

I could have saved so much time, if that info is already mentioned in the doc I followed[2]. To prevent this happening for others, thought to send a PR adding the warning to the route discussion page.

[1] https://remix.run/docs/en/main/file-conventions/remix-config
[2] https://remix.run/docs/en/main/discussion/routes