### PR TITLE
Dedup workflow runs on PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,7 @@
 on:
   push:
-    branches-ignore:
-      - release-v2
-      - v2
+    branches:
+      - main
   pull_request:
     branches-ignore:
       - release-v2

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,8 +1,7 @@
 on:
   push:
-    branches-ignore:
-      - release-v2
-      - v2
+    branches:
+      - main
   pull_request:
     branches-ignore:
       - release-v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,7 @@
 on:
   push:
-    branches-ignore:
-      - release-v2
-      - v2
+    branches:
+      - main
   pull_request:
     branches-ignore:
       - release-v2


### PR DESCRIPTION
We're currently running duplicate workflows for build/test/check on all PRs because we run on pushes to every branch _and_ PRs to any branch.  So a new commit pushed to a PR triggers the workflow twice.  This PR updates the push trigger to only run on pushes to `main`.

Sample run from https://github.com/remix-run/remix/pull/10894 that triggered this PR:

<img width="916" height="423" alt="Screenshot 2025-12-16 at 2 20 55 PM" src="https://github.com/user-attachments/assets/ac0e0ded-ffc7-47a5-8a15-74d871bcb69d" />
