### PR TITLE
docs(single-fetch): typo & missing parens around function

### DIFF
--- a/docs/guides/single-fetch.md
+++ b/docs/guides/single-fetch.md
@@ -46,7 +46,7 @@ On the client side, this also means that your need to wrap your client-side [`hy
 
 Previously, Remix has a concept of an `ABORT_TIMEOUT` built-into the default [`entry.server.tsx`][entry-server] files which would terminate the React renderer, but it didn't do anything in particular to clean up any pending deferred promises.
 
-Now that Remix is streaming internally, we can cancel the `turbo-stream` processing and automatically reject any pending promises and stream up those errors to the client. By default, this happens after 4950ms - a value that was chosen to be just under the current 5000ms `ABORT_DELAY` in most entry.server.tsx files - since we need to cancel the promises and let the rejections stream up through the React renderer prior to aborting the React sid eof things.
+Now that Remix is streaming internally, we can cancel the `turbo-stream` processing and automatically reject any pending promises and stream up those errors to the client. By default, this happens after 4950ms - a value that was chosen to be just under the current 5000ms `ABORT_DELAY` in most entry.server.tsx files - since we need to cancel the promises and let the rejections stream up through the React renderer prior to aborting the React side of things.
 
 You can control this by exporting a `streamTimeout` numeric value from your `entry.server.tsx` and Remix will use that as the number of milliseconds after which to reject any outstanding Promises from `loader`/`action`'s. It's recommended to decouple this value from the timeout in which you abort the React renderer - and you should always set the React timeout to a higher value so it has time to stream down the underlying rejections from your `streamTimeout`.
 
@@ -124,7 +124,7 @@ export default function Component() {
   //    ^? { message: string, date: string }
 
   // ✅ After opting into single fetch types, types are serialized via turbo-stream
-  const data = useLoaderData<typeof loader>;
+  const data = useLoaderData<typeof loader>();
   //    ^? { message: string, date: Date }
 }
 ```


### PR DESCRIPTION
This pull request updates the documentation for the [Single Fetch guide](https://remix.run/docs/en/main/guides/single-fetch).

A typo is fixed and a missing parenthesis is added.