### PR TITLE
docs(start/tutorial): replace `placekitten` service with `placecats`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -164,6 +164,7 @@
 - dnsbty
 - dogukanakkaya
 - dokeet
+- domluther
 - donavon
 - Drew-Daniels
 - dschlabach

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -168,7 +168,7 @@ export default function Contact() {
   const contact = {
     first: "Your",
     last: "Name",
-    avatar: "https://placekitten.com/200/200",
+    avatar: "https://placecats.com/200/200",
     twitter: "your_handle",
     notes: "Some notes",
     favorite: true,


### PR DESCRIPTION
placekitten.com seems to be down and searching seems to suggest it has been for a while (or is frequently?)
I updated the tutorial link to use https://placecats.com/ instead for the profile images.
