### PR TITLE
Improve multipart parser benchmark harness

### DIFF
--- a/packages/multipart-parser/bench/parsers/multipart-parser.ts
+++ b/packages/multipart-parser/bench/parsers/multipart-parser.ts
@@ -5,7 +5,10 @@ import { MultipartMessage } from '../messages.ts'
 export function parse(message: MultipartMessage): number {
   let start = performance.now()
 
-  for (let _ of parseMultipart(message.generateChunks(), { boundary: message.boundary })) {
+  for (let _ of parseMultipart(message.generateChunks(), {
+    boundary: message.boundary,
+    maxFileSize: Number.POSITIVE_INFINITY,
+  })) {
     // Do nothing with the part, just iterate through it to measure parsing time
   }
 

--- a/packages/multipart-parser/bench/runner.ts
+++ b/packages/multipart-parser/bench/runner.ts
@@ -14,30 +14,63 @@ const benchmarks = [
   { name: '5 large files', message: messages.fiveLargeFiles },
 ]
 
+const config = {
+  warmup: getNumberFromEnv('BENCH_WARMUP', 20),
+  times: getNumberFromEnv('BENCH_TIMES', 200),
+  rounds: getNumberFromEnv('BENCH_ROUNDS', 1),
+}
+
 interface Parser {
   parse(message: messages.MultipartMessage): Promise<number>
 }
 
-async function runParserBenchmarks(parser: Parser, times = 200): Promise<BenchmarkResults[string]> {
+async function runParserBenchmarks(parser: Parser, times = config.times): Promise<BenchmarkResults[string]> {
   let results: BenchmarkResults[string] = {}
 
   for (let benchmark of benchmarks) {
     let measurements: number[] = []
-    for (let i = 0; i < times; ++i) {
-      measurements.push(await parser.parse(benchmark.message))
+
+    for (let i = 0; i < config.warmup; ++i) {
+      await parser.parse(benchmark.message)
     }
 
-    results[benchmark.name] = getMeanAndStdDev(measurements)
+    for (let round = 0; round < config.rounds; ++round) {
+      for (let i = 0; i < times; ++i) {
+        measurements.push(await parser.parse(benchmark.message))
+      }
+
+      if (typeof (globalThis as { gc?: () => void }).gc === 'function') {
+        ;(globalThis as { gc: () => void }).gc()
+      }
+    }
+
+    results[benchmark.name] = getStats(measurements)
   }
 
   return results
 }
 
-function getMeanAndStdDev(measurements: number[]): string {
+function getMeanAndStdDev(measurements: number[]): number[] {
   let mean = measurements.reduce((a, b) => a + b, 0) / measurements.length
   let variance = measurements.reduce((a, b) => a + (b - mean) ** 2, 0) / measurements.length
   let stdDev = Math.sqrt(variance)
-  return mean.toFixed(2) + ' ms ± ' + stdDev.toFixed(2)
+
+  return [mean, stdDev]
+}
+
+function getPercentile(sorted: number[], percentile: number): number {
+  let index = Math.floor((sorted.length - 1) * percentile)
+  return sorted[index]
+}
+
+function getStats(measurements: number[]): string {
+  let [mean, stdDev] = getMeanAndStdDev(measurements)
+  let sorted = [...measurements].sort((a, b) => a - b)
+  let median = getPercentile(sorted, 0.5)
+  let p95 = getPercentile(sorted, 0.95)
+
+  return `${mean.toFixed(2)} ms ± ${stdDev.toFixed(2)} ` +
+    `(median ${median.toFixed(2)} ms, p95 ${p95.toFixed(2)} ms, n=${measurements.length})`
 }
 
 interface BenchmarkResults {
@@ -81,7 +114,34 @@ function printResults(results: BenchmarkResults) {
   console.table(results)
 }
 
-runBenchmarks(process.argv[2]).then(printResults, (error) => {
+let parserName = process.argv[2]
+if (parserName && /^\d+$/.test(parserName)) {
+  config.times = Number(parserName)
+  parserName = undefined
+}
+
+if (process.argv[3]) {
+  config.times = Number(process.argv[3])
+}
+
+if (process.argv[4]) {
+  config.warmup = Number(process.argv[4])
+}
+
+if (process.argv[5]) {
+  config.rounds = Number(process.argv[5])
+}
+
+runBenchmarks(parserName).then(printResults, (error) => {
   console.error(error)
   process.exit(1)
 })
+
+function getNumberFromEnv(name: string, fallback: number): number {
+  let value = process.env[name]
+  if (value == null) return fallback
+  let parsed = Number(value)
+  if (Number.isFinite(parsed) && parsed > 0) return parsed
+
+  return fallback
+}


### PR DESCRIPTION
## Summary

- Benchmark-only updates: tunable warmup/rounds and richer timing stats.
- Keep parser comparisons intact.
