### PR TITLE
fix(component): correct DOM nodes ordering & fragment parentage in vnode hierarchy

### DIFF
--- a/packages/component/.changes/patch.fix-hydration-out-of-order.md
+++ b/packages/component/.changes/patch.fix-hydration-out-of-order.md
@@ -1,0 +1,1 @@
+Fix DOM node ordering when calling handle.update() after the app has hydrated

--- a/packages/component/src/lib/reconcile.ts
+++ b/packages/component/src/lib/reconcile.ts
@@ -389,7 +389,7 @@ export function diffVNodes(
       frame,
       scheduler,
       styles,
-      vParent,
+      next,
       rootTarget,
       undefined,
       anchor,

--- a/packages/component/src/lib/reconcile.ts
+++ b/packages/component/src/lib/reconcile.ts
@@ -711,17 +711,7 @@ function insert(
   if (isFragmentNode(node)) {
     // Insert fragment children in order before the same anchor
     for (let child of node._children) {
-      cursor = insert(
-        child,
-        domParent,
-        frame,
-        scheduler,
-        styles,
-        vParent,
-        rootTarget,
-        anchor,
-        cursor,
-      )
+      cursor = insert(child, domParent, frame, scheduler, styles, node, rootTarget, anchor, cursor)
     }
     return cursor
   }
@@ -1658,7 +1648,7 @@ export function findNextSiblingDomAnchor(curr: VNode): Node | null {
     vParent._content && isFragmentNode(vParent._content)
       ? vParent._content._children
       : vParent._children
-  if (!children) return null
+  if (!children || children.length === 0) return findNextSiblingDomAnchor(vParent)
 
   let idx = children.indexOf(curr)
   if (idx === -1) return null

--- a/packages/component/src/lib/reconcile.ts
+++ b/packages/component/src/lib/reconcile.ts
@@ -23,6 +23,7 @@ import {
   isHostNode,
   isTextNode,
   findContextFromAncestry,
+  isNonRenderNode,
 } from './vnode.ts'
 import { invariant } from './invariant.ts'
 import { diffHostProps } from './diff-props.ts'
@@ -361,6 +362,10 @@ export function diffVNodes(
     return rootCursor
   }
 
+  if (isNonRenderNode(curr) && isNonRenderNode(next)) {
+    return rootCursor
+  }
+
   if (isCommittedTextNode(curr) && isTextNode(next)) {
     diffText(curr, next, vParent)
     return rootCursor
@@ -424,7 +429,7 @@ function replace(
     return
   }
 
-  let replacementAnchor = findNextSiblingDomAnchor(curr, vParent) ?? anchor
+  let replacementAnchor = findNextSiblingDomAnchor(curr) ?? anchor
   remove(curr, domParent, scheduler, styles)
   insert(next, domParent, frame, scheduler, styles, vParent, rootTarget, replacementAnchor)
 }
@@ -540,6 +545,10 @@ function insert(
   let doInsert = anchor
     ? (dom: Node) => domParent.insertBefore(dom, anchor)
     : (dom: Node) => domParent.appendChild(dom)
+
+  if (isNonRenderNode(node)) {
+    return cursor
+  }
 
   if (isTextNode(node)) {
     if (cursor instanceof Text) {
@@ -1641,7 +1650,8 @@ function shouldDispatchInlineMixinLifecycle(node: Node): boolean {
   return true
 }
 
-export function findNextSiblingDomAnchor(curr: VNode, vParent?: VNode): Node | null {
+export function findNextSiblingDomAnchor(curr: VNode): Node | null {
+  let vParent = curr._parent
   if (!vParent || !Array.isArray(vParent._children)) return null
   let children = vParent._children
   let idx = children.indexOf(curr)

--- a/packages/component/src/lib/reconcile.ts
+++ b/packages/component/src/lib/reconcile.ts
@@ -1644,10 +1644,7 @@ export function findNextSiblingDomAnchor(curr: VNode): Node | null {
   let vParent = curr._parent
   if (!vParent) return null
 
-  let children =
-    vParent._content && isFragmentNode(vParent._content)
-      ? vParent._content._children
-      : vParent._children
+  let children = vParent._children
   if (!children || children.length === 0) return findNextSiblingDomAnchor(vParent)
 
   let idx = children.indexOf(curr)
@@ -1656,7 +1653,7 @@ export function findNextSiblingDomAnchor(curr: VNode): Node | null {
     let dom = findFirstDomAnchor(children[i])
     if (dom) return dom
   }
-  return null
+  return findNextSiblingDomAnchor(vParent)
 }
 
 function reclaimPersistedMixinNode(

--- a/packages/component/src/lib/reconcile.ts
+++ b/packages/component/src/lib/reconcile.ts
@@ -1642,18 +1642,21 @@ function shouldDispatchInlineMixinLifecycle(node: Node): boolean {
 
 export function findNextSiblingDomAnchor(curr: VNode): Node | null {
   let vParent = curr._parent
-  if (!vParent) return null
-
+  if (!vParent || !Array.isArray(vParent._children)) return null
   let children = vParent._children
-  if (!children || children.length === 0) return findNextSiblingDomAnchor(vParent)
-
   let idx = children.indexOf(curr)
   if (idx === -1) return null
   for (let i = idx + 1; i < children.length; i++) {
     let dom = findFirstDomAnchor(children[i])
     if (dom) return dom
   }
-  return findNextSiblingDomAnchor(vParent)
+
+  // If this is a fragment, there may be additional siblings not in this fragment
+  // but that still come after this node in the DOM order.
+  if (isFragmentNode(vParent)) {
+    return findNextSiblingDomAnchor(vParent)
+  }
+  return null
 }
 
 function reclaimPersistedMixinNode(

--- a/packages/component/src/lib/reconcile.ts
+++ b/packages/component/src/lib/reconcile.ts
@@ -1644,6 +1644,10 @@ export function findNextSiblingDomAnchor(curr: VNode): Node | null {
   let vParent = curr._parent
   if (!vParent || !Array.isArray(vParent._children)) return null
   let children = vParent._children
+  // If there are no children, this node is the only content of its parent component
+  // and the next sibling anchor is whatever comes after the parent component in the DOM.
+  if (children.length === 0) return findNextSiblingDomAnchor(vParent)
+
   let idx = children.indexOf(curr)
   if (idx === -1) return null
   for (let i = idx + 1; i < children.length; i++) {

--- a/packages/component/src/lib/reconcile.ts
+++ b/packages/component/src/lib/reconcile.ts
@@ -1652,8 +1652,14 @@ function shouldDispatchInlineMixinLifecycle(node: Node): boolean {
 
 export function findNextSiblingDomAnchor(curr: VNode): Node | null {
   let vParent = curr._parent
-  if (!vParent || !Array.isArray(vParent._children)) return null
-  let children = vParent._children
+  if (!vParent) return null
+
+  let children =
+    vParent._content && isFragmentNode(vParent._content)
+      ? vParent._content._children
+      : vParent._children
+  if (!children) return null
+
   let idx = children.indexOf(curr)
   if (idx === -1) return null
   for (let i = idx + 1; i < children.length; i++) {

--- a/packages/component/src/lib/scheduler.ts
+++ b/packages/component/src/lib/scheduler.ts
@@ -128,7 +128,7 @@ export function createScheduler(
             // Needed for fragment self-updates that add children - without this, new children
             // would be appended after siblings. The keyed diff has placement logic, but unkeyed
             // diff relies on anchor for correct positioning.
-            let anchor = findNextSiblingDomAnchor(vnode, vParent) || undefined
+            let anchor = findNextSiblingDomAnchor(vnode) || undefined
             try {
               renderComponent(
                 handle,

--- a/packages/component/src/lib/to-vnode.ts
+++ b/packages/component/src/lib/to-vnode.ts
@@ -1,7 +1,7 @@
 import { Fragment } from './component.ts'
 import { invariant } from './invariant.ts'
 import type { RemixElement, RemixNode } from './jsx.ts'
-import { isRemixElement, TEXT_NODE, type VNode } from './vnode.ts'
+import { isRemixElement, NON_RENDER_NODE, TEXT_NODE, type VNode } from './vnode.ts'
 
 function flatMapChildrenToVNodes(node: RemixElement): VNode[] {
   return 'children' in node.props
@@ -24,7 +24,7 @@ function flattenRemixNodeArray(nodes: RemixNode[], out: RemixNode[] = []): Remix
 
 export function toVNode(node: RemixNode): VNode {
   if (node === null || node === undefined || typeof node === 'boolean') {
-    return { type: TEXT_NODE, _text: '' }
+    return { type: NON_RENDER_NODE }
   }
 
   if (typeof node === 'string' || typeof node === 'number' || typeof node === 'bigint') {

--- a/packages/component/src/lib/vdom.ts
+++ b/packages/component/src/lib/vdom.ts
@@ -140,6 +140,7 @@ export function createRangeRoot(
             hydrationCursor,
           )
           vroot = vnode
+          vParent._content = vroot
           hydrationCursor = null
         },
       ])

--- a/packages/component/src/lib/vdom.ts
+++ b/packages/component/src/lib/vdom.ts
@@ -140,7 +140,6 @@ export function createRangeRoot(
             hydrationCursor,
           )
           vroot = vnode
-          vParent._content = vroot
           hydrationCursor = null
         },
       ])
@@ -226,7 +225,6 @@ export function createRoot(container: HTMLElement, options: VirtualRootOptions =
             hydrationCursor,
           )
           vroot = vnode
-          vParent._content = vnode
           hydrationCursor = undefined
         },
       ])

--- a/packages/component/src/lib/vdom.ts
+++ b/packages/component/src/lib/vdom.ts
@@ -225,6 +225,7 @@ export function createRoot(container: HTMLElement, options: VirtualRootOptions =
             hydrationCursor,
           )
           vroot = vnode
+          vParent._content = vnode
           hydrationCursor = undefined
         },
       ])

--- a/packages/component/src/lib/vnode.ts
+++ b/packages/component/src/lib/vnode.ts
@@ -3,6 +3,7 @@ import { Fragment, Frame } from './component.ts'
 import type { ElementProps, RemixElement, RemixNode } from './jsx.ts'
 
 export const TEXT_NODE = Symbol('TEXT_NODE')
+export const NON_RENDER_NODE = Symbol('NON_RENDER_NODE')
 export const ROOT_VNODE = Symbol('ROOT_VNODE')
 
 export type VNodeType =
@@ -10,6 +11,7 @@ export type VNodeType =
   | string // host element
   | Function // component
   | typeof TEXT_NODE
+  | typeof NON_RENDER_NODE
   | typeof Fragment
   | typeof Frame
 
@@ -93,12 +95,20 @@ export type CommittedComponentNode = VNode & {
   _handle: ComponentHandle
 }
 
+export type NonRenderNode = VNode & {
+  type: typeof NON_RENDER_NODE
+}
+
 export function isFragmentNode(node: VNode): node is FragmentNode {
   return node.type === Fragment
 }
 
 export function isTextNode(node: VNode): node is TextNode {
   return node.type === TEXT_NODE
+}
+
+export function isNonRenderNode(node: VNode): node is NonRenderNode {
+  return node.type === NON_RENDER_NODE
 }
 
 export function isCommittedTextNode(node: VNode): node is CommittedTextNode {

--- a/packages/component/src/test/hydration.components.test.tsx
+++ b/packages/component/src/test/hydration.components.test.tsx
@@ -197,9 +197,9 @@ describe('hydration', () => {
 
       let updatedSpans = container.querySelectorAll('span')
       expect(updatedSpans).toHaveLength(3)
-      expect(updatedSpans[0].textContent).toBe('First')
+      expect(updatedSpans[0]).toBe(existingSpans[0])
       expect(updatedSpans[1].textContent).toBe('after First')
-      expect(updatedSpans[2].textContent).toBe('Second')
+      expect(updatedSpans[2]).toBe(existingSpans[1])
     })
   })
 

--- a/packages/component/src/test/hydration.components.test.tsx
+++ b/packages/component/src/test/hydration.components.test.tsx
@@ -4,7 +4,7 @@ import { createRoot } from '../lib/vdom.ts'
 import { renderToString } from '../lib/stream.ts'
 import { clientEntry } from '../lib/client-entries.ts'
 import { invariant } from '../lib/invariant.ts'
-import { on, ref } from '../index.ts'
+import { on, ref, type Renderable } from '../index.ts'
 
 describe('hydration', () => {
   let container: HTMLDivElement
@@ -158,6 +158,50 @@ describe('hydration', () => {
       root.flush()
 
       expect(existingButton.textContent).toBe('Count: 6')
+    })
+
+    it('hydrates with null elements without breaking the ordering of siblings', async () => {
+      let secondElement: Renderable = null
+      let handleForComponent: Handle
+      let NullChanging = clientEntry('/with-null.js#WithNull', function WithNull(handle: Handle) {
+        handleForComponent = handle
+        return () => (
+          <div>
+            <span>First</span>
+            {secondElement}
+            <span>Second</span>
+          </div>
+        )
+      })
+
+      let html = await renderToString(<NullChanging />)
+      container.innerHTML = html
+
+      let existingSpans = container.querySelectorAll('span')
+      expect(existingSpans).toHaveLength(2)
+      invariant(existingSpans[0] && existingSpans[1])
+      expect(existingSpans[0].textContent).toBe('First')
+      expect(existingSpans[1].textContent).toBe('Second')
+
+      let root = createRoot(container)
+      root.render(<NullChanging />)
+      root.flush()
+
+      let hydratedSpans = container.querySelectorAll('span')
+      expect(hydratedSpans).toHaveLength(2)
+      expect(hydratedSpans[0]).toBe(existingSpans[0])
+      expect(hydratedSpans[1]).toBe(existingSpans[1])
+
+      // Now update to a version without the null to ensure ordering is preserved
+      secondElement = <span>after First</span>
+      // @ts-expect-error - the handle is being set
+      await handleForComponent.update()
+
+      let updatedSpans = container.querySelectorAll('span')
+      expect(updatedSpans).toHaveLength(3)
+      expect(updatedSpans[0].textContent).toBe('First')
+      expect(updatedSpans[1].textContent).toBe('after First')
+      expect(updatedSpans[2].textContent).toBe('Second')
     })
   })
 

--- a/packages/component/src/test/hydration.components.test.tsx
+++ b/packages/component/src/test/hydration.components.test.tsx
@@ -162,9 +162,7 @@ describe('hydration', () => {
 
     it('hydrates with null elements without breaking the ordering of siblings', async () => {
       let secondElement: Renderable = null
-      let handleForComponent: Handle
       let NullChanging = clientEntry('/with-null.js#WithNull', function WithNull(handle: Handle) {
-        handleForComponent = handle
         return () => (
           <div>
             <span>First</span>
@@ -194,8 +192,8 @@ describe('hydration', () => {
 
       // Now update to a version without the null to ensure ordering is preserved
       secondElement = <span>after First</span>
-      // @ts-expect-error - the handle is being set
-      await handleForComponent.update()
+      root.render(<NullChanging />)
+      root.flush()
 
       let updatedSpans = container.querySelectorAll('span')
       expect(updatedSpans).toHaveLength(3)

--- a/packages/component/src/test/vdom.dom-order.test.tsx
+++ b/packages/component/src/test/vdom.dom-order.test.tsx
@@ -477,7 +477,11 @@ describe('vnode rendering', () => {
             <span id="second">Second</span>
             <>
               <span id="third">Third</span>
-              <Middle id="middle-2" />
+              <>
+                <>
+                  <Middle id="middle-2" />
+                </>
+              </>
               <span id="fourth">Fourth</span>
             </>
           </>

--- a/packages/component/src/test/vdom.dom-order.test.tsx
+++ b/packages/component/src/test/vdom.dom-order.test.tsx
@@ -351,6 +351,53 @@ describe('vnode rendering', () => {
       )
     })
 
+    it('maintains DOM order when fragment component has multiple renders before changing', () => {
+      let container = document.createElement('div')
+      let root = createRoot(container)
+
+      let showMiddle = false
+      let capturedUpdate = () => {}
+
+      function Dynamic(handle: Handle) {
+        capturedUpdate = () => handle.update()
+        return () => (showMiddle ? <span id="middle">Middle</span> : null)
+      }
+
+      function App() {
+        return () => (
+          <main>
+            <>
+              <Dynamic />
+              <span id="tail">Tail</span>
+            </>
+            <footer id="footer">Footer</footer>
+          </main>
+        )
+      }
+
+      root.render(<App />)
+      let originalTail = container.querySelector('#tail')
+      let originalFooter = container.querySelector('#footer')
+      expect(container.innerHTML).toBe(
+        '<main><span id="tail">Tail</span><footer id="footer">Footer</footer></main>',
+      )
+
+      root.render(<App />)
+      root.flush()
+      expect(container.querySelector('#tail')).toBe(originalTail)
+      expect(container.querySelector('#footer')).toBe(originalFooter)
+
+      showMiddle = true
+      capturedUpdate()
+      root.flush()
+
+      expect(container.innerHTML).toBe(
+        '<main><span id="middle">Middle</span><span id="tail">Tail</span><footer id="footer">Footer</footer></main>',
+      )
+      expect(container.querySelector('#tail')).toBe(originalTail)
+      expect(container.querySelector('#footer')).toBe(originalFooter)
+    })
+
     it('maintains sibling order when a component toggles null in the middle slot', () => {
       let container = document.createElement('div')
       let root = createRoot(container)

--- a/packages/component/src/test/vdom.dom-order.test.tsx
+++ b/packages/component/src/test/vdom.dom-order.test.tsx
@@ -449,64 +449,50 @@ describe('vnode rendering', () => {
       expect(container.querySelector('#second')).toBe(second)
     })
 
-    it('maintains DOM order when replacing a component with non-render middle content', () => {
+    it('maintains DOM order with non-render content in a fragment', () => {
       let container = document.createElement('div')
       let root = createRoot(container)
 
       let showMiddle = false
       let capturedUpdate = () => {}
 
-      function PageA() {
-        return () => <div>Page A</div>
-      }
-
-      function PageB(handle: Handle) {
+      function Middle(handle: Handle) {
         capturedUpdate = () => handle.update()
-        return () => (
-          <>
-            <span>Start</span>
-            {showMiddle ? <span>Middle</span> : null}
-            <span>End</span>
-          </>
-        )
+        return () => {
+          if (showMiddle) return <span id="middle">Middle</span>
+          return undefined
+        }
       }
 
-      let Page: typeof PageA | typeof PageB = PageA
-
-      function App() {
-        return () => (
-          <main>
-            <nav>Nav</nav>
-            <Page />
-            <footer>Footer</footer>
-          </main>
-        )
-      }
-
-      root.render(<App />)
+      root.render(
+        <>
+          <span id="first">First</span>
+          <Middle />
+          <span id="second">Second</span>
+        </>,
+      )
       expect(container.innerHTML).toBe(
-        '<main><nav>Nav</nav><div>Page A</div><footer>Footer</footer></main>',
+        '<span id="first">First</span><span id="second">Second</span>',
       )
 
-      Page = PageB
-      root.render(<App />)
-      expect(container.innerHTML).toBe(
-        '<main><nav>Nav</nav><span>Start</span><span>End</span><footer>Footer</footer></main>',
-      )
+      let first = container.querySelector('#first')
+      let second = container.querySelector('#second')
 
       showMiddle = true
       capturedUpdate()
       root.flush()
       expect(container.innerHTML).toBe(
-        '<main><nav>Nav</nav><span>Start</span><span>Middle</span><span>End</span><footer>Footer</footer></main>',
+        '<span id="first">First</span><span id="middle">Middle</span><span id="second">Second</span>',
       )
 
       showMiddle = false
       capturedUpdate()
       root.flush()
       expect(container.innerHTML).toBe(
-        '<main><nav>Nav</nav><span>Start</span><span>End</span><footer>Footer</footer></main>',
+        '<span id="first">First</span><span id="second">Second</span>',
       )
+      expect(container.querySelector('#first')).toBe(first)
+      expect(container.querySelector('#second')).toBe(second)
     })
   })
 })

--- a/packages/component/src/test/vdom.dom-order.test.tsx
+++ b/packages/component/src/test/vdom.dom-order.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { createRoot } from '../lib/vdom.ts'
 import type { Handle } from '../lib/component.ts'
+import { invariant } from '../lib/invariant.ts'
 
 describe('vnode rendering', () => {
   describe('conditional rendering and DOM order', () => {
@@ -458,47 +459,55 @@ describe('vnode rendering', () => {
       let root = createRoot(container)
 
       let showMiddle = false
-      let capturedUpdate = () => {}
+      let capturedUpdates: (() => void)[] = []
 
       function Middle(handle: Handle) {
-        capturedUpdate = () => handle.update()
-        return () => {
-          if (showMiddle) return <span id="middle">Middle</span>
+        capturedUpdates.push(() => handle.update())
+        return ({ id }: { id: string }) => {
+          if (showMiddle) return <span id={id}>Middle</span>
           return undefined
         }
       }
 
-      root.render(
-        <>
-          <span id="first">First</span>
-          <Middle />
-          <span id="second">Second</span>
-        </>,
-      )
-      expect(container.innerHTML).toBe(
-        '<span id="first">First</span><span id="second">Second</span>',
-      )
+      function App() {
+        return () => (
+          <>
+            <span id="first">First</span>
+            <Middle id="middle-1" />
+            <span id="second">Second</span>
+            <>
+              <span id="third">Third</span>
+              <Middle id="middle-2" />
+              <span id="fourth">Fourth</span>
+            </>
+          </>
+        )
+      }
+
+      root.render(<App />)
 
       let first = container.querySelector('#first')
       let second = container.querySelector('#second')
+      invariant(first && second)
+      expect(first.nextSibling).toBe(second)
+
+      let third = container.querySelector('#third')
+      let fourth = container.querySelector('#fourth')
+      invariant(third && fourth)
+      expect(second.nextSibling).toBe(third)
+      expect(third.nextSibling).toBe(fourth)
 
       showMiddle = true
-      capturedUpdate()
+      capturedUpdates.forEach((update) => update())
       root.flush()
-      expect(container.innerHTML).toBe(
-        '<span id="first">First</span><span id="middle">Middle</span><span id="second">Second</span>',
-      )
-      expect(container.querySelector('#first')).toBe(first)
-      expect(container.querySelector('#second')).toBe(second)
 
-      showMiddle = false
-      capturedUpdate()
-      root.flush()
-      expect(container.innerHTML).toBe(
-        '<span id="first">First</span><span id="second">Second</span>',
-      )
-      expect(container.querySelector('#first')).toBe(first)
-      expect(container.querySelector('#second')).toBe(second)
+      let middle1 = container.querySelector('#middle-1')
+      let middle2 = container.querySelector('#middle-2')
+      invariant(middle1 && middle2)
+      expect(middle1.previousSibling).toBe(first)
+      expect(middle1.nextSibling).toBe(second)
+      expect(middle2.previousSibling).toBe(third)
+      expect(middle2.nextSibling).toBe(fourth)
     })
   })
 })

--- a/packages/component/src/test/vdom.dom-order.test.tsx
+++ b/packages/component/src/test/vdom.dom-order.test.tsx
@@ -431,6 +431,8 @@ describe('vnode rendering', () => {
       expect(container.innerHTML).toBe(
         '<main><span id="first">First</span><span id="middle">Middle</span><span id="second">Second</span></main>',
       )
+      expect(container.querySelector('#first')).toBe(first)
+      expect(container.querySelector('#second')).toBe(second)
 
       mode = 'false'
       capturedUpdate()
@@ -438,6 +440,8 @@ describe('vnode rendering', () => {
       expect(container.innerHTML).toBe(
         '<main><span id="first">First</span><span id="second">Second</span></main>',
       )
+      expect(container.querySelector('#first')).toBe(first)
+      expect(container.querySelector('#second')).toBe(second)
 
       mode = 'element'
       capturedUpdate()
@@ -484,6 +488,8 @@ describe('vnode rendering', () => {
       expect(container.innerHTML).toBe(
         '<span id="first">First</span><span id="middle">Middle</span><span id="second">Second</span>',
       )
+      expect(container.querySelector('#first')).toBe(first)
+      expect(container.querySelector('#second')).toBe(second)
 
       showMiddle = false
       capturedUpdate()

--- a/packages/component/src/test/vdom.dom-order.test.tsx
+++ b/packages/component/src/test/vdom.dom-order.test.tsx
@@ -349,5 +349,164 @@ describe('vnode rendering', () => {
         '<main><span>0</span><span>1</span><span>2</span><footer>Footer</footer></main>',
       )
     })
+
+    it('maintains sibling order when a component toggles null in the middle slot', () => {
+      let container = document.createElement('div')
+      let root = createRoot(container)
+
+      let middleVisible = false
+      let capturedUpdate = () => {}
+
+      function Middle(handle: Handle) {
+        capturedUpdate = () => handle.update()
+        return () => (middleVisible ? <span id="middle">Middle</span> : null)
+      }
+
+      root.render(
+        <main>
+          <span id="first">First</span>
+          <Middle />
+          <span id="second">Second</span>
+        </main>,
+      )
+      expect(container.innerHTML).toBe(
+        '<main><span id="first">First</span><span id="second">Second</span></main>',
+      )
+
+      let first = container.querySelector('#first')
+      let second = container.querySelector('#second')
+
+      middleVisible = true
+      capturedUpdate()
+      root.flush()
+      expect(container.innerHTML).toBe(
+        '<main><span id="first">First</span><span id="middle">Middle</span><span id="second">Second</span></main>',
+      )
+      expect(container.querySelector('#first')).toBe(first)
+      expect(container.querySelector('#second')).toBe(second)
+
+      middleVisible = false
+      capturedUpdate()
+      root.flush()
+      expect(container.innerHTML).toBe(
+        '<main><span id="first">First</span><span id="second">Second</span></main>',
+      )
+      expect(container.querySelector('#first')).toBe(first)
+      expect(container.querySelector('#second')).toBe(second)
+    })
+
+    it('maintains sibling order when a component toggles undefined and booleans', () => {
+      let container = document.createElement('div')
+      let root = createRoot(container)
+
+      let mode: 'undefined' | 'false' | 'element' = 'undefined'
+      let capturedUpdate = () => {}
+
+      function Middle(handle: Handle) {
+        capturedUpdate = () => handle.update()
+        return () => {
+          if (mode === 'element') return <span id="middle">Middle</span>
+          if (mode === 'false') return false
+          return undefined
+        }
+      }
+
+      root.render(
+        <main>
+          <span id="first">First</span>
+          <Middle />
+          <span id="second">Second</span>
+        </main>,
+      )
+      expect(container.innerHTML).toBe(
+        '<main><span id="first">First</span><span id="second">Second</span></main>',
+      )
+
+      let first = container.querySelector('#first')
+      let second = container.querySelector('#second')
+
+      mode = 'element'
+      capturedUpdate()
+      root.flush()
+      expect(container.innerHTML).toBe(
+        '<main><span id="first">First</span><span id="middle">Middle</span><span id="second">Second</span></main>',
+      )
+
+      mode = 'false'
+      capturedUpdate()
+      root.flush()
+      expect(container.innerHTML).toBe(
+        '<main><span id="first">First</span><span id="second">Second</span></main>',
+      )
+
+      mode = 'element'
+      capturedUpdate()
+      root.flush()
+      expect(container.innerHTML).toBe(
+        '<main><span id="first">First</span><span id="middle">Middle</span><span id="second">Second</span></main>',
+      )
+      expect(container.querySelector('#first')).toBe(first)
+      expect(container.querySelector('#second')).toBe(second)
+    })
+
+    it('maintains DOM order when replacing a component with non-render middle content', () => {
+      let container = document.createElement('div')
+      let root = createRoot(container)
+
+      let showMiddle = false
+      let capturedUpdate = () => {}
+
+      function PageA() {
+        return () => <div>Page A</div>
+      }
+
+      function PageB(handle: Handle) {
+        capturedUpdate = () => handle.update()
+        return () => (
+          <>
+            <span>Start</span>
+            {showMiddle ? <span>Middle</span> : null}
+            <span>End</span>
+          </>
+        )
+      }
+
+      let Page: typeof PageA | typeof PageB = PageA
+
+      function App() {
+        return () => (
+          <main>
+            <nav>Nav</nav>
+            <Page />
+            <footer>Footer</footer>
+          </main>
+        )
+      }
+
+      root.render(<App />)
+      expect(container.innerHTML).toBe(
+        '<main><nav>Nav</nav><div>Page A</div><footer>Footer</footer></main>',
+      )
+
+      Page = PageB
+      root.render(<App />)
+      expect(container.innerHTML).toBe(
+        '<main><nav>Nav</nav><span>Start</span><span>End</span><footer>Footer</footer></main>',
+      )
+
+      showMiddle = true
+      capturedUpdate()
+      root.flush()
+      expect(container.innerHTML).toBe(
+        '<main><nav>Nav</nav><span>Start</span><span>Middle</span><span>End</span><footer>Footer</footer></main>',
+      )
+
+      showMiddle = false
+      capturedUpdate()
+      root.flush()
+      expect(container.innerHTML).toBe(
+        '<main><nav>Nav</nav><span>Start</span><span>End</span><footer>Footer</footer></main>',
+      )
+    })
   })
 })

--- a/packages/component/src/test/vdom.dom-order.test.tsx
+++ b/packages/component/src/test/vdom.dom-order.test.tsx
@@ -455,11 +455,8 @@ describe('vnode rendering', () => {
     })
 
     it('maintains DOM order with non-render content in a fragment', () => {
-      let container = document.createElement('div')
-      let root = createRoot(container)
-
-      let showMiddle = false
       let capturedUpdates: (() => void)[] = []
+      let showMiddle = false
 
       function Middle(handle: Handle) {
         capturedUpdates.push(() => handle.update())
@@ -485,45 +482,68 @@ describe('vnode rendering', () => {
               <span id="fourth">Fourth</span>
             </>
             <div id="div">
-              <Middle id="middle-3" />
+              <>
+                <span id="fifth">Fifth</span>
+                <Middle id="middle-3" />
+                <span id="sixth">Sixth</span>
+              </>
             </div>
-            <span id="fifth">Fifth</span>
+            <span id="seventh">Seventh</span>
           </>
         )
       }
 
-      root.render(<App />)
+      let updateMethods: Array<(root: ReturnType<typeof createRoot>) => void> = [
+        () => capturedUpdates.forEach((update) => update()),
+        (root) => root.render(<App />),
+      ]
 
-      let first = container.querySelector('#first')
-      let second = container.querySelector('#second')
-      invariant(first && second)
-      expect(first.nextSibling).toBe(second)
+      for (let updateMethod of updateMethods) {
+        showMiddle = false
+        let container = document.createElement('div')
+        let root = createRoot(container)
 
-      let third = container.querySelector('#third')
-      let fourth = container.querySelector('#fourth')
-      invariant(third && fourth)
-      expect(second.nextSibling).toBe(third)
-      expect(third.nextSibling).toBe(fourth)
+        root.render(<App />)
 
-      let div = container.querySelector('#div')
-      let fifth = container.querySelector('#fifth')
-      invariant(div && fifth)
-      expect(fourth.nextSibling).toBe(div)
-      expect(div.nextSibling).toBe(fifth)
+        let first = container.querySelector('#first')
+        let second = container.querySelector('#second')
+        invariant(first && second)
+        expect(first.nextSibling).toBe(second)
 
-      showMiddle = true
-      capturedUpdates.forEach((update) => update())
-      root.flush()
+        let third = container.querySelector('#third')
+        let fourth = container.querySelector('#fourth')
+        invariant(third && fourth)
+        expect(second.nextSibling).toBe(third)
+        expect(third.nextSibling).toBe(fourth)
 
-      let middle1 = container.querySelector('#middle-1')
-      let middle2 = container.querySelector('#middle-2')
-      let middle3 = container.querySelector('#middle-3')
-      invariant(middle1 && middle2 && middle3)
-      expect(middle1.previousSibling).toBe(first)
-      expect(middle1.nextSibling).toBe(second)
-      expect(middle2.previousSibling).toBe(third)
-      expect(middle2.nextSibling).toBe(fourth)
-      expect(middle3.parentNode).toBe(div)
+        let div = container.querySelector('#div')
+        let fifth = container.querySelector('#fifth')
+        let sixth = container.querySelector('#sixth')
+        invariant(div && fifth && sixth)
+        expect(fourth.nextSibling).toBe(div)
+        expect(fifth.parentNode).toBe(div)
+        expect(fifth.nextSibling).toBe(sixth)
+
+        let seventh = container.querySelector('#seventh')
+        invariant(seventh)
+        expect(div.nextSibling).toBe(seventh)
+
+        showMiddle = true
+        updateMethod(root)
+        root.flush()
+
+        let middle1 = container.querySelector('#middle-1')
+        let middle2 = container.querySelector('#middle-2')
+        let middle3 = container.querySelector('#middle-3')
+        invariant(middle1 && middle2 && middle3)
+        expect(middle1.previousSibling).toBe(first)
+        expect(middle1.nextSibling).toBe(second)
+        expect(middle2.previousSibling).toBe(third)
+        expect(middle2.nextSibling).toBe(fourth)
+        expect(middle3.parentNode).toBe(div)
+        expect(middle3.previousSibling).toBe(fifth)
+        expect(middle3.nextSibling).toBe(sixth)
+      }
     })
   })
 })

--- a/packages/component/src/test/vdom.dom-order.test.tsx
+++ b/packages/component/src/test/vdom.dom-order.test.tsx
@@ -484,6 +484,10 @@ describe('vnode rendering', () => {
               </>
               <span id="fourth">Fourth</span>
             </>
+            <div id="div">
+              <Middle id="middle-3" />
+            </div>
+            <span id="fifth">Fifth</span>
           </>
         )
       }
@@ -501,17 +505,25 @@ describe('vnode rendering', () => {
       expect(second.nextSibling).toBe(third)
       expect(third.nextSibling).toBe(fourth)
 
+      let div = container.querySelector('#div')
+      let fifth = container.querySelector('#fifth')
+      invariant(div && fifth)
+      expect(fourth.nextSibling).toBe(div)
+      expect(div.nextSibling).toBe(fifth)
+
       showMiddle = true
       capturedUpdates.forEach((update) => update())
       root.flush()
 
       let middle1 = container.querySelector('#middle-1')
       let middle2 = container.querySelector('#middle-2')
-      invariant(middle1 && middle2)
+      let middle3 = container.querySelector('#middle-3')
+      invariant(middle1 && middle2 && middle3)
       expect(middle1.previousSibling).toBe(first)
       expect(middle1.nextSibling).toBe(second)
       expect(middle2.previousSibling).toBe(third)
       expect(middle2.nextSibling).toBe(fourth)
+      expect(middle3.parentNode).toBe(div)
     })
   })
 })


### PR DESCRIPTION
Fixes https://github.com/remix-run/remix/issues/11061

Non-renderable nodes (`null`, `undefined`, `boolean`) are currently represented in the vDom as empty text nodes. However, the server serialization completely omits them from the output. Hence, if these nodes are ever replaced in a later update on the client with renderable content, there is no `_dom` reference to use to determine where to insert the new content. Additionally, the `findNextSiblingDomAnchor` check currently also fails as the `vParent` is the parent of the `next` vNode, not the current. Therefore, nodes end up being amended to the end of their parent's children by default as shown in https://github.com/remix-run/remix/issues/11061.

This change:
- Adds a `NON_RENDER_NODE` to represent nodes that the code shouldn't try to find in the DOM
- Forces `findNextSiblingDomAnchor` to always use the current parent by not passing it as a second parameter, but reading it from the `curr` parameter
- Allows `findNextSiblingDomAnchor` to recursively search up the tree to find the next sibling if its parent is a fragment. This is because a node might not have a sibling within the fragment, but when the fragment is flattened at the DOM level, it does have one. Therefore, going up a level allows that possible next node to be found.
- Fixes bug where the parent of vNode in a fragment was set to the parent of the fragment, not the fragment itself
    - This may have been intentional. However, as the vParent's children array isn't been updated to reflect these grandchildren, `findNextSiblingDomAnchor` fails to find all of the siblings. I tried update the vParent to track its grandchildren with the hope of being able to remove the recursion, but that resulted in duplication between having the grandchildren and their containing fragment, which really broke the diff'ing logic. 

For context:
This set of changes is the only one I found that worked, but I also tried:
- Filtering out non-renderable nodes rather than tracking them in a separate type as this _seems_ to be the method used by React and Preact (I might be wrong on that last point). However, this cases issues with needlessly tearing down components and recreating them when their previous sibling changed from non-renderable to renderable.
- Inserting a comment where the non-renderable node would be if it was rendered rather than relying on finding the next sibling. However, `skipComments` caused these comments to be skipped when looking for the anchor. Rather than updating this to not skip this comment, I abandoned this approach as it smelled off.