### PR TITLE
fix(fetch-router): fix exports

### DIFF
--- a/packages/fetch-router/package.json
+++ b/packages/fetch-router/package.json
@@ -21,7 +21,6 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./html-template": "./src/html-template.ts",
     "./logger-middleware": "./src/logger-middleware.ts",
     "./response-helpers": "./src/response-helpers.ts",
     "./package.json": "./package.json"


### PR DESCRIPTION
There's no `./src/html-template.ts` and we have the `@remix-run/html-template` package