### PR TITLE
Make formData middleware idempotent

### DIFF
--- a/packages/form-data-middleware/.changes/patch.no-op-if-already-parsed.md
+++ b/packages/form-data-middleware/.changes/patch.no-op-if-already-parsed.md
@@ -1,0 +1,1 @@
+`formData()` is now a no-op if `FormData` has already been parsed earlier in the request pipeline, so the middleware can be registered multiple times without re-reading or re-parsing the request body.

--- a/packages/form-data-middleware/src/lib/form-data.test.ts
+++ b/packages/form-data-middleware/src/lib/form-data.test.ts
@@ -236,4 +236,86 @@ describe('formData middleware', () => {
     assert.equal(upload2.type, 'text/plain')
     assert.equal(await upload2.text(), 'test 2')
   })
+
+  it('is a no-op when FormData has already been parsed by an earlier middleware', async () => {
+    let firstUploadHandler = mock.fn<FileUploadHandler>((upload) => `first:${upload.name}`)
+    let secondUploadHandler = mock.fn<FileUploadHandler>((upload) => `second:${upload.name}`)
+
+    let router = createRouter({
+      middleware: [
+        formData({ uploadHandler: firstUploadHandler }),
+        formData({ uploadHandler: secondUploadHandler }),
+      ],
+    })
+
+    router.post('/', (context) =>
+      Response.json({
+        file: context.get(FormData).get('file'),
+      }),
+    )
+
+    let boundary = '----WebKitFormBoundary1234567890'
+    let response = await router.fetch('https://remix.run/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${boundary}`,
+      },
+      body: [
+        `--${boundary}`,
+        'Content-Disposition: form-data; name="file"; filename="test.txt"',
+        'Content-Type: text/plain',
+        '',
+        'test',
+        `--${boundary}--`,
+      ].join('\r\n'),
+    })
+
+    assert.equal(response.status, 200)
+    assert.deepEqual(await response.json(), {
+      file: 'first:test.txt',
+    })
+    assert.equal(firstUploadHandler.mock.calls.length, 1)
+    assert.equal(secondUploadHandler.mock.calls.length, 0)
+  })
+
+  it('is a no-op when FormData has already been parsed by earlier request pipeline middleware', async () => {
+    let globalUploadHandler = mock.fn<FileUploadHandler>((upload) => `global:${upload.name}`)
+    let routeUploadHandler = mock.fn<FileUploadHandler>((upload) => `route:${upload.name}`)
+
+    let router = createRouter({
+      middleware: [formData({ uploadHandler: globalUploadHandler })],
+    })
+
+    router.post('/', {
+      middleware: [formData({ uploadHandler: routeUploadHandler })],
+      action(context) {
+        return Response.json({
+          file: context.get(FormData).get('file'),
+        })
+      },
+    })
+
+    let boundary = '----WebKitFormBoundary1234567890'
+    let response = await router.fetch('https://remix.run/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${boundary}`,
+      },
+      body: [
+        `--${boundary}`,
+        'Content-Disposition: form-data; name="file"; filename="test.txt"',
+        'Content-Type: text/plain',
+        '',
+        'test',
+        `--${boundary}--`,
+      ].join('\r\n'),
+    })
+
+    assert.equal(response.status, 200)
+    assert.deepEqual(await response.json(), {
+      file: 'global:test.txt',
+    })
+    assert.equal(globalUploadHandler.mock.calls.length, 1)
+    assert.equal(routeUploadHandler.mock.calls.length, 0)
+  })
 })

--- a/packages/form-data-middleware/src/lib/form-data.ts
+++ b/packages/form-data-middleware/src/lib/form-data.ts
@@ -35,6 +35,10 @@ export function formData(options?: FormDataOptions): Middleware {
   let uploadHandler = options?.uploadHandler
 
   return async (context) => {
+    if (context.has(FormData)) {
+      return
+    }
+
     if (context.method === 'GET' || context.method === 'HEAD') {
       return
     }


### PR DESCRIPTION
`formData()` currently tries to parse the request body every time it appears in a middleware chain. That makes duplicate registration unsafe when the same middleware is attached globally and again at route scope.

This updates the middleware to treat an existing `FormData` value in request context as authoritative and return early instead of re-reading the request body.

- short-circuit `formData()` when `context.has(FormData)` is already true
- keep duplicate `formData()` registrations safe across merged request middleware pipelines
- add regression coverage for duplicate middleware and global-plus-route middleware
- add a patch change file for the bug fix
