### PR TITLE
templates: update `CacheStorage` type reference

### DIFF
--- a/templates/cloudflare-workers/load-context.ts
+++ b/templates/cloudflare-workers/load-context.ts
@@ -1,3 +1,4 @@
+import { type CacheStorage } from "@cloudflare/workers-types";
 import { type PlatformProxy } from "wrangler";
 
 type GetLoadContextArgs = {

--- a/templates/cloudflare-workers/server.ts
+++ b/templates/cloudflare-workers/server.ts
@@ -1,3 +1,4 @@
+import { type CacheStorage } from "@cloudflare/workers-types";
 import { createRequestHandler, type ServerBuild } from "@remix-run/cloudflare";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore This file won’t exist if it hasn’t yet been built
@@ -6,6 +7,7 @@ import { getLoadContext } from "./load-context";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const handleRemixRequest = createRequestHandler(build as any as ServerBuild);
+declare const caches: CacheStorage;
 
 export default {
   async fetch(request, env, ctx) {


### PR DESCRIPTION
## Problem

The type of caches references `CacheStorage` from `lib.dom.d.ts`, but this is incompatible with the actual implementation on the Cloudflare network.
The first one is from `lib.dom.d.ts`, and the other is from `@cloudflare/workers-types`.

<img src="https://github.com/user-attachments/assets/a614bde3-114d-40d5-b3ef-a8badce57ec0" width=400 />
<img src="https://github.com/user-attachments/assets/a1c6fd00-e06b-419a-a828-36fc2eef5b2e" width=400 />

This is because "DOM" is specified as the `lib` in `tsconfig.json`, which is correct in itself, but some adjustments are needed.

## Solution
I think there are two approaches. [[Source for the fix]](https://blog.cloudflare.com/improving-workers-types/)

First, import and declare `CacheStorage` type from `@cloudflare/workers-types` in the file where caches is defined.

Second, separate the `tsconfig.json` for `server.ts` and the `app` folder. While this approach allows for more accurate types, it makes the project more complicated.
```
.
├── tsconfig.app.json
├── tsconfig.cloudflare.json
└── tsconfig.json

// tsconfig.app.json
{
 "include": ["app"],
}
// tsconfig.cloudflare.json
{
 "include": ["server.ts"],
 "compilerOptions": {
    "target": "esnext",
    "module": "esnext",
    "lib": ["esnext"],
    "types": ["@cloudflare/workers-types"]
  }
}
// tsconfig.json
{
 "files": [],
  "references": [
    { "path": "./tsconfig.app.json" },
    { "path": "./tsconfig.cloudflare.json" }
  ]
}
```

If you handle the server outside of Remix (e.g. Remix + Hono), the second approach is better. However, the first approach works well in most cases.