### PR TITLE
Update tutorial.md: unnecessory suffix in stylesheet finlename causes Internal Server Error

### DIFF
--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -125,7 +125,7 @@ You can import CSS files directly into JavaScript modules. Vite will fingerprint
 import type { LinksFunction } from "@remix-run/node";
 // existing imports
 
-import appStylesHref from "./app.css?url";
+import appStylesHref from "./app.css";
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: appStylesHref },


### PR DESCRIPTION
I'm proceeding with [Remix's Tutorial](https://remix.run/docs/en/main/start/tutorial#adding-stylesheets-with-links) and found something wrong.

I got following error after what I exactly followed tutorial's instructions.
```
12:02:15 PM [vite] Internal server error: Failed to resolve import "/app.css?url" from "app/root.tsx". Does the file exist?
```

I noteced that `?url` is not necessory.
This PR fixes this issue.


Thanks.