### PR TITLE
chore: fix `lint:deno` script

### DIFF
--- a/integration/helpers/deno-template/app/root.tsx
+++ b/integration/helpers/deno-template/app/root.tsx
@@ -8,7 +8,6 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
-import * as React from "react";
 
 export const links: LinksFunction = () => [
   ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),

--- a/integration/helpers/deno-template/app/routes/_index.tsx
+++ b/integration/helpers/deno-template/app/routes/_index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import type { MetaFunction } from "@remix-run/deno";
 
 export const meta: MetaFunction = () => {


### PR DESCRIPTION
Following [this update from Deno Lint](https://github.com/denoland/deno_lint/pull/1277), JSX files are now considered by the `no-unused-vars` deno lint rule.

I tried a few options:
- Adding `deno.json` 
- Adding a `tsconfig.json` (a bit redundant according to Deno docs)
- Removing those imports

All the solutions have some pros/cons, I've personally never used deno so I don't feel 100% confident implementing the first solution (My IDE was still complaining).

Feedback from Deno users are more than welcome 🙏 

I would not mind removing all those `import * as React from "react";` since we're using React ^18.

Another solution would be to at least [pin the Deno version](https://github.com/remix-run/remix/blob/ad7f1eabf1956d1ac1012de7cf18521e869742fd/.github/workflows/lint.yml#L46) in the Github Action to avoid surprises like this one.