### PR TITLE
fix simple + pathological benchmarks

### DIFF
--- a/packages/route-pattern/bench/pathological.bench.ts
+++ b/packages/route-pattern/bench/pathological.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe } from 'vitest'
-import { ArrayMatcher } from '@remix-run/route-pattern'
+import { ArrayMatcher, TrieMatcher } from '@remix-run/route-pattern'
 
 function generateRoutes(): string[] {
   let routes: string[] = []
@@ -113,20 +113,28 @@ let urls = [
   'https://example.com/search?missing=params',
 ]
 
-let matchers = [{ name: 'array', matcher: new ArrayMatcher<null>() }]
-
 describe('setup', () => {
-  for (let { name, matcher } of matchers) {
-    bench(name, () => {
-      routes.forEach((route) => matcher.add(route, null))
-    })
-  }
+  bench('array', () => {
+    let matcher = new ArrayMatcher<null>()
+    routes.forEach((route) => matcher.add(route, null))
+  })
+
+  bench('trie', () => {
+    let matcher = new TrieMatcher<null>()
+    routes.forEach((route) => matcher.add(route, null))
+  })
 })
 
 describe('match', () => {
-  for (let { name, matcher } of matchers) {
-    bench(name, () => {
-      urls.forEach((url) => matcher.match(url))
-    })
-  }
+  let arrayMatcher = new ArrayMatcher<null>()
+  routes.forEach((route) => arrayMatcher.add(route, null))
+  bench('array', () => {
+    urls.forEach((url) => arrayMatcher.match(url))
+  })
+
+  let trieMatcher = new TrieMatcher<null>()
+  routes.forEach((route) => trieMatcher.add(route, null))
+  bench('trie', () => {
+    urls.forEach((url) => trieMatcher.match(url))
+  })
 })

--- a/packages/route-pattern/bench/simple.bench.ts
+++ b/packages/route-pattern/bench/simple.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe } from 'vitest'
-import { ArrayMatcher } from '@remix-run/route-pattern'
+import { ArrayMatcher, TrieMatcher } from '@remix-run/route-pattern'
 
 let routes = [
   '/',
@@ -107,22 +107,36 @@ let urls = [
   'https://example.com/test',
 ]
 
-let matchers = [{ name: 'array', matcher: new ArrayMatcher<null>() }]
-
 describe('setup', () => {
-  for (let { name, matcher } of matchers) {
-    bench(name, () => {
-      for (let route of routes) {
-        matcher.add(route, null)
-      }
-    })
-  }
+  bench('array', () => {
+    let matcher = new ArrayMatcher<null>()
+    for (let route of routes) {
+      matcher.add(route, null)
+    }
+  })
+
+  bench('trie', () => {
+    let matcher = new TrieMatcher<null>()
+    for (let route of routes) {
+      matcher.add(route, null)
+    }
+  })
 })
 
 describe('match', () => {
-  for (let { name, matcher } of matchers) {
-    bench(name, () => {
-      urls.forEach((url) => matcher.match(url))
-    })
+  let arrayMatcher = new ArrayMatcher<null>()
+  for (let route of routes) {
+    arrayMatcher.add(route, null)
   }
+  bench('array', () => {
+    urls.forEach((url) => arrayMatcher.match(url))
+  })
+
+  let trieMatcher = new TrieMatcher<null>()
+  for (let route of routes) {
+    trieMatcher.add(route, null)
+  }
+  bench('trie', () => {
+    urls.forEach((url) => trieMatcher.match(url))
+  })
 })


### PR DESCRIPTION
previously, vitest would run callback fn passed to `bench` TONS of time during the benchmark, which would bloat each matcher with tons of duplicates. That was making tests hang seemingly forever with just the ArrayMatcher.

now, matches are created within the `describe` block instead so they only get initialized once and TrieMatcher is being benchmarked too.