### PR TITLE
chore: enable TypeScript `isolatedDeclarations`

### DIFF
--- a/packages/fetch-proxy/tsconfig.json
+++ b/packages/fetch-proxy/tsconfig.json
@@ -7,6 +7,8 @@
     "target": "ESNext",
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "composite": true,
+    "isolatedDeclarations": true
   }
 }

--- a/packages/file-storage/tsconfig.json
+++ b/packages/file-storage/tsconfig.json
@@ -7,6 +7,8 @@
     "target": "ESNext",
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "composite": true,
+    "isolatedDeclarations": true
   }
 }

--- a/packages/form-data-parser/tsconfig.json
+++ b/packages/form-data-parser/tsconfig.json
@@ -7,6 +7,8 @@
     "target": "ESNext",
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "composite": true,
+    "isolatedDeclarations": true
   }
 }

--- a/packages/headers/src/lib/if-none-match.ts
+++ b/packages/headers/src/lib/if-none-match.ts
@@ -52,7 +52,7 @@ export class IfNoneMatch implements HeaderValue, IfNoneMatchInit {
     return this.has(tag) || this.tags.includes('*');
   }
 
-  toString() {
+  toString(): string {
     return this.tags.join(', ');
   }
 }

--- a/packages/headers/tsconfig.json
+++ b/packages/headers/tsconfig.json
@@ -7,6 +7,8 @@
     "target": "ESNext",
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "composite": true,
+    "isolatedDeclarations": true
   }
 }

--- a/packages/lazy-file/tsconfig.json
+++ b/packages/lazy-file/tsconfig.json
@@ -7,6 +7,8 @@
     "target": "ESNext",
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "composite": true,
+    "isolatedDeclarations": true
   }
 }

--- a/packages/multipart-parser/tsconfig.json
+++ b/packages/multipart-parser/tsconfig.json
@@ -7,6 +7,8 @@
     "target": "ESNext",
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "composite": true,
+    "isolatedDeclarations": true
   }
 }

--- a/packages/node-fetch-server/tsconfig.json
+++ b/packages/node-fetch-server/tsconfig.json
@@ -7,6 +7,8 @@
     "target": "ESNext",
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "composite": true,
+    "isolatedDeclarations": true
   }
 }

--- a/packages/route-pattern/src/lib/parse.ts
+++ b/packages/route-pattern/src/lib/parse.ts
@@ -16,7 +16,7 @@ type Enum = { type: 'enum'; members: Array<string> };
 type Optional = { type: 'optional'; nodes: Array<Node> };
 type Node = Text | Param | Glob | Enum | Optional;
 
-export function parse(source: string) {
+export function parse(source: string): Ast {
   const { protocol, hostname, pathname, search } = split(source);
   const ast: Ast = {};
   if (protocol) ast.protocol = parsePart(source, protocol);

--- a/packages/route-pattern/src/lib/split.ts
+++ b/packages/route-pattern/src/lib/split.ts
@@ -1,6 +1,11 @@
 type Span = [number, number];
 
-export function split(source: string) {
+export function split(source: string): {
+  protocol?: Span;
+  hostname?: Span;
+  pathname?: Span;
+  search?: Span;
+} {
   const result: {
     protocol?: Span;
     hostname?: Span;

--- a/packages/route-pattern/tsconfig.json
+++ b/packages/route-pattern/tsconfig.json
@@ -7,6 +7,8 @@
     "target": "ESNext",
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "composite": true,
+    "isolatedDeclarations": true
   }
 }

--- a/packages/tar-parser/src/lib/utils.ts
+++ b/packages/tar-parser/src/lib/utils.ts
@@ -53,7 +53,12 @@ export function indexOf(buffer: Uint8Array, value: number, offset: number, end: 
   return end;
 }
 
-export function getString(buffer: Uint8Array, offset: number, size: number, label = 'utf-8') {
+export function getString(
+  buffer: Uint8Array,
+  offset: number,
+  size: number,
+  label = 'utf-8',
+): string {
   return new TextDecoder(label).decode(
     buffer.subarray(offset, indexOf(buffer, 0, offset, offset + size)),
   );
@@ -61,7 +66,7 @@ export function getString(buffer: Uint8Array, offset: number, size: number, labe
 
 const Utf8Decoder = new TextDecoder();
 
-export function getOctal(buffer: Uint8Array, offset: number, size: number) {
+export function getOctal(buffer: Uint8Array, offset: number, size: number): number | null {
   let value = buffer.subarray(offset, offset + size);
   offset = 0;
 

--- a/packages/tar-parser/tsconfig.json
+++ b/packages/tar-parser/tsconfig.json
@@ -7,6 +7,8 @@
     "target": "ESNext",
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "composite": true,
+    "isolatedDeclarations": true
   }
 }


### PR DESCRIPTION
Feel free to close if not useful, but It seemed like most function returns were explicitly typed anyways and `isolatedDeclarations: "true"` could provide useful if non-tsc based dts generation was to be used such as [tsdown#with-isolateddeclarations](https://tsdown.dev/options/dts#with-isolateddeclarations).