### PR TITLE
deps(dev): update `valibot`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -426,6 +426,7 @@
 - lukahartwig
 - lukasgerm
 - LukeAskew
+- lukebowerman
 - lukeshiru
 - m0nica
 - m5r

--- a/packages/remix-dev/__tests__/validateRouteConfig-test.ts
+++ b/packages/remix-dev/__tests__/validateRouteConfig-test.ts
@@ -75,7 +75,7 @@ describe("validateRouteConfig", () => {
         "Route config in "routes.ts" is invalid.
 
         Path: routes.0.children.0.file
-        Invalid type: Expected string but received undefined"
+        Invalid key: Expected "file" but received undefined"
       `);
   });
 
@@ -129,7 +129,7 @@ describe("validateRouteConfig", () => {
         "Route config in "routes.ts" is invalid.
 
         Path: routes.0.children.0.file
-        Invalid type: Expected string but received undefined
+        Invalid key: Expected "file" but received undefined
 
         Path: routes.0.children.1.file
         Invalid type: Expected string but received 123

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -74,7 +74,7 @@
     "set-cookie-parser": "^2.6.0",
     "tar-fs": "^2.1.3",
     "tsconfig-paths": "^4.0.0",
-    "valibot": "^0.41.0",
+    "valibot": "^1.2.0",
     "vite-node": "^3.1.3",
     "ws": "^7.5.10"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1006,8 +1006,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.6
       valibot:
-        specifier: ^0.41.0
-        version: 0.41.0(typescript@5.1.6)
+        specifier: ^1.2.0
+        version: 1.2.0(typescript@5.1.6)
       vite:
         specifier: ^5.1.0 || ^6.0.0
         version: 6.0.6(@types/node@18.17.1)
@@ -14305,8 +14305,8 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.3
       convert-source-map: 1.8.0
 
-  /valibot@0.41.0(typescript@5.1.6):
-    resolution: {integrity: sha512-igDBb8CTYr8YTQlOKgaN9nSS0Be7z+WRuaeYqGf3Cjz3aKmSnqEmYnkfVjzIuumGqfHpa3fLIvMEAfhrpqN8ng==}
+  /valibot@1.2.0(typescript@5.1.6):
+    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:


### PR DESCRIPTION
Update valibot to address a high severity vulnerability described in [GHSA-vqpr-j7v3-hqw9](https://github.com/advisories/GHSA-vqpr-j7v3-hqw9).

This is a similar change to https://github.com/remix-run/react-router/pull/14608 but targeting the Remix v2 series.