### PR TITLE
Support 304 responses on document requests

### DIFF
--- a/.changeset/slow-socks-juggle.md
+++ b/.changeset/slow-socks-juggle.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+Support 304 responses on document requests

--- a/integration/single-fetch-test.ts
+++ b/integration/single-fetch-test.ts
@@ -1925,8 +1925,23 @@ test.describe("single-fetch", () => {
         `,
       },
     });
-    let res = await fixture.requestSingleFetchData("/_root.data");
-    expect(res.data).toEqual({
+
+    // Document requests
+    let documentRes = await fixture.requestDocument("/");
+    let html = await documentRes.text();
+    expect(html).toContain("<body>");
+    expect(html).toContain("<h1>Hello from the loader!</h1>");
+    documentRes = await fixture.requestDocument("/", {
+      headers: {
+        "If-None-Match": "1234",
+      },
+    });
+    expect(documentRes.status).toBe(304);
+    expect(await documentRes.text()).toBe("");
+
+    // Data requests
+    let dataRes = await fixture.requestSingleFetchData("/_root.data");
+    expect(dataRes.data).toEqual({
       root: {
         data: {
           message: "ROOT",
@@ -1938,13 +1953,13 @@ test.describe("single-fetch", () => {
         },
       },
     });
-    res = await fixture.requestSingleFetchData("/_root.data", {
+    dataRes = await fixture.requestSingleFetchData("/_root.data", {
       headers: {
         "If-None-Match": "1234",
       },
     });
-    expect(res.status).toBe(304);
-    expect(res.data).toBeNull();
+    expect(dataRes.status).toBe(304);
+    expect(dataRes.data).toBeNull();
   });
 
   test.describe("revalidations/_routes param", () => {

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -465,6 +465,11 @@ async function handleDocumentRequest(
 
   let headers = getDocumentHeaders(build, context);
 
+  // 304 responses should not have a body or a content-type
+  if (context.statusCode === 304) {
+    return new Response(null, { status: 304, headers });
+  }
+
   // Sanitize errors outside of development environments
   if (context.errors) {
     Object.values(context.errors).forEach((err) => {


### PR DESCRIPTION
Same fix as https://github.com/remix-run/remix/pull/9941 (for https://github.com/remix-run/remix/issues/9930) but for document requests