### PR TITLE
ci: skip auto formatting of GitHub workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -41,6 +41,7 @@ jobs:
           git config --local user.name "Remix Run Bot"
 
           git add .
+          git reset .github/workflows # PAT doesn't have permission to push workflow changes
           if [ -z "$(git status --porcelain)" ]; then
             echo "No formatting changes"
             exit 0
@@ -48,4 +49,3 @@ jobs:
           git commit -m "chore: format"
           git push
           echo "Pushed formatting changes https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"
-


### PR DESCRIPTION
Ironically, the formatting in the `format.yml` workflow hadn't been formatted by Prettier and had an additional line break at the end. The format workflow then tried to automatically format this and commit it in CI, but the PAT doesn't have permission to edit workflows so it breaks the build.

To avoid this happening again, I'm making it so the auto format skips workflow files. This way, you'll still get auto formatting in your editor, it just won't get into this situation in CI.