### PR TITLE
Fog of War: Allow customization of the manifest endpoint

### DIFF
--- a/.changeset/friendly-baboons-try.md
+++ b/.changeset/friendly-baboons-try.md
@@ -1,0 +1,6 @@
+---
+"@remix-run/react": patch
+"@remix-run/server-runtime": patch
+---
+
+Fog of War: allow customization of the manifest endpoint via the config

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -528,16 +528,14 @@ export async function resolveConfig(
     entryServerFile = `entry.server.${serverRuntime}.tsx`;
   }
 
-  if (appConfig.future?.unstable_fogOfWar !== false) {
+  let fogOfWar = appConfig.future?.unstable_fogOfWar;
+  if (fogOfWar === true || typeof fogOfWar === "string") {
     if (isSpaMode) {
       throw new Error(
         "You can not use `future.unstable_fogOfWar` in SPA Mode (`ssr: false`)"
       );
     }
-    if (
-      typeof appConfig.future?.unstable_fogOfWar === "string" &&
-      !appConfig.future?.unstable_fogOfWar.startsWith("/")
-    ) {
+    if (typeof fogOfWar === "string" && !fogOfWar.startsWith("/")) {
       throw new Error(
         "If you choose to customize the manifest path via `future.unstable_fogOfWar`, " +
           "you must specify a root-relative path starting with `/`."
@@ -620,9 +618,7 @@ export async function resolveConfig(
     v3_relativeSplatPath: appConfig.future?.v3_relativeSplatPath === true,
     v3_throwAbortReason: appConfig.future?.v3_throwAbortReason === true,
     unstable_singleFetch: appConfig.future?.unstable_singleFetch === true,
-    unstable_fogOfWar: appConfig.future?.unstable_fogOfWar
-      ? appConfig.future?.unstable_fogOfWar
-      : false,
+    unstable_fogOfWar: fogOfWar ?? false,
   };
 
   if (appConfig.future) {

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -529,7 +529,8 @@ export async function resolveConfig(
   }
 
   let fogOfWar = appConfig.future?.unstable_fogOfWar;
-  if (fogOfWar === true || typeof fogOfWar === "string") {
+  let isFogOfWarEnabled = fogOfWar === true || typeof fogOfWar === "string";
+  if (isFogOfWarEnabled) {
     if (isSpaMode) {
       throw new Error(
         "You can not use `future.unstable_fogOfWar` in SPA Mode (`ssr: false`)"
@@ -618,7 +619,7 @@ export async function resolveConfig(
     v3_relativeSplatPath: appConfig.future?.v3_relativeSplatPath === true,
     v3_throwAbortReason: appConfig.future?.v3_throwAbortReason === true,
     unstable_singleFetch: appConfig.future?.unstable_singleFetch === true,
-    unstable_fogOfWar: fogOfWar ?? false,
+    unstable_fogOfWar: isFogOfWarEnabled ? fogOfWar! : false,
   };
 
   if (appConfig.future) {

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -38,7 +38,7 @@ interface FutureConfig {
   v3_relativeSplatPath: boolean;
   v3_throwAbortReason: boolean;
   unstable_singleFetch: boolean;
-  unstable_fogOfWar: boolean;
+  unstable_fogOfWar: boolean | string;
 }
 
 type NodeBuiltinsPolyfillOptions = Pick<
@@ -528,10 +528,21 @@ export async function resolveConfig(
     entryServerFile = `entry.server.${serverRuntime}.tsx`;
   }
 
-  if (isSpaMode && appConfig.future?.unstable_fogOfWar === true) {
-    throw new Error(
-      "You can not use `future.unstable_fogOfWar` in SPA Mode (`ssr: false`)"
-    );
+  if (appConfig.future?.unstable_fogOfWar !== false) {
+    if (isSpaMode) {
+      throw new Error(
+        "You can not use `future.unstable_fogOfWar` in SPA Mode (`ssr: false`)"
+      );
+    }
+    if (
+      typeof appConfig.future?.unstable_fogOfWar === "string" &&
+      !appConfig.future?.unstable_fogOfWar.startsWith("/")
+    ) {
+      throw new Error(
+        "If you choose to customize the manifest path via `future.unstable_fogOfWar`, " +
+          "you must specify a root-relative path starting with `/`."
+      );
+    }
   }
 
   let entryClientFilePath = userEntryClientFile
@@ -609,7 +620,9 @@ export async function resolveConfig(
     v3_relativeSplatPath: appConfig.future?.v3_relativeSplatPath === true,
     v3_throwAbortReason: appConfig.future?.v3_throwAbortReason === true,
     unstable_singleFetch: appConfig.future?.unstable_singleFetch === true,
-    unstable_fogOfWar: appConfig.future?.unstable_fogOfWar === true,
+    unstable_fogOfWar: appConfig.future?.unstable_fogOfWar
+      ? appConfig.future?.unstable_fogOfWar
+      : false,
   };
 
   if (appConfig.future) {

--- a/packages/remix-react/entry.ts
+++ b/packages/remix-react/entry.ts
@@ -43,7 +43,7 @@ export interface EntryContext extends RemixContextObject {
 export interface FutureConfig {
   v3_fetcherPersist: boolean;
   v3_relativeSplatPath: boolean;
-  unstable_fogOfWar: boolean;
+  unstable_fogOfWar: boolean | string;
   unstable_singleFetch: boolean;
 }
 

--- a/packages/remix-react/fog-of-war.ts
+++ b/packages/remix-react/fog-of-war.ts
@@ -31,7 +31,7 @@ const URL_LIMIT = 7680;
 let fogOfWar: FogOfWarInfo | null = null;
 
 export function isFogOfWarEnabled(future: FutureConfig, isSpaMode: boolean) {
-  return future.unstable_fogOfWar === true && !isSpaMode;
+  return future.unstable_fogOfWar !== false && !isSpaMode;
 }
 
 export function getPartialManifest(manifest: AssetsManifest, router: Router) {
@@ -246,7 +246,11 @@ export async function fetchAndApplyManifestPatches(
   patchRoutes: Router["patchRoutes"]
 ): Promise<void> {
   let { nextPaths, knownGoodPaths, known404Paths } = _fogOfWar;
-  let manifestPath = `${basename ?? "/"}/__manifest`.replace(/\/+/g, "/");
+  let path =
+    typeof future.unstable_fogOfWar === "string"
+      ? future.unstable_fogOfWar
+      : "/__manifest";
+  let manifestPath = `${basename ?? "/"}${path}`.replace(/\/+/g, "/");
   let url = new URL(manifestPath, window.location.origin);
   url.searchParams.set("version", manifest.version);
   paths.forEach((path) => url.searchParams.append("p", path));

--- a/packages/remix-react/fog-of-war.ts
+++ b/packages/remix-react/fog-of-war.ts
@@ -31,7 +31,11 @@ const URL_LIMIT = 7680;
 let fogOfWar: FogOfWarInfo | null = null;
 
 export function isFogOfWarEnabled(future: FutureConfig, isSpaMode: boolean) {
-  return future.unstable_fogOfWar !== false && !isSpaMode;
+  return (
+    (typeof future.unstable_fogOfWar === "string" ||
+      future.unstable_fogOfWar === true) &&
+    !isSpaMode
+  );
 }
 
 export function getPartialManifest(manifest: AssetsManifest, router: Router) {

--- a/packages/remix-server-runtime/entry.ts
+++ b/packages/remix-server-runtime/entry.ts
@@ -33,7 +33,7 @@ export interface FutureConfig {
   v3_fetcherPersist: boolean;
   v3_relativeSplatPath: boolean;
   v3_throwAbortReason: boolean;
-  unstable_fogOfWar: boolean;
+  unstable_fogOfWar: boolean | string;
   unstable_singleFetch: boolean;
 }
 

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -136,17 +136,20 @@ export const createRequestHandler: CreateRequestHandlerFunction = (
 
     // Manifest request for fog of war
 
-    let manifestUrl = `${_build.basename ?? "/"}/__manifest`.replace(
-      /\/+/g,
-      "/"
-    );
-    if (url.pathname === manifestUrl) {
-      try {
-        let res = await handleManifestRequest(_build, routes, url);
-        return res;
-      } catch (e) {
-        handleError(e);
-        return new Response("Unknown Server Error", { status: 500 });
+    if (_build.future.unstable_fogOfWar !== false) {
+      let path =
+        typeof _build.future.unstable_fogOfWar === "string"
+          ? _build.future.unstable_fogOfWar
+          : "/__manifest";
+      let manifestUrl = `${_build.basename ?? "/"}${path}`.replace(/\/+/g, "/");
+      if (url.pathname === manifestUrl) {
+        try {
+          let res = await handleManifestRequest(_build, routes, url);
+          return res;
+        } catch (e) {
+          handleError(e);
+          return new Response("Unknown Server Error", { status: 500 });
+        }
       }
     }
 

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -135,8 +135,10 @@ export const createRequestHandler: CreateRequestHandlerFunction = (
     };
 
     // Manifest request for fog of war
-
-    if (_build.future.unstable_fogOfWar !== false) {
+    let isFogOfWarEnabled =
+      _build.future.unstable_fogOfWar === true ||
+      typeof _build.future.unstable_fogOfWar === "string";
+    if (isFogOfWarEnabled) {
       let path =
         typeof _build.future.unstable_fogOfWar === "string"
           ? _build.future.unstable_fogOfWar

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -106,7 +106,9 @@ export function createRemixStub(
         future: {
           v3_fetcherPersist: future?.v3_fetcherPersist === true,
           v3_relativeSplatPath: future?.v3_relativeSplatPath === true,
-          unstable_fogOfWar: future?.unstable_fogOfWar === true,
+          unstable_fogOfWar: future?.unstable_fogOfWar
+            ? future.unstable_fogOfWar
+            : false,
           unstable_singleFetch: future?.unstable_singleFetch === true,
         },
         manifest: {


### PR DESCRIPTION
Allow users to customize the manifest endpoint for fog of war via the future flag:

```js
future: {
  unstable_fogOfWar: "/my/manifest/path",
}
```

In React Router v7, it would move to a top-level Vite plugin config field.  