### PR TITLE
chore: remove date from automated changelog entries

### DIFF
--- a/scripts/changes-preview.ts
+++ b/scripts/changes-preview.ts
@@ -44,11 +44,10 @@ function main() {
   console.log(colorize('CHANGELOG PREVIEW', colors.lightBlue))
   console.log()
 
-  let now = new Date()
   for (let release of releases) {
     console.log(colorize(`${release.packageName}/CHANGELOG.md:`, colors.gray))
     console.log()
-    console.log(generateChangelogContent(release, { date: now }))
+    console.log(generateChangelogContent(release))
   }
 
   console.log(colorize('COMMIT MESSAGE', colors.lightBlue))

--- a/scripts/changes-version.ts
+++ b/scripts/changes-version.ts
@@ -101,8 +101,6 @@ function main() {
   console.log('═'.repeat(80))
   console.log()
 
-  let now = new Date()
-
   // Process each package
   for (let release of releases) {
     console.log(
@@ -114,7 +112,7 @@ function main() {
     updatePackageJson(release.packageName, release.nextVersion)
 
     // Update CHANGELOG.md
-    let changelogContent = generateChangelogContent(release, { date: now })
+    let changelogContent = generateChangelogContent(release)
     updateChangelog(release.packageName, changelogContent)
 
     // Delete change files

--- a/scripts/utils/changes.ts
+++ b/scripts/utils/changes.ts
@@ -246,8 +246,6 @@ export function formatChangelogEntry(content: string): string {
 }
 
 interface ChangelogContentOptions {
-  /** Date to include in the heading. If null, date is omitted. */
-  date?: Date | null
   /** Whether to include package name in heading. Default: false */
   includePackageName?: boolean
   /** Markdown heading level (2 = ##, 3 = ###). Default: 2 */
@@ -261,13 +259,12 @@ export function generateChangelogContent(
   release: PackageRelease,
   options: ChangelogContentOptions = {},
 ): string {
-  let { date = null, includePackageName = false, headingLevel = 2 } = options
+  let { includePackageName = false, headingLevel = 2 } = options
   let lines: string[] = []
 
   let headingPrefix = '#'.repeat(headingLevel)
   let packagePart = includePackageName ? `${release.packageName} ` : ''
-  let datePart = date ? ` (${date.toISOString().split('T')[0]})` : ''
-  lines.push(`${headingPrefix} ${packagePart}v${release.nextVersion}${datePart}`)
+  lines.push(`${headingPrefix} ${packagePart}v${release.nextVersion}`)
   lines.push('')
 
   // Sort changes alphabetically by filename, with breaking changes hoisted to the top


### PR DESCRIPTION
These dates are generated as part of the "Version Packages" PR flow, which means they might be incorrect by the time the PR is actually merged.