### PR TITLE
change argument order for on function with AbortSignal

### DIFF
--- a/packages/interaction/README.md
+++ b/packages/interaction/README.md
@@ -167,7 +167,7 @@ dispose()
 
 // Using an external AbortSignal
 let controller = new AbortController()
-on(button, controller.signal, { click: () => {} })
+on(button, { click: () => {} }, { signal: controller.signal })
 controller.abort() // removes all listeners added via that call
 
 // Containers


### PR DESCRIPTION
It's easier to make a PR about this than an issue/discussion. Just curious what you think about doing this to avoid unfortunate function overloading. Overloading is irritating as a consumer of the types. Having an optional `options` argument at the end seems reasonable.