### PR TITLE
fix(component): fix `node` replacement

### DIFF
--- a/packages/component/.changes/patch.fix-node-replacement.md
+++ b/packages/component/.changes/patch.fix-node-replacement.md
@@ -1,0 +1,3 @@
+Fix node replacement
+
+Anchors were being calculated incorrectly because it removed the old node before inserting the new one, Now it correctly uses the old node as the anchor for insertion and inserts the new node before removing the old one.

--- a/packages/component/src/lib/vdom.ts
+++ b/packages/component/src/lib/vdom.ts
@@ -463,9 +463,10 @@ function replace(
   vParent: VNode,
   anchor?: Node,
 ) {
-  anchor = anchor || findNextSiblingDomAnchor(curr, curr._parent) || undefined
-  remove(curr, domParent, scheduler)
+  anchor =
+    anchor || findFirstDomAnchor(curr) || findNextSiblingDomAnchor(curr, curr._parent) || undefined
   insert(next, domParent, frame, scheduler, vParent, anchor)
+  remove(curr, domParent, scheduler)
 }
 
 function diffHost(


### PR DESCRIPTION
Anchors were being calculated incorrectly because it removed the old node before inserting the new one, Now it correctly uses the old node as the anchor for insertion and inserts the new node before removing the old one.