### PR TITLE
Add a failing test for a GET request with a body

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -76,6 +76,7 @@
 - benwis
 - bgschiller
 - binajmen
+- blittle
 - bmac
 - bmarvinb
 - bmontalvo

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -99,21 +99,13 @@ test.afterAll(() => {
 ////////////////////////////////////////////////////////////////////////////////
 
 test("[description of what you expect it to do]", async ({ page }) => {
-  let app = new PlaywrightFixture(appFixture, page);
-  // You can test any request your app might get using `fixture`.
-  let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch("pizza");
-
-  // If you need to test interactivity use the `app`
-  await app.goto("/");
-  await app.clickLink("/burgers");
-  await page.waitForSelector("text=cheeseburger");
-
-  // If you're not sure what's going on, you can "poke" the app, it'll
-  // automatically open up in your browser for 20 seconds, so be quick!
-  // await app.poke(20);
-
-  // Go check out the other tests to see what else you can do.
+  // The request throws, which produces a 500 error in prod.
+  // Instead it should respond with a 400 bad request.
+  let response = await fixture.requestDocument("/", {
+    method: "GET",
+    body: "something",
+  });
+  expect(response.status).toBe(400);
 });
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -1,6 +1,5 @@
 import { test, expect } from "@playwright/test";
 
-import { PlaywrightFixture } from "./helpers/playwright-fixture.js";
 import type { Fixture, AppFixture } from "./helpers/create-fixture.js";
 import {
   createAppFixture,


### PR DESCRIPTION
Add a failing test for when there is a GET request with a body. The request throws, which produces a 500 error in prod. Instead it should respond with a 400 bad request.

The issue is Remix Server Runtime has [a function that proxies](https://github.com/remix-run/remix/blob/f51ec665c3adbc24548310c5f6bb43f67057458a/packages/remix-server-runtime/data.ts#L153) the original request object and changes it into a new request object. This throws an error, which results in a 500 level error from Remix. While it is proper to error, I don't think this should be a 500 level error. It is a bad request from the client, and the client should get a 400 level error. 500 means something bad went wrong on the server, or something we did wrong. 400 means something the client did wrong (like send a body in a GET).  Often time 500 vs 400 server errors also effect SLAs. We have a guaranteed "uptime", and 500s showing up imply that the server went down, which it didn't.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [x] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
