### PR TITLE
Allow a nonce to be set on single fetch stream transfer inline scripts

### DIFF
--- a/.changeset/nasty-vans-brake.md
+++ b/.changeset/nasty-vans-brake.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": minor
+---
+
+Allow a nonce to be set on single fetch stream transfer inline scripts

--- a/.changeset/nasty-vans-brake.md
+++ b/.changeset/nasty-vans-brake.md
@@ -1,5 +1,5 @@
 ---
-"@remix-run/react": minor
+"@remix-run/react": patch
 ---
 
 Allow a nonce to be set on single fetch stream transfer inline scripts

--- a/docs/guides/single-fetch.md
+++ b/docs/guides/single-fetch.md
@@ -344,6 +344,10 @@ It's best to try to avoid using the `response` stub _and also_ returning a `Resp
 - The `Response` instance status will take priority over any `response` stub status
 - Headers operations on the `response` stub `headers` will be re-played on the returned `Response` headers instance
 
+### Inline Scripts
+
+The `<RemixServer>` component renders inline scripts that handle the streaming data on the client side. If you have a [content security policy for scripts][csp] with [nonce-sources][csp-nonce], you can use `<RemixServer nonce>` to pass through the nonce to these `<script>` tags.
+
 [future-flags]: ../file-conventions/remix-config#future
 [should-revalidate]: ../route/should-revalidate
 [entry-server]: ../file-conventions/entry.server
@@ -361,3 +365,5 @@ It's best to try to avoid using the `response` stub _and also_ returning a `Resp
 [resource-routes]: ../guides/resource-routes
 [responsestub]: #headers
 [streaming-format]: #streaming-data-format
+[csp]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
+[csp-nonce]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources

--- a/integration/single-fetch-test.ts
+++ b/integration/single-fetch-test.ts
@@ -2478,7 +2478,7 @@ test.describe("single-fetch", () => {
       files: {
         ...files,
         "app/root.tsx": js`
-          import { Form, Link, Links, Meta, Outlet, Scripts } from "@remix-run/react";
+          import { Links, Meta, Outlet, Scripts } from "@remix-run/react";
 
           export function loader() {
             return {
@@ -2494,14 +2494,6 @@ test.describe("single-fetch", () => {
                   <Links />
                 </head>
                 <body>
-                  <Link to="/">Home</Link><br/>
-                  <Link to="/data">Data</Link><br/>
-                  <Link to="/a/b/c">/a/b/c</Link><br/>
-                  <Form method="post" action="/data">
-                    <button type="submit" name="key" value="value">
-                      Submit
-                    </button>
-                  </Form>
                   <Outlet />
                   <Scripts nonce="the-nonce" />
                 </body>

--- a/integration/single-fetch-test.ts
+++ b/integration/single-fetch-test.ts
@@ -2467,4 +2467,104 @@ test.describe("single-fetch", () => {
       expect(await app.page.locator("nav link[as='fetch']").count()).toEqual(0);
     });
   });
+
+  test("supports nonce on streaming script tags", async ({ page }) => {
+    let fixture = await createFixture({
+      config: {
+        future: {
+          unstable_singleFetch: true,
+        },
+      },
+      files: {
+        ...files,
+        "app/root.tsx": js`
+          import { Form, Link, Links, Meta, Outlet, Scripts } from "@remix-run/react";
+
+          export function loader() {
+            return {
+              message: "ROOT",
+            };
+          }
+
+          export default function Root() {
+            return (
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
+                <body>
+                  <Link to="/">Home</Link><br/>
+                  <Link to="/data">Data</Link><br/>
+                  <Link to="/a/b/c">/a/b/c</Link><br/>
+                  <Form method="post" action="/data">
+                    <button type="submit" name="key" value="value">
+                      Submit
+                    </button>
+                  </Form>
+                  <Outlet />
+                  <Scripts nonce="the-nonce" />
+                </body>
+              </html>
+            );
+          }
+        `,
+        "app/entry.server.tsx": js`
+          import { PassThrough } from "node:stream";
+
+          import type { EntryContext } from "@remix-run/node";
+          import { createReadableStreamFromReadable } from "@remix-run/node";
+          import { RemixServer } from "@remix-run/react";
+          import { renderToPipeableStream } from "react-dom/server";
+
+          export default function handleRequest(
+            request: Request,
+            responseStatusCode: number,
+            responseHeaders: Headers,
+            remixContext: EntryContext
+          ) {
+            return new Promise((resolve, reject) => {
+              const { pipe } = renderToPipeableStream(
+                <RemixServer context={remixContext} url={request.url} nonce="the-nonce" />,
+                {
+                  onShellReady() {
+                    const body = new PassThrough();
+                    const stream = createReadableStreamFromReadable(body);
+                    responseHeaders.set("Content-Type", "text/html");
+                    resolve(
+                      new Response(stream, {
+                        headers: responseHeaders,
+                        status: responseStatusCode,
+                      })
+                    );
+                    pipe(body);
+                  },
+                  onShellError(error: unknown) {
+                    reject(error);
+                  },
+                  onError(error: unknown) {
+                    responseStatusCode = 500;
+                  },
+                }
+              );
+            });
+          }
+        `,
+      },
+    });
+    let appFixture = await createAppFixture(fixture);
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/data", true);
+    let scripts = await page.$$("script");
+    expect(scripts.length).toBe(6);
+    let remixScriptsCount = 0;
+    for (let script of scripts) {
+      let content = await script.innerHTML();
+      if (content.includes("window.__remix")) {
+        remixScriptsCount++;
+        expect(await script.getAttribute("nonce")).toEqual("the-nonce");
+      }
+    }
+    expect(remixScriptsCount).toBe(4);
+  });
 });

--- a/packages/remix-react/server.tsx
+++ b/packages/remix-react/server.tsx
@@ -15,6 +15,7 @@ export interface RemixServerProps {
   context: EntryContext;
   url: string | URL;
   abortDelay?: number;
+  nonce?: string;
 }
 
 /**
@@ -26,6 +27,7 @@ export function RemixServer({
   context,
   url,
   abortDelay,
+  nonce,
 }: RemixServerProps): ReactElement {
   if (typeof url === "string") {
     url = new URL(url);
@@ -101,6 +103,7 @@ export function RemixServer({
             identifier={0}
             reader={context.serverHandoffStream.getReader()}
             textDecoder={new TextDecoder()}
+            nonce={nonce}
           />
         </React.Suspense>
       ) : null}

--- a/packages/remix-react/single-fetch.tsx
+++ b/packages/remix-react/single-fetch.tsx
@@ -29,6 +29,7 @@ interface StreamTransferProps {
   identifier: number;
   reader: ReadableStreamDefaultReader<Uint8Array>;
   textDecoder: TextDecoder;
+  nonce?: string;
 }
 
 // StreamTransfer recursively renders down chunks of the `serverHandoffStream`
@@ -38,6 +39,7 @@ export function StreamTransfer({
   identifier,
   reader,
   textDecoder,
+  nonce,
 }: StreamTransferProps) {
   // If the user didn't render the <Scripts> component then we don't have to
   // bother streaming anything in
@@ -74,6 +76,7 @@ export function StreamTransfer({
   let { done, value } = promise.result;
   let scriptTag = value ? (
     <script
+      nonce={nonce}
       dangerouslySetInnerHTML={{
         __html: `window.__remixContext.streamController.enqueue(${escapeHtml(
           JSON.stringify(value)
@@ -87,6 +90,7 @@ export function StreamTransfer({
       <>
         {scriptTag}
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `window.__remixContext.streamController.close();`,
           }}
@@ -103,6 +107,7 @@ export function StreamTransfer({
             identifier={identifier + 1}
             reader={reader}
             textDecoder={textDecoder}
+            nonce={nonce}
           />
         </React.Suspense>
       </>


### PR DESCRIPTION
Closes: #9359

- [x] Docs
- [x] Tests

Testing Strategy:

I added a test case to `integration/single-fetch-test.ts`, and I patched `@remix-run/react` in our application with these changes and saw that it fixed our CSP violations.
