### PR TITLE
Remove dead exports in social auth demo

### DIFF
--- a/demos/social-auth/app/controllers/account/page.tsx
+++ b/demos/social-auth/app/controllers/account/page.tsx
@@ -12,7 +12,7 @@ import type { AuthIdentity } from '../../utils/auth-session.ts'
 
 let { tokens } = designSystem
 
-export interface AccountPageProps {
+interface AccountPageProps {
   identity: AuthIdentity
   logoutAction: string
 }

--- a/demos/social-auth/app/controllers/auth/error-page.tsx
+++ b/demos/social-auth/app/controllers/auth/error-page.tsx
@@ -5,7 +5,7 @@ import { Document } from '../ui/document.tsx'
 import { Notice } from '../ui/notice.tsx'
 import * as styles from '../ui/styles.ts'
 
-export interface ErrorPageProps {
+interface ErrorPageProps {
   title: string
   message: RemixNode
   loginHref: string

--- a/demos/social-auth/app/controllers/auth/forgot-password/page.tsx
+++ b/demos/social-auth/app/controllers/auth/forgot-password/page.tsx
@@ -11,7 +11,7 @@ import * as styles from '../../ui/styles.ts'
 
 let { tokens } = designSystem
 
-export interface ForgotPasswordPageProps {
+interface ForgotPasswordPageProps {
   formAction: string
   loginHref: string
   error?: string
@@ -50,7 +50,7 @@ export function ForgotPasswordPage() {
   )
 }
 
-export interface ForgotPasswordSentPageProps {
+interface ForgotPasswordSentPageProps {
   email: string
   loginHref: string
   resetHref?: string

--- a/demos/social-auth/app/controllers/auth/reset-password/page.tsx
+++ b/demos/social-auth/app/controllers/auth/reset-password/page.tsx
@@ -6,7 +6,7 @@ import { Document } from '../../ui/document.tsx'
 import { Notice } from '../../ui/notice.tsx'
 import * as styles from '../../ui/styles.ts'
 
-export interface ResetPasswordPageProps {
+interface ResetPasswordPageProps {
   formAction: string
   loginHref: string
   error?: string
@@ -54,7 +54,7 @@ export function ResetPasswordPage() {
   )
 }
 
-export interface ResetPasswordCompletePageProps {
+interface ResetPasswordCompletePageProps {
   loginHref: string
 }
 

--- a/demos/social-auth/app/controllers/auth/signup/page.tsx
+++ b/demos/social-auth/app/controllers/auth/signup/page.tsx
@@ -6,7 +6,7 @@ import { Document } from '../../ui/document.tsx'
 import { Notice } from '../../ui/notice.tsx'
 import * as styles from '../../ui/styles.ts'
 
-export interface SignupPageProps {
+interface SignupPageProps {
   formAction: string
   loginHref: string
   error?: string

--- a/demos/social-auth/app/controllers/home/page.tsx
+++ b/demos/social-auth/app/controllers/home/page.tsx
@@ -8,7 +8,7 @@ import * as styles from '../ui/styles.ts'
 import { ExternalAuthSection } from './external-auth-section.tsx'
 import { LoginFooter } from './footer.tsx'
 
-export interface LoginPageProps {
+interface LoginPageProps {
   formAction: string
   signupHref: string
   forgotPasswordHref: string

--- a/demos/social-auth/app/controllers/home/social-provider-button.tsx
+++ b/demos/social-auth/app/controllers/home/social-provider-button.tsx
@@ -2,7 +2,7 @@ import type { RemixNode } from 'remix/component'
 
 import * as styles from '../ui/styles.ts'
 
-export interface SocialProviderButtonProps {
+interface SocialProviderButtonProps {
   label: string
   icon: RemixNode
   href?: string

--- a/demos/social-auth/app/controllers/ui/auth-card.tsx
+++ b/demos/social-auth/app/controllers/ui/auth-card.tsx
@@ -2,7 +2,7 @@ import type { RemixNode } from 'remix/component'
 
 import * as styles from './styles.ts'
 
-export interface AuthCardProps {
+interface AuthCardProps {
   title: string
   subtitle?: string
   children: RemixNode

--- a/demos/social-auth/app/controllers/ui/document.tsx
+++ b/demos/social-auth/app/controllers/ui/document.tsx
@@ -2,7 +2,7 @@ import type { RemixNode } from 'remix/component'
 
 import * as styles from './styles.ts'
 
-export interface DocumentProps {
+interface DocumentProps {
   title: string
   children: RemixNode
 }

--- a/demos/social-auth/app/controllers/ui/form-field.tsx
+++ b/demos/social-auth/app/controllers/ui/form-field.tsx
@@ -3,7 +3,7 @@ import { css } from 'remix/component'
 
 import * as styles from './styles.ts'
 
-export interface TextFieldProps {
+interface TextFieldProps {
   id: string
   name: string
   type: 'email' | 'password' | 'text'

--- a/demos/social-auth/app/controllers/ui/notice.tsx
+++ b/demos/social-auth/app/controllers/ui/notice.tsx
@@ -2,7 +2,7 @@ import type { RemixNode } from 'remix/component'
 
 import * as styles from './styles.ts'
 
-export interface NoticeProps {
+interface NoticeProps {
   tone: 'error' | 'success'
   children: RemixNode
 }

--- a/demos/social-auth/app/data/schema.ts
+++ b/demos/social-auth/app/data/schema.ts
@@ -107,7 +107,6 @@ export let passwordResetTokens = table({
 
 export type User = TableRow<typeof users>
 export type AuthAccount = TableRow<typeof authAccounts>
-export type PasswordResetToken = TableRow<typeof passwordResetTokens>
 
 export function normalizeEmail(email: string): string {
   return email.trim().toLowerCase()

--- a/demos/social-auth/app/data/setup.ts
+++ b/demos/social-auth/app/data/setup.ts
@@ -48,7 +48,7 @@ async function initialize(): Promise<void> {
   }
 }
 
-export function getDatabaseFilePath(): string {
+function getDatabaseFilePath(): string {
   let fileName =
     process.env.NODE_ENV === 'test'
       ? 'social-auth.test.' + process.pid + '.' + Date.now() + '.sqlite'

--- a/demos/social-auth/app/middleware/auth.ts
+++ b/demos/social-auth/app/middleware/auth.ts
@@ -93,7 +93,7 @@ export function getReturnToQuery(url: URL): { returnTo?: string } {
   return returnTo ? { returnTo } : {}
 }
 
-export function getSafeReturnTo(returnTo: string | null): string | undefined {
+function getSafeReturnTo(returnTo: string | null): string | undefined {
   if (returnTo == null || returnTo === '') {
     return undefined
   }

--- a/demos/social-auth/app/router.ts
+++ b/demos/social-auth/app/router.ts
@@ -19,7 +19,7 @@ import { externalProviderRegistry, type ExternalProviderRegistry } from './utils
 
 await initializeSocialAuthDatabase()
 
-export type RootMiddleware = [
+type RootMiddleware = [
   ReturnType<typeof staticFiles>,
   ReturnType<typeof formData>,
   ReturnType<typeof session>,

--- a/demos/social-auth/app/utils/external-auth.ts
+++ b/demos/social-auth/app/utils/external-auth.ts
@@ -5,7 +5,7 @@ import { routes } from '../routes.ts'
 
 export type ExternalProviderName = 'google' | 'github' | 'x'
 
-export type ExternalProviderFor<name extends ExternalProviderName> = name extends 'google'
+type ExternalProviderFor<name extends ExternalProviderName> = name extends 'google'
   ? OAuthProvider<GoogleAuthProfile, 'google'>
   : name extends 'github'
     ? OAuthProvider<GitHubAuthProfile, 'github'>
@@ -31,7 +31,7 @@ export interface ExternalProviderLink {
   disabledReason?: string
 }
 
-export interface ProviderStatus {
+interface ProviderStatus {
   enabled: boolean
   missingEnvVars: string[]
 }

--- a/demos/social-auth/test/helpers.ts
+++ b/demos/social-auth/test/helpers.ts
@@ -26,7 +26,7 @@ export async function createTestRouter(
   })
 }
 
-export function getCookie(response: Response, name: string): string | null {
+function getCookie(response: Response, name: string): string | null {
   for (let header of response.headers.getSetCookie()) {
     let setCookie = new SetCookie(header)
     if (setCookie.name === name) {


### PR DESCRIPTION
This trims dead export surface from the social auth demo without changing its runtime behavior.

Most of the cleanup is just tightening module boundaries: props interfaces and helper types that are only used inside a single file no longer need to be part of the demo's public surface.

- makes local-only page and UI `*Props` interfaces internal to their modules
- narrows a few helper/type exports in the demo internals, including router, auth, database setup, external auth, and test helpers
- removes an unused schema type export while keeping the existing login UI intact, including the placeholder remember-me checkbox
