### PR TITLE
Support Fog of War form discovery and fix link prefetching

### DIFF
--- a/.changeset/shiny-dolphins-mate.md
+++ b/.changeset/shiny-dolphins-mate.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Fog of War: Support route discovery from `<Form>` components

--- a/integration/client-data-test.ts
+++ b/integration/client-data-test.ts
@@ -2354,7 +2354,7 @@ test.describe("single fetch", () => {
         });
 
         let app = new PlaywrightFixture(appFixture, page);
-        await app.goto("/", true);
+        await app.goto("/", false);
 
         if (browserName === "webkit") {
           // No prefetch support :/

--- a/integration/client-data-test.ts
+++ b/integration/client-data-test.ts
@@ -2312,6 +2312,62 @@ test.describe("single fetch", () => {
           ]);
         }
       });
+
+      test("does not prefetch server loader if a client loader is present (fog of war)", async ({
+        page,
+        browserName,
+      }) => {
+        appFixture = await createAppFixture(
+          await createTestFixture({
+            config: {
+              future: {
+                unstable_fogOfWar: true,
+              },
+            },
+            files: {
+              ...getFiles({
+                parentClientLoader: true,
+                parentClientLoaderHydrate: false,
+                childClientLoader: false,
+                childClientLoaderHydrate: false,
+              }),
+              "app/routes/_index.tsx": js`
+                import { Link } from '@remix-run/react'
+                export default function Component() {
+                  return (
+                    <>
+                      <Link prefetch="render" to="/parent">Go to /parent</Link>
+                      <Link prefetch="render" to="/parent/child">Go to /parent/child</Link>
+                    </>
+                  );
+                }
+            `,
+            },
+          })
+        );
+
+        let dataUrls: string[] = [];
+        page.on("request", (request) => {
+          if (request.url().includes(".data")) {
+            dataUrls.push(request.url());
+          }
+        });
+
+        let app = new PlaywrightFixture(appFixture, page);
+        await app.goto("/", true);
+
+        if (browserName === "webkit") {
+          // No prefetch support :/
+          expect(dataUrls).toEqual([]);
+        } else {
+          // Only prefetch child server loader since parent has a `clientLoader`
+          expect(dataUrls).toEqual([
+            expect.stringMatching(
+              /parent\/child\.data\?_routes=routes%2Fparent\.child/
+            ),
+          ]);
+        }
+      });
     });
 
     test.describe("clientAction - critical route module", () => {

--- a/integration/client-data-test.ts
+++ b/integration/client-data-test.ts
@@ -2312,62 +2312,6 @@ test.describe("single fetch", () => {
           ]);
         }
       });
-
-      test("does not prefetch server loader if a client loader is present (fog of war)", async ({
-        page,
-        browserName,
-      }) => {
-        appFixture = await createAppFixture(
-          await createTestFixture({
-            config: {
-              future: {
-                unstable_fogOfWar: true,
-              },
-            },
-            files: {
-              ...getFiles({
-                parentClientLoader: true,
-                parentClientLoaderHydrate: false,
-                childClientLoader: false,
-                childClientLoaderHydrate: false,
-              }),
-              "app/routes/_index.tsx": js`
-                import { Link } from '@remix-run/react'
-                export default function Component() {
-                  return (
-                    <>
-                      <Link prefetch="render" to="/parent">Go to /parent</Link>
-                      <Link prefetch="render" to="/parent/child">Go to /parent/child</Link>
-                    </>
-                  );
-                }
-            `,
-            },
-          })
-        );
-
-        let dataUrls: string[] = [];
-        page.on("request", (request) => {
-          if (request.url().includes(".data")) {
-            dataUrls.push(request.url());
-          }
-        });
-
-        let app = new PlaywrightFixture(appFixture, page);
-        await app.goto("/", false);
-
-        if (browserName === "webkit") {
-          // No prefetch support :/
-          expect(dataUrls).toEqual([]);
-        } else {
-          // Only prefetch child server loader since parent has a `clientLoader`
-          expect(dataUrls).toEqual([
-            expect.stringMatching(
-              /parent\/child\.data\?_routes=routes%2Fparent\.child/
-            ),
-          ]);
-        }
-      });
     });
 
     test.describe("clientAction - critical route module", () => {

--- a/integration/package.json
+++ b/integration/package.json
@@ -14,7 +14,7 @@
     "@remix-run/dev": "workspace:*",
     "@remix-run/express": "workspace:*",
     "@remix-run/node": "workspace:*",
-    "@remix-run/router": "1.17.0",
+    "@remix-run/router": "0.0.0-experimental-3ce8d73c7",
     "@remix-run/server-runtime": "workspace:*",
     "@types/express": "^4.17.9",
     "@vanilla-extract/css": "^1.10.0",

--- a/integration/package.json
+++ b/integration/package.json
@@ -14,7 +14,7 @@
     "@remix-run/dev": "workspace:*",
     "@remix-run/express": "workspace:*",
     "@remix-run/node": "workspace:*",
-    "@remix-run/router": "0.0.0-experimental-3ce8d73c7",
+    "@remix-run/router": "0.0.0-experimental-078ef8de9",
     "@remix-run/server-runtime": "workspace:*",
     "@types/express": "^4.17.9",
     "@vanilla-extract/css": "^1.10.0",

--- a/integration/prefetch-test.ts
+++ b/integration/prefetch-test.ts
@@ -714,6 +714,106 @@ test.describe("single fetch", () => {
     });
   });
 
+  test.describe("prefetch=render (fog of war)", () => {
+    let appFixture: AppFixture;
+
+    test.afterAll(() => {
+      appFixture?.close();
+    });
+
+    test("adds prefetch tags after discovery", async ({ page }) => {
+      let fixture = await createFixture({
+        config: {
+          future: {
+            unstable_fogOfWar: true,
+            unstable_singleFetch: true,
+          },
+        },
+        files: {
+          "app/root.tsx": js`
+            import * as React from "react";
+            import {
+              Link,
+              Links,
+              Meta,
+              Outlet,
+              Scripts,
+              useLoaderData,
+            } from "@remix-run/react";
+
+            export default function Root() {
+              let [discover, setDiscover] = React.useState(false);
+              return (
+                <html lang="en">
+                  <head>
+                    <Meta />
+                    <Links />
+                  </head>
+                  <body>
+                    <nav id="nav">
+                      <Link
+                        to="/with-loader"
+                        discover={discover ? "render" : "none"}
+                        prefetch="render">
+                        Loader Page
+                      </Link>
+                      <br/>
+                      <button onClick={() => setDiscover(true)}>
+                        Discover Link
+                      </button>
+                    </nav>
+                    <Outlet />
+                    <Scripts />
+                  </body>
+                </html>
+              );
+            }
+          `,
+
+          "app/routes/_index.tsx": js`
+            export default function() {
+              return <h2 className="index">Index</h2>;
+            }
+          `,
+
+          "app/routes/with-loader.tsx": js`
+            export function loader() {
+              return { message: 'data from the loader' };
+            }
+            export default function() {
+              return <h2 className="with-loader">With Loader</h2>;
+            }
+          `,
+        },
+      });
+      appFixture = await createAppFixture(fixture);
+      let app = new PlaywrightFixture(appFixture, page);
+
+      let consoleLogs: string[] = [];
+      page.on("console", (msg) => {
+        consoleLogs.push(msg.text());
+      });
+
+      let selectors = {
+        data: "#nav link[href='/with-loader.data']",
+        route: "#nav link[href^='/build/routes/with-loader-']",
+      };
+      await app.goto("/", true);
+      expect(await app.page.$(selectors.data)).toBeNull();
+      expect(await app.page.$(selectors.route)).toBeNull();
+      expect(consoleLogs).toEqual([
+        "Tried to prefetch /with-loader but no routes matched.",
+      ]);
+
+      await app.clickElement("button");
+      await page.waitForSelector(selectors.data, { state: "attached" });
+      await page.waitForSelector(selectors.route, { state: "attached" });
+
+      // Ensure no other links in the #nav element
+      expect(await page.locator("#nav link").count()).toBe(2);
+    });
+  });
+
   test.describe("prefetch=intent (hover)", () => {
     let fixture: Fixture;
     let appFixture: AppFixture;

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -32,7 +32,7 @@
     "@mdx-js/mdx": "^2.3.0",
     "@npmcli/package-json": "^4.0.1",
     "@remix-run/node": "workspace:*",
-    "@remix-run/router": "0.0.0-experimental-3ce8d73c7",
+    "@remix-run/router": "0.0.0-experimental-078ef8de9",
     "@remix-run/server-runtime": "workspace:*",
     "@types/mdx": "^2.0.5",
     "@vanilla-extract/integration": "^6.2.0",

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -32,7 +32,7 @@
     "@mdx-js/mdx": "^2.3.0",
     "@npmcli/package-json": "^4.0.1",
     "@remix-run/node": "workspace:*",
-    "@remix-run/router": "1.17.0",
+    "@remix-run/router": "0.0.0-experimental-3ce8d73c7",
     "@remix-run/server-runtime": "workspace:*",
     "@types/mdx": "^2.0.5",
     "@vanilla-extract/integration": "^6.2.0",

--- a/packages/remix-react/__tests__/exports-test.tsx
+++ b/packages/remix-react/__tests__/exports-test.tsx
@@ -32,8 +32,9 @@ let nonReExportedKeys = new Set([
 // type safety, plus Link/NavLink have wrappers to support prefetching
 let modifiedExports = new Set([
   "Await", // types
-  "Link", // remix-specific prefetching loigc
-  "NavLink", // remix-specific prefetching loigc
+  "Form", // remix-specific discovery logic
+  "Link", // remix-specific discovery/prefetching logic
+  "NavLink", // remix-specific discovery/prefetching logic
   "ScrollRestoration", // remix-specific SSR restoration logic
   "defer", // types
   "json", // types

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -13,11 +13,13 @@ import type {
 } from "@remix-run/router";
 import type {
   FetcherWithComponents,
+  FormProps,
   LinkProps,
   NavLinkProps,
 } from "react-router-dom";
 import {
   Await as AwaitRR,
+  Form as RouterForm,
   Link as RouterLink,
   NavLink as RouterNavLink,
   UNSAFE_DataRouterContext as DataRouterContext,
@@ -31,6 +33,7 @@ import {
   useRouteLoaderData as useRouteLoaderDataRR,
   useLocation,
   useHref,
+  useFormAction,
 } from "react-router-dom";
 import type { SerializeFrom } from "@remix-run/server-runtime";
 
@@ -270,6 +273,33 @@ let Link = React.forwardRef<HTMLAnchorElement, RemixLinkProps>(
 );
 Link.displayName = "Link";
 export { Link };
+
+export interface RemixFormProps extends FormProps {
+  discover?: DiscoverBehavior;
+}
+
+/**
+ * This component renders a form tag and is the primary way the user will
+ * submit information via your website.
+ *
+ * @see https://remix.run/components/form
+ */
+let Form = React.forwardRef<HTMLFormElement, RemixFormProps>(
+  ({ discover = "render", ...props }, forwardedRef) => {
+    let isAbsolute =
+      typeof props.action === "string" && ABSOLUTE_URL_REGEX.test(props.action);
+    return (
+      <RouterForm
+        {...props}
+        data-discover={
+          !isAbsolute && discover === "render" ? "true" : undefined
+        }
+      />
+    );
+  }
+);
+Form.displayName = "Form";
+export { Form };
 
 export function composeEventHandlers<
   EventType extends React.SyntheticEvent | Event

--- a/packages/remix-react/components.tsx
+++ b/packages/remix-react/components.tsx
@@ -33,7 +33,6 @@ import {
   useRouteLoaderData as useRouteLoaderDataRR,
   useLocation,
   useHref,
-  useFormAction,
 } from "react-router-dom";
 import type { SerializeFrom } from "@remix-run/server-runtime";
 

--- a/packages/remix-react/fog-of-war.ts
+++ b/packages/remix-react/fog-of-war.ts
@@ -129,7 +129,11 @@ export function useFogOFWarDiscovery(
     }
 
     // Register a link href for patching
-    function registerPath(path: string | null) {
+    function registerElement(el: Element) {
+      let path =
+        el.tagName === "FORM"
+          ? el.getAttribute("action")
+          : el.getAttribute("href");
       if (!path) {
         return;
       }
@@ -164,14 +168,14 @@ export function useFogOFWarDiscovery(
       }
     }
 
-    // Register and fetch patches for all initially-rendered links
+    // Register and fetch patches for all initially-rendered links/forms
     document.body
-      .querySelectorAll("a[data-discover]")
-      .forEach((a) => registerPath(a.getAttribute("href")));
+      .querySelectorAll("a[data-discover], form[data-discover]")
+      .forEach((el) => registerElement(el));
 
     fetchPatches();
 
-    // Setup a MutationObserver to fetch all subsequently rendered links
+    // Setup a MutationObserver to fetch all subsequently rendered links/forms
     let debouncedFetchPatches = debounce(fetchPatches, 100);
 
     function isElement(node: Node): node is Element {
@@ -179,20 +183,26 @@ export function useFogOFWarDiscovery(
     }
 
     let observer = new MutationObserver((records) => {
-      let links = new Set<Element>();
+      let elements = new Set<Element>();
       records.forEach((r) => {
         [r.target, ...r.addedNodes].forEach((node) => {
           if (!isElement(node)) return;
           if (node.tagName === "A" && node.getAttribute("data-discover")) {
-            links.add(node);
-          } else if (node.tagName !== "A") {
+            elements.add(node);
+          } else if (
+            node.tagName === "FORM" &&
+            node.getAttribute("data-discover")
+          ) {
+            elements.add(node);
+          }
+          if (node.tagName !== "A") {
             node
-              .querySelectorAll("a[data-discover]")
-              .forEach((el) => links.add(el));
+              .querySelectorAll("a[data-discover], form[data-discover]")
+              .forEach((el) => elements.add(el));
           }
         });
       });
-      links.forEach((link) => registerPath(link.getAttribute("href")));
+      elements.forEach((el) => registerElement(el));
 
       debouncedFetchPatches();
     });
@@ -201,7 +211,7 @@ export function useFogOFWarDiscovery(
       subtree: true,
       childList: true,
       attributes: true,
-      attributeFilter: ["data-discover", "href"],
+      attributeFilter: ["data-discover", "href", "action"],
     });
 
     return () => observer.disconnect();

--- a/packages/remix-react/index.tsx
+++ b/packages/remix-react/index.tsx
@@ -4,7 +4,6 @@ export type {
   FetcherWithComponents,
   FormEncType,
   FormMethod,
-  FormProps,
   Location,
   NavigateFunction,
   Navigation,
@@ -28,7 +27,6 @@ export {
   parsePath,
   renderMatches,
   resolvePath,
-  Form,
   Navigate,
   NavigationType,
   Outlet,
@@ -73,6 +71,7 @@ export type { RemixBrowserProps } from "./browser";
 export { RemixBrowser } from "./browser";
 export type {
   AwaitProps,
+  RemixFormProps as FormProps,
   RemixNavLinkProps as NavLinkProps,
   RemixLinkProps as LinkProps,
   UIMatch,
@@ -82,6 +81,7 @@ export {
   Meta,
   Links,
   Scripts,
+  Form,
   Link,
   NavLink,
   PrefetchPageLinks,

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -19,10 +19,10 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@remix-run/router": "1.17.0",
+    "@remix-run/router": "0.0.0-experimental-3ce8d73c7",
     "@remix-run/server-runtime": "workspace:*",
-    "react-router": "6.24.0",
-    "react-router-dom": "6.24.0",
+    "react-router": "0.0.0-experimental-3ce8d73c7",
+    "react-router-dom": "0.0.0-experimental-3ce8d73c7",
     "turbo-stream": "2.2.0"
   },
   "devDependencies": {

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -19,10 +19,10 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@remix-run/router": "0.0.0-experimental-3ce8d73c7",
+    "@remix-run/router": "0.0.0-experimental-078ef8de9",
     "@remix-run/server-runtime": "workspace:*",
-    "react-router": "0.0.0-experimental-3ce8d73c7",
-    "react-router-dom": "0.0.0-experimental-3ce8d73c7",
+    "react-router": "0.0.0-experimental-078ef8de9",
+    "react-router-dom": "0.0.0-experimental-078ef8de9",
     "turbo-stream": "2.2.0"
   },
   "devDependencies": {

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -19,7 +19,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@remix-run/router": "0.0.0-experimental-3ce8d73c7",
+    "@remix-run/router": "0.0.0-experimental-078ef8de9",
     "@types/cookie": "^0.6.0",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie": "^0.6.0",

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -19,7 +19,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@remix-run/router": "1.17.0",
+    "@remix-run/router": "0.0.0-experimental-3ce8d73c7",
     "@types/cookie": "^0.6.0",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie": "^0.6.0",

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@remix-run/node": "workspace:*",
     "@remix-run/react": "workspace:*",
-    "@remix-run/router": "1.17.0",
-    "react-router-dom": "6.24.0"
+    "@remix-run/router": "0.0.0-experimental-3ce8d73c7",
+    "react-router-dom": "0.0.0-experimental-3ce8d73c7"
   },
   "devDependencies": {
     "@remix-run/server-runtime": "workspace:*",

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@remix-run/node": "workspace:*",
     "@remix-run/react": "workspace:*",
-    "@remix-run/router": "0.0.0-experimental-3ce8d73c7",
-    "react-router-dom": "0.0.0-experimental-3ce8d73c7"
+    "@remix-run/router": "0.0.0-experimental-078ef8de9",
+    "react-router-dom": "0.0.0-experimental-078ef8de9"
   },
   "devDependencies": {
     "@remix-run/server-runtime": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,8 +323,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/remix-node
       '@remix-run/router':
-        specifier: 1.17.0
-        version: 1.17.0
+        specifier: 0.0.0-experimental-3ce8d73c7
+        version: 0.0.0-experimental-3ce8d73c7
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../packages/remix-server-runtime
@@ -868,8 +868,8 @@ importers:
         specifier: ^2.10.0
         version: link:../remix-react
       '@remix-run/router':
-        specifier: 1.17.0
-        version: 1.17.0
+        specifier: 0.0.0-experimental-3ce8d73c7
+        version: 0.0.0-experimental-3ce8d73c7
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../remix-server-runtime
@@ -1214,17 +1214,17 @@ importers:
   packages/remix-react:
     dependencies:
       '@remix-run/router':
-        specifier: 1.17.0
-        version: 1.17.0
+        specifier: 0.0.0-experimental-3ce8d73c7
+        version: 0.0.0-experimental-3ce8d73c7
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../remix-server-runtime
       react-router:
-        specifier: 6.24.0
-        version: 6.24.0(react@18.2.0)
+        specifier: 0.0.0-experimental-3ce8d73c7
+        version: 0.0.0-experimental-3ce8d73c7(react@18.2.0)
       react-router-dom:
-        specifier: 6.24.0
-        version: 6.24.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: 0.0.0-experimental-3ce8d73c7
+        version: 0.0.0-experimental-3ce8d73c7(react-dom@18.2.0)(react@18.2.0)
       turbo-stream:
         specifier: 2.2.0
         version: 2.2.0
@@ -1300,8 +1300,8 @@ importers:
   packages/remix-server-runtime:
     dependencies:
       '@remix-run/router':
-        specifier: 1.17.0
-        version: 1.17.0
+        specifier: 0.0.0-experimental-3ce8d73c7
+        version: 0.0.0-experimental-3ce8d73c7
       '@types/cookie':
         specifier: ^0.6.0
         version: 0.6.0
@@ -1337,11 +1337,11 @@ importers:
         specifier: workspace:*
         version: link:../remix-react
       '@remix-run/router':
-        specifier: 1.17.0
-        version: 1.17.0
+        specifier: 0.0.0-experimental-3ce8d73c7
+        version: 0.0.0-experimental-3ce8d73c7
       react-router-dom:
-        specifier: 6.24.0
-        version: 6.24.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: 0.0.0-experimental-3ce8d73c7
+        version: 0.0.0-experimental-3ce8d73c7(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@remix-run/server-runtime':
         specifier: workspace:*
@@ -4198,8 +4198,8 @@ packages:
       - encoding
     dev: false
 
-  /@remix-run/router@1.17.0:
-    resolution: {integrity: sha512-2D6XaHEVvkCn682XBnipbJjgZUU7xjLtA4dGJRBVUKpEaDYOZMENZoZjAOSb7qirxt5RupjzZxz4fK2FO+EFPw==}
+  /@remix-run/router@0.0.0-experimental-3ce8d73c7:
+    resolution: {integrity: sha512-ZtVO2ciMn+rYTeNWDgzYDxNTz98A+sgMq6IrOTgmP4ok7k9a7DVPuJ0jcBrO3RqSzUYSLs/riZNf64HcKcU5dA==}
     engines: {node: '>=14.0.0'}
     dev: false
 
@@ -12783,26 +12783,26 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /react-router-dom@6.24.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-960sKuau6/yEwS8e+NVEidYQb1hNjAYM327gjEyXlc6r3Skf2vtwuJ2l7lssdegD2YjoKG5l8MsVyeTDlVeY8g==}
+  /react-router-dom@0.0.0-experimental-3ce8d73c7(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-sNOYzTFoJWi0/IkhL/I7GXmF5QmSPk/iCjJUMeUqOgB8G+uHeiJ3de3AekdvbN7yGXKtFYHFnD2m2jFD3DoGdQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.17.0
+      '@remix-run/router': 0.0.0-experimental-3ce8d73c7
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-router: 6.24.0(react@18.2.0)
+      react-router: 0.0.0-experimental-3ce8d73c7(react@18.2.0)
     dev: false
 
-  /react-router@6.24.0(react@18.2.0):
-    resolution: {integrity: sha512-sQrgJ5bXk7vbcC4BxQxeNa5UmboFm35we1AFK0VvQaz9g0LzxEIuLOhHIoZ8rnu9BO21ishGeL9no1WB76W/eg==}
+  /react-router@0.0.0-experimental-3ce8d73c7(react@18.2.0):
+    resolution: {integrity: sha512-0LnUeFtDZ8hW+c8D7HUyvaPPZqfn1XLq6DKtbLsqFohcSzPf1N9J5fKD5yP4562t06cr6BdnpZstuGy27lWXIA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.17.0
+      '@remix-run/router': 0.0.0-experimental-3ce8d73c7
       react: 18.2.0
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,8 +323,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/remix-node
       '@remix-run/router':
-        specifier: 0.0.0-experimental-3ce8d73c7
-        version: 0.0.0-experimental-3ce8d73c7
+        specifier: 0.0.0-experimental-078ef8de9
+        version: 0.0.0-experimental-078ef8de9
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../packages/remix-server-runtime
@@ -868,8 +868,8 @@ importers:
         specifier: ^2.10.0
         version: link:../remix-react
       '@remix-run/router':
-        specifier: 0.0.0-experimental-3ce8d73c7
-        version: 0.0.0-experimental-3ce8d73c7
+        specifier: 0.0.0-experimental-078ef8de9
+        version: 0.0.0-experimental-078ef8de9
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../remix-server-runtime
@@ -1214,17 +1214,17 @@ importers:
   packages/remix-react:
     dependencies:
       '@remix-run/router':
-        specifier: 0.0.0-experimental-3ce8d73c7
-        version: 0.0.0-experimental-3ce8d73c7
+        specifier: 0.0.0-experimental-078ef8de9
+        version: 0.0.0-experimental-078ef8de9
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../remix-server-runtime
       react-router:
-        specifier: 0.0.0-experimental-3ce8d73c7
-        version: 0.0.0-experimental-3ce8d73c7(react@18.2.0)
+        specifier: 0.0.0-experimental-078ef8de9
+        version: 0.0.0-experimental-078ef8de9(react@18.2.0)
       react-router-dom:
-        specifier: 0.0.0-experimental-3ce8d73c7
-        version: 0.0.0-experimental-3ce8d73c7(react-dom@18.2.0)(react@18.2.0)
+        specifier: 0.0.0-experimental-078ef8de9
+        version: 0.0.0-experimental-078ef8de9(react-dom@18.2.0)(react@18.2.0)
       turbo-stream:
         specifier: 2.2.0
         version: 2.2.0
@@ -1300,8 +1300,8 @@ importers:
   packages/remix-server-runtime:
     dependencies:
       '@remix-run/router':
-        specifier: 0.0.0-experimental-3ce8d73c7
-        version: 0.0.0-experimental-3ce8d73c7
+        specifier: 0.0.0-experimental-078ef8de9
+        version: 0.0.0-experimental-078ef8de9
       '@types/cookie':
         specifier: ^0.6.0
         version: 0.6.0
@@ -1337,11 +1337,11 @@ importers:
         specifier: workspace:*
         version: link:../remix-react
       '@remix-run/router':
-        specifier: 0.0.0-experimental-3ce8d73c7
-        version: 0.0.0-experimental-3ce8d73c7
+        specifier: 0.0.0-experimental-078ef8de9
+        version: 0.0.0-experimental-078ef8de9
       react-router-dom:
-        specifier: 0.0.0-experimental-3ce8d73c7
-        version: 0.0.0-experimental-3ce8d73c7(react-dom@18.2.0)(react@18.2.0)
+        specifier: 0.0.0-experimental-078ef8de9
+        version: 0.0.0-experimental-078ef8de9(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@remix-run/server-runtime':
         specifier: workspace:*
@@ -4198,8 +4198,8 @@ packages:
       - encoding
     dev: false
 
-  /@remix-run/router@0.0.0-experimental-3ce8d73c7:
-    resolution: {integrity: sha512-ZtVO2ciMn+rYTeNWDgzYDxNTz98A+sgMq6IrOTgmP4ok7k9a7DVPuJ0jcBrO3RqSzUYSLs/riZNf64HcKcU5dA==}
+  /@remix-run/router@0.0.0-experimental-078ef8de9:
+    resolution: {integrity: sha512-yNOui/DT7OUQ4hwChgMxmqg4ZW7dLWLLC2BJMlYZ62yo1OwOOMqeinhd6sby+5QpmC0f0yWUq2P64pRoilNGqw==}
     engines: {node: '>=14.0.0'}
     dev: false
 
@@ -12783,26 +12783,26 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /react-router-dom@0.0.0-experimental-3ce8d73c7(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-sNOYzTFoJWi0/IkhL/I7GXmF5QmSPk/iCjJUMeUqOgB8G+uHeiJ3de3AekdvbN7yGXKtFYHFnD2m2jFD3DoGdQ==}
+  /react-router-dom@0.0.0-experimental-078ef8de9(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-RpTnERo7rPMeejJYj6a/PVjLI5cski1usw9ev/drsYwW+yliLwBk+oEdZyrqEa2UpALxDWI3LV2tUifv3WbVIA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@remix-run/router': 0.0.0-experimental-3ce8d73c7
+      '@remix-run/router': 0.0.0-experimental-078ef8de9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-router: 0.0.0-experimental-3ce8d73c7(react@18.2.0)
+      react-router: 0.0.0-experimental-078ef8de9(react@18.2.0)
     dev: false
 
-  /react-router@0.0.0-experimental-3ce8d73c7(react@18.2.0):
-    resolution: {integrity: sha512-0LnUeFtDZ8hW+c8D7HUyvaPPZqfn1XLq6DKtbLsqFohcSzPf1N9J5fKD5yP4562t06cr6BdnpZstuGy27lWXIA==}
+  /react-router@0.0.0-experimental-078ef8de9(react@18.2.0):
+    resolution: {integrity: sha512-UOclz2sUAPlq0vfbRPNJLpvG7bh1jqhihkTG+LXcazpHPhVCi4bgkqVC0jCdi69hkQp3PO3J8++Drx6CoSMsAw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
     dependencies:
-      '@remix-run/router': 0.0.0-experimental-3ce8d73c7
+      '@remix-run/router': 0.0.0-experimental-078ef8de9
       react: 18.2.0
     dev: false
 


### PR DESCRIPTION
* We forgot to enable Fog of War discovery for `<Form>` components in the first pass
* Add an E2E test to ensure that we can prefetch after FOW discovery - requires an RR prerelease before CI will pass