### PR TITLE
Do not cache user public files as immutable

### DIFF
--- a/.changeset/fast-bottles-repeat.md
+++ b/.changeset/fast-bottles-repeat.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/serve": patch
+---
+
+Do not make user files in public folder cache as immutable, recude cache max age to 1 hour

--- a/.changeset/fast-bottles-repeat.md
+++ b/.changeset/fast-bottles-repeat.md
@@ -2,4 +2,4 @@
 "@remix-run/serve": patch
 ---
 
-Do not make user files in public folder cache as immutable, recude cache max age to 1 hour
+Do not cache user files in public folder as immutable, reduce cache max age to 1 hour

--- a/contributors.yml
+++ b/contributors.yml
@@ -729,3 +729,4 @@
 - zayenz
 - zhe
 - zwhitchcox
+- remorses

--- a/packages/remix-serve/cli.ts
+++ b/packages/remix-serve/cli.ts
@@ -126,10 +126,16 @@ async function run() {
   app.disable("x-powered-by");
   app.use(compression());
   app.use(
-    build.publicPath,
-    express.static(build.assetsBuildDirectory, {
+    path.posix.join(build.publicPath, "./assets"),
+    express.static(path.posix.join(build.assetsBuildDirectory, "./assets"), {
       immutable: true,
       maxAge: "1y",
+    })
+  );
+  app.use(
+    build.publicPath,
+    express.static(build.assetsBuildDirectory, {
+      maxAge: "1h",
     })
   );
   app.use(express.static("public", { maxAge: "1h" }));


### PR DESCRIPTION
The Remix `build.assetsBuildDirectory` is `build/client`, this folder contains user public files. The serve code is caching these files as immutable which means that even if the user changes the content of a file but not the name the file it will not be revalidated. 

This PR makes immutable only files generated by Remix, which contain an hash in the name. Files in `public` will be cached only for 1 hour instead.

Fix https://github.com/remix-run/remix/issues/9353

