### PR TITLE
Debugging of jest tests does not work

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -701,3 +701,4 @@
 - zayenz
 - zhe
 - zwhitchcox
+- bbonch

--- a/jest/jest.config.shared.js
+++ b/jest/jest.config.shared.js
@@ -8,11 +8,6 @@ const ignorePatterns = [
 
 /** @type {import('jest').Config} */
 module.exports = {
-  moduleNameMapper: {
-    "^@web3-storage/multipart-parser$": require.resolve(
-      "@web3-storage/multipart-parser"
-    ),
-  },
   modulePathIgnorePatterns: ignorePatterns,
   setupFiles: ["<rootDir>/__tests__/setup.ts"],
   testMatch: ["<rootDir>/**/*-test.[jt]s?(x)"],


### PR DESCRIPTION
Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

In the root directory run to debug any test
```
node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand packages/create-remix/__tests__/create-remix-test.ts
``` 
It fails with
```
Error: Cannot find module '@web3-storage/multipart-parser'
``` 
This module is used only in remix-server-runtime. 
I removed moduleNameMapper from jest.config.shared.js
I ran tests inside packages/remix-server-runtime successfully.
I seems @web3-storage/multipart-parser mapping is not required.
After that debugging works
