### PR TITLE
Add github workflow for v2 publishes

### DIFF
--- a/.github/workflows/publish-v2.yaml
+++ b/.github/workflows/publish-v2.yaml
@@ -1,0 +1,41 @@
+on:
+  push:
+    tags:
+      - 'remix@2.*'
+
+jobs:
+  publish:
+    name: publish (v2)
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # Required for publishing the GitHub release
+      id-token: write # The OIDC ID token is used for authentication with JSR
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Publish
+        run: pnpm publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This is a copy of the [`publish.yaml`](https://github.com/remix-run/remix/blob/main/.github/workflows/publish.yaml) workflow but instead of ignoring `remix@x.y.z` tags it will only kick off for those tags, and thus will only be triggered for releases from the v2 branch.

Sibling PR to update the v2 branch to follow the same github release flow where we tag locally and push to github for publishing from CI: https://github.com/remix-run/remix/pull/10748