### PR TITLE
Docs: Clarify `useActionData` Hook Scope

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -497,6 +497,7 @@
 - nobeeakon
 - nordiauwu
 - not-ivy
+- npapagna
 - nrako
 - nurul3101
 - nvh95

--- a/docs/hooks/use-action-data.md
+++ b/docs/hooks/use-action-data.md
@@ -5,7 +5,9 @@ toc: false
 
 # `useActionData`
 
-Returns the serialized data from the most recent route action or `undefined` if there isn't one.
+Returns the serialized data from the [route action](../route/action.md) where this hook is called. It returns `undefined` if there's no `action` defined.
+
+**Important**: This hook cannot access data from actions defined in parent or child routes.
 
 ```tsx lines=[10,14]
 import type { ActionFunctionArgs } from "@remix-run/node"; // or cloudflare/deno

--- a/docs/hooks/use-action-data.md
+++ b/docs/hooks/use-action-data.md
@@ -5,9 +5,7 @@ toc: false
 
 # `useActionData`
 
-Returns the serialized data from the [route action](../route/action.md) where this hook is called. It returns `undefined` if there's no `action` defined.
-
-**Important**: This hook cannot access data from actions defined in parent or child routes.
+Returns the serialized data from the most recent route [action][action] or `undefined` if there isn't one. This hook only returns action data from the route in context - it can not access data from other parent or child routes.
 
 ```tsx lines=[10,14]
 import type { ActionFunctionArgs } from "@remix-run/node"; // or cloudflare/deno


### PR DESCRIPTION
The current documentation for the `useActionData` hook might unintentionally imply that it can be used to access data from any route action. However, the hook is limited to accessing data associated with the current route action where it's called.

This PR clarifies this limitation in the documentation to prevent confusion.

See #9717 for more information.