### PR TITLE
Require Node 24.3+ for native TypeScript execution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This guide will help you get started.
 
 ## Setting Up Your Environment
 
-We develop Remix using [pnpm](https://pnpm.io) on Node 25.
+We develop Remix using [pnpm](https://pnpm.io) on Node 24.3+.
 
 If you're using [VS Code](https://code.visualstudio.com/), we recommend installing the [`node:test runner` extension](https://marketplace.visualstudio.com/items?itemName=connor4312.nodejs-testing) for a smooth testing experience.
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typescript-eslint": "^8.40.0"
   },
   "engines": {
-    "node": ">=25"
+    "node": ">=24.3.0"
   },
   "scripts": {
     "postinstall": "test -n \"$CI\" || pnpm --filter @remix-run/component exec playwright install",


### PR DESCRIPTION
This updates our minimum Node.js requirement from Node 25 to Node 24.3+.

- sets the repo `engines.node` requirement to `>=24.3.0`
- updates contributor setup docs from Node 25 to Node 24.3+
- aligns with the Node release where native TypeScript type stripping no longer emits the experimental warning

This keeps our guidance and engine floor aligned with the latest Node 24 release that supports native TypeScript execution without the experimental warning.
