### PR TITLE
fix(dev): optimizeDeps entries file path for vite

### DIFF
--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -1107,9 +1107,9 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
           optimizeDeps: {
             entries: ctx.remixConfig.future.unstable_optimizeDeps
               ? [
-                  ctx.entryClientFilePath,
+                  importViteEsmSync().normalizePath(ctx.entryClientFilePath),
                   ...Object.values(ctx.remixConfig.routes).map((route) =>
-                    path.join(ctx.remixConfig.appDirectory, route.file)
+                    resolveRelativeRouteFilePath(route, ctx.remixConfig)
                   ),
                 ]
               : [],


### PR DESCRIPTION
## Pull Request Description:

**Normalize Path for Vite Dependency Optimization on Windows**

This PR addresses an issue with Vite's dependency optimization on Windows systems where incorrect path formats can lead to constant dependency reloading and performance degradation.

**Problem:**
On Windows, paths often use backslashes (`\`) as separators, while Vite expects forward slashes (`/`). This mismatch can cause Vite to incorrectly identify and optimize dependencies.

**Example:**
- **Incorrect Path:** `C:\data\projects\remix\app\entry.client.tsx`
- **Correct Path:** `C:/data/projects/remix/app/entry.client.tsx`

**Solution:**
This PR normalizes the paths using `importViteEsmSync().normalizePath()` to ensure they are compatible with Vite's dependency optimization.

**Specific Changes:**

- **Normalized Entry Point:**
  ```javascript
  - ctx.entryClientFilePath
  + importViteEsmSync().normalizePath(ctx.entryClientFilePath)
  ```
- **Optimized Route File Paths:**
  ```javascript
  - path.join(ctx.remixConfig.appDirectory, route.file)
  + resolveRelativeRouteFilePath(route, ctx.remixConfig)
  ```

**Expected Benefits:**

- **Improved Build Performance:** Faster build times and smoother development experience.
- **Enhanced Stability:** Prevents unexpected dependency reloads and other related issues.

**Testing:**

Please thoroughly test this change on Windows systems to verify that the issue is resolved and there are no unintended side effects.

**Additional Considerations:**

- **Other Potential Path Issues:** Consider other areas where path normalization might be necessary.
- **Vite and Remix Versions:** This fix has been tested with Vite v5.4.11 and Remix v2.14.0.

**Please review and merge this PR if the changes are satisfactory.**
