### PR TITLE
Fix window error in PrefetchPageLinks during SSR in Single Fetch

### DIFF
--- a/.changeset/tall-mirrors-glow.md
+++ b/.changeset/tall-mirrors-glow.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/react": patch
+---
+
+Fix `window is not defined` error in Single Fetch when server-rendering `<PrefetchPageLinks>`

--- a/packages/remix-react/single-fetch.tsx
+++ b/packages/remix-react/single-fetch.tsx
@@ -381,7 +381,14 @@ function stripIndexParam(url: URL) {
 export function singleFetchUrl(reqUrl: URL | string) {
   let url =
     typeof reqUrl === "string"
-      ? new URL(reqUrl, window.location.origin)
+      ? new URL(
+          reqUrl,
+          // This can be called during the SSR flow via PrefetchPageLinksImpl so
+          // don't assume window is available
+          typeof window === "undefined"
+            ? "server://singlefetch/"
+            : window.location.origin
+        )
       : reqUrl;
 
   if (url.pathname === "/") {


### PR DESCRIPTION
Backport the same change from https://github.com/remix-run/react-router/pull/11522

Closes https://github.com/remix-run/remix/issues/10474