### PR TITLE
routes.ts: Add `v3_routeConfig` future flag

### DIFF
--- a/docs/start/future-flags.md
+++ b/docs/start/future-flags.md
@@ -472,19 +472,25 @@ You shouldn't need to make any changes to your application code for this feature
 
 You may find some usage for the new [`<Link discover>`][discover-prop] API if you wish to disable eager route discovery on certain links.
 
-## unstable_optimizeDeps
+## v3_routeConfig
 
-Opt into automatic [dependency optimization][dependency-optimization] during development. This flag will remain in an "unstable" state until React Router v7 so you do not need to adopt this in your Remix v2 app prior to upgrading to React Router v7.
+Config-based routing is the new default in React Router v7, configured via the `routes.ts` file in the app directory. Support for `routes.ts` and its related APIs in Remix are designed as a migration path to help minimize the number of changes required when moving your Remix project over to React Router v7. While some new packages have been introduced within the `@remix-run` scope, these new packages only exist to keep the code in `routes.ts` as similar as possible to the equivalent code for React Router v7.
 
-## routes.ts
-
-Config-based routing is the new default in React Router v7. Support for `routes.ts` and its related APIs in Remix are designed as a migration path to help minimize the number of changes required when moving your Remix project over to React Router v7. Since React Router v7 is not yet stable, these APIs are also considered unstable.
-
-While not a future flag, the presence of an `app/routes.ts` file when using the Remix Vite plugin will disable Remix's built-in file system routing and opt your project into React Router v7's config-based routing. To opt back in to file system routing, this can be explicitly configured within `routes.ts` as we'll cover below.
+When the `v3_routeConfig` future flag is enabled, Remix's built-in file system routing will be disabled and your project will opted into React Router v7's config-based routing. To opt back in to file system routing, this can be explicitly configured within `routes.ts` as we'll cover below.
 
 **Update your code**
 
 To migrate Remix's file system routing and route config to the equivalent setup in React Router v7, you can follow these steps:
+
+👉 **Enable the Flag**
+
+```ts filename=vite.config.ts
+remix({
+  future: {
+    v3_routeConfig: true,
+  },
+});
+```
 
 👉 **Install `@remix-run/route-config`**
 
@@ -613,6 +619,10 @@ export const routes: RouteConfig = [
 ];
 ```
 
+## unstable_optimizeDeps
+
+Opt into automatic [dependency optimization][dependency-optimization] during development. This flag will remain in an "unstable" state until React Router v7 so you do not need to adopt this in your Remix v2 app prior to upgrading to React Router v7.
+
 [development-strategy]: ../guides/api-development-strategy
 [fetcherpersist-rfc]: https://github.com/remix-run/remix/discussions/7698
 [relativesplatpath-changelog]: https://github.com/remix-run/remix/blob/main/CHANGELOG.md#futurev3_relativesplatpath
@@ -632,5 +642,5 @@ export const routes: RouteConfig = [
 [vite-url-imports]: https://vitejs.dev/guide/assets.html#explicit-url-imports
 [mdx]: https://mdxjs.com
 [mdx-rollup-plugin]: https://mdxjs.com/packages/rollup
-[dependency-optimization]: ../guides/dependency-optimization
 [remix-flat-routes]: https://github.com/kiliman/remix-flat-routes
+[dependency-optimization]: ../guides/dependency-optimization

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -32,13 +32,19 @@ export const viteConfig = {
     `;
     return text;
   },
-  basic: async (args: { port: number; fsAllow?: string[] }) => {
+  basic: async (args: {
+    port: number;
+    fsAllow?: string[];
+    routeConfig?: boolean;
+  }) => {
     return dedent`
       import { vitePlugin as remix } from "@remix-run/dev";
 
       export default {
         ${await viteConfig.server(args)}
-        plugins: [remix()]
+        plugins: [remix(${
+          args.routeConfig ? "{ future: { v3_routeConfig: true } }" : ""
+        })]
       }
     `;
   },

--- a/integration/vite-fs-routes-test.ts
+++ b/integration/vite-fs-routes-test.ts
@@ -23,7 +23,9 @@ test.describe("fs-routes", () => {
           import { vitePlugin as remix } from "@remix-run/dev";
 
           export default defineConfig({
-            plugins: [remix()],
+            plugins: [remix({
+              future: { v3_routeConfig: true },
+            })],
           });
         `,
         "app/routes.ts": js`
@@ -254,7 +256,9 @@ test.describe("emits warnings for route conflicts", async () => {
           import { vitePlugin as remix } from "@remix-run/dev";
 
           export default defineConfig({
-            plugins: [remix()],
+            plugins: [remix({
+              future: { v3_routeConfig: true },
+            })],
           });
         `,
         "app/routes.ts": js`
@@ -326,7 +330,9 @@ test.describe("", () => {
           import { vitePlugin as remix } from "@remix-run/dev";
 
           export default defineConfig({
-            plugins: [remix()],
+            plugins: [remix({
+              future: { v3_routeConfig: true },
+            })],
           });
         `,
         "app/routes.ts": js`
@@ -373,7 +379,9 @@ test.describe("pathless routes and route collisions", () => {
           import { vitePlugin as remix } from "@remix-run/dev";
 
           export default defineConfig({
-            plugins: [remix()],
+            plugins: [remix({
+              future: { v3_routeConfig: true },
+            })],
           });
         `,
         "app/routes.ts": js`

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -40,6 +40,7 @@ describe("readConfig", () => {
           "v3_fetcherPersist": false,
           "v3_lazyRouteDiscovery": false,
           "v3_relativeSplatPath": false,
+          "v3_routeConfig": false,
           "v3_singleFetch": false,
           "v3_throwAbortReason": false,
         },

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -721,6 +721,7 @@ export async function resolveConfig(
     v3_throwAbortReason: appConfig.future?.v3_throwAbortReason === true,
     v3_singleFetch: appConfig.future?.v3_singleFetch === true,
     v3_lazyRouteDiscovery: appConfig.future?.v3_lazyRouteDiscovery === true,
+    v3_routeConfig: appConfig.future?.v3_routeConfig === true,
     unstable_optimizeDeps: appConfig.future?.unstable_optimizeDeps === true,
   };
 


### PR DESCRIPTION
Stacked on https://github.com/remix-run/remix/pull/10107.

This ensures that projects with an existing `app/routes.ts` file aren't broken. This also brings behaviour slightly closer to React Router v7 since a missing `routes.ts` file is now an error when the future flag is enabled.