### PR TITLE
docs(file-conventions/root): fix wording

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -654,6 +654,7 @@
 - twhitbeck
 - tylerbrostrom
 - udasitharani
+- udohjeremiah
 - uerkw
 - uhoh-itsmaciek
 - unhackit

--- a/docs/file-conventions/root.md
+++ b/docs/file-conventions/root.md
@@ -152,7 +152,7 @@ export function ErrorBoundary() {
 
 Because your `Layout` component is used in both success and error flows, this same restriction holds. If you need to fork logic in your `Layout` depending on if it was a successful request or not, you can use `useRouteLoaderData("root")` and `useRouteError()`.
 
-<docs-warn>Because your `<Layout>` component is used for rendering the `ErrorBoundary`, you should be _very defensive_ to ensure that you can render your `ErrorBoundary` without encountering any render errors. If your `Layout` throws another error trying to render the boundary, then it can't can't be used and your UI will fall back to the very minimal built-in default `ErrorBoundary`.</docs-warn>
+<docs-warn>Because your `<Layout>` component is used for rendering the `ErrorBoundary`, you should be _very defensive_ to ensure that you can render your `ErrorBoundary` without encountering any render errors. If your `Layout` throws another error trying to render the boundary, then it can't be used and your UI will fall back to the very minimal built-in default `ErrorBoundary`.</docs-warn>
 
 ```tsx filename="app/root.tsx" lines=[6-7,19-29,32-34]
 export function Layout({


### PR DESCRIPTION
This PR removes the repeated word `can't`.