### PR TITLE
fix(form-data-parser): handle non-ASCII filenames in multipart uploads

### DIFF
--- a/packages/headers/src/lib/content-disposition.test.ts
+++ b/packages/headers/src/lib/content-disposition.test.ts
@@ -226,3 +226,42 @@ describe('ContentDisposition.from', () => {
     assert.equal(result.filename, 'test.txt')
   })
 })
+
+describe('ContentDisposition non-ASCII filename handling', () => {
+  it('decodes percent-encoded UTF-8 Japanese filename', () => {
+    // Simulates what happens when raw-headers encodes テスト画像.png
+    let header = new ContentDisposition(
+      'form-data; name="file"; filename="%E3%83%86%E3%82%B9%E3%83%88%E7%94%BB%E5%83%8F.png"',
+    )
+    assert.equal(header.preferredFilename, 'テスト画像.png')
+  })
+
+  it('decodes percent-encoded UTF-8 Chinese filename', () => {
+    // Simulates what happens when raw-headers encodes 文件.png
+    let header = new ContentDisposition(
+      'form-data; name="file"; filename="%E6%96%87%E4%BB%B6.png"',
+    )
+    assert.equal(header.preferredFilename, '文件.png')
+  })
+
+  it('decodes percent-encoded UTF-8 Korean filename', () => {
+    // Simulates what happens when raw-headers encodes 파일.png
+    let header = new ContentDisposition(
+      'form-data; name="file"; filename="%ED%8C%8C%EC%9D%BC.png"',
+    )
+    assert.equal(header.preferredFilename, '파일.png')
+  })
+
+  it('handles mixed ASCII and non-ASCII in filename', () => {
+    // Simulates test_テスト.png
+    let header = new ContentDisposition(
+      'form-data; name="file"; filename="test_%E3%83%86%E3%82%B9%E3%83%88.png"',
+    )
+    assert.equal(header.preferredFilename, 'test_テスト.png')
+  })
+
+  it('leaves plain ASCII filenames unchanged', () => {
+    let header = new ContentDisposition('form-data; name="file"; filename="plain.txt"')
+    assert.equal(header.preferredFilename, 'plain.txt')
+  })
+})

--- a/packages/headers/src/lib/content-disposition.test.ts
+++ b/packages/headers/src/lib/content-disposition.test.ts
@@ -238,17 +238,13 @@ describe('ContentDisposition non-ASCII filename handling', () => {
 
   it('decodes percent-encoded UTF-8 Chinese filename', () => {
     // Simulates what happens when raw-headers encodes 文件.png
-    let header = new ContentDisposition(
-      'form-data; name="file"; filename="%E6%96%87%E4%BB%B6.png"',
-    )
+    let header = new ContentDisposition('form-data; name="file"; filename="%E6%96%87%E4%BB%B6.png"')
     assert.equal(header.preferredFilename, '文件.png')
   })
 
   it('decodes percent-encoded UTF-8 Korean filename', () => {
     // Simulates what happens when raw-headers encodes 파일.png
-    let header = new ContentDisposition(
-      'form-data; name="file"; filename="%ED%8C%8C%EC%9D%BC.png"',
-    )
+    let header = new ContentDisposition('form-data; name="file"; filename="%ED%8C%8C%EC%9D%BC.png"')
     assert.equal(header.preferredFilename, '파일.png')
   })
 

--- a/packages/headers/src/lib/content-disposition.ts
+++ b/packages/headers/src/lib/content-disposition.ts
@@ -156,6 +156,9 @@ function percentDecode(value: string): string {
  * Decodes percent-encoded UTF-8 bytes in a string back to Unicode characters.
  * This handles filenames that were encoded to pass through native Headers validation.
  * Only decodes if percent-encoding is present; returns original string otherwise.
+ *
+ * @param value - The string to decode
+ * @returns The decoded string with percent-encoded UTF-8 bytes converted to Unicode
  */
 function decodePercentEncodedUtf8(value: string): string {
   // Check if there are any percent-encoded sequences

--- a/packages/headers/src/lib/content-disposition.ts
+++ b/packages/headers/src/lib/content-disposition.ts
@@ -157,7 +157,7 @@ function percentDecode(value: string): string {
  * This handles filenames that were encoded to pass through native Headers validation.
  * Only decodes if percent-encoding is present; returns original string otherwise.
  *
- * @param value - The string to decode
+ * @param value The string to decode
  * @returns The decoded string with percent-encoded UTF-8 bytes converted to Unicode
  */
 function decodePercentEncodedUtf8(value: string): string {
@@ -167,24 +167,10 @@ function decodePercentEncodedUtf8(value: string): string {
   }
 
   try {
-    // Convert percent-encoded sequences to bytes
-    let bytes: number[] = []
-    let i = 0
-    while (i < value.length) {
-      if (value[i] === '%' && i + 2 < value.length) {
-        let hex = value.substring(i + 1, i + 3)
-        if (/^[0-9A-Fa-f]{2}$/.test(hex)) {
-          bytes.push(parseInt(hex, 16))
-          i += 3
-          continue
-        }
-      }
-      bytes.push(value.charCodeAt(i))
-      i++
-    }
-
-    // Decode UTF-8 bytes
-    return new TextDecoder('utf-8', { fatal: false }).decode(new Uint8Array(bytes))
+    let bytes = Uint8Array.from(value.match(/%[0-9A-Fa-f]{2}|./g)!, (token) =>
+      token[0] === '%' ? parseInt(token.slice(1), 16) : token.charCodeAt(0),
+    )
+    return new TextDecoder('utf-8', { fatal: false }).decode(bytes)
   } catch {
     // If decoding fails, return the original value
     return value

--- a/packages/headers/src/lib/raw-headers.test.ts
+++ b/packages/headers/src/lib/raw-headers.test.ts
@@ -128,11 +128,10 @@ describe('parseRawHeaders non-ASCII handling', () => {
   })
 
   it('preserves ASCII-only header values unchanged', () => {
-    let headers = parseRawHeaders('Content-Disposition: form-data; name="file"; filename="test.txt"')
-    assert.equal(
-      headers.get('content-disposition'),
-      'form-data; name="file"; filename="test.txt"',
+    let headers = parseRawHeaders(
+      'Content-Disposition: form-data; name="file"; filename="test.txt"',
     )
+    assert.equal(headers.get('content-disposition'), 'form-data; name="file"; filename="test.txt"')
   })
 
   it('handles mixed ASCII and non-ASCII', () => {

--- a/packages/headers/src/lib/raw-headers.ts
+++ b/packages/headers/src/lib/raw-headers.ts
@@ -5,6 +5,9 @@ const CRLF = '\r\n'
 /**
  * Encodes non-ASCII characters in a string using percent-encoding.
  * This is needed because the native Headers class only accepts ISO-8859-1 characters.
+ *
+ * @param value - The string to encode
+ * @returns The encoded string with non-ASCII characters percent-encoded
  */
 function encodeNonAscii(value: string): string {
   let encoder = new TextEncoder()

--- a/packages/headers/src/lib/raw-headers.ts
+++ b/packages/headers/src/lib/raw-headers.ts
@@ -8,13 +8,17 @@ const CRLF = '\r\n'
  */
 function encodeNonAscii(value: string): string {
   let encoder = new TextEncoder()
-  return [...value].reduce((result, char) => {
+
+  return Array.from(value).reduce((result, char) => {
     let code = char.charCodeAt(0)
+
     if (code > 127) {
-      // Encode non-ASCII characters as UTF-8 percent-encoded bytes
-      let bytes = encoder.encode(char)
-      return result + [...bytes].map(byte => '%' + byte.toString(16).toUpperCase().padStart(2, '0')).join('')
+      return encoder.encode(char).reduce(
+        (acc, byte) => acc + '%' + byte.toString(16).toUpperCase().padStart(2, '0'),
+        result
+      )
     }
+
     return result + char
   }, '')
 }

--- a/packages/headers/src/lib/raw-headers.ts
+++ b/packages/headers/src/lib/raw-headers.ts
@@ -7,20 +7,16 @@ const CRLF = '\r\n'
  * This is needed because the native Headers class only accepts ISO-8859-1 characters.
  */
 function encodeNonAscii(value: string): string {
-  let result = ''
-  for (let i = 0; i < value.length; i++) {
-    let code = value.charCodeAt(i)
+  let encoder = new TextEncoder()
+  return [...value].reduce((result, char) => {
+    let code = char.charCodeAt(0)
     if (code > 127) {
       // Encode non-ASCII characters as UTF-8 percent-encoded bytes
-      let bytes = new TextEncoder().encode(value[i])
-      for (let byte of bytes) {
-        result += '%' + byte.toString(16).toUpperCase().padStart(2, '0')
-      }
-    } else {
-      result += value[i]
+      let bytes = encoder.encode(char)
+      return result + [...bytes].map(byte => '%' + byte.toString(16).toUpperCase().padStart(2, '0')).join('')
     }
-  }
-  return result
+    return result + char
+  }, '')
 }
 
 /**

--- a/packages/headers/src/lib/raw-headers.ts
+++ b/packages/headers/src/lib/raw-headers.ts
@@ -6,7 +6,7 @@ const CRLF = '\r\n'
  * Encodes non-ASCII characters in a string using percent-encoding.
  * This is needed because the native Headers class only accepts ISO-8859-1 characters.
  *
- * @param value - The string to encode
+ * @param value The string to encode
  * @returns The encoded string with non-ASCII characters percent-encoded
  */
 function encodeNonAscii(value: string): string {
@@ -16,10 +16,9 @@ function encodeNonAscii(value: string): string {
     let code = char.charCodeAt(0)
 
     if (code > 127) {
-      return encoder.encode(char).reduce(
-        (acc, byte) => acc + '%' + byte.toString(16).toUpperCase().padStart(2, '0'),
-        result
-      )
+      return encoder
+        .encode(char)
+        .reduce((acc, byte) => acc + '%' + byte.toString(16).toUpperCase().padStart(2, '0'), result)
     }
 
     return result + char


### PR DESCRIPTION
## Summary

Fixes #11032 

The Pull Request #11039 was written by an AI bot that got into some controversy and seems to be offline since then. This pull request continues the work of the previous pull request so it can be merged.

## Root Cause
The `parseRawHeaders` function in `@remix-run/headers` uses the native `Headers.append()` method, which throws a TypeError for non-ASCII characters in header values. This affects `Content-Disposition` headers containing non-ASCII filenames.

## Solution
1. Catch the encoding error: When `Headers.append()` throws for non-ASCII characters, catch the error (handling different runtime error messages for browsers and Node.js)

2. Percent-encode non-ASCII bytes: Encode non-ASCII characters as percent-encoded UTF-8 bytes (e.g., `テスト` → `%E3%83%86%E3%82%B9%E3%83%88`)

3. Decode when accessing filename: Update `ContentDisposition.preferredFilename` to decode percent-encoded UTF-8 back to Unicode characters