### PR TITLE
feat(data-table): reject all-empty insertMany batches

### DIFF
--- a/packages/data-table-mysql/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-mysql/src/lib/sql-compiler.test.ts
@@ -273,10 +273,12 @@ describe('mysql sql-compiler', () => {
       })
     })
 
-    it('compile for many with default values', async () => {
-      await db.createMany(accounts, [{}, {}])
-
-      let compiled = compileMysqlStatement(statements[0])
+    it('compile for many with default values', () => {
+      let compiled = compileMysqlStatement({
+        kind: 'insertMany',
+        table: accounts,
+        values: [{}, {}],
+      })
       assert.deepEqual(compiled, {
         text: 'insert into `accounts` () values ()',
         values: [],

--- a/packages/data-table-postgres/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-postgres/src/lib/sql-compiler.test.ts
@@ -290,10 +290,12 @@ describe('postgres sql-compiler', () => {
       })
     })
 
-    it('compile for many with default values', async () => {
-      await db.createMany(accounts, [{}, {}])
-
-      let compiled = compilePostgresStatement(statements[0])
+    it('compile for many with default values', () => {
+      let compiled = compilePostgresStatement({
+        kind: 'insertMany',
+        table: accounts,
+        values: [{}, {}],
+      })
       assert.deepEqual(compiled, {
         text: 'insert into "accounts" default values',
         values: [],

--- a/packages/data-table-sqlite/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-sqlite/src/lib/sql-compiler.test.ts
@@ -486,9 +486,12 @@ describe('sqlite sql-compiler', () => {
       })
     })
 
-    it('compile for many with default values', async () => {
-      await db.createMany(accounts, [{}, {}])
-      let compiled = compileSqliteStatement(statements[0])
+    it('compile for many with default values', () => {
+      let compiled = compileSqliteStatement({
+        kind: 'insertMany',
+        table: accounts,
+        values: [{}, {}],
+      })
       assert.deepEqual(compiled, {
         text: 'insert into "accounts" default values',
         values: [],

--- a/packages/data-table/README.md
+++ b/packages/data-table/README.md
@@ -187,6 +187,8 @@ let insertedRows = await db.createMany(
 )
 ```
 
+`createMany`/`insertMany` throw when every row in the batch is empty (no explicit values).
+
 ### Update and delete helpers
 
 ```ts

--- a/packages/data-table/src/lib/database.ts
+++ b/packages/data-table/src/lib/database.ts
@@ -1255,6 +1255,14 @@ export class QueryBuilder<
     let preparedValues = values.map((value) =>
       prepareInsertValues(this.#table, value, this.#database.now(), options?.touch ?? true),
     )
+
+    if (
+      preparedValues.length > 0 &&
+      preparedValues.every((preparedValue) => Object.keys(preparedValue).length === 0)
+    ) {
+      throw new DataTableQueryError('insertMany() requires at least one explicit value across the batch')
+    }
+
     let returning = options?.returning
 
     assertReturningCapability(this.#database.adapter, 'insertMany', returning)


### PR DESCRIPTION
This changes `insertMany`/`createMany` to fail fast when a batch contains only empty rows.

- `insertMany([{}])` and `createMany(table, [{}, {}])` now throw `DataTableQueryError`
- Keeps `insertMany([])` as a no-op
- Keeps explicit single-row default-value inserts valid via `create({})`
- Updates docs and tests for the new contract
- Adjusts sqlite/mysql/postgres compiler tests to assert default-values SQL directly via compiler input so compiler coverage remains intact

This avoids the previous surprising behavior where all-empty multi-row batches silently collapsed to a single default-row insert.

```ts
// Before
await db.createMany(accounts, [{}, {}])
// inserted one default row
```

```ts
// After
await db.createMany(accounts, [{}, {}])
// throws DataTableQueryError:
// "insertMany() requires at least one explicit value across the batch"

await db.create(accounts, {})
// still valid for explicit single default-row insert
```
