### PR TITLE
Remove redundant data-table migration Database export

### DIFF
--- a/packages/data-table/.changes/minor.migration-system-features.md
+++ b/packages/data-table/.changes/minor.migration-system-features.md
@@ -13,3 +13,5 @@ Migration callbacks now use split handles: `{ db, schema }`.
 Migration-time DDL, DML, and introspection now share the same transaction token when migration transactions are enabled. In `dryRun`, schema introspection (`schema.hasTable` / `schema.hasColumn`) reads live adapter/database state and does not simulate pending dry-run operations.
 
 Add public subpath exports for migrations, Node migration loading, SQL helpers, operators, and SQL builders. SQL compilation stays adapter-owned, while shared SQL compiler helpers remain available from `remix/data-table/sql-helpers`.
+
+`@remix-run/data-table/migrations` no longer exports a separate `Database` type alias. Migration callbacks still receive `context.db` as the main `Database` runtime, so if you need the type directly, import `Database` from `@remix-run/data-table` instead.

--- a/packages/data-table/src/lib/database.ts
+++ b/packages/data-table/src/lib/database.ts
@@ -1,25 +1,15 @@
-import type {
-  ColumnDefinition,
-  DatabaseAdapter,
-  DataManipulationResult,
-  TransactionOptions,
-  TransactionToken,
-} from './adapter.ts'
+import type { ColumnDefinition, DatabaseAdapter, TransactionToken } from './adapter.ts'
 import type { ColumnBuilder } from './column.ts'
 import { QueryBuilder } from './database/query-builder.ts'
 import { Database, withDatabaseInternals } from './database/runtime.ts'
 import type { ColumnInput, NormalizeColumnInput, TableMetadataLike } from './references.ts'
-import type { SqlStatement } from './sql.ts'
 import type {
   AnyRelation,
   AnyTable,
-  LoadedRelationMap,
   OrderDirection,
-  PrimaryKeyInput,
   TableName,
   TablePrimaryKey,
   TableRow,
-  TableRowWith,
   TableValidate,
   tableMetadataKey,
   TimestampConfig,

--- a/packages/data-table/src/lib/database/query-builder.ts
+++ b/packages/data-table/src/lib/database/query-builder.ts
@@ -20,7 +20,6 @@ import type {
   QueryColumnName,
   QueryColumnTypeMap,
   QueryColumns,
-  QueryForTable,
   RelationMapForSourceName,
   ReturningInput,
   SelectedAliasRow,
@@ -36,9 +35,6 @@ import type {
   AnyTable,
   LoadedRelationMap,
   OrderByClause,
-  TableName,
-  TablePrimaryKey,
-  TableRow,
 } from '../table.ts'
 import { getPrimaryKeyObject, getTableColumns, getTableName } from '../table.ts'
 

--- a/packages/data-table/src/lib/database/runtime.ts
+++ b/packages/data-table/src/lib/database/runtime.ts
@@ -31,7 +31,6 @@ import type {
   LoadedRelationMap,
   PrimaryKeyInput,
   TableName,
-  TablePrimaryKey,
   TableRow,
   TableRowWith,
 } from '../table.ts'

--- a/packages/data-table/src/lib/migrations.ts
+++ b/packages/data-table/src/lib/migrations.ts
@@ -1,4 +1,4 @@
-import type { Database as DataManipulationDatabase } from './database.ts'
+import type { Database } from './database.ts'
 import type { ColumnDefinition, ForeignKeyAction, IndexDefinition } from './adapter.ts'
 import type { ColumnBuilder } from './column.ts'
 import type { SqlStatement } from './sql.ts'
@@ -8,11 +8,6 @@ import type { AnyTable } from './table.ts'
  * Controls how each migration is wrapped in transactions.
  */
 export type MigrationTransactionMode = 'auto' | 'required' | 'none'
-
-/**
- * Database API available inside migrations.
- */
-export type Database = DataManipulationDatabase
 
 /**
  * Runtime context passed to migration `up`/`down` handlers.

--- a/packages/data-table/src/lib/migrations/runner.ts
+++ b/packages/data-table/src/lib/migrations/runner.ts
@@ -1,9 +1,8 @@
 import { createDatabase, createDatabaseWithTransaction } from '../database.ts'
-import type { Database as DataManipulationDatabase } from '../database.ts'
+import type { Database } from '../database.ts'
 import type { DatabaseAdapter, TransactionToken } from '../adapter.ts'
 import type { SqlStatement } from '../sql.ts'
 import type {
-  Database as MigrationDatabase,
   MigrateOptions,
   MigrateResult,
   MigrationContext,
@@ -94,7 +93,7 @@ function assertNoMigrationDrift(
   }
 }
 
-function createDryRunDatabase(adapter: DatabaseAdapter): DataManipulationDatabase {
+function createDryRunDatabase(adapter: DatabaseAdapter): Database {
   let error = new Error('Cannot execute data operations while running migrations with dryRun')
   let throwDryRunError = async (): Promise<never> => {
     throw error
@@ -232,10 +231,8 @@ async function runMigrations(input: RunMigrationsInput): Promise<MigrateResult> 
         },
         { transaction: token },
       )
-      let migrationDb: MigrationDatabase = db
-
       let context: MigrationContext = {
-        db: migrationDb,
+        db,
         schema,
       }
 

--- a/packages/data-table/src/migrations.ts
+++ b/packages/data-table/src/migrations.ts
@@ -1,6 +1,5 @@
 export type {
   AlterTableBuilder,
-  Database,
   CreateMigrationInput,
   Migration,
   MigrationContext,

--- a/packages/remix/.changes/minor.remix.update-exports.md
+++ b/packages/remix/.changes/minor.remix.update-exports.md
@@ -3,3 +3,5 @@ BREAKING CHANGE: Remove the `remix/data-table/sql` export. Import `SqlStatement`
 `remix/data-table/sql-helpers` remains available for adapter-facing SQL utilities.
 
 `remix/data-table` now exports the `Database` class as a runtime value. You can construct a database directly with `new Database(adapter, options)` or keep using `createDatabase(adapter, options)`, which now delegates to the class constructor.
+
+`remix/data-table/migrations` no longer exports a separate `Database` type alias. Import `Database` from `remix/data-table` when you need the migration `db` type directly.


### PR DESCRIPTION
This removes the extra `Database` type export from the data-table migrations entrypoints. Migration callbacks already receive the main `Database` runtime on `context.db`, so keeping a second alias in `@remix-run/data-table/migrations` and `remix/data-table/migrations` was redundant.

- removes the separate `Database` type export from the migrations entrypoints
- updates internal migration types to reference the main `Database` type directly
- prunes a few stale imports uncovered by the cleanup pass

```ts
// Before
import type { Database } from 'remix/data-table/migrations'
```

```ts
// After
import type { Database } from 'remix/data-table'
```
