### PR TITLE
Remove unnecessary `as const` from `enum_()` usage

### DIFF
--- a/packages/data-schema/.changes/patch.remove-unnecessary-as-const-from-enum.md
+++ b/packages/data-schema/.changes/patch.remove-unnecessary-as-const-from-enum.md
@@ -1,0 +1,1 @@
+Remove unnecessary `as const` from `enum_()` examples in docs and tests since the `const` type parameter already preserves literal type inference.

--- a/packages/data-schema/README.md
+++ b/packages/data-schema/README.md
@@ -18,7 +18,7 @@ let User = object({
   email: string().pipe(email()),
   username: string().pipe(minLength(3), maxLength(20)),
   age: coerce.number().pipe(min(13)),
-  role: enum_(['admin', 'member', 'guest'] as const),
+  role: enum_(['admin', 'member', 'guest']),
   flags: object({
     beta: coerce.boolean(),
   }),
@@ -153,7 +153,7 @@ import { literal, enum_, union } from '@remix-run/data-schema'
 let yes = literal('yes')
 
 // One of several allowed values
-let Status = enum_(['active', 'inactive', 'pending'] as const)
+let Status = enum_(['active', 'inactive', 'pending'])
 
 // First schema that matches wins
 let StringOrNumber = union([string(), number()])

--- a/packages/data-schema/src/lib/schema.test.ts
+++ b/packages/data-schema/src/lib/schema.test.ts
@@ -25,7 +25,14 @@ import {
   union,
 } from './schema.ts'
 import { minLength } from './checks.ts'
-import type { Issue, ValidationResult } from './schema.ts'
+import type { InferOutput, Issue, ValidationResult } from './schema.ts'
+
+type Equal<left, right> =
+  (<value>() => value extends left ? 1 : 2) extends <value>() => value extends right ? 1 : 2
+    ? true
+    : false
+
+function expectType<condition extends true>(_value?: condition): void {}
 
 function assertSuccess<output>(
   result: ValidationResult<output>,
@@ -659,7 +666,7 @@ describe('any', () => {
 
 describe('enum_', () => {
   it('accepts allowed values', () => {
-    let schema = enum_(['active', 'inactive', 'pending'] as const)
+    let schema = enum_(['active', 'inactive', 'pending'])
 
     assertSuccess(schema['~standard'].validate('active'))
     assertSuccess(schema['~standard'].validate('inactive'))
@@ -667,7 +674,7 @@ describe('enum_', () => {
   })
 
   it('rejects values not in the list', () => {
-    let schema = enum_(['active', 'inactive'] as const)
+    let schema = enum_(['active', 'inactive'])
     let result = schema['~standard'].validate('deleted')
 
     assertFailure(result)
@@ -676,16 +683,24 @@ describe('enum_', () => {
   })
 
   it('works with numeric values', () => {
-    let schema = enum_([0, 1, 2] as const)
+    let schema = enum_([0, 1, 2])
 
     assertSuccess(schema['~standard'].validate(1))
     assertFailure(schema['~standard'].validate(3))
   })
 
   it('uses strict equality', () => {
-    let schema = enum_([1, 2, 3] as const)
+    let schema = enum_([1, 2, 3])
 
     assertFailure(schema['~standard'].validate('1'))
+  })
+
+  it('infers literal types without as const', () => {
+    let stringEnum = enum_(['active', 'inactive', 'pending'])
+    expectType<Equal<InferOutput<typeof stringEnum>, 'active' | 'inactive' | 'pending'>>()
+
+    let numericEnum = enum_([0, 1, 2])
+    expectType<Equal<InferOutput<typeof numericEnum>, 0 | 1 | 2>>()
   })
 })
 


### PR DESCRIPTION
Hey folks! 👋

The `enum_` function signature already uses a `const` type parameter (`<const values extends readonly [unknown, ...unknown[]]>`), which means TypeScript infers literal types automatically — no `as const` needed at call sites.

This PR removes the redundant `as const` from the docs and tests, and adds a type-level test to prove the inference works without it.

## Changes

- Removed `as const` from 2 `enum_()` examples in README.md
- Removed `as const` from 4 `enum_()` calls in schema.test.ts
- Added a type-level test asserting that `enum_(['active', 'inactive', 'pending'])` infers `'active' | 'inactive' | 'pending'` (not `string`), and similarly for numeric enums