### PR TITLE
feat(remix-serve): Allow opting out of using `source-map-support`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -383,6 +383,7 @@
 - levippaul
 - LewisArdern
 - lfantone
+- lforst
 - lifeiscontent
 - lili21
 - lionotm

--- a/docs/start/v2.md
+++ b/docs/start/v2.md
@@ -1064,6 +1064,9 @@ import sourceMapSupport from "source-map-support";
 sourceMapSupport.install();
 ```
 
+`source-map-support` introduces incompatibilities with certain observability tools, causing the tool not to be able to properly unminify your errors.
+If you want to opt out of using `source-map-support` when using `remix-serve`, you can set `REMIX_NO_SOURCE_MAP_SUPPORT=1` as environment variable.
+
 ## Netlify adapter
 
 The `@remix-run/netlify` runtime adapter has been deprecated in favor of

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -18,22 +18,24 @@ import getPort from "get-port";
 
 process.env.NODE_ENV = process.env.NODE_ENV ?? "production";
 
-sourceMapSupport.install({
-  retrieveSourceMap: function (source) {
-    let match = source.startsWith("file://");
-    if (match) {
-      let filePath = url.fileURLToPath(source);
-      let sourceMapPath = `${filePath}.map`;
-      if (fs.existsSync(sourceMapPath)) {
-        return {
-          url: source,
-          map: fs.readFileSync(sourceMapPath, "utf8"),
-        };
+if (!process.env.REMIX_NO_SOURCE_MAP_SUPPORT) {
+  sourceMapSupport.install({
+    retrieveSourceMap: function (source) {
+      let match = source.startsWith("file://");
+      if (match) {
+        let filePath = url.fileURLToPath(source);
+        let sourceMapPath = `${filePath}.map`;
+        if (fs.existsSync(sourceMapPath)) {
+          return {
+            url: source,
+            map: fs.readFileSync(sourceMapPath, "utf8"),
+          };
+        }
       }
-    }
-    return null;
-  },
-});
+      return null;
+    },
+  });
+}
 
 run();
 


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

This PR adds a way to opt out of using `source-map-support` when using `remix-serve`, which can cause issues with certain observability providers like Sentry.

Closes: https://github.com/remix-run/remix/discussions/9752

- [x] Docs
- [ ] Tests

Testing Strategy:

I had a hard time coming up with a way to test this in the existing testing framework. I am not too familiar with the code base. If someone can point me into the right direction I am happy to add tests! :)
