### PR TITLE
Fix `dest already exists` build errors

### DIFF
--- a/.changeset/tiny-crabs-deliver.md
+++ b/.changeset/tiny-crabs-deliver.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Fix `dest already exists` build errors by only moving SSR assets to the client build directory when they're not already present on disk

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -829,11 +829,6 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
     return JSON.parse(manifestContents) as Vite.Manifest;
   };
 
-  let getViteManifestFilePaths = (viteManifest: Vite.Manifest): Set<string> => {
-    let filePaths = Object.values(viteManifest).map((chunk) => chunk.file);
-    return new Set(filePaths);
-  };
-
   let getViteManifestAssetPaths = (
     viteManifest: Vite.Manifest
   ): Set<string> => {
@@ -1405,9 +1400,6 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
           let serverBuildDirectory = getServerBuildDirectory(ctx);
 
           let ssrViteManifest = await loadViteManifest(serverBuildDirectory);
-          let clientViteManifest = await loadViteManifest(clientBuildDirectory);
-
-          let clientFilePaths = getViteManifestFilePaths(clientViteManifest);
           let ssrAssetPaths = getViteManifestAssetPaths(ssrViteManifest);
 
           // We only move assets that aren't in the client build, otherwise we
@@ -1419,8 +1411,9 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
           let movedAssetPaths: string[] = [];
           for (let ssrAssetPath of ssrAssetPaths) {
             let src = path.join(serverBuildDirectory, ssrAssetPath);
-            if (!clientFilePaths.has(ssrAssetPath)) {
-              let dest = path.join(clientBuildDirectory, ssrAssetPath);
+            let dest = path.join(clientBuildDirectory, ssrAssetPath);
+
+            if (!fse.existsSync(dest)) {
               await fse.move(src, dest);
               movedAssetPaths.push(dest);
             } else {


### PR DESCRIPTION
Fixes #9498.

This fix was inspired by #9800, but I decided to make this more error-proof by inspecting files on disk rather than inspecting the Vite manifest files/assets and potentially getting it wrong (as we have already).