### PR TITLE
`test` command accepts test file path

### DIFF
--- a/packages/async-context-middleware/package.json
+++ b/packages/async-context-middleware/package.json
@@ -44,7 +44,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/compression-middleware/package.json
+++ b/packages/compression-middleware/package.json
@@ -48,7 +48,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/cookie/package.json
+++ b/packages/cookie/package.json
@@ -43,7 +43,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/fetch-proxy/package.json
+++ b/packages/fetch-proxy/package.json
@@ -43,7 +43,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/fetch-router/package.json
+++ b/packages/fetch-router/package.json
@@ -47,7 +47,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/file-storage/package.json
+++ b/packages/file-storage/package.json
@@ -55,7 +55,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/form-data-middleware/package.json
+++ b/packages/form-data-middleware/package.json
@@ -46,7 +46,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/form-data-parser/package.json
+++ b/packages/form-data-parser/package.json
@@ -43,7 +43,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -44,7 +44,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/headers/package.json
+++ b/packages/headers/package.json
@@ -40,7 +40,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/html-template/package.json
+++ b/packages/html-template/package.json
@@ -40,7 +40,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/lazy-file/package.json
+++ b/packages/lazy-file/package.json
@@ -43,7 +43,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/logger-middleware/package.json
+++ b/packages/logger-middleware/package.json
@@ -44,7 +44,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/method-override-middleware/package.json
+++ b/packages/method-override-middleware/package.json
@@ -45,7 +45,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/mime/package.json
+++ b/packages/mime/package.json
@@ -42,7 +42,7 @@
     "clean": "git clean -fdX",
     "codegen": "node --disable-warning=ExperimentalWarning ./scripts/codegen.js",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts' './scripts/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/multipart-parser/package.json
+++ b/packages/multipart-parser/package.json
@@ -52,7 +52,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/node-fetch-server/package.json
+++ b/packages/node-fetch-server/package.json
@@ -41,7 +41,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/response/package.json
+++ b/packages/response/package.json
@@ -61,7 +61,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/route-pattern/package.json
+++ b/packages/route-pattern/package.json
@@ -44,7 +44,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/session-middleware/package.json
+++ b/packages/session-middleware/package.json
@@ -49,7 +49,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -55,7 +55,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/static-middleware/package.json
+++ b/packages/static-middleware/package.json
@@ -52,7 +52,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/tar-parser/package.json
+++ b/packages/tar-parser/package.json
@@ -42,7 +42,7 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "node --disable-warning=ExperimentalWarning --test",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [


### PR DESCRIPTION
Previously, each package had a hardcoded glob for `--test` in its `test` script which blocked the ability to run a single test file via `pnpm test`.

```sh
pnpm test # run all tests
pnpm test src/lib/route-pattern.test.ts # run a single test file
```

You can also combine with the [`--test-name-pattern` flag](https://nodejs.org/api/test.html#filtering-tests-by-name) to filter tests by their name.