### PR TITLE
Update quickstart to compliant with express 5

### DIFF
--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -162,7 +162,7 @@ const app = express();
 app.use(express.static("build/client"));
 
 // and your app is "just a request handler"
-app.all("*", createRequestHandler({ build }));
+app.all(/(.*)/, createRequestHandler({ build }));
 
 app.listen(3000, () => {
   console.log("App listening on http://localhost:3000");


### PR DESCRIPTION
Changing
```js
app.all("*", createRequestHandler({ build }));
```
to
```js
app.all(/(.*)/, createRequestHandler({ build }));
```
to compliant with express 5.

cf. https://github.com/expressjs/express/issues/5936