### PR TITLE
Clean up social auth demo controller creation

### DIFF
--- a/demos/social-auth/app/controllers/auth/controller.tsx
+++ b/demos/social-auth/app/controllers/auth/controller.tsx
@@ -1,13 +1,13 @@
 import type { Controller } from 'remix/fetch-router'
 
 import { forgotPasswordController } from './forgot-password/controller.tsx'
-import { createGitHubAuthController, githubAuthController } from './github/controller.ts'
-import { createGoogleAuthController, googleAuthController } from './google/controller.ts'
+import { createGitHubAuthController } from './github/controller.ts'
+import { createGoogleAuthController } from './google/controller.ts'
 import { login } from './login-action.ts'
 import { logout } from './logout-action.ts'
 import { resetPasswordController } from './reset-password/controller.tsx'
 import { signupController } from './signup/controller.tsx'
-import { createXAuthController, xAuthController } from './x/controller.ts'
+import { createXAuthController } from './x/controller.ts'
 import type { AppContext } from '../../router.ts'
 import type { routes } from '../../routes.ts'
 import {
@@ -32,15 +32,3 @@ export function createAuthController(
   } satisfies Controller<typeof routes.auth, AppContext>
 }
 
-export let authController = {
-  actions: {
-    login,
-    logout,
-    signup: signupController,
-    forgotPassword: forgotPasswordController,
-    resetPassword: resetPasswordController,
-    google: googleAuthController,
-    github: githubAuthController,
-    x: xAuthController,
-  },
-} satisfies Controller<typeof routes.auth, AppContext>

--- a/demos/social-auth/app/controllers/auth/github/controller.ts
+++ b/demos/social-auth/app/controllers/auth/github/controller.ts
@@ -71,4 +71,3 @@ export function createGitHubAuthController(
   } satisfies Controller<typeof routes.auth.github, AppContext>
 }
 
-export let githubAuthController = createGitHubAuthController()

--- a/demos/social-auth/app/controllers/auth/google/controller.ts
+++ b/demos/social-auth/app/controllers/auth/google/controller.ts
@@ -71,4 +71,3 @@ export function createGoogleAuthController(
   } satisfies Controller<typeof routes.auth.google, AppContext>
 }
 
-export let googleAuthController = createGoogleAuthController()

--- a/demos/social-auth/app/controllers/auth/x/controller.ts
+++ b/demos/social-auth/app/controllers/auth/x/controller.ts
@@ -71,4 +71,3 @@ export function createXAuthController(
   } satisfies Controller<typeof routes.auth.x, AppContext>
 }
 
-export let xAuthController = createXAuthController()

--- a/demos/social-auth/app/controllers/home/controller.tsx
+++ b/demos/social-auth/app/controllers/home/controller.tsx
@@ -40,4 +40,3 @@ export function createHomeController(
   }
 }
 
-export let home = createHomeController()


### PR DESCRIPTION
This cleans up duplicate controller creation in the social auth demo and standardizes on the style the router actually uses today.

Controllers that depend on the injected `externalProviderRegistry` now expose only factory functions. That keeps per-router provider injection intact for tests and alternate configurations, while removing the unused module-scope controller objects that were built with the default registry.

- removes the unused `authController`, `home`, `githubAuthController`, `googleAuthController`, and `xAuthController` exports
- keeps `createHomeController` and `createAuthController` as the single entry points for registry-dependent controllers
- trims the provider controller modules so they no longer define and immediately instantiate duplicate controller objects
