### PR TITLE
docs(fetch-router): fix import

### DIFF
--- a/packages/fetch-router/README.md
+++ b/packages/fetch-router/README.md
@@ -31,7 +31,7 @@ The example below is a small site with a home page, an "about" page, and a blog.
 
 ```ts
 import { createRouter, route } from '@remix-run/fetch-router'
-import { logger } from '@remix-run/fetch-router/logger-middleware'
+import { logger } from '@remix-run/logger-middleware'
 
 // `route()` creates a "route map" that organizes routes by name. The keys
 // of the map may be any name, and may be nested to group related routes.


### PR DESCRIPTION
https://github.com/remix-run/remix/blob/main/packages/fetch-router/CHANGELOG.md#v0100-2025-11-19

> v0.10.0 (2025-11-19)
>
> BREAKING CHANGE: All middleware has been extracted into separate npm packages for independent versioning and deployment. Update your imports:
>
> ...

But, fetch routers readme still references the previously included middleware

This PR fixes that