### PR TITLE
docs(start/quickstart): add future Vite compatibility

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -198,6 +198,7 @@
 - evanwinter
 - everdimension
 - exegeteio
+- ezekeal
 - F3n67u
 - FAL-coffee
 - fayez-nazzal

--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -91,7 +91,16 @@ export default function App() {
 
 ## Build and Run
 
-First build the app for production:
+First you will need to specify the type as `module` in `package.json` to satisfy esmodule requirements for `remix-run` and future versions of `vite`.
+
+```jsonc filename=package.json lines=[2] nocopy
+{
+  "type": "module"
+  // ...
+}
+```
+
+Next build the app for production:
 
 ```shellscript nonumber
 npx remix vite:build
@@ -100,15 +109,6 @@ npx remix vite:build
 You should now see a `build` folder containing a `server` folder (the server version of your app) and a `client` folder (the browser version) with some build artifacts in them. (This is all [configurable][vite_config].)
 
 👉 **Run the app with `remix-serve`**
-
-First you will need to specify the type in `package.json` as module so that `remix-serve` can run your app.
-
-```jsonc filename=package.json lines=[2] nocopy
-{
-  "type": "module"
-  // ...
-}
-```
 
 Now you can run your app with `remix-serve`:
 


### PR DESCRIPTION
Current versions of vite warn that esmodule support is required for future versions. Moving this step earlier will avoid confusion.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
