### PR TITLE
Update Template READMEs and links

### DIFF
--- a/templates/cloudflare-workers/README.md
+++ b/templates/cloudflare-workers/README.md
@@ -1,20 +1,11 @@
-# Welcome to Remix + Vite!
+# Welcome to Remix + Cloudflare Workers!
 
-📖 See the [Remix docs](https://remix.run/docs) and the [Remix Vite docs](https://remix.run/docs/en/main/guides/vite) for details on supported features.
-
-## Typegen
-
-Generate types for your Cloudflare bindings in `wrangler.toml`:
-
-```sh
-pnpm typegen
-```
-
-You will need to rerun typegen whenever you make changes to `wrangler.toml`.
+- 📖 [Remix docs](https://remix.run/docs)
+- 📖 [Remix Cloudflare docs](https://remix.run/guides/vite#cloudflare)
 
 ## Development
 
-Run the Vite dev server:
+Run the dev server:
 
 ```sh
 npm run dev
@@ -27,6 +18,16 @@ npm run build
 npm start
 ```
 
+## Typegen
+
+Generate types for your Cloudflare bindings in `wrangler.toml`:
+
+```sh
+npm run typegen
+```
+
+You will need to rerun typegen whenever you make changes to `wrangler.toml`.
+
 ## Deployment
 
 If you don't already have an account, then [create a cloudflare account here](https://dash.cloudflare.com/sign-up) and after verifying your email address with Cloudflare, go to your dashboard and set up your free custom Cloudflare Workers subdomain.
@@ -34,5 +35,5 @@ If you don't already have an account, then [create a cloudflare account here](ht
 Once that's done, you should be able to deploy your app:
 
 ```sh
-pnpm run deploy
+npm run deploy
 ```

--- a/templates/cloudflare-workers/app/routes/_index.tsx
+++ b/templates/cloudflare-workers/app/routes/_index.tsx
@@ -5,7 +5,7 @@ export const meta: MetaFunction = () => {
     { title: "New Remix App" },
     {
       name: "description",
-      content: "Welcome to Remix! Using Vite and Cloudflare Workers!",
+      content: "Welcome to Remix on Cloudflare Workers!",
     },
   ];
 };
@@ -13,8 +13,13 @@ export const meta: MetaFunction = () => {
 export default function Index() {
   return (
     <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.8" }}>
-      <h1>Welcome to Remix (with Vite and Cloudflare Workers)</h1>
+      <h1>Welcome to Remix on Cloudflare Workers</h1>
       <ul>
+        <li>
+          <a target="_blank" href="https://remix.run/docs" rel="noreferrer">
+            Remix Docs
+          </a>
+        </li>
         <li>
           <a
             target="_blank"
@@ -22,11 +27,6 @@ export default function Index() {
             rel="noreferrer"
           >
             Cloudflare Workers Docs
-          </a>
-        </li>
-        <li>
-          <a target="_blank" href="https://remix.run/docs" rel="noreferrer">
-            Remix Docs
           </a>
         </li>
       </ul>

--- a/templates/cloudflare/README.md
+++ b/templates/cloudflare/README.md
@@ -1,20 +1,11 @@
-# Welcome to Remix + Vite!
+# Welcome to Remix + Cloudflare!
 
-📖 See the [Remix docs](https://remix.run/docs) and the [Remix Vite docs](https://remix.run/docs/en/main/guides/vite) for details on supported features.
-
-## Typegen
-
-Generate types for your Cloudflare bindings in `wrangler.toml`:
-
-```sh
-npm run typegen
-```
-
-You will need to rerun typegen whenever you make changes to `wrangler.toml`.
+- 📖 [Remix docs](https://remix.run/docs)
+- 📖 [Remix Cloudflare docs](https://remix.run/guides/vite#cloudflare)
 
 ## Development
 
-Run the Vite dev server:
+Run the dev server:
 
 ```sh
 npm run dev
@@ -26,6 +17,16 @@ To run Wrangler:
 npm run build
 npm run start
 ```
+
+## Typegen
+
+Generate types for your Cloudflare bindings in `wrangler.toml`:
+
+```sh
+npm run typegen
+```
+
+You will need to rerun typegen whenever you make changes to `wrangler.toml`.
 
 ## Deployment
 

--- a/templates/cloudflare/app/routes/_index.tsx
+++ b/templates/cloudflare/app/routes/_index.tsx
@@ -5,7 +5,7 @@ export const meta: MetaFunction = () => {
     { title: "New Remix App" },
     {
       name: "description",
-      content: "Welcome to Remix! Using Vite and Cloudflare!",
+      content: "Welcome to Remix on Cloudflare!",
     },
   ];
 };
@@ -13,8 +13,13 @@ export const meta: MetaFunction = () => {
 export default function Index() {
   return (
     <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.8" }}>
-      <h1>Welcome to Remix (with Vite and Cloudflare)</h1>
+      <h1>Welcome to Remix on Cloudflare</h1>
       <ul>
+        <li>
+          <a target="_blank" href="https://remix.run/docs" rel="noreferrer">
+            Remix Docs
+          </a>
+        </li>
         <li>
           <a
             target="_blank"
@@ -22,11 +27,6 @@ export default function Index() {
             rel="noreferrer"
           >
             Cloudflare Pages Docs - Remix guide
-          </a>
-        </li>
-        <li>
-          <a target="_blank" href="https://remix.run/docs" rel="noreferrer">
-            Remix Docs
           </a>
         </li>
       </ul>

--- a/templates/express/README.md
+++ b/templates/express/README.md
@@ -1,10 +1,10 @@
-# Welcome to Remix + Vite!
+# Welcome to Remix!
 
-📖 See the [Remix docs](https://remix.run/docs) and the [Remix Vite docs](https://remix.run/docs/en/main/guides/vite) for details on supported features.
+- 📖 [Remix docs](https://remix.run/docs)
 
 ## Development
 
-Run the Express server with Vite dev middleware:
+Run the dev server:
 
 ```shellscript
 npm run dev
@@ -28,7 +28,9 @@ Now you'll need to pick a host to deploy it to.
 
 ### DIY
 
-If you're familiar with deploying Express applications you should be right at home. Just make sure to deploy the output of `npm run build`
+If you're familiar with deploying Node applications, the built-in Remix app server is production-ready.
+
+Make sure to deploy the output of `npm run build`
 
 - `build/server`
 - `build/client`

--- a/templates/express/app/routes/_index.tsx
+++ b/templates/express/app/routes/_index.tsx
@@ -15,19 +15,19 @@ export default function Index() {
         <li>
           <a
             target="_blank"
-            href="https://remix.run/tutorials/blog"
+            href="https://remix.run/start/quickstart"
             rel="noreferrer"
           >
-            15m Quickstart Blog Tutorial
+            5m Quick Start
           </a>
         </li>
         <li>
           <a
             target="_blank"
-            href="https://remix.run/tutorials/jokes"
+            href="https://remix.run/start/tutorial"
             rel="noreferrer"
           >
-            Deep Dive Jokes App Tutorial
+            30m Tutorial
           </a>
         </li>
         <li>

--- a/templates/remix-javascript/README.md
+++ b/templates/remix-javascript/README.md
@@ -1,10 +1,10 @@
-# Welcome to Remix + Vite!
+# Welcome to Remix!
 
-📖 See the [Remix docs](https://remix.run/docs) and the [Remix Vite docs](https://remix.run/docs/en/main/guides/vite) for details on supported features.
+- 📖 [Remix docs](https://remix.run/docs)
 
 ## Development
 
-Run the Vite dev server:
+Run the dev server:
 
 ```shellscript
 npm run dev

--- a/templates/remix-javascript/app/routes/_index.jsx
+++ b/templates/remix-javascript/app/routes/_index.jsx
@@ -13,19 +13,19 @@ export default function Index() {
         <li>
           <a
             target="_blank"
-            href="https://remix.run/tutorials/blog"
+            href="https://remix.run/start/quickstart"
             rel="noreferrer"
           >
-            15m Quickstart Blog Tutorial
+            5m Quick Start
           </a>
         </li>
         <li>
           <a
             target="_blank"
-            href="https://remix.run/tutorials/jokes"
+            href="https://remix.run/start/tutorial"
             rel="noreferrer"
           >
-            Deep Dive Jokes App Tutorial
+            30m Tutorial
           </a>
         </li>
         <li>

--- a/templates/remix/README.md
+++ b/templates/remix/README.md
@@ -1,10 +1,10 @@
-# Welcome to Remix + Vite!
+# Welcome to Remix!
 
-📖 See the [Remix docs](https://remix.run/docs) and the [Remix Vite docs](https://remix.run/docs/en/main/guides/vite) for details on supported features.
+- 📖 [Remix docs](https://remix.run/docs)
 
 ## Development
 
-Run the Vite dev server:
+Run the dev server:
 
 ```shellscript
 npm run dev

--- a/templates/remix/app/routes/_index.tsx
+++ b/templates/remix/app/routes/_index.tsx
@@ -15,19 +15,19 @@ export default function Index() {
         <li>
           <a
             target="_blank"
-            href="https://remix.run/tutorials/blog"
+            href="https://remix.run/start/quickstart"
             rel="noreferrer"
           >
-            15m Quickstart Blog Tutorial
+            5m Quick Start
           </a>
         </li>
         <li>
           <a
             target="_blank"
-            href="https://remix.run/tutorials/jokes"
+            href="https://remix.run/start/tutorial"
             rel="noreferrer"
           >
-            Deep Dive Jokes App Tutorial
+            30m Tutorial
           </a>
         </li>
         <li>

--- a/templates/spa/README.md
+++ b/templates/spa/README.md
@@ -1,6 +1,6 @@
 # templates/spa
 
-This template leverages [Remix SPA Mode](https://remix.run/docs/en/main/guides/spa-mode) and the [Remix Vite Plugin](https://remix.run/docs/en/main/guides/vite) to build your app as a Single-Page Application using [Client Data](https://remix.run/docs/en/main/guides/client-data) for all of your data loads and mutations.
+This template leverages [Remix SPA Mode](https://remix.run/docs/en/main/guides/spa-mode) to build your app as a Single-Page Application using [Client Data](https://remix.run/docs/en/main/guides/client-data) for all of your data loads and mutations.
 
 ## Setup
 


### PR DESCRIPTION
Starting to update our templates just a bit. This is the first step:

- Remove unnecessary mention of Vite -- people trying out Remix for the first time don't need to know about the compiler, this made more sense
- Update links from old tutorials to the current ones