### PR TITLE
route-pattern: rank

### DIFF
--- a/packages/route-pattern/src/experimental/route-pattern/rank.test.ts
+++ b/packages/route-pattern/src/experimental/route-pattern/rank.test.ts
@@ -1,0 +1,251 @@
+import * as assert from 'node:assert/strict'
+import test, { describe } from 'node:test'
+import * as Rank from './rank.ts'
+
+// todo tests:
+// - hostname
+//   - edge cases:
+//     - back-to-back variables
+//     - back-to-back wildcards
+// - pathname
+//   - edge cases:
+//     - back-to-back variables
+//     - back-to-back wildcards
+// - search
+//   - exact value > any value
+//   - any value > key only
+//   - more constraints win
+
+function rank(args: Partial<Rank.Type>): Rank.Type {
+  return {
+    hostname: args.hostname ?? [],
+    pathname: args.pathname ?? [],
+    search: args.search ?? new Map(),
+  }
+}
+
+describe('rank', () => {
+  describe('compare', () => {
+    function assertCompare(
+      url: URL | string,
+      a: Partial<Rank.Type>,
+      b: Partial<Rank.Type>,
+      expected: -1 | 0 | 1,
+    ) {
+      url = typeof url === 'string' ? new URL(url) : url
+      assert.equal(Rank.compare(url, rank(a), rank(b)), expected)
+    }
+
+    describe('hostname', () => {
+      test('static vs variable', () => {
+        assertCompare(
+          'https://example.com',
+          //       0123456789
+          { hostname: [] },
+          { hostname: [{ type: ':', begin: 0, end: 7 }] },
+          -1,
+        )
+      })
+
+      test('variable vs wildcard', () => {
+        assertCompare(
+          'https://example.com',
+          { hostname: [{ type: ':', begin: 0, end: 7 }] },
+          { hostname: [{ type: '*', begin: 0, end: 7 }] },
+          -1,
+        )
+      })
+
+      test('variable vs variable (same range = tie)', () => {
+        assertCompare(
+          'https://example.com',
+          { hostname: [{ type: ':', begin: 0, end: 7 }] },
+          { hostname: [{ type: ':', begin: 0, end: 7 }] },
+          0,
+        )
+      })
+
+      test('wildcard vs wildcard (same range = tie)', () => {
+        assertCompare(
+          'https://example.com',
+          { hostname: [{ type: '*', begin: 0, end: 7 }] },
+          { hostname: [{ type: '*', begin: 0, end: 7 }] },
+          0,
+        )
+      })
+
+      test('variable with prefix and suffix', () => {
+        assertCompare(
+          'https://example.com',
+          { hostname: [{ type: ':', begin: 1, end: 6 }] },
+          { hostname: [{ type: ':', begin: 0, end: 7 }] },
+          -1,
+        )
+      })
+
+      // todo:
+      // URL = a.b-xxx.yyy-c.d , (a) pattern = a.*b-c.d vs (b) pattern = a.b-*c.d
+      // a wins because the static `-c` suffix differs first (semantically) compared to `b-` prefix
+
+      test('wildcard with prefix and suffix', () => {
+        assertCompare(
+          'https://example.com',
+          { hostname: [{ type: '*', begin: 1, end: 6 }] },
+          { hostname: [{ type: '*', begin: 0, end: 7 }] },
+          -1,
+        )
+      })
+
+      test('tie on variables and wildcards, break tie eventually', () => {
+        assertCompare(
+          'https://ab.cd.ef.gh.com',
+          //       0123456789 1
+          {
+            hostname: [
+              { type: '*', begin: 0, end: 5 },
+              { type: ':', begin: 6, end: 8 },
+              { type: '*', begin: 10, end: 11 },
+            ],
+          },
+          {
+            hostname: [
+              { type: '*', begin: 0, end: 5 },
+              { type: ':', begin: 6, end: 8 },
+              { type: '*', begin: 9, end: 11 },
+            ],
+          },
+          -1,
+        )
+      })
+    })
+
+    describe('pathname', () => {
+      test('static vs variable', () => {
+        assertCompare(
+          'https://example.com/posts/123',
+          { pathname: [] },
+          { pathname: [{ type: ':', begin: 0, end: 3 }] },
+          -1,
+        )
+      })
+
+      test('variable vs wildcard', () => {
+        assertCompare(
+          'https://example.com/posts/123',
+          { pathname: [{ type: ':', begin: 0, end: 3 }] },
+          { pathname: [{ type: '*', begin: 0, end: 3 }] },
+          -1,
+        )
+      })
+
+      test('variable vs variable (same range = tie)', () => {
+        assertCompare(
+          'https://example.com/posts/123',
+          { pathname: [{ type: ':', begin: 0, end: 3 }] },
+          { pathname: [{ type: ':', begin: 0, end: 3 }] },
+          0,
+        )
+      })
+
+      test('wildcard vs wildcard (same range = tie)', () => {
+        assertCompare(
+          'https://example.com/posts/123',
+          { pathname: [{ type: '*', begin: 0, end: 3 }] },
+          { pathname: [{ type: '*', begin: 0, end: 3 }] },
+          0,
+        )
+      })
+
+      test('variable with prefix and suffix', () => {
+        assertCompare(
+          'https://example.com/posts/123',
+          { pathname: [{ type: ':', begin: 1, end: 6 }] },
+          { pathname: [{ type: ':', begin: 0, end: 3 }] },
+          -1,
+        )
+      })
+
+      test('wildcard with prefix and suffix', () => {
+        assertCompare(
+          'https://example.com/posts/123',
+          { pathname: [{ type: '*', begin: 1, end: 6 }] },
+          { pathname: [{ type: '*', begin: 0, end: 3 }] },
+          -1,
+        )
+      })
+
+      test('tie on variables and wildcards, break tie eventually', () => {
+        assertCompare(
+          'https://example.com/posts/123/456/789',
+          {
+            pathname: [
+              { type: '*', begin: 0, end: 3 },
+              { type: ':', begin: 4, end: 7 },
+              { type: '*', begin: 9, end: 11 },
+            ],
+          },
+          {
+            pathname: [
+              { type: '*', begin: 0, end: 3 },
+              { type: ':', begin: 4, end: 7 },
+              { type: '*', begin: 8, end: 11 },
+            ],
+          },
+          -1,
+        )
+      })
+    })
+
+    describe('search', () => {
+      test('exact value > any value', () => {
+        assertCompare(
+          'https://example.com/posts?q=hello',
+          { search: new Map([['q', new Set(['hello'])]]) },
+          { search: new Map([['q', new Set()]]) },
+          -1,
+        )
+      })
+
+      test('any value > key only', () => {
+        assertCompare(
+          'https://example.com/posts?q=hello',
+          { search: new Map([['q', new Set()]]) },
+          { search: new Map([['q', null]]) },
+          -1,
+        )
+      })
+
+      test('more constraints win', () => {
+        assertCompare(
+          'https://example.com/posts?q=hello&a=1',
+          {
+            search: new Map([
+              ['q', null],
+              ['a', null],
+            ]),
+          },
+          { search: new Map([['q', null]]) },
+          -1,
+        )
+      })
+
+      test('tie on different keys (same count)', () => {
+        assertCompare(
+          'https://example.com/posts?q=hello&a=1',
+          { search: new Map([['q', null]]) },
+          { search: new Map([['a', null]]) },
+          0,
+        )
+      })
+
+      test('multiple exact values > single any value', () => {
+        assertCompare(
+          'https://example.com/posts?q=hello&q=world',
+          { search: new Map([['q', new Set(['hello', 'world'])]]) },
+          { search: new Map([['q', new Set()]]) },
+          -1,
+        )
+      })
+    })
+  })
+})

--- a/packages/route-pattern/src/experimental/route-pattern/rank.ts
+++ b/packages/route-pattern/src/experimental/route-pattern/rank.ts
@@ -1,0 +1,157 @@
+/* eslint-disable jsdoc/require-param */
+
+import type * as Search from './search.ts'
+
+type Rank = {
+  hostname: ParamRange[]
+  pathname: ParamRange[]
+  search: Search.Constraints
+}
+export type Type = Rank
+
+type ParamRange = {
+  type: ':' | '*'
+  begin: number
+  end: number
+}
+
+type SearchRank = {
+  exactValue: number
+  anyValue: number
+  key: number
+}
+
+/**
+ * Compare two ranks, returning the winner.
+ * @returns -1 if a wins, 1 if b wins, 0 if tied.
+ */
+export function compare(url: URL, a: Rank, b: Rank): -1 | 0 | 1 {
+  // Hostname comparison
+  let hostnameResult = compareHostname(url.hostname, a.hostname, b.hostname)
+  if (hostnameResult !== 0) return hostnameResult
+
+  // Pathname comparison
+  let pathnameResult = comparePathname(a.pathname, b.pathname)
+  if (pathnameResult !== 0) return pathnameResult
+
+  // Search comparison
+  let searchResult = compareSearch(a.search, b.search)
+  if (searchResult !== 0) return searchResult
+
+  return 0
+}
+
+function compareHostname(hostname: string, a: ParamRange[], b: ParamRange[]): -1 | 0 | 1 {
+  if (a.length === 0 && b.length === 0) return 0
+  if (a.length === 0 && b.length > 0) return -1
+  if (a.length > 0 && b.length === 0) return 1
+
+  // Encoding of hostname chars: 0 = static, 1 = variable (:), 2 = wildcard (*)
+  // Note: `Int8Array` defaults to 0 for all indices not explicitly set.
+
+  let aEncoding = new Int8Array(hostname.length)
+  for (let range of a) {
+    aEncoding.fill(range.type === ':' ? 1 : 2, range.begin, range.end)
+  }
+
+  let bEncoding = new Int8Array(hostname.length)
+  for (let range of b) {
+    bEncoding.fill(range.type === ':' ? 1 : 2, range.begin, range.end)
+  }
+
+  // Build segments right-to-left: desc order by begin
+  let segments: Array<{ begin: number; end: number }> = []
+  let end = hostname.length
+  for (let i = hostname.length - 1; i >= 0; i--) {
+    if (hostname[i] === '.') {
+      segments.push({ begin: i + 1, end })
+      end = i
+    }
+  }
+  segments.push({ begin: 0, end }) // leftmost segment
+
+  for (let segment of segments) {
+    for (let j = segment.begin; j < segment.end; j++) {
+      if (aEncoding[j] < bEncoding[j]) return -1 // a is more specific
+      if (aEncoding[j] > bEncoding[j]) return 1 // b is more specific
+    }
+  }
+
+  return 0
+}
+
+function comparePathname(a: ParamRange[], b: ParamRange[]): -1 | 0 | 1 {
+  if (a.length === 0 && b.length === 0) return 0
+  if (a.length === 0 && b.length > 0) return -1
+  if (a.length > 0 && b.length === 0) return 1
+
+  let i = 0
+  let aIndex = 0
+  let bIndex = 0
+
+  while (aIndex < a.length || bIndex < b.length) {
+    let aRange = a[aIndex]
+    let bRange = b[bIndex]
+
+    if (aRange === undefined) return -1 // a is fully static from here
+    if (bRange === undefined) return 1 // b is fully static from here
+
+    // Skip to the minimum begin of the two current ranges
+    i = Math.min(aRange.begin, bRange.begin)
+
+    if (i < aRange.begin) return -1 // a has static content at i
+    if (i < bRange.begin) return 1 // b has static content at i
+
+    if (aRange.type === ':' && bRange.type === '*') return -1 // a is more specific
+    if (aRange.type === '*' && bRange.type === ':') return 1 // b is more specific
+
+    let minEnd = Math.min(aRange.end, bRange.end)
+    i = minEnd
+
+    // Advance range indices if we've reached their ends
+    if (i >= aRange.end) aIndex += 1
+    if (i >= bRange.end) bIndex += 1
+  }
+
+  return 0
+}
+
+function rankSearch(constraints: Search.Constraints): SearchRank {
+  let exactValue = 0
+  let anyValue = 0
+  let key = 0
+
+  for (let constraint of constraints.values()) {
+    if (constraint === null) {
+      key -= 1
+      continue
+    }
+    if (constraint.size === 0) {
+      anyValue -= 1
+      continue
+    }
+    exactValue -= constraint.size
+  }
+
+  return { exactValue, anyValue, key }
+}
+
+function compareSearch(a: Search.Constraints, b: Search.Constraints): -1 | 0 | 1 {
+  let aRank = rankSearch(a)
+  let bRank = rankSearch(b)
+
+  // More constraints = more negative values = more specific
+  // Compare exactValue (lower/more negative wins)
+  if (aRank.exactValue < bRank.exactValue) return -1
+  if (aRank.exactValue > bRank.exactValue) return 1
+
+  // Tiebreak on anyValue (lower/more negative wins)
+  if (aRank.anyValue < bRank.anyValue) return -1
+  if (aRank.anyValue > bRank.anyValue) return 1
+
+  // Tiebreak on key (lower/more negative wins)
+  if (aRank.key < bRank.key) return -1
+  if (aRank.key > bRank.key) return 1
+
+  return 0
+}


### PR DESCRIPTION
# RoutePattern Ranking

## Rank Structure

```ts
type Rank = {
  hostname: ParamRange[]
  pathname: ParamRange[]
  search: Search.Constraints
}

type ParamRange = {
  type: ':' | '*'
  begin: number
  end: number
}
```

## Constraints

- `ParamRange[]` is ordered by `begin` (equivalently by `end`)
- Ranges never overlap
- Indices are relative to the part (hostname or pathname)
  - hostname: `0` to `url.hostname.length`
  - pathname: `0` to `url.pathname.length`
- Protocol and port are ignored (static only)

## Example

Pattern: `https://:subdomain.example.com/posts/*rest/:id`

Matched URL: `https://api.example.com/posts/2024/archive/123`

```ts
const rank = {
  hostname: [
    { type: ':', begin: 0, end: 3 }  // "api"
  ],
  pathname: [
    { type: '*', begin: 6, end: 19 }, // "2024/archive"
    { type: ':', begin: 20, end: 23 } // "123"
  ],
  search: new Map() // from pattern.ast.search
}
```

## Comparison

Compare in order: hostname → pathname → search → insertion order

### Hostname Comparison

1. Create `Int8Array` of length `url.hostname.length` (initialized to `0`)
2. For each `ParamRange`, fill indices `[begin, end)` with:
   - `0` = static (default)
   - `1` = `:` (variable param)
   - `2` = `*` (wildcard)
3. Compare segments **right-to-left** (hostname specificity is reversed)
   - Find `.` separators, start after the last `.`
   - Within each segment, compare char-by-char **left-to-right**
   - Lower value wins (static > variable > wildcard)
   - If segment tied, move to next segment (right-to-left)

### Pathname Comparison

Optimized char-by-char comparison without allocating Int8Array:

1. Track `i = 0` (current char index in URL pathname)
2. Track current range index for each pattern (index into `ParamRange[]`)
3. Skip `i` to `min(currentRange1.begin, currentRange2.begin)`
4. At `i`:
   - If one range starts after `i` → other has static content → static wins
   - Otherwise compare range types: `:` > `*`
   - If same type → increment `i`
5. When `i` reaches range `end`, increment that pattern's current range index
6. Repeat until winner determined or all ranges exhausted

### Search Comparison

More constrained search wins:
- `?q=1` > `?q=` > `?q`
- `?q&a` vs `?q&b` → tie

Convert `Search.Constraints` to counts:
```ts
{
  exactValue: number  // e.g. ?q=1
  anyValue: number    // e.g. ?q=
  key: number         // e.g. ?q
}
```

Compare in order (higher wins):
1. `exactValue` count
2. `anyValue` count (tiebreaker)
3. `key` count (tiebreaker)

### Insertion Order

Final tiebreaker: lower insertion order wins (earlier = higher priority)

## Performance

- **Rank computation**: Must be fast (computed during matching, possibly incrementally in TrieMatcher)
- **Rank comparison**: Can be slower (only compare actual matches, often just one)
