### PR TITLE
apply react-router/pull/13061 to address __manifest version mismatches

### DIFF
--- a/.changeset/spicy-knives-impress.md
+++ b/.changeset/spicy-knives-impress.md
@@ -1,0 +1,6 @@
+---
+"@remix-run/react": patch
+"@remix-run/server-runtime": patch
+---
+
+Detect manifest version mismatches after new deploys and trigger hard reloads on subsequent navigations in active sessions

--- a/packages/remix-react/fog-of-war.ts
+++ b/packages/remix-react/fog-of-war.ts
@@ -80,6 +80,7 @@ export function getPatchRoutesOnNavigationFunction(
     }
     await fetchAndApplyManifestPatches(
       [path],
+      true,
       manifest,
       routeModules,
       future,
@@ -139,6 +140,7 @@ export function useFogOFWarDiscovery(
       try {
         await fetchAndApplyManifestPatches(
           lazyPaths,
+          false,
           manifest,
           routeModules,
           future,
@@ -203,6 +205,7 @@ export function useFogOFWarDiscovery(
 
 export async function fetchAndApplyManifestPatches(
   paths: string[],
+  reloadOnVersionMismatch: boolean,
   manifest: AssetsManifest,
   routeModules: RouteModules,
   future: FutureConfig,
@@ -230,6 +233,29 @@ export async function fetchAndApplyManifestPatches(
 
     if (!res.ok) {
       throw new Error(`${res.status} ${res.statusText}`);
+    } else if (
+      res.status === 204 &&
+      res.headers.has("X-Remix-Reload-Document")
+    ) {
+      if (reloadOnVersionMismatch) {
+        // TODO: If this was a fetcher call we don't want to navigate - can we
+        // detect and hard reload instead?
+        window.location.href = paths[0];
+        throw new Error("Detected manifest version mismatch, reloading...");
+      } else {
+        // No-op during eager route discovery so we will trigger a hard reload
+        // of the destination during the next navigation instead of reloading
+        // while the user is sitting on the current page.  Works almost seamlessly
+        // on navigations, but may be slightly more disruptive on fetcher calls.
+        // Still better than the `React.useContext` error that occurs without
+        // this detection though...
+        console.warn(
+          "Detected a manifest version mismatch during eager route discovery. " +
+            "The next navigation will result in a new document navigation to sync " +
+            "up with the latest manifest."
+        );
+        return;
+      }
     } else if (res.status >= 400) {
       throw new Error(await res.text());
     }

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -298,6 +298,15 @@ async function handleManifestRequest(
   routes: ServerRoute[],
   url: URL
 ) {
+  if (build.assets.version !== url.searchParams.get("version")) {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        "X-Remix-Reload-Document": "true",
+      },
+    });
+  }
+
   let patches: Record<string, EntryRoute> = {};
 
   if (url.searchParams.has("p")) {


### PR DESCRIPTION
Backport of https://github.com/remix-run/react-router/pull/13061 for Remix (2.15.4 I guess?)