### PR TITLE
route-pattern: PartPattern.{parse,variants,toString}

### DIFF
--- a/packages/route-pattern/package.json
+++ b/packages/route-pattern/package.json
@@ -36,6 +36,7 @@
     "@ark/attest": "^0.49.0",
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:",
+    "dedent": "^1.7.1",
     "find-my-way": "^9.1.0",
     "path-to-regexp": "^8.2.0",
     "vitest": "4.0.15"

--- a/packages/route-pattern/src/experimental/errors.test.ts
+++ b/packages/route-pattern/src/experimental/errors.test.ts
@@ -1,0 +1,24 @@
+import dedent from 'dedent'
+import { describe, expect, it } from 'vitest'
+
+import { ParseError } from './errors.ts'
+
+describe('ParseError', () => {
+  it('exposes type, source, and index properties', () => {
+    let error = new ParseError('unmatched (', 'foo(bar', 3)
+    expect(error.type).toBe('unmatched (')
+    expect(error.source).toBe('foo(bar')
+    expect(error.index).toBe(3)
+    expect(() => {}).toThrow()
+  })
+
+  it('shows caret under the problematic index', () => {
+    let error = new ParseError('unmatched (', 'api/(v:major', 4)
+    expect(error.toString()).toBe(dedent`
+      ParseError: unmatched (
+
+      api/(v:major
+          ^
+    `)
+  })
+})

--- a/packages/route-pattern/src/experimental/errors.ts
+++ b/packages/route-pattern/src/experimental/errors.ts
@@ -1,0 +1,20 @@
+type ParseErrorType = 'unmatched (' | 'unmatched )' | 'missing variable name' | 'dangling escape'
+
+export class ParseError extends Error {
+  type: ParseErrorType
+  source: string
+  index: number
+
+  constructor(type: ParseErrorType, source: string, index: number) {
+    let underline = ' '.repeat(index) + '^'
+    let message = `${type}\n\n${source}\n${underline}`
+
+    super(message)
+    this.name = 'ParseError'
+    this.type = type
+    this.source = source
+    this.index = index
+  }
+}
+
+export class InternalError extends Error {}

--- a/packages/route-pattern/src/experimental/part-pattern.test.ts
+++ b/packages/route-pattern/src/experimental/part-pattern.test.ts
@@ -1,0 +1,251 @@
+import * as assert from 'node:assert/strict'
+import test, { describe } from 'node:test'
+
+import { PartPattern } from './part-pattern.ts'
+import { ParseError } from './errors.ts'
+
+describe('PartPattern', () => {
+  describe('parse', () => {
+    type AST = ConstructorParameters<typeof PartPattern>[0]
+    function assertParse(source: string, ast: AST) {
+      assert.deepStrictEqual(PartPattern.parse(source), new PartPattern(ast))
+    }
+
+    function assertParseError(source: string, type: ParseError['type'], index: number) {
+      assert.throws(() => PartPattern.parse(source), new ParseError(type, source, index))
+    }
+
+    test('parses static text', () => {
+      assertParse('abc', {
+        tokens: [{ type: 'text', text: 'abc' }],
+        paramNames: [],
+        optionals: new Map(),
+      })
+    })
+
+    test('parses a variable', () => {
+      assertParse(':abc', {
+        tokens: [{ type: ':', nameIndex: 0 }],
+        paramNames: ['abc'],
+        optionals: new Map(),
+      })
+      assertParse(':_hello_WORLD', {
+        tokens: [{ type: ':', nameIndex: 0 }],
+        paramNames: ['_hello_WORLD'],
+        optionals: new Map(),
+      })
+      assertParse(':$_hello_WORLD$123$', {
+        tokens: [{ type: ':', nameIndex: 0 }],
+        paramNames: ['$_hello_WORLD$123$'],
+        optionals: new Map(),
+      })
+    })
+
+    test('parses a wildcard', () => {
+      assertParse('*', {
+        tokens: [{ type: '*', nameIndex: 0 }],
+        paramNames: ['*'],
+        optionals: new Map(),
+      })
+      assertParse('*abc', {
+        tokens: [{ type: '*', nameIndex: 0 }],
+        paramNames: ['abc'],
+        optionals: new Map(),
+      })
+      assertParse('*_hello_WORLD', {
+        tokens: [{ type: '*', nameIndex: 0 }],
+        paramNames: ['_hello_WORLD'],
+        optionals: new Map(),
+      })
+      assertParse('*$_hello_WORLD$123$', {
+        tokens: [{ type: '*', nameIndex: 0 }],
+        paramNames: ['$_hello_WORLD$123$'],
+        optionals: new Map(),
+      })
+    })
+
+    test('parses an optional', () => {
+      assertParse('aa(bb)cc', {
+        tokens: [
+          { type: 'text', text: 'aa' },
+          { type: '(' },
+          { type: 'text', text: 'bb' },
+          { type: ')' },
+          { type: 'text', text: 'cc' },
+        ],
+        paramNames: [],
+        optionals: new Map([[1, 3]]),
+      })
+      assertParse('(aa(bb)cc)', {
+        tokens: [
+          { type: '(' },
+          { type: 'text', text: 'aa' },
+          { type: '(' },
+          { type: 'text', text: 'bb' },
+          { type: ')' },
+          { type: 'text', text: 'cc' },
+          { type: ')' },
+        ],
+        paramNames: [],
+        optionals: new Map([
+          [0, 6],
+          [2, 4],
+        ]),
+      })
+    })
+
+    test('parses combinations of text, variables, wildcards, optionals', () => {
+      assertParse('api/(v:major(.:minor)/)run', {
+        tokens: [
+          { type: 'text', text: 'api/' },
+          { type: '(' },
+          { type: 'text', text: 'v' },
+          { type: ':', nameIndex: 0 },
+          { type: '(' },
+          { type: 'text', text: '.' },
+          { type: ':', nameIndex: 1 },
+          { type: ')' },
+          { type: 'text', text: '/' },
+          { type: ')' },
+          { type: 'text', text: 'run' },
+        ],
+        paramNames: ['major', 'minor'],
+        optionals: new Map([
+          [1, 9],
+          [4, 7],
+        ]),
+      })
+
+      assertParse('*/node_modules/(*path/):package/dist/index.:ext', {
+        tokens: [
+          { type: '*', nameIndex: 0 },
+          { type: 'text', text: '/node_modules/' },
+          { type: '(' },
+          { type: '*', nameIndex: 1 },
+          { type: 'text', text: '/' },
+          { type: ')' },
+          { type: ':', nameIndex: 2 },
+          { type: 'text', text: '/dist/index.' },
+          { type: ':', nameIndex: 3 },
+        ],
+        paramNames: ['*', 'path', 'package', 'ext'],
+        optionals: new Map([[2, 5]]),
+      })
+    })
+
+    test('parses repeated param names', () => {
+      assertParse(':id/:id', {
+        tokens: [
+          { type: ':', nameIndex: 0 },
+          { type: 'text', text: '/' },
+          { type: ':', nameIndex: 1 },
+        ],
+        paramNames: ['id', 'id'],
+        optionals: new Map(),
+      })
+      assertParse('*id/*id', {
+        tokens: [
+          { type: '*', nameIndex: 0 },
+          { type: 'text', text: '/' },
+          { type: '*', nameIndex: 1 },
+        ],
+        paramNames: ['id', 'id'],
+        optionals: new Map(),
+      })
+      assertParse('*/*', {
+        tokens: [
+          { type: '*', nameIndex: 0 },
+          { type: 'text', text: '/' },
+          { type: '*', nameIndex: 1 },
+        ],
+        paramNames: ['*', '*'],
+        optionals: new Map(),
+      })
+      assertParse(':a/*a/:b/*b/:b/*a/:a', {
+        tokens: [
+          { type: ':', nameIndex: 0 },
+          { type: 'text', text: '/' },
+          { type: '*', nameIndex: 1 },
+          { type: 'text', text: '/' },
+          { type: ':', nameIndex: 2 },
+          { type: 'text', text: '/' },
+          { type: '*', nameIndex: 3 },
+          { type: 'text', text: '/' },
+          { type: ':', nameIndex: 4 },
+          { type: 'text', text: '/' },
+          { type: '*', nameIndex: 5 },
+          { type: 'text', text: '/' },
+          { type: ':', nameIndex: 6 },
+        ],
+        paramNames: ['a', 'a', 'b', 'b', 'b', 'a', 'a'],
+        optionals: new Map(),
+      })
+    })
+
+    test("throws 'unmatched ('", () => {
+      assertParseError('(', 'unmatched (', 0)
+      assertParseError('(()', 'unmatched (', 0)
+      assertParseError('()(', 'unmatched (', 2)
+    })
+    test("throws 'unmatched )'", () => {
+      assertParseError(')', 'unmatched )', 0)
+      assertParseError(')()', 'unmatched )', 0)
+      assertParseError('())', 'unmatched )', 2)
+    })
+    test("throws 'missing variable name'", () => {
+      assertParseError(':', 'missing variable name', 0)
+      assertParseError('a:', 'missing variable name', 1)
+      assertParseError('(a:)', 'missing variable name', 2)
+      assertParseError(':(a)', 'missing variable name', 0)
+      assertParseError(':123', 'missing variable name', 0)
+      assertParseError('::', 'missing variable name', 0)
+    })
+    test("throws 'dangling escape'", () => {
+      assertParseError('\\', 'dangling escape', 0)
+    })
+  })
+
+  describe('variants', () => {
+    function assertVariants(source: string, variants: PartPattern['variants']) {
+      assert.deepStrictEqual(PartPattern.parse(source).variants, variants)
+    }
+
+    test('produces all possible combinations of optionals', () => {
+      assertVariants('a(:b)*c', [
+        { key: 'a{*}', paramNames: ['c'] },
+        { key: 'a{:}{*}', paramNames: ['b', 'c'] },
+      ])
+      assertVariants('a(:b)c(*d)e', [
+        { key: 'ace', paramNames: [] },
+        { key: 'ac{*}e', paramNames: ['d'] },
+        { key: 'a{:}ce', paramNames: ['b'] },
+        { key: 'a{:}c{*}e', paramNames: ['b', 'd'] },
+      ])
+      assertVariants('a(:b(*c):d)e', [
+        { key: 'ae', paramNames: [] },
+        { key: 'a{:}{:}e', paramNames: ['b', 'd'] },
+        { key: 'a{:}{*}{:}e', paramNames: ['b', 'c', 'd'] },
+      ])
+      assertVariants('a(:b(*c):d)e(*f)g', [
+        { key: 'aeg', paramNames: [] },
+        { key: 'ae{*}g', paramNames: ['f'] },
+        { key: 'a{:}{:}eg', paramNames: ['b', 'd'] },
+        { key: 'a{:}{:}e{*}g', paramNames: ['b', 'd', 'f'] },
+        { key: 'a{:}{*}{:}eg', paramNames: ['b', 'c', 'd'] },
+        { key: 'a{:}{*}{:}e{*}g', paramNames: ['b', 'c', 'd', 'f'] },
+      ])
+    })
+  })
+
+  describe('toString', () => {
+    test('stringifies combinations of text, variables, wildcards, optionals', () => {
+      let examples = [
+        'api/(v:major(.:minor)/)run',
+        '*/node_modules/(*path/):package/dist/index.:ext',
+      ]
+      for (let source of examples) {
+        assert.equal(PartPattern.parse(source).toString(), source)
+      }
+    })
+  })
+})

--- a/packages/route-pattern/src/experimental/part-pattern.ts
+++ b/packages/route-pattern/src/experimental/part-pattern.ts
@@ -1,0 +1,208 @@
+import { ParseError } from './errors.ts'
+import type { Span } from './span.ts'
+
+type AST = {
+  tokens: Array<Token>
+  paramNames: Array<string>
+  optionals: Map<number, number>
+}
+
+type Token =
+  | { type: 'text'; text: string }
+  | { type: '(' | ')' }
+  | { type: ':' | '*'; nameIndex: number }
+
+type Variant = {
+  key: string
+  paramNames: Array<string>
+}
+
+const IDENTIFIER_RE = /^[a-zA-Z_$][a-zA-Z_$0-9]*/
+
+export class PartPattern {
+  readonly tokens: AST['tokens']
+  readonly paramNames: AST['paramNames']
+  readonly optionals: AST['optionals']
+  #variants: Array<Variant> | undefined
+
+  constructor(ast: AST) {
+    this.tokens = ast.tokens
+    this.paramNames = ast.paramNames
+    this.optionals = ast.optionals
+  }
+
+  static parse(source: string, span?: Span): PartPattern {
+    span ??= [0, source.length]
+
+    let ast: AST = {
+      tokens: [],
+      paramNames: [],
+      optionals: new Map(),
+    }
+
+    let appendText = (text: string) => {
+      let currentToken = ast.tokens.at(-1)
+      if (currentToken?.type === 'text') {
+        currentToken.text += text
+      } else {
+        ast.tokens.push({ type: 'text', text })
+      }
+    }
+
+    let i = span[0]
+    let optionalStack: Array<number> = []
+    while (i < span[1]) {
+      let char = source[i]
+
+      // optional begin
+      if (char === '(') {
+        optionalStack.push(ast.tokens.length)
+        ast.tokens.push({ type: char })
+        i += 1
+        continue
+      }
+
+      // optional end
+      if (char === ')') {
+        let begin = optionalStack.pop()
+        if (begin === undefined) {
+          throw new ParseError('unmatched )', source, i)
+        }
+        ast.optionals.set(begin, ast.tokens.length)
+        ast.tokens.push({ type: char })
+        i += 1
+        continue
+      }
+
+      // variable
+      if (char === ':') {
+        i += 1
+        let name = IDENTIFIER_RE.exec(source.slice(i, span[1]))?.[0]
+        if (!name) {
+          throw new ParseError('missing variable name', source, i - 1)
+        }
+        ast.tokens.push({ type: ':', nameIndex: ast.paramNames.length })
+        ast.paramNames.push(name)
+        i += name.length
+        continue
+      }
+
+      // wildcard
+      if (char === '*') {
+        i += 1
+        let name = IDENTIFIER_RE.exec(source.slice(i, span[1]))?.[0]
+        ast.tokens.push({ type: '*', nameIndex: ast.paramNames.length })
+        ast.paramNames.push(name ?? '*')
+        i += name?.length ?? 0
+        continue
+      }
+
+      // escaped char
+      if (char === '\\') {
+        if (i + 1 === span[1]) {
+          throw new ParseError('dangling escape', source, i)
+        }
+        let text = source.slice(i, i + 2)
+        appendText(text)
+        i += text.length
+        continue
+      }
+
+      // text
+      appendText(char)
+      i += 1
+    }
+    if (optionalStack.length > 0) {
+      throw new ParseError('unmatched (', source, optionalStack.at(-1)!)
+    }
+
+    return new PartPattern(ast)
+  }
+
+  get variants(): Array<Variant> {
+    if (this.#variants !== undefined) {
+      return this.#variants
+    }
+
+    let result: Array<Variant> = []
+
+    let stack: Array<{ index: number; variant: Variant }> = [
+      { index: 0, variant: { key: '', paramNames: [] } },
+    ]
+    while (stack.length > 0) {
+      let { index, variant } = stack.pop()!
+
+      if (index === this.tokens.length) {
+        result.push(variant)
+        continue
+      }
+
+      let token = this.tokens[index]
+      if (token.type === '(') {
+        stack.push(
+          { index: index + 1, variant }, // include optional
+          { index: this.optionals.get(index)! + 1, variant: structuredClone(variant) }, // exclude optional
+        )
+        continue
+      }
+      if (token.type === ')') {
+        stack.push({ index: index + 1, variant })
+        continue
+      }
+
+      if (token.type === ':') {
+        variant.key += '{:}'
+        variant.paramNames.push(this.paramNames[token.nameIndex])
+        stack.push({ index: index + 1, variant })
+        continue
+      }
+
+      if (token.type === '*') {
+        variant.key += '{*}'
+        variant.paramNames.push(this.paramNames[token.nameIndex])
+        stack.push({ index: index + 1, variant })
+        continue
+      }
+
+      if (token.type === 'text') {
+        variant.key += token.text
+        stack.push({ index: index + 1, variant })
+        continue
+      }
+
+      throw unrecognized(token.type)
+    }
+
+    this.#variants = result
+    return result
+  }
+
+  toString(): string {
+    let result = ''
+    for (let token of this.tokens) {
+      if (token.type === '(' || token.type === ')') {
+        result += token.type
+        continue
+      }
+
+      if (token.type === ':' || token.type === '*') {
+        let name = this.paramNames[token.nameIndex]
+        if (name === '*') name = ''
+        result += token.type + name
+        continue
+      }
+
+      if (token.type === 'text') {
+        result += token.text
+        continue
+      }
+
+      throw unrecognized(token.type)
+    }
+    return result
+  }
+}
+
+function unrecognized(tokenType: never) {
+  return new Error(`Unrecognized token type '${tokenType}'`)
+}

--- a/packages/route-pattern/src/experimental/span.ts
+++ b/packages/route-pattern/src/experimental/span.ts
@@ -1,0 +1,1 @@
+export type Span = [begin: number, end: number]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -930,6 +930,9 @@ importers:
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20251125.1
+      dedent:
+        specifier: ^1.7.1
+        version: 1.7.1
       find-my-way:
         specifier: ^9.1.0
         version: 9.3.0
@@ -2804,6 +2807,14 @@ packages:
       supports-color:
         optional: true
 
+  dedent@1.7.1:
+    resolution: {integrity: sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -4560,6 +4571,7 @@ packages:
   wrangler@4.55.0:
     resolution: {integrity: sha512-50icmLX8UbNaq0FmFHbcvvOh7I6rDA/FyaMYRcNSl1iX0JwuKswezmmtYvYPxPTkbYz7FUYR8GPZLaT23uzFqw==}
     engines: {node: '>=20.0.0'}
+    deprecated: This version can incorrectly automatically delegate 'wrangler deploy' to 'opennextjs-cloudflare'
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^4.20251213.0
@@ -6249,6 +6261,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  dedent@1.7.1: {}
 
   deep-eql@5.0.2: {}
 


### PR DESCRIPTION
## Context

During the development of `route-pattern`, the design for the Route Pattern DSL changed many times. This wasn't unexpected, but it did mean that the matching APIs (`ArrayMatcher`, `TrieMatcher`, etc.) and parsing algorithms always had to "catch up" to the newest DSL changes. Over time, this led to some bolted-on bits and some gaps in the matching/parsing.

Additionally, the current `ArrayMatcher` and `TrieMatcher` aren't guaranteed to return the same "best" match. `ArrayMatcher` just bails as soon as it finds its first match and `TrieMatcher` does some ad-hoc scoring.

The goal moving forward is to spec out the parsing/matching (via unit tests + docs) and implement a simple, consistent ranking metric for `ArrayMatcher`, `TrieMatcher`, or any other matcher.

Here's my plan:

- `PartPattern.{parse,variants,toString}` (this PR)
- `RoutePattern.{parse,join}`
- `TrieMatcher.{add,matchAll}` (w/o ranking)
- Ranking + `TrieMatcher.{match, matchAll}`
- `ArrayMatcher.{add,match,matchAll}`

## `PartPattern`

As a first step towards this goal, this PR implements a new design for the parts of a Route Pattern that are allowed to use the pattern DSL. Today, that includes the protocol, hostname, and pathname, but in the future its likely that the protocol will be simplified to just accept the known network schemes (`http`, `https`, `http(s)`, `ws`, `wss`, `ws(s)`, `ftp`, ...).

Knowing that we want to eventually use `PartPattern`s within `RoutePattern`s to power a `TrieMatcher`, this new implementation aims for a simpler flat AST:

<img width="2434" height="1158" alt="image" src="https://github.com/user-attachments/assets/ddf68fdd-db67-4400-bd5e-60f4ace0f789" />

This AST representation has a couple benefits over the previous implementation:

**Traversal** is simpler and faster since its just a for-loop where you can decide to skip any optionals as you go. Specifically, **variants** (for construction trie branches) are trivial to implement.

**Feature detection** is simpler and faster. For example, does this part pattern have any params? Check `ast.paramNames.length > 0`? Any optionals? Check `ast.optionals.size > 0`. Etc.

**Joining patterns** is more efficient. Previously, `RoutePattern.join` reparsed the entire pathname on every invocation whereas with this AST, we can simple concatenate the two `pathnames` (adding a `/` text node between them as necessary) and quickly apply an offset to the second pattern's `paramNames` and `optionals`. 
  
To be clear, the goal isn't necessary to be faster at parsing part patterns — that can come later with optimizations if needed — but to have a purpose-built structure for our DSL.