### PR TITLE
Add failing test for syncronous blocker.proceed calls

### DIFF
--- a/integration/blocking-test.ts
+++ b/integration/blocking-test.ts
@@ -115,9 +115,6 @@ test("handles synchronous proceeding correctly", async ({ page }) => {
   // - immediately call blocker.proceed() once we enter the blocked state
   // - and land back one history entry (/a)
   await page.goBack();
-  console.log(await app.getHtml());
-  await new Promise((r) => setTimeout(r, 1000));
-  console.log(await app.getHtml());
   await page.waitForSelector("#a");
   expect(await app.getHtml()).toContain("A");
 });

--- a/integration/blocking-test.ts
+++ b/integration/blocking-test.ts
@@ -115,6 +115,9 @@ test("handles synchronous proceeding correctly", async ({ page }) => {
   // - immediately call blocker.proceed() once we enter the blocked state
   // - and land back one history entry (/a)
   await page.goBack();
+  console.log(await app.getHtml());
+  await new Promise((r) => setTimeout(r, 1000));
+  console.log(await app.getHtml());
   await page.waitForSelector("#a");
   expect(await app.getHtml()).toContain("A");
 });

--- a/integration/blocking-test.ts
+++ b/integration/blocking-test.ts
@@ -1,0 +1,120 @@
+import { test, expect } from "@playwright/test";
+
+import type { AppFixture, Fixture } from "./helpers/create-fixture.js";
+import {
+  createFixture,
+  js,
+  createAppFixture,
+} from "./helpers/create-fixture.js";
+import { PlaywrightFixture } from "./helpers/playwright-fixture.js";
+
+let fixture: Fixture;
+let appFixture: AppFixture;
+
+test.afterAll(() => appFixture.close());
+
+test("handles synchronous proceeding correctly", async ({ page }) => {
+  fixture = await createFixture({
+    files: {
+      "app/routes/_index.tsx": js`
+        import { Link } from "@remix-run/react";
+
+        export default function Component() {
+          return (
+            <div>
+              <h1 id="index">Index</h1>
+              <Link to="/a">/a</Link>
+            </div>
+          )
+        }
+      `,
+      "app/routes/a.tsx": js`
+        import { Link } from "@remix-run/react";
+
+        export default function Component() {
+          return (
+            <div>
+              <h1 id="a">A</h1>
+              <Link to="/b">/b</Link>
+            </div>
+          )
+        }
+      `,
+      "app/routes/b.tsx": js`
+      import * as React from "react";
+      import { Form, useAction, useBlocker } from "@remix-run/react";
+
+        export default function Component() {
+          return (
+            <div>
+              <h1 id="b">B</h1>
+              <ImportantForm />
+            </div>
+          )
+        }
+
+        function ImportantForm() {
+          let [value, setValue] = React.useState("");
+          let shouldBlock = React.useCallback<BlockerFunction>(
+            ({ currentLocation, nextLocation }) =>
+              value !== "" && currentLocation.pathname !== nextLocation.pathname,
+            [value]
+          );
+          let blocker = useBlocker(shouldBlock);
+
+          // Reset the blocker if the user cleans the form
+          React.useEffect(() => {
+            if (blocker.state === "blocked") {
+              blocker.proceed();
+            }
+          }, [blocker]);
+
+          return (
+            <>
+              <p>
+                Is the form dirty?{" "}
+                {value !== "" ? (
+                  <span style={{ color: "red" }}>Yes</span>
+                ) : (
+                  <span style={{ color: "green" }}>No</span>
+                )}
+              </p>
+
+              <Form method="post">
+                <label>
+                  Enter some important data:
+                  <input
+                    name="data"
+                    value={value}
+                    onChange={(e) => setValue(e.target.value)}
+                  />
+                </label>
+                <button type="submit">Save</button>
+              </Form>
+            </>
+          );
+        }
+      `,
+    },
+  });
+
+  // This creates an interactive app using puppeteer.
+  appFixture = await createAppFixture(fixture);
+
+  let app = new PlaywrightFixture(appFixture, page);
+
+  await app.goto("/");
+  await app.clickLink("/a");
+  await page.waitForSelector("#a");
+  await app.clickLink("/b");
+  await page.waitForSelector("#b");
+  await page.getByLabel("Enter some important data:").fill("Hello Remix!");
+
+  // Going back should:
+  // - block
+  // - immediately call blocker.proceed() once we enter the blocked state
+  // - and land back one history entry (/a)
+  await page.goBack();
+  await page.waitForSelector("#a");
+  expect(await app.getHtml()).toContain("A");
+});

--- a/integration/helpers/create-fixture.ts
+++ b/integration/helpers/create-fixture.ts
@@ -364,7 +364,7 @@ export async function createFixtureProject(
     `);
   }
   contents = contents.replace(
-    "global.INJECTED_FIXTURE_REMIX_CONFIG",
+    /(global|globalThis)\.INJECTED_FIXTURE_REMIX_CONFIG/,
     `${serializeJavaScript(init.config ?? {})}`
   );
   fse.writeFileSync(path.join(projectDir, "remix.config.js"), contents);

--- a/integration/helpers/deno-template/remix.config.js
+++ b/integration/helpers/deno-template/remix.config.js
@@ -13,5 +13,5 @@ module.exports = {
 
   // !!! Don't adjust this without changing the code that overwrites this
   // in createFixtureProject()
-  ...global.INJECTED_FIXTURE_REMIX_CONFIG,
+  ...globalThis.INJECTED_FIXTURE_REMIX_CONFIG,
 };

--- a/integration/package.json
+++ b/integration/package.json
@@ -14,7 +14,7 @@
     "@remix-run/dev": "workspace:*",
     "@remix-run/express": "workspace:*",
     "@remix-run/node": "workspace:*",
-    "@remix-run/router": "1.19.1",
+    "@remix-run/router": "0.0.0-experimental-7d87ffb8c",
     "@remix-run/server-runtime": "workspace:*",
     "@types/express": "^4.17.9",
     "@vanilla-extract/css": "^1.10.0",

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -32,7 +32,7 @@
     "@mdx-js/mdx": "^2.3.0",
     "@npmcli/package-json": "^4.0.1",
     "@remix-run/node": "workspace:*",
-    "@remix-run/router": "1.19.1",
+    "@remix-run/router": "0.0.0-experimental-7d87ffb8c",
     "@remix-run/server-runtime": "workspace:*",
     "@types/mdx": "^2.0.5",
     "@vanilla-extract/integration": "^6.2.0",

--- a/packages/remix-react/package.json
+++ b/packages/remix-react/package.json
@@ -19,10 +19,10 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@remix-run/router": "1.19.1",
+    "@remix-run/router": "0.0.0-experimental-7d87ffb8c",
     "@remix-run/server-runtime": "workspace:*",
-    "react-router": "6.26.1",
-    "react-router-dom": "6.26.1",
+    "react-router": "0.0.0-experimental-7d87ffb8c",
+    "react-router-dom": "0.0.0-experimental-7d87ffb8c",
     "turbo-stream": "2.3.0"
   },
   "devDependencies": {

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -19,7 +19,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@remix-run/router": "1.19.1",
+    "@remix-run/router": "0.0.0-experimental-7d87ffb8c",
     "@types/cookie": "^0.6.0",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cookie": "^0.6.0",

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@remix-run/node": "workspace:*",
     "@remix-run/react": "workspace:*",
-    "@remix-run/router": "1.19.1",
-    "react-router-dom": "6.26.1"
+    "@remix-run/router": "0.0.0-experimental-7d87ffb8c",
+    "react-router-dom": "0.0.0-experimental-7d87ffb8c"
   },
   "devDependencies": {
     "@remix-run/server-runtime": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,8 +323,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/remix-node
       '@remix-run/router':
-        specifier: 1.19.1
-        version: 1.19.1
+        specifier: 0.0.0-experimental-7d87ffb8c
+        version: 0.0.0-experimental-7d87ffb8c
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../packages/remix-server-runtime
@@ -871,8 +871,8 @@ importers:
         specifier: ^2.11.2
         version: link:../remix-react
       '@remix-run/router':
-        specifier: 1.19.1
-        version: 1.19.1
+        specifier: 0.0.0-experimental-7d87ffb8c
+        version: 0.0.0-experimental-7d87ffb8c
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../remix-server-runtime
@@ -1217,17 +1217,17 @@ importers:
   packages/remix-react:
     dependencies:
       '@remix-run/router':
-        specifier: 1.19.1
-        version: 1.19.1
+        specifier: 0.0.0-experimental-7d87ffb8c
+        version: 0.0.0-experimental-7d87ffb8c
       '@remix-run/server-runtime':
         specifier: workspace:*
         version: link:../remix-server-runtime
       react-router:
-        specifier: 6.26.1
-        version: 6.26.1(react@18.2.0)
+        specifier: 0.0.0-experimental-7d87ffb8c
+        version: 0.0.0-experimental-7d87ffb8c(react@18.2.0)
       react-router-dom:
-        specifier: 6.26.1
-        version: 6.26.1(react-dom@18.2.0)(react@18.2.0)
+        specifier: 0.0.0-experimental-7d87ffb8c
+        version: 0.0.0-experimental-7d87ffb8c(react-dom@18.2.0)(react@18.2.0)
       turbo-stream:
         specifier: 2.3.0
         version: 2.3.0
@@ -1303,8 +1303,8 @@ importers:
   packages/remix-server-runtime:
     dependencies:
       '@remix-run/router':
-        specifier: 1.19.1
-        version: 1.19.1
+        specifier: 0.0.0-experimental-7d87ffb8c
+        version: 0.0.0-experimental-7d87ffb8c
       '@types/cookie':
         specifier: ^0.6.0
         version: 0.6.0
@@ -1340,11 +1340,11 @@ importers:
         specifier: workspace:*
         version: link:../remix-react
       '@remix-run/router':
-        specifier: 1.19.1
-        version: 1.19.1
+        specifier: 0.0.0-experimental-7d87ffb8c
+        version: 0.0.0-experimental-7d87ffb8c
       react-router-dom:
-        specifier: 6.26.1
-        version: 6.26.1(react-dom@18.2.0)(react@18.2.0)
+        specifier: 0.0.0-experimental-7d87ffb8c
+        version: 0.0.0-experimental-7d87ffb8c(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@remix-run/server-runtime':
         specifier: workspace:*
@@ -4201,8 +4201,8 @@ packages:
       - encoding
     dev: false
 
-  /@remix-run/router@1.19.1:
-    resolution: {integrity: sha512-S45oynt/WH19bHbIXjtli6QmwNYvaz+vtnubvNpNDvUOoA/OWh6j1OikIP3G+v5GHdxyC6EXoChG3HgYGEUfcg==}
+  /@remix-run/router@0.0.0-experimental-7d87ffb8c:
+    resolution: {integrity: sha512-Vu0Zw3Pm+/tEpE3MFI0ONEQbZEMlMddBCf8JwnYeQGwsaIXYk3oLpv1zE7n8QdF6A+Z7C2ieWMDde+wb+4060g==}
     engines: {node: '>=14.0.0'}
     dev: false
 
@@ -12786,26 +12786,26 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /react-router-dom@6.26.1(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-veut7m41S1fLql4pLhxeSW3jlqs+4MtjRLj0xvuCEXsxusJCbs6I8yn9BxzzDX2XDgafrccY6hwjmd/bL54tFw==}
+  /react-router-dom@0.0.0-experimental-7d87ffb8c(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-5l2H4fEjrfJICAUkBwpJHQV4LMYXixTAL7eLqQIoKVI3zqyh3kPhY9CHxEk+5liiVrJhxmhIt4loFycLTAS4Hg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.19.1
+      '@remix-run/router': 0.0.0-experimental-7d87ffb8c
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-router: 6.26.1(react@18.2.0)
+      react-router: 0.0.0-experimental-7d87ffb8c(react@18.2.0)
     dev: false
 
-  /react-router@6.26.1(react@18.2.0):
-    resolution: {integrity: sha512-kIwJveZNwp7teQRI5QmwWo39A5bXRyqpH0COKKmPnyD2vBvDwgFXSqDUYtt1h+FEyfnE8eXr7oe0MxRzVwCcvQ==}
+  /react-router@0.0.0-experimental-7d87ffb8c(react@18.2.0):
+    resolution: {integrity: sha512-DWE9pSHTPECV+9RHyzSJTgA1rexfR6tj0LjRzgxBxOVgmojtbNP9tXZc8UrP+5l9LxfGmLtvQu6w4EO3tyRSkw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.19.1
+      '@remix-run/router': 0.0.0-experimental-7d87ffb8c
       react: 18.2.0
     dev: false
 


### PR DESCRIPTION
Add a failing integration test for https://github.com/remix-run/react-router/issues/11613 since it relies on specific behavior of browser `history.go` calls that doesn't seem to be accurately implemented in JSDOM.

This should fail initially and be fixed once we point to an experimental RR release with the fix from https://github.com/remix-run/react-router/pull/11930