### PR TITLE
docs: add example for `createSession` function

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -717,3 +717,4 @@
 - zayenz
 - zhe
 - zwhitchcox
+- wflore19

--- a/docs/utils/sessions.md
+++ b/docs/utils/sessions.md
@@ -196,7 +196,17 @@ Because of nested routes, multiple loaders can be called to construct a single p
 
 ## `createSession`
 
-TODO:
+Creates a new Session object with optional initial data and session ID.
+
+```ts
+import { createSession } from "@remix-run/node"; // or cloudflare/deno
+
+const sessionData = { username: "johndoe", theme: "dark" };
+const session = createSession(sessionData, "user-session-123");
+
+console.log(session.get("username")); // "johndoe"
+console.log(session.id); // "user-session-123"
+```
 
 ## `isSession`
 


### PR DESCRIPTION
Closes: #xxx

## Description ✏️
- Adds an example in documentation for the `createSession` function

## Type of Change 🐞
- [x] Docs
- [ ] Tests

## Screenshots 📸
Currently there is no example for `createSession()`, only a placeholder "TODO:"
![image](https://github.com/user-attachments/assets/6e89c89c-c322-470c-a37e-8f7381ec01f7)

