### PR TITLE
proposal: named type parameters

### DIFF
--- a/packages/fetch-router/src/lib/route-map.ts
+++ b/packages/fetch-router/src/lib/route-map.ts
@@ -4,27 +4,27 @@ import type { HrefBuilderArgs, Join, RouteMatch } from '@remix-run/route-pattern
 import type { RequestMethod } from './request-methods.ts'
 import type { Simplify } from './type-utils.ts'
 
-export interface RouteMap<T extends string = string> {
-  [K: string]: Route<RequestMethod | 'ANY', T> | RouteMap<T>
+export interface RouteMap<name extends string = string> {
+  [name: string]: Route<RequestMethod | 'ANY', name> | RouteMap<name>
 }
 
 export class Route<
-  M extends RequestMethod | 'ANY' = RequestMethod | 'ANY',
-  P extends string = string,
+  method extends RequestMethod | 'ANY' = RequestMethod | 'ANY',
+  pattern extends string = string,
 > {
-  readonly method: M | 'ANY'
-  readonly pattern: RoutePattern<P>
+  readonly method: method | 'ANY'
+  readonly pattern: RoutePattern<pattern>
 
-  constructor(method: M | 'ANY', pattern: P | RoutePattern<P>) {
+  constructor(method: method | 'ANY', pattern: pattern | RoutePattern<pattern>) {
     this.method = method
     this.pattern = typeof pattern === 'string' ? new RoutePattern(pattern) : pattern
   }
 
-  href(...args: HrefBuilderArgs<P>): string {
+  href(...args: HrefBuilderArgs<pattern>): string {
     return this.pattern.href(...args)
   }
 
-  match(url: string | URL): RouteMatch<P> | null {
+  match(url: string | URL): RouteMatch<pattern> | null {
     return this.pattern.match(url)
   }
 }
@@ -32,11 +32,11 @@ export class Route<
 /**
  * Create a route map from a set of route definitions.
  */
-export function createRoutes<const R extends RouteDefs>(defs: R): BuildRouteMap<'/', R>
-export function createRoutes<P extends string, const R extends RouteDefs>(
-  base: P | RoutePattern<P>,
-  defs: R,
-): BuildRouteMap<P, R>
+export function createRoutes<const defs extends RouteDefs>(defs: defs): BuildRouteMap<'/', defs>
+export function createRoutes<pattern extends string, const defs extends RouteDefs>(
+  base: pattern | RoutePattern<pattern>,
+  defs: defs,
+): BuildRouteMap<pattern, defs>
 export function createRoutes(baseOrDefs: any, defs?: RouteDefs): RouteMap {
   return typeof baseOrDefs === 'string' || baseOrDefs instanceof RoutePattern
     ? buildRouteMap(
@@ -46,10 +46,10 @@ export function createRoutes(baseOrDefs: any, defs?: RouteDefs): RouteMap {
     : buildRouteMap(new RoutePattern('/'), baseOrDefs)
 }
 
-function buildRouteMap<P extends string, R extends RouteDefs>(
-  base: RoutePattern<P>,
-  defs: R,
-): BuildRouteMap<P, R> {
+function buildRouteMap<pattern extends string, defs extends RouteDefs>(
+  base: RoutePattern<pattern>,
+  defs: defs,
+): BuildRouteMap<pattern, defs> {
   let routes: any = {}
 
   for (let key in defs) {
@@ -70,31 +70,31 @@ function buildRouteMap<P extends string, R extends RouteDefs>(
 }
 
 // prettier-ignore
-export type BuildRouteMap<P extends string, R extends RouteDefs> = Simplify<{
-  -readonly [K in keyof R]: (
-    R[K] extends Route<infer M extends RequestMethod | 'ANY', infer S extends string> ? Route<M, Join<P, S>> :
-    R[K] extends RouteDef ? BuildRoute<P, R[K]> :
-    R[K] extends RouteDefs ? BuildRouteMap<P, R[K]> :
+export type BuildRouteMap<basePattern extends string, defs extends RouteDefs> = Simplify<{
+  -readonly [name in keyof defs]: (
+    defs[name] extends Route<infer method extends RequestMethod | 'ANY', infer pattern extends string> ? Route<method, Join<basePattern, pattern>> :
+    defs[name] extends RouteDef ? BuildRoute<basePattern, defs[name]> :
+    defs[name] extends RouteDefs ? BuildRouteMap<basePattern, defs[name]> :
     never
   )
 }>
 
 // prettier-ignore
-type BuildRoute<P extends string, D extends RouteDef> = 
-  D extends string ? Route<'ANY', Join<P, D>> :
-  D extends RoutePattern<infer S extends string> ? Route<'ANY', Join<P, S>> :
-  D extends { method: infer M, pattern: infer S } ? (
-    S extends string ? Route<M extends RequestMethod ? M : 'ANY', Join<P, S>> :
-    S extends RoutePattern<infer S extends string> ? Route<M extends RequestMethod ? M : 'ANY', Join<P, S>> :
+type BuildRoute<basePattern extends string, def extends RouteDef> = 
+  def extends string ? Route<'ANY', Join<basePattern, def>> :
+  def extends RoutePattern<infer pattern extends string> ? Route<'ANY', Join<basePattern, pattern>> :
+  def extends { method: infer method, pattern: infer pattern } ? (
+    pattern extends string ? Route<method extends RequestMethod ? method : 'ANY', Join<basePattern, pattern>> :
+    pattern extends RoutePattern<infer pattern extends string> ? Route<method extends RequestMethod ? method : 'ANY', Join<basePattern, pattern>> :
     never
   ) :
   never
 
 export interface RouteDefs {
-  [K: string]: Route | RouteDef | RouteDefs
+  [name: string]: Route | RouteDef | RouteDefs
 }
 
-export type RouteDef<T extends string = string> =
-  | T
-  | RoutePattern<T>
-  | { method?: RequestMethod; pattern: T | RoutePattern<T> }
+export type RouteDef<pattern extends string = string> =
+  | pattern
+  | RoutePattern<pattern>
+  | { method?: RequestMethod; pattern: pattern | RoutePattern<pattern> }


### PR DESCRIPTION
I've spent a lot of time over the last couple years deep in strongly typed libraries with the legendary [David Blass](https://x.com/ssalbdivad). One pattern of his that I've adopted is naming type parameters of generics like you would variable names (because that's effectively what they are). It felt weird/ugly to me at first, but after using it for a couple years, I find it much more readable, especially as types get more complex (e.g. >2 parameters in play) and while doing type transformations like mapped types.

I've mocked this up in a couple of files to demonstrate both the pure types side as well as how the type parameters are used within methods and how they nicely align with parameter names.

If ya'll are open to this, I'm happy to finish converting the rest of this package here, and will open up separate PRs for other packages that need this.