### PR TITLE
Add DISABLE_ROUTES_LOGS env to disable route logs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -138,6 +138,7 @@
 - davecranwell-vocovo
 - DavidHollins6
 - davongit
+- dchueri
 - dcramer
 - Deanmv
 - defjosiah

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -133,7 +133,7 @@ async function run() {
     })
   );
   app.use(express.static("public", { maxAge: "1h" }));
-  app.use(morgan("tiny"));
+  if (process.env.DISABLE_ROUTES_LOGS) app.use(morgan("tiny"));
 
   app.all(
     "*",


### PR DESCRIPTION
The logs that appear when a user accesses an Remix route in production make it difficult to locate other logs, especially when there are many simultaneous users.

![image](https://github.com/user-attachments/assets/e8a77d38-377c-4f82-9d03-3256d276dc47)

Testing Strategy:
Simply adding DISABLE_ROUTES_LOGS to the envs will be enough to suppress just these logs.

