### PR TITLE
Clean redundant `?client-route=1` usage in dev

### DIFF
--- a/.changeset/slimy-shrimps-roll.md
+++ b/.changeset/slimy-shrimps-roll.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Clean up redundant `?client-route=1` imports in development


### PR DESCRIPTION
This PR is aiming to address two things:
1) Support the move to vite-plugin-react-swc: https://github.com/remix-run/remix/pull/9092
2) Potentially unlock this fix in Hydrogen: https://github.com/Shopify/hydrogen/pull/2078

The `?client-route=1` virtual modules that wrap all client routes are only necessary for a build optimisation that removes unused exports from route files on the client. The only reason these virtual modules were used in development was to keep the dev and build code paths as similar as possible. However, since it's causing other issues, and it also necessitated _extra_ code in dev to special-case HMR for these files, we're opting to remove `?client-route=1` usage in dev entirely.