### PR TITLE
docs: add missing public API JSDoc

### DIFF
--- a/packages/component/src/lib/component.ts
+++ b/packages/component/src/lib/component.ts
@@ -1,8 +1,14 @@
 import type { ElementProps, ElementType, RemixNode, Renderable } from './jsx.ts'
 import { TypedEventTarget } from './typed-event-target.ts'
 
+/**
+ * Task queued to run after a component update completes.
+ */
 export type Task = (signal: AbortSignal) => void
 
+/**
+ * Runtime handle passed to component setup functions.
+ */
 export interface Handle<C = Record<string, never>> {
   /**
    * Stable identifier per component instance. Useful for HTML APIs like
@@ -87,11 +93,17 @@ export interface Handle<C = Record<string, never>> {
  */
 export type NoContext = Record<string, never>
 
+/**
+ * Component factory shape used by the Remix component runtime.
+ */
 export type Component<Context = NoContext, Setup = undefined, Props = ElementProps> = (
   handle: Handle<Context>,
   setup: Setup,
 ) => (props: Props) => RemixNode
 
+/**
+ * Infers the context provided by a component or handle-compatible function.
+ */
 export type ContextFrom<ComponentType> =
   ComponentType extends Component<infer Provided, any, any>
     ? Provided
@@ -99,19 +111,31 @@ export type ContextFrom<ComponentType> =
       ? Provided
       : never
 
+/**
+ * Context storage API exposed on component handles.
+ */
 export interface Context<C> {
   set(values: C): void
   get<ComponentType>(component: ComponentType): ContextFrom<ComponentType>
   get(component: ElementType | symbol): unknown | undefined
 }
 
+/**
+ * Content that can be rendered into a frame.
+ */
 export type FrameContent = ReadableStream<Uint8Array> | string | RemixNode
 
+/**
+ * Events emitted by frame handles during reloads.
+ */
 export type FrameHandleEventMap = {
   reloadStart: Event
   reloadComplete: Event
 }
 
+/**
+ * Public API for interacting with a frame instance.
+ */
 export type FrameHandle = TypedEventTarget<FrameHandleEventMap> & {
   src: string
   reload(): Promise<AbortSignal>
@@ -120,6 +144,9 @@ export type FrameHandle = TypedEventTarget<FrameHandleEventMap> & {
   $runtime?: unknown
 }
 
+/**
+ * Props accepted by the built-in `Frame` component.
+ */
 export interface FrameProps {
   name?: string
   src: string
@@ -160,6 +187,12 @@ type ComponentConfig = {
 
 export type ComponentHandle = ReturnType<typeof createComponent>
 
+/**
+ * Creates the internal runtime wrapper for a component instance.
+ *
+ * @param config Component runtime configuration.
+ * @returns Component runtime helpers used by the reconciler.
+ */
 export function createComponent<C = NoContext>(config: ComponentConfig) {
   let taskQueue: Task[] = []
   let renderCtrl: AbortController | null = null
@@ -267,10 +300,21 @@ export function createComponent<C = NoContext>(config: ComponentConfig) {
   return { render, remove, setScheduleUpdate, frame: config.frame, getContextValue }
 }
 
+/**
+ * Built-in component used to render nested frame content.
+ *
+ * @param handle Component handle for the frame instance.
+ * @returns A placeholder render function handled by the reconciler.
+ */
 export function Frame(handle: Handle<FrameHandle>) {
   return (_: FrameProps) => null // reconciler renders
 }
 
+/**
+ * Built-in component used to group children without adding a host element.
+ *
+ * @returns A placeholder render function handled by the reconciler.
+ */
 export function Fragment() {
   return (_: FragmentProps) => null // reconciler renders
 }

--- a/packages/component/src/lib/create-element.ts
+++ b/packages/component/src/lib/create-element.ts
@@ -1,6 +1,14 @@
 import { jsx } from './jsx.ts'
 import type { RemixElement } from './jsx.ts'
 
+/**
+ * Creates a Remix virtual element from a JSX-like call signature.
+ *
+ * @param type Host tag or component function.
+ * @param props Element props.
+ * @param children Child nodes.
+ * @returns A Remix virtual element.
+ */
 export function createElement(
   type: string,
   props?: Record<string, any>,

--- a/packages/component/src/lib/dom.ts
+++ b/packages/component/src/lib/dom.ts
@@ -21,6 +21,9 @@ export interface LayoutAnimationConfig {
   easing?: string
 }
 
+/**
+ * Shared host-element props accepted by all built-in DOM element types.
+ */
 export interface HostProps<eventTarget extends EventTarget> {
   key?: any
   children?: RemixNode

--- a/packages/component/src/lib/error-event.ts
+++ b/packages/component/src/lib/error-event.ts
@@ -1,3 +1,6 @@
+/**
+ * Error event shape emitted by the component runtime.
+ */
 export type ComponentErrorEvent = ErrorEvent & {
   readonly error: unknown
 }

--- a/packages/component/src/lib/event-listeners.ts
+++ b/packages/component/src/lib/event-listeners.ts
@@ -1,3 +1,6 @@
+/**
+ * Event type with `currentTarget` narrowed to the dispatched target.
+ */
 export type Dispatched<event extends Event, target extends EventTarget> = Omit<
   event,
   'currentTarget'
@@ -109,6 +112,13 @@ export type EventMap<target extends EventTarget> = (
   GlobalEventHandlersEventMap & Record<string, Event>
 )
 
+/**
+ * Adds typed event listeners and reentry abort signals to a target.
+ *
+ * @param target Event target to attach listeners to.
+ * @param signal Lifetime signal used to remove all listeners.
+ * @param listeners Listener map keyed by event type.
+ */
 export function addEventListeners<target extends EventTarget>(
   target: target,
   signal: AbortSignal,

--- a/packages/component/src/lib/frame.ts
+++ b/packages/component/src/lib/frame.ts
@@ -38,8 +38,14 @@ type FrameMarkerData = FrameData & {
 
 type PendingClientEntries = Map<Comment, [Comment, RemixElement]>
 
+/**
+ * Loads a client entry module for hydration.
+ */
 export type LoadModule = (moduleUrl: string, exportName: string) => Promise<Function> | Function
 
+/**
+ * Resolves frame content for the given frame source.
+ */
 export type ResolveFrame = (
   src: string,
   signal?: AbortSignal,

--- a/packages/component/src/lib/jsx.ts
+++ b/packages/component/src/lib/jsx.ts
@@ -70,6 +70,14 @@ export type Props<T extends keyof JSX.IntrinsicElements> = NormalizeMixProp<
   JSX.IntrinsicElements[T]
 >
 
+/**
+ * Creates a Remix virtual element.
+ *
+ * @param type Host tag or component function.
+ * @param props Element props.
+ * @param key Optional reconciliation key.
+ * @returns A Remix virtual element.
+ */
 export function jsx(type: string, props: ElementProps, key?: string): RemixElement
 export function jsx(type: Function, props: ElementProps, key?: string): RemixElement
 export function jsx(type: any, props: any, key?: any): RemixElement {

--- a/packages/component/src/lib/mixin.ts
+++ b/packages/component/src/lib/mixin.ts
@@ -65,6 +65,9 @@ type MixinHandleEventMap<node extends EventTarget = Element> = {
   commit: MixinUpdateEvent<node>
 }
 
+/**
+ * Runtime handle passed to mixin setup functions.
+ */
 export type MixinHandle<
   node extends EventTarget = Element,
   props extends ElementProps = ElementProps,
@@ -90,6 +93,9 @@ type MixinRuntimeType<
     ) => void | null | RemixElement | MixinElement<node, props>)
   | void
 
+/**
+ * Public mixin setup function signature.
+ */
 export type MixinType<
   node extends EventTarget = Element,
   args extends unknown[] = [],
@@ -103,6 +109,9 @@ export type MixinType<
     ) => void | null | RemixElement | MixinElement<node, props>)
   | void
 
+/**
+ * Serializable descriptor stored in the `mix` prop.
+ */
 export type MixinDescriptor<
   node extends EventTarget = Element,
   args extends unknown[] = [],
@@ -113,6 +122,9 @@ export type MixinDescriptor<
   readonly __node?: (node: node) => void
 }
 
+/**
+ * Accepted value shape for the `mix` prop.
+ */
 export type MixValue<
   node extends EventTarget = Element,
   props extends ElementProps = ElementProps,
@@ -185,6 +197,12 @@ export type MixinRuntimeState = {
 
 let mixinHandleId = 0
 
+/**
+ * Creates a typed mixin factory that can be passed through the `mix` prop.
+ *
+ * @param type Mixin setup function.
+ * @returns A function that captures mixin arguments and returns a descriptor.
+ */
 export function createMixin<
   node extends EventTarget = Element,
   args extends unknown[] = [],

--- a/packages/component/src/lib/mixins/animate-layout-mixin.tsx
+++ b/packages/component/src/lib/mixins/animate-layout-mixin.tsx
@@ -248,6 +248,12 @@ let animateLayoutMixin = createMixin<Element, [config?: LayoutConfig], ElementPr
   }
 })
 
+/**
+ * Animates layout changes for an element using FLIP-style transforms.
+ *
+ * @param config Layout animation configuration.
+ * @returns A mixin descriptor for the target element.
+ */
 export function animateLayout<target extends EventTarget = Element>(
   config: LayoutConfig = true,
 ): MixinDescriptor<target, [LayoutConfig?], ElementProps> {

--- a/packages/component/src/lib/mixins/animate-mixins.tsx
+++ b/packages/component/src/lib/mixins/animate-mixins.tsx
@@ -259,6 +259,12 @@ let animateExitMixin = createMixin<Element, [config: AnimationConfig], ElementPr
   }
 })
 
+/**
+ * Animates an element when it is inserted into the DOM.
+ *
+ * @param config Entrance animation configuration.
+ * @returns A mixin descriptor for the target element.
+ */
 export function animateEntrance<target extends EventTarget = Element>(
   config: AnimationConfig = true,
 ): MixinDescriptor<target, [AnimationConfig], ElementProps> {
@@ -269,6 +275,12 @@ export function animateEntrance<target extends EventTarget = Element>(
   >
 }
 
+/**
+ * Animates an element when it is removed from the DOM.
+ *
+ * @param config Exit animation configuration.
+ * @returns A mixin descriptor for the target element.
+ */
 export function animateExit<target extends EventTarget = Element>(
   config: AnimationConfig = true,
 ): MixinDescriptor<target, [AnimationConfig], ElementProps> {

--- a/packages/component/src/lib/mixins/css-mixin.tsx
+++ b/packages/component/src/lib/mixins/css-mixin.tsx
@@ -16,6 +16,9 @@ type StyleManagerLike = {
 
 let clientStyleCache: StyleCache = new Map()
 
+/**
+ * Applies generated class names for CSS object styles.
+ */
 export let css = createMixin<Element, [styles: CSSProps], ElementProps>((handle) => {
   let activeSelector = ''
   let currentStyles: CSSProps = {}

--- a/packages/component/src/lib/mixins/keys-mixin.tsx
+++ b/packages/component/src/lib/mixins/keys-mixin.tsx
@@ -86,6 +86,9 @@ type KeysEventsMixin = typeof baseKeysEvents & {
   readonly pageDown: typeof pageDownEventType
 }
 
+/**
+ * Normalizes common keyboard keys into custom key-specific DOM events.
+ */
 export let keysEvents: KeysEventsMixin = Object.assign(baseKeysEvents, {
   escape: escapeEventType,
   enter: enterEventType,

--- a/packages/component/src/lib/mixins/link-mixin.tsx
+++ b/packages/component/src/lib/mixins/link-mixin.tsx
@@ -21,6 +21,9 @@ type LinkCurrentProps = ElementProps & {
 
 let nativeLinkHostTypes = new Set(['a', 'area'])
 
+/**
+ * Adds client-side navigation behavior to anchor-like elements.
+ */
 export let link = createMixin<
   HTMLElement,
   [href: string, options?: NavigationOptions],

--- a/packages/component/src/lib/mixins/on-mixin.tsx
+++ b/packages/component/src/lib/mixins/on-mixin.tsx
@@ -62,6 +62,14 @@ let onMixin = createMixin<
   }
 })
 
+/**
+ * Attaches a typed DOM event handler through the mixin system.
+ *
+ * @param type Event type to listen for.
+ * @param handler Event handler.
+ * @param captureBoolean Whether to listen during capture.
+ * @returns A mixin descriptor for the target element.
+ */
 export function on<
   target extends Element = Element,
   type extends EventType<target> = EventType<target>,

--- a/packages/component/src/lib/mixins/press-mixin.tsx
+++ b/packages/component/src/lib/mixins/press-mixin.tsx
@@ -16,6 +16,9 @@ declare global {
   }
 }
 
+/**
+ * Event emitted by the `pressEvents` mixin for pointer and keyboard presses.
+ */
 export class PressEvent extends Event {
   clientX: number
   clientY: number
@@ -184,6 +187,9 @@ type PressEventsMixin = typeof basePressEvents & {
   readonly cancel: typeof pressCancelEventType
 }
 
+/**
+ * Normalizes pointer and keyboard input into press lifecycle events.
+ */
 export let pressEvents: PressEventsMixin = Object.assign(basePressEvents, {
   press: pressEventType,
   down: pressDownEventType,

--- a/packages/component/src/lib/mixins/ref-mixin.tsx
+++ b/packages/component/src/lib/mixins/ref-mixin.tsx
@@ -1,8 +1,14 @@
 import { createMixin } from '../mixin.ts'
 import type { ElementProps } from '../jsx.ts'
 
+/**
+ * Callback invoked with the bound node and a lifetime signal.
+ */
 export type RefCallback<node extends EventTarget> = (node: node, signal: AbortSignal) => void
 
+/**
+ * Calls a callback when an element is inserted and aborts it when removed.
+ */
 export let ref = createMixin<Element, [callback: RefCallback<Element>], ElementProps>((handle) => {
   let controller: AbortController | undefined
 

--- a/packages/component/src/lib/navigation.ts
+++ b/packages/component/src/lib/navigation.ts
@@ -11,6 +11,9 @@ type SourceElementNavigateEvent = NavigateEvent & {
   sourceElement?: Element | null
 }
 
+/**
+ * Options for client-side frame-aware navigation.
+ */
 export type NavigationOptions = {
   src?: string
   target?: string
@@ -18,6 +21,12 @@ export type NavigationOptions = {
   resetScroll?: boolean
 }
 
+/**
+ * Performs a Navigation API transition understood by Remix frame runtime state.
+ *
+ * @param href Destination URL.
+ * @param options Navigation options.
+ */
 export async function navigate(href: string, options?: NavigationOptions) {
   let state = {
     target: options?.target,

--- a/packages/component/src/lib/run.ts
+++ b/packages/component/src/lib/run.ts
@@ -8,15 +8,24 @@ import type { LoadModule, ResolveFrame } from './frame.ts'
 import { startNavigationListener } from './navigation.ts'
 import { TypedEventTarget } from './typed-event-target.ts'
 
+/**
+ * Options for starting the client runtime.
+ */
 export type RunInit = {
   loadModule: LoadModule
   resolveFrame?: ResolveFrame
 }
 
+/**
+ * Events emitted by the application runtime.
+ */
 export type AppRuntimeEventMap = {
   error: ComponentErrorEvent
 }
 
+/**
+ * Client runtime returned by `run()`.
+ */
 export type AppRuntime = TypedEventTarget<AppRuntimeEventMap> & {
   ready(): Promise<void>
   flush(): void
@@ -34,6 +43,12 @@ export function getNamedFrame(name: string): FrameHandle {
   return namedFrames.get(name) ?? getTopFrame()
 }
 
+/**
+ * Starts the client-side Remix component runtime for the current document.
+ *
+ * @param init Runtime hooks for loading modules and resolving frames.
+ * @returns The running application runtime.
+ */
 export function run(init: RunInit): AppRuntime {
   let styleManager = defaultStyleManager
   let errorTarget = new TypedEventTarget<AppRuntimeEventMap>()

--- a/packages/component/src/lib/scheduler.ts
+++ b/packages/component/src/lib/scheduler.ts
@@ -14,6 +14,9 @@ type EmptyFn = () => void
 type SchedulerPhaseType = 'beforeUpdate' | 'commit'
 type SchedulerPhaseListener = EventListenerOrEventListenerObject | null
 
+/**
+ * Scheduler API used by the reconciler and frame runtime.
+ */
 export type Scheduler = ReturnType<typeof createScheduler>
 
 // Protect against infinite cascading updates (e.g. handle.update() during render)
@@ -23,6 +26,14 @@ export type SchedulerPhaseEvent = Event & {
   parents: ParentNode[]
 }
 
+/**
+ * Creates the DOM update scheduler used by the component runtime.
+ *
+ * @param doc Document associated with the rendered tree.
+ * @param rootTarget Event target that receives runtime errors.
+ * @param styles Style manager used during reconciliation.
+ * @returns A scheduler instance.
+ */
 export function createScheduler(
   doc: Document,
   rootTarget: EventTarget,

--- a/packages/component/src/lib/spring.ts
+++ b/packages/component/src/lib/spring.ts
@@ -14,12 +14,18 @@
 
 export type SpringPreset = 'smooth' | 'snappy' | 'bouncy'
 
+/**
+ * Options for generating a spring easing iterator.
+ */
 export interface SpringOptions {
   duration?: number // perceptual duration in ms (default: 300) - affects stiffness
   bounce?: number // -1 to ~0.95: negative = overdamped, 0 = critical, positive = bouncy
   velocity?: number // initial velocity in units per second
 }
 
+/**
+ * Iterator returned by `spring()`, decorated for CSS and WAAPI use.
+ */
 export interface SpringIterator extends IterableIterator<number> {
   /** Time when spring settles to rest (milliseconds) */
   duration: number

--- a/packages/component/src/lib/stream.ts
+++ b/packages/component/src/lib/stream.ts
@@ -16,6 +16,9 @@ export function createVNode(type: ElementType, props: ElementProps, key?: Key): 
   return { type, props, key }
 }
 
+/**
+ * Options for server-side rendering to a byte stream.
+ */
 export interface RenderToStreamOptions {
   frameSrc?: string | URL
   topFrameSrc?: string | URL
@@ -27,6 +30,9 @@ export interface RenderToStreamOptions {
   ) => Promise<string | ReadableStream<Uint8Array>> | string | ReadableStream<Uint8Array>
 }
 
+/**
+ * Context passed to `resolveFrame` during server rendering.
+ */
 export interface ResolveFrameContext {
   currentFrameSrc: string
   topFrameSrc: string
@@ -141,6 +147,13 @@ function createSsrThrowingSignal(): AbortSignal {
   })
 }
 
+/**
+ * Renders a node tree to a streaming HTML response body.
+ *
+ * @param node Node tree to render.
+ * @param options Stream rendering options.
+ * @returns A readable byte stream of HTML.
+ */
 export function renderToStream(
   node: RemixNode,
   options?: RenderToStreamOptions,
@@ -1047,6 +1060,12 @@ async function drain(stream: ReadableStream<Uint8Array>): Promise<string> {
   return html
 }
 
+/**
+ * Renders a node tree to a complete HTML string.
+ *
+ * @param node Node tree to render.
+ * @returns Rendered HTML.
+ */
 export async function renderToString(node: RemixNode): Promise<string> {
   return drain(
     renderToStream(node, {

--- a/packages/component/src/lib/tween.ts
+++ b/packages/component/src/lib/tween.ts
@@ -54,6 +54,9 @@ function cubicBezierDerivative(t: number, p1: number, p2: number): number {
   return 3 * oneMinusT * oneMinusT * p1 + 6 * oneMinusT * t * (p2 - p1) + 3 * t * t * (1 - p2)
 }
 
+/**
+ * Cubic-bezier control points used by `tween()`.
+ */
 export interface BezierCurve {
   x1: number
   y1: number
@@ -62,6 +65,9 @@ export interface BezierCurve {
 }
 
 // Common easing presets
+/**
+ * Common cubic-bezier presets for `tween()`.
+ */
 export const easings = {
   linear: { x1: 0, y1: 0, x2: 1, y2: 1 },
   ease: { x1: 0.25, y1: 0.1, x2: 0.25, y2: 1 },
@@ -70,6 +76,9 @@ export const easings = {
   easeInOut: { x1: 0.42, y1: 0, x2: 0.58, y2: 1 },
 } as const
 
+/**
+ * Options for generating tweened values over time.
+ */
 export interface TweenOptions {
   from: number
   to: number

--- a/packages/component/src/lib/vdom.ts
+++ b/packages/component/src/lib/vdom.ts
@@ -15,16 +15,25 @@ import { ROOT_VNODE, type VNode } from './vnode.ts'
 import { resetStyleState, defaultStyleManager } from './diff-props.ts'
 import type { StyleManager } from './style/index.ts'
 
+/**
+ * Events emitted by virtual roots.
+ */
 export type VirtualRootEventMap = {
   error: ComponentErrorEvent
 }
 
+/**
+ * Root controller returned by `createRoot()` and `createRangeRoot()`.
+ */
 export type VirtualRoot = TypedEventTarget<VirtualRootEventMap> & {
   render: (element: RemixNode) => void
   dispose: () => void
   flush: () => void
 }
 
+/**
+ * Options for creating a virtual DOM root.
+ */
 export type VirtualRootOptions = {
   frame?: FrameHandle
   scheduler?: Scheduler
@@ -52,10 +61,18 @@ function getHydrationComponentIdFromRangeStart(start: Node): string | undefined 
   return id.length > 0 ? id : undefined
 }
 
+/**
+ * Creates a virtual root bounded by two DOM nodes.
+ *
+ * @param boundaries Start and end marker nodes that define the render region.
+ * @param options Root configuration.
+ * @returns A virtual root controller.
+ */
 export function createRangeRoot(
-  [start, end]: [Node, Node],
+  boundaries: [Node, Node],
   options: VirtualRootOptions = {},
 ): VirtualRoot {
+  let [start, end] = boundaries
   let vroot: VNode | null = null
   let styles = options.styleManager ?? defaultStyleManager
 
@@ -145,6 +162,13 @@ export function createRangeRoot(
   })
 }
 
+/**
+ * Creates a virtual root for a host container element.
+ *
+ * @param container Host element to render into.
+ * @param options Root configuration.
+ * @returns A virtual root controller.
+ */
 export function createRoot(container: HTMLElement, options: VirtualRootOptions = {}): VirtualRoot {
   let vroot: VNode | null = null
   let styles = options.styleManager ?? defaultStyleManager

--- a/packages/compression-middleware/src/lib/compression.ts
+++ b/packages/compression-middleware/src/lib/compression.ts
@@ -5,6 +5,9 @@ import { isCompressibleMimeType } from '@remix-run/mime'
 
 type Encoding = 'br' | 'gzip' | 'deflate'
 
+/**
+ * Configuration for automatic response compression.
+ */
 export interface CompressionOptions {
   /**
    * Minimum size in bytes to compress (only enforced if Content-Length present).

--- a/packages/cop-middleware/src/lib/cop.ts
+++ b/packages/cop-middleware/src/lib/cop.ts
@@ -12,12 +12,21 @@ interface BypassPattern {
   matchesSubtree: boolean
 }
 
+/**
+ * Reason reported when cross-origin protection rejects a request.
+ */
 export type CopFailureReason = 'cross-origin-request' | 'cross-origin-request-from-old-browser'
 
+/**
+ * Custom response handler for rejected cross-origin requests.
+ */
 export interface CopDenyHandler {
   (reason: CopFailureReason, context: RequestContext): Response | Promise<Response>
 }
 
+/**
+ * Configuration for the cross-origin protection middleware.
+ */
 export interface CopOptions {
   trustedOrigins?: readonly string[]
   insecureBypassPatterns?: readonly string[]
@@ -107,6 +116,12 @@ class CrossOriginProtection {
   }
 }
 
+/**
+ * Creates middleware that rejects unsafe cross-origin requests.
+ *
+ * @param options Cross-origin protection options.
+ * @returns Middleware that validates request origin headers.
+ */
 export function cop(options: CopOptions = {}): Middleware {
   let protection = new CrossOriginProtection(options)
 

--- a/packages/cors-middleware/src/lib/cors.ts
+++ b/packages/cors-middleware/src/lib/cors.ts
@@ -5,8 +5,14 @@ let defaultCorsMethods = ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE']
 
 type OriginMatcher = string | RegExp | ReadonlyArray<string | RegExp>
 
+/**
+ * Return shape for a dynamic CORS origin resolver.
+ */
 export type CorsOriginResolverResult = '*' | string | boolean | null | undefined
 
+/**
+ * Resolves the allowed origin for a given request origin.
+ */
 export interface CorsOriginResolver {
   (
     origin: string,
@@ -14,10 +20,19 @@ export interface CorsOriginResolver {
   ): CorsOriginResolverResult | Promise<CorsOriginResolverResult>
 }
 
+/**
+ * Accepted forms for configuring allowed CORS origins.
+ */
 export type CorsOrigin = OriginMatcher | boolean | CorsOriginResolver
 
+/**
+ * Return shape for a dynamic allowed-headers resolver.
+ */
 export type CorsAllowedHeadersResolverResult = readonly string[] | null | undefined
 
+/**
+ * Resolves the allowed request headers for a preflight request.
+ */
 export interface CorsAllowedHeadersResolver {
   (
     request: Request,

--- a/packages/csrf-middleware/src/lib/csrf.ts
+++ b/packages/csrf-middleware/src/lib/csrf.ts
@@ -6,8 +6,14 @@ let defaultTokenHeaderNames = ['x-csrf-token', 'x-xsrf-token', 'csrf-token']
 
 type OriginMatcher = string | RegExp | ReadonlyArray<string | RegExp>
 
+/**
+ * Return shape for a dynamic CSRF origin resolver.
+ */
 export type CsrfOriginResolverResult = boolean | null | undefined
 
+/**
+ * Resolves whether an unsafe cross-origin request should be allowed.
+ */
 export interface CsrfOriginResolver {
   (
     origin: string,
@@ -15,10 +21,19 @@ export interface CsrfOriginResolver {
   ): CsrfOriginResolverResult | Promise<CsrfOriginResolverResult>
 }
 
+/**
+ * Accepted forms for configuring allowed CSRF origins.
+ */
 export type CsrfOrigin = OriginMatcher | CsrfOriginResolver
 
+/**
+ * Return shape for a dynamic CSRF token resolver.
+ */
 export type CsrfTokenResolverResult = string | null | undefined
 
+/**
+ * Resolves the submitted CSRF token for a request.
+ */
 export interface CsrfTokenResolver {
   (context: RequestContext): CsrfTokenResolverResult | Promise<CsrfTokenResolverResult>
 }

--- a/packages/data-schema/src/lib/schema.ts
+++ b/packages/data-schema/src/lib/schema.ts
@@ -129,6 +129,12 @@ type IssueDescriptor = {
   values?: Record<string, unknown>
 }
 
+/**
+ * Creates a sync Standard Schema-compatible schema from a validation function.
+ *
+ * @param validator Validator that returns either a parsed value or validation issues.
+ * @returns A chainable schema object.
+ */
 export function createSchema<input, output>(
   validator: (
     value: unknown,
@@ -272,10 +278,29 @@ function createIssueFromContext(context: ValidationContext, descriptor: IssueDes
   return createIssue(message, path)
 }
 
+/**
+ * Creates a Standard Schema issue object.
+ *
+ * @param message Human-readable validation message.
+ * @param path Optional issue path within the input value.
+ * @returns A Standard Schema issue.
+ */
 export function createIssue(message: string, path: Issue['path']): Issue {
   return !path || path.length === 0 ? { message } : { message, path }
 }
 
+/**
+ * Creates a Standard Schema failure result with a single issue.
+ *
+ * @param message Human-readable validation message.
+ * @param path Optional issue path within the input value.
+ * @param options Optional issue metadata used for localized error mapping.
+ * @param options.code Optional error code passed to the error map.
+ * @param options.values Optional values passed to the error map.
+ * @param options.input Optional input value passed to the error map.
+ * @param options.parseOptions Optional parse options used for localization and error mapping.
+ * @returns A failure result containing one issue.
+ */
 export function fail(
   message: string,
   path: Issue['path'],

--- a/packages/data-table/src/lib/adapter.ts
+++ b/packages/data-table/src/lib/adapter.ts
@@ -146,13 +146,22 @@ export type DataManipulationOperation =
   | UpsertOperation
   | RawOperation
 
+/**
+ * Qualified table reference used in migration operations.
+ */
 export type TableRef = {
   name: string
   schema?: string
 }
 
+/**
+ * Referential actions supported by foreign key constraints.
+ */
 export type ForeignKeyAction = 'cascade' | 'restrict' | 'set null' | 'set default' | 'no action'
 
+/**
+ * Logical column type names used by schema definitions.
+ */
 export type ColumnTypeName =
   | 'varchar'
   | 'text'
@@ -168,11 +177,17 @@ export type ColumnTypeName =
   | 'binary'
   | 'enum'
 
+/**
+ * Default value definition for a column.
+ */
 export type ColumnDefault =
   | { kind: 'literal'; value: unknown }
   | { kind: 'now' }
   | { kind: 'sql'; expression: string }
 
+/**
+ * Definition for a computed or generated column.
+ */
 export type ColumnComputed = {
   expression: string
   stored: boolean
@@ -192,11 +207,17 @@ export type ColumnReference = {
   onUpdate?: ForeignKeyAction
 }
 
+/**
+ * Check constraint declared on a column definition.
+ */
 export type ColumnCheck = {
   expression: string
   name: string
 }
 
+/**
+ * Normalized column definition used in schema operations.
+ */
 export type ColumnDefinition = {
   type: ColumnTypeName
   nullable?: boolean
@@ -219,21 +240,33 @@ export type ColumnDefinition = {
   charset?: string
 }
 
+/**
+ * Primary key constraint definition.
+ */
 export type PrimaryKeyConstraint = {
   columns: string[]
   name: string
 }
 
+/**
+ * Unique constraint definition.
+ */
 export type UniqueConstraint = {
   columns: string[]
   name: string
 }
 
+/**
+ * Check constraint definition.
+ */
 export type CheckConstraint = {
   expression: string
   name: string
 }
 
+/**
+ * Foreign key constraint definition.
+ */
 export type ForeignKeyConstraint = {
   columns: string[]
   references: {
@@ -245,8 +278,14 @@ export type ForeignKeyConstraint = {
   onUpdate?: ForeignKeyAction
 }
 
+/**
+ * Index method used when creating an index.
+ */
 export type IndexMethod = 'btree' | 'hash' | 'gin' | 'gist' | 'fulltext' | (string & {})
 
+/**
+ * Index definition used in schema operations.
+ */
 export type IndexDefinition = {
   table: TableRef
   name: string
@@ -256,6 +295,9 @@ export type IndexDefinition = {
   using?: IndexMethod
 }
 
+/**
+ * Operation that creates a new table.
+ */
 export type CreateTableOperation = {
   kind: 'createTable'
   table: TableRef
@@ -268,75 +310,117 @@ export type CreateTableOperation = {
   comment?: string
 }
 
+/**
+ * Alter-table change that adds a column.
+ */
 export type AddColumnChange = {
   kind: 'addColumn'
   column: string
   definition: ColumnDefinition
 }
 
+/**
+ * Alter-table change that replaces a column definition.
+ */
 export type ChangeColumnChange = {
   kind: 'changeColumn'
   column: string
   definition: ColumnDefinition
 }
 
+/**
+ * Alter-table change that renames a column.
+ */
 export type RenameColumnChange = {
   kind: 'renameColumn'
   from: string
   to: string
 }
 
+/**
+ * Alter-table change that drops a column.
+ */
 export type DropColumnChange = {
   kind: 'dropColumn'
   column: string
   ifExists?: boolean
 }
 
+/**
+ * Alter-table change that adds a primary key.
+ */
 export type AddPrimaryKeyChange = {
   kind: 'addPrimaryKey'
   constraint: PrimaryKeyConstraint
 }
 
+/**
+ * Alter-table change that drops a primary key.
+ */
 export type DropPrimaryKeyChange = {
   kind: 'dropPrimaryKey'
   name: string
 }
 
+/**
+ * Alter-table change that adds a unique constraint.
+ */
 export type AddUniqueChange = {
   kind: 'addUnique'
   constraint: UniqueConstraint
 }
 
+/**
+ * Alter-table change that drops a unique constraint.
+ */
 export type DropUniqueChange = {
   kind: 'dropUnique'
   name: string
 }
 
+/**
+ * Alter-table change that adds a foreign key constraint.
+ */
 export type AddForeignKeyChange = {
   kind: 'addForeignKey'
   constraint: ForeignKeyConstraint
 }
 
+/**
+ * Alter-table change that drops a foreign key constraint.
+ */
 export type DropForeignKeyChange = {
   kind: 'dropForeignKey'
   name: string
 }
 
+/**
+ * Alter-table change that adds a check constraint.
+ */
 export type AddCheckChange = {
   kind: 'addCheck'
   constraint: CheckConstraint
 }
 
+/**
+ * Alter-table change that drops a check constraint.
+ */
 export type DropCheckChange = {
   kind: 'dropCheck'
   name: string
 }
 
+/**
+ * Alter-table change that updates a table comment.
+ */
 export type SetTableCommentChange = {
   kind: 'setTableComment'
   comment: string
 }
 
+/**
+ * Union of supported `alterTable` changes.
+ */
 export type AlterTableChange =
   | AddColumnChange
   | ChangeColumnChange
@@ -352,6 +436,9 @@ export type AlterTableChange =
   | DropCheckChange
   | SetTableCommentChange
 
+/**
+ * Operation that applies one or more table changes.
+ */
 export type AlterTableOperation = {
   kind: 'alterTable'
   table: TableRef
@@ -359,12 +446,18 @@ export type AlterTableOperation = {
   ifExists?: boolean
 }
 
+/**
+ * Operation that renames a table.
+ */
 export type RenameTableOperation = {
   kind: 'renameTable'
   from: TableRef
   to: TableRef
 }
 
+/**
+ * Operation that drops a table.
+ */
 export type DropTableOperation = {
   kind: 'dropTable'
   table: TableRef
@@ -372,12 +465,18 @@ export type DropTableOperation = {
   cascade?: boolean
 }
 
+/**
+ * Operation that creates an index.
+ */
 export type CreateIndexOperation = {
   kind: 'createIndex'
   index: IndexDefinition
   ifNotExists?: boolean
 }
 
+/**
+ * Operation that drops an index.
+ */
 export type DropIndexOperation = {
   kind: 'dropIndex'
   table: TableRef
@@ -385,6 +484,9 @@ export type DropIndexOperation = {
   ifExists?: boolean
 }
 
+/**
+ * Operation that renames an index.
+ */
 export type RenameIndexOperation = {
   kind: 'renameIndex'
   table: TableRef
@@ -392,30 +494,45 @@ export type RenameIndexOperation = {
   to: string
 }
 
+/**
+ * Operation that adds a table-level foreign key.
+ */
 export type AddForeignKeyOperation = {
   kind: 'addForeignKey'
   table: TableRef
   constraint: ForeignKeyConstraint
 }
 
+/**
+ * Operation that drops a table-level foreign key.
+ */
 export type DropForeignKeyOperation = {
   kind: 'dropForeignKey'
   table: TableRef
   name: string
 }
 
+/**
+ * Operation that adds a table-level check constraint.
+ */
 export type AddCheckOperation = {
   kind: 'addCheck'
   table: TableRef
   constraint: CheckConstraint
 }
 
+/**
+ * Operation that drops a table-level check constraint.
+ */
 export type DropCheckOperation = {
   kind: 'dropCheck'
   table: TableRef
   name: string
 }
 
+/**
+ * Union of schema and migration operations understood by adapters.
+ */
 export type DataMigrationOperation =
   | CreateTableOperation
   | AlterTableOperation

--- a/packages/data-table/src/lib/database.ts
+++ b/packages/data-table/src/lib/database.ts
@@ -169,6 +169,9 @@ type PrimaryKeyInputForRow<
 
 type ReturningInput<row extends Record<string, unknown>> = '*' | (keyof row & string)[]
 
+/**
+ * Table-like metadata accepted by `database.query()`.
+ */
 export type QueryTableInput<
   tableName extends string,
   row extends Record<string, unknown>,
@@ -193,6 +196,9 @@ export type QueryTableInput<
   }
 } & Record<string, unknown>
 
+/**
+ * Query builder type produced for a table-like input.
+ */
 export type QueryBuilderFor<
   tableName extends string,
   row extends Record<string, unknown>,
@@ -206,6 +212,9 @@ export type QueryBuilderFor<
   primaryKey
 >
 
+/**
+ * Signature of the database `query` helper.
+ */
 export type QueryMethod = <
   tableName extends string,
   row extends Record<string, unknown>,
@@ -214,25 +223,40 @@ export type QueryMethod = <
   table: QueryTableInput<tableName, row, primaryKey>,
 ) => QueryBuilderFor<tableName, row, primaryKey>
 
+/**
+ * Result metadata for write operations that do not return rows.
+ */
 export type WriteResult = {
   affectedRows: number
   insertId?: unknown
 }
 
+/**
+ * Result metadata for write operations that return multiple rows.
+ */
 export type WriteRowsResult<row> = {
   affectedRows: number
   insertId?: unknown
   rows: row[]
 }
 
+/**
+ * Result metadata for write operations that return a single row.
+ */
 export type WriteRowResult<row> = {
   affectedRows: number
   insertId?: unknown
   row: row | null
 }
 
+/**
+ * Queryable column type map for a concrete table.
+ */
 export type QueryColumnTypesForTable<table extends AnyTable> = QueryColumnTypeMap<table>
 
+/**
+ * Query builder type produced for a concrete table.
+ */
 export type QueryForTable<
   table extends AnyTable,
   loaded extends Record<string, unknown> = {},
@@ -244,17 +268,32 @@ export type QueryForTable<
   TablePrimaryKey<table>
 >
 
+/**
+ * Column names accepted in single-table queries.
+ */
 export type SingleTableColumn<table extends AnyTable> = QueryColumns<QueryColumnTypeMap<table>>
 
+/**
+ * `where` input accepted in single-table queries.
+ */
 export type SingleTableWhere<table extends AnyTable> = WhereInput<SingleTableColumn<table>>
 
+/**
+ * Tuple form accepted by `orderBy` for a single table.
+ */
 export type OrderByTuple<table extends AnyTable> = [
   column: SingleTableColumn<table>,
   direction?: OrderDirection,
 ]
 
+/**
+ * `orderBy` input accepted in single-table queries.
+ */
 export type OrderByInput<table extends AnyTable> = OrderByTuple<table> | OrderByTuple<table>[]
 
+/**
+ * Options for loading many rows from a table.
+ */
 export type FindManyOptions<
   table extends AnyTable,
   relations extends RelationMapForSourceName<TableName<table>> = {},
@@ -266,6 +305,9 @@ export type FindManyOptions<
   with?: relations
 }
 
+/**
+ * Options for loading a single row from a table.
+ */
 export type FindOneOptions<
   table extends AnyTable,
   relations extends RelationMapForSourceName<TableName<table>> = {},
@@ -273,6 +315,9 @@ export type FindOneOptions<
   where: SingleTableWhere<table>
 }
 
+/**
+ * Options for updating a single row.
+ */
 export type UpdateOptions<
   table extends AnyTable,
   relations extends RelationMapForSourceName<TableName<table>> = {},
@@ -281,6 +326,9 @@ export type UpdateOptions<
   with?: relations
 }
 
+/**
+ * Options for updating many rows.
+ */
 export type UpdateManyOptions<table extends AnyTable> = {
   where: SingleTableWhere<table>
   orderBy?: OrderByInput<table>
@@ -289,6 +337,9 @@ export type UpdateManyOptions<table extends AnyTable> = {
   touch?: boolean
 }
 
+/**
+ * Options for deleting many rows.
+ */
 export type DeleteManyOptions<table extends AnyTable> = {
   where: SingleTableWhere<table>
   orderBy?: OrderByInput<table>
@@ -296,15 +347,24 @@ export type DeleteManyOptions<table extends AnyTable> = {
   offset?: number
 }
 
+/**
+ * Options for counting rows.
+ */
 export type CountOptions<table extends AnyTable> = {
   where?: SingleTableWhere<table>
 }
 
+/**
+ * Options for create operations that return only write metadata.
+ */
 export type CreateResultOptions = {
   touch?: boolean
   returnRow?: false
 }
 
+/**
+ * Options for create operations that return the inserted row.
+ */
 export type CreateRowOptions<
   table extends AnyTable,
   relations extends RelationMapForSourceName<TableName<table>> = {},
@@ -314,11 +374,17 @@ export type CreateRowOptions<
   returnRow: true
 }
 
+/**
+ * Options for bulk-create operations that return only write metadata.
+ */
 export type CreateManyResultOptions = {
   touch?: boolean
   returnRows?: false
 }
 
+/**
+ * Options for bulk-create operations that return inserted rows.
+ */
 export type CreateManyRowsOptions = {
   touch?: boolean
   returnRows: true

--- a/packages/data-table/src/lib/operators.ts
+++ b/packages/data-table/src/lib/operators.ts
@@ -56,6 +56,9 @@ export type Predicate<column extends string = string> =
       predicates: Predicate<column>[]
     }
 
+/**
+ * Object shorthand accepted in `where` clauses.
+ */
 export type WhereObject<column extends string = string> = Partial<Record<column, unknown>>
 
 /**

--- a/packages/data-table/src/lib/table.ts
+++ b/packages/data-table/src/lib/table.ts
@@ -13,49 +13,88 @@ import type { Pretty } from './types.ts'
  */
 export { columnMetadataKey, tableMetadataKey } from './references.ts'
 
+/**
+ * Column builder map used when declaring a table.
+ */
 export type TableColumnsDefinition = Record<string, ColumnBuilder<any>>
 
+/**
+ * Validation lifecycle operations.
+ */
 export type TableValidationOperation = 'create' | 'update'
+/**
+ * Write lifecycle operations.
+ */
 export type TableWriteOperation = TableValidationOperation
+/**
+ * All lifecycle operations exposed by table hooks.
+ */
 export type TableLifecycleOperation = TableWriteOperation | 'delete' | 'read'
 
+/**
+ * Single validation issue reported by table hooks.
+ */
 export type ValidationIssue = {
   message: string
   path?: Array<string | number>
 }
 
+/**
+ * Validation failure returned from table hooks.
+ */
 export type ValidationFailure = {
   issues: ReadonlyArray<ValidationIssue>
 }
 
+/**
+ * Context passed to the `validate` hook.
+ */
 export type TableValidationContext<row extends Record<string, unknown>> = {
   operation: TableValidationOperation
   tableName: string
   value: Partial<row>
 }
 
+/**
+ * Result returned from the `validate` hook.
+ */
 export type TableValidationResult<row extends Record<string, unknown>> =
   | { value: Partial<row> }
   | ValidationFailure
 
+/**
+ * Validation hook that runs before writes.
+ */
 export type TableValidate<row extends Record<string, unknown>> = (
   context: TableValidationContext<row>,
 ) => TableValidationResult<row>
 
+/**
+ * Context passed to the `beforeWrite` hook.
+ */
 export type TableBeforeWriteContext<row extends Record<string, unknown>> = {
   operation: TableWriteOperation
   tableName: string
   value: Partial<row>
 }
 
+/**
+ * Result returned from the `beforeWrite` hook.
+ */
 export type TableBeforeWriteResult<row extends Record<string, unknown>> =
   | { value: Partial<row> }
   | ValidationFailure
 
+/**
+ * Hook invoked before a row write executes.
+ */
 export type TableBeforeWrite<row extends Record<string, unknown>> = (
   context: TableBeforeWriteContext<row>,
 ) => TableBeforeWriteResult<row>
 
+/**
+ * Context passed to the `afterWrite` hook.
+ */
 export type TableAfterWriteContext<row extends Record<string, unknown>> = {
   operation: TableWriteOperation
   tableName: string
@@ -64,10 +103,16 @@ export type TableAfterWriteContext<row extends Record<string, unknown>> = {
   insertId?: unknown
 }
 
+/**
+ * Hook invoked after a row write completes.
+ */
 export type TableAfterWrite<row extends Record<string, unknown>> = (
   context: TableAfterWriteContext<row>,
 ) => void
 
+/**
+ * Context passed to the `beforeDelete` hook.
+ */
 export type TableBeforeDeleteContext = {
   tableName: string
   where: ReadonlyArray<Predicate<string>>
@@ -76,10 +121,19 @@ export type TableBeforeDeleteContext = {
   offset?: number
 }
 
+/**
+ * Result returned from the `beforeDelete` hook.
+ */
 export type TableBeforeDeleteResult = void | ValidationFailure
 
+/**
+ * Hook invoked before a delete operation executes.
+ */
 export type TableBeforeDelete = (context: TableBeforeDeleteContext) => TableBeforeDeleteResult
 
+/**
+ * Context passed to the `afterDelete` hook.
+ */
 export type TableAfterDeleteContext = {
   tableName: string
   where: ReadonlyArray<Predicate<string>>
@@ -89,8 +143,14 @@ export type TableAfterDeleteContext = {
   affectedRows: number
 }
 
+/**
+ * Hook invoked after a delete operation completes.
+ */
 export type TableAfterDelete = (context: TableAfterDeleteContext) => void
 
+/**
+ * Context passed to the `afterRead` hook.
+ */
 export type TableAfterReadContext<row extends Record<string, unknown>> = {
   tableName: string
   /**
@@ -99,10 +159,16 @@ export type TableAfterReadContext<row extends Record<string, unknown>> = {
   value: Partial<row>
 }
 
+/**
+ * Result returned from the `afterRead` hook.
+ */
 export type TableAfterReadResult<row extends Record<string, unknown>> =
   | { value: Partial<row> }
   | ValidationFailure
 
+/**
+ * Hook invoked after a row is read.
+ */
 export type TableAfterRead<row extends Record<string, unknown>> = (
   context: TableAfterReadContext<row>,
 ) => TableAfterReadResult<row>
@@ -126,8 +192,14 @@ type NormalizePrimaryKey<
     ? readonly [primaryKey]
     : DefaultPrimaryKey<columns>
 
+/**
+ * Timestamp configuration accepted by `table()`.
+ */
 export type TimestampOptions = boolean | { createdAt?: string; updatedAt?: string }
 
+/**
+ * Resolved timestamp column names for a table.
+ */
 export type TimestampConfig = {
   createdAt: string
   updatedAt: string
@@ -153,6 +225,9 @@ type TableMetadata<
   validate?: TableValidate<TableRowFromColumns<columns>>
 }
 
+/**
+ * Typed reference to a table column.
+ */
 export type ColumnReference<
   tableName extends string,
   columnName extends string,
@@ -164,8 +239,14 @@ export type ColumnReference<
   }
 }
 
+/**
+ * Any column reference.
+ */
 export type AnyColumn = ColumnReference<string, string>
 
+/**
+ * Column reference narrowed by a qualified column name string.
+ */
 export type ColumnReferenceForQualifiedName<qualifiedName extends string> = AnyColumn & {
   [columnMetadataKey]: {
     qualifiedName: qualifiedName
@@ -180,6 +261,9 @@ type TableRowFromColumns<columns extends TableColumnsDefinition> = Pretty<{
   [column in keyof columns & string]: ColumnOutput<columns[column]>
 }>
 
+/**
+ * Fully-typed table object returned by `table()`.
+ */
 export type Table<
   name extends string,
   columns extends TableColumnsDefinition,
@@ -188,6 +272,9 @@ export type Table<
   [tableMetadataKey]: TableMetadata<name, columns, primaryKey>
 } & TableColumnReferences<name, columns>
 
+/**
+ * Table-like object with erased concrete column types.
+ */
 export type AnyTable = TableMetadataLike<
   string,
   TableColumnsDefinition,
@@ -209,30 +296,54 @@ export type AnyTable = TableMetadataLike<
   }
 } & Record<string, unknown>
 
+/**
+ * Name of a concrete table.
+ */
 export type TableName<table extends AnyTable> = table[typeof tableMetadataKey]['name']
 
+/**
+ * Column builder map for a concrete table.
+ */
 export type TableColumns<table extends AnyTable> = table[typeof tableMetadataKey]['columns']
 
+/**
+ * Primary-key column list for a concrete table.
+ */
 export type TablePrimaryKey<table extends AnyTable> = table[typeof tableMetadataKey]['primaryKey']
 
 export type TableTimestamps<table extends AnyTable> = table[typeof tableMetadataKey]['timestamps']
 
+/**
+ * Row shape produced by a concrete table.
+ */
 export type TableRow<table extends AnyTable> = TableRowFromColumns<TableColumns<table>>
 
+/**
+ * Row shape with loaded relations merged in.
+ */
 export type TableRowWith<
   table extends AnyTable,
   loaded extends Record<string, unknown> = {},
 > = Pretty<TableRow<table> & loaded>
 
+/**
+ * Unqualified column names for a concrete table.
+ */
 export type TableColumnName<table extends AnyTable> = keyof TableColumns<table> & string
 
 export type QualifiedTableColumnName<table extends AnyTable> =
   `${TableName<table>}.${TableColumnName<table>}`
 
+/**
+ * Column input accepted for a concrete table.
+ */
 export type TableColumnInput<table extends AnyTable> = ColumnInput<
   TableColumnName<table> | QualifiedTableColumnName<table>
 >
 
+/**
+ * Plain metadata snapshot of a table.
+ */
 export type TableReference<table extends AnyTable = AnyTable> = {
   kind: 'table'
   name: TableName<table>
@@ -376,15 +487,27 @@ export function getTableTimestamps<table extends AnyTable>(table: table): TableT
   return table[tableMetadataKey].timestamps as TableTimestamps<table>
 }
 
+/**
+ * Sort direction accepted by `orderBy`.
+ */
 export type OrderDirection = 'asc' | 'desc'
 
+/**
+ * Normalized `orderBy` clause.
+ */
 export type OrderByClause = {
   column: string
   direction: OrderDirection
 }
 
+/**
+ * Cardinality of a relation.
+ */
 export type RelationCardinality = 'one' | 'many'
 
+/**
+ * Supported relation kinds.
+ */
 export type RelationKind = 'hasMany' | 'hasOne' | 'belongsTo' | 'hasManyThrough'
 
 export type RelationResult<relation extends AnyRelation> =
@@ -394,6 +517,9 @@ export type RelationResult<relation extends AnyRelation> =
       : TableRowWith<target, loaded> | null
     : never
 
+/**
+ * Named relation map for a source table.
+ */
 export type RelationMapForTable<table extends AnyTable> = Record<
   string,
   Relation<table, AnyTable, RelationCardinality, any>
@@ -403,25 +529,40 @@ export type LoadedRelationMap<relations extends RelationMapForTable<any>> = Pret
   [name in keyof relations]: RelationResult<relations[name]>
 }>
 
+/**
+ * Column or column list used to join relations.
+ */
 export type KeySelector<table extends AnyTable> =
   | (keyof TableRow<table> & string)
   | readonly (keyof TableRow<table> & string)[]
 
+/**
+ * Options for defining a `hasMany` relation.
+ */
 export type HasManyOptions<source extends AnyTable, target extends AnyTable> = {
   foreignKey?: KeySelector<target>
   targetKey?: KeySelector<source>
 }
 
+/**
+ * Options for defining a `hasOne` relation.
+ */
 export type HasOneOptions<source extends AnyTable, target extends AnyTable> = {
   foreignKey?: KeySelector<target>
   targetKey?: KeySelector<source>
 }
 
+/**
+ * Options for defining a `belongsTo` relation.
+ */
 export type BelongsToOptions<source extends AnyTable, target extends AnyTable> = {
   foreignKey?: KeySelector<source>
   targetKey?: KeySelector<target>
 }
 
+/**
+ * Options for defining a `hasManyThrough` relation.
+ */
 export type HasManyThroughOptions<source extends AnyTable, target extends AnyTable> = {
   through: Relation<source, AnyTable, RelationCardinality, any>
   throughForeignKey?: KeySelector<target>
@@ -442,6 +583,9 @@ export type ThroughRelationMetadata = {
   throughTargetKey: string[]
 }
 
+/**
+ * Relation descriptor used by query loading.
+ */
 export type Relation<
   source extends AnyTable,
   target extends AnyTable,
@@ -471,6 +615,9 @@ export type Relation<
   ): Relation<source, target, cardinality, loaded & LoadedRelationMap<relations>>
 }
 
+/**
+ * Relation descriptor with erased table types.
+ */
 export type AnyRelation = Relation<AnyTable, AnyTable, RelationCardinality, any>
 
 export type CreateTableOptions<
@@ -834,6 +981,9 @@ export function timestamps(): Record<
   }
 }
 
+/**
+ * Primary-key input accepted by `find()`, `update()`, and similar helpers.
+ */
 export type PrimaryKeyInput<table extends AnyTable> =
   TablePrimaryKey<table> extends readonly [infer column extends string]
     ? column extends keyof TableColumns<table> & string

--- a/packages/fetch-router/src/lib/controller.ts
+++ b/packages/fetch-router/src/lib/controller.ts
@@ -5,6 +5,9 @@ import type { RequestContext } from './request-context.ts'
 import type { RequestMethod } from './request-methods.ts'
 import type { Route, RouteMap } from './route-map.ts'
 
+/**
+ * Controller object that mirrors a route map with matching action handlers.
+ */
 export type Controller<routes extends RouteMap> = {
   actions: ControllerActions<routes>
   middleware?: Middleware[]

--- a/packages/fetch-router/src/lib/request-methods.ts
+++ b/packages/fetch-router/src/lib/request-methods.ts
@@ -5,6 +5,9 @@ export type RequestBodyMethod = 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
  */
 export const RequestBodyMethods = ['POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'] as const
 
+/**
+ * All HTTP request methods supported by the router.
+ */
 export type RequestMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 
 /**

--- a/packages/fetch-router/src/lib/route-helpers/form.ts
+++ b/packages/fetch-router/src/lib/route-helpers/form.ts
@@ -4,6 +4,9 @@ import type { RequestMethod } from '../request-methods.ts'
 import { createRoutes } from '../route-map.ts'
 import type { BuildRouteMap } from '../route-map.ts'
 
+/**
+ * Options for generating a paired `index`/`action` form route map.
+ */
 export interface FormOptions {
   /**
    * The method the `<form>` uses to submit the action.

--- a/packages/fetch-router/src/lib/route-helpers/resource.ts
+++ b/packages/fetch-router/src/lib/route-helpers/resource.ts
@@ -2,11 +2,17 @@ import type { RoutePattern } from '@remix-run/route-pattern'
 
 import { type BuildRouteMap, createRoutes } from '../route-map.ts'
 
+/**
+ * Named CRUD routes available for singleton resources.
+ */
 export type ResourceMethod = 'new' | 'show' | 'create' | 'edit' | 'update' | 'destroy'
 
 // prettier-ignore
 export const ResourceMethods = ['new', 'show', 'create', 'edit', 'update', 'destroy'] as const
 
+/**
+ * Options for generating singleton resource routes.
+ */
 export type ResourceOptions = {
   /**
    * Custom names to use for the resource routes.

--- a/packages/fetch-router/src/lib/route-helpers/resources.ts
+++ b/packages/fetch-router/src/lib/route-helpers/resources.ts
@@ -2,11 +2,17 @@ import type { RoutePattern } from '@remix-run/route-pattern'
 
 import { type BuildRouteMap, createRoutes } from '../route-map.ts'
 
+/**
+ * Named CRUD routes available for resource collections.
+ */
 export type ResourcesMethod = 'index' | 'new' | 'show' | 'create' | 'edit' | 'update' | 'destroy'
 
 // prettier-ignore
 export const ResourcesMethods = ['index', 'new', 'show', 'create', 'edit', 'update', 'destroy'] as const
 
+/**
+ * Options for generating collection resource routes.
+ */
 export type ResourcesOptions = {
   /**
    * The parameter name to use for the resource.

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -14,6 +14,9 @@ import {
 } from './controller.ts'
 import { type RouteMap, Route } from './route-map.ts'
 
+/**
+ * Normalized route match payload stored in the router matcher.
+ */
 export type MatchData = {
   handler: RequestHandler<any>
   method: RequestMethod | 'ANY'

--- a/packages/file-storage-s3/src/lib/s3.ts
+++ b/packages/file-storage-s3/src/lib/s3.ts
@@ -10,6 +10,9 @@ type ListedObject = {
   size: number
 }
 
+/**
+ * Configuration for an S3-backed `FileStorage` implementation.
+ */
 export interface S3FileStorageOptions {
   /**
    * AWS access key ID used to sign S3 requests.

--- a/packages/headers/src/lib/vary.ts
+++ b/packages/headers/src/lib/vary.ts
@@ -1,5 +1,8 @@
 import { type HeaderValue } from './header-value.ts'
 
+/**
+ * Object form for constructing a `Vary` header value.
+ */
 export interface VaryInit {
   /**
    * The request header names that determine cache eligibility.

--- a/packages/html-template/src/lib/safe-html.ts
+++ b/packages/html-template/src/lib/safe-html.ts
@@ -115,6 +115,9 @@ function htmlHelper(strings: TemplateStringsArray, ...values: Interpolation[]): 
   return createSafeHtml(out)
 }
 
+/**
+ * Tagged template helper for creating `SafeHtml` values.
+ */
 export const html = htmlHelper as SafeHtmlHelper
 
 html.raw = (strings, ...values) => {

--- a/packages/mime/src/lib/define-mime-type.ts
+++ b/packages/mime/src/lib/define-mime-type.ts
@@ -1,3 +1,6 @@
+/**
+ * Definition used to register a custom MIME type.
+ */
 export interface MimeTypeDefinition {
   /** The file extension(s) to register (e.g., ['x-myformat']) */
   extensions: string | string[]

--- a/packages/response/src/lib/compress.ts
+++ b/packages/response/src/lib/compress.ts
@@ -11,9 +11,15 @@ import type { BrotliOptions, ZlibOptions } from 'node:zlib'
 
 import { AcceptEncoding, CacheControl, Vary } from '@remix-run/headers'
 
+/**
+ * Encodings supported by `compressResponse`.
+ */
 export type Encoding = 'br' | 'gzip' | 'deflate'
 const defaultEncodings: Encoding[] = ['br', 'gzip', 'deflate']
 
+/**
+ * Configuration for negotiated response compression.
+ */
 export interface CompressResponseOptions {
   /**
    * Minimum size in bytes to compress (only enforced if Content-Length is present).

--- a/packages/route-pattern/src/lib/array-matcher.ts
+++ b/packages/route-pattern/src/lib/array-matcher.ts
@@ -2,6 +2,9 @@ import { RoutePattern } from './route-pattern.ts'
 import type { Match, Matcher } from './matcher.ts'
 import * as Specificity from './specificity.ts'
 
+/**
+ * Matcher implementation that checks patterns in insertion order and sorts matches by specificity.
+ */
 export class ArrayMatcher<data> implements Matcher<data> {
   readonly ignoreCase: boolean
   #patterns: Array<{ pattern: RoutePattern; data: data }> = []

--- a/packages/route-pattern/src/lib/matcher.ts
+++ b/packages/route-pattern/src/lib/matcher.ts
@@ -1,5 +1,8 @@
 import type { RoutePattern, RoutePatternMatch } from './route-pattern.ts'
 
+/**
+ * Successful pattern match paired with matcher-specific data.
+ */
 export type Match<source extends string = string, data = unknown> = RoutePatternMatch<source> & {
   data: data
 }

--- a/packages/route-pattern/src/lib/route-pattern.ts
+++ b/packages/route-pattern/src/lib/route-pattern.ts
@@ -27,6 +27,9 @@ type AST = {
   search: Map<string, Set<string> | null>
 }
 
+/**
+ * Result returned when a URL matches a route pattern.
+ */
 export type RoutePatternMatch<source extends string = string> = {
   pattern: RoutePattern
   url: URL

--- a/packages/route-pattern/src/lib/route-pattern/href.ts
+++ b/packages/route-pattern/src/lib/route-pattern/href.ts
@@ -6,6 +6,9 @@ import type { Split, SplitPattern } from '../types/split.ts'
 import type { Simplify } from '../types/utils.ts'
 
 // todo: `Split<source>` return { hostname: "" } instead of { hostname: undefined } which causes issues
+/**
+ * Tuple of arguments accepted by `RoutePattern.href()` for a given pattern.
+ */
 export type HrefArgs<source extends string> = _HrefArgs<ParseHrefParams<source>>
 // prettier-ignore
 type _HrefArgs<params> =
@@ -117,6 +120,9 @@ type HrefErrorDetails =
       pattern: RoutePattern
     }
 
+/**
+ * Error thrown when a route pattern cannot generate an href from the supplied args.
+ */
 export class HrefError extends Error {
   details: HrefErrorDetails
 

--- a/packages/route-pattern/src/lib/route-pattern/params.ts
+++ b/packages/route-pattern/src/lib/route-pattern/params.ts
@@ -1,6 +1,9 @@
 import type { Split, SplitPattern } from '../types/split'
 import type { Simplify } from '../types/utils'
 
+/**
+ * Extracted route params for a route-pattern source string.
+ */
 export type Params<source extends string> = Simplify<Omit<ParseParams<Split<source>>, '*'>>
 
 // prettier-ignore

--- a/packages/route-pattern/src/lib/route-pattern/parse.ts
+++ b/packages/route-pattern/src/lib/route-pattern/parse.ts
@@ -88,6 +88,9 @@ type ParseErrorType =
   | 'dangling escape'
   | 'invalid protocol'
 
+/**
+ * Error thrown when a route pattern cannot be parsed.
+ */
 export class ParseError extends Error {
   type: ParseErrorType
   source: string

--- a/packages/route-pattern/src/lib/trie-matcher.ts
+++ b/packages/route-pattern/src/lib/trie-matcher.ts
@@ -12,6 +12,9 @@ import { matchSearch } from './route-pattern/match.ts'
 
 type Param = Extract<PartPatternToken, { type: ':' | '*' }>
 
+/**
+ * Trie-based matcher optimized for repeated route lookups.
+ */
 export class TrieMatcher<data = unknown> implements Matcher<data> {
   readonly ignoreCase: boolean
   trie: Trie<data>

--- a/packages/session-storage-memcache/src/lib/memcache-storage.ts
+++ b/packages/session-storage-memcache/src/lib/memcache-storage.ts
@@ -7,6 +7,9 @@ const MAX_MEMCACHE_KEY_LENGTH = 250
 const HASH_LENGTH = 64
 type SessionData = ReturnType<typeof createSession>['data']
 
+/**
+ * Options for Memcache-backed session storage.
+ */
 export interface MemcacheSessionStorageOptions {
   /**
    * Whether to reuse session IDs sent from the client that are not found in storage.

--- a/packages/session-storage-redis/src/lib/redis-storage.ts
+++ b/packages/session-storage-redis/src/lib/redis-storage.ts
@@ -3,6 +3,9 @@ import type { SessionStorage } from '@remix-run/session'
 
 type SessionData = ReturnType<typeof createSession>['data']
 
+/**
+ * Minimal Redis client contract required by `createRedisSessionStorage`.
+ */
 export interface RedisSessionStorageClient {
   get(key: string): Promise<string | null> | string | null
   set(key: string, value: string): Promise<unknown> | unknown
@@ -11,6 +14,9 @@ export interface RedisSessionStorageClient {
   expire?(key: string, ttlSeconds: number): Promise<unknown> | unknown
 }
 
+/**
+ * Options for Redis-backed session storage.
+ */
 export interface RedisSessionStorageOptions {
   /**
    * Prefix for session keys in Redis.

--- a/packages/session/src/lib/session-storage/fs.ts
+++ b/packages/session/src/lib/session-storage/fs.ts
@@ -5,6 +5,9 @@ import * as path from 'node:path'
 import { createSession, type SessionData } from '../session.ts'
 import type { SessionStorage } from '../session-storage.ts'
 
+/**
+ * Options for filesystem-backed session storage.
+ */
 export interface FsSessionStorageOptions {
   /**
    * Whether to reuse session IDs sent from the client that are not found in storage.


### PR DESCRIPTION
This adds missing JSDoc to public APIs across the Remix subpackages by scanning each package's `package.json` exports and documenting the declarations those exports actually expose.

- adds missing docs for exported functions, interfaces, type aliases, and public constants
- fills the biggest gaps in `component` and `data-table`, with smaller fixes in `fetch-router`, `route-pattern`, middleware packages, `response`, session storage packages, and a few other public surfaces
- does not change runtime behavior or the public API shape; this is documentation-only work to make the exported surface easier to understand in editors and generated docs

The goal here is to document the APIs users can import, not internal helpers. That keeps the comments aligned with the real public surface and avoids adding noise to implementation-only files.
