### PR TITLE
Fix  error when using vite-imagetool

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -632,6 +632,7 @@
 - TimonVS
 - tjefferson08
 - tmcw
+- tobigumo
 - tombiju
 - tombohub
 - tombyrer

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -1407,6 +1407,7 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
           let clientViteManifest = await loadViteManifest(clientBuildDirectory);
 
           let clientFilePaths = getViteManifestFilePaths(clientViteManifest);
+          let clientAssetPaths = getViteManifestAssetPaths(clientViteManifest);
           let ssrAssetPaths = getViteManifestAssetPaths(ssrViteManifest);
 
           // We only move assets that aren't in the client build, otherwise we
@@ -1418,7 +1419,10 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
           let movedAssetPaths: string[] = [];
           for (let ssrAssetPath of ssrAssetPaths) {
             let src = path.join(serverBuildDirectory, ssrAssetPath);
-            if (!clientFilePaths.has(ssrAssetPath)) {
+            if (
+              !clientFilePaths.has(ssrAssetPath) &&
+              !clientAssetPaths.has(ssrAssetPath)
+            ) {
               let dest = path.join(clientBuildDirectory, ssrAssetPath);
               await fse.move(src, dest);
               movedAssetPaths.push(dest);


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

This PR resolves issue #9498 and is also related to PR #9305.

In PR #9305, the client asset list was changed to a file list. However, vite-imagetool generates assets during the build process, and these assets are not included in the file list, which seems to be causing the error.

I have modified the code to check both the asset list and the file list. This change appears to allow the build to complete without errors, and vite-imagetool seems to function correctly.

However, this is not a fundamental solution, and since I am not very familiar with Remix, I would appreciate any feedback on this PR.


Closes: #9498

- [ ] Docs
- [ ] Tests

Testing Strategy:

I didn't see any tests for the `plugin` file, so I didn't include them here.

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
