### PR TITLE
fix(component): normalize SVG className to class

### DIFF
--- a/packages/component/.changes/patch.fix-svg-classname-mapping.md
+++ b/packages/component/.changes/patch.fix-svg-classname-mapping.md
@@ -1,0 +1,3 @@
+Fix SVG `className` prop normalization to render as `class` in both client DOM updates and SSR stream output.
+
+Also add SVG regression coverage to prevent accidental `class-name` output.

--- a/packages/component/src/lib/diff-props.ts
+++ b/packages/component/src/lib/diff-props.ts
@@ -76,8 +76,8 @@ function normalizePropName(name: string, isSvg: boolean): { ns?: string; attr: s
   if (name.startsWith('aria-') || name.startsWith('data-')) return { attr: name }
 
   // DOM property -> HTML mappings
+  if (name === 'className') return { attr: 'class' }
   if (!isSvg) {
-    if (name === 'className') return { attr: 'class' }
     if (name === 'htmlFor') return { attr: 'for' }
     if (name === 'tabIndex') return { attr: 'tabindex' }
     if (name === 'acceptCharset') return { attr: 'accept-charset' }

--- a/packages/component/src/lib/stream.ts
+++ b/packages/component/src/lib/stream.ts
@@ -794,8 +794,8 @@ function transformAttributeName(name: string, isSvg: boolean): string {
   if (name.startsWith('aria-') || name.startsWith('data-')) return name
 
   // HTML mappings
+  if (name === 'className') return 'class'
   if (!isSvg) {
-    if (name === 'className') return 'class'
     if (name === 'htmlFor') return 'for'
     if (name === 'tabIndex') return 'tabindex'
     if (name === 'acceptCharset') return 'accept-charset'

--- a/packages/component/src/test/stream.test.tsx
+++ b/packages/component/src/test/stream.test.tsx
@@ -455,13 +455,13 @@ describe('stream', () => {
   describe('svg', () => {
     it('renders SVG with preserved viewBox and kebab-cased attributes', async () => {
       let stream = renderToStream(
-        <svg viewBox="0 0 24 24" fill="none">
+        <svg viewBox="0 0 24 24" fill="none" className="icon">
           <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
         </svg>,
       )
       let html = await drain(stream)
       expect(html).toBe(
-        '<svg viewBox="0 0 24 24" fill="none"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5"></path></svg>',
+        '<svg viewBox="0 0 24 24" fill="none" class="icon"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5"></path></svg>',
       )
     })
 

--- a/packages/component/src/test/vdom.svg.test.tsx
+++ b/packages/component/src/test/vdom.svg.test.tsx
@@ -11,7 +11,7 @@ describe('vnode rendering', () => {
       let { render } = createRoot(container)
 
       render(
-        <svg viewBox="0 0 24 24" fill="none">
+        <svg viewBox="0 0 24 24" fill="none" class="icon">
           <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
         </svg>,
       )
@@ -26,6 +26,7 @@ describe('vnode rendering', () => {
 
       // Attribute casing: preserve exceptions and kebab-case general SVG attrs
       expect(svg.getAttribute('viewBox')).toBe('0 0 24 24')
+      expect(svg.getAttribute('class')).toBe('icon')
       expect(path.getAttribute('stroke-linecap')).toBe('round')
       expect(path.getAttribute('stroke-linejoin')).toBe('round')
     })


### PR DESCRIPTION
## Summary
- fix `component` host prop normalization so `className` maps to `class` in SVG for client DOM updates
- align SSR stream attribute normalization with the same `className` -> `class` behavior for SVG output
- add/adjust SVG regression coverage in both VDOM and stream tests, and add a patch change file for release notes