### PR TITLE
Fix text-to-innerHTML transition removeChild error

### DIFF
--- a/packages/component/src/lib/reconcile.ts
+++ b/packages/component/src/lib/reconcile.ts
@@ -1238,7 +1238,7 @@ export function remove(
   styles: StyleManager,
 ) {
   if (isCommittedTextNode(node)) {
-    domParent.removeChild(node._dom)
+    node._dom.parentNode?.removeChild(node._dom)
     return
   }
 

--- a/packages/component/src/test/vdom.props.test.tsx
+++ b/packages/component/src/test/vdom.props.test.tsx
@@ -104,6 +104,22 @@ describe('vnode rendering', () => {
       root.render(<div innerHTML="<span>From innerHTML</span>" />)
       expect(container.innerHTML).toBe('<div><span>From innerHTML</span></div>')
     })
+
+    it('switches from text children to innerHTML without throwing', () => {
+      let container = document.createElement('div')
+      let root = createRoot(container)
+      let renderError: unknown
+      root.addEventListener('error', (event) => {
+        renderError = (event as ErrorEvent).error
+      })
+
+      root.render(<div>From text child</div>)
+      expect(container.innerHTML).toBe('<div>From text child</div>')
+
+      root.render(<div innerHTML="<span>From innerHTML</span>" />)
+      expect(container.innerHTML).toBe('<div><span>From innerHTML</span></div>')
+      expect(renderError).toBeUndefined()
+    })
   })
 
   describe('css mixin', () => {


### PR DESCRIPTION
Switching a host node from text children to `innerHTML` could dispatch a `NotFoundError` through the root `error` event even though the DOM ended up in the expected final state.

- Adds a regression test for `<div>text</div> -> <div innerHTML="..." />` transitions
- Verifies the update does not emit root `error` events
- Makes text-node removal idempotent when the node was already detached by an earlier `innerHTML` update

```tsx
let renderError: unknown
root.addEventListener('error', (event) => {
  renderError = (event as ErrorEvent).error
})

root.render(<div>From text child</div>)
root.render(<div innerHTML="<span>From innerHTML</span>" />)

expect(renderError).toBeUndefined()
```

```ts
// before
if (isCommittedTextNode(node)) {
  domParent.removeChild(node._dom)
}

// after
if (isCommittedTextNode(node)) {
  node._dom.parentNode?.removeChild(node._dom)
}
```
