### PR TITLE
v2: handle root path with `basename` when using Single Fetch

### DIFF
--- a/.changeset/itchy-chefs-give.md
+++ b/.changeset/itchy-chefs-give.md
@@ -1,0 +1,6 @@
+---
+"@remix-run/react": patch
+"@remix-run/server-runtime": patch
+---
+
+fix(singlefetch): handle root path with basename

--- a/contributors.yml
+++ b/contributors.yml
@@ -662,6 +662,7 @@
 - tascord
 - TheRealAstoo
 - therealflyingcoder
+- ThisIsAreku
 - thomasheyenbrock
 - thomasrettig
 - thomasverleye

--- a/packages/remix-react/single-fetch.tsx
+++ b/packages/remix-react/single-fetch.tsx
@@ -393,6 +393,8 @@ export function singleFetchUrl(reqUrl: URL | string) {
 
   if (url.pathname === "/") {
     url.pathname = "_root.data";
+  } else if (url.pathname === window.__remixContext.basename) {
+    url.pathname = window.__remixContext.basename.concat("_root.data");
   } else {
     url.pathname = `${url.pathname.replace(/\/$/, "")}.data`;
   }

--- a/packages/remix-server-runtime/server.ts
+++ b/packages/remix-server-runtime/server.ts
@@ -195,7 +195,7 @@ export const createRequestHandler: CreateRequestHandlerFunction = (
       let handlerUrl = new URL(request.url);
       handlerUrl.pathname = handlerUrl.pathname
         .replace(/\.data$/, "")
-        .replace(/^\/_root$/, "/");
+        .replace(_build.basename ? /\/_root$/ : /^\/_root$/, "/");
 
       let singleFetchMatches = matchServerRoutes(
         routes,


### PR DESCRIPTION
Using `v3_singleFetch`with a `basename` set (i.e. `/foo/`), a data loader should request `/foo/_root.data` instead of `/foo.data`, as the later is outside the basename.

This PR port the patch of https://github.com/remix-run/react-router/issues/12295#issuecomment-2484079378 into the remix v2 branch

Closes: #10212