### PR TITLE
opt-in type inference for single-fetch

### DIFF
--- a/.changeset/young-eagles-grab.md
+++ b/.changeset/young-eagles-grab.md
@@ -3,32 +3,4 @@
 ---
 
 Opt-in types for single-fetch
-
-To opt-in to type inference for single-fetch, add `future/single-fetch.d.ts` to `include` in your `tsconfig.json`:
-
-```json
-{
-  "include": [
-    "./node_modules/@remix-run/react/future/single-fetch.d.ts"
-  ]
-}
-```
-
-This changes `useLoaderData` and `useActionData` types to return single-fetch aware types instead of `SerializedFrom` types:
-
-
-```ts
-const loader = () => {
-  return { hello: "world", date: new Date() }
-}
-
-// Without opting into single-fetch types
-// Types from `loader` are serialized via `JSON.stringify` and `JSON.parse`
-const before = useLoaderData<typeof loader>();
-//    ^? { hello: string, date: string }
-
-// Opting into single-fetch types
-// Types from `loader` are serialized via `turbo-stream`
-const after = useLoaderData<typeof loader>();
-//    ^? { hello: string, date: Date }
-```
+- To opt-in to type inference for single-fetch, add `./node_modules/@remix-run/react/future/single-fetch.d.ts` to `include` in your `tsconfig.json`

--- a/.changeset/young-eagles-grab.md
+++ b/.changeset/young-eagles-grab.md
@@ -1,0 +1,34 @@
+---
+"@remix-run/react": patch
+---
+
+Opt-in types for single-fetch
+
+To opt-in to type inference for single-fetch, add `future/single-fetch.d.ts` to `include` in your `tsconfig.json`:
+
+```json
+{
+  "include": [
+    "./node_modules/@remix-run/react/future/single-fetch.d.ts"
+  ]
+}
+```
+
+This changes `useLoaderData` and `useActionData` types to return single-fetch aware types instead of `SerializedFrom` types:
+
+
+```ts
+const loader = () => {
+  return { hello: "world", date: new Date() }
+}
+
+// Without opting into single-fetch types
+// Types from `loader` are serialized via `JSON.stringify` and `JSON.parse`
+const before = useLoaderData<typeof loader>();
+//    ^? { hello: string, date: string }
+
+// Opting into single-fetch types
+// Types from `loader` are serialized via `turbo-stream`
+const after = useLoaderData<typeof loader>();
+//    ^? { hello: string, date: Date }
+```

--- a/docs/guides/single-fetch.md
+++ b/docs/guides/single-fetch.md
@@ -51,9 +51,9 @@ You can control this by exporting a `streamTimeout` numeric value from your `ent
 
 ### Type Inference
 
-the current type-inference in Remix has a built-in assumption of JSON-serialized responses. So, if you return a Javascript object from a `loader` or `action` without using the `json` utility, Remix will assume that object was converted to a JSON `Response` internally.
+Without Single Fetch, any plain Javascript object returned from a `loader` or `action` is automatically serialized into a JSON response (as if you returned it via `json`). The type inference assumes this is the case and infer naked object returns as if they were JSON serialized.
 
-With the new streaming format, this assumption no longer holds, so some of the type built-in inference is no longer accurate once you have opted-into Single Fetch. For example, they would assume that a `Date` would be serialized to a string on the client 😕.
+With Single Fetch, naked objects will be streamed directly, so the built-in type inference is no longer accurate once you have opted-into Single Fetch. For example, they would assume that a `Date` would be serialized to a string on the client 😕.
 
 In order to ensure you get the proper types when using Single Fetch, we've included a set of type overrides that you can include in your `tsconfig.json` which aligns the types with the Single Fetch behavior:
 

--- a/docs/guides/single-fetch.md
+++ b/docs/guides/single-fetch.md
@@ -51,9 +51,9 @@ You can control this by exporting a `streamTimeout` numeric value from your `ent
 
 ### Type Inference
 
-The current generics support type inference but have a built-in assumption of JSON-serialized responses. So, if you return a Javascript object from a `loader` or `action` without using the `json` utility, Remix will convert that to a JSON `Response` internally.
+the current type-inference in Remix has a built-in assumption of JSON-serialized responses. So, if you return a Javascript object from a `loader` or `action` without using the `json` utility, Remix will assume that object was converted to a JSON `Response` internally.
 
-With the new streaming format, this assumption no longer holds, so `useLoaderData<typeof loader>()` and other related generics (`useActionData`, `useRouteLoaderData`, `useFetcher`) in their current form will _not_ indicate the proper types because it would assume that a `Date` would be a string on the client 😕.
+With the new streaming format, this assumption no longer holds, so some of the type built-in inference is no longer accurate once you have opted-into Single Fetch. For example, they would assume that a `Date` would be serialized to a string on the client 😕.
 
 In order to ensure you get the proper types when using Single Fetch, we've included a set of type overrides that you can include in your `tsconfig.json` which aligns the types with the Single Fetch behavior:
 
@@ -66,7 +66,9 @@ In order to ensure you get the proper types when using Single Fetch, we've inclu
 }
 ```
 
-This will update your typings to reflect the advanced serialization capabilities provided by Single Fetch's streaming format:
+**`useLoaderData`, `useActionData`, `useRouteLoaderData`, and `useFetcher`**
+
+These methods do not require any code changes on your part - adding the single fetch types will cause their generics to deserialize correctly:
 
 ```ts
 export async function loader() {
@@ -88,11 +90,9 @@ export default function Component() {
 }
 ```
 
-In some cases, we couldn't strictly override the generics verbatim, so we had to introduce a new type you can use when opting into Single Fetch:
+**`useMatches`**
 
-**useMatches**
-
-`useMatches`, requires a manual cast to specify the loader type in order to get proper type inference on a given `match.data`. When using Single Fetch, you will need to replace the `UIMatch` type with `UIMatch_SingleFetch`:
+`useMatches` requires a manual cast to specify the loader type in order to get proper type inference on a given `match.data`. When using Single Fetch, you will need to replace the `UIMatch` type with `UIMatch_SingleFetch`:
 
 ```diff
   let matches = useMatches();
@@ -102,7 +102,7 @@ In some cases, we couldn't strictly override the generics verbatim, so we had to
 
 **`meta` Function**
 
-`meta` functions also require generic to indicate the current and ancestor route loader types in order to properly type the `data` and `matches` parameters. When using Single Fetch, you will need to replace the `MetaArgs` type with `MetaArgs_SingleFetch`:
+`meta` functions also require a generic to indicate the current and ancestor route loader types in order to properly type the `data` and `matches` parameters. When using Single Fetch, you will need to replace the `MetaArgs` type with `MetaArgs_SingleFetch`:
 
 ```diff
   export function meta({

--- a/docs/guides/single-fetch.md
+++ b/docs/guides/single-fetch.md
@@ -51,11 +51,26 @@ You can control this by exporting a `streamTimeout` numeric value from your `ent
 
 ### Type Inference
 
-The current generics support type inference but have a built-in assumption of a JSON-serialized response. With the new streaming format, this assumption no longer holds so `useLoaderData<typeof loader>()` will _not_ return the proper types because it would assume that a `Date` would be a string on the client 😕. Unfortunately, we can't make these types aware of a runtime future flag and we do not want to introduce another hook just for this. Thankfully, the manual typing is much simpler without needing to think about JSON serialization, so the current recommendation is to skip the generics when opting into single fetch and manually cast the type yourself:
+The current generics support type inference but have a built-in assumption of a JSON-serialized response. So, if you return a Javascript object without using the `json` utility, Remix will convert that to a JSON `Response` internally.
+
+With the new streaming format, this assumption no longer holds, so `useLoaderData<typeof loader>()` in it's current form will _not_ return the proper types because it would assume that a `Date` would be a string on the client 😕.
+
+In order to ensure you get the proper types when using Single Fetch, we've included a set of type overrides that you can include in your `tsconfig.json` which aligns the `useLoaderData`/`useActionData`/etc. types with the Single Fetch behavior:
+
+```json
+{
+  "include": [
+    // ...
+    "./node_modules/@remix-run/react/future/single-fetch.d.ts"
+  ]
+}
+```
+
+This will update your typings to reflect the advanced serialization capabilities provided by Single Fetch's streaming format:
 
 ```ts
 export async function loader() {
-  const data = await fetchSomeData(); // Assume this returns
+  const data = await fetchSomeData();
   return {
     message: data.message, // <- string
     date: data.date, // <- Date
@@ -63,25 +78,13 @@ export async function loader() {
 }
 
 export default function Component() {
-  // ❌ Before
+  // ❌ Before opting into single fetch types, types are serialized via JSON.stringify
   const data = useLoaderData<typeof loader>();
   //    ^? { message: string, date: string }
 
-  // ✅ After
-  const data = useLoaderData() as unknown as Awaited<
-    ReturnType<typeof loader>
-  >;
+  // ✅ After opting into single fetch types, types are serialized via turbo-stream
+  const data = useLoaderData<typeof loader>;
   //    ^? { message: string, date: Date }
-}
-```
-
-In the next version of Remix, we may re-introduce this generic, but in the meantime you could wrap this up into your own utility:
-
-```ts
-function useTypedLoaderData<T>() {
-  return useLoaderData() as unknown as Awaited<
-    ReturnType<T>
-  >;
 }
 ```
 

--- a/packages/remix-react/future/single-fetch.d.ts
+++ b/packages/remix-react/future/single-fetch.d.ts
@@ -1,0 +1,51 @@
+import type { AppLoadContext } from "@remix-run/server-runtime";
+
+type Serializable =
+  | undefined
+  | null
+  | boolean
+  | string
+  | symbol
+  | number
+  | Array<Serializable>
+  | { [key: PropertyKey]: Serializable }
+  | bigint
+  | Date
+  | URL
+  | RegExp
+  | Error
+  | Map<Serializable, Serializable>
+  | Set<Serializable>
+  | Promise<Serializable>;
+
+type Params<Key extends string = string> = {
+  readonly [key in Key]: string | undefined;
+};
+
+type ResponseStub = {
+  status?: number;
+  headers: Headers;
+};
+
+type DataFunction = (
+  args: {
+    request: Request;
+    params: Params;
+    context: AppLoadContext;
+    response: ResponseStub;
+  },
+  handlerCtx?: unknown
+) => Serializable;
+
+type Loader = DataFunction & { hydrate?: boolean };
+type Action = DataFunction;
+
+declare module "@remix-run/react" {
+  export function useLoaderData<T>(): T extends Loader
+    ? Awaited<ReturnType<T>>
+    : never;
+
+  export function useActionData<T>(): T extends Action
+    ? Awaited<ReturnType<T>>
+    : never;
+}

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -101,6 +101,7 @@ export type {
   ClientLoaderFunction,
   ClientLoaderFunctionArgs,
   MetaArgs,
+  MetaMatch as UNSAFE_MetaMatch,
   MetaDescriptor,
   MetaFunction,
   RouteModules as UNSAFE_RouteModules,

--- a/packages/remix-react/rollup.config.js
+++ b/packages/remix-react/rollup.config.js
@@ -51,6 +51,7 @@ module.exports = function rollup() {
           { src: "LICENSE.md", dest: [outputDir, sourceDir] },
           { src: `${sourceDir}/package.json`, dest: outputDir },
           { src: `${sourceDir}/README.md`, dest: outputDir },
+          { src: `${sourceDir}/future`, dest: outputDir },
         ],
       }),
       copyToPlaygrounds(),


### PR DESCRIPTION
Note: using `include` rather than `typeRoots`/`types` since those are designed for `@types` packages and `include` is lighter weight