### PR TITLE
Fix createRangeRoot boundary-parent invariant

### DIFF
--- a/packages/component/src/lib/vdom.ts
+++ b/packages/component/src/lib/vdom.ts
@@ -52,7 +52,7 @@ export function createRangeRoot(
 
   let container = end.parentNode
   invariant(container, 'Expected parent node')
-  invariant(end.parentNode === container, 'Boundaries must share parent')
+  invariant(start.parentNode === container, 'Boundaries must share parent')
 
   let hydrationCursor = start.nextSibling
 

--- a/packages/component/src/test/vdom.range-root.test.tsx
+++ b/packages/component/src/test/vdom.range-root.test.tsx
@@ -375,6 +375,17 @@ describe('createRangeRoot', () => {
   })
 
   describe('boundary handling', () => {
+    it('throws when start and end markers do not share a parent node', () => {
+      let containerA = document.createElement('div')
+      let containerB = document.createElement('div')
+      let start = document.createComment('start')
+      let end = document.createComment('end')
+      containerA.appendChild(start)
+      containerB.appendChild(end)
+
+      expect(() => createRangeRoot([start, end])).toThrow('Boundaries must share parent')
+    })
+
     it('does not affect content before start marker', () => {
       let container = document.createElement('div')
       container.innerHTML = '<header>Before</header><!--start--><!--end-->'


### PR DESCRIPTION
`createRangeRoot` requires the start and end boundary nodes to share the same parent, but the existing invariant never actually validated that condition. It compared `end.parentNode` to a local variable assigned from `end.parentNode`, so the check was always true.

- Adds a regression test that builds split-parent boundaries and asserts `createRangeRoot` throws
- Fixes the invariant to validate `start.parentNode === end.parentNode`
- Keeps the change scoped to boundary validation behavior only

```ts
// regression test
let containerA = document.createElement('div')
let containerB = document.createElement('div')
let start = document.createComment('start')
let end = document.createComment('end')
containerA.appendChild(start)
containerB.appendChild(end)

expect(() => createRangeRoot([start, end])).toThrow('Boundaries must share parent')
```

```ts
// fix
let container = end.parentNode
invariant(container, 'Expected parent node')
invariant(start.parentNode === container, 'Boundaries must share parent')
```
