### PR TITLE
Single Fetch: Add undefined to the useRouteLoaderData type override

### DIFF
--- a/.changeset/silver-laws-invite.md
+++ b/.changeset/silver-laws-invite.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Single Fetch: Add `undefined` to the `useRouteLoaderData` type override

--- a/packages/remix-react/future/single-fetch.d.ts
+++ b/packages/remix-react/future/single-fetch.d.ts
@@ -26,7 +26,7 @@ declare module "@remix-run/react" {
 
   export function useRouteLoaderData<T extends Loader>(
     routeId: string
-  ): Serialize<T>;
+  ): Serialize<T> | undefined;
 
   export function useFetcher<T extends Loader | Action>(
     opts?: Parameters<typeof useFetcherRR>[0]


### PR DESCRIPTION
It was mentioned in https://github.com/remix-run/remix/issues/9793#issuecomment-2251424789 that the `useRouteLoaderData` Single Fetch override was losing the `| undefined`