### PR TITLE
feat(fetch-router): make `@remix-run/html-template` an optional peerDep

### DIFF
--- a/packages/fetch-router/package.json
+++ b/packages/fetch-router/package.json
@@ -58,6 +58,11 @@
     "@remix-run/html-template": "workspace:*",
     "@remix-run/route-pattern": "workspace:*"
   },
+  "peerDependenciesMeta": {
+    "@remix-run/html-template": {
+      "optional": true
+    }
+  },
   "scripts": {
     "build": "pnpm run clean && pnpm run build:types && pnpm run build:index && pnpm run build:html-template && pnpm run build:logger-middleware && pnpm run build:response-helpers",
     "build:html-template": "esbuild src/html-template.ts --bundle --outfile=dist/html-template.js --format=esm --platform=neutral --sourcemap",


### PR DESCRIPTION
This way people who aren't using the `html` response helper, don't need to install this package