### PR TITLE
component(change): handle.update() promise, cascading update guard

### DIFF
--- a/demos/frames/app/assets/state-search-page.tsx
+++ b/demos/frames/app/assets/state-search-page.tsx
@@ -13,9 +13,8 @@ export let StateSearchPage = clientEntry(moduleUrl, (handle: Handle, setup?: str
           async submit(event) {
             event.preventDefault()
             query = input.value.trim()
-            handle.update(() => {
-              input.select()
-            })
+            await handle.update()
+            input.select()
           },
         }}
         css={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}

--- a/packages/component/.changes/minor.handle-update-promise.md
+++ b/packages/component/.changes/minor.handle-update-promise.md
@@ -1,0 +1,24 @@
+BREAKING CHANGE: `handle.update()` now returns `Promise<AbortSignal>` instead of accepting an optional task callback.
+
+- The promise is resolved when the update is complete (DOM is updated, tasks have run)
+- The signal is aborted when the component updates again or is removed.
+
+```tsx
+let signal = await handle.update()
+// dom is updated
+// focus/scroll elements
+// do fetches, etc.
+```
+
+Note that `await handle.update()` resumes on a microtask after the flush completes, so the browser may paint before your code runs. For work that must happen synchronously during the flush (e.g. measuring elements and triggering another update without flicker), continue to use `handle.queueTask()` instead.
+
+```tsx
+handle.update()
+handle.queueTask(() => {
+  let rect = widthReferenceNode.getBoundingClientRect()
+  if (rect.width !== width) {
+    width = rect.width
+    handle.update()
+  }
+})
+```

--- a/packages/component/README.md
+++ b/packages/component/README.md
@@ -423,7 +423,7 @@ function Component(handle: Handle) {
 
 Components receive a `Handle` as their first argument with the following API:
 
-- **`handle.update(task?)`** - Schedule an update. Optionally provide a task to run after the update.
+- **`handle.update()`** - Schedule an update and await completion to get an `AbortSignal`.
 - **`handle.queueTask(task)`** - Schedule a task to run after the next update. Useful for DOM operations that need to happen after rendering (e.g., moving focus, scrolling, measuring elements, etc.).
 - **`handle.on(target, listeners)`** - Listen to an event target with automatic cleanup when the component disconnects.
 - **`handle.signal`** - An `AbortSignal` that's aborted when the component is disconnected. Useful for cleanup.
@@ -432,9 +432,9 @@ Components receive a `Handle` as their first argument with the following API:
 - **`handle.frame`** - The component's closest frame. Call `handle.frame.reload()` to refresh the frame's server content.
 - **`handle.frames.get(name)`** - Look up named frames in the current runtime tree for adjacent frame reloads.
 
-### `handle.update(task?)`
+### `handle.update()`
 
-Schedule an update. Optionally provide a task to run after the update completes.
+Schedule an update and optionally await completion to coordinate post-update work.
 
 ```tsx
 function Counter(handle: Handle) {
@@ -455,7 +455,7 @@ function Counter(handle: Handle) {
 }
 ```
 
-You can pass a task to run after the update:
+You can await the update before doing DOM work:
 
 ```tsx
 function Player(handle: Handle) {
@@ -469,12 +469,11 @@ function Player(handle: Handle) {
         disabled={isPlaying}
         connect={(node) => (playButton = node)}
         on={{
-          click: () => {
+          async click() {
             isPlaying = true
-            handle.update(() => {
-              // Focus the enabled button after update completes
-              stopButton.focus()
-            })
+            await handle.update()
+            // Focus the enabled button after update completes
+            stopButton.focus()
           },
         }}
       >
@@ -484,12 +483,11 @@ function Player(handle: Handle) {
         disabled={!isPlaying}
         connect={(node) => (stopButton = node)}
         on={{
-          click: () => {
+          async click() {
             isPlaying = false
-            handle.update(() => {
-              // Focus the enabled button after update completes
-              playButton.focus()
-            })
+            await handle.update()
+            // Focus the enabled button after update completes
+            playButton.focus()
           },
         }}
       >

--- a/packages/component/demos/readme/entry.tsx
+++ b/packages/component/demos/readme/entry.tsx
@@ -344,7 +344,7 @@ function ResizeComponent(handle: Handle) {
 }
 
 // ============================================================================
-// handle.update(task) - Player
+// handle.update() - Player
 // ============================================================================
 function Player(handle: Handle) {
   let isPlaying = false
@@ -357,12 +357,11 @@ function Player(handle: Handle) {
         disabled={isPlaying}
         connect={(node) => (playButton = node)}
         on={{
-          click: () => {
+          async click() {
             isPlaying = true
-            handle.update(() => {
-              // Focus the enabled button after update completes
-              stopButton.focus()
-            })
+            await handle.update()
+            // Focus the enabled button after update completes
+            stopButton.focus()
           },
         }}
         css={{
@@ -376,12 +375,11 @@ function Player(handle: Handle) {
         disabled={!isPlaying}
         connect={(node) => (stopButton = node)}
         on={{
-          click: () => {
+          async click() {
             isPlaying = false
-            handle.update(() => {
-              // Focus the enabled button after update completes
-              playButton.focus()
-            })
+            await handle.update()
+            // Focus the enabled button after update completes
+            playButton.focus()
           },
         }}
         css={{
@@ -641,7 +639,7 @@ function DemoApp(handle: Handle) {
         <ResizeComponent />
       </Example>
 
-      <Example title="handle.update(task) - Player">
+      <Example title="handle.update() - Player">
         <Player />
       </Example>
 

--- a/packages/component/src/test/vdom.scheduler.test.tsx
+++ b/packages/component/src/test/vdom.scheduler.test.tsx
@@ -69,9 +69,10 @@ describe('vnode rendering', () => {
         })
 
         capturedUpdate = () => {
-          handle.update(() => {
+          handle.queueTask(() => {
             taskCount++
           })
+          handle.update()
         }
         return () => null
       }


### PR DESCRIPTION
BREAKING CHANGE: `handle.update()` now returns `Promise<AbortSignal>` instead of accepting an optional task callback.

- The promise is resolved when the update is complete (DOM is updated, tasks have run)
- The signal is aborted when the component updates again or is removed.

```tsx
let signal = await handle.update()
// dom is updated
// focus/scroll elements
// do fetches, etc.
```

## Motivation

1. `this.update(task)` was extra, convenience API
2. it lead to deeply nested callback soup
   ```tsx
   async function handler() {
     state = 'verifying'
     handle.update(signal => {
       let token = await fetchToken(signal)
       state = 'processing'
       handle.update(signal => {
         await process(token, signal)
         state = 'complete'
         handle.update()
       }
     }
   }
   
   async function handler() {
     state = 'verifying'
     let signal = await handle.update()
     let token = await fetchToken(signal)
     state = 'processing'
     signal = await handle.update()
     await process(token, signal)
     state = 'complete'
     handle.update()
   }
   ```
 3. queueTask is now specifically for doing layout measurement + updates or reactive prop tasks, instead of having to decide between the update callback or a separate call to queueTask