### PR TITLE
templates: fix `fontFamily` in `tailwind.config.ts`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -628,6 +628,7 @@
 - sobrinho
 - souredoutlook
 - squidpunch
+- staticWagomU
 - staylor
 - stephanerangaya
 - stephenwade

--- a/templates/cloudflare-workers/tailwind.config.ts
+++ b/templates/cloudflare-workers/tailwind.config.ts
@@ -6,14 +6,14 @@ export default {
     extend: {
       fontFamily: {
         sans: [
-          '"Inter"',
+          "Inter",
           "ui-sans-serif",
           "system-ui",
           "sans-serif",
-          '"Apple Color Emoji"',
-          '"Segoe UI Emoji"',
-          '"Segoe UI Symbol"',
-          '"Noto Color Emoji"',
+          "Apple Color Emoji",
+          "Segoe UI Emoji",
+          "Segoe UI Symbol",
+          "Noto Color Emoji",
         ],
       },
     },

--- a/templates/cloudflare/tailwind.config.ts
+++ b/templates/cloudflare/tailwind.config.ts
@@ -6,14 +6,14 @@ export default {
     extend: {
       fontFamily: {
         sans: [
-          '"Inter"',
+          "Inter",
           "ui-sans-serif",
           "system-ui",
           "sans-serif",
-          '"Apple Color Emoji"',
-          '"Segoe UI Emoji"',
-          '"Segoe UI Symbol"',
-          '"Noto Color Emoji"',
+          "Apple Color Emoji",
+          "Segoe UI Emoji",
+          "Segoe UI Symbol",
+          "Noto Color Emoji",
         ],
       },
     },

--- a/templates/express/tailwind.config.ts
+++ b/templates/express/tailwind.config.ts
@@ -6,14 +6,14 @@ export default {
     extend: {
       fontFamily: {
         sans: [
-          '"Inter"',
+          "Inter",
           "ui-sans-serif",
           "system-ui",
           "sans-serif",
-          '"Apple Color Emoji"',
-          '"Segoe UI Emoji"',
-          '"Segoe UI Symbol"',
-          '"Noto Color Emoji"',
+          "Apple Color Emoji",
+          "Segoe UI Emoji",
+          "Segoe UI Symbol",
+          "Noto Color Emoji",
         ],
       },
     },

--- a/templates/remix-javascript/tailwind.config.js
+++ b/templates/remix-javascript/tailwind.config.js
@@ -4,14 +4,14 @@ export default {
     extend: {
       fontFamily: {
         sans: [
-          '"Inter"',
+          "Inter",
           "ui-sans-serif",
           "system-ui",
           "sans-serif",
-          '"Apple Color Emoji"',
-          '"Segoe UI Emoji"',
-          '"Segoe UI Symbol"',
-          '"Noto Color Emoji"',
+          "Apple Color Emoji",
+          "Segoe UI Emoji",
+          "Segoe UI Symbol",
+          "Noto Color Emoji",
         ],
       },
     },

--- a/templates/remix/tailwind.config.ts
+++ b/templates/remix/tailwind.config.ts
@@ -6,14 +6,14 @@ export default {
     extend: {
       fontFamily: {
         sans: [
-          '"Inter"',
+          "Inter",
           "ui-sans-serif",
           "system-ui",
           "sans-serif",
-          '"Apple Color Emoji"',
-          '"Segoe UI Emoji"',
-          '"Segoe UI Symbol"',
-          '"Noto Color Emoji"',
+          "Apple Color Emoji",
+          "Segoe UI Emoji",
+          "Segoe UI Symbol",
+          "Noto Color Emoji",
         ],
       },
     },

--- a/templates/spa/tailwind.config.ts
+++ b/templates/spa/tailwind.config.ts
@@ -6,14 +6,14 @@ export default {
     extend: {
       fontFamily: {
         sans: [
-          '"Inter"',
+          "Inter",
           "ui-sans-serif",
           "system-ui",
           "sans-serif",
-          '"Apple Color Emoji"',
-          '"Segoe UI Emoji"',
-          '"Segoe UI Symbol"',
-          '"Noto Color Emoji"',
+          "Apple Color Emoji",
+          "Segoe UI Emoji",
+          "Segoe UI Symbol",
+          "Noto Color Emoji",
         ],
       },
     },


### PR DESCRIPTION
Removed unnecessary quotes around font names in the `fontFamily.sans` array of the Tailwind CSS configuration file for improved readability and consistency.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

Closes: #

- [ ] Docs
- [ ] Tests

Testing Strategy:

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->

This is the first time I am contributing to remix. I would appreciate it if you could let me know if I need to add any tests.
