### PR TITLE
Bug: `Form` crash on submit with empty multipart form data

### DIFF
--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -58,28 +58,104 @@ test.beforeAll(async () => {
     // `createFixture` will make an app and run your tests against it.
     ////////////////////////////////////////////////////////////////////////////
     files: {
-      "app/routes/_index.tsx": js`
-        import { json } from "@remix-run/node";
-        import { useLoaderData, Link } from "@remix-run/react";
+      "app/routes/html-form.tsx": js`
+        import { json, useActionData } from "@remix-run/react";
 
-        export function loader() {
+        export async function action({ request }) {
           return json("pizza");
         }
 
-        export default function Index() {
-          let data = useLoaderData();
+        export default function Route() {
+          const data = useActionData();
+
           return (
-            <div>
-              {data}
-              <Link to="/burgers">Other Route</Link>
-            </div>
-          )
+            <form method="post">
+              <div>
+                <label>
+                  <input type="checkbox" name="checkbox" defaultChecked /> Checkbox
+                </label>
+              </div>
+              <div>
+                <button type="submit">Submit</button>
+              </div>
+              {data != null && <pre>{data}</pre>}
+            </form>
+          );
         }
       `,
+      "app/routes/html-multipart-form.tsx": js`
+        import { json, useActionData } from "@remix-run/react";
 
-      "app/routes/burgers.tsx": js`
-        export default function Index() {
-          return <div>cheeseburger</div>;
+        export async function action({ request }) {
+          return json("pizza");
+        }
+
+        export default function Route() {
+          const data = useActionData();
+
+          return (
+            <form method="post" encType="multipart/form-data">
+              <div>
+                <label>
+                  <input type="checkbox" name="checkbox" defaultChecked /> Checkbox
+                </label>
+              </div>
+              <div>
+                <button type="submit">Submit</button>
+              </div>
+              {data != null && <pre>{data}</pre>}
+            </form>
+          );
+        }
+      `,
+      "app/routes/remix-form.tsx": js`
+        import { Form, json, useActionData } from "@remix-run/react";
+
+        export async function action({ request }) {
+          return json("pizza");
+        }
+
+        export default function Route() {
+          const data = useActionData();
+
+          return (
+            <Form method="post">
+              <div>
+                <label>
+                  <input type="checkbox" name="checkbox" defaultChecked /> Checkbox
+                </label>
+              </div>
+              <div>
+                <button type="submit">Submit</button>
+              </div>
+              {data != null && <pre>{data}</pre>}
+            </Form>
+          );
+        }
+      `,
+      "app/routes/remix-multipart-form.tsx": js`
+        import { Form, json, useActionData } from "@remix-run/react";
+
+        export async function action({ request }) {
+          return json("pizza");
+        }
+
+        export default function Route() {
+          const data = useActionData();
+
+          return (
+            <Form method="post" encType="multipart/form-data">
+              <div>
+                <label>
+                  <input type="checkbox" name="checkbox" defaultChecked /> Checkbox
+                </label>
+              </div>
+              <div>
+                <button type="submit">Submit</button>
+              </div>
+              {data != null && <pre>{data}</pre>}
+            </Form>
+          );
         }
       `,
     },
@@ -98,22 +174,76 @@ test.afterAll(() => {
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("[description of what you expect it to do]", async ({ page }) => {
-  let app = new PlaywrightFixture(appFixture, page);
-  // You can test any request your app might get using `fixture`.
-  let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch("pizza");
+test.describe("HTML <form> action", () => {
+  test("form body does not crash app", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/html-form");
+    await app.clickElement("[type=submit]");
+    await page.waitForSelector("pre");
+    expect(await app.getHtml("pre")).toBe(`<pre>pizza</pre>`);
+  });
 
-  // If you need to test interactivity use the `app`
-  await app.goto("/");
-  await app.clickLink("/burgers");
-  await page.waitForSelector("text=cheeseburger");
+  test("empty form body does not crash app", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/html-form");
+    await app.clickElement("[type=checkbox]");
+    await app.clickElement("[type=submit]");
+    await page.waitForSelector("pre");
+    expect(await app.getHtml("pre")).toBe(`<pre>pizza</pre>`);
+  });
+  
+  test("multipart form body does not crash app", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/html-multipart-form");
+    await app.clickElement("[type=submit]");
+    await page.waitForSelector("pre");
+    expect(await app.getHtml("pre")).toBe(`<pre>pizza</pre>`);
+  });
 
-  // If you're not sure what's going on, you can "poke" the app, it'll
-  // automatically open up in your browser for 20 seconds, so be quick!
-  // await app.poke(20);
+  test("empty multipart form body does not crash app", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/html-multipart-form");
+    await app.clickElement("[type=checkbox]");
+    await app.clickElement("[type=submit]");
+    await page.waitForSelector("pre");
+    expect(await app.getHtml("pre")).toBe(`<pre>pizza</pre>`);
+  });
+});
 
-  // Go check out the other tests to see what else you can do.
+test.describe("Remix <Form> action", () => {
+  test("form body does not crash app", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/remix-form");
+    await app.clickElement("[type=submit]");
+    await page.waitForSelector("pre");
+    expect(await app.getHtml("pre")).toBe(`<pre>pizza</pre>`);
+  });
+
+  test("empty form body does not crash app", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/remix-form");
+    await app.clickElement("[type=checkbox]");
+    await app.clickElement("[type=submit]");
+    await page.waitForSelector("pre");
+    expect(await app.getHtml("pre")).toBe(`<pre>pizza</pre>`);
+  });
+  
+  test("multipart form body does not crash app", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/remix-multipart-form");
+    await app.clickElement("[type=submit]");
+    await page.waitForSelector("pre");
+    expect(await app.getHtml("pre")).toBe(`<pre>pizza</pre>`);
+  });
+
+  test("empty multipart form body does not crash app", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/remix-multipart-form");
+    await app.clickElement("[type=checkbox]");
+    await app.clickElement("[type=submit]");
+    await page.waitForSelector("pre");
+    expect(await app.getHtml("pre")).toBe(`<pre>pizza</pre>`);
+  });
 });
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The combination of `<Form>`, `encType="multipart/form-data"`, and an empty form body is crashing the Remix client on submit with error `TypeError: Failed to fetch`.

This PR provides eight tests, seven passing and one failing.

Multipart form encoding is a sensible default for a larger app where many, but not all, forms contain file inputs. A few of our smaller forms are all checkboxes, and eventually we figured out they were crashing if everything was unchecked. We eventually identified `<Form>` as the culprit.

For now we can work around this by setting `encType="application/x-www-form-urlencoded"` on our "oops all checkboxes" forms.

---

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
