### PR TITLE
Stabilize `future.v3_routeConfig`

### DIFF
--- a/.changeset/sour-years-cover.md
+++ b/.changeset/sour-years-cover.md
@@ -2,7 +2,9 @@
 "@remix-run/dev": patch
 ---
 
-When the `future.unstable_routeConfig` flag is enabled, your route config in `app/routes.ts` is no longer defined via the `routes` export and must now be defined via the default export.
+Stabilize the `future.v3_routeConfig` future flag, replacing `future.unstable_routeConfig`. This enables support for `routes.ts` to assist with the migration to React Router v7.
+
+Note that if you had already enabled the `future.unstable_routeConfig` flag, your route config in `app/routes.ts` is no longer defined via the `routes` export and must now be defined via the default export.
 
 ```diff
 import { type RouteConfig } from "@remix-run/route-config";

--- a/docs/start/future-flags.md
+++ b/docs/start/future-flags.md
@@ -472,11 +472,11 @@ You shouldn't need to make any changes to your application code for this feature
 
 You may find some usage for the new [`<Link discover>`][discover-prop] API if you wish to disable eager route discovery on certain links.
 
-## unstable_routeConfig
+## v3_routeConfig
 
 Config-based routing is the new default in React Router v7, configured via the `routes.ts` file in the app directory. Support for `routes.ts` and its related APIs in Remix are designed as a migration path to help minimize the number of changes required when moving your Remix project over to React Router v7. While some new packages have been introduced within the `@remix-run` scope, these new packages only exist to keep the code in `routes.ts` as similar as possible to the equivalent code for React Router v7.
 
-When the `unstable_routeConfig` future flag is enabled, Remix's built-in file system routing will be disabled and your project will opted into React Router v7's config-based routing. To opt back in to file system routing, this can be explicitly configured within `routes.ts` as we'll cover below.
+When the `v3_routeConfig` future flag is enabled, Remix's built-in file system routing will be disabled and your project will opted into React Router v7's config-based routing. To opt back in to file system routing, this can be explicitly configured within `routes.ts` as we'll cover below.
 
 **Update your code**
 
@@ -487,7 +487,7 @@ To migrate Remix's file system routing and route config to the equivalent setup 
 ```ts filename=vite.config.ts
 remix({
   future: {
-    unstable_routeConfig: true,
+    v3_routeConfig: true,
   },
 });
 ```
@@ -604,7 +604,7 @@ Note that if you need to mix and match different route config approaches, they c
 
 ```ts
 import { flatRoutes } from "@remix-run/fs-routes";
-import type { RouteConfig } from "@remix-run/route-config";
+import { type RouteConfig } from "@remix-run/route-config";
 import { route } from "@remix-run/route-config";
 import { remixRoutesOptionAdapter } from "@remix-run/routes-option-adapter";
 

--- a/docs/start/future-flags.md
+++ b/docs/start/future-flags.md
@@ -604,7 +604,7 @@ Note that if you need to mix and match different route config approaches, they c
 
 ```ts
 import { flatRoutes } from "@remix-run/fs-routes";
-import { type RouteConfig } from "@remix-run/route-config";
+import type { RouteConfig } from "@remix-run/route-config";
 import { route } from "@remix-run/route-config";
 import { remixRoutesOptionAdapter } from "@remix-run/routes-option-adapter";
 

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -43,7 +43,7 @@ export const viteConfig = {
       export default {
         ${await viteConfig.server(args)}
         plugins: [remix(${
-          args.routeConfig ? "{ future: { unstable_routeConfig: true } }" : ""
+          args.routeConfig ? "{ future: { v3_routeConfig: true } }" : ""
         })]
       }
     `;

--- a/integration/vite-fs-routes-test.ts
+++ b/integration/vite-fs-routes-test.ts
@@ -24,7 +24,7 @@ test.describe("fs-routes", () => {
 
           export default defineConfig({
             plugins: [remix({
-              future: { unstable_routeConfig: true },
+              future: { v3_routeConfig: true },
             })],
           });
         `,
@@ -257,7 +257,7 @@ test.describe("emits warnings for route conflicts", async () => {
 
           export default defineConfig({
             plugins: [remix({
-              future: { unstable_routeConfig: true },
+              future: { v3_routeConfig: true },
             })],
           });
         `,
@@ -331,7 +331,7 @@ test.describe("", () => {
 
           export default defineConfig({
             plugins: [remix({
-              future: { unstable_routeConfig: true },
+              future: { v3_routeConfig: true },
             })],
           });
         `,
@@ -380,7 +380,7 @@ test.describe("pathless routes and route collisions", () => {
 
           export default defineConfig({
             plugins: [remix({
-              future: { unstable_routeConfig: true },
+              future: { v3_routeConfig: true },
             })],
           });
         `,

--- a/integration/vite-route-config-test.ts
+++ b/integration/vite-route-config-test.ts
@@ -43,7 +43,7 @@ test.describe("route config", () => {
 
         export default {
           plugins: [remix({
-            future: { unstable_routeConfig: true },
+            future: { v3_routeConfig: true },
           })]
         }
       `,
@@ -64,7 +64,7 @@ test.describe("route config", () => {
 
         export default {
           plugins: [remix({
-            future: { unstable_routeConfig: true },
+            future: { v3_routeConfig: true },
             routes: () => {},
           })]
         }
@@ -88,7 +88,7 @@ test.describe("route config", () => {
         export default {
           ${await viteConfig.server({ port })}
           plugins: [remix({
-            future: { unstable_routeConfig: true },
+            future: { v3_routeConfig: true },
             routes: () => {},
           })]
         }
@@ -113,7 +113,7 @@ test.describe("route config", () => {
 
         export default {
           plugins: [remix({
-            future: { unstable_routeConfig: true },
+            future: { v3_routeConfig: true },
           })]
         }
       `,

--- a/packages/remix-dev/__tests__/readConfig-test.ts
+++ b/packages/remix-dev/__tests__/readConfig-test.ts
@@ -37,10 +37,10 @@ describe("readConfig", () => {
         "entryServerFilePath": Any<String>,
         "future": {
           "unstable_optimizeDeps": false,
-          "unstable_routeConfig": false,
           "v3_fetcherPersist": false,
           "v3_lazyRouteDiscovery": false,
           "v3_relativeSplatPath": false,
+          "v3_routeConfig": false,
           "v3_singleFetch": false,
           "v3_throwAbortReason": false,
         },

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -48,10 +48,10 @@ interface FutureConfig {
   v3_fetcherPersist: boolean;
   v3_relativeSplatPath: boolean;
   v3_throwAbortReason: boolean;
+  v3_routeConfig: boolean;
   v3_singleFetch: boolean;
   v3_lazyRouteDiscovery: boolean;
   unstable_optimizeDeps: boolean;
-  unstable_routeConfig: boolean;
 }
 
 type NodeBuiltinsPolyfillOptions = Pick<
@@ -579,7 +579,7 @@ export async function resolveConfig(
     root: { path: "", id: "root", file: rootRouteFile },
   };
 
-  if (appConfig.future?.unstable_routeConfig) {
+  if (appConfig.future?.v3_routeConfig) {
     invariant(routesViteNodeContext);
     invariant(vite);
 
@@ -719,10 +719,10 @@ export async function resolveConfig(
     v3_fetcherPersist: appConfig.future?.v3_fetcherPersist === true,
     v3_relativeSplatPath: appConfig.future?.v3_relativeSplatPath === true,
     v3_throwAbortReason: appConfig.future?.v3_throwAbortReason === true,
+    v3_routeConfig: appConfig.future?.v3_routeConfig === true,
     v3_singleFetch: appConfig.future?.v3_singleFetch === true,
     v3_lazyRouteDiscovery: appConfig.future?.v3_lazyRouteDiscovery === true,
     unstable_optimizeDeps: appConfig.future?.unstable_optimizeDeps === true,
-    unstable_routeConfig: appConfig.future?.unstable_routeConfig === true,
   };
 
   if (appConfig.future) {
@@ -732,6 +732,7 @@ export async function resolveConfig(
       "unstable_cssSideEffectImports",
       "unstable_dev",
       "unstable_postcss",
+      "unstable_routeConfig",
       "unstable_tailwind",
       "unstable_vanillaExtract",
       "v2_errorBoundary",
@@ -740,6 +741,12 @@ export async function resolveConfig(
       "v2_normalizeFormMethod",
       "v2_routeConvention",
     ];
+
+    if ("unstable_routeConfig" in userFlags) {
+      logger.warn(
+        "The `unstable_routeConfig` future flag has been stabilized as `v3_routeConfig`."
+      );
+    }
 
     if ("v2_dev" in userFlags) {
       if (userFlags.v2_dev === true) {


### PR DESCRIPTION
To coincide with the release of React Router v7, this stabilizes the `routes.ts` future flag.