### PR TITLE
Change hydration check from URL to matches

### DIFF
--- a/.changeset/tender-elephants-kneel.md
+++ b/.changeset/tender-elephants-kneel.md
@@ -1,0 +1,7 @@
+---
+"@remix-run/react": patch
+"@remix-run/server-runtime": patch
+---
+
+- Change initial hydration route mismatch from a URL check to a matches check to be resistant to URL inconsistenceis
+  - Also, add loop prevention detection using `sessionStorage`

--- a/.changeset/tender-elephants-kneel.md
+++ b/.changeset/tender-elephants-kneel.md
@@ -4,4 +4,3 @@
 ---
 
 - Change initial hydration route mismatch from a URL check to a matches check to be resistant to URL inconsistenceis
-  - Also, add loop prevention detection using `sessionStorage`

--- a/packages/remix-react/__tests__/components-test.tsx
+++ b/packages/remix-react/__tests__/components-test.tsx
@@ -293,7 +293,7 @@ describe("<RemixServer>", () => {
 describe("<RemixBrowser>", () => {
   it("handles empty default export objects from the compiler", () => {
     window.__remixContext = {
-      url: "/",
+      ssrMatches: ["root", "empty"],
       state: {
         loaderData: {},
       },

--- a/packages/remix-react/browser.tsx
+++ b/packages/remix-react/browser.tsx
@@ -261,7 +261,7 @@ export function RemixBrowser(_props: RemixBrowserProps): ReactElement {
         (initialMatches || []).length !== ssrMatches.length ||
         !(initialMatches || []).every((m, i) => ssrMatches[i] === m.route.id);
 
-      if (hasDifferentSSRMatches) {
+      if (hasDifferentSSRMatches && !window.__remixContext.isSpaMode) {
         let ssr = ssrMatches.join(",");
         let client = (initialMatches || []).map((m) => m.route.id).join(",");
         let errorMsg =

--- a/packages/remix-react/browser.tsx
+++ b/packages/remix-react/browser.tsx
@@ -248,26 +248,25 @@ export function RemixBrowser(_props: RemixBrowserProps): ReactElement {
         window.__remixContext.basename
       );
 
-      // Hard reload if the path we tried to load is not the current path.
+      // Hard reload if the matches we rendered on the server aren't the matches
+      // we matched in the client, otherwise we'll try to hydrate without the
+      // right modules and throw a hydration error, which can put React into an
+      // infinite hydration loop when hydrating the full `<html>` document.
       // This is usually the result of 2 rapid back/forward clicks from an
       // external site into a Remix app, where we initially start the load for
       // one URL and while the JS chunks are loading a second forward click moves
-      // us to a new URL.  Avoid comparing search params because of CDNs which
-      // can be configured to ignore certain params and only pathname is relevant
-      // towards determining the route matches.
+      // us to a new URL.
       let ssrMatches = window.__remixContext.ssrMatches;
-      let mismatchBetweenSsrMatchesAndHydratedMatches =
+      let hasDifferentSSRMatches =
         (initialMatches || []).length !== ssrMatches.length ||
         !(initialMatches || []).every((m, i) => ssrMatches[i] === m.route.id);
 
-      if (mismatchBetweenSsrMatchesAndHydratedMatches) {
+      if (hasDifferentSSRMatches) {
         let ssr = ssrMatches.join(",");
-        let client = initialMatches
-          ? initialMatches.map((m) => m.route.id).join(",")
-          : "[]";
+        let client = (initialMatches || []).map((m) => m.route.id).join(",");
         let errorMsg =
-          `SSR Matches (${ssr}) do not match client matches at time of ` +
-          `hydration (${client}), reloading page...`;
+          `SSR Matches (${ssr}) do not match client matches (${client}) at ` +
+          `time of hydration , reloading page...`;
         console.error(errorMsg);
 
         window.location.reload();

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -515,7 +515,7 @@ async function handleDocumentRequest(
     staticHandlerContext: context,
     criticalCss,
     serverHandoffString: createServerHandoffString({
-      url: context.location.pathname,
+      ssrMatches: context.matches.map((m) => m.route.id),
       basename: build.basename,
       criticalCss,
       future: build.future,
@@ -592,7 +592,7 @@ async function handleDocumentRequest(
       ...entryContext,
       staticHandlerContext: context,
       serverHandoffString: createServerHandoffString({
-        url: context.location.pathname,
+        ssrMatches: context.matches.map((m) => m.route.id),
         basename: build.basename,
         future: build.future,
         isSpaMode: build.isSpaMode,

--- a/packages/remix-server-runtime/serverHandoff.ts
+++ b/packages/remix-server-runtime/serverHandoff.ts
@@ -20,7 +20,7 @@ export function createServerHandoffString<T>(serverHandoff: {
   // we'd end up including duplicate info
   state?: ValidateShape<T, HydrationState>;
   criticalCss?: string;
-  url: string;
+  ssrMatches: string[];
   basename: string | undefined;
   future: FutureConfig;
   isSpaMode: boolean;


### PR DESCRIPTION
The original issue this check was fixing was https://github.com/remix-run/remix/issues/1757 - see about reproducing that in today's landscape - maybe the original infinite loop is no longer an issue? 

**Update:** I'm having trouble reproducing the original issue so I'm inclined to remove this check from RR v7 entirely.  But for now, switching to matches should make it less error-prone.

Closes https://github.com/remix-run/remix/issues/9692, https://github.com/remix-run/remix/issues/8872, https://github.com/remix-run/remix/issues/7529
