### PR TITLE
Change preview branch name to preview/main

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,7 +1,7 @@
 # Create "installable" preview branches
 #
-# Commits to `main` push builds to a `preview` branch:
-#   pnpm install "remix-run/remix#preview&path:packages/remix"
+# Commits to `main` push builds to a `preview/main` branch:
+#   pnpm install "remix-run/remix#preview/main&path:packages/remix"
 #
 # Pull Requests create `preview/{number}` branches:
 #   pnpm install "remix-run/remix#preview/12345&path:packages/remix"
@@ -69,25 +69,15 @@ jobs:
           git config --local user.email "hello@remix.run"
           git config --local user.name "Remix Run Bot"
 
-      # Build and force push over the preview branch
+      # Build and force push over the preview/main branch
       - name: Build/push branch (push)
         if: github.event_name == 'push'
         run: |
-          pnpm run setup-installable-branch preview
-
-          echo ""
-          set -x
-          git status
-          git fetch origin
-          git branch --all
-          
-          git push --force --set-upstream origin preview
-
-          set +x
-          
+          pnpm run setup-installable-branch preview/main
+          git push --force --set-upstream origin preview/main
           echo "💿 pushed installable branch: https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"
 
-      # Build and force push over the PR preview/* branch + comment on the PR
+      # Build and force push over the PR preview/{number} branch + comment on the PR
       - name: Build/push branch (pull_request)
         if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open'
         env:
@@ -107,7 +97,7 @@ jobs:
           git push --set-upstream origin ${{ inputs.installableBranch }}
           echo "💿 pushed installable branch: https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"
 
-      # Cleanup PR preview/* branches when the PR is closed
+      # Cleanup PR preview/{number} branches when the PR is closed
       - name: Cleanup preview branch
         if: github.event_name == 'pull_request' && github.event.pull_request.state == 'closed'
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,15 +162,15 @@ The prerelease suffix is stripped (e.g. `3.0.0-rc.7` → `3.0.0`). The bump type
 
 ## Preview builds
 
-We maintain installable builds of `main` in a `preview` branch as a way for folks to test out the latest `main` branch without needing to publish releases to npm and clutter up the npm registry and version history UI.
+We maintain installable builds of `main` in a `preview/main` branch as a way for folks to test out the latest `main` branch without needing to publish releases to npm and clutter up the npm registry and version history UI.
 
-This is managed via the [`preview` workflow](/.github/workflows/preview.yaml) which uses the [`setup-installable-branch.ts`](./scripts/setup-installable-branch.ts) script to build and commit the build and required `package.json` changes to the `preview` branch on every new commit to `main`.
+This is managed via the [`preview` workflow](/.github/workflows/preview.yaml) which uses the [`setup-installable-branch.ts`](./scripts/setup-installable-branch.ts) script to build and commit the build and required `package.json` changes to the `preview/main` branch on every new commit to `main`.
 
-The `preview` branch build can be [installed directly](https://pnpm.io/package-sources#install-from-a-git-repository-combining-different-parameters) with `pnpm` (version 9+):
+The `preview/main` branch build can be [installed directly](https://pnpm.io/package-sources#install-from-a-git-repository-combining-different-parameters) with `pnpm` (version 9+):
 
 ```sh
-pnpm install "remix-run/remix#preview&path:packages/remix"
+pnpm install "remix-run/remix#preview/main&path:packages/remix"
 
 # Or, just install a single package
-pnpm install "remix-run/remix#preview&path:packages/@remix-run/fetch-router"
+pnpm install "remix-run/remix#preview/main&path:packages/@remix-run/fetch-router"
 ```

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ npm install remix
 npm install @remix-run/fetch-router
 ```
 
-If you want to play around with the bleeding edge, we also build the latest `main` branch into a `preview` branch which can be [installed directly](https://pnpm.io/package-sources#install-from-a-git-repository-combining-different-parameters) with `pnpm` (version 9+):
+If you want to play around with the bleeding edge, we also build the latest `main` branch into a `preview/main` branch which can be [installed directly](https://pnpm.io/package-sources#install-from-a-git-repository-combining-different-parameters) with `pnpm` (version 9+):
 
 ```sh
-pnpm install "remix-run/remix#preview&path:packages/remix"
+pnpm install "remix-run/remix#preview/main&path:packages/remix"
 
 # Or, just install a single package
-pnpm install "remix-run/remix#preview&path:packages/@remix-run/fetch-router"
+pnpm install "remix-run/remix#preview/main&path:packages/@remix-run/fetch-router"
 ```
 
 ## Contributing

--- a/scripts/setup-installable-branch.ts
+++ b/scripts/setup-installable-branch.ts
@@ -5,9 +5,9 @@ import { logAndExec } from './utils/process.ts'
 
 /**
  * This script prepares a base branch (usually `main`) to be PNPM-installable
- * directly from GitHub via a new branch (usually `preview`):
+ * directly from GitHub via a new branch (usually `preview/main`):
  *
- *   pnpm install "remix-run/remix#preview&path:packages/remix"
+ *   pnpm install "remix-run/remix#preview/main&path:packages/remix"
  *
  * To do this, we can run a build, make some minor changes to the repo, and
  * commit the build + changes to the new branch. These changes would never be
@@ -22,7 +22,7 @@ import { logAndExec } from './utils/process.ts'
  *  - Copies all `publishConfig`'s down so we get `exports` from `dist/` instead of `src/`
  *  - Commits the changes
  *
- * Then, after pushing, `pnpm install "remix-run/remix#preview&path:packages/remix"`
+ * Then, after pushing, `pnpm install "remix-run/remix#preview/main&path:packages/remix"`
  * sees the `remix` nested deps and they all point to github with similar URLs so
  * they install as nested deps the same way.
  */


### PR DESCRIPTION
We can't seem to push a branch `preview` to the origin, potentially due to the existence of `preview/*` branches for PRs?  This PR updates the branch name to `preview/main` to align with the format of PR preview branches.

```sh
remix (main)> git checkout -b preview; git push origin preview
Switched to a new branch 'preview'
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To github.com:remix-run/remix.git
 ! [remote rejected]     preview -> preview (directory file conflict)
error: failed to push some refs to 'github.com:remix-run/remix.git'
```