### PR TITLE
fix(fetch-router): make `Router`'s `fetch` spec-compliant

### DIFF
--- a/packages/fetch-router/CHANGELOG.md
+++ b/packages/fetch-router/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This is the changelog for [`fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router). It follows [semantic versioning](https://semver.org/).
 
+## HEAD
+
+- Fix an issue where `Router`'s `fetch` wasn't spec-compliant
+
 ## v0.6.0 (2025-10-10)
 
 - BREAKING CHANGE: Rename

--- a/packages/fetch-router/src/lib/router.test.ts
+++ b/packages/fetch-router/src/lib/router.test.ts
@@ -124,6 +124,23 @@ describe('router.fetch()', () => {
     assert.equal(response.status, 200)
     assert.equal(await response.text(), 'Admin')
   })
+
+  it('replaces any corresponding options set in the original `Request` when options are provided', async () => {
+    let requestLog: Array<string | null> = []
+    let router = createRouter()
+    router.use(({ request }) => {
+      requestLog.push(request.headers.get('From'))
+    })
+    router.get('/', () => new Response('Home'))
+
+    await router.fetch('https://remix.run')
+    assert.deepEqual(requestLog, [null])
+
+    requestLog = []
+
+    await router.fetch('https://remix.run', { headers: { From: 'admin@remix.run' } })
+    assert.deepEqual(requestLog, ['admin@remix.run'])
+  })
 })
 
 describe('router.map()', () => {

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -85,7 +85,7 @@ export class Router {
    * Fetch a response from the router.
    */
   async fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
-    let request = input instanceof Request ? input : new Request(input, init)
+    let request = new Request(input, init)
 
     let response = await this.dispatch(request)
     if (response == null) {


### PR DESCRIPTION
As @rossipedia [mentioned on Discord](https://discord.com/channels/770287896669978684/940264701785423992/1426664672878268591), `Router`'s `fetch` currently isn't spec-compliant if you pass both `Request` & `init`

> A [`RequestInit`](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit) object containing any custom settings that you want to apply to the request.
> 
> If you construct a new `Request` from an existing `Request`, any options you set in an _options_ argument for the new request replace any corresponding options set in the original `Request`.

https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options