### PR TITLE
Make file-storage race-condition test deterministic on Windows

### DIFF
--- a/packages/file-storage/src/lib/backends/fs.test.ts
+++ b/packages/file-storage/src/lib/backends/fs.test.ts
@@ -150,14 +150,14 @@ describe('fs file storage', () => {
       lastModified,
     })
 
-    let setPromise = storage.set('one', file1)
-    await storage.set('two', file2)
+    let setOnePromise = storage.set('one', file1)
+    let setTwoPromise = storage.set('two', file2)
+    await Promise.all([setOnePromise, setTwoPromise])
 
     let retrieved1 = await storage.get('one')
     assert.ok(retrieved1)
     assert.equal(await retrieved1.text(), 'Hello, world!')
 
-    await setPromise
     let retrieved2 = await storage.get('two')
     assert.ok(retrieved2)
     assert.equal(await retrieved2.text(), 'Hello, universe!')


### PR DESCRIPTION
This PR fixes a flaky Windows failure in `@remix-run/file-storage` where the `handles race conditions` test could read key `one` before its async write completed.

- Fixes the failure seen in [actions run 22498542791](https://github.com/remix-run/remix/actions/runs/22498542791)
- Keeps concurrent writes, but awaits both `storage.set()` calls with `Promise.all(...)` before any `get()` assertions
- Prevents leaked async activity after test completion (which was surfacing as `ENOENT`/`unhandledRejection` in CI)
