### PR TITLE
interaction: throw when calling set after dispose

### DIFF
--- a/packages/interaction/src/lib/interaction.test.ts
+++ b/packages/interaction/src/lib/interaction.test.ts
@@ -96,6 +96,13 @@ describe('interaction', () => {
       expect(secondListenerCalled).toBe(false)
     })
 
+    it('throws when calling set after dispose', () => {
+      let target = new EventTarget()
+      let container = createContainer(target)
+      container.dispose()
+      expect(() => container.set({ test: () => {} })).toThrow('Container has been disposed')
+    })
+
     describe('listenWith', () => {
       it('provides options with listenWith', () => {
         let target = new EventTarget()

--- a/packages/interaction/src/lib/interaction.ts
+++ b/packages/interaction/src/lib/interaction.ts
@@ -139,6 +139,9 @@ export function createContainer<target extends EventTarget>(
   return {
     dispose: () => controller.abort(),
     set: (listeners) => {
+      if (controller.signal.aborted) {
+        throw new Error('Container has been disposed')
+      }
       // TODO: figure out if we can remove this cast
       for (let type of Object.keys(listeners) as Array<EventType<target>>) {
         let raw = listeners[type]


### PR DESCRIPTION
because containers listeners are disposed via signals, and signals can't be "unaborted"