### PR TITLE
docs(utils/sessions): Correction about `commitSession` in non-cookie sessions

### DIFF
--- a/docs/utils/sessions.md
+++ b/docs/utils/sessions.md
@@ -277,7 +277,7 @@ For purely cookie-based sessions (where the session data itself is stored in the
 
 The main advantage of cookie session storage is that you don't need any additional backend services or databases to use it. It can also be beneficial in some load-balanced scenarios. However, cookie-based sessions may not exceed the browser's max-allowed cookie length (typically 4kb).
 
-The downside is that you have to `commitSession` in almost every loader and action. If your loader or action changes the session at all, it must be committed. That means if you `session.flash` in an action, and then `session.get` in another, you must commit it for that flashed message to go away. With other session storage strategies you only have to commit it when it's created (the browser cookie doesn't need to change because it doesn't store the session data, just the key to find it elsewhere).
+The downside is that you have to send a "Set-Cookie" header from almost every loader and action, this can cause complications when writing to simultaneous requests for the same session. With other session storage strategies you only have to send a "Set-Cookie" header it when it's created (the browser cookie doesn't need to change because it doesn't store the session data, just the key to find it elsewhere). Note that you still need to call `commitSession()` whenever you change the session for anything based on `createSessionStorage`, you just don't need to send an updated header.
 
 ```ts
 import { createCookieSessionStorage } from "@remix-run/node"; // or cloudflare/deno

--- a/docs/utils/sessions.md
+++ b/docs/utils/sessions.md
@@ -277,7 +277,7 @@ For purely cookie-based sessions (where the session data itself is stored in the
 
 The main advantage of cookie session storage is that you don't need any additional backend services or databases to use it. It can also be beneficial in some load-balanced scenarios. However, cookie-based sessions may not exceed the browser's max-allowed cookie length (typically 4kb).
 
-The downside is that you have to `commitSession` and send a "Set-Cookie" header from every loader and action that changes the session. That means, for example, that if you `session.flash` in an action, and then `session.get` in another, you must commit it for that flashed message to go away.
+The downside is that you have to `commitSession` and send a "Set-Cookie" header from every loader and action that changes the session. This means, for example, that if you `session.flash` in an action, and then `session.get` in another, you must commit it for that flashed message to go away.
 
 This can cause complications if loaders or actions are writing to the same session at the same time.
 

--- a/docs/utils/sessions.md
+++ b/docs/utils/sessions.md
@@ -277,7 +277,13 @@ For purely cookie-based sessions (where the session data itself is stored in the
 
 The main advantage of cookie session storage is that you don't need any additional backend services or databases to use it. It can also be beneficial in some load-balanced scenarios. However, cookie-based sessions may not exceed the browser's max-allowed cookie length (typically 4kb).
 
-The downside is that you have to send a "Set-Cookie" header from almost every loader and action, this can cause complications when writing to simultaneous requests for the same session. With other session storage strategies you only have to send a "Set-Cookie" header when it's created (the browser cookie doesn't need to change because it doesn't store the session data, just the key to find it elsewhere). Note that you still need to call `commitSession()` whenever you change the session for anything based on `createSessionStorage`, you just don't need to send an updated header.
+The downside is that you have to `commitSession` and send a "Set-Cookie" header from every loader and action that changes the session. That mean, for example, that if you `session.flash` in an action, and then `session.get` in another, you must commit it for that flashed message to go away.
+
+This can cause complications when handling simultaneous requests for the same session. 
+
+With other session storage strategies you only have to send a "Set-Cookie" header when it's created (the browser cookie doesn't need to change because it doesn't store the session data, just the key to find it elsewhere). 
+
+Note that you still need to call `commitSession()` whenever you change the session for anything based on `createSessionStorage`, you just don't need to send an updated header.
 
 ```ts
 import { createCookieSessionStorage } from "@remix-run/node"; // or cloudflare/deno

--- a/docs/utils/sessions.md
+++ b/docs/utils/sessions.md
@@ -277,13 +277,13 @@ For purely cookie-based sessions (where the session data itself is stored in the
 
 The main advantage of cookie session storage is that you don't need any additional backend services or databases to use it. It can also be beneficial in some load-balanced scenarios. However, cookie-based sessions may not exceed the browser's max-allowed cookie length (typically 4kb).
 
-The downside is that you have to `commitSession` and send a "Set-Cookie" header from every loader and action that changes the session. That mean, for example, that if you `session.flash` in an action, and then `session.get` in another, you must commit it for that flashed message to go away.
+The downside is that you have to `commitSession` and send a "Set-Cookie" header from every loader and action that changes the session. That means, for example, that if you `session.flash` in an action, and then `session.get` in another, you must commit it for that flashed message to go away.
 
-This can cause complications when handling simultaneous requests for the same session. 
+This can cause complications if loaders or actions are writing to the same session at the same time.
 
-With other session storage strategies you only have to send a "Set-Cookie" header when it's created (the browser cookie doesn't need to change because it doesn't store the session data, just the key to find it elsewhere). 
+With other session storage strategies you only have to send a "Set-Cookie" header when the session is created (the browser cookie doesn't need to change because it doesn't store the session data, just the key to find it elsewhere). 
 
-Note that you still need to call `commitSession()` whenever you change the session for anything based on `createSessionStorage`, you just don't need to send an updated header.
+Note that you still need to call `commitSession()` when you change the session for anything based on `createSessionStorage`, you just don't need to send an updated header.
 
 ```ts
 import { createCookieSessionStorage } from "@remix-run/node"; // or cloudflare/deno

--- a/docs/utils/sessions.md
+++ b/docs/utils/sessions.md
@@ -277,7 +277,7 @@ For purely cookie-based sessions (where the session data itself is stored in the
 
 The main advantage of cookie session storage is that you don't need any additional backend services or databases to use it. It can also be beneficial in some load-balanced scenarios. However, cookie-based sessions may not exceed the browser's max-allowed cookie length (typically 4kb).
 
-The downside is that you have to send a "Set-Cookie" header from almost every loader and action, this can cause complications when writing to simultaneous requests for the same session. With other session storage strategies you only have to send a "Set-Cookie" header it when it's created (the browser cookie doesn't need to change because it doesn't store the session data, just the key to find it elsewhere). Note that you still need to call `commitSession()` whenever you change the session for anything based on `createSessionStorage`, you just don't need to send an updated header.
+The downside is that you have to send a "Set-Cookie" header from almost every loader and action, this can cause complications when writing to simultaneous requests for the same session. With other session storage strategies you only have to send a "Set-Cookie" header when it's created (the browser cookie doesn't need to change because it doesn't store the session data, just the key to find it elsewhere). Note that you still need to call `commitSession()` whenever you change the session for anything based on `createSessionStorage`, you just don't need to send an updated header.
 
 ```ts
 import { createCookieSessionStorage } from "@remix-run/node"; // or cloudflare/deno


### PR DESCRIPTION
Closes: #9444

- [x] Docs
- n/a Tests 

The docs for `createCookieSessionStorage` state:

> With other session storage strategies you only have to commit it when it's created

https://remix.run/docs/en/main/utils/sessions#createcookiesessionstorage

When we moved from `createCookieSessionStorage` to another storage solution (`createKvSessionStorage` from `@vercel/remix`), we followed this advice and removed calls to `commitSession` (assuming it was not needed, and that `session.set` would be all that is required) but it resulted in sessions not being saved.

Elsewhere in the docs for `createSessionStorage`:

> updateData will be called from commitSession

https://remix.run/docs/en/main/utils/sessions#createsessionstorage

Which seems to imply that anything based on `createSessionStorage` will require a call to `commitSession` in order to update the session, and I'm fairly sure explains why we would have bugs when removing calls to `commitSession`.
