### PR TITLE
templates(remix-tutorial): Add artificial delay to contact retrieval for demonstration

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -361,6 +361,7 @@
 - kauffmanes
 - kayac-chang
 - kbariotis
+- kei-yamazaki
 - KenanYusuf
 - kentcdodds
 - kevinrambaud

--- a/templates/remix-tutorial/app/data.ts
+++ b/templates/remix-tutorial/app/data.ts
@@ -79,6 +79,7 @@ export async function createEmptyContact() {
 }
 
 export async function getContact(id: string) {
+  await new Promise((resolve) => setTimeout(resolve, 500));
   return fakeContacts.get(id);
 }
 


### PR DESCRIPTION
Add Loading Delay to Contact Fetch Operation

Closes: # (no specific issue to close)

[x] Tests
[ ] Docs

## Changes Made
Added a 500ms artificial delay to the `getContact` function to simulate network latency in the contact fetching operation. This change helps to demonstrate loading states in the UI more effectively during the tutorial.

## Testing Strategy
This change can be tested by:
1. Running the tutorial application
2. Navigating to a contact's details page
3. Verifying that there is a noticeable 500ms delay before the contact information appears
4. Confirming that the loading state is properly displayed during this delay

The delay is implemented using a Promise-based setTimeout, which is a common pattern for simulating network conditions in demo applications.

## Impact
This is a minor change that only affects the tutorial example and does not impact any core functionality. The delay is small enough to maintain a good user experience while being long enough to demonstrate loading states effectively.