### PR TITLE
docs(hooks/use-revalidator): update code example

### DIFF
--- a/docs/hooks/use-revalidator.md
+++ b/docs/hooks/use-revalidator.md
@@ -38,16 +38,34 @@ The state of the revalidation. Either `"idle"` or `"loading"`.
 Initiates a revalidation.
 
 ```tsx
-function useLivePageData() {
-  const revalidator = useRevalidator();
-  const interval = useInterval(5000);
 
-  useEffect(() => {
-    if (revalidator.state === "idle") {
-      revalidator.revalidate();
+function useLivePageData() {
+  const revalidator = useRevalidator()
+
+  useInterval(() => {
+    if (revalidator.state === 'idle') {
+      revalidator.revalidate()
     }
-  }, [interval, revalidator]);
+  }, 5000)
 }
+
+function useInterval(callback: () => void, delay?: number) {
+  useEffect(() => {
+    if (delay === undefined) return
+
+    let id: ReturnType<typeof setTimeout>
+
+    function tick() {
+      callback()
+      id = setTimeout(tick, delay)
+    }
+
+    id = setTimeout(tick, delay)
+
+    return () => clearTimeout(id)
+  }, [callback, delay])
+}
+
 ```
 
 ## Notes

--- a/docs/hooks/use-revalidator.md
+++ b/docs/hooks/use-revalidator.md
@@ -38,7 +38,6 @@ The state of the revalidation. Either `"idle"` or `"loading"`.
 Initiates a revalidation.
 
 ```tsx
-
 function useLivePageData() {
   const revalidator = useRevalidator()
 
@@ -48,25 +47,9 @@ function useLivePageData() {
     }
   }, 5000)
 }
-
-function useInterval(callback: () => void, delay?: number) {
-  useEffect(() => {
-    if (delay === undefined) return
-
-    let id: ReturnType<typeof setTimeout>
-
-    function tick() {
-      callback()
-      id = setTimeout(tick, delay)
-    }
-
-    id = setTimeout(tick, delay)
-
-    return () => clearTimeout(id)
-  }, [callback, delay])
-}
-
 ```
+
+See [here](https://overreacted.io/making-setinterval-declarative-with-react-hooks/) for a sample `useInterval` implementation.
 
 ## Notes
 


### PR DESCRIPTION

The original example looks like a GPT solution, the interval was never accounted for and the useEffect would just keep running immediately as soon as the revalidation completes

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
