### PR TITLE
docs: add JSDoc API cross-links

### DIFF
--- a/packages/component/src/lib/component.ts
+++ b/packages/component/src/lib/component.ts
@@ -145,7 +145,7 @@ export type FrameHandle = TypedEventTarget<FrameHandleEventMap> & {
 }
 
 /**
- * Props accepted by the built-in `Frame` component.
+ * Props accepted by the built-in {@link Frame} component.
  */
 export interface FrameProps {
   name?: string

--- a/packages/component/src/lib/jsx.ts
+++ b/packages/component/src/lib/jsx.ts
@@ -2,7 +2,7 @@ import type * as dom from './dom.d.ts'
 import type { Component, Handle, RenderFn } from './component.ts'
 
 /**
- * Any valid element type accepted by JSX or `createElement`.
+ * Any valid element type accepted by JSX or {@link import('./create-element.ts').createElement}.
  * - `string` for host elements (e.g., 'div')
  * - `Function` for user components
  */
@@ -16,8 +16,8 @@ export type ElementType = string | Function
 export type ElementProps = Record<string, any>
 
 /**
- * A virtual element produced by JSX/`createElement` describing UI.  Carries a
- * `$rmx` brand used to distinguish it from plain objects at runtime.
+ * A virtual element produced by JSX or {@link import('./create-element.ts').createElement}
+ * describing UI. Carries a `$rmx` brand used to distinguish it from plain objects at runtime.
  */
 export interface RemixElement {
   type: ElementType

--- a/packages/component/src/lib/mixins/press-mixin.tsx
+++ b/packages/component/src/lib/mixins/press-mixin.tsx
@@ -17,7 +17,7 @@ declare global {
 }
 
 /**
- * Event emitted by the `pressEvents` mixin for pointer and keyboard presses.
+ * Event emitted by the {@link pressEvents} mixin for pointer and keyboard presses.
  */
 export class PressEvent extends Event {
   clientX: number

--- a/packages/component/src/lib/run.ts
+++ b/packages/component/src/lib/run.ts
@@ -9,7 +9,7 @@ import { startNavigationListener } from './navigation.ts'
 import { TypedEventTarget } from './typed-event-target.ts'
 
 /**
- * Options for starting the client runtime.
+ * Options for starting the client runtime with {@link run}.
  */
 export type RunInit = {
   loadModule: LoadModule
@@ -24,7 +24,7 @@ export type AppRuntimeEventMap = {
 }
 
 /**
- * Client runtime returned by `run()`.
+ * Client runtime returned by {@link run}.
  */
 export type AppRuntime = TypedEventTarget<AppRuntimeEventMap> & {
   ready(): Promise<void>

--- a/packages/component/src/lib/spring.ts
+++ b/packages/component/src/lib/spring.ts
@@ -24,7 +24,7 @@ export interface SpringOptions {
 }
 
 /**
- * Iterator returned by `spring()`, decorated for CSS and WAAPI use.
+ * Iterator returned by {@link spring}, decorated for CSS and WAAPI use.
  */
 export interface SpringIterator extends IterableIterator<number> {
   /** Time when spring settles to rest (milliseconds) */

--- a/packages/component/src/lib/tween.ts
+++ b/packages/component/src/lib/tween.ts
@@ -55,7 +55,7 @@ function cubicBezierDerivative(t: number, p1: number, p2: number): number {
 }
 
 /**
- * Cubic-bezier control points used by `tween()`.
+ * Cubic-bezier control points used by {@link tween}.
  */
 export interface BezierCurve {
   x1: number
@@ -66,7 +66,7 @@ export interface BezierCurve {
 
 // Common easing presets
 /**
- * Common cubic-bezier presets for `tween()`.
+ * Common cubic-bezier presets for {@link tween}.
  */
 export const easings = {
   linear: { x1: 0, y1: 0, x2: 1, y2: 1 },

--- a/packages/component/src/lib/vdom.ts
+++ b/packages/component/src/lib/vdom.ts
@@ -23,7 +23,7 @@ export type VirtualRootEventMap = {
 }
 
 /**
- * Root controller returned by `createRoot()` and `createRangeRoot()`.
+ * Root controller returned by {@link createRoot} and {@link createRangeRoot}.
  */
 export type VirtualRoot = TypedEventTarget<VirtualRootEventMap> & {
   render: (element: RemixNode) => void
@@ -32,7 +32,7 @@ export type VirtualRoot = TypedEventTarget<VirtualRootEventMap> & {
 }
 
 /**
- * Options for creating a virtual DOM root.
+ * Options for creating a virtual DOM root with {@link createRoot} or {@link createRangeRoot}.
  */
 export type VirtualRootOptions = {
   frame?: FrameHandle

--- a/packages/cookie/src/lib/cookie.ts
+++ b/packages/cookie/src/lib/cookie.ts
@@ -251,7 +251,7 @@ export class Cookie implements CookieProperties {
  *
  * @param name The name of the cookie
  * @param options Options for the cookie
- * @returns A new `Cookie` object
+ * @returns A new {@link Cookie} object
  */
 export function createCookie(name: string, options?: CookieOptions): Cookie {
   return new Cookie(name, options)

--- a/packages/data-schema/src/lib/checks.ts
+++ b/packages/data-schema/src/lib/checks.ts
@@ -4,7 +4,7 @@ import type { Check } from './schema.ts'
  * Require a string to be at least `length` characters long.
  *
  * @param length The minimum number of characters
- * @returns A `Check` that enforces the minimum length
+ * @returns A {@link Check} that enforces the minimum length
  */
 export function minLength(length: number): Check<string> {
   return {
@@ -21,7 +21,7 @@ export function minLength(length: number): Check<string> {
  * Require a string to be at most `length` characters long.
  *
  * @param length The maximum number of characters
- * @returns A `Check` that enforces the maximum length
+ * @returns A {@link Check} that enforces the maximum length
  */
 export function maxLength(length: number): Check<string> {
   return {
@@ -37,7 +37,7 @@ export function maxLength(length: number): Check<string> {
 /**
  * Require a string to be a valid email address.
  *
- * @returns A `Check` that validates email-like strings
+ * @returns A {@link Check} that validates email-like strings
  */
 export function email(): Check<string> {
   return {
@@ -52,7 +52,7 @@ export function email(): Check<string> {
 /**
  * Require a string to be a valid URL.
  *
- * @returns A `Check` that validates URL-like strings
+ * @returns A {@link Check} that validates URL-like strings
  */
 export function url(): Check<string> {
   return {
@@ -73,7 +73,7 @@ export function url(): Check<string> {
  * Require a number to be greater than or equal to `limit`.
  *
  * @param limit The inclusive minimum value
- * @returns A `Check` that enforces the lower bound
+ * @returns A {@link Check} that enforces the lower bound
  */
 export function min(limit: number): Check<number> {
   return {
@@ -90,7 +90,7 @@ export function min(limit: number): Check<number> {
  * Require a number to be less than or equal to `limit`.
  *
  * @param limit The inclusive maximum value
- * @returns A `Check` that enforces the upper bound
+ * @returns A {@link Check} that enforces the upper bound
  */
 export function max(limit: number): Check<number> {
   return {

--- a/packages/data-schema/src/lib/schema.ts
+++ b/packages/data-schema/src/lib/schema.ts
@@ -40,9 +40,10 @@ export type ErrorMapContext = {
 export type ErrorMap = (context: ErrorMapContext) => string | undefined
 
 /**
- * Options passed to `parse` and `parseSafe`.
+ * Options passed to {@link parse} and {@link parseSafe}.
  *
- * This mirrors `ValidationOptions`, but also supports a convenience `abortEarly` option at the top level.
+ * This mirrors {@link ValidationOptions}, but also supports a convenience `abortEarly`
+ * option at the top level.
  */
 export type ParseOptions = StandardSchemaV1.Options & {
   abortEarly?: boolean
@@ -1092,7 +1093,7 @@ export function union<schemas extends Schema<any, any>[]>(
 }
 
 /**
- * Error thrown by `parse()` when validation fails.
+ * Error thrown by {@link parse} when validation fails.
  */
 export class ValidationError extends Error {
   /**
@@ -1112,7 +1113,7 @@ export class ValidationError extends Error {
 }
 
 /**
- * Validate a value and return the typed output or throw a `ValidationError`.
+ * Validate a value and return the typed output or throw a {@link ValidationError}.
  *
  * @param schema The schema to validate against
  * @param value The value to validate

--- a/packages/data-table/src/lib/database.ts
+++ b/packages/data-table/src/lib/database.ts
@@ -896,7 +896,7 @@ class DatabaseRuntime implements Database {
  * @param adapter Adapter implementation responsible for SQL execution.
  * @param options Optional runtime options.
  * @param options.now Clock function used for auto-managed timestamps.
- * @returns A `Database` API instance.
+ * @returns A {@link Database} API instance.
  * @example
  * ```ts
  * import { column as c, createDatabase, table } from 'remix/data-table'
@@ -934,7 +934,7 @@ export function createDatabase(
  * @param token Active adapter transaction token.
  * @param options Optional runtime options.
  * @param options.now Clock function used for auto-managed timestamps.
- * @returns A `Database` API instance bound to the provided transaction.
+ * @returns A {@link Database} API instance bound to the provided transaction.
  */
 export function createDatabaseWithTransaction(
   adapter: DatabaseAdapter,

--- a/packages/data-table/src/lib/sql.ts
+++ b/packages/data-table/src/lib/sql.ts
@@ -12,8 +12,8 @@ export type SqlStatement = {
 /**
  * Tagged-template helper for building parameterized SQL statements.
  * @param strings Template string parts.
- * @param values Interpolated values or nested `SqlStatement` values.
- * @returns A normalized SQL statement.
+ * @param values Interpolated values or nested {@link SqlStatement} values.
+ * @returns A normalized {@link SqlStatement}.
  * @example
  * ```ts
  * import { sql } from 'remix/data-table'
@@ -53,9 +53,9 @@ export function sql(strings: TemplateStringsArray, ...values: unknown[]): SqlSta
 }
 
 /**
- * Returns `true` when a value matches the `SqlStatement` shape.
+ * Returns `true` when a value matches the {@link SqlStatement} shape.
  * @param value Value to inspect.
- * @returns Whether the value is a SQL statement object.
+ * @returns Whether the value is a {@link SqlStatement} object.
  */
 export function isSqlStatement(value: unknown): value is SqlStatement {
   if (typeof value !== 'object' || value === null) {

--- a/packages/data-table/src/lib/table.ts
+++ b/packages/data-table/src/lib/table.ts
@@ -193,7 +193,7 @@ type NormalizePrimaryKey<
     : DefaultPrimaryKey<columns>
 
 /**
- * Timestamp configuration accepted by `table()`.
+ * Timestamp configuration accepted by {@link table}.
  */
 export type TimestampOptions = boolean | { createdAt?: string; updatedAt?: string }
 
@@ -262,7 +262,7 @@ type TableRowFromColumns<columns extends TableColumnsDefinition> = Pretty<{
 }>
 
 /**
- * Fully-typed table object returned by `table()`.
+ * Fully-typed table object returned by {@link table}.
  */
 export type Table<
   name extends string,
@@ -537,7 +537,7 @@ export type KeySelector<table extends AnyTable> =
   | readonly (keyof TableRow<table> & string)[]
 
 /**
- * Options for defining a `hasMany` relation.
+ * Options for defining a {@link hasMany} relation.
  */
 export type HasManyOptions<source extends AnyTable, target extends AnyTable> = {
   foreignKey?: KeySelector<target>
@@ -545,7 +545,7 @@ export type HasManyOptions<source extends AnyTable, target extends AnyTable> = {
 }
 
 /**
- * Options for defining a `hasOne` relation.
+ * Options for defining a {@link hasOne} relation.
  */
 export type HasOneOptions<source extends AnyTable, target extends AnyTable> = {
   foreignKey?: KeySelector<target>
@@ -553,7 +553,7 @@ export type HasOneOptions<source extends AnyTable, target extends AnyTable> = {
 }
 
 /**
- * Options for defining a `belongsTo` relation.
+ * Options for defining a {@link belongsTo} relation.
  */
 export type BelongsToOptions<source extends AnyTable, target extends AnyTable> = {
   foreignKey?: KeySelector<source>
@@ -561,7 +561,7 @@ export type BelongsToOptions<source extends AnyTable, target extends AnyTable> =
 }
 
 /**
- * Options for defining a `hasManyThrough` relation.
+ * Options for defining a {@link hasManyThrough} relation.
  */
 export type HasManyThroughOptions<source extends AnyTable, target extends AnyTable> = {
   through: Relation<source, AnyTable, RelationCardinality, any>

--- a/packages/fetch-proxy/src/lib/fetch-proxy.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.ts
@@ -1,7 +1,7 @@
 import { SetCookie } from '@remix-run/headers'
 
 /**
- * Options for `createFetchProxy`.
+ * Options for {@link createFetchProxy}.
  */
 export interface FetchProxyOptions {
   /**
@@ -34,7 +34,7 @@ export interface FetchProxyOptions {
 
 /**
  * A [`fetch` function](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch)
- * that forwards requests to another server.
+ * created by {@link createFetchProxy} that forwards requests to another server.
  *
  * @param input The URL or request to forward
  * @param init Optional request init options

--- a/packages/fetch-router/src/lib/controller.ts
+++ b/packages/fetch-router/src/lib/controller.ts
@@ -40,7 +40,7 @@ type RequestHandlerWithMiddleware<
 }
 
 /**
- * Build an `Action` type from a string, `RoutePattern`, or `Route`.
+ * Build an {@link Action} type from a string, {@link RoutePattern}, or {@link Route}.
  */
 // prettier-ignore
 export type BuildAction<method extends RequestMethod | 'ANY', route extends string | RoutePattern | Route> =

--- a/packages/fetch-router/src/lib/request-context.ts
+++ b/packages/fetch-router/src/lib/request-context.ts
@@ -13,7 +13,7 @@ export function createContextKey<value>(defaultValue?: value): ContextKey<value>
 }
 
 /**
- * A type-safe key for storing and retrieving values from `RequestContext`.
+ * A type-safe key for storing and retrieving values from {@link RequestContext}.
  */
 export interface ContextKey<value> {
   /**

--- a/packages/fetch-router/src/lib/route-map.ts
+++ b/packages/fetch-router/src/lib/route-map.ts
@@ -5,7 +5,7 @@ import type { RequestMethod } from './request-methods.ts'
 import type { Simplify } from './type-utils.ts'
 
 /**
- * A map of route names to `Route` objects or nested `RouteMap` objects.
+ * A map of route names to {@link Route} objects or nested route maps.
  */
 export interface RouteMap<pattern extends string = string> {
   [name: string]: Route<RequestMethod | 'ANY', pattern> | RouteMap<pattern>
@@ -59,7 +59,7 @@ export class Route<
 }
 
 /**
- * Build a `Route` type from a request method and pattern.
+ * Build a {@link Route} type from a request method and pattern.
  */
 // prettier-ignore
 export type BuildRoute<method extends RequestMethod | 'ANY', pattern extends string | RoutePattern> =

--- a/packages/file-storage/src/lib/backends/fs.ts
+++ b/packages/file-storage/src/lib/backends/fs.ts
@@ -8,7 +8,7 @@ import type { FileStorage, FileMetadata, ListOptions, ListResult } from '../file
 type MetadataJson = Omit<FileMetadata, 'size'>
 
 /**
- * Creates a `FileStorage` that is backed by a filesystem directory using node:fs.
+ * Creates a {@link FileStorage} that is backed by a filesystem directory using `node:fs`.
  *
  * Important: No attempt is made to avoid overwriting existing files, so the directory used should
  * be a new directory solely dedicated to this storage object.
@@ -19,7 +19,7 @@ type MetadataJson = Omit<FileMetadata, 'size'>
  * same storage object.
  *
  * @param directory The directory where files are stored
- * @returns A new file storage backed by a filesystem directory
+ * @returns A new {@link FileStorage} backed by a filesystem directory
  */
 export function createFsFileStorage(directory: string): FileStorage {
   let rootDir = path.resolve(directory)

--- a/packages/file-storage/src/lib/backends/memory.ts
+++ b/packages/file-storage/src/lib/backends/memory.ts
@@ -1,8 +1,9 @@
 import type { FileStorage, ListOptions, ListResult } from '../file-storage.ts'
 
 /**
- * Creates a simple, in-memory implementation of the `FileStorage` interface.
- * @returns A new in-memory file storage instance
+ * Creates a simple, in-memory implementation of the {@link FileStorage} interface.
+ *
+ * @returns A new in-memory {@link FileStorage} instance
  */
 export function createMemoryFileStorage(): FileStorage {
   let map = new Map<string, File>()

--- a/packages/form-data-middleware/src/lib/form-data.ts
+++ b/packages/form-data-middleware/src/lib/form-data.ts
@@ -7,7 +7,7 @@ import {
 import type { Middleware } from '@remix-run/fetch-router'
 
 /**
- * Options for the `formData` middleware.
+ * Options for the {@link formData} middleware.
  */
 export interface FormDataOptions extends ParseFormDataOptions {
   /**

--- a/packages/headers/src/lib/accept.ts
+++ b/packages/headers/src/lib/accept.ts
@@ -3,7 +3,7 @@ import { parseParams } from './param-values.ts'
 import { isIterable } from './utils.ts'
 
 /**
- * Initializer for an `Accept` header value.
+ * Initializer for an {@link Accept} header value.
  */
 export type AcceptInit = Iterable<string | [string, number]> | Record<string, number>
 

--- a/packages/headers/src/lib/cookie.ts
+++ b/packages/headers/src/lib/cookie.ts
@@ -3,7 +3,7 @@ import { parseParams, quote } from './param-values.ts'
 import { isIterable } from './utils.ts'
 
 /**
- * Initializer for a `Cookie` header value.
+ * Initializer for a {@link Cookie} header value.
  */
 export type CookieInit = Iterable<[string, string]> | Record<string, string>
 

--- a/packages/headers/src/lib/range.ts
+++ b/packages/headers/src/lib/range.ts
@@ -1,7 +1,7 @@
 import { type HeaderValue } from './header-value.ts'
 
 /**
- * Initializer for a `Range` header value.
+ * Initializer for a {@link Range} header value.
  */
 export interface RangeInit {
   /**

--- a/packages/headers/src/lib/vary.ts
+++ b/packages/headers/src/lib/vary.ts
@@ -1,7 +1,7 @@
 import { type HeaderValue } from './header-value.ts'
 
 /**
- * Object form for constructing a `Vary` header value.
+ * Object form for constructing a {@link Vary} header value.
  */
 export interface VaryInit {
   /**

--- a/packages/html-template/src/lib/safe-html.ts
+++ b/packages/html-template/src/lib/safe-html.ts
@@ -13,10 +13,10 @@ function createSafeHtml(value: string): SafeHtml {
 }
 
 /**
- * Checks if a value is a `SafeHtml` string.
+ * Checks if a value is a {@link SafeHtml} string.
  *
  * @param value The value to check
- * @returns `true` if the value is a `SafeHtml` string
+ * @returns `true` if the value is a {@link SafeHtml} string
  */
 export function isSafeHtml(value: unknown): value is SafeHtml {
   return typeof value === 'object' && value != null && (value as any)[kSafeHtml] === true
@@ -116,7 +116,7 @@ function htmlHelper(strings: TemplateStringsArray, ...values: Interpolation[]): 
 }
 
 /**
- * Tagged template helper for creating `SafeHtml` values.
+ * Tagged template helper for creating {@link SafeHtml} values.
  */
 export const html = htmlHelper as SafeHtmlHelper
 

--- a/packages/lazy-file/src/lib/lazy-file.ts
+++ b/packages/lazy-file/src/lib/lazy-file.ts
@@ -21,7 +21,7 @@ export interface LazyContent {
 }
 
 /**
- * Options for creating a `LazyBlob`.
+ * Options for creating a {@link LazyBlob}.
  */
 export interface LazyBlobOptions {
   /**
@@ -166,7 +166,7 @@ export class LazyBlob {
 }
 
 /**
- * Options for creating a `LazyFile`.
+ * Options for creating a {@link LazyFile}.
  */
 export interface LazyFileOptions extends LazyBlobOptions {
   /**

--- a/packages/logger-middleware/src/lib/logger.ts
+++ b/packages/logger-middleware/src/lib/logger.ts
@@ -1,7 +1,7 @@
 import type { Middleware } from '@remix-run/fetch-router'
 
 /**
- * Options for the `logger` middleware.
+ * Options for the {@link logger} middleware.
  */
 export interface LoggerOptions {
   /**

--- a/packages/method-override-middleware/src/lib/method-override.ts
+++ b/packages/method-override-middleware/src/lib/method-override.ts
@@ -2,7 +2,7 @@ import { RequestMethods } from '@remix-run/fetch-router'
 import type { Middleware, RequestContext, RequestMethod } from '@remix-run/fetch-router'
 
 /**
- * Options for the `methodOverride` middleware.
+ * Options for the {@link methodOverride} middleware.
  */
 export interface MethodOverrideOptions {
   /**
@@ -16,8 +16,9 @@ export interface MethodOverrideOptions {
 /**
  * Middleware that overrides `context.method` with the value of the method override field.
  *
- * Note: This middleware must be placed after the `formData` middleware in the middleware chain, or
- * some other middleware that provides `context.get(FormData)`.
+ * Note: This middleware must be placed after the
+ * {@link import('@remix-run/form-data-middleware').formData} middleware in the middleware
+ * chain, or some other middleware that provides `context.get(FormData)`.
  *
  * @param options Options for the method override middleware
  * @returns A middleware that overrides `context.method` with the value of the method override field

--- a/packages/mime/src/lib/detect-mime-type.ts
+++ b/packages/mime/src/lib/detect-mime-type.ts
@@ -4,7 +4,8 @@ import { customMimeTypeByExtension } from './define-mime-type.ts'
 /**
  * Detects the MIME type for a given file extension or filename.
  *
- * Custom MIME types registered via `defineMimeType()` take precedence over built-in types.
+ * Custom MIME types registered via {@link import('./define-mime-type.ts').defineMimeType}
+ * take precedence over built-in types.
  *
  * @param extension The file extension (e.g. "txt", ".txt") or filename (e.g. "file.txt")
  * @returns The MIME type string, or undefined if not found

--- a/packages/mime/src/lib/is-compressible-mime-type.ts
+++ b/packages/mime/src/lib/is-compressible-mime-type.ts
@@ -8,7 +8,8 @@ import { customCompressibleByMimeType } from './define-mime-type.ts'
  * - Compressible MIME types from mime-db
  * - Any text/* type
  * - Types with +json, +text, or +xml suffix
- * - MIME types explicitly registered as compressible via `defineMimeType()`
+ * - MIME types explicitly registered as compressible via
+ *   {@link import('./define-mime-type.ts').defineMimeType}
  *
  * Accepts either a bare MIME type or a full Content-Type header value with parameters.
  *

--- a/packages/mime/src/lib/mime-type-to-content-type.ts
+++ b/packages/mime/src/lib/mime-type-to-content-type.ts
@@ -8,7 +8,8 @@ import { customCharsetByMimeType } from './define-mime-type.ts'
  * - All `+json` suffixed types (RFC 8259 defines JSON as UTF-8)
  * - `application/json`, `application/javascript`
  *
- * Custom charset registered via `defineMimeType()` takes precedence over built-in rules.
+ * Custom charset registered via {@link import('./define-mime-type.ts').defineMimeType}
+ * takes precedence over built-in rules.
  *
  * Note: `text/xml` is excluded because XML has built-in encoding detection.
  * Per the XML spec, documents without an encoding declaration must be UTF-8 or

--- a/packages/multipart-parser/src/lib/multipart-request.ts
+++ b/packages/multipart-parser/src/lib/multipart-request.ts
@@ -24,12 +24,13 @@ export function isMultipartRequest(request: Request): boolean {
 }
 
 /**
- * Parse a multipart [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and yield each part as
- * a `MultipartPart` object. Useful in HTTP server contexts for handling incoming `multipart/*` requests.
+ * Parse a multipart [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request)
+ * and yield each part as a {@link MultipartPart} object. Useful in HTTP server contexts
+ * for handling incoming `multipart/*` requests.
  *
  * @param request The `Request` object containing multipart data
  * @param options Optional parser options, such as `maxHeaderSize` and `maxFileSize`
- * @returns An async generator yielding `MultipartPart` objects
+ * @returns An async generator yielding {@link MultipartPart} objects
  */
 export async function* parseMultipartRequest(
   request: Request,

--- a/packages/multipart-parser/src/lib/multipart.node.ts
+++ b/packages/multipart-parser/src/lib/multipart.node.ts
@@ -10,14 +10,14 @@ import {
 import { getMultipartBoundary } from './multipart-request.ts'
 
 /**
- * Parse a `multipart/*` Node.js `Buffer` and yield each part as a `MultipartPart` object.
+ * Parse a `multipart/*` Node.js `Buffer` and yield each part as a {@link MultipartPart} object.
  *
- * Note: This is a low-level API that requires manual handling of the content and boundary. If you're
- * building a web server, consider using `parseMultipartRequest(request)` instead.
+ * Note: This is a low-level API that requires manual handling of the content and boundary.
+ * If you're building a web server, consider using {@link parseMultipartRequest} instead.
  *
  * @param message The multipart message as a `Buffer` or an iterable of `Buffer` chunks
  * @param options Options for the parser
- * @returns A generator yielding `MultipartPart` objects
+ * @returns A generator yielding {@link MultipartPart} objects
  */
 export function* parseMultipart(
   message: Buffer | Iterable<Buffer>,
@@ -27,14 +27,15 @@ export function* parseMultipart(
 }
 
 /**
- * Parse a `multipart/*` Node.js `Readable` stream and yield each part as a `MultipartPart` object.
+ * Parse a `multipart/*` Node.js `Readable` stream and yield each part as a
+ * {@link MultipartPart} object.
  *
- * Note: This is a low-level API that requires manual handling of the stream and boundary. If you're
- * building a web server, consider using `parseMultipartRequest(request)` instead.
+ * Note: This is a low-level API that requires manual handling of the stream and boundary.
+ * If you're building a web server, consider using {@link parseMultipartRequest} instead.
  *
  * @param stream A Node.js `Readable` stream containing multipart data
  * @param options Options for the parser
- * @returns An async generator yielding `MultipartPart` objects
+ * @returns An async generator yielding {@link MultipartPart} objects
  */
 export async function* parseMultipartStream(
   stream: Readable,
@@ -55,11 +56,11 @@ export function isMultipartRequest(req: http.IncomingMessage): boolean {
 }
 
 /**
- * Parse a multipart Node.js request and yield each part as a `MultipartPart` object.
+ * Parse a multipart Node.js request and yield each part as a {@link MultipartPart} object.
  *
  * @param req The Node.js `http.IncomingMessage` object containing multipart data
  * @param options Options for the parser
- * @returns An async generator yielding `MultipartPart` objects
+ * @returns An async generator yielding {@link MultipartPart} objects
  */
 export async function* parseMultipartRequest(
   req: http.IncomingMessage,

--- a/packages/multipart-parser/src/lib/multipart.ts
+++ b/packages/multipart-parser/src/lib/multipart.ts
@@ -73,14 +73,16 @@ export interface ParseMultipartOptions {
 }
 
 /**
- * Parse a `multipart/*` message from a buffer/iterable and yield each part as a `MultipartPart` object.
+ * Parse a `multipart/*` message from a buffer/iterable and yield each part as a
+ * {@link MultipartPart} object.
  *
- * Note: This is a low-level API that requires manual handling of the content and boundary. If you're
- * building a web server, consider using `parseMultipartRequest(request)` instead.
+ * Note: This is a low-level API that requires manual handling of the content and boundary.
+ * If you're building a web server, consider using
+ * {@link import('./multipart-request.ts').parseMultipartRequest} instead.
  *
  * @param message The multipart message as a `Uint8Array` or an iterable of `Uint8Array` chunks
  * @param options Options for the parser
- * @returns A generator that yields `MultipartPart` objects
+ * @returns A generator that yields {@link MultipartPart} objects
  */
 export function* parseMultipart(
   message: Uint8Array | Iterable<Uint8Array>,
@@ -107,14 +109,15 @@ export function* parseMultipart(
 }
 
 /**
- * Parse a `multipart/*` message stream and yield each part as a `MultipartPart` object.
+ * Parse a `multipart/*` message stream and yield each part as a {@link MultipartPart} object.
  *
- * Note: This is a low-level API that requires manual handling of the content and boundary. If you're
- * building a web server, consider using `parseMultipartRequest(request)` instead.
+ * Note: This is a low-level API that requires manual handling of the content and boundary.
+ * If you're building a web server, consider using
+ * {@link import('./multipart-request.ts').parseMultipartRequest} instead.
  *
  * @param stream A stream containing multipart data as a `ReadableStream<Uint8Array>`
  * @param options Options for the parser
- * @returns An async generator that yields `MultipartPart` objects
+ * @returns An async generator that yields {@link MultipartPart} objects
  */
 export async function* parseMultipartStream(
   stream: ReadableStream<Uint8Array>,
@@ -137,7 +140,7 @@ export async function* parseMultipartStream(
 }
 
 /**
- * Options for configuring a `MultipartParser`.
+ * Options for configuring a {@link MultipartParser}.
  */
 export type MultipartParserOptions = Omit<ParseMultipartOptions, 'boundary'>
 

--- a/packages/response/src/lib/compress.ts
+++ b/packages/response/src/lib/compress.ts
@@ -12,13 +12,13 @@ import type { BrotliOptions, ZlibOptions } from 'node:zlib'
 import { AcceptEncoding, CacheControl, Vary } from '@remix-run/headers'
 
 /**
- * Encodings supported by `compressResponse`.
+ * Encodings supported by {@link compressResponse}.
  */
 export type Encoding = 'br' | 'gzip' | 'deflate'
 const defaultEncodings: Encoding[] = ['br', 'gzip', 'deflate']
 
 /**
- * Configuration for negotiated response compression.
+ * Configuration for negotiated response compression in {@link compressResponse}.
  */
 export interface CompressResponseOptions {
   /**

--- a/packages/response/src/lib/file.ts
+++ b/packages/response/src/lib/file.ts
@@ -9,7 +9,7 @@ import {
 import { isCompressibleMimeType, mimeTypeToContentType } from '@remix-run/mime'
 
 /**
- * Minimal interface for file-like objects used by `createFileResponse`.
+ * Minimal interface for file-like objects used by {@link createFileResponse}.
  */
 export interface FileLike {
   /** File compatibility - included for interface completeness */
@@ -47,7 +47,7 @@ export interface FileLike {
 export type FileDigestFunction<file extends FileLike = File> = (file: file) => Promise<string>
 
 /**
- * Options for creating a file response.
+ * Options for creating a file response with {@link createFileResponse}.
  */
 export interface FileResponseOptions<file extends FileLike = File> {
   /**
@@ -109,7 +109,8 @@ export interface FileResponseOptions<file extends FileLike = File> {
  * Creates a file [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)
  * with full HTTP semantics including ETags, Last-Modified, conditional requests, and Range support.
  *
- * Accepts both native `File` objects and `LazyFile` from `@remix-run/lazy-file`.
+ * Accepts both native `File` objects and
+ * {@link import('@remix-run/lazy-file').LazyFile} values.
  *
  * @param file The file to send (native `File` or `LazyFile`)
  * @param request The request object

--- a/packages/session-storage-redis/src/lib/redis-storage.ts
+++ b/packages/session-storage-redis/src/lib/redis-storage.ts
@@ -4,7 +4,7 @@ import type { SessionStorage } from '@remix-run/session'
 type SessionData = ReturnType<typeof createSession>['data']
 
 /**
- * Minimal Redis client contract required by `createRedisSessionStorage`.
+ * Minimal Redis client contract required by {@link createRedisSessionStorage}.
  */
 export interface RedisSessionStorageClient {
   get(key: string): Promise<string | null> | string | null
@@ -15,7 +15,7 @@ export interface RedisSessionStorageClient {
 }
 
 /**
- * Options for Redis-backed session storage.
+ * Options for Redis-backed session storage created by {@link createRedisSessionStorage}.
  */
 export interface RedisSessionStorageOptions {
   /**

--- a/packages/static-middleware/src/lib/static.ts
+++ b/packages/static-middleware/src/lib/static.ts
@@ -15,7 +15,7 @@ import { generateDirectoryListing } from './directory-listing.ts'
 export type AcceptRangesFunction = (file: File) => boolean
 
 /**
- * Options for the `staticFiles` middleware.
+ * Options for the {@link staticFiles} middleware in addition to {@link FileResponseOptions}.
  */
 export interface StaticFilesOptions extends Omit<FileResponseOptions, 'acceptRanges'> {
   /**

--- a/packages/tar-parser/src/lib/tar.ts
+++ b/packages/tar-parser/src/lib/tar.ts
@@ -212,7 +212,7 @@ export async function parseTar(
 }
 
 /**
- * Options for configuring a `TarParser`.
+ * Options for configuring a {@link TarParser}.
  */
 export type TarParserOptions = ParseTarHeaderOptions
 


### PR DESCRIPTION
This updates the public API JSDoc pass to use `{@link ...}` tags where the docs refer to other relevant Remix APIs. The goal is to make the API docs easier to navigate and to align the repo with the updated `write-api-docs` guidance.

- replace plain-text references to related public APIs with JSDoc links across exported docs
- use explicit import-style link tags when the related API lives in another module or package
- keep the linking targeted so the docs gain useful cross-references without turning every identifier into a link
- make no runtime or public API behavior changes

The changes span multiple packages because this was done from the public export surface outward rather than by editing a single package in isolation. That keeps the cross-reference pass consistent across component, router, data, file, multipart, response, and utility APIs.
