### PR TITLE
Support for Max-Age=0

### DIFF
--- a/packages/headers/src/lib/set-cookie.ts
+++ b/packages/headers/src/lib/set-cookie.ts
@@ -171,7 +171,7 @@ export class SetCookie implements HeaderValue, SetCookieInit {
     if (this.httpOnly) {
       parts.push('HttpOnly')
     }
-    if (this.maxAge) {
+    if (this.maxAge || this.maxAge === 0) {
       parts.push(`Max-Age=${this.maxAge}`)
     }
     if (this.partitioned) {


### PR DESCRIPTION
This fixes a bug in the header package, where Max-Age is not serialized into the Set-Cookie header when it is equal to 0 because it is falsy