### PR TITLE
Fix experimental and nightly releases

### DIFF
--- a/packages/remix-fs-routes/rollup.config.js
+++ b/packages/remix-fs-routes/rollup.config.js
@@ -36,7 +36,11 @@ module.exports = function rollup() {
         }),
         nodeResolve({ extensions: [".ts"] }),
         copy({
-          targets: [{ src: "LICENSE.md", dest: sourceDir }],
+          targets: [
+            { src: "LICENSE.md", dest: sourceDir },
+            { src: `${sourceDir}/package.json`, dest: outputDir },
+            { src: `${sourceDir}/README.md`, dest: outputDir },
+          ],
         }),
         copyToPlaygrounds(),
       ],

--- a/packages/remix-route-config/rollup.config.js
+++ b/packages/remix-route-config/rollup.config.js
@@ -36,7 +36,11 @@ module.exports = function rollup() {
         }),
         nodeResolve({ extensions: [".ts"] }),
         copy({
-          targets: [{ src: "LICENSE.md", dest: sourceDir }],
+          targets: [
+            { src: "LICENSE.md", dest: sourceDir },
+            { src: `${sourceDir}/package.json`, dest: outputDir },
+            { src: `${sourceDir}/README.md`, dest: outputDir },
+          ],
         }),
         copyToPlaygrounds(),
       ],

--- a/packages/remix-routes-option-adapter/rollup.config.js
+++ b/packages/remix-routes-option-adapter/rollup.config.js
@@ -36,7 +36,11 @@ module.exports = function rollup() {
         }),
         nodeResolve({ extensions: [".ts"] }),
         copy({
-          targets: [{ src: "LICENSE.md", dest: sourceDir }],
+          targets: [
+            { src: "LICENSE.md", dest: sourceDir },
+            { src: `${sourceDir}/package.json`, dest: outputDir },
+            { src: `${sourceDir}/README.md`, dest: outputDir },
+          ],
         }),
         copyToPlaygrounds(),
       ],


### PR DESCRIPTION
Since `package.json` files aren't being copied to the `build` directory for these new packages, publishing of experimental and nightly releases are currently failing. I've added the missing targets that are present in other packages. This was missed because these packages were back-ported from React Router where the build setup is different and a singular `build` directory isn't present.