### PR TITLE
[docs] Fix Typo in createSessionStorage

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -546,6 +546,7 @@
 - remix-run-bot
 - richardhunghhw
 - riencoertjens
+- risv1
 - rkulinski
 - rlfarman
 - roachjc

--- a/docs/utils/sessions.md
+++ b/docs/utils/sessions.md
@@ -218,7 +218,7 @@ Remix makes it easy to store sessions in your own database if needed. The `creat
 - `createData` will be called from `commitSession` on the initial session creation when no session ID exists in the cookie
 - `readData` will be called from `getSession` when a session ID exists in the cookie
 - `updateData` will be called from `commitSession` when a session ID already exists in the cookie
-- `deleteData` is called from `destorySession`
+- `deleteData` is called from `destroySession`
 
 The following example shows how you could do this using a generic database client:
 


### PR DESCRIPTION
Closes: #9918 

- [x] Docs

# Description 
Fixed a typo in createSessionStorage

---
Orignal:
![image](https://github.com/user-attachments/assets/ed07a6d7-d2bd-4982-b9b2-3acaa0b2fd93)
