### PR TITLE
perf(remix-dev/vite): use `structuredClone` instead of `JSON.parse(JSON.stringify())`

### DIFF
--- a/.changeset/tall-jars-destroy.md
+++ b/.changeset/tall-jars-destroy.md
@@ -1,5 +1,5 @@
 ---
-"@remix-run/dev": major
+"@remix-run/dev": patch
 ---
 
 Change JSON.parse(JSON.stringify to structuredClone native function

--- a/.changeset/tall-jars-destroy.md
+++ b/.changeset/tall-jars-destroy.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": major
+---
+
+Change JSON.parse(JSON.stringify to structuredClone native function

--- a/.changeset/tall-jars-destroy.md
+++ b/.changeset/tall-jars-destroy.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": patch
 ---
 
-Change JSON.parse(JSON.stringify to structuredClone native function
+Use `structuredClone` instead of `JSON.parse(JSON.stringify())`

--- a/contributors.yml
+++ b/contributors.yml
@@ -707,3 +707,4 @@
 - zayenz
 - zhe
 - zwhitchcox
+- xSyki

--- a/packages/remix-dev/vite/static/refresh-utils.cjs
+++ b/packages/remix-dev/vite/static/refresh-utils.cjs
@@ -13,7 +13,7 @@ function debounce(fn, delay) {
 const enqueueUpdate = debounce(async () => {
   let manifest;
   if (routeUpdates.size > 0) {
-    manifest = JSON.parse(JSON.stringify(__remixManifest));
+    manifest = structuredClone(__remixManifest);
 
     for (let route of routeUpdates.values()) {
       manifest.routes[route.id] = route;

--- a/packages/remix-dev/vite/static/refresh-utils.cjs
+++ b/packages/remix-dev/vite/static/refresh-utils.cjs
@@ -13,7 +13,9 @@ function debounce(fn, delay) {
 const enqueueUpdate = debounce(async () => {
   let manifest;
   if (routeUpdates.size > 0) {
-    manifest = structuredClone(__remixManifest);
+    manifest = typeof structuredClone === 'function' ? 
+      structuredClone(__remixManifest) : 
+      JSON.parse(JSON.stringify(__remixManifest));
 
     for (let route of routeUpdates.values()) {
       manifest.routes[route.id] = route;


### PR DESCRIPTION
`JSON.parse(JSON.stringify(` is not a recommended method for doing deepCopy. I suggest changing it to native structuredClone

https://developer.mozilla.org/en-US/docs/Web/API/structuredClone

https://web.dev/articles/structured-clone

## Benchmarks

https://jsperf.app/watawu

## Support

https://caniuse.com/?search=structuredClone

Testing Strategy:

Called function directly
