### PR TITLE
route-pattern: fix benchmarks for types

### DIFF
--- a/packages/route-pattern/bench/types/href.ts
+++ b/packages/route-pattern/bench/types/href.ts
@@ -17,8 +17,13 @@ bench('href > complex route', () => {
 }).types([4575, 'instantiations'])
 
 bench('href > mediarss', () => {
-  type Route = keyof typeof import('../routes/mediarss.ts').routes
-  let routes: { [route in Route]: RoutePattern<route> } = {} as any
+  type Routes = typeof import('../routes/mediarss.ts').routes
+  let routes: { [route in keyof Routes]: RoutePattern<Routes[route]> } = {} as any
+
+  // @ts-expect-error missing required params: 'token'
+  routes.feed.href()
+  // @ts-expect-error missing required params: 'token'
+  routes.feed.href({ extra: '123' })
 
   routes.feed.href({ token: '123' })
   routes.media.href({ token: '123', path: 'users' })
@@ -55,4 +60,4 @@ bench('href > mediarss', () => {
   routes.adminApiMediaStream.href({ path: 'users' })
   routes.adminApiMediaUpload.href()
   routes.adminApiArtwork.href({ path: 'users' })
-}).types([39583, 'instantiations'])
+}).types([79421, 'instantiations'])

--- a/packages/route-pattern/bench/types/join.ts
+++ b/packages/route-pattern/bench/types/join.ts
@@ -17,8 +17,8 @@ bench('Join', () => {
 
 bench('join > mediarss', () => {
   const other = '/comments/:commentId'
-  type Route = keyof typeof import('../routes/mediarss.ts').routes
-  let routes: { [route in Route]: RoutePattern<route> } = {} as any
+  type Routes = typeof import('../routes/mediarss.ts').routes
+  let routes: { [route in keyof Routes]: RoutePattern<Routes[route]> } = {} as any
 
   routes.feed.join(other)
   routes.media.join(other)
@@ -55,4 +55,4 @@ bench('join > mediarss', () => {
   routes.adminApiMediaStream.join(other)
   routes.adminApiMediaUpload.join(other)
   routes.adminApiArtwork.join(other)
-}).types([44665, 'instantiations'])
+}).types([81580, 'instantiations'])

--- a/packages/route-pattern/bench/types/new.ts
+++ b/packages/route-pattern/bench/types/new.ts
@@ -16,8 +16,8 @@ bench('new > complex route', () => {
 }).types([3, 'instantiations'])
 
 bench('new > mediarss', () => {
-  type Route = keyof typeof import('../routes/mediarss.ts').routes
-  let routes: { [route in Route]: RoutePattern<route> } = {} as any
+  type Routes = typeof import('../routes/mediarss.ts').routes
+  let routes: { [route in keyof Routes]: RoutePattern<Routes[route]> } = {} as any
 
   routes.feed
   routes.media
@@ -54,4 +54,4 @@ bench('new > mediarss', () => {
   routes.adminApiMediaStream
   routes.adminApiMediaUpload
   routes.adminApiArtwork
-}).types([64, 'instantiations'])
+}).types([128, 'instantiations'])

--- a/packages/route-pattern/bench/types/params.ts
+++ b/packages/route-pattern/bench/types/params.ts
@@ -19,8 +19,8 @@ bench('params > complex route', () => {
 }).types([3804, 'instantiations'])
 
 bench('params > mediarss', () => {
-  type Route = keyof typeof import('../routes/mediarss.ts').routes
-  let routes: { [route in Route]: RoutePattern<route> } = {} as any
+  type Routes = typeof import('../routes/mediarss.ts').routes
+  let routes: { [route in keyof Routes]: RoutePattern<Routes[route]> } = {} as any
   let url: URL = {} as any
 
   routes.feed.match(url)?.params
@@ -58,4 +58,4 @@ bench('params > mediarss', () => {
   routes.adminApiMediaStream.match(url)?.params
   routes.adminApiMediaUpload.match(url)?.params
   routes.adminApiArtwork.match(url)?.params
-}).types([39534, 'instantiations'])
+}).types([74851, 'instantiations'])


### PR DESCRIPTION
Previously, we were using the route _name_ instead of route _path_ as the RoutePattern source