### PR TITLE
fix: update turbo-stream to v2.3.0

### DIFF
--- a/.changeset/sweet-roses-shake.md
+++ b/.changeset/sweet-roses-shake.md
@@ -1,0 +1,8 @@
+---
+"@remix-run/react": patch
+"@remix-run/server-runtime": patch
+---
+
+fix: update turbo-stream to v2.3.0
+fix: stabilize object key order for unstable_singleFetch
+fix: unstable_singleFetch can now have payloads as large as you have memory 

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -23,7 +23,7 @@
     "@remix-run/server-runtime": "workspace:*",
     "react-router": "6.26.0",
     "react-router-dom": "6.26.0",
-    "turbo-stream": "2.2.0"
+    "turbo-stream": "2.3.0"
   },
   "devDependencies": {
     "@remix-run/node": "workspace:*",

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -25,7 +25,7 @@
     "cookie": "^0.6.0",
     "set-cookie-parser": "^2.4.8",
     "source-map": "^0.7.3",
-    "turbo-stream": "2.2.0"
+    "turbo-stream": "2.3.0"
   },
   "devDependencies": {
     "@types/set-cookie-parser": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1229,8 +1229,8 @@ importers:
         specifier: 6.26.0
         version: 6.26.0(react-dom@18.2.0)(react@18.2.0)
       turbo-stream:
-        specifier: 2.2.0
-        version: 2.2.0
+        specifier: 2.3.0
+        version: 2.3.0
     devDependencies:
       '@remix-run/node':
         specifier: workspace:*
@@ -1321,8 +1321,8 @@ importers:
         specifier: ^0.7.3
         version: 0.7.3
       turbo-stream:
-        specifier: 2.2.0
-        version: 2.2.0
+        specifier: 2.3.0
+        version: 2.3.0
     devDependencies:
       '@types/set-cookie-parser':
         specifier: ^2.4.1
@@ -14317,8 +14317,8 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
-  /turbo-stream@2.2.0:
-    resolution: {integrity: sha512-FKFg7A0To1VU4CH9YmSMON5QphK0BXjSoiC7D9yMh+mEEbXLUP9qJ4hEt1qcjKtzncs1OpcnjZO8NgrlVbZH+g==}
+  /turbo-stream@2.3.0:
+    resolution: {integrity: sha512-PhEr9mdexoVv+rJkQ3c8TjrN3DUghX37GNJkSMksoPR4KrXIPnM2MnqRt07sViIqX9IdlhrgtTSyjoVOASq6cg==}
     dev: false
 
   /tweetnacl@0.14.5:


### PR DESCRIPTION
fix: stabilize object key order for unstable_singleFetch
fix: unstable_singleFetch can now have payloads as large as you have memory

Closes: https://github.com/remix-run/remix/issues/9421

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
