### PR TITLE
Add crawling/prerendering support to fetch-router

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,6 @@
     "@remix-run/ui": "workspace:*",
     "front-matter": "^4.0.2",
     "marked": "^17.0.1",
-    "node-html-parser": "^7.0.2",
     "prettier": "^3.5.3",
     "remix": "workspace:*",
     "semver": "^7.7.3"

--- a/docs/src/server/prerender.ts
+++ b/docs/src/server/prerender.ts
@@ -33,7 +33,7 @@ for (let version of versions || getDefaultVersions()) {
   }
 }
 
-// First pass: spider the site and collect fragment/markdown variant paths
+// First pass: spider the site and collect markdown variant paths
 let paths = [
   '/',
   '/api.json',
@@ -47,7 +47,6 @@ for await (let { pathname, filepath, response } of crawl(docsRouter, { paths }))
   let url = `http://localhost${pathname}`
   let match = routes.docs.match(url)
   if (match && !routes.markdown.match(url)) {
-    variantPaths.push(routes.fragment.href(match.params))
     variantPaths.push(routes.markdown.href(match.params))
   }
 }

--- a/docs/src/server/prerender.ts
+++ b/docs/src/server/prerender.ts
@@ -2,12 +2,11 @@ import * as cp from 'node:child_process'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as util from 'node:util'
-import { parse } from 'node-html-parser'
 import * as semver from 'semver'
-import { type Router } from 'remix/fetch-router'
 import { createRouter, getDefaultVersions } from './router.tsx'
 import type { ServerContext } from './components.tsx'
 import { routes } from './routes.ts'
+import { crawl } from 'remix/fetch-router'
 
 let { values: cliArgs } = util.parseArgs({
   options: {
@@ -34,99 +33,38 @@ for (let version of versions || getDefaultVersions()) {
   }
 }
 
-await spider(
-  docsRouter,
-  outputDir,
-  new Set([
-    '/',
-    '/api.json',
-    ...(versions
-      ?.filter((v) => v.crawl)
-      .flatMap((v) => [`/${v.version}/api.json`, `/${v.version}/`]) || []),
-  ]),
-)
-
-// Spider the website served by router, beginning at /
-async function spider(router: Router, outputDir: string, urlQueue = new Set(['/'])) {
-  await fs.mkdir(outputDir, { recursive: true })
-
-  // Track URLs we have already downloaded to avoid loops
-  let downloadedUrls = new Set<string>()
-
-  for (let urlPath of urlQueue) {
-    if (urlPath && !downloadedUrls.has(urlPath)) {
-      let { downloadedUrl, discoveredUrls } = await crawl(router, urlPath, outputDir)
-      downloadedUrls.add(downloadedUrl)
-      discoveredUrls
-        .filter((href) => !downloadedUrls.has(href))
-        .forEach((href) => urlQueue.add(href))
-    }
+// First pass: spider the site and collect fragment/markdown variant paths
+let paths = [
+  '/',
+  '/api.json',
+  ...(versions
+    ?.filter((v) => v.crawl)
+    .flatMap((v) => [`/${v.version}/api.json`, `/${v.version}/`]) || []),
+]
+let variantPaths: string[] = []
+for await (let { pathname, filepath, response } of crawl(docsRouter, { paths })) {
+  await writeResult(pathname, filepath, response)
+  let url = `http://localhost${pathname}`
+  let match = routes.docs.match(url)
+  if (match && !routes.markdown.match(url)) {
+    variantPaths.push(routes.fragment.href(match.params))
+    variantPaths.push(routes.markdown.href(match.params))
   }
-
-  console.log(`\nCrawling complete!`)
 }
 
-async function crawl(router: Router, urlPath: string, outputDir: string) {
-  let response
-  try {
-    response = await router.fetch(new Request(`http://localhost${urlPath}`))
-    if (!response.ok) {
-      throw new Error(`Error fetching ${urlPath}: ${response.status} ${response.statusText}`)
-    }
-  } catch (error) {
-    console.error('Error fetching', urlPath)
-    throw error
-  }
+// Second pass: fetch variant paths without spidering
+for await (let { pathname, filepath, response } of crawl(docsRouter, {
+  paths: variantPaths,
+  spider: false,
+})) {
+  await writeResult(pathname, filepath, response)
+}
 
-  let isHtmlFile = response.headers.get('Content-Type')?.includes('text/html')
-
-  // Always put `index.html` files into directories - this leads to the best
-  // support with and without trailing slashes on github pages:
-  // https://github.com/slorber/trailing-slash-guide?tab=readme-ov-file#summary
-  let outputPath = isHtmlFile
-    ? path.join(outputDir, urlPath, 'index.html')
-    : path.join(outputDir, urlPath)
-
-  console.log(`Crawled ${urlPath} -> ./${path.relative(process.cwd(), outputPath)}`)
-
+async function writeResult(pathname: string, filepath: string, response: Response) {
+  let outputPath = path.join(outputDir, filepath)
   await fs.mkdir(path.dirname(outputPath), { recursive: true })
-
-  if (isHtmlFile) {
-    let html = await response.text()
-    await fs.writeFile(outputPath, html, 'utf-8')
-
-    // Parse HTML files for other resources/links to add to queue
-    return {
-      downloadedUrl: urlPath,
-      discoveredUrls: parse(html)
-        .querySelectorAll('a:not([rel="nofollow"]),link:not([rel="preload"]):not([rel="prefetch"])')
-        .map((link) => link.getAttribute('href'))
-        .filter((href) => href && !isAbsoluteUrl(href))
-        .map((href) => resolveRelativeLink(href!, urlPath))
-        .flatMap((href) => {
-          let match = routes.docs.match(`http://localhost${href}`)
-          return match ? [href, routes.markdown.href(match.params)] : [href]
-        }),
-    }
-  } else {
-    let content = await response.arrayBuffer()
-    await fs.writeFile(outputPath, new Uint8Array(content))
-    return { downloadedUrl: urlPath, discoveredUrls: [] }
-  }
-}
-
-function isAbsoluteUrl(href: string): boolean {
-  return href.startsWith('http://') || href.startsWith('https://') || href.startsWith('//')
-}
-
-function resolveRelativeLink(link: string, url: string): string {
-  if (link.startsWith('/')) {
-    return link
-  }
-
-  // Handle relative paths like '../' or 'page'
-  let base = url.endsWith('/') ? url : path.dirname(url)
-  return path.posix.join(base, link)
+  await fs.writeFile(outputPath, new Uint8Array(await response.arrayBuffer()))
+  console.log(`Crawled ${pathname} -> ./${path.relative(process.cwd(), outputPath)}`)
 }
 
 async function getVersionsToBuild(): Promise<ServerContext['versions']> {

--- a/docs/src/server/prerender.ts
+++ b/docs/src/server/prerender.ts
@@ -34,7 +34,7 @@ for (let version of versions || getDefaultVersions()) {
   }
 }
 
-// First pass: spider the site and collect fragment/markdown variant paths
+// First pass: spider the site and collect markdown variant paths
 let paths = [
   '/',
   '/api.json',
@@ -48,7 +48,6 @@ for await (let { pathname, filepath, response } of crawl(docsRouter, { paths }))
   let url = `http://localhost${pathname}`
   let match = routes.docs.match(url)
   if (match && !routes.markdown.match(url)) {
-    variantPaths.push(routes.fragment.href(match.params))
     variantPaths.push(routes.markdown.href(match.params))
   }
 }

--- a/docs/src/server/prerender.ts
+++ b/docs/src/server/prerender.ts
@@ -2,13 +2,12 @@ import * as cp from 'node:child_process'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as util from 'node:util'
-import { parse } from 'node-html-parser'
 import * as semver from 'semver'
-import { type Router } from 'remix/fetch-router'
 import { createRouter, getDefaultVersions } from './router.tsx'
 import type { ServerContext } from './components.tsx'
 import { discoverMarkdownFiles } from './markdown.ts'
 import { routes } from './routes.ts'
+import { crawl } from 'remix/fetch-router'
 
 let { values: cliArgs } = util.parseArgs({
   options: {
@@ -35,114 +34,38 @@ for (let version of versions || getDefaultVersions()) {
   }
 }
 
-await spider(
-  docsRouter,
-  outputDir,
-  new Set([
-    '/',
-    '/api.json',
-    ...(versions
-      ?.filter((v) => v.crawl)
-      .flatMap((v) => [`/${v.version}/api.json`, `/${v.version}/`]) || []),
-  ]),
-)
-
-// Spider the website served by router, beginning at /
-async function spider(router: Router, outputDir: string, urlQueue = new Set(['/'])) {
-  await fs.mkdir(outputDir, { recursive: true })
-
-  // Track URLs we have already downloaded to avoid loops
-  let downloadedUrls = new Set<string>()
-
-  for (let urlPath of urlQueue) {
-    if (urlPath && !downloadedUrls.has(urlPath)) {
-      let { downloadedUrl, discoveredUrls } = await crawl(router, urlPath, outputDir)
-      downloadedUrls.add(downloadedUrl)
-      discoveredUrls
-        .filter((href) => !downloadedUrls.has(href))
-        .forEach((href) => urlQueue.add(href))
-    }
+// First pass: spider the site and collect fragment/markdown variant paths
+let paths = [
+  '/',
+  '/api.json',
+  ...(versions
+    ?.filter((v) => v.crawl)
+    .flatMap((v) => [`/${v.version}/api.json`, `/${v.version}/`]) || []),
+]
+let variantPaths: string[] = []
+for await (let { pathname, filepath, response } of crawl(docsRouter, { paths })) {
+  await writeResult(pathname, filepath, response)
+  let url = `http://localhost${pathname}`
+  let match = routes.docs.match(url)
+  if (match && !routes.markdown.match(url)) {
+    variantPaths.push(routes.fragment.href(match.params))
+    variantPaths.push(routes.markdown.href(match.params))
   }
-
-  console.log(`\nCrawling complete!`)
 }
 
-async function crawl(router: Router, urlPath: string, outputDir: string) {
-  let response
-  try {
-    response = await router.fetch(new Request(`http://localhost${urlPath}`))
-    if (!response.ok) {
-      throw new Error(`Error fetching ${urlPath}: ${response.status} ${response.statusText}`)
-    }
-  } catch (error) {
-    console.error('Error fetching', urlPath)
-    throw error
-  }
+// Second pass: fetch variant paths without spidering
+for await (let { pathname, filepath, response } of crawl(docsRouter, {
+  paths: variantPaths,
+  spider: false,
+})) {
+  await writeResult(pathname, filepath, response)
+}
 
-  let isHtmlFile = response.headers.get('Content-Type')?.includes('text/html')
-
-  // Always put `index.html` files into directories - this leads to the best
-  // support with and without trailing slashes on github pages:
-  // https://github.com/slorber/trailing-slash-guide?tab=readme-ov-file#summary
-  let outputPath = isHtmlFile
-    ? path.join(outputDir, urlPath, 'index.html')
-    : path.join(outputDir, urlPath)
-
-  console.log(`Crawled ${urlPath} -> ./${path.relative(process.cwd(), outputPath)}`)
-
+async function writeResult(pathname: string, filepath: string, response: Response) {
+  let outputPath = path.join(outputDir, filepath)
   await fs.mkdir(path.dirname(outputPath), { recursive: true })
-
-  if (isHtmlFile) {
-    let html = await response.text()
-    await fs.writeFile(outputPath, html, 'utf-8')
-
-    let parsedHtml = parse(html)
-
-    // Honor `<meta name="robots" content="nofollow">` (e.g. on package
-    // overview pages) by skipping link discovery. Per-link `rel="nofollow"`
-    // is filtered separately in the selector below.
-    let robots = parsedHtml.querySelector('meta[name="robots"]')?.getAttribute('content') || ''
-    let noFollow = robots
-      .split(',')
-      .map((s) => s.trim().toLowerCase())
-      .includes('nofollow')
-
-    if (noFollow) {
-      return { downloadedUrl: urlPath, discoveredUrls: [] }
-    }
-
-    // Parse HTML files for other resources/links to add to queue
-    return {
-      downloadedUrl: urlPath,
-      discoveredUrls: parsedHtml
-        .querySelectorAll('a:not([rel="nofollow"]),link:not([rel="preload"]):not([rel="prefetch"])')
-        .map((link) => link.getAttribute('href'))
-        .filter((href) => href && !isAbsoluteUrl(href))
-        .map((href) => resolveRelativeLink(href!, urlPath))
-        .flatMap((href) => {
-          let match = routes.docs.match(`http://localhost${href}`)
-          return match ? [href, routes.markdown.href(match.params)] : [href]
-        }),
-    }
-  } else {
-    let content = await response.arrayBuffer()
-    await fs.writeFile(outputPath, new Uint8Array(content))
-    return { downloadedUrl: urlPath, discoveredUrls: [] }
-  }
-}
-
-function isAbsoluteUrl(href: string): boolean {
-  return href.startsWith('http://') || href.startsWith('https://') || href.startsWith('//')
-}
-
-function resolveRelativeLink(link: string, url: string): string {
-  if (link.startsWith('/')) {
-    return link
-  }
-
-  // Handle relative paths like '../' or 'page'
-  let base = url.endsWith('/') ? url : path.dirname(url)
-  return path.posix.join(base, link)
+  await fs.writeFile(outputPath, new Uint8Array(await response.arrayBuffer()))
+  console.log(`Crawled ${pathname} -> ./${path.relative(process.cwd(), outputPath)}`)
 }
 
 async function getVersionsToBuild(): Promise<ServerContext['versions']> {

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -38,16 +38,6 @@ export function createRouter(versions: ServerContext['versions']) {
       let body = await stream(router, request, node, init)
       return createHtmlResponse(body, init)
     },
-    async fragment(request: Request, node: RemixNode, init?: ResponseInit) {
-      let body = await stream(router, request, node, init)
-      return new Response(body, {
-        ...init,
-        headers: {
-          'Content-Type': 'text/html; charset=utf-8',
-          ...init?.headers,
-        },
-      })
-    },
   }
 
   router.map(routes, {

--- a/packages/fetch-router/.changes/minor.add-crawl.md
+++ b/packages/fetch-router/.changes/minor.add-crawl.md
@@ -1,0 +1,14 @@
+Add `crawl()` API for prerendering and static-site generation
+
+- `crawl(router, options?)` returns an async iterable that fetches every reachable URL in a router, yielding a `CrawlResult` (`{ pathname, filepath, response }`) for each page
+- HTML responses are parsed for navigation links (`<a href>` and `<link rel="alternate" href>`) and referenced assets (`<link href>`, `<script src>`, `<img src>`);
+- The `spider` and `concurrency` options on `CrawlOptions` control link-following and parallelism
+- `crawl()` throws on non-2xx responses so missing pages surface as build failures.
+
+```ts
+import { crawl } from 'remix/fetch-router'
+
+for await (let { pathname, filepath, response } of crawl(router)) {
+  await writeResponseToDisk(filepath, response)
+}
+```

--- a/packages/fetch-router/README.md
+++ b/packages/fetch-router/README.md
@@ -10,6 +10,7 @@ A minimal, composable router built on the [web Fetch API](https://developer.mozi
 - **Declarative Route Maps**: Define your route structure upfront with type-safe route names and request methods
 - **Flexible Middleware**: Apply middleware globally, per-route, or to entire route hierarchies
 - **Easy Testing**: Use standard `fetch()` to test your routes - no special test harness required
+- **Crawling and Prerendering**: Walk your router with `crawl()` to generate a static build by following links and assets
 
 ## Installation
 
@@ -767,6 +768,56 @@ let button = html`<button>${icon} Click me</button>` // icon is not escaped
 **Warning**: Only use `html.raw` with trusted content. Unlike the regular `html` template tag, `html.raw` does not escape its interpolations, which can lead to XSS vulnerabilities if used with untrusted user input.
 
 See the [`html-template` documentation](https://github.com/remix-run/remix/tree/main/packages/html-template#readme) for more details.
+
+### Crawling and Prerendering
+
+The `crawl()` function fetches every reachable URL in a router and yields the results as an async iterable, making it easy to prerender a site to a static build. By default it starts at `/`, and spiders the site to download links and assets (CSS, JavaScript, images).
+
+```ts
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import { crawl } from 'remix/fetch-router'
+import { router } from './router.ts'
+
+for await (let { pathname, filepath, response } of crawl(router)) {
+  let outputPath = path.join('dist', filepath)
+  await fs.mkdir(path.dirname(outputPath), { recursive: true })
+  await fs.writeFile(outputPath, new Uint8Array(await response.arrayBuffer()))
+  console.log(`Crawled ${pathname} -> ${outputPath}`)
+}
+```
+
+Each crawl result has three properties:
+
+- `pathname` - the URL path that was fetched (e.g. `/about`)
+- `filepath` - the relative file path to write the response to (e.g., `/about/index.html`, `/styles.css`)
+- `response` - the `Response` returned by the router
+
+If any response is non-2xx, `crawl()` throws. This is intentional — for static-site generation, a missing page is almost always a bug worth surfacing rather than silently skipping.
+
+#### Crawl Options
+
+`crawl()` accepts a options to control its behavior:
+
+- `paths` - the initial URL paths to put in the queue (defaults to `['/']`)
+- `spider` - whether to discover and crawl linked documents in HTML responses (`<a href>`, `<link rel="alternate" href>`) (defaults to `true`)
+- `concurrency` - the maximum number of concurrent requests (defaults to `1`)
+
+#### Link Discovery
+
+By default, only the initial paths and it's referenced assets (CSS, JS, images) are fetched.
+
+When `spider` is `true`, the crawler discovers additional URLs by parsing each HTML response and inspecting:
+
+- `<a href>` for navigation links (skips `rel="nofollow"`)
+- `<link rel="alternate" href>` for alternate representations of the same page, e.g. markdown variants or RSS feeds (skips `rel="nofollow"`)
+- `<link href>` for stylesheets and other linked resources (skips `rel="preload"`, `rel="prefetch"`, `rel="modulepreload"`, and `rel="alternate"`)
+- `<script src>` and `<img src>` for scripts and images
+- Certain URL patterns are always skipped:
+  - absolute URLs (e.g. `https://example.com/...` or `//example.com/...`)
+  - non-navigable schemes (`mailto:`, `tel:`, `javascript:`, `data:`)
+  - fragment-only links (`#...`)
+  - paths that have already been visited
 
 ### Testing
 

--- a/packages/fetch-router/README.md
+++ b/packages/fetch-router/README.md
@@ -10,6 +10,7 @@ A minimal, composable router built on the [web Fetch API](https://developer.mozi
 - **Declarative Route Maps**: Define your route structure upfront with type-safe route names and request methods
 - **Flexible Middleware**: Apply middleware globally, per-route, or to controllers
 - **Easy Testing**: Use standard `fetch()` to test your routes - no special test harness required
+- **Crawling and Prerendering**: Walk your router with `crawl()` to generate a static build by following links and assets
 
 ## Installation
 
@@ -820,6 +821,56 @@ let button = html`<button>${icon} Click me</button>` // icon is not escaped
 **Warning**: Only use `html.raw` with trusted content. Unlike the regular `html` template tag, `html.raw` does not escape its interpolations, which can lead to XSS vulnerabilities if used with untrusted user input.
 
 See the [`html-template` documentation](https://github.com/remix-run/remix/tree/main/packages/html-template#readme) for more details.
+
+### Crawling and Prerendering
+
+The `crawl()` function fetches every reachable URL in a router and yields the results as an async iterable, making it easy to prerender a site to a static build. By default it starts at `/`, and spiders the site to download links and assets (CSS, JavaScript, images).
+
+```ts
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import { crawl } from 'remix/fetch-router'
+import { router } from './router.ts'
+
+for await (let { pathname, filepath, response } of crawl(router)) {
+  let outputPath = path.join('dist', filepath)
+  await fs.mkdir(path.dirname(outputPath), { recursive: true })
+  await fs.writeFile(outputPath, new Uint8Array(await response.arrayBuffer()))
+  console.log(`Crawled ${pathname} -> ${outputPath}`)
+}
+```
+
+Each crawl result has three properties:
+
+- `pathname` - the URL path that was fetched (e.g. `/about`)
+- `filepath` - the relative file path to write the response to (e.g., `/about/index.html`, `/styles.css`)
+- `response` - the `Response` returned by the router
+
+If any response is non-2xx, `crawl()` throws. This is intentional — for static-site generation, a missing page is almost always a bug worth surfacing rather than silently skipping.
+
+#### Crawl Options
+
+`crawl()` accepts a options to control its behavior:
+
+- `paths` - the initial URL paths to put in the queue (defaults to `['/']`)
+- `spider` - whether to discover and crawl linked documents in HTML responses (`<a href>`, `<link rel="alternate" href>`) (defaults to `true`)
+- `concurrency` - the maximum number of concurrent requests (defaults to `1`)
+
+#### Link Discovery
+
+By default, only the initial paths and it's referenced assets (CSS, JS, images) are fetched.
+
+When `spider` is `true`, the crawler discovers additional URLs by parsing each HTML response and inspecting:
+
+- `<a href>` for navigation links (skips `rel="nofollow"`)
+- `<link rel="alternate" href>` for alternate representations of the same page, e.g. markdown variants or RSS feeds (skips `rel="nofollow"`)
+- `<link href>` for stylesheets and other linked resources (skips `rel="preload"`, `rel="prefetch"`, `rel="modulepreload"`, and `rel="alternate"`)
+- `<script src>` and `<img src>` for scripts and images
+- Certain URL patterns are always skipped:
+  - absolute URLs (e.g. `https://example.com/...` or `//example.com/...`)
+  - non-navigable schemes (`mailto:`, `tel:`, `javascript:`, `data:`)
+  - fragment-only links (`#...`)
+  - paths that have already been visited
 
 ### Testing
 

--- a/packages/fetch-router/bench/fixtures/blog-post.html
+++ b/packages/fetch-router/bench/fixtures/blog-post.html
@@ -1,0 +1,515 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Building Scalable Web Applications in 2024 | Engineering Blog</title>
+    <meta
+      name="description"
+      content="A comprehensive guide to building scalable web applications using modern tools and best practices."
+    />
+    <link rel="stylesheet" href="/styles/main.css" />
+    <link rel="stylesheet" href="/styles/blog.css" />
+    <link rel="stylesheet" href="/styles/syntax-highlighting.css" />
+    <link rel="canonical" href="https://example.com/blog/scalable-web-apps-2024" />
+    <script src="/scripts/analytics.js"></script>
+    <script src="/scripts/reading-time.js" defer></script>
+    <script src="/scripts/code-copy.js" defer></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav>
+        <a href="/" class="logo">
+          <img src="/images/logo.svg" alt="Company Logo" width="120" height="32" />
+        </a>
+        <ul>
+          <li><a href="/blog">Blog</a></li>
+          <li><a href="/docs">Docs</a></li>
+          <li><a href="/about">About</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main class="blog-post">
+      <article>
+        <header class="post-header">
+          <div class="post-meta">
+            <a href="/blog/category/engineering" class="category">Engineering</a>
+            <time datetime="2024-01-15">January 15, 2024</time>
+            <span class="reading-time">12 min read</span>
+          </div>
+          <h1>Building Scalable Web Applications in 2024</h1>
+          <p class="post-subtitle">
+            A comprehensive guide to modern architecture, performance optimization, and best
+            practices
+          </p>
+          <div class="post-author">
+            <img src="/images/authors/jane-smith.jpg" alt="Jane Smith" width="48" height="48" />
+            <div>
+              <strong><a href="/authors/jane-smith">Jane Smith</a></strong>
+              <span>Senior Engineering Manager</span>
+            </div>
+          </div>
+          <img
+            src="/images/blog/scalable-apps-hero.jpg"
+            alt="Architecture diagram"
+            class="post-hero-image"
+            loading="lazy"
+          />
+        </header>
+
+        <div class="post-content">
+          <p>
+            Building scalable web applications has become increasingly complex as user expectations
+            rise and technology evolves. In this comprehensive guide, we'll explore the essential
+            principles, patterns, and tools you need to build applications that can grow with your
+            business.
+          </p>
+
+          <h2 id="introduction">Introduction</h2>
+          <p>
+            Scalability isn't just about handling more users—it's about maintaining performance,
+            reliability, and developer productivity as your application grows. Whether you're
+            building a startup MVP or an enterprise platform, understanding scalability from day one
+            will save you countless hours of refactoring later.
+          </p>
+
+          <h2 id="architecture">Modern Application Architecture</h2>
+          <p>
+            The foundation of any scalable application is its architecture. Let's explore the key
+            components:
+          </p>
+
+          <h3>Microservices vs Monoliths</h3>
+          <p>
+            The debate between <a href="/blog/microservices-guide">microservices</a> and
+            <a href="/blog/monolith-patterns">monolithic architectures</a> continues, but the
+            reality is nuanced. Start with a modular monolith and extract services only when you
+            have clear boundaries and organizational support.
+          </p>
+
+          <h3>API Design</h3>
+          <p>Your API is the contract between your frontend and backend. Design it carefully:</p>
+          <ul>
+            <li>
+              Use <a href="https://restfulapi.net/" rel="nofollow">RESTful principles</a> for
+              resource-based APIs
+            </li>
+            <li>
+              Consider <a href="https://graphql.org/" rel="nofollow">GraphQL</a> for complex data
+              requirements
+            </li>
+            <li>Implement proper <a href="/blog/api-versioning">versioning strategies</a></li>
+            <li>
+              Document everything with
+              <a href="https://www.openapis.org/" rel="nofollow">OpenAPI</a>
+            </li>
+          </ul>
+
+          <h2 id="database">Database Strategy</h2>
+          <p>Your database is often the first bottleneck. Here's how to design for scale:</p>
+
+          <h3>Choosing the Right Database</h3>
+          <p>Not all databases are created equal. Consider your access patterns:</p>
+          <ul>
+            <li>
+              <strong>PostgreSQL</strong> - Excellent for relational data with complex queries. See
+              our <a href="/blog/postgres-optimization">PostgreSQL optimization guide</a>.
+            </li>
+            <li>
+              <strong>MongoDB</strong> - Great for document-oriented data and flexible schemas
+            </li>
+            <li><strong>Redis</strong> - Perfect for caching and real-time features</li>
+            <li><strong>Elasticsearch</strong> - Essential for full-text search at scale</li>
+          </ul>
+
+          <h3>Indexing Strategy</h3>
+          <p>
+            Proper indexing can make the difference between milliseconds and seconds. Here's a basic
+            example:
+          </p>
+
+          <pre><code class="language-sql">-- Create a composite index for common queries
+CREATE INDEX idx_users_email_status
+ON users(email, status)
+WHERE deleted_at IS NULL;
+
+-- Add partial index for active users
+CREATE INDEX idx_active_users
+ON users(created_at)
+WHERE status = 'active';</code></pre>
+
+          <h2 id="caching">Caching Strategies</h2>
+          <p>
+            Implement caching at multiple layers to reduce database load and improve response times.
+            Learn more in our <a href="/blog/caching-patterns">caching patterns guide</a>.
+          </p>
+
+          <h3>Application-Level Caching</h3>
+          <pre><code class="language-typescript">import { createCache } from '@/lib/cache'
+
+const userCache = createCache({
+  ttl: 300, // 5 minutes
+  maxSize: 1000
+})
+
+async function getUser(id: string) {
+  let cached = userCache.get(id)
+  if (cached) return cached
+
+  let user = await db.users.findById(id)
+  userCache.set(id, user)
+  return user
+}</code></pre>
+
+          <h2 id="performance">Performance Optimization</h2>
+          <p>Performance is a feature, not an afterthought. Here are key areas to focus on:</p>
+
+          <h3>Frontend Performance</h3>
+          <ul>
+            <li><a href="/blog/code-splitting">Code splitting</a> to reduce initial bundle size</li>
+            <li><a href="/blog/lazy-loading">Lazy loading</a> images and routes</li>
+            <li>
+              Implement <a href="/blog/service-workers">service workers</a> for offline support
+            </li>
+            <li>
+              Use <a href="https://web.dev/vitals/" rel="nofollow">Core Web Vitals</a> as metrics
+            </li>
+          </ul>
+
+          <h3>Backend Performance</h3>
+          <pre><code class="language-typescript">// Use connection pooling
+import { Pool } from 'pg'
+
+const pool = new Pool({
+  max: 20,
+  idleTimeoutMillis: 30000,
+  connectionTimeoutMillis: 2000,
+})
+
+// Implement request batching
+async function batchGetUsers(ids: string[]) {
+  let query = 'SELECT * FROM users WHERE id = ANY($1)'
+  let result = await pool.query(query, [ids])
+  return result.rows
+}</code></pre>
+
+          <h2 id="monitoring">Monitoring and Observability</h2>
+          <p>You can't improve what you don't measure. Essential monitoring includes:</p>
+          <ul>
+            <li>
+              <strong>Application metrics</strong> - Request rates, error rates, latency (see
+              <a href="/blog/metrics-guide">our metrics guide</a>)
+            </li>
+            <li><strong>Infrastructure metrics</strong> - CPU, memory, disk, network</li>
+            <li><strong>Business metrics</strong> - Conversion rates, user engagement</li>
+            <li><strong>Logs</strong> - Structured logging with context</li>
+          </ul>
+
+          <h2 id="deployment">Deployment and DevOps</h2>
+          <p>Modern deployment practices enable rapid iteration while maintaining stability:</p>
+
+          <h3>CI/CD Pipeline</h3>
+          <pre><code class="language-yaml"># .github/workflows/deploy.yml
+name: Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run tests
+        run: npm test
+      - name: Build
+        run: npm run build
+      - name: Deploy
+        run: npm run deploy</code></pre>
+
+          <h2 id="conclusion">Conclusion</h2>
+          <p>
+            Building scalable web applications is a journey, not a destination. Start with solid
+            foundations, measure everything, and iterate based on real user data. For more insights,
+            check out our <a href="/blog/series/scalability">scalability series</a>.
+          </p>
+
+          <p>Want to learn more? Read our related articles:</p>
+          <ul>
+            <li><a href="/blog/microservices-guide">The Complete Microservices Guide</a></li>
+            <li><a href="/blog/database-sharding">Database Sharding Strategies</a></li>
+            <li><a href="/blog/load-balancing">Load Balancing Best Practices</a></li>
+            <li><a href="/blog/disaster-recovery">Disaster Recovery Planning</a></li>
+          </ul>
+
+          <p>
+            Building scalable web applications has become increasingly complex as user expectations
+            rise and technology evolves. In this comprehensive guide, we'll explore the essential
+            principles, patterns, and tools you need to build applications that can grow with your
+            business.
+          </p>
+
+          <h2 id="introduction">Introduction</h2>
+          <p>
+            Scalability isn't just about handling more users—it's about maintaining performance,
+            reliability, and developer productivity as your application grows. Whether you're
+            building a startup MVP or an enterprise platform, understanding scalability from day one
+            will save you countless hours of refactoring later.
+          </p>
+
+          <h2 id="architecture">Modern Application Architecture</h2>
+          <p>
+            The foundation of any scalable application is its architecture. Let's explore the key
+            components:
+          </p>
+
+          <h3>Microservices vs Monoliths</h3>
+          <p>
+            The debate between <a href="/blog/microservices-guide">microservices</a> and
+            <a href="/blog/monolith-patterns">monolithic architectures</a> continues, but the
+            reality is nuanced. Start with a modular monolith and extract services only when you
+            have clear boundaries and organizational support.
+          </p>
+
+          <h3>API Design</h3>
+          <p>Your API is the contract between your frontend and backend. Design it carefully:</p>
+          <ul>
+            <li>
+              Use <a href="https://restfulapi.net/" rel="nofollow">RESTful principles</a> for
+              resource-based APIs
+            </li>
+            <li>
+              Consider <a href="https://graphql.org/" rel="nofollow">GraphQL</a> for complex data
+              requirements
+            </li>
+            <li>Implement proper <a href="/blog/api-versioning">versioning strategies</a></li>
+            <li>
+              Document everything with
+              <a href="https://www.openapis.org/" rel="nofollow">OpenAPI</a>
+            </li>
+          </ul>
+
+          <h2 id="database">Database Strategy</h2>
+          <p>Your database is often the first bottleneck. Here's how to design for scale:</p>
+
+          <h3>Choosing the Right Database</h3>
+          <p>Not all databases are created equal. Consider your access patterns:</p>
+          <ul>
+            <li>
+              <strong>PostgreSQL</strong> - Excellent for relational data with complex queries. See
+              our <a href="/blog/postgres-optimization">PostgreSQL optimization guide</a>.
+            </li>
+            <li>
+              <strong>MongoDB</strong> - Great for document-oriented data and flexible schemas
+            </li>
+            <li><strong>Redis</strong> - Perfect for caching and real-time features</li>
+            <li><strong>Elasticsearch</strong> - Essential for full-text search at scale</li>
+          </ul>
+
+          <h3>Indexing Strategy</h3>
+          <p>
+            Proper indexing can make the difference between milliseconds and seconds. Here's a basic
+            example:
+          </p>
+
+          <pre><code class="language-sql">-- Create a composite index for common queries
+CREATE INDEX idx_users_email_status
+ON users(email, status)
+WHERE deleted_at IS NULL;
+
+-- Add partial index for active users
+CREATE INDEX idx_active_users
+ON users(created_at)
+WHERE status = 'active';</code></pre>
+
+          <h2 id="caching">Caching Strategies</h2>
+          <p>
+            Implement caching at multiple layers to reduce database load and improve response times.
+            Learn more in our <a href="/blog/caching-patterns">caching patterns guide</a>.
+          </p>
+
+          <h3>Application-Level Caching</h3>
+          <pre><code class="language-typescript">import { createCache } from '@/lib/cache'
+
+const userCache = createCache({
+  ttl: 300, // 5 minutes
+  maxSize: 1000
+})
+
+async function getUser(id: string) {
+  let cached = userCache.get(id)
+  if (cached) return cached
+
+  let user = await db.users.findById(id)
+  userCache.set(id, user)
+  return user
+}</code></pre>
+
+          <h2 id="performance">Performance Optimization</h2>
+          <p>Performance is a feature, not an afterthought. Here are key areas to focus on:</p>
+
+          <h3>Frontend Performance</h3>
+          <ul>
+            <li><a href="/blog/code-splitting">Code splitting</a> to reduce initial bundle size</li>
+            <li><a href="/blog/lazy-loading">Lazy loading</a> images and routes</li>
+            <li>
+              Implement <a href="/blog/service-workers">service workers</a> for offline support
+            </li>
+            <li>
+              Use <a href="https://web.dev/vitals/" rel="nofollow">Core Web Vitals</a> as metrics
+            </li>
+          </ul>
+
+          <h3>Backend Performance</h3>
+          <pre><code class="language-typescript">// Use connection pooling
+import { Pool } from 'pg'
+
+const pool = new Pool({
+  max: 20,
+  idleTimeoutMillis: 30000,
+  connectionTimeoutMillis: 2000,
+})
+
+// Implement request batching
+async function batchGetUsers(ids: string[]) {
+  let query = 'SELECT * FROM users WHERE id = ANY($1)'
+  let result = await pool.query(query, [ids])
+  return result.rows
+}</code></pre>
+
+          <h2 id="monitoring">Monitoring and Observability</h2>
+          <p>You can't improve what you don't measure. Essential monitoring includes:</p>
+          <ul>
+            <li>
+              <strong>Application metrics</strong> - Request rates, error rates, latency (see
+              <a href="/blog/metrics-guide">our metrics guide</a>)
+            </li>
+            <li><strong>Infrastructure metrics</strong> - CPU, memory, disk, network</li>
+            <li><strong>Business metrics</strong> - Conversion rates, user engagement</li>
+            <li><strong>Logs</strong> - Structured logging with context</li>
+          </ul>
+
+          <h2 id="deployment">Deployment and DevOps</h2>
+          <p>Modern deployment practices enable rapid iteration while maintaining stability:</p>
+
+          <h3>CI/CD Pipeline</h3>
+          <pre><code class="language-yaml"># .github/workflows/deploy.yml
+name: Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run tests
+        run: npm test
+      - name: Build
+        run: npm run build
+      - name: Deploy
+        run: npm run deploy</code></pre>
+
+          <h2 id="conclusion">Conclusion</h2>
+          <p>
+            Building scalable web applications is a journey, not a destination. Start with solid
+            foundations, measure everything, and iterate based on real user data. For more insights,
+            check out our <a href="/blog/series/scalability">scalability series</a>.
+          </p>
+
+          <p>Want to learn more? Read our related articles:</p>
+          <ul>
+            <li><a href="/blog/microservices-guide">The Complete Microservices Guide</a></li>
+            <li><a href="/blog/database-sharding">Database Sharding Strategies</a></li>
+            <li><a href="/blog/load-balancing">Load Balancing Best Practices</a></li>
+            <li><a href="/blog/disaster-recovery">Disaster Recovery Planning</a></li>
+          </ul>
+        </div>
+
+        <footer class="post-footer">
+          <div class="post-tags">
+            <a href="/blog/tag/architecture" class="tag">Architecture</a>
+            <a href="/blog/tag/scalability" class="tag">Scalability</a>
+            <a href="/blog/tag/performance" class="tag">Performance</a>
+            <a href="/blog/tag/databases" class="tag">Databases</a>
+          </div>
+          <div class="post-share">
+            <span>Share:</span>
+            <a href="https://twitter.com/share" rel="nofollow">Twitter</a>
+            <a href="https://linkedin.com/share" rel="nofollow">LinkedIn</a>
+            <a href="https://news.ycombinator.com/submit" rel="nofollow">HN</a>
+          </div>
+        </footer>
+      </article>
+
+      <aside class="sidebar">
+        <div class="author-bio">
+          <h3>About the Author</h3>
+          <img src="/images/authors/jane-smith.jpg" alt="Jane Smith" width="80" height="80" />
+          <p>
+            <strong><a href="/authors/jane-smith">Jane Smith</a></strong> is a Senior Engineering
+            Manager with 15 years of experience building scalable systems.
+          </p>
+          <a href="https://twitter.com/janesmith" rel="nofollow">Follow on Twitter</a>
+        </div>
+
+        <div class="related-posts">
+          <h3>Related Posts</h3>
+          <ul>
+            <li>
+              <a href="/blog/microservices-guide">
+                <img src="/images/blog/microservices-thumb.jpg" alt="" width="60" height="60" />
+                <span>The Complete Microservices Guide</span>
+              </a>
+            </li>
+            <li>
+              <a href="/blog/database-optimization">
+                <img src="/images/blog/database-thumb.jpg" alt="" width="60" height="60" />
+                <span>Database Optimization Techniques</span>
+              </a>
+            </li>
+            <li>
+              <a href="/blog/caching-patterns">
+                <img src="/images/blog/caching-thumb.jpg" alt="" width="60" height="60" />
+                <span>Advanced Caching Patterns</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+
+        <div class="newsletter">
+          <h3>Subscribe to our Newsletter</h3>
+          <p>Get the latest posts delivered right to your inbox.</p>
+          <form action="/api/subscribe" method="post">
+            <input type="email" name="email" placeholder="your@email.com" required />
+            <button type="submit" class="btn">Subscribe</button>
+          </form>
+        </div>
+      </aside>
+    </main>
+
+    <footer class="site-footer">
+      <div class="footer-links">
+        <div>
+          <h4>Product</h4>
+          <ul>
+            <li><a href="/features">Features</a></li>
+            <li><a href="/pricing">Pricing</a></li>
+            <li><a href="/docs">Documentation</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Company</h4>
+          <ul>
+            <li><a href="/about">About</a></li>
+            <li><a href="/blog">Blog</a></li>
+            <li><a href="/careers">Careers</a></li>
+          </ul>
+        </div>
+      </div>
+      <p>&copy; 2024 Company. <a href="/privacy">Privacy</a> | <a href="/terms">Terms</a></p>
+    </footer>
+  </body>
+</html>

--- a/packages/fetch-router/bench/fixtures/docs-page.html
+++ b/packages/fetch-router/bench/fixtures/docs-page.html
@@ -1,0 +1,860 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>API Reference - Authentication | Documentation</title>
+    <link rel="stylesheet" href="/docs/styles/main.css" />
+    <link rel="stylesheet" href="/docs/styles/docs.css" />
+    <link rel="stylesheet" href="/docs/styles/code.css" />
+    <link rel="icon" href="/favicon.ico" />
+    <script src="/docs/scripts/search.js" defer></script>
+    <script src="/docs/scripts/navigation.js" defer></script>
+    <script src="/docs/scripts/code-examples.js" defer></script>
+  </head>
+  <body>
+    <header class="docs-header">
+      <div class="header-content">
+        <a href="/" class="logo">
+          <img src="/images/logo.svg" alt="Logo" width="120" height="32" />
+        </a>
+        <nav class="main-nav">
+          <a href="/docs">Documentation</a>
+          <a href="/docs/api">API Reference</a>
+          <a href="/docs/guides">Guides</a>
+          <a href="/blog">Blog</a>
+        </nav>
+        <div class="header-actions">
+          <input type="search" placeholder="Search docs..." class="search-input" />
+          <a href="https://github.com/company/repo" rel="nofollow">GitHub</a>
+        </div>
+      </div>
+    </header>
+
+    <div class="docs-layout">
+      <aside class="docs-sidebar">
+        <nav>
+          <div class="nav-section">
+            <h3>Getting Started</h3>
+            <ul>
+              <li><a href="/docs/introduction">Introduction</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/installation">Installation</a></li>
+              <li><a href="/docs/configuration">Configuration</a></li>
+            </ul>
+          </div>
+
+          <div class="nav-section">
+            <h3>Core Concepts</h3>
+            <ul>
+              <li><a href="/docs/architecture">Architecture</a></li>
+              <li><a href="/docs/routing">Routing</a></li>
+              <li><a href="/docs/data-loading">Data Loading</a></li>
+              <li><a href="/docs/forms">Forms</a></li>
+              <li><a href="/docs/error-handling">Error Handling</a></li>
+            </ul>
+          </div>
+
+          <div class="nav-section active">
+            <h3>API Reference</h3>
+            <ul>
+              <li><a href="/docs/api/overview">Overview</a></li>
+              <li><a href="/docs/api/authentication" class="active">Authentication</a></li>
+              <li><a href="/docs/api/users">Users</a></li>
+              <li><a href="/docs/api/projects">Projects</a></li>
+              <li><a href="/docs/api/teams">Teams</a></li>
+              <li><a href="/docs/api/webhooks">Webhooks</a></li>
+              <li><a href="/docs/api/errors">Error Codes</a></li>
+            </ul>
+          </div>
+
+          <div class="nav-section">
+            <h3>Guides</h3>
+            <ul>
+              <li><a href="/docs/guides/deployment">Deployment</a></li>
+              <li><a href="/docs/guides/testing">Testing</a></li>
+              <li><a href="/docs/guides/performance">Performance</a></li>
+              <li><a href="/docs/guides/security">Security</a></li>
+              <li><a href="/docs/guides/migrations">Migrations</a></li>
+            </ul>
+          </div>
+
+          <div class="nav-section">
+            <h3>Advanced</h3>
+            <ul>
+              <li><a href="/docs/advanced/caching">Caching Strategies</a></li>
+              <li><a href="/docs/advanced/rate-limiting">Rate Limiting</a></li>
+              <li><a href="/docs/advanced/webhooks">Webhook Security</a></li>
+              <li><a href="/docs/advanced/batching">Request Batching</a></li>
+            </ul>
+          </div>
+
+          <div class="nav-section">
+            <h3>Resources</h3>
+            <ul>
+              <li><a href="/docs/changelog">Changelog</a></li>
+              <li><a href="/docs/examples">Examples</a></li>
+              <li><a href="/docs/faq">FAQ</a></li>
+              <li><a href="/docs/support">Support</a></li>
+            </ul>
+          </div>
+        </nav>
+      </aside>
+
+      <main class="docs-content">
+        <div class="breadcrumbs">
+          <a href="/docs">Documentation</a>
+          <span>/</span>
+          <a href="/docs/api">API Reference</a>
+          <span>/</span>
+          <span>Authentication</span>
+        </div>
+
+        <article>
+          <h1>Authentication</h1>
+          <p class="lead">
+            Learn how to authenticate your API requests using API keys, OAuth 2.0, or JWT tokens.
+          </p>
+
+          <div class="table-of-contents">
+            <h2>On This Page</h2>
+            <ul>
+              <li><a href="#api-keys">API Keys</a></li>
+              <li><a href="#oauth">OAuth 2.0</a></li>
+              <li><a href="#jwt">JWT Tokens</a></li>
+              <li><a href="#examples">Code Examples</a></li>
+              <li><a href="#best-practices">Best Practices</a></li>
+            </ul>
+          </div>
+
+          <h2 id="api-keys">API Keys</h2>
+          <p>
+            API keys are the simplest way to authenticate. Include your API key in the
+            <code>Authorization</code> header of every request.
+          </p>
+
+          <h3>Getting Your API Key</h3>
+          <ol>
+            <li>Navigate to your <a href="/dashboard/settings/api-keys">API Keys settings</a></li>
+            <li>Click "Create New Key"</li>
+            <li>Give your key a descriptive name</li>
+            <li>Copy and securely store your key (it won't be shown again)</li>
+          </ol>
+
+          <div class="code-example">
+            <pre><code class="language-bash">curl https://api.example.com/v1/users \
+  -H "Authorization: Bearer YOUR_API_KEY"</code></pre>
+          </div>
+
+          <div class="callout callout-warning">
+            <strong>Security Note:</strong> Never commit API keys to version control or expose them
+            in client-side code. Use environment variables and
+            <a href="/docs/guides/security#secrets">secure secret management</a>.
+          </div>
+
+          <h3>API Key Permissions</h3>
+          <p>API keys can be scoped to specific permissions. Available scopes include:</p>
+
+          <table>
+            <thead>
+              <tr>
+                <th>Scope</th>
+                <th>Description</th>
+                <th>Operations</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>users:read</code></td>
+                <td>Read user data</td>
+                <td>GET /users, GET /users/:id</td>
+              </tr>
+              <tr>
+                <td><code>users:write</code></td>
+                <td>Create and update users</td>
+                <td>POST /users, PUT /users/:id, PATCH /users/:id</td>
+              </tr>
+              <tr>
+                <td><code>users:delete</code></td>
+                <td>Delete users</td>
+                <td>DELETE /users/:id</td>
+              </tr>
+              <tr>
+                <td><code>projects:read</code></td>
+                <td>Read project data</td>
+                <td>GET /projects, GET /projects/:id</td>
+              </tr>
+              <tr>
+                <td><code>projects:write</code></td>
+                <td>Create and update projects</td>
+                <td>POST /projects, PUT /projects/:id</td>
+              </tr>
+              <tr>
+                <td><code>teams:admin</code></td>
+                <td>Full team management</td>
+                <td>All team endpoints</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h2 id="oauth">OAuth 2.0</h2>
+          <p>
+            For applications that need to access user data on behalf of users, use OAuth 2.0. We
+            support the authorization code flow with PKCE for maximum security.
+          </p>
+
+          <h3>OAuth Flow</h3>
+          <p>The OAuth 2.0 flow involves several steps:</p>
+
+          <ol>
+            <li>
+              <strong>Register your application</strong>
+              <p>
+                Create an OAuth application in your
+                <a href="/dashboard/settings/oauth-apps">OAuth Apps settings</a>. You'll receive a
+                client ID and client secret.
+              </p>
+            </li>
+            <li>
+              <strong>Redirect users to authorize</strong>
+              <div class="code-example">
+                <pre><code class="language-typescript">let params = new URLSearchParams({
+  client_id: 'YOUR_CLIENT_ID',
+  redirect_uri: 'https://yourapp.com/callback',
+  response_type: 'code',
+  scope: 'users:read projects:write',
+  state: 'random_state_value'
+})
+
+window.location.href = `https://api.example.com/oauth/authorize?${params}`</code></pre>
+              </div>
+            </li>
+            <li>
+              <strong>Handle the callback</strong>
+              <p>After authorization, users are redirected back with an authorization code:</p>
+              <div class="code-example">
+                <pre><code class="language-typescript">// In your callback handler
+let code = new URL(window.location.href).searchParams.get('code')
+
+// Exchange code for access token
+let response = await fetch('https://api.example.com/oauth/token', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    client_id: 'YOUR_CLIENT_ID',
+    client_secret: 'YOUR_CLIENT_SECRET',
+    code: code,
+    grant_type: 'authorization_code'
+  })
+})
+
+let { access_token, refresh_token } = await response.json()</code></pre>
+              </div>
+            </li>
+            <li>
+              <strong>Use the access token</strong>
+              <div class="code-example">
+                <pre><code class="language-typescript">let response = await fetch('https://api.example.com/v1/users/me', {
+  headers: {
+    'Authorization': `Bearer ${access_token}`
+  }
+})</code></pre>
+              </div>
+            </li>
+          </ol>
+
+          <h3>Refreshing Tokens</h3>
+          <p>Access tokens expire after 1 hour. Use refresh tokens to obtain new access tokens:</p>
+
+          <div class="code-example">
+            <pre><code class="language-typescript">let response = await fetch('https://api.example.com/oauth/token', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    client_id: 'YOUR_CLIENT_ID',
+    client_secret: 'YOUR_CLIENT_SECRET',
+    refresh_token: refresh_token,
+    grant_type: 'refresh_token'
+  })
+})
+
+let { access_token } = await response.json()</code></pre>
+          </div>
+
+          <h2 id="jwt">JWT Tokens</h2>
+          <p>
+            For service-to-service authentication, you can use JWT tokens signed with RS256. This is
+            useful for <a href="/docs/guides/webhooks">webhook validation</a> and server-side
+            integrations.
+          </p>
+
+          <h3>Creating a JWT</h3>
+          <div class="code-example">
+            <pre><code class="language-typescript">import jwt from 'jsonwebtoken'
+import fs from 'fs'
+
+let privateKey = fs.readFileSync('private-key.pem')
+
+let token = jwt.sign(
+  {
+    iss: 'YOUR_CLIENT_ID',
+    sub: 'user-id',
+    aud: 'https://api.example.com',
+    exp: Math.floor(Date.now() / 1000) + 3600
+  },
+  privateKey,
+  { algorithm: 'RS256' }
+)</code></pre>
+          </div>
+
+          <h3>Verifying a JWT</h3>
+          <p>
+            When you receive a JWT from our API (such as in webhook payloads), verify it using our
+            public key:
+          </p>
+
+          <div class="code-example">
+            <pre><code class="language-typescript">import jwt from 'jsonwebtoken'
+
+// Fetch our public key from /.well-known/jwks.json
+let publicKey = await fetchPublicKey()
+
+try {
+  let decoded = jwt.verify(token, publicKey, {
+    algorithms: ['RS256'],
+    audience: 'https://yourapp.com',
+    issuer: 'https://api.example.com'
+  })
+  console.log('Valid token:', decoded)
+} catch (err) {
+  console.error('Invalid token:', err)
+}</code></pre>
+          </div>
+
+          <h2 id="examples">Code Examples</h2>
+
+          <h3>JavaScript/TypeScript</h3>
+          <div class="code-example">
+            <pre><code class="language-typescript">import { ApiClient } from '@example/api-client'
+
+let client = new ApiClient({
+  apiKey: process.env.API_KEY
+})
+
+// List users
+let users = await client.users.list({ limit: 10 })
+
+// Create a user
+let newUser = await client.users.create({
+  email: 'user@example.com',
+  name: 'John Doe'
+})</code></pre>
+          </div>
+
+          <h3>Python</h3>
+          <div class="code-example">
+            <pre><code class="language-python">from example_api import ApiClient
+
+client = ApiClient(api_key=os.environ['API_KEY'])
+
+# List users
+users = client.users.list(limit=10)
+
+# Create a user
+new_user = client.users.create(
+    email='user@example.com',
+    name='John Doe'
+)</code></pre>
+          </div>
+
+          <h3>Ruby</h3>
+          <div class="code-example">
+            <pre><code class="language-ruby">require 'example_api'
+
+client = ExampleApi::Client.new(api_key: ENV['API_KEY'])
+
+# List users
+users = client.users.list(limit: 10)
+
+# Create a user
+new_user = client.users.create(
+  email: 'user@example.com',
+  name: 'John Doe'
+)</code></pre>
+          </div>
+
+          <h2 id="best-practices">Best Practices</h2>
+
+          <h3>Security Recommendations</h3>
+          <ul>
+            <li>
+              <strong>Rotate keys regularly</strong> - Set up a rotation schedule for API keys
+              (every 90 days recommended). See
+              <a href="/docs/guides/key-rotation">key rotation guide</a>.
+            </li>
+            <li>
+              <strong>Use separate keys per environment</strong> - Never use production keys in
+              development. Create
+              <a href="/dashboard/settings/api-keys">environment-specific keys</a>.
+            </li>
+            <li>
+              <strong>Implement rate limiting</strong> - Protect your integration with
+              <a href="/docs/advanced/rate-limiting">client-side rate limiting</a>.
+            </li>
+            <li>
+              <strong>Monitor API usage</strong> - Set up alerts for unusual activity in your
+              <a href="/dashboard/usage">usage dashboard</a>.
+            </li>
+            <li>
+              <strong>Use HTTPS only</strong> - Never send credentials over unencrypted connections
+            </li>
+          </ul>
+
+          <h3>Error Handling</h3>
+          <p>
+            Authentication errors return specific status codes. See our
+            <a href="/docs/api/errors">error reference</a> for details:
+          </p>
+
+          <table>
+            <thead>
+              <tr>
+                <th>Status Code</th>
+                <th>Error</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>401</td>
+                <td>Unauthorized</td>
+                <td>Invalid or missing API key</td>
+              </tr>
+              <tr>
+                <td>403</td>
+                <td>Forbidden</td>
+                <td>Valid key but insufficient permissions</td>
+              </tr>
+              <tr>
+                <td>429</td>
+                <td>Rate Limited</td>
+                <td>Too many requests, see <a href="/docs/api/rate-limits">rate limits</a></td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div class="next-steps">
+            <h3>Next Steps</h3>
+            <ul>
+              <li><a href="/docs/api/users">Explore the Users API →</a></li>
+              <li><a href="/docs/guides/security">Read the Security Guide →</a></li>
+              <li><a href="/docs/examples">Browse Code Examples →</a></li>
+            </ul>
+          </div>
+        </article>
+
+        <div class="breadcrumbs">
+          <a href="/docs">Documentation</a>
+          <span>/</span>
+          <a href="/docs/api">API Reference</a>
+          <span>/</span>
+          <span>Authentication</span>
+        </div>
+
+        <article>
+          <h1>Authentication</h1>
+          <p class="lead">
+            Learn how to authenticate your API requests using API keys, OAuth 2.0, or JWT tokens.
+          </p>
+
+          <div class="table-of-contents">
+            <h2>On This Page</h2>
+            <ul>
+              <li><a href="#api-keys">API Keys</a></li>
+              <li><a href="#oauth">OAuth 2.0</a></li>
+              <li><a href="#jwt">JWT Tokens</a></li>
+              <li><a href="#examples">Code Examples</a></li>
+              <li><a href="#best-practices">Best Practices</a></li>
+            </ul>
+          </div>
+
+          <h2 id="api-keys">API Keys</h2>
+          <p>
+            API keys are the simplest way to authenticate. Include your API key in the
+            <code>Authorization</code> header of every request.
+          </p>
+
+          <h3>Getting Your API Key</h3>
+          <ol>
+            <li>Navigate to your <a href="/dashboard/settings/api-keys">API Keys settings</a></li>
+            <li>Click "Create New Key"</li>
+            <li>Give your key a descriptive name</li>
+            <li>Copy and securely store your key (it won't be shown again)</li>
+          </ol>
+
+          <div class="code-example">
+            <pre><code class="language-bash">curl https://api.example.com/v1/users \
+  -H "Authorization: Bearer YOUR_API_KEY"</code></pre>
+          </div>
+
+          <div class="callout callout-warning">
+            <strong>Security Note:</strong> Never commit API keys to version control or expose them
+            in client-side code. Use environment variables and
+            <a href="/docs/guides/security#secrets">secure secret management</a>.
+          </div>
+
+          <h3>API Key Permissions</h3>
+          <p>API keys can be scoped to specific permissions. Available scopes include:</p>
+
+          <table>
+            <thead>
+              <tr>
+                <th>Scope</th>
+                <th>Description</th>
+                <th>Operations</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>users:read</code></td>
+                <td>Read user data</td>
+                <td>GET /users, GET /users/:id</td>
+              </tr>
+              <tr>
+                <td><code>users:write</code></td>
+                <td>Create and update users</td>
+                <td>POST /users, PUT /users/:id, PATCH /users/:id</td>
+              </tr>
+              <tr>
+                <td><code>users:delete</code></td>
+                <td>Delete users</td>
+                <td>DELETE /users/:id</td>
+              </tr>
+              <tr>
+                <td><code>projects:read</code></td>
+                <td>Read project data</td>
+                <td>GET /projects, GET /projects/:id</td>
+              </tr>
+              <tr>
+                <td><code>projects:write</code></td>
+                <td>Create and update projects</td>
+                <td>POST /projects, PUT /projects/:id</td>
+              </tr>
+              <tr>
+                <td><code>teams:admin</code></td>
+                <td>Full team management</td>
+                <td>All team endpoints</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h2 id="oauth">OAuth 2.0</h2>
+          <p>
+            For applications that need to access user data on behalf of users, use OAuth 2.0. We
+            support the authorization code flow with PKCE for maximum security.
+          </p>
+
+          <h3>OAuth Flow</h3>
+          <p>The OAuth 2.0 flow involves several steps:</p>
+
+          <ol>
+            <li>
+              <strong>Register your application</strong>
+              <p>
+                Create an OAuth application in your
+                <a href="/dashboard/settings/oauth-apps">OAuth Apps settings</a>. You'll receive a
+                client ID and client secret.
+              </p>
+            </li>
+            <li>
+              <strong>Redirect users to authorize</strong>
+              <div class="code-example">
+                <pre><code class="language-typescript">let params = new URLSearchParams({
+  client_id: 'YOUR_CLIENT_ID',
+  redirect_uri: 'https://yourapp.com/callback',
+  response_type: 'code',
+  scope: 'users:read projects:write',
+  state: 'random_state_value'
+})
+
+window.location.href = `https://api.example.com/oauth/authorize?${params}`</code></pre>
+              </div>
+            </li>
+            <li>
+              <strong>Handle the callback</strong>
+              <p>After authorization, users are redirected back with an authorization code:</p>
+              <div class="code-example">
+                <pre><code class="language-typescript">// In your callback handler
+let code = new URL(window.location.href).searchParams.get('code')
+
+// Exchange code for access token
+let response = await fetch('https://api.example.com/oauth/token', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    client_id: 'YOUR_CLIENT_ID',
+    client_secret: 'YOUR_CLIENT_SECRET',
+    code: code,
+    grant_type: 'authorization_code'
+  })
+})
+
+let { access_token, refresh_token } = await response.json()</code></pre>
+              </div>
+            </li>
+            <li>
+              <strong>Use the access token</strong>
+              <div class="code-example">
+                <pre><code class="language-typescript">let response = await fetch('https://api.example.com/v1/users/me', {
+  headers: {
+    'Authorization': `Bearer ${access_token}`
+  }
+})</code></pre>
+              </div>
+            </li>
+          </ol>
+
+          <h3>Refreshing Tokens</h3>
+          <p>Access tokens expire after 1 hour. Use refresh tokens to obtain new access tokens:</p>
+
+          <div class="code-example">
+            <pre><code class="language-typescript">let response = await fetch('https://api.example.com/oauth/token', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    client_id: 'YOUR_CLIENT_ID',
+    client_secret: 'YOUR_CLIENT_SECRET',
+    refresh_token: refresh_token,
+    grant_type: 'refresh_token'
+  })
+})
+
+let { access_token } = await response.json()</code></pre>
+          </div>
+
+          <h2 id="jwt">JWT Tokens</h2>
+          <p>
+            For service-to-service authentication, you can use JWT tokens signed with RS256. This is
+            useful for <a href="/docs/guides/webhooks">webhook validation</a> and server-side
+            integrations.
+          </p>
+
+          <h3>Creating a JWT</h3>
+          <div class="code-example">
+            <pre><code class="language-typescript">import jwt from 'jsonwebtoken'
+import fs from 'fs'
+
+let privateKey = fs.readFileSync('private-key.pem')
+
+let token = jwt.sign(
+  {
+    iss: 'YOUR_CLIENT_ID',
+    sub: 'user-id',
+    aud: 'https://api.example.com',
+    exp: Math.floor(Date.now() / 1000) + 3600
+  },
+  privateKey,
+  { algorithm: 'RS256' }
+)</code></pre>
+          </div>
+
+          <h3>Verifying a JWT</h3>
+          <p>
+            When you receive a JWT from our API (such as in webhook payloads), verify it using our
+            public key:
+          </p>
+
+          <div class="code-example">
+            <pre><code class="language-typescript">import jwt from 'jsonwebtoken'
+
+// Fetch our public key from /.well-known/jwks.json
+let publicKey = await fetchPublicKey()
+
+try {
+  let decoded = jwt.verify(token, publicKey, {
+    algorithms: ['RS256'],
+    audience: 'https://yourapp.com',
+    issuer: 'https://api.example.com'
+  })
+  console.log('Valid token:', decoded)
+} catch (err) {
+  console.error('Invalid token:', err)
+}</code></pre>
+          </div>
+
+          <h2 id="examples">Code Examples</h2>
+
+          <h3>JavaScript/TypeScript</h3>
+          <div class="code-example">
+            <pre><code class="language-typescript">import { ApiClient } from '@example/api-client'
+
+let client = new ApiClient({
+  apiKey: process.env.API_KEY
+})
+
+// List users
+let users = await client.users.list({ limit: 10 })
+
+// Create a user
+let newUser = await client.users.create({
+  email: 'user@example.com',
+  name: 'John Doe'
+})</code></pre>
+          </div>
+
+          <h3>Python</h3>
+          <div class="code-example">
+            <pre><code class="language-python">from example_api import ApiClient
+
+client = ApiClient(api_key=os.environ['API_KEY'])
+
+# List users
+users = client.users.list(limit=10)
+
+# Create a user
+new_user = client.users.create(
+    email='user@example.com',
+    name='John Doe'
+)</code></pre>
+          </div>
+
+          <h3>Ruby</h3>
+          <div class="code-example">
+            <pre><code class="language-ruby">require 'example_api'
+
+client = ExampleApi::Client.new(api_key: ENV['API_KEY'])
+
+# List users
+users = client.users.list(limit: 10)
+
+# Create a user
+new_user = client.users.create(
+  email: 'user@example.com',
+  name: 'John Doe'
+)</code></pre>
+          </div>
+
+          <h2 id="best-practices">Best Practices</h2>
+
+          <h3>Security Recommendations</h3>
+          <ul>
+            <li>
+              <strong>Rotate keys regularly</strong> - Set up a rotation schedule for API keys
+              (every 90 days recommended). See
+              <a href="/docs/guides/key-rotation">key rotation guide</a>.
+            </li>
+            <li>
+              <strong>Use separate keys per environment</strong> - Never use production keys in
+              development. Create
+              <a href="/dashboard/settings/api-keys">environment-specific keys</a>.
+            </li>
+            <li>
+              <strong>Implement rate limiting</strong> - Protect your integration with
+              <a href="/docs/advanced/rate-limiting">client-side rate limiting</a>.
+            </li>
+            <li>
+              <strong>Monitor API usage</strong> - Set up alerts for unusual activity in your
+              <a href="/dashboard/usage">usage dashboard</a>.
+            </li>
+            <li>
+              <strong>Use HTTPS only</strong> - Never send credentials over unencrypted connections
+            </li>
+          </ul>
+
+          <h3>Error Handling</h3>
+          <p>
+            Authentication errors return specific status codes. See our
+            <a href="/docs/api/errors">error reference</a> for details:
+          </p>
+
+          <table>
+            <thead>
+              <tr>
+                <th>Status Code</th>
+                <th>Error</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>401</td>
+                <td>Unauthorized</td>
+                <td>Invalid or missing API key</td>
+              </tr>
+              <tr>
+                <td>403</td>
+                <td>Forbidden</td>
+                <td>Valid key but insufficient permissions</td>
+              </tr>
+              <tr>
+                <td>429</td>
+                <td>Rate Limited</td>
+                <td>Too many requests, see <a href="/docs/api/rate-limits">rate limits</a></td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div class="next-steps">
+            <h3>Next Steps</h3>
+            <ul>
+              <li><a href="/docs/api/users">Explore the Users API →</a></li>
+              <li><a href="/docs/guides/security">Read the Security Guide →</a></li>
+              <li><a href="/docs/examples">Browse Code Examples →</a></li>
+            </ul>
+          </div>
+        </article>
+      </main>
+
+      <aside class="docs-toc">
+        <h4>On This Page</h4>
+        <nav>
+          <ul>
+            <li><a href="#api-keys">API Keys</a></li>
+            <li><a href="#oauth">OAuth 2.0</a></li>
+            <li><a href="#jwt">JWT Tokens</a></li>
+            <li><a href="#examples">Code Examples</a></li>
+            <li><a href="#best-practices">Best Practices</a></li>
+          </ul>
+        </nav>
+        <div class="toc-footer">
+          <a href="https://github.com/company/repo/blob/main/docs/authentication.md" rel="nofollow"
+            >Edit this page</a
+          >
+        </div>
+      </aside>
+    </div>
+
+    <footer class="docs-footer">
+      <div class="footer-content">
+        <div class="footer-section">
+          <h4>Documentation</h4>
+          <ul>
+            <li><a href="/docs/introduction">Introduction</a></li>
+            <li><a href="/docs/quickstart">Quickstart</a></li>
+            <li><a href="/docs/api">API Reference</a></li>
+            <li><a href="/docs/guides">Guides</a></li>
+          </ul>
+        </div>
+        <div class="footer-section">
+          <h4>Community</h4>
+          <ul>
+            <li><a href="https://github.com/company/repo" rel="nofollow">GitHub</a></li>
+            <li><a href="https://discord.gg/company" rel="nofollow">Discord</a></li>
+            <li><a href="https://twitter.com/company" rel="nofollow">Twitter</a></li>
+            <li><a href="/blog">Blog</a></li>
+          </ul>
+        </div>
+        <div class="footer-section">
+          <h4>Support</h4>
+          <ul>
+            <li><a href="/docs/faq">FAQ</a></li>
+            <li><a href="/support">Contact Support</a></li>
+            <li><a href="/status">System Status</a></li>
+            <li><a href="/changelog">Changelog</a></li>
+          </ul>
+        </div>
+      </div>
+      <p>&copy; 2024 Company. <a href="/privacy">Privacy</a> | <a href="/terms">Terms</a></p>
+    </footer>
+  </body>
+</html>

--- a/packages/fetch-router/bench/fixtures/landing-page.html
+++ b/packages/fetch-router/bench/fixtures/landing-page.html
@@ -1,0 +1,308 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Amazing Product - Transform Your Workflow</title>
+    <link rel="stylesheet" href="/styles/main.css" />
+    <link rel="stylesheet" href="/styles/landing.css" />
+    <link rel="icon" href="/favicon.ico" />
+    <script src="/scripts/analytics.js"></script>
+    <script src="/scripts/main.js" defer></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="main-nav">
+        <a href="/" class="logo">
+          <img src="/images/logo.svg" alt="Company Logo" width="150" height="40" />
+        </a>
+        <ul class="nav-links">
+          <li><a href="/features">Features</a></li>
+          <li><a href="/pricing">Pricing</a></li>
+          <li><a href="/docs">Documentation</a></li>
+          <li><a href="/blog">Blog</a></li>
+          <li><a href="/about">About</a></li>
+          <li><a href="/contact">Contact</a></li>
+        </ul>
+        <div class="nav-actions">
+          <a href="/login" class="btn btn-secondary">Sign In</a>
+          <a href="/signup" class="btn btn-primary">Get Started</a>
+        </div>
+      </nav>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <h1>Transform Your Workflow with Our Amazing Product</h1>
+          <p class="hero-subtitle">
+            The all-in-one solution for modern teams. Boost productivity, streamline communication,
+            and achieve more together.
+          </p>
+          <div class="hero-actions">
+            <a href="/signup" class="btn btn-large btn-primary">Start Free Trial</a>
+            <a href="/demo" class="btn btn-large btn-outline">Watch Demo</a>
+          </div>
+          <img
+            src="/images/hero-screenshot.png"
+            alt="Product Screenshot"
+            class="hero-image"
+            loading="lazy"
+          />
+        </div>
+      </section>
+
+      <section class="features">
+        <h2>Powerful Features for Every Team</h2>
+        <div class="feature-grid">
+          <div class="feature-card">
+            <img
+              src="/images/icons/collaboration.svg"
+              alt="Collaboration Icon"
+              width="64"
+              height="64"
+            />
+            <h3>Real-time Collaboration</h3>
+            <p>Work together seamlessly with live updates, comments, and mentions.</p>
+            <a href="/features/collaboration">Learn more →</a>
+          </div>
+          <div class="feature-card">
+            <img src="/images/icons/automation.svg" alt="Automation Icon" width="64" height="64" />
+            <h3>Smart Automation</h3>
+            <p>Automate repetitive tasks and focus on what matters most.</p>
+            <a href="/features/automation">Learn more →</a>
+          </div>
+          <div class="feature-card">
+            <img src="/images/icons/analytics.svg" alt="Analytics Icon" width="64" height="64" />
+            <h3>Advanced Analytics</h3>
+            <p>Get insights into team performance with detailed analytics.</p>
+            <a href="/features/analytics">Learn more →</a>
+          </div>
+          <div class="feature-card">
+            <img src="/images/icons/security.svg" alt="Security Icon" width="64" height="64" />
+            <h3>Enterprise Security</h3>
+            <p>Bank-grade encryption and compliance with industry standards.</p>
+            <a href="/features/security">Learn more →</a>
+          </div>
+          <div class="feature-card">
+            <img
+              src="/images/icons/integrations.svg"
+              alt="Integrations Icon"
+              width="64"
+              height="64"
+            />
+            <h3>Seamless Integrations</h3>
+            <p>Connect with your favorite tools and services in seconds.</p>
+            <a href="/features/integrations">Learn more →</a>
+          </div>
+          <div class="feature-card">
+            <img src="/images/icons/mobile.svg" alt="Mobile Icon" width="64" height="64" />
+            <h3>Mobile First</h3>
+            <p>Access everything from anywhere with our native mobile apps.</p>
+            <a href="/features/mobile">Learn more →</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="testimonials">
+        <h2>Loved by Teams Worldwide</h2>
+        <div class="testimonial-grid">
+          <blockquote class="testimonial">
+            <p>
+              "This product has completely transformed how our team works. We've seen a 50% increase
+              in productivity."
+            </p>
+            <footer>
+              <img src="/images/avatars/sarah.jpg" alt="Sarah Johnson" width="48" height="48" />
+              <cite>
+                <strong>Sarah Johnson</strong>
+                <span>CEO, TechCorp</span>
+              </cite>
+            </footer>
+          </blockquote>
+          <blockquote class="testimonial">
+            <p>"The best tool we've ever used. Simple, powerful, and gets out of your way."</p>
+            <footer>
+              <img src="/images/avatars/mike.jpg" alt="Mike Chen" width="48" height="48" />
+              <cite>
+                <strong>Mike Chen</strong>
+                <span>Product Manager, StartupXYZ</span>
+              </cite>
+            </footer>
+          </blockquote>
+          <blockquote class="testimonial">
+            <p>
+              "Finally, a solution that actually works. Our team adopted it in days, not months."
+            </p>
+            <footer>
+              <img src="/images/avatars/emily.jpg" alt="Emily Rodriguez" width="48" height="48" />
+              <cite>
+                <strong>Emily Rodriguez</strong>
+                <span>Director of Engineering, BigCo</span>
+              </cite>
+            </footer>
+          </blockquote>
+        </div>
+      </section>
+
+      <section class="cta">
+        <h2>Ready to Get Started?</h2>
+        <p>Join thousands of teams already using our platform.</p>
+        <a href="/signup" class="btn btn-large btn-primary">Start Your Free Trial</a>
+        <p class="cta-note">No credit card required. Cancel anytime.</p>
+      </section>
+
+      <section class="features">
+        <h2>Powerful Features for Every Team</h2>
+        <div class="feature-grid">
+          <div class="feature-card">
+            <img
+              src="/images/icons/collaboration.svg"
+              alt="Collaboration Icon"
+              width="64"
+              height="64"
+            />
+            <h3>Real-time Collaboration</h3>
+            <p>Work together seamlessly with live updates, comments, and mentions.</p>
+            <a href="/features/collaboration">Learn more →</a>
+          </div>
+          <div class="feature-card">
+            <img src="/images/icons/automation.svg" alt="Automation Icon" width="64" height="64" />
+            <h3>Smart Automation</h3>
+            <p>Automate repetitive tasks and focus on what matters most.</p>
+            <a href="/features/automation">Learn more →</a>
+          </div>
+          <div class="feature-card">
+            <img src="/images/icons/analytics.svg" alt="Analytics Icon" width="64" height="64" />
+            <h3>Advanced Analytics</h3>
+            <p>Get insights into team performance with detailed analytics.</p>
+            <a href="/features/analytics">Learn more →</a>
+          </div>
+          <div class="feature-card">
+            <img src="/images/icons/security.svg" alt="Security Icon" width="64" height="64" />
+            <h3>Enterprise Security</h3>
+            <p>Bank-grade encryption and compliance with industry standards.</p>
+            <a href="/features/security">Learn more →</a>
+          </div>
+          <div class="feature-card">
+            <img
+              src="/images/icons/integrations.svg"
+              alt="Integrations Icon"
+              width="64"
+              height="64"
+            />
+            <h3>Seamless Integrations</h3>
+            <p>Connect with your favorite tools and services in seconds.</p>
+            <a href="/features/integrations">Learn more →</a>
+          </div>
+          <div class="feature-card">
+            <img src="/images/icons/mobile.svg" alt="Mobile Icon" width="64" height="64" />
+            <h3>Mobile First</h3>
+            <p>Access everything from anywhere with our native mobile apps.</p>
+            <a href="/features/mobile">Learn more →</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="testimonials">
+        <h2>Loved by Teams Worldwide</h2>
+        <div class="testimonial-grid">
+          <blockquote class="testimonial">
+            <p>
+              "This product has completely transformed how our team works. We've seen a 50% increase
+              in productivity."
+            </p>
+            <footer>
+              <img src="/images/avatars/sarah.jpg" alt="Sarah Johnson" width="48" height="48" />
+              <cite>
+                <strong>Sarah Johnson</strong>
+                <span>CEO, TechCorp</span>
+              </cite>
+            </footer>
+          </blockquote>
+          <blockquote class="testimonial">
+            <p>"The best tool we've ever used. Simple, powerful, and gets out of your way."</p>
+            <footer>
+              <img src="/images/avatars/mike.jpg" alt="Mike Chen" width="48" height="48" />
+              <cite>
+                <strong>Mike Chen</strong>
+                <span>Product Manager, StartupXYZ</span>
+              </cite>
+            </footer>
+          </blockquote>
+          <blockquote class="testimonial">
+            <p>
+              "Finally, a solution that actually works. Our team adopted it in days, not months."
+            </p>
+            <footer>
+              <img src="/images/avatars/emily.jpg" alt="Emily Rodriguez" width="48" height="48" />
+              <cite>
+                <strong>Emily Rodriguez</strong>
+                <span>Director of Engineering, BigCo</span>
+              </cite>
+            </footer>
+          </blockquote>
+        </div>
+      </section>
+
+      <section class="cta">
+        <h2>Ready to Get Started?</h2>
+        <p>Join thousands of teams already using our platform.</p>
+        <a href="/signup" class="btn btn-large btn-primary">Start Your Free Trial</a>
+        <p class="cta-note">No credit card required. Cancel anytime.</p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="footer-content">
+        <div class="footer-section">
+          <h4>Product</h4>
+          <ul>
+            <li><a href="/features">Features</a></li>
+            <li><a href="/pricing">Pricing</a></li>
+            <li><a href="/security">Security</a></li>
+            <li><a href="/roadmap">Roadmap</a></li>
+            <li><a href="/changelog">Changelog</a></li>
+          </ul>
+        </div>
+        <div class="footer-section">
+          <h4>Resources</h4>
+          <ul>
+            <li><a href="/docs">Documentation</a></li>
+            <li><a href="/guides">Guides</a></li>
+            <li><a href="/api">API Reference</a></li>
+            <li><a href="/support">Support</a></li>
+            <li><a href="/community">Community</a></li>
+          </ul>
+        </div>
+        <div class="footer-section">
+          <h4>Company</h4>
+          <ul>
+            <li><a href="/about">About</a></li>
+            <li><a href="/blog">Blog</a></li>
+            <li><a href="/careers">Careers</a></li>
+            <li><a href="/press">Press</a></li>
+            <li><a href="/contact">Contact</a></li>
+          </ul>
+        </div>
+        <div class="footer-section">
+          <h4>Legal</h4>
+          <ul>
+            <li><a href="/privacy">Privacy Policy</a></li>
+            <li><a href="/terms">Terms of Service</a></li>
+            <li><a href="/cookies">Cookie Policy</a></li>
+            <li><a href="/compliance">Compliance</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2024 Company Name. All rights reserved.</p>
+        <div class="social-links">
+          <a href="https://twitter.com/company" rel="nofollow">Twitter</a>
+          <a href="https://github.com/company" rel="nofollow">GitHub</a>
+          <a href="https://linkedin.com/company/company" rel="nofollow">LinkedIn</a>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/packages/fetch-router/bench/package.json
+++ b/packages/fetch-router/bench/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "fetch-router-bench",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "bench": "pnpm run --filter \".\" --sequential \"/^bench:/\"",
+    "bench:concurrency": "node src/crawl-concurrency.ts",
+    "bench:parse-html": "vitest bench --run"
+  },
+  "dependencies": {
+    "@remix-run/fetch-router": "workspace:^",
+    "node-html-parser": "^7.1.0"
+  },
+  "devDependencies": {
+    "vitest": "4.0.15"
+  }
+}

--- a/packages/fetch-router/bench/package.json
+++ b/packages/fetch-router/bench/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "bench": "pnpm run --filter \".\" --sequential \"/^bench:/\"",
     "bench:concurrency": "node src/crawl-concurrency.ts",
+    "bench:throughput": "node src/crawl-throughput.ts",
     "bench:parse-html": "vitest bench --run"
   },
   "dependencies": {

--- a/packages/fetch-router/bench/src/crawl-concurrency.ts
+++ b/packages/fetch-router/bench/src/crawl-concurrency.ts
@@ -1,0 +1,81 @@
+/**
+ * Benchmark: crawl() concurrency
+ *
+ * Simulates a ~100-page site where each handler has configurable async latency
+ * to model real-world I/O. Measures total wall-clock time across concurrency
+ * levels to show the speedup from parallel fetching.
+ *
+ * Run: node --disable-warning=ExperimentalWarning bench/src/crawl-concurrency.bench.ts
+ */
+
+import { crawl, createRouter } from '../../src/index.ts'
+
+// Build a site graph with the given number of pages and latency per request.
+// The root page links to all other pages; each other page links back to root.
+function buildRouter(pageCount: number, latencyMs: number) {
+  let router = createRouter()
+
+  let links = Array.from({ length: pageCount - 1 }, (_, i) => `<a href="/page/${i}">`)
+
+  router.get('/', () =>
+    new Promise<Response>((resolve) =>
+      setTimeout(
+        () => resolve(new Response(links.join(''), { headers: { 'Content-Type': 'text/html' } })),
+        latencyMs,
+      ),
+    ),
+  )
+
+  for (let i = 0; i < pageCount - 1; i++) {
+    router.get(`/page/${i}`, () =>
+      new Promise<Response>((resolve) =>
+        setTimeout(
+          () =>
+            resolve(
+              new Response('<a href="/">Home</a>', { headers: { 'Content-Type': 'text/html' } }),
+            ),
+          latencyMs,
+        ),
+      ),
+    )
+  }
+
+  return router
+}
+
+async function runCrawl(router: ReturnType<typeof createRouter>, concurrency: number) {
+  let count = 0
+  for await (let _ of crawl(router, { concurrency })) {
+    count++
+  }
+  return count
+}
+
+async function benchmark(label: string, pageCount: number, latencyMs: number) {
+  let router = buildRouter(pageCount, latencyMs)
+
+  console.log(`\n${label} (${pageCount} pages, ${latencyMs}ms latency/request)`)
+  console.log('-'.repeat(60))
+
+  let levels = [1, 2, 4, 8, 16, 32]
+  let baseline: number | null = null
+
+  for (let concurrency of levels) {
+    let start = performance.now()
+    let count = await runCrawl(router, concurrency)
+    let elapsed = performance.now() - start
+
+    if (baseline === null) baseline = elapsed
+    let speedup = baseline / elapsed
+
+    console.log(
+      `  concurrency=${String(concurrency).padStart(2)}: ${elapsed.toFixed(0).padStart(6)}ms` +
+        `  (${speedup.toFixed(2)}x speedup, ${count} pages)`,
+    )
+  }
+}
+
+await benchmark('Small site', 20, 10)
+await benchmark('Medium site', 50, 10)
+await benchmark('Large site', 100, 10)
+await benchmark('High latency', 50, 25)

--- a/packages/fetch-router/bench/src/crawl-throughput.ts
+++ b/packages/fetch-router/bench/src/crawl-throughput.ts
@@ -1,0 +1,99 @@
+/**
+ * Benchmark: crawl() throughput
+ *
+ * Measures raw HTML-parsing and link-extraction throughput using a zero-latency
+ * router so I/O doesn't obscure the cost of parsing and extraction.
+ *
+ * The site is a 100-page graph built from the realistic HTML fixtures,
+ * with internal links rewritten to point at sibling pages.
+ *
+ * Run: node bench/src/crawl-throughput.ts
+ */
+
+import { readFileSync } from 'node:fs'
+import { crawl, createRouter } from '../../src/index.ts'
+
+const PAGE_COUNT = 100
+const TRIALS = 10
+
+// Load and duplicate the docs-page fixture (richest link/asset density)
+let template = readFileSync(new URL('../fixtures/docs-page.html', import.meta.url), 'utf-8')
+
+// Inject internal links into the template so the spider actually traverses the site
+function buildPageHtml(index: number, total: number): string {
+  // Link to the next 5 pages (wrapping) to create a connected graph
+  let links = Array.from(
+    { length: Math.min(5, total - 1) },
+    (_, k) => `<a href="/page/${(index + k + 1) % total}">Page ${(index + k + 1) % total}</a>`,
+  ).join('\n')
+  return template + `\n<nav class="bench-links">${links}</nav>`
+}
+
+function buildRouter() {
+  let router = createRouter({
+    // Return empty 200 for any unregistered asset paths (CSS, JS, images from fixtures)
+    defaultHandler: () => new Response('', { status: 200 }),
+  })
+
+  // Root redirects into the page graph
+  let rootHtml = `<html><body>${Array.from({ length: Math.min(5, PAGE_COUNT) }, (_, i) => `<a href="/page/${i}">Page ${i}</a>`).join('')}</body></html>`
+  router.get('/', () => new Response(rootHtml, { headers: { 'Content-Type': 'text/html' } }))
+
+  for (let i = 0; i < PAGE_COUNT; i++) {
+    let html = buildPageHtml(i, PAGE_COUNT)
+    router.get(`/page/${i}`, () => new Response(html, { headers: { 'Content-Type': 'text/html' } }))
+  }
+
+  return router
+}
+
+async function runOnce(router: ReturnType<typeof createRouter>): Promise<number> {
+  let count = 0
+  for await (let _ of crawl(router)) {
+    count++
+  }
+  return count
+}
+
+function stats(samples: number[]): { min: number; median: number; max: number; mean: number } {
+  let sorted = [...samples].sort((a, b) => a - b)
+  let mid = Math.floor(sorted.length / 2)
+  return {
+    min: sorted[0],
+    median: sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid],
+    max: sorted[sorted.length - 1],
+    mean: samples.reduce((a, b) => a + b, 0) / samples.length,
+  }
+}
+
+async function benchmark(label: string) {
+  let router = buildRouter()
+
+  // Warm-up
+  await runOnce(router)
+
+  let elapsed: number[] = []
+  let pageCount = 0
+  for (let t = 0; t < TRIALS; t++) {
+    let start = performance.now()
+    pageCount = await runOnce(router)
+    elapsed.push(performance.now() - start)
+  }
+
+  let s = stats(elapsed)
+  let pagesPerSec = (pageCount / s.median) * 1000
+
+  console.log(`\n${label}`)
+  console.log('-'.repeat(60))
+  console.log(`  Pages crawled : ${pageCount}`)
+  console.log(`  Trials        : ${TRIALS}`)
+  console.log(`  Min           : ${s.min.toFixed(1)}ms`)
+  console.log(`  Median        : ${s.median.toFixed(1)}ms`)
+  console.log(`  Max           : ${s.max.toFixed(1)}ms`)
+  console.log(`  Throughput    : ${pagesPerSec.toFixed(0)} pages/sec  ← headline number`)
+
+  return { pagesPerSec, medianMs: s.median }
+}
+
+console.log(`Crawl throughput benchmark  (${PAGE_COUNT} pages, ${TRIALS} trials, zero I/O latency)`)
+await benchmark('Current implementation')

--- a/packages/fetch-router/bench/src/html-parser.bench.ts
+++ b/packages/fetch-router/bench/src/html-parser.bench.ts
@@ -1,0 +1,160 @@
+import { bench, describe } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { parse as customParse } from '../../src/lib/html-parser.ts'
+import { parse as nodeHtmlParse } from 'node-html-parser'
+import type { HTMLElement } from '../../src/lib/html-parser.ts'
+import type { HTMLElement as NodeHTMLElement } from 'node-html-parser'
+
+// Load HTML fixtures and duplicate to reach target sizes (~20KB, ~30KB, ~45KB)
+let landingPage = readFileSync(new URL('../fixtures/landing-page.html', import.meta.url), 'utf-8')
+let blogPost = readFileSync(new URL('../fixtures/blog-post.html', import.meta.url), 'utf-8')
+let docsPage = readFileSync(new URL('../fixtures/docs-page.html', import.meta.url), 'utf-8')
+
+// Helper function to extract links and assets (matching crawl.ts logic)
+function extractLinksAndAssets(elements: HTMLElement[]): { links: string[]; assets: string[] } {
+  return {
+    links: elements
+      .filter((el) => el.name === 'a' && el.getAttribute('href'))
+      .map((el) => el.getAttribute('href') as string),
+    assets: elements
+      .filter(
+        (el) =>
+          (el.name === 'link' && el.getAttribute('href')) ||
+          ((el.name === 'script' || el.name === 'img') && el.getAttribute('src')),
+      )
+      .map((el) => (el.getAttribute('href') || el.getAttribute('src')) as string),
+  }
+}
+
+// Extract links and assets using node-html-parser's querySelectorAll
+function extractLinksAndAssetsNodeHtml(root: NodeHTMLElement): {
+  links: string[]
+  assets: string[]
+} {
+  return {
+    links: root
+      .querySelectorAll('a[href]')
+      .map((el) => el.getAttribute('href'))
+      .filter((href): href is string => href != null),
+    assets: [
+      ...root.querySelectorAll('link[href]').map((el) => el.getAttribute('href')),
+      ...root.querySelectorAll('script[src]').map((el) => el.getAttribute('src')),
+      ...root.querySelectorAll('img[src]').map((el) => el.getAttribute('src')),
+    ].filter((attr): attr is string => attr != null),
+  }
+}
+
+// Validate that both parsers extract identical links and assets for each fixture
+let fixtures = [
+  { name: 'Landing Page', html: landingPage },
+  { name: 'Blog Post', html: blogPost },
+  { name: 'Docs Page', html: docsPage },
+]
+
+for (let { name, html } of fixtures) {
+  let customResult = extractLinksAndAssets(customParse(html))
+  let nodeResult = extractLinksAndAssetsNodeHtml(nodeHtmlParse(html))
+
+  console.log(
+    `[${name}] custom: ${customResult.links.length} links, ${customResult.assets.length} assets` +
+      ` | node-html-parser: ${nodeResult.links.length} links, ${nodeResult.assets.length} assets`,
+  )
+
+  if (
+    customResult.links.length !== nodeResult.links.length ||
+    customResult.assets.length !== nodeResult.assets.length
+  ) {
+    throw new Error(
+      `[${name}] Extraction mismatch! ` +
+        `links: ${customResult.links.length} vs ${nodeResult.links.length}, ` +
+        `assets: ${customResult.assets.length} vs ${nodeResult.assets.length}`,
+    )
+  }
+
+  let sortedCustomLinks = customResult.links.toSorted()
+  let sortedNodeLinks = nodeResult.links.toSorted()
+  let sortedCustomAssets = customResult.assets.toSorted()
+  let sortedNodeAssets = nodeResult.assets.toSorted()
+
+  for (let i = 0; i < sortedCustomLinks.length; i++) {
+    if (sortedCustomLinks[i] !== sortedNodeLinks[i]) {
+      throw new Error(
+        `[${name}] Link mismatch at index ${i}: "${sortedCustomLinks[i]}" vs "${sortedNodeLinks[i]}"`,
+      )
+    }
+  }
+
+  for (let i = 0; i < sortedCustomAssets.length; i++) {
+    if (sortedCustomAssets[i] !== sortedNodeAssets[i]) {
+      throw new Error(
+        `[${name}] Asset mismatch at index ${i}: "${sortedCustomAssets[i]}" vs "${sortedNodeAssets[i]}"`,
+      )
+    }
+  }
+}
+
+describe('Raw Parsing - Landing Page (~10KB)', () => {
+  bench('custom parser', () => {
+    customParse(landingPage)
+  })
+
+  bench('node-html-parser', () => {
+    nodeHtmlParse(landingPage)
+  })
+})
+
+describe('Raw Parsing - Blog Post (~20KB)', () => {
+  bench('custom parser', () => {
+    customParse(blogPost)
+  })
+
+  bench('node-html-parser', () => {
+    nodeHtmlParse(blogPost)
+  })
+})
+
+describe('Raw Parsing - Docs Page (~30KB)', () => {
+  bench('custom parser', () => {
+    customParse(docsPage)
+  })
+
+  bench('node-html-parser', () => {
+    nodeHtmlParse(docsPage)
+  })
+})
+
+describe('Full Crawl Scenario - Landing Page', () => {
+  bench('custom parser + extraction', () => {
+    let elements = customParse(landingPage)
+    extractLinksAndAssets(elements)
+  })
+
+  bench('node-html-parser + extraction', () => {
+    let root = nodeHtmlParse(landingPage)
+    extractLinksAndAssetsNodeHtml(root)
+  })
+})
+
+describe('Full Crawl Scenario - Blog Post', () => {
+  bench('custom parser + extraction', () => {
+    let elements = customParse(blogPost)
+    extractLinksAndAssets(elements)
+  })
+
+  bench('node-html-parser + extraction', () => {
+    let root = nodeHtmlParse(blogPost)
+    extractLinksAndAssetsNodeHtml(root)
+  })
+})
+
+describe('Full Crawl Scenario - Docs Page', () => {
+  bench('custom parser + extraction', () => {
+    let elements = customParse(docsPage)
+    extractLinksAndAssets(elements)
+  })
+
+  bench('node-html-parser + extraction', () => {
+    let root = nodeHtmlParse(docsPage)
+    extractLinksAndAssetsNodeHtml(root)
+  })
+})

--- a/packages/fetch-router/src/index.ts
+++ b/packages/fetch-router/src/index.ts
@@ -26,5 +26,7 @@ export type {
 export { RequestMethods } from './lib/request-methods.ts'
 export type { RequestMethod } from './lib/request-methods.ts'
 
+export type { CrawlOptions, CrawlResult } from './lib/crawl.ts'
+export { crawl } from './lib/crawl.ts'
 export { createRouter } from './lib/router.ts'
 export type { MatchData, Router, RouterOptions } from './lib/router.ts'

--- a/packages/fetch-router/src/index.ts
+++ b/packages/fetch-router/src/index.ts
@@ -26,5 +26,7 @@ export type {
 export { RequestMethods, isRequestMethod } from './lib/request-methods.ts'
 export type { RequestMethod } from './lib/request-methods.ts'
 
+export type { CrawlOptions, CrawlResult } from './lib/crawl.ts'
+export { crawl } from './lib/crawl.ts'
 export { createRouter } from './lib/router.ts'
 export type { RouteEntry, Router, RouterOptions } from './lib/router.ts'

--- a/packages/fetch-router/src/lib/crawl.test.ts
+++ b/packages/fetch-router/src/lib/crawl.test.ts
@@ -1,0 +1,259 @@
+import * as assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { crawl } from './crawl.ts'
+import { createRouter } from './router.ts'
+
+function html(content: string): Response {
+  return new Response(content, { headers: { 'Content-Type': 'text/html' } })
+}
+
+function css(content = ''): Response {
+  return new Response(content, { headers: { 'Content-Type': 'text/css' } })
+}
+
+function js(content = ''): Response {
+  return new Response(content, { headers: { 'Content-Type': 'application/javascript' } })
+}
+
+describe('crawl(router)', () => {
+  it('visits the root path by default', async () => {
+    let router = createRouter()
+    router.get('/', () => html('hello'))
+
+    let visited: [string, string, string][] = []
+    for await (let { pathname, filepath, response } of crawl(router)) {
+      visited.push([pathname, filepath, await response.text()])
+    }
+    assert.deepEqual(visited, [['/', '/index.html', 'hello']])
+  })
+
+  it('visits custom initial paths', async () => {
+    let router = createRouter()
+    router.get('/a', () => html('A'))
+    router.get('/b', () => html('B'))
+
+    let visited: [string, string, string][] = []
+    for await (let { pathname, filepath, response } of crawl(router, {
+      paths: ['/a', '/b'],
+    })) {
+      visited.push([pathname, filepath, await response.text()])
+    }
+    assert.deepEqual(visited, [
+      ['/a', '/a/index.html', 'A'],
+      ['/b', '/b/index.html', 'B'],
+    ])
+  })
+
+  it('uses correct file paths based on content type', async () => {
+    let router = createRouter()
+    router.get('/', () => html('<html></html>'))
+    router.get('/about', () => html('<html></html>'))
+    router.get('/about/', () => html('<html></html>'))
+    router.get('/style.css', () => css('body {}'))
+    router.get('/app.js', () => js('console.log()'))
+
+    let filePaths: string[] = []
+    for await (let { filepath } of crawl(router, {
+      paths: ['/', '/about', '/about/', '/style.css', '/app.js'],
+    })) {
+      filePaths.push(filepath)
+    }
+    assert.deepEqual(filePaths, [
+      '/index.html',
+      '/about/index.html',
+      '/about/index.html',
+      '/style.css',
+      '/app.js',
+    ])
+  })
+
+  it('does not follow links when spider is false', async () => {
+    let router = createRouter()
+    router.get('/', () => html('<a href="/about">About</a>'))
+    router.get('/about', () => html('<html></html>'))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router, { spider: false })) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/'])
+  })
+
+  it('follows links by default (spider is true)', async () => {
+    let router = createRouter()
+    router.get('/', () => html('<a href="/about">About</a>'))
+    router.get('/about', () => html('<html></html>'))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router)) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/', '/about'])
+  })
+
+  it('always queues CSS, JS, and image assets regardless of spider mode', async () => {
+    let router = createRouter()
+    router.get('/', () =>
+      html(`
+        <link rel="stylesheet" href="/style.css">
+        <script src="/app.js"></script>
+        <img src="/logo.png">
+      `),
+    )
+    router.get('/style.css', () => css('body {}'))
+    router.get('/app.js', () => js())
+    router.get('/logo.png', () => new Response('', { headers: { 'Content-Type': 'image/png' } }))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router)) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/', '/style.css', '/app.js', '/logo.png'])
+  })
+
+  it('skips absolute http/https URLs by default', async () => {
+    let router = createRouter()
+    router.get('/', () => html('<a href="https://example.com/page">External</a>'))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router)) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/'])
+  })
+
+  it('skips protocol-relative URLs by default', async () => {
+    let router = createRouter()
+    router.get('/', () => html('<a href="//example.com/page">External</a>'))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router)) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/'])
+  })
+
+  it('skips non-navigable href schemes', async () => {
+    let router = createRouter()
+    router.get('/', () =>
+      html(`
+        <a href="#section">Anchor</a>
+        <a href="mailto:a@b.com">Email</a>
+        <a href="tel:123">Phone</a>
+        <a href="javascript:void(0)">JS</a>
+        <a href="data:text/plain,hello">Data</a>
+        <a href="/real">Real</a>
+      `),
+    )
+    router.get('/real', () => html('<html></html>'))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router)) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/', '/real'])
+  })
+
+  it('does not follow links with rel="nofollow"', async () => {
+    let router = createRouter()
+    router.get('/', () =>
+      html('<a href="/nofollow" rel="nofollow">Skip</a><a href="/follow">Follow</a>'),
+    )
+    router.get('/follow', () => html('<html></html>'))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router)) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/', '/follow'])
+  })
+
+  it('does not queue preload, prefetch, or modulepreload link elements', async () => {
+    let router = createRouter()
+    router.get('/', () =>
+      html(`
+        <link rel="preload" href="/preload.css" as="style">
+        <link rel="prefetch" href="/prefetch.js">
+        <link rel="modulepreload" href="/module.js">
+        <link rel="stylesheet" href="/real.css">
+      `),
+    )
+    router.get('/real.css', () => css())
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router)) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/', '/real.css'])
+  })
+
+  it('resolves relative hrefs against the current page URL', async () => {
+    let router = createRouter()
+    router.get('/blog/', () => html('<a href="post-1">Post 1</a>'))
+    router.get('/blog/post-1', () => html('<html></html>'))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router, { paths: ['/blog/'] })) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/blog/', '/blog/post-1'])
+  })
+
+  it('throws on non-2xx responses', async () => {
+    let router = createRouter()
+    router.get('/', () => new Response('Not Found', { status: 404, statusText: 'Not Found' }))
+
+    await assert.rejects(
+      async () => {
+        for await (let _ of crawl(router)) {
+        }
+      },
+      { message: 'Crawl failed: 404 Not Found (/)' },
+    )
+  })
+
+  it('fetches pages concurrently when concurrency > 1', async () => {
+    let router = createRouter()
+    let inflight = 0
+    let maxInflight = 0
+
+    function slowHtml(content: string): Promise<Response> {
+      inflight++
+      maxInflight = Math.max(maxInflight, inflight)
+      return new Promise((resolve) =>
+        setTimeout(() => {
+          inflight--
+          resolve(html(content))
+        }, 20),
+      )
+    }
+
+    router.get('/', () => slowHtml('<a href="/a">A</a><a href="/b">B</a><a href="/c">C</a>'))
+    router.get('/a', () => slowHtml('<html></html>'))
+    router.get('/b', () => slowHtml('<html></html>'))
+    router.get('/c', () => slowHtml('<html></html>'))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router, { concurrency: 3 })) {
+      visited.push(pathname)
+    }
+
+    assert.deepEqual(visited.toSorted(), ['/', '/a', '/b', '/c'])
+    assert.ok(maxInflight > 1, `expected concurrent requests, got max inflight: ${maxInflight}`)
+  })
+
+  it('does not visit the same path twice', async () => {
+    let router = createRouter()
+    router.get('/', () => html('<a href="/shared">Shared</a>'))
+    router.get('/about', () => html('<a href="/shared">Shared</a>'))
+    router.get('/shared', () => html('<html></html>'))
+
+    let visitCount: Record<string, number> = {}
+    for await (let { pathname } of crawl(router, { paths: ['/', '/about'] })) {
+      visitCount[pathname] = (visitCount[pathname] ?? 0) + 1
+    }
+    assert.equal(visitCount['/shared'], 1)
+  })
+
+})

--- a/packages/fetch-router/src/lib/crawl.test.ts
+++ b/packages/fetch-router/src/lib/crawl.test.ts
@@ -256,4 +256,66 @@ describe('crawl(router)', () => {
     assert.equal(visitCount['/shared'], 1)
   })
 
+  it('follows same-site link[rel="alternate"] when spider is true', async () => {
+    let router = createRouter()
+    router.get('/', () =>
+      html('<link rel="alternate" type="text/markdown" href="/index.md"><h1>Home</h1>'),
+    )
+    router.get('/index.md', () => new Response('# Home', { headers: { 'Content-Type': 'text/markdown' } }))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router)) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited.toSorted(), ['/', '/index.md'])
+  })
+
+  it('does not follow link[rel="alternate"] when spider is false', async () => {
+    let router = createRouter()
+    router.get('/', () =>
+      html('<link rel="alternate" type="text/markdown" href="/index.md"><h1>Home</h1>'),
+    )
+    router.get('/index.md', () => new Response('# Home', { headers: { 'Content-Type': 'text/markdown' } }))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router, { spider: false })) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/'])
+  })
+
+  it('skips cross-origin link[rel="alternate"] hrefs', async () => {
+    let router = createRouter()
+    router.get('/', () =>
+      html(`
+        <link rel="alternate" type="application/rss+xml" href="https://example.com/feed.xml">
+        <link rel="alternate" type="application/rss+xml" href="//example.com/feed.xml">
+      `),
+    )
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router)) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/'])
+  })
+
+  it('does not follow link[rel="alternate nofollow"]', async () => {
+    let router = createRouter()
+    router.get('/', () =>
+      html(`
+        <link rel="alternate nofollow" type="text/markdown" href="/skip.md">
+        <link rel="alternate" type="text/markdown" href="/follow.md">
+      `),
+    )
+    router.get('/skip.md', () => new Response('skip', { headers: { 'Content-Type': 'text/markdown' } }))
+    router.get('/follow.md', () => new Response('follow', { headers: { 'Content-Type': 'text/markdown' } }))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router)) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited.toSorted(), ['/', '/follow.md'])
+  })
+
 })

--- a/packages/fetch-router/src/lib/crawl.test.ts
+++ b/packages/fetch-router/src/lib/crawl.test.ts
@@ -300,6 +300,96 @@ describe('crawl(router)', () => {
     assert.deepEqual(visited, ['/'])
   })
 
+  it('does not follow links on pages with <meta name="robots" content="nofollow">', async () => {
+    let router = createRouter()
+    router.get('/', () =>
+      html(`
+        <meta name="robots" content="nofollow">
+        <a href="/about">About</a>
+        <a href="/contact">Contact</a>
+      `),
+    )
+    router.get('/about', () => html('<html></html>'))
+    router.get('/contact', () => html('<html></html>'))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router)) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/'])
+  })
+
+  it('does not follow links on pages with <meta name="robots" content="noindex, nofollow">', async () => {
+    let router = createRouter()
+    router.get('/', () =>
+      html(`
+        <meta name="robots" content="noindex, nofollow">
+        <a href="/about">About</a>
+      `),
+    )
+    router.get('/about', () => html('<html></html>'))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router)) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/'])
+  })
+
+  it('does not follow links on pages with <meta name="googlebot" content="nofollow">', async () => {
+    let router = createRouter()
+    router.get('/', () =>
+      html(`
+        <meta name="googlebot" content="nofollow">
+        <a href="/about">About</a>
+      `),
+    )
+    router.get('/about', () => html('<html></html>'))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router)) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/'])
+  })
+
+  it('still follows links on pages without a meta robots nofollow directive', async () => {
+    let router = createRouter()
+    router.get('/', () =>
+      html(`
+        <meta name="robots" content="noindex">
+        <a href="/about">About</a>
+      `),
+    )
+    router.get('/about', () => html('<html></html>'))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router)) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/', '/about'])
+  })
+
+  it('still queues assets even when meta robots nofollow prevents link following', async () => {
+    let router = createRouter()
+    router.get('/', () =>
+      html(`
+        <meta name="robots" content="nofollow">
+        <link rel="stylesheet" href="/style.css">
+        <a href="/about">About</a>
+      `),
+    )
+    router.get('/style.css', () => css())
+    router.get('/about', () => html('<html></html>'))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router)) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited.toSorted(), ['/', '/style.css'])
+  })
+
+
   it('does not follow link[rel="alternate nofollow"]', async () => {
     let router = createRouter()
     router.get('/', () =>

--- a/packages/fetch-router/src/lib/crawl.ts
+++ b/packages/fetch-router/src/lib/crawl.ts
@@ -1,0 +1,192 @@
+import { parse } from './html-parser.ts'
+import type { HTMLElement } from './html-parser.ts'
+
+const BASE_URL = 'http://localhost'
+
+export interface CrawlResult {
+  pathname: string
+  filepath: string
+  response: Response
+}
+
+export interface CrawlOptions {
+  /**
+   * Initial URL paths to put in the crawl queue.
+   * @default ['/']
+   */
+  paths?: string[]
+  /**
+   * Whether to follow outbound links found in HTML documents.
+   * @default true
+   */
+  spider?: boolean
+  /**
+   * Maximum number of concurrent requests.
+   * @default 1
+   */
+  concurrency?: number
+}
+
+export async function* crawl(
+  router: { fetch(request: Request): Promise<Response> },
+  options: CrawlOptions = {},
+): AsyncIterableIterator<CrawlResult> {
+  let { paths = ['/'], spider = true, concurrency = 1 } = options
+
+  // Array queue (vs Set) so concurrent fetches can push discovered paths to the
+  // tail while the dispatch loop reads from the head
+  let queue: string[] = []
+  let visited = new Set<string>()
+  let results: CrawlResult[] = []
+  let active = 0
+  let error: unknown
+
+  // Resettable gate — lets the generator sleep until a fetch completes
+  let notify: () => void = () => {}
+  let gate = new Promise<void>((r) => (notify = r))
+  function bump() {
+    let n = notify
+    gate = new Promise<void>((r) => (notify = r))
+    n()
+  }
+
+  enqueue(paths)
+
+  while (true) {
+    // Dispatch up to concurrency limit
+    while (active < concurrency && queue.length > 0) {
+      fetchOne(queue.shift()!)
+    }
+
+    if (error) throw error
+    if (results.length > 0) {
+      yield results.shift()!
+      continue
+    }
+    if (active === 0 && queue.length === 0) break
+
+    await gate
+  }
+
+  function enqueue(pathnames: string[]) {
+    pathnames.forEach((p) => {
+      if (!visited.has(p)) {
+        visited.add(p)
+        queue.push(p)
+      }
+    })
+  }
+
+  async function fetchOne(pathname: string) {
+    active++
+    try {
+      let response = await router.fetch(new Request(`${BASE_URL}${pathname}`))
+
+      if (!response.ok) {
+        throw new Error(`Crawl failed: ${response.status} ${response.statusText} (${pathname})`)
+      }
+
+      let isHtml = response.headers.get('Content-Type')?.includes('text/html')
+
+      if (isHtml) {
+        let cloned = response.clone()
+        results.push({
+          pathname,
+          // / -> /index.html, /about -> /about/index.html, /about/ -> /about/index.html
+          // Always put `index.html` files into directories - this leads to the best
+          // support with and without trailing slashes on github pages:
+          // https://github.com/slorber/trailing-slash-guide?tab=readme-ov-file#summary
+          filepath: pathname.replace(/\/?$/, '/index.html'),
+          response,
+        })
+
+        let elements = parse(await cloned.text())
+
+        // Always queue referenced assets (CSS, JS, images)
+        enqueue(extractAssetPaths(elements, pathname))
+
+        // Only follow navigation links when spider mode is enabled
+        if (spider) {
+          enqueue(extractLinkPaths(elements, pathname))
+        }
+      } else {
+        results.push({ pathname, filepath: pathname, response })
+      }
+    } catch (e) {
+      error = e
+    } finally {
+      active--
+      bump()
+    }
+  }
+}
+
+function extractAssetPaths(elements: HTMLElement[], baseUrl: string): string[] {
+  let linkAttrs = elements
+    .filter(
+      (el) =>
+        el.name === 'link' &&
+        !rel(el).includes('preload') &&
+        !rel(el).includes('prefetch') &&
+        !rel(el).includes('modulepreload'),
+    )
+    .map((el) => el.getAttribute('href'))
+
+  let srcAttrs = elements
+    .filter((el) => (el.name === 'script' || el.name === 'img') && el.getAttribute('src'))
+    .map((el) => el.getAttribute('src'))
+
+  return [...linkAttrs, ...srcAttrs]
+    .filter((href): href is string => href != null)
+    .filter((href) => !isNonNavigable(href))
+    .filter(isRelativeUrl)
+    .map((href) => resolveHref(href, baseUrl))
+    .filter((href): href is string => href != null)
+}
+
+function extractLinkPaths(elements: HTMLElement[], baseUrl: string): string[] {
+  return elements
+    .filter((el) => el.name === 'a' && !rel(el).includes('nofollow'))
+    .map((el) => el.getAttribute('href'))
+    .filter((href): href is string => href != null)
+    .filter((href) => !isNonNavigable(href))
+    .filter(isRelativeUrl)
+    .map((href) => resolveHref(href, baseUrl))
+    .filter((href): href is string => href != null)
+}
+
+function rel(el: HTMLElement) {
+  return el.getAttribute('rel')?.split(/\s+/) || []
+}
+
+function isNonNavigable(href: string): boolean {
+  return (
+    href.startsWith('#') ||
+    href.startsWith('mailto:') ||
+    href.startsWith('tel:') ||
+    href.startsWith('javascript:') ||
+    href.startsWith('data:')
+  )
+}
+
+function isRelativeUrl(href: string): boolean {
+  return !href.startsWith('http://') && !href.startsWith('https://') && !href.startsWith('//')
+}
+
+function resolveHref(href: string, baseUrl: string): string | null {
+  // Absolute URL — extract pathname
+  if (/^https?:\/\//.test(href) || href.startsWith('//')) {
+    try {
+      return new URL(href).pathname
+    } catch {
+      return null
+    }
+  }
+
+  // Relative URL — resolve against the current page's path
+  try {
+    return new URL(href, `${BASE_URL}${baseUrl}`).pathname
+  } catch {
+    return null
+  }
+}

--- a/packages/fetch-router/src/lib/crawl.ts
+++ b/packages/fetch-router/src/lib/crawl.ts
@@ -1,34 +1,59 @@
 import { parse } from './html-parser.ts'
 import type { HTMLElement } from './html-parser.ts'
+import type { createRouter, Router } from './router.ts'
 
 const BASE_URL = 'http://localhost'
 
+/** The result of crawling a single URL. */
 export interface CrawlResult {
+  /** The pathname that was crawled (e.g. `/about`, `/assets/styles.css`). */
   pathname: string
+  /** The relative file path where the response should be written (e.g. `/about/index.html`, `/assets/styles.css`). */
   filepath: string
+  /** The response from the router for this pathname. */
   response: Response
 }
 
+/** Options for the {@link crawl} function. */
 export interface CrawlOptions {
   /**
-   * Initial URL paths to put in the crawl queue.
-   * @default ['/']
+   * Initial URL paths to put in the crawl queue (defaults to `['/']`)
    */
   paths?: string[]
   /**
-   * Whether to follow outbound links found in HTML documents.
-   * @default true
+   * Whether to crawl links found in HTML documents (default `true`)
    */
   spider?: boolean
   /**
-   * Maximum number of concurrent requests.
-   * @default 1
+   * Maximum number of concurrent requests (default 1)
    */
   concurrency?: number
 }
 
+/**
+ * Crawls a router by fetching pages and following links, yielding each result
+ * as it is fetched. HTML responses are parsed for additional links and assets
+ * to enqueue (disable via `spider:false`). Non-HTML responses are yielded as-is
+ * with their pathname as the filepath.
+ *
+ * @example
+ * import { crawl, createRouter } from 'remix/fetch-router'
+ *
+ * let router = createRouter()
+ * router.get('/', homeHandler)
+ * router.get('/about', aboutHandler)
+ *
+ * for await (let { pathname, filepath, response } of crawl(router)) {
+ *   await writeResponse(filepath, response);
+ *   console.log(`Crawled ${pathname} -> ${filepath}`);
+ * }
+ *
+ * @param router A `remix/fetch-router` created with {@link createRouter}.
+ * @param options Optional crawl configuration.
+ * @returns An async iterable of crawl results, yielding each page as it is fetched.
+ */
 export async function* crawl(
-  router: { fetch(request: Request): Promise<Response> },
+  router: Router,
   options: CrawlOptions = {},
 ): AsyncIterableIterator<CrawlResult> {
   let { paths = ['/'], spider = true, concurrency = 1 } = options

--- a/packages/fetch-router/src/lib/crawl.ts
+++ b/packages/fetch-router/src/lib/crawl.ts
@@ -4,53 +4,60 @@ import type { createRouter, Router } from './router.ts'
 
 const BASE_URL = 'http://localhost'
 
-/** The result of crawling a single URL. */
+/**
+ * A single result yielded by {@link crawl}, representing one URL that was
+ * fetched and the file path it should be written to.
+ */
 export interface CrawlResult {
-  /** The pathname that was crawled (e.g. `/about`, `/assets/styles.css`). */
+  /** The pathname that was fetched (e.g. `/about`, `/assets/styles.css`). */
   pathname: string
-  /** The relative file path where the response should be written (e.g. `/about/index.html`, `/assets/styles.css`). */
+  /**
+   * The relative file path where the response should be written
+   * (e.g. `/about/index.html`, `/assets/styles.css`). HTML responses are
+   * mapped to `index.html` files inside a directory; non-HTML responses
+   * keep their original pathname.
+   */
   filepath: string
-  /** The response from the router for this pathname. */
+  /** The `Response` returned by the router for this pathname. */
   response: Response
 }
 
 /** Options for the {@link crawl} function. */
 export interface CrawlOptions {
-  /**
-   * Initial URL paths to put in the crawl queue (defaults to `['/']`)
-   */
+  /** Initial URL paths to put in the crawl queue (defaults to `['/']`). */
   paths?: string[]
   /**
-   * Whether to crawl links found in HTML documents (default `true`)
+   * Whether to follow navigation-style links found in HTML responses
+   * (`<a href>` and `<link rel="alternate" href>`); defaults to `true`.
+   * When `false`, only the initial paths are fetched, but assets
+   * referenced by those pages (CSS, scripts, images) are still queued.
    */
   spider?: boolean
-  /**
-   * Maximum number of concurrent requests (default 1)
-   */
+  /** Maximum number of concurrent requests (defaults to `1`). */
   concurrency?: number
 }
 
 /**
  * Crawls a router by fetching pages and following links, yielding each result
  * as it is fetched. HTML responses are parsed for additional links and assets
- * to enqueue (disable via `spider:false`). Non-HTML responses are yielded as-is
- * with their pathname as the filepath.
+ * to enqueue (disable link-following with `spider: false`); non-HTML responses
+ * are yielded as-is with their pathname as the filepath.
+ *
+ * Throws if any response is non-2xx, which makes `crawl()` well-suited for
+ * static-site generation where every reachable page must build successfully.
  *
  * @example
- * import { crawl, createRouter } from 'remix/fetch-router'
- *
- * let router = createRouter()
- * router.get('/', homeHandler)
- * router.get('/about', aboutHandler)
+ * import { crawl } from 'remix/fetch-router'
+ * import { router } from './router.ts'
  *
  * for await (let { pathname, filepath, response } of crawl(router)) {
- *   await writeResponse(filepath, response);
- *   console.log(`Crawled ${pathname} -> ${filepath}`);
+ *   await writeResponse(filepath, response)
+ *   console.log(`Crawled ${pathname} -> ${filepath}`)
  * }
  *
- * @param router A `remix/fetch-router` created with {@link createRouter}.
+ * @param router A router created with {@link createRouter}.
  * @param options Optional crawl configuration.
- * @returns An async iterable of crawl results, yielding each page as it is fetched.
+ * @returns An async iterable of {@link CrawlResult} values, yielding each page as it is fetched.
  */
 export async function* crawl(
   router: Router,
@@ -153,7 +160,8 @@ function extractAssetPaths(elements: HTMLElement[], baseUrl: string): string[] {
         el.name === 'link' &&
         !rel(el).includes('preload') &&
         !rel(el).includes('prefetch') &&
-        !rel(el).includes('modulepreload'),
+        !rel(el).includes('modulepreload') &&
+        !rel(el).includes('alternate'),
     )
     .map((el) => el.getAttribute('href'))
 
@@ -171,7 +179,11 @@ function extractAssetPaths(elements: HTMLElement[], baseUrl: string): string[] {
 
 function extractLinkPaths(elements: HTMLElement[], baseUrl: string): string[] {
   return elements
-    .filter((el) => el.name === 'a' && !rel(el).includes('nofollow'))
+    .filter(
+      (el) =>
+        !rel(el).includes('nofollow') &&
+        (el.name === 'a' || (el.name === 'link' && rel(el).includes('alternate'))),
+    )
     .map((el) => el.getAttribute('href'))
     .filter((href): href is string => href != null)
     .filter((href) => !isNonNavigable(href))

--- a/packages/fetch-router/src/lib/crawl.ts
+++ b/packages/fetch-router/src/lib/crawl.ts
@@ -137,8 +137,9 @@ export async function* crawl(
         // Always queue referenced assets (CSS, JS, images)
         enqueue(extractAssetPaths(elements, pathname))
 
-        // Only follow navigation links when spider mode is enabled
-        if (spider) {
+        // Only follow navigation links when spider mode is enabled and the page
+        // does not have a <meta name="robots" content="nofollow"> directive
+        if (spider && shouldCrawlLinks(elements)) {
           enqueue(extractLinkPaths(elements, pathname))
         }
       } else {
@@ -190,6 +191,17 @@ function extractLinkPaths(elements: HTMLElement[], baseUrl: string): string[] {
     .filter(isRelativeUrl)
     .map((href) => resolveHref(href, baseUrl))
     .filter((href): href is string => href != null)
+}
+
+function shouldCrawlLinks(elements: HTMLElement[]): boolean {
+  let hasPageNoFollowDirective = elements.some((el) => {    
+    if (el.name !== 'meta') return false
+    let name = el.getAttribute('name')?.toLowerCase()
+    if (name !== 'robots' && name !== 'googlebot') return false
+    let content = el.getAttribute('content')?.toLowerCase() ?? ''
+    return content.split(/[\s,]+/).includes('nofollow')
+  })
+  return !hasPageNoFollowDirective
 }
 
 function rel(el: HTMLElement) {

--- a/packages/fetch-router/src/lib/crawl.ts
+++ b/packages/fetch-router/src/lib/crawl.ts
@@ -232,6 +232,9 @@ function resolveHref(href: string, baseUrl: string): string | null {
     }
   }
 
+  // Root-relative path — no URL parsing needed
+  if (href.startsWith('/')) return href
+
   // Relative URL — resolve against the current page's path
   try {
     return new URL(href, `${BASE_URL}${baseUrl}`).pathname

--- a/packages/fetch-router/src/lib/html-parser.test.ts
+++ b/packages/fetch-router/src/lib/html-parser.test.ts
@@ -6,7 +6,7 @@ import { parse } from './html-parser.ts'
 
 // Use the landing-page fixture from bench/fixtures as a realistic HTML document.
 // Expected counts were validated against node-html-parser's querySelectorAll.
-let fixtureHtml = readFileSync(
+const fixtureHtml = readFileSync(
   new URL('../../bench/fixtures/landing-page.html', import.meta.url),
   'utf-8',
 )
@@ -111,7 +111,10 @@ describe('parse()', () => {
 
     assert.equal(srcs.length, EXPECTED_IMG, 'every img should have a src')
     assert.ok(srcs.includes('/images/logo.svg'), 'should include /images/logo.svg')
-    assert.ok(srcs.includes('/images/hero-screenshot.png'), 'should include /images/hero-screenshot.png')
+    assert.ok(
+      srcs.includes('/images/hero-screenshot.png'),
+      'should include /images/hero-screenshot.png',
+    )
   })
 
   it('parses a simple HTML snippet correctly', () => {

--- a/packages/fetch-router/src/lib/html-parser.test.ts
+++ b/packages/fetch-router/src/lib/html-parser.test.ts
@@ -1,0 +1,153 @@
+import * as assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { describe, it } from 'node:test'
+
+import { parse } from './html-parser.ts'
+
+// Use the landing-page fixture from bench/fixtures as a realistic HTML document.
+// Expected counts were validated against node-html-parser's querySelectorAll.
+let fixtureHtml = readFileSync(
+  new URL('../../bench/fixtures/landing-page.html', import.meta.url),
+  'utf-8',
+)
+
+// node-html-parser finds 222 elements; our parser also picks up <!DOCTYPE> as "!doctype"
+const EXPECTED_TOTAL = 223
+const EXPECTED_HEAD = 1
+const EXPECTED_BODY = 1
+const EXPECTED_DIV = 26
+const EXPECTED_A = 47
+const EXPECTED_IMG = 20
+const EXPECTED_SCRIPT = 2
+const EXPECTED_LINK = 3
+const EXPECTED_META = 2
+const EXPECTED_SECTION = 7
+const EXPECTED_LI = 25
+
+describe('parse()', () => {
+  it('parses all elements from a realistic HTML document', () => {
+    let elements = parse(fixtureHtml)
+    assert.equal(elements.length, EXPECTED_TOTAL)
+  })
+
+  it('parses the correct number of head elements', () => {
+    let elements = parse(fixtureHtml)
+    let head = elements.filter((el) => el.name === 'head')
+    assert.equal(head.length, EXPECTED_HEAD)
+  })
+
+  it('parses the correct number of body elements', () => {
+    let elements = parse(fixtureHtml)
+    let body = elements.filter((el) => el.name === 'body')
+    assert.equal(body.length, EXPECTED_BODY)
+  })
+
+  it('parses the correct number of div elements', () => {
+    let elements = parse(fixtureHtml)
+    let divs = elements.filter((el) => el.name === 'div')
+    assert.equal(divs.length, EXPECTED_DIV)
+  })
+
+  it('parses the correct number of anchor elements', () => {
+    let elements = parse(fixtureHtml)
+    let anchors = elements.filter((el) => el.name === 'a')
+    assert.equal(anchors.length, EXPECTED_A)
+  })
+
+  it('parses the correct number of img elements', () => {
+    let elements = parse(fixtureHtml)
+    let imgs = elements.filter((el) => el.name === 'img')
+    assert.equal(imgs.length, EXPECTED_IMG)
+  })
+
+  it('parses the correct number of script elements', () => {
+    let elements = parse(fixtureHtml)
+    let scripts = elements.filter((el) => el.name === 'script')
+    assert.equal(scripts.length, EXPECTED_SCRIPT)
+  })
+
+  it('parses the correct number of link elements', () => {
+    let elements = parse(fixtureHtml)
+    let links = elements.filter((el) => el.name === 'link')
+    assert.equal(links.length, EXPECTED_LINK)
+  })
+
+  it('parses the correct number of meta elements', () => {
+    let elements = parse(fixtureHtml)
+    let metas = elements.filter((el) => el.name === 'meta')
+    assert.equal(metas.length, EXPECTED_META)
+  })
+
+  it('parses the correct number of section elements', () => {
+    let elements = parse(fixtureHtml)
+    let sections = elements.filter((el) => el.name === 'section')
+    assert.equal(sections.length, EXPECTED_SECTION)
+  })
+
+  it('parses the correct number of list items', () => {
+    let elements = parse(fixtureHtml)
+    let lis = elements.filter((el) => el.name === 'li')
+    assert.equal(lis.length, EXPECTED_LI)
+  })
+
+  it('extracts href attributes from anchor elements', () => {
+    let elements = parse(fixtureHtml)
+    let hrefs = elements
+      .filter((el) => el.name === 'a')
+      .map((el) => el.getAttribute('href'))
+      .filter((href): href is string => href != null)
+
+    assert.equal(hrefs.length, EXPECTED_A, 'every anchor should have an href')
+    assert.ok(hrefs.includes('/features'), 'should include /features link')
+    assert.ok(hrefs.includes('/signup'), 'should include /signup link')
+  })
+
+  it('extracts src attributes from img elements', () => {
+    let elements = parse(fixtureHtml)
+    let srcs = elements
+      .filter((el) => el.name === 'img')
+      .map((el) => el.getAttribute('src'))
+      .filter((src): src is string => src != null)
+
+    assert.equal(srcs.length, EXPECTED_IMG, 'every img should have a src')
+    assert.ok(srcs.includes('/images/logo.svg'), 'should include /images/logo.svg')
+    assert.ok(srcs.includes('/images/hero-screenshot.png'), 'should include /images/hero-screenshot.png')
+  })
+
+  it('parses a simple HTML snippet correctly', () => {
+    let elements = parse('<div class="test"><a href="/home">Home</a></div>')
+
+    assert.equal(elements.length, 2)
+    assert.equal(elements[0].name, 'div')
+    assert.equal(elements[0].getAttribute('class'), 'test')
+    assert.equal(elements[1].name, 'a')
+    assert.equal(elements[1].getAttribute('href'), '/home')
+  })
+
+  it('handles self-closing tags', () => {
+    let elements = parse('<img src="/photo.jpg" /><br /><input type="text" />')
+
+    assert.equal(elements.length, 3)
+    assert.equal(elements[0].name, 'img')
+    assert.equal(elements[0].getAttribute('src'), '/photo.jpg')
+    assert.equal(elements[1].name, 'br')
+    assert.equal(elements[2].name, 'input')
+    assert.equal(elements[2].getAttribute('type'), 'text')
+  })
+
+  it('skips HTML comments', () => {
+    let elements = parse('<!-- this is a comment --><div>content</div>')
+
+    assert.equal(elements.length, 1)
+    assert.equal(elements[0].name, 'div')
+  })
+
+  it('handles boolean attributes', () => {
+    let elements = parse('<input disabled required type="checkbox" />')
+
+    assert.equal(elements.length, 1)
+    assert.equal(elements[0].getAttribute('disabled'), '')
+    assert.equal(elements[0].getAttribute('required'), '')
+    assert.equal(elements[0].getAttribute('type'), 'checkbox')
+  })
+})

--- a/packages/fetch-router/src/lib/html-parser.ts
+++ b/packages/fetch-router/src/lib/html-parser.ts
@@ -1,0 +1,222 @@
+export interface HTMLElement {
+  name: string
+  getAttribute(name: string): string | null
+}
+
+const State = {
+  TEXT: 0,
+  TAG_OPEN: 1,
+  TAG_NAME: 2,
+  BEFORE_ATTR: 3,
+  ATTR_NAME: 4,
+  AFTER_ATTR_NAME: 5,
+  ATTR_VALUE_UNQUOTED: 6,
+  ATTR_VALUE_DOUBLE_QUOTED: 7,
+  ATTR_VALUE_SINGLE_QUOTED: 8,
+  COMMENT: 9,
+} as const
+
+type StateValue = (typeof State)[keyof typeof State]
+
+class Element implements HTMLElement {
+  name: string
+  #attributes: Map<string, string>
+
+  constructor(name: string) {
+    this.name = name.toLowerCase()
+    this.#attributes = new Map()
+  }
+
+  setAttribute(name: string, value: string) {
+    this.#attributes.set(name.toLowerCase(), value)
+  }
+
+  getAttribute(name: string): string | null {
+    return this.#attributes.get(name.toLowerCase()) ?? null
+  }
+}
+
+export function parse(html: string): HTMLElement[] {
+  let elements: HTMLElement[] = []
+  let state: StateValue = State.TEXT
+  let i = 0
+  let currentElement: Element | null = null
+  let currentTagName = ''
+  let currentAttrName = ''
+  let currentAttrValue = ''
+
+  while (i < html.length) {
+    let char = html[i]
+
+    switch (state) {
+      case State.TEXT:
+        if (char === '<') {
+          // Check if this is a comment
+          if (html.substring(i, i + 4) === '<!--') {
+            state = State.COMMENT
+            i += 4
+            continue
+          }
+          // Check if this is a closing tag
+          if (html[i + 1] === '/') {
+            // Skip closing tags
+            i++
+            while (i < html.length && html[i] !== '>') {
+              i++
+            }
+            i++
+            continue
+          }
+          state = State.TAG_OPEN
+          currentTagName = ''
+        }
+        break
+
+      case State.COMMENT:
+        // Skip until we find -->
+        if (html.substring(i, i + 3) === '-->') {
+          state = State.TEXT
+          i += 3
+          continue
+        }
+        break
+
+      case State.TAG_OPEN:
+        if (char === '>') {
+          state = State.TEXT
+        } else if (/\s/.test(char)) {
+          // Ignore leading whitespace
+        } else {
+          state = State.TAG_NAME
+          currentTagName = char
+        }
+        break
+
+      case State.TAG_NAME:
+        if (char === '>' || char === '/') {
+          currentElement = new Element(currentTagName)
+          elements.push(currentElement)
+          if (char === '/') {
+            // Self-closing tag, skip to >
+            while (i < html.length && html[i] !== '>') {
+              i++
+            }
+          }
+          state = State.TEXT
+          currentElement = null
+        } else if (/\s/.test(char)) {
+          currentElement = new Element(currentTagName)
+          state = State.BEFORE_ATTR
+        } else {
+          currentTagName += char
+        }
+        break
+
+      case State.BEFORE_ATTR:
+        if (char === '>' || char === '/') {
+          elements.push(currentElement!)
+          if (char === '/') {
+            // Self-closing tag, skip to >
+            while (i < html.length && html[i] !== '>') {
+              i++
+            }
+          }
+          state = State.TEXT
+          currentElement = null
+        } else if (!/\s/.test(char)) {
+          state = State.ATTR_NAME
+          currentAttrName = char
+          currentAttrValue = ''
+        }
+        break
+
+      case State.ATTR_NAME:
+        if (char === '=') {
+          state = State.AFTER_ATTR_NAME
+        } else if (/\s/.test(char)) {
+          // Boolean attribute
+          currentElement!.setAttribute(currentAttrName, '')
+          state = State.BEFORE_ATTR
+          currentAttrName = ''
+        } else if (char === '>' || char === '/') {
+          // Boolean attribute at end of tag
+          currentElement!.setAttribute(currentAttrName, '')
+          elements.push(currentElement!)
+          if (char === '/') {
+            // Self-closing tag, skip to >
+            while (i < html.length && html[i] !== '>') {
+              i++
+            }
+          }
+          state = State.TEXT
+          currentElement = null
+          currentAttrName = ''
+        } else {
+          currentAttrName += char
+        }
+        break
+
+      case State.AFTER_ATTR_NAME:
+        if (char === '"') {
+          state = State.ATTR_VALUE_DOUBLE_QUOTED
+          currentAttrValue = ''
+        } else if (char === "'") {
+          state = State.ATTR_VALUE_SINGLE_QUOTED
+          currentAttrValue = ''
+        } else if (!/\s/.test(char)) {
+          state = State.ATTR_VALUE_UNQUOTED
+          currentAttrValue = char
+        }
+        break
+
+      case State.ATTR_VALUE_DOUBLE_QUOTED:
+        if (char === '"') {
+          currentElement!.setAttribute(currentAttrName, currentAttrValue)
+          state = State.BEFORE_ATTR
+          currentAttrName = ''
+          currentAttrValue = ''
+        } else {
+          currentAttrValue += char
+        }
+        break
+
+      case State.ATTR_VALUE_SINGLE_QUOTED:
+        if (char === "'") {
+          currentElement!.setAttribute(currentAttrName, currentAttrValue)
+          state = State.BEFORE_ATTR
+          currentAttrName = ''
+          currentAttrValue = ''
+        } else {
+          currentAttrValue += char
+        }
+        break
+
+      case State.ATTR_VALUE_UNQUOTED:
+        if (/\s/.test(char) || char === '>' || char === '/') {
+          currentElement!.setAttribute(currentAttrName, currentAttrValue)
+          currentAttrName = ''
+          currentAttrValue = ''
+          if (char === '>' || char === '/') {
+            elements.push(currentElement!)
+            if (char === '/') {
+              // Self-closing tag, skip to >
+              while (i < html.length && html[i] !== '>') {
+                i++
+              }
+            }
+            state = State.TEXT
+            currentElement = null
+          } else {
+            state = State.BEFORE_ATTR
+          }
+        } else {
+          currentAttrValue += char
+        }
+        break
+    }
+
+    i++
+  }
+
+  return elements
+}

--- a/packages/fetch-router/src/lib/html-parser.ts
+++ b/packages/fetch-router/src/lib/html-parser.ts
@@ -44,6 +44,7 @@ export function parse(html: string): HTMLElement[] {
   let currentTagName = ''
   let currentAttrName = ''
   let currentAttrValue = ''
+  let attrValueStart = 0
 
   while (i < html.length) {
     let char = html[i]
@@ -159,9 +160,11 @@ export function parse(html: string): HTMLElement[] {
       case State.AFTER_ATTR_NAME:
         if (char === '"') {
           state = State.ATTR_VALUE_DOUBLE_QUOTED
+          attrValueStart = i + 1
           currentAttrValue = ''
         } else if (char === "'") {
           state = State.ATTR_VALUE_SINGLE_QUOTED
+          attrValueStart = i + 1
           currentAttrValue = ''
         } else if (!/\s/.test(char)) {
           state = State.ATTR_VALUE_UNQUOTED
@@ -171,23 +174,19 @@ export function parse(html: string): HTMLElement[] {
 
       case State.ATTR_VALUE_DOUBLE_QUOTED:
         if (char === '"') {
-          currentElement!.setAttribute(currentAttrName, currentAttrValue)
+          currentElement!.setAttribute(currentAttrName, html.slice(attrValueStart, i))
           state = State.BEFORE_ATTR
           currentAttrName = ''
           currentAttrValue = ''
-        } else {
-          currentAttrValue += char
         }
         break
 
       case State.ATTR_VALUE_SINGLE_QUOTED:
         if (char === "'") {
-          currentElement!.setAttribute(currentAttrName, currentAttrValue)
+          currentElement!.setAttribute(currentAttrName, html.slice(attrValueStart, i))
           state = State.BEFORE_ATTR
           currentAttrName = ''
           currentAttrValue = ''
-        } else {
-          currentAttrValue += char
         }
         break
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,9 +213,6 @@ importers:
       marked:
         specifier: ^17.0.1
         version: 17.0.3
-      node-html-parser:
-        specifier: ^7.0.2
-        version: 7.0.2
       prettier:
         specifier: ^3.5.3
         version: 3.7.4
@@ -834,6 +831,19 @@ importers:
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20251125.1
+
+  packages/fetch-router/bench:
+    dependencies:
+      '@remix-run/fetch-router':
+        specifier: workspace:^
+        version: link:..
+      node-html-parser:
+        specifier: ^7.1.0
+        version: 7.1.0
+    devDependencies:
+      vitest:
+        specifier: 4.0.15
+        version: 4.0.15(@types/node@24.10.4)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/fetch-router/demos/bun:
     dependencies:
@@ -2022,7 +2032,7 @@ importers:
         version: 0.25.12
       node-html-parser:
         specifier: ^7.0.2
-        version: 7.0.2
+        version: 7.1.0
       playwright:
         specifier: 'catalog:'
         version: 1.59.0
@@ -4842,8 +4852,8 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  node-html-parser@7.0.2:
-    resolution: {integrity: sha512-DxodLVh7a6JMkYzWyc8nBX9MaF4M0lLFYkJHlWOiu7+9/I6mwNK9u5TbAMC7qfqDJEPX9OIoWA2A9t4C2l1mUQ==}
+  node-html-parser@7.1.0:
+    resolution: {integrity: sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -7895,7 +7905,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  node-html-parser@7.0.2:
+  node-html-parser@7.1.0:
     dependencies:
       css-select: 5.2.2
       he: 1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,9 +207,6 @@ importers:
       marked:
         specifier: ^17.0.1
         version: 17.0.3
-      node-html-parser:
-        specifier: ^7.0.2
-        version: 7.0.2
       prettier:
         specifier: ^3.5.3
         version: 3.7.4
@@ -794,6 +791,19 @@ importers:
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20251125.1
+
+  packages/fetch-router/bench:
+    dependencies:
+      '@remix-run/fetch-router':
+        specifier: workspace:^
+        version: link:..
+      node-html-parser:
+        specifier: ^7.1.0
+        version: 7.1.0
+    devDependencies:
+      vitest:
+        specifier: 4.0.15
+        version: 4.0.15(@types/node@24.10.4)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/fetch-router/demos/bun:
     dependencies:
@@ -1982,7 +1992,7 @@ importers:
         version: 0.25.12
       node-html-parser:
         specifier: ^7.0.2
-        version: 7.0.2
+        version: 7.1.0
       playwright:
         specifier: 'catalog:'
         version: 1.59.0
@@ -4815,8 +4825,8 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  node-html-parser@7.0.2:
-    resolution: {integrity: sha512-DxodLVh7a6JMkYzWyc8nBX9MaF4M0lLFYkJHlWOiu7+9/I6mwNK9u5TbAMC7qfqDJEPX9OIoWA2A9t4C2l1mUQ==}
+  node-html-parser@7.1.0:
+    resolution: {integrity: sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -7866,7 +7876,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  node-html-parser@7.0.2:
+  node-html-parser@7.1.0:
     dependencies:
       css-select: 5.2.2
       he: 1.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ packages:
   - packages/*/demo
   - packages/assets/bench
   - packages/cli/test/fixtures/*
+  - packages/fetch-router/bench
   - packages/fetch-router/demos/*
   - packages/form-data-parser/demos/*
   - packages/ui/demos

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ packages:
   - packages/assets/bench
   - packages/cli/bootstrap
   - packages/cli/test/fixtures/*
+  - packages/fetch-router/bench
   - packages/fetch-router/demos/*
   - packages/form-data-parser/demos/*
   - packages/ui/demos


### PR DESCRIPTION
This PR adds a new `crawl(router, opts)` API to `fetch-router` that enables first-class crawling/spidering of the application served by the router - enabling very easy pre-rendering (basically a built-in `wget`).  

The spidering logic is implemented with a minimal custom HTML parser and benchmarked against [node-html-parser](https://www.npmjs.com/package/node-html-parser) via `pnpm i; cd packages/fetch-router/bench; pnpm bench`.  It's currently around 2-3x faster because it only implements the the minimal capabilities needed to extract link/asset paths from a document (no CSS selector support, etc).

```ts
import { crawl } from 'remix/fetch-router'

for await (let { pathname, filepath, response } of crawl(router)) {
  let outputPath = path.join('dist', filepath)
  await fs.mkdir(path.dirname(outputPath), { recursive: true })
  await fs.writeFile(outputPath, new Uint8Array(await response.arrayBuffer()))
  console.log(`Crawled ${pathname} -> ${outputPath}`)
}
```

I've converted our docs generation to use this new API as well