### PR TITLE
fix(node-fetch-server): use `:authority` header to set URL of http/2 requests

### DIFF
--- a/packages/node-fetch-server/CHANGELOG.md
+++ b/packages/node-fetch-server/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This is the changelog for [`node-fetch-server`](https://github.com/remix-run/remix/tree/main/packages/node-fetch-server). It follows [semantic versioning](https://semver.org/).
 
+## Unreleased
+
+- Use `:authority` header to set URL of http/2 requests.
+
 ## v0.12.0 (2025-11-04)
 
 - Use `tsc` directly instead of `esbuild` to build the package. This means modules in the `dist` directory now mirror the layout of modules in the `src` directory.

--- a/packages/node-fetch-server/src/lib/request-listener.test.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.test.ts
@@ -184,6 +184,24 @@ describe('createRequestListener', () => {
     })
   })
 
+  it('uses the `:authority` header to construct the URL for http/2 requests', async () => {
+    await new Promise<void>((resolve) => {
+      let handler: FetchHandler = async (request) => {
+        assert.equal(request.url, 'http://example.com/')
+        return new Response('Hello, world!')
+      }
+
+      let listener = createRequestListener(handler)
+      assert.ok(listener)
+
+      let req = createMockRequest({ headers: { ':authority': 'example.com' } })
+      let res = createMockResponse({ req })
+
+      listener(req, res)
+      resolve()
+    })
+  })
+
   it('uses the `host` option to override the `Host` header', async () => {
     await new Promise<void>((resolve) => {
       let handler: FetchHandler = async (request) => {
@@ -397,6 +415,7 @@ function createMockRequest({
       method,
       rawHeaders,
       socket,
+      headers,
     },
   ) as http.IncomingMessage
 }

--- a/packages/node-fetch-server/src/lib/request-listener.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.ts
@@ -148,7 +148,7 @@ export function createRequest(
 
   let protocol =
     options?.protocol ?? ('encrypted' in req.socket && req.socket.encrypted ? 'https:' : 'http:')
-  let host = options?.host ?? headers.get('Host') ?? 'localhost'
+  let host = options?.host ?? headers.get('Host') ?? req.headers[':authority'] ?? 'localhost'
   let url = new URL(req.url!, `${protocol}//${host}`)
 
   let init: RequestInit = { method, headers, signal: controller.signal }


### PR DESCRIPTION
Hello :wave:,

A react-router 7 app that was switched to use SSL for local development introduced a bug where the host of the `request` URL was always `localhost` with no port. I believe it is the same root cause as https://github.com/remix-run/react-router/issues/14010 however the behavior in the latest release differs from that of the description in that issue.

The problem appears to be that this library only considers the `Host` header. [RFC 7540](https://httpwg.org/specs/rfc7540.html#HttpRequest) states:
> Clients that generate HTTP/2 requests directly SHOULD use the :authority pseudo-header field instead of the Host header field. 

This issue can be demonstrated with the http2 demo included in this repo. When it is updated to output the URL like so:
```
diff --git a/packages/node-fetch-server/demos/http2/server.js b/packages/node-fetch-server/demos/http2/server.js
index d5847aa72..c88ff3f5a 100644
--- a/packages/node-fetch-server/demos/http2/server.js
+++ b/packages/node-fetch-server/demos/http2/server.js
@@ -20,7 +20,7 @@ server.on(
     let url = new URL(request.url)

     if (url.pathname === '/') {
-      return new Response('Hello HTTP/2!', {
+      return new Response(`Hello HTTP/2! ${url}\n`, {
         headers: {
           'Content-Type': 'text/plain',
         },
```

On the main branch this is the output:
```
$ curl --cacert server.crt https://localhost:44100
Hello HTTP/2! https://localhost/
```

With this PR this is the output:
```
$ curl --cacert server.crt https://localhost:44100
Hello HTTP/2! https://localhost:44100/

```