### PR TITLE
chore(file-storage): remove S3 docs & deps

### DIFF
--- a/packages/file-storage/README.md
+++ b/packages/file-storage/README.md
@@ -46,29 +46,6 @@ fileFromStorage.type // 'text/plain'
 await storage.remove(key)
 ```
 
-### Amazon S3
-
-```ts
-import { createS3FileStorage } from '@remix-run/file-storage/s3'
-
-let storage = createS3FileStorage({
-  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-  bucket: 'my-bucket',
-  region: 'us-east-1',
-})
-
-// Use the same API as other storage implementations
-await storage.set('my-key', file)
-let retrieved = await storage.get('my-key')
-```
-
-The S3 implementation also supports:
-
-- S3-compatible services (like MinIO, Cloudflare R2) via the `endpoint` option
-- Temporary credentials via the `sessionToken` option
-- All standard `FileStorage` operations including listing, pagination, and prefix filtering
-
 ## Related Packages
 
 - [`form-data-parser`](https://github.com/remix-run/remix/tree/main/packages/form-data-parser) - Pairs well with this library for storing `FileUpload` objects received in `multipart/form-data` requests

--- a/packages/file-storage/package.json
+++ b/packages/file-storage/package.json
@@ -41,9 +41,6 @@
       "./package.json": "./package.json"
     }
   },
-  "dependencies": {
-    "aws4fetch": "^1.0.20"
-  },
   "peerDependencies": {
     "@remix-run/fs": "workspace:^",
     "@remix-run/lazy-file": "workspace:^"


### PR DESCRIPTION
Docs, deps and exports were added in https://github.com/remix-run/remix/commit/6378d4d181e5259a8d3263db0b6e1a82232eb512.

Exports were again removed in https://github.com/remix-run/remix/commit/b9be3a9727f764e6dd056e414305e745ddcec7bf, but docs and deps are still present.

This PR removed these leftovers as well