### PR TITLE
templates(cloudflare-workers): use static assets

### DIFF
--- a/templates/cloudflare-workers/env.d.ts
+++ b/templates/cloudflare-workers/env.d.ts
@@ -1,4 +1,0 @@
-declare module "__STATIC_CONTENT_MANIFEST" {
-  const manifest: string;
-  export default manifest;
-}

--- a/templates/cloudflare-workers/load-context.ts
+++ b/templates/cloudflare-workers/load-context.ts
@@ -3,8 +3,9 @@ import { type PlatformProxy } from "wrangler";
 type GetLoadContextArgs = {
   request: Request;
   context: {
-    cloudflare: Omit<PlatformProxy<Env, IncomingRequestCfProperties>, "dispose" | "caches"> & {
-      caches: PlatformProxy<Env, IncomingRequestCfProperties>['caches'] | CacheStorage;
+    cloudflare: Omit<PlatformProxy<Env>, "dispose" | "caches" | "cf"> & {
+      caches: PlatformProxy<Env>['caches'] | CacheStorage;
+      cf: Request['cf'];
     };
   };
 }

--- a/templates/cloudflare-workers/load-context.ts
+++ b/templates/cloudflare-workers/load-context.ts
@@ -1,13 +1,21 @@
 import { type PlatformProxy } from "wrangler";
 
-// PlatformProxy’s caches property is incompatible with the caches global
-// https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/api/integrations/platform/caches.ts
-type Cloudflare = Omit<PlatformProxy<Env>, "dispose" | "caches"> & {
-  caches: CacheStorage;
-};
+type GetLoadContextArgs = {
+  request: Request;
+  context: {
+    cloudflare: Omit<PlatformProxy<Env, IncomingRequestCfProperties>, "dispose" | "caches"> & {
+      caches: PlatformProxy<Env, IncomingRequestCfProperties>['caches'] | CacheStorage;
+    };
+  };
+}
 
 declare module "@remix-run/cloudflare" {
-  interface AppLoadContext {
-    cloudflare: Cloudflare;
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface AppLoadContext extends ReturnType<typeof getLoadContext> {
+    // This will merge the result of `getLoadContext` into the `AppLoadContext`
   }
+}
+
+export function getLoadContext({ context }: GetLoadContextArgs) {
+  return context;
 }

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -12,7 +12,6 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@cloudflare/kv-asset-handler": "^0.3.2",
     "@remix-run/cloudflare": "*",
     "@remix-run/react": "*",
     "@remix-run/server-runtime": "*",
@@ -21,7 +20,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20240512.0",
+    "@cloudflare/workers-types": "^4.20240925.0",
     "@remix-run/dev": "*",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
@@ -39,7 +38,7 @@
     "typescript": "^5.1.6",
     "vite": "^5.1.0",
     "vite-tsconfig-paths": "^4.2.1",
-    "wrangler": "3.57.1"
+    "wrangler": "^3.78.10"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -38,7 +38,7 @@
     "typescript": "^5.1.6",
     "vite": "^5.1.0",
     "vite-tsconfig-paths": "^4.2.1",
-    "wrangler": "^3.78.10"
+    "wrangler": "3.78.10"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -38,7 +38,7 @@
     "typescript": "^5.1.6",
     "vite": "^5.1.0",
     "vite-tsconfig-paths": "^4.2.1",
-    "wrangler": "3.78.10"
+    "wrangler": "3.84.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20240925.0",
+    "@cloudflare/workers-types": "^4.20241022.0",
     "@remix-run/dev": "*",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",

--- a/templates/cloudflare-workers/server.ts
+++ b/templates/cloudflare-workers/server.ts
@@ -1,56 +1,37 @@
-import { getAssetFromKV } from "@cloudflare/kv-asset-handler";
 import { createRequestHandler, type ServerBuild } from "@remix-run/cloudflare";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore This file won’t exist if it hasn’t yet been built
 import * as build from "./build/server"; // eslint-disable-line import/no-unresolved
-// eslint-disable-next-line import/no-unresolved
-import __STATIC_CONTENT_MANIFEST from "__STATIC_CONTENT_MANIFEST";
+import { getLoadContext } from "./load-context";
 
-const MANIFEST = JSON.parse(__STATIC_CONTENT_MANIFEST);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const handleRemixRequest = createRequestHandler(build as any as ServerBuild);
 
 export default {
   async fetch(request, env, ctx) {
-    const waitUntil = ctx.waitUntil.bind(ctx);
-    const passThroughOnException = ctx.passThroughOnException.bind(ctx);
     try {
-      const url = new URL(request.url);
-      const ttl = url.pathname.startsWith("/assets/")
-        ? 60 * 60 * 24 * 365 // 1 year
-        : 60 * 5; // 5 minutes
-      return await getAssetFromKV(
-        { request, waitUntil },
-        {
-          ASSET_NAMESPACE: env.__STATIC_CONTENT,
-          ASSET_MANIFEST: MANIFEST,
-          cacheControl: {
-            browserTTL: ttl,
-            edgeTTL: ttl,
+      const loadContext = getLoadContext({
+        request,
+        context: {
+          cloudflare: {
+            // This object matches the return value from Wrangler's
+            // `getPlatformProxy` used during development via Remix's
+            // `cloudflareDevProxyVitePlugin`:
+            // https://developers.cloudflare.com/workers/wrangler/api/#getplatformproxy
+            cf: request.cf,
+            ctx: {
+              waitUntil: ctx.waitUntil.bind(ctx),
+              passThroughOnException: ctx.passThroughOnException.bind(ctx),
+            },
+            caches,
+            env,
           },
         }
-      );
-    } catch (error) {
-      // No-op
-    }
-
-    try {
-      const loadContext = {
-        cloudflare: {
-          // This object matches the return value from Wrangler's
-          // `getPlatformProxy` used during development via Remix's
-          // `cloudflareDevProxyVitePlugin`:
-          // https://developers.cloudflare.com/workers/wrangler/api/#getplatformproxy
-          cf: request.cf,
-          ctx: { waitUntil, passThroughOnException },
-          caches,
-          env,
-        },
-      };
+      });
       return await handleRemixRequest(request, loadContext);
     } catch (error) {
       console.log(error);
       return new Response("An unexpected error occurred", { status: 500 });
     }
   },
-} satisfies ExportedHandler<Env & { __STATIC_CONTENT: KVNamespace<string> }>;
+} satisfies ExportedHandler<Env>;

--- a/templates/cloudflare-workers/vite.config.ts
+++ b/templates/cloudflare-workers/vite.config.ts
@@ -4,6 +4,7 @@ import {
   cloudflareDevProxyVitePlugin,
 } from "@remix-run/dev";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { getLoadContext } from "./load-context";
 
 declare module "@remix-run/cloudflare" {
   interface Future {
@@ -13,7 +14,9 @@ declare module "@remix-run/cloudflare" {
 
 export default defineConfig({
   plugins: [
-    cloudflareDevProxyVitePlugin(),
+    cloudflareDevProxyVitePlugin({
+      getLoadContext,
+    }),
     remix({
       future: {
         v3_fetcherPersist: true,

--- a/templates/cloudflare-workers/wrangler.toml
+++ b/templates/cloudflare-workers/wrangler.toml
@@ -1,12 +1,14 @@
+#:schema node_modules/wrangler/config-schema.json
 name = "remix-cloudflare-workers-template"
 
 main = "./server.ts"
 workers_dev = true
 # https://developers.cloudflare.com/workers/platform/compatibility-dates
-compatibility_date = "2023-04-20"
+compatibility_date = "2024-09-26"
 
-[site]
-bucket = "./build/client"
+[assets]
+# https://developers.cloudflare.com/workers/static-assets/binding/
+directory = "./build/client"
 
 [build]
 command = "npm run build"


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

This PR updates the cloudflare-workers template to use the Static Assets feature [announced today](https://blog.cloudflare.com/builder-day-2024-announcements/#static-asset-hosting).

> Note: Static assets is currently in open beta

You can learn more about Static Assets in the [documentation](https://developers.cloudflare.com/workers/static-assets/?cf_history_state=%7B%22guid%22%3A%22C255D9FF78CD46CDA4F76812EA68C350%22%2C%22historyId%22%3A14%2C%22targetId%22%3A%22167AF5232FF9C5279F7F203D0E95B587%22%7D).

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

To test, please run `create-remix` with the template on my fork 

```sh
npx create-remix@latest --template edmundhung/remix/templates/cloudflare-workers
```

Then deploy it with wrangler by running:

```sh
npm run deploy
```

Woohoo! Your Remix app is now running on Cloudflare Workers: https://template.remix-run.workers.dev

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
