### PR TITLE
docs: update tailwind import with additional query string based on ta…

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -306,6 +306,7 @@
 - johnpolacek
 - johnson444
 - joms
+- joonmo-you
 - joshball
 - JoshuaKGoldberg
 - jplhomer

--- a/docs/styling/tailwind.md
+++ b/docs/styling/tailwind.md
@@ -55,7 +55,7 @@ import type { LinksFunction } from "@remix-run/node"; // or cloudflare/deno
 
 // ...
 
-import styles from "./tailwind.css";
+import styles from "./tailwind.css?url";
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: styles },


### PR DESCRIPTION
The official documentation provided by Tailwind suggests adding a query string at the end of the path to the Tailwind file.
A Remix application doesn't properly import the Tailwind file without the query string.