### PR TITLE
added codemods to docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -704,3 +704,4 @@
 - zayenz
 - zhe
 - zwhitchcox
+- dfordp

--- a/docs/start/v2.md
+++ b/docs/start/v2.md
@@ -114,6 +114,30 @@ If you are using `v2_dev` config, you'll need to move it to the `dev` config fie
 +   }
   }
 ```
+#### Codemods
+
+To assist with the upgrade from v1 to v2, we have added features that utilize codemods to automatically update your code to many of the new updates and patterns. Run the following command to automatically update your code for Remix.js migration:
+
+  > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod remix-js/v2/migration-recipe
+  > ```
+These will run the following codemods from the radix-vue Codemod repository:
+
+
+- **add-matches-param-and-array-return-to-meta-export**
+- **remix_1_add-meta-v1-wrapper**
+- **remix-run_v1_meta-function-args-wrapper**
+- **remix_1_use-route-error-codemod**
+- **remix-run_1_use-transition-to-use-navigation**
+- **fetcher-submission-properties-flattening**
+- **typescript_2_update-links-function-and-property-names**
+- **rename-browser-build-directory**
+- **webpack_v2_migrate-dev-server-port**
+- **remix_1_replace-response-with-create-readable-stream**
+- **nodejs-module-exports-server-build-directory-to-path**
+
 
 ## File System Route Convention
 
@@ -245,6 +269,13 @@ In v1, Remix would only use the result of the leaf "rendered" route `headers` fu
 
 In v2, Remix now uses the deepest `headers` function that it finds in the rendered routes. This more easily allows you to share headers across routes from a common ancestor. Then as needed you can add `headers` functions to deeper routes if they require specific behavior.
 
+
+ > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod remix-js/v2/add-matches-param-and-array-return-to-meta-export
+  > ```
+
 ## Route `meta`
 
 In Remix v2, the signature for route `meta` functions and how Remix handles meta tags under the hood have changed.
@@ -282,6 +313,13 @@ export function meta(args) {
   });
 }
 ```
+
+ > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod remix-js/v2/remix-1-add-meta-v1-wrapper
+  > ```
+
 
 It's important to note that this function will _not_ merge meta across the entire hierarchy by default. This is because you may have some routes that return an array of objects directly without the `metaV1` function and this could result in unpredictable behavior. If you want to merge meta across the entire hierarchy, use the `metaV1` function for all of your route's meta exports.
 
@@ -452,6 +490,13 @@ export function ErrorBoundary() {
 }
 ```
 
+
+ > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod remix-js/v2/remix-1-use-route-error-codemod
+  > ```
+
 ## `formMethod`
 
 ```js filename=remix.config.js
@@ -517,6 +562,12 @@ function SomeComponent() {
 }
 ```
 
+ > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod remix-js/v2/remix-run-1-use-transition-to-use-navigation
+  > ```
+
 You can derive the previous `transition.type` with the following examples. Keep in mind, there's probably a simpler way to get the same behavior, usually checking `navigation.state`, `navigation.formData` or the data returned from an action with `useActionData` can get the UX you're looking for. Feel free to ask us in Discord, and we'll help you out :D
 
 ```tsx
@@ -559,6 +610,8 @@ function Component() {
 }
 ```
 
+
+
 **A note on GET submissions**
 
 In Remix v1, GET submissions such as `<Form method="get">` or `submit({}, { method: 'get' })` went from `idle -> submitting -> idle` in `transition.state`. This is not quite semantically correct since even though you're "submitting" a form, you're performing a GET navigation and only executing loaders (not actions). Functionally, it's no different from a `<Link>` or `navigate()` except that the user may be specifying the search param values via inputs.
@@ -596,6 +649,12 @@ function SomeComponent() {
   fetcher.type;
 }
 ```
+
+ > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod remix-js/v2/typescript-2-update-links-function-and-property-names
+  > ```
 
 You can derive the previous `fetcher.type` with the following examples. Keep in mind, there's probably a simpler way to get the same behavior, usually checking `fetcher.state`, `fetcher.formData` or the data returned from an action on `fetcher.data` can get the UX you're looking for. Feel free to ask us in Discord, and we'll help you out :D
 
@@ -696,6 +755,12 @@ module.exports = {
 };
 ```
 
+ > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod remix-js/v2/rename-browser-build-directory
+  > ```
+
 ## `devServerBroadcastDelay`
 
 Remove `devServerBroadcastDelay` from your `remix.config.js` as the race conditions that necessitated this option have
@@ -730,6 +795,12 @@ module.exports = {
   },
 };
 ```
+ > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod remix-js/v2/webpack-v2-migrate-dev-server-port
+  > ```
+
 
 Once you upgrade from v1 to v2, this flattens to a [root-level `dev` config][dev-after-upgrading].
 
@@ -750,6 +821,12 @@ module.exports = {
   serverBuildPath: "./build/index.js",
 };
 ```
+
+ > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod remix-js/v2/nodejs-module-exports-server-build-directory-to-path
+  > ```
 
 Remix used to create more than a single module for the server, but it now creates a single file.
 
@@ -1049,6 +1126,11 @@ Remix v2 also no longer exports these polyfilled implementations from `@remix-ru
     });
   }
 ```
+ > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod remix-js/v2/remix-1-replace-response-with-create-readable-stream
+  > ```
 
 ## `source-map-support`
 


### PR DESCRIPTION
To assist with the upgrade from v1 to v2, we have added features that utilize codemods to automatically update your code to many of the new updates and patterns.

These codemods include breaking changes which aren't implemented interally but have to updated across multiple repositories using the framework.

These will run the following codemods from the radix-vue Codemod repository:
- add-matches-param-and-array-return-to-meta-export
- remix_1_add-meta-v1-wrapper
- remix_1_use-route-error-codemod
- remix-run_1_use-transition-to-use-navigation
- fetcher-submission-properties-flattening
- typescript_2_update-links-function-and-property-names
- rename-browser-build-directory
- webpack_v2_migrate-dev-server-port
- remix_1_replace-response-with-create-readable-stream
- nodejs-module-exports-server-build-directory-to-path
- migration recipe

## v1 → v2

- **Link to Official Upgrade Guide**: [[[Insert Link](https://v3-migration.vuejs.org/)](https://v3-migration.vuejs.org/)]

### add-matches-param-and-array-return-to-meta-export

- Instead of returning an object from `meta`, you will now return an array of descriptors and manage the merge yourself. This brings the `meta` API closer to `links`, and it allows for more flexibility and control over how meta tags are rendered.

### Additional Details

- Return type: Now returns an array of descriptors instead of an object.
- Function parameters: Added `matches` parameter to access route hierarchy information.
- Object structure: Replaced object literal with an array of objects, each representing a meta descriptor.
- https://go.codemod.com/ShZuosf

---

### remix_1_add-meta-v1-wrapper

- Using the `metaV1` function, you can pass in the `meta` function's arguments and the same object it currently returns. This function will use the same merging logic to merge the leaf route's meta with its **direct parent route** meta before converting it to an array of meta descriptors usable in v2.

### Additional Details

- You can update your `meta` exports with the `@remix-run/v1-meta` package to continue using v1 conventions.
- Note that this function will *not* merge meta across the entire hierarchy by default  because you may have some routes that return an array of objects directly without the `metaV1` function and this could result in unpredictable behavior. If you want to merge meta across the entire hierarchy, use the `metaV1` function for all of your route's meta exports.
- https://go.codemod.com/W5rzM7B

---

### remix_1_use-route-error-codemod

---

### remix-run_1_use-transition-to-use-navigation

- This hook is now called `useNavigation` to avoid confusion with the recent React hook by the same name. It also no longer has the `type` field and flattens the `submission` object into the `navigation` object itself.

### Additional Details

- You can derive the previous `transition.type` with the following examples. Keep in mind, there's probably a simpler way to get the same behavior, usually checking `navigation.state`, `navigation.formData` or the data returned from an action with `useActionData` can get the UX you're looking for.
- https://go.codemod.com/bBF5eVZ

---

### fetcher-submission-properties-flattening

- Like `useNavigation`, `useFetcher` has flattened the `submission` and removed the `type` field.

### Additional Details

- You can derive the previous `fetcher.type` with the following examples. Keep in mind, there's probably a simpler way to get the same behavior, usually checking `fetcher.state`, `fetcher.formData` or the data returned from an action on `fetcher.data` can get the UX you're looking for.
- https://go.codemod.com/Z5eYUyV

---

### typescript_2_update-links-function-and-property-names

- Route `links` properties should all be the React camelCase values instead of HTML lowercase values.

### Additional Details

- https://go.codemod.com/KmTxkbz

---

### rename-browser-build-directory

- In your `remix.config.js`, rename `browserBuildDirectory` to `assetsBuildDirectory`.

### Additional Details

- https://go.codemod.com/To1ApaP

---

### webpack_v2_migrate-dev-server-port

- In your `remix.config.js`, rename `devServerPort` to `future.v2_dev.port`.

### Additional Details

- https://go.codemod.com/nZMuPVE

---

### remix_1_replace-response-with-create-readable-stream

- One place this is likely to surface and require a change is your `app/entry.server.tsx` file, where you'll also need to convert the Node [`[PassThrough](https://nodejs.org/api/stream.html#class-streampassthrough)`](https://nodejs.org/api/stream.html#class-streampassthrough) into a web [`[ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) via `createReadableStreamFromReadable`

### Additional Details

- https://go.codemod.com/GBuAz5U

---

### nodejs-module-exports-server-build-directory-to-path

- In your `remix.config.js`, rename `serverBuildDirectory` to `serverBuildPath` and specify a module path, not a directory.

### Additional Details

- https://go.codemod.com/P5CTNhm