### PR TITLE
Remove unused Vite file system watcher

### DIFF
--- a/.changeset/metal-candles-complain.md
+++ b/.changeset/metal-candles-complain.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+Remove unused Vite file system watcher

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -39,7 +39,7 @@ import * as VirtualModule from "./vmod";
 import { resolveFileUrl } from "./resolve-file-url";
 import { combineURLs } from "./combine-urls";
 import { removeExports } from "./remove-exports";
-import { isInRemixMonorepo } from "./is-in-remix-monorepo";
+import { ssrExternals } from "./ssr-externals";
 import { getVite, preloadVite } from "./vite";
 import * as ViteNode from "./vite-node";
 
@@ -619,27 +619,6 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
   let viteChildCompiler: Vite.ViteDevServer | null = null;
   let routesViteNodeContext: ViteNode.Context | null = null;
 
-  let ssrExternals = isInRemixMonorepo()
-    ? [
-        // This is only needed within the Remix repo because these
-        // packages are linked to a directory outside of node_modules
-        // so Vite treats them as internal code by default.
-        "@remix-run/architect",
-        "@remix-run/cloudflare-pages",
-        "@remix-run/cloudflare-workers",
-        "@remix-run/cloudflare",
-        "@remix-run/css-bundle",
-        "@remix-run/deno",
-        "@remix-run/dev",
-        "@remix-run/express",
-        "@remix-run/netlify",
-        "@remix-run/node",
-        "@remix-run/react",
-        "@remix-run/serve",
-        "@remix-run/server-runtime",
-      ]
-    : undefined;
-
   // This is initialized by `updateRemixPluginContext` during Vite's `config`
   // hook, so most of the code can assume this defined without null check.
   // During dev, `updateRemixPluginContext` is called again on every config file
@@ -1051,12 +1030,6 @@ export const remixVitePlugin: RemixVitePlugin = (remixUserConfig = {}) => {
         routesViteNodeContext = await ViteNode.createContext({
           root: viteUserConfig.root,
           mode: viteConfigEnv.mode,
-          server: {
-            watch: viteCommand === "build" ? null : undefined,
-          },
-          ssr: {
-            external: ssrExternals,
-          },
         });
 
         await updateRemixPluginContext();

--- a/packages/remix-dev/vite/ssr-externals.ts
+++ b/packages/remix-dev/vite/ssr-externals.ts
@@ -1,0 +1,22 @@
+import { isInRemixMonorepo } from "./is-in-remix-monorepo";
+
+export const ssrExternals = isInRemixMonorepo()
+  ? [
+      // This is only needed within the Remix repo because these
+      // packages are linked to a directory outside of node_modules
+      // so Vite treats them as internal code by default.
+      "@remix-run/architect",
+      "@remix-run/cloudflare-pages",
+      "@remix-run/cloudflare-workers",
+      "@remix-run/cloudflare",
+      "@remix-run/css-bundle",
+      "@remix-run/deno",
+      "@remix-run/dev",
+      "@remix-run/express",
+      "@remix-run/netlify",
+      "@remix-run/node",
+      "@remix-run/react",
+      "@remix-run/serve",
+      "@remix-run/server-runtime",
+    ]
+  : undefined;

--- a/packages/remix-dev/vite/vite-node.ts
+++ b/packages/remix-dev/vite/vite-node.ts
@@ -4,6 +4,7 @@ import { installSourcemapsSupport } from "vite-node/source-map";
 import type * as Vite from "vite";
 
 import { getVite, preloadVite } from "./vite";
+import { ssrExternals } from "./ssr-externals";
 
 export type Context = {
   devServer: Vite.ViteDevServer;
@@ -11,29 +12,34 @@ export type Context = {
   runner: ViteNodeRunner;
 };
 
-export async function createContext(
-  viteConfig: Vite.InlineConfig = {}
-): Promise<Context> {
+export async function createContext({
+  root,
+  mode,
+}: {
+  root: Vite.UserConfig["root"];
+  mode: Vite.ConfigEnv["mode"];
+}): Promise<Context> {
   await preloadVite();
   let vite = getVite();
 
-  let devServer = await vite.createServer(
-    vite.mergeConfig(
-      {
-        server: {
-          preTransformRequests: false,
-          hmr: false,
-        },
-        optimizeDeps: {
-          noDiscovery: true,
-        },
-        configFile: false,
-        envFile: false,
-        plugins: [],
-      },
-      viteConfig
-    )
-  );
+  let devServer = await vite.createServer({
+    root,
+    mode,
+    server: {
+      preTransformRequests: false,
+      hmr: false,
+      watch: null,
+    },
+    ssr: {
+      external: ssrExternals,
+    },
+    optimizeDeps: {
+      noDiscovery: true,
+    },
+    configFile: false,
+    envFile: false,
+    plugins: [],
+  });
   await devServer.pluginContainer.buildStart({});
 
   let server = new ViteNodeServer(devServer);


### PR DESCRIPTION
Fixes #10324.

This PR completely disables the vite-node file watcher because, even in dev, it's unused. The Vite dev server created for resolving `routes.ts` is only updated when the main dev server's file system watcher picks up a change: [routesViteNodeContext](https://github.com/remix-run/remix/blob/04d4fa2983ee7c1726a91b6f7223a586c696974a/packages/remix-dev/vite/plugin.ts#L1377-L1414). If the change is at all relevant to `routes.ts`, its module graph is completely invalidated. We can be confident in this change because we have tests that check you can update a file in the `routes.ts` module graph and get a new route config during dev: https://github.com/remix-run/remix/blob/04d4fa2983ee7c1726a91b6f7223a586c696974a/integration/vite-route-config-test.ts#L229-L297

Since the issue was caused by our use of `vite.mergeConfig`, I also simplified the code to avoid this API entirely.