### PR TITLE
route-pattern: type testing utilities

### DIFF
--- a/packages/route-pattern/src/lib/href.test.ts
+++ b/packages/route-pattern/src/lib/href.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test'
 
 import { type HrefBuilder, MissingParamError, createHrefBuilder } from './href.ts'
 import { RoutePattern } from './route-pattern.ts'
-import type { Assert, IsEqual } from './type-utils.d.ts'
+import type { Assert, IsEqual } from '../type-utils.d.ts'
 
 describe('href', () => {
   it('uses a default protocol', () => {

--- a/packages/route-pattern/src/lib/params.test.ts
+++ b/packages/route-pattern/src/lib/params.test.ts
@@ -1,5 +1,5 @@
 import type { Params } from './params.ts'
-import type { Assert, IsEqual } from './type-utils.d.ts'
+import type { Assert, IsEqual } from '../type-utils.d.ts'
 
 // prettier-ignore
 export type Tests = [

--- a/packages/route-pattern/src/lib/split.test.ts
+++ b/packages/route-pattern/src/lib/split.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import { type Split, split } from './split.ts'
-import type { Assert, IsEqual } from './type-utils.d.ts'
+import type { Assert, IsEqual } from '../type-utils.d.ts'
 
 describe('split', () => {
   it('splits route patterns into protocol, hostname, port, pathname, search', () => {

--- a/packages/route-pattern/src/lib/variant.test.ts
+++ b/packages/route-pattern/src/lib/variant.test.ts
@@ -1,5 +1,5 @@
 import type { Variant } from './variant.ts'
-import type { Assert, IsEqual } from './type-utils.d.ts'
+import type { Assert, IsEqual } from '../type-utils.d.ts'
 
 // prettier-ignore
 export type Tests = [

--- a/packages/route-pattern/src/lib/variant.ts
+++ b/packages/route-pattern/src/lib/variant.ts
@@ -8,7 +8,7 @@ import type {
   Text,
   Optional,
 } from './parse.ts'
-import type { IsEqual } from './type-utils.d.ts'
+import type { IsEqual } from '../type-utils.d.ts'
 
 // prettier-ignore
 export type Variant<T extends string> =

--- a/packages/route-pattern/src/type-utils.d.ts
+++ b/packages/route-pattern/src/type-utils.d.ts
@@ -1,5 +1,3 @@
 export type Assert<T extends true> = T
 export type IsEqual<A, B> =
   (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
-
-type Pretty<T> = { [K in keyof T]: T[K] } & {}


### PR DESCRIPTION
move out of `src/lib/` and remove unused `Pretty` type