### PR TITLE
docs(guides/single-fetch): fix type override

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -140,6 +140,7 @@
 - davecalnan
 - davecranwell-vocovo
 - DavidHollins6
+- david-crespo
 - davongit
 - dcramer
 - Deanmv

--- a/docs/guides/single-fetch.md
+++ b/docs/guides/single-fetch.md
@@ -152,7 +152,7 @@ You can do this in any file covered by your `tsconfig.json` > `include`.
 We recommend you do this in your `vite.config.ts` to keep it colocated with the `future.unstable_singleFetch` future flag in the Remix plugin:
 
 ```ts
-declare module "@remix-run/node" {
+declare module "@remix-run/server-runtime" {
   // or cloudflare, deno, etc.
   interface Future {
     unstable_singleFetch: true;


### PR DESCRIPTION
As of 2.12, the `Future` type thing is in `@remix-run/server-runtime`, not `@remix-run/node`. I was very confused about why it wasn't working.

https://github.com/remix-run/remix/blob/6f83cf3d11436f6306a5d5f2468ce2cc4fe8e3ea/CHANGELOG.md#L256-L284