### PR TITLE
chore(templates): add .eslintrc.cjs example template to fix broken links (#10739)

### DIFF
--- a/templates/remix/.eslintrc.cjs
+++ b/templates/remix/.eslintrc.cjs
@@ -1,0 +1,46 @@
+// ESLint configuration recommended for Remix templates
+// This is a minimal, modern example that works for both JavaScript and TypeScript projects.
+// Adjust parser/plugins according to your project's needs.
+
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    node: true,
+    es2024: true,
+  },
+  extends: [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
+    "plugin:jsx-a11y/recommended",
+    "prettier"
+  ],
+  settings: {
+    react: {
+      version: "detect"
+    }
+  },
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module"
+  },
+  rules: {
+    "react/react-in-jsx-scope": "off"
+  },
+  overrides: [
+    {
+      files: ["*.ts", "*.tsx"],
+      parser: "@typescript-eslint/parser",
+      extends: ["plugin:@typescript-eslint/recommended"],
+      parserOptions: {
+        project: "./tsconfig.json",
+        tsconfigRootDir: __dirname,
+      }
+    },
+    {
+      files: [".eslintrc.cjs", "scripts/**/*.js"],
+      env: { node: true }
+    }
+  ]
+};

--- a/templates/remix/README.md
+++ b/templates/remix/README.md
@@ -1,0 +1,7 @@
+# Remix template ESLint example
+
+This directory contains an example `.eslintrc.cjs` file used by the Remix templates.
+It provides a starting point for ESLint configuration for both JavaScript and TypeScript projects.
+
+If you use `create-remix` to generate a new project and need an ESLint config, copy `.eslintrc.cjs`
+from this folder into your project root and adjust the `overrides` and `parserOptions.project` as needed.


### PR DESCRIPTION
## What I did

Added an example `.eslintrc.cjs` file to the `templates/remix/` folder and updated the README with instructions.

This resolves [#10739](https://github.com/remix-run/remix/issues/10739), where links to example ESLint configuration files were broken.

## Why

- Provides a working ESLint config for new Remix templates.
- Helps developers quickly set up linting for both JavaScript and TypeScript.
- Fixes broken documentation links.

## How to test

1. Navigate to `templates/remix/`.
2. Copy `.eslintrc.cjs` into a Remix project.
3. Run `eslint .` to confirm it works.

---

✅ This PR introduces no breaking changes.
