### PR TITLE
Add fetch-router package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The benefit is code that's not just reusable, but **future-proof**.
 We currently publish the following packages:
 
 - [fetch-proxy](packages/fetch-proxy): Seamlessly construct HTTP proxies with the familiar `fetch()` API
+- [fetch-router](packages/fetch-router): A minimal, composable router built on the web Fetch API and `route-pattern`.
 - [file-storage](packages/file-storage): Robust key/value storage tailored for JavaScript `File` objects, simplifying file management
 - [form-data-parser](packages/form-data-parser): An enhanced `request.formData()` wrapper enabling efficient, streaming file uploads
 - [headers](packages/headers): A comprehensive toolkit for effortlessly managing HTTP headers


### PR DESCRIPTION
@mjackson I would commit this directly but I just wanted to make sure there wasn't a reason `fetch-router` isn't listed in the main `README` first