### PR TITLE
interaction: fix keys types on doc/window

### DIFF
--- a/packages/interaction/src/lib/interactions/keys.ts
+++ b/packages/interaction/src/lib/interactions/keys.ts
@@ -116,6 +116,40 @@ declare global {
     [pageDown]: KeyboardEvent
     [tab]: KeyboardEvent
   }
+
+  interface WindowEventMap {
+    [escape]: KeyboardEvent
+    [enter]: KeyboardEvent
+    [space]: KeyboardEvent
+    [backspace]: KeyboardEvent
+    [del]: KeyboardEvent
+    [arrowLeft]: KeyboardEvent
+    [arrowRight]: KeyboardEvent
+    [arrowUp]: KeyboardEvent
+    [arrowDown]: KeyboardEvent
+    [home]: KeyboardEvent
+    [end]: KeyboardEvent
+    [pageUp]: KeyboardEvent
+    [pageDown]: KeyboardEvent
+    [tab]: KeyboardEvent
+  }
+
+  interface DocumentEventMap {
+    [escape]: KeyboardEvent
+    [enter]: KeyboardEvent
+    [space]: KeyboardEvent
+    [backspace]: KeyboardEvent
+    [del]: KeyboardEvent
+    [arrowLeft]: KeyboardEvent
+    [arrowRight]: KeyboardEvent
+    [arrowUp]: KeyboardEvent
+    [arrowDown]: KeyboardEvent
+    [home]: KeyboardEvent
+    [end]: KeyboardEvent
+    [pageUp]: KeyboardEvent
+    [pageDown]: KeyboardEvent
+    [tab]: KeyboardEvent
+  }
 }
 
 const keys = [


### PR DESCRIPTION
Follow up on #10820 

This type still fails at the moment

```ts
on(window || document, {
  [Keys.escape]() {
    writeLog('escape')
  },
})
```