### PR TITLE
feat: support Vite 6 HMR

### DIFF
--- a/.changeset/cyan-bats-work.md
+++ b/.changeset/cyan-bats-work.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": minor
+---
+
+Add support for Vite 6 (hot update related parts)

--- a/contributors.yml
+++ b/contributors.yml
@@ -591,6 +591,7 @@
 - sambostock
 - sandstone991
 - sandulat
+- sapphi-red
 - sarahse
 - sathvik-k
 - sbernheim4


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->

In Vite v5 and below, Vite mixed the client modules and the SSR modules in a single module graph. This caused a unnecessary HMR when a file that only affects a single environment (e.g. editing a SSR only module triggered a HMR on the client side unconditionally).

In Vite v6, the module graphs are separated for each environment to give a way to remove that unnecessary HMR. But that means the frameworks now have to trigger HMR on their own when a module in a different environment is changed.

This PR implements that HMR triggering logic. It triggers the client HMR when the SSR module is changed like it was working in Vite 5. This code triggers unnecessary HMR as same as Vite v5, but at least makes remix work with Vite 6. I think that can be improved in a separate PR.

Testing Strategy: I ran `pnpm i && pnpm vite-ecosystem-ci:build && pnpm vite-ecosystem-ci:test` with both Vite 5.x and 6.x.
