### PR TITLE
feat(data-table) add data-table-mssql adapter package

### DIFF
--- a/.github/workflows/data-table-integration.yaml
+++ b/.github/workflows/data-table-integration.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - '.github/workflows/data-table-integration.yaml'
       - 'packages/data-table/**'
+      - 'packages/data-table-mssql/**'
       - 'packages/data-table-postgres/**'
       - 'packages/data-table-mysql/**'
       - 'packages/data-table-sqlite/**'
@@ -16,6 +17,7 @@ on:
     paths:
       - '.github/workflows/data-table-integration.yaml'
       - 'packages/data-table/**'
+      - 'packages/data-table-mssql/**'
       - 'packages/data-table-postgres/**'
       - 'packages/data-table-mysql/**'
       - 'packages/data-table-sqlite/**'
@@ -57,10 +59,53 @@ jobs:
           pnpm --filter @remix-run/data-table-mysql run test
           pnpm --filter @remix-run/data-table-mysql run test:coverage
           pnpm --filter @remix-run/data-table-mysql run build
+          pnpm --filter @remix-run/data-table-mssql run typecheck
+          pnpm --filter @remix-run/data-table-mssql run test
+          pnpm --filter @remix-run/data-table-mssql run build
           pnpm --filter @remix-run/data-table-sqlite run typecheck
           pnpm --filter @remix-run/data-table-sqlite run test
           pnpm --filter @remix-run/data-table-sqlite run test:coverage
           pnpm --filter @remix-run/data-table-sqlite run build
+
+  mssql-integration:
+    name: MSSQL Integration
+    runs-on: ubuntu-latest
+
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: 'Y'
+          SA_PASSWORD: 'YourStrong!Passw0rd'
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd="/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'YourStrong!Passw0rd' -Q 'SELECT 1' -C"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run mssql integration tests
+        env:
+          DATA_TABLE_INTEGRATION: '1'
+          DATA_TABLE_MSSQL_URL: Server=127.0.0.1,1433;Database=master;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true;Encrypt=false
+        run: pnpm --filter @remix-run/data-table-mssql run test
 
   postgres-integration:
     name: Postgres Integration

--- a/.github/workflows/data-table-integration.yaml
+++ b/.github/workflows/data-table-integration.yaml
@@ -61,51 +61,12 @@ jobs:
           pnpm --filter @remix-run/data-table-mysql run build
           pnpm --filter @remix-run/data-table-mssql run typecheck
           pnpm --filter @remix-run/data-table-mssql run test
+          pnpm --filter @remix-run/data-table-mssql run test:coverage
           pnpm --filter @remix-run/data-table-mssql run build
           pnpm --filter @remix-run/data-table-sqlite run typecheck
           pnpm --filter @remix-run/data-table-sqlite run test
           pnpm --filter @remix-run/data-table-sqlite run test:coverage
           pnpm --filter @remix-run/data-table-sqlite run build
-
-  mssql-integration:
-    name: MSSQL Integration
-    runs-on: ubuntu-latest
-
-    services:
-      mssql:
-        image: mcr.microsoft.com/mssql/server:2022-latest
-        env:
-          ACCEPT_EULA: 'Y'
-          SA_PASSWORD: 'YourStrong!Passw0rd'
-        ports:
-          - 1433:1433
-        options: >-
-          --health-cmd="/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'YourStrong!Passw0rd' -Q 'SELECT 1' -C"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=20
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: 'package.json'
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run mssql integration tests
-        env:
-          DATA_TABLE_INTEGRATION: '1'
-          DATA_TABLE_MSSQL_URL: Server=127.0.0.1,1433;Database=master;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true;Encrypt=false
-        run: pnpm --filter @remix-run/data-table-mssql run test
 
   postgres-integration:
     name: Postgres Integration
@@ -215,3 +176,43 @@ jobs:
         env:
           DATA_TABLE_INTEGRATION: '1'
         run: node --disable-warning=ExperimentalWarning --test './packages/data-table-sqlite/src/lib/adapter.integration.test.ts'
+
+  mssql-integration:
+    name: MSSQL Integration
+    runs-on: ubuntu-latest
+
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: 'Y'
+          SA_PASSWORD: 'YourStrong!Passw0rd'
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd="/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'YourStrong!Passw0rd' -Q 'SELECT 1' -C"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run mssql integration tests
+        env:
+          DATA_TABLE_INTEGRATION: '1'
+          DATA_TABLE_MSSQL_URL: Server=127.0.0.1,1433;Database=master;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true;Encrypt=false
+        run: node --disable-warning=ExperimentalWarning --test './packages/data-table-mssql/src/lib/adapter.integration.test.ts'

--- a/packages/data-table-mssql/.changes/README.md
+++ b/packages/data-table-mssql/.changes/README.md
@@ -1,0 +1,3 @@
+# Changes Directory
+
+See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/data-table-mssql/.changes/minor.initial-release.md
+++ b/packages/data-table-mssql/.changes/minor.initial-release.md
@@ -1,0 +1,1 @@
+Initial release of `@remix-run/data-table-mssql`.

--- a/packages/data-table-mssql/CHANGELOG.md
+++ b/packages/data-table-mssql/CHANGELOG.md
@@ -1,9 +1,3 @@
 # `data-table-mssql` CHANGELOG
 
 This is the changelog for [`data-table-mssql`](https://github.com/remix-run/remix/tree/main/packages/data-table-mssql). It follows [semantic versioning](https://semver.org/).
-
-## v0.1.0
-
-### Minor Changes
-
-- Initial release.

--- a/packages/data-table-mssql/CHANGELOG.md
+++ b/packages/data-table-mssql/CHANGELOG.md
@@ -1,0 +1,9 @@
+# `data-table-mssql` CHANGELOG
+
+This is the changelog for [`data-table-mssql`](https://github.com/remix-run/remix/tree/main/packages/data-table-mssql). It follows [semantic versioning](https://semver.org/).
+
+## v0.1.0
+
+### Minor Changes
+
+- Initial release.

--- a/packages/data-table-mssql/LICENSE
+++ b/packages/data-table-mssql/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/data-table-mssql/README.md
+++ b/packages/data-table-mssql/README.md
@@ -1,0 +1,97 @@
+# data-table-mssql
+
+MSSQL adapter for [`remix/data-table`](https://github.com/remix-run/remix/tree/main/packages/data-table).
+Use this package when you want `data-table` APIs backed by `mssql`.
+
+## Features
+
+- **Native `mssql` Integration**: Works with `ConnectionPool`
+- **Full `data-table` API Support**: Queries, relations, writes, and transactions
+- **MSSQL Capabilities Enabled By Default**:
+  - `returning: false`
+  - `savepoints: true`
+  - `upsert: true`
+
+## Installation
+
+```sh
+npm i remix mssql
+```
+
+## Usage
+
+```ts
+import sql from 'mssql'
+import { createDatabase } from 'remix/data-table'
+import { createMssqlDatabaseAdapter } from 'remix/data-table-mssql'
+
+let pool = await sql.connect(process.env.DATABASE_URL)
+
+let db = createDatabase(createMssqlDatabaseAdapter(pool))
+```
+
+Use `db.query(...)`, relation loading, and transactions from `remix/data-table`.
+
+## Adapter Capabilities
+
+`data-table-mssql` reports this capability set by default:
+
+- `returning: false`
+- `savepoints: true`
+- `upsert: true`
+
+### `returning` On MSSQL
+
+MSSQL does not support the `RETURNING` clause used by Postgres and SQLite.
+When `returning` is `false` (the default), operations like
+`db.create(table, values, { returnRow: true })` issue a follow-up `SELECT` to
+fetch the created row.
+
+MSSQL _does_ support the `OUTPUT` clause which can serve a similar role. If you
+enable the capability override the adapter will use `OUTPUT inserted.*` /
+`OUTPUT deleted.*` instead of a follow-up query:
+
+```ts
+let adapter = createMssqlDatabaseAdapter(pool, {
+  capabilities: { returning: true },
+})
+```
+
+## Advanced Usage
+
+### Transaction Options
+
+Transaction options are passed through to the adapter as hints.
+
+```ts
+await db.transaction(async (txDb) => txDb.exec('select 1'), {
+  isolationLevel: 'serializable',
+  readOnly: false,
+})
+```
+
+### Capability Overrides For Testing
+
+You can override capabilities to verify fallback paths in tests.
+
+```ts
+import { createMssqlDatabaseAdapter } from 'remix/data-table-mssql'
+
+let adapter = createMssqlDatabaseAdapter(pool, {
+  capabilities: {
+    returning: true,
+  },
+})
+```
+
+## Related Packages
+
+- [`data-table`](https://github.com/remix-run/remix/tree/main/packages/data-table) - Core query/relations API
+- [`data-schema`](https://github.com/remix-run/remix/tree/main/packages/data-schema) - Schema definitions and validation
+- [`data-table-postgres`](https://github.com/remix-run/remix/tree/main/packages/data-table-postgres) - Postgres adapter
+- [`data-table-mysql`](https://github.com/remix-run/remix/tree/main/packages/data-table-mysql) - MySQL adapter
+- [`data-table-sqlite`](https://github.com/remix-run/remix/tree/main/packages/data-table-sqlite) - SQLite adapter
+
+## License
+
+See [LICENSE](https://github.com/remix-run/remix/blob/main/LICENSE)

--- a/packages/data-table-mssql/README.md
+++ b/packages/data-table-mssql/README.md
@@ -70,6 +70,13 @@ await db.transaction(async (txDb) => txDb.exec('select 1'), {
 })
 ```
 
+### Savepoints
+
+MSSQL uses `SAVE TRANSACTION` / `ROLLBACK TRANSACTION` instead of the standard
+`SAVEPOINT` / `ROLLBACK TO SAVEPOINT` syntax. Additionally, MSSQL does not
+support `RELEASE SAVEPOINT`, so `releaseSavepoint` is a no-op in this adapter.
+All other savepoint operations work as expected.
+
 ### Capability Overrides For Testing
 
 You can override capabilities to verify fallback paths in tests.

--- a/packages/data-table-mssql/README.md
+++ b/packages/data-table-mssql/README.md
@@ -40,23 +40,6 @@ Use `db.query(...)`, relation loading, and transactions from `remix/data-table`.
 - `savepoints: true`
 - `upsert: true`
 
-### `returning` On MSSQL
-
-MSSQL does not support the `RETURNING` clause used by Postgres and SQLite.
-When `returning` is `false` (the default), operations like
-`db.create(table, values, { returnRow: true })` issue a follow-up `SELECT` to
-fetch the created row.
-
-MSSQL _does_ support the `OUTPUT` clause which can serve a similar role. If you
-enable the capability override the adapter will use `OUTPUT inserted.*` /
-`OUTPUT deleted.*` instead of a follow-up query:
-
-```ts
-let adapter = createMssqlDatabaseAdapter(pool, {
-  capabilities: { returning: true },
-})
-```
-
 ## Advanced Usage
 
 ### Transaction Options
@@ -70,12 +53,27 @@ await db.transaction(async (txDb) => txDb.exec('select 1'), {
 })
 ```
 
-### Savepoints
+> **Note:** SQL Server does not support `SET TRANSACTION READ ONLY`. The
+> `readOnly` option is silently ignored.
 
-MSSQL uses `SAVE TRANSACTION` / `ROLLBACK TRANSACTION` instead of the standard
-`SAVEPOINT` / `ROLLBACK TO SAVEPOINT` syntax. Additionally, MSSQL does not
-support `RELEASE SAVEPOINT`, so `releaseSavepoint` is a no-op in this adapter.
-All other savepoint operations work as expected.
+### `returning` On MSSQL
+
+MSSQL does not support the `RETURNING` clause used by Postgres and SQLite.
+When `returning` is `false` (the default), operations like
+`db.create(table, values, { returnRow: true })` issue a follow-up `SELECT` to
+fetch the created row.
+
+You can enable `OUTPUT` clause support via a capability override:
+
+```ts
+let adapter = createMssqlDatabaseAdapter(pool, {
+  capabilities: { returning: true },
+})
+```
+
+> **Note:** SQL Server does not allow `OUTPUT` without `INTO` on tables that
+> have triggers. If your tables use triggers, keep `returning: false` (the
+> default).
 
 ### Capability Overrides For Testing
 

--- a/packages/data-table-mssql/README.md
+++ b/packages/data-table-mssql/README.md
@@ -1,16 +1,20 @@
 # data-table-mssql
 
-MSSQL adapter for [`remix/data-table`](https://github.com/remix-run/remix/tree/main/packages/data-table).
+SQL Server adapter for [`remix/data-table`](https://github.com/remix-run/remix/tree/main/packages/data-table).
 Use this package when you want `data-table` APIs backed by `mssql`.
 
 ## Features
 
-- **Native `mssql` Integration**: Works with `ConnectionPool`
+- **Native `mssql` Integration**: Works with `ConnectionPool` and SQL Server connection strings
 - **Full `data-table` API Support**: Queries, relations, writes, and transactions
+- **Adapter-Owned Compiler**: SQL compilation lives in this adapter, with optional shared pure helpers from `data-table`
+- **Migration DDL Support**: Compiles and executes `DataMigrationOperation` operations for `remix/data-table/migrations`
 - **MSSQL Capabilities Enabled By Default**:
   - `returning: false`
   - `savepoints: true`
   - `upsert: true`
+  - `transactionalDdl: true`
+  - `migrationLock: true`
 
 ## Installation
 
@@ -39,6 +43,8 @@ Use `db.query(...)`, relation loading, and transactions from `remix/data-table`.
 - `returning: false`
 - `savepoints: true`
 - `upsert: true`
+- `transactionalDdl: true`
+- `migrationLock: true`
 
 ## Advanced Usage
 
@@ -49,16 +55,15 @@ Transaction options are passed through to the adapter as hints.
 ```ts
 await db.transaction(async (txDb) => txDb.exec('select 1'), {
   isolationLevel: 'serializable',
-  readOnly: false,
 })
 ```
 
 > **Note:** SQL Server does not support `SET TRANSACTION READ ONLY`. The
-> `readOnly` option is silently ignored.
+> `readOnly` option is accepted but silently ignored.
 
 ### `returning` On MSSQL
 
-MSSQL does not support the `RETURNING` clause used by Postgres and SQLite.
+SQL Server does not support the `RETURNING` clause used by Postgres and SQLite.
 When `returning` is `false` (the default), operations like
 `db.create(table, values, { returnRow: true })` issue a follow-up `SELECT` to
 fetch the created row.
@@ -84,7 +89,7 @@ import { createMssqlDatabaseAdapter } from 'remix/data-table-mssql'
 
 let adapter = createMssqlDatabaseAdapter(pool, {
   capabilities: {
-    returning: true,
+    savepoints: false,
   },
 })
 ```
@@ -92,7 +97,7 @@ let adapter = createMssqlDatabaseAdapter(pool, {
 ## Related Packages
 
 - [`data-table`](https://github.com/remix-run/remix/tree/main/packages/data-table) - Core query/relations API
-- [`data-schema`](https://github.com/remix-run/remix/tree/main/packages/data-schema) - Schema definitions and validation
+- [`data-schema`](https://github.com/remix-run/remix/tree/main/packages/data-schema) - Schema parsing and validation
 - [`data-table-postgres`](https://github.com/remix-run/remix/tree/main/packages/data-table-postgres) - Postgres adapter
 - [`data-table-mysql`](https://github.com/remix-run/remix/tree/main/packages/data-table-mysql) - MySQL adapter
 - [`data-table-sqlite`](https://github.com/remix-run/remix/tree/main/packages/data-table-sqlite) - SQLite adapter

--- a/packages/data-table-mssql/package.json
+++ b/packages/data-table-mssql/package.json
@@ -2,7 +2,7 @@
   "name": "@remix-run/data-table-mssql",
   "version": "0.0.0",
   "description": "MSSQL adapter for @remix-run/data-table",
-  "author": "Michael Jackson <mjijackson@gmail.com>",
+  "author": "Isaac Cloos <cloosisaac@gmail.com>",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/data-table-mssql/package.json
+++ b/packages/data-table-mssql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@remix-run/data-table-mssql",
   "version": "0.0.0",
-  "description": "MSSQL adapter for @remix-run/data-table",
+  "description": "MSSQL adapter for remix/data-table",
   "author": "Isaac Cloos <cloosisaac@gmail.com>",
   "license": "MIT",
   "repository": {
@@ -33,7 +33,6 @@
     }
   },
   "devDependencies": {
-    "@remix-run/data-schema": "workspace:*",
     "@remix-run/data-table": "workspace:*",
     "@types/mssql": "^9.1.8",
     "@types/node": "catalog:",
@@ -56,6 +55,7 @@
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "node --disable-warning=ExperimentalWarning --test",
+    "test:coverage": "node --disable-warning=ExperimentalWarning --experimental-test-coverage --test-coverage-include='src/**/*.ts' --test-coverage-lines=90 --test-coverage-branches=90 --test-coverage-functions=90 --test ./src/lib/adapter.test.ts ./src/lib/sql-compiler.test.ts",
     "typecheck": "tsgo --noEmit"
   },
   "keywords": [

--- a/packages/data-table-mssql/package.json
+++ b/packages/data-table-mssql/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@remix-run/data-table-mssql",
+  "version": "0.0.0",
+  "description": "MSSQL adapter for @remix-run/data-table",
+  "author": "Michael Jackson <mjijackson@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/remix-run/remix.git",
+    "directory": "packages/data-table-mssql"
+  },
+  "homepage": "https://github.com/remix-run/remix/tree/main/packages/data-table-mssql#readme",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "dist",
+    "src",
+    "!src/**/*.test.ts"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "./package.json": "./package.json"
+    }
+  },
+  "devDependencies": {
+    "@remix-run/data-schema": "workspace:*",
+    "@remix-run/data-table": "workspace:*",
+    "@types/mssql": "^9.1.8",
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "mssql": "^12.2.0"
+  },
+  "dependencies": {
+    "@remix-run/data-table": "workspace:^"
+  },
+  "peerDependencies": {
+    "mssql": "^12.2.0"
+  },
+  "peerDependenciesMeta": {
+    "mssql": {
+      "optional": true
+    }
+  },
+  "scripts": {
+    "build": "tsgo -p tsconfig.build.json",
+    "clean": "git clean -fdX",
+    "prepublishOnly": "pnpm run build",
+    "test": "node --disable-warning=ExperimentalWarning --test",
+    "typecheck": "tsgo --noEmit"
+  },
+  "keywords": [
+    "remix",
+    "orm",
+    "mssql",
+    "database",
+    "sql"
+  ]
+}

--- a/packages/data-table-mssql/src/index.ts
+++ b/packages/data-table-mssql/src/index.ts
@@ -1,0 +1,9 @@
+export type {
+  MssqlDatabaseAdapterOptions,
+  MssqlDatabaseClient,
+  MssqlDatabasePool,
+  MssqlDatabaseRequest,
+  MssqlDatabaseTransaction,
+  MssqlQueryResult,
+} from './lib/adapter.ts'
+export { createMssqlDatabaseAdapter, MssqlDatabaseAdapter } from './lib/adapter.ts'

--- a/packages/data-table-mssql/src/index.ts
+++ b/packages/data-table-mssql/src/index.ts
@@ -2,8 +2,7 @@ export type {
   MssqlDatabaseAdapterOptions,
   MssqlDatabaseClient,
   MssqlDatabasePool,
-  MssqlDatabaseRequest,
-  MssqlDatabaseTransaction,
   MssqlQueryResult,
+  MssqlDatabaseTransaction,
 } from './lib/adapter.ts'
 export { createMssqlDatabaseAdapter, MssqlDatabaseAdapter } from './lib/adapter.ts'

--- a/packages/data-table-mssql/src/index.ts
+++ b/packages/data-table-mssql/src/index.ts
@@ -3,6 +3,6 @@ export type {
   MssqlDatabaseClient,
   MssqlDatabasePool,
   MssqlQueryResult,
-  MssqlDatabaseTransaction,
+  MssqlTransactionClient,
 } from './lib/adapter.ts'
 export { createMssqlDatabaseAdapter, MssqlDatabaseAdapter } from './lib/adapter.ts'

--- a/packages/data-table-mssql/src/lib/adapter.integration.test.ts
+++ b/packages/data-table-mssql/src/lib/adapter.integration.test.ts
@@ -21,42 +21,48 @@ describe('mssql adapter integration', () => {
 
     pool = await sql.connect(process.env.DATA_TABLE_MSSQL_URL as string)
 
-    await pool.request().query('if object_id(\'tasks\', \'U\') is not null drop table [tasks]')
-    await pool.request().query('if object_id(\'projects\', \'U\') is not null drop table [projects]')
-    await pool.request().query('if object_id(\'accounts\', \'U\') is not null drop table [accounts]')
+    await pool.request().query("if object_id('tasks', 'U') is not null drop table [tasks]")
+    await pool.request().query("if object_id('projects', 'U') is not null drop table [projects]")
+    await pool.request().query("if object_id('accounts', 'U') is not null drop table [accounts]")
 
-    await pool.request().query(
-      [
-        'create table [accounts] (',
-        '  [id] int primary key,',
-        '  [email] nvarchar(255) not null,',
-        '  [status] nvarchar(32) not null,',
-        '  [nickname] nvarchar(255) null',
-        ')',
-      ].join('\n'),
-    )
+    await pool
+      .request()
+      .query(
+        [
+          'create table [accounts] (',
+          '  [id] int primary key,',
+          '  [email] nvarchar(255) not null,',
+          '  [status] nvarchar(32) not null,',
+          '  [nickname] nvarchar(255) null',
+          ')',
+        ].join('\n'),
+      )
 
-    await pool.request().query(
-      [
-        'create table [projects] (',
-        '  [id] int primary key,',
-        '  [account_id] int not null,',
-        '  [name] nvarchar(255) not null,',
-        '  [archived] bit not null',
-        ')',
-      ].join('\n'),
-    )
+    await pool
+      .request()
+      .query(
+        [
+          'create table [projects] (',
+          '  [id] int primary key,',
+          '  [account_id] int not null,',
+          '  [name] nvarchar(255) not null,',
+          '  [archived] bit not null',
+          ')',
+        ].join('\n'),
+      )
 
-    await pool.request().query(
-      [
-        'create table [tasks] (',
-        '  [id] int primary key,',
-        '  [project_id] int not null,',
-        '  [title] nvarchar(255) not null,',
-        '  [state] nvarchar(32) not null',
-        ')',
-      ].join('\n'),
-    )
+    await pool
+      .request()
+      .query(
+        [
+          'create table [tasks] (',
+          '  [id] int primary key,',
+          '  [project_id] int not null,',
+          '  [title] nvarchar(255) not null,',
+          '  [state] nvarchar(32) not null',
+          ')',
+        ].join('\n'),
+      )
   })
 
   after(async () => {
@@ -64,9 +70,9 @@ describe('mssql adapter integration', () => {
       return
     }
 
-    await pool.request().query('if object_id(\'tasks\', \'U\') is not null drop table [tasks]')
-    await pool.request().query('if object_id(\'projects\', \'U\') is not null drop table [projects]')
-    await pool.request().query('if object_id(\'accounts\', \'U\') is not null drop table [accounts]')
+    await pool.request().query("if object_id('tasks', 'U') is not null drop table [tasks]")
+    await pool.request().query("if object_id('projects', 'U') is not null drop table [projects]")
+    await pool.request().query("if object_id('accounts', 'U') is not null drop table [accounts]")
     await pool.close()
   })
 
@@ -106,10 +112,10 @@ describe('mssql adapter integration', () => {
       async () => {
         let db = createDatabase(createMssqlDatabaseAdapter(pool))
 
-        await db.transaction(async tx => {
-          await tx.query(txAccounts).insertMany([
-            { id: 1, email: 'a@test.com', status: 'active', nickname: null },
-          ])
+        await db.transaction(async (tx) => {
+          await tx
+            .query(txAccounts)
+            .insertMany([{ id: 1, email: 'a@test.com', status: 'active', nickname: null }])
         })
 
         let result = await pool.request().query('select [id] from [accounts] order by [id]')
@@ -135,10 +141,10 @@ describe('mssql adapter integration', () => {
         let db = createDatabase(createMssqlDatabaseAdapter(pool))
 
         await assert.rejects(() =>
-          db.transaction(async tx => {
-            await tx.query(txAccounts).insertMany([
-              { id: 2, email: 'b@test.com', status: 'active', nickname: null },
-            ])
+          db.transaction(async (tx) => {
+            await tx
+              .query(txAccounts)
+              .insertMany([{ id: 2, email: 'b@test.com', status: 'active', nickname: null }])
             throw new Error('forced rollback')
           }),
         )
@@ -170,10 +176,9 @@ describe('mssql adapter integration', () => {
           { id: 2, email: 'b@test.com', status: 'active', nickname: null },
         ])
 
-        let count = await db.transaction(
-          async (tx) => tx.count(txAccounts),
-          { isolationLevel: 'serializable' },
-        )
+        let count = await db.transaction(async (tx) => tx.count(txAccounts), {
+          isolationLevel: 'serializable',
+        })
 
         assert.equal(count, 2)
       },
@@ -186,34 +191,30 @@ describe('mssql adapter integration', () => {
       await pool.request().query('delete from [accounts]')
     })
 
-    it(
-      'paginates results with limit and offset',
-      { skip: !integrationEnabled },
-      async () => {
-        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+    it('paginates results with limit and offset', { skip: !integrationEnabled }, async () => {
+      let db = createDatabase(createMssqlDatabaseAdapter(pool))
 
-        await db.query(txAccounts).insertMany([
-          { id: 1, email: 'a@test.com', status: 'active', nickname: null },
-          { id: 2, email: 'b@test.com', status: 'active', nickname: null },
-          { id: 3, email: 'c@test.com', status: 'active', nickname: null },
-          { id: 4, email: 'd@test.com', status: 'active', nickname: null },
-        ])
+      await db.query(txAccounts).insertMany([
+        { id: 1, email: 'a@test.com', status: 'active', nickname: null },
+        { id: 2, email: 'b@test.com', status: 'active', nickname: null },
+        { id: 3, email: 'c@test.com', status: 'active', nickname: null },
+        { id: 4, email: 'd@test.com', status: 'active', nickname: null },
+      ])
 
-        let page1 = await db.query(txAccounts).orderBy('id', 'asc').limit(2).offset(0).all()
+      let page1 = await db.query(txAccounts).orderBy('id', 'asc').limit(2).offset(0).all()
 
-        assert.deepEqual(
-          page1.map((r) => r.id),
-          [1, 2],
-        )
+      assert.deepEqual(
+        page1.map((r) => r.id),
+        [1, 2],
+      )
 
-        let page2 = await db.query(txAccounts).orderBy('id', 'asc').limit(2).offset(2).all()
+      let page2 = await db.query(txAccounts).orderBy('id', 'asc').limit(2).offset(2).all()
 
-        assert.deepEqual(
-          page2.map((r) => r.id),
-          [3, 4],
-        )
-      },
-    )
+      assert.deepEqual(
+        page2.map((r) => r.id),
+        [3, 4],
+      )
+    })
   })
 
   // ── Transaction option permutations ──────────────────────────────────
@@ -237,10 +238,7 @@ describe('mssql adapter integration', () => {
           nickname: null,
         })
 
-        let count = await db.transaction(
-          async (tx) => tx.count(txAccounts),
-          { readOnly: true },
-        )
+        let count = await db.transaction(async (tx) => tx.count(txAccounts), { readOnly: true })
 
         assert.equal(count, 1)
       },
@@ -266,10 +264,10 @@ describe('mssql adapter integration', () => {
           nickname: null,
         })
 
-        let count = await db.transaction(
-          async (tx) => tx.count(txAccounts),
-          { isolationLevel: 'serializable', readOnly: true },
-        )
+        let count = await db.transaction(async (tx) => tx.count(txAccounts), {
+          isolationLevel: 'serializable',
+          readOnly: true,
+        })
 
         assert.equal(count, 1)
       },
@@ -334,43 +332,37 @@ describe('mssql adapter integration', () => {
       await pool.request().query('delete from [accounts]')
     })
 
-    it(
-      'supports nested transactions via savepoints',
-      { skip: !integrationEnabled },
-      async () => {
-        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+    it('supports nested transactions via savepoints', { skip: !integrationEnabled }, async () => {
+      let db = createDatabase(createMssqlDatabaseAdapter(pool))
 
-        await db.transaction(async (outerTx) => {
-          await outerTx.query(txAccounts).insert({
-            id: 1,
-            email: 'outer@test.com',
-            status: 'active',
-            nickname: null,
-          })
-
-          await outerTx
-            .transaction(async (innerTx) => {
-              await innerTx.query(txAccounts).insert({
-                id: 2,
-                email: 'inner@test.com',
-                status: 'active',
-                nickname: null,
-              })
-              throw new Error('rollback inner savepoint')
-            })
-            .catch(() => undefined)
+      await db.transaction(async (outerTx) => {
+        await outerTx.query(txAccounts).insert({
+          id: 1,
+          email: 'outer@test.com',
+          status: 'active',
+          nickname: null,
         })
 
-        let result = await pool
-          .request()
-          .query('select [id] from [accounts] order by [id]')
-        assert.deepEqual(
-          result.recordset.map((r: { id: number }) => r.id),
-          [1],
-          'inner savepoint rollback should discard inner row but keep outer row',
-        )
-      },
-    )
+        await outerTx
+          .transaction(async (innerTx) => {
+            await innerTx.query(txAccounts).insert({
+              id: 2,
+              email: 'inner@test.com',
+              status: 'active',
+              nickname: null,
+            })
+            throw new Error('rollback inner savepoint')
+          })
+          .catch(() => undefined)
+      })
+
+      let result = await pool.request().query('select [id] from [accounts] order by [id]')
+      assert.deepEqual(
+        result.recordset.map((r: { id: number }) => r.id),
+        [1],
+        'inner savepoint rollback should discard inner row but keep outer row',
+      )
+    })
   })
 
   describe('capabilities savepoints: false', () => {
@@ -420,10 +412,12 @@ describe('mssql adapter integration', () => {
           nickname: null,
         })
 
-        await db.query(txAccounts).upsert(
-          { id: 1, email: 'after@test.com', status: 'active', nickname: null },
-          { conflictTarget: ['id'] },
-        )
+        await db
+          .query(txAccounts)
+          .upsert(
+            { id: 1, email: 'after@test.com', status: 'active', nickname: null },
+            { conflictTarget: ['id'] },
+          )
 
         let rows = await db.query(txAccounts).where(eq('id', 1)).all()
         assert.equal(rows.length, 1)
@@ -448,10 +442,12 @@ describe('mssql adapter integration', () => {
 
         await assert.rejects(
           () =>
-            db.query(txAccounts).upsert(
-              { id: 1, email: 'x@test.com', status: 'active', nickname: null },
-              { conflictTarget: ['id'] },
-            ),
+            db
+              .query(txAccounts)
+              .upsert(
+                { id: 1, email: 'x@test.com', status: 'active', nickname: null },
+                { conflictTarget: ['id'] },
+              ),
           (error: Error) => {
             assert.match(error.message, /upsert/i)
             return true
@@ -504,32 +500,34 @@ describe('mssql adapter integration', () => {
       await pool
         .request()
         .query("if object_id('data_types', 'U') is not null drop table [data_types]")
-      await pool.request().query(
-        [
-          'create table [data_types] (',
-          '  [id] int primary key,',
-          '  [col_tinyint] tinyint null,',
-          '  [col_smallint] smallint null,',
-          '  [col_int] int null,',
-          '  [col_bigint] bigint null,',
-          '  [col_decimal] decimal(10,2) null,',
-          '  [col_numeric] numeric(18,4) null,',
-          '  [col_float] float null,',
-          '  [col_real] real null,',
-          '  [col_money] money null,',
-          '  [col_smallmoney] smallmoney null,',
-          '  [col_bit] bit null,',
-          '  [col_char] char(10) null,',
-          '  [col_varchar] varchar(50) null,',
-          '  [col_nchar] nchar(10) null,',
-          '  [col_nvarchar] nvarchar(50) null,',
-          '  [col_date] date null,',
-          '  [col_datetime] datetime null,',
-          '  [col_datetime2] datetime2 null,',
-          '  [col_uniqueidentifier] uniqueidentifier null',
-          ')',
-        ].join('\n'),
-      )
+      await pool
+        .request()
+        .query(
+          [
+            'create table [data_types] (',
+            '  [id] int primary key,',
+            '  [col_tinyint] tinyint null,',
+            '  [col_smallint] smallint null,',
+            '  [col_int] int null,',
+            '  [col_bigint] bigint null,',
+            '  [col_decimal] decimal(10,2) null,',
+            '  [col_numeric] numeric(18,4) null,',
+            '  [col_float] float null,',
+            '  [col_real] real null,',
+            '  [col_money] money null,',
+            '  [col_smallmoney] smallmoney null,',
+            '  [col_bit] bit null,',
+            '  [col_char] char(10) null,',
+            '  [col_varchar] varchar(50) null,',
+            '  [col_nchar] nchar(10) null,',
+            '  [col_nvarchar] nvarchar(50) null,',
+            '  [col_date] date null,',
+            '  [col_datetime] datetime null,',
+            '  [col_datetime2] datetime2 null,',
+            '  [col_uniqueidentifier] uniqueidentifier null',
+            ')',
+          ].join('\n'),
+        )
     })
 
     after(async () => {
@@ -574,20 +572,22 @@ describe('mssql adapter integration', () => {
       'returns correct JS types for all common SQL Server column types',
       { skip: !integrationEnabled },
       async () => {
-        await pool.request().query(
-          [
-            'insert into [data_types] values (',
-            '  1,',
-            '  255, -32768, 2147483647, 9223372036854775807,',
-            '  12345.67, 1234567890.1234, 3.141592653589793, 1.5,',
-            '  12345.6789, 1234.5678,',
-            '  1,',
-            "  'hello', 'world', N'日本語', N'unicode test',",
-            "  '2025-06-15', '2025-06-15 10:30:00', '2025-06-15T10:30:00.1234567',",
-            "  'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11'",
-            ')',
-          ].join('\n'),
-        )
+        await pool
+          .request()
+          .query(
+            [
+              'insert into [data_types] values (',
+              '  1,',
+              '  255, -32768, 2147483647, 9223372036854775807,',
+              '  12345.67, 1234567890.1234, 3.141592653589793, 1.5,',
+              '  12345.6789, 1234.5678,',
+              '  1,',
+              "  'hello', 'world', N'日本語', N'unicode test',",
+              "  '2025-06-15', '2025-06-15 10:30:00', '2025-06-15T10:30:00.1234567',",
+              "  'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11'",
+              ')',
+            ].join('\n'),
+          )
 
         let db = createDatabase(createMssqlDatabaseAdapter(pool))
         let rows = await db.query(dataTypes).all()
@@ -659,38 +659,34 @@ describe('mssql adapter integration', () => {
       },
     )
 
-    it(
-      'returns null for all nullable column types',
-      { skip: !integrationEnabled },
-      async () => {
-        await pool.request().query('insert into [data_types] ([id]) values (1)')
+    it('returns null for all nullable column types', { skip: !integrationEnabled }, async () => {
+      await pool.request().query('insert into [data_types] ([id]) values (1)')
 
-        let db = createDatabase(createMssqlDatabaseAdapter(pool))
-        let rows = await db.query(dataTypes).where(eq('id', 1)).all()
-        assert.equal(rows.length, 1)
-        let row = rows[0]
+      let db = createDatabase(createMssqlDatabaseAdapter(pool))
+      let rows = await db.query(dataTypes).where(eq('id', 1)).all()
+      assert.equal(rows.length, 1)
+      let row = rows[0]
 
-        assert.equal(row.col_tinyint, null)
-        assert.equal(row.col_smallint, null)
-        assert.equal(row.col_int, null)
-        assert.equal(row.col_bigint, null)
-        assert.equal(row.col_decimal, null)
-        assert.equal(row.col_numeric, null)
-        assert.equal(row.col_float, null)
-        assert.equal(row.col_real, null)
-        assert.equal(row.col_money, null)
-        assert.equal(row.col_smallmoney, null)
-        assert.equal(row.col_bit, null)
-        assert.equal(row.col_char, null)
-        assert.equal(row.col_varchar, null)
-        assert.equal(row.col_nchar, null)
-        assert.equal(row.col_nvarchar, null)
-        assert.equal(row.col_date, null)
-        assert.equal(row.col_datetime, null)
-        assert.equal(row.col_datetime2, null)
-        assert.equal(row.col_uniqueidentifier, null)
-      },
-    )
+      assert.equal(row.col_tinyint, null)
+      assert.equal(row.col_smallint, null)
+      assert.equal(row.col_int, null)
+      assert.equal(row.col_bigint, null)
+      assert.equal(row.col_decimal, null)
+      assert.equal(row.col_numeric, null)
+      assert.equal(row.col_float, null)
+      assert.equal(row.col_real, null)
+      assert.equal(row.col_money, null)
+      assert.equal(row.col_smallmoney, null)
+      assert.equal(row.col_bit, null)
+      assert.equal(row.col_char, null)
+      assert.equal(row.col_varchar, null)
+      assert.equal(row.col_nchar, null)
+      assert.equal(row.col_nvarchar, null)
+      assert.equal(row.col_date, null)
+      assert.equal(row.col_datetime, null)
+      assert.equal(row.col_datetime2, null)
+      assert.equal(row.col_uniqueidentifier, null)
+    })
   })
 
   // ── Data type parameter inference ────────────────────────────────────
@@ -701,20 +697,22 @@ describe('mssql adapter integration', () => {
       await pool
         .request()
         .query("if object_id('type_params', 'U') is not null drop table [type_params]")
-      await pool.request().query(
-        [
-          'create table [type_params] (',
-          '  [id] int primary key,',
-          '  [int_val] int null,',
-          '  [float_val] float null,',
-          '  [decimal_val] decimal(10,2) null,',
-          '  [bit_val] bit null,',
-          '  [varchar_val] varchar(50) null,',
-          '  [nvarchar_val] nvarchar(50) null,',
-          '  [datetime2_val] datetime2 null',
-          ')',
-        ].join('\n'),
-      )
+      await pool
+        .request()
+        .query(
+          [
+            'create table [type_params] (',
+            '  [id] int primary key,',
+            '  [int_val] int null,',
+            '  [float_val] float null,',
+            '  [decimal_val] decimal(10,2) null,',
+            '  [bit_val] bit null,',
+            '  [varchar_val] varchar(50) null,',
+            '  [nvarchar_val] nvarchar(50) null,',
+            '  [datetime2_val] datetime2 null',
+            ')',
+          ].join('\n'),
+        )
     })
 
     after(async () => {
@@ -772,10 +770,7 @@ describe('mssql adapter integration', () => {
         assert.equal(row.varchar_val, 'hello world')
         assert.equal(row.nvarchar_val, '日本語テスト')
         assert.ok(row.datetime2_val instanceof Date)
-        assert.equal(
-          (row.datetime2_val as Date).toISOString(),
-          testDate.toISOString(),
-        )
+        assert.equal((row.datetime2_val as Date).toISOString(), testDate.toISOString())
       },
     )
 
@@ -807,6 +802,41 @@ describe('mssql adapter integration', () => {
         assert.equal(row.varchar_val, null)
         assert.equal(row.nvarchar_val, null)
         assert.equal(row.datetime2_val, null)
+      },
+    )
+  })
+
+  describe('raw sql', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'returns affectedRows for raw update statements',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+        await db.exec('insert into [accounts] ([id], [email], [status]) values (1, ?, ?)', [
+          'a@test.com',
+          'active',
+        ])
+        await db.exec('insert into [accounts] ([id], [email], [status]) values (2, ?, ?)', [
+          'b@test.com',
+          'inactive',
+        ])
+        await db.exec('insert into [accounts] ([id], [email], [status]) values (3, ?, ?)', [
+          'c@test.com',
+          'active',
+        ])
+
+        let result = await db.exec('update [accounts] set [status] = ? where [status] = ?', [
+          'disabled',
+          'active',
+        ])
+
+        assert.equal(result.affectedRows, 2)
       },
     )
   })

--- a/packages/data-table-mssql/src/lib/adapter.integration.test.ts
+++ b/packages/data-table-mssql/src/lib/adapter.integration.test.ts
@@ -1,6 +1,6 @@
 import { after, before, beforeEach, describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { nullable, number, string } from '@remix-run/data-schema'
+import { any, nullable, number, string } from '@remix-run/data-schema'
 import { createDatabase, createTable, eq } from '@remix-run/data-table'
 import sql, { type ConnectionPool } from 'mssql'
 
@@ -492,6 +492,321 @@ describe('mssql adapter integration', () => {
 
         let result = await pool.request().query('select [id] from [accounts]')
         assert.equal(result.recordset.length, 0)
+      },
+    )
+  })
+
+  // ── Data type output ─────────────────────────────────────────────────
+
+  describe('data type output', () => {
+    before(async () => {
+      if (!integrationEnabled) return
+      await pool
+        .request()
+        .query("if object_id('data_types', 'U') is not null drop table [data_types]")
+      await pool.request().query(
+        [
+          'create table [data_types] (',
+          '  [id] int primary key,',
+          '  [col_tinyint] tinyint null,',
+          '  [col_smallint] smallint null,',
+          '  [col_int] int null,',
+          '  [col_bigint] bigint null,',
+          '  [col_decimal] decimal(10,2) null,',
+          '  [col_numeric] numeric(18,4) null,',
+          '  [col_float] float null,',
+          '  [col_real] real null,',
+          '  [col_money] money null,',
+          '  [col_smallmoney] smallmoney null,',
+          '  [col_bit] bit null,',
+          '  [col_char] char(10) null,',
+          '  [col_varchar] varchar(50) null,',
+          '  [col_nchar] nchar(10) null,',
+          '  [col_nvarchar] nvarchar(50) null,',
+          '  [col_date] date null,',
+          '  [col_datetime] datetime null,',
+          '  [col_datetime2] datetime2 null,',
+          '  [col_uniqueidentifier] uniqueidentifier null',
+          ')',
+        ].join('\n'),
+      )
+    })
+
+    after(async () => {
+      if (!integrationEnabled) return
+      await pool
+        .request()
+        .query("if object_id('data_types', 'U') is not null drop table [data_types]")
+    })
+
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [data_types]')
+    })
+
+    let dataTypes = createTable({
+      name: 'data_types',
+      columns: {
+        id: number(),
+        col_tinyint: any(),
+        col_smallint: any(),
+        col_int: any(),
+        col_bigint: any(),
+        col_decimal: any(),
+        col_numeric: any(),
+        col_float: any(),
+        col_real: any(),
+        col_money: any(),
+        col_smallmoney: any(),
+        col_bit: any(),
+        col_char: any(),
+        col_varchar: any(),
+        col_nchar: any(),
+        col_nvarchar: any(),
+        col_date: any(),
+        col_datetime: any(),
+        col_datetime2: any(),
+        col_uniqueidentifier: any(),
+      },
+    })
+
+    it(
+      'returns correct JS types for all common SQL Server column types',
+      { skip: !integrationEnabled },
+      async () => {
+        await pool.request().query(
+          [
+            'insert into [data_types] values (',
+            '  1,',
+            '  255, -32768, 2147483647, 9223372036854775807,',
+            '  12345.67, 1234567890.1234, 3.141592653589793, 1.5,',
+            '  12345.6789, 1234.5678,',
+            '  1,',
+            "  'hello', 'world', N'日本語', N'unicode test',",
+            "  '2025-06-15', '2025-06-15 10:30:00', '2025-06-15T10:30:00.1234567',",
+            "  'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11'",
+            ')',
+          ].join('\n'),
+        )
+
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+        let rows = await db.query(dataTypes).all()
+        assert.equal(rows.length, 1)
+        let row = rows[0]
+
+        // Integer types → number
+        assert.equal(typeof row.col_tinyint, 'number')
+        assert.equal(row.col_tinyint, 255)
+
+        assert.equal(typeof row.col_smallint, 'number')
+        assert.equal(row.col_smallint, -32768)
+
+        assert.equal(typeof row.col_int, 'number')
+        assert.equal(row.col_int, 2147483647)
+
+        // bigint → string (mssql driver default for 64-bit integers)
+        assert.equal(String(row.col_bigint), '9223372036854775807')
+
+        // Decimal/numeric → number
+        assert.equal(typeof row.col_decimal, 'number')
+        assert.equal(row.col_decimal, 12345.67)
+
+        assert.equal(typeof row.col_numeric, 'number')
+        assert.equal(row.col_numeric, 1234567890.1234)
+
+        // Float/real → number
+        assert.equal(typeof row.col_float, 'number')
+        assert.ok(Math.abs((row.col_float as number) - 3.141592653589793) < 1e-10)
+
+        assert.equal(typeof row.col_real, 'number')
+        assert.ok(Math.abs((row.col_real as number) - 1.5) < 1e-5)
+
+        // Money → number
+        assert.equal(typeof row.col_money, 'number')
+        assert.equal(row.col_money, 12345.6789)
+
+        assert.equal(typeof row.col_smallmoney, 'number')
+        assert.equal(row.col_smallmoney, 1234.5678)
+
+        // Bit → boolean
+        assert.equal(typeof row.col_bit, 'boolean')
+        assert.equal(row.col_bit, true)
+
+        // Character types → string
+        assert.equal(typeof row.col_char, 'string')
+        assert.equal((row.col_char as string).trimEnd(), 'hello')
+
+        assert.equal(typeof row.col_varchar, 'string')
+        assert.equal(row.col_varchar, 'world')
+
+        assert.equal(typeof row.col_nchar, 'string')
+        assert.equal((row.col_nchar as string).trimEnd(), '日本語')
+
+        assert.equal(typeof row.col_nvarchar, 'string')
+        assert.equal(row.col_nvarchar, 'unicode test')
+
+        // Date/time types → Date
+        assert.ok(row.col_date instanceof Date)
+        assert.ok(row.col_datetime instanceof Date)
+        assert.ok(row.col_datetime2 instanceof Date)
+
+        // Uniqueidentifier → string (GUID format)
+        assert.equal(typeof row.col_uniqueidentifier, 'string')
+        assert.match(
+          (row.col_uniqueidentifier as string).toLowerCase(),
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+        )
+      },
+    )
+
+    it(
+      'returns null for all nullable column types',
+      { skip: !integrationEnabled },
+      async () => {
+        await pool.request().query('insert into [data_types] ([id]) values (1)')
+
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+        let rows = await db.query(dataTypes).where(eq('id', 1)).all()
+        assert.equal(rows.length, 1)
+        let row = rows[0]
+
+        assert.equal(row.col_tinyint, null)
+        assert.equal(row.col_smallint, null)
+        assert.equal(row.col_int, null)
+        assert.equal(row.col_bigint, null)
+        assert.equal(row.col_decimal, null)
+        assert.equal(row.col_numeric, null)
+        assert.equal(row.col_float, null)
+        assert.equal(row.col_real, null)
+        assert.equal(row.col_money, null)
+        assert.equal(row.col_smallmoney, null)
+        assert.equal(row.col_bit, null)
+        assert.equal(row.col_char, null)
+        assert.equal(row.col_varchar, null)
+        assert.equal(row.col_nchar, null)
+        assert.equal(row.col_nvarchar, null)
+        assert.equal(row.col_date, null)
+        assert.equal(row.col_datetime, null)
+        assert.equal(row.col_datetime2, null)
+        assert.equal(row.col_uniqueidentifier, null)
+      },
+    )
+  })
+
+  // ── Data type parameter inference ────────────────────────────────────
+
+  describe('data type parameter inference', () => {
+    before(async () => {
+      if (!integrationEnabled) return
+      await pool
+        .request()
+        .query("if object_id('type_params', 'U') is not null drop table [type_params]")
+      await pool.request().query(
+        [
+          'create table [type_params] (',
+          '  [id] int primary key,',
+          '  [int_val] int null,',
+          '  [float_val] float null,',
+          '  [decimal_val] decimal(10,2) null,',
+          '  [bit_val] bit null,',
+          '  [varchar_val] varchar(50) null,',
+          '  [nvarchar_val] nvarchar(50) null,',
+          '  [datetime2_val] datetime2 null',
+          ')',
+        ].join('\n'),
+      )
+    })
+
+    after(async () => {
+      if (!integrationEnabled) return
+      await pool
+        .request()
+        .query("if object_id('type_params', 'U') is not null drop table [type_params]")
+    })
+
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [type_params]')
+    })
+
+    let typeParams = createTable({
+      name: 'type_params',
+      columns: {
+        id: number(),
+        int_val: nullable(any()),
+        float_val: nullable(any()),
+        decimal_val: nullable(any()),
+        bit_val: nullable(any()),
+        varchar_val: nullable(any()),
+        nvarchar_val: nullable(any()),
+        datetime2_val: nullable(any()),
+      },
+    })
+
+    it(
+      'roundtrips JS values through adapter insert and select',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+        let testDate = new Date('2025-06-15T10:30:00.000Z')
+
+        await db.query(typeParams).insert({
+          id: 1,
+          int_val: 42,
+          float_val: 3.14,
+          decimal_val: 99.95,
+          bit_val: true,
+          varchar_val: 'hello world',
+          nvarchar_val: '日本語テスト',
+          datetime2_val: testDate,
+        })
+
+        let rows = await db.query(typeParams).all()
+        assert.equal(rows.length, 1)
+        let row = rows[0]
+
+        assert.equal(row.int_val, 42)
+        assert.ok(Math.abs((row.float_val as number) - 3.14) < 1e-10)
+        assert.equal(row.decimal_val, 99.95)
+        assert.equal(row.bit_val, true)
+        assert.equal(row.varchar_val, 'hello world')
+        assert.equal(row.nvarchar_val, '日本語テスト')
+        assert.ok(row.datetime2_val instanceof Date)
+        assert.equal(
+          (row.datetime2_val as Date).toISOString(),
+          testDate.toISOString(),
+        )
+      },
+    )
+
+    it(
+      'roundtrips null values through adapter insert and select',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+        await db.query(typeParams).insert({
+          id: 1,
+          int_val: null,
+          float_val: null,
+          decimal_val: null,
+          bit_val: null,
+          varchar_val: null,
+          nvarchar_val: null,
+          datetime2_val: null,
+        })
+
+        let rows = await db.query(typeParams).where(eq('id', 1)).all()
+        assert.equal(rows.length, 1)
+        let row = rows[0]
+
+        assert.equal(row.int_val, null)
+        assert.equal(row.float_val, null)
+        assert.equal(row.decimal_val, null)
+        assert.equal(row.bit_val, null)
+        assert.equal(row.varchar_val, null)
+        assert.equal(row.nvarchar_val, null)
+        assert.equal(row.datetime2_val, null)
       },
     )
   })

--- a/packages/data-table-mssql/src/lib/adapter.integration.test.ts
+++ b/packages/data-table-mssql/src/lib/adapter.integration.test.ts
@@ -274,29 +274,6 @@ describe('mssql adapter integration', () => {
         assert.equal(count, 1)
       },
     )
-
-    it(
-      'writes succeed when readOnly is true because MSSQL ignores it',
-      { skip: !integrationEnabled },
-      async () => {
-        let db = createDatabase(createMssqlDatabaseAdapter(pool))
-
-        await db.transaction(
-          async (tx) => {
-            await tx.query(txAccounts).insert({
-              id: 1,
-              email: 'write-ro@test.com',
-              status: 'active',
-              nickname: null,
-            })
-          },
-          { isolationLevel: 'read committed', readOnly: true },
-        )
-
-        let result = await pool.request().query('select [id] from [accounts]')
-        assert.equal(result.recordset.length, 1)
-      },
-    )
   })
 
   // ── Capability override tests ────────────────────────────────────────

--- a/packages/data-table-mssql/src/lib/adapter.integration.test.ts
+++ b/packages/data-table-mssql/src/lib/adapter.integration.test.ts
@@ -1,9 +1,13 @@
 import { after, before, beforeEach, describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { any, nullable, number, string } from '@remix-run/data-schema'
-import { createDatabase, createTable, eq } from '@remix-run/data-table'
+import { column, createDatabase, table, eq } from '@remix-run/data-table'
 import sql, { type ConnectionPool } from 'mssql'
 
+import {
+  resetAdapterIntegrationSchema,
+  setupAdapterIntegrationSchema,
+  teardownAdapterIntegrationSchema,
+} from '../../../data-table/test/adapter-integration-schema.ts'
 import { runAdapterIntegrationContract } from '../../../data-table/test/adapter-integration-contract.ts'
 
 import { createMssqlDatabaseAdapter } from './adapter.ts'
@@ -20,49 +24,9 @@ describe('mssql adapter integration', () => {
     }
 
     pool = await sql.connect(process.env.DATA_TABLE_MSSQL_URL as string)
-
-    await pool.request().query("if object_id('tasks', 'U') is not null drop table [tasks]")
-    await pool.request().query("if object_id('projects', 'U') is not null drop table [projects]")
-    await pool.request().query("if object_id('accounts', 'U') is not null drop table [accounts]")
-
-    await pool
-      .request()
-      .query(
-        [
-          'create table [accounts] (',
-          '  [id] int primary key,',
-          '  [email] nvarchar(255) not null,',
-          '  [status] nvarchar(32) not null,',
-          '  [nickname] nvarchar(255) null',
-          ')',
-        ].join('\n'),
-      )
-
-    await pool
-      .request()
-      .query(
-        [
-          'create table [projects] (',
-          '  [id] int primary key,',
-          '  [account_id] int not null,',
-          '  [name] nvarchar(255) not null,',
-          '  [archived] bit not null',
-          ')',
-        ].join('\n'),
-      )
-
-    await pool
-      .request()
-      .query(
-        [
-          'create table [tasks] (',
-          '  [id] int primary key,',
-          '  [project_id] int not null,',
-          '  [title] nvarchar(255) not null,',
-          '  [state] nvarchar(32) not null',
-          ')',
-        ].join('\n'),
-      )
+    await setupAdapterIntegrationSchema(async (statement) => {
+      await pool.request().query(statement)
+    }, 'mssql')
   })
 
   after(async () => {
@@ -70,9 +34,9 @@ describe('mssql adapter integration', () => {
       return
     }
 
-    await pool.request().query("if object_id('tasks', 'U') is not null drop table [tasks]")
-    await pool.request().query("if object_id('projects', 'U') is not null drop table [projects]")
-    await pool.request().query("if object_id('accounts', 'U') is not null drop table [accounts]")
+    await teardownAdapterIntegrationSchema(async (statement) => {
+      await pool.request().query(statement)
+    }, 'mssql')
     await pool.close()
   })
 
@@ -80,9 +44,9 @@ describe('mssql adapter integration', () => {
     integrationEnabled,
     createDatabase: () => createDatabase(createMssqlDatabaseAdapter(pool)),
     resetDatabase: async () => {
-      await pool.request().query('delete from [tasks]')
-      await pool.request().query('delete from [projects]')
-      await pool.request().query('delete from [accounts]')
+      await resetAdapterIntegrationSchema(async (statement) => {
+        await pool.request().query(statement)
+      }, 'mssql')
     },
   })
 
@@ -90,13 +54,13 @@ describe('mssql adapter integration', () => {
   // verify that committed rows are visible or that rolled-back rows are discarded
   // at the driver level, so these tests confirm the mssql driver's transaction
   // semantics directly.
-  let txAccounts = createTable({
+  let txAccounts = table({
     name: 'accounts',
     columns: {
-      id: number(),
-      email: string(),
-      status: string(),
-      nickname: nullable(string()),
+      id: column.integer(),
+      email: column.text(),
+      status: column.text(),
+      nickname: column.text().nullable(),
     },
   })
 
@@ -542,29 +506,29 @@ describe('mssql adapter integration', () => {
       await pool.request().query('delete from [data_types]')
     })
 
-    let dataTypes = createTable({
+    let dataTypes = table({
       name: 'data_types',
       columns: {
-        id: number(),
-        col_tinyint: any(),
-        col_smallint: any(),
-        col_int: any(),
-        col_bigint: any(),
-        col_decimal: any(),
-        col_numeric: any(),
-        col_float: any(),
-        col_real: any(),
-        col_money: any(),
-        col_smallmoney: any(),
-        col_bit: any(),
-        col_char: any(),
-        col_varchar: any(),
-        col_nchar: any(),
-        col_nvarchar: any(),
-        col_date: any(),
-        col_datetime: any(),
-        col_datetime2: any(),
-        col_uniqueidentifier: any(),
+        id: column.integer(),
+        col_tinyint: column.integer().nullable(),
+        col_smallint: column.integer().nullable(),
+        col_int: column.integer().nullable(),
+        col_bigint: column.bigint().nullable(),
+        col_decimal: column.decimal(10, 2).nullable(),
+        col_numeric: column.decimal(18, 4).nullable(),
+        col_float: column.decimal(15, 10).nullable(),
+        col_real: column.decimal(7, 5).nullable(),
+        col_money: column.decimal(19, 4).nullable(),
+        col_smallmoney: column.decimal(10, 4).nullable(),
+        col_bit: column.boolean().nullable(),
+        col_char: column.text().nullable(),
+        col_varchar: column.text().nullable(),
+        col_nchar: column.text().nullable(),
+        col_nvarchar: column.text().nullable(),
+        col_date: column.date().nullable(),
+        col_datetime: column.timestamp().nullable(),
+        col_datetime2: column.timestamp().nullable(),
+        col_uniqueidentifier: column.uuid().nullable(),
       },
     })
 
@@ -727,17 +691,17 @@ describe('mssql adapter integration', () => {
       await pool.request().query('delete from [type_params]')
     })
 
-    let typeParams = createTable({
+    let typeParams = table({
       name: 'type_params',
       columns: {
-        id: number(),
-        int_val: nullable(any()),
-        float_val: nullable(any()),
-        decimal_val: nullable(any()),
-        bit_val: nullable(any()),
-        varchar_val: nullable(any()),
-        nvarchar_val: nullable(any()),
-        datetime2_val: nullable(any()),
+        id: column.integer(),
+        int_val: column.integer().nullable(),
+        float_val: column.decimal(15, 10).nullable(),
+        decimal_val: column.decimal(10, 2).nullable(),
+        bit_val: column.boolean().nullable(),
+        varchar_val: column.text().nullable(),
+        nvarchar_val: column.text().nullable(),
+        datetime2_val: column.timestamp().nullable(),
       },
     })
 
@@ -839,5 +803,259 @@ describe('mssql adapter integration', () => {
         assert.equal(result.affectedRows, 2)
       },
     )
+  })
+
+  // ── DDL migration operations ─────────────────────────────────────────
+
+  describe('DDL migration operations', () => {
+    before(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query("if object_id('ddl_test', 'U') is not null drop table [ddl_test]")
+      await pool
+        .request()
+        .query("if object_id('ddl_renamed', 'U') is not null drop table [ddl_renamed]")
+    })
+
+    after(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query("if object_id('ddl_test', 'U') is not null drop table [ddl_test]")
+      await pool
+        .request()
+        .query("if object_id('ddl_renamed', 'U') is not null drop table [ddl_renamed]")
+    })
+
+    it(
+      'creates a table, alters columns, creates/drops indexes, and renames table via DDL ops',
+      { skip: !integrationEnabled },
+      async () => {
+        let adapter = createMssqlDatabaseAdapter(pool)
+
+        // createTable with ifNotExists
+        await adapter.migrate({
+          operation: {
+            kind: 'createTable',
+            table: { name: 'ddl_test' },
+            ifNotExists: true,
+            columns: {
+              id: { type: 'integer', nullable: false },
+              name: { type: 'varchar', length: 100, nullable: false },
+              email: { type: 'text' },
+            },
+            primaryKey: { name: 'ddl_test_pk', columns: ['id'] },
+          },
+          transaction: undefined,
+        })
+
+        let hasTable = await adapter.hasTable({ name: 'ddl_test' })
+        assert.equal(hasTable, true)
+
+        let hasIdColumn = await adapter.hasColumn({ name: 'ddl_test' }, 'id')
+        assert.equal(hasIdColumn, true)
+
+        // createIndex with ifNotExists
+        await adapter.migrate({
+          operation: {
+            kind: 'createIndex',
+            ifNotExists: true,
+            index: {
+              table: { name: 'ddl_test' },
+              name: 'ddl_test_name_idx',
+              columns: ['name'],
+            },
+          },
+          transaction: undefined,
+        })
+
+        // idempotent — running again should not throw
+        await adapter.migrate({
+          operation: {
+            kind: 'createIndex',
+            ifNotExists: true,
+            index: {
+              table: { name: 'ddl_test' },
+              name: 'ddl_test_name_idx',
+              columns: ['name'],
+            },
+          },
+          transaction: undefined,
+        })
+
+        // alterTable: addColumn, changeColumn with nullable: true, changeColumn with nullable: false
+        await adapter.migrate({
+          operation: {
+            kind: 'alterTable',
+            table: { name: 'ddl_test' },
+            changes: [
+              {
+                kind: 'addColumn',
+                column: 'status',
+                definition: { type: 'varchar', length: 32, nullable: true },
+              },
+              {
+                kind: 'changeColumn',
+                column: 'name',
+                definition: { type: 'varchar', length: 200 },
+              },
+              {
+                kind: 'changeColumn',
+                column: 'email',
+                definition: { type: 'varchar', length: 320, nullable: false },
+              },
+            ],
+          },
+          transaction: undefined,
+        })
+
+        let hasStatusColumn = await adapter.hasColumn({ name: 'ddl_test' }, 'status')
+        assert.equal(hasStatusColumn, true)
+
+        // Insert a row to verify the schema change actually worked
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+        let ddlTable = table({
+          name: 'ddl_test',
+          columns: {
+            id: column.integer(),
+            name: column.text(),
+            email: column.text(),
+            status: column.text().nullable(),
+          },
+        })
+
+        await db.query(ddlTable).insert({
+          id: 1,
+          name: 'a'.repeat(200),
+          email: 'test@example.com',
+          status: null,
+        })
+
+        let rows = await db.query(ddlTable).where(eq('id', 1)).all()
+        assert.equal(rows.length, 1)
+        assert.equal(rows[0].name.length, 200)
+        assert.equal(rows[0].status, null)
+
+        // dropIndex
+        await adapter.migrate({
+          operation: {
+            kind: 'dropIndex',
+            table: { name: 'ddl_test' },
+            name: 'ddl_test_name_idx',
+            ifExists: true,
+          },
+          transaction: undefined,
+        })
+
+        // dropTable with ifExists (idempotent)
+        await adapter.migrate({
+          operation: {
+            kind: 'dropTable',
+            table: { name: 'ddl_test' },
+            ifExists: true,
+          },
+          transaction: undefined,
+        })
+
+        let hasTableAfterDrop = await adapter.hasTable({ name: 'ddl_test' })
+        assert.equal(hasTableAfterDrop, false)
+
+        // idempotent — should not throw
+        await adapter.migrate({
+          operation: {
+            kind: 'dropTable',
+            table: { name: 'ddl_test' },
+            ifExists: true,
+          },
+          transaction: undefined,
+        })
+      },
+    )
+  })
+
+  // ── Offset without explicit orderBy ──────────────────────────────────
+
+  describe('offset without explicit orderBy', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'returns results when offset is used without an explicit orderBy',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+        await db.query(txAccounts).insertMany([
+          { id: 1, email: 'a@test.com', status: 'active', nickname: null },
+          { id: 2, email: 'b@test.com', status: 'active', nickname: null },
+          { id: 3, email: 'c@test.com', status: 'active', nickname: null },
+        ])
+
+        let rows = await db.query(txAccounts).offset(1).all()
+
+        assert.equal(rows.length, 2)
+      },
+    )
+  })
+
+  // ── Returning with update and delete ─────────────────────────────────
+
+  describe('returning with update and delete', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'returns affected rows for update with OUTPUT clause',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(
+          createMssqlDatabaseAdapter(pool, { capabilities: { returning: true } }),
+        )
+
+        await db.query(txAccounts).insertMany([
+          { id: 1, email: 'a@test.com', status: 'active', nickname: null },
+          { id: 2, email: 'b@test.com', status: 'active', nickname: null },
+        ])
+
+        let result = await db
+          .query(txAccounts)
+          .where(eq('status', 'active'))
+          .update({ status: 'paused' }, { returning: '*' })
+
+        assert.equal(result.affectedRows, 2)
+        assert.ok('rows' in result)
+        if ('rows' in result) {
+          assert.equal(result.rows.length, 2)
+        }
+      },
+    )
+
+    it('returns deleted rows with OUTPUT clause', { skip: !integrationEnabled }, async () => {
+      let db = createDatabase(
+        createMssqlDatabaseAdapter(pool, { capabilities: { returning: true } }),
+      )
+
+      await db.query(txAccounts).insertMany([
+        { id: 1, email: 'a@test.com', status: 'active', nickname: null },
+        { id: 2, email: 'b@test.com', status: 'inactive', nickname: null },
+      ])
+
+      let result = await db
+        .query(txAccounts)
+        .where(eq('status', 'active'))
+        .delete({ returning: '*' })
+
+      assert.equal(result.affectedRows, 1)
+      assert.ok('rows' in result)
+      if ('rows' in result) {
+        assert.equal(result.rows.length, 1)
+        assert.equal(result.rows[0].id, 1)
+      }
+
+      let remaining = await db.query(txAccounts).all()
+      assert.equal(remaining.length, 1)
+      assert.equal(remaining[0].id, 2)
+    })
   })
 })

--- a/packages/data-table-mssql/src/lib/adapter.integration.test.ts
+++ b/packages/data-table-mssql/src/lib/adapter.integration.test.ts
@@ -1,0 +1,521 @@
+import { after, before, beforeEach, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { nullable, number, string } from '@remix-run/data-schema'
+import { createDatabase, createTable, eq } from '@remix-run/data-table'
+import sql, { type ConnectionPool } from 'mssql'
+
+import { runAdapterIntegrationContract } from '../../../data-table/test/adapter-integration-contract.ts'
+
+import { createMssqlDatabaseAdapter } from './adapter.ts'
+
+let integrationEnabled =
+  process.env.DATA_TABLE_INTEGRATION === '1' && typeof process.env.DATA_TABLE_MSSQL_URL === 'string'
+
+describe('mssql adapter integration', () => {
+  let pool: ConnectionPool
+
+  before(async () => {
+    if (!integrationEnabled) {
+      return
+    }
+
+    pool = await sql.connect(process.env.DATA_TABLE_MSSQL_URL as string)
+
+    await pool.request().query('if object_id(\'tasks\', \'U\') is not null drop table [tasks]')
+    await pool.request().query('if object_id(\'projects\', \'U\') is not null drop table [projects]')
+    await pool.request().query('if object_id(\'accounts\', \'U\') is not null drop table [accounts]')
+
+    await pool.request().query(
+      [
+        'create table [accounts] (',
+        '  [id] int primary key,',
+        '  [email] nvarchar(255) not null,',
+        '  [status] nvarchar(32) not null,',
+        '  [nickname] nvarchar(255) null',
+        ')',
+      ].join('\n'),
+    )
+
+    await pool.request().query(
+      [
+        'create table [projects] (',
+        '  [id] int primary key,',
+        '  [account_id] int not null,',
+        '  [name] nvarchar(255) not null,',
+        '  [archived] bit not null',
+        ')',
+      ].join('\n'),
+    )
+
+    await pool.request().query(
+      [
+        'create table [tasks] (',
+        '  [id] int primary key,',
+        '  [project_id] int not null,',
+        '  [title] nvarchar(255) not null,',
+        '  [state] nvarchar(32) not null',
+        ')',
+      ].join('\n'),
+    )
+  })
+
+  after(async () => {
+    if (!integrationEnabled) {
+      return
+    }
+
+    await pool.request().query('if object_id(\'tasks\', \'U\') is not null drop table [tasks]')
+    await pool.request().query('if object_id(\'projects\', \'U\') is not null drop table [projects]')
+    await pool.request().query('if object_id(\'accounts\', \'U\') is not null drop table [accounts]')
+    await pool.close()
+  })
+
+  runAdapterIntegrationContract({
+    integrationEnabled,
+    createDatabase: () => createDatabase(createMssqlDatabaseAdapter(pool)),
+    resetDatabase: async () => {
+      await pool.request().query('delete from [tasks]')
+      await pool.request().query('delete from [projects]')
+      await pool.request().query('delete from [accounts]')
+    },
+  })
+
+  // MSSQL-specific transaction tests: The shared integration contract does not
+  // verify that committed rows are visible or that rolled-back rows are discarded
+  // at the driver level, so these tests confirm the mssql driver's transaction
+  // semantics directly.
+  let txAccounts = createTable({
+    name: 'accounts',
+    columns: {
+      id: number(),
+      email: string(),
+      status: string(),
+      nickname: nullable(string()),
+    },
+  })
+
+  describe('transaction commit', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'persists rows inserted inside a committed transaction',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+        await db.transaction(async tx => {
+          await tx.query(txAccounts).insertMany([
+            { id: 1, email: 'a@test.com', status: 'active', nickname: null },
+          ])
+        })
+
+        let result = await pool.request().query('select [id] from [accounts] order by [id]')
+        assert.deepEqual(
+          result.recordset.map((r: { id: number }) => r.id),
+          [1],
+          'row inserted inside committed transaction must be visible after commit',
+        )
+      },
+    )
+  })
+
+  describe('transaction rollback', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'discards rows inserted inside a rolled-back transaction',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+        await assert.rejects(() =>
+          db.transaction(async tx => {
+            await tx.query(txAccounts).insertMany([
+              { id: 2, email: 'b@test.com', status: 'active', nickname: null },
+            ])
+            throw new Error('forced rollback')
+          }),
+        )
+
+        let result = await pool.request().query('select [id] from [accounts] order by [id]')
+        assert.deepEqual(
+          result.recordset.map((r: { id: number }) => r.id),
+          [],
+          'row inserted inside rolled-back transaction must not be visible after rollback',
+        )
+      },
+    )
+  })
+
+  describe('transaction isolation level', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'applies the requested isolation level without error',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+        await db.query(txAccounts).insertMany([
+          { id: 1, email: 'a@test.com', status: 'active', nickname: null },
+          { id: 2, email: 'b@test.com', status: 'active', nickname: null },
+        ])
+
+        let count = await db.transaction(
+          async (tx) => tx.count(txAccounts),
+          { isolationLevel: 'serializable' },
+        )
+
+        assert.equal(count, 2)
+      },
+    )
+  })
+
+  describe('limit and offset pagination', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'paginates results with limit and offset',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+        await db.query(txAccounts).insertMany([
+          { id: 1, email: 'a@test.com', status: 'active', nickname: null },
+          { id: 2, email: 'b@test.com', status: 'active', nickname: null },
+          { id: 3, email: 'c@test.com', status: 'active', nickname: null },
+          { id: 4, email: 'd@test.com', status: 'active', nickname: null },
+        ])
+
+        let page1 = await db.query(txAccounts).orderBy('id', 'asc').limit(2).offset(0).all()
+
+        assert.deepEqual(
+          page1.map((r) => r.id),
+          [1, 2],
+        )
+
+        let page2 = await db.query(txAccounts).orderBy('id', 'asc').limit(2).offset(2).all()
+
+        assert.deepEqual(
+          page2.map((r) => r.id),
+          [3, 4],
+        )
+      },
+    )
+  })
+
+  // ── Transaction option permutations ──────────────────────────────────
+
+  describe('transaction with readOnly option', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'ignores readOnly true and completes without error',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+        await db.query(txAccounts).insert({
+          id: 1,
+          email: 'ro@test.com',
+          status: 'active',
+          nickname: null,
+        })
+
+        let count = await db.transaction(
+          async (tx) => tx.count(txAccounts),
+          { readOnly: true },
+        )
+
+        assert.equal(count, 1)
+      },
+    )
+  })
+
+  describe('transaction with isolationLevel and readOnly combined', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'applies isolation level and ignores readOnly when both are set',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+        await db.query(txAccounts).insert({
+          id: 1,
+          email: 'both@test.com',
+          status: 'active',
+          nickname: null,
+        })
+
+        let count = await db.transaction(
+          async (tx) => tx.count(txAccounts),
+          { isolationLevel: 'serializable', readOnly: true },
+        )
+
+        assert.equal(count, 1)
+      },
+    )
+
+    it(
+      'writes succeed when readOnly is true because MSSQL ignores it',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+        await db.transaction(
+          async (tx) => {
+            await tx.query(txAccounts).insert({
+              id: 1,
+              email: 'write-ro@test.com',
+              status: 'active',
+              nickname: null,
+            })
+          },
+          { isolationLevel: 'read committed', readOnly: true },
+        )
+
+        let result = await pool.request().query('select [id] from [accounts]')
+        assert.equal(result.recordset.length, 1)
+      },
+    )
+  })
+
+  // ── Capability override tests ────────────────────────────────────────
+
+  describe('capabilities returning: true', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'uses OUTPUT clause for insert when returning is enabled',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(
+          createMssqlDatabaseAdapter(pool, { capabilities: { returning: true } }),
+        )
+
+        let created = await db.create(
+          txAccounts,
+          { id: 1, email: 'ret@test.com', status: 'active', nickname: null },
+          { returnRow: true },
+        )
+
+        assert.equal(created.id, 1)
+        assert.equal(created.email, 'ret@test.com')
+      },
+    )
+  })
+
+  describe('capabilities returning: false (default)', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'falls back to a SELECT after insert when returning is disabled',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+        let created = await db.create(
+          txAccounts,
+          { id: 1, email: 'noret@test.com', status: 'active', nickname: null },
+          { returnRow: true },
+        )
+
+        assert.equal(created.id, 1)
+        assert.equal(created.email, 'noret@test.com')
+      },
+    )
+  })
+
+  describe('capabilities savepoints: true (default)', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'supports nested transactions via savepoints',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+        await db.transaction(async (outerTx) => {
+          await outerTx.query(txAccounts).insert({
+            id: 1,
+            email: 'outer@test.com',
+            status: 'active',
+            nickname: null,
+          })
+
+          await outerTx
+            .transaction(async (innerTx) => {
+              await innerTx.query(txAccounts).insert({
+                id: 2,
+                email: 'inner@test.com',
+                status: 'active',
+                nickname: null,
+              })
+              throw new Error('rollback inner savepoint')
+            })
+            .catch(() => undefined)
+        })
+
+        let result = await pool
+          .request()
+          .query('select [id] from [accounts] order by [id]')
+        assert.deepEqual(
+          result.recordset.map((r: { id: number }) => r.id),
+          [1],
+          'inner savepoint rollback should discard inner row but keep outer row',
+        )
+      },
+    )
+  })
+
+  describe('capabilities savepoints: false', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'throws when attempting nested transactions without savepoint support',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(
+          createMssqlDatabaseAdapter(pool, { capabilities: { savepoints: false } }),
+        )
+
+        await assert.rejects(
+          () =>
+            db.transaction(async (outerTx) => {
+              await outerTx.transaction(async () => undefined)
+            }),
+          (error: Error) => {
+            assert.match(error.message, /savepoint/i)
+            return true
+          },
+        )
+      },
+    )
+  })
+
+  describe('capabilities upsert: true (default)', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'performs upsert using MERGE when upsert capability is enabled',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+        await db.query(txAccounts).insert({
+          id: 1,
+          email: 'before@test.com',
+          status: 'active',
+          nickname: null,
+        })
+
+        await db.query(txAccounts).upsert(
+          { id: 1, email: 'after@test.com', status: 'active', nickname: null },
+          { conflictTarget: ['id'] },
+        )
+
+        let rows = await db.query(txAccounts).where(eq('id', 1)).all()
+        assert.equal(rows.length, 1)
+        assert.equal(rows[0].email, 'after@test.com')
+      },
+    )
+  })
+
+  describe('capabilities upsert: false', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'throws when attempting upsert without upsert capability',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(
+          createMssqlDatabaseAdapter(pool, { capabilities: { upsert: false } }),
+        )
+
+        await assert.rejects(
+          () =>
+            db.query(txAccounts).upsert(
+              { id: 1, email: 'x@test.com', status: 'active', nickname: null },
+              { conflictTarget: ['id'] },
+            ),
+          (error: Error) => {
+            assert.match(error.message, /upsert/i)
+            return true
+          },
+        )
+      },
+    )
+  })
+
+  // ── Transaction rollback with isolation level ────────────────────────
+
+  describe('transaction rollback with isolation level', () => {
+    beforeEach(async () => {
+      if (!integrationEnabled) return
+      await pool.request().query('delete from [accounts]')
+    })
+
+    it(
+      'rolls back writes under serializable isolation',
+      { skip: !integrationEnabled },
+      async () => {
+        let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+        await assert.rejects(() =>
+          db.transaction(
+            async (tx) => {
+              await tx.query(txAccounts).insert({
+                id: 1,
+                email: 'rollser@test.com',
+                status: 'active',
+                nickname: null,
+              })
+              throw new Error('forced rollback')
+            },
+            { isolationLevel: 'serializable' },
+          ),
+        )
+
+        let result = await pool.request().query('select [id] from [accounts]')
+        assert.equal(result.recordset.length, 0)
+      },
+    )
+  })
+})

--- a/packages/data-table-mssql/src/lib/adapter.test.ts
+++ b/packages/data-table-mssql/src/lib/adapter.test.ts
@@ -1,0 +1,655 @@
+import * as assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { number, string } from '@remix-run/data-schema'
+import { createDatabase, createTable, eq, ilike, inList, sql } from '@remix-run/data-table'
+
+import { createMssqlDatabaseAdapter } from './adapter.ts'
+
+let accounts = createTable({
+  name: 'accounts',
+  columns: {
+    id: number(),
+    email: string(),
+  },
+})
+
+let projects = createTable({
+  name: 'projects',
+  columns: {
+    id: number(),
+    account_id: number(),
+    name: string(),
+  },
+})
+
+describe('mssql adapter', () => {
+  /**
+   * Creates a mock pool whose transaction records lifecycle events (begin, commit,
+   * rollback) and executed SQL text into the returned `lifecycle` array.
+   */
+  function createLifecyclePool() {
+    let lifecycle: string[] = []
+
+    let transaction = {
+      async begin() {
+        lifecycle.push('begin')
+      },
+      async commit() {
+        lifecycle.push('commit')
+      },
+      async rollback() {
+        lifecycle.push('rollback')
+      },
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query(text: string) {
+            lifecycle.push(text)
+            return { recordset: [], rowsAffected: [0] }
+          },
+        }
+      },
+    }
+
+    let pool = {
+      request() {
+        throw new Error('not used')
+      },
+      transaction() {
+        return transaction
+      },
+    }
+
+    return { pool: pool as never, lifecycle }
+  }
+
+  it('compiles ilike() with lower() and parses count results', async () => {
+    let statements: Array<{ text: string; values: unknown[] }> = []
+
+    let pool = {
+      request() {
+        let values: unknown[] = []
+
+        return {
+          input(_name: string, value: unknown) {
+            values.push(value)
+            return this
+          },
+          async query(text: string) {
+            statements.push({ text, values: [...values] })
+            return {
+              recordset: [{ count: '3' }],
+              rowsAffected: [1],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(createMssqlDatabaseAdapter(pool as never))
+
+    let count = await db.query(accounts).where(ilike('email', '%EXAMPLE%')).count()
+
+    assert.equal(count, 3)
+    assert.match(statements[0].text, /lower\(\[email\]\) like lower\(@p1\)/)
+    assert.deepEqual(statements[0].values, ['%EXAMPLE%'])
+  })
+
+  it('starts and commits transactions on pooled connections', async () => {
+    let lifecycle: string[] = []
+
+    let transaction = {
+      async begin() {
+        lifecycle.push('begin')
+      },
+      async commit() {
+        lifecycle.push('commit')
+      },
+      async rollback() {
+        lifecycle.push('rollback')
+      },
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query() {
+            lifecycle.push('query')
+            return {
+              recordset: [],
+              rowsAffected: [1],
+            }
+          },
+        }
+      },
+    }
+
+    let pool = {
+      request() {
+        throw new Error('unexpected root query')
+      },
+      transaction() {
+        lifecycle.push('transaction')
+        return transaction
+      },
+    }
+
+    let db = createDatabase(createMssqlDatabaseAdapter(pool as never))
+
+    await db.transaction(async (transactionDatabase) => {
+      await transactionDatabase.query(accounts).insert({ id: 1, email: 'a@example.com' })
+    })
+
+    assert.deepEqual(lifecycle, ['transaction', 'begin', 'query', 'commit'])
+  })
+
+  it('applies isolationLevel serializable', async () => {
+    let { pool, lifecycle } = createLifecyclePool()
+    let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+    await db.transaction(async () => undefined, { isolationLevel: 'serializable' })
+
+    assert.deepEqual(lifecycle, ['begin', 'set transaction isolation level serializable', 'commit'])
+  })
+
+  it('applies isolationLevel read uncommitted', async () => {
+    let { pool, lifecycle } = createLifecyclePool()
+    let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+    await db.transaction(async () => undefined, { isolationLevel: 'read uncommitted' })
+
+    assert.deepEqual(lifecycle, [
+      'begin',
+      'set transaction isolation level read uncommitted',
+      'commit',
+    ])
+  })
+
+  it('applies isolationLevel read committed', async () => {
+    let { pool, lifecycle } = createLifecyclePool()
+    let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+    await db.transaction(async () => undefined, { isolationLevel: 'read committed' })
+
+    assert.deepEqual(lifecycle, [
+      'begin',
+      'set transaction isolation level read committed',
+      'commit',
+    ])
+  })
+
+  it('applies isolationLevel repeatable read', async () => {
+    let { pool, lifecycle } = createLifecyclePool()
+    let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+    await db.transaction(async () => undefined, { isolationLevel: 'repeatable read' })
+
+    assert.deepEqual(lifecycle, [
+      'begin',
+      'set transaction isolation level repeatable read',
+      'commit',
+    ])
+  })
+
+  it('ignores readOnly true and does not emit any SQL for it', async () => {
+    let { pool, lifecycle } = createLifecyclePool()
+    let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+    await db.transaction(async () => undefined, { readOnly: true })
+
+    // No SET TRANSACTION READ ONLY should appear — MSSQL does not support it.
+    assert.deepEqual(lifecycle, ['begin', 'commit'])
+  })
+
+  it('ignores readOnly false and does not emit any SQL for it', async () => {
+    let { pool, lifecycle } = createLifecyclePool()
+    let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+    await db.transaction(async () => undefined, { readOnly: false })
+
+    assert.deepEqual(lifecycle, ['begin', 'commit'])
+  })
+
+  it('applies isolationLevel and ignores readOnly when both are provided', async () => {
+    let { pool, lifecycle } = createLifecyclePool()
+    let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+    await db.transaction(async () => undefined, {
+      isolationLevel: 'serializable',
+      readOnly: true,
+    })
+
+    // Only the isolation level SQL is emitted; readOnly is silently ignored.
+    assert.deepEqual(lifecycle, ['begin', 'set transaction isolation level serializable', 'commit'])
+  })
+
+  it('emits no option SQL when transaction is called with empty options', async () => {
+    let { pool, lifecycle } = createLifecyclePool()
+    let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+    await db.transaction(async () => undefined, {})
+
+    assert.deepEqual(lifecycle, ['begin', 'commit'])
+  })
+
+  it('compiles column-to-column comparisons from string references', async () => {
+    let statements: Array<{ text: string; values: unknown[] }> = []
+
+    let pool = {
+      request() {
+        let values: unknown[] = []
+
+        return {
+          input(_name: string, value: unknown) {
+            values.push(value)
+            return this
+          },
+          async query(text: string) {
+            statements.push({ text, values: [...values] })
+
+            return {
+              recordset: [{ count: '0' }],
+              rowsAffected: [1],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(createMssqlDatabaseAdapter(pool as never))
+
+    await db
+      .query(accounts)
+      .join(projects, eq('accounts.id', 'projects.account_id'))
+      .where(eq('accounts.email', 'ops@example.com'))
+      .count()
+
+    assert.match(statements[0].text, /\[accounts\]\.\[id\]\s*=\s*\[projects\]\.\[account_id\]/)
+    assert.match(statements[0].text, /\[accounts\]\.\[email\]\s*=\s*@p1/)
+    assert.deepEqual(statements[0].values, ['ops@example.com'])
+  })
+
+  it('does not create dangling bind parameters for inList predicates', async () => {
+    let statements: Array<{ text: string; values: unknown[] }> = []
+
+    let pool = {
+      request() {
+        let values: unknown[] = []
+
+        return {
+          input(_name: string, value: unknown) {
+            values.push(value)
+            return this
+          },
+          async query(text: string) {
+            statements.push({ text, values: [...values] })
+
+            return {
+              recordset: [{ count: '0' }],
+              rowsAffected: [1],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(createMssqlDatabaseAdapter(pool as never))
+
+    await db
+      .query(accounts)
+      .where(inList('id', [1, 3]))
+      .count()
+
+    assert.match(statements[0].text, /\[id\]\s+in\s+\(@p1,\s*@p2\)/)
+    assert.deepEqual(statements[0].values, [1, 3])
+  })
+
+  it('loads the inserted row for create({ returnRow: true }) without RETURNING support', async () => {
+    let statements: Array<{ text: string; values: unknown[] }> = []
+    let calls = 0
+
+    let pool = {
+      request() {
+        let values: unknown[] = []
+
+        return {
+          input(_name: string, value: unknown) {
+            values.push(value)
+            return this
+          },
+          async query(text: string) {
+            calls += 1
+            statements.push({ text, values: [...values] })
+
+            if (calls === 1) {
+              return {
+                recordset: [],
+                rowsAffected: [1],
+              }
+            }
+
+            if (calls === 2) {
+              return {
+                recordset: [{ id: 2, email: 'fallback@example.com' }],
+                rowsAffected: [1],
+              }
+            }
+
+            throw new Error('unexpected query call')
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(createMssqlDatabaseAdapter(pool as never))
+
+    let created = await db.create(
+      accounts,
+      {
+        id: 2,
+        email: 'fallback@example.com',
+      },
+      { returnRow: true },
+    )
+
+    assert.equal(created.id, 2)
+    assert.equal(created.email, 'fallback@example.com')
+    assert.equal(statements.length, 2)
+    assert.match(statements[0].text, /^insert into \[accounts\]/)
+    assert.match(statements[1].text, /^select top \(1\) \* from \[accounts\]/)
+    assert.match(statements[1].text, /where \(\(\[id\] = @p1\)\)/)
+    assert.deepEqual(statements[1].values, [2])
+  })
+
+  it('compiles upsert statements with merge using conflict targets', async () => {
+    let statements: Array<{ text: string; values: unknown[] }> = []
+
+    let pool = {
+      request() {
+        let values: unknown[] = []
+
+        return {
+          input(_name: string, value: unknown) {
+            values.push(value)
+            return this
+          },
+          async query(text: string) {
+            statements.push({ text, values: [...values] })
+
+            return {
+              recordset: [],
+              rowsAffected: [1],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(createMssqlDatabaseAdapter(pool as never))
+
+    await db.query(accounts).upsert(
+      {
+        id: 7,
+        email: 'upsert@example.com',
+      },
+      {
+        conflictTarget: ['id'],
+      },
+    )
+
+    assert.match(statements[0].text, /^merge \[accounts\] with \(holdlock\) as target using \(values \(@p1, @p2\)\)/)
+    assert.match(statements[0].text, /on target\.\[id\] = source\.\[id\]/)
+    assert.match(statements[0].text, /when matched then update set target\.\[id\] = @p3, target\.\[email\] = @p4/)
+    assert.match(statements[0].text, /when not matched then insert \(\[id\], \[email\]\) values \(source\.\[id\], source\.\[email\]\)/)
+    assert.deepEqual(statements[0].values, [7, 'upsert@example.com', 7, 'upsert@example.com'])
+  })
+
+  it('rewrites raw sql ? placeholders to named @p1, @p2, … parameters', async () => {
+    let statements: Array<{ text: string; values: unknown[] }> = []
+
+    let pool = {
+      request() {
+        let values: unknown[] = []
+
+        return {
+          input(_name: string, value: unknown) {
+            values.push(value)
+            return this
+          },
+          async query(text: string) {
+            statements.push({ text, values: [...values] })
+            return {
+              recordset: [],
+              rowsAffected: [0],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(createMssqlDatabaseAdapter(pool as never))
+
+    await db.exec(sql`select * from accounts where id = ${42} and email = ${'a@example.com'}`)
+
+    assert.equal(statements[0].text, 'select * from accounts where id = @p1 and email = @p2')
+    assert.deepEqual(statements[0].values, [42, 'a@example.com'])
+  })
+
+  it('uses T-SQL savepoints for nested transactions and omits release', async () => {
+    let lifecycle: string[] = []
+
+    let transaction = {
+      async begin() {
+        lifecycle.push('begin')
+      },
+      async commit() {
+        lifecycle.push('commit')
+      },
+      async rollback() {
+        lifecycle.push('rollback')
+      },
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query(text: string) {
+            lifecycle.push(text)
+            return {
+              recordset: [],
+              rowsAffected: [0],
+            }
+          },
+        }
+      },
+    }
+
+    let pool = {
+      request() {
+        throw new Error('not used')
+      },
+      transaction() {
+        lifecycle.push('transaction')
+        return transaction
+      },
+    }
+
+    let db = createDatabase(createMssqlDatabaseAdapter(pool as never))
+
+    await db.transaction(async (outerTx) => {
+      await outerTx
+        .transaction(async () => {
+          throw new Error('abort nested')
+        })
+        .catch(() => undefined)
+    })
+
+    assert.deepEqual(lifecycle, [
+      'transaction',
+      'begin',
+      'save transaction [sp_0]',
+      'rollback transaction [sp_0]',
+      // releaseSavepoint is a no-op for MSSQL — no RELEASE SAVEPOINT SQL
+      'commit',
+    ])
+  })
+
+  it('emits TOP (n) for limit-only selects without offset', async () => {
+    let statements: Array<{ text: string }> = []
+
+    let pool = {
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query(text: string) {
+            statements.push({ text })
+            return {
+              recordset: [],
+              rowsAffected: [0],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(createMssqlDatabaseAdapter(pool as never))
+
+    await db.query(accounts).limit(5).orderBy('id', 'asc').all()
+
+    assert.match(statements[0].text, /^select top \(5\)/)
+    assert.doesNotMatch(statements[0].text, /offset/)
+  })
+
+  it('emits OFFSET…FETCH NEXT for limit + offset selects and omits TOP', async () => {
+    let statements: Array<{ text: string }> = []
+
+    let pool = {
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query(text: string) {
+            statements.push({ text })
+            return {
+              recordset: [],
+              rowsAffected: [0],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(createMssqlDatabaseAdapter(pool as never))
+
+    await db.query(accounts).limit(5).offset(10).orderBy('id', 'asc').all()
+
+    assert.doesNotMatch(statements[0].text, /top/)
+    assert.match(statements[0].text, /offset 10 rows fetch next 5 rows only/)
+  })
+
+  it('injects ORDER BY (SELECT 1) when offset is used without an explicit orderBy', async () => {
+    let statements: Array<{ text: string }> = []
+
+    let pool = {
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query(text: string) {
+            statements.push({ text })
+            return {
+              recordset: [],
+              rowsAffected: [0],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(createMssqlDatabaseAdapter(pool as never))
+
+    await db.query(accounts).offset(10).all()
+
+    assert.match(statements[0].text, /order by \(select 1\) offset 10 rows/)
+    assert.doesNotMatch(statements[0].text, /fetch next/)
+  })
+
+  it('uses OUTPUT inserted.* for insert when capabilities.returning is enabled', async () => {
+    let statements: Array<{ text: string; values: unknown[] }> = []
+    let calls = 0
+
+    let pool = {
+      request() {
+        let values: unknown[] = []
+
+        return {
+          input(_name: string, value: unknown) {
+            values.push(value)
+            return this
+          },
+          async query(text: string) {
+            calls += 1
+            statements.push({ text, values: [...values] })
+            return {
+              recordset: [{ id: 3, email: 'output@example.com' }],
+              rowsAffected: [1],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(
+      createMssqlDatabaseAdapter(pool as never, { capabilities: { returning: true } }),
+    )
+
+    let created = await db.create(
+      accounts,
+      { id: 3, email: 'output@example.com' },
+      { returnRow: true },
+    )
+
+    assert.equal(created.id, 3)
+    assert.equal(created.email, 'output@example.com')
+    // With returning enabled, a single INSERT…OUTPUT statement is issued (no fallback SELECT)
+    assert.equal(calls, 1)
+    assert.match(statements[0].text, /^insert into \[accounts\]/)
+    assert.match(statements[0].text, / output inserted\.\*/)
+  })
+})

--- a/packages/data-table-mssql/src/lib/adapter.test.ts
+++ b/packages/data-table-mssql/src/lib/adapter.test.ts
@@ -22,6 +22,14 @@ let projects = createTable({
   },
 })
 
+let invoices = createTable({
+  name: 'billing.invoices',
+  columns: {
+    id: number(),
+    account_id: number(),
+  },
+})
+
 describe('mssql adapter', () => {
   /**
    * Creates a mock pool whose transaction records lifecycle events (begin, commit,
@@ -96,7 +104,7 @@ describe('mssql adapter', () => {
     let count = await db.query(accounts).where(ilike('email', '%EXAMPLE%')).count()
 
     assert.equal(count, 3)
-    assert.match(statements[0].text, /lower\(\[email\]\) like lower\(@p1\)/)
+    assert.match(statements[0].text, /lower\(\[email\]\) like lower\(@dt_p1\)/)
     assert.deepEqual(statements[0].values, ['%EXAMPLE%'])
   })
 
@@ -154,7 +162,12 @@ describe('mssql adapter', () => {
 
     await db.transaction(async () => undefined, { isolationLevel: 'serializable' })
 
-    assert.deepEqual(lifecycle, ['begin', 'set transaction isolation level serializable', 'commit'])
+    assert.deepEqual(lifecycle, [
+      'begin',
+      'set transaction isolation level serializable',
+      'set transaction isolation level read committed',
+      'commit',
+    ])
   })
 
   it('ignores readOnly true and does not emit any SQL for it', async () => {
@@ -163,7 +176,7 @@ describe('mssql adapter', () => {
 
     await db.transaction(async () => undefined, { readOnly: true })
 
-    // No SET TRANSACTION READ ONLY should appear — MSSQL does not support it.
+    // No SET TRANSACTION READ ONLY should appear - MSSQL does not support it.
     assert.deepEqual(lifecycle, ['begin', 'commit'])
   })
 
@@ -176,8 +189,14 @@ describe('mssql adapter', () => {
       readOnly: true,
     })
 
-    // Only the isolation level SQL is emitted; readOnly is silently ignored.
-    assert.deepEqual(lifecycle, ['begin', 'set transaction isolation level serializable', 'commit'])
+    // Only the isolation level is applied; readOnly is silently ignored.
+    // Isolation level is reset to read committed before commit.
+    assert.deepEqual(lifecycle, [
+      'begin',
+      'set transaction isolation level serializable',
+      'set transaction isolation level read committed',
+      'commit',
+    ])
   })
 
   it('compiles column-to-column comparisons from string references', async () => {
@@ -216,7 +235,7 @@ describe('mssql adapter', () => {
       .count()
 
     assert.match(statements[0].text, /\[accounts\]\.\[id\]\s*=\s*\[projects\]\.\[account_id\]/)
-    assert.match(statements[0].text, /\[accounts\]\.\[email\]\s*=\s*@p1/)
+    assert.match(statements[0].text, /\[accounts\]\.\[email\]\s*=\s*@dt_p1/)
     assert.deepEqual(statements[0].values, ['ops@example.com'])
   })
 
@@ -254,7 +273,7 @@ describe('mssql adapter', () => {
       .where(inList('id', [1, 3]))
       .count()
 
-    assert.match(statements[0].text, /\[id\]\s+in\s+\(@p1,\s*@p2\)/)
+    assert.match(statements[0].text, /\[id\]\s+in\s+\(@dt_p1,\s*@dt_p2\)/)
     assert.deepEqual(statements[0].values, [1, 3])
   })
 
@@ -314,7 +333,7 @@ describe('mssql adapter', () => {
     assert.equal(statements.length, 2)
     assert.match(statements[0].text, /^insert into \[accounts\]/)
     assert.match(statements[1].text, /^select top \(1\) \* from \[accounts\]/)
-    assert.match(statements[1].text, /where \(\(\[id\] = @p1\)\)/)
+    assert.match(statements[1].text, /where \(\(\[id\] = @dt_p1\)\)/)
     assert.deepEqual(statements[1].values, [2])
   })
 
@@ -357,14 +376,23 @@ describe('mssql adapter', () => {
       },
     )
 
-    assert.match(statements[0].text, /^merge \[accounts\] with \(holdlock\) as target using \(values \(@p1, @p2\)\)/)
+    assert.match(
+      statements[0].text,
+      /^merge \[accounts\] with \(holdlock\) as target using \(values \(@dt_p1, @dt_p2\)\)/,
+    )
     assert.match(statements[0].text, /on target\.\[id\] = source\.\[id\]/)
-    assert.match(statements[0].text, /when matched then update set target\.\[id\] = @p3, target\.\[email\] = @p4/)
-    assert.match(statements[0].text, /when not matched then insert \(\[id\], \[email\]\) values \(source\.\[id\], source\.\[email\]\)/)
+    assert.match(
+      statements[0].text,
+      /when matched then update set target\.\[id\] = @dt_p3, target\.\[email\] = @dt_p4/,
+    )
+    assert.match(
+      statements[0].text,
+      /when not matched then insert \(\[id\], \[email\]\) values \(source\.\[id\], source\.\[email\]\)/,
+    )
     assert.deepEqual(statements[0].values, [7, 'upsert@example.com', 7, 'upsert@example.com'])
   })
 
-  it('rewrites raw sql ? placeholders to named @p1, @p2, … parameters', async () => {
+  it('rewrites raw sql ? placeholders to named @dt_p1, @dt_p2, ... parameters', async () => {
     let statements: Array<{ text: string; values: unknown[] }> = []
 
     let pool = {
@@ -394,7 +422,7 @@ describe('mssql adapter', () => {
 
     await db.exec(sql`select * from accounts where id = ${42} and email = ${'a@example.com'}`)
 
-    assert.equal(statements[0].text, 'select * from accounts where id = @p1 and email = @p2')
+    assert.equal(statements[0].text, 'select * from accounts where id = @dt_p1 and email = @dt_p2')
     assert.deepEqual(statements[0].values, [42, 'a@example.com'])
   })
 
@@ -452,7 +480,7 @@ describe('mssql adapter', () => {
       'begin',
       'save transaction [sp_0]',
       'rollback transaction [sp_0]',
-      // releaseSavepoint is a no-op for MSSQL — no RELEASE SAVEPOINT SQL
+      // releaseSavepoint is a no-op for MSSQL - no RELEASE SAVEPOINT SQL
       'commit',
     ])
   })
@@ -488,7 +516,7 @@ describe('mssql adapter', () => {
     assert.doesNotMatch(statements[0].text, /offset/)
   })
 
-  it('emits OFFSET…FETCH NEXT for limit + offset selects and omits TOP', async () => {
+  it('emits OFFSET...FETCH NEXT for limit + offset selects and omits TOP', async () => {
     let statements: Array<{ text: string }> = []
 
     let pool = {
@@ -590,9 +618,111 @@ describe('mssql adapter', () => {
 
     assert.equal(created.id, 3)
     assert.equal(created.email, 'output@example.com')
-    // With returning enabled, a single INSERT…OUTPUT statement is issued (no fallback SELECT)
+    // With returning enabled, a single INSERT...OUTPUT statement is issued (no fallback SELECT)
     assert.equal(calls, 1)
     assert.match(statements[0].text, /^insert into \[accounts\]/)
     assert.match(statements[0].text, / output inserted\.\*/)
+  })
+
+  it('compiles cross-schema table references in joins', async () => {
+    let statements: Array<{ text: string; values: unknown[] }> = []
+
+    let pool = {
+      request() {
+        let values: unknown[] = []
+
+        return {
+          input(_name: string, value: unknown) {
+            values.push(value)
+            return this
+          },
+          async query(text: string) {
+            statements.push({ text, values: [...values] })
+            return {
+              recordset: [{ count: '0' }],
+              rowsAffected: [1],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(createMssqlDatabaseAdapter(pool as never))
+
+    await db.query(invoices).join(accounts, eq(accounts.id, invoices.account_id)).count()
+
+    assert.match(statements[0].text, /from \[billing\]\.\[invoices\]/)
+    assert.match(statements[0].text, /join \[accounts\]/)
+    assert.match(
+      statements[0].text,
+      /\[accounts\]\.\[id\]\s*=\s*\[billing\]\.\[invoices\]\.\[account_id\]/,
+    )
+  })
+
+  it('does not reset isolation level on commit when none was set', async () => {
+    let { pool, lifecycle } = createLifecyclePool()
+    let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+    await db.transaction(async () => undefined)
+
+    // No SET TRANSACTION ISOLATION LEVEL should appear.
+    assert.deepEqual(lifecycle, ['begin', 'commit'])
+  })
+
+  it('attempts best-effort isolation level reset on rollback', async () => {
+    let { pool, lifecycle } = createLifecyclePool()
+    let db = createDatabase(createMssqlDatabaseAdapter(pool))
+
+    await assert.rejects(() =>
+      db.transaction(
+        async () => {
+          throw new Error('forced rollback')
+        },
+        { isolationLevel: 'repeatable read' },
+      ),
+    )
+
+    assert.deepEqual(lifecycle, [
+      'begin',
+      'set transaction isolation level repeatable read',
+      'set transaction isolation level read committed',
+      'rollback',
+    ])
+  })
+
+  it('treats dotted select aliases as single identifiers', async () => {
+    let statements: Array<{ text: string; values: unknown[] }> = []
+
+    let pool = {
+      request() {
+        let values: unknown[] = []
+
+        return {
+          input(_name: string, value: unknown) {
+            values.push(value)
+            return this
+          },
+          async query(text: string) {
+            statements.push({ text, values: [...values] })
+            return {
+              recordset: [],
+              rowsAffected: [0],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(createMssqlDatabaseAdapter(pool as never))
+
+    await db.query(accounts).select({ 'account.email': accounts.email }).all()
+
+    assert.match(statements[0].text, /as \[account\.email\]/)
   })
 })

--- a/packages/data-table-mssql/src/lib/adapter.test.ts
+++ b/packages/data-table-mssql/src/lib/adapter.test.ts
@@ -1,33 +1,43 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { number, string } from '@remix-run/data-schema'
-import { createDatabase, createTable, eq, ilike, inList, sql } from '@remix-run/data-table'
+import type { DataMigrationOperation } from '@remix-run/data-table'
+import { column, createDatabase, table, eq, ilike, inList, sql } from '@remix-run/data-table'
 
 import { createMssqlDatabaseAdapter } from './adapter.ts'
 
-let accounts = createTable({
+let accounts = table({
   name: 'accounts',
   columns: {
-    id: number(),
-    email: string(),
+    id: column.integer(),
+    email: column.text(),
   },
 })
 
-let projects = createTable({
+let projects = table({
   name: 'projects',
   columns: {
-    id: number(),
-    account_id: number(),
-    name: string(),
+    id: column.integer(),
+    account_id: column.integer(),
+    name: column.text(),
   },
 })
 
-let invoices = createTable({
+let invoices = table({
   name: 'billing.invoices',
   columns: {
-    id: number(),
-    account_id: number(),
+    id: column.integer(),
+    account_id: column.integer(),
   },
+})
+
+let accountProjects = table({
+  name: 'account_projects',
+  columns: {
+    account_id: column.integer(),
+    project_id: column.integer(),
+    email: column.text(),
+  },
+  primaryKey: ['account_id', 'project_id'],
 })
 
 describe('mssql adapter', () => {
@@ -624,6 +634,42 @@ describe('mssql adapter', () => {
     assert.match(statements[0].text, / output inserted\.\*/)
   })
 
+  it('does not expose insertId for composite primary keys', async () => {
+    let pool = {
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query() {
+            return {
+              recordset: [{ account_id: 1, project_id: 2, email: 'team@example.com' }],
+              rowsAffected: [1],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(
+      createMssqlDatabaseAdapter(pool as never, { capabilities: { returning: true } }),
+    )
+    let result = await db.query(accountProjects).insert(
+      {
+        account_id: 1,
+        project_id: 2,
+        email: 'team@example.com',
+      },
+      { returning: '*' },
+    )
+
+    assert.equal(result.affectedRows, 1)
+    assert.equal(result.insertId, undefined)
+  })
+
   it('compiles cross-schema table references in joins', async () => {
     let statements: Array<{ text: string; values: unknown[] }> = []
 
@@ -724,5 +770,796 @@ describe('mssql adapter', () => {
     await db.query(accounts).select({ 'account.email': accounts.email }).all()
 
     assert.match(statements[0].text, /as \[account\.email\]/)
+  })
+
+  it('applies explicit capability overrides', () => {
+    let adapter = createMssqlDatabaseAdapter(
+      {
+        request() {
+          throw new Error('not used')
+        },
+        transaction() {
+          throw new Error('not used')
+        },
+      } as never,
+      {
+        capabilities: {
+          returning: false,
+          savepoints: false,
+          upsert: false,
+          transactionalDdl: false,
+          migrationLock: false,
+        },
+      },
+    )
+
+    assert.deepEqual(adapter.capabilities, {
+      returning: false,
+      savepoints: false,
+      upsert: false,
+      transactionalDdl: false,
+      migrationLock: false,
+    })
+  })
+
+  it('short-circuits insertMany([]) and returns empty rows for returning queries', async () => {
+    let pool = {
+      request() {
+        throw new Error('should not be called')
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(
+      createMssqlDatabaseAdapter(pool as never, { capabilities: { returning: true } }),
+    )
+
+    let result = await db.query(accounts).insertMany([], { returning: '*' })
+
+    assert.deepEqual(result, {
+      affectedRows: 0,
+      insertId: undefined,
+      rows: [],
+    })
+  })
+
+  it('throws for unknown transaction tokens', async () => {
+    let pool = {
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query() {
+            return { recordset: [], rowsAffected: [0] }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let adapter = createMssqlDatabaseAdapter(pool as never)
+
+    await assert.rejects(
+      () => adapter.commitTransaction({ id: 'tx_unknown' }),
+      /Unknown transaction token/,
+    )
+
+    await assert.rejects(
+      () => adapter.rollbackTransaction({ id: 'tx_unknown' }),
+      /Unknown transaction token/,
+    )
+  })
+
+  it('checks table and column existence through adapter introspection hooks', async () => {
+    let statements: Array<{ text: string; values: unknown[] }> = []
+
+    let pool = {
+      request() {
+        let values: unknown[] = []
+
+        return {
+          input(_name: string, value: unknown) {
+            values.push(value)
+            return this
+          },
+          async query(text: string) {
+            statements.push({ text, values: [...values] })
+
+            if (text.includes('information_schema')) {
+              return {
+                recordset: [{ exists: 1 }],
+                rowsAffected: [1],
+              }
+            }
+
+            return {
+              recordset: [{ exists: 1 }],
+              rowsAffected: [1],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let adapter = createMssqlDatabaseAdapter(pool as never)
+    let hasTable = await adapter.hasTable({ schema: 'app', name: 'users' })
+    let hasColumn = await adapter.hasColumn({ schema: 'app', name: 'users' }, 'email')
+
+    assert.equal(hasTable, true)
+    assert.equal(hasColumn, true)
+    assert.match(statements[0].text, /object_id/)
+    assert.match(statements[1].text, /information_schema\.columns/)
+    assert.match(statements[1].text, /table_schema = @dt_p1/)
+    assert.deepEqual(statements[1].values, ['app', 'users', 'email'])
+  })
+
+  it('checks table and column existence without a schema qualifier', async () => {
+    let statements: Array<{ text: string; values: unknown[] }> = []
+
+    let pool = {
+      request() {
+        let values: unknown[] = []
+
+        return {
+          input(_name: string, value: unknown) {
+            values.push(value)
+            return this
+          },
+          async query(text: string) {
+            statements.push({ text, values: [...values] })
+
+            return {
+              recordset: [{ exists: 0 }],
+              rowsAffected: [1],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let adapter = createMssqlDatabaseAdapter(pool as never)
+    let hasTable = await adapter.hasTable({ name: 'users' })
+    let hasColumn = await adapter.hasColumn({ name: 'users' }, 'email')
+
+    assert.equal(hasTable, false)
+    assert.equal(hasColumn, false)
+    assert.match(statements[0].text, /object_id/)
+    assert.deepEqual(statements[0].values, ['[users]'])
+    assert.match(statements[1].text, /information_schema\.columns/)
+    assert.doesNotMatch(statements[1].text, /table_schema/)
+    assert.deepEqual(statements[1].values, ['users', 'email'])
+  })
+
+  it('routes introspection through transaction clients when a token is provided', async () => {
+    let poolQueries = 0
+    let transactionStatements: string[] = []
+
+    let transaction = {
+      async begin() {},
+      async commit() {},
+      async rollback() {},
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query(text: string) {
+            transactionStatements.push(text)
+            return {
+              recordset: [{ exists: 1 }],
+              rowsAffected: [1],
+            }
+          },
+        }
+      },
+    }
+
+    let pool = {
+      request() {
+        poolQueries += 1
+        return {
+          input() {
+            return this
+          },
+          async query() {
+            return { recordset: [], rowsAffected: [0] }
+          },
+        }
+      },
+      transaction() {
+        return transaction
+      },
+    }
+
+    let adapter = createMssqlDatabaseAdapter(pool as never)
+    let token = await adapter.beginTransaction()
+
+    await adapter.hasTable({ name: 'users' }, token)
+    await adapter.hasColumn({ name: 'users' }, 'email', token)
+    await adapter.commitTransaction(token)
+
+    assert.equal(poolQueries, 0)
+    assert.equal(transactionStatements.length, 2)
+    assert.match(transactionStatements[0], /object_id/)
+    assert.match(transactionStatements[1], /information_schema\.columns/)
+  })
+
+  it('executes migrate operations with transaction tokens and migration locks', async () => {
+    let lifecycle: string[] = []
+
+    let transaction = {
+      async begin() {
+        lifecycle.push('begin')
+      },
+      async commit() {
+        lifecycle.push('commit')
+      },
+      async rollback() {
+        lifecycle.push('rollback')
+      },
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query(text: string) {
+            lifecycle.push(text)
+            return { recordset: [], rowsAffected: [0] }
+          },
+        }
+      },
+    }
+
+    let pool = {
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query(text: string) {
+            lifecycle.push(text)
+            return { recordset: [], rowsAffected: [0] }
+          },
+        }
+      },
+      transaction() {
+        return transaction
+      },
+    }
+
+    let adapter = createMssqlDatabaseAdapter(pool as never)
+    let token = await adapter.beginTransaction()
+
+    await adapter.acquireMigrationLock()
+    let result = await adapter.migrate({
+      operation: {
+        kind: 'alterTable',
+        table: { name: 'users' },
+        changes: [
+          { kind: 'addColumn', column: 'email', definition: { type: 'text', nullable: false } },
+          { kind: 'dropColumn', column: 'legacy_email', ifExists: true },
+        ],
+      },
+      transaction: token,
+    })
+    await adapter.releaseMigrationLock()
+    await adapter.commitTransaction(token)
+
+    assert.equal(result.affectedOperations, 2)
+    assert.deepEqual(lifecycle, [
+      'begin',
+      "declare @dt_lock_result int; exec @dt_lock_result = sp_getapplock @Resource = 'data_table_migrations', @LockMode = 'Exclusive', @LockTimeout = 60000, @LockOwner = 'Session'; select @dt_lock_result as [returnValue]",
+      'alter table [users] add [email] varchar(max) not null',
+      'alter table [users] drop column if exists [legacy_email]',
+      "exec sp_releaseapplock @Resource = 'data_table_migrations', @LockOwner = 'Session'",
+      'commit',
+    ])
+  })
+
+  it('throws when migration lock acquisition fails', async () => {
+    let pool = {
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query() {
+            return { recordset: [{ returnValue: -1 }], rowsAffected: [0] }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let adapter = createMssqlDatabaseAdapter(pool as never)
+
+    await assert.rejects(() => adapter.acquireMigrationLock(), {
+      message: /Failed to acquire migration lock/,
+    })
+  })
+
+  it('compiles rich table migrations including literals, references, and comments', () => {
+    let pool = {
+      request() {
+        throw new Error('not used')
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let adapter = createMssqlDatabaseAdapter(pool as never)
+
+    let compiled = adapter.compileSql({
+      kind: 'createTable',
+      table: { name: 'users' },
+      ifNotExists: true,
+      columns: {
+        id: { type: 'integer', nullable: false, primaryKey: true },
+        email: { type: 'varchar', length: 320, nullable: false, unique: true },
+        visits: { type: 'integer', default: { kind: 'literal', value: 0 } },
+        bigint_visits: { type: 'bigint', default: { kind: 'literal', value: 12n } },
+        is_admin: { type: 'boolean', default: { kind: 'literal', value: false } },
+        nickname: { type: 'text', default: { kind: 'literal', value: null } },
+        safe_slug: { type: 'text', default: { kind: 'sql', expression: 'md5(email)' } },
+        created_at: { type: 'timestamp', withTimezone: true, default: { kind: 'now' } },
+        birthday: {
+          type: 'date',
+          default: { kind: 'literal', value: new Date('2024-01-02T00:00:00.000Z') },
+        },
+        score: { type: 'decimal', precision: 10, scale: 2 },
+        ratio: { type: 'decimal', precision: 8 },
+        starts_at: { type: 'time' },
+        ends_at: { type: 'time', withTimezone: true },
+        metadata: { type: 'json' },
+        blob: { type: 'binary' },
+        role: { type: 'enum', enumValues: ['admin', 'user'] },
+        full_name: {
+          type: 'text',
+          computed: { expression: "first_name + ' ' + last_name", stored: true },
+        },
+        display_name: {
+          type: 'text',
+          computed: { expression: "first_name + ' ' + last_name", stored: false },
+        },
+        name: {
+          type: 'text',
+          checks: [{ expression: 'len(name) > 1', name: 'users_name_len_check' }],
+        },
+        manager_id: {
+          type: 'integer',
+          references: {
+            table: { schema: 'app', name: 'users' },
+            columns: ['id'],
+            name: 'users_manager_fk',
+            onDelete: 'set null',
+            onUpdate: 'cascade',
+          },
+        },
+        escaped: { type: 'text', default: { kind: 'literal', value: "O'Hare" } },
+      },
+      primaryKey: { name: 'users_pk', columns: ['id'] },
+      uniques: [{ name: 'users_email_unique', columns: ['email'] }],
+      checks: [{ name: 'users_name_check', expression: 'len(name) > 1' }],
+      foreignKeys: [
+        {
+          name: 'users_account_fk',
+          columns: ['id'],
+          references: { table: { schema: 'app', name: 'accounts' }, columns: ['id'] },
+          onDelete: 'cascade',
+          onUpdate: 'restrict',
+        },
+      ],
+      comment: "owner's table",
+    })
+
+    assert.equal(compiled.length, 2)
+    assert.match(
+      compiled[0].text,
+      /if object_id\(N'\[users\]', N'U'\) is null create table \[users\] \(/,
+    )
+    assert.match(compiled[0].text, /\[email\] varchar\(320\) not null unique/)
+    assert.match(compiled[0].text, /\[visits\] int default 0/)
+    assert.match(compiled[0].text, /\[bigint_visits\] bigint default 12/)
+    assert.match(compiled[0].text, /\[is_admin\] bit default 0/)
+    assert.match(compiled[0].text, /\[nickname\] varchar\(max\) default null/)
+    assert.match(compiled[0].text, /\[safe_slug\] varchar\(max\) default md5\(email\)/)
+    assert.match(compiled[0].text, /\[created_at\] datetimeoffset default getdate\(\)/)
+    assert.match(compiled[0].text, /\[birthday\] date default '2024-01-02T00:00:00.000Z'/)
+    assert.match(compiled[0].text, /\[score\] decimal\(10, 2\)/)
+    assert.match(compiled[0].text, /\[ratio\] decimal/)
+    assert.match(compiled[0].text, /\[starts_at\] time/)
+    assert.match(compiled[0].text, /\[ends_at\] time/)
+    assert.match(compiled[0].text, /\[metadata\] nvarchar\(max\)/)
+    assert.match(compiled[0].text, /\[blob\] varbinary\(max\)/)
+    assert.match(compiled[0].text, /\[role\] varchar\(255\)/)
+    assert.match(compiled[0].text, /\[full_name\] as \(first_name \+ ' ' \+ last_name\) persisted/)
+    assert.match(compiled[0].text, /\[display_name\] as \(first_name \+ ' ' \+ last_name\)/)
+    assert.doesNotMatch(compiled[0].text, /\[display_name\].*persisted/)
+    assert.match(compiled[0].text, /\[name\] varchar\(max\) check \(len\(name\) > 1\)/)
+    assert.match(
+      compiled[0].text,
+      /\[manager_id\] int references \[app\]\.\[users\] \(\[id\]\) on delete set null on update cascade/,
+    )
+    assert.match(compiled[0].text, /\[escaped\] varchar\(max\) default 'O''Hare'/)
+    assert.match(compiled[0].text, /constraint \[users_pk\] primary key \(\[id\]\)/)
+    assert.match(compiled[0].text, /constraint \[users_email_unique\] unique \(\[email\]\)/)
+    assert.match(compiled[0].text, /constraint \[users_name_check\] check \(len\(name\) > 1\)/)
+    assert.match(
+      compiled[0].text,
+      /constraint \[users_account_fk\] foreign key \(\[id\]\) references \[app\]\.\[accounts\] \(\[id\]\) on delete cascade on update restrict/,
+    )
+    assert.match(compiled[1].text, /sp_updateextendedproperty/)
+    assert.match(compiled[1].text, /sp_addextendedproperty/)
+    assert.match(compiled[1].text, /fn_listextendedproperty/)
+    assert.match(compiled[1].text, /owner''s table/)
+  })
+
+  it('compiles alterTable changes and standalone DDL operations', () => {
+    let pool = {
+      request() {
+        throw new Error('not used')
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let adapter = createMssqlDatabaseAdapter(pool as never)
+
+    let alterStatements = adapter.compileSql({
+      kind: 'alterTable',
+      table: { schema: 'app', name: 'users' },
+      changes: [
+        { kind: 'addColumn', column: 'email', definition: { type: 'text', nullable: false } },
+        { kind: 'changeColumn', column: 'email', definition: { type: 'varchar', length: 255 } },
+        {
+          kind: 'changeColumn',
+          column: 'nickname',
+          definition: { type: 'varchar', length: 100, nullable: true },
+        },
+        {
+          kind: 'changeColumn',
+          column: 'status',
+          definition: { type: 'varchar', length: 32, nullable: false },
+        },
+        { kind: 'renameColumn', from: 'email', to: 'contact_email' },
+        { kind: 'dropColumn', column: 'legacy_email', ifExists: true },
+        { kind: 'addPrimaryKey', constraint: { name: 'users_pk', columns: ['id'] } },
+        { kind: 'dropPrimaryKey', name: 'users_pk' },
+        {
+          kind: 'addUnique',
+          constraint: { name: 'users_email_unique', columns: ['contact_email'] },
+        },
+        { kind: 'dropUnique', name: 'users_email_unique' },
+        {
+          kind: 'addForeignKey',
+          constraint: {
+            name: 'users_account_fk',
+            columns: ['account_id'],
+            references: { table: { name: 'accounts' }, columns: ['id'] },
+          },
+        },
+        { kind: 'dropForeignKey', name: 'users_account_fk' },
+        {
+          kind: 'addCheck',
+          constraint: { name: 'users_status_check', expression: "status <> 'deleted'" },
+        },
+        { kind: 'dropCheck', name: 'users_status_check' },
+        { kind: 'setTableComment', comment: 'Updated users table' },
+      ],
+    })
+
+    assert.equal(alterStatements.length, 15)
+    assert.equal(
+      alterStatements[0].text,
+      'alter table [app].[users] add [email] varchar(max) not null',
+    )
+    assert.match(
+      alterStatements[1].text,
+      /alter table \[app\]\.\[users\] alter column \[email\] varchar\(255\)/,
+    )
+    assert.equal(
+      alterStatements[2].text,
+      'alter table [app].[users] alter column [nickname] varchar(100) null',
+    )
+    assert.equal(
+      alterStatements[3].text,
+      'alter table [app].[users] alter column [status] varchar(32) not null',
+    )
+    assert.match(alterStatements[4].text, /sp_rename/)
+    assert.match(alterStatements[4].text, /\[app\]\.\[users\]\.email/)
+    assert.match(alterStatements[4].text, /contact_email/)
+    assert.equal(
+      alterStatements[5].text,
+      'alter table [app].[users] drop column if exists [legacy_email]',
+    )
+    assert.equal(
+      alterStatements[6].text,
+      'alter table [app].[users] add constraint [users_pk] primary key ([id])',
+    )
+    assert.equal(alterStatements[7].text, 'alter table [app].[users] drop constraint [users_pk]')
+    assert.equal(
+      alterStatements[8].text,
+      'alter table [app].[users] add constraint [users_email_unique] unique ([contact_email])',
+    )
+    assert.equal(
+      alterStatements[9].text,
+      'alter table [app].[users] drop constraint [users_email_unique]',
+    )
+    assert.equal(
+      alterStatements[10].text,
+      'alter table [app].[users] add constraint [users_account_fk] foreign key ([account_id]) references [accounts] ([id])',
+    )
+    assert.equal(
+      alterStatements[11].text,
+      'alter table [app].[users] drop constraint [users_account_fk]',
+    )
+    assert.equal(
+      alterStatements[12].text,
+      `alter table [app].[users] add constraint [users_status_check] check (status <> 'deleted')`,
+    )
+    assert.equal(
+      alterStatements[13].text,
+      'alter table [app].[users] drop constraint [users_status_check]',
+    )
+    assert.match(alterStatements[14].text, /sp_updateextendedproperty/)
+    assert.match(alterStatements[14].text, /sp_addextendedproperty/)
+    assert.match(alterStatements[14].text, /fn_listextendedproperty/)
+    assert.match(alterStatements[14].text, /Updated users table/)
+
+    let createIndex = adapter.compileSql({
+      kind: 'createIndex',
+      ifNotExists: true,
+      index: {
+        table: { name: 'users' },
+        name: 'email_idx',
+        columns: ['email'],
+        unique: true,
+        where: 'email is not null',
+      },
+    })
+    assert.match(
+      createIndex[0].text,
+      /if not exists \(select 1 from sys\.indexes where name = 'email_idx' and object_id = object_id\(N'\[users\]'\)\) create unique index \[email_idx\] on \[users\] \(\[email\]\) where email is not null/,
+    )
+
+    let dropIndex = adapter.compileSql({
+      kind: 'dropIndex',
+      table: { name: 'users' },
+      name: 'email_idx',
+      ifExists: true,
+    })
+    assert.equal(dropIndex[0].text, 'drop index if exists [email_idx] on [users]')
+
+    let renameIndex = adapter.compileSql({
+      kind: 'renameIndex',
+      table: { name: 'users' },
+      from: 'email_idx',
+      to: 'users_email_idx',
+    })
+    assert.match(renameIndex[0].text, /sp_rename/)
+    assert.match(renameIndex[0].text, /email_idx/)
+    assert.match(renameIndex[0].text, /users_email_idx/)
+
+    let renameTable = adapter.compileSql({
+      kind: 'renameTable',
+      from: { schema: 'app', name: 'users' },
+      to: { schema: 'app', name: 'members' },
+    })
+    assert.match(renameTable[0].text, /sp_rename/)
+    assert.match(renameTable[0].text, /\[app\]\.\[users\]/)
+    assert.match(renameTable[0].text, /members/)
+
+    let dropTable = adapter.compileSql({
+      kind: 'dropTable',
+      table: { name: 'users' },
+      ifExists: true,
+    })
+    assert.match(dropTable[0].text, /if object_id/)
+    assert.match(dropTable[0].text, /drop table \[users\]/)
+  })
+
+  it('throws for unsupported DDL kinds', () => {
+    let pool = {
+      request() {
+        throw new Error('not used')
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let adapter = createMssqlDatabaseAdapter(pool as never)
+
+    assert.throws(
+      () => adapter.compileSql({ kind: 'unknown' } as never),
+      /Unsupported data migration operation kind/,
+    )
+  })
+
+  it('compiles every DDL operation kind through compileSql()', () => {
+    let pool = {
+      request() {
+        throw new Error('not used')
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let adapter = createMssqlDatabaseAdapter(pool as never)
+
+    let operations: DataMigrationOperation[] = [
+      {
+        kind: 'createTable',
+        table: { schema: 'app', name: 'users' },
+        ifNotExists: true,
+        columns: {
+          id: { type: 'integer', nullable: false, primaryKey: true },
+        },
+      },
+      {
+        kind: 'alterTable',
+        table: { schema: 'app', name: 'users' },
+        changes: [
+          { kind: 'addColumn', column: 'email', definition: { type: 'text', nullable: false } },
+        ],
+      },
+      {
+        kind: 'renameTable',
+        from: { schema: 'app', name: 'users' },
+        to: { schema: 'app', name: 'accounts' },
+      },
+      { kind: 'dropTable', table: { schema: 'app', name: 'accounts' }, ifExists: true },
+      {
+        kind: 'createIndex',
+        index: {
+          table: { schema: 'app', name: 'users' },
+          columns: ['email'],
+          name: 'users_email_idx',
+        },
+      },
+      { kind: 'dropIndex', table: { schema: 'app', name: 'users' }, name: 'users_email_idx' },
+      {
+        kind: 'renameIndex',
+        table: { schema: 'app', name: 'users' },
+        from: 'users_email_idx',
+        to: 'users_email_idx_new',
+      },
+      {
+        kind: 'addForeignKey',
+        table: { schema: 'app', name: 'projects' },
+        constraint: {
+          columns: ['account_id'],
+          references: {
+            table: { schema: 'app', name: 'accounts' },
+            columns: ['id'],
+          },
+          name: 'projects_account_id_fk',
+          onDelete: 'cascade',
+        },
+      },
+      {
+        kind: 'dropForeignKey',
+        table: { schema: 'app', name: 'projects' },
+        name: 'projects_account_id_fk',
+      },
+      {
+        kind: 'addCheck',
+        table: { schema: 'app', name: 'users' },
+        constraint: {
+          name: 'users_email_check',
+          expression: "charindex('@', email) > 1",
+        },
+      },
+      { kind: 'dropCheck', table: { schema: 'app', name: 'users' }, name: 'users_email_check' },
+      { kind: 'raw', sql: sql`select 1` },
+    ]
+
+    for (let operation of operations) {
+      let compiled = adapter.compileSql(operation)
+      assert.ok(compiled.length > 0, operation.kind)
+    }
+  })
+
+  it('normalizes bigint count rows', async () => {
+    let pool = {
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query() {
+            return {
+              recordset: [{ count: 5n }],
+              rowsAffected: [1],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(createMssqlDatabaseAdapter(pool as never))
+    let count = await db.query(accounts).count()
+
+    assert.equal(count, 5)
+  })
+
+  it('normalizes non-object rows and falls back count to row length', async () => {
+    let pool = {
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query() {
+            return {
+              recordset: [1, null, { count: 'oops' }],
+              rowsAffected: [3],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let db = createDatabase(createMssqlDatabaseAdapter(pool as never))
+    let count = await db.query(accounts).count()
+
+    assert.equal(count, 3)
+  })
+
+  it('returns undefined affectedRows for raw operations', async () => {
+    let pool = {
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query() {
+            return {
+              recordset: [{ ok: true }],
+              rowsAffected: [],
+            }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let result = await createMssqlDatabaseAdapter(pool as never).execute({
+      operation: {
+        kind: 'raw',
+        sql: {
+          text: 'select 1',
+          values: [],
+        },
+      },
+      transaction: undefined,
+    })
+
+    assert.equal(result.affectedRows, undefined)
+    assert.deepEqual(result.rows, [{ ok: true }])
   })
 })

--- a/packages/data-table-mssql/src/lib/adapter.test.ts
+++ b/packages/data-table-mssql/src/lib/adapter.test.ts
@@ -1059,16 +1059,84 @@ describe('mssql adapter', () => {
     assert.equal(result.affectedOperations, 2)
     assert.deepEqual(lifecycle, [
       'begin',
-      "declare @dt_lock_result int; exec @dt_lock_result = sp_getapplock @Resource = 'data_table_migrations', @LockMode = 'Exclusive', @LockTimeout = 60000, @LockOwner = 'Session'; select @dt_lock_result as [returnValue]",
+      'begin',
+      "declare @dt_lock_result int; exec @dt_lock_result = sp_getapplock @Resource = 'data_table_migrations', @LockMode = 'Exclusive', @LockTimeout = 60000, @LockOwner = 'Transaction'; select @dt_lock_result as [returnValue]",
       'alter table [users] add [email] varchar(max) not null',
       'alter table [users] drop column if exists [legacy_email]',
-      "exec sp_releaseapplock @Resource = 'data_table_migrations', @LockOwner = 'Session'",
+      'commit',
+      'commit',
+    ])
+  })
+
+  it('routes migration operations through the migration lock transaction when no token is provided', async () => {
+    let lifecycle: string[] = []
+
+    let transaction = {
+      async begin() {
+        lifecycle.push('begin')
+      },
+      async commit() {
+        lifecycle.push('commit')
+      },
+      async rollback() {
+        lifecycle.push('rollback')
+      },
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query(text: string) {
+            lifecycle.push(text)
+            return { recordset: [], rowsAffected: [0] }
+          },
+        }
+      },
+    }
+
+    let pool = {
+      request() {
+        throw new Error('migration queries should use the lock transaction client')
+      },
+      transaction() {
+        return transaction
+      },
+    }
+
+    let adapter = createMssqlDatabaseAdapter(pool as never)
+
+    await adapter.acquireMigrationLock()
+    let result = await adapter.migrate({
+      operation: {
+        kind: 'alterTable',
+        table: { name: 'users' },
+        changes: [{ kind: 'dropColumn', column: 'legacy_email', ifExists: true }],
+      },
+    })
+    await adapter.releaseMigrationLock()
+
+    assert.equal(result.affectedOperations, 1)
+    assert.deepEqual(lifecycle, [
+      'begin',
+      "declare @dt_lock_result int; exec @dt_lock_result = sp_getapplock @Resource = 'data_table_migrations', @LockMode = 'Exclusive', @LockTimeout = 60000, @LockOwner = 'Transaction'; select @dt_lock_result as [returnValue]",
+      'alter table [users] drop column if exists [legacy_email]',
       'commit',
     ])
   })
 
   it('throws when migration lock acquisition fails', async () => {
-    let pool = {
+    let lifecycle: string[] = []
+
+    let transaction = {
+      async begin() {
+        lifecycle.push('begin')
+      },
+      async commit() {
+        lifecycle.push('commit')
+      },
+      async rollback() {
+        lifecycle.push('rollback')
+      },
       request() {
         return {
           input() {
@@ -1079,8 +1147,14 @@ describe('mssql adapter', () => {
           },
         }
       },
-      transaction() {
+    }
+
+    let pool = {
+      request() {
         throw new Error('not used')
+      },
+      transaction() {
+        return transaction
       },
     }
 
@@ -1089,6 +1163,38 @@ describe('mssql adapter', () => {
     await assert.rejects(() => adapter.acquireMigrationLock(), {
       message: /Failed to acquire migration lock/,
     })
+
+    assert.deepEqual(lifecycle, ['begin', 'rollback'])
+  })
+
+  it('treats migration lock hooks as no-ops when capabilities.migrationLock is false', async () => {
+    let lifecycle: string[] = []
+
+    let pool = {
+      request() {
+        return {
+          input() {
+            return this
+          },
+          async query(text: string) {
+            lifecycle.push(text)
+            return { recordset: [], rowsAffected: [0] }
+          },
+        }
+      },
+      transaction() {
+        throw new Error('not used')
+      },
+    }
+
+    let adapter = createMssqlDatabaseAdapter(pool as never, {
+      capabilities: { migrationLock: false },
+    })
+
+    await adapter.acquireMigrationLock()
+    await adapter.releaseMigrationLock()
+
+    assert.deepEqual(lifecycle, [])
   })
 
   it('compiles rich table migrations including literals, references, and comments', () => {

--- a/packages/data-table-mssql/src/lib/adapter.test.ts
+++ b/packages/data-table-mssql/src/lib/adapter.test.ts
@@ -157,45 +157,6 @@ describe('mssql adapter', () => {
     assert.deepEqual(lifecycle, ['begin', 'set transaction isolation level serializable', 'commit'])
   })
 
-  it('applies isolationLevel read uncommitted', async () => {
-    let { pool, lifecycle } = createLifecyclePool()
-    let db = createDatabase(createMssqlDatabaseAdapter(pool))
-
-    await db.transaction(async () => undefined, { isolationLevel: 'read uncommitted' })
-
-    assert.deepEqual(lifecycle, [
-      'begin',
-      'set transaction isolation level read uncommitted',
-      'commit',
-    ])
-  })
-
-  it('applies isolationLevel read committed', async () => {
-    let { pool, lifecycle } = createLifecyclePool()
-    let db = createDatabase(createMssqlDatabaseAdapter(pool))
-
-    await db.transaction(async () => undefined, { isolationLevel: 'read committed' })
-
-    assert.deepEqual(lifecycle, [
-      'begin',
-      'set transaction isolation level read committed',
-      'commit',
-    ])
-  })
-
-  it('applies isolationLevel repeatable read', async () => {
-    let { pool, lifecycle } = createLifecyclePool()
-    let db = createDatabase(createMssqlDatabaseAdapter(pool))
-
-    await db.transaction(async () => undefined, { isolationLevel: 'repeatable read' })
-
-    assert.deepEqual(lifecycle, [
-      'begin',
-      'set transaction isolation level repeatable read',
-      'commit',
-    ])
-  })
-
   it('ignores readOnly true and does not emit any SQL for it', async () => {
     let { pool, lifecycle } = createLifecyclePool()
     let db = createDatabase(createMssqlDatabaseAdapter(pool))
@@ -203,15 +164,6 @@ describe('mssql adapter', () => {
     await db.transaction(async () => undefined, { readOnly: true })
 
     // No SET TRANSACTION READ ONLY should appear — MSSQL does not support it.
-    assert.deepEqual(lifecycle, ['begin', 'commit'])
-  })
-
-  it('ignores readOnly false and does not emit any SQL for it', async () => {
-    let { pool, lifecycle } = createLifecyclePool()
-    let db = createDatabase(createMssqlDatabaseAdapter(pool))
-
-    await db.transaction(async () => undefined, { readOnly: false })
-
     assert.deepEqual(lifecycle, ['begin', 'commit'])
   })
 
@@ -226,15 +178,6 @@ describe('mssql adapter', () => {
 
     // Only the isolation level SQL is emitted; readOnly is silently ignored.
     assert.deepEqual(lifecycle, ['begin', 'set transaction isolation level serializable', 'commit'])
-  })
-
-  it('emits no option SQL when transaction is called with empty options', async () => {
-    let { pool, lifecycle } = createLifecyclePool()
-    let db = createDatabase(createMssqlDatabaseAdapter(pool))
-
-    await db.transaction(async () => undefined, {})
-
-    assert.deepEqual(lifecycle, ['begin', 'commit'])
   })
 
   it('compiles column-to-column comparisons from string references', async () => {

--- a/packages/data-table-mssql/src/lib/adapter.ts
+++ b/packages/data-table-mssql/src/lib/adapter.ts
@@ -1,14 +1,30 @@
 import type {
   AdapterCapabilityOverrides,
-  AdapterExecuteRequest,
-  AdapterResult,
+  ColumnDefinition,
+  DataManipulationOperation,
+  DataManipulationRequest,
+  DataManipulationResult,
+  DataMigrationOperation,
+  DataMigrationRequest,
+  DataMigrationResult,
   DatabaseAdapter,
+  SqlStatement,
+  TableRef,
   TransactionOptions,
   TransactionToken,
 } from '@remix-run/data-table'
 import { getTablePrimaryKey } from '@remix-run/data-table'
+import {
+  isDataManipulationOperation as isDataManipulationOperationHelper,
+  quoteLiteral as quoteLiteralHelper,
+  quoteTableRef as quoteTableRefHelper,
+} from '@remix-run/data-table/sql-helpers'
 
-import { compileMssqlStatement } from './sql-compiler.ts'
+import { compileMssqlOperation } from './sql-compiler.ts'
+
+type Pretty<value> = {
+  [key in keyof value]: value[key]
+} & {}
 
 /**
  * Result shape returned by mssql `query()` calls.
@@ -18,9 +34,6 @@ export type MssqlQueryResult = {
   rowsAffected?: number[]
 }
 
-/**
- * Minimal mssql request contract used internally by this adapter.
- */
 type MssqlDatabaseRequest = {
   input(name: string, value: unknown): MssqlDatabaseRequest
   query(text: string): Promise<MssqlQueryResult>
@@ -36,18 +49,22 @@ export type MssqlDatabaseClient = {
 /**
  * Mssql transaction client with begin/commit/rollback lifecycle.
  */
-export type MssqlDatabaseTransaction = MssqlDatabaseClient & {
-  begin(): Promise<unknown>
-  commit(): Promise<void>
-  rollback(): Promise<void>
-}
+export type MssqlTransactionClient = Pretty<
+  MssqlDatabaseClient & {
+    begin(): Promise<unknown>
+    commit(): Promise<void>
+    rollback(): Promise<void>
+  }
+>
 
 /**
  * Mssql pool-like client contract used by this adapter.
  */
-export type MssqlDatabasePool = MssqlDatabaseClient & {
-  transaction(): MssqlDatabaseTransaction
-}
+export type MssqlDatabasePool = Pretty<
+  MssqlDatabaseClient & {
+    transaction(): MssqlTransactionClient
+  }
+>
 
 /**
  * Mssql adapter configuration.
@@ -64,7 +81,7 @@ export class MssqlDatabaseAdapter implements DatabaseAdapter {
   capabilities
 
   #client: MssqlDatabasePool
-  #transactions = new Map<string, MssqlDatabaseTransaction>()
+  #transactions = new Map<string, MssqlTransactionClient>()
   #isolatedTransactions = new Set<string>()
   #transactionCounter = 0
 
@@ -74,32 +91,83 @@ export class MssqlDatabaseAdapter implements DatabaseAdapter {
       returning: options?.capabilities?.returning ?? false,
       savepoints: options?.capabilities?.savepoints ?? true,
       upsert: options?.capabilities?.upsert ?? true,
+      transactionalDdl: options?.capabilities?.transactionalDdl ?? true,
+      migrationLock: options?.capabilities?.migrationLock ?? true,
     }
   }
 
-  async execute(request: AdapterExecuteRequest): Promise<AdapterResult> {
-    if (request.statement.kind === 'insertMany' && request.statement.values.length === 0) {
+  compileSql(operation: DataManipulationOperation | DataMigrationOperation): SqlStatement[] {
+    if (isDataManipulationOperation(operation)) {
+      let compiled = compileMssqlOperation(operation)
+      return [{ text: compiled.text, values: compiled.values }]
+    }
+
+    return compileMssqlMigrationOperations(operation)
+  }
+
+  async execute(request: DataManipulationRequest): Promise<DataManipulationResult> {
+    if (request.operation.kind === 'insertMany' && request.operation.values.length === 0) {
       return {
         affectedRows: 0,
         insertId: undefined,
-        rows: request.statement.returning ? [] : undefined,
+        rows: request.operation.returning ? [] : undefined,
       }
     }
 
-    let statement = compileMssqlStatement(request.statement)
+    let statement = compileMssqlOperation(request.operation)
     let client = this.#resolveClient(request.transaction)
     let result = await runMssqlQuery(client, statement.text, statement.values)
     let rows = normalizeRows(result.recordset ?? [])
 
-    if (request.statement.kind === 'count' || request.statement.kind === 'exists') {
+    if (request.operation.kind === 'count' || request.operation.kind === 'exists') {
       rows = normalizeCountRows(rows)
     }
 
     return {
       rows,
-      affectedRows: normalizeAffectedRows(request.statement.kind, result.rowsAffected),
-      insertId: normalizeInsertId(request.statement.kind, request.statement, rows),
+      affectedRows: normalizeAffectedRows(request.operation.kind, result.rowsAffected, rows),
+      insertId: normalizeInsertId(request.operation.kind, request.operation, rows),
     }
+  }
+
+  async migrate(request: DataMigrationRequest): Promise<DataMigrationResult> {
+    let statements = this.compileSql(request.operation)
+    let client = this.#resolveClient(request.transaction)
+
+    for (let statement of statements) {
+      await runMssqlQuery(client, statement.text, statement.values)
+    }
+
+    return {
+      affectedOperations: statements.length,
+    }
+  }
+
+  async hasTable(table: TableRef, transaction?: TransactionToken): Promise<boolean> {
+    let client = this.#resolveClient(transaction)
+    let objectName = toMssqlObjectName(table)
+    let result = await runMssqlQuery(
+      client,
+      "select case when object_id(@dt_p1, N'U') is not null then 1 else 0 end as [exists]",
+      [objectName],
+    )
+    let row = (result.recordset ?? [])[0] as Record<string, unknown> | undefined
+    return toBooleanExists(row?.exists)
+  }
+
+  async hasColumn(
+    table: TableRef,
+    column: string,
+    transaction?: TransactionToken,
+  ): Promise<boolean> {
+    let client = this.#resolveClient(transaction)
+    let sql = table.schema
+      ? 'select case when exists(select 1 from information_schema.columns where table_schema = @dt_p1 and table_name = @dt_p2 and column_name = @dt_p3) then 1 else 0 end as [exists]'
+      : 'select case when exists(select 1 from information_schema.columns where table_name = @dt_p1 and column_name = @dt_p2) then 1 else 0 end as [exists]'
+    let values = table.schema ? [table.schema, table.name, column] : [table.name, column]
+    let result = await runMssqlQuery(client, sql, values)
+    let row = (result.recordset ?? [])[0] as Record<string, unknown> | undefined
+    return toBooleanExists(row?.exists)
   }
 
   async beginTransaction(options?: TransactionOptions): Promise<TransactionToken> {
@@ -169,6 +237,29 @@ export class MssqlDatabaseAdapter implements DatabaseAdapter {
     this.#transactionClient(token)
   }
 
+  async acquireMigrationLock(): Promise<void> {
+    let result = await runMssqlQuery(
+      this.#client,
+      "declare @dt_lock_result int; exec @dt_lock_result = sp_getapplock @Resource = 'data_table_migrations', @LockMode = 'Exclusive', @LockTimeout = 60000, @LockOwner = 'Session'; select @dt_lock_result as [returnValue]",
+    )
+
+    let row = result.recordset?.[0] as Record<string, unknown> | undefined
+    let returnValue = row?.returnValue
+
+    if (typeof returnValue === 'number' && returnValue < 0) {
+      throw new Error(
+        'Failed to acquire migration lock (sp_getapplock returned ' + returnValue + ')',
+      )
+    }
+  }
+
+  async releaseMigrationLock(): Promise<void> {
+    await runMssqlQuery(
+      this.#client,
+      "exec sp_releaseapplock @Resource = 'data_table_migrations', @LockOwner = 'Session'",
+    )
+  }
+
   #resolveClient(token: TransactionToken | undefined): MssqlDatabaseClient {
     if (!token) {
       return this.#client
@@ -177,7 +268,7 @@ export class MssqlDatabaseAdapter implements DatabaseAdapter {
     return this.#transactionClient(token)
   }
 
-  #transactionClient(token: TransactionToken): MssqlDatabaseTransaction {
+  #transactionClient(token: TransactionToken): MssqlTransactionClient {
     let transaction = this.#transactions.get(token.id)
 
     if (!transaction) {
@@ -193,6 +284,16 @@ export class MssqlDatabaseAdapter implements DatabaseAdapter {
  * @param client Mssql connection pool.
  * @param options Optional adapter capability overrides.
  * @returns A configured mssql adapter.
+ * @example
+ * ```ts
+ * import mssql from 'mssql'
+ * import { createDatabase } from 'remix/data-table'
+ * import { createMssqlDatabaseAdapter } from 'remix/data-table-mssql'
+ *
+ * let pool = await mssql.connect(process.env.DATABASE_URL)
+ * let adapter = createMssqlDatabaseAdapter(pool)
+ * let db = createDatabase(adapter)
+ * ```
  */
 export function createMssqlDatabaseAdapter(
   client: MssqlDatabasePool,
@@ -252,36 +353,41 @@ function normalizeCountRows(rows: Record<string, unknown>[]): Record<string, unk
 }
 
 function normalizeAffectedRows(
-  kind: AdapterExecuteRequest['statement']['kind'],
+  kind: DataManipulationRequest['operation']['kind'],
   rowsAffected: number[] | undefined,
+  rows: Record<string, unknown>[],
 ): number | undefined {
   if (kind === 'select' || kind === 'count' || kind === 'exists') {
     return undefined
   }
 
-  if (!rowsAffected || rowsAffected.length === 0) {
+  if (rowsAffected && rowsAffected.length > 0) {
+    let total = 0
+
+    for (let amount of rowsAffected) {
+      total += amount
+    }
+
+    return total
+  }
+
+  if (kind === 'raw') {
     return undefined
   }
 
-  let total = 0
-
-  for (let amount of rowsAffected) {
-    total += amount
-  }
-
-  return total
+  return rows.length
 }
 
 function normalizeInsertId(
-  kind: AdapterExecuteRequest['statement']['kind'],
-  statement: AdapterExecuteRequest['statement'],
+  kind: DataManipulationRequest['operation']['kind'],
+  operation: DataManipulationRequest['operation'],
   rows: Record<string, unknown>[],
 ): unknown {
-  if (!isInsertStatementKind(kind) || !isInsertStatement(statement)) {
+  if (!isInsertOperationKind(kind) || !isInsertOperation(operation)) {
     return undefined
   }
 
-  let primaryKey = getTablePrimaryKey(statement.table)
+  let primaryKey = getTablePrimaryKey(operation.table)
 
   if (primaryKey.length !== 1) {
     return undefined
@@ -297,17 +403,574 @@ function quoteIdentifier(value: string): string {
   return '[' + value.replace(/]/g, ']]') + ']'
 }
 
-function isInsertStatementKind(kind: AdapterExecuteRequest['statement']['kind']): boolean {
+function quoteTableRef(table: TableRef): string {
+  return quoteTableRefHelper(table, quoteIdentifier)
+}
+
+function quoteLiteral(value: unknown): string {
+  return quoteLiteralHelper(value, { booleansAsIntegers: true })
+}
+
+function toMssqlObjectName(table: TableRef): string {
+  if (table.schema) {
+    return quoteIdentifier(table.schema) + '.' + quoteIdentifier(table.name)
+  }
+
+  return quoteIdentifier(table.name)
+}
+
+function toBooleanExists(value: unknown): boolean {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (typeof value === 'number') {
+    return value > 0
+  }
+
+  if (typeof value === 'string') {
+    return value === '1' || value.toLowerCase() === 'true'
+  }
+
+  return false
+}
+
+function isInsertOperationKind(kind: DataManipulationRequest['operation']['kind']): boolean {
   return kind === 'insert' || kind === 'insertMany' || kind === 'upsert'
 }
 
-function isInsertStatement(
-  statement: AdapterExecuteRequest['statement'],
-): statement is Extract<
-  AdapterExecuteRequest['statement'],
+function isInsertOperation(
+  operation: DataManipulationRequest['operation'],
+): operation is Extract<
+  DataManipulationRequest['operation'],
   { kind: 'insert' | 'insertMany' | 'upsert' }
 > {
   return (
-    statement.kind === 'insert' || statement.kind === 'insertMany' || statement.kind === 'upsert'
+    operation.kind === 'insert' || operation.kind === 'insertMany' || operation.kind === 'upsert'
   )
+}
+
+function isDataManipulationOperation(
+  operation: DataManipulationOperation | DataMigrationOperation,
+): operation is DataManipulationOperation {
+  return isDataManipulationOperationHelper(operation)
+}
+
+function compileMssqlMigrationOperations(operation: DataMigrationOperation): SqlStatement[] {
+  if (operation.kind === 'raw') {
+    return [{ text: operation.sql.text, values: [...operation.sql.values] }]
+  }
+
+  if (operation.kind === 'createTable') {
+    let columns = Object.keys(operation.columns).map(
+      (columnName) =>
+        quoteIdentifier(columnName) + ' ' + compileMssqlColumn(operation.columns[columnName]),
+    )
+    let tableConstraints: string[] = []
+
+    if (operation.primaryKey) {
+      tableConstraints.push(
+        'constraint ' +
+          quoteIdentifier(operation.primaryKey.name) +
+          ' primary key (' +
+          operation.primaryKey.columns.map((column) => quoteIdentifier(column)).join(', ') +
+          ')',
+      )
+    }
+
+    for (let unique of operation.uniques ?? []) {
+      tableConstraints.push(
+        'constraint ' +
+          quoteIdentifier(unique.name) +
+          ' ' +
+          'unique (' +
+          unique.columns.map((column) => quoteIdentifier(column)).join(', ') +
+          ')',
+      )
+    }
+
+    for (let check of operation.checks ?? []) {
+      tableConstraints.push(
+        'constraint ' + quoteIdentifier(check.name) + ' ' + 'check (' + check.expression + ')',
+      )
+    }
+
+    for (let foreignKey of operation.foreignKeys ?? []) {
+      let clause =
+        'constraint ' +
+        quoteIdentifier(foreignKey.name) +
+        ' ' +
+        'foreign key (' +
+        foreignKey.columns.map((column) => quoteIdentifier(column)).join(', ') +
+        ') references ' +
+        quoteTableRef(foreignKey.references.table) +
+        ' (' +
+        foreignKey.references.columns.map((column) => quoteIdentifier(column)).join(', ') +
+        ')'
+
+      if (foreignKey.onDelete) {
+        clause += ' on delete ' + foreignKey.onDelete
+      }
+
+      if (foreignKey.onUpdate) {
+        clause += ' on update ' + foreignKey.onUpdate
+      }
+
+      tableConstraints.push(clause)
+    }
+
+    let tableName = quoteTableRef(operation.table)
+    let body = [...columns, ...tableConstraints].join(', ')
+    let statements: SqlStatement[] = []
+
+    if (operation.ifNotExists) {
+      statements.push({
+        text:
+          'if object_id(N' +
+          quoteLiteral(toMssqlObjectName(operation.table)) +
+          ", N'U') is null " +
+          'create table ' +
+          tableName +
+          ' (' +
+          body +
+          ')',
+        values: [],
+      })
+    } else {
+      statements.push({
+        text: 'create table ' + tableName + ' (' + body + ')',
+        values: [],
+      })
+    }
+
+    if (operation.comment) {
+      statements.push({
+        text: compileSetTableComment(operation.table, operation.comment),
+        values: [],
+      })
+    }
+
+    return statements
+  }
+
+  if (operation.kind === 'alterTable') {
+    let sqlStatements: SqlStatement[] = []
+
+    for (let change of operation.changes) {
+      let sql = 'alter table ' + quoteTableRef(operation.table) + ' '
+
+      if (change.kind === 'addColumn') {
+        sql += 'add ' + quoteIdentifier(change.column) + ' ' + compileMssqlColumn(change.definition)
+      } else if (change.kind === 'changeColumn') {
+        let typeSql = compileMssqlColumnType(change.definition)
+        sql += 'alter column ' + quoteIdentifier(change.column) + ' ' + typeSql
+        if (change.definition.nullable === false) {
+          sql += ' not null'
+        } else if (change.definition.nullable === true) {
+          sql += ' null'
+        }
+      } else if (change.kind === 'renameColumn') {
+        sqlStatements.push({
+          text:
+            'exec sp_rename ' +
+            quoteLiteral(toMssqlObjectName(operation.table) + '.' + change.from) +
+            ', ' +
+            quoteLiteral(change.to) +
+            ", N'COLUMN'",
+          values: [],
+        })
+        continue
+      } else if (change.kind === 'dropColumn') {
+        sql +=
+          'drop column ' + (change.ifExists ? 'if exists ' : '') + quoteIdentifier(change.column)
+      } else if (change.kind === 'addPrimaryKey') {
+        sql +=
+          'add ' +
+          'constraint ' +
+          quoteIdentifier(change.constraint.name) +
+          ' ' +
+          'primary key (' +
+          change.constraint.columns.map((column) => quoteIdentifier(column)).join(', ') +
+          ')'
+      } else if (change.kind === 'dropPrimaryKey') {
+        sql += 'drop constraint ' + quoteIdentifier(change.name)
+      } else if (change.kind === 'addUnique') {
+        sql +=
+          'add ' +
+          'constraint ' +
+          quoteIdentifier(change.constraint.name) +
+          ' ' +
+          'unique (' +
+          change.constraint.columns.map((column) => quoteIdentifier(column)).join(', ') +
+          ')'
+      } else if (change.kind === 'dropUnique') {
+        sql += 'drop constraint ' + quoteIdentifier(change.name)
+      } else if (change.kind === 'addForeignKey') {
+        sql +=
+          'add ' +
+          'constraint ' +
+          quoteIdentifier(change.constraint.name) +
+          ' ' +
+          'foreign key (' +
+          change.constraint.columns.map((column) => quoteIdentifier(column)).join(', ') +
+          ') references ' +
+          quoteTableRef(change.constraint.references.table) +
+          ' (' +
+          change.constraint.references.columns.map((column) => quoteIdentifier(column)).join(', ') +
+          ')'
+      } else if (change.kind === 'dropForeignKey') {
+        sql += 'drop constraint ' + quoteIdentifier(change.name)
+      } else if (change.kind === 'addCheck') {
+        sql +=
+          'add ' +
+          'constraint ' +
+          quoteIdentifier(change.constraint.name) +
+          ' ' +
+          'check (' +
+          change.constraint.expression +
+          ')'
+      } else if (change.kind === 'dropCheck') {
+        sql += 'drop constraint ' + quoteIdentifier(change.name)
+      } else if (change.kind === 'setTableComment') {
+        sqlStatements.push({
+          text: compileSetTableComment(operation.table, change.comment),
+          values: [],
+        })
+        continue
+      } else {
+        continue
+      }
+
+      sqlStatements.push({ text: sql, values: [] })
+    }
+
+    return sqlStatements
+  }
+
+  if (operation.kind === 'renameTable') {
+    return [
+      {
+        text:
+          'exec sp_rename ' +
+          quoteLiteral(toMssqlObjectName(operation.from)) +
+          ', ' +
+          quoteLiteral(operation.to.name),
+        values: [],
+      },
+    ]
+  }
+
+  if (operation.kind === 'dropTable') {
+    if (operation.ifExists) {
+      return [
+        {
+          text:
+            'if object_id(N' +
+            quoteLiteral(toMssqlObjectName(operation.table)) +
+            ", N'U') is not null " +
+            'drop table ' +
+            quoteTableRef(operation.table),
+          values: [],
+        },
+      ]
+    }
+
+    return [
+      {
+        text: 'drop table ' + quoteTableRef(operation.table),
+        values: [],
+      },
+    ]
+  }
+
+  if (operation.kind === 'createIndex') {
+    let createIndexSql =
+      'create ' +
+      (operation.index.unique ? 'unique ' : '') +
+      'index ' +
+      quoteIdentifier(operation.index.name) +
+      ' on ' +
+      quoteTableRef(operation.index.table) +
+      ' (' +
+      operation.index.columns.map((column) => quoteIdentifier(column)).join(', ') +
+      ')' +
+      (operation.index.where ? ' where ' + operation.index.where : '')
+
+    if (operation.ifNotExists) {
+      createIndexSql =
+        'if not exists (select 1 from sys.indexes where name = ' +
+        quoteLiteral(operation.index.name) +
+        ' and object_id = object_id(N' +
+        quoteLiteral(toMssqlObjectName(operation.index.table)) +
+        ')) ' +
+        createIndexSql
+    }
+
+    return [
+      {
+        text: createIndexSql,
+        values: [],
+      },
+    ]
+  }
+
+  if (operation.kind === 'dropIndex') {
+    return [
+      {
+        text:
+          'drop index ' +
+          (operation.ifExists ? 'if exists ' : '') +
+          quoteIdentifier(operation.name) +
+          ' on ' +
+          quoteTableRef(operation.table),
+        values: [],
+      },
+    ]
+  }
+
+  if (operation.kind === 'renameIndex') {
+    return [
+      {
+        text:
+          'exec sp_rename ' +
+          quoteLiteral(toMssqlObjectName(operation.table) + '.' + operation.from) +
+          ', ' +
+          quoteLiteral(operation.to) +
+          ", N'INDEX'",
+        values: [],
+      },
+    ]
+  }
+
+  if (operation.kind === 'addForeignKey') {
+    return [
+      {
+        text:
+          'alter table ' +
+          quoteTableRef(operation.table) +
+          ' add ' +
+          'constraint ' +
+          quoteIdentifier(operation.constraint.name) +
+          ' ' +
+          'foreign key (' +
+          operation.constraint.columns.map((column) => quoteIdentifier(column)).join(', ') +
+          ') references ' +
+          quoteTableRef(operation.constraint.references.table) +
+          ' (' +
+          operation.constraint.references.columns
+            .map((column) => quoteIdentifier(column))
+            .join(', ') +
+          ')' +
+          (operation.constraint.onDelete ? ' on delete ' + operation.constraint.onDelete : '') +
+          (operation.constraint.onUpdate ? ' on update ' + operation.constraint.onUpdate : ''),
+        values: [],
+      },
+    ]
+  }
+
+  if (operation.kind === 'dropForeignKey') {
+    return [
+      {
+        text:
+          'alter table ' +
+          quoteTableRef(operation.table) +
+          ' drop constraint ' +
+          quoteIdentifier(operation.name),
+        values: [],
+      },
+    ]
+  }
+
+  if (operation.kind === 'addCheck') {
+    return [
+      {
+        text:
+          'alter table ' +
+          quoteTableRef(operation.table) +
+          ' add ' +
+          'constraint ' +
+          quoteIdentifier(operation.constraint.name) +
+          ' ' +
+          'check (' +
+          operation.constraint.expression +
+          ')',
+        values: [],
+      },
+    ]
+  }
+
+  if (operation.kind === 'dropCheck') {
+    return [
+      {
+        text:
+          'alter table ' +
+          quoteTableRef(operation.table) +
+          ' drop constraint ' +
+          quoteIdentifier(operation.name),
+        values: [],
+      },
+    ]
+  }
+
+  throw new Error('Unsupported data migration operation kind')
+}
+
+function compileSetTableComment(table: TableRef, comment: string): string {
+  let schema = quoteLiteral(table.schema ?? 'dbo')
+  let name = quoteLiteral(table.name)
+  let value = 'N' + quoteLiteral(comment)
+
+  return (
+    'if exists (select 1 from fn_listextendedproperty(' +
+    "N'MS_Description', N'SCHEMA', N" +
+    schema +
+    ", N'TABLE', N" +
+    name +
+    ', null, null)) ' +
+    "exec sp_updateextendedproperty @name = N'MS_Description', @value = " +
+    value +
+    ", @level0type = N'SCHEMA', @level0name = N" +
+    schema +
+    ", @level1type = N'TABLE', @level1name = N" +
+    name +
+    ' else ' +
+    "exec sp_addextendedproperty @name = N'MS_Description', @value = " +
+    value +
+    ", @level0type = N'SCHEMA', @level0name = N" +
+    schema +
+    ", @level1type = N'TABLE', @level1name = N" +
+    name
+  )
+}
+
+function compileMssqlColumn(definition: ColumnDefinition): string {
+  // MSSQL computed columns use `AS (expression)` without a data type
+  if (definition.computed) {
+    let parts = ['as (' + definition.computed.expression + ')']
+    if (definition.computed.stored) {
+      parts.push('persisted')
+    }
+    return parts.join(' ')
+  }
+
+  let parts = [compileMssqlColumnType(definition)]
+
+  if (definition.nullable === false) {
+    parts.push('not null')
+  }
+
+  if (definition.default) {
+    if (definition.default.kind === 'now') {
+      parts.push('default getdate()')
+    } else if (definition.default.kind === 'sql') {
+      parts.push('default ' + definition.default.expression)
+    } else {
+      parts.push('default ' + quoteLiteral(definition.default.value))
+    }
+  }
+
+  if (definition.autoIncrement && !definition.identity) {
+    parts.push('identity(1,1)')
+  }
+
+  if (definition.identity) {
+    let start = definition.identity.start ?? 1
+    let increment = definition.identity.increment ?? 1
+    parts.push('identity(' + String(start) + ',' + String(increment) + ')')
+  }
+
+  if (definition.primaryKey) {
+    parts.push('primary key')
+  }
+
+  if (definition.unique) {
+    parts.push('unique')
+  }
+
+  if (definition.references) {
+    let clause =
+      'references ' +
+      quoteTableRef(definition.references.table) +
+      ' (' +
+      definition.references.columns.map((column) => quoteIdentifier(column)).join(', ') +
+      ')'
+
+    if (definition.references.onDelete) {
+      clause += ' on delete ' + definition.references.onDelete
+    }
+
+    if (definition.references.onUpdate) {
+      clause += ' on update ' + definition.references.onUpdate
+    }
+
+    parts.push(clause)
+  }
+
+  if (definition.checks && definition.checks.length > 0) {
+    for (let check of definition.checks) {
+      parts.push('check (' + check.expression + ')')
+    }
+  }
+
+  return parts.join(' ')
+}
+
+function compileMssqlColumnType(definition: ColumnDefinition): string {
+  if (definition.type === 'varchar') {
+    return 'varchar(' + String(definition.length ?? 255) + ')'
+  }
+
+  if (definition.type === 'text') {
+    return 'varchar(max)'
+  }
+
+  if (definition.type === 'integer') {
+    return 'int'
+  }
+
+  if (definition.type === 'bigint') {
+    return 'bigint'
+  }
+
+  if (definition.type === 'decimal') {
+    if (definition.precision !== undefined && definition.scale !== undefined) {
+      return 'decimal(' + String(definition.precision) + ', ' + String(definition.scale) + ')'
+    }
+
+    return 'decimal'
+  }
+
+  if (definition.type === 'boolean') {
+    return 'bit'
+  }
+
+  if (definition.type === 'uuid') {
+    return 'uniqueidentifier'
+  }
+
+  if (definition.type === 'date') {
+    return 'date'
+  }
+
+  if (definition.type === 'time') {
+    return 'time'
+  }
+
+  if (definition.type === 'timestamp') {
+    return definition.withTimezone ? 'datetimeoffset' : 'datetime2'
+  }
+
+  if (definition.type === 'json') {
+    return 'nvarchar(max)'
+  }
+
+  if (definition.type === 'binary') {
+    return 'varbinary(max)'
+  }
+
+  if (definition.type === 'enum') {
+    return 'varchar(255)'
+  }
+
+  return 'varchar(max)'
 }

--- a/packages/data-table-mssql/src/lib/adapter.ts
+++ b/packages/data-table-mssql/src/lib/adapter.ts
@@ -46,7 +46,6 @@ export type MssqlDatabaseTransaction = MssqlDatabaseClient & {
  * Mssql pool-like client contract used by this adapter.
  */
 export type MssqlDatabasePool = MssqlDatabaseClient & {
-  query(command: string): Promise<MssqlQueryResult>
   transaction(): MssqlDatabaseTransaction
 }
 
@@ -66,6 +65,7 @@ export class MssqlDatabaseAdapter implements DatabaseAdapter {
 
   #client: MssqlDatabasePool
   #transactions = new Map<string, MssqlDatabaseTransaction>()
+  #isolatedTransactions = new Set<string>()
   #transactionCounter = 0
 
   constructor(client: MssqlDatabasePool, options?: MssqlDatabaseAdapterOptions) {
@@ -115,6 +115,10 @@ export class MssqlDatabaseAdapter implements DatabaseAdapter {
 
     this.#transactions.set(token.id, transaction)
 
+    if (options?.isolationLevel) {
+      this.#isolatedTransactions.add(token.id)
+    }
+
     return token
   }
 
@@ -122,9 +126,13 @@ export class MssqlDatabaseAdapter implements DatabaseAdapter {
     let transaction = this.#transactionClient(token)
 
     try {
+      if (this.#isolatedTransactions.has(token.id)) {
+        await runMssqlQuery(transaction, 'set transaction isolation level read committed')
+      }
       await transaction.commit()
     } finally {
       this.#transactions.delete(token.id)
+      this.#isolatedTransactions.delete(token.id)
     }
   }
 
@@ -132,9 +140,17 @@ export class MssqlDatabaseAdapter implements DatabaseAdapter {
     let transaction = this.#transactionClient(token)
 
     try {
+      if (this.#isolatedTransactions.has(token.id)) {
+        try {
+          await runMssqlQuery(transaction, 'set transaction isolation level read committed')
+        } catch {
+          // Best-effort: transaction may be in a failed state
+        }
+      }
       await transaction.rollback()
     } finally {
       this.#transactions.delete(token.id)
+      this.#isolatedTransactions.delete(token.id)
     }
   }
 
@@ -193,7 +209,7 @@ async function runMssqlQuery(
   let request = client.request()
 
   for (let index = 0; index < values.length; index += 1) {
-    request.input('p' + String(index + 1), values[index])
+    request.input('dt_p' + String(index + 1), values[index])
   }
 
   return request.query(text)

--- a/packages/data-table-mssql/src/lib/adapter.ts
+++ b/packages/data-table-mssql/src/lib/adapter.ts
@@ -1,0 +1,302 @@
+import type {
+  AdapterCapabilityOverrides,
+  AdapterExecuteRequest,
+  AdapterResult,
+  DatabaseAdapter,
+  TransactionOptions,
+  TransactionToken,
+} from '@remix-run/data-table'
+import { getTablePrimaryKey } from '@remix-run/data-table'
+
+import { compileMssqlStatement } from './sql-compiler.ts'
+
+/**
+ * Result shape returned by mssql request `query()` calls.
+ */
+export type MssqlQueryResult = {
+  recordset?: unknown[]
+  rowsAffected?: number[]
+}
+
+/**
+ * Minimal mssql request contract used by this adapter.
+ */
+export type MssqlDatabaseRequest = {
+  input(name: string, value: unknown): MssqlDatabaseRequest
+  query(text: string): Promise<MssqlQueryResult>
+}
+
+/**
+ * Minimal mssql client contract used by this adapter.
+ */
+export type MssqlDatabaseClient = {
+  request(): MssqlDatabaseRequest
+}
+
+/**
+ * Minimal mssql transaction contract used by this adapter.
+ */
+export type MssqlDatabaseTransaction = MssqlDatabaseClient & {
+  commit(): Promise<void>
+  rollback(): Promise<void>
+}
+
+/**
+ * Internal handle returned by pool.transaction() before begin() is called.
+ */
+type MssqlTransactionHandle = MssqlDatabaseTransaction & {
+  begin(): Promise<unknown>
+}
+
+/**
+ * Minimal mssql pool contract used by this adapter.
+ */
+export type MssqlDatabasePool = MssqlDatabaseClient & {
+  transaction(): MssqlTransactionHandle
+}
+
+/**
+ * Mssql adapter configuration.
+ */
+export type MssqlDatabaseAdapterOptions = {
+  capabilities?: AdapterCapabilityOverrides
+}
+
+/**
+ * `DatabaseAdapter` implementation for mssql-compatible pools.
+ */
+export class MssqlDatabaseAdapter implements DatabaseAdapter {
+  dialect = 'mssql'
+  capabilities
+
+  #client: MssqlDatabasePool
+  #transactions = new Map<string, MssqlDatabaseTransaction>()
+  #transactionCounter = 0
+
+  constructor(client: MssqlDatabasePool, options?: MssqlDatabaseAdapterOptions) {
+    this.#client = client
+    this.capabilities = {
+      returning: options?.capabilities?.returning ?? false,
+      savepoints: options?.capabilities?.savepoints ?? true,
+      upsert: options?.capabilities?.upsert ?? true,
+    }
+  }
+
+  async execute(request: AdapterExecuteRequest): Promise<AdapterResult> {
+    if (request.statement.kind === 'insertMany' && request.statement.values.length === 0) {
+      return {
+        affectedRows: 0,
+        insertId: undefined,
+        rows: request.statement.returning ? [] : undefined,
+      }
+    }
+
+    let statement = compileMssqlStatement(request.statement)
+    let queryable = this.#resolveClient(request.transaction)
+    let result = await runMssqlQuery(queryable, statement.text, statement.values)
+    let rows = normalizeRows(result.recordset ?? [])
+
+    if (request.statement.kind === 'count' || request.statement.kind === 'exists') {
+      rows = normalizeCountRows(rows)
+    }
+
+    return {
+      rows,
+      affectedRows: normalizeAffectedRows(request.statement.kind, result.rowsAffected),
+      insertId: normalizeInsertId(request.statement.kind, request.statement, rows),
+    }
+  }
+
+  async beginTransaction(options?: TransactionOptions): Promise<TransactionToken> {
+    let transaction = this.#client.transaction()
+    await transaction.begin()
+
+    if (options?.isolationLevel) {
+      await runMssqlQuery(transaction, 'set transaction isolation level ' + options.isolationLevel)
+    }
+
+    this.#transactionCounter += 1
+    let token = { id: 'tx_' + String(this.#transactionCounter) }
+
+    this.#transactions.set(token.id, transaction)
+
+    return token
+  }
+
+  async commitTransaction(token: TransactionToken): Promise<void> {
+    let transaction = this.#transactionClient(token)
+
+    try {
+      await transaction.commit()
+    } finally {
+      this.#transactions.delete(token.id)
+    }
+  }
+
+  async rollbackTransaction(token: TransactionToken): Promise<void> {
+    let transaction = this.#transactionClient(token)
+
+    try {
+      await transaction.rollback()
+    } finally {
+      this.#transactions.delete(token.id)
+    }
+  }
+
+  async createSavepoint(token: TransactionToken, name: string): Promise<void> {
+    let transaction = this.#transactionClient(token)
+    await runMssqlQuery(transaction, 'save transaction ' + quoteIdentifier(name))
+  }
+
+  async rollbackToSavepoint(token: TransactionToken, name: string): Promise<void> {
+    let transaction = this.#transactionClient(token)
+    await runMssqlQuery(transaction, 'rollback transaction ' + quoteIdentifier(name))
+  }
+
+  // MSSQL does not support RELEASE SAVEPOINT — this is intentionally a no-op.
+  async releaseSavepoint(token: TransactionToken, _name: string): Promise<void> {
+    this.#transactionClient(token)
+  }
+
+  #resolveClient(token: TransactionToken | undefined): MssqlDatabaseClient {
+    if (!token) {
+      return this.#client
+    }
+
+    return this.#transactionClient(token)
+  }
+
+  #transactionClient(token: TransactionToken): MssqlDatabaseTransaction {
+    let transaction = this.#transactions.get(token.id)
+
+    if (!transaction) {
+      throw new Error('Unknown transaction token: ' + token.id)
+    }
+
+    return transaction
+  }
+}
+
+/**
+ * Creates a mssql `DatabaseAdapter`.
+ * @param client Mssql connection pool.
+ * @param options Optional adapter capability overrides.
+ * @returns A configured mssql adapter.
+ */
+export function createMssqlDatabaseAdapter(
+  client: MssqlDatabasePool,
+  options?: MssqlDatabaseAdapterOptions,
+): MssqlDatabaseAdapter {
+  return new MssqlDatabaseAdapter(client, options)
+}
+
+async function runMssqlQuery(
+  client: MssqlDatabaseClient,
+  text: string,
+  values: unknown[] = [],
+): Promise<MssqlQueryResult> {
+  let request = client.request()
+
+  for (let index = 0; index < values.length; index += 1) {
+    request.input('p' + String(index + 1), values[index])
+  }
+
+  return request.query(text)
+}
+
+function normalizeRows(rows: unknown[]): Record<string, unknown>[] {
+  return rows.map((row) => {
+    if (typeof row !== 'object' || row === null) {
+      return {}
+    }
+
+    return { ...(row as Record<string, unknown>) }
+  })
+}
+
+function normalizeCountRows(rows: Record<string, unknown>[]): Record<string, unknown>[] {
+  return rows.map((row) => {
+    let count = row.count
+
+    if (typeof count === 'string') {
+      let numeric = Number(count)
+
+      if (!Number.isNaN(numeric)) {
+        return {
+          ...row,
+          count: numeric,
+        }
+      }
+    }
+
+    if (typeof count === 'bigint') {
+      return {
+        ...row,
+        count: Number(count),
+      }
+    }
+
+    return row
+  })
+}
+
+function normalizeAffectedRows(
+  kind: AdapterExecuteRequest['statement']['kind'],
+  rowsAffected: number[] | undefined,
+): number | undefined {
+  if (kind === 'select' || kind === 'count' || kind === 'exists' || kind === 'raw') {
+    return undefined
+  }
+
+  if (!rowsAffected || rowsAffected.length === 0) {
+    return undefined
+  }
+
+  let total = 0
+
+  for (let amount of rowsAffected) {
+    total += amount
+  }
+
+  return total
+}
+
+function normalizeInsertId(
+  kind: AdapterExecuteRequest['statement']['kind'],
+  statement: AdapterExecuteRequest['statement'],
+  rows: Record<string, unknown>[],
+): unknown {
+  if (!isInsertStatementKind(kind) || !isInsertStatement(statement)) {
+    return undefined
+  }
+
+  let primaryKey = getTablePrimaryKey(statement.table)
+
+  if (primaryKey.length !== 1) {
+    return undefined
+  }
+
+  let key = primaryKey[0]
+  let row = rows[rows.length - 1]
+
+  return row ? row[key] : undefined
+}
+
+function quoteIdentifier(value: string): string {
+  return '[' + value.replace(/]/g, ']]') + ']'
+}
+
+function isInsertStatementKind(kind: AdapterExecuteRequest['statement']['kind']): boolean {
+  return kind === 'insert' || kind === 'insertMany' || kind === 'upsert'
+}
+
+function isInsertStatement(
+  statement: AdapterExecuteRequest['statement'],
+): statement is Extract<
+  AdapterExecuteRequest['statement'],
+  { kind: 'insert' | 'insertMany' | 'upsert' }
+> {
+  return (
+    statement.kind === 'insert' || statement.kind === 'insertMany' || statement.kind === 'upsert'
+  )
+}

--- a/packages/data-table-mssql/src/lib/adapter.ts
+++ b/packages/data-table-mssql/src/lib/adapter.ts
@@ -11,7 +11,7 @@ import { getTablePrimaryKey } from '@remix-run/data-table'
 import { compileMssqlStatement } from './sql-compiler.ts'
 
 /**
- * Result shape returned by mssql request `query()` calls.
+ * Result shape returned by mssql `query()` calls.
  */
 export type MssqlQueryResult = {
   recordset?: unknown[]
@@ -19,9 +19,9 @@ export type MssqlQueryResult = {
 }
 
 /**
- * Minimal mssql request contract used by this adapter.
+ * Minimal mssql request contract used internally by this adapter.
  */
-export type MssqlDatabaseRequest = {
+type MssqlDatabaseRequest = {
   input(name: string, value: unknown): MssqlDatabaseRequest
   query(text: string): Promise<MssqlQueryResult>
 }
@@ -34,25 +34,20 @@ export type MssqlDatabaseClient = {
 }
 
 /**
- * Minimal mssql transaction contract used by this adapter.
+ * Mssql transaction client with begin/commit/rollback lifecycle.
  */
 export type MssqlDatabaseTransaction = MssqlDatabaseClient & {
+  begin(): Promise<unknown>
   commit(): Promise<void>
   rollback(): Promise<void>
 }
 
 /**
- * Internal handle returned by pool.transaction() before begin() is called.
- */
-type MssqlTransactionHandle = MssqlDatabaseTransaction & {
-  begin(): Promise<unknown>
-}
-
-/**
- * Minimal mssql pool contract used by this adapter.
+ * Mssql pool-like client contract used by this adapter.
  */
 export type MssqlDatabasePool = MssqlDatabaseClient & {
-  transaction(): MssqlTransactionHandle
+  query(command: string): Promise<MssqlQueryResult>
+  transaction(): MssqlDatabaseTransaction
 }
 
 /**
@@ -92,8 +87,8 @@ export class MssqlDatabaseAdapter implements DatabaseAdapter {
     }
 
     let statement = compileMssqlStatement(request.statement)
-    let queryable = this.#resolveClient(request.transaction)
-    let result = await runMssqlQuery(queryable, statement.text, statement.values)
+    let client = this.#resolveClient(request.transaction)
+    let result = await runMssqlQuery(client, statement.text, statement.values)
     let rows = normalizeRows(result.recordset ?? [])
 
     if (request.statement.kind === 'count' || request.statement.kind === 'exists') {

--- a/packages/data-table-mssql/src/lib/adapter.ts
+++ b/packages/data-table-mssql/src/lib/adapter.ts
@@ -255,7 +255,7 @@ function normalizeAffectedRows(
   kind: AdapterExecuteRequest['statement']['kind'],
   rowsAffected: number[] | undefined,
 ): number | undefined {
-  if (kind === 'select' || kind === 'count' || kind === 'exists' || kind === 'raw') {
+  if (kind === 'select' || kind === 'count' || kind === 'exists') {
     return undefined
   }
 

--- a/packages/data-table-mssql/src/lib/adapter.ts
+++ b/packages/data-table-mssql/src/lib/adapter.ts
@@ -83,6 +83,7 @@ export class MssqlDatabaseAdapter implements DatabaseAdapter {
   #client: MssqlDatabasePool
   #transactions = new Map<string, MssqlTransactionClient>()
   #isolatedTransactions = new Set<string>()
+  #migrationLockTransaction?: MssqlTransactionClient
   #transactionCounter = 0
 
   constructor(client: MssqlDatabasePool, options?: MssqlDatabaseAdapterOptions) {
@@ -238,34 +239,80 @@ export class MssqlDatabaseAdapter implements DatabaseAdapter {
   }
 
   async acquireMigrationLock(): Promise<void> {
-    let result = await runMssqlQuery(
-      this.#client,
-      "declare @dt_lock_result int; exec @dt_lock_result = sp_getapplock @Resource = 'data_table_migrations', @LockMode = 'Exclusive', @LockTimeout = 60000, @LockOwner = 'Session'; select @dt_lock_result as [returnValue]",
-    )
+    if (!this.capabilities.migrationLock) {
+      return
+    }
 
-    let row = result.recordset?.[0] as Record<string, unknown> | undefined
-    let returnValue = row?.returnValue
+    if (this.#migrationLockTransaction) {
+      return
+    }
 
-    if (typeof returnValue === 'number' && returnValue < 0) {
-      throw new Error(
-        'Failed to acquire migration lock (sp_getapplock returned ' + returnValue + ')',
+    let transaction = this.#client.transaction()
+    await transaction.begin()
+
+    try {
+      let result = await runMssqlQuery(
+        transaction,
+        "declare @dt_lock_result int; exec @dt_lock_result = sp_getapplock @Resource = 'data_table_migrations', @LockMode = 'Exclusive', @LockTimeout = 60000, @LockOwner = 'Transaction'; select @dt_lock_result as [returnValue]",
       )
+
+      let row = result.recordset?.[0] as Record<string, unknown> | undefined
+      let returnValue = row?.returnValue
+
+      if (typeof returnValue === 'number' && returnValue < 0) {
+        throw new Error(
+          'Failed to acquire migration lock (sp_getapplock returned ' + returnValue + ')',
+        )
+      }
+
+      this.#migrationLockTransaction = transaction
+    } catch (error) {
+      try {
+        await transaction.rollback()
+      } catch {
+        // Best-effort rollback in case lock acquisition leaves tx in a failed state.
+      }
+
+      throw error
     }
   }
 
   async releaseMigrationLock(): Promise<void> {
-    await runMssqlQuery(
-      this.#client,
-      "exec sp_releaseapplock @Resource = 'data_table_migrations', @LockOwner = 'Session'",
-    )
+    if (!this.capabilities.migrationLock) {
+      return
+    }
+
+    let transaction = this.#migrationLockTransaction
+
+    if (!transaction) {
+      return
+    }
+
+    this.#migrationLockTransaction = undefined
+
+    try {
+      await transaction.commit()
+    } catch (error) {
+      try {
+        await transaction.rollback()
+      } catch {
+        // Best-effort rollback if commit fails.
+      }
+
+      throw error
+    }
   }
 
   #resolveClient(token: TransactionToken | undefined): MssqlDatabaseClient {
-    if (!token) {
-      return this.#client
+    if (token) {
+      return this.#transactionClient(token)
     }
 
-    return this.#transactionClient(token)
+    if (this.#migrationLockTransaction) {
+      return this.#migrationLockTransaction
+    }
+
+    return this.#client
   }
 
   #transactionClient(token: TransactionToken): MssqlTransactionClient {
@@ -617,7 +664,9 @@ function compileMssqlMigrationOperations(operation: DataMigrationOperation): Sql
           quoteTableRef(change.constraint.references.table) +
           ' (' +
           change.constraint.references.columns.map((column) => quoteIdentifier(column)).join(', ') +
-          ')'
+          ')' +
+          (change.constraint.onDelete ? ' on delete ' + change.constraint.onDelete : '') +
+          (change.constraint.onUpdate ? ' on update ' + change.constraint.onUpdate : '')
       } else if (change.kind === 'dropForeignKey') {
         sql += 'drop constraint ' + quoteIdentifier(change.name)
       } else if (change.kind === 'addCheck') {

--- a/packages/data-table-mssql/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-mssql/src/lib/sql-compiler.test.ts
@@ -145,7 +145,10 @@ describe('mssql sql-compiler', () => {
     })
 
     it('compile in-list predicates', async () => {
-      await db.query(accounts).where(inList('id', [1, 2])).all()
+      await db
+        .query(accounts)
+        .where(inList('id', [1, 2]))
+        .all()
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
@@ -165,7 +168,10 @@ describe('mssql sql-compiler', () => {
     })
 
     it('compile not-in predicates', async () => {
-      await db.query(accounts).where(notInList('id', [1, 2])).all()
+      await db
+        .query(accounts)
+        .where(notInList('id', [1, 2]))
+        .all()
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {

--- a/packages/data-table-mssql/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-mssql/src/lib/sql-compiler.test.ts
@@ -1,0 +1,555 @@
+import * as assert from 'node:assert/strict'
+import { beforeEach, describe, it } from 'node:test'
+import { boolean, number, string } from '@remix-run/data-schema'
+import {
+  and,
+  createDatabase,
+  createTable,
+  eq,
+  gt,
+  ilike,
+  inList,
+  isNull,
+  ne,
+  notInList,
+  or,
+} from '@remix-run/data-table'
+import type { AdapterStatement, DatabaseAdapter } from '@remix-run/data-table'
+
+import { compileMssqlStatement } from './sql-compiler.ts'
+
+let accounts = createTable({
+  name: 'accounts',
+  columns: {
+    id: number(),
+    email: string(),
+    status: string(),
+    deleted: boolean(),
+  },
+})
+
+let tasks = createTable({
+  name: 'tasks',
+  columns: {
+    id: number(),
+    name: string(),
+    account_id: number(),
+  },
+})
+
+let statements: AdapterStatement[] = []
+
+let fakeAdapter = {
+  capabilities: {
+    upsert: true,
+    returning: true,
+  },
+
+  execute: async (request) => {
+    statements.push(request.statement)
+    return {}
+  },
+} as DatabaseAdapter
+
+let db = createDatabase(fakeAdapter)
+
+describe('mssql sql-compiler', () => {
+  beforeEach(() => {
+    statements = []
+  })
+
+  describe('select statement', () => {
+    it('compile wildcard selection', async () => {
+      await db.query(accounts).all()
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts]',
+        values: [],
+      })
+    })
+
+    it('compile selected aliases', async () => {
+      await db
+        .query(accounts)
+        .select({
+          accountId: accounts.id,
+          accountEmail: accounts.email,
+        })
+        .all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select [accounts].[id] as [accountId], [accounts].[email] as [accountEmail] from [accounts]',
+        values: [],
+      })
+    })
+
+    it('compile inner joins', async () => {
+      await db.query(accounts).join(tasks, eq(accounts.id, tasks.account_id)).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] inner join [tasks] on [accounts].[id] = [tasks].[account_id]',
+        values: [],
+      })
+    })
+
+    it('compile left joins', async () => {
+      await db.query(accounts).leftJoin(tasks, eq(accounts.id, tasks.account_id)).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] left join [tasks] on [accounts].[id] = [tasks].[account_id]',
+        values: [],
+      })
+    })
+
+    it('compile right joins', async () => {
+      await db.query(accounts).rightJoin(tasks, eq(accounts.id, tasks.account_id)).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] right join [tasks] on [accounts].[id] = [tasks].[account_id]',
+        values: [],
+      })
+    })
+
+    it('compile object where filters', async () => {
+      await db.query(accounts).where({ status: 'enabled' }).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] where (([status] = @p1))',
+        values: ['enabled'],
+      })
+    })
+
+    it('compile null where filters', async () => {
+      await db.query(accounts).where({ status: null }).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] where (([status] is null))',
+        values: [],
+      })
+    })
+
+    it('compile predicate operators', async () => {
+      await db.query(accounts).where(ne('status', 'disabled')).where(gt('id', 10)).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] where ([status] <> @p1) and ([id] > @p2)',
+        values: ['disabled', 10],
+      })
+    })
+
+    it('compile in-list predicates', async () => {
+      await db.query(accounts).where(inList('id', [1, 2])).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] where ([id] in (@p1, @p2))',
+        values: [1, 2],
+      })
+    })
+
+    it('compile empty in-list predicates', async () => {
+      await db.query(accounts).where(inList('id', [])).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] where (1 = 0)',
+        values: [],
+      })
+    })
+
+    it('compile not-in predicates', async () => {
+      await db.query(accounts).where(notInList('id', [1, 2])).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] where ([id] not in (@p1, @p2))',
+        values: [1, 2],
+      })
+    })
+
+    it('compile empty not-in predicates', async () => {
+      await db.query(accounts).where(notInList('id', [])).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] where (1 = 1)',
+        values: [],
+      })
+    })
+
+    it('compile logical combinators', async () => {
+      await db
+        .query(accounts)
+        .where(
+          and(
+            eq(accounts.id, 1),
+            or(eq(accounts.status, 'enabled'), eq(accounts.status, 'disabled')),
+          ),
+        )
+        .all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] where (([accounts].[id] = @p1) and (([accounts].[status] = @p2) or ([accounts].[status] = @p3)))',
+        values: [1, 'enabled', 'disabled'],
+      })
+    })
+
+    it('compile group by and having', async () => {
+      await db.query(tasks).groupBy(tasks.account_id).having({ account_id: 20 }).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [tasks] group by [tasks].[account_id] having (([account_id] = @p1))',
+        values: [20],
+      })
+    })
+
+    it('compile ilike predicates', async () => {
+      await db.query(accounts).where(ilike('status', 'EnA')).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] where (lower([status]) like lower(@p1))',
+        values: ['EnA'],
+      })
+    })
+
+    it('compile isNull predicates', async () => {
+      await db.query(accounts).where(isNull(accounts.status)).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] where ([accounts].[status] is null)',
+        values: [],
+      })
+    })
+
+    it('compile pagination with limit-only via top', async () => {
+      await db.query(accounts).limit(10).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select top (10) * from [accounts]',
+        values: [],
+      })
+    })
+
+    it('compile pagination with explicit order for offset/fetch', async () => {
+      await db.query(accounts).orderBy(accounts.id).offset(5).limit(10).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] order by [accounts].[id] ASC offset 5 rows fetch next 10 rows only',
+        values: [],
+      })
+    })
+
+    it('compile pagination with synthetic order for offset-only queries', async () => {
+      await db.query(accounts).offset(5).all()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] order by (select 1) offset 5 rows',
+        values: [],
+      })
+    })
+  })
+
+  describe('count - exists statement', () => {
+    it('compile count', async () => {
+      await db.query(tasks).where({ account_id: 1 }).count()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select count(*) as [count] from (select 1 as [__dt_col] from [tasks] where (([account_id] = @p1))) as [__dt_count]',
+        values: [1],
+      })
+    })
+
+    it('compile exists', async () => {
+      await db.query(tasks).where({ account_id: 1 }).exists()
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select count(*) as [count] from (select 1 as [__dt_col] from [tasks] where (([account_id] = @p1))) as [__dt_count]',
+        values: [1],
+      })
+    })
+  })
+
+  describe('insert statement', () => {
+    it('compile for one', async () => {
+      await db.create(accounts, {
+        id: 1,
+        email: 'info@remix.run',
+        status: 'enabled',
+      })
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'insert into [accounts] ([id], [email], [status]) values (@p1, @p2, @p3)',
+        values: [1, 'info@remix.run', 'enabled'],
+      })
+    })
+
+    it('compile for one with output', async () => {
+      await db.query(accounts).insert(
+        {
+          id: 1,
+          email: 'info@remix.run',
+          status: 'enabled',
+        },
+        { returning: '*' },
+      )
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'insert into [accounts] ([id], [email], [status]) output inserted.* values (@p1, @p2, @p3)',
+        values: [1, 'info@remix.run', 'enabled'],
+      })
+    })
+
+    it('compile for one with default values', async () => {
+      await db.create(accounts, {})
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'insert into [accounts] default values',
+        values: [],
+      })
+    })
+
+    it('compile for many', async () => {
+      await db.createMany(accounts, [
+        { id: 1, email: 'info@remix.run', status: 'enabled' },
+        { id: 2, email: 'contact@remix.run', status: 'draft' },
+      ])
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'insert into [accounts] ([id], [email], [status]) values (@p1, @p2, @p3), (@p4, @p5, @p6)',
+        values: [1, 'info@remix.run', 'enabled', 2, 'contact@remix.run', 'draft'],
+      })
+    })
+
+    it('compile for many and return values', async () => {
+      await db.query(accounts).insertMany(
+        [
+          { id: 1, email: 'info@remix.run', status: 'enabled' },
+          { id: 2, email: 'contact@remix.run', status: 'draft' },
+        ],
+        { returning: '*' },
+      )
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'insert into [accounts] ([id], [email], [status]) output inserted.* values (@p1, @p2, @p3), (@p4, @p5, @p6)',
+        values: [1, 'info@remix.run', 'enabled', 2, 'contact@remix.run', 'draft'],
+      })
+    })
+
+    it('compile for many with default values', () => {
+      let compiled = compileMssqlStatement({
+        kind: 'insertMany',
+        table: accounts,
+        values: [{}, {}],
+      })
+      assert.deepEqual(compiled, {
+        text: 'insert into [accounts] default values',
+        values: [],
+      })
+    })
+
+    it('compile for many without data', async () => {
+      await db.createMany(accounts, [])
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select 0 where 1 = 0',
+        values: [],
+      })
+    })
+  })
+
+  describe('update statement', () => {
+    it('compile for one', async () => {
+      await db.query(accounts).where({ id: 1 }).update({
+        email: 'info@remix.run',
+        status: 'enabled',
+      })
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'update [accounts] set [email] = @p1, [status] = @p2 where (([id] = @p3))',
+        values: ['info@remix.run', 'enabled', 1],
+      })
+    })
+
+    it('compile with output values', async () => {
+      await db.query(accounts).where({ id: 1 }).update(
+        {
+          email: 'info@remix.run',
+        },
+        { returning: '*' },
+      )
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'update [accounts] set [email] = @p1 output inserted.* where (([id] = @p2))',
+        values: ['info@remix.run', 1],
+      })
+    })
+  })
+
+  describe('upsert statement', () => {
+    it('throws without values', async () => {
+      await db.query(accounts).upsert(
+        {},
+        {
+          conflictTarget: ['id'],
+        },
+      )
+
+      assert.throws(() => compileMssqlStatement(statements[0]))
+    })
+
+    it('compile with update columns', async () => {
+      await db.query(accounts).upsert(
+        {
+          status: 'enabled',
+          email: 'info@remix.run',
+        },
+        {
+          conflictTarget: ['id'],
+          update: {
+            email: 'contact@remix.run',
+          },
+        },
+      )
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'merge [accounts] with (holdlock) as target using (values (@p1, @p2)) as source ([status], [email]) on target.[id] = source.[id] when matched then update set target.[email] = @p3 when not matched then insert ([status], [email]) values (source.[status], source.[email]);',
+        values: ['enabled', 'info@remix.run', 'contact@remix.run'],
+      })
+    })
+
+    it('compile without update columns', async () => {
+      await db.query(accounts).upsert(
+        {
+          status: 'enabled',
+          email: 'info@remix.run',
+        },
+        {
+          conflictTarget: ['id'],
+          update: {},
+        },
+      )
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'merge [accounts] with (holdlock) as target using (values (@p1, @p2)) as source ([status], [email]) on target.[id] = source.[id] when not matched then insert ([status], [email]) values (source.[status], source.[email]);',
+        values: ['enabled', 'info@remix.run'],
+      })
+    })
+
+    it('compile with output values', async () => {
+      await db.query(accounts).upsert(
+        {
+          id: 1,
+          status: 'enabled',
+          email: 'info@remix.run',
+        },
+        {
+          conflictTarget: ['id'],
+          update: {
+            status: 'disabled',
+          },
+          returning: '*',
+        },
+      )
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'merge [accounts] with (holdlock) as target using (values (@p1, @p2, @p3)) as source ([id], [status], [email]) on target.[id] = source.[id] when matched then update set target.[status] = @p4 when not matched then insert ([id], [status], [email]) values (source.[id], source.[status], source.[email]) output inserted.*;',
+        values: [1, 'enabled', 'info@remix.run', 'disabled'],
+      })
+    })
+  })
+
+  describe('delete statement', () => {
+    it('compile for one', async () => {
+      await db.delete(accounts, 10)
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'delete from [accounts] where (([id] = @p1))',
+        values: [10],
+      })
+    })
+
+    it('compile for many', async () => {
+      await db.deleteMany(accounts, {
+        where: {
+          status: 'enabled',
+        },
+      })
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'delete from [accounts] where (([status] = @p1))',
+        values: ['enabled'],
+      })
+    })
+
+    it('compile with output values', async () => {
+      await db.query(accounts).where({ id: 10 }).delete({ returning: '*' })
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'delete from [accounts] output deleted.* where (([id] = @p1))',
+        values: [10],
+      })
+    })
+  })
+
+  describe('raw statement', () => {
+    it('compile with positional parameters', () => {
+      let compiled = compileMssqlStatement({
+        kind: 'raw',
+        sql: {
+          text: 'select * from accounts where id = ? and status = ?',
+          values: [10, 'active'],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: 'select * from accounts where id = @p1 and status = @p2',
+        values: [10, 'active'],
+      })
+    })
+
+    it('compile without positional parameters', () => {
+      let compiled = compileMssqlStatement({
+        kind: 'raw',
+        sql: {
+          text: 'select * from accounts',
+          values: [],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: 'select * from accounts',
+        values: [],
+      })
+    })
+  })
+})

--- a/packages/data-table-mssql/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-mssql/src/lib/sql-compiler.test.ts
@@ -119,7 +119,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'select * from [accounts] where (([status] = @p1))',
+        text: 'select * from [accounts] where (([status] = @dt_p1))',
         values: ['enabled'],
       })
     })
@@ -139,7 +139,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'select * from [accounts] where ([status] <> @p1) and ([id] > @p2)',
+        text: 'select * from [accounts] where ([status] <> @dt_p1) and ([id] > @dt_p2)',
         values: ['disabled', 10],
       })
     })
@@ -149,7 +149,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'select * from [accounts] where ([id] in (@p1, @p2))',
+        text: 'select * from [accounts] where ([id] in (@dt_p1, @dt_p2))',
         values: [1, 2],
       })
     })
@@ -169,7 +169,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'select * from [accounts] where ([id] not in (@p1, @p2))',
+        text: 'select * from [accounts] where ([id] not in (@dt_p1, @dt_p2))',
         values: [1, 2],
       })
     })
@@ -197,7 +197,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'select * from [accounts] where (([accounts].[id] = @p1) and (([accounts].[status] = @p2) or ([accounts].[status] = @p3)))',
+        text: 'select * from [accounts] where (([accounts].[id] = @dt_p1) and (([accounts].[status] = @dt_p2) or ([accounts].[status] = @dt_p3)))',
         values: [1, 'enabled', 'disabled'],
       })
     })
@@ -207,7 +207,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'select * from [tasks] group by [tasks].[account_id] having (([account_id] = @p1))',
+        text: 'select * from [tasks] group by [tasks].[account_id] having (([account_id] = @dt_p1))',
         values: [20],
       })
     })
@@ -217,7 +217,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'select * from [accounts] where (lower([status]) like lower(@p1))',
+        text: 'select * from [accounts] where (lower([status]) like lower(@dt_p1))',
         values: ['EnA'],
       })
     })
@@ -269,7 +269,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'select count(*) as [count] from (select 1 as [__dt_col] from [tasks] where (([account_id] = @p1))) as [__dt_count]',
+        text: 'select count(*) as [count] from (select 1 as [__dt_col] from [tasks] where (([account_id] = @dt_p1))) as [__dt_count]',
         values: [1],
       })
     })
@@ -279,7 +279,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'select count(*) as [count] from (select 1 as [__dt_col] from [tasks] where (([account_id] = @p1))) as [__dt_count]',
+        text: 'select count(*) as [count] from (select 1 as [__dt_col] from [tasks] where (([account_id] = @dt_p1))) as [__dt_count]',
         values: [1],
       })
     })
@@ -295,7 +295,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'insert into [accounts] ([id], [email], [status]) values (@p1, @p2, @p3)',
+        text: 'insert into [accounts] ([id], [email], [status]) values (@dt_p1, @dt_p2, @dt_p3)',
         values: [1, 'info@remix.run', 'enabled'],
       })
     })
@@ -312,7 +312,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'insert into [accounts] ([id], [email], [status]) output inserted.* values (@p1, @p2, @p3)',
+        text: 'insert into [accounts] ([id], [email], [status]) output inserted.* values (@dt_p1, @dt_p2, @dt_p3)',
         values: [1, 'info@remix.run', 'enabled'],
       })
     })
@@ -335,7 +335,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'insert into [accounts] ([id], [email], [status]) values (@p1, @p2, @p3), (@p4, @p5, @p6)',
+        text: 'insert into [accounts] ([id], [email], [status]) values (@dt_p1, @dt_p2, @dt_p3), (@dt_p4, @dt_p5, @dt_p6)',
         values: [1, 'info@remix.run', 'enabled', 2, 'contact@remix.run', 'draft'],
       })
     })
@@ -351,7 +351,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'insert into [accounts] ([id], [email], [status]) output inserted.* values (@p1, @p2, @p3), (@p4, @p5, @p6)',
+        text: 'insert into [accounts] ([id], [email], [status]) output inserted.* values (@dt_p1, @dt_p2, @dt_p3), (@dt_p4, @dt_p5, @dt_p6)',
         values: [1, 'info@remix.run', 'enabled', 2, 'contact@remix.run', 'draft'],
       })
     })
@@ -388,7 +388,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'update [accounts] set [email] = @p1, [status] = @p2 where (([id] = @p3))',
+        text: 'update [accounts] set [email] = @dt_p1, [status] = @dt_p2 where (([id] = @dt_p3))',
         values: ['info@remix.run', 'enabled', 1],
       })
     })
@@ -403,8 +403,29 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'update [accounts] set [email] = @p1 output inserted.* where (([id] = @p2))',
+        text: 'update [accounts] set [email] = @dt_p1 output inserted.* where (([id] = @dt_p2))',
         values: ['info@remix.run', 1],
+      })
+    })
+
+    it('compile for many', async () => {
+      await db.updateMany(
+        accounts,
+        {
+          email: 'info@remix.run',
+          status: 'enabled',
+        },
+        {
+          where: {
+            status: 'disabled',
+          },
+        },
+      )
+
+      let compiled = compileMssqlStatement(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'update [accounts] set [email] = @dt_p1, [status] = @dt_p2 where (([status] = @dt_p3))',
+        values: ['info@remix.run', 'enabled', 'disabled'],
       })
     })
   })
@@ -437,7 +458,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'merge [accounts] with (holdlock) as target using (values (@p1, @p2)) as source ([status], [email]) on target.[id] = source.[id] when matched then update set target.[email] = @p3 when not matched then insert ([status], [email]) values (source.[status], source.[email]);',
+        text: 'merge [accounts] with (holdlock) as target using (values (@dt_p1, @dt_p2)) as source ([status], [email]) on target.[id] = source.[id] when matched then update set target.[email] = @dt_p3 when not matched then insert ([status], [email]) values (source.[status], source.[email]);',
         values: ['enabled', 'info@remix.run', 'contact@remix.run'],
       })
     })
@@ -456,7 +477,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'merge [accounts] with (holdlock) as target using (values (@p1, @p2)) as source ([status], [email]) on target.[id] = source.[id] when not matched then insert ([status], [email]) values (source.[status], source.[email]);',
+        text: 'merge [accounts] with (holdlock) as target using (values (@dt_p1, @dt_p2)) as source ([status], [email]) on target.[id] = source.[id] when not matched then insert ([status], [email]) values (source.[status], source.[email]);',
         values: ['enabled', 'info@remix.run'],
       })
     })
@@ -479,7 +500,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'merge [accounts] with (holdlock) as target using (values (@p1, @p2, @p3)) as source ([id], [status], [email]) on target.[id] = source.[id] when matched then update set target.[status] = @p4 when not matched then insert ([id], [status], [email]) values (source.[id], source.[status], source.[email]) output inserted.*;',
+        text: 'merge [accounts] with (holdlock) as target using (values (@dt_p1, @dt_p2, @dt_p3)) as source ([id], [status], [email]) on target.[id] = source.[id] when matched then update set target.[status] = @dt_p4 when not matched then insert ([id], [status], [email]) values (source.[id], source.[status], source.[email]) output inserted.*;',
         values: [1, 'enabled', 'info@remix.run', 'disabled'],
       })
     })
@@ -491,7 +512,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'delete from [accounts] where (([id] = @p1))',
+        text: 'delete from [accounts] where (([id] = @dt_p1))',
         values: [10],
       })
     })
@@ -505,7 +526,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'delete from [accounts] where (([status] = @p1))',
+        text: 'delete from [accounts] where (([status] = @dt_p1))',
         values: ['enabled'],
       })
     })
@@ -515,7 +536,7 @@ describe('mssql sql-compiler', () => {
 
       let compiled = compileMssqlStatement(statements[0])
       assert.deepEqual(compiled, {
-        text: 'delete from [accounts] output deleted.* where (([id] = @p1))',
+        text: 'delete from [accounts] output deleted.* where (([id] = @dt_p1))',
         values: [10],
       })
     })
@@ -532,7 +553,7 @@ describe('mssql sql-compiler', () => {
       })
 
       assert.deepEqual(compiled, {
-        text: 'select * from accounts where id = @p1 and status = @p2',
+        text: 'select * from accounts where id = @dt_p1 and status = @dt_p2',
         values: [10, 'active'],
       })
     })

--- a/packages/data-table-mssql/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-mssql/src/lib/sql-compiler.test.ts
@@ -1,43 +1,50 @@
 import * as assert from 'node:assert/strict'
 import { beforeEach, describe, it } from 'node:test'
-import { boolean, number, string } from '@remix-run/data-schema'
 import {
   and,
+  between,
+  column,
   createDatabase,
-  createTable,
+  table,
   eq,
   gt,
+  gte,
   ilike,
   inList,
   isNull,
+  like,
+  lt,
+  lte,
   ne,
   notInList,
+  notNull,
+  type DataManipulationOperation,
+  type DatabaseAdapter,
   or,
 } from '@remix-run/data-table'
-import type { AdapterStatement, DatabaseAdapter } from '@remix-run/data-table'
 
-import { compileMssqlStatement } from './sql-compiler.ts'
+import { compileMssqlOperation } from './sql-compiler.ts'
 
-let accounts = createTable({
+let accounts = table({
   name: 'accounts',
   columns: {
-    id: number(),
-    email: string(),
-    status: string(),
-    deleted: boolean(),
+    id: column.integer(),
+    email: column.text(),
+    status: column.text(),
+    deleted: column.boolean(),
   },
 })
 
-let tasks = createTable({
+let tasks = table({
   name: 'tasks',
   columns: {
-    id: number(),
-    name: string(),
-    account_id: number(),
+    id: column.integer(),
+    name: column.text(),
+    account_id: column.integer(),
   },
 })
 
-let statements: AdapterStatement[] = []
+let statements: DataManipulationOperation[] = []
 
 let fakeAdapter = {
   capabilities: {
@@ -46,7 +53,7 @@ let fakeAdapter = {
   },
 
   execute: async (request) => {
-    statements.push(request.statement)
+    statements.push(request.operation)
     return {}
   },
 } as DatabaseAdapter
@@ -61,7 +68,7 @@ describe('mssql sql-compiler', () => {
   describe('select statement', () => {
     it('compile wildcard selection', async () => {
       await db.query(accounts).all()
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select * from [accounts]',
         values: [],
@@ -77,37 +84,37 @@ describe('mssql sql-compiler', () => {
         })
         .all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select [accounts].[id] as [accountId], [accounts].[email] as [accountEmail] from [accounts]',
         values: [],
       })
     })
 
-    it('compile inner joins', async () => {
+    it('compile joins', async () => {
       await db.query(accounts).join(tasks, eq(accounts.id, tasks.account_id)).all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select * from [accounts] inner join [tasks] on [accounts].[id] = [tasks].[account_id]',
         values: [],
       })
     })
 
-    it('compile left joins', async () => {
+    it('compile left join', async () => {
       await db.query(accounts).leftJoin(tasks, eq(accounts.id, tasks.account_id)).all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select * from [accounts] left join [tasks] on [accounts].[id] = [tasks].[account_id]',
         values: [],
       })
     })
 
-    it('compile right joins', async () => {
+    it('compile right join', async () => {
       await db.query(accounts).rightJoin(tasks, eq(accounts.id, tasks.account_id)).all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select * from [accounts] right join [tasks] on [accounts].[id] = [tasks].[account_id]',
         values: [],
@@ -117,7 +124,7 @@ describe('mssql sql-compiler', () => {
     it('compile object where filters', async () => {
       await db.query(accounts).where({ status: 'enabled' }).all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select * from [accounts] where (([status] = @dt_p1))',
         values: ['enabled'],
@@ -127,7 +134,7 @@ describe('mssql sql-compiler', () => {
     it('compile null where filters', async () => {
       await db.query(accounts).where({ status: null }).all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select * from [accounts] where (([status] is null))',
         values: [],
@@ -137,7 +144,7 @@ describe('mssql sql-compiler', () => {
     it('compile predicate operators', async () => {
       await db.query(accounts).where(ne('status', 'disabled')).where(gt('id', 10)).all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select * from [accounts] where ([status] <> @dt_p1) and ([id] > @dt_p2)',
         values: ['disabled', 10],
@@ -150,7 +157,7 @@ describe('mssql sql-compiler', () => {
         .where(inList('id', [1, 2]))
         .all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select * from [accounts] where ([id] in (@dt_p1, @dt_p2))',
         values: [1, 2],
@@ -160,7 +167,7 @@ describe('mssql sql-compiler', () => {
     it('compile empty in-list predicates', async () => {
       await db.query(accounts).where(inList('id', [])).all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select * from [accounts] where (1 = 0)',
         values: [],
@@ -173,7 +180,7 @@ describe('mssql sql-compiler', () => {
         .where(notInList('id', [1, 2]))
         .all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select * from [accounts] where ([id] not in (@dt_p1, @dt_p2))',
         values: [1, 2],
@@ -183,7 +190,7 @@ describe('mssql sql-compiler', () => {
     it('compile empty not-in predicates', async () => {
       await db.query(accounts).where(notInList('id', [])).all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select * from [accounts] where (1 = 1)',
         values: [],
@@ -201,7 +208,7 @@ describe('mssql sql-compiler', () => {
         )
         .all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select * from [accounts] where (([accounts].[id] = @dt_p1) and (([accounts].[status] = @dt_p2) or ([accounts].[status] = @dt_p3)))',
         values: [1, 'enabled', 'disabled'],
@@ -211,29 +218,88 @@ describe('mssql sql-compiler', () => {
     it('compile group by and having', async () => {
       await db.query(tasks).groupBy(tasks.account_id).having({ account_id: 20 }).all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select * from [tasks] group by [tasks].[account_id] having (([account_id] = @dt_p1))',
         values: [20],
       })
     })
 
-    it('compile ilike predicates', async () => {
-      await db.query(accounts).where(ilike('status', 'EnA')).all()
+    it('compile boolean predicates', async () => {
+      await db.query(accounts).where(isNull(accounts.status)).where(notNull(accounts.email)).all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
-        text: 'select * from [accounts] where (lower([status]) like lower(@dt_p1))',
-        values: ['EnA'],
+        text: 'select * from [accounts] where ([accounts].[status] is null) and ([accounts].[email] is not null)',
+        values: [],
       })
     })
 
-    it('compile isNull predicates', async () => {
-      await db.query(accounts).where(isNull(accounts.status)).all()
+    it('compile gte/lt/lte/between/like/ilike predicates', async () => {
+      await db
+        .query(accounts)
+        .where(gte('id', 1))
+        .where(lt('id', 20))
+        .where(lte('id', 30))
+        .where(between('id', 2, 9))
+        .where(like('email', '%@example.com'))
+        .where(ilike('email', '%@example.com'))
+        .all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
-        text: 'select * from [accounts] where ([accounts].[status] is null)',
+        text: 'select * from [accounts] where ([id] >= @dt_p1) and ([id] < @dt_p2) and ([id] <= @dt_p3) and ([id] between @dt_p4 and @dt_p5) and ([email] like @dt_p6) and (lower([email]) like lower(@dt_p7))',
+        values: [1, 20, 30, 2, 9, '%@example.com', '%@example.com'],
+      })
+    })
+
+    it('compile empty logical combinators', async () => {
+      await db.query(accounts).where(and()).where(or()).all()
+
+      let compiled = compileMssqlOperation(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] where (1 = 1) and (1 = 0)',
+        values: [],
+      })
+    })
+
+    it('compile distinct selection with order by', async () => {
+      await db.query(accounts).distinct().orderBy('id', 'desc').all()
+
+      let compiled = compileMssqlOperation(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select distinct * from [accounts] order by [id] DESC',
+        values: [],
+      })
+    })
+
+    it('compile boolean bindings', async () => {
+      await db.query(accounts).where({ deleted: true }).all()
+
+      let compiled = compileMssqlOperation(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from [accounts] where (([deleted] = @dt_p1))',
+        values: [true],
+      })
+    })
+
+    it('compile wildcard segment path', () => {
+      let compiled = compileMssqlOperation({
+        kind: 'select',
+        table: accounts,
+        select: [{ column: 'accounts.*', alias: 'allColumns' }],
+        joins: [],
+        where: [],
+        groupBy: [],
+        having: [],
+        orderBy: [],
+        limit: undefined,
+        offset: undefined,
+        distinct: false,
+      })
+
+      assert.deepEqual(compiled, {
+        text: 'select [accounts].* as [allColumns] from [accounts]',
         values: [],
       })
     })
@@ -241,7 +307,7 @@ describe('mssql sql-compiler', () => {
     it('compile pagination with limit-only via top', async () => {
       await db.query(accounts).limit(10).all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select top (10) * from [accounts]',
         values: [],
@@ -251,7 +317,7 @@ describe('mssql sql-compiler', () => {
     it('compile pagination with explicit order for offset/fetch', async () => {
       await db.query(accounts).orderBy(accounts.id).offset(5).limit(10).all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select * from [accounts] order by [accounts].[id] ASC offset 5 rows fetch next 10 rows only',
         values: [],
@@ -261,7 +327,7 @@ describe('mssql sql-compiler', () => {
     it('compile pagination with synthetic order for offset-only queries', async () => {
       await db.query(accounts).offset(5).all()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select * from [accounts] order by (select 1) offset 5 rows',
         values: [],
@@ -273,7 +339,7 @@ describe('mssql sql-compiler', () => {
     it('compile count', async () => {
       await db.query(tasks).where({ account_id: 1 }).count()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select count(*) as [count] from (select 1 as [__dt_col] from [tasks] where (([account_id] = @dt_p1))) as [__dt_count]',
         values: [1],
@@ -283,7 +349,7 @@ describe('mssql sql-compiler', () => {
     it('compile exists', async () => {
       await db.query(tasks).where({ account_id: 1 }).exists()
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select count(*) as [count] from (select 1 as [__dt_col] from [tasks] where (([account_id] = @dt_p1))) as [__dt_count]',
         values: [1],
@@ -299,14 +365,14 @@ describe('mssql sql-compiler', () => {
         status: 'enabled',
       })
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'insert into [accounts] ([id], [email], [status]) values (@dt_p1, @dt_p2, @dt_p3)',
         values: [1, 'info@remix.run', 'enabled'],
       })
     })
 
-    it('compile for one with output', async () => {
+    it('compile for one and return values', async () => {
       await db.query(accounts).insert(
         {
           id: 1,
@@ -316,17 +382,34 @@ describe('mssql sql-compiler', () => {
         { returning: '*' },
       )
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'insert into [accounts] ([id], [email], [status]) output inserted.* values (@dt_p1, @dt_p2, @dt_p3)',
         values: [1, 'info@remix.run', 'enabled'],
       })
     })
 
+    it('compile for one and return selected columns', async () => {
+      await db.query(accounts).insert(
+        {
+          id: 2,
+          email: 'contact@remix.run',
+          status: 'active',
+        },
+        { returning: ['id', 'email'] },
+      )
+
+      let compiled = compileMssqlOperation(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'insert into [accounts] ([id], [email], [status]) output inserted.[id], inserted.[email] values (@dt_p1, @dt_p2, @dt_p3)',
+        values: [2, 'contact@remix.run', 'active'],
+      })
+    })
+
     it('compile for one with default values', async () => {
       await db.create(accounts, {})
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'insert into [accounts] default values',
         values: [],
@@ -339,7 +422,7 @@ describe('mssql sql-compiler', () => {
         { id: 2, email: 'contact@remix.run', status: 'draft' },
       ])
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'insert into [accounts] ([id], [email], [status]) values (@dt_p1, @dt_p2, @dt_p3), (@dt_p4, @dt_p5, @dt_p6)',
         values: [1, 'info@remix.run', 'enabled', 2, 'contact@remix.run', 'draft'],
@@ -355,15 +438,30 @@ describe('mssql sql-compiler', () => {
         { returning: '*' },
       )
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'insert into [accounts] ([id], [email], [status]) output inserted.* values (@dt_p1, @dt_p2, @dt_p3), (@dt_p4, @dt_p5, @dt_p6)',
         values: [1, 'info@remix.run', 'enabled', 2, 'contact@remix.run', 'draft'],
       })
     })
 
-    it('compile for many with default values', () => {
-      let compiled = compileMssqlStatement({
+    it('compile for many with default values (single row)', () => {
+      let compiled = compileMssqlOperation({
+        kind: 'insertMany',
+        table: accounts,
+        values: [{}],
+      })
+      assert.deepEqual(compiled, {
+        text: 'insert into [accounts] default values',
+        values: [],
+      })
+    })
+
+    it('compile for many with default values collapses multiple empty rows to one insert', () => {
+      // When all rows are empty objects, collectColumns returns [] and the
+      // compiler falls back to DEFAULT VALUES — which only inserts a single row.
+      // This is a known limitation shared across all adapter SQL compilers.
+      let compiled = compileMssqlOperation({
         kind: 'insertMany',
         table: accounts,
         values: [{}, {}],
@@ -377,7 +475,7 @@ describe('mssql sql-compiler', () => {
     it('compile for many without data', async () => {
       await db.createMany(accounts, [])
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'select 0 where 1 = 0',
         values: [],
@@ -392,7 +490,7 @@ describe('mssql sql-compiler', () => {
         status: 'enabled',
       })
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'update [accounts] set [email] = @dt_p1, [status] = @dt_p2 where (([id] = @dt_p3))',
         values: ['info@remix.run', 'enabled', 1],
@@ -407,7 +505,7 @@ describe('mssql sql-compiler', () => {
         { returning: '*' },
       )
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'update [accounts] set [email] = @dt_p1 output inserted.* where (([id] = @dt_p2))',
         values: ['info@remix.run', 1],
@@ -428,7 +526,7 @@ describe('mssql sql-compiler', () => {
         },
       )
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'update [accounts] set [email] = @dt_p1, [status] = @dt_p2 where (([status] = @dt_p3))',
         values: ['info@remix.run', 'enabled', 'disabled'],
@@ -445,7 +543,7 @@ describe('mssql sql-compiler', () => {
         },
       )
 
-      assert.throws(() => compileMssqlStatement(statements[0]))
+      assert.throws(() => compileMssqlOperation(statements[0]))
     })
 
     it('compile with update columns', async () => {
@@ -462,7 +560,7 @@ describe('mssql sql-compiler', () => {
         },
       )
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'merge [accounts] with (holdlock) as target using (values (@dt_p1, @dt_p2)) as source ([status], [email]) on target.[id] = source.[id] when matched then update set target.[email] = @dt_p3 when not matched then insert ([status], [email]) values (source.[status], source.[email]);',
         values: ['enabled', 'info@remix.run', 'contact@remix.run'],
@@ -481,7 +579,7 @@ describe('mssql sql-compiler', () => {
         },
       )
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'merge [accounts] with (holdlock) as target using (values (@dt_p1, @dt_p2)) as source ([status], [email]) on target.[id] = source.[id] when not matched then insert ([status], [email]) values (source.[status], source.[email]);',
         values: ['enabled', 'info@remix.run'],
@@ -504,7 +602,7 @@ describe('mssql sql-compiler', () => {
         },
       )
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'merge [accounts] with (holdlock) as target using (values (@dt_p1, @dt_p2, @dt_p3)) as source ([id], [status], [email]) on target.[id] = source.[id] when matched then update set target.[status] = @dt_p4 when not matched then insert ([id], [status], [email]) values (source.[id], source.[status], source.[email]) output inserted.*;',
         values: [1, 'enabled', 'info@remix.run', 'disabled'],
@@ -516,7 +614,7 @@ describe('mssql sql-compiler', () => {
     it('compile for one', async () => {
       await db.delete(accounts, 10)
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'delete from [accounts] where (([id] = @dt_p1))',
         values: [10],
@@ -530,7 +628,7 @@ describe('mssql sql-compiler', () => {
         },
       })
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'delete from [accounts] where (([status] = @dt_p1))',
         values: ['enabled'],
@@ -540,7 +638,7 @@ describe('mssql sql-compiler', () => {
     it('compile with output values', async () => {
       await db.query(accounts).where({ id: 10 }).delete({ returning: '*' })
 
-      let compiled = compileMssqlStatement(statements[0])
+      let compiled = compileMssqlOperation(statements[0])
       assert.deepEqual(compiled, {
         text: 'delete from [accounts] output deleted.* where (([id] = @dt_p1))',
         values: [10],
@@ -549,8 +647,8 @@ describe('mssql sql-compiler', () => {
   })
 
   describe('raw statement', () => {
-    it('compile with positional parameters', () => {
-      let compiled = compileMssqlStatement({
+    it('compile', () => {
+      let compiled = compileMssqlOperation({
         kind: 'raw',
         sql: {
           text: 'select * from accounts where id = ? and status = ?',
@@ -564,8 +662,8 @@ describe('mssql sql-compiler', () => {
       })
     })
 
-    it('compile without positional parameters', () => {
-      let compiled = compileMssqlStatement({
+    it('compile without placeholders', () => {
+      let compiled = compileMssqlOperation({
         kind: 'raw',
         sql: {
           text: 'select * from accounts',
@@ -577,6 +675,35 @@ describe('mssql sql-compiler', () => {
         text: 'select * from accounts',
         values: [],
       })
+    })
+  })
+
+  describe('error handling', () => {
+    it('throws for unsupported statements', () => {
+      assert.throws(
+        () => compileMssqlOperation({ kind: 'unknown' } as never),
+        /Unsupported operation kind/,
+      )
+    })
+
+    it('throws for unsupported predicates', () => {
+      assert.throws(
+        () =>
+          compileMssqlOperation({
+            kind: 'select',
+            table: accounts,
+            select: '*',
+            joins: [],
+            where: [{ type: 'unknown' } as never],
+            groupBy: [],
+            having: [],
+            orderBy: [],
+            limit: undefined,
+            offset: undefined,
+            distinct: false,
+          }),
+        /Unsupported predicate/,
+      )
     })
   })
 })

--- a/packages/data-table-mssql/src/lib/sql-compiler.ts
+++ b/packages/data-table-mssql/src/lib/sql-compiler.ts
@@ -81,7 +81,7 @@ export function compileMssqlStatement(statement: AdapterStatement): CompiledSql 
     return {
       text:
         'update ' +
-        quoteIdentifier(getTableName(statement.table)) +
+        quotePath(getTableName(statement.table)) +
         ' set ' +
         columns
           .map((column) => quotePath(column) + ' = ' + pushValue(context, statement.changes[column]))
@@ -96,7 +96,7 @@ export function compileMssqlStatement(statement: AdapterStatement): CompiledSql 
     return {
       text:
         'delete from ' +
-        quoteIdentifier(getTableName(statement.table)) +
+        quotePath(getTableName(statement.table)) +
         compileOutputClause(statement.returning, 'deleted') +
         compileWhereClause(statement.where, context),
       values: context.values,
@@ -122,7 +122,7 @@ function compileInsertStatement(
     return {
       text:
         'insert into ' +
-        quoteIdentifier(getTableName(table)) +
+        quotePath(getTableName(table)) +
         compileOutputClause(returning, 'inserted') +
         ' default values',
       values: context.values,
@@ -132,7 +132,7 @@ function compileInsertStatement(
   return {
     text:
       'insert into ' +
-      quoteIdentifier(getTableName(table)) +
+      quotePath(getTableName(table)) +
       ' (' +
       columns.map((column) => quotePath(column)).join(', ') +
       ')' +
@@ -163,7 +163,7 @@ function compileInsertManyStatement(
     return {
       text:
         'insert into ' +
-        quoteIdentifier(getTableName(table)) +
+        quotePath(getTableName(table)) +
         compileOutputClause(returning, 'inserted') +
         ' default values',
       values: context.values,
@@ -173,7 +173,7 @@ function compileInsertManyStatement(
   return {
     text:
       'insert into ' +
-      quoteIdentifier(getTableName(table)) +
+      quotePath(getTableName(table)) +
       ' (' +
       columns.map((column) => quotePath(column)).join(', ') +
       ')' +
@@ -226,7 +226,7 @@ function compileUpsertStatement(statement: UpsertStatement, context: CompileCont
   return {
     text:
       'merge ' +
-      quoteIdentifier(getTableName(statement.table)) +
+      quotePath(getTableName(statement.table)) +
       ' with (holdlock) as target using (values (' +
       sourceValues.join(', ') +
       ')) as source (' +
@@ -257,7 +257,7 @@ function compileRawStatement(statement: SqlStatement): CompiledSql {
 
   let index = 1
   let text = statement.text.replace(/\?/g, function replaceParameter() {
-    let placeholder = '@p' + String(index)
+    let placeholder = '@dt_p' + String(index)
     index += 1
     return placeholder
   })
@@ -273,14 +273,14 @@ function compileFromClause(
   joins: JoinClause[],
   context: CompileContext,
 ): string {
-  let output = ' from ' + quoteIdentifier(getTableName(table))
+  let output = ' from ' + quotePath(getTableName(table))
 
   for (let join of joins) {
     output +=
       ' ' +
       normalizeJoinType(join.type) +
       ' join ' +
-      quoteIdentifier(getTableName(join.table)) +
+      quotePath(getTableName(join.table)) +
       ' on ' +
       compilePredicate(join.on, context)
   }
@@ -544,7 +544,7 @@ function quotePath(path: string): string {
 
 function pushValue(context: CompileContext, value: unknown): string {
   context.values.push(value)
-  return '@p' + String(context.values.length)
+  return '@dt_p' + String(context.values.length)
 }
 
 function collectColumns(rows: Record<string, unknown>[]): string[] {

--- a/packages/data-table-mssql/src/lib/sql-compiler.ts
+++ b/packages/data-table-mssql/src/lib/sql-compiler.ts
@@ -1,0 +1,570 @@
+import { getTableName, getTablePrimaryKey } from '@remix-run/data-table'
+import type { AdapterStatement, Predicate, SqlStatement } from '@remix-run/data-table'
+
+type JoinClause = Extract<AdapterStatement, { kind: 'select' }>['joins'][number]
+type UpsertStatement = Extract<AdapterStatement, { kind: 'upsert' }>
+type StatementTable = Extract<AdapterStatement, { kind: 'select' }>['table']
+
+type CompiledSql = {
+  text: string
+  values: unknown[]
+}
+
+type CompileContext = {
+  values: unknown[]
+}
+
+export function compileMssqlStatement(statement: AdapterStatement): CompiledSql {
+  if (statement.kind === 'raw') {
+    return compileRawStatement(statement.sql)
+  }
+
+  let context: CompileContext = { values: [] }
+
+  if (statement.kind === 'select') {
+    let selection = '*'
+
+    if (statement.select !== '*') {
+      selection = statement.select
+        .map((field) => quotePath(field.column) + ' as ' + quoteIdentifier(field.alias))
+        .join(', ')
+    }
+
+    return {
+      text:
+        'select ' +
+        (statement.distinct ? 'distinct ' : '') +
+        compileTopClause(statement.limit, statement.offset) +
+        selection +
+        compileFromClause(statement.table, statement.joins, context) +
+        compileWhereClause(statement.where, context) +
+        compileGroupByClause(statement.groupBy) +
+        compileHavingClause(statement.having, context) +
+        compileOrderByClause(statement.orderBy) +
+        compileOffsetClause(statement.orderBy.length > 0, statement.limit, statement.offset),
+      values: context.values,
+    }
+  }
+
+  if (statement.kind === 'count' || statement.kind === 'exists') {
+    let inner =
+      'select 1 as ' +
+      quoteIdentifier('__dt_col') +
+      compileFromClause(statement.table, statement.joins, context) +
+      compileWhereClause(statement.where, context) +
+      compileGroupByClause(statement.groupBy) +
+      compileHavingClause(statement.having, context)
+
+    return {
+      text:
+        'select count(*) as ' +
+        quoteIdentifier('count') +
+        ' from (' +
+        inner +
+        ') as ' +
+        quoteIdentifier('__dt_count'),
+      values: context.values,
+    }
+  }
+
+  if (statement.kind === 'insert') {
+    return compileInsertStatement(statement.table, statement.values, statement.returning, context)
+  }
+
+  if (statement.kind === 'insertMany') {
+    return compileInsertManyStatement(statement.table, statement.values, statement.returning, context)
+  }
+
+  if (statement.kind === 'update') {
+    let columns = Object.keys(statement.changes)
+
+    return {
+      text:
+        'update ' +
+        quoteIdentifier(getTableName(statement.table)) +
+        ' set ' +
+        columns
+          .map((column) => quotePath(column) + ' = ' + pushValue(context, statement.changes[column]))
+          .join(', ') +
+        compileOutputClause(statement.returning, 'inserted') +
+        compileWhereClause(statement.where, context),
+      values: context.values,
+    }
+  }
+
+  if (statement.kind === 'delete') {
+    return {
+      text:
+        'delete from ' +
+        quoteIdentifier(getTableName(statement.table)) +
+        compileOutputClause(statement.returning, 'deleted') +
+        compileWhereClause(statement.where, context),
+      values: context.values,
+    }
+  }
+
+  if (statement.kind === 'upsert') {
+    return compileUpsertStatement(statement, context)
+  }
+
+  throw new Error('Unsupported statement kind')
+}
+
+function compileInsertStatement(
+  table: StatementTable,
+  values: Record<string, unknown>,
+  returning: '*' | string[] | undefined,
+  context: CompileContext,
+): CompiledSql {
+  let columns = Object.keys(values)
+
+  if (columns.length === 0) {
+    return {
+      text:
+        'insert into ' +
+        quoteIdentifier(getTableName(table)) +
+        compileOutputClause(returning, 'inserted') +
+        ' default values',
+      values: context.values,
+    }
+  }
+
+  return {
+    text:
+      'insert into ' +
+      quoteIdentifier(getTableName(table)) +
+      ' (' +
+      columns.map((column) => quotePath(column)).join(', ') +
+      ')' +
+      compileOutputClause(returning, 'inserted') +
+      ' values (' +
+      columns.map((column) => pushValue(context, values[column])).join(', ') +
+      ')',
+    values: context.values,
+  }
+}
+
+function compileInsertManyStatement(
+  table: StatementTable,
+  rows: Record<string, unknown>[],
+  returning: '*' | string[] | undefined,
+  context: CompileContext,
+): CompiledSql {
+  if (rows.length === 0) {
+    return {
+      text: 'select 0 where 1 = 0',
+      values: context.values,
+    }
+  }
+
+  let columns = collectColumns(rows)
+
+  if (columns.length === 0) {
+    return {
+      text:
+        'insert into ' +
+        quoteIdentifier(getTableName(table)) +
+        compileOutputClause(returning, 'inserted') +
+        ' default values',
+      values: context.values,
+    }
+  }
+
+  return {
+    text:
+      'insert into ' +
+      quoteIdentifier(getTableName(table)) +
+      ' (' +
+      columns.map((column) => quotePath(column)).join(', ') +
+      ')' +
+      compileOutputClause(returning, 'inserted') +
+      ' values ' +
+      rows
+        .map(
+          (row) =>
+            '(' +
+            columns
+              .map((column) => {
+                let value = Object.prototype.hasOwnProperty.call(row, column) ? row[column] : null
+                return pushValue(context, value)
+              })
+              .join(', ') +
+            ')',
+        )
+        .join(', '),
+    values: context.values,
+  }
+}
+
+function compileUpsertStatement(statement: UpsertStatement, context: CompileContext): CompiledSql {
+  let insertColumns = Object.keys(statement.values)
+
+  if (insertColumns.length === 0) {
+    throw new Error('upsert requires at least one value')
+  }
+
+  let conflictTarget = statement.conflictTarget ?? [...getTablePrimaryKey(statement.table)]
+
+  if (conflictTarget.length === 0) {
+    throw new Error('upsert requires at least one conflict target column')
+  }
+
+  let sourceValues = insertColumns.map((column) => pushValue(context, statement.values[column]))
+
+  let updateValues = statement.update ?? statement.values
+  let updateColumns = Object.keys(updateValues)
+  let whenMatchedClause = ''
+
+  if (updateColumns.length > 0) {
+    whenMatchedClause =
+      ' when matched then update set ' +
+      updateColumns
+        .map((column) => 'target.' + quotePath(column) + ' = ' + pushValue(context, updateValues[column]))
+        .join(', ')
+  }
+
+  return {
+    text:
+      'merge ' +
+      quoteIdentifier(getTableName(statement.table)) +
+      ' with (holdlock) as target using (values (' +
+      sourceValues.join(', ') +
+      ')) as source (' +
+      insertColumns.map((column) => quotePath(column)).join(', ') +
+      ') on ' +
+      conflictTarget
+        .map((column) => 'target.' + quotePath(column) + ' = source.' + quotePath(column))
+        .join(' and ') +
+      whenMatchedClause +
+      ' when not matched then insert (' +
+      insertColumns.map((column) => quotePath(column)).join(', ') +
+      ') values (' +
+      insertColumns.map((column) => 'source.' + quotePath(column)).join(', ') +
+      ')' +
+      compileOutputClause(statement.returning, 'inserted') +
+      ';',
+    values: context.values,
+  }
+}
+
+function compileRawStatement(statement: SqlStatement): CompiledSql {
+  if (!statement.text.includes('?')) {
+    return {
+      text: statement.text,
+      values: [...statement.values],
+    }
+  }
+
+  let index = 1
+  let text = statement.text.replace(/\?/g, function replaceParameter() {
+    let placeholder = '@p' + String(index)
+    index += 1
+    return placeholder
+  })
+
+  return {
+    text,
+    values: [...statement.values],
+  }
+}
+
+function compileFromClause(
+  table: StatementTable,
+  joins: JoinClause[],
+  context: CompileContext,
+): string {
+  let output = ' from ' + quoteIdentifier(getTableName(table))
+
+  for (let join of joins) {
+    output +=
+      ' ' +
+      normalizeJoinType(join.type) +
+      ' join ' +
+      quoteIdentifier(getTableName(join.table)) +
+      ' on ' +
+      compilePredicate(join.on, context)
+  }
+
+  return output
+}
+
+function compileWhereClause(predicates: Predicate[], context: CompileContext): string {
+  if (predicates.length === 0) {
+    return ''
+  }
+
+  return (
+    ' where ' +
+    predicates.map((predicate) => '(' + compilePredicate(predicate, context) + ')').join(' and ')
+  )
+}
+
+function compileGroupByClause(columns: string[]): string {
+  if (columns.length === 0) {
+    return ''
+  }
+
+  return ' group by ' + columns.map((column) => quotePath(column)).join(', ')
+}
+
+function compileHavingClause(predicates: Predicate[], context: CompileContext): string {
+  if (predicates.length === 0) {
+    return ''
+  }
+
+  return (
+    ' having ' +
+    predicates.map((predicate) => '(' + compilePredicate(predicate, context) + ')').join(' and ')
+  )
+}
+
+function compileOrderByClause(orderBy: { column: string; direction: 'asc' | 'desc' }[]): string {
+  if (orderBy.length === 0) {
+    return ''
+  }
+
+  return (
+    ' order by ' +
+    orderBy
+      .map((clause) => quotePath(clause.column) + ' ' + clause.direction.toUpperCase())
+      .join(', ')
+  )
+}
+
+function compileTopClause(limit: number | undefined, offset: number | undefined): string {
+  if (limit === undefined || offset !== undefined) {
+    return ''
+  }
+
+  return 'top (' + String(limit) + ') '
+}
+
+function compileOffsetClause(
+  hasOrderBy: boolean,
+  limit: number | undefined,
+  offset: number | undefined,
+): string {
+  if (offset === undefined) {
+    return ''
+  }
+
+  let output = ''
+
+  if (!hasOrderBy) {
+    output += ' order by (select 1)'
+  }
+
+  output += ' offset ' + String(offset) + ' rows'
+
+  if (limit !== undefined) {
+    output += ' fetch next ' + String(limit) + ' rows only'
+  }
+
+  return output
+}
+
+function compileOutputClause(
+  returning: '*' | string[] | undefined,
+  tableAlias: 'inserted' | 'deleted',
+): string {
+  if (!returning) {
+    return ''
+  }
+
+  if (returning === '*') {
+    return ' output ' + tableAlias + '.*'
+  }
+
+  return (
+    ' output ' +
+    returning
+      .map((column) => {
+        if (column.includes('.')) {
+          return quotePath(column)
+        }
+
+        return tableAlias + '.' + quoteIdentifier(column)
+      })
+      .join(', ')
+  )
+}
+
+function compilePredicate(predicate: Predicate, context: CompileContext): string {
+  if (predicate.type === 'comparison') {
+    let column = quotePath(predicate.column)
+
+    if (predicate.operator === 'eq') {
+      if (
+        predicate.valueType === 'value' &&
+        (predicate.value === null || predicate.value === undefined)
+      ) {
+        return column + ' is null'
+      }
+
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return column + ' = ' + comparisonValue
+    }
+
+    if (predicate.operator === 'ne') {
+      if (
+        predicate.valueType === 'value' &&
+        (predicate.value === null || predicate.value === undefined)
+      ) {
+        return column + ' is not null'
+      }
+
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return column + ' <> ' + comparisonValue
+    }
+
+    if (predicate.operator === 'gt') {
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return column + ' > ' + comparisonValue
+    }
+
+    if (predicate.operator === 'gte') {
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return column + ' >= ' + comparisonValue
+    }
+
+    if (predicate.operator === 'lt') {
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return column + ' < ' + comparisonValue
+    }
+
+    if (predicate.operator === 'lte') {
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return column + ' <= ' + comparisonValue
+    }
+
+    if (predicate.operator === 'in' || predicate.operator === 'notIn') {
+      let values = Array.isArray(predicate.value) ? predicate.value : []
+
+      if (values.length === 0) {
+        return predicate.operator === 'in' ? '1 = 0' : '1 = 1'
+      }
+
+      let keyword = predicate.operator === 'in' ? 'in' : 'not in'
+
+      return (
+        column +
+        ' ' +
+        keyword +
+        ' (' +
+        values.map((value) => pushValue(context, value)).join(', ') +
+        ')'
+      )
+    }
+
+    if (predicate.operator === 'like') {
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return column + ' like ' + comparisonValue
+    }
+
+    if (predicate.operator === 'ilike') {
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return 'lower(' + column + ') like lower(' + comparisonValue + ')'
+    }
+  }
+
+  if (predicate.type === 'between') {
+    return (
+      quotePath(predicate.column) +
+      ' between ' +
+      pushValue(context, predicate.lower) +
+      ' and ' +
+      pushValue(context, predicate.upper)
+    )
+  }
+
+  if (predicate.type === 'null') {
+    return (
+      quotePath(predicate.column) + (predicate.operator === 'isNull' ? ' is null' : ' is not null')
+    )
+  }
+
+  if (predicate.type === 'logical') {
+    if (predicate.predicates.length === 0) {
+      return predicate.operator === 'and' ? '1 = 1' : '1 = 0'
+    }
+
+    let joiner = predicate.operator === 'and' ? ' and ' : ' or '
+
+    return predicate.predicates
+      .map((child) => '(' + compilePredicate(child, context) + ')')
+      .join(joiner)
+  }
+
+  throw new Error('Unsupported predicate')
+}
+
+function compileComparisonValue(
+  predicate: Extract<Predicate, { type: 'comparison' }>,
+  context: CompileContext,
+): string {
+  if (predicate.valueType === 'column') {
+    return quotePath(predicate.value)
+  }
+
+  return pushValue(context, predicate.value)
+}
+
+function normalizeJoinType(type: string): string {
+  if (type === 'left') {
+    return 'left'
+  }
+
+  if (type === 'right') {
+    return 'right'
+  }
+
+  return 'inner'
+}
+
+function quoteIdentifier(value: string): string {
+  return '[' + value.replace(/]/g, ']]') + ']'
+}
+
+function quotePath(path: string): string {
+  if (path === '*') {
+    return '*'
+  }
+
+  return path
+    .split('.')
+    .map((segment) => {
+      if (segment === '*') {
+        return '*'
+      }
+
+      return quoteIdentifier(segment)
+    })
+    .join('.')
+}
+
+function pushValue(context: CompileContext, value: unknown): string {
+  context.values.push(value)
+  return '@p' + String(context.values.length)
+}
+
+function collectColumns(rows: Record<string, unknown>[]): string[] {
+  let columns: string[] = []
+  let seen = new Set<string>()
+
+  for (let row of rows) {
+    for (let key in row) {
+      if (!Object.prototype.hasOwnProperty.call(row, key)) {
+        continue
+      }
+
+      if (seen.has(key)) {
+        continue
+      }
+
+      seen.add(key)
+      columns.push(key)
+    }
+  }
+
+  return columns
+}

--- a/packages/data-table-mssql/src/lib/sql-compiler.ts
+++ b/packages/data-table-mssql/src/lib/sql-compiler.ts
@@ -1,31 +1,31 @@
 import { getTableName, getTablePrimaryKey } from '@remix-run/data-table'
-import type { AdapterStatement, Predicate, SqlStatement } from '@remix-run/data-table'
+import type { DataManipulationOperation, Predicate, SqlStatement } from '@remix-run/data-table'
+import {
+  collectColumns as collectColumnsHelper,
+  normalizeJoinType as normalizeJoinTypeHelper,
+  quotePath as quotePathHelper,
+} from '@remix-run/data-table/sql-helpers'
 
-type JoinClause = Extract<AdapterStatement, { kind: 'select' }>['joins'][number]
-type UpsertStatement = Extract<AdapterStatement, { kind: 'upsert' }>
-type StatementTable = Extract<AdapterStatement, { kind: 'select' }>['table']
-
-type CompiledSql = {
-  text: string
-  values: unknown[]
-}
+type JoinClause = Extract<DataManipulationOperation, { kind: 'select' }>['joins'][number]
+type UpsertOperation = Extract<DataManipulationOperation, { kind: 'upsert' }>
+type OperationTable = Extract<DataManipulationOperation, { kind: 'select' }>['table']
 
 type CompileContext = {
   values: unknown[]
 }
 
-export function compileMssqlStatement(statement: AdapterStatement): CompiledSql {
-  if (statement.kind === 'raw') {
-    return compileRawStatement(statement.sql)
+export function compileMssqlOperation(operation: DataManipulationOperation): SqlStatement {
+  if (operation.kind === 'raw') {
+    return compileRawOperation(operation.sql)
   }
 
   let context: CompileContext = { values: [] }
 
-  if (statement.kind === 'select') {
+  if (operation.kind === 'select') {
     let selection = '*'
 
-    if (statement.select !== '*') {
-      selection = statement.select
+    if (operation.select !== '*') {
+      selection = operation.select
         .map((field) => quotePath(field.column) + ' as ' + quoteIdentifier(field.alias))
         .join(', ')
     }
@@ -33,27 +33,27 @@ export function compileMssqlStatement(statement: AdapterStatement): CompiledSql 
     return {
       text:
         'select ' +
-        (statement.distinct ? 'distinct ' : '') +
-        compileTopClause(statement.limit, statement.offset) +
+        (operation.distinct ? 'distinct ' : '') +
+        compileTopClause(operation.limit, operation.offset) +
         selection +
-        compileFromClause(statement.table, statement.joins, context) +
-        compileWhereClause(statement.where, context) +
-        compileGroupByClause(statement.groupBy) +
-        compileHavingClause(statement.having, context) +
-        compileOrderByClause(statement.orderBy) +
-        compileOffsetClause(statement.orderBy.length > 0, statement.limit, statement.offset),
+        compileFromClause(operation.table, operation.joins, context) +
+        compileWhereClause(operation.where, context) +
+        compileGroupByClause(operation.groupBy) +
+        compileHavingClause(operation.having, context) +
+        compileOrderByClause(operation.orderBy) +
+        compileOffsetClause(operation.orderBy.length > 0, operation.limit, operation.offset),
       values: context.values,
     }
   }
 
-  if (statement.kind === 'count' || statement.kind === 'exists') {
+  if (operation.kind === 'count' || operation.kind === 'exists') {
     let inner =
       'select 1 as ' +
       quoteIdentifier('__dt_col') +
-      compileFromClause(statement.table, statement.joins, context) +
-      compileWhereClause(statement.where, context) +
-      compileGroupByClause(statement.groupBy) +
-      compileHavingClause(statement.having, context)
+      compileFromClause(operation.table, operation.joins, context) +
+      compileWhereClause(operation.where, context) +
+      compileGroupByClause(operation.groupBy) +
+      compileHavingClause(operation.having, context)
 
     return {
       text:
@@ -67,62 +67,62 @@ export function compileMssqlStatement(statement: AdapterStatement): CompiledSql 
     }
   }
 
-  if (statement.kind === 'insert') {
-    return compileInsertStatement(statement.table, statement.values, statement.returning, context)
+  if (operation.kind === 'insert') {
+    return compileInsertOperation(operation.table, operation.values, operation.returning, context)
   }
 
-  if (statement.kind === 'insertMany') {
-    return compileInsertManyStatement(
-      statement.table,
-      statement.values,
-      statement.returning,
+  if (operation.kind === 'insertMany') {
+    return compileInsertManyOperation(
+      operation.table,
+      operation.values,
+      operation.returning,
       context,
     )
   }
 
-  if (statement.kind === 'update') {
-    let columns = Object.keys(statement.changes)
+  if (operation.kind === 'update') {
+    let columns = Object.keys(operation.changes)
 
     return {
       text:
         'update ' +
-        quotePath(getTableName(statement.table)) +
+        quotePath(getTableName(operation.table)) +
         ' set ' +
         columns
           .map(
-            (column) => quotePath(column) + ' = ' + pushValue(context, statement.changes[column]),
+            (column) => quotePath(column) + ' = ' + pushValue(context, operation.changes[column]),
           )
           .join(', ') +
-        compileOutputClause(statement.returning, 'inserted') +
-        compileWhereClause(statement.where, context),
+        compileOutputClause(operation.returning, 'inserted') +
+        compileWhereClause(operation.where, context),
       values: context.values,
     }
   }
 
-  if (statement.kind === 'delete') {
+  if (operation.kind === 'delete') {
     return {
       text:
         'delete from ' +
-        quotePath(getTableName(statement.table)) +
-        compileOutputClause(statement.returning, 'deleted') +
-        compileWhereClause(statement.where, context),
+        quotePath(getTableName(operation.table)) +
+        compileOutputClause(operation.returning, 'deleted') +
+        compileWhereClause(operation.where, context),
       values: context.values,
     }
   }
 
-  if (statement.kind === 'upsert') {
-    return compileUpsertStatement(statement, context)
+  if (operation.kind === 'upsert') {
+    return compileUpsertOperation(operation, context)
   }
 
-  throw new Error('Unsupported statement kind')
+  throw new Error('Unsupported operation kind')
 }
 
-function compileInsertStatement(
-  table: StatementTable,
+function compileInsertOperation(
+  table: OperationTable,
   values: Record<string, unknown>,
   returning: '*' | string[] | undefined,
   context: CompileContext,
-): CompiledSql {
+): SqlStatement {
   let columns = Object.keys(values)
 
   if (columns.length === 0) {
@@ -151,12 +151,12 @@ function compileInsertStatement(
   }
 }
 
-function compileInsertManyStatement(
-  table: StatementTable,
+function compileInsertManyOperation(
+  table: OperationTable,
   rows: Record<string, unknown>[],
   returning: '*' | string[] | undefined,
   context: CompileContext,
-): CompiledSql {
+): SqlStatement {
   if (rows.length === 0) {
     return {
       text: 'select 0 where 1 = 0',
@@ -203,22 +203,22 @@ function compileInsertManyStatement(
   }
 }
 
-function compileUpsertStatement(statement: UpsertStatement, context: CompileContext): CompiledSql {
-  let insertColumns = Object.keys(statement.values)
+function compileUpsertOperation(operation: UpsertOperation, context: CompileContext): SqlStatement {
+  let insertColumns = Object.keys(operation.values)
 
   if (insertColumns.length === 0) {
     throw new Error('upsert requires at least one value')
   }
 
-  let conflictTarget = statement.conflictTarget ?? [...getTablePrimaryKey(statement.table)]
+  let conflictTarget = operation.conflictTarget ?? [...getTablePrimaryKey(operation.table)]
 
   if (conflictTarget.length === 0) {
     throw new Error('upsert requires at least one conflict target column')
   }
 
-  let sourceValues = insertColumns.map((column) => pushValue(context, statement.values[column]))
+  let sourceValues = insertColumns.map((column) => pushValue(context, operation.values[column]))
 
-  let updateValues = statement.update ?? statement.values
+  let updateValues = operation.update ?? operation.values
   let updateColumns = Object.keys(updateValues)
   let whenMatchedClause = ''
 
@@ -236,7 +236,7 @@ function compileUpsertStatement(statement: UpsertStatement, context: CompileCont
   return {
     text:
       'merge ' +
-      quotePath(getTableName(statement.table)) +
+      quotePath(getTableName(operation.table)) +
       ' with (holdlock) as target using (values (' +
       sourceValues.join(', ') +
       ')) as source (' +
@@ -251,13 +251,13 @@ function compileUpsertStatement(statement: UpsertStatement, context: CompileCont
       ') values (' +
       insertColumns.map((column) => 'source.' + quotePath(column)).join(', ') +
       ')' +
-      compileOutputClause(statement.returning, 'inserted') +
+      compileOutputClause(operation.returning, 'inserted') +
       ';',
     values: context.values,
   }
 }
 
-function compileRawStatement(statement: SqlStatement): CompiledSql {
+function compileRawOperation(statement: SqlStatement): SqlStatement {
   if (!statement.text.includes('?')) {
     return {
       text: statement.text,
@@ -279,7 +279,7 @@ function compileRawStatement(statement: SqlStatement): CompiledSql {
 }
 
 function compileFromClause(
-  table: StatementTable,
+  table: OperationTable,
   joins: JoinClause[],
   context: CompileContext,
 ): string {
@@ -520,15 +520,7 @@ function compileComparisonValue(
 }
 
 function normalizeJoinType(type: string): string {
-  if (type === 'left') {
-    return 'left'
-  }
-
-  if (type === 'right') {
-    return 'right'
-  }
-
-  return 'inner'
+  return normalizeJoinTypeHelper(type)
 }
 
 function quoteIdentifier(value: string): string {
@@ -536,20 +528,7 @@ function quoteIdentifier(value: string): string {
 }
 
 function quotePath(path: string): string {
-  if (path === '*') {
-    return '*'
-  }
-
-  return path
-    .split('.')
-    .map((segment) => {
-      if (segment === '*') {
-        return '*'
-      }
-
-      return quoteIdentifier(segment)
-    })
-    .join('.')
+  return quotePathHelper(path, quoteIdentifier)
 }
 
 function pushValue(context: CompileContext, value: unknown): string {
@@ -558,23 +537,5 @@ function pushValue(context: CompileContext, value: unknown): string {
 }
 
 function collectColumns(rows: Record<string, unknown>[]): string[] {
-  let columns: string[] = []
-  let seen = new Set<string>()
-
-  for (let row of rows) {
-    for (let key in row) {
-      if (!Object.prototype.hasOwnProperty.call(row, key)) {
-        continue
-      }
-
-      if (seen.has(key)) {
-        continue
-      }
-
-      seen.add(key)
-      columns.push(key)
-    }
-  }
-
-  return columns
+  return collectColumnsHelper(rows)
 }

--- a/packages/data-table-mssql/src/lib/sql-compiler.ts
+++ b/packages/data-table-mssql/src/lib/sql-compiler.ts
@@ -72,7 +72,12 @@ export function compileMssqlStatement(statement: AdapterStatement): CompiledSql 
   }
 
   if (statement.kind === 'insertMany') {
-    return compileInsertManyStatement(statement.table, statement.values, statement.returning, context)
+    return compileInsertManyStatement(
+      statement.table,
+      statement.values,
+      statement.returning,
+      context,
+    )
   }
 
   if (statement.kind === 'update') {
@@ -84,7 +89,9 @@ export function compileMssqlStatement(statement: AdapterStatement): CompiledSql 
         quotePath(getTableName(statement.table)) +
         ' set ' +
         columns
-          .map((column) => quotePath(column) + ' = ' + pushValue(context, statement.changes[column]))
+          .map(
+            (column) => quotePath(column) + ' = ' + pushValue(context, statement.changes[column]),
+          )
           .join(', ') +
         compileOutputClause(statement.returning, 'inserted') +
         compileWhereClause(statement.where, context),
@@ -219,7 +226,10 @@ function compileUpsertStatement(statement: UpsertStatement, context: CompileCont
     whenMatchedClause =
       ' when matched then update set ' +
       updateColumns
-        .map((column) => 'target.' + quotePath(column) + ' = ' + pushValue(context, updateValues[column]))
+        .map(
+          (column) =>
+            'target.' + quotePath(column) + ' = ' + pushValue(context, updateValues[column]),
+        )
         .join(', ')
   }
 

--- a/packages/data-table-mssql/tsconfig.build.json
+++ b/packages/data-table-mssql/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/data-table-mssql/tsconfig.json
+++ b/packages/data-table-mssql/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "target": "ESNext",
+    "types": ["node"],
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": ["vendor"]
+}

--- a/packages/data-table/src/lib/migrations/journal-store.ts
+++ b/packages/data-table/src/lib/migrations/journal-store.ts
@@ -35,14 +35,7 @@ export async function hasMigrationJournal(
   tableName: string,
 ): Promise<boolean> {
   try {
-    await adapter.execute({
-      operation: {
-        kind: 'raw',
-        sql: rawSql('select 1 from ' + tableName + ' limit 1'),
-      },
-    })
-
-    return true
+    return await adapter.hasTable({ name: tableName })
   } catch {
     return false
   }

--- a/packages/data-table/test/adapter-integration-schema.ts
+++ b/packages/data-table/test/adapter-integration-schema.ts
@@ -1,4 +1,4 @@
-export type AdapterIntegrationDialect = 'mysql' | 'postgres' | 'sqlite'
+export type AdapterIntegrationDialect = 'mssql' | 'mysql' | 'postgres' | 'sqlite'
 
 export type AdapterIntegrationStatementRunner = (statement: string) => Promise<void>
 
@@ -78,6 +78,41 @@ let postgresSchemaStatements: AdapterIntegrationSchemaStatements = {
   reset: ['delete from tasks', 'delete from projects', 'delete from accounts'],
 }
 
+let mssqlSchemaStatements: AdapterIntegrationSchemaStatements = {
+  drop: [
+    "if object_id('tasks', 'U') is not null drop table [tasks]",
+    "if object_id('projects', 'U') is not null drop table [projects]",
+    "if object_id('accounts', 'U') is not null drop table [accounts]",
+  ],
+  create: [
+    [
+      'create table [accounts] (',
+      '  [id] int primary key,',
+      '  [email] nvarchar(255) not null,',
+      '  [status] nvarchar(32) not null,',
+      '  [nickname] nvarchar(255) null',
+      ')',
+    ].join('\n'),
+    [
+      'create table [projects] (',
+      '  [id] int primary key,',
+      '  [account_id] int not null,',
+      '  [name] nvarchar(255) not null,',
+      '  [archived] bit not null',
+      ')',
+    ].join('\n'),
+    [
+      'create table [tasks] (',
+      '  [id] int primary key,',
+      '  [project_id] int not null,',
+      '  [title] nvarchar(255) not null,',
+      '  [state] nvarchar(32) not null',
+      ')',
+    ].join('\n'),
+  ],
+  reset: ['delete from [tasks]', 'delete from [projects]', 'delete from [accounts]'],
+}
+
 let sqliteSchemaStatements: AdapterIntegrationSchemaStatements = {
   drop: [
     'drop table if exists tasks',
@@ -140,6 +175,10 @@ export async function resetAdapterIntegrationSchema(
 function getAdapterIntegrationSchemaStatements(
   dialect: AdapterIntegrationDialect,
 ): AdapterIntegrationSchemaStatements {
+  if (dialect === 'mssql') {
+    return mssqlSchemaStatements
+  }
+
   if (dialect === 'mysql') {
     return mysqlSchemaStatements
   }

--- a/packages/remix/.changes/minor.remix.update-exports-data-table-mssql.md
+++ b/packages/remix/.changes/minor.remix.update-exports-data-table-mssql.md
@@ -1,0 +1,3 @@
+Added `package.json` `exports`:
+
+- `remix/data-table-mssql` to re-export APIs from `@remix-run/data-table-mssql`

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -30,6 +30,7 @@
     "./data-schema/coerce": "./src/data-schema/coerce.ts",
     "./data-schema/lazy": "./src/data-schema/lazy.ts",
     "./data-table": "./src/data-table.ts",
+    "./data-table-mssql": "./src/data-table-mssql.ts",
     "./data-table-mysql": "./src/data-table-mysql.ts",
     "./data-table-postgres": "./src/data-table-postgres.ts",
     "./data-table-sqlite": "./src/data-table-sqlite.ts",
@@ -123,6 +124,10 @@
       "./data-table": {
         "types": "./dist/data-table.d.ts",
         "default": "./dist/data-table.js"
+      },
+      "./data-table-mssql": {
+        "types": "./dist/data-table-mssql.d.ts",
+        "default": "./dist/data-table-mssql.js"
       },
       "./data-table-mysql": {
         "types": "./dist/data-table-mysql.d.ts",
@@ -326,6 +331,7 @@
     "@remix-run/tar-parser": "workspace:^",
     "@remix-run/data-schema": "workspace:^",
     "@remix-run/data-table": "workspace:^",
+    "@remix-run/data-table-mssql": "workspace:^",
     "@remix-run/data-table-mysql": "workspace:^",
     "@remix-run/data-table-postgres": "workspace:^",
     "@remix-run/data-table-sqlite": "workspace:^",

--- a/packages/remix/src/data-table-mssql.ts
+++ b/packages/remix/src/data-table-mssql.ts
@@ -1,0 +1,2 @@
+// IMPORTANT: This file is auto-generated, please do not edit manually.
+export * from '@remix-run/data-table-mssql'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,6 +388,25 @@ importers:
         specifier: ^12.4.1
         version: 12.6.2
 
+  packages/data-table-mssql:
+    dependencies:
+      '@remix-run/data-table':
+        specifier: workspace:^
+        version: link:../data-table
+    devDependencies:
+      '@types/mssql':
+        specifier: ^9.1.8
+        version: 9.1.9(@azure/core-client@1.10.1)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.10.4
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20251125.1
+      mssql:
+        specifier: ^12.2.0
+        version: 12.2.0(@azure/core-client@1.10.1)
+
   packages/data-table-mysql:
     dependencies:
       '@remix-run/data-table':
@@ -913,6 +932,9 @@ importers:
       '@remix-run/data-table':
         specifier: workspace:^
         version: link:../data-table
+      '@remix-run/data-table-mssql':
+        specifier: workspace:^
+        version: link:../data-table-mssql
       '@remix-run/data-table-mysql':
         specifier: workspace:^
         version: link:../data-table-mysql
@@ -1237,6 +1259,77 @@ packages:
 
   '@ark/util@0.56.0':
     resolution: {integrity: sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==}
+
+  '@azure-rest/core-client@2.5.1':
+    resolution: {integrity: sha512-EHaOXW0RYDKS5CFffnixdyRPak5ytiCtU7uXDcP/uiY+A6jFRwNGzzJBiznkCzvi5EYpY+YWinieqHb0oY916A==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/abort-controller@2.1.2':
+    resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-auth@1.10.1':
+    resolution: {integrity: sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-client@1.10.1':
+    resolution: {integrity: sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-http-compat@2.3.2':
+    resolution: {integrity: sha512-Tf6ltdKzOJEgxZeWLCjMxrxbodB/ZeCbzzA1A2qHbhzAjzjHoBVSUeSl/baT/oHAxhc4qdqVaDKnc2+iE932gw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@azure/core-client': ^1.10.0
+      '@azure/core-rest-pipeline': ^1.22.0
+
+  '@azure/core-lro@2.7.2':
+    resolution: {integrity: sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-paging@1.6.2':
+    resolution: {integrity: sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-rest-pipeline@1.22.2':
+    resolution: {integrity: sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-tracing@1.3.1':
+    resolution: {integrity: sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-util@1.13.1':
+    resolution: {integrity: sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/identity@4.13.0':
+    resolution: {integrity: sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/keyvault-common@2.0.0':
+    resolution: {integrity: sha512-wRLVaroQtOqfg60cxkzUkGKrKMsCP6uYXAOomOIysSMyt1/YM0eUn9LqieAWM8DLcU4+07Fio2YGpPeqUbpP9w==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/keyvault-keys@4.10.0':
+    resolution: {integrity: sha512-eDT7iXoBTRZ2n3fLiftuGJFD+yjkiB1GNqzU2KbY1TLYeXeSPVTVgn2eJ5vmRTZ11978jy2Kg2wI7xa9Tyr8ag==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/logger@1.3.0':
+    resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/msal-browser@4.29.0':
+    resolution: {integrity: sha512-/f3eHkSNUTl6DLQHm+bKecjBKcRQxbd/XLx8lvSYp8Nl/HRyPuIPOijt9Dt0sH50/SxOwQ62RnFCmFlGK+bR/w==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-common@15.15.0':
+    resolution: {integrity: sha512-/n+bN0AKlVa+AOcETkJSKj38+bvFs78BaP4rNtv3MJCmPH0YrHiskMRe74OhyZ5DZjGISlFyxqvf9/4QVEi2tw==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-node@3.8.8':
+    resolution: {integrity: sha512-+f1VrJH1iI517t4zgmuhqORja0bL6LDQXfBqkjuMmfTYXTQQnh1EvwwxO3UbKLT05N0obF72SRHFrC1RBDv5Gg==}
+    engines: {node: '>=16'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -2107,6 +2200,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@js-joda/core@5.7.0':
+    resolution: {integrity: sha512-WBu4ULVVxySLLzK1Ppq+OdfP+adRS4ntmDQT915rzDJ++i95gc2jZkM5B6LWEAwN3lGXpfie3yPABozdD3K3Vg==}
+
   '@octokit/endpoint@10.1.1':
     resolution: {integrity: sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==}
     engines: {node: '>= 18'}
@@ -2350,6 +2446,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@tediousjs/connection-string@0.6.0':
+    resolution: {integrity: sha512-GxlsW354Vi6QqbUgdPyQVcQjI7cZBdGV5vOYVYuCVDTylx2wl3WHR2HlhcxxHTrMigbelpXsdcZso+66uxPfow==}
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -2417,6 +2516,9 @@ packages:
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
+  '@types/mssql@9.1.9':
+    resolution: {integrity: sha512-P0nCgw6vzY23UxZMnbI4N7fnLGANt4LI4yvxze1paPj+LuN28cFv5EI+QidP8udnId/BKhkcRhm/BleNsjK65A==}
+
   '@types/node@20.12.14':
     resolution: {integrity: sha512-scnD59RpYD91xngrQQLGkE+6UrHUPzeKZWhhjBSa3HSkwjbQc38+q3RoIVEwxQGRw3M+j5hpNAM+lgV3cVormg==}
 
@@ -2439,6 +2541,9 @@ packages:
 
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
+
+  '@types/readable-stream@4.0.23':
+    resolution: {integrity: sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==}
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
@@ -2571,6 +2676,10 @@ packages:
     peerDependencies:
       typescript: '*'
 
+  '@typespec/ts-http-runtime@0.3.3':
+    resolution: {integrity: sha512-91fp6CAAJSRtH5ja95T1FHSKa8aPW9/Zw6cta81jlZTUw/+Vq8jM/AfF/14h2b71wwR84JUTW/3Y8QPhDAawFA==}
+    engines: {node: '>=20.0.0'}
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
@@ -2656,6 +2765,10 @@ packages:
   '@vitest/utils@4.0.15':
     resolution: {integrity: sha512-HXjPW2w5dxhTD0dLwtYHDnelK3j8sR8cWIaLxr22evTyY6q8pRCjZSmhRWVjBaOVXChQd6AwMzi9pucorXCPZA==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -2678,6 +2791,10 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -2814,6 +2931,9 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  bl@6.1.6:
+    resolution: {integrity: sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==}
+
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
@@ -2842,14 +2962,24 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
   bun-types@1.1.26:
     resolution: {integrity: sha512-n7jDe62LsB2+WE8Q8/mT3azkPaatKlj/2MyP6hi3mKvPz9oPpB6JW/Ll6JHtNLudasFFuvfgklYSE+rreGvBjw==}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -2945,6 +3075,10 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
 
   comment-parser@1.4.1:
     resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
@@ -3057,9 +3191,21 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
@@ -3117,6 +3263,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -3312,6 +3461,14 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
@@ -3571,6 +3728,14 @@ packages:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -3650,6 +3815,11 @@ packages:
   is-deflate@1.0.0:
     resolution: {integrity: sha512-YDoFpuZWu1VRXlsnlYMzKyVRITXj7Ej/V9gXQ2/pAe7X1J7M/RNOqaIYi6qUn+B7nGyB9pDXrv02dsB58d2ZAQ==}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -3673,6 +3843,11 @@ packages:
   is-gzip@1.0.0:
     resolution: {integrity: sha512-rcfALRIb1YewtnksfRIHGcIY93QnK8BIQ/2c9yDYcG/Y6+vRoJuTWBmmSEbyLLYtXm7q35pHOHbZFQBaLrhlWQ==}
     engines: {node: '>=0.10.0'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -3725,6 +3900,10 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
@@ -3752,6 +3931,9 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  js-md4@0.3.2:
+    resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -3806,6 +3988,16 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -3824,8 +4016,29 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -4003,6 +4216,11 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mssql@12.2.0:
+    resolution: {integrity: sha512-lwwLHAqcWOz8okjboQpIEp5OghUFGJhuuQZS3+WF1ZXbaEaCEGKOfiQET3w/5Xz0tyZfDNCQVCm9wp5GwXut6g==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   multipasta@0.2.5:
     resolution: {integrity: sha512-c8eMDb1WwZcE02WVjHoOmUVk7fnKU/RmUcosHACglrWAuPQsEJv+E8430sXj6jNc1jHw0zrS16aCjQh4BcEb4A==}
 
@@ -4021,6 +4239,9 @@ packages:
 
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  native-duplexpair@1.0.0:
+    resolution: {integrity: sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA==}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -4088,6 +4309,10 @@ packages:
 
   oniguruma-to-es@4.3.4:
     resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -4272,6 +4497,10 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -4334,6 +4563,10 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   redis@5.11.0:
     resolution: {integrity: sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==}
     engines: {node: '>= 18'}
@@ -4391,6 +4624,10 @@ packages:
     resolution: {integrity: sha512-iTNAbFSlRpcHeeWu73ywU/8KuU/LZmNCSxp6fjQkJBD3ivUb8tpDrXhIxEzA05HlYMEwmtaUnb3RP+YNv162OQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -4560,6 +4797,9 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
   sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
     engines: {node: '>= 0.6'}
@@ -4614,6 +4854,9 @@ packages:
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -4671,6 +4914,14 @@ packages:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tarn@3.0.2:
+    resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
+    engines: {node: '>=8.0.0'}
+
+  tedious@19.2.1:
+    resolution: {integrity: sha512-pk1Q16Yl62iocuQB+RWbg6rFUFkIyzqOFQ6NfysCltRvQqKwfurgj8v/f2X+CKvDhSL4IJ0cCOfCHDg9PWEEYA==}
+    engines: {node: '>=18.17'}
 
   test-exclude@7.0.2:
     resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
@@ -4753,6 +5004,9 @@ packages:
 
   tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -4862,6 +5116,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -5061,6 +5319,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -5140,6 +5402,150 @@ snapshots:
       '@ark/util': 0.56.0
 
   '@ark/util@0.56.0': {}
+
+  '@azure-rest/core-client@2.5.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-rest-pipeline': 1.22.2
+      '@azure/core-tracing': 1.3.1
+      '@typespec/ts-http-runtime': 0.3.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/abort-controller@2.1.2':
+    dependencies:
+      tslib: 2.7.0
+
+  '@azure/core-auth@1.10.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-util': 1.13.1
+      tslib: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-client@1.10.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-rest-pipeline': 1.22.2
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-http-compat@2.3.2(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.22.2)':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.22.2
+
+  '@azure/core-lro@2.7.2':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-paging@1.6.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-rest-pipeline@1.22.2':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      '@typespec/ts-http-runtime': 0.3.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-tracing@1.3.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-util@1.13.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@typespec/ts-http-runtime': 0.3.3
+      tslib: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/identity@4.13.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.22.2
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      '@azure/msal-browser': 4.29.0
+      '@azure/msal-node': 3.8.8
+      open: 10.2.0
+      tslib: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/keyvault-common@2.0.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.22.2
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/keyvault-keys@4.10.0(@azure/core-client@1.10.1)':
+    dependencies:
+      '@azure-rest/core-client': 2.5.1
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-http-compat': 2.3.2(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.22.2)
+      '@azure/core-lro': 2.7.2
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': 1.22.2
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/keyvault-common': 2.0.0
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
+
+  '@azure/logger@1.3.0':
+    dependencies:
+      '@typespec/ts-http-runtime': 0.3.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/msal-browser@4.29.0':
+    dependencies:
+      '@azure/msal-common': 15.15.0
+
+  '@azure/msal-common@15.15.0': {}
+
+  '@azure/msal-node@3.8.8':
+    dependencies:
+      '@azure/msal-common': 15.15.0
+      jsonwebtoken: 9.0.3
+      uuid: 8.3.2
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -5798,6 +6204,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@js-joda/core@5.7.0': {}
+
   '@octokit/endpoint@10.1.1':
     dependencies:
       '@octokit/types': 13.6.2
@@ -5998,6 +6406,8 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@tediousjs/connection-string@0.6.0': {}
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -6081,6 +6491,15 @@ snapshots:
 
   '@types/mime@1.3.5': {}
 
+  '@types/mssql@9.1.9(@azure/core-client@1.10.1)':
+    dependencies:
+      '@types/node': 24.10.4
+      tarn: 3.0.2
+      tedious: 19.2.1(@azure/core-client@1.10.1)
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
+
   '@types/node@20.12.14':
     dependencies:
       undici-types: 5.26.5
@@ -6106,6 +6525,10 @@ snapshots:
   '@types/react@19.2.7':
     dependencies:
       csstype: 3.2.3
+
+  '@types/readable-stream@4.0.23':
+    dependencies:
+      '@types/node': 24.10.4
 
   '@types/semver@7.5.8': {}
 
@@ -6277,6 +6700,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typespec/ts-http-runtime@0.3.3':
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      tslib: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@vitest/browser@3.2.4(playwright@1.57.0)(vite@7.3.0(@types/node@24.10.4)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)':
@@ -6400,6 +6831,10 @@ snapshots:
       '@vitest/pretty-format': 4.0.15
       tinyrainbow: 3.0.3
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -6414,6 +6849,8 @@ snapshots:
   acorn@8.14.0: {}
 
   acorn@8.15.0: {}
+
+  agent-base@7.1.4: {}
 
   ajv@6.12.6:
     dependencies:
@@ -6570,6 +7007,13 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  bl@6.1.6:
+    dependencies:
+      '@types/readable-stream': 4.0.23
+      buffer: 6.0.3
+      inherits: 2.0.4
+      readable-stream: 4.7.0
+
   blake3-wasm@2.1.5: {}
 
   body-parser@1.20.2:
@@ -6616,9 +7060,16 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  buffer-equal-constant-time@1.0.1: {}
+
   buffer-from@1.1.2: {}
 
   buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -6627,6 +7078,10 @@ snapshots:
     dependencies:
       '@types/node': 20.12.14
       '@types/ws': 8.5.12
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
 
   busboy@1.6.0:
     dependencies:
@@ -6724,6 +7179,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@11.1.0: {}
+
   comment-parser@1.4.1: {}
 
   concat-map@0.0.1: {}
@@ -6813,11 +7270,20 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.0
       es-errors: 1.3.0
       gopd: 1.0.1
+
+  define-lazy-prop@3.0.0: {}
 
   define-properties@1.2.1:
     dependencies:
@@ -6877,6 +7343,10 @@ snapshots:
       stream-shift: 1.0.3
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -7234,6 +7704,10 @@ snapshots:
 
   etag@1.8.1: {}
 
+  event-target-shim@5.0.1: {}
+
+  events@3.3.0: {}
+
   exit-hook@2.2.1: {}
 
   exit@0.1.2: {}
@@ -7526,6 +8000,20 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -7603,6 +8091,8 @@ snapshots:
 
   is-deflate@1.0.0: {}
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -7624,6 +8114,10 @@ snapshots:
       is-extglob: 2.1.1
 
   is-gzip@1.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-map@2.0.3: {}
 
@@ -7675,6 +8169,10 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
   isarray@1.0.0: {}
 
   isarray@2.0.5: {}
@@ -7707,6 +8205,8 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  js-md4@0.3.2: {}
 
   js-tokens@10.0.0: {}
 
@@ -7746,6 +8246,30 @@ snapshots:
       jsonparse: 1.3.1
       through2: 4.0.2
 
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.3
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -7765,7 +8289,21 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   long@5.3.2: {}
 
@@ -7928,6 +8466,17 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mssql@12.2.0(@azure/core-client@1.10.1):
+    dependencies:
+      '@tediousjs/connection-string': 0.6.0
+      commander: 11.1.0
+      debug: 4.4.3
+      tarn: 3.0.2
+      tedious: 19.2.1(@azure/core-client@1.10.1)
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
+
   multipasta@0.2.5: {}
 
   mysql2@3.16.3:
@@ -7949,6 +8498,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   napi-build-utils@2.0.0: {}
+
+  native-duplexpair@1.0.0: {}
 
   natural-compare@1.4.0: {}
 
@@ -8023,6 +8574,13 @@ snapshots:
       oniguruma-parser: 0.12.1
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
 
   optionator@0.9.4:
     dependencies:
@@ -8192,6 +8750,8 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  process@0.11.10: {}
+
   property-information@7.1.0: {}
 
   proxy-addr@2.0.7:
@@ -8265,6 +8825,14 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
 
   redis@5.11.0:
     dependencies:
@@ -8355,6 +8923,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.53.5
       '@rollup/rollup-win32-x64-msvc': 4.53.5
       fsevents: 2.3.3
+
+  run-applescript@7.1.0: {}
 
   rxjs@7.8.2:
     dependencies:
@@ -8585,6 +9155,8 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sprintf-js@1.1.3: {}
+
   sqlstring@2.3.3: {}
 
   stackback@0.0.2: {}
@@ -8651,6 +9223,10 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -8715,6 +9291,24 @@ snapshots:
       minizlib: 3.0.1
       mkdirp: 3.0.1
       yallist: 5.0.0
+
+  tarn@3.0.2: {}
+
+  tedious@19.2.1(@azure/core-client@1.10.1):
+    dependencies:
+      '@azure/core-auth': 1.10.1
+      '@azure/identity': 4.13.0
+      '@azure/keyvault-keys': 4.10.0(@azure/core-client@1.10.1)
+      '@js-joda/core': 5.7.0
+      '@types/node': 24.10.4
+      bl: 6.1.6
+      iconv-lite: 0.7.2
+      js-md4: 0.3.2
+      native-duplexpair: 1.0.0
+      sprintf-js: 1.1.3
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
 
   test-exclude@7.0.2:
     dependencies:
@@ -8781,6 +9375,8 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.7.0: {}
+
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:
@@ -8916,6 +9512,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@8.3.2: {}
 
   vary@1.1.2: {}
 
@@ -9137,6 +9735,10 @@ snapshots:
   ws@8.18.0: {}
 
   ws@8.18.3: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
<details>
<summary>Previous yaps</summary>

> Drafting this to get it out there. I'm curious about the interest from the team in juggling a growing number of adapters (given how easy it was to create this one).
>
> I will update this desc with greater nuance after I sleep on it. There are a few outstanding nitpicks I have. Specifically the isolationLevel integration, and other `data-table` package Options bits. It was a bit touchy finding a balance between mirroring the other adapter implementations and fully embracing the `mssql` package apis.
>
> Any and all feedback is always welcome 😄
</details>

Drafting again for schema migration support. Sorry for the spam!
