### PR TITLE
Use fetcher docs typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -594,6 +594,7 @@
 - schpet
 - scott-erickson
 - scottybrown
+- ScottDalessandro
 - sdavids
 - sean-roberts
 - SeanGroff

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -19,7 +19,7 @@ export function SomeComponent() {
 
 ### `key`
 
-By default, `useFetcher` generate a unique fetcher scoped to that component (however, it may be looked up in [`useFetchers()`][use_fetchers] while in-flight). If you want to identify a fetcher with your own key such that you can access it from elsewhere in your app, you can do that with the `key` option:
+By default, `useFetcher` generates a unique fetcher scoped to that component (however, it may be looked up in [`useFetchers()`][use_fetchers] while in-flight). If you want to identify a fetcher with your own key such that you can access it from elsewhere in your app, you can do that with the `key` option:
 
 ```tsx lines=[2,8]
 function AddToBagButton() {


### PR DESCRIPTION
This fixed a typo in the `useFetcher` docs. "generate" should be "generates" since the subject "useFetcher" is singular (third person) in present tense.

- Docs

Testing Strategy:

I did not test this, I edited Documentation.
