### PR TITLE
gotchas.md: remove typeof window gotcha

### DIFF
--- a/docs/guides/gotchas.md
+++ b/docs/guides/gotchas.md
@@ -8,30 +8,6 @@ Rendering your app on the server and in the browser with React has some inherent
 
 This document should help you get over these bumps.
 
-## `typeof window` checks
-
-Because the same JavaScript code can run in the browser as well as the server, sometimes you need to have a part of your code that only runs in one context or the other:
-
-```ts bad
-if (typeof window === "undefined") {
-  // running in a server environment
-} else {
-  // running in a browser environment
-}
-```
-
-This works fine in a Node.js environment, however, Deno actually supports `window`! So if you really want to check whether you're running in the browser, it's better to check for `document` instead:
-
-```ts good
-if (typeof document === "undefined") {
-  // running in a server environment
-} else {
-  // running in a browser environment
-}
-```
-
-This will work for all JS environments (Node.js, Deno, Workers, etc.).
-
 ## Browser extensions injecting code
 
 You may run into this warning in the browser:


### PR DESCRIPTION
Deno since version 2 has erased the `window` global.

https://deno.com/blog/v2.0-release-candidate#changes-to-global-variables