### PR TITLE
feat(data-table): add standard-schema table validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - **Monorepo**: pnpm workspace with packages in `packages/` directory
 - **Key packages**: headers, fetch-proxy, fetch-router, file-storage, form-data-parser, lazy-file, multipart-parser, node-fetch-server, route-pattern, tar-parser
 - **Package exports**: All `exports` in `package.json` have a dedicated file in `src` that defines the public API by re-exporting from within `src/lib`
+- **Cross-package boundaries**: Avoid re-exporting APIs/types from other packages. Consumers should import from the owning package directly. Reuse shared concepts from sibling packages internally instead of creating bespoke duplicate implementations.
 - **Philosophy**: Web standards-first, runtime-agnostic (Node.js, Bun, Deno, Cloudflare Workers). Use Web Streams API, Uint8Array, Web Crypto API, Blob/File instead of Node.js APIs
 - **Tests run from source** (no build required), using Node.js test runner
 

--- a/packages/data-table/.changes/minor.table-standard-schema.md
+++ b/packages/data-table/.changes/minor.table-standard-schema.md
@@ -1,0 +1,3 @@
+Make `createTable()` results Standard Schema-compatible so tables can be used directly with `parse()`/`parseSafe()` from `remix/data-schema`.
+
+Table parsing now mirrors write validation semantics used by `create()`/`update()`: partial objects are accepted, provided values are parsed via column schemas, and unknown columns are rejected.

--- a/packages/data-table/src/index.ts
+++ b/packages/data-table/src/index.ts
@@ -25,7 +25,6 @@ export type {
   ColumnReference,
   ColumnReferenceForQualifiedName,
   ColumnSchemas,
-  DataSchema,
   HasManyOptions,
   HasManyThroughOptions,
   HasOneOptions,

--- a/packages/data-table/src/lib/table.test.ts
+++ b/packages/data-table/src/lib/table.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { number, string } from '@remix-run/data-schema'
+import { number, parseSafe, string } from '@remix-run/data-schema'
 
 import {
   columnMetadataKey,
@@ -32,6 +32,38 @@ describe('table metadata', () => {
     assert.equal(tableReference.kind, 'table')
     assert.equal(users.id[columnMetadataKey].qualifiedName, 'users.id')
     assert.equal(users[tableMetadataKey].name, 'users')
+  })
+
+  it('is standard-schema compatible with create-style validation semantics', () => {
+    let users = createTable({
+      name: 'users',
+      columns: {
+        id: number(),
+        email: string(),
+      },
+    })
+
+    let partialResult = parseSafe(users, { id: 1 })
+    assert.equal(partialResult.success, true)
+
+    if (partialResult.success) {
+      assert.deepEqual(partialResult.value, { id: 1 })
+    }
+
+    let unknownKeyResult = parseSafe(users, { id: 1, extra: 'x' })
+    assert.equal(unknownKeyResult.success, false)
+
+    if (!unknownKeyResult.success) {
+      assert.deepEqual(unknownKeyResult.issues[0].path, ['extra'])
+      assert.match(unknownKeyResult.issues[0].message, /Unknown column "extra"/)
+    }
+
+    let invalidValueResult = parseSafe(users, { id: 'not-a-number' })
+    assert.equal(invalidValueResult.success, false)
+
+    if (!invalidValueResult.success) {
+      assert.deepEqual(invalidValueResult.issues[0].path, ['id'])
+    }
   })
 
   it('builds relations with functional helpers', () => {


### PR DESCRIPTION
- make `createTable()` results Standard Schema-compatible so tables can be passed directly to `parse()`/`parseSafe()` from `remix/data-schema`
- align direct table parsing semantics with `data-table` write validation: partial payloads allowed, unknown columns rejected, provided values parsed by each column schema
- route write-path validation through the shared table validator to keep behavior consistent
- remove `data-table` re-export of `DataSchema` and use `Schema` directly from `data-schema` internally
