### PR TITLE
fix #9826: support conditional return types from loader when serializing

### DIFF
--- a/packages/remix-server-runtime/single-fetch.ts
+++ b/packages/remix-server-runtime/single-fetch.ts
@@ -387,16 +387,25 @@ type DataFunctionReturnValue =
   | TypedDeferredData<Record<string, unknown>>
   | TypedResponse<Record<string, unknown>>;
 
+type Unwrap<T extends DataFunctionReturnValue> = T extends TypedDeferredData<
+  infer D
+>
+  ? D
+  : T extends TypedResponse<Record<string, unknown>>
+  ? SerializeFrom<T>
+  : T extends DataWithResponseInit<infer D>
+  ? D
+  : T;
+
 // Backwards-compatible type for Remix v2 where json/defer still use the old types,
 // and only non-json/defer returns use the new types.  This allows for incremental
 // migration of loaders to return naked objects.  In the next major version,
 // json/defer will be removed so everything will use the new simplified typings.
 // prettier-ignore
-export type Serialize<T extends Loader | Action> =
-  Awaited<ReturnType<T>> extends TypedDeferredData<infer D> ? D :
-  Awaited<ReturnType<T>> extends TypedResponse<Record<string, unknown>> ? SerializeFrom<T> :
-  Awaited<ReturnType<T>> extends DataWithResponseInit<infer D> ? D :
-  Awaited<ReturnType<T>>;
+export type Serialize<T extends Loader | Action, R = Awaited<ReturnType<T>>> =
+  R extends DataFunctionReturnValue
+    ? Unwrap<R>
+    : R;
 
 export type Loader = (
   args: LoaderFunctionArgs


### PR DESCRIPTION
Tested this in my own Remix project. See #9826 for more details.

Before:
<img width="1010" alt="Screenshot 2024-08-05 at 3 55 10 PM" src="https://github.com/user-attachments/assets/e8f8e6bd-ba48-4bc4-9143-5aa1a1d0de51">

After:
<img width="939" alt="Screenshot 2024-08-05 at 3 56 05 PM" src="https://github.com/user-attachments/assets/118d8b27-ad44-4c70-bebe-438669dd535f">