### PR TITLE
chore: fix changelog generation logic

### DIFF
--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -1,9 +1,9 @@
+# `remix` CHANGELOG
+
+This is the changelog for [`remix`](https://github.com/remix-run/remix/tree/main/packages/remix). It follows [semantic versioning](https://semver.org/).
+
 ## v3.0.0-alpha.0
 
 ### Major Changes
 
 - Initial alpha release of `remix` package for Remix 3
-
-# `remix` CHANGELOG
-
-This is the changelog for [`remix`](https://github.com/remix-run/remix/tree/main/packages/remix). It follows [semantic versioning](https://semver.org/).

--- a/scripts/changes-preview.ts
+++ b/scripts/changes-preview.ts
@@ -44,7 +44,7 @@ function main() {
   console.log()
 
   for (let release of releases) {
-    console.log(colorize(`${release.packageName}/CHANGELOG.md:`, colors.gray))
+    console.log(colorize(`${release.packageDirName}/CHANGELOG.md:`, colors.gray))
     console.log()
     console.log(generateChangelogContent(release))
   }

--- a/scripts/changes-validate.ts
+++ b/scripts/changes-validate.ts
@@ -1,16 +1,16 @@
 import * as fs from 'node:fs'
 import { parseAllChangeFiles, formatValidationErrors } from './utils/changes.ts'
 import { colors, colorize } from './utils/color.ts'
-import { getAllPackageNames, getPackageFile } from './utils/packages.ts'
+import { getAllPackageDirNames, getPackageFile } from './utils/packages.ts'
 
-function detectPackagesWithMissingChangelogs(): string[] {
-  let packageNames = getAllPackageNames()
+function getMissingChangelogPackageDirNames(): string[] {
+  let packageDirNames = getAllPackageDirNames()
   let missing: string[] = []
 
-  for (let packageName of packageNames) {
-    let changelogPath = getPackageFile(packageName, 'CHANGELOG.md')
+  for (let packageDirName of packageDirNames) {
+    let changelogPath = getPackageFile(packageDirName, 'CHANGELOG.md')
     if (!fs.existsSync(changelogPath)) {
-      missing.push(packageName)
+      missing.push(packageDirName)
     }
   }
 
@@ -26,13 +26,13 @@ function main() {
 
   // Validate all packages have changelogs
   console.log('Validating package changelogs...\n')
-  let packagesWithMissingChangelogs = detectPackagesWithMissingChangelogs()
+  let missingChangelogPackageDirNames = getMissingChangelogPackageDirNames()
 
-  if (packagesWithMissingChangelogs.length > 0) {
+  if (missingChangelogPackageDirNames.length > 0) {
     hasErrors = true
     console.error(colorize('Missing changelogs', colors.red) + '\n')
-    for (let packageName of packagesWithMissingChangelogs) {
-      console.error(`📦 ${packageName}: Missing CHANGELOG.md file`)
+    for (let packageDirName of missingChangelogPackageDirNames) {
+      console.error(`📦 ${packageDirName}: Missing CHANGELOG.md file`)
     }
     console.error()
   }

--- a/scripts/changes-version-pr.ts
+++ b/scripts/changes-version-pr.ts
@@ -29,7 +29,7 @@ async function main() {
   if (!result.valid) {
     console.error('Validation errors found:')
     for (let error of result.errors) {
-      console.error(`  ${error.package}/${error.file}: ${error.error}`)
+      console.error(`  ${error.packageDirName}/${error.file}: ${error.error}`)
     }
     process.exit(1)
   }
@@ -120,10 +120,10 @@ async function main() {
     console.log(`\n✅ Created PR #${newPr.number}: ${newPr.html_url}`)
   }
 
-  // Set package labels
-  let packageNames = releases.map((r) => r.packageName)
-  console.log(`\nSetting labels: ${packageNames.map((p) => `pkg:${p}`).join(', ')}`)
-  await setPrPkgLabels(prNumber, packageNames)
+  // Set package labels (using directory names for cleaner labels)
+  let packageDirNames = releases.map((r) => r.packageDirName)
+  console.log(`\nSetting labels: ${packageDirNames.map((p) => `pkg:${p}`).join(', ')}`)
+  await setPrPkgLabels(prNumber, packageDirNames)
 }
 
 main().catch((error) => {

--- a/scripts/changes-version.ts
+++ b/scripts/changes-version.ts
@@ -16,15 +16,15 @@ import {
   generateCommitMessage,
 } from './utils/changes.ts'
 import { colors, colorize } from './utils/color.ts'
-import { getPackageFile, getPackageDir } from './utils/packages.ts'
+import { getPackageFile, getPackagePath } from './utils/packages.ts'
 import { readJson, writeJson, readFile, writeFile } from './utils/fs.ts'
 import { logAndExec } from './utils/process.ts'
 
 /**
  * Updates package.json version
  */
-function updatePackageJson(packageName: string, newVersion: string) {
-  let packageJsonPath = getPackageFile(packageName, 'package.json')
+function updatePackageJson(packageDirName: string, newVersion: string) {
+  let packageJsonPath = getPackageFile(packageDirName, 'package.json')
   let packageJson = readJson(packageJsonPath)
   packageJson.version = newVersion
   writeJson(packageJsonPath, packageJson)
@@ -34,33 +34,34 @@ function updatePackageJson(packageName: string, newVersion: string) {
 /**
  * Updates CHANGELOG.md with new content
  */
-function updateChangelog(packageName: string, newContent: string) {
-  let changelogPath = getPackageFile(packageName, 'CHANGELOG.md')
+function updateChangelog(packageDirName: string, newContent: string) {
+  let changelogPath = getPackageFile(packageDirName, 'CHANGELOG.md')
   let existingChangelog = readFile(changelogPath)
 
-  // Find where to insert (after the heading and intro, before first ## version)
   let lines = existingChangelog.split('\n')
-  let insertIndex = 0
 
-  // Skip past the initial # heading and introductory text
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].startsWith('## ')) {
-      insertIndex = i
-      break
-    }
+  // Find the first ## version entry
+  let firstVersionIndex = lines.findIndex((line) => line.startsWith('## '))
+
+  let updatedChangelog: string
+  if (firstVersionIndex !== -1) {
+    // Insert before the first version entry
+    lines.splice(firstVersionIndex, 0, newContent)
+    updatedChangelog = lines.join('\n')
+  } else {
+    // No version entries yet - append to the end
+    updatedChangelog = existingChangelog.trimEnd() + '\n\n' + newContent + '\n'
   }
 
-  // Insert new content
-  lines.splice(insertIndex, 0, newContent)
-  writeFile(changelogPath, lines.join('\n'))
+  writeFile(changelogPath, updatedChangelog)
   console.log(`  ✓ Updated CHANGELOG.md`)
 }
 
 /**
  * Deletes all change files (except README.md)
  */
-function deleteChangeFiles(packageName: string) {
-  let changesDir = path.join(getPackageDir(packageName), '.changes')
+function deleteChangeFiles(packageDirName: string) {
+  let changesDir = path.join(getPackagePath(packageDirName), '.changes')
   let files = fs.readdirSync(changesDir)
   let changeFiles = files.filter((file) => file !== 'README.md' && file.endsWith('.md'))
 
@@ -110,14 +111,14 @@ function main() {
     )
 
     // Update package.json
-    updatePackageJson(release.packageName, release.nextVersion)
+    updatePackageJson(release.packageDirName, release.nextVersion)
 
     // Update CHANGELOG.md
     let changelogContent = generateChangelogContent(release)
-    updateChangelog(release.packageName, changelogContent)
+    updateChangelog(release.packageDirName, changelogContent)
 
     // Delete change files
-    deleteChangeFiles(release.packageName)
+    deleteChangeFiles(release.packageDirName)
 
     console.log()
   }

--- a/scripts/generate-remix.ts
+++ b/scripts/generate-remix.ts
@@ -97,15 +97,15 @@ async function getRemixRunPackages() {
   console.log('🔍 Scanning packages...')
 
   // Get all packages except remix itself
-  let packageDirs = (await fs.readdir(packagesDir, { withFileTypes: true }))
+  let packageDirNames = (await fs.readdir(packagesDir, { withFileTypes: true }))
     .filter((dirent) => dirent.isDirectory() && dirent.name !== 'remix')
     .map((dirent) => dirent.name)
 
   let remixRunPackages: RemixRunPackage[] = []
 
   // Scan each package for its exports
-  for (let packageDir of packageDirs) {
-    let packageJsonPath = path.join(packagesDir, packageDir, 'package.json')
+  for (let packageDirName of packageDirNames) {
+    let packageJsonPath = path.join(packagesDir, packageDirName, 'package.json')
     let packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'))
     let packageName = packageJson.name as string
 
@@ -148,7 +148,7 @@ async function getRemixRunPackages() {
       }
     }
 
-    let changesDir = path.join(packagesDir, packageDir, '.changes')
+    let changesDir = path.join(packagesDir, packageDirName, '.changes')
     try {
       let changeFiles = await fs.readdir(changesDir)
       for (let changeFile of changeFiles) {

--- a/scripts/setup-installable-branch.ts
+++ b/scripts/setup-installable-branch.ts
@@ -110,9 +110,9 @@ async function updateGitignore() {
 async function updatePackageDependencies() {
   let packagesDir = path.join(process.cwd(), 'packages')
 
-  let packageDirs = await fsp.readdir(packagesDir, { withFileTypes: true })
+  let packageDirNames = await fsp.readdir(packagesDir, { withFileTypes: true })
 
-  for (let dir of packageDirs) {
+  for (let dir of packageDirNames) {
     if (!dir.isDirectory()) continue
 
     let packageJsonPath = path.join(packagesDir, dir.name, 'package.json')
@@ -134,9 +134,9 @@ async function updatePackageDependencies() {
     if (pkg.dependencies) {
       for (let name of Object.keys(pkg.dependencies)) {
         if (name.startsWith('@remix-run/')) {
-          let packageName = name.replace('@remix-run/', '')
+          let packageDirName = name.replace('@remix-run/', '')
           pkg.dependencies[name] =
-            `remix-run/remix#${installableBranch}&path:packages/${packageName}`
+            `remix-run/remix#${installableBranch}&path:packages/${packageDirName}`
         }
       }
     }

--- a/scripts/utils/github.ts
+++ b/scripts/utils/github.ts
@@ -37,7 +37,7 @@ export async function createRelease(
 
   let tagName = `${packageName}@${version}`
   let releaseName = `${packageName} v${version}`
-  let changes = getChangelogEntry(packageName, version)
+  let changes = getChangelogEntry({ packageName, version })
   let body = changes?.body ?? 'No changelog entry found for this version.'
 
   if (preview) {


### PR DESCRIPTION
This fixes a couple of issues with our publish flow:

- When adding changes to a changelog that doesn't yet have any releases, the new changes were added to the top of the changelog.
- When publishing a release to GitHub, the logic for extracting the changelog for a given package version expected to receive the directory name (e.g. `"fetch-router"`) but was instead receiving the npm package name (`@remix-run/fetch-router`).

To avoid issues like this in the future, this also refactors to avoid the naming confusion that caused this.

I've also expanded the publish dry run script to check npm for unpublished versions and show a preview of GitHub release changelogs.