### PR TITLE
docs(file-conventions/remix-config): Remove hidden metadata from front matter for remix-config

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -330,6 +330,7 @@
 - joshball
 - JoshuaKGoldberg
 - jplhomer
+- Jr-14
 - jrf0110
 - jrubins
 - jsbmg

--- a/docs/file-conventions/remix-config.md
+++ b/docs/file-conventions/remix-config.md
@@ -1,6 +1,5 @@
 ---
 title: remix.config.js
-hidden: true
 ---
 
 # remix.config.js


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

If this is a simple docs change, go ahead and delete all this.

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create a
[Feature Request discussion](https://github.com/remix-run/remix/discussions/new?category=ideas)
to first discuss any significant new features.

https://github.com/remix-run/remix/blob/main/CONTRIBUTING.md

Please fill in or delete each item below:

-->
I noticed that remix-config was missing in the sidebar on File conventions. The link is also hidden and tucked away in https://remix.run/docs/en/main/guides/migrating-react-router-app#configuration. I thought it'd be good to have remix config displayed in File conventions for easier access.

`remix.config.js` is missing in File Conventions
![image](https://github.com/user-attachments/assets/5b779093-56ee-4506-a207-b550df7a93ff)

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
