### PR TITLE
Override cookie encode

### DIFF
--- a/packages/remix-server-runtime/__tests__/cookies-test.ts
+++ b/packages/remix-server-runtime/__tests__/cookies-test.ts
@@ -193,6 +193,38 @@ describe("cookies", () => {
       );
     });
   });
+
+  describe("encode/decode options", () => {
+    it("Will not Base64 encode/decode the cookie if `encode` and `decode` are set to custom functions", async () => {
+      let testValue = { hello: "world" };
+      let cookie = createCookie("my-cookie", {
+        encode: (value) => JSON.stringify(value),
+        decode: (value) => JSON.parse(value),
+      });
+      let setCookie = await cookie.serialize(testValue);
+
+      expect(setCookie).toBe("my-cookie=" + JSON.stringify(testValue));
+    });
+
+    it("Will not allow `encode` and `decode` to be set at the same time as `secrets`", async () => {
+      let secrets = ["foo"];
+      let encode = (value) => JSON.stringify(value);
+
+      expect(() => {
+        createCookie("my-cookie", { secrets, encode });
+      }).toThrowErrorMatchingInlineSnapshot(
+        "sign is not supported with encode option"
+      );
+
+      let decode = (value) => JSON.parse(value);
+
+      expect(() => {
+        createCookie("my-cookie", { secrets, decode });
+      }).toThrowErrorMatchingInlineSnapshot(
+        "unsign is not supported with decode option"
+      );
+    });
+  });
 });
 
 function spyConsole() {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

## Current behaviour
Right now, the Base64 encoding is applied before the value is sent to the cookie serializer. but the `options` object still takes parameters for overriding the `encode`/ `decode` functions.

## Expected behaviour 
I would expect that when I add my own `encode`/`decode` functions, that the value isn't Base64 encoded anymore.

## Side effects
One side effect of this change, is that you can't sign cookies using the `secrets` property any more. But the user can still handle that themselves in the `encode`/`decode` functions.

This will give more flexibility to the cookie utils in remix, and allow developers to keep a good DX, by not having to use different APIs for different cookies minimizing confusion.

## Testing Strategy
[These new tests covers this code](https://github.com/remix-run/remix/compare/main...Evanion:override-cookie-encode?expand=1#diff-09eb98fd8e0c75af0f2010a7fa9344eeca487b5f71d03787d765ea871b2741dd)

