### PR TITLE
Unify data-table Database runtime and type

### DIFF
--- a/packages/data-table/.changes/minor.database-class-export.md
+++ b/packages/data-table/.changes/minor.database-class-export.md
@@ -1,0 +1,1 @@
+`@remix-run/data-table` now exports `Database` as the runtime class instead of separating the runtime implementation from a structural `Database` type. You can construct databases directly with `new Database(adapter, options)` or keep using `createDatabase(adapter, options)`, which now delegates to the class constructor.

--- a/packages/data-table/src/index.ts
+++ b/packages/data-table/src/index.ts
@@ -177,7 +177,6 @@ export type {
   CreateManyRowsOptions,
   CreateResultOptions,
   CreateRowOptions,
-  Database,
   DeleteManyOptions,
   FindManyOptions,
   FindOneOptions,
@@ -196,4 +195,4 @@ export type {
   WriteRowResult,
   WriteRowsResult,
 } from './lib/database.ts'
-export { createDatabase, QueryBuilder } from './lib/database.ts'
+export { createDatabase, Database, QueryBuilder } from './lib/database.ts'

--- a/packages/data-table/src/lib/database.test.ts
+++ b/packages/data-table/src/lib/database.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, it } from 'node:test'
 
 import type { DataManipulationOperation, DatabaseAdapter } from './adapter.ts'
 import { column } from './column.ts'
-import { createDatabase } from './database.ts'
+import { createDatabase, Database } from './database.ts'
 import { DataTableAdapterError, DataTableQueryError, DataTableValidationError } from './errors.ts'
 import { belongsTo, table, hasMany, hasManyThrough, hasOne, timestamps } from './table.ts'
 import { eq } from './operators.ts'
@@ -103,6 +103,35 @@ afterEach(() => {
 })
 
 describe('query builder', () => {
+  it('supports direct construction and createDatabase wrapper', async () => {
+    let adapter = createAdapter({
+      accounts: [{ id: 1, email: 'amy@studio.test', status: 'active' }],
+      projects: [],
+      tasks: [],
+      memberships: [],
+    })
+    let direct = new Database(adapter, {
+      now() {
+        return '2026-01-01T00:00:00.000Z'
+      },
+    })
+    let wrapped = createDatabase(adapter, {
+      now() {
+        return '2026-01-01T00:00:00.000Z'
+      },
+    })
+
+    let directRows = await direct.query(accounts).all()
+    let wrappedRows = await wrapped.query(accounts).all()
+
+    assert.equal(direct instanceof Database, true)
+    assert.equal(wrapped instanceof Database, true)
+    assert.equal(direct.now(), '2026-01-01T00:00:00.000Z')
+    assert.equal(wrapped.now(), '2026-01-01T00:00:00.000Z')
+    assert.equal(directRows.length, 1)
+    assert.equal(wrappedRows.length, 1)
+  })
+
   it('is immutable and supports eager hasMany loading', async () => {
     let adapter = createAdapter({
       accounts: [
@@ -2093,7 +2122,7 @@ function createAdapter(
 }
 
 function createTestDatabase(adapter: DatabaseAdapter) {
-  return createDatabase(adapter, {
+  return new Database(adapter, {
     now() {
       return '2026-01-01T00:00:00.000Z'
     },

--- a/packages/data-table/src/lib/database.ts
+++ b/packages/data-table/src/lib/database.ts
@@ -7,7 +7,7 @@ import type {
 } from './adapter.ts'
 import type { ColumnBuilder } from './column.ts'
 import { QueryBuilder } from './database/query-builder.ts'
-import { DatabaseRuntime } from './database/runtime.ts'
+import { Database, withDatabaseInternals } from './database/runtime.ts'
 import type { ColumnInput, NormalizeColumnInput, TableMetadataLike } from './references.ts'
 import type { SqlStatement } from './sql.ts'
 import type {
@@ -332,79 +332,8 @@ export type CreateManyRowsOptions = {
 }
 
 /**
- * High-level database runtime used to build and execute data manipulation operations.
- *
- * Create instances with {@link createDatabase}.
- */
-export type Database = {
-  adapter: DatabaseAdapter
-  now(): unknown
-  query: QueryMethod
-  create<table extends AnyTable>(
-    table: table,
-    values: Partial<TableRow<table>>,
-    options?: CreateResultOptions,
-  ): Promise<WriteResult>
-  create<table extends AnyTable, relations extends RelationMapForSourceName<TableName<table>> = {}>(
-    table: table,
-    values: Partial<TableRow<table>>,
-    options: CreateRowOptions<table, relations>,
-  ): Promise<TableRowWith<table, LoadedRelationMap<relations>>>
-  createMany<table extends AnyTable>(
-    table: table,
-    values: Array<Partial<TableRow<table>>>,
-    options?: CreateManyResultOptions,
-  ): Promise<WriteResult>
-  createMany<table extends AnyTable>(
-    table: table,
-    values: Array<Partial<TableRow<table>>>,
-    options: CreateManyRowsOptions,
-  ): Promise<TableRow<table>[]>
-  find<table extends AnyTable, relations extends RelationMapForSourceName<TableName<table>> = {}>(
-    table: table,
-    value: PrimaryKeyInput<table>,
-    options?: { with?: relations },
-  ): Promise<TableRowWith<table, LoadedRelationMap<relations>> | null>
-  findOne<
-    table extends AnyTable,
-    relations extends RelationMapForSourceName<TableName<table>> = {},
-  >(
-    table: table,
-    options: FindOneOptions<table, relations>,
-  ): Promise<TableRowWith<table, LoadedRelationMap<relations>> | null>
-  findMany<
-    table extends AnyTable,
-    relations extends RelationMapForSourceName<TableName<table>> = {},
-  >(
-    table: table,
-    options?: FindManyOptions<table, relations>,
-  ): Promise<Array<TableRowWith<table, LoadedRelationMap<relations>>>>
-  count<table extends AnyTable>(table: table, options?: CountOptions<table>): Promise<number>
-  update<table extends AnyTable, relations extends RelationMapForSourceName<TableName<table>> = {}>(
-    table: table,
-    value: PrimaryKeyInput<table>,
-    changes: Partial<TableRow<table>>,
-    options?: UpdateOptions<table, relations>,
-  ): Promise<TableRowWith<table, LoadedRelationMap<relations>>>
-  updateMany<table extends AnyTable>(
-    table: table,
-    changes: Partial<TableRow<table>>,
-    options: UpdateManyOptions<table>,
-  ): Promise<WriteResult>
-  delete<table extends AnyTable>(table: table, value: PrimaryKeyInput<table>): Promise<boolean>
-  deleteMany<table extends AnyTable>(
-    table: table,
-    options: DeleteManyOptions<table>,
-  ): Promise<WriteResult>
-  exec(statement: string | SqlStatement, values?: unknown[]): Promise<DataManipulationResult>
-  transaction<result>(
-    callback: (database: Database) => Promise<result>,
-    options?: TransactionOptions,
-  ): Promise<result>
-}
-
-/**
  * Creates a database runtime from an adapter.
+ * Thin wrapper around `new Database(adapter, options)`.
  * @param adapter Adapter implementation responsible for SQL execution.
  * @param options Optional runtime options.
  * @param options.now Clock function used for auto-managed timestamps.
@@ -429,14 +358,7 @@ export function createDatabase(
   adapter: DatabaseAdapter,
   options?: { now?: () => unknown },
 ): Database {
-  let now = options?.now ?? defaultNow
-
-  return new DatabaseRuntime({
-    adapter,
-    token: undefined,
-    now,
-    savepointCounter: { value: 0 },
-  })
+  return new Database(adapter, options)
 }
 
 /**
@@ -453,18 +375,13 @@ export function createDatabaseWithTransaction(
   token: TransactionToken,
   options?: { now?: () => unknown },
 ): Database {
-  let now = options?.now ?? defaultNow
-
-  return new DatabaseRuntime({
+  return new Database(
     adapter,
-    token,
-    now,
-    savepointCounter: { value: 0 },
-  })
+    withDatabaseInternals(options, {
+      token,
+      savepointCounter: { value: 0 },
+    }),
+  )
 }
 
-function defaultNow(): Date {
-  return new Date()
-}
-
-export { QueryBuilder }
+export { Database, QueryBuilder }

--- a/packages/data-table/src/lib/database/runtime.ts
+++ b/packages/data-table/src/lib/database/runtime.ts
@@ -11,7 +11,6 @@ import type {
   CreateManyRowsOptions,
   CreateResultOptions,
   CreateRowOptions,
-  Database,
   DeleteManyOptions,
   FindManyOptions,
   FindOneOptions,
@@ -53,22 +52,64 @@ type SavepointCounter = {
   value: number
 }
 
-export class DatabaseRuntime implements Database, QueryExecutionContext {
+const databaseInternalOptionsKey = Symbol('databaseInternalOptions')
+
+type DatabaseOptions = {
+  now?: () => unknown
+}
+
+type DatabaseInternalOptions = {
+  token?: TransactionToken
+  savepointCounter?: SavepointCounter
+}
+
+type DatabaseOptionsWithInternals = DatabaseOptions & {
+  [databaseInternalOptionsKey]: DatabaseInternalOptions
+}
+
+export function withDatabaseInternals(
+  options: DatabaseOptions | undefined,
+  internal: DatabaseInternalOptions,
+): DatabaseOptions {
+  let databaseOptions: DatabaseOptions = {
+    now: options?.now,
+  }
+
+  Object.defineProperty(databaseOptions, databaseInternalOptionsKey, {
+    value: internal,
+    enumerable: false,
+  })
+
+  return databaseOptions
+}
+
+function hasDatabaseInternals(options: DatabaseOptions): options is DatabaseOptionsWithInternals {
+  return databaseInternalOptionsKey in options
+}
+
+/**
+ * High-level database runtime used to build and execute data manipulation operations.
+ *
+ * Create instances directly with `new Database(adapter, options)` or use
+ * `createDatabase(adapter, options)` as a thin wrapper.
+ */
+export class Database implements QueryExecutionContext {
   #adapter: DatabaseAdapter
   #token?: TransactionToken
   #now: () => unknown
   #savepointCounter: SavepointCounter
 
-  constructor(options: {
-    adapter: DatabaseAdapter
-    token?: TransactionToken
-    now: () => unknown
-    savepointCounter: SavepointCounter
-  }) {
-    this.#adapter = options.adapter
-    this.#token = options.token
-    this.#now = options.now
-    this.#savepointCounter = options.savepointCounter
+  constructor(
+    adapter: DatabaseAdapter,
+    options?: DatabaseOptions,
+  ) {
+    let internal =
+      options && hasDatabaseInternals(options) ? options[databaseInternalOptionsKey] : undefined
+
+    this.#adapter = adapter
+    this.#token = internal?.token
+    this.#now = options?.now ?? defaultNow
+    this.#savepointCounter = internal?.savepointCounter ?? { value: 0 }
   }
 
   get adapter(): DatabaseAdapter {
@@ -431,12 +472,16 @@ export class DatabaseRuntime implements Database, QueryExecutionContext {
   ): Promise<result> {
     if (!this.#token) {
       let token = await this.#adapter.beginTransaction(options)
-      let tx = new DatabaseRuntime({
-        adapter: this.#adapter,
-        token,
-        now: this.#now,
-        savepointCounter: this.#savepointCounter,
-      })
+      let tx = new Database(
+        this.#adapter,
+        withDatabaseInternals(
+          { now: this.#now },
+          {
+            token,
+            savepointCounter: this.#savepointCounter,
+          },
+        ),
+      )
 
       try {
         let result = await callback(tx)
@@ -484,4 +529,9 @@ export class DatabaseRuntime implements Database, QueryExecutionContext {
       })
     }
   }
+}
+
+
+function defaultNow(): Date {
+  return new Date()
 }

--- a/packages/data-table/src/lib/type-safety.test.ts
+++ b/packages/data-table/src/lib/type-safety.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'node:assert/strict'
 import { afterEach, describe, it } from 'node:test'
 
 import { column } from './column.ts'
-import { createDatabase } from './database.ts'
+import { createDatabase, Database } from './database.ts'
 import type {
   QueryBuilder,
   QueryColumnTypesForTable,
@@ -79,6 +79,22 @@ describe('type safety', () => {
     expectType<Equal<Row['happened_at'], unknown>>()
     expectType<Equal<Row['big_counter'], unknown>>()
     expectType<Equal<Row['validated_payload'], unknown>>()
+  })
+
+  it('types direct construction, helper construction, and transaction callbacks as Database', async () => {
+    let direct = new Database(createAdapter())
+    let wrapped = createDatabase(createAdapter())
+
+    expectType<Equal<typeof direct, Database>>()
+    expectType<Equal<typeof wrapped, Database>>()
+
+    await direct.transaction(async (transactionDatabase) => {
+      expectType<Equal<typeof transactionDatabase, Database>>()
+      return undefined
+    })
+
+    assert.equal(direct instanceof Database, true)
+    assert.equal(wrapped instanceof Database, true)
   })
 
   it('exposes query builder generics as column and row output maps', () => {

--- a/packages/remix/.changes/minor.remix.update-exports.md
+++ b/packages/remix/.changes/minor.remix.update-exports.md
@@ -1,3 +1,5 @@
 BREAKING CHANGE: Remove the `remix/data-table/sql` export. Import `SqlStatement`, `sql`, and `rawSql` from `remix/data-table` instead.
 
 `remix/data-table/sql-helpers` remains available for adapter-facing SQL utilities.
+
+`remix/data-table` now exports the `Database` class as a runtime value. You can construct a database directly with `new Database(adapter, options)` or keep using `createDatabase(adapter, options)`, which now delegates to the class constructor.


### PR DESCRIPTION
This replaces the split between the structural `Database` type and the internal `DatabaseRuntime` implementation in `@remix-run/data-table`. `Database` is now the public runtime class, while `createDatabase()` stays as compatibility sugar around direct construction.

It also keeps the transaction-bound construction path internal so the public constructor signature stays narrow in the emitted types instead of exposing the symbol-keyed transaction wiring.

- export `Database` as a runtime value from `@remix-run/data-table` and `remix/data-table`
- remove the separate `DatabaseRuntime` runtime / structural `Database` type split
- keep `createDatabase(adapter, options?)` as a thin wrapper around `new Database(adapter, options)`
- add runtime and type-safety coverage for direct construction and transaction callback typing

```ts
// Before
import { createDatabase, type Database } from 'remix/data-table'

let db: Database = createDatabase(adapter)
```

```ts
// After
import { Database, createDatabase } from 'remix/data-table'

let db = new Database(adapter)
let sameDb = createDatabase(adapter)
```
