### PR TITLE
Fix RouteHandle type augmentation

### DIFF
--- a/docs/route/handle.md
+++ b/docs/route/handle.md
@@ -7,9 +7,26 @@ title: handle
 Exporting a handle allows you to create application conventions with the [`useMatches`][use-matches] hook. You can put whatever values you want on it:
 
 ```tsx
-export const handle = {
-  its: "all yours",
+import {RouteHandle} from '@remix-run/react/dist/routeModules'
+
+export const handle: RouteHandle = {
+  pageType: "Home",
+  i18n: "en"
 };
+```
+
+You can augment `RouteHandle` with your own app's object shape:
+
+```ts
+// remix.d.ts
+
+declare module '@remix-run/react/dist/routeModules' {
+  interface RouteHandle {
+    pageType: string
+    subscriptionRequired?: boolean
+    i18n?: string
+  }
+}
 ```
 
 This is almost always used in conjunction with `useMatches`. To see what kinds of things you can do with it, refer to [`useMatches`][use-matches] for more information.

--- a/packages/remix-react/routeModules.ts
+++ b/packages/remix-react/routeModules.ts
@@ -175,7 +175,7 @@ export type RouteComponent = ComponentType<{}>;
  *
  * @see https://remix.run/route/handle
  */
-export type RouteHandle = unknown;
+export interface RouteHandle {}
 
 export async function loadRouteModule(
   route: EntryRoute,

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -246,8 +246,10 @@ type LdJsonValue = LdJsonPrimitive | LdJsonObject | LdJsonArray;
 
 /**
  * An arbitrary object that is associated with a route.
+ *
+ * @see https://remix.run/route/handle
  */
-export type RouteHandle = unknown;
+export interface RouteHandle {}
 
 export interface EntryRouteModule {
   clientAction?: ClientActionFunction;


### PR DESCRIPTION
Updates `RouteHandle` from a type to an interface to support property augmentation in TypeScript 5.5+. 

`RouteHandle` was declared as a type instead of an interface, which leads to projects using TypeScript 5.5+ to not allow the object to be augmented with an app's custom properties. Replace type with interface and update docs.

This issue was a result of TypeScript 5.5 fixing a bug, see https://github.com/microsoft/TypeScript/issues/58961. In previous versions, the bug allowed interfaces to override types and override their properties.

Example:
```tsx
// remix.d.ts
declare module '@remix-run/react/dist/routeModules' {
  export interface RouteHandle { // "Duplicate identifier" ts error when RouteHandle is `type`
    pageType: string
    subscriptionRequired?: boolean
    i18n?: string
  }
}
```

- [x] Docs
- [ ] ~~Tests~~

<!--
Please explain how you tested this. For example:

> This test covers this code: <link to test>

Or

> I opened up my windows machine and ran this script:
>
> ```
> npx create-remix@0.0.0-experimental-7e420ee3 my-test
> cd my-test
> npm run dev
> ```
-->
