### PR TITLE
fix: Fix type error for Resource Routes

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -265,6 +265,7 @@
 - itsMapleLeaf
 - izznatsir
 - jacargentina
+- jack-davies
 - jack-r-warren
 - jacob-ebey
 - JacobParis

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -270,4 +270,5 @@ export interface ServerRouteModule extends EntryRouteModule {
   action?: ActionFunction;
   headers?: HeadersFunction | { [name: string]: string };
   loader?: LoaderFunction;
+  default?: any; // override optional as Resource Routes do not define a default
 }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Hi there,

I noticed that on the Cloudflare pages starter a type error is raised on the `functions/[[path]].ts` file when a resource route is added without a default export:

![Screenshot from 2024-05-19 11-55-35](https://github.com/remix-run/remix/assets/16322213/1f024514-ad9e-40d4-9d49-85337a6b1de7)

I'm not sure if this type change has implications elsewhere, but based on my understanding of server routes it seems appropriate for `default` to be optional.

Testing Strategy:

I made the type change locally and confirmed it fixes the type error.