### PR TITLE
Proxy request.signal through in vite dev

### DIFF
--- a/.changeset/hungry-experts-suffer.md
+++ b/.changeset/hungry-experts-suffer.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Abort request.signal in vite dev when the node response is closed

--- a/.changeset/hungry-experts-suffer.md
+++ b/.changeset/hungry-experts-suffer.md
@@ -2,4 +2,4 @@
 "@remix-run/dev": patch
 ---
 
-Abort request.signal in vite dev when the node response is closed
+Properly abort `request.signal` during `vite dev` when the node response is closed

--- a/packages/remix-dev/vite/cloudflare-proxy-plugin.ts
+++ b/packages/remix-dev/vite/cloudflare-proxy-plugin.ts
@@ -70,7 +70,7 @@ export const cloudflareDevProxyVitePlugin = <Env, Cf extends CfProperties>({
               )) as ServerBuild;
 
               let handler = createRequestHandler(build, "development");
-              let req = fromNodeRequest(nodeReq);
+              let req = fromNodeRequest(nodeReq, nodeRes);
               let loadContext = getLoadContext
                 ? await getLoadContext({ request: req, context })
                 : context;

--- a/packages/remix-dev/vite/node-adapter.ts
+++ b/packages/remix-dev/vite/node-adapter.ts
@@ -32,7 +32,8 @@ function fromNodeHeaders(nodeHeaders: IncomingHttpHeaders): Headers {
 
 // Based on `createRemixRequest` in packages/remix-express/server.ts
 export function fromNodeRequest(
-  nodeReq: Vite.Connect.IncomingMessage
+  nodeReq: Vite.Connect.IncomingMessage,
+  nodeRes: ServerResponse<Vite.Connect.IncomingMessage>
 ): Request {
   let origin =
     nodeReq.headers.origin && "null" !== nodeReq.headers.origin
@@ -44,9 +45,15 @@ export function fromNodeRequest(
     "Expected `nodeReq.originalUrl` to be defined"
   );
   let url = new URL(nodeReq.originalUrl, origin);
+
+  // Abort action/loaders once we can no longer write a response
+  let controller = new AbortController();
+  nodeRes.on("close", () => controller.abort());
+
   let init: RequestInit = {
     method: nodeReq.method,
     headers: fromNodeHeaders(nodeReq.headers),
+    signal: controller.signal,
   };
 
   if (nodeReq.method !== "GET" && nodeReq.method !== "HEAD") {

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -1382,7 +1382,7 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
                   nodeReq,
                   nodeRes
                 ) => {
-                  let req = fromNodeRequest(nodeReq);
+                  let req = fromNodeRequest(nodeReq, nodeRes);
                   let res = await handler(req, await remixDevLoadContext(req));
                   await toNodeRequest(res, nodeRes);
                 };


### PR DESCRIPTION
Found this wasn't working right while testing https://github.com/remix-run/remix/pull/9975.  Aligned with how we do it in the express adapter.

Closes https://github.com/remix-run/remix/issues/9438