### PR TITLE
fix(component): preserve controlled input updates

### DIFF
--- a/packages/component/src/lib/reconcile.ts
+++ b/packages/component/src/lib/reconcile.ts
@@ -142,7 +142,7 @@ function ensureControlledReflection(
   }
 
   node._controlledState = state
-  scheduler.enqueueCommitPhase([
+  scheduler.enqueueTasks([
     () => {
       if (state.disposed) return
       node._dom.addEventListener('input', state.onInput)

--- a/packages/component/src/test/vdom.controlled-props.test.tsx
+++ b/packages/component/src/test/vdom.controlled-props.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { userEvent } from '@vitest/browser/context'
 import type { Handle } from '../lib/component.ts'
 import { createRoot } from '../lib/vdom.ts'
 import { on } from '../index.ts'
@@ -30,6 +31,108 @@ describe('vdom controlled props', () => {
     await Promise.resolve()
     await Promise.resolve()
     expect(input.checked).toBe(true)
+  })
+
+  it('allows controlled value changes when an input event calls handle.update()', () => {
+    function App(handle: Handle) {
+      let value = 'hello'
+      let renderCount = 0
+
+      function rerender() {
+        renderCount++
+        handle.update()
+      }
+
+      return () => (
+        <>
+          <input
+            value={value}
+            mix={[
+              on('input', (event) => {
+                let nextValue = event.currentTarget.value
+                if (/\d/.test(nextValue)) return
+                value = nextValue
+                rerender()
+              }),
+            ]}
+          />
+          <output>{`${renderCount}:${value}`}</output>
+        </>
+      )
+    }
+
+    let container = document.createElement('div')
+    let root = createRoot(container)
+    root.render(<App />)
+    root.flush()
+
+    let input = container.querySelector('input') as HTMLInputElement
+    let output = container.querySelector('output') as HTMLOutputElement
+
+    input.value = 'helloa'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    root.flush()
+
+    expect(input.value).toBe('helloa')
+    expect(output.textContent).toBe('1:helloa')
+  })
+
+  it('preserves controlled updates from real typing while rejecting invalid input', async () => {
+    function App(handle: Handle) {
+      let value = 'hello'
+      let renderCount = 0
+
+      function rerender() {
+        renderCount++
+        handle.update()
+      }
+
+      return () => (
+        <>
+          <label htmlFor="tracked">Tracked</label>
+          <input
+            id="tracked"
+            value={value}
+            mix={[
+              on('input', (event) => {
+                let nextValue = event.currentTarget.value
+                if (/\d/.test(nextValue)) return
+                value = nextValue
+                rerender()
+              }),
+            ]}
+          />
+          <output>{`${renderCount}:${value}`}</output>
+        </>
+      )
+    }
+
+    let container = document.createElement('div')
+    document.body.appendChild(container)
+    let root = createRoot(container)
+    root.render(<App />)
+    root.flush()
+
+    let input = container.querySelector('input') as HTMLInputElement
+    let output = container.querySelector('output') as HTMLOutputElement
+
+    await userEvent.type(input, 'a')
+    root.flush()
+    expect(input.value).toBe('helloa')
+    expect(output.textContent).toBe('1:helloa')
+
+    await userEvent.type(input, '1')
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(input.value).toBe('helloa')
+    expect(output.textContent).toBe('1:helloa')
+
+    await userEvent.type(input, 'b')
+    root.flush()
+    expect(input.value).toBe('helloab')
+    expect(output.textContent).toBe('2:helloab')
+
+    container.remove()
   })
 
   it('does not clobber controlled value when input event commits a new value', async () => {


### PR DESCRIPTION
## Summary
- register controlled restore listeners after mixin input listeners so user `input` handlers see the typed DOM value first
- preserve the existing controlled restore behavior when an input event does not commit a new controlled value
- add regression coverage for valid controlled updates and listener registration order

## Test plan
- [x] `pnpm --filter @remix-run/component test -- src/test/vdom.controlled-props.test.tsx`
- [x] `pnpm build` in `packages/component/demos`
- [x] `pnpm run lint`

Made with [Cursor](https://cursor.com)