### PR TITLE
Add back optional response stub for v2

### DIFF
--- a/.changeset/fresh-pigs-leave.md
+++ b/.changeset/fresh-pigs-leave.md
@@ -1,7 +1,0 @@
----
-"@remix-run/server-runtime": patch
----
-
-Remove `response` stub from `LoaderFunctionArgs`/`ActionFunctionArgs`
-
-- Instead, you will need to use `defineLaoder`/`defineAction` with single fetch to gain type access to the `response` stub

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -11,6 +11,7 @@ import type {
 import type { AppData, AppLoadContext } from "./data";
 import type { LinkDescriptor } from "./links";
 import type { SerializeFrom } from "./serialize";
+import type { ResponseStub } from "./single-fetch";
 
 export interface RouteModules<RouteModule> {
   [routeId: string]: RouteModule | undefined;
@@ -40,6 +41,8 @@ export type ActionFunction = (
 export type ActionFunctionArgs = RRActionFunctionArgs<AppLoadContext> & {
   // Context is always provided in Remix, and typed for module augmentation support.
   context: AppLoadContext;
+  // TODO: (v7) Make this non-optional once single-fetch is the default
+  response?: ResponseStub;
 };
 
 /**
@@ -71,6 +74,8 @@ export type LoaderFunction = (
 export type LoaderFunctionArgs = RRLoaderFunctionArgs<AppLoadContext> & {
   // Context is always provided in Remix, and typed for module augmentation support.
   context: AppLoadContext;
+  // TODO: (v7) Make this non-optional once single-fetch is the default
+  response?: ResponseStub;
 };
 
 /**


### PR DESCRIPTION
Partial revert of #9398 since it's too confusing to take this away for v2 (and explain to folks how to properly do resource routes) when it'll always be there in the future.