### PR TITLE
BREAKING: Component API tweaks

### DIFF
--- a/packages/component/.changes/minor.component-api-tweaks.md
+++ b/packages/component/.changes/minor.component-api-tweaks.md
@@ -1,0 +1,299 @@
+BREAKING CHANGE: Updated Component API
+
+- Removed stateless components favoring a single component shape
+- Components no longer called with `this` function context
+- Introduced `setup` prop
+  - `setup` prop is passed to the setup function
+  - `props` are only passed to the render function
+
+## Example:
+
+**Before**
+
+```tsx
+function Counter(
+  // `this` binding
+  this: Handle,
+  // props available in setup scope
+  { initialCount }: { initialCount: number },
+) {
+  let count = initialCount
+
+  return ({ label }: { label: string }) => (
+    <button
+      on={{
+        click: () => {
+          count++
+          this.update()
+        },
+      }}
+    >
+      {label} {count}
+    </button>
+  )
+}
+
+let el = <Counter initialCount={10} label="Count" />
+```
+
+**After**
+
+```tsx
+function Counter(
+  // handle is a normal parameter
+  handle: Handle,
+  // only `setup` prop available in setup scope
+  setup: number,
+) {
+  let count = setup
+
+  // props only available in render scope
+  return (props: { label: string }) => (
+    <button
+      on={{
+        click() {
+          count++
+          handle.update()
+        },
+      }}
+    >
+      {props.label} {count}
+    </button>
+  )
+}
+
+// usage
+let el = <Counter setup={10} label="Count" />
+```
+
+## Discussion:
+
+### Removing stateless components
+
+There was conceptual overhead of "stateful vs. stateless components" that is completely gone. All components must return a render function whether state is managed or not.
+
+By having only one component shape, you no longer have to think about when to return a function and when not to. It also smooths over refactors and the cognitive overhead of swapping between the two forms as the requirements change.
+
+Additionally, the subtle difference between the two forms was hard to spot in practice.
+
+```tsx
+// this has a bug
+function Counter(this: Handle) {
+  let count = 0
+  return (
+    <button
+      on={{
+        click: () => {
+          count++
+          this.update()
+        },
+      }}
+    >
+      This has a bug.
+    </button>
+  )
+}
+
+// this was the fix, very hard to spot!
+function Counter(this: Handle) {
+  let count = 0
+  return () => (
+    <button
+      on={{
+        click: () => {
+          count++
+          this.update()
+        },
+      }}
+    >
+      This doesn't
+    </button>
+  )
+}
+```
+
+The utility of being able to write `return (` instead of `() => (` has little benefit compared to the risks it created.
+
+- Both `handle` and `props` are optional arguments.
+- All components must return a function, there is no longer a distinction between stateful or stateless components
+
+```tsx
+// "stateless" component before
+function SomeLayout({ children }: { children: RemixNode }) {
+  return (
+    <div>
+      <h1>Some Title</h1>
+      <main>{children}</main>
+    </div>
+  )
+}
+
+// after this change (returns a render function)
+function SomeLayout() {
+  return ({ children }: { children: RemixNode }) => (
+    <div>
+      <h1>Some Title</h1>
+      <main>{children}</main>
+    </div>
+  )
+}
+```
+
+### The `setup` prop
+
+The `setup` prop exists primarily to keep regular props out of the setup scope, preventing accidental stale captures.
+
+When props were available in the setup scope it was easy to accidentally capture the initial value and then lose updates from parents.
+
+For example:
+
+```tsx
+function Counter(
+  this: Handle,
+  // captured `label` in the wrong scope
+  props: { label: string; initialCount: number },
+) {
+  let count = initialCount
+
+  return () => (
+    <button
+      on={{
+        click: () => {
+          count++
+          this.update()
+        },
+      }}
+    >
+      {label /* stale! */} {count}
+    </button>
+  )
+}
+```
+
+This was particularly troublesome when a component switched from stateless to stateful. If you forgot to shuffle the props from the setup scope to the newly created render scope, all of the props are now stale. It was also easy to define new props for an existing component in the setup scope when it should have been in the render scope.
+
+Now it's simply impossible to make these mistakes because the props aren't available in the setup scope at all.
+
+```tsx
+function Counter(
+  handle: Handle,
+  // only the setup prop is passed here, no access to `label`
+  setup: { count: number },
+) {
+  let count = setup.count
+
+  return ({ label }: { label: string }) => (
+    <button
+      on={{
+        click() {
+          count++
+          handle.update()
+        },
+      }}
+    >
+      {label} {count}
+    </button>
+  )
+}
+
+let el = <Counter setup={{ count: 10 }} label="Count" />
+```
+
+Now, the only way to make a prop stale is to do it very intentionally:
+
+```tsx
+// this is a bad example, showing the difficulty and ill-advised method of
+// making a prop value static by moving props into the setup scope
+function Counter(handle: Handle, setup: number) {
+  let count = setup
+  let initialLabel: string
+
+  return (props: { label: string }) => {
+    // what used to be an accident is now difficult to do on purpose
+    if (!initialLabel) {
+      initialLabel = props.label
+    }
+    return (
+      <button
+        on={{
+          click: () => {
+            count++
+            handle.update()
+          },
+        }}
+      >
+        {initialLabel} {count}
+      </button>
+    )
+  }
+}
+```
+
+However, it is advised to use the setup prop if you intend for a value to be static, like `setup.count`. Props that are rendered should typically be props and not setup.
+
+### `this` binding removal
+
+We used `this` simply for its "optional first position" characteristic. Otherwise, it was difficult to decide which parameter should come first: handle or props?
+
+```tsx
+// need handle but not props
+function PropsFirst(_: PropType, handle: Handle) {}
+
+// or with a reversed signature, need props but not handle
+function HandleFirst(_: Handle, props: PropType) {}
+```
+
+Using `this` as an optional context argument solved the problem well:
+
+```tsx
+function Neither() {}
+function Both(this: Handle, props: PropType) {}
+function OnlyHandle(this: Handle) {}
+function OnlyProps(props: PropType) {}
+```
+
+This is no longer a concern since props have been removed from the setup scope because:
+
+- If you need `setup` then you are likely stateful
+- If you are stateful you need the handle
+- Therefore `setup` isn't useful without `handle`
+
+This affords a function signature that doesn't require skipping the first argument to get access to the second:
+
+```tsx
+function OnlyHandle(handle: Handle) {}
+function Both(handle: Handle, setup: SomeInterface) {}
+function Neither() {}
+function OnlySetup(_: Handle, setup: SomeInterface) {
+  // rare: unclear what setup would be used for without a handle
+}
+```
+
+So without needing `this` for anything other than an optional first argument, we can remove the constraint. This allows for more flexible function syntax instead of requiring arrow function expressions everywhere inside a component.
+
+```tsx
+function Counter(handle: Handle, setup: number) {
+  let count = setup
+
+  // function declarations inside the setup scope
+  function updateCount() {
+    count++
+    handle.update()
+  }
+
+  return (props: { label: string }) => {
+    return (
+      <button
+        on={{
+          // object method shorthand
+          click() {
+            updateCount()
+          },
+        }}
+      >
+        {props.label} {count}
+      </button>
+    )
+  }
+}
+```

--- a/packages/component/bench/frameworks/remix/index.tsx
+++ b/packages/component/bench/frameworks/remix/index.tsx
@@ -12,8 +12,8 @@ import { type Handle, createRoot } from '@remix-run/component'
 
 export const name = 'remix'
 
-function Button({ id, text, fn }: { id: string; text: string; fn: () => void }) {
-  return (
+function Button() {
+  return ({ id, text, fn }: { id: string; text: string; fn: () => void }) => (
     <div class="col-sm-6 smallpad">
       <button id={id} class="btn btn-primary btn-block" type="button" on={{ click: fn }}>
         {text}
@@ -23,28 +23,25 @@ function Button({ id, text, fn }: { id: string; text: string; fn: () => void }) 
 }
 
 // Stateful Metric Card Component
-function MetricCard(
-  this: Handle,
-  { id, label, value, change }: { id: number; label: string; value: string; change: string },
-) {
+function MetricCard(handle: Handle) {
   let selected = false
   let hovered = false
 
-  return () => (
+  return ({ id, label, value, change }: { id: number; label: string; value: string; change: string }) => (
     <div
       class={`metric-card ${selected ? 'selected' : ''}`}
       on={{
         click: () => {
           selected = !selected
-          this.update()
+          handle.update()
         },
         mouseenter: () => {
           hovered = true
-          this.update()
+          handle.update()
         },
         mouseleave: () => {
           hovered = false
-          this.update()
+          handle.update()
         },
         focus: (e: any) => {
           e.currentTarget.style.outline = '2px solid #222'
@@ -76,10 +73,10 @@ function MetricCard(
 }
 
 // Stateful Chart Bar Component
-function ChartBar(this: Handle, { value, index }: { value: number; index: number }) {
+function ChartBar(handle: Handle) {
   let hovered = false
 
-  return () => (
+  return ({ value, index }: { value: number; index: number }) => (
     <div
       class="chart-bar"
       style={{
@@ -96,11 +93,11 @@ function ChartBar(this: Handle, { value, index }: { value: number; index: number
         click: () => {},
         mouseenter: () => {
           hovered = true
-          this.update()
+          handle.update()
         },
         mouseleave: () => {
           hovered = false
-          this.update()
+          handle.update()
         },
         focus: (e: any) => {
           e.currentTarget.style.outline = '2px solid #222'
@@ -116,28 +113,25 @@ function ChartBar(this: Handle, { value, index }: { value: number; index: number
 }
 
 // Stateful Activity Item Component
-function ActivityItem(
-  this: Handle,
-  { id, title, time, icon }: { id: number; title: string; time: string; icon: string },
-) {
+function ActivityItem(handle: Handle) {
   let read = false
   let hovered = false
 
-  return () => (
+  return ({ id, title, time, icon }: { id: number; title: string; time: string; icon: string }) => (
     <li
       class={`activity-item ${read ? 'read' : ''}`}
       on={{
         click: () => {
           read = !read
-          this.update()
+          handle.update()
         },
         mouseenter: () => {
           hovered = true
-          this.update()
+          handle.update()
         },
         mouseleave: () => {
           hovered = false
-          this.update()
+          handle.update()
         },
       }}
       style={{
@@ -174,13 +168,13 @@ function ActivityItem(
 }
 
 // Stateful Dropdown Menu Component
-function DropdownMenu(this: Handle, { rowId }: { rowId: number }) {
+function DropdownMenu(handle: Handle) {
   let open = false
   let hovered = false
 
   let actions = ['View Details', 'Edit', 'Duplicate', 'Archive', 'Delete']
 
-  return () => (
+  return ({ rowId }: { rowId: number }) => (
     <div style={{ position: 'relative', display: 'inline-block' }}>
       <button
         class="btn btn-primary"
@@ -188,15 +182,15 @@ function DropdownMenu(this: Handle, { rowId }: { rowId: number }) {
           click: (e: any) => {
             e.stopPropagation()
             open = !open
-            this.update()
+            handle.update()
           },
           mouseenter: () => {
             hovered = true
-            this.update()
+            handle.update()
           },
           mouseleave: () => {
             hovered = false
-            this.update()
+            handle.update()
           },
           focus: (e: any) => {
             e.currentTarget.style.outline = '2px solid #222'
@@ -231,7 +225,7 @@ function DropdownMenu(this: Handle, { rowId }: { rowId: number }) {
           on={{
             mouseleave: () => {
               open = false
-              this.update()
+              handle.update()
             },
           }}
         >
@@ -242,7 +236,7 @@ function DropdownMenu(this: Handle, { rowId }: { rowId: number }) {
                 click: (e: any) => {
                   e.stopPropagation()
                   open = false
-                  this.update()
+                  handle.update()
                 },
                 mouseenter: (e: any) => {
                   e.currentTarget.style.backgroundColor = '#f5f5f5'
@@ -267,25 +261,25 @@ function DropdownMenu(this: Handle, { rowId }: { rowId: number }) {
 }
 
 // Stateful Dashboard Table Row Component
-function DashboardTableRow(this: Handle, { row }: { row: Row }) {
+function DashboardTableRow(handle: Handle) {
   let hovered = false
   let selected = false
 
-  return () => (
+  return ({ row }: { row: Row }) => (
     <tr
       class={selected ? 'danger' : ''}
       on={{
         click: () => {
           selected = !selected
-          this.update()
+          handle.update()
         },
         mouseenter: () => {
           hovered = true
-          this.update()
+          handle.update()
         },
         mouseleave: () => {
           hovered = false
-          this.update()
+          handle.update()
         },
       }}
       style={{
@@ -309,7 +303,7 @@ function DashboardTableRow(this: Handle, { row }: { row: Row }) {
 }
 
 // Stateful Search Input Component
-function SearchInput(this: Handle) {
+function SearchInput(handle: Handle) {
   let value = ''
   let focused = false
 
@@ -321,15 +315,15 @@ function SearchInput(this: Handle) {
       on={{
         input: (e: any) => {
           value = e.target.value
-          this.update()
+          handle.update()
         },
         focus: () => {
           focused = true
-          this.update()
+          handle.update()
         },
         blur: () => {
           focused = false
-          this.update()
+          handle.update()
         },
       }}
       style={{
@@ -346,7 +340,7 @@ function SearchInput(this: Handle) {
 }
 
 // Stateful Form Widgets Component
-function FormWidgets(this: Handle) {
+function FormWidgets(handle: Handle) {
   let selectValue = 'option1'
   let checkboxValues = new Set<string>()
   let radioValue = 'radio1'
@@ -365,7 +359,7 @@ function FormWidgets(this: Handle) {
           on={{
             change: (e: any) => {
               selectValue = e.target.value
-              this.update()
+              handle.update()
             },
             focus: (e: any) => {
               e.currentTarget.style.borderColor = '#337ab7'
@@ -407,7 +401,7 @@ function FormWidgets(this: Handle) {
                 } else {
                   checkboxValues.delete(`checkbox-${idx}`)
                 }
-                this.update()
+                handle.update()
               },
               focus: (e: any) => {
                 e.currentTarget.style.outline = '2px solid #337ab7'
@@ -434,7 +428,7 @@ function FormWidgets(this: Handle) {
               on={{
                 change: (e: any) => {
                   radioValue = e.target.value
-                  this.update()
+                  handle.update()
                 },
                 focus: (e: any) => {
                   e.currentTarget.style.outline = '2px solid #337ab7'
@@ -469,7 +463,7 @@ function FormWidgets(this: Handle) {
             on={{
               change: (e: any) => {
                 toggleValue = e.target.checked
-                this.update()
+                handle.update()
               },
               focus: (e: any) => {
                 e.currentTarget.style.outline = '2px solid #222'
@@ -545,17 +539,17 @@ function FormWidgets(this: Handle) {
   )
 }
 
-function Dashboard(this: Handle, { onSwitchToTable }: { onSwitchToTable: () => void }) {
+function Dashboard(handle: Handle) {
   let dashboardRows = buildData(300)
 
   let sortDashboardAsc = () => {
     dashboardRows = sortRows(dashboardRows, true)
-    this.update()
+    handle.update()
   }
 
   let sortDashboardDesc = () => {
     dashboardRows = sortRows(dashboardRows, false)
-    this.update()
+    handle.update()
   }
   let chartData = [65, 45, 78, 52, 89, 34, 67, 91, 43, 56, 72, 38, 55, 82, 47, 63, 71, 39, 58, 84]
   let activities = Array.from({ length: 50 }, (_, i) => ({
@@ -565,7 +559,7 @@ function Dashboard(this: Handle, { onSwitchToTable }: { onSwitchToTable: () => v
     icon: ['O', 'P', 'S', 'C', 'U'][i % 5],
   }))
 
-  return () => (
+  return ({ onSwitchToTable }: { onSwitchToTable: () => void }) => (
     <div class="container" style={{ maxWidth: '1400px' }}>
       <div
         style={{
@@ -726,29 +720,29 @@ function Dashboard(this: Handle, { onSwitchToTable }: { onSwitchToTable: () => v
   )
 }
 
-function App(this: Handle) {
+function App(handle: Handle) {
   let rows: Row[] = []
   let selected: number | null = null
   let view: 'table' | 'dashboard' = 'table'
 
   let setRows = (newRows: Row[]) => {
     rows = newRows
-    this.update()
+    handle.update()
   }
 
   let setSelected = (newSelected: number | null) => {
     selected = newSelected
-    this.update()
+    handle.update()
   }
 
   let switchToDashboard = () => {
     view = 'dashboard'
-    this.update()
+    handle.update()
   }
 
   let switchToTable = () => {
     view = 'table'
-    this.update()
+    handle.update()
   }
 
   return () => {
@@ -771,7 +765,7 @@ function App(this: Handle) {
                   fn={() => {
                     rows = get1000Rows()
                     selected = null
-                    this.update()
+                    handle.update()
                   }}
                 />
                 <Button
@@ -780,7 +774,7 @@ function App(this: Handle) {
                   fn={() => {
                     rows = get10000Rows()
                     selected = null
-                    this.update()
+                    handle.update()
                   }}
                 />
                 <Button
@@ -803,7 +797,7 @@ function App(this: Handle) {
                   fn={() => {
                     rows = []
                     selected = null
-                    this.update()
+                    handle.update()
                   }}
                 />
                 <Button

--- a/packages/component/demos/basic/entry.tsx
+++ b/packages/component/demos/basic/entry.tsx
@@ -1,13 +1,13 @@
 import { createRoot, type Handle } from '@remix-run/component'
 
-function App(this: Handle) {
+function App(handle: Handle) {
   let count = 0
   return () => (
     <button
       on={{
         click: () => {
           count++
-          this.update()
+          handle.update()
         },
       }}
     >

--- a/packages/component/demos/drummer/app.tsx
+++ b/packages/component/demos/drummer/app.tsx
@@ -16,10 +16,10 @@ import {
 } from './components.tsx'
 import { createVoiceLooper } from './voice-looper.ts'
 
-export function App(this: Handle<Drummer>) {
+export function App(handle: Handle<Drummer>) {
   let drummer = new Drummer(80)
 
-  this.on(document, {
+  handle.on(document, {
     [space]() {
       drummer.toggle()
     },
@@ -31,7 +31,7 @@ export function App(this: Handle<Drummer>) {
     },
   })
 
-  this.context.set(drummer)
+  handle.context.set(drummer)
 
   return () => (
     <Layout>
@@ -41,20 +41,20 @@ export function App(this: Handle<Drummer>) {
   )
 }
 
-export function Equalizer(this: Handle) {
-  let drummer = this.context.get(App)
+export function Equalizer(handle: Handle) {
+  let drummer = handle.context.get(App)
 
   let kickVolumes = [0.4, 0.8, 0.3, 0.1]
   let snareVolumes = [0.4, 1, 0.7]
   let hatVolumes = [0.1, 0.8]
 
-  let createVoice = createVoiceLooper(this.update)
+  let createVoice = createVoiceLooper(handle.update)
 
   let kick = createVoice()
   let snare = createVoice()
   let hat = createVoice()
 
-  this.on(drummer, {
+  handle.on(drummer, {
     kick() {
       kick.trigger(1)
     },
@@ -67,8 +67,8 @@ export function Equalizer(this: Handle) {
   })
 
   // initial animation on connect
-  this.queueTask(() => {
-    this.update()
+  handle.queueTask(() => {
+    handle.update()
   })
 
   return () => {
@@ -98,13 +98,13 @@ export function Equalizer(this: Handle) {
   }
 }
 
-function DrumControls(this: Handle) {
-  let drummer = this.context.get(App)
+function DrumControls(handle: Handle) {
+  let drummer = handle.context.get(App)
   let stop: HTMLButtonElement
   let play: HTMLButtonElement
 
-  this.on(drummer, {
-    change: () => this.update(),
+  handle.on(drummer, {
+    change: () => handle.update(),
   })
 
   return () => (
@@ -127,7 +127,7 @@ function DrumControls(this: Handle) {
         on={{
           click: () => {
             drummer.play()
-            this.queueTask(() => {
+            handle.queueTask(() => {
               stop.focus()
             })
           },
@@ -142,7 +142,7 @@ function DrumControls(this: Handle) {
         on={{
           [press]: () => {
             drummer.stop()
-            this.queueTask(() => {
+            handle.queueTask(() => {
               play.focus()
             })
           },
@@ -154,8 +154,8 @@ function DrumControls(this: Handle) {
   )
 }
 
-function TempoDisplay(this: Handle) {
-  let drummer = this.context.get(App)
+function TempoDisplay(handle: Handle) {
+  let drummer = handle.context.get(App)
   return () => (
     <TempoLayout>
       <BPMDisplay bpm={drummer.bpm} />

--- a/packages/component/demos/drummer/components.tsx
+++ b/packages/component/demos/drummer/components.tsx
@@ -1,7 +1,7 @@
 import type { Handle, RemixNode, Props } from '@remix-run/component'
 
-export function Layout({ children }: { children: RemixNode }) {
-  return (
+export function Layout() {
+  return ({ children }: { children: RemixNode }) => (
     <div
       css={{
         boxSizing: 'border-box',
@@ -52,8 +52,8 @@ export function Layout({ children }: { children: RemixNode }) {
   )
 }
 
-export function EqualizerLayout({ children }: { children: RemixNode }) {
-  return (
+export function EqualizerLayout() {
+  return ({ children }: { children: RemixNode }) => (
     <div
       css={{
         display: 'flex',
@@ -72,8 +72,8 @@ export function EqualizerLayout({ children }: { children: RemixNode }) {
   )
 }
 
-export function TempoLayout({ children }: { children: RemixNode }) {
-  return (
+export function TempoLayout() {
+  return ({ children }: { children: RemixNode }) => (
     <div
       css={{
         display: 'flex',
@@ -88,8 +88,8 @@ export function TempoLayout({ children }: { children: RemixNode }) {
   )
 }
 
-export function TempoButtons({ children }: { children: RemixNode }) {
-  return (
+export function TempoButtons() {
+  return ({ children }: { children: RemixNode }) => (
     <div
       css={{
         width: 56,
@@ -105,8 +105,8 @@ export function TempoButtons({ children }: { children: RemixNode }) {
   )
 }
 
-export function BPMDisplay(this: Handle, { bpm }: { bpm: number }) {
-  return (
+export function BPMDisplay() {
+  return ({ bpm }: { bpm: number }) => (
     <div
       css={{
         height: '100%',
@@ -149,7 +149,7 @@ export function BPMDisplay(this: Handle, { bpm }: { bpm: number }) {
   )
 }
 
-export function EqualizerBar(this: Handle) {
+export function EqualizerBar(handle: Handle) {
   let colors = [
     '#FF3000',
     '#FF3000',
@@ -192,8 +192,8 @@ export function EqualizerBar(this: Handle) {
   }
 }
 
-export function ControlGroup({ children, css, ...rest }: Props<'div'>) {
-  return (
+export function ControlGroup() {
+  return ({ children, css, ...rest }: Props<'div'>) => (
     <div
       {...rest}
       css={{
@@ -215,8 +215,8 @@ export function ControlGroup({ children, css, ...rest }: Props<'div'>) {
   )
 }
 
-export function Button({ children, ...rest }: Props<'button'>) {
-  return (
+export function Button() {
+  return ({ children, ...rest }: Props<'button'>) => (
     <button
       {...rest}
       css={{
@@ -249,29 +249,31 @@ export function Button({ children, ...rest }: Props<'button'>) {
   )
 }
 
-export function Triangle({ label, orientation }: { label: string; orientation: 'up' | 'down' }) {
-  let up = '5,1.34 9.33,8.66 0.67,8.66'
-  let down = '5,8.66 9.33,1.34 0.67,1.34'
-  return (
-    <svg
-      aria-label={label}
-      viewBox="0 0 10 10"
-      style={{
-        width: 14,
-        height: 14,
-      }}
-    >
-      <polygon points={orientation === 'up' ? up : down} fill="currentColor" />
-    </svg>
-  )
+export function Triangle() {
+  return ({ label, orientation }: { label: string; orientation: 'up' | 'down' }) => {
+    let up = '5,1.34 9.33,8.66 0.67,8.66'
+    let down = '5,8.66 9.33,1.34 0.67,1.34'
+    return (
+      <svg
+        aria-label={label}
+        viewBox="0 0 10 10"
+        style={{
+          width: 14,
+          height: 14,
+        }}
+      >
+        <polygon points={orientation === 'up' ? up : down} fill="currentColor" />
+      </svg>
+    )
+  }
 }
 
 interface TempoButtonProps extends Props<'button'> {
   orientation: 'up' | 'down'
 }
 
-export function TempoButton({ orientation, css, ...rest }: TempoButtonProps) {
-  return (
+export function TempoButton() {
+  return ({ orientation, css, ...rest }: TempoButtonProps) => (
     <button
       {...rest}
       css={{
@@ -305,7 +307,7 @@ export function TempoButton({ orientation, css, ...rest }: TempoButtonProps) {
 }
 
 export function Logo() {
-  return (
+  return () => (
     <svg
       height="65"
       viewBox="0 0 400 143"

--- a/packages/component/demos/keyed-list/entry.tsx
+++ b/packages/component/demos/keyed-list/entry.tsx
@@ -5,7 +5,7 @@ type ListItem = {
   label: string
 }
 
-function App(this: Handle) {
+function App(handle: Handle) {
   let items: ListItem[] = [
     { id: 'a', label: 'Item A' },
     { id: 'b', label: 'Item B' },
@@ -20,7 +20,7 @@ function App(this: Handle) {
     let newItems = [...items]
     ;[newItems[index - 1], newItems[index]] = [newItems[index], newItems[index - 1]]
     items = newItems
-    this.update()
+    handle.update()
   }
 
   let moveDown = (index: number) => {
@@ -28,12 +28,12 @@ function App(this: Handle) {
     let newItems = [...items]
     ;[newItems[index], newItems[index + 1]] = [newItems[index + 1], newItems[index]]
     items = newItems
-    this.update()
+    handle.update()
   }
 
   let reverse = () => {
     items = [...items].reverse()
-    this.update()
+    handle.update()
   }
 
   let shuffle = () => {
@@ -43,7 +43,7 @@ function App(this: Handle) {
       ;[newItems[i], newItems[j]] = [newItems[j], newItems[i]]
     }
     items = newItems
-    this.update()
+    handle.update()
   }
 
   let toggleAutoShuffle = () => {
@@ -55,7 +55,7 @@ function App(this: Handle) {
         shuffle()
       }, 1000)
     }
-    this.update()
+    handle.update()
   }
 
   return () => (

--- a/packages/component/demos/readme/entry.tsx
+++ b/packages/component/demos/readme/entry.tsx
@@ -4,14 +4,14 @@ import { TypedEventTarget } from '@remix-run/interaction'
 // ============================================================================
 // Getting Started - Basic App Example
 // ============================================================================
-function App(this: Handle) {
+function App(handle: Handle) {
   let count = 0
   return () => (
     <button
       on={{
         click: () => {
           count++
-          this.update()
+          handle.update()
         },
       }}
     >
@@ -23,7 +23,7 @@ function App(this: Handle) {
 // ============================================================================
 // Component State and Updates - Counter
 // ============================================================================
-function Counter(this: Handle) {
+function Counter(handle: Handle) {
   let count = 0
 
   return () => (
@@ -33,7 +33,7 @@ function Counter(this: Handle) {
         on={{
           click: () => {
             count++
-            this.update()
+            handle.update()
           },
         }}
       >
@@ -44,28 +44,28 @@ function Counter(this: Handle) {
 }
 
 // ============================================================================
-// Non-Stateful Components - Greeting
+// Components - Greeting
 // ============================================================================
-function Greeting(this: Handle, props: { name: string }) {
-  return <h1>Hello, {props.name}!</h1>
+function Greeting(handle: Handle) {
+  return (props: { name: string }) => <h1>Hello, {props.name}!</h1>
 }
 
 // ============================================================================
 // Stateful Components - CounterWithSetup
 // ============================================================================
-function CounterWithSetup(this: Handle, setupProps: { initial: number }) {
+function CounterWithSetup(handle: Handle, setup: number) {
   // Setup phase: runs once
-  let count = setupProps.initial
+  let count = setup
 
   // Return render function: runs on every update
-  return (renderProps: { label?: string }) => (
+  return (props: { label?: string }) => (
     <div>
-      {renderProps.label || 'Count'}: {count}
+      {props.label || 'Count'}: {count}
       <button
         on={{
           click: () => {
             count++
-            this.update()
+            handle.update()
           },
         }}
       >
@@ -78,22 +78,19 @@ function CounterWithSetup(this: Handle, setupProps: { initial: number }) {
 // ============================================================================
 // Setup Props vs Render Props - CounterWithLabel
 // ============================================================================
-function CounterWithLabel(
-  this: Handle,
-  setupProps: { initial: number }, // receives { initial: 5, label: "Total" }
-) {
-  let count = setupProps.initial // use initial for setup
+function CounterWithLabel(handle: Handle, setup: number) {
+  let count = setup // use setup for initialization
 
-  return (renderProps: { label?: string }) => {
-    // renderProps also receives { initial: 5, label: "Total" }
+  return (props: { label?: string }) => {
+    // props only contains render-time values
     return (
       <div>
-        {renderProps.label}: {count}
+        {props.label}: {count}
         <button
           on={{
             click: () => {
               count++
-              this.update()
+              handle.update()
             },
           }}
         >
@@ -107,7 +104,7 @@ function CounterWithLabel(
 // ============================================================================
 // Events - SearchInput
 // ============================================================================
-function SearchInput(this: Handle) {
+function SearchInput(handle: Handle) {
   let query = ''
   let results: string[] = []
   let loading = false
@@ -122,14 +119,14 @@ function SearchInput(this: Handle) {
           input: (event, signal) => {
             query = event.currentTarget.value
             loading = true
-            this.update()
+            handle.update()
 
             // Simulated search with timeout
             setTimeout(() => {
               if (signal.aborted) return
               results = query ? [`Result for "${query}" 1`, `Result for "${query}" 2`] : []
               loading = false
-              this.update()
+              handle.update()
             }, 300)
           },
         }}
@@ -149,14 +146,14 @@ function SearchInput(this: Handle) {
 // ============================================================================
 // Global Events - KeyboardTracker
 // ============================================================================
-function KeyboardTracker(this: Handle) {
+function KeyboardTracker(handle: Handle) {
   let keys: string[] = []
 
-  this.on(document, {
+  handle.on(document, {
     keydown: (event) => {
       keys.push(event.key)
       if (keys.length > 10) keys.shift()
-      this.update()
+      handle.update()
     },
   })
 
@@ -166,7 +163,7 @@ function KeyboardTracker(this: Handle) {
 // ============================================================================
 // CSS Prop - Button (Basic)
 // ============================================================================
-function ButtonBasic(this: Handle) {
+function ButtonBasic(handle: Handle) {
   return () => (
     <button
       css={{
@@ -192,7 +189,7 @@ function ButtonBasic(this: Handle) {
 // ============================================================================
 // CSS Prop - Button (Advanced with nested rules)
 // ============================================================================
-function ButtonAdvanced(this: Handle) {
+function ButtonAdvanced(handle: Handle) {
   return () => (
     <button
       css={{
@@ -237,7 +234,7 @@ function ButtonAdvanced(this: Handle) {
 // ============================================================================
 // Connect Prop - Form (Basic)
 // ============================================================================
-function FormBasic(this: Handle) {
+function FormBasic(handle: Handle) {
   let inputRef: HTMLInputElement
 
   return () => (
@@ -267,7 +264,7 @@ function FormBasic(this: Handle) {
 // ============================================================================
 // Connect Prop with AbortSignal - ResizeObserver Component
 // ============================================================================
-function ResizeComponent(this: Handle) {
+function ResizeComponent(handle: Handle) {
   let dimensions = { width: 0, height: 0 }
 
   return () => (
@@ -279,7 +276,7 @@ function ResizeComponent(this: Handle) {
           if (entry) {
             dimensions.width = Math.round(entry.contentRect.width)
             dimensions.height = Math.round(entry.contentRect.height)
-            this.update()
+            handle.update()
           }
         })
         observer.observe(node)
@@ -306,9 +303,9 @@ function ResizeComponent(this: Handle) {
 }
 
 // ============================================================================
-// this.update(task) - Player
+// handle.update(task) - Player
 // ============================================================================
-function Player(this: Handle) {
+function Player(handle: Handle) {
   let isPlaying = false
   let playButton: HTMLButtonElement
   let stopButton: HTMLButtonElement
@@ -321,7 +318,7 @@ function Player(this: Handle) {
         on={{
           click: () => {
             isPlaying = true
-            this.update(() => {
+            handle.update(() => {
               // Focus the enabled button after update completes
               stopButton.focus()
             })
@@ -340,7 +337,7 @@ function Player(this: Handle) {
         on={{
           click: () => {
             isPlaying = false
-            this.update(() => {
+            handle.update(() => {
               // Focus the enabled button after update completes
               playButton.focus()
             })
@@ -358,9 +355,9 @@ function Player(this: Handle) {
 }
 
 // ============================================================================
-// this.queueTask - Form with scroll
+// handle.queueTask - Form with scroll
 // ============================================================================
-function FormWithScroll(this: Handle) {
+function FormWithScroll(handle: Handle) {
   let showDetails = false
   let detailsSection: HTMLElement
 
@@ -373,10 +370,10 @@ function FormWithScroll(this: Handle) {
           on={{
             change: (event) => {
               showDetails = event.currentTarget.checked
-              this.update()
+              handle.update()
               if (showDetails) {
                 // Scroll to the expanded section after it renders
-                this.queueTask(() => {
+                handle.queueTask(() => {
                   detailsSection.scrollIntoView({ behavior: 'smooth', block: 'start' })
                 })
               }
@@ -405,29 +402,29 @@ function FormWithScroll(this: Handle) {
 }
 
 // ============================================================================
-// this.signal - Clock
+// handle.signal - Clock
 // ============================================================================
-function Clock(this: Handle) {
+function Clock(handle: Handle) {
   let interval = setInterval(() => {
     // clear the interval when the component is disconnected
-    if (this.signal.aborted) {
+    if (handle.signal.aborted) {
       clearInterval(interval)
       return
     }
-    this.update()
+    handle.update()
   }, 1000)
   return () => <span>{new Date().toLocaleTimeString()}</span>
 }
 
 // ============================================================================
-// this.id - LabeledInput
+// handle.id - LabeledInput
 // ============================================================================
-function LabeledInput(this: Handle) {
+function LabeledInput(handle: Handle) {
   return () => (
     <div css={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-      <label htmlFor={this.id}>Name</label>
+      <label htmlFor={handle.id}>Name</label>
       <input
-        id={this.id}
+        id={handle.id}
         type="text"
         css={{ padding: '4px 8px', borderRadius: '4px', border: '1px solid rgba(255,255,255,0.3)' }}
       />
@@ -438,8 +435,8 @@ function LabeledInput(this: Handle) {
 // ============================================================================
 // Context API - Theme Provider and Consumer
 // ============================================================================
-function ThemeProvider(this: Handle<{ theme: string }>) {
-  this.context.set({ theme: 'dark' })
+function ThemeProvider(handle: Handle<{ theme: string }>) {
+  handle.context.set({ theme: 'dark' })
 
   return () => (
     <div css={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
@@ -448,11 +445,11 @@ function ThemeProvider(this: Handle<{ theme: string }>) {
   )
 }
 
-function ThemedHeader(this: Handle) {
+function ThemedHeader(handle: Handle) {
   // Consume context from ThemeProvider
-  let { theme } = this.context.get(ThemeProvider)
+  let { theme } = handle.context.get(ThemeProvider)
 
-  return (
+  return () => (
     <header
       css={{
         backgroundColor: theme === 'dark' ? '#000' : '#fff',
@@ -480,9 +477,9 @@ class Theme extends TypedEventTarget<{ change: Event }> {
   }
 }
 
-function ThemeProviderAdvanced(this: Handle<Theme>) {
+function ThemeProviderAdvanced(handle: Handle<Theme>) {
   let theme = new Theme()
-  this.context.set(theme)
+  handle.context.set(theme)
 
   return () => (
     <div css={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
@@ -502,11 +499,11 @@ function ThemeProviderAdvanced(this: Handle<Theme>) {
   )
 }
 
-function ThemedContent(this: Handle) {
-  let theme = this.context.get(ThemeProviderAdvanced)
+function ThemedContent(handle: Handle) {
+  let theme = handle.context.get(ThemeProviderAdvanced)
 
   // Subscribe to theme changes and update when it changes
-  this.on(theme, { change: () => this.update() })
+  handle.on(theme, { change: () => handle.update() })
 
   return () => (
     <div
@@ -525,7 +522,7 @@ function ThemedContent(this: Handle) {
 // ============================================================================
 // Fragments - List
 // ============================================================================
-function ListWithFragment(this: Handle) {
+function ListWithFragment(handle: Handle) {
   return () => (
     <ul css={{ margin: 0, paddingLeft: '20px' }}>
       <>
@@ -540,8 +537,8 @@ function ListWithFragment(this: Handle) {
 // ============================================================================
 // Example Container Component
 // ============================================================================
-function Example(this: Handle, props: { title: string; children: RemixNode }) {
-  return (
+function Example(handle: Handle) {
+  return (props: { title: string; children: RemixNode }) => (
     <div className="example">
       <h2>{props.title}</h2>
       <div className="example-content">{props.children}</div>
@@ -552,7 +549,7 @@ function Example(this: Handle, props: { title: string; children: RemixNode }) {
 // ============================================================================
 // Main Demo App
 // ============================================================================
-function DemoApp(this: Handle) {
+function DemoApp(handle: Handle) {
   return () => (
     <div className="examples-grid">
       <Example title="Getting Started - Counter">
@@ -563,16 +560,16 @@ function DemoApp(this: Handle) {
         <Counter />
       </Example>
 
-      <Example title="Non-Stateful - Greeting">
+      <Example title="Greeting">
         <Greeting name="World" />
       </Example>
 
-      <Example title="Stateful - Counter with Setup">
-        <CounterWithSetup initial={10} label="Total" />
+      <Example title="Counter with Setup">
+        <CounterWithSetup setup={10} label="Total" />
       </Example>
 
       <Example title="Setup vs Render Props">
-        <CounterWithLabel initial={5} label="Score" />
+        <CounterWithLabel setup={5} label="Score" />
       </Example>
 
       <Example title="Events - Search Input">
@@ -599,19 +596,19 @@ function DemoApp(this: Handle) {
         <ResizeComponent />
       </Example>
 
-      <Example title="this.update(task) - Player">
+      <Example title="handle.update(task) - Player">
         <Player />
       </Example>
 
-      <Example title="this.queueTask - Scroll to Section">
+      <Example title="handle.queueTask - Scroll to Section">
         <FormWithScroll />
       </Example>
 
-      <Example title="this.signal - Clock">
+      <Example title="handle.signal - Clock">
         <Clock />
       </Example>
 
-      <Example title="this.id - Labeled Input">
+      <Example title="handle.id - Labeled Input">
         <LabeledInput />
       </Example>
 

--- a/packages/component/src/index.ts
+++ b/packages/component/src/index.ts
@@ -25,4 +25,4 @@ export type { HostProps } from './lib/dom.ts'
 export type { VirtualRoot, VirtualRootOptions } from './lib/vdom.ts'
 
 // Export types from component.ts
-export type { Handle, ComponentProps } from './lib/component.ts'
+export type { Handle } from './lib/component.ts'

--- a/packages/component/src/lib/vdom.keys-extra.test.tsx
+++ b/packages/component/src/lib/vdom.keys-extra.test.tsx
@@ -10,12 +10,12 @@ describe('vnode rendering (keys extra)', () => {
 
       type CardData = { id: string; title: string }
 
-      function Card({ card }: { card: CardData }) {
-        return <div data-id={card.id}>{card.title}</div>
+      function Card() {
+        return ({ card }: { card: CardData }) => <div data-id={card.id}>{card.title}</div>
       }
 
-      function Column({ cards, isAddingCard }: { cards: CardData[]; isAddingCard: boolean }) {
-        return (
+      function Column() {
+        return ({ cards, isAddingCard }: { cards: CardData[]; isAddingCard: boolean }) => (
           <div>
             {cards.map((card) => (
               <Card key={card.id} card={card} />
@@ -62,8 +62,8 @@ describe('vnode rendering (keys extra)', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
 
-      function List({ values }: { values: (string | number)[] }) {
-        return (
+      function List() {
+        return ({ values }: { values: (string | number)[] }) => (
           <ul>
             {values.map((value) => (
               <li key={value} data-id={value}>
@@ -90,8 +90,8 @@ describe('vnode rendering (keys extra)', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
 
-      function List({ values }: { values: string[] }) {
-        return (
+      function List() {
+        return ({ values }: { values: string[] }) => (
           <ol>
             {values.map((value) => (
               <li key={value} data-id={value}>
@@ -125,8 +125,8 @@ describe('vnode rendering (keys extra)', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
 
-      function List({ values }: { values: string[] }) {
-        return (
+      function List() {
+        return ({ values }: { values: string[] }) => (
           <ul>
             {values.map((value) => (
               <li key={value} data-id={value}>
@@ -161,8 +161,8 @@ describe('vnode rendering (keys extra)', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
 
-      function List({ values }: { values: string[] }) {
-        return (
+      function List() {
+        return ({ values }: { values: string[] }) => (
           <ul>
             {values.map((value) => (
               <li key={value} data-id={value}>
@@ -196,8 +196,8 @@ describe('vnode rendering (keys extra)', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
 
-      function List({ values }: { values: string[] }) {
-        return (
+      function List() {
+        return ({ values }: { values: string[] }) => (
           <ul>
             {values.map((value) => (
               <li key={value} data-id={value}>
@@ -230,8 +230,8 @@ describe('vnode rendering (keys extra)', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
 
-      function List({ values }: { values: string[] }) {
-        return (
+      function List() {
+        return ({ values }: { values: string[] }) => (
           <ul>
             {values.map((value) => (
               <li key={value} data-id={value}>
@@ -267,8 +267,8 @@ describe('vnode rendering (keys extra)', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
 
-      function List({ values }: { values: string[] }) {
-        return (
+      function List() {
+        return ({ values }: { values: string[] }) => (
           <ul>
             {values.map((value) => (
               <li key={value} data-id={value}>
@@ -337,8 +337,8 @@ describe('vnode rendering (keys extra)', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
 
-      function Item({ label }: { label: string }) {
-        return <li>{label}</li>
+      function Item() {
+        return ({ label }: { label: string }) => <li>{label}</li>
       }
 
       root.render(
@@ -369,8 +369,8 @@ describe('vnode rendering (keys extra)', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
 
-      function List({ labels }: { labels: string[] }) {
-        return (
+      function List() {
+        return ({ labels }: { labels: string[] }) => (
           <ul>
             {labels.map((label, index) => (
               <li key="dup" data-index={index}>
@@ -426,8 +426,8 @@ describe('vnode rendering (keys extra)', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
 
-      function Item({ id, label }: { id: string; label: string }) {
-        return (
+      function Item() {
+        return ({ id, label }: { id: string; label: string }) => (
           <>
             <span key={id + '-label'} data-id={id}>
               {label}

--- a/packages/component/src/lib/vdom.test.tsx
+++ b/packages/component/src/lib/vdom.test.tsx
@@ -197,8 +197,10 @@ describe('vnode rendering', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
 
-      function SvgGroup({ href, children }: { href: string; children?: RemixNode }) {
-        return () => <g href={href}>{children}</g>
+      function SvgGroup() {
+        return ({ href, children }: { href: string; children?: RemixNode }) => (
+          <g href={href}>{children}</g>
+        )
       }
 
       root.render(
@@ -465,7 +467,7 @@ describe('vnode rendering', () => {
       let container = document.createElement('div')
 
       let setupCalls = 0
-      function App(this: Handle) {
+      function App(handle: Handle) {
         let state = ++setupCalls
         return ({ title }: { title: string }) => (
           <div>
@@ -485,7 +487,7 @@ describe('vnode rendering', () => {
       let container = document.createElement('div')
 
       let setupCalls = 0
-      function App(this: Handle) {
+      function App(handle: Handle) {
         let state = ++setupCalls
         return ({ title }: { title: string }) => (
           <>
@@ -561,7 +563,7 @@ describe('vnode rendering', () => {
       let container = document.createElement('div')
       let { render } = createRoot(container)
       function App() {
-        return <div>Hello, world!</div>
+        return () => <div>Hello, world!</div>
       }
       render(
         <div>
@@ -580,7 +582,7 @@ describe('vnode rendering', () => {
     it('inserts a component', () => {
       let container = document.createElement('div')
       function App() {
-        return <div>Hello, world!</div>
+        return () => <div>Hello, world!</div>
       }
       let { render } = createRoot(container)
       render(<App />)
@@ -591,11 +593,11 @@ describe('vnode rendering', () => {
       let container = document.createElement('div')
 
       let capturedUpdate = () => {}
-      function App(this: Handle) {
+      function App(handle: Handle) {
         let count = 1
         capturedUpdate = () => {
           count++
-          this.update()
+          handle.update()
         }
         return () => <div>{count}</div>
       }
@@ -621,11 +623,11 @@ describe('vnode rendering', () => {
       let container = document.createElement('div')
 
       let capturedUpdate = () => {}
-      function App(this: Handle) {
+      function App(handle: Handle) {
         let count = 1
         capturedUpdate = () => {
           count++
-          this.update()
+          handle.update()
         }
         return () => (
           <>
@@ -659,8 +661,8 @@ describe('vnode rendering', () => {
       let root = createRoot(container)
       let capturedRaise: Handle['raise'] = () => {}
 
-      function App(this: Handle) {
-        capturedRaise = this.raise
+      function App(handle: Handle) {
+        capturedRaise = handle.raise
         return () => <div>App</div>
       }
 
@@ -683,12 +685,12 @@ describe('vnode rendering', () => {
 
     let taskRan = false
     let capturedUpdate = () => {}
-    function App(this: Handle) {
+    function App(handle: Handle) {
       capturedUpdate = () => {
-        this.queueTask(() => {
+        handle.queueTask(() => {
           taskRan = true
         })
-        this.update()
+        handle.update()
       }
 
       return () => <div>Hello, world!</div>
@@ -710,9 +712,9 @@ describe('vnode rendering', () => {
 
     let taskRan = false
     let capturedUpdate = () => {}
-    function App(this: Handle) {
+    function App(handle: Handle) {
       capturedUpdate = () => {
-        this.update(() => {
+        handle.update(() => {
           taskRan = true
         })
       }
@@ -755,7 +757,7 @@ describe('vnode rendering', () => {
       root.render(<div>Hello, world!</div>)
       expect(container.innerHTML).toBe('<div>Hello, world!</div>')
       function App() {
-        return <div>Goodbye, world!</div>
+        return () => <div>Goodbye, world!</div>
       }
       root.render(<App />)
       expect(container.innerHTML).toBe('<div>Goodbye, world!</div>')
@@ -765,7 +767,7 @@ describe('vnode rendering', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
       function App() {
-        return <div>Hello, world!</div>
+        return () => <div>Hello, world!</div>
       }
       root.render(<App />)
       expect(container.innerHTML).toBe('<div>Hello, world!</div>')
@@ -786,12 +788,12 @@ describe('vnode rendering', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
       function App() {
-        return <div>Hello, world!</div>
+        return () => <div>Hello, world!</div>
       }
       root.render(<App />)
       expect(container.innerHTML).toBe('<div>Hello, world!</div>')
       function App2() {
-        return <div>Goodbye, world!</div>
+        return () => <div>Goodbye, world!</div>
       }
       root.render(<App2 />)
       expect(container.innerHTML).toBe('<div>Goodbye, world!</div>')
@@ -801,7 +803,7 @@ describe('vnode rendering', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
       function App() {
-        return <div>Hello, world!</div>
+        return () => <div>Hello, world!</div>
       }
       root.render(<App />)
       expect(container.innerHTML).toBe('<div>Hello, world!</div>')
@@ -824,7 +826,7 @@ describe('vnode rendering', () => {
       )
       expect(container.innerHTML).toBe('<div>Hello, world!</div>')
       function App() {
-        return <div>Goodbye, world!</div>
+        return () => <div>Goodbye, world!</div>
       }
       root.render(<App />)
       expect(container.innerHTML).toBe('<div>Goodbye, world!</div>')
@@ -862,7 +864,7 @@ describe('vnode rendering', () => {
       root.render('Hello, world!')
       expect(container.innerHTML).toBe('Hello, world!')
       function App() {
-        return <div>Goodbye, world!</div>
+        return () => <div>Goodbye, world!</div>
       }
       root.render(<App />)
       expect(container.innerHTML).toBe('<div>Goodbye, world!</div>')
@@ -928,7 +930,7 @@ describe('vnode rendering', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
       function Frag() {
-        return (
+        return () => (
           <>
             <span>A</span>
             <span>B</span>
@@ -959,7 +961,7 @@ describe('vnode rendering', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
       function App() {
-        return <div>Hello, world!</div>
+        return () => <div>Hello, world!</div>
       }
       root.render(
         <div>
@@ -969,7 +971,7 @@ describe('vnode rendering', () => {
       expect(container.innerHTML).toBe('<div><div>Hello, world!</div></div>')
 
       function App2() {
-        return <div>Goodbye, world!</div>
+        return () => <div>Goodbye, world!</div>
       }
       root.render(
         <div>
@@ -1008,7 +1010,7 @@ describe('vnode rendering', () => {
     it('renders when descendant throws', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
-      function Throws() {
+      function Throws(): () => null {
         throw new Error('Test')
       }
       root.render(
@@ -1022,7 +1024,7 @@ describe('vnode rendering', () => {
     it('removes in progress nodes', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
-      function Throws() {
+      function Throws(): () => null {
         throw new Error('Test')
       }
       root.render(
@@ -1038,12 +1040,12 @@ describe('vnode rendering', () => {
     it('renders fallback from deeply thrown errors', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
-      function Throws() {
+      function Throws(): () => null {
         throw new Error('Test')
       }
 
       function App() {
-        return (
+        return () => (
           <div>
             <h1>App</h1>
             <Throws />
@@ -1068,7 +1070,7 @@ describe('vnode rendering', () => {
         if (count === 1) {
           throw new Error('Test')
         }
-        return <div>All good</div>
+        return () => <div>All good</div>
       }
 
       root.render(
@@ -1109,7 +1111,7 @@ describe('vnode rendering', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
 
-      function ThrowsOnce() {
+      function ThrowsOnce(): () => null {
         throw new Error('boom')
       }
 
@@ -1131,7 +1133,7 @@ describe('vnode rendering', () => {
       invariant(left instanceof HTMLSpanElement && right instanceof HTMLSpanElement)
 
       function Ok() {
-        return <div id="ok">OK</div>
+        return () => <div id="ok">OK</div>
       }
       root.render(
         <div>
@@ -1154,7 +1156,7 @@ describe('vnode rendering', () => {
       let root = createRoot(container)
 
       function App() {
-        return (
+        return () => (
           <Catch fallback={<div id="outer">Outer</div>}>
             <div>
               <Catch fallback={<div id="inner">Inner</div>}>
@@ -1311,7 +1313,7 @@ describe('vnode rendering', () => {
 
       let clickCount = 0
       function App() {
-        return (
+        return () => (
           <button
             on={{
               click: () => {
@@ -1404,13 +1406,13 @@ describe('vnode rendering', () => {
     it('provides and reads context', () => {
       let container = document.createElement('div')
 
-      function App(this: Handle<{ value: string }>) {
-        this.context.set({ value: 'test' })
+      function App(handle: Handle<{ value: string }>) {
+        handle.context.set({ value: 'test' })
         return ({ children }: { children: RemixNode }) => <div>{children}</div>
       }
 
-      function Child(this: Handle) {
-        let { value } = this.context.get(App)
+      function Child(handle: Handle) {
+        let { value } = handle.context.get(App)
         return () => <main>Child: {value}</main>
       }
 
@@ -1427,18 +1429,20 @@ describe('vnode rendering', () => {
       let container = document.createElement('div')
 
       let capturedUpdate = () => {}
-      function App(this: Handle<{ value: string }>) {
-        this.context.set({ value: 'test' })
+      function App(handle: Handle<{ value: string }>) {
+        handle.context.set({ value: 'test' })
         capturedUpdate = () => {
-          this.context.set({ value: 'test2' })
-          this.update()
+          handle.context.set({ value: 'test2' })
+          handle.update()
         }
         return ({ children }: { children: RemixNode }) => <div>{children}</div>
       }
 
-      function Child(this: Handle) {
-        let { value } = this.context.get(App)
-        return <main>Child: {value}</main>
+      function Child(handle: Handle) {
+        return () => {
+          let { value } = handle.context.get(App)
+          return <main>Child: {value}</main>
+        }
       }
 
       let root = createRoot(container)
@@ -1460,14 +1464,14 @@ describe('vnode rendering', () => {
       let options: string[] = []
       let renderListbox = () => {}
 
-      function Listbox(this: Handle<{ registerOption: (option: string) => void }>) {
-        this.context.set({
+      function Listbox(handle: Handle<{ registerOption: (option: string) => void }>) {
+        handle.context.set({
           registerOption: (option: string) => {
             options.push(option)
           },
         })
 
-        renderListbox = this.update
+        renderListbox = handle.update
 
         return ({ children }: { children: RemixNode }) => {
           options = []
@@ -1475,15 +1479,15 @@ describe('vnode rendering', () => {
         }
       }
 
-      function Option(this: Handle) {
-        let { registerOption } = this.context.get(Listbox)
+      function Option(handle: Handle) {
+        let { registerOption } = handle.context.get(Listbox)
         return ({ value }: { value: string }) => {
           registerOption(value)
           return <div>Option</div>
         }
       }
 
-      function App(this: Handle) {
+      function App(handle: Handle) {
         return () => (
           <Listbox>
             <Option value="Option 1" />
@@ -1511,9 +1515,9 @@ describe('vnode rendering', () => {
 
       let capturedParentUpdate = () => {}
       let appRenderCount = 0
-      function Parent(this: Handle) {
+      function Parent(handle: Handle) {
         capturedParentUpdate = () => {
-          this.update()
+          handle.update()
         }
         return ({ children }: { children: RemixNode }) => {
           appRenderCount++
@@ -1523,9 +1527,9 @@ describe('vnode rendering', () => {
 
       let childRenderCount = 0
       let capturedChildUpdate = () => {}
-      function Child(this: Handle) {
+      function Child(handle: Handle) {
         capturedChildUpdate = () => {
-          this.update()
+          handle.update()
         }
         return () => {
           childRenderCount++
@@ -1564,13 +1568,13 @@ describe('vnode rendering', () => {
 
       let taskCount = 0
       let capturedUpdate = () => {}
-      function App(this: Handle) {
-        this.queueTask(() => {
+      function App(handle: Handle) {
+        handle.queueTask(() => {
           taskCount++
         })
 
         capturedUpdate = () => {
-          this.update(() => {
+          handle.update(() => {
             taskCount++
           })
         }
@@ -1588,13 +1592,13 @@ describe('vnode rendering', () => {
   })
 
   describe('signals', () => {
-    it('provides mounted signal on this.signal', () => {
+    it('provides mounted signal on handle.signal', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
 
       let capturedSignal: AbortSignal | undefined
-      function App(this: Handle) {
-        capturedSignal = this.signal
+      function App(handle: Handle) {
+        capturedSignal = handle.signal
         return () => null
       }
 
@@ -1613,8 +1617,8 @@ describe('vnode rendering', () => {
       let root = createRoot(container)
 
       let signals: AbortSignal[] = []
-      function App(this: Handle) {
-        this.queueTask((signal) => {
+      function App(handle: Handle) {
+        handle.queueTask((signal) => {
           signals.push(signal)
         })
         return () => null
@@ -1642,8 +1646,8 @@ describe('vnode rendering', () => {
       let root = createRoot(container)
       let clickCount = 0
 
-      function App(this: Handle) {
-        this.on(document, {
+      function App(handle: Handle) {
+        handle.on(document, {
           click: () => {
             clickCount++
           },
@@ -1666,8 +1670,8 @@ describe('vnode rendering', () => {
       let root = createRoot(container)
       let clickCount = 0
 
-      function App(this: Handle) {
-        this.on(document, {
+      function App(handle: Handle) {
+        handle.on(document, {
           click: (event) => {
             clickCount++
           },
@@ -1690,8 +1694,8 @@ describe('vnode rendering', () => {
 
     describe('types', () => {
       it('provides literal event and target types to listeners', () => {
-        function App(this: Handle) {
-          this.on(document, {
+        function App(handle: Handle) {
+          handle.on(document, {
             keydown: (event) => {
               type test = Assert<Equal<typeof event, Dispatched<KeyboardEvent, Document>>>
             },
@@ -1709,7 +1713,7 @@ describe('vnode rendering', () => {
 
       let capturedNode: Element | null = null
 
-      function App(this: Handle) {
+      function App(handle: Handle) {
         return () => (
           <div
             connect={(node: Element, signal: AbortSignal) => {
@@ -1741,9 +1745,9 @@ describe('vnode rendering', () => {
     let capturedUpdate = () => {}
     let connectCalls = 0
 
-    function App(this: Handle) {
-      capturedUpdate = () => this.update()
-      return () => (
+      function App(handle: Handle) {
+        capturedUpdate = () => handle.update()
+        return () => (
         <div
           connect={() => {
             connectCalls++
@@ -1770,8 +1774,8 @@ describe('vnode rendering', () => {
       let showB = false
       let capturedUpdate = () => {}
 
-      function A(this: Handle) {
-        capturedUpdate = () => this.update()
+      function A(handle: Handle) {
+        capturedUpdate = () => handle.update()
         return () => (showB ? <span>B</span> : <div>A</div>)
       }
 
@@ -1802,11 +1806,11 @@ describe('vnode rendering', () => {
       let capturedUpdate = () => {}
 
       function B() {
-        return <span>B</span>
+        return () => <span>B</span>
       }
 
-      function A(this: Handle) {
-        capturedUpdate = () => this.update()
+      function A(handle: Handle) {
+        capturedUpdate = () => handle.update()
         return () => (showB ? <B /> : <div>A</div>)
       }
 

--- a/packages/component/src/lib/vdom.ts
+++ b/packages/component/src/lib/vdom.ts
@@ -318,6 +318,17 @@ function flatMapChildrenToVNodes(node: RemixElement): VNode[] {
     : []
 }
 
+function flattenRemixNodeArray(nodes: RemixNode[], out: RemixNode[] = []): RemixNode[] {
+  for (let child of nodes) {
+    if (Array.isArray(child)) {
+      flattenRemixNodeArray(child, out)
+    } else {
+      out.push(child)
+    }
+  }
+  return out
+}
+
 export function toVNode(node: RemixNode): VNode {
   if (node === null || node === undefined || typeof node === 'boolean') {
     return { type: TEXT_NODE, _text: '' }
@@ -328,7 +339,8 @@ export function toVNode(node: RemixNode): VNode {
   }
 
   if (Array.isArray(node)) {
-    return { type: Fragment, _children: node.flat(Infinity).map(toVNode) }
+    let flatChildren = flattenRemixNodeArray(node)
+    return { type: Fragment, _children: flatChildren.map(toVNode) }
   }
 
   if (node.type === Fragment) {
@@ -669,7 +681,9 @@ function isCommittedComponentNode(node: VNode): node is CommittedComponentNode {
 }
 
 function isFrameworkProp(name: string): boolean {
-  return name === 'children' || name === 'key' || name === 'on' || name === 'css'
+  return (
+    name === 'children' || name === 'key' || name === 'on' || name === 'css' || name === 'setup'
+  )
 }
 
 // TODO: would rather actually diff el.style object directly instead of writing


### PR DESCRIPTION
- Removed stateless components favoring a single component shape
- Components no longer called with `this` function context
- Introduced `setup` prop
  - `setup` prop is passed to the setup function
  - `props` are only passed to the render function