### PR TITLE
docs(form-data-parser): mention breaking change regarding the default value of `maxFiles` in v0.9.0

### DIFF
--- a/packages/form-data-parser/.changes/minor.changelog-0.9.md
+++ b/packages/form-data-parser/.changes/minor.changelog-0.9.md
@@ -1,0 +1,1 @@
+Mention breaking change regarding the default value of `maxFiles` in 0.9.0

--- a/packages/form-data-parser/CHANGELOG.md
+++ b/packages/form-data-parser/CHANGELOG.md
@@ -38,6 +38,7 @@ This release updates to `multipart-parser` 0.10.0 and removes the restrictions o
 
 - `FileUpload` is now a normal subclass of `File` with all the same functionality (instead of just implementing the same interface)
 - Add `maxFiles` option to `parseFormData` to allow limiting the number of files uploaded in a single request
+- BREAKING CHANGE: the default limit of the number of files uploaded in a single request is capped from unlimited to 20 files
 
 ```ts
 let formData = await parseFormData(request, { maxFiles: 5 })

--- a/packages/form-data-parser/CHANGELOG.md
+++ b/packages/form-data-parser/CHANGELOG.md
@@ -29,7 +29,7 @@ This is the changelog for [`form-data-parser`](https://github.com/remix-run/remi
 
 ## v0.9.1 (2025-06-13)
 
-- Export `FormDataParserError` and `MaxFilesExceededError`
+- Export `FormDataParseError` and `MaxFilesExceededError`
 - Re-export `MultipartParseError`, `MaxHeaderSizeExceededError`, and `MaxFileSizeExceededError` from multipart parser
 
 ## v0.9.0 (2025-06-13)
@@ -38,7 +38,7 @@ This release updates to `multipart-parser` 0.10.0 and removes the restrictions o
 
 - `FileUpload` is now a normal subclass of `File` with all the same functionality (instead of just implementing the same interface)
 - Add `maxFiles` option to `parseFormData` to allow limiting the number of files uploaded in a single request
-- BREAKING CHANGE: the default limit of the number of files uploaded in a single request is capped from unlimited to 20 files
+- BREAKING CHANGE: the default limit of the number of files uploaded in a single request is capped from unlimited to 20 files. `MaxFilesExceededError` (subclass of `FormDataParseError`) is thrown if the limit is exceeded.
 
 ```ts
 let formData = await parseFormData(request, { maxFiles: 5 })


### PR DESCRIPTION
- Before 0.9.0: unlimited numbers of files per submit
- After 0.9.0: up to 20 files per submit

This is nothing other than a breaking change. It affected on applications that support batch upload features. (e.g. upload files for more than a hundred users)

This breaking change was introduced by https://github.com/remix-run/remix/commit/39a24fa060b5e92aa9d6d8dda2bc4853a42cab9b.