### PR TITLE
Fix docs for environment variables in Cloudflare

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -471,6 +471,7 @@
 - mochi-sann
 - mohammadhosseinbagheri
 - monitaure
+- monsterdeveloper
 - mootari
 - morinokami
 - mrkhosravian

--- a/docs/guides/envvars.md
+++ b/docs/guides/envvars.md
@@ -46,19 +46,19 @@ export async function loader() {
 }
 ```
 
-If you're using the `@remix-run/cloudflare-pages` adapter, env variables work a little differently. Since Cloudflare Pages are powered by Functions, you'll need to define your local environment variables in the [`.dev.vars`][dev-vars] file. It has the same syntax as `.env` example file mentioned above.
+If you're using the `@remix-run/cloudflare-pages` or `@remix-run/cloudflare` adapters, env variables work a little differently. You'll need to define your local environment variables in the [`.dev.vars`][dev-vars] file. It has the same syntax as `.env` example file mentioned above.
 
-Then, they'll be available via Remix's `context.env` in your `loader`/`action` functions:
+Then, they'll be available via Remix's `context.cloudflare.env` in your `loader`/`action` functions:
 
 ```tsx
 export const loader = async ({
   context,
 }: LoaderFunctionArgs) => {
-  console.log(context.env.SOME_SECRET);
+  console.log(context.cloudflare.env.SOME_SECRET);
 };
 ```
 
-Note that `.env` files are only for development. You should not use them in production, so Remix doesn't load them when running `remix serve`. You'll need to follow your host's guides on adding secrets to your production server, via the links below.
+Note that `.env` and `.dev.vars` files are only for development. You should not use them in production, so Remix doesn't load them when running `remix serve`. You'll need to follow your host's guides on adding secrets to your production server, via the links below.
 
 ### Production
 


### PR DESCRIPTION
[Current docs](https://remix.run/docs/en/main/guides/envvars#local-development) say that env variables in Cloudflare environment are accessible through `context.env`, which was true for the classic compiler, but doesn't work with Vite.

Now as Vite is the default for Remix, env variables in Cloudflare are accessible through `context.cloudflare.env`. This PR reflects this change.