### PR TITLE
chore(server-runtime): update `cookie`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -371,6 +371,7 @@
 - kiyadotdev
 - klauspaiva
 - klirium
+- knisterpeter
 - knowler
 - konradkalemba
 - krolebord

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -22,7 +22,7 @@
     "@remix-run/router": "1.21.0-pre.0",
     "@types/cookie": "^0.6.0",
     "@web3-storage/multipart-parser": "^1.0.0",
-    "cookie": "^0.6.0",
+    "cookie": "^0.7.0",
     "set-cookie-parser": "^2.4.8",
     "source-map": "^0.7.3",
     "turbo-stream": "2.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1373,8 +1373,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       cookie:
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.0
+        version: 0.7.2
       set-cookie-parser:
         specifier: ^2.4.8
         version: 2.6.0
@@ -6672,6 +6672,11 @@ packages:
   /cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
+
+  /cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+    dev: false
 
   /cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}


### PR DESCRIPTION
The version 0.6.0 of the `cookie` package has a security flaw described here (https://github.com/jshttp/cookie/pull/167).

This PR does update the library to the closest fixed version.

Closes #10077