### PR TITLE
feat(fetch-router): add `exclude` option to `createResource` & `createResources`

### DIFF
--- a/packages/fetch-router/src/lib/resource.test.ts
+++ b/packages/fetch-router/src/lib/resource.test.ts
@@ -63,6 +63,30 @@ describe('createResource', () => {
     assert.equal((book as any).create, undefined)
   })
 
+  it('creates a resource with exclude option', () => {
+    let book = resource('book', { exclude: ['new', 'create', 'edit', 'destroy'] })
+
+    type T = [
+      Assert<
+        IsEqual<
+          typeof book,
+          {
+            show: Route<'GET', '/book'>
+            update: Route<'PUT', '/book'>
+          }
+        >
+      >,
+    ]
+
+    assert.deepEqual(book.show, new Route('GET', '/book'))
+    assert.deepEqual(book.update, new Route('PUT', '/book'))
+    // Other routes are excluded from the type
+    assert.equal((book as any).new, undefined)
+    assert.equal((book as any).create, undefined)
+    assert.equal((book as any).edit, undefined)
+    assert.equal((book as any).destroy, undefined)
+  })
+
   it('creates a resource with custom route names', () => {
     let book = resource('book', {
       names: {
@@ -165,6 +189,45 @@ describe('createResource', () => {
     assert.equal((book as any).edit, undefined)
     assert.equal((book as any).destroy, undefined)
   })
+
+  it('creates a resource with custom route names and exclude option', () => {
+    let book = resource('book', {
+      exclude: ['new', 'edit', 'destroy'],
+      names: {
+        show: 'view',
+        create: 'store',
+        update: 'save',
+      },
+    })
+
+    type T = [
+      Assert<
+        IsEqual<
+          typeof book,
+          {
+            view: Route<'GET', '/book'>
+            store: Route<'POST', '/book'>
+            save: Route<'PUT', '/book'>
+          }
+        >
+      >,
+    ]
+
+    assert.deepEqual(book.view, new Route('GET', '/book'))
+    assert.deepEqual(book.store, new Route('POST', '/book'))
+    assert.deepEqual(book.save, new Route('PUT', '/book'))
+    // Other routes are excluded from the type
+    assert.equal((book as any).new, undefined)
+    assert.equal((book as any).edit, undefined)
+    assert.equal((book as any).destroy, undefined)
+  })
+
+  it('throws an error if both only and exclude are specified', () => {
+    assert.throws(
+      () => resource('book', { only: ['show'], exclude: ['destroy'] } as any),
+      /Cannot specify both "only" and "exclude" options/,
+    )
+  })
 })
 
 describe('createResources', () => {
@@ -231,6 +294,32 @@ describe('createResources', () => {
 
   it('creates resources with only option', () => {
     let books = resources('books', { only: ['index', 'show', 'create'] })
+
+    type T = [
+      Assert<
+        IsEqual<
+          typeof books,
+          {
+            index: Route<'GET', '/books'>
+            show: Route<'GET', '/books/:id'>
+            create: Route<'POST', '/books'>
+          }
+        >
+      >,
+    ]
+
+    assert.deepEqual(books.index, new Route('GET', '/books'))
+    assert.deepEqual(books.show, new Route('GET', '/books/:id'))
+    assert.deepEqual(books.create, new Route('POST', '/books'))
+    // Other routes are excluded from the type
+    assert.equal((books as any).new, undefined)
+    assert.equal((books as any).edit, undefined)
+    assert.equal((books as any).update, undefined)
+    assert.equal((books as any).destroy, undefined)
+  })
+
+  it('creates resources with exclude option', () => {
+    let books = resources('books', { exclude: ['new', 'edit', 'update', 'destroy'] })
 
     type T = [
       Assert<
@@ -390,6 +479,39 @@ describe('createResources', () => {
     assert.equal((books as any).destroy, undefined)
   })
 
+  it('creates resources with custom route names and exclude option', () => {
+    let books = resources('books', {
+      exclude: ['new', 'edit', 'update', 'destroy'],
+      names: {
+        index: 'list',
+        show: 'view',
+        create: 'store',
+      },
+    })
+
+    type T = [
+      Assert<
+        IsEqual<
+          typeof books,
+          {
+            list: Route<'GET', '/books'>
+            view: Route<'GET', '/books/:id'>
+            store: Route<'POST', '/books'>
+          }
+        >
+      >,
+    ]
+
+    assert.deepEqual(books.list, new Route('GET', '/books'))
+    assert.deepEqual(books.view, new Route('GET', '/books/:id'))
+    assert.deepEqual(books.store, new Route('POST', '/books'))
+    // Other routes are excluded from the type
+    assert.equal((books as any).new, undefined)
+    assert.equal((books as any).edit, undefined)
+    assert.equal((books as any).update, undefined)
+    assert.equal((books as any).destroy, undefined)
+  })
+
   it('creates resources with custom route names and custom param', () => {
     let posts = resources('posts', {
       param: 'slug',
@@ -485,6 +607,13 @@ describe('createResources', () => {
     assert.deepEqual(
       routes.brands.products.destroy,
       new Route('DELETE', '/brands/:brandId/products/:id'),
+    )
+  })
+
+  it('throws an error if both only and exclude are specified', () => {
+    assert.throws(
+      () => resources('books', { only: ['index'], exclude: ['destroy'] } as any),
+      /Cannot specify both "only" and "exclude" options/,
     )
   })
 })


### PR DESCRIPTION
This PR adds an `exclude` option to `createResource` and `createResources`, providing a more ergonomic way to define CRUD routes when you want most methods except a few.

## Motivation

Currently, when you want most CRUD methods except one or two, you need to explicitly list everything with `only`:

```typescript
// Before: verbose when you only want to exclude one or two methods
const users = resources('users', {
  only: ['index', 'show', 'edit', 'update', 'destroy'] // just to skip 'new' and 'create'
})
```

This is tedious for common scenarios like resources where certain operations are handled elsewhere (e.g., user registration through a separate auth flow, or soft-delete instead of destroy). The `exclude` option makes this cleaner:

```typescript
// After: clearer intent
const users = resources('users', {
  exclude: ['new', 'create'] // registration handled by separate auth system
})
```

## Changes

- Added `exclude` option to `ResourceOptions` and `ResourcesOptions` types
- Implemented mutually exclusive constraint between `only` and `exclude` at both type and runtime levels
- Updated type inference to properly handle the `exclude` option
- Added runtime validation that throws an error if both options are provided
- Added comprehensive test coverage for the new functionality

## Type Safety

The implementation uses discriminated union types to prevent using both `only` and `exclude` simultaneously:

```typescript
// TypeScript error: Type 'never' is not assignable to type...
const invalid = resources('books', {
  only: ['index', 'show'],
  exclude: ['destroy'] // Type error
})
```

Runtime validation also catches this case:

```typescript
// Throws: "Cannot specify both "only" and "exclude" options"
const invalid = resources('books', {
  only: ['index'],
  exclude: ['destroy']
})
```

## Examples

```typescript
// Singleton resource - read-only profile (no create/destroy)
const profile = resource('profile', {
  exclude: ['create', 'destroy']
})
// Generates: show, new, edit, update

// Collection - registration happens via auth system, no deletions
const users = resources('users', {
  exclude: ['new', 'create', 'destroy']
})
// Generates: index, show, edit, update

// Works with all existing options
const posts = resources('posts', {
  exclude: ['destroy'],
  param: 'slug',
  names: { index: 'list', show: 'view' }
})
```

## Backward Compatibility

This change is fully backward compatible:
- Existing code using `only` continues to work unchanged
- No breaking changes to types or function signatures
- The `exclude` option is purely additive