### PR TITLE
fix: when no operation command, execute the `dev` in the `remix` cli

### DIFF
--- a/packages/remix-dev/__tests__/cli-test.ts
+++ b/packages/remix-dev/__tests__/cli-test.ts
@@ -5,6 +5,8 @@ import util from "node:util";
 import fse from "fs-extra";
 import semver from "semver";
 
+import { run } from "../cli/run";
+
 let execFile = util.promisify(childProcess.execFile);
 
 const TEMP_DIR = path.join(
@@ -20,6 +22,16 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await fse.remove(TEMP_DIR);
+});
+
+jest.mock("../cli/commands", () => {
+  let originalModule = jest.requireActual("../cli/commands");
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    dev: jest.fn(),
+  };
 });
 
 async function execRemix(
@@ -197,6 +209,34 @@ describe("remix CLI", () => {
     it("prints the current version", async () => {
       let { stdout } = await execRemix(["--version"]);
       expect(!!semver.valid(stdout.trim())).toBe(true);
+    });
+  });
+
+  describe("the `dev` command", () => {
+    beforeEach(() => {
+      let remixRoot = path.join(__dirname, "fixtures", "node");
+
+      fse.copySync(remixRoot, TEMP_DIR);
+    });
+
+    it("call the `dev` command process", async () => {
+      let res = await run(["dev"]);
+
+      expect(res).toBeUndefined();
+    });
+  });
+
+  describe("not command specified", () => {
+    beforeEach(() => {
+      let remixRoot = path.join(__dirname, "fixtures", "node");
+
+      fse.copySync(remixRoot, TEMP_DIR);
+    });
+
+    it("call the `dev` command process", async () => {
+      let res = await run([]);
+
+      expect(res).toBeUndefined();
     });
   });
 });

--- a/packages/remix-dev/cli/run.ts
+++ b/packages/remix-dev/cli/run.ts
@@ -163,7 +163,7 @@ export async function run(argv: string[] = process.argv.slice(2)) {
       "--tls-key": String,
       "--tls-cert": String,
 
-      ...(argv[0].startsWith("vite:") ||
+      ...(argv[0]?.startsWith("vite:") ||
       argv[0] === "reveal" ||
       argv[0] === "routes"
         ? // Handle commands that support Vite's --config flag
@@ -176,7 +176,7 @@ export async function run(argv: string[] = process.argv.slice(2)) {
             "-c": "--command",
           }),
 
-      ...(argv[0].startsWith("vite:")
+      ...(argv[0]?.startsWith("vite:")
         ? {
             // Vite commands
             // --config, --force and --port are already defined above


### PR DESCRIPTION
Currently, `remix` occurred error when we not give operator command to `remix` cli

```
$ npx remix 
TypeError: Cannot read properties of undefined (reading 'startsWith')
    at Object.run (/app/packages/remix-dev/dist/cli/run.js:171:17)
    at Object.<anonymous> (/app/packages/remix-dev/dist/cli.js:16:11)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
    at Module._load (node:internal/modules/cjs/loader:1024:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:174:12)
    at node:internal/main/run_main_module:28:49
```

Because, there are parts of `cli` that expect operation command to always exist. We originally expect the shortcut to the `dev` command to run, so I modified it.

- [ ] Docs
- [x] Tests

Testing Strategy:

I added tests so, you can check with run test runner.

```
pnpm jest packages/remix-dev/__tests__/cli-test.ts
```

Or, package build and run cli.

```
pnpm build
node packages/remix-dev/dist/cli.js 
```
