### PR TITLE
templates(remix): fix syntax highlighting in `README`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -742,3 +742,4 @@
 - zayenz
 - zhe
 - zwhitchcox
+- mr-mashanlo

--- a/templates/remix/README.md
+++ b/templates/remix/README.md
@@ -6,7 +6,7 @@
 
 Run the dev server:
 
-```shellscript
+```sh
 npm run dev
 ```
 


### PR DESCRIPTION
Replaced incorrect `shellscript` code block with `sh` in README for proper syntax highlighting.