### PR TITLE
Throw single fetch redirects fetched from the server

### DIFF
--- a/.changeset/unlucky-melons-promise.md
+++ b/.changeset/unlucky-melons-promise.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Throw unwrapped single fetch redirect to align with pre-single fetch behavior

--- a/packages/remix-react/single-fetch.tsx
+++ b/packages/remix-react/single-fetch.tsx
@@ -491,7 +491,7 @@ function unwrapSingleFetchResult(result: SingleFetchResult, routeId: string) {
     if (result.replace) {
       headers["X-Remix-Replace"] = "yes";
     }
-    return redirect(result.redirect, { status: result.status, headers });
+    throw redirect(result.redirect, { status: result.status, headers });
   } else if ("data" in result) {
     return result.data;
   } else {


### PR DESCRIPTION
Align the logic with [non-Single Fetch](https://github.com/remix-run/remix/blob/main/packages/remix-react/routes.tsx#L588) to always throw redirects from the client loader so short circuit any further processing and avoid type inference mismatches

Closes #10208