### PR TITLE
Add `charset` to Content-Type for text-based MIME types

### DIFF
--- a/packages/mime/.changes/minor.detect-content-type.md
+++ b/packages/mime/.changes/minor.detect-content-type.md
@@ -1,0 +1,1 @@
+Add `detectContentType(extension)` function that returns a Content-Type header value with `charset` for text-based types.

--- a/packages/mime/.changes/minor.mime-type-to-content-type.md
+++ b/packages/mime/.changes/minor.mime-type-to-content-type.md
@@ -1,0 +1,1 @@
+Add `mimeTypeToContentType(mimeType)` function that converts a MIME type to a Content-Type header value, adding `charset` for text-based types.

--- a/packages/mime/README.md
+++ b/packages/mime/README.md
@@ -2,7 +2,7 @@
 
 Utilities for working with MIME types.
 
-Data used for these utilities is generated at build time from [mime-db](https://github.com/jshttp/mime-db), but only includes standard MIME types, Experimental (`x-`) and vendor-specific (`vnd.`) MIME types have been excluded.
+Data used for these utilities is generated at build time from [mime-db](https://github.com/jshttp/mime-db), but only includes standard MIME types. Experimental (`x-`) and vendor-specific (`vnd.`) MIME types have been excluded.
 
 ## Installation
 
@@ -24,6 +24,19 @@ detectMimeType('.txt') // 'text/plain'
 detectMimeType('file.txt') // 'text/plain'
 detectMimeType('path/to/file.txt') // 'text/plain'
 detectMimeType('unknown') // undefined
+```
+
+### `detectContentType(extension)`
+
+Detects the Content-Type header value for a given file extension or filename, including `charset` for text-based types. See [`mimeTypeToContentType`](#mimetypetocontenttypemimetype) for charset logic.
+
+```ts
+import { detectContentType } from '@remix-run/mime'
+
+detectContentType('css') // 'text/css; charset=utf-8'
+detectContentType('.json') // 'application/json; charset=utf-8'
+detectContentType('image.png') // 'image/png'
+detectContentType('path/to/file.unknown') // undefined
 ```
 
 ### `isCompressibleMimeType(mimeType)`
@@ -48,6 +61,19 @@ isCompressibleMimeType('text/html; charset=utf-8') // true
 isCompressibleMimeType('application/json; charset=utf-8') // true
 isCompressibleMimeType('image/png; charset=utf-8') // false
 isCompressibleMimeType('video/mp4; charset=utf-8') // false
+```
+
+### `mimeTypeToContentType(mimeType)`
+
+Converts a MIME type to a Content-Type header value, adding `; charset=utf-8` to text-based MIME types: `text/*` (except `text/xml` which has built-in encoding declarations), `application/json`, `application/javascript`, and all `+json` suffixed types. All other types are returned unchanged.
+
+```ts
+import { mimeTypeToContentType } from '@remix-run/mime'
+
+mimeTypeToContentType('text/css') // 'text/css; charset=utf-8'
+mimeTypeToContentType('application/json') // 'application/json; charset=utf-8'
+mimeTypeToContentType('application/ld+json') // 'application/ld+json; charset=utf-8'
+mimeTypeToContentType('image/png') // 'image/png'
 ```
 
 ## License

--- a/packages/mime/src/index.ts
+++ b/packages/mime/src/index.ts
@@ -1,2 +1,4 @@
+export { detectContentType } from './lib/detect-content-type.ts'
 export { detectMimeType } from './lib/detect-mime-type.ts'
 export { isCompressibleMimeType } from './lib/is-compressible-mime-type.ts'
+export { mimeTypeToContentType } from './lib/mime-type-to-content-type.ts'

--- a/packages/mime/src/lib/detect-content-type.test.ts
+++ b/packages/mime/src/lib/detect-content-type.test.ts
@@ -1,0 +1,60 @@
+import * as assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { detectContentType } from './detect-content-type.ts'
+
+describe('detectContentType()', () => {
+  it('returns Content-Type with charset for text types', () => {
+    assert.equal(detectContentType('css'), 'text/css; charset=utf-8')
+    assert.equal(detectContentType('.css'), 'text/css; charset=utf-8')
+    assert.equal(detectContentType('style.css'), 'text/css; charset=utf-8')
+  })
+
+  it('returns Content-Type with charset for JavaScript', () => {
+    assert.equal(detectContentType('js'), 'text/javascript; charset=utf-8')
+    assert.equal(detectContentType('mjs'), 'text/javascript; charset=utf-8')
+  })
+
+  it('returns Content-Type with charset for JSON', () => {
+    assert.equal(detectContentType('json'), 'application/json; charset=utf-8')
+    assert.equal(detectContentType('data.json'), 'application/json; charset=utf-8')
+  })
+
+  it('returns Content-Type without charset for binary types', () => {
+    assert.equal(detectContentType('png'), 'image/png')
+    assert.equal(detectContentType('jpg'), 'image/jpeg')
+    assert.equal(detectContentType('gif'), 'image/gif')
+    assert.equal(detectContentType('pdf'), 'application/pdf')
+    assert.equal(detectContentType('zip'), 'application/zip')
+  })
+
+  it('returns Content-Type with charset for all text/* types', () => {
+    assert.equal(detectContentType('txt'), 'text/plain; charset=utf-8')
+    assert.equal(detectContentType('html'), 'text/html; charset=utf-8')
+    assert.equal(detectContentType('md'), 'text/markdown; charset=utf-8')
+    assert.equal(detectContentType('csv'), 'text/csv; charset=utf-8')
+  })
+
+  it('returns Content-Type without charset for XML types', () => {
+    // XML has built-in encoding declarations, so charset is not added
+    assert.equal(detectContentType('xml'), 'text/xml')
+    assert.equal(detectContentType('svg'), 'image/svg+xml')
+  })
+
+  it('returns undefined for unknown extensions', () => {
+    assert.equal(detectContentType('unknown'), undefined)
+    assert.equal(detectContentType('.xxyyzz'), undefined)
+    assert.equal(detectContentType('file.xxyyzz'), undefined)
+  })
+
+  it('handles paths', () => {
+    assert.equal(detectContentType('path/to/style.css'), 'text/css; charset=utf-8')
+    assert.equal(detectContentType('/absolute/path/image.png'), 'image/png')
+  })
+
+  it('is case-insensitive', () => {
+    assert.equal(detectContentType('CSS'), 'text/css; charset=utf-8')
+    assert.equal(detectContentType('JSON'), 'application/json; charset=utf-8')
+    assert.equal(detectContentType('PNG'), 'image/png')
+  })
+})

--- a/packages/mime/src/lib/detect-content-type.ts
+++ b/packages/mime/src/lib/detect-content-type.ts
@@ -1,0 +1,23 @@
+import { detectMimeType } from './detect-mime-type.ts'
+import { mimeTypeToContentType } from './mime-type-to-content-type.ts'
+
+/**
+ * Detects the Content-Type header value for a given file extension or filename.
+ *
+ * Returns a full Content-Type value including charset when appropriate, based on
+ * the charset defined in mime-db for the detected MIME type.
+ *
+ * @param extension The file extension (e.g. "css", ".css") or filename (e.g. "style.css")
+ * @returns The Content-Type value, or undefined if not found
+ *
+ * @example
+ * detectContentType('css')           // 'text/css;charset=utf-8'
+ * detectContentType('.css')          // 'text/css;charset=utf-8'
+ * detectContentType('style.css')     // 'text/css;charset=utf-8'
+ * detectContentType('image.png')     // 'image/png'
+ * detectContentType('unknown')       // undefined
+ */
+export function detectContentType(extension: string): string | undefined {
+  let mimeType = detectMimeType(extension)
+  return mimeType ? mimeTypeToContentType(mimeType) : undefined
+}

--- a/packages/mime/src/lib/mime-type-to-content-type.test.ts
+++ b/packages/mime/src/lib/mime-type-to-content-type.test.ts
@@ -1,0 +1,62 @@
+import * as assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { mimeTypeToContentType } from './mime-type-to-content-type.ts'
+
+describe('mimeTypeToContentType()', () => {
+  it('adds charset for all text/* types (except text/xml)', () => {
+    assert.equal(mimeTypeToContentType('text/plain'), 'text/plain; charset=utf-8')
+    assert.equal(mimeTypeToContentType('text/html'), 'text/html; charset=utf-8')
+    assert.equal(mimeTypeToContentType('text/css'), 'text/css; charset=utf-8')
+    assert.equal(mimeTypeToContentType('text/javascript'), 'text/javascript; charset=utf-8')
+    assert.equal(mimeTypeToContentType('text/markdown'), 'text/markdown; charset=utf-8')
+    assert.equal(mimeTypeToContentType('text/csv'), 'text/csv; charset=utf-8')
+  })
+
+  it('adds charset for +json suffixed types', () => {
+    assert.equal(mimeTypeToContentType('application/json'), 'application/json; charset=utf-8')
+    assert.equal(
+      mimeTypeToContentType('application/manifest+json'),
+      'application/manifest+json; charset=utf-8',
+    )
+    assert.equal(mimeTypeToContentType('application/ld+json'), 'application/ld+json; charset=utf-8')
+    assert.equal(
+      mimeTypeToContentType('application/geo+json'),
+      'application/geo+json; charset=utf-8',
+    )
+  })
+
+  it('adds charset for application/javascript', () => {
+    assert.equal(
+      mimeTypeToContentType('application/javascript'),
+      'application/javascript; charset=utf-8',
+    )
+  })
+
+  it('does not add charset for text/xml (has built-in encoding declarations)', () => {
+    assert.equal(mimeTypeToContentType('text/xml'), 'text/xml')
+  })
+
+  it('does not add charset for binary types', () => {
+    assert.equal(mimeTypeToContentType('image/png'), 'image/png')
+    assert.equal(mimeTypeToContentType('image/jpeg'), 'image/jpeg')
+    assert.equal(mimeTypeToContentType('video/mp4'), 'video/mp4')
+    assert.equal(mimeTypeToContentType('audio/mpeg'), 'audio/mpeg')
+    assert.equal(mimeTypeToContentType('application/pdf'), 'application/pdf')
+    assert.equal(mimeTypeToContentType('application/zip'), 'application/zip')
+    assert.equal(mimeTypeToContentType('application/octet-stream'), 'application/octet-stream')
+    assert.equal(mimeTypeToContentType('font/woff2'), 'font/woff2')
+  })
+
+  it('does not duplicate charset if already present', () => {
+    assert.equal(mimeTypeToContentType('text/plain; charset=utf-8'), 'text/plain; charset=utf-8')
+    assert.equal(
+      mimeTypeToContentType('text/html;charset=iso-8859-1'),
+      'text/html;charset=iso-8859-1',
+    )
+  })
+
+  it('handles unknown MIME types', () => {
+    assert.equal(mimeTypeToContentType('application/x-custom'), 'application/x-custom')
+  })
+})

--- a/packages/mime/src/lib/mime-type-to-content-type.ts
+++ b/packages/mime/src/lib/mime-type-to-content-type.ts
@@ -1,0 +1,47 @@
+/**
+ * Converts a MIME type to a Content-Type header value, adding charset when appropriate.
+ *
+ * Adds `; charset=utf-8` to text-based MIME types:
+ * - All `text/*` types (except `text/xml`)
+ * - All `+json` suffixed types (RFC 8259 defines JSON as UTF-8)
+ * - `application/json`, `application/javascript`
+ *
+ * Note: `text/xml` is excluded because XML has built-in encoding detection.
+ * Per the XML spec, documents without an encoding declaration must be UTF-8 or
+ * UTF-16, detectable from byte patterns. Adding an external charset parameter
+ * is redundant and can conflict with the document's internal declaration.
+ *
+ * @see https://www.w3.org/TR/xml/#charencoding
+ *
+ * @param mimeType The MIME type (e.g. "text/css", "image/png")
+ * @returns The Content-Type value with charset if appropriate
+ *
+ * @example
+ * mimeTypeToContentType('text/html')           // 'text/html; charset=utf-8'
+ * mimeTypeToContentType('application/json')    // 'application/json; charset=utf-8'
+ * mimeTypeToContentType('application/ld+json') // 'application/ld+json; charset=utf-8'
+ * mimeTypeToContentType('image/png')           // 'image/png'
+ * mimeTypeToContentType('text/xml')            // 'text/xml'
+ */
+export function mimeTypeToContentType(mimeType: string): string {
+  if (
+    // Already has charset
+    mimeType.includes('charset') ||
+    // Exclude text/xml - XML has built-in encoding detection (see JSDoc above)
+    mimeType === 'text/xml'
+  ) {
+    return mimeType
+  }
+
+  // Text-based types that should have charset=utf-8
+  if (
+    mimeType.startsWith('text/') ||
+    mimeType.endsWith('+json') ||
+    mimeType === 'application/json' ||
+    mimeType === 'application/javascript'
+  ) {
+    return `${mimeType}; charset=utf-8`
+  }
+
+  return mimeType
+}

--- a/packages/response/.changes/patch.content-type-charset.md
+++ b/packages/response/.changes/patch.content-type-charset.md
@@ -1,0 +1,1 @@
+`createFileResponse` now includes `charset` in Content-Type for text-based files.

--- a/packages/response/src/lib/file.ts
+++ b/packages/response/src/lib/file.ts
@@ -1,5 +1,5 @@
 import SuperHeaders from '@remix-run/headers'
-import { isCompressibleMimeType } from '@remix-run/mime'
+import { isCompressibleMimeType, mimeTypeToContentType } from '@remix-run/mime'
 
 /**
  * Custom function for computing file digests.
@@ -105,7 +105,7 @@ export async function createFileResponse(
 
   let headers = new SuperHeaders(request.headers)
 
-  let contentType = file.type
+  let contentType = mimeTypeToContentType(file.type)
   let contentLength = file.size
 
   let etag: string | undefined

--- a/packages/static-middleware/src/lib/static.test.ts
+++ b/packages/static-middleware/src/lib/static.test.ts
@@ -53,7 +53,7 @@ describe('staticFiles middleware', () => {
 
       assert.equal(response.status, 200)
       assert.equal(await response.text(), 'Hello, World!')
-      assert.equal(response.headers.get('Content-Type'), 'text/plain')
+      assert.equal(response.headers.get('Content-Type'), 'text/plain; charset=utf-8')
     })
 
     it('serves a file with HEAD request', async () => {
@@ -71,7 +71,7 @@ describe('staticFiles middleware', () => {
 
       assert.equal(response.status, 200)
       assert.equal(await response.text(), '')
-      assert.equal(response.headers.get('Content-Type'), 'text/plain')
+      assert.equal(response.headers.get('Content-Type'), 'text/plain; charset=utf-8')
     })
 
     it('serves files from nested directories', async () => {
@@ -440,7 +440,7 @@ describe('staticFiles middleware', () => {
       let response = await router.fetch('https://remix.run/subdir/')
       assert.equal(response.status, 200)
       assert.equal(await response.text(), '<h1>Index Page</h1>')
-      assert.equal(response.headers.get('Content-Type'), 'text/html')
+      assert.equal(response.headers.get('Content-Type'), 'text/html; charset=utf-8')
     })
 
     it('serves default index.html when requesting a directory without trailing slash', async () => {
@@ -457,7 +457,7 @@ describe('staticFiles middleware', () => {
       let response = await router.fetch('https://remix.run/subdir')
       assert.equal(response.status, 200)
       assert.equal(await response.text(), '<h1>Index Page</h1>')
-      assert.equal(response.headers.get('Content-Type'), 'text/html')
+      assert.equal(response.headers.get('Content-Type'), 'text/html; charset=utf-8')
     })
 
     it('serves default index.htm when index.html does not exist', async () => {
@@ -474,7 +474,7 @@ describe('staticFiles middleware', () => {
       let response = await router.fetch('https://remix.run/subdir/')
       assert.equal(response.status, 200)
       assert.equal(await response.text(), '<h1>HTM Index Page</h1>')
-      assert.equal(response.headers.get('Content-Type'), 'text/html')
+      assert.equal(response.headers.get('Content-Type'), 'text/html; charset=utf-8')
     })
 
     it('prefers index.html over index.htm when both exist', async () => {
@@ -660,7 +660,7 @@ describe('staticFiles middleware', () => {
 
       assert.equal(response.status, 200)
       assert.equal(await response.text(), 'Hello, World!')
-      assert.equal(response.headers.get('Content-Type'), 'text/plain')
+      assert.equal(response.headers.get('Content-Type'), 'text/plain; charset=utf-8')
     })
   })
 })


### PR DESCRIPTION
Adds `; charset=utf-8` to Content-Type headers for text-based MIME types. Note, `text/xml` is excluded since XML has built-in encoding detection via `<?xml encoding="..."?>`

To power this, I've added a couple of utilities to the `mime` package:
- `mimeTypeToContentType(mimeType)` - converts a MIME type to a Content-Type header value, adding charset for text-based types
- `detectContentType(extension)` - like `detectMimeType` but returns a full Content-Type with charset