### PR TITLE
Trim trailing slashes from single fetch data URLs

### DIFF
--- a/.changeset/large-donkeys-remember.md
+++ b/.changeset/large-donkeys-remember.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Ensure single fetch calls don't include any trailing slash from the pathname (i.e., /path/.data)

--- a/packages/remix-react/single-fetch.tsx
+++ b/packages/remix-react/single-fetch.tsx
@@ -304,7 +304,13 @@ export function singleFetchUrl(reqUrl: URL | string) {
     typeof reqUrl === "string"
       ? new URL(reqUrl, window.location.origin)
       : reqUrl;
-  url.pathname = `${url.pathname === "/" ? "_root" : url.pathname}.data`;
+
+  if (url.pathname === "/") {
+    url.pathname = "_root.data";
+  } else {
+    url.pathname = `${url.pathname.replace(/\/$/, "")}.data`;
+  }
+
   return url;
 }
 


### PR DESCRIPTION
Noticed this doing some testing on RR v7 - fixing it here and then will copy the fix over to RR v7