### PR TITLE
RELEASE: fix single fetch generic as cast (again)

### DIFF
--- a/.changeset/light-moons-reply.md
+++ b/.changeset/light-moons-reply.md
@@ -1,0 +1,5 @@
+---
+"remix": patch
+---
+
+REMOVE: bump prerelease

--- a/packages/remix-server-runtime/serialize.ts
+++ b/packages/remix-server-runtime/serialize.ts
@@ -23,11 +23,7 @@ type SingleFetchEnabled =
  * `type LoaderData = SerializeFrom<typeof loader>`
  */
 export type SerializeFrom<T> =
-  SingleFetchEnabled extends true ?
-    T extends (...args: any[]) => unknown ?
-      SingleFetch_SerializeFrom<T> :
-      never
-  :
+  SingleFetchEnabled extends true ? SingleFetch_SerializeFrom<T> :
   T extends (...args: any[]) => infer Output ?
     Parameters<T> extends [ClientLoaderFunctionArgs | ClientActionFunctionArgs] ?
       // Client data functions may not serialize


### PR DESCRIPTION
We had _two_ checks to ensure that the generic type was a function. For back compat, we need to allow non-function types, but #9948 only removed one of the checks. This removes the other check.

Type tests didn't catch this as we only check single-fetch types assuming the outer checks that rely on interface merging pass. We can't test the whole `SerializeFrom` type with interface merging in our repo as that will override types in the entire repo to be single-fetch aware.