### PR TITLE
Add isbot to spa mode template

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -704,3 +704,4 @@
 - zayenz
 - zhe
 - zwhitchcox
+- m-nakamura145

--- a/templates/spa/package.json
+++ b/templates/spa/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@remix-run/node": "*",
     "@remix-run/react": "*",
+    "isbot": "^4.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

I encountered an issue while working with the SPA mode template in Remix. The error message was as follows:
```
[vite] Internal server error: Cannot find module 'isbot' imported from '/my-remix-app/app/entry.server.tsx'
```
This was caused by a missing isbot dependency in the package.json. To resolve this, I added isbot to the dependencies in the package.json.

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
