### PR TITLE
Ensure remix is first in release PR package sections

### DIFF
--- a/scripts/utils/release-pr.test.ts
+++ b/scripts/utils/release-pr.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import type { PackageRelease } from './changes.ts'
+import { generatePrBody } from './release-pr.ts'
+
+function makeRelease({
+  packageDirName,
+  packageName,
+  nextVersion,
+}: {
+  packageDirName: string
+  packageName: string
+  nextVersion: string
+}): PackageRelease {
+  return {
+    packageDirName,
+    packageName,
+    currentVersion: '1.0.0',
+    nextVersion,
+    bump: 'patch',
+    changes: [{ file: 'patch.test-change.md', bump: 'patch', content: 'Test change' }],
+    dependencyBumps: [],
+  }
+}
+
+test('generatePrBody puts remix first and sorts remaining packages alphabetically', () => {
+  let body = generatePrBody([
+    makeRelease({
+      packageDirName: 'zeta',
+      packageName: '@remix-run/zeta',
+      nextVersion: '1.0.1',
+    }),
+    makeRelease({
+      packageDirName: 'remix',
+      packageName: 'remix',
+      nextVersion: '3.0.0',
+    }),
+    makeRelease({
+      packageDirName: 'beta',
+      packageName: '@remix-run/beta',
+      nextVersion: '1.0.1',
+    }),
+    makeRelease({
+      packageDirName: 'alpha',
+      packageName: '@remix-run/alpha',
+      nextVersion: '1.0.1',
+    }),
+  ])
+
+  let remixTableIndex = body.indexOf('| remix |')
+  let alphaTableIndex = body.indexOf('| @remix-run/alpha |')
+  let betaTableIndex = body.indexOf('| @remix-run/beta |')
+  let zetaTableIndex = body.indexOf('| @remix-run/zeta |')
+
+  assert.notEqual(remixTableIndex, -1)
+  assert.notEqual(alphaTableIndex, -1)
+  assert.notEqual(betaTableIndex, -1)
+  assert.notEqual(zetaTableIndex, -1)
+  assert.ok(remixTableIndex < alphaTableIndex)
+  assert.ok(alphaTableIndex < betaTableIndex)
+  assert.ok(betaTableIndex < zetaTableIndex)
+
+  let remixChangelogIndex = body.indexOf('## remix v3.0.0')
+  let alphaChangelogIndex = body.indexOf('## @remix-run/alpha v1.0.1')
+  let betaChangelogIndex = body.indexOf('## @remix-run/beta v1.0.1')
+  let zetaChangelogIndex = body.indexOf('## @remix-run/zeta v1.0.1')
+
+  assert.notEqual(remixChangelogIndex, -1)
+  assert.notEqual(alphaChangelogIndex, -1)
+  assert.notEqual(betaChangelogIndex, -1)
+  assert.notEqual(zetaChangelogIndex, -1)
+  assert.ok(remixChangelogIndex < alphaChangelogIndex)
+  assert.ok(alphaChangelogIndex < betaChangelogIndex)
+  assert.ok(betaChangelogIndex < zetaChangelogIndex)
+})

--- a/scripts/utils/release-pr.ts
+++ b/scripts/utils/release-pr.ts
@@ -8,9 +8,10 @@ let maxBodyLength = 60_000
  * Generates the PR body for a release PR
  */
 export function generatePrBody(releases: PackageRelease[]): string {
+  let orderedReleases = sortReleasesForDisplay(releases)
   let header = generateHeader()
-  let releasesTable = generateReleasesTable(releases)
-  let changelogs = generateChangelogs(releases)
+  let releasesTable = generateReleasesTable(orderedReleases)
+  let changelogs = generateChangelogs(orderedReleases)
 
   let fullBody = [header, releasesTable, changelogs].join('\n\n')
 
@@ -22,9 +23,26 @@ export function generatePrBody(releases: PackageRelease[]): string {
   // Truncate changelogs section to fit
   let baseLength = header.length + releasesTable.length + 100 // buffer for truncation notice
   let availableForChangelogs = maxBodyLength - baseLength
-  let truncatedChangelogs = truncateChangelogs(releases, availableForChangelogs)
+  let truncatedChangelogs = truncateChangelogs(orderedReleases, availableForChangelogs)
 
   return [header, releasesTable, truncatedChangelogs].join('\n\n')
+}
+
+function sortReleasesForDisplay(releases: PackageRelease[]): PackageRelease[] {
+  return [...releases].sort((a, b) => {
+    let aIsRemix = a.packageDirName === 'remix'
+    let bIsRemix = b.packageDirName === 'remix'
+
+    if (aIsRemix && !bIsRemix) {
+      return -1
+    }
+
+    if (!aIsRemix && bIsRemix) {
+      return 1
+    }
+
+    return a.packageName.localeCompare(b.packageName)
+  })
 }
 
 function generateHeader(): string {


### PR DESCRIPTION
## Summary
- enforce a single ordering rule for release PR display data
- always place `remix` first
- sort all remaining changed packages alphabetically
- apply this order to both the Releases table and Changelogs section

## Testing
- node --disable-warning=ExperimentalWarning --test ./scripts/utils/release-pr.test.ts