### PR TITLE
chore: bump `undici`

### DIFF
--- a/.changeset/young-avocados-ring.md
+++ b/.changeset/young-avocados-ring.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/node": patch
+---
+
+Bump `undici` to version `6.21.2` to address [security advisory](https://github.com/nodejs/undici/security/advisories/GHSA-c76h-2ccp-4975)

--- a/packages/remix-node/package.json
+++ b/packages/remix-node/package.json
@@ -26,7 +26,7 @@
     "cookie-signature": "^1.1.0",
     "source-map-support": "^0.5.21",
     "stream-slice": "^0.1.2",
-    "undici": "^6.11.1"
+    "undici": "^6.21.2"
   },
   "devDependencies": {
     "@types/cookie-signature": "^1.0.3",

--- a/packages/remix-server-runtime/__tests__/server-test.ts
+++ b/packages/remix-server-runtime/__tests__/server-test.ts
@@ -164,11 +164,11 @@ describe("shared server runtime", () => {
           loader() {
             let headers = new Headers({ "x-test": "yes" });
             let headersProxy = new Proxy(headers, {
-              get(target, prop, receiver) {
+              get(target, prop) {
                 if (prop === "set") {
                   throw new TypeError("immutable");
                 }
-                return Reflect.get(target, prop, receiver);
+                return target[prop].bind(target);
               },
             });
             // Mock a "response" that will pass the `isResponse` check
@@ -665,11 +665,11 @@ describe("shared server runtime", () => {
           loader() {
             let headers = new Headers({ "x-test": "yes" });
             let headersProxy = new Proxy(headers, {
-              get(target, prop, receiver) {
+              get(target, prop) {
                 if (prop === "set") {
                   throw new TypeError("immutable");
                 }
-                return Reflect.get(target, prop, receiver);
+                return target[prop].bind(target);
               },
             });
             // Mock a "response" that will pass the `isResponse` check
@@ -707,11 +707,11 @@ describe("shared server runtime", () => {
           loader() {
             let headers = new Headers({ "x-test": "yes" });
             let headersProxy = new Proxy(headers, {
-              get(target, prop, receiver) {
+              get(target, prop) {
                 if (prop === "set") {
                   throw new TypeError("immutable");
                 }
-                return Reflect.get(target, prop, receiver);
+                return target[prop].bind(target);
               },
             });
             // Mock a "response" that will pass the `isResponse` check

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1307,8 +1307,8 @@ importers:
         specifier: ^0.1.2
         version: 0.1.2
       undici:
-        specifier: ^6.11.1
-        version: 6.11.1
+        specifier: ^6.21.2
+        version: 6.21.2
     devDependencies:
       '@types/cookie-signature':
         specifier: ^1.0.3
@@ -14898,9 +14898,9 @@ packages:
     dependencies:
       '@fastify/busboy': 2.1.0
 
-  /undici@6.11.1:
-    resolution: {integrity: sha512-KyhzaLJnV1qa3BSHdj4AZ2ndqI0QWPxYzaIOio0WzcEJB9gvuysprJSLtpvc2D9mhR9jPDUk7xlJlZbH2KR5iw==}
-    engines: {node: '>=18.0'}
+  /undici@6.21.2:
+    resolution: {integrity: sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==}
+    engines: {node: '>=18.17'}
     dev: false
 
   /unenv-nightly@2.0.0-1724863496.70db6f1:


### PR DESCRIPTION
Replaces https://github.com/remix-run/remix/pull/10428

See https://github.com/nodejs/undici/releases/tag/v6.21.1