### PR TITLE
Rename future flag from fogOfWar to lazyRouteDiscovery

### DIFF
--- a/.changeset/happy-dots-sleep.md
+++ b/.changeset/happy-dots-sleep.md
@@ -1,0 +1,8 @@
+---
+"@remix-run/dev": minor
+"@remix-run/react": minor
+"@remix-run/server-runtime": minor
+"@remix-run/testing": minor
+---
+
+Rename `future.unstable_fogOfWar` to `future.unstable_lazyRouteDiscovery` for clarity

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -40,7 +40,7 @@ You can also pass a `Partial<Path>` value:
 
 ### `discover`
 
-Defines the route discovery behavior when using [`future.unstable_fogOfWar`][fog-of-war].
+Defines the route discovery behavior when using [`future.unstable_lazyRouteDiscovery`][lazy-route-discovery].
 
 ```tsx
 <>
@@ -236,4 +236,4 @@ Please note that this API is marked unstable and may be subject to breaking chan
 [document-start-view-transition]: https://developer.mozilla.org/en-US/docs/Web/API/Document/startViewTransition
 [use-view-transition-state]: ../hooks/use-view-transition-state
 [relativesplatpath]: ../hooks/use-resolved-path#splat-paths
-[fog-of-war]: ../guides/fog-of-war
+[lazy-route-discovery]: ../guides/lazy-route-discovery

--- a/docs/guides/lazy-route-discovery.md
+++ b/docs/guides/lazy-route-discovery.md
@@ -1,12 +1,12 @@
 ---
-title: Fog of War
+title: Lazy Route Discovery
 ---
 
-# Fog Of War
+# Lazy Route Discovery (a.k.a. "Fog of War")
 
 <docs-warning>This is an unstable API and will continue to change, do not adopt in production</docs-warning>
 
-Remix introduced support for "Fog of War" ([RFC][rfc]) behind the `future.unstable_fogOfWar` [Future Flag][future-flags] in [`v2.10.0`][2.10.0]. This allows you to opt-into this behavior which will become the default in the next major version of Remix - a.k.a. React Router v7 ([1][rr-v7], [2][rr-v7-2]).
+Remix introduced support for Lazy Route Discovery (a.k.a. "Fog of War") ([RFC][rfc]) behind the `future.unstable_lazyRouteDiscovery` [Future Flag][future-flags] in [`v2.10.0`][2.10.0]. This allows you to opt-into this behavior which will become the default in the next major version of Remix - a.k.a. React Router v7 ([1][rr-v7], [2][rr-v7-2]). For more information on this feature, please check out the [blog post][blog-post].
 
 ## Current Behavior
 
@@ -61,3 +61,4 @@ If you wish to opt-out of this eager route discovery on a per-link basis, you ca
 [link-discover]: ../components/link#discover
 [rr-v7]: https://remix.run/blog/merging-remix-and-react-router
 [rr-v7-2]: https://remix.run/blog/incremental-path-to-react-19
+[blog-post]: https://remix.run/blog/fog-of-war

--- a/docs/start/future-flags.md
+++ b/docs/start/future-flags.md
@@ -336,15 +336,15 @@ You likely won't need to adjust any code, unless you had custom logic inside of 
 
 Opt into [Single Fetch][single-fetch] behavior (details will be expanded once the flag stabilizes).
 
-## unstable_fogOfWar
+## unstable_lazyRouteDiscovery
 
-Opt into [Fog of War][fog-of-war] behavior (details will be expanded once the flag stabilizes).
+Opt into [Lazy Route Discovery][lazy-route-discovery] behavior (details will be expanded once the flag stabilizes).
 
 [development-strategy]: ../guides/api-development-strategy
 [fetcherpersist-rfc]: https://github.com/remix-run/remix/discussions/7698
 [relativesplatpath-changelog]: https://github.com/remix-run/remix/blob/main/CHANGELOG.md#futurev3_relativesplatpath
 [single-fetch]: ../guides/single-fetch
-[fog-of-war]: ../guides/fog-of-war
+[lazy-route-discovery]: ../guides/lazy-route-discovery
 [vite]: https://vitejs.dev
 [vite-docs]: ../guides/vite
 [supported-remix-config-options]: ../file-conventions/vite-config

--- a/integration/fog-of-war-test.ts
+++ b/integration/fog-of-war-test.ts
@@ -106,7 +106,7 @@ test.describe("Fog of War", () => {
     let fixture = await createFixture({
       config: {
         future: {
-          unstable_fogOfWar: true,
+          unstable_lazyRouteDiscovery: true,
         },
       },
       files: {
@@ -152,7 +152,7 @@ test.describe("Fog of War", () => {
     let fixture = await createFixture({
       config: {
         future: {
-          unstable_fogOfWar: true,
+          unstable_lazyRouteDiscovery: true,
         },
       },
       files: getFiles(),
@@ -176,7 +176,7 @@ test.describe("Fog of War", () => {
     let fixture = await createFixture({
       config: {
         future: {
-          unstable_fogOfWar: true,
+          unstable_lazyRouteDiscovery: true,
         },
       },
       files: getFiles(),
@@ -211,7 +211,7 @@ test.describe("Fog of War", () => {
     let fixture = await createFixture({
       config: {
         future: {
-          unstable_fogOfWar: true,
+          unstable_lazyRouteDiscovery: true,
         },
       },
       files: getFiles(),
@@ -244,7 +244,7 @@ test.describe("Fog of War", () => {
     let fixture = await createFixture({
       config: {
         future: {
-          unstable_fogOfWar: true,
+          unstable_lazyRouteDiscovery: true,
         },
       },
       files: {
@@ -310,7 +310,7 @@ test.describe("Fog of War", () => {
     let fixture = await createFixture({
       config: {
         future: {
-          unstable_fogOfWar: true,
+          unstable_lazyRouteDiscovery: true,
         },
       },
       files: {
@@ -371,7 +371,7 @@ test.describe("Fog of War", () => {
     let fixture = await createFixture({
       config: {
         future: {
-          unstable_fogOfWar: true,
+          unstable_lazyRouteDiscovery: true,
         },
       },
       files: {
@@ -422,7 +422,7 @@ test.describe("Fog of War", () => {
     let fixture = await createFixture({
       config: {
         future: {
-          unstable_fogOfWar: true,
+          unstable_lazyRouteDiscovery: true,
         },
       },
       files: {
@@ -486,7 +486,7 @@ test.describe("Fog of War", () => {
     let fixture = await createFixture({
       config: {
         future: {
-          unstable_fogOfWar: true,
+          unstable_lazyRouteDiscovery: true,
         },
       },
       files: {
@@ -534,7 +534,7 @@ test.describe("Fog of War", () => {
     let fixture = await createFixture({
       config: {
         future: {
-          unstable_fogOfWar: true,
+          unstable_lazyRouteDiscovery: true,
         },
       },
       files: {
@@ -605,7 +605,7 @@ test.describe("Fog of War", () => {
     let fixture = await createFixture({
       config: {
         future: {
-          unstable_fogOfWar: true,
+          unstable_lazyRouteDiscovery: true,
         },
       },
       files: {
@@ -721,7 +721,7 @@ test.describe("Fog of War", () => {
     let fixture = await createFixture({
       config: {
         future: {
-          unstable_fogOfWar: true,
+          unstable_lazyRouteDiscovery: true,
         },
       },
       files: {
@@ -845,7 +845,7 @@ test.describe("Fog of War", () => {
     let fixture = await createFixture({
       config: {
         future: {
-          unstable_fogOfWar: true,
+          unstable_lazyRouteDiscovery: true,
         },
       },
       files: {

--- a/integration/prefetch-test.ts
+++ b/integration/prefetch-test.ts
@@ -725,7 +725,7 @@ test.describe("single fetch", () => {
       let fixture = await createFixture({
         config: {
           future: {
-            unstable_fogOfWar: true,
+            unstable_lazyRouteDiscovery: true,
             unstable_singleFetch: true,
           },
         },

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -36,7 +36,7 @@ describe("readConfig", () => {
         "entryServerFile": "entry.server.tsx",
         "entryServerFilePath": Any<String>,
         "future": {
-          "unstable_fogOfWar": false,
+          "unstable_lazyRouteDiscovery": false,
           "unstable_singleFetch": false,
           "v3_fetcherPersist": false,
           "v3_relativeSplatPath": false,

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -38,7 +38,7 @@ interface FutureConfig {
   v3_relativeSplatPath: boolean;
   v3_throwAbortReason: boolean;
   unstable_singleFetch: boolean;
-  unstable_fogOfWar: boolean;
+  unstable_lazyRouteDiscovery: boolean;
 }
 
 type NodeBuiltinsPolyfillOptions = Pick<
@@ -528,9 +528,9 @@ export async function resolveConfig(
     entryServerFile = `entry.server.${serverRuntime}.tsx`;
   }
 
-  if (isSpaMode && appConfig.future?.unstable_fogOfWar === true) {
+  if (isSpaMode && appConfig.future?.unstable_lazyRouteDiscovery === true) {
     throw new Error(
-      "You can not use `future.unstable_fogOfWar` in SPA Mode (`ssr: false`)"
+      "You can not use `future.unstable_lazyRouteDiscovery` in SPA Mode (`ssr: false`)"
     );
   }
 
@@ -609,7 +609,8 @@ export async function resolveConfig(
     v3_relativeSplatPath: appConfig.future?.v3_relativeSplatPath === true,
     v3_throwAbortReason: appConfig.future?.v3_throwAbortReason === true,
     unstable_singleFetch: appConfig.future?.unstable_singleFetch === true,
-    unstable_fogOfWar: appConfig.future?.unstable_fogOfWar === true,
+    unstable_lazyRouteDiscovery:
+      appConfig.future?.unstable_lazyRouteDiscovery === true,
   };
 
   if (appConfig.future) {

--- a/packages/remix-react/entry.ts
+++ b/packages/remix-react/entry.ts
@@ -43,7 +43,7 @@ export interface EntryContext extends RemixContextObject {
 export interface FutureConfig {
   v3_fetcherPersist: boolean;
   v3_relativeSplatPath: boolean;
-  unstable_fogOfWar: boolean;
+  unstable_lazyRouteDiscovery: boolean;
   unstable_singleFetch: boolean;
 }
 

--- a/packages/remix-react/fog-of-war.ts
+++ b/packages/remix-react/fog-of-war.ts
@@ -31,7 +31,7 @@ const URL_LIMIT = 7680;
 let fogOfWar: FogOfWarInfo | null = null;
 
 export function isFogOfWarEnabled(future: FutureConfig, isSpaMode: boolean) {
-  return future.unstable_fogOfWar === true && !isSpaMode;
+  return future.unstable_lazyRouteDiscovery === true && !isSpaMode;
 }
 
 export function getPartialManifest(manifest: AssetsManifest, router: Router) {

--- a/packages/remix-server-runtime/entry.ts
+++ b/packages/remix-server-runtime/entry.ts
@@ -33,7 +33,7 @@ export interface FutureConfig {
   v3_fetcherPersist: boolean;
   v3_relativeSplatPath: boolean;
   v3_throwAbortReason: boolean;
-  unstable_fogOfWar: boolean;
+  unstable_lazyRouteDiscovery: boolean;
   unstable_singleFetch: boolean;
 }
 

--- a/packages/remix-testing/create-remix-stub.tsx
+++ b/packages/remix-testing/create-remix-stub.tsx
@@ -106,7 +106,8 @@ export function createRemixStub(
         future: {
           v3_fetcherPersist: future?.v3_fetcherPersist === true,
           v3_relativeSplatPath: future?.v3_relativeSplatPath === true,
-          unstable_fogOfWar: future?.unstable_fogOfWar === true,
+          unstable_lazyRouteDiscovery:
+            future?.unstable_lazyRouteDiscovery === true,
           unstable_singleFetch: future?.unstable_singleFetch === true,
         },
         manifest: {


### PR DESCRIPTION
The "fog of war" phrasing is a nice metaphor for this and works well in blog posts but it's pretty confusing to see as a future flag without the proper context or video game familiarity.  We're going to rename the flag for clarity and we'll still use the "fog of war" metaphor in docs and blog posts etc.