### PR TITLE
Added ?url to CSS import to fix "import not found: default" errors

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,3 +1,4 @@
+- andrioid
 - aaronpowell96
 - aaronshaf
 - AbePlays

--- a/docs/styling/tailwind.md
+++ b/docs/styling/tailwind.md
@@ -55,7 +55,7 @@ import type { LinksFunction } from "@remix-run/node"; // or cloudflare/deno
 
 // ...
 
-import styles from "./tailwind.css";
+import styles from "./tailwind.css?url"; // ?url bypasses Vite injection
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: styles },


### PR DESCRIPTION
Closes: #

- [x] Docs
- [ ] Tests

Testing Strategy:

This should hopefully make it so that fresh Remix projects attempting to use Tailwind don't get greeted with "import not found: default" (client) or "malformed url" (server) when following the instructions.

I suspect this is caused by new Vite behavior of automatically injecting imported CSS. The docs clearly expect an URL, but that's not what Vite is returning here.
