### PR TITLE
docs: standardize package README structure and install guidance

### DIFF
--- a/packages/async-context-middleware/README.md
+++ b/packages/async-context-middleware/README.md
@@ -1,13 +1,17 @@
 # async-context-middleware
 
-Middleware for storing request context in `AsyncLocalStorage` for use with [`@remix-run/fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router).
+Request-scoped async context middleware for Remix. It stores each request context in [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) so utilities can access it anywhere in the same async call stack.
 
-This middleware stores the request context in [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) (using `node:async_hooks`), making it available to all functions in the same async execution context.
+## Features
+
+- **Request Context Access** - Read request context from anywhere in the same async execution flow
+- **Simple Router Integration** - Add a single middleware at the router level
+- **Node Async Hooks** - Built on `node:async_hooks` `AsyncLocalStorage`
 
 ## Installation
 
 ```sh
-npm install @remix-run/async-context-middleware
+npm i remix
 ```
 
 ## Usage

--- a/packages/component/README.md
+++ b/packages/component/README.md
@@ -1,6 +1,6 @@
-# Remix Component
+# component
 
-A minimal component system that leans on JavaScript and DOM primitives.
+A minimal component system for the web that leans on JavaScript and DOM primitives.
 
 ## Features
 
@@ -13,7 +13,7 @@ A minimal component system that leans on JavaScript and DOM primitives.
 ## Installation
 
 ```sh
-npm install @remix-run/component
+npm i remix
 ```
 
 ## Getting Started

--- a/packages/compression-middleware/README.md
+++ b/packages/compression-middleware/README.md
@@ -1,13 +1,18 @@
 # compression-middleware
 
-Middleware for compressing HTTP responses for use with [`@remix-run/fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router).
+Response compression middleware for Remix. It negotiates `br`, `gzip`, and `deflate` from `Accept-Encoding` and applies sensible defaults for when compression is useful.
 
-Automatically compresses responses using `gzip`, `brotli`, or `deflate` based on the client's `Accept-Encoding` header, with intelligent defaults for media type filtering and threshold-based compression.
+## Features
+
+- **Encoding Negotiation** - Selects the best supported encoding from `Accept-Encoding`
+- **Compression Guards** - Skips already-compressed responses and range-enabled responses
+- **Size Thresholds** - Configurable minimum response size for compression
+- **MIME Filtering** - Compresses only content types likely to benefit
 
 ## Installation
 
 ```sh
-npm install @remix-run/compression-middleware
+npm i remix
 ```
 
 ## Usage

--- a/packages/cookie/README.md
+++ b/packages/cookie/README.md
@@ -1,8 +1,6 @@
 # cookie
 
-Simplify HTTP cookie management in JavaScript with type-safe, secure cookie handling. `@remix-run/cookie` provides a clean, intuitive API for creating, parsing, and serializing HTTP cookies with built-in support for signing, secret rotation, and comprehensive cookie attribute management.
-
-HTTP cookies are essential for web applications, from session management and user preferences to authentication tokens and tracking. While the standard cookie parsing libraries provide basic functionality, they often leave complex scenarios like secure signing, secret rotation, and type-safe value handling up to you.
+Type-safe cookie parsing and serialization for Remix. It supports secure signing, secret rotation, and complete cookie attribute control.
 
 ## Features
 
@@ -13,7 +11,7 @@ HTTP cookies are essential for web applications, from session management and use
 ## Installation
 
 ```sh
-npm install @remix-run/cookie
+npm i remix
 ```
 
 ## Usage

--- a/packages/fetch-proxy/README.md
+++ b/packages/fetch-proxy/README.md
@@ -1,12 +1,7 @@
 # fetch-proxy
 
-`fetch-proxy` is an HTTP proxy for the [JavaScript Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
-
-HTTP proxies are essential for many web architectures: load balancing, API gateways, development servers that forward to backend services, and middleware that needs to intercept and modify traffic. Traditional proxy implementations often require platform-specific APIs or complex server setups.
-
-In the context of servers, an HTTP proxy server is a server that forwards all requests it receives to another server and returns the responses it receives. When you think about it this way, a [`fetch` function](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) is like a mini proxy server sitting right there in your code. You send it requests, it goes and talks to some other server, and it gives you back the response it received.
-
-`fetch-proxy` allows you to easily create `fetch` functions that act as proxies to "target" servers using the familiar web-standard Fetch API.
+HTTP proxy utilities built on the web [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
+Use `fetch-proxy` to create `fetch` handlers that forward requests to target servers while optionally rewriting headers and cookies.
 
 ## Features
 
@@ -17,10 +12,8 @@ In the context of servers, an HTTP proxy server is a server that forwards all re
 
 ## Installation
 
-Install from [npm](https://www.npmjs.com/):
-
 ```sh
-npm i @remix-run/fetch-proxy
+npm i remix
 ```
 
 ## Usage

--- a/packages/fetch-router/README.md
+++ b/packages/fetch-router/README.md
@@ -1,6 +1,6 @@
 # fetch-router
 
-A minimal, composable router built on the [web Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) and [`route-pattern`](../route-pattern). Ideal for building APIs, web services, and server-rendered applications across any JavaScript runtime.
+A minimal, composable router built on the [web Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) and [`route-pattern`](https://github.com/remix-run/remix/tree/main/packages/route-pattern). Ideal for building APIs, web services, and server-rendered applications.
 
 ## Features
 
@@ -11,16 +11,10 @@ A minimal, composable router built on the [web Fetch API](https://developer.mozi
 - **Flexible Middleware**: Apply middleware globally, per-route, or to entire route hierarchies
 - **Easy Testing**: Use standard `fetch()` to test your routes - no special test harness required
 
-## Goals
-
-- **Simplicity**: A router should be simple to understand and use. The entire API surface fits in your head.
-- **Composability**: Small routers combine to build large applications. Middleware and nested routers make organization natural.
-- **Standards-Based**: Built on web standards that work across runtimes. No proprietary APIs or Node.js-specific code.
-
 ## Installation
 
 ```sh
-npm install @remix-run/fetch-router
+npm i remix
 ```
 
 ## Usage

--- a/packages/file-storage/README.md
+++ b/packages/file-storage/README.md
@@ -1,10 +1,6 @@
 # file-storage
 
-`file-storage` is a key/value interface for storing [`File` objects](https://developer.mozilla.org/en-US/docs/Web/API/File) in JavaScript.
-
-Handling file uploads and storage is a common requirement in web applications, but each storage backend (local disk, AWS S3, Cloudflare R2, etc.) has its own API and conventions. This fragmentation makes it difficult to write portable code that can easily switch between storage providers or support multiple backends simultaneously.
-
-Similar to how `localStorage` allows you to store key/value pairs of strings in the browser, `file-storage` allows you to store key/value pairs of files on the server with a consistent interface regardless of the underlying storage mechanism.
+Key/value storage interfaces for server-side [`File` objects](https://developer.mozilla.org/en-US/docs/Web/API/File). `file-storage` gives Remix apps one consistent API across local disk and cloud object storage backends.
 
 ## Features
 
@@ -15,10 +11,8 @@ Similar to how `localStorage` allows you to store key/value pairs of strings in 
 
 ## Installation
 
-Install from [npm](https://www.npmjs.com/):
-
 ```sh
-npm install @remix-run/file-storage
+npm i remix
 ```
 
 ## Usage

--- a/packages/form-data-middleware/README.md
+++ b/packages/form-data-middleware/README.md
@@ -1,11 +1,18 @@
 # form-data-middleware
 
-Middleware for parsing [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) from incoming request bodies for use with [`@remix-run/fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router).
+Form body parsing middleware for Remix. It parses incoming [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) and exposes `context.formData` and uploaded files on `context.files`.
+
+## Features
+
+- **Request Form Parsing** - Parses request body form data once per request
+- **File Access** - Exposes uploaded files as `context.files`
+- **Custom Upload Handling** - Supports pluggable upload handlers for file processing
+- **Error Control** - Optional suppression for malformed form data
 
 ## Installation
 
 ```sh
-npm install @remix-run/form-data-middleware
+npm i remix
 ```
 
 ## Usage

--- a/packages/form-data-parser/README.md
+++ b/packages/form-data-parser/README.md
@@ -26,10 +26,8 @@ For attackers, this creates an attack vector where malicious actors can overwhel
 
 ## Installation
 
-Install from [npm](https://www.npmjs.com/):
-
 ```sh
-npm install @remix-run/form-data-parser
+npm i remix
 ```
 
 ## Usage

--- a/packages/fs/README.md
+++ b/packages/fs/README.md
@@ -1,8 +1,6 @@
 # fs
 
-Lazy, streaming filesystem utilities for JavaScript.
-
-This package provides utilities for working with files on the local filesystem using the [`LazyFile`](https://github.com/remix-run/remix/tree/main/packages/lazy-file)/ native [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) API.
+Lazy, streaming filesystem utilities for JavaScript. This package provides utilities for working with files on the local filesystem using the [`LazyFile`](https://github.com/remix-run/remix/tree/main/packages/lazy-file)/ native [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) API.
 
 ## Features
 
@@ -11,10 +9,8 @@ This package provides utilities for working with files on the local filesystem u
 
 ## Installation
 
-Install from [npm](https://www.npmjs.com/):
-
 ```sh
-npm install @remix-run/fs
+npm i remix
 ```
 
 ## Usage

--- a/packages/headers/README.md
+++ b/packages/headers/README.md
@@ -1,13 +1,17 @@
 # headers
 
-Utilities for parsing, manipulating and stringifying HTTP header values.
+Typed utilities for parsing, manipulating, and serializing HTTP header values. `headers` provides focused classes for common HTTP headers.
 
-HTTP headers contain critical information—from content negotiation and caching directives to authentication tokens and file metadata. While the native `Headers` API provides a basic string-based interface, it leaves the complexities of parsing specific header formats entirely up to you.
+## Features
+
+- **Header-Specific Classes** - Purpose-built APIs for `Accept`, `Cache-Control`, `Content-Type`, and more
+- **Round-Trip Safety** - Parse from raw values and serialize back with `.toString()`
+- **Typed Operations** - Work with structured values instead of manual string parsing
 
 ## Installation
 
 ```sh
-npm install @remix-run/headers
+npm i remix
 ```
 
 ## Individual Header Utilities

--- a/packages/html-template/README.md
+++ b/packages/html-template/README.md
@@ -1,10 +1,6 @@
 # html-template
 
-Safe HTML template tag with auto-escaping for JavaScript.
-
-Building HTML strings with user input is dangerous. Without proper escaping, you risk XSS (cross-site scripting) vulnerabilities where malicious code can be injected into your pages. Manual escaping is error-prone and easy to forget, especially when composing HTML from multiple sources.
-
-`html-template` provides a tagged template literal for safely constructing HTML strings with automatic escaping of interpolated values to prevent XSS vulnerabilities.
+Safe HTML template literals for Remix. `html-template` automatically escapes interpolated values to prevent XSS while still supporting explicit trusted HTML insertion.
 
 ## Features
 
@@ -17,10 +13,8 @@ Building HTML strings with user input is dangerous. Without proper escaping, you
 
 ## Installation
 
-Install from [npm](https://www.npmjs.com/):
-
 ```sh
-npm install @remix-run/html-template
+npm i remix
 ```
 
 ## Usage

--- a/packages/interaction/README.md
+++ b/packages/interaction/README.md
@@ -12,7 +12,7 @@ Enhanced events and custom interactions for any [EventTarget](https://developer.
 ## Installation
 
 ```sh
-npm install @remix-run/interaction
+npm i remix
 ```
 
 ## Getting Started

--- a/packages/lazy-file/README.md
+++ b/packages/lazy-file/README.md
@@ -1,6 +1,6 @@
 # lazy-file
 
-`lazy-file` is a lazy, streaming `Blob`/`File` implementation for JavaScript.
+A lazy, streaming `Blob`/`File` implementation for JavaScript.
 
 It allows you to easily create [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob)-like and [File](https://developer.mozilla.org/en-US/docs/Web/API/File)-like objects that defer reading their contents until needed, which is ideal for situations where a file's contents do not fit in memory all at once. When file contents are read, they are streamed to avoid buffering.
 
@@ -12,7 +12,7 @@ It allows you to easily create [Blob](https://developer.mozilla.org/en-US/docs/W
 - **Standard Constructors** - Accepts all the same content types as the original [`Blob()`](https://developer.mozilla.org/en-US/docs/Web/API/Blob/Blob) and [`File()`](https://developer.mozilla.org/en-US/docs/Web/API/File/File) constructors
 - **Slice Support** - Supports [`Blob.slice()`](https://developer.mozilla.org/en-US/docs/Web/API/Blob/slice), even on streaming content
 
-## The Problem
+## Why You Need This
 
 JavaScript's [File API](https://developer.mozilla.org/en-US/docs/Web/API/File) is useful, but it's not a great fit for streaming server environments where you don't want to buffer file contents. In particular, [`the File() constructor`](https://developer.mozilla.org/en-US/docs/Web/API/File/File) requires the contents of a file to be supplied up front when the object is first created, like this:
 
@@ -33,10 +33,8 @@ All other `File` functionality works as you'd expect.
 
 ## Installation
 
-Install from [npm](https://www.npmjs.com/):
-
 ```sh
-npm install @remix-run/lazy-file
+npm i remix
 ```
 
 ## Usage

--- a/packages/logger-middleware/README.md
+++ b/packages/logger-middleware/README.md
@@ -1,13 +1,17 @@
 # logger-middleware
 
-Middleware for logging HTTP requests and responses for use with [`@remix-run/fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router).
+HTTP request/response logging middleware for Remix. It logs request metadata and response details with configurable output formats.
 
-Logs information about HTTP requests and responses with customizable formatting.
+## Features
+
+- **Request/Response Logging** - Logs method, path, status, and response metadata
+- **Token-Based Formatting** - Customize log output with built-in placeholders
+- **Structured Timing Data** - Includes request duration and timestamps
 
 ## Installation
 
 ```sh
-npm install @remix-run/logger-middleware
+npm i remix
 ```
 
 ## Usage

--- a/packages/method-override-middleware/README.md
+++ b/packages/method-override-middleware/README.md
@@ -1,13 +1,17 @@
 # method-override-middleware
 
-Middleware for overriding HTTP request methods from form data for use with [`@remix-run/fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router).
+Method override middleware for Remix. It allows HTML forms to simulate `PUT`, `PATCH`, and `DELETE` requests using a hidden form field.
 
-Allows HTML forms (which only support GET and POST) to submit with other HTTP methods like PUT, PATCH, or DELETE by including a special form field.
+## Features
+
+- **Form Method Overrides** - Translate posted form fields into request methods
+- **HTML Form Friendly** - Supports REST-style routes from standard browser forms
+- **Configurable Field Name** - Choose a custom override field key
 
 ## Installation
 
 ```sh
-npm install @remix-run/method-override-middleware
+npm i remix
 ```
 
 ## Usage

--- a/packages/mime/README.md
+++ b/packages/mime/README.md
@@ -1,13 +1,18 @@
-# @remix-run/mime
+# mime
 
-Utilities for working with MIME types.
+MIME type detection and content-type helpers for Remix. This package maps extensions to MIME types and provides utilities for charset and compressibility checks.
 
-Data used for these utilities is generated at build time from [mime-db](https://github.com/jshttp/mime-db).
+## Features
+
+- **MIME Detection** - Detect MIME types from extensions and filenames
+- **Content-Type Helpers** - Build `Content-Type` values with charset handling
+- **Compression Signals** - Check whether a media type is likely compressible
+- **Generated Data** - Built from [mime-db](https://github.com/jshttp/mime-db)
 
 ## Installation
 
-```bash
-npm install @remix-run/mime
+```sh
+npm i remix
 ```
 
 ## Usage

--- a/packages/multipart-parser/README.md
+++ b/packages/multipart-parser/README.md
@@ -1,16 +1,6 @@
 # multipart-parser
 
-`multipart-parser` is a fast, streaming multipart parser that works in **any JavaScript environment**, from serverless functions to traditional servers. Whether you're handling file uploads, parsing email attachments, or working with multipart API responses, `multipart-parser` has you covered.
-
-## Why multipart-parser?
-
-- **Universal JavaScript** - One library that works everywhere: Node.js, Bun, Deno, Cloudflare Workers, and browsers
-- **Blazing Fast** - Consistently outperforms popular alternatives like busboy in benchmarks
-- **Zero Dependencies** - Lightweight and secure with no external dependencies
-- **Memory Efficient** - Streaming architecture that `yield`s files as they are found in the stream
-- **Type Safe** - Written in TypeScript with comprehensive type definitions
-- **Standards Based** - Built on the web standard [Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) for maximum compatibility
-- **Production Ready** - Battle-tested error handling with specific error types for common scenarios
+Fast streaming multipart parsing for JavaScript. `multipart-parser` processes multipart bodies incrementally so large uploads can be handled without buffering the entire multipart payload in memory.
 
 ## Features
 
@@ -23,10 +13,8 @@
 
 ## Installation
 
-Install from [npm](https://www.npmjs.com/):
-
 ```sh
-npm install @remix-run/multipart-parser
+npm i remix
 ```
 
 ## Usage

--- a/packages/node-fetch-server/README.md
+++ b/packages/node-fetch-server/README.md
@@ -1,19 +1,6 @@
 # node-fetch-server
 
-Build portable Node.js servers using web-standard Fetch API primitives
-
-`node-fetch-server` brings the simplicity and familiarity of the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to Node.js server development. Instead of dealing with Node's traditional `req`/`res` objects, you work with web-standard [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) objects—the same APIs you already use in the browser and modern JavaScript runtimes.
-
-## Why node-fetch-server?
-
-The Fetch API is already the standard for server development in:
-
-- [`Bun.serve`](https://bun.sh/docs/api/http#bun-serve)
-- [Cloudflare Workers](https://developers.cloudflare.com/workers/runtime-apis/handlers/fetch/)
-- [`Deno.serve`](https://docs.deno.com/api/deno/~/Deno.serve)
-- [Fastly Compute](https://js-compute-reference-docs.edgecompute.app/docs/)
-
-Now you can use the same pattern in Node.js!
+Build Node.js servers with web-standard Fetch API primitives. `node-fetch-server` converts Node's HTTP server interfaces into [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request)/[`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) flows that match modern runtimes.
 
 ## Features
 
@@ -27,7 +14,7 @@ Now you can use the same pattern in Node.js!
 ## Installation
 
 ```sh
-npm install @remix-run/node-fetch-server
+npm i remix
 ```
 
 ## Quick Start

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -1,3 +1,15 @@
 # remix
 
-The Remix Web Framework
+A modern web framework for JavaScript.
+
+See [remix.run](https://remix.run) for more information.
+
+## Installation
+
+```sh
+npm i remix
+```
+
+## License
+
+See [LICENSE](https://github.com/remix-run/remix/blob/main/LICENSE)

--- a/packages/response/README.md
+++ b/packages/response/README.md
@@ -1,8 +1,6 @@
 # response
 
-Response helpers for the web Fetch API. `response` provides a collection of helper functions for creating common HTTP responses with proper headers and semantics.
-
-Basically, these are all the static response helpers we wish existed on the `Response` API, but don't (yet!).
+Response helper utilities for the web Fetch API. `response` provides focused helpers for common HTTP responses with correct headers and caching semantics.
 
 ## Features
 
@@ -15,7 +13,7 @@ Basically, these are all the static response helpers we wish existed on the `Res
 ## Installation
 
 ```sh
-npm install @remix-run/response
+npm i remix
 ```
 
 ## Usage

--- a/packages/route-pattern/README.md
+++ b/packages/route-pattern/README.md
@@ -1,6 +1,22 @@
 # route-pattern
 
-Fast URL matching and href generation with type safe params.
+Type-safe URL matching and href generation for JavaScript. `route-pattern` supports path params, wildcards, optionals, and full-URL patterns with predictable ranking.
+
+## Features
+
+- **Type-Safe Params** - Infer params from patterns for compile-time route correctness
+- **Flexible Pattern Syntax** - Variables, wildcards, optionals, and query constraints
+- **Full URL Support** - Match protocol, host, pathname, and search params
+- **Deterministic Ranking** - Static segments beat params, and params beat wildcards
+- **Runtime Agnostic** - Works across Node.js, Bun, Deno, Cloudflare Workers, and browsers
+
+## Installation
+
+```sh
+npm i remix
+```
+
+## Quick Example
 
 ```ts
 import { RoutePattern } from 'remix/route-pattern'
@@ -17,20 +33,6 @@ api.href({ path: 'users/profile' }) // '/api/users/profile'
 let cdn = new RoutePattern('http(s)://:region.cdn.com/assets/*file.:ext')
 cdn.match('https://us-west.cdn.com/assets/images/logo.png') // { params: { region: 'us-west', file: 'images/logo', ext: 'png' } }
 cdn.href({ region: 'us-west', file: 'images/logo', ext: 'png' }) // 'https://us-west.cdn.com/assets/images/logo.png'
-```
-
-**Goals**
-
-- **Universal**: Runs on any JS runtime (Node, Bun, Deno, Cloudflare Workers, browsers, ...)
-- **Type-safe params**: Autocomplete and validation for variables, wildcards, and search params
-- **Full URL matching**: Protocol, hostname, port, pathname, search params
-- **Fast**: Includes matchers optimized for small and large apps
-- **Simple ranking**: Static segments beat variables, variables beat wildcards
-
-## Installation
-
-```sh
-npm install @remix-run/route-pattern
 ```
 
 ## Intuitive syntax

--- a/packages/session-middleware/README.md
+++ b/packages/session-middleware/README.md
@@ -1,11 +1,17 @@
 # session-middleware
 
-Middleware for managing sessions with [`@remix-run/fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router) via securely signed cookies.
+Session middleware for Remix using signed cookies. It loads session state from incoming requests, exposes it on `context.session`, and persists updates automatically.
+
+## Features
+
+- **Session Lifecycle Handling** - Reads and saves session state per request
+- **Context Integration** - Exposes session APIs directly on request context
+- **Secure Cookie Support** - Designed for signed session cookies
 
 ## Installation
 
 ```sh
-npm install @remix-run/session-middleware
+npm i remix
 ```
 
 ## Usage

--- a/packages/session/README.md
+++ b/packages/session/README.md
@@ -1,6 +1,6 @@
 # session
 
-A full-featured session management library for JavaScript. This package provides a flexible and secure way to manage user sessions in server-side applications with a flexible API for different session storage strategies.
+A session management library for JavaScript. This package provides a flexible and secure way to manage user sessions in server-side applications with a flexible API for different session storage strategies.
 
 ## Features
 
@@ -11,7 +11,7 @@ A full-featured session management library for JavaScript. This package provides
 ## Installation
 
 ```sh
-npm install @remix-run/session
+npm i remix
 ```
 
 ## Usage

--- a/packages/static-middleware/README.md
+++ b/packages/static-middleware/README.md
@@ -1,21 +1,19 @@
 # static-middleware
 
-Middleware for serving static files from the filesystem for use with [`@remix-run/fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router).
-
-Serves static files from a directory with support for ETags, range requests, and conditional requests.
+Static file serving middleware for Remix. Serves static files from a directory with support for ETags, range requests, and conditional requests.
 
 ## Features
 
-- [ETag support](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) (weak and strong)
-- [Range request support](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) (HTTP 206 Partial Content)
-- [Conditional request support](https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests) (If-None-Match, If-Modified-Since)
+- [ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) support (weak and strong)
+- [Range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) support (HTTP 206 Partial Content)
+- [Conditional request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests) support (If-None-Match, If-Modified-Since)
 - Path traversal protection
-- Automatic fall through to next middleware/handler if file not found
+- Automatic fallback to next middleware/handler if file not found
 
 ## Installation
 
 ```sh
-npm install @remix-run/static-middleware
+npm i remix
 ```
 
 ## Usage

--- a/packages/tar-parser/README.md
+++ b/packages/tar-parser/README.md
@@ -1,10 +1,6 @@
 # tar-parser
 
-`tar-parser` is a fast, efficient parser for [tar archives](<https://en.wikipedia.org/wiki/Tar_(computing)>).
-
-Tar archives are ubiquitous in software development, used for distributing packages, backing up files, and transferring data. Most existing JavaScript tar parsers are either Node.js-specific or don't handle streaming efficiently, forcing you to buffer entire archives in memory. This makes them unsuitable for serverless environments or processing large archives.
-
-`tar-parser` can be used in any JavaScript environment (not just Node.js) and processes archives as streams, making it ideal for modern web development across all runtimes.
+Streaming [tar archive](<https://en.wikipedia.org/wiki/Tar_(computing)>) parsing for JavaScript. `tar-parser` handles POSIX/GNU/PAX archives incrementally so large tar files can be processed without buffering the full payload.
 
 ## Features
 
@@ -16,10 +12,8 @@ Tar archives are ubiquitous in software development, used for distributing packa
 
 ## Installation
 
-Install from [npm](https://www.npmjs.com/):
-
 ```sh
-npm install @remix-run/tar-parser
+npm i remix
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- standardize subpackage README top sections to a consistent format
- ensure install sections use concise `npm i remix` guidance
- tighten intros and align feature/highlight sections across packages

## Notes
- docs-only changes
- includes updates to the umbrella `packages/remix/README.md` for consistency