### PR TITLE
docs(hooks/use-view-transition-state): fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -631,6 +631,7 @@
 - staylor
 - stephanerangaya
 - stephenwade
+- strackfeldt
 - SufianBabri
 - supachaidev
 - syeef

--- a/docs/hooks/use-view-transition-state.md
+++ b/docs/hooks/use-view-transition-state.md
@@ -12,7 +12,7 @@ Consider clicking on an image in a list that you need to expand into the hero im
 ```jsx
 function NavImage({ src, alt, id }) {
   const to = `/images/${idx}`;
-  const vt = useViewTransitionState(href);
+  const vt = useViewTransitionState(to);
   return (
     <Link to={to} viewTransition>
       <img


### PR DESCRIPTION
href is not defined, you should be to
