### PR TITLE
fix(remix-dev): mark `routes.ts` support unstable

### DIFF
--- a/.changeset/popular-humans-attend.md
+++ b/.changeset/popular-humans-attend.md
@@ -2,18 +2,18 @@
 "@remix-run/dev": minor
 ---
 
-Add support for `routes.ts` behind `future.v3_routeConfig` flag to assist with the migration to React Router v7.
+Add support for `routes.ts` behind `future.unstable_routeConfig` flag to assist with the migration to React Router v7.
 
 Config-based routing is the new default in React Router v7, configured via the `routes.ts` file in the app directory. Support for `routes.ts` and its related APIs in Remix are designed as a migration path to help minimize the number of changes required when moving your Remix project over to React Router v7. While some new packages have been introduced within the `@remix-run` scope, these new packages only exist to keep the code in `routes.ts` as similar as possible to the equivalent code for React Router v7.
 
-When the `v3_routeConfig` future flag is enabled, Remix's built-in file system routing will be disabled and your project will opted into React Router v7's config-based routing.
+When the `unstable_routeConfig` future flag is enabled, Remix's built-in file system routing will be disabled and your project will opted into React Router v7's config-based routing.
 
 To enable the flag, in your `vite.config.ts` file:
 
 ```ts
 remix({
   future: {
-    v3_routeConfig: true,
+    unstable_routeConfig: true,
   },
 });
 ```

--- a/docs/start/future-flags.md
+++ b/docs/start/future-flags.md
@@ -472,11 +472,11 @@ You shouldn't need to make any changes to your application code for this feature
 
 You may find some usage for the new [`<Link discover>`][discover-prop] API if you wish to disable eager route discovery on certain links.
 
-## v3_routeConfig
+## unstable_routeConfig
 
 Config-based routing is the new default in React Router v7, configured via the `routes.ts` file in the app directory. Support for `routes.ts` and its related APIs in Remix are designed as a migration path to help minimize the number of changes required when moving your Remix project over to React Router v7. While some new packages have been introduced within the `@remix-run` scope, these new packages only exist to keep the code in `routes.ts` as similar as possible to the equivalent code for React Router v7.
 
-When the `v3_routeConfig` future flag is enabled, Remix's built-in file system routing will be disabled and your project will opted into React Router v7's config-based routing. To opt back in to file system routing, this can be explicitly configured within `routes.ts` as we'll cover below.
+When the `unstable_routeConfig` future flag is enabled, Remix's built-in file system routing will be disabled and your project will opted into React Router v7's config-based routing. To opt back in to file system routing, this can be explicitly configured within `routes.ts` as we'll cover below.
 
 **Update your code**
 
@@ -487,7 +487,7 @@ To migrate Remix's file system routing and route config to the equivalent setup 
 ```ts filename=vite.config.ts
 remix({
   future: {
-    v3_routeConfig: true,
+    unstable_routeConfig: true,
   },
 });
 ```

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -43,7 +43,7 @@ export const viteConfig = {
       export default {
         ${await viteConfig.server(args)}
         plugins: [remix(${
-          args.routeConfig ? "{ future: { v3_routeConfig: true } }" : ""
+          args.routeConfig ? "{ future: { unstable_routeConfig: true } }" : ""
         })]
       }
     `;

--- a/integration/vite-fs-routes-test.ts
+++ b/integration/vite-fs-routes-test.ts
@@ -24,7 +24,7 @@ test.describe("fs-routes", () => {
 
           export default defineConfig({
             plugins: [remix({
-              future: { v3_routeConfig: true },
+              future: { unstable_routeConfig: true },
             })],
           });
         `,
@@ -257,7 +257,7 @@ test.describe("emits warnings for route conflicts", async () => {
 
           export default defineConfig({
             plugins: [remix({
-              future: { v3_routeConfig: true },
+              future: { unstable_routeConfig: true },
             })],
           });
         `,
@@ -331,7 +331,7 @@ test.describe("", () => {
 
           export default defineConfig({
             plugins: [remix({
-              future: { v3_routeConfig: true },
+              future: { unstable_routeConfig: true },
             })],
           });
         `,
@@ -380,7 +380,7 @@ test.describe("pathless routes and route collisions", () => {
 
           export default defineConfig({
             plugins: [remix({
-              future: { v3_routeConfig: true },
+              future: { unstable_routeConfig: true },
             })],
           });
         `,

--- a/integration/vite-route-config-test.ts
+++ b/integration/vite-route-config-test.ts
@@ -43,7 +43,7 @@ test.describe("route config", () => {
 
         export default {
           plugins: [remix({
-            future: { v3_routeConfig: true },
+            future: { unstable_routeConfig: true },
           })]
         }
       `,
@@ -64,7 +64,7 @@ test.describe("route config", () => {
 
         export default {
           plugins: [remix({
-            future: { v3_routeConfig: true },
+            future: { unstable_routeConfig: true },
             routes: () => {},
           })]
         }
@@ -88,7 +88,7 @@ test.describe("route config", () => {
         export default {
           ${await viteConfig.server({ port })}
           plugins: [remix({
-            future: { v3_routeConfig: true },
+            future: { unstable_routeConfig: true },
             routes: () => {},
           })]
         }
@@ -113,7 +113,7 @@ test.describe("route config", () => {
 
         export default {
           plugins: [remix({
-            future: { v3_routeConfig: true },
+            future: { unstable_routeConfig: true },
           })]
         }
       `,

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -37,10 +37,10 @@ describe("readConfig", () => {
         "entryServerFilePath": Any<String>,
         "future": {
           "unstable_optimizeDeps": false,
+          "unstable_routeConfig": false,
           "v3_fetcherPersist": false,
           "v3_lazyRouteDiscovery": false,
           "v3_relativeSplatPath": false,
-          "unstable_routeConfig": false,
           "v3_singleFetch": false,
           "v3_throwAbortReason": false,
         },

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -40,7 +40,7 @@ describe("readConfig", () => {
           "v3_fetcherPersist": false,
           "v3_lazyRouteDiscovery": false,
           "v3_relativeSplatPath": false,
-          "v3_routeConfig": false,
+          "unstable_routeConfig": false,
           "v3_singleFetch": false,
           "v3_throwAbortReason": false,
         },

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -50,8 +50,8 @@ interface FutureConfig {
   v3_throwAbortReason: boolean;
   v3_singleFetch: boolean;
   v3_lazyRouteDiscovery: boolean;
-  unstable_routeConfig: boolean;
   unstable_optimizeDeps: boolean;
+  unstable_routeConfig: boolean;
 }
 
 type NodeBuiltinsPolyfillOptions = Pick<
@@ -721,8 +721,8 @@ export async function resolveConfig(
     v3_throwAbortReason: appConfig.future?.v3_throwAbortReason === true,
     v3_singleFetch: appConfig.future?.v3_singleFetch === true,
     v3_lazyRouteDiscovery: appConfig.future?.v3_lazyRouteDiscovery === true,
-    unstable_routeConfig: appConfig.future?.unstable_routeConfig === true,
     unstable_optimizeDeps: appConfig.future?.unstable_optimizeDeps === true,
+    unstable_routeConfig: appConfig.future?.unstable_routeConfig === true,
   };
 
   if (appConfig.future) {

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -50,7 +50,7 @@ interface FutureConfig {
   v3_throwAbortReason: boolean;
   v3_singleFetch: boolean;
   v3_lazyRouteDiscovery: boolean;
-  v3_routeConfig: boolean;
+  unstable_routeConfig: boolean;
   unstable_optimizeDeps: boolean;
 }
 
@@ -579,7 +579,7 @@ export async function resolveConfig(
     root: { path: "", id: "root", file: rootRouteFile },
   };
 
-  if (appConfig.future?.v3_routeConfig) {
+  if (appConfig.future?.unstable_routeConfig) {
     invariant(routesViteNodeContext);
     invariant(vite);
 
@@ -721,7 +721,7 @@ export async function resolveConfig(
     v3_throwAbortReason: appConfig.future?.v3_throwAbortReason === true,
     v3_singleFetch: appConfig.future?.v3_singleFetch === true,
     v3_lazyRouteDiscovery: appConfig.future?.v3_lazyRouteDiscovery === true,
-    v3_routeConfig: appConfig.future?.v3_routeConfig === true,
+    unstable_routeConfig: appConfig.future?.unstable_routeConfig === true,
     unstable_optimizeDeps: appConfig.future?.unstable_optimizeDeps === true,
   };
 


### PR DESCRIPTION
Until React Router v7 is released and we know the API is stable, we're opting to mark `routes.ts` support as unstable.