### PR TITLE
route-pattern: `PartPattern` variants

### DIFF
--- a/packages/route-pattern/src/experimental/errors.test.ts
+++ b/packages/route-pattern/src/experimental/errors.test.ts
@@ -14,7 +14,7 @@ describe('ParseError', () => {
     assert.equal(error.index, 3)
   })
 
-  test('shows caret under the problematic index', () => {
+  test('underlines the error indices', () => {
     let error = new ParseError('unmatched (', 'api/(v:major', 4)
     assert.equal(
       error.toString(),
@@ -41,7 +41,7 @@ describe('HrefError', () => {
         dedent`
           HrefError: pattern requires hostname
 
-          https://*:8080/api
+          Pattern: https://*:8080/api
         `,
       )
     })
@@ -59,12 +59,12 @@ describe('HrefError', () => {
       assert.equal(
         error.toString(),
         dedent`
-          HrefError: missing params for pathname
+          HrefError: missing params
 
           Pattern: https://example.com/:id
           Params: {}
-          Variants for pathname:
-            - :id (missing: id)
+          Pathname variants:
+            - {:id} (missing: id)
         `,
       )
     })
@@ -80,13 +80,13 @@ describe('HrefError', () => {
       assert.equal(
         error.toString(),
         dedent`
-          HrefError: missing params for pathname
+          HrefError: missing params
 
           Pattern: https://example.com/:a/:b(/:c)
           Params: {"a":"x"}
-          Variants for pathname:
-            - :a/:b (missing: b)
-            - :a/:b/:c (missing: b, c)
+          Pathname variants:
+            - {:a}/{:b} (missing: b)
+            - {:a}/{:b}/{:c} (missing: b, c)
         `,
       )
     })
@@ -102,15 +102,15 @@ describe('HrefError', () => {
       assert.equal(
         error.toString(),
         dedent`
-          HrefError: missing params for pathname
+          HrefError: missing params
 
           Pattern: https://example.com/:a(:b)-:a(:c)
           Params: {"b":"thing"}
-          Variants for pathname:
-            - :a-:a (missing: a)
-            - :a-:a:c (missing: a, c)
-            - :a:b-:a (missing: a)
-            - :a:b-:a:c (missing: a, c)
+          Pathname variants:
+            - {:a}-{:a} (missing: a)
+            - {:a}-{:a}{:c} (missing: a, c)
+            - {:a}{:b}-{:a} (missing: a)
+            - {:a}{:b}-{:a}{:c} (missing: a, c)
         `,
       )
     })
@@ -168,7 +168,7 @@ describe('HrefError', () => {
         dedent`
           HrefError: pattern contains nameless wildcard
 
-          https://example.com/api/*/users
+          Pattern: https://example.com/api/*/users
         `,
       )
     })

--- a/packages/route-pattern/src/experimental/variant.ts
+++ b/packages/route-pattern/src/experimental/variant.ts
@@ -1,0 +1,78 @@
+import { unreachable } from './errors.ts'
+import type { PartPattern, Token } from './part-pattern.ts'
+
+type Variant = {
+  /** Params use `nameIndex` to reference params in the PartPattern's `paramNames` */
+  tokens: Array<Extract<Token, { type: 'text' | ':' | '*' }>>
+
+  /** Pre-computed subset of `paramNames` that are required for this variant */
+  requiredParams: Array<string>
+}
+
+export type Type = Variant
+
+export function generate(pattern: PartPattern): Array<Variant> {
+  let result: Array<Variant> = []
+
+  let stack: Array<{ index: number; tokens: Variant['tokens'] }> = [{ index: 0, tokens: [] }]
+
+  while (stack.length > 0) {
+    let { index, tokens } = stack.pop()!
+
+    if (index === pattern.tokens.length) {
+      let requiredParams: Array<string> = []
+      for (let token of tokens) {
+        if (token.type === ':' || token.type === '*') {
+          requiredParams.push(pattern.paramNames[token.nameIndex])
+        }
+      }
+      result.push({ tokens, requiredParams })
+      continue
+    }
+
+    let token = pattern.tokens[index]
+
+    if (token.type === '(') {
+      stack.push(
+        { index: index + 1, tokens },
+        { index: pattern.optionals.get(index)! + 1, tokens: tokens.slice() },
+      )
+      continue
+    }
+
+    if (token.type === ')') {
+      stack.push({ index: index + 1, tokens })
+      continue
+    }
+
+    if (token.type === ':' || token.type === '*' || token.type === 'text') {
+      tokens.push(token)
+      stack.push({ index: index + 1, tokens })
+      continue
+    }
+  }
+
+  return result
+}
+
+export function toString(tokens: Variant['tokens'], paramNames: Array<string>): string {
+  let result = ''
+
+  for (let token of tokens) {
+    if (token.type === 'text') {
+      result += token.text
+      continue
+    }
+
+    if (token.type === ':' || token.type === '*') {
+      let name = paramNames[token.nameIndex]
+      if (name === '*') name = ''
+      result += `{${token.type}${name}}`
+      continue
+    }
+
+    unreachable(token.type)
+  }
+
+  return result
+}


### PR DESCRIPTION
Variants are now an array of tokens (excluding optional tokens with `type: '(' | ')'`) along with a pre-computed set of `paramNames`. Both of these speed up `href` creation by ~2-5x based on some ad-hoc benchmarks I ran locally, which makes sense because we can just do a V8-optimized loop over the tokens and fill in the params as we hit them instead of doing a `String.replaceAll` with a `RegExp` for the params.

<img width="1090" height="919" alt="Screenshot 2026-01-14 at 6 20 02 PM" src="https://github.com/user-attachments/assets/4ce4d718-88d0-4001-a484-41f179c21c39" />

^I tried 3 versions of the `String.{replace/replaceAll}` approach to steelman it, but tokens are still much faster

The main motivation of this change was actually to make the variants reusable across `{RoutePattern,PartPattern}.href` and `TrieMatcher.insert` for better consistency, but the speed ups are a nice by product of using a better representation.