### PR TITLE
docs: update broken react-router links

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -98,6 +98,7 @@
 - c43721
 - camiaei
 - CanRau
+- caprolactam
 - ccssmnn
 - cephalization
 - chaance

--- a/docs/file-conventions/vite-config.md
+++ b/docs/file-conventions/vite-config.md
@@ -140,6 +140,6 @@ You may also want to enable the `manifest` option since, when server bundles are
 [minimatch]: https://npm.im/minimatch
 [presets]: ../guides/presets
 [server-bundles]: ../guides/server-bundles
-[rr-basename]: https://reactrouter.com/routers/create-browser-router#basename
+[rr-basename]: https://reactrouter.com/en/main/routers/create-browser-router#basename
 [vite-public-base-path]: https://vitejs.dev/config/shared-options.html#base
 [vite-base]: https://vitejs.dev/config/shared-options.html#base

--- a/docs/guides/migrating-react-router-app.md
+++ b/docs/guides/migrating-react-router-app.md
@@ -693,7 +693,7 @@ Now then, go off and _remix your app_. We think you'll like what you build along
 - [Common "gotchas"][common-gotchas]
 
 [react-router]: https://reactrouter.com
-[react-router-docs]: https://reactrouter.com/start/concepts
+[react-router-docs]: https://reactrouter.com/en/main/start/concepts
 [migration-guide-from-v5-to-v6]: https://reactrouter.com/en/6.22.3/upgrading/v5
 [backwards-compatibility-package]: https://www.npmjs.com/package/react-router-dom-v5-compat
 [a-few-tweaks-to-improve-progressive-enhancement]: ../pages/philosophy#progressive-enhancement

--- a/docs/hooks/use-resolved-path.md
+++ b/docs/hooks/use-resolved-path.md
@@ -46,6 +46,6 @@ When you enable the flag, this "bug" is fixed so that path resolution is consist
 - [`resolvePath`][rr-resolve-path]
 
 [nav-link-component]: ../components/nav-link
-[rr-resolve-path]: https://reactrouter.com/utils/resolve-path
-[rr-use-resolved-path-splat]: https://reactrouter.com/hooks/use-resolved-path#splat-paths
+[rr-resolve-path]: https://reactrouter.com/en/main/utils/resolve-path
+[rr-use-resolved-path-splat]: https://reactrouter.com/en/main/hooks/use-resolved-path#splat-paths
 [remix-config-future]: https://remix.run/docs/en/main/file-conventions/remix-config#future

--- a/docs/utils/is-route-error-response.md
+++ b/docs/utils/is-route-error-response.md
@@ -7,4 +7,4 @@ toc: false
 
 <docs-info>This util is simply a re-export of [React Router's `isRouteErrorResponse`][rr-isrouteerrorresponse].</docs-info>
 
-[rr-isrouteerrorresponse]: https://reactrouter.com/utils/is-route-error-response
+[rr-isrouteerrorresponse]: https://reactrouter.com/en/main/utils/is-route-error-response


### PR DESCRIPTION
Some links to reactrouter.com are broken. Specifically, the language and branch params need to be added.
e.g.
```diff
- https://reactrouter.com/foo
+ https://reactrouter.com/en/main/foo
```
I also checked that the updated links are working correctly.