### PR TITLE
docs(route/headers): fix typo

### DIFF
--- a/docs/route/headers.md
+++ b/docs/route/headers.md
@@ -58,7 +58,7 @@ If we are looking at `/users/123/profile` then three routes are rendering:
 
 If a user is looking at `/users/123/profile` and `users.$userId.profile.tsx` does not export a `headers` function, then Remix will use the return value of `users.$userId.tsx`'s `headers` function. If that file doesn't export one, then it will use the result of the one in `users.tsx`, and so on.
 
-If all three define `headers`, the deepest module wins, in this case `users.$userId.profile.tsx`. However, if your `users.$userId.profile.tsx`'s `loader` threw and bubbled to a boundary in `users.userId.tsx` - then `users.userId.tsx`'s `headers` function would be used as it is the leaf rendered route.
+If all three define `headers`, the deepest module wins, in this case `users.$userId.profile.tsx`. However, if your `users.$userId.profile.tsx`'s `loader` threw and bubbled to a boundary in `users.$userId.tsx` - then `users.$userId.tsx`'s `headers` function would be used as it is the leaf rendered route.
 
 We don't want surprise headers in your responses, so it's your job to merge them if you'd like. Remix passes in the `parentHeaders` to your `headers` function. So `users.tsx` headers get passed to `users.$userId.tsx`, and then `users.$userId.tsx`'s `headers` are passed to `users.$userId.profile.tsx`'s `headers`.
 


### PR DESCRIPTION
This adds the `$` omitted from the file names.