### PR TITLE
perf(component): better memoize `ancestorIsScheduled` lookups in scheduler

### DIFF
--- a/packages/component/src/lib/scheduler.ts
+++ b/packages/component/src/lib/scheduler.ts
@@ -117,10 +117,11 @@ export function createScheduler(
 
         if (batch.size > 0) {
           let vnodes = Array.from(batch)
-          let noScheduledAncestor = new Set<VNode>()
+          let noAncestorInBatch = new Set<VNode>()
+          let ancestorInBatch = new Set<VNode>()
 
           for (let [vnode, domParent] of vnodes) {
-            if (ancestorIsScheduled(vnode, batch, noScheduledAncestor)) continue
+            if (ancestorIsScheduled(vnode, batch, noAncestorInBatch, ancestorInBatch)) continue
             let handle = vnode._handle
             let curr = vnode._content
             let vParent = vnode._parent!
@@ -192,29 +193,34 @@ export function createScheduler(
   function ancestorIsScheduled(
     vnode: VNode,
     batch: Map<CommittedComponentNode, ParentNode>,
-    safe: Set<VNode>,
+    noAncestorInBatch: Set<VNode>,
+    ancestorInBatch: Set<VNode>,
   ): boolean {
     let path: VNode[] = []
     let current = vnode._parent
 
     while (current) {
-      // Already verified this node has no scheduled ancestor above it
-      if (safe.has(current)) {
-        for (let node of path) safe.add(node)
+      // Already verified this node has **no** scheduled ancestor above it
+      if (noAncestorInBatch.has(current)) {
+        for (let node of path) noAncestorInBatch.add(node)
         return false
       }
 
-      path.push(current)
-
-      if (isCommittedComponentNode(current) && batch.has(current)) {
+      if (
+        // Already verified this node has a scheduled ancestor above it
+        ancestorInBatch.has(current) ||
+        (isCommittedComponentNode(current) && batch.has(current))
+      ) {
+        for (let node of path) ancestorInBatch.add(node)
         return true
       }
 
+      path.push(current)
       current = current._parent
     }
 
     // Reached root - mark entire path as safe for future lookups
-    for (let node of path) safe.add(node)
+    for (let node of path) noAncestorInBatch.add(node)
     return false
   }
 


### PR DESCRIPTION
Optimize cases with deep tree like

```
vnodes = [C*, D*, E*, A*] // let vnodes = Array.from(batch)

Root
│
A*
│
A1
|
.
|
.
An
│
└── T
    │
    ├── C*         ← hits A*, caches A1...An and T in `ancestorInBatch`, skip render
    ├── D*         ← hits T in `ancestorInBatch`, skip render
    └── E*         ← hits T in `ancestorInBatch`, skip render

render A* at the end
```

Component T could be a table with many rows (C, D, E, etc.) located deep in the page.

Looks like there’s no such benchmark case yet...


UPD:

i got a bit rough numbers for case of table located deep in the page.
I think this might be interesting

| Input Parameters <br> (Rows / Depth) | Baseline <br> (No Optimization) | Optimized <br> (Current Version) | Improvement <br> (Delta) |
| :--- | :--- | :--- | :---: |
| 10,000 Rows, Depth: 100 | 58 ms | **47 ms** |  1.23x |
| 100,000 Rows, Depth: 100 | 479 ms | **365 ms** |  1.31x |
| 1,000,000 Rows, Depth: 100 | 4955 ms | **3846 ms** |  1.28x |
