### PR TITLE
Add make-pr skill (stacked on supersede-pr)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,4 @@ A skill is a reusable local instruction set stored in a `SKILL.md` file.
 ### Available skills
 
 - **supersede-pr**: Replace one GitHub PR with another and explicitly close the superseded PR (instead of relying on `Closes #...` keywords). (file: `./skills/supersede-pr/SKILL.md`)
+- **make-pr**: Create GitHub pull requests with clear context, issue/feature bullets, and required usage examples for new or changed APIs. (file: `./skills/make-pr/SKILL.md`)

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: make-pr
+description: Create GitHub pull requests with clear, reviewer-friendly descriptions. Use when asked to open or prepare a PR, especially when the PR needs strong context, related links, and feature usage examples. This skill enforces concise PR structure, avoids redundant sections like validation/testing, and creates the PR with gh CLI.
+---
+
+# Make PR
+
+## Overview
+
+Use this skill to draft and open a PR with consistent, high-signal writing.
+Keep headings sparse and focus on the problem/feature explanation, context links, and practical code examples.
+
+## Workflow
+
+1. Gather context from branch diff and related work.
+- Capture what changed, why it changed, and who it affects.
+- Find related issues/PRs and include links when relevant.
+
+1. Draft the PR body with minimal structure.
+- Start with 1-2 short introductory paragraphs.
+- In those intro paragraphs, include clear bullets describing:
+  - the feature and/or issue addressed
+  - key behavior/API changes
+  - expected impact
+- If the change is extensive, expand to up to 3-4 paragraphs and include background context with related links.
+
+1. Add required usage examples for feature work.
+- If the PR introduces a new feature, include a comprehensive usage snippet.
+- If it replaces or improves an older approach, include before/after examples.
+
+1. Exclude redundant sections.
+- Do not include `Validation`, `Testing`, or other process sections that are already implicit in PR workflow.
+- Do not add boilerplate sections that do not help review.
+
+1. Create the PR.
+- Save the body to a temporary file and run:
+```bash
+gh pr create --base main --head <branch> --title "<title>" --body-file <file>
+```
+
+## Body Template
+
+Use this as a base and fill with concrete repo-specific details:
+
+```md
+<One or two short intro paragraphs explaining the change and why it matters.>
+
+- <Feature/issue addressed>
+- <What changed in behavior or API>
+- <Why this is needed now>
+
+<Optional additional context paragraph(s), up to 3-4 total for large changes, including links to related PRs/issues.>
+
+```ts
+// New feature usage example
+```
+
+```ts
+// Before
+```
+
+```ts
+// After
+```
+```

--- a/skills/make-pr/agents/openai.yaml
+++ b/skills/make-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Make PR"
+  short_description: "Create high-quality GitHub pull requests"
+  default_prompt: "Use $make-pr to draft and create a GitHub pull request with clear context and examples."


### PR DESCRIPTION
Add a stacked follow-up to the supersede-pr skill work by introducing a second reusable skill for writing and opening GitHub pull requests.

- adds `skills/make-pr` with concrete guidance for PR structure and content
- requires clear intro context and feature/issue bullets
- requires comprehensive usage examples for new features and before/after examples for improvements
- avoids noisy PR sections like validation/testing and keeps headings sparse
- links the new skill in `AGENTS.md`

This PR is intentionally stacked on top of #11088.
