### PR TITLE
Update single fetch deprecation notice to also include info about null

### DIFF
--- a/.changeset/grumpy-llamas-leave.md
+++ b/.changeset/grumpy-llamas-leave.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+Update externally-accessed resource routes warning to cover null usage as well

--- a/integration/single-fetch-test.ts
+++ b/integration/single-fetch-test.ts
@@ -1687,12 +1687,46 @@ test.describe("single-fetch", () => {
     });
 
     expect(warnLogs).toEqual([
-      "⚠️ REMIX FUTURE CHANGE: Resource routes will no longer be able to return " +
-        "raw JavaScript objects in v3 when Single Fetch becomes the default. You " +
-        "can prepare for this change at your convenience by wrapping the data " +
-        "returned from your `loader` function in the `routes/resource` route with " +
-        "`json()`.  For instructions on making this change see " +
-        "https://remix.run/docs/en/v2.9.2/guides/single-fetch#resource-routes",
+      "⚠️ REMIX FUTURE CHANGE: Externally-accessed resource routes will no longer be " +
+        "able to return raw JavaScript objects or `null` in React Router v7 when " +
+        "Single Fetch becomes the default. You can prepare for this change at your " +
+        `convenience by wrapping the data returned from your \`loader\` function in ` +
+        `the \`routes/resource\` route with \`json()\`.  For instructions on making this ` +
+        "change, see https://remix.run/docs/en/v2.13.1/guides/single-fetch#resource-routes",
+    ]);
+    console.warn = oldConsoleWarn;
+  });
+
+  test("wraps resource route 'null' returns in json with a deprecation warning", async () => {
+    let oldConsoleWarn = console.warn;
+    let warnLogs: unknown[] = [];
+    console.warn = (...args) => warnLogs.push(...args);
+
+    let fixture = await createFixture({
+      config: {
+        future: {
+          v3_singleFetch: true,
+        },
+      },
+      files: {
+        ...files,
+        "app/routes/resource.tsx": js`
+          export function loader() {
+            return null;
+          }
+        `,
+      },
+    });
+    let res = await fixture.requestResource("/resource");
+    expect(await res.json()).toEqual(null);
+
+    expect(warnLogs).toEqual([
+      "⚠️ REMIX FUTURE CHANGE: Externally-accessed resource routes will no longer be " +
+        "able to return raw JavaScript objects or `null` in React Router v7 when " +
+        "Single Fetch becomes the default. You can prepare for this change at your " +
+        `convenience by wrapping the data returned from your \`loader\` function in ` +
+        `the \`routes/resource\` route with \`json()\`.  For instructions on making this ` +
+        "change, see https://remix.run/docs/en/v2.13.1/guides/single-fetch#resource-routes",
     ]);
     console.warn = oldConsoleWarn;
   });

--- a/packages/remix-server-runtime/deprecations.ts
+++ b/packages/remix-server-runtime/deprecations.ts
@@ -4,7 +4,7 @@ export function resourceRouteJsonWarning(
 ) {
   return (
     "⚠️ REMIX FUTURE CHANGE: Resource routes will no longer be able to " +
-    "return raw JavaScript objects in v3 when Single Fetch becomes the default. " +
+    "return null or raw JavaScript objects in v3 when Single Fetch becomes the default. " +
     "You can prepare for this change at your convenience by wrapping the data " +
     `returned from your \`${type}\` function in the \`${routeId}\` route with ` +
     "`json()`.  For instructions on making this change see " +

--- a/packages/remix-server-runtime/deprecations.ts
+++ b/packages/remix-server-runtime/deprecations.ts
@@ -3,11 +3,11 @@ export function resourceRouteJsonWarning(
   routeId: string
 ) {
   return (
-    "⚠️ REMIX FUTURE CHANGE: Resource routes will no longer be able to " +
-    "return null or raw JavaScript objects in v3 when Single Fetch becomes the default. " +
-    "You can prepare for this change at your convenience by wrapping the data " +
-    `returned from your \`${type}\` function in the \`${routeId}\` route with ` +
-    "`json()`.  For instructions on making this change see " +
-    "https://remix.run/docs/en/v2.9.2/guides/single-fetch#resource-routes"
+    "⚠️ REMIX FUTURE CHANGE: Externally-accessed resource routes will no longer be " +
+    "able to return raw JavaScript objects or `null` in React Router v7 when " +
+    "Single Fetch becomes the default. You can prepare for this change at your " +
+    `convenience by wrapping the data returned from your \`${type}\` function in ` +
+    `the \`${routeId}\` route with \`json()\`.  For instructions on making this ` +
+    "change, see https://remix.run/docs/en/v2.13.1/guides/single-fetch#resource-routes"
   );
 }


### PR DESCRIPTION
Resource routes can no longer just return null, call this out in the deprecation notice.

It just took me a minute to realise it was the null which was triggering the message.