### PR TITLE
Update state-management.md

### DIFF
--- a/docs/discussion/state-management.md
+++ b/docs/discussion/state-management.md
@@ -199,7 +199,7 @@ function Sidebar({ children }) {
   const [isOpen, setIsOpen] = React.useState(false);
 
   // synchronize initially
-  useLayoutEffect(() => {
+  useEffect(() => {
     const isOpen = window.localStorage.getItem("sidebar");
     setIsOpen(isOpen);
   }, []);


### PR DESCRIPTION
Change localStorage example to `useEffect` rather than `useLayoutEffect` to reflect the [useLayoutEffect constraint](https://remix.run/docs/en/main/guides/constraints#uselayouteffect).