### PR TITLE
chore: remove git tags from `changes:preview` output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@
   - For **v1.x+ packages**: Use standard semver - "major" for breaking changes, "minor" for new features, "patch" for bug fixes.
   - **Breaking changes are relative to main**: If you introduce a new API in a PR and then change it within the same PR before merging, that's not considered a breaking change.
 - **Validating changes**: `pnpm changes:validate` checks that all change files follow the correct naming convention and format.
-- **Previewing releases**: `pnpm changes:preview` shows which packages will be released, what the CHANGELOG will look like, the commit message and tags.
+- **Previewing releases**: `pnpm changes:preview` shows which packages will be released, what the CHANGELOG will look like, and the commit message.
 - **Automated releases**: When changes are pushed to `main`, the [changes-version-pr workflow](/.github/workflows/changes-version-pr.yaml) automatically opens/updates a "Version Packages" PR. The [publish workflow](/.github/workflows/publish.yaml) runs on every push to `main` and publishes when no change files are present (i.e., after merging the Version Packages PR).
 - **Manual releases**: `pnpm changes:version` updates package.json, CHANGELOG.md, and creates a git commit. Push to `main` and the publish workflow will handle the rest (including tags and GitHub releases).
 - **How publishing works**: The publish workflow checks for change files. If none exist, it runs `pnpm publish --recursive --report-summary`, reads the summary JSON to see what was published, then creates git tags and GitHub releases for each published package.

--- a/scripts/changes-preview.ts
+++ b/scripts/changes-preview.ts
@@ -55,13 +55,6 @@ function main() {
   console.log(generateCommitMessage(releases))
   console.log()
 
-  console.log(colorize('GIT TAGS', colors.lightBlue))
-  console.log()
-  for (let release of releases) {
-    console.log(`${release.packageName}@${release.nextVersion}`)
-  }
-  console.log()
-
   console.log(colorize('VERSION COMMAND', colors.lightBlue))
   console.log()
   console.log('pnpm changes:version')


### PR DESCRIPTION
Since git tags are now managed in CI after a successful npm publish, the `changes:preview` output is misleading in showing the list of git tags for the version commit.