### PR TITLE
fix `pnpm install` from github repo commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,5 +172,5 @@ The `preview/main` branch build can be [installed directly](https://pnpm.io/pack
 pnpm install "remix-run/remix#preview/main&path:packages/remix"
 
 # Or, just install a single package
-pnpm install "remix-run/remix#preview/main&path:packages/@remix-run/fetch-router"
+pnpm install "remix-run/remix#preview/main&path:packages/fetch-router"
 ```

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you want to play around with the bleeding edge, we also build the latest `mai
 pnpm install "remix-run/remix#preview/main&path:packages/remix"
 
 # Or, just install a single package
-pnpm install "remix-run/remix#preview/main&path:packages/@remix-run/fetch-router"
+pnpm install "remix-run/remix#preview/main&path:packages/fetch-router"
 ```
 
 ## Contributing


### PR DESCRIPTION
should reference a file path in the repo, not the package name