### PR TITLE
fix(ui): improve on() extracted handler inference

### DIFF
--- a/packages/ui/.changes/patch.on-extracted-handler-inference.md
+++ b/packages/ui/.changes/patch.on-extracted-handler-inference.md
@@ -1,0 +1,1 @@
+Fix `on()` type inference for extracted event handlers when passing only an explicit target element generic.

--- a/packages/ui/demos/draggable/draggable.tsx
+++ b/packages/ui/demos/draggable/draggable.tsx
@@ -33,7 +33,7 @@ const baseDraggable = createMixin<HTMLElement, [boolean], DraggableProps>((handl
       stopDrag()
     }
 
-    return <handle.element {...props} mix={[on('pointerdown', (event) => onPointerDown(event))]} />
+    return <handle.element {...props} mix={[on('pointerdown', onPointerDown)]} />
   }
 
   function onPointerDown(event: PointerEvent) {

--- a/packages/ui/demos/draggable/draggable.tsx
+++ b/packages/ui/demos/draggable/draggable.tsx
@@ -33,7 +33,7 @@ const baseDraggable = createMixin<HTMLElement, [boolean], DraggableProps>((handl
       stopDrag()
     }
 
-    return <handle.element {...props} mix={[on('pointerdown', onPointerDown)]} />
+    return <handle.element {...props} mix={[on('pointerdown', (event) => onPointerDown(event))]} />
   }
 
   function onPointerDown(event: PointerEvent) {

--- a/packages/ui/src/components/accordion/accordion.tsx
+++ b/packages/ui/src/components/accordion/accordion.tsx
@@ -417,11 +417,7 @@ function AccordionImpl(handle: Handle<AccordionProps, AccordionContext>) {
 }
 
 export function onAccordionChange(handler: AccordionChangeHandler, captureBoolean?: boolean) {
-  return on<HTMLElement, typeof ACCORDION_CHANGE_EVENT>(
-    ACCORDION_CHANGE_EVENT,
-    handler,
-    captureBoolean,
-  )
+  return on<HTMLElement>(ACCORDION_CHANGE_EVENT, handler, captureBoolean)
 }
 
 export const Accordion = AccordionImpl

--- a/packages/ui/src/components/combobox/combobox.tsx
+++ b/packages/ui/src/components/combobox/combobox.tsx
@@ -967,11 +967,7 @@ const combobox = {
 } as const
 
 export function onComboboxChange(handler: ComboboxChangeHandler, captureBoolean?: boolean) {
-  return on<HTMLElement, typeof COMBOBOX_CHANGE_EVENT>(
-    COMBOBOX_CHANGE_EVENT,
-    handler,
-    captureBoolean,
-  )
+  return on<HTMLElement>(COMBOBOX_CHANGE_EVENT, handler, captureBoolean)
 }
 
 export function Combobox(handle: Handle<ComboboxProps>) {

--- a/packages/ui/src/components/menu/menu.tsx
+++ b/packages/ui/src/components/menu/menu.tsx
@@ -1407,7 +1407,7 @@ const menu = {
 } as const
 
 export function onMenuSelect(handler: MenuSelectHandler, captureBoolean?: boolean) {
-  return on<HTMLElement, typeof MENU_SELECT_EVENT>(MENU_SELECT_EVENT, handler, captureBoolean)
+  return on<HTMLElement>(MENU_SELECT_EVENT, handler, captureBoolean)
 }
 
 export interface MenuProps extends Omit<Props<'button'>, 'children'> {

--- a/packages/ui/src/components/select/select.tsx
+++ b/packages/ui/src/components/select/select.tsx
@@ -533,7 +533,7 @@ const select = {
 } as const
 
 export function onSelectChange(handler: SelectChangeHandler, captureBoolean?: boolean) {
-  return on<HTMLElement, typeof SELECT_CHANGE_EVENT>(SELECT_CHANGE_EVENT, handler, captureBoolean)
+  return on<HTMLElement>(SELECT_CHANGE_EVENT, handler, captureBoolean)
 }
 
 function SelectLabel(handle: Handle) {

--- a/packages/ui/src/components/tabs/tabs.tsx
+++ b/packages/ui/src/components/tabs/tabs.tsx
@@ -447,7 +447,7 @@ export const trigger = triggerMixin
 const tabs = { Context, list, panel, trigger } as const
 
 export function onTabsChange(handler: TabsChangeHandler, captureBoolean?: boolean) {
-  return on<HTMLElement, typeof TABS_CHANGE_EVENT>(TABS_CHANGE_EVENT, handler, captureBoolean)
+  return on<HTMLElement>(TABS_CHANGE_EVENT, handler, captureBoolean)
 }
 
 export function Tabs(handle: Handle<TabsProps>) {

--- a/packages/ui/src/runtime/mixins/on-mixin.ts
+++ b/packages/ui/src/runtime/mixins/on-mixin.ts
@@ -17,6 +17,14 @@ type EventType<target extends Element> = Extract<AddEventType<target>, string>
 type ListenerFor<target extends Element, type extends EventType<target>> = SignaledListener<
   Parameters<AddEventListenerFor<target, type>>[0]
 >
+type OnTuple<target extends Element, type extends EventType<target>> = [
+  type: type,
+  handler: ListenerFor<target, type>,
+  captureBoolean?: boolean,
+]
+type OnArgs<target extends Element> = {
+  [type in EventType<target>]: OnTuple<target, type>
+}[EventType<target>]
 
 const onMixin = createMixin<
   Element,
@@ -72,18 +80,24 @@ const onMixin = createMixin<
  * @returns A mixin descriptor for the target element.
  */
 export function on<
-  target extends Element = Element,
-  type extends EventType<target> = EventType<target>,
->(
-  type: type,
-  handler: ListenerFor<target, type>,
-  captureBoolean?: boolean,
-): MixinDescriptor<target, [type, ListenerFor<target, type>, boolean?], ElementProps> {
+  target extends Element,
+  type extends EventType<target>,
+>(...args: OnTuple<target, type>): MixinDescriptor<target, OnTuple<target, type>, ElementProps>
+export function on<target extends Element>(...args: OnArgs<target>): MixinDescriptor<
+  target,
+  OnArgs<target>,
+  ElementProps
+>
+export function on(
+  ...args: [type: string, handler: SignaledListener<any>, captureBoolean?: boolean]
+): any {
+  let [type, handler, captureBoolean] = args
+
   // Keep this typed wrapper so JSX host context can infer event/currentTarget
   // from `type`, rather than exposing the raw `string` + `Event` runtime signature.
   return onMixin(
-    type as string,
-    handler as unknown as SignaledListener<Event>,
+    type,
+    handler as SignaledListener<Event>,
     captureBoolean,
-  ) as unknown as MixinDescriptor<target, [type, ListenerFor<target, type>, boolean?], ElementProps>
+  )
 }

--- a/packages/ui/src/test/jsx.test.tsx
+++ b/packages/ui/src/test/jsx.test.tsx
@@ -214,6 +214,32 @@ describe('jsx', () => {
       let applied = <div mix={[withOnMixin()]} />
     })
 
+    it('accepts extracted on handlers with target-only generics', () => {
+      let onClick = (event: MouseEvent) => {
+        event.preventDefault()
+      }
+      let stopPropagation = (event: Event) => {
+        event.stopPropagation()
+      }
+      let onKeydown = (event: KeyboardEvent) => {
+        event.preventDefault()
+      }
+
+      let button = <button mix={[on<HTMLElement>('click', onClick)]} />
+      let details = (
+        <details
+          mix={[
+            on<HTMLDetailsElement>('mousedown', stopPropagation),
+            on<HTMLDetailsElement>('touchstart', stopPropagation),
+            on<HTMLDetailsElement>('focusin', stopPropagation),
+          ]}
+        />
+      )
+
+      // @ts-expect-error click handlers should not widen to unrelated event payloads
+      let bad = <button mix={[on<HTMLElement>('click', onKeydown)]} />
+    })
+
     it('infers ref mixin node type from host context', () => {
       let element = (
         <button


### PR DESCRIPTION
`on()` has two inference modes: JSX host context can infer the target element for inline handlers, and callers can pass an explicit target generic when the handler is created outside that context. The explicit-target path was too broad: `on<HTMLElement>(...)` defaulted the event type to the full event-name union instead of inferring it from the string literal argument.

That meant extracted handlers could be rejected even when the event name and handler were correct:

```tsx
let onClick = (event: MouseEvent) => {
  event.preventDefault()
}

on<HTMLElement>('click', onClick)
```

This updates the target-only overload to select from event-specific argument tuples, so the first argument still narrows the handler type after the target element is specified.

- preserves existing JSX host-context inference for inline `on()` handlers
- adds type coverage for valid extracted handlers and mismatched extracted handlers
- simplifies internal UI component event helpers that now only need the target generic for custom events