### PR TITLE
Update to node 24 and update CI to use the engines version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version-file: 'package.json'
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version-file: 'package.json'
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,8 +25,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
+          node-version-file: 'package.json'
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version-file: 'package.json'
           cache: pnpm
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typescript-eslint": "^8.40.0"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "scripts": {
     "postinstall": "test -n \"$CI\" || pnpm --filter @remix-run/component exec playwright install",


### PR DESCRIPTION
Dedup the places we define the node version by updating `package.json` `engines.node` to 24 (active LTS) and updating CI scripts to read the node version from that field.