### PR TITLE
Fixes infinite reloading when path starts with 2 or more slashes

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -157,6 +157,7 @@
 - dhargitai
 - dhmacs
 - dima-takoy
+- dimanche-matin
 - dmarkow
 - dmillar
 - DNLHC

--- a/packages/remix-dev/vite/node-adapter.ts
+++ b/packages/remix-dev/vite/node-adapter.ts
@@ -43,7 +43,7 @@ export function fromNodeRequest(
     nodeReq.originalUrl,
     "Expected `nodeReq.originalUrl` to be defined"
   );
-  let url = new URL(nodeReq.originalUrl, origin);
+  let url = new URL(`${origin}${nodeReq.originalUrl}`);
   let init: RequestInit = {
     method: nodeReq.method,
     headers: fromNodeHeaders(nodeReq.headers),


### PR DESCRIPTION
Related to #9692.

This issue seems to occur when creating an URL object from 2 string parameters and the url parameter begins with 2 or more slashes. The domain in the base parameter is replaced by the segment following the 2 or more slashes in the url parameter.

<img width="689" alt="url_1_crop-min" src="https://github.com/user-attachments/assets/49fef659-783d-4f02-885a-c5a76e1863f4">

`https://example.com//foo` becomes `https://foo/`

<img width="691" alt="url_2_crop-min" src="https://github.com/user-attachments/assets/b189e9f3-edbd-42bc-9873-c009c31877a8">

`https://example.com//foo/bar` becomes `https://foo/bar`