### PR TITLE
Fix `dest already exists` error during Vite build

### DIFF
--- a/.changeset/five-planets-grin.md
+++ b/.changeset/five-planets-grin.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fix `dest already exists` error when running `remix vite:build`

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -830,6 +830,11 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
     return JSON.parse(manifestContents) as Vite.Manifest;
   };
 
+  let getViteManifestFilePaths = (viteManifest: Vite.Manifest): Set<string> => {
+    let filePaths = Object.values(viteManifest).map((chunk) => chunk.file);
+    return new Set(filePaths);
+  };
+
   let getViteManifestAssetPaths = (
     viteManifest: Vite.Manifest
   ): Set<string> => {
@@ -1401,7 +1406,7 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
           let ssrViteManifest = await loadViteManifest(serverBuildDirectory);
           let clientViteManifest = await loadViteManifest(clientBuildDirectory);
 
-          let clientAssetPaths = getViteManifestAssetPaths(clientViteManifest);
+          let clientFilePaths = getViteManifestFilePaths(clientViteManifest);
           let ssrAssetPaths = getViteManifestAssetPaths(ssrViteManifest);
 
           // We only move assets that aren't in the client build, otherwise we
@@ -1413,7 +1418,7 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
           let movedAssetPaths: string[] = [];
           for (let ssrAssetPath of ssrAssetPaths) {
             let src = path.join(serverBuildDirectory, ssrAssetPath);
-            if (!clientAssetPaths.has(ssrAssetPath)) {
+            if (!clientFilePaths.has(ssrAssetPath)) {
               let dest = path.join(clientBuildDirectory, ssrAssetPath);
               await fse.move(src, dest);
               movedAssetPaths.push(dest);


### PR DESCRIPTION
This fixes the issue raised in #9239.

This issue occurs when a server asset is present in the client build but isn't present in any of the client manifest's `assets` arrays. Unfortunately I wasn't able to work out _why_ this can happen, but we can still handle this case regardless.

The list of client assets was only used to determine whether to _move_ a server asset or _remove_ it. This means it's safe to expand the list of client assets to be the list of all files in the client build, regardless of whether they're considered assets or not. The server asset detection logic remains the same so we won't be moving additional files.