### PR TITLE
route-pattern: param tokens

### DIFF
--- a/packages/route-pattern/.changes/minor.param-tokens.md
+++ b/packages/route-pattern/.changes/minor.param-tokens.md
@@ -1,0 +1,45 @@
+BREAKING CHANGE: Change how params are represented within `RoutePattern.ast`
+
+Previously, `RoutePattern.ast.{hostname,pathname}.tokens` had param tokens like:
+
+```ts
+type ParamToken = { type: ':', '*', nameIndex: number }
+```
+
+where the `nameIndex` was used to access the param name from `paramNames`:
+
+```ts
+let { pathname } = pattern.ast
+
+for (let token of pathname.tokens) {
+  if (token.type === ':' || token.type === '*') {
+    let paramName = pathname.paramNames[token.nameIndex]
+    console.log('name: ', paramName)
+  }
+}
+```
+
+This has now been simplified so that param tokens contain their own name:
+
+```ts
+type ParamToken = { type: ':' | '*', name: string }
+
+let { pathname } = pattern.ast
+
+for (let token of pathname.tokens) {
+   if (token.type === ':' || token.type === '*') {
+      console.log('name: ', token.name)
+   }
+}
+```
+
+If you want to iterate over _just_ the params, there's a new `.params` getter:
+
+```ts
+let { pathname } = pattern.ast
+
+for (let param of pathname.params) {
+  console.log('type: ', param.type)
+  console.log('name: ', param.name)
+}
+```

--- a/packages/route-pattern/.changes/patch.match-perf.md
+++ b/packages/route-pattern/.changes/patch.match-perf.md
@@ -1,0 +1,2 @@
+`ArrayMatcher.match` (optimized for small apps) got ~1.06x faster for our small app benchmark.
+`TrieMatcher.match` (optimized for large apps) got ~1.17x faster across the board.

--- a/packages/route-pattern/src/lib/errors.ts
+++ b/packages/route-pattern/src/lib/errors.ts
@@ -80,8 +80,10 @@ export class HrefError extends Error {
       let paramNames = Object.keys(details.params)
       let variants = details.partPattern.variants.map((variant) => {
         let key = variant.toString()
-        let missing = new Set(variant.requiredParams.filter((p) => !paramNames.includes(p)))
-        return `  - ${key || '<empty>'} (missing: ${Array.from(missing).join(', ')})`
+        let missing = Array.from(
+          new Set(variant.params.filter((p) => !paramNames.includes(p.name)).map((p) => p.name)),
+        )
+        return `  - ${key || '<empty>'} (missing: ${missing.join(', ')})`
       })
       let partTitle =
         details.partPattern.type.charAt(0).toUpperCase() + details.partPattern.type.slice(1)

--- a/packages/route-pattern/src/lib/route-pattern.ts
+++ b/packages/route-pattern/src/lib/route-pattern.ts
@@ -198,9 +198,9 @@ export class RoutePattern<source extends string = string> {
     let params: Record<string, string | undefined> = {}
 
     // hostname params
-    this.ast.hostname?.paramNames.forEach((name) => {
-      if (name === '*') return
-      params[name] = undefined
+    this.ast.hostname?.params.forEach((param) => {
+      if (param.name === '*') return
+      params[param.name] = undefined
     })
     hostname?.forEach((param) => {
       if (param.name === '*') return
@@ -208,9 +208,9 @@ export class RoutePattern<source extends string = string> {
     })
 
     // pathname params
-    this.ast.pathname.paramNames.forEach((name) => {
-      if (name === '*') return
-      params[name] = undefined
+    this.ast.pathname.params.forEach((param) => {
+      if (param.name === '*') return
+      params[param.name] = undefined
     })
     pathname.forEach((param) => {
       if (param.name === '*') return

--- a/packages/route-pattern/src/lib/route-pattern/hostname.ts
+++ b/packages/route-pattern/src/lib/route-pattern/hostname.ts
@@ -16,6 +16,5 @@ function isNamelessWildcard(part: PartPattern): boolean {
   if (part.tokens.length !== 1) return false
   let token = part.tokens[0]
   if (token.type !== '*') return false
-  let name = part.paramNames[token.nameIndex]
-  return name === '*'
+  return token.name === '*'
 }

--- a/packages/route-pattern/src/lib/route-pattern/part-pattern.test.ts
+++ b/packages/route-pattern/src/lib/route-pattern/part-pattern.test.ts
@@ -24,48 +24,40 @@ describe('PartPattern', () => {
     it('parses static text', () => {
       assertParse('abc', {
         tokens: [{ type: 'text', text: 'abc' }],
-        paramNames: [],
         optionals: new Map(),
       })
     })
 
     it('parses a variable', () => {
       assertParse(':abc', {
-        tokens: [{ type: ':', nameIndex: 0 }],
-        paramNames: ['abc'],
+        tokens: [{ type: ':', name: 'abc' }],
         optionals: new Map(),
       })
       assertParse(':_hello_WORLD', {
-        tokens: [{ type: ':', nameIndex: 0 }],
-        paramNames: ['_hello_WORLD'],
+        tokens: [{ type: ':', name: '_hello_WORLD' }],
         optionals: new Map(),
       })
       assertParse(':$_hello_WORLD$123$', {
-        tokens: [{ type: ':', nameIndex: 0 }],
-        paramNames: ['$_hello_WORLD$123$'],
+        tokens: [{ type: ':', name: '$_hello_WORLD$123$' }],
         optionals: new Map(),
       })
     })
 
     it('parses a wildcard', () => {
       assertParse('*', {
-        tokens: [{ type: '*', nameIndex: 0 }],
-        paramNames: ['*'],
+        tokens: [{ type: '*', name: '*' }],
         optionals: new Map(),
       })
       assertParse('*abc', {
-        tokens: [{ type: '*', nameIndex: 0 }],
-        paramNames: ['abc'],
+        tokens: [{ type: '*', name: 'abc' }],
         optionals: new Map(),
       })
       assertParse('*_hello_WORLD', {
-        tokens: [{ type: '*', nameIndex: 0 }],
-        paramNames: ['_hello_WORLD'],
+        tokens: [{ type: '*', name: '_hello_WORLD' }],
         optionals: new Map(),
       })
       assertParse('*$_hello_WORLD$123$', {
-        tokens: [{ type: '*', nameIndex: 0 }],
-        paramNames: ['$_hello_WORLD$123$'],
+        tokens: [{ type: '*', name: '$_hello_WORLD$123$' }],
         optionals: new Map(),
       })
     })
@@ -79,7 +71,6 @@ describe('PartPattern', () => {
           { type: ')' },
           { type: 'text', text: 'cc' },
         ],
-        paramNames: [],
         optionals: new Map([[1, 3]]),
       })
       assertParse('(aa(bb)cc)', {
@@ -92,7 +83,6 @@ describe('PartPattern', () => {
           { type: 'text', text: 'cc' },
           { type: ')' },
         ],
-        paramNames: [],
         optionals: new Map([
           [0, 6],
           [2, 4],
@@ -107,16 +97,15 @@ describe('PartPattern', () => {
           { type: 'separator' },
           { type: '(' },
           { type: 'text', text: 'v' },
-          { type: ':', nameIndex: 0 },
+          { type: ':', name: 'major' },
           { type: '(' },
           { type: 'text', text: '.' },
-          { type: ':', nameIndex: 1 },
+          { type: ':', name: 'minor' },
           { type: ')' },
           { type: 'separator' },
           { type: ')' },
           { type: 'text', text: 'run' },
         ],
-        paramNames: ['major', 'minor'],
         optionals: new Map([
           [2, 10],
           [5, 8],
@@ -125,59 +114,54 @@ describe('PartPattern', () => {
 
       assertParse('*/node_modules/(*path/):package/dist/index.:ext', {
         tokens: [
-          { type: '*', nameIndex: 0 },
+          { type: '*', name: '*' },
           { type: 'separator' },
           { type: 'text', text: 'node_modules' },
           { type: 'separator' },
           { type: '(' },
-          { type: '*', nameIndex: 1 },
+          { type: '*', name: 'path' },
           { type: 'separator' },
           { type: ')' },
-          { type: ':', nameIndex: 2 },
+          { type: ':', name: 'package' },
           { type: 'separator' },
           { type: 'text', text: 'dist' },
           { type: 'separator' },
           { type: 'text', text: 'index.' },
-          { type: ':', nameIndex: 3 },
+          { type: ':', name: 'ext' },
         ],
-        paramNames: ['*', 'path', 'package', 'ext'],
         optionals: new Map([[4, 7]]),
       })
     })
 
     it('parses repeated param names', () => {
       assertParse(':id/:id', {
-        tokens: [{ type: ':', nameIndex: 0 }, { type: 'separator' }, { type: ':', nameIndex: 1 }],
-        paramNames: ['id', 'id'],
+        tokens: [{ type: ':', name: 'id' }, { type: 'separator' }, { type: ':', name: 'id' }],
         optionals: new Map(),
       })
       assertParse('*id/*id', {
-        tokens: [{ type: '*', nameIndex: 0 }, { type: 'separator' }, { type: '*', nameIndex: 1 }],
-        paramNames: ['id', 'id'],
+        tokens: [{ type: '*', name: 'id' }, { type: 'separator' }, { type: '*', name: 'id' }],
         optionals: new Map(),
       })
       assertParse('*/*', {
-        tokens: [{ type: '*', nameIndex: 0 }, { type: 'separator' }, { type: '*', nameIndex: 1 }],
-        paramNames: ['*', '*'],
+        tokens: [{ type: '*', name: '*' }, { type: 'separator' }, { type: '*', name: '*' }],
         optionals: new Map(),
       })
       assertParse(':a/*a/:b/*b/:b/*a/:a', {
         tokens: [
-          { type: ':', nameIndex: 0 },
+          { type: ':', name: 'a' },
           { type: 'separator' },
-          { type: '*', nameIndex: 1 },
+          { type: '*', name: 'a' },
           { type: 'separator' },
-          { type: ':', nameIndex: 2 },
+          { type: ':', name: 'b' },
           { type: 'separator' },
-          { type: '*', nameIndex: 3 },
+          { type: '*', name: 'b' },
           { type: 'separator' },
-          { type: ':', nameIndex: 4 },
+          { type: ':', name: 'b' },
           { type: 'separator' },
-          { type: '*', nameIndex: 5 },
+          { type: '*', name: 'a' },
           { type: 'separator' },
-          { type: ':', nameIndex: 6 },
+          { type: ':', name: 'a' },
         ],
-        paramNames: ['a', 'a', 'b', 'b', 'b', 'a', 'a'],
         optionals: new Map(),
       })
     })

--- a/packages/route-pattern/src/lib/route-pattern/pathname.ts
+++ b/packages/route-pattern/src/lib/route-pattern/pathname.ts
@@ -60,14 +60,8 @@ export function join(a: PartPattern, b: PartPattern, ignoreCase: boolean): PartP
   let tokenOffset = tokens.length
 
   b.tokens.forEach((token) => {
-    if (token.type === ':' || token.type === '*') {
-      tokens.push({ ...token, nameIndex: token.nameIndex + a.paramNames.length })
-    } else {
-      tokens.push(token)
-    }
+    tokens.push(token)
   })
-
-  let paramNames = [...a.paramNames, ...b.paramNames]
 
   let optionals = new Map()
   for (let [begin, end] of a.optionals) {
@@ -82,5 +76,5 @@ export function join(a: PartPattern, b: PartPattern, ignoreCase: boolean): PartP
     optionals.set(tokenOffset + begin, tokenOffset + end)
   }
 
-  return new PartPattern({ tokens, paramNames, optionals }, { type: 'pathname', ignoreCase })
+  return new PartPattern({ tokens, optionals }, { type: 'pathname', ignoreCase })
 }

--- a/packages/route-pattern/src/lib/variant.ts
+++ b/packages/route-pattern/src/lib/variant.ts
@@ -3,28 +3,29 @@ import type { PartPattern, PartPatternToken } from './route-pattern/part-pattern
 
 type Token = Extract<PartPatternToken, { type: 'text' | ':' | '*' | 'separator' }>
 
+type Param = Extract<PartPatternToken, { type: ':' | '*' }>
+
 export class Variant {
-  /** Params use `nameIndex` to reference params in the PartPattern's `paramNames` */
   tokens: Array<Token>
 
   #partPattern: PartPattern
-  #requiredParams: Array<string> | undefined
+  #params: Array<Param> | undefined
 
   constructor(partPattern: PartPattern, tokens: Array<Token>) {
     this.#partPattern = partPattern
     this.tokens = tokens
   }
 
-  get requiredParams(): Array<string> {
-    if (this.#requiredParams === undefined) {
-      this.#requiredParams = []
+  get params(): Array<Param> {
+    if (this.#params === undefined) {
+      this.#params = []
       for (let token of this.tokens) {
         if (token.type === ':' || token.type === '*') {
-          this.#requiredParams.push(this.#partPattern.paramNames[token.nameIndex])
+          this.#params.push(token)
         }
       }
     }
-    return this.#requiredParams
+    return this.#params
   }
 
   static generate(pattern: PartPattern): Array<Variant> {
@@ -81,8 +82,7 @@ export class Variant {
       }
 
       if (token.type === ':' || token.type === '*') {
-        let name = this.#partPattern.paramNames[token.nameIndex]
-        if (name === '*') name = ''
+        let name = token.name === '*' ? '' : token.name
         result += `{${token.type}${name}}`
         continue
       }


### PR DESCRIPTION
This PR changes how params are stored with `PartPatterns` so that param names are stored directly in the param token. You can still access only the params via the `get params()` getter.

## Context

Previously, params kept track of their type (variable = `':'`, wildcard = `'*'`) and their "param index" while the param name was stored separately in a `paramNames: Array<string>`.
This design was initially chosen to facilitate generation of pattern variants (combinations of optionals) as strings.

Since then, we've changed other parts of the code so that variants are not strings, but `Array<Token>` (excluding optional token types `(` and `)`). As a result, every usage of `Token.nameIndex` was being used immediately to index into `paramNames`.

The one exception was that `ArrayMatcher` and `TrieMatcher` used named capture groups in their `RegExp`s where the name was encoding the type of the param (`v` for `:`, `w` for `*`). Those `RegExp`s were including a param index as a suffix to the group name for example `v4` would be the 5th param (zero-indexing), whose type was `:`.

So before this PR, param names were stored separately from params which was already a bit confusing, but it also necessitated fancy named capture group encoding to recover the name and type for each param during matching. Additionally, named capture groups actually carry a significant perf cost when calling `RegExp.exec`.

## Perf

At least as fast  for `ArrayMatcher.match` on small apps (which is the intended use case for it). Hard to say since 1.06x faster is right on the cusp of being past the expected variance.

**1.17x faster** for `TrieMatcher.match` faster across the board.

Comparing to this PR branch to `main`:

<img width="1098" height="1196" alt="Screenshot 2026-01-28 at 3 33 19 PM" src="https://github.com/user-attachments/assets/b646c14b-51be-452d-a3f9-3fcf7ace345e" />

Additionally, performance for `href` seems to be either unaffected or  **1.07x - 1.18x faster** depending on the use case:

<img width="978" height="822" alt="Screenshot 2026-01-28 at 9 54 10 PM" src="https://github.com/user-attachments/assets/b224ddde-77ee-4ad7-b770-03611b4989f9" />
