### PR TITLE
Adopt RR stabilized v7_skipActionErrorRevalidation flag

### DIFF
--- a/.changeset/quiet-pugs-allow.md
+++ b/.changeset/quiet-pugs-allow.md
@@ -1,0 +1,6 @@
+---
+"@remix-run/react": patch
+---
+
+Single Fetch (unstable): Adopt React Router's stabilized `future.v7_skipActionErrorRevalidation` under the hood
+ - This also stabilizes the `shouldRevalidate` parameter from `unstable_actionStatus` to `actionStatus`

--- a/docs/guides/single-fetch.md
+++ b/docs/guides/single-fetch.md
@@ -540,7 +540,7 @@ Previously, Remix would always revalidate all active loaders after _any_ action 
 
 With Single Fetch, if an `action` returns or throws a `Response` with a `4xx/5xx` status code, Remix will _not revalidate_ loaders by default. If an `action` returns or throws anything that is not a 4xx/5xx Response, then the revalidation behavior is unchanged. The reasoning here is that in most cases, if you return a `4xx`/`5xx` Response, you didn't actually mutate any data so there is no need to reload data.
 
-If you _want_ to continue revalidating one or more loaders after a 4xx/5xx action response, you can opt-into revalidation on a per-route basis by returning `true` from your [`shouldRevalidate`][should-revalidate] function. There is also a new `unstable_actionStatus` parameter passed to the function that you can use if you need to decide based on the action status code.
+If you _want_ to continue revalidating one or more loaders after a 4xx/5xx action response, you can opt-into revalidation on a per-route basis by returning `true` from your [`shouldRevalidate`][should-revalidate] function. There is also a new `actionStatus` parameter passed to the function that you can use if you need to decide based on the action status code.
 
 Revalidation is handled via a `?_routes` query string parameter on the single fetch HTTP call which limits the loaders being called. This means that when you are doing fine-grained revalidation, you will have cache enumerations based on the routes being requested - but all of the information is in the URL so you should not need any special CDN configurations (as opposed to if this was done via a custom header that required your CDN to respect the `Vary` header).
 

--- a/integration/package.json
+++ b/integration/package.json
@@ -14,7 +14,7 @@
     "@remix-run/dev": "workspace:*",
     "@remix-run/express": "workspace:*",
     "@remix-run/node": "workspace:*",
-    "@remix-run/router": "1.17.1",
+    "@remix-run/router": "1.18.0-pre.0",
     "@remix-run/server-runtime": "workspace:*",
     "@types/express": "^4.17.9",
     "@vanilla-extract/css": "^1.10.0",

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -32,7 +32,7 @@
     "@mdx-js/mdx": "^2.3.0",
     "@npmcli/package-json": "^4.0.1",
     "@remix-run/node": "workspace:*",
-    "@remix-run/router": "1.17.1",
+    "@remix-run/router": "1.18.0-pre.0",
     "@remix-run/server-runtime": "workspace:*",
     "@types/mdx": "^2.0.5",
     "@vanilla-extract/integration": "^6.2.0",

--- a/packages/remix-react/browser.tsx
+++ b/packages/remix-react/browser.tsx
@@ -326,7 +326,7 @@ export function RemixBrowser(_props: RemixBrowserProps): ReactElement {
         v7_prependBasename: true,
         v7_relativeSplatPath: window.__remixContext.future.v3_relativeSplatPath,
         // Single fetch enables this underlying behavior
-        unstable_skipActionErrorRevalidation:
+        v7_skipActionErrorRevalidation:
           window.__remixContext.future.unstable_singleFetch === true,
       },
       hydrationData,

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -19,10 +19,10 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@remix-run/router": "1.17.1",
+    "@remix-run/router": "1.18.0-pre.0",
     "@remix-run/server-runtime": "workspace:*",
-    "react-router": "6.24.1",
-    "react-router-dom": "6.24.1",
+    "react-router": "6.25.0-pre.0",
+    "react-router-dom": "6.25.0-pre.0",
     "turbo-stream": "2.2.0"
   },
   "devDependencies": {

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -19,7 +19,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@remix-run/router": "1.17.1",
+    "@remix-run/router": "1.18.0-pre.0",
     "@types/cookie": "^0.6.0",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie": "^0.6.0",

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@remix-run/node": "workspace:*",
     "@remix-run/react": "workspace:*",
-    "@remix-run/router": "1.17.1",
-    "react-router-dom": "6.24.1"
+    "@remix-run/router": "1.18.0-pre.0",
+    "react-router-dom": "6.25.0-pre.0"
   },
   "devDependencies": {
     "@remix-run/server-runtime": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,8 +323,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/remix-node
       '@remix-run/router':
-        specifier: 1.17.1
-        version: 1.17.1
+        specifier: 1.18.0-pre.0
+        version: 1.18.0-pre.0
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../packages/remix-server-runtime
@@ -871,8 +871,8 @@ importers:
         specifier: ^2.10.2
         version: link:../remix-react
       '@remix-run/router':
-        specifier: 1.17.1
-        version: 1.17.1
+        specifier: 1.18.0-pre.0
+        version: 1.18.0-pre.0
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../remix-server-runtime
@@ -1217,17 +1217,17 @@ importers:
   packages/remix-react:
     dependencies:
       '@remix-run/router':
-        specifier: 1.17.1
-        version: 1.17.1
+        specifier: 1.18.0-pre.0
+        version: 1.18.0-pre.0
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../remix-server-runtime
       react-router:
-        specifier: 6.24.1
-        version: 6.24.1(react@18.2.0)
+        specifier: 6.25.0-pre.0
+        version: 6.25.0-pre.0(react@18.2.0)
       react-router-dom:
-        specifier: 6.24.1
-        version: 6.24.1(react-dom@18.2.0)(react@18.2.0)
+        specifier: 6.25.0-pre.0
+        version: 6.25.0-pre.0(react-dom@18.2.0)(react@18.2.0)
       turbo-stream:
         specifier: 2.2.0
         version: 2.2.0
@@ -1303,8 +1303,8 @@ importers:
   packages/remix-server-runtime:
     dependencies:
       '@remix-run/router':
-        specifier: 1.17.1
-        version: 1.17.1
+        specifier: 1.18.0-pre.0
+        version: 1.18.0-pre.0
       '@types/cookie':
         specifier: ^0.6.0
         version: 0.6.0
@@ -1340,11 +1340,11 @@ importers:
         specifier: workspace:*
         version: link:../remix-react
       '@remix-run/router':
-        specifier: 1.17.1
-        version: 1.17.1
+        specifier: 1.18.0-pre.0
+        version: 1.18.0-pre.0
       react-router-dom:
-        specifier: 6.24.1
-        version: 6.24.1(react-dom@18.2.0)(react@18.2.0)
+        specifier: 6.25.0-pre.0
+        version: 6.25.0-pre.0(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@remix-run/server-runtime':
         specifier: workspace:*
@@ -4201,8 +4201,8 @@ packages:
       - encoding
     dev: false
 
-  /@remix-run/router@1.17.1:
-    resolution: {integrity: sha512-mCOMec4BKd6BRGBZeSnGiIgwsbLGp3yhVqAD8H+PxiRNEHgDpZb8J1TnrSDlg97t0ySKMQJTHCWBCmBpSmkF6Q==}
+  /@remix-run/router@1.18.0-pre.0:
+    resolution: {integrity: sha512-Zo1fE2mPJCJyrUKW3+wpLXb/RWRZyBWmHxuaI9ar6D55qLxSDi8hJKtfGZT2buw4uM9n0q2f0/t0Omkirbf25w==}
     engines: {node: '>=14.0.0'}
     dev: false
 
@@ -12786,26 +12786,26 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /react-router-dom@6.24.1(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-U19KtXqooqw967Vw0Qcn5cOvrX5Ejo9ORmOtJMzYWtCT4/WOfFLIZGGsVLxcd9UkBO0mSTZtXqhZBsWlHr7+Sg==}
+  /react-router-dom@6.25.0-pre.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-RpL0UlhWxadZA1AAKqVoTRiu1PhdM9HSOI+UYu/N8keBSVc/k3s5/kfh+GlH1Z2/KGxlVsahb5wnO6zfpeetRQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.17.1
+      '@remix-run/router': 1.18.0-pre.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-router: 6.24.1(react@18.2.0)
+      react-router: 6.25.0-pre.0(react@18.2.0)
     dev: false
 
-  /react-router@6.24.1(react@18.2.0):
-    resolution: {integrity: sha512-PTXFXGK2pyXpHzVo3rR9H7ip4lSPZZc0bHG5CARmj65fTT6qG7sTngmb6lcYu1gf3y/8KxORoy9yn59pGpCnpg==}
+  /react-router@6.25.0-pre.0(react@18.2.0):
+    resolution: {integrity: sha512-5ein7idemBBQz6RsTEdjsQIIwFrjqpRsMqchPvvIAgeVz4Vv11qj1RYF0DRUUTgwJRkLxt5o0YmqvOWD/hgLOg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.17.1
+      '@remix-run/router': 1.18.0-pre.0
       react: 18.2.0
     dev: false
 


### PR DESCRIPTION
Remix Sibling PR to https://github.com/remix-run/react-router/pull/11769

This will fail CI until we get an RR experimental or prerelease out with the name change