### PR TITLE
refactor: remove redundant '@remix-run/node/install' import

### DIFF
--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -1,4 +1,3 @@
-import "@remix-run/node/install";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";


### PR DESCRIPTION
`remix-serve` cli seems calling `installGlobals` function of `@remix-run/node` package twice. In my usage, it's called with 2 different `nativeFetch` flags and that seems causing unnecessary dependency (`@remix-run/web-fetch`) loaded on the server runtime.

This PR removes the first call of `installGlobals` (by removing import of `@remix-run/node/install`), and tries to avoid the above situation.