### PR TITLE
Don't apply single fetch revalidation de-optimization in SPA Mode

### DIFF
--- a/.changeset/clean-kangaroos-juggle.md
+++ b/.changeset/clean-kangaroos-juggle.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Don't apply Single Fetch revalidation de-optimization when in SPA mode since there is no server HTTP request

--- a/packages/remix-react/browser.tsx
+++ b/packages/remix-react/browser.tsx
@@ -303,13 +303,15 @@ export function RemixBrowser(_props: RemixBrowserProps): ReactElement {
       },
       hydrationData,
       mapRouteProperties,
-      dataStrategy: window.__remixContext.future.v3_singleFetch
-        ? getSingleFetchDataStrategy(
-            window.__remixManifest,
-            window.__remixRouteModules,
-            () => router
-          )
-        : undefined,
+      dataStrategy:
+        window.__remixContext.future.v3_singleFetch &&
+        !window.__remixContext.isSpaMode
+          ? getSingleFetchDataStrategy(
+              window.__remixManifest,
+              window.__remixRouteModules,
+              () => router
+            )
+          : undefined,
       patchRoutesOnNavigation: getPatchRoutesOnNavigationFunction(
         window.__remixManifest,
         window.__remixRouteModules,


### PR DESCRIPTION
Closes https://github.com/remix-run/react-router/issues/12740 for Remix v2 to ease single fetch flag  adoption