### PR TITLE
Fix post-release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,8 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
-          cache: "npm"
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
 
       - id: find_package_version
         run: |
@@ -98,26 +98,26 @@ jobs:
     needs: [release, find_package_version]
     uses: ./.github/workflows/release-comments.yml
 
-  deployments:
-    name: 🚀 Deployment Tests
-    if: github.repository == 'remix-run/remix'
-    needs: [release, find_package_version]
-    uses: ./.github/workflows/deployments.yml
-    secrets:
-      TEST_AWS_ACCESS_KEY_ID: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
-      TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
-      TEST_CF_ACCOUNT_ID: ${{ secrets.TEST_CF_ACCOUNT_ID }}
-      TEST_CF_GLOBAL_API_KEY: ${{ secrets.TEST_CF_GLOBAL_API_KEY }}
-      TEST_CF_EMAIL: ${{ secrets.TEST_CF_EMAIL }}
-      TEST_CF_PAGES_API_TOKEN: ${{ secrets.TEST_CF_PAGES_API_TOKEN }}
-      TEST_CF_API_TOKEN: ${{ secrets.TEST_CF_API_TOKEN }}
-      TEST_DENO_DEPLOY_TOKEN: ${{ secrets.TEST_DENO_DEPLOY_TOKEN }}
-      TEST_FLY_TOKEN: ${{ secrets.TEST_FLY_TOKEN }}
+  # deployments:
+  #   name: 🚀 Deployment Tests
+  #   if: github.repository == 'remix-run/remix'
+  #   needs: [release, find_package_version]
+  #   uses: ./.github/workflows/deployments.yml
+  #   secrets:
+  #     TEST_AWS_ACCESS_KEY_ID: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
+  #     TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
+  #     TEST_CF_ACCOUNT_ID: ${{ secrets.TEST_CF_ACCOUNT_ID }}
+  #     TEST_CF_GLOBAL_API_KEY: ${{ secrets.TEST_CF_GLOBAL_API_KEY }}
+  #     TEST_CF_EMAIL: ${{ secrets.TEST_CF_EMAIL }}
+  #     TEST_CF_PAGES_API_TOKEN: ${{ secrets.TEST_CF_PAGES_API_TOKEN }}
+  #     TEST_CF_API_TOKEN: ${{ secrets.TEST_CF_API_TOKEN }}
+  #     TEST_DENO_DEPLOY_TOKEN: ${{ secrets.TEST_DENO_DEPLOY_TOKEN }}
+  #     TEST_FLY_TOKEN: ${{ secrets.TEST_FLY_TOKEN }}
 
-  stacks:
-    name: 🥞 Remix Stacks Test
-    if: github.repository == 'remix-run/remix'
-    needs: [release, find_package_version]
-    uses: ./.github/workflows/stacks.yml
-    with:
-      version: ${{ needs.find_package_version.outputs.package_version }}
+  # stacks:
+  #   name: 🥞 Remix Stacks Test
+  #   if: github.repository == 'remix-run/remix'
+  #   needs: [release, find_package_version]
+  #   uses: ./.github/workflows/stacks.yml
+  #   with:
+  #     version: ${{ needs.find_package_version.outputs.package_version }}


### PR DESCRIPTION
I noticed that CI wasn't commenting on issues after releases recently, and it looks like the `Find Package` job was failing due to a missing `npm->pnpm` update so it was looking for a `package-lock.json` file and erroring out: https://github.com/remix-run/remix/actions/runs/8818933926/job/24209000833

I also commented out the deployments and stacks tests since I don't think they've passed in quite some time.  Maybe after things simplify in the next version we can revisit that idea - would be great to have those running reliably again - even if on a subset of platforms: https://github.com/remix-run/remix/actions/runs/8162173613