### PR TITLE
separate handler registration from router creation

### DIFF
--- a/packages/fetch-router/demos/bun/app/routes.ts
+++ b/packages/fetch-router/demos/bun/app/routes.ts
@@ -1,6 +1,6 @@
-import { route, form, resources } from '@remix-run/fetch-router'
+import { createRoutes, form, resources } from '@remix-run/fetch-router'
 
-export let routes = route({
+export let routes = createRoutes({
   home: '/',
   login: form('/login'),
   logout: { method: 'POST', pattern: '/logout' },

--- a/packages/fetch-router/demos/bun/index.ts
+++ b/packages/fetch-router/demos/bun/index.ts
@@ -6,7 +6,7 @@ Bun.serve({
   port: PORT,
   async fetch(request) {
     try {
-      return await router.fetch(request)
+      return await router(request)
     } catch (error) {
       console.error(error)
       return new Response('Internal Server Error', { status: 500 })

--- a/packages/fetch-router/demos/cf-workers/app/router.ts
+++ b/packages/fetch-router/demos/cf-workers/app/router.ts
@@ -1,4 +1,4 @@
-import { createRouter } from '@remix-run/fetch-router'
+import { createHandlers } from '@remix-run/fetch-router'
 import { createCookie } from '@remix-run/cookie'
 import { createCookieSessionStorage } from '@remix-run/session/cookie-storage'
 import { formData } from '@remix-run/form-data-middleware'
@@ -30,11 +30,9 @@ function requireAuth(): Middleware {
   }
 }
 
-export let router = createRouter({
-  middleware: [logger(), formData(), session(sessionCookie, sessionStorage)],
-})
+let handlers = createHandlers()
 
-router.map(routes.home, async ({ session }) => {
+handlers.add(routes.home, async ({ session }) => {
   let posts = await data.getPosts(env.DB)
   let username = session.get('username') as string | undefined
 
@@ -80,7 +78,7 @@ router.map(routes.home, async ({ session }) => {
   `)
 })
 
-router.map(routes.login, {
+handlers.add(routes.login, {
   index({ session }) {
     let username = session.get('username') as string | undefined
     if (username) {
@@ -123,12 +121,12 @@ router.map(routes.login, {
   },
 })
 
-router.post(routes.logout, ({ session }) => {
+handlers.post(routes.logout, ({ session }) => {
   session.destroy()
   return redirect(routes.home.href())
 })
 
-router.map(routes.posts, {
+handlers.add(routes.posts, {
   new: {
     middleware: [requireAuth()],
     action() {
@@ -194,4 +192,8 @@ router.map(routes.posts, {
       </html>
     `)
   },
+})
+
+export let router = handlers.router({
+  middleware: [logger(), formData(), session(sessionCookie, sessionStorage)],
 })

--- a/packages/fetch-router/demos/cf-workers/app/routes.ts
+++ b/packages/fetch-router/demos/cf-workers/app/routes.ts
@@ -1,6 +1,6 @@
-import { route, form, resources } from '@remix-run/fetch-router'
+import { createRoutes, form, resources } from '@remix-run/fetch-router'
 
-export let routes = route({
+export let routes = createRoutes({
   home: '/',
   login: form('/login'),
   logout: { method: 'POST', pattern: '/logout' },

--- a/packages/fetch-router/demos/cf-workers/worker.ts
+++ b/packages/fetch-router/demos/cf-workers/worker.ts
@@ -3,7 +3,7 @@ import { router } from './app/router.ts'
 export default {
   async fetch(request): Promise<Response> {
     try {
-      return await router.fetch(request)
+      return await router(request)
     } catch (error) {
       console.error(error)
       return new Response('Internal Server Error', { status: 500 })

--- a/packages/fetch-router/demos/node/app/router.ts
+++ b/packages/fetch-router/demos/node/app/router.ts
@@ -1,4 +1,4 @@
-import { createRouter } from '@remix-run/fetch-router'
+import { createHandlers } from '@remix-run/fetch-router'
 import { createCookie } from '@remix-run/cookie'
 import { createCookieSessionStorage } from '@remix-run/session/cookie-storage'
 import { formData } from '@remix-run/form-data-middleware'
@@ -28,11 +28,9 @@ function requireAuth(): Middleware {
   }
 }
 
-export let router = createRouter({
-  middleware: [logger(), formData(), session(sessionCookie, sessionStorage)],
-})
+let handlers = createHandlers()
 
-router.map(routes.home, ({ session }) => {
+handlers.add(routes.home, ({ session }) => {
   let posts = data.getPosts()
   let username = session.get('username') as string | undefined
 
@@ -78,7 +76,7 @@ router.map(routes.home, ({ session }) => {
   `)
 })
 
-router.map(routes.login, {
+handlers.add(routes.login, {
   index({ session }) {
     let username = session.get('username') as string | undefined
     if (username) {
@@ -119,12 +117,12 @@ router.map(routes.login, {
   },
 })
 
-router.post(routes.logout, ({ session }) => {
+handlers.post(routes.logout, ({ session }) => {
   session.destroy()
   return redirect(routes.home.href())
 })
 
-router.map(routes.posts, {
+handlers.add(routes.posts, {
   new: {
     middleware: [requireAuth()],
     action() {
@@ -190,4 +188,8 @@ router.map(routes.posts, {
       </html>
     `)
   },
+})
+
+export let router = handlers.router({
+  middleware: [logger(), formData(), session(sessionCookie, sessionStorage)],
 })

--- a/packages/fetch-router/demos/node/app/routes.ts
+++ b/packages/fetch-router/demos/node/app/routes.ts
@@ -1,6 +1,6 @@
-import { route, form, resources } from '@remix-run/fetch-router'
+import { createRoutes, form, resources } from '@remix-run/fetch-router'
 
-export let routes = route({
+export let routes = createRoutes({
   home: '/',
   login: form('/login'),
   logout: { method: 'POST', pattern: '/logout' },

--- a/packages/fetch-router/demos/node/server.ts
+++ b/packages/fetch-router/demos/node/server.ts
@@ -8,7 +8,7 @@ const PORT = 44100
 let server = http.createServer(
   createRequestListener(async (request) => {
     try {
-      return await router.fetch(request)
+      return await router(request)
     } catch (error) {
       console.error(error)
       return new Response('Internal Server Error', { status: 500 })

--- a/packages/fetch-router/src/index.ts
+++ b/packages/fetch-router/src/index.ts
@@ -13,12 +13,11 @@ export type { RequestMethod } from './lib/request-methods.ts'
 export {
   Route,
   createRoutes,
-  createRoutes as route, // shorthand
 } from './lib/route-map.ts'
 export type { BuildRoute, RouteMap, RouteDefs, RouteDef } from './lib/route-map.ts'
 
-export { createRouter } from './lib/router.ts'
-export type { MatchData, Router, RouterOptions } from './lib/router.ts'
+export { createHandlers, createRouter } from './lib/router.ts'
+export type { MatchData, Router, RouterOptions, Handlers, LegacyRouter } from './lib/router.ts'
 
 // Route helpers
 


### PR DESCRIPTION
Replace `createRouter` with `createHandlers` so that route/handler registration is guaranteed to happen before router is created. That way matchers can be created with full knowledge of all routes they will ever need to handle, enabling some optimizations based on feature detection.