### PR TITLE
fix(ci): Update deno template path

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -203,7 +203,7 @@ async function incrementRemixVersion(nextVersion) {
   await Promise.all(
     [
       path.join(".vscode", "deno_resolve_npm_imports.json"),
-      path.join("templates", "deno", ".vscode", "resolve_npm_imports.json"),
+      path.join("templates", "classic-remix-compiler", "deno", ".vscode", "resolve_npm_imports.json"),
     ].map((importMapPath) =>
       updateDenoImportMap(path.join(rootDir, importMapPath), nextVersion)
     )


### PR DESCRIPTION
The nightly build is currently [failing](https://github.com/remix-run/remix/actions/runs/8919927675/job/24496985160#step:7:33) with 

```
[Error: ENOENT: no such file or directory, open '/home/runner/work/remix/remix/templates/deno/.vscode/resolve_npm_imports.json']
```

because the deno template was moved in #9077.

This PR updates the path in the `incrementRemixVersion` utility to solve that.