### PR TITLE
docs: try to prevent "remix" package footgun

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -349,6 +349,7 @@
 - kiliman
 - kimdontdoit
 - KingSora
+- kisaragi-hiu
 - kishanhitk
 - kiyadotdev
 - klauspaiva

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -1,3 +1,10 @@
+# Deprecated
+
+The `remix` package is no longer used for Remix modules. It was [officially deprecated in v1.6.0](https://github.com/remix-run/remix/releases/tag/v1.6.0) then finally [removed in v2.0.0](https://github.com/remix-run/remix/releases/tag/remix@2.0.0). This package should be removed from your project dependencies if you have it installed.
+
+For stats about Remix, please consider referring to @remix-run/router or @remix
+-run/server-runtime instead.
+
 # Welcome to Remix!
 
 [Remix](https://remix.run) is a web framework that helps you build better websites with React.


### PR DESCRIPTION
Inspired by https://twitter.com/ryanflorence/status/1790041089778373076.

[The `remix` package on npm](https://www.npmjs.com/package/remix) is the first thing that comes up when one searches "remix" (as the exact match), appears updated regularly, and has no indication that it's no longer used. To hopefully mitigate this, this PR adds an explanation to point people to places they probably intended to go to.

This confusion is probably quite bad: of the 9 public dependents (npm says there are 11 but only lists 9, so I'm assuming the other 2 are private): one (`remix-redis-session`) has ~4000 weekly downloads (it depends on 1.3), the others all have 2 or 1 digit weekly downloads. That leaves about 18000 new downloads stepping into the footgun, which is comparatively about 4x (`remix` divided by `@remix-run/server-runtime`) or 0.5x (`remix` divided by `@remix-run/router`) as bad as the [biome](https://www.npmjs.com/package/biome) / [@biomejs/biome](https://www.npmjs.com/package/@biomejs/biome) situation judging by the ratios of weekly downloads.