### PR TITLE
Update create-remix.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -548,6 +548,7 @@
 - pmbanugo
 - Pouet--
 - prasook-jain
+- pratham15541
 - pratikdevdas
 - princerajroy
 - prvnbist

--- a/docs/other-api/create-remix.md
+++ b/docs/other-api/create-remix.md
@@ -41,7 +41,7 @@ yarn create remix@latest <projectDir>
 # or
 pnpm create remix@latest <projectDir>
 # or
-bunx create-remix@latest <projectDir>
+bunx create remix@latest <projectDir>
 ```
 
 ### `create-remix --template`


### PR DESCRIPTION
Fix: Correct Remix app creation command by removing unnecessary hyphen

The command `bunx create-remix@latest` failed due to an incorrect hyphen. Replaced it with `bunx create remix@latest` to successfully create the Remix app.

By using  `bunx create-remix@latest` command it throws error `Scripts not found`

