### PR TITLE
docs(guides/spa-mode): fix default `sirv-cli` configuration

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -706,3 +706,4 @@
 - zayenz
 - zhe
 - zwhitchcox
+- ivan-kobzar

--- a/docs/guides/spa-mode.md
+++ b/docs/guides/spa-mode.md
@@ -86,7 +86,7 @@ To deploy, you can serve your app from any HTTP server of your choosing. The ser
 For a simple example, you could use [sirv-cli][sirv-cli]:
 
 ```shellscript
-npx sirv-cli build/client/ --single
+npx sirv-cli build/client/ --host 0.0.0.0 --port 3000 --single
 ```
 
 Or, if you are serving via an `express` server (although at that point you may want to consider just running Remix in SSR mode 😉):


### PR DESCRIPTION
Small change in [SPA Mode](https://remix.run/docs/en/main/guides/spa-mode) page.
To make `sirv-cli` works with default deployment setup we need to provide `--host` and `--port` flags.
Should be useful for beginners and save some time.
