### PR TITLE
chore: enforce heading levels 4+ in change files

### DIFF
--- a/packages/component/.changes/minor.component-api-tweaks.md
+++ b/packages/component/.changes/minor.component-api-tweaks.md
@@ -6,7 +6,7 @@ BREAKING CHANGE: Updated Component API
   - `setup` prop is passed to the setup function
   - `props` are only passed to the render function
 
-## Example:
+#### Example:
 
 **Before**
 
@@ -66,9 +66,9 @@ function Counter(
 let el = <Counter setup={10} label="Count" />
 ```
 
-## Discussion:
+#### Discussion:
 
-### Removing stateless components
+##### Removing stateless components
 
 There was conceptual overhead of "stateful vs. stateless components" that is completely gone. All components must return a render function whether state is managed or not.
 
@@ -139,7 +139,7 @@ function SomeLayout() {
 }
 ```
 
-### The `setup` prop
+##### The `setup` prop
 
 The `setup` prop exists primarily to keep regular props out of the setup scope, preventing accidental stale captures.
 
@@ -231,7 +231,7 @@ function Counter(handle: Handle, setup: number) {
 
 However, it is advised to use the setup prop if you intend for a value to be static, like `setup.count`. Props that are rendered should typically be props and not setup.
 
-### `this` binding removal
+##### `this` binding removal
 
 We used `this` simply for its "optional first position" characteristic. Otherwise, it was difficult to decide which parameter should come first: handle or props?
 

--- a/scripts/utils/changes.ts
+++ b/scripts/utils/changes.ts
@@ -308,6 +308,18 @@ function parsePackageChanges(packageName: string): ParsedPackageChanges {
       continue
     }
 
+    // Check for headings that aren't level 4, 5, or 6
+    let invalidHeadingMatch = content.match(/^(#{1,3}|#{7,})\s+/m)
+    if (invalidHeadingMatch) {
+      let headingLevel = invalidHeadingMatch[1].length
+      errors.push({
+        package: packageName,
+        file,
+        error: `Headings in change files must be level 4 (####), 5 (#####), or 6 (######), but found level ${headingLevel}. This is because change files are nested within the changelog which already uses heading levels 1-3.`,
+      })
+      continue
+    }
+
     // Validate breaking change prefix matches the correct bump type (only for stable releases)
     // In prerelease mode, breaking changes don't need special handling since we're just bumping counter
     if (prereleaseConfig === null) {

--- a/scripts/utils/version-pr.ts
+++ b/scripts/utils/version-pr.ts
@@ -36,7 +36,7 @@ function generateHeader(): string {
 }
 
 function generateReleasesTable(releases: PackageRelease[]): string {
-  let lines = ['## Releases', '', '| Package | Version |', '|---------|---------|']
+  let lines = ['# Releases', '', '| Package | Version |', '|---------|---------|']
 
   for (let release of releases) {
     lines.push(
@@ -48,7 +48,7 @@ function generateReleasesTable(releases: PackageRelease[]): string {
 }
 
 function generateChangelogs(releases: PackageRelease[]): string {
-  let lines = ['## Changelogs']
+  let lines = ['# Changelogs']
 
   for (let release of releases) {
     lines.push('')
@@ -61,12 +61,12 @@ function generateChangelogs(releases: PackageRelease[]): string {
 function generatePackageChangelog(release: PackageRelease): string {
   return generateChangelogContent(release, {
     includePackageName: true,
-    headingLevel: 3,
+    headingLevel: 2,
   })
 }
 
 function truncateChangelogs(releases: PackageRelease[], maxLength: number): string {
-  let lines = ['## Changelogs']
+  let lines = ['# Changelogs']
   let currentLength = lines.join('\n').length
   let includedCount = 0
 


### PR DESCRIPTION
This also makes the heading levels in the Version Packages PR match the generated changelogs.