### PR TITLE
templates(cloudflare): remove `wrangler.toml` bindings warning

### DIFF
--- a/templates/cloudflare/README.md
+++ b/templates/cloudflare/README.md
@@ -30,10 +30,6 @@ You will need to rerun typegen whenever you make changes to `wrangler.toml`.
 
 ## Deployment
 
-> [!WARNING]  
-> Cloudflare does _not_ use `wrangler.toml` to configure deployment bindings.
-> You **MUST** [configure deployment bindings manually in the Cloudflare dashboard][bindings].
-
 First, build your app for production:
 
 ```sh
@@ -45,8 +41,6 @@ Then, deploy your app to Cloudflare Pages:
 ```sh
 npm run deploy
 ```
-
-[bindings]: https://developers.cloudflare.com/pages/functions/bindings/
 
 ## Styling
 


### PR DESCRIPTION
Two months ago, cloudflare [announced](https://blog.cloudflare.com/pages-workers-integrations-monorepos-nextjs-wrangler#configure-pages-projects-with-wranglertoml) that:

> you can now configure Pages projects using wrangler.toml — the same configuration file format that is already used for configuring Workers.

Considering that change, it seems like this warning is defunct and will cause unnecessary complexity for users when trying to set up a remix cloudflare pages application.