### PR TITLE
Fix `routes.ts` errors with multiple dev packages

### DIFF
--- a/.changeset/curvy-otters-wave.md
+++ b/.changeset/curvy-otters-wave.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/dev": patch
+---
+
+When `future.v3_routeConfig` is enabled, fix errors evaluating `routes.ts` when multiple copies of `@remix-run/dev` are present

--- a/packages/remix-dev/config/routes.ts
+++ b/packages/remix-dev/config/routes.ts
@@ -3,19 +3,22 @@ import * as v from "valibot";
 
 import invariant from "../invariant";
 
-let routeConfigAppDirectory: string;
+declare global {
+  // eslint-disable-next-line prefer-let/prefer-let
+  var __remixAppDirectory: string;
+}
 
-export function setRouteConfigAppDirectory(directory: string) {
-  routeConfigAppDirectory = directory;
+export function setAppDirectory(directory: string) {
+  globalThis.__remixAppDirectory = directory;
 }
 
 /**
  * Provides the absolute path to the app directory, for use within `routes.ts`.
  * This is designed to support resolving file system routes.
  */
-export function getRouteConfigAppDirectory() {
-  invariant(routeConfigAppDirectory);
-  return routeConfigAppDirectory;
+export function getAppDirectory() {
+  invariant(globalThis.__remixAppDirectory);
+  return globalThis.__remixAppDirectory;
 }
 
 export interface RouteManifestEntry {


### PR DESCRIPTION
This is backporting a fix from `@react-router/dev` that ensures that the `getAppDirectory` function in `routes.ts` works when there are multiple copies of `@remix-run/dev`.