### PR TITLE
fix(create-remix): add fallback git author to initial commit

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -372,6 +372,7 @@
 - kishanhitk
 - kiyadotdev
 - klauspaiva
+- klibardi
 - klirium
 - knowler
 - konradkalemba

--- a/packages/create-remix/index.ts
+++ b/packages/create-remix/index.ts
@@ -507,10 +507,24 @@ async function gitInitStep(ctx: Context) {
     while: async () => {
       let options = { cwd: ctx.cwd, stdio: "ignore" } as const;
       let commitMsg = "Initial commit from create-remix";
+      const commitUser = "create-remix";
+      const commitEmail = "<>"
       try {
         await execa("git", ["init"], options);
         await execa("git", ["add", "."], options);
-        await execa("git", ["commit", "-m", commitMsg], options);
+        await execa(
+          "git",
+          [
+            "-c",
+            `user.name='${commitUser}'`,
+            "-c",
+            `user.email='${commitEmail}'`,
+            "commit",
+            "-m",
+            commitMsg
+          ],
+          options
+        );
       } catch (err) {
         error("Oh no!", "Failed to initialize git.");
         throw err;


### PR DESCRIPTION


When run in an environment where git global config has not been set via
```
git config --global user.email "you@example.com"
git config --global user.name "Your Name"
```
and cannot be inferred from local username and hostname, the initialization process fails (git exits with exit code 128).

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

Manual, just tried running it with various git setups.
