### PR TITLE
test(data-table-sqlite): add compiler tests

### DIFF
--- a/packages/data-table-sqlite/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-sqlite/src/lib/sql-compiler.test.ts
@@ -507,13 +507,12 @@ describe('sqlite sql-compiler', () => {
 
   describe('update statement', () => {
     it('compile for one', async () => {
-      await db.update(accounts, 1, {
+      await db.query(accounts).where({ id: 1 }).update({
         email: 'info@remix.run',
         status: 'enabled',
       })
 
-      // is QueryBuilder's responsability to ensure entry exists in db ?
-      let compiled = compileSqliteStatement(statements[1]) // statements[0] is for the initial select
+      let compiled = compileSqliteStatement(statements[0])
       assert.deepEqual(compiled, {
         text: 'update "accounts" set "email" = ?, "status" = ? where (("id" = ?))',
         values: ['info@remix.run', 'enabled', 1],


### PR DESCRIPTION
## Add test suite for SQLite SQL compiler

Hello Remix team 👋

I am currently working on an `oracledb` adapter, as I will need it in a professional context.  
Integration testing for this database is… challenging (I’ll let you guess why 😅).

For that reason, I would like to test the SQL compilers in isolation.  
This PR introduces a test suite for the SQLite compiler to validate generated SQL statements and bound parameters.

The main goal is to:
- increase confidence in the SQL compilation layer,
- make future refactors safer,
- and enable isolated validation of compiler behavior.

Not all use cases are covered yet for SQLite.  
I would also appreciate clarification on some specifics behavior:

- QueryBuilder's `update` appears to perform a `get` beforehand to ensure the entry exists in the database. It's not de case for delete
- `insertMany` with many empty values call `insert into "accounts" default values` once

Is this intentional?

If this direction is not something you’re interested in, feel free to close the PR without hesitation