### PR TITLE
Avoid hydration loops when layout error renders also throw

### DIFF
--- a/.changeset/mighty-experts-agree.md
+++ b/.changeset/mighty-experts-agree.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Avoid hydration loops when `Layout` `ErrorBoundary` renders also throw

--- a/integration/root-route-test.ts
+++ b/integration/root-route-test.ts
@@ -153,4 +153,74 @@ test.describe("root route", () => {
 
     console.error = oldConsoleError;
   });
+
+  test("Skip the Layout on subsequent client renders if the ErrorBoundary throws", async ({
+    page,
+  }) => {
+    let oldConsoleError;
+    oldConsoleError = console.error;
+    console.error = () => {};
+
+    fixture = await createFixture(
+      {
+        files: {
+          "app/root.tsx": js`
+            import * as React from "react";
+            import { defer } from "@remix-run/node";
+            import { Await, Scripts, useRouteError, useRouteLoaderData } from "@remix-run/react";
+
+            export function Layout({ children }) {
+              let data = useRouteLoaderData("root");
+              return (
+                <html>
+                  <head>
+                    <title>Layout Title</title>
+                  </head>
+                  <body id="layout">
+                    <React.Suspense fallback={<p id="loading">Loading...</p>}>
+                      <Await resolve={data.lazy}>
+                        {(v) => <p>{v.this.should.throw}</p>}
+                      </Await>
+                    </React.Suspense>
+                    {children}
+                    <Scripts />
+                  </body>
+                </html>
+              );
+            }
+            export function loader() {
+              return defer({
+                // this lets the app hydrate properly, then reject the deferred promise,
+                // which should throw on the initial render _and_ the error render,
+                // resulting in us bubbling to the default error boundary and skipping
+                // our Layout component entirely
+                lazy: new Promise((r) => setTimeout(() => r(null), 1000)),
+              });
+            }
+            export default function Root() {
+              return <p>success</p>;
+            }
+            export function ErrorBoundary() {
+              return <p>error</p>;
+            }
+          `,
+        },
+      },
+      ServerMode.Development
+    );
+    appFixture = await createAppFixture(fixture, ServerMode.Development);
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/", false);
+    expect(await app.page.$("#layout")).toBeDefined();
+    expect(await app.getHtml("#loading")).toMatch("Loading...");
+    await page.waitForSelector("h1");
+    expect(await app.page.$("#layout")).toBeNull();
+    expect(await app.getHtml("title")).toMatch("Application Error");
+    expect(await app.getHtml("h1")).toMatch("Application Error");
+    expect(await app.getHtml("pre")).toMatch(
+      "TypeError: Cannot read properties of null"
+    );
+
+    console.error = oldConsoleError;
+  });
 });

--- a/integration/root-route-test.ts
+++ b/integration/root-route-test.ts
@@ -193,7 +193,7 @@ test.describe("root route", () => {
                 // this lets the app hydrate properly, then reject the deferred promise,
                 // which should throw on the initial render _and_ the error render,
                 // resulting in us bubbling to the default error boundary and skipping
-                // our Layout component entirely
+                // our Layout component entirely to avoid a loop
                 lazy: new Promise((r) => setTimeout(() => r(null), 1000)),
               });
             }

--- a/integration/root-route-test.ts
+++ b/integration/root-route-test.ts
@@ -154,7 +154,65 @@ test.describe("root route", () => {
     console.error = oldConsoleError;
   });
 
-  test("Skip the Layout on subsequent client renders if the ErrorBoundary throws", async ({
+  test("Skip the Layout on subsequent server renders if Layout/ErrorBoundary throws (sync)", async ({
+    page,
+  }) => {
+    let oldConsoleError;
+    oldConsoleError = console.error;
+    console.error = () => {};
+
+    fixture = await createFixture(
+      {
+        files: {
+          "app/root.tsx": js`
+            import * as React from "react";
+            import { defer } from "@remix-run/node";
+            import { Await, Scripts, useRouteError, useRouteLoaderData } from "@remix-run/react";
+
+            export function Layout({ children }) {
+              let data = useRouteLoaderData("root");
+              return (
+                <html>
+                  <head>
+                    <title>Layout Title</title>
+                  </head>
+                  <body id="layout">
+                    <p>{data.this.should.throw}</p>
+                    {children}
+                    <Scripts />
+                  </body>
+                </html>
+              );
+            }
+            export function loader() {
+              return { ok: true };
+            }
+            export default function Root() {
+              return <p>success</p>;
+            }
+            export function ErrorBoundary() {
+              return <p>error</p>;
+            }
+          `,
+        },
+      },
+      ServerMode.Development
+    );
+    appFixture = await createAppFixture(fixture, ServerMode.Development);
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/");
+    // The server should send back the fallback 500 HTML since it was unable
+    // to render the Layout/ErrorBoundary combo
+    expect(await app.page.$("#layout")).toBeNull();
+    expect(await app.getHtml("pre")).toMatch("Unexpected Server Error");
+    expect(await app.getHtml("pre")).toMatch(
+      "Cannot read properties of undefined"
+    );
+
+    console.error = oldConsoleError;
+  });
+
+  test("Skip the Layout on subsequent client renders if Layout/ErrorBoundary throws (async)", async ({
     page,
   }) => {
     let oldConsoleError;
@@ -194,7 +252,7 @@ test.describe("root route", () => {
                 // which should throw on the initial render _and_ the error render,
                 // resulting in us bubbling to the default error boundary and skipping
                 // our Layout component entirely to avoid a loop
-                lazy: new Promise((r) => setTimeout(() => r(null), 1000)),
+                lazy: new Promise((r) => setTimeout(() => r(null), 100)),
               });
             }
             export default function Root() {
@@ -202,6 +260,129 @@ test.describe("root route", () => {
             }
             export function ErrorBoundary() {
               return <p>error</p>;
+            }
+          `,
+        },
+      },
+      ServerMode.Development
+    );
+    appFixture = await createAppFixture(fixture, ServerMode.Development);
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/", false);
+    expect(await app.page.$("#layout")).toBeDefined();
+    expect(await app.getHtml("#loading")).toMatch("Loading...");
+    await page.waitForSelector("h1");
+    expect(await app.page.$("#layout")).toBeNull();
+    expect(await app.getHtml("title")).toMatch("Application Error");
+    expect(await app.getHtml("h1")).toMatch("Application Error");
+    expect(await app.getHtml("pre")).toMatch(
+      "TypeError: Cannot read properties of null"
+    );
+
+    console.error = oldConsoleError;
+  });
+
+  test("Skip the Layout on subsequent server renders if the Layout/DefaultErrorBoundary throws (sync)", async ({
+    page,
+  }) => {
+    let oldConsoleError;
+    oldConsoleError = console.error;
+    console.error = () => {};
+
+    fixture = await createFixture(
+      {
+        files: {
+          "app/root.tsx": js`
+            import * as React from "react";
+            import { defer } from "@remix-run/node";
+            import { Await, Scripts, useRouteError, useRouteLoaderData } from "@remix-run/react";
+
+            export function Layout({ children }) {
+              let data = useRouteLoaderData("root");
+              return (
+                <html>
+                  <head>
+                    <title>Layout Title</title>
+                  </head>
+                  <body id="layout">
+                    <p>{data.this.should.throw}</p>
+                    {children}
+                    <Scripts />
+                  </body>
+                </html>
+              );
+            }
+            export function loader() {
+              return { ok: true };
+            }
+            export default function Root() {
+              return <p>success</p>;
+            }
+          `,
+        },
+      },
+      ServerMode.Development
+    );
+    appFixture = await createAppFixture(fixture, ServerMode.Development);
+    let app = new PlaywrightFixture(appFixture, page);
+
+    await app.goto("/");
+    // The server should send back the fallback 500 HTML since it was unable
+    // to render the Layout/ErrorBoundary combo
+    expect(await app.page.$("#layout")).toBeNull();
+    expect(await app.getHtml("pre")).toMatch("Unexpected Server Error");
+    expect(await app.getHtml("pre")).toMatch(
+      "Cannot read properties of undefined"
+    );
+
+    console.error = oldConsoleError;
+  });
+
+  test("Skip the Layout on subsequent client renders if the Layout/DefaultErrorBoundary throws (async)", async ({
+    page,
+  }) => {
+    let oldConsoleError;
+    oldConsoleError = console.error;
+    console.error = () => {};
+
+    fixture = await createFixture(
+      {
+        files: {
+          "app/root.tsx": js`
+            import * as React from "react";
+            import { defer } from "@remix-run/node";
+            import { Await, Scripts, useRouteError, useRouteLoaderData } from "@remix-run/react";
+
+            export function Layout({ children }) {
+              let data = useRouteLoaderData("root");
+              return (
+                <html>
+                  <head>
+                    <title>Layout Title</title>
+                  </head>
+                  <body id="layout">
+                    <React.Suspense fallback={<p id="loading">Loading...</p>}>
+                      <Await resolve={data.lazy}>
+                        {(v) => <p>{v.this.should.throw}</p>}
+                      </Await>
+                    </React.Suspense>
+                    {children}
+                    <Scripts />
+                  </body>
+                </html>
+              );
+            }
+            export function loader() {
+              return defer({
+                // this lets the app hydrate properly, then reject the deferred promise,
+                // which should throw on the initial render _and_ the error render,
+                // resulting in us bubbling to the default error boundary and skipping
+                // our Layout component entirely to avoid a loop
+                lazy: new Promise((r) => setTimeout(() => r(null), 100)),
+              });
+            }
+            export default function Root() {
+              return <p>success</p>;
             }
           `,
         },

--- a/packages/remix-react/errorBoundaries.tsx
+++ b/packages/remix-react/errorBoundaries.tsx
@@ -103,7 +103,7 @@ export function RemixRootDefaultErrorBoundary({ error }: { error: unknown }) {
   }
 
   return (
-    <BoundaryShell title="Application Error!">
+    <BoundaryShell title="Application Error!" isRenderError>
       <h1 style={{ fontSize: "24px" }}>Application Error</h1>
       <pre
         style={{
@@ -123,15 +123,25 @@ export function RemixRootDefaultErrorBoundary({ error }: { error: unknown }) {
 export function BoundaryShell({
   title,
   renderScripts,
+  isRenderError,
   children,
 }: {
   title: string;
   renderScripts?: boolean;
+  isRenderError?: boolean;
   children: React.ReactNode | React.ReactNode[];
 }) {
   let { routeModules } = useRemixContext();
+  let rootRoute = routeModules.root;
 
-  if (routeModules.root?.Layout) {
+  // If the root route has a Layout and does not have an ErrorBoundary, then
+  // render the error UI inside the Layout.  However, if the root route has an
+  // ErrorBoundary and we're in this flow, that must mean we threw trying to
+  // render the root route error boundary - so don't try to render
+  // Layout+ErrorBoundary again since we'll just get into a loop.  Skip the
+  // Layout and just render our own shell here.
+  let isBubbledRenderError = isRenderError && rootRoute?.ErrorBoundary != null;
+  if (rootRoute && rootRoute.Layout && !isBubbledRenderError) {
     return children;
   }
 

--- a/packages/remix-react/errorBoundaries.tsx
+++ b/packages/remix-react/errorBoundaries.tsx
@@ -147,7 +147,6 @@ export function BoundaryShell({
   children: React.ReactNode | React.ReactNode[];
 }) {
   let { routeModules } = useRemixContext();
-  let rootRoute = routeModules.root;
 
   // Generally speaking, when the root route has a Layout we want to use that
   // as the app shell instead of the default `BoundaryShell` wrapper markup below.
@@ -165,7 +164,7 @@ export function BoundaryShell({
   // during hydration that wraps `RouterProvider`, then we can't trust the
   // `Layout` and should fallback to the default app shell so we're always
   // returning an `<html>` document.
-  if (rootRoute && rootRoute.Layout && !isOutsideRemixApp) {
+  if (routeModules.root?.Layout && !isOutsideRemixApp) {
     return children;
   }
 


### PR DESCRIPTION
If you have a root `Layout` we will try to render that on the success _and_ error flows.  If the error flow _also_ throws during hydration (i.e., from a delayed resolved promise render) and we bubble to our default error boundary, then we can get into an infinite loop because we choose _not_ to render the surrounding `<html>` in the error boundary when a `Layout` exists.

Instead, if we are inside the default error boundary and the root route has both a `Layout` and an `ErrorBoundary` then we must have thrown trying to render the error via the `Layout` and we _should_ render the default `<html>` shell.  Otherwise we get into a react hydration loop because the DOM rejects when we try to add our default error boundary children (`h1`, `pre`) as children of `#document`.

Closes #9553 