### PR TITLE
Upgrade monorepo test/dev runtime to Node 25

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This guide will help you get started.
 
 ## Setting Up Your Environment
 
-We develop Remix using [pnpm](https://pnpm.io) on Node 24.
+We develop Remix using [pnpm](https://pnpm.io) on Node 25.
 
 If you're using [VS Code](https://code.visualstudio.com/), we recommend installing the [`node:test runner` extension](https://marketplace.visualstudio.com/items?itemName=connor4312.nodejs-testing) for a smooth testing experience.
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typescript-eslint": "^8.40.0"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=25"
   },
   "scripts": {
     "postinstall": "test -n \"$CI\" || pnpm --filter @remix-run/component exec playwright install",

--- a/packages/headers/src/lib/content-disposition.test.ts
+++ b/packages/headers/src/lib/content-disposition.test.ts
@@ -193,7 +193,7 @@ describe('ContentDisposition', () => {
 
     it('correctly decodes windows-1252 encoded filename', () => {
       let header = new ContentDisposition("attachment; filename*=windows-1252''file%80.txt")
-      assert.equal(header.preferredFilename, 'file\x80.txt')
+      assert.equal(header.preferredFilename, 'file€.txt')
     })
 
     it('handles UTF-8 encoded filename correctly', () => {


### PR DESCRIPTION
## Summary
- bump the root Node engine from `>=24` to `>=25` so local dev, tests, and CI use Node 25
- update contributor setup docs from Node 24 to Node 25
- fix the `ContentDisposition` windows-1252 expectation to match Node 25 decoding (`%80` => `€`)

## Context
- This supersedes #11085

## Validation
- `pnpm test`
- `pnpm run lint`
