### PR TITLE
Remove the data-table sql subpath export

### DIFF
--- a/packages/data-table/.changes/minor.sql-root-api.md
+++ b/packages/data-table/.changes/minor.sql-root-api.md
@@ -1,0 +1,3 @@
+BREAKING CHANGE: Remove the `@remix-run/data-table/sql` export. Import `SqlStatement`, `sql`, and `rawSql` from `@remix-run/data-table` instead.
+
+`@remix-run/data-table/sql-helpers` remains available as the adapter-facing SQL helper module.

--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -25,7 +25,6 @@
     "./migrations/node": "./src/migrations/node.ts",
     "./operators": "./src/operators.ts",
     "./sql-helpers": "./src/sql-helpers.ts",
-    "./sql": "./src/sql.ts",
     "./package.json": "./package.json"
   },
   "publishConfig": {
@@ -49,10 +48,6 @@
       "./sql-helpers": {
         "types": "./dist/sql-helpers.d.ts",
         "default": "./dist/sql-helpers.js"
-      },
-      "./sql": {
-        "types": "./dist/sql.d.ts",
-        "default": "./dist/sql.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/data-table/src/sql.ts
+++ b/packages/data-table/src/sql.ts
@@ -1,2 +1,0 @@
-export type { SqlStatement } from './lib/sql.ts'
-export { isSqlStatement, rawSql, sql } from './lib/sql.ts'

--- a/packages/remix/.changes/minor.remix.update-exports.md
+++ b/packages/remix/.changes/minor.remix.update-exports.md
@@ -1,3 +1,3 @@
-Added `package.json` `exports`:
+BREAKING CHANGE: Remove the `remix/data-table/sql` export. Import `SqlStatement`, `sql`, and `rawSql` from `remix/data-table` instead.
 
-- `remix/data-schema/form-data` to re-export APIs from `@remix-run/data-schema/form-data`
+`remix/data-table/sql-helpers` remains available for adapter-facing SQL utilities.

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -40,7 +40,6 @@
     "./data-table/migrations": "./src/data-table/migrations.ts",
     "./data-table/migrations/node": "./src/data-table/migrations/node.ts",
     "./data-table/operators": "./src/data-table/operators.ts",
-    "./data-table/sql": "./src/data-table/sql.ts",
     "./data-table/sql-helpers": "./src/data-table/sql-helpers.ts",
     "./fetch-proxy": "./src/fetch-proxy.ts",
     "./fetch-router": "./src/fetch-router.ts",
@@ -167,10 +166,6 @@
       "./data-table/operators": {
         "types": "./dist/data-table/operators.d.ts",
         "default": "./dist/data-table/operators.js"
-      },
-      "./data-table/sql": {
-        "types": "./dist/data-table/sql.d.ts",
-        "default": "./dist/data-table/sql.js"
       },
       "./data-table/sql-helpers": {
         "types": "./dist/data-table/sql-helpers.d.ts",

--- a/packages/remix/src/data-table/sql.ts
+++ b/packages/remix/src/data-table/sql.ts
@@ -1,2 +1,0 @@
-// IMPORTANT: This file is auto-generated, please do not edit manually.
-export * from '@remix-run/data-table/sql'


### PR DESCRIPTION
This removes the redundant `data-table/sql` subpath export from both `@remix-run/data-table` and `remix`.

- keep `sql`, `rawSql`, and `SqlStatement` on the root `data-table` export
- keep `data-table/sql-helpers` as the adapter-facing subpath
- remove the public `isSqlStatement` API along with the deleted `sql` entrypoint

The codebase already treats raw SQL as part of the main `data-table` API, while `sql-helpers` is the separate low-level module for adapter/compiler code. This change makes that split explicit and removes the duplicate import path.

```ts
// Before
import { sql, rawSql, type SqlStatement } from 'remix/data-table/sql'
```

```ts
// After
import { sql, rawSql, type SqlStatement } from 'remix/data-table'
```
