### PR TITLE
Remove redundant data-table sql/operators subpath exports

### DIFF
--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -21,8 +21,6 @@
   "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
-    "./operators": "./src/operators.ts",
-    "./sql": "./src/sql.ts",
     "./package.json": "./package.json"
   },
   "publishConfig": {
@@ -30,14 +28,6 @@
       ".": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "./operators": {
-        "types": "./dist/operators.d.ts",
-        "default": "./dist/operators.js"
-      },
-      "./sql": {
-        "types": "./dist/sql.d.ts",
-        "default": "./dist/sql.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/remix/.changes/minor.remix.update-exports-1770842066071.md
+++ b/packages/remix/.changes/minor.remix.update-exports-1770842066071.md
@@ -4,5 +4,3 @@ Added `package.json` `exports`:
 - `remix/data-table-mysql` to re-export APIs from `@remix-run/data-table-mysql`
 - `remix/data-table-postgres` to re-export APIs from `@remix-run/data-table-postgres`
 - `remix/data-table-sqlite` to re-export APIs from `@remix-run/data-table-sqlite`
-- `remix/data-table/operators` to re-export APIs from `@remix-run/data-table/operators`
-- `remix/data-table/sql` to re-export APIs from `@remix-run/data-table/sql`

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -33,8 +33,6 @@
     "./data-table-mysql": "./src/data-table-mysql.ts",
     "./data-table-postgres": "./src/data-table-postgres.ts",
     "./data-table-sqlite": "./src/data-table-sqlite.ts",
-    "./data-table/operators": "./src/data-table/operators.ts",
-    "./data-table/sql": "./src/data-table/sql.ts",
     "./fetch-proxy": "./src/fetch-proxy.ts",
     "./fetch-router": "./src/fetch-router.ts",
     "./fetch-router/routes": "./src/fetch-router/routes.ts",
@@ -137,14 +135,6 @@
       "./data-table-sqlite": {
         "types": "./dist/data-table-sqlite.d.ts",
         "default": "./dist/data-table-sqlite.js"
-      },
-      "./data-table/operators": {
-        "types": "./dist/data-table/operators.d.ts",
-        "default": "./dist/data-table/operators.js"
-      },
-      "./data-table/sql": {
-        "types": "./dist/data-table/sql.d.ts",
-        "default": "./dist/data-table/sql.js"
       },
       "./fetch-proxy": {
         "types": "./dist/fetch-proxy.d.ts",

--- a/packages/remix/src/data-table/operators.ts
+++ b/packages/remix/src/data-table/operators.ts
@@ -1,2 +1,0 @@
-// IMPORTANT: This file is auto-generated, please do not edit manually.
-export * from '@remix-run/data-table/operators'

--- a/packages/remix/src/data-table/sql.ts
+++ b/packages/remix/src/data-table/sql.ts
@@ -1,2 +1,0 @@
-// IMPORTANT: This file is auto-generated, please do not edit manually.
-export * from '@remix-run/data-table/sql'


### PR DESCRIPTION
This removes redundant `sql` and `operators` subpath exports from `@remix-run/data-table` and the mirrored `remix` package exports.

All of the same APIs are still available from the main `data-table` entrypoint, so users only need a single import path.

- Removed `@remix-run/data-table/operators` and `@remix-run/data-table/sql` from `@remix-run/data-table` export maps
- Removed `remix/data-table/operators` and `remix/data-table/sql` from `remix` export maps
- Deleted the now-unused Remix passthrough files for those subpaths
- Updated the existing Remix change file to stop advertising those two mirrored exports

```ts
// Before
import { sql } from 'remix/data-table/sql'
import { eq } from 'remix/data-table/operators'
```

```ts
// After
import { eq, sql } from 'remix/data-table'
```
