### PR TITLE
fix(component): restore navigation api fallback

### DIFF
--- a/packages/component/.changes/patch.restore-navigation-api-fallback.md
+++ b/packages/component/.changes/patch.restore-navigation-api-fallback.md
@@ -1,0 +1,1 @@
+Restore graceful frame-navigation fallback when the Navigation API is unavailable so `run()` apps still boot and imperative `navigate()` calls degrade to normal document navigations instead of throwing during startup.

--- a/packages/component/src/lib/navigation.ts
+++ b/packages/component/src/lib/navigation.ts
@@ -11,6 +11,10 @@ type SourceElementNavigateEvent = NavigateEvent & {
   sourceElement?: Element | null
 }
 
+type WindowWithNavigation = Window & {
+  navigation?: Navigation
+}
+
 /**
  * Options for client-side frame-aware navigation.
  */
@@ -28,13 +32,19 @@ export type NavigationOptions = {
  * @param options Navigation options.
  */
 export async function navigate(href: string, options?: NavigationOptions) {
+  let navigation = getNavigation()
+  if (!navigation) {
+    window.location.assign(href)
+    return
+  }
+
   let state = {
     target: options?.target,
     src: options?.src ?? href,
     resetScroll: options?.resetScroll !== false,
     $rmx: true,
   } satisfies NavigationState
-  let transition = window.navigation.navigate(href, { state, history: options?.history })
+  let transition = navigation.navigate(href, { state, history: options?.history })
   await transition.finished
 }
 
@@ -44,7 +54,8 @@ export async function navigate(href: string, options?: NavigationOptions) {
  * @param signal Abort signal used to remove the listener.
  */
 export function startNavigationListener(signal: AbortSignal) {
-  let navigation = window.navigation
+  let navigation = getNavigation()
+  if (!navigation) return
 
   navigation.updateCurrentEntry({
     state: { target: undefined, src: window.location.href, resetScroll: true, $rmx: true },
@@ -116,6 +127,10 @@ function getTraverseNavigationState(event: NavigateEvent): NavigationState | und
   }
 
   return undefined
+}
+
+function getNavigation() {
+  return (window as WindowWithNavigation).navigation
 }
 
 function getSourceElementNavigationState(event: NavigateEvent): NavigationState | undefined {

--- a/packages/component/src/test/navigation-fallback.test.ts
+++ b/packages/component/src/test/navigation-fallback.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { navigate, startNavigationListener } from '../lib/navigation.ts'
+import { run } from '../lib/run.ts'
+
+describe('navigation fallback', () => {
+  let initialHref = ''
+
+  beforeEach(() => {
+    initialHref = window.location.href
+  })
+
+  afterEach(() => {
+    history.replaceState(history.state, '', initialHref)
+    document.body.innerHTML = ''
+    vi.unstubAllGlobals()
+  })
+
+  it('falls back to window.location.assign when the Navigation API is unavailable', async () => {
+    vi.stubGlobal('navigation', undefined)
+
+    let changed = new Promise<void>((resolve) => {
+      window.addEventListener(
+        'hashchange',
+        () => {
+          resolve()
+        },
+        { once: true },
+      )
+    })
+
+    await navigate('#rmx-fallback')
+    await changed
+
+    expect(window.location.hash).toBe('#rmx-fallback')
+  })
+
+  it('ignores navigation listener setup when the Navigation API is unavailable', () => {
+    vi.stubGlobal('navigation', undefined)
+
+    let controller = new AbortController()
+
+    expect(() => {
+      startNavigationListener(controller.signal)
+    }).not.toThrow()
+  })
+
+  it('boots run() when the Navigation API is unavailable', async () => {
+    vi.stubGlobal('navigation', undefined)
+
+    let app = run({
+      loadModule() {
+        throw new Error('loadModule should not be called during this test')
+      },
+    })
+
+    await expect(app.ready()).resolves.toBeUndefined()
+
+    app.dispose()
+  })
+})


### PR DESCRIPTION
This restores the graceful fallback that lets `@remix-run/component` frame-navigation apps boot when the Navigation API is unavailable.

The fallback was added in `b14082938`, but it was dropped during the frame-navigation refactor in #11147 when `navigation.ts` started reading `window.navigation` unconditionally. That left older Safari/iOS versions and WebViews without `window.navigation` throwing during `run()` startup instead of degrading to normal document navigations.

- guard `window.navigation` before setting up the runtime listener
- fall back to `window.location.assign(...)` for imperative `navigate(...)` calls when the Navigation API is missing
- add regression coverage for `navigate()`, `startNavigationListener()`, and `run()` without `window.navigation`
- add a patch change file for the restored degradation behavior
