### PR TITLE
Fix Vite import analysis of `@remix-run/react`

### DIFF
--- a/.changeset/slow-jars-yell.md
+++ b/.changeset/slow-jars-yell.md
@@ -1,0 +1,6 @@
+---
+"@remix-run/dev": patch
+"@remix-run/react": patch
+---
+
+Fix Vite import analysis of `@remix-run/react` failing when the package is not marked as external

--- a/packages/remix-dev/compiler/js/plugins/hmr.ts
+++ b/packages/remix-dev/compiler/js/plugins/hmr.ts
@@ -58,6 +58,7 @@ export function createHotContext(id: string): ImportMetaHot {
   let disposed = false;
 
   let hot = {
+    __remixCompiler: true,
     accept: (dep, cb) => {
       if (typeof dep !== "string") {
         cb = dep;

--- a/packages/remix-react/browser.tsx
+++ b/packages/remix-react/browser.tsx
@@ -79,10 +79,23 @@ let hmrRouterReadyPromise = new Promise<Router>((resolve) => {
   return undefined;
 });
 
-// @ts-expect-error
-if (import.meta && import.meta.hot) {
+if (
+  import.meta &&
   // @ts-expect-error
-  import.meta.hot.accept(
+  import.meta.hot &&
+  // This HMR code is only valid in the classic compiler
+  // @ts-expect-error
+  import.meta.hot.__remixCompiler
+) {
+  // NOTE: The use of ["accept"] here is a minimal workaround to prevent Vite
+  // from attempting to resolve the "remix:manifest" module ID (and failing)
+  // during its import analysis phase. This happens if this package is not
+  // marked as external, e.g. when running the code in a non-Node environment
+  // like workerd. Even with the runtime check above, Vite will still attempt to
+  // resolve the "remix:manifest" module ID if it's used in a call to
+  // `import.meta.hot.accept`.
+  // @ts-expect-error
+  import.meta.hot["accept"](
     "remix:manifest",
     async ({
       assetsManifest,


### PR DESCRIPTION
If `@remix-run/react` is not marked as external, Vite's import analysis trips up on our call to `import.meta.hot.accept` which is only valid for the classic compiler. This PR does a couple of things to address this:

- Replaces `import.meta.hot.accept` with `import.meta.hot["accept"]` so Vite's static analysis doesn't pick it up.
- Adds a new `__remixCompiler` flag to our custom `import.meta.hot` implementation in the classic compiler. This then allows us to ensure that this custom HMR logic isn't executed when using Vite.