### PR TITLE
fix publicPath joining with module paths to support absolute publicPath

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -959,13 +959,13 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
         path: route.path,
         index: route.index,
         caseSensitive: route.caseSensitive,
-        module: path.posix.join(
-          ctx.remixConfig.publicPath,
+        module: new URL(
           `${resolveFileUrl(
             ctx,
             resolveRelativeRouteFilePath(route, ctx.remixConfig)
-          )}`
-        ),
+          )}`,
+          ctx.remixConfig.publicPath
+        ).href,
         hasAction: sourceExports.includes("action"),
         hasLoader: sourceExports.includes("loader"),
         hasClientAction: sourceExports.includes("clientAction"),
@@ -977,21 +977,21 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
 
     return {
       version: String(Math.random()),
-      url: path.posix.join(
-        ctx.remixConfig.publicPath,
-        VirtualModule.url(browserManifestId)
-      ),
+      url: new URL(
+        VirtualModule.url(browserManifestId),
+        ctx.remixConfig.publicPath
+      ).href,
       hmr: {
-        runtime: path.posix.join(
-          ctx.remixConfig.publicPath,
-          VirtualModule.url(injectHmrRuntimeId)
-        ),
+        runtime: new URL(
+          VirtualModule.url(injectHmrRuntimeId),
+          ctx.remixConfig.publicPath
+        ).href,
       },
       entry: {
-        module: path.posix.join(
-          ctx.remixConfig.publicPath,
-          resolveFileUrl(ctx, ctx.entryClientFilePath)
-        ),
+        module: new URL(
+          resolveFileUrl(ctx, ctx.entryClientFilePath),
+          ctx.remixConfig.publicPath
+        ).href,
         imports: [],
       },
       routes,
@@ -1872,21 +1872,21 @@ async function getRouteMetadata(
     path: route.path,
     index: route.index,
     caseSensitive: route.caseSensitive,
-    url: path.posix.join(
-      ctx.remixConfig.publicPath,
+    url: new URL(
       "/" +
         path.relative(
           ctx.rootDirectory,
           resolveRelativeRouteFilePath(route, ctx.remixConfig)
-        )
-    ),
-    module: path.posix.join(
-      ctx.remixConfig.publicPath,
+        ),
+      ctx.remixConfig.publicPath
+      ).href,
+    module: new URL(
       `${resolveFileUrl(
         ctx,
         resolveRelativeRouteFilePath(route, ctx.remixConfig)
-      )}?import`
-    ), // Ensure the Vite dev server responds with a JS module
+      )}?import`,
+      ctx.remixConfig.publicPath
+    ).href, // Ensure the Vite dev server responds with a JS module
     hasAction: sourceExports.includes("action"),
     hasClientAction: sourceExports.includes("clientAction"),
     hasLoader: sourceExports.includes("loader"),


### PR DESCRIPTION
Currently if you set the `base` property in `vite.config.ts` to an full url (ie `http://localhost:5173/`), when running `vite:dev` the _modulepreload_ link tags remove the second slash(`/`) in `http://local...`.

Current behaviour:
```
<link rel="modulepreload" href="http:/localhost:5173/app/entry.client.tsx" crossorigin="anonymous">
```

Expected behaviour:
```
<link rel="modulepreload" href="http://localhost:5173/app/entry.client.tsx" crossorigin="anonymous">
```

This is not the case when first running `vite:build` then serving the output with `remix-serve ./build/server/index.js`, then it behaves as expected.

I also checked the classic remix compiler, it also behaves as expected.

# Testing Strategy:

> In a fresh remix project, I pointed `@remix/run` to the local path of this MR using `pnpm link`.
> Making sure the `base` property inside `vite.config.ts` was set to the origin of the local dev server (ie `http://localhost:5173/`)
>
> ```
> pnpm create remix my-test
> cd my-test
> pnpm run dev
> ```
>
> Then I verified that the _modulepreload_ link href works as the expected behaviour above.

I'm a bit unsure if all of the places should be changed, however since they all are based on the same path I think this should be correct. And in the limited testing I did there where no issues.

