### PR TITLE
Remove AbortController and respect URL length limits

### DIFF
--- a/.changeset/tall-news-trade.md
+++ b/.changeset/tall-news-trade.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+[REMOVE] Remove abort logic and use a POST on large URL requests

--- a/.changeset/tall-news-trade.md
+++ b/.changeset/tall-news-trade.md
@@ -2,4 +2,4 @@
 "@remix-run/react": patch
 ---
 
-[REMOVE] Remove abort logic and use a POST on large URL requests
+[REMOVE] FOW: Remove abort controller logic and skip prefetching if URL is too large

--- a/packages/remix-react/fog-of-war.ts
+++ b/packages/remix-react/fog-of-war.ts
@@ -241,6 +241,12 @@ export async function fetchAndApplyManifestPatches(
         })
       : await fetch(url);
 
+  if (!res.ok) {
+    throw new Error(`${res.status} ${res.statusText}`);
+  } else if (res.status >= 400) {
+    throw new Error(await res.text());
+  }
+
   let data = (await res.json()) as {
     notFoundPaths: string[];
     patches: AssetsManifest["routes"];

--- a/packages/remix-react/fog-of-war.ts
+++ b/packages/remix-react/fog-of-war.ts
@@ -230,16 +230,13 @@ export async function fetchAndApplyManifestPatches(
   url.searchParams.set("version", manifest.version);
   paths.forEach((path) => url.searchParams.append("p", path));
 
-  // GET requests should be good up to 8k - but some providers (GCP) also have
-  // hard limits on entire GET request sizes including headers and such so let's
-  // be somewhat conservative here and move to a POST if our params go beyond 4k.
-  let res =
-    url.searchParams.toString().length > 4196
-      ? await fetch(url.pathname, {
-          method: "post",
-          body: url.searchParams,
-        })
-      : await fetch(url);
+  // If the URL is nearing the ~8k limit on GET requests, skip this optimization
+  // step and just let discovery happen on link click
+  if (url.toString().length > 7168) {
+    return;
+  }
+
+  let res = await fetch(url);
 
   if (!res.ok) {
     throw new Error(`${res.status} ${res.statusText}`);

--- a/packages/remix-react/fog-of-war.ts
+++ b/packages/remix-react/fog-of-war.ts
@@ -228,7 +228,7 @@ export async function fetchAndApplyManifestPatches(
   let manifestPath = `${basename ?? "/"}/__manifest`.replace(/\/+/g, "/");
   let url = new URL(manifestPath, window.location.origin);
   url.searchParams.set("version", manifest.version);
-  paths.forEach((path) => url.searchParams.append("paths", path));
+  paths.forEach((path) => url.searchParams.append("p", path));
 
   // GET requests should be good up to 8k - but some providers (GCP) also have
   // hard limits on entire GET request sizes including headers and such so let's

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -305,7 +305,7 @@ async function handleManifestRequest(
       ? new URLSearchParams(await request.text())
       : url.searchParams;
 
-  let paths = searchParams.getAll("paths");
+  let paths = searchParams.getAll("p");
   if (paths.length > 0) {
     for (let path of paths) {
       let matches = matchServerRoutes(routes, path, build.basename);

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -142,7 +142,7 @@ export const createRequestHandler: CreateRequestHandlerFunction = (
     );
     if (url.pathname === manifestUrl) {
       try {
-        let res = await handleManifestRequest(_build, routes, url);
+        let res = await handleManifestRequest(_build, routes, request, url);
         return res;
       } catch (e) {
         handleError(e);
@@ -292,6 +292,7 @@ export const createRequestHandler: CreateRequestHandlerFunction = (
 async function handleManifestRequest(
   build: ServerBuild,
   routes: ServerRoute[],
+  request: Request,
   url: URL
 ) {
   let data: {
@@ -299,7 +300,12 @@ async function handleManifestRequest(
     notFoundPaths: string[];
   } = { patches: {}, notFoundPaths: [] };
 
-  let paths = url.searchParams.getAll("paths");
+  let searchParams =
+    request.method === "POST"
+      ? new URLSearchParams(await request.text())
+      : url.searchParams;
+
+  let paths = searchParams.getAll("paths");
   if (paths.length > 0) {
     for (let path of paths) {
       let matches = matchServerRoutes(routes, path, build.basename);

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -319,9 +319,13 @@ async function handleManifestRequest(
       }
     }
     return json(data, {
-      headers: {
-        "Cache-Control": "public, max-age=31536000, immutable",
-      },
+      ...(request.method === "GET"
+        ? {
+            headers: {
+              "Cache-Control": "public, max-age=31536000, immutable",
+            },
+          }
+        : {}),
     }) as Response; // Override the TypedResponse stuff
   }
 


### PR DESCRIPTION
* Using the abort controller causes log noise in `StrictMode`, and there's no real benefit to aborting since the response is still valid so might as well patch those routes to avoid subsequent requests if we navigate back to those routes.
* Switch to a `POST` request if the URL goes beyond 4196 characters (a fairly conservative limit) to avoid running into URL or Request size limits
  * Only GET requests get the built-in `Cache-Control` response header