### PR TITLE
test(session): Test deleteId values on regenerateId()

### DIFF
--- a/packages/session/src/lib/session.test.ts
+++ b/packages/session/src/lib/session.test.ts
@@ -93,6 +93,18 @@ describe('Session', () => {
 
     session.regenerateId()
     assert.notEqual(session.id, originalId)
+    assert.equal(session.deleteId, undefined)
+    assert.equal(session.dirty, true)
+  })
+
+  it('deletes the old session ID', () => {
+    let session = createSession()
+    let originalId = session.id
+    assert.equal(session.dirty, false)
+
+    session.regenerateId(true)
+    assert.notEqual(session.id, originalId)
+    assert.equal(session.deleteId, originalId)
     assert.equal(session.dirty, true)
   })
 


### PR DESCRIPTION
Ensure deleteId stay undefined with `regenerateId(false)` and is filled with originalId with `regenerateId(true)`