### PR TITLE
fix(headers): correct windows-1252 test assertion for Node 24.13.1

### DIFF
--- a/packages/headers/.changes/patch.fix-windows-1252-test.md
+++ b/packages/headers/.changes/patch.fix-windows-1252-test.md
@@ -1,0 +1,7 @@
+Correct the windows-1252 test assertion to expect the Euro sign (€) for byte 0x80.
+
+The original assertion was changed from `€` to `\x80` in fa226ba75 to work around
+a Node.js bug where TextDecoder used a Latin-1 fast path for windows-1252, skipping
+the spec-defined mapping of 0x80 to U+20AC. Node 24.13.1 resolved this with proper
+WHATWG Encoding Standard compliance (nodejs/node#60893, nodejs/node#61093), making
+the workaround unnecessary.

--- a/packages/headers/src/lib/content-disposition.test.ts
+++ b/packages/headers/src/lib/content-disposition.test.ts
@@ -193,7 +193,7 @@ describe('ContentDisposition', () => {
 
     it('correctly decodes windows-1252 encoded filename', () => {
       let header = new ContentDisposition("attachment; filename*=windows-1252''file%80.txt")
-      assert.equal(header.preferredFilename, 'file\x80.txt')
+      assert.equal(header.preferredFilename, 'file€.txt')
     })
 
     it('handles UTF-8 encoded filename correctly', () => {


### PR DESCRIPTION
## Summary

The "correctly decodes windows-1252 encoded filename" test in `content-disposition.test.ts`
has been failing on the Windows CI runner since it picked up Node 24.13.1.

The test expects `'file\x80.txt'` but receives `'file€.txt'`. This is because Node 24.13.1
introduced proper WHATWG Encoding Standard compliance for windows-1252 via
nodejs/node#60893 and nodejs/node#61093. Under the standard, byte `0x80` maps to
`U+20AC` (Euro sign, `€`), not the C1 control character `U+0080`.

The assertion originally expected `€` but was changed to `\x80` in fa226ba75 as a
workaround for the old TextDecoder behavior. This PR reverts the assertion to the
spec-correct value.

The Ubuntu runner still passes because it is on 24.13.0, but it will also fail once
the runner image updates.

Failing CI run: https://github.com/remix-run/remix/actions/runs/22331705571

## Test plan

- [ ] `pnpm --filter @remix-run/headers run test` passes locally
- [ ] CI passes on both ubuntu-latest and windows-latest