### PR TITLE
fix: widen the `crossOrigin` type in `HtmlLinkProps`

### DIFF
--- a/packages/remix-react/links.ts
+++ b/packages/remix-react/links.ts
@@ -22,7 +22,7 @@ interface HtmlLinkProps {
   /**
    * How the element handles crossorigin requests
    */
-  crossOrigin?: "anonymous" | "use-credentials";
+  crossOrigin?: LiteralUnion<"anonymous" | "use-credentials", string>;
 
   /**
    * Relationship between the document containing the hyperlink and the destination resource


### PR DESCRIPTION
Closes: #10068

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
