### PR TITLE
Ensure ancestor pathless/index routes are loaded via manifest requests

### DIFF
--- a/.changeset/eleven-oranges-lie.md
+++ b/.changeset/eleven-oranges-lie.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/server-runtime": patch
+---
+
+Load ancestor pathless/index routes in lazy route discovery for upwards non-eager-discoery routing

--- a/integration/fog-of-war-test.ts
+++ b/integration/fog-of-war-test.ts
@@ -1510,4 +1510,83 @@ test.describe("Fog of War", () => {
       )
     ).toEqual(["root", "routes/a", "routes/_index", "routes/a.b"]);
   });
+
+  test("loads ancestor index routes on navigations", async ({ page }) => {
+    let fixture = await createFixture({
+      config: {
+        future: {
+          v3_lazyRouteDiscovery: true,
+        },
+      },
+      files: {
+        ...getFiles(),
+        "app/root.tsx": js`
+          import * as React from "react";
+          import { Link, Links, Meta, Outlet, Scripts } from "@remix-run/react";
+          export default function Root() {
+            let [showLink, setShowLink] = React.useState(false);
+            return (
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
+                <body>
+                  <Link to="/" discover="none">Home</Link><br/>
+                  <Link to="/a" discover="none">/a</Link><br/>
+                  <Link to="/a/b" discover="none">/a/b</Link><br/>
+                  <Link to="/a/b/c" discover="none">/a/b/c</Link><br/>
+                  <Outlet />
+                  <Scripts />
+                </body>
+              </html>
+            );
+          }
+        `,
+        "app/routes/a._index.tsx": js`
+          export default function Index() {
+            return <h3 id="a-index">A INDEX</h3>;
+          }
+        `,
+        "app/routes/a.b._index.tsx": js`
+          export default function Index() {
+            return <h3 id="b-index">B INDEX</h3>;
+          }
+        `,
+      },
+    });
+    let appFixture = await createAppFixture(fixture);
+    let app = new PlaywrightFixture(appFixture, page);
+
+    await app.goto("/", true);
+    expect(
+      await page.evaluate(() =>
+        Object.keys((window as any).__remixManifest.routes)
+      )
+    ).toEqual(["root", "routes/_index"]);
+
+    await app.clickLink("/a/b/c");
+    await page.waitForSelector("#c");
+
+    // /a/b is not discovered yet even thought it's rendered
+    expect(
+      await page.evaluate(() =>
+        Object.keys((window as any).__remixManifest.routes)
+      )
+    ).toEqual([
+      "root",
+      "routes/_index",
+      "routes/a",
+      "routes/a._index",
+      "routes/a.b",
+      "routes/a.b._index",
+      "routes/a.b.c",
+    ]);
+
+    await app.clickLink("/a/b");
+    await page.waitForSelector("#b-index");
+
+    await app.clickLink("/a");
+    await page.waitForSelector("#a-index");
+  });
 });

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -310,7 +310,28 @@ async function handleManifestRequest(
   let patches: Record<string, EntryRoute> = {};
 
   if (url.searchParams.has("p")) {
-    for (let path of url.searchParams.getAll("p")) {
+    let paths = new Set<string>();
+
+    // In addition to responding with the patches for the requested paths, we
+    // need to include patches for each partial path so that we pick up any
+    // pathless/index routes below ancestor segments.  So if we
+    // get a request for `/parent/child`, we need to look for a match on `/parent`
+    // so that if a `parent._index` route exists we return it so it's available
+    // for client side matching if the user routes back up to `/parent`.
+    // This is the same thing we do on initial load in <Scripts> via
+    // `getPartialManifest()`
+    url.searchParams.getAll("p").forEach((path) => {
+      if (!path.startsWith("/")) {
+        path = `/${path}`;
+      }
+      let segments = path.split("/").slice(1);
+      segments.forEach((_, i) => {
+        let partialPath = segments.slice(0, i + 1).join("/");
+        paths.add(`/${partialPath}`);
+      });
+    });
+
+    for (let path of paths) {
       let matches = matchServerRoutes(routes, path, build.basename);
       if (matches) {
         for (let match of matches) {


### PR DESCRIPTION
Backport of https://github.com/remix-run/react-router/pull/13203 for Remix v2