### PR TITLE
docs: update hydration mismatch link to React 18+ documentation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -480,6 +480,7 @@
 - mjackson
 - mjangir
 - mkrtchian
+- mlane
 - mochi-sann
 - mohammadhosseinbagheri
 - monitaure

--- a/docs/guides/migrating-react-router-app.md
+++ b/docs/guides/migrating-react-router-app.md
@@ -699,7 +699,7 @@ Now then, go off and _remix your app_. We think you'll like what you build along
 [a-few-tweaks-to-improve-progressive-enhancement]: ../pages/philosophy#progressive-enhancement
 [routing-conventions]: ./routing
 [a-catch-all-route]: ../file-conventions/routes#splat-routes
-[hydration-mismatch]: https://reactjs.org/docs/react-dom.html#hydrate
+[hydration-mismatch]: https://react.dev/reference/react-dom/client/hydrateRoot
 [loader-data]: ../route/loader
 [client-only-component]: https://github.com/sergiodxa/remix-utils/blob/main/src/react/client-only.tsx
 [remix-utils]: https://www.npmjs.com/package/remix-utils


### PR DESCRIPTION
## 🔗 docs: update hydration mismatch link to React 18+ documentation

### Description
This PR updates the hydration mismatch reference in the Remix documentation, replacing the outdated link to the **legacy React docs** (`legacy.reactjs.org`) with the correct **React 18+ documentation** (`react.dev/reference/react-dom/client/hydrateRoot`).

### Why?
- The old link points to deprecated React docs.
- React 18+ introduced `hydrateRoot`, which is the recommended approach for hydration.
- The new link provides up-to-date guidance on handling hydration in modern React applications.

### Changes
- **Updated link:** `legacy.reactjs.org/docs/react-dom.html#hydrate` → `react.dev/reference/react-dom/client/hydrateRoot`

This ensures Remix users get the most accurate and relevant information when handling hydration mismatches. 🚀
