### PR TITLE
fix: fix incorrect useActionData type

### DIFF
--- a/packages/remix-react/future/single-fetch.d.ts
+++ b/packages/remix-react/future/single-fetch.d.ts
@@ -57,7 +57,7 @@ declare module "@remix-run/react" {
     : never;
 
   export function useActionData<T>(): T extends ActionFunction_SingleFetch
-    ? SingleFetchSerialize_V2<T>
+    ? SingleFetchSerialize_V2<T> | undefined
     : never;
 
   export function useRouteLoaderData<T>(


### PR DESCRIPTION
When a page loads, `actionData` is undefined. The current single-fetch types do not support this.

Could be wrong, but we ran into this issue implementing Single Fetch in our project. TypeScript is happy with everything, but our page crashes due to an undefined `actionData`.