### PR TITLE
route-pattern: consistency with `URLSearchParams`

### DIFF
--- a/packages/route-pattern/.changes/minor.make-search-param-patterns-consitent-with-urlsearchparams.md
+++ b/packages/route-pattern/.changes/minor.make-search-param-patterns-consitent-with-urlsearchparams.md
@@ -1,0 +1,75 @@
+BREAKING CHANGE: Make search param pattern decoding and serialization consistent with `URLSearchParams`. Affects: `RoutePattern.{match,href,search,ast.search}`
+
+Previously, `RoutePattern` treated `?q` and `?q=` as **different** constraints:
+
+```ts
+// Before: `?q` and `?q=` are different
+
+let url = new URL('https://example.com?q')
+
+// Matches "key only" constraint?
+new RoutePattern('?q').match(url) // ✅ match
+
+// Matches "key and value" constraint?
+new RoutePattern('?q=').match(url) // ❌ no match (`null`)
+
+// Different constraints serialized to different strings
+new RoutePattern('?q').search // -> 'q'
+new RoutePattern('?q=').search // -> 'q='
+```
+
+There were two main problems with that approach:
+
+**Unintuitive matching**
+
+```ts
+// URL search looks like `?q=`
+let url = new URL('https://example.com?q=')
+
+// Pattern search looks like `?q=`
+let pattern = new RoutePattern('?q=')
+
+// But "key and value" constraint doesn't match!
+pattern.match(url) // ❌ no match (`null`)
+```
+
+
+**Parsing and serialization**
+
+For consistency with `URLSearchParams`, search param patterns should be parsed according to the [WHATWG `application/x-www-form-urlencoded` parsing spec](https://url.spec.whatwg.org/#application/x-www-form-urlencoded-parsing) and should also [encode spaces as `+`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#percent_encoding).
+
+Now, we use `URLSearchParams` to parse search param patterns to guarantee decodings are consistent:
+
+```ts
+let url = new URL('https://example.com?q=a+b')
+// Decodes `+` to ` `
+url.searchParams.getAll('q') // -> ['a b']
+
+// Before
+let pattern = new RoutePattern('?q=a+b')
+// Does not decode `+` to ` `
+pattern.ast.search.get('q') // -> ❌ Set { 'a+b' }
+
+// After
+let pattern = new RoutePattern('?q=a+b')
+// Decodes `+` to ` `
+pattern.ast.search.get('q') // -> ✅ Set { 'a b' }
+```
+
+Similarly, now that `?q` and `?q=` are semantically equivalent, they should serialize to the same thing:
+
+```ts
+new URLSearchParams('q=').toString() // 'q='
+
+// Before
+new RoutePattern('?q=').search // ❌ 'q'
+
+// After
+new RoutePattern('?q=').search // ✅ 'q='
+```
+
+As a result, `RoutePattern`s can no longer represent a "key and any value" constraint.
+In practice, this was a niche use-case so we chose correctness and consistency with `URLSearchParams`.
+If the need for "key and any value" constraints arises, we can later introduce a separate syntax for that without the unintuitive shortcoming of `?q=`.
+
+With "key and any value" constraints removed, the `missing-search-param` error type thrown by `RoutePattern.href` was made obsolete and was removed.

--- a/packages/route-pattern/README.md
+++ b/packages/route-pattern/README.md
@@ -61,11 +61,10 @@ new RoutePattern('docs(/guides/:category)') // multiple segments optional: /docs
 new RoutePattern('api(/v:major(.:minor))') // nested optionals: /api, /api/v2, /api/v2.1
 ```
 
-**Search params** narrow matches using `?key` or `?key=value`:
+**Search params** narrow matches using `?key`, `?key=`, or `?key=value`. Parsing and serialization follow `URLSearchParams` (`application/x-www-form-urlencoded`): `?key` and `?key=` are the same constraint (stored as an empty `Set` in `ast.search`: key must be present; empty value is OK), and spaces use `+` / `%20` like in real query strings.
 
 ```ts
-new RoutePattern('search?q') // requires ?q in URL
-new RoutePattern('search?q=') // requires ?q with any value
+new RoutePattern('search?q') // same constraint as ?q= — key must be present
 new RoutePattern('search?q=routing') // requires ?q=routing exactly
 ```
 
@@ -138,12 +137,11 @@ matcher.match('https://example.com/blog/hello')
 let router = new ArrayMatcher<string>()
 router.add('search', 'no-params')
 router.add('search?q', 'has-q')
-router.add('search?q=', 'has-q-with-value')
 router.add('search?q=hello', 'exact-match')
 
 router.match('https://example.com/search?q=hello')
 // { pattern: 'search?q=hello', params: {}, data: 'exact-match' }
-// More constrained search params = more specific
+// More constrained search params = more specific (`?q` and `?q=` tie)
 ```
 
 ## Benchmark

--- a/packages/route-pattern/src/lib/matcher.test.ts
+++ b/packages/route-pattern/src/lib/matcher.test.ts
@@ -508,12 +508,13 @@ function testSuite(MatcherClass: MatcherConstructor): void {
         assert.ok(match)
       })
 
-      it('returns null when any value constraint has empty value', () => {
+      it('matches key-only constraint', () => {
         let matcher = new MatcherClass()
         matcher.add('://example.com/search?q=', null)
 
-        assert.equal(matcher.match('http://example.com/search?q='), null)
-        assert.equal(matcher.match('http://example.com/search?q'), null)
+        assert.ok(matcher.match('http://example.com/search?q'))
+        assert.ok(matcher.match('http://example.com/search?q='))
+        assert.ok(matcher.match('http://example.com/search?q=test'))
       })
 
       it('matches specific value with exact match', () => {
@@ -586,7 +587,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
 
         let match = matcher.match('http://example.com/search?q=test&lang=en')
         assert.ok(match)
-        assert.equal(match.pattern.source, '://example.com/search?q&lang')
+        assert.equal(match.pattern.source, '://example.com/search?q=&lang=')
       })
 
       it('prefers exact value over any value', () => {
@@ -599,7 +600,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
         assert.equal(match.pattern.source, '://example.com/api?format=json')
       })
 
-      it('prefers any value over bare presence', () => {
+      it('ties specificity for both forms of key only constraints; tiebreaks using insertion order', () => {
         let matcher = new MatcherClass()
         matcher.add('://example.com/search?q', null)
         matcher.add('://example.com/search?q=', null)
@@ -810,7 +811,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
 
         let match = matcher.match('http://example.com/search?q=test')
         assert.ok(match)
-        assert.equal(match.pattern.source, '://example.com/search?q')
+        assert.equal(match.pattern.source, '://example.com/search?q=')
       })
 
       it('returns null when no patterns match', () => {

--- a/packages/route-pattern/src/lib/route-pattern.test.ts
+++ b/packages/route-pattern/src/lib/route-pattern.test.ts
@@ -9,7 +9,7 @@ describe('RoutePattern', () => {
     function assertParse(
       source: string,
       expected: { [K in Exclude<keyof RoutePattern['ast'], 'search'>]?: string } & {
-        search?: Record<string, Array<string> | null>
+        search?: Record<string, Array<string>>
       },
     ) {
       let pattern = new RoutePattern(source)
@@ -17,7 +17,7 @@ describe('RoutePattern', () => {
       if (expected.search) {
         for (let name in expected.search) {
           let value = expected.search[name]
-          expectedSearch.set(name, value ? new Set(expected.search[name]) : null)
+          expectedSearch.set(name, value.length === 0 ? new Set() : new Set(value))
         }
       }
       assert.deepEqual(
@@ -52,9 +52,16 @@ describe('RoutePattern', () => {
     })
 
     it('parses search', () => {
-      assertParse('?q', { search: { q: null } })
+      assertParse('?q', { search: { q: [] } })
       assertParse('?q=', { search: { q: [] } })
       assertParse('?q=1', { search: { q: ['1'] } })
+    })
+
+    it('decodes search params like URLSearchParams (spaces, +, reserved chars, UTF-8)', () => {
+      assertParse('?q=a+b', { search: { q: ['a b'] } })
+      assertParse('?q=a%20b', { search: { q: ['a b'] } })
+      assertParse('?q=a%2Bb', { search: { q: ['a+b'] } })
+      assertParse('?q=caf%C3%A9', { search: { q: ['café'] } })
     })
 
     it('parses protocol + hostname', () => {
@@ -120,7 +127,7 @@ describe('RoutePattern', () => {
     })
 
     it('parses search params into constraints grouped by param name', () => {
-      assertParse('?q&q', { search: { q: null } })
+      assertParse('?q&q', { search: { q: [] } })
       assertParse('?q&q=', { search: { q: [] } })
       assertParse('?q&q=1', { search: { q: ['1'] } })
       assertParse('?q=&q=1', { search: { q: ['1'] } })
@@ -182,11 +189,11 @@ describe('RoutePattern', () => {
     })
 
     it('returns search', () => {
-      assert.equal(new RoutePattern('?q').search, 'q')
+      assert.equal(new RoutePattern('?q').search, 'q=')
       assert.equal(new RoutePattern('?q=').search, 'q=')
       assert.equal(new RoutePattern('?q=1').search, 'q=1')
       assert.equal(new RoutePattern('?q=1&q=2').search, 'q=1&q=2')
-      assert.equal(new RoutePattern('/posts?filter').search, 'filter')
+      assert.equal(new RoutePattern('/posts?filter').search, 'filter=')
       assert.equal(new RoutePattern('/posts?sort=asc').search, 'sort=asc')
       assert.equal(new RoutePattern('/posts').search, '')
       assert.equal(new RoutePattern('').search, '')
@@ -251,11 +258,11 @@ describe('RoutePattern', () => {
     })
 
     it('reconstructs search params', () => {
-      assertSource('?q', '/?q')
+      assertSource('?q', '/?q=')
       assertSource('?q=', '/?q=')
       assertSource('?q=1', '/?q=1')
       assertSource('?q=1&q=2', '/?q=1&q=2')
-      assertSource('/posts?filter')
+      assertSource('/posts?filter', '/posts?filter=')
       assertSource('/posts?sort=asc')
       assertSource('/posts?tag=foo&tag=bar')
       assertSource('https://example.com/posts?q=1')
@@ -280,7 +287,7 @@ describe('RoutePattern', () => {
       assertSource('http(s)://example.com/base')
       assertSource('http://old.com:3000/keep/this')
       assertSource('users/:id?tab=profile', '/users/:id?tab=profile')
-      assertSource('://example.com/path?q=1&q=2&filter')
+      assertSource('://example.com/path?q=1&q=2&filter', '://example.com/path?q=1&q=2&filter=')
     })
   })
 
@@ -360,7 +367,7 @@ describe('RoutePattern', () => {
       assertJoin(
         'https://api.example.com:8000/v1/:resource',
         '/users/(admin/)posts?filter&sort=asc',
-        'https://api.example.com:8000/v1/:resource/users/(admin/)posts?filter&sort=asc',
+        'https://api.example.com:8000/v1/:resource/users/(admin/)posts?filter=&sort=asc',
       )
 
       assertJoin(
@@ -696,7 +703,7 @@ describe('RoutePattern', () => {
         assert.equal(result, '/posts?category=books&category=electronics')
       })
 
-      describe('with bare constraint (?q)', () => {
+      describe('with key-only constraint (?q)', () => {
         it('includes empty value without user param', () => {
           let pattern = new RoutePattern('/posts?filter')
           let result = pattern.href()
@@ -705,19 +712,6 @@ describe('RoutePattern', () => {
 
         it('uses user param value', () => {
           let pattern = new RoutePattern('/posts?filter')
-          let result = pattern.href(undefined, { filter: 'active' })
-          assert.equal(result, '/posts?filter=active')
-        })
-      })
-
-      describe('with empty-value constraint (?q=)', () => {
-        it('throws without user param', () => {
-          let pattern = new RoutePattern('/posts?filter=')
-          assert.throws(() => pattern.href(), hrefError('missing-search-params'))
-        })
-
-        it('uses user param value', () => {
-          let pattern = new RoutePattern('/posts?filter=')
           let result = pattern.href(undefined, { filter: 'active' })
           assert.equal(result, '/posts?filter=active')
         })
@@ -891,25 +885,30 @@ describe('RoutePattern', () => {
     })
 
     describe('search', () => {
-      it('matches bare parameter for presence only', () => {
+      it('matches key-only constraint when no value is present', () => {
         assertMatch('?q', 'https://example.com?q', {})
+        assertMatch('?q', 'https://example.com?q=', {})
+        assertMatch('?q=', 'https://example.com?q', {})
+        assertMatch('?q=', 'https://example.com?q=', {})
       })
 
-      it('matches bare parameter when URL has value', () => {
+      it('matches key-only constraint when a value is present', () => {
         assertMatch('?q', 'https://example.com?q=search', {})
-      })
-
-      it('requires non-empty value when pattern has empty value', () => {
         assertMatch('?q=', 'https://example.com?q=search', {})
-        assertMatch('?q=', 'https://example.com?q=', null)
-        assertMatch('?q=', 'https://example.com?q', null)
       })
 
-      it('matches parameter with specific value', () => {
+      it('matches parameter with required value', () => {
         assertMatch('?sort=asc', 'https://example.com?sort=asc', {})
       })
 
-      it('matches parameter with multiple values', () => {
+      it('matches when URL searchParams decode like URLSearchParams (spaces, +, UTF-8, reserved)', () => {
+        assertMatch('?q=a+b', 'https://example.com?q=a+b', {})
+        assertMatch('?q=a+b', 'https://example.com?q=a%20b', {})
+        assertMatch('?q=café', 'https://example.com?q=café', {})
+        assertMatch('?q=café', 'https://example.com?q=caf%C3%A9', {})
+      })
+
+      it('matches parameter with multiple required values', () => {
         assertMatch('?tag=foo&tag=bar', 'https://example.com?tag=foo&tag=bar', {})
       })
 
@@ -917,19 +916,16 @@ describe('RoutePattern', () => {
         assertMatch('?filter&sort=asc', 'https://example.com?filter=active&sort=asc', {})
       })
 
-      it('allows extra parameters with bare constraint', () => {
+      it('allows extra parameters with key-only constraint', () => {
         assertMatch('?q', 'https://example.com?q=search&page=2&limit=10', {})
+        assertMatch('?q=', 'https://example.com?q=search&page=2&limit=10', {})
       })
 
-      it('allows extra parameters with empty value constraint', () => {
-        assertMatch('?filter=', 'https://example.com?filter=active&sort=asc&page=1', {})
-      })
-
-      it('allows extra parameters with specific value', () => {
+      it('allows extra parameters with required value constraint', () => {
         assertMatch('?sort=asc', 'https://example.com?sort=asc&filter=active&page=2', {})
       })
 
-      it('allows extra parameters with multiple constraints', () => {
+      it('allows extra parameters with multiple required value constraints', () => {
         assertMatch(
           '?filter&sort=asc',
           'https://example.com?filter=active&sort=asc&page=1&limit=20',

--- a/packages/route-pattern/src/lib/route-pattern.ts
+++ b/packages/route-pattern/src/lib/route-pattern.ts
@@ -14,17 +14,26 @@ type AST = {
   readonly port: string | null
   readonly pathname: PartPattern
   /**
-   * - `null`: key must be present
-   * - Empty `Set`: key must be present with a value
-   * - Non-empty `Set`: key must be present with all these values
+   * Required values keyed by search param name
+   *
+   * Follows
+   * [WHATWG's application/x-www-form-urlencoded parsing](https://url.spec.whatwg.org/#application/x-www-form-urlencoded) spec
+   * (same as [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#percent_encoding)).
+   * For example, `+` is decoded as ` ` (literal space) instead of `%20`.
+   *
+   * - **Empty `Set`**: key must appear; value may be anything (including empty).
+   * - **Non-empty `Set`**: key must appear with all listed values; extra values are OK.
+   *
+   * Examples:
    *
    * ```ts
-   * new Map([['q', null]])                // -> ?q, ?q=, ?q=1
-   * new Map([['q', new Set()]])           // -> ?q=1
-   * new Map([['q', new Set(['x', 'y'])]]) // -> ?q=x&q=y
+   * parseSearch('q')            // -> Map([['q', new Set()]])
+   * parseSearch('q=')           // -> Map([['q', new Set()]])
+   * parseSearch('q=x&q=y')      // -> Map([['q', new Set(['x', 'y'])]])
+   * parseSearch('q&q=&q=x&q=y') // -> Map([['q', new Set(['x', 'y'])]])
    * ```
    */
-  readonly search: ReadonlyMap<string, ReadonlySet<string> | null>
+  readonly search: ReadonlyMap<string, ReadonlySet<string>>
 }
 
 /**

--- a/packages/route-pattern/src/lib/route-pattern/href.test.ts
+++ b/packages/route-pattern/src/lib/route-pattern/href.test.ts
@@ -47,46 +47,6 @@ describe('HrefError', () => {
     })
   })
 
-  describe('missing-search-params', () => {
-    it('shows single missing search param', () => {
-      let pattern = new RoutePattern('https://example.com/search?q=')
-      let error = new HrefError({
-        type: 'missing-search-params',
-        pattern,
-        missingParams: ['q'],
-        searchParams: {},
-      })
-      assert.equal(
-        error.toString(),
-        dedent`
-          HrefError: missing required search param(s): 'q'
-
-          Pattern: https://example.com/search?q=
-          Search params: {}
-        `,
-      )
-    })
-
-    it('shows multiple missing search params', () => {
-      let pattern = new RoutePattern('https://example.com/search?q=&sort=')
-      let error = new HrefError({
-        type: 'missing-search-params',
-        pattern,
-        missingParams: ['q', 'sort'],
-        searchParams: { page: 1 },
-      })
-      assert.equal(
-        error.toString(),
-        dedent`
-          HrefError: missing required search param(s): 'q', 'sort'
-
-          Pattern: https://example.com/search?q=&sort=
-          Search params: {"page":1}
-        `,
-      )
-    })
-  })
-
   describe('nameless-wildcard', () => {
     it('shows error message with pattern', () => {
       let pattern = new RoutePattern('https://example.com/api/*/users')

--- a/packages/route-pattern/src/lib/route-pattern/href.ts
+++ b/packages/route-pattern/src/lib/route-pattern/href.ts
@@ -68,29 +68,16 @@ export function hrefSearch(pattern: RoutePattern, searchParams: SearchParams): s
     }
   }
 
-  let missingParams: Array<string> = []
-  for (let [key, constraint] of constraints) {
-    if (constraint === null) {
+  for (let [key, requiredValues] of constraints) {
+    if (requiredValues.size === 0) {
       if (key in searchParams) continue
       urlSearchParams.append(key, '')
-    } else if (constraint.size === 0) {
-      if (key in searchParams) continue
-      missingParams.push(key)
     } else {
-      for (let value of constraint) {
+      for (let value of requiredValues) {
         if (urlSearchParams.getAll(key).includes(value)) continue
         urlSearchParams.append(key, value)
       }
     }
-  }
-
-  if (missingParams.length > 0) {
-    throw new HrefError({
-      type: 'missing-search-params',
-      pattern,
-      missingParams,
-      searchParams: searchParams,
-    })
   }
 
   let result = urlSearchParams.toString()
@@ -108,12 +95,6 @@ type HrefErrorDetails =
       partPattern: PartPattern
       missingParams: Array<string>
       params: Record<string, unknown>
-    }
-  | {
-      type: 'missing-search-params'
-      pattern: RoutePattern
-      missingParams: Array<string>
-      searchParams: SearchParams
     }
   | {
       type: 'nameless-wildcard'
@@ -152,12 +133,6 @@ export class HrefError extends Error {
 
     if (details.type === 'nameless-wildcard') {
       return `pattern contains nameless wildcard\n\nPattern: ${pattern}`
-    }
-
-    if (details.type === 'missing-search-params') {
-      let params = details.missingParams.map((p) => `'${p}'`).join(', ')
-      let searchParamsStr = JSON.stringify(details.searchParams)
-      return `missing required search param(s): ${params}\n\nPattern: ${pattern}\nSearch params: ${searchParamsStr}`
     }
 
     if (details.type === 'missing-params') {

--- a/packages/route-pattern/src/lib/route-pattern/join.ts
+++ b/packages/route-pattern/src/lib/route-pattern/join.ts
@@ -100,24 +100,22 @@ type Search = RoutePattern['ast']['search']
  * @returns the merged search constraints
  */
 export function joinSearch(a: Search, b: Search): Search {
-  let result = new Map<string, Set<string> | null>()
+  let result = new Map<string, Set<string>>()
 
-  for (let [name, constraint] of a) {
-    result.set(name, constraint === null ? null : new Set(constraint))
+  for (let [name, requiredValues] of a) {
+    result.set(name, new Set(requiredValues))
   }
 
-  for (let [name, constraint] of b) {
+  for (let [name, requiredValues] of b) {
     let current = result.get(name)
 
-    if (current === null || current === undefined) {
-      result.set(name, constraint === null ? null : new Set(constraint))
+    if (current === undefined) {
+      result.set(name, new Set(requiredValues))
       continue
     }
 
-    if (constraint !== null) {
-      for (let value of constraint) {
-        current.add(value)
-      }
+    for (let value of requiredValues) {
+      current.add(value)
     }
   }
 

--- a/packages/route-pattern/src/lib/route-pattern/match.ts
+++ b/packages/route-pattern/src/lib/route-pattern/match.ts
@@ -11,22 +11,17 @@ export function matchSearch(
   params: URLSearchParams,
   constraints: RoutePattern['ast']['search'],
 ): boolean {
-  for (let [name, constraint] of constraints) {
+  for (let [name, requiredValues] of constraints) {
     let hasParam = params.has(name)
     let values = params.getAll(name)
 
-    if (constraint === null) {
+    if (requiredValues.size === 0) {
       if (!hasParam) return false
       continue
     }
 
-    if (constraint.size === 0) {
-      if (values.every((value) => value === '')) return false
-      continue
-    }
-
-    for (let value of constraint) {
-      if (!values.includes(value)) return false
+    for (let requiredValue of requiredValues) {
+      if (!values.includes(requiredValue)) return false
     }
   }
   return true

--- a/packages/route-pattern/src/lib/route-pattern/parse.ts
+++ b/packages/route-pattern/src/lib/route-pattern/parse.ts
@@ -28,56 +28,19 @@ function isNamelessWildcard(part: PartPattern): boolean {
   return token.name === '*'
 }
 
-/**
- * Parse a search string into search constraints.
- *
- * Search constraints define what query params must be present:
- * - `null`: param must be present (e.g., `?q`, `?q=`, `?q=1`)
- * - Empty `Set`: param must be present with a value (e.g., `?q=1`)
- * - Non-empty `Set`: param must be present with all these values (e.g., `?q=x&q=y`)
- *
- * Examples:
- * ```ts
- * parse('q')       // -> Map([['q', null]])
- * parse('q=')      // -> Map([['q', new Set()]])
- * parse('q=x&q=y') // -> Map([['q', new Set(['x', 'y'])]])
- * ```
- *
- * @param source the search string to parse (without leading `?`)
- * @returns the parsed search constraints
- */
 export function parseSearch(source: string): RoutePattern['ast']['search'] {
-  let constraints: Map<string, Set<string> | null> = new Map()
+  let constraints = new Map<string, Set<string>>()
 
-  for (let param of source.split('&')) {
-    if (param === '') continue
-    let equalIndex = param.indexOf('=')
-
-    // `?q`
-    if (equalIndex === -1) {
-      let name = decodeURIComponent(param)
-      if (!constraints.get(name)) {
-        constraints.set(name, null)
-      }
-      continue
+  let searchParams = new URLSearchParams(source)
+  for (let [key, value] of searchParams) {
+    let requiredValues = constraints.get(key)
+    if (!requiredValues) {
+      requiredValues = new Set()
+      constraints.set(key, requiredValues)
     }
-
-    let name = decodeURIComponent(param.slice(0, equalIndex))
-    let value = decodeURIComponent(param.slice(equalIndex + 1))
-
-    // `?q=`
-    if (value.length === 0) {
-      if (!constraints.get(name)) {
-        constraints.set(name, new Set())
-      }
-      continue
-    }
-
-    // `?q=1`
-    let constraint = constraints.get(name)
-    constraints.set(name, constraint ? constraint.add(value) : new Set([value]))
+    if (value === '') continue
+    requiredValues.add(value)
   }
-
   return constraints
 }
 

--- a/packages/route-pattern/src/lib/route-pattern/serialize.ts
+++ b/packages/route-pattern/src/lib/route-pattern/serialize.ts
@@ -7,24 +7,17 @@ import type { RoutePattern } from '../route-pattern.ts'
  * @returns the query string (without leading `?`), or undefined if empty
  */
 export function serializeSearch(constraints: RoutePattern['ast']['search']): string | undefined {
-  if (constraints.size === 0) {
-    return undefined
-  }
+  if (constraints.size === 0) return undefined
 
-  let parts: Array<string> = []
-
+  let searchParams = new URLSearchParams()
   for (let [key, constraint] of constraints) {
-    if (constraint === null) {
-      parts.push(encodeURIComponent(key))
-    } else if (constraint.size === 0) {
-      parts.push(`${encodeURIComponent(key)}=`)
+    if (constraint.size === 0) {
+      searchParams.append(key, '')
     } else {
       for (let value of constraint) {
-        parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+        searchParams.append(key, value)
       }
     }
   }
-
-  let result = parts.join('&')
-  return result || undefined
+  return searchParams.toString()
 }

--- a/packages/route-pattern/src/lib/specificity.test.ts
+++ b/packages/route-pattern/src/lib/specificity.test.ts
@@ -148,11 +148,11 @@ describe('specificity', () => {
         )
       })
 
-      it('ranks any value higher than key only', () => {
+      it('ranks ?q and ?q= equally', () => {
         assertCompare(
           ['https://example.com/posts?q=', 'https://example.com/posts?q'],
           'https://example.com/posts?q=hello',
-          1,
+          0,
         )
       })
 

--- a/packages/route-pattern/src/lib/specificity.ts
+++ b/packages/route-pattern/src/lib/specificity.ts
@@ -168,11 +168,8 @@ function compareSearch(
   let aSpecificity = searchSpecificity(a)
   let bSpecificity = searchSpecificity(b)
 
-  if (aSpecificity.keyAndExactValue > bSpecificity.keyAndExactValue) return 1
-  if (aSpecificity.keyAndExactValue < bSpecificity.keyAndExactValue) return -1
-
-  if (aSpecificity.keyAndAnyValue > bSpecificity.keyAndAnyValue) return 1
-  if (aSpecificity.keyAndAnyValue < bSpecificity.keyAndAnyValue) return -1
+  if (aSpecificity.keyValue > bSpecificity.keyValue) return 1
+  if (aSpecificity.keyValue < bSpecificity.keyValue) return -1
 
   if (aSpecificity.key > bSpecificity.key) return 1
   if (aSpecificity.key < bSpecificity.key) return -1
@@ -181,25 +178,18 @@ function compareSearch(
 }
 
 function searchSpecificity(constraints: RoutePattern['ast']['search']): {
-  keyAndExactValue: number
-  keyAndAnyValue: number
   key: number
+  keyValue: number
 } {
-  let exactValue = 0
-  let anyValue = 0
-  let key = 0
+  let specificity = { key: 0, keyValue: 0 }
 
   for (let constraint of constraints.values()) {
-    if (constraint === null) {
-      key += 1
-      continue
-    }
     if (constraint.size === 0) {
-      anyValue += 1
+      specificity.key += 1
       continue
     }
-    exactValue += constraint.size
+    specificity.keyValue += constraint.size
   }
 
-  return { keyAndExactValue: exactValue, keyAndAnyValue: anyValue, key }
+  return specificity
 }


### PR DESCRIPTION
BREAKING CHANGE: Make search param pattern decoding and serialization consistent with `URLSearchParams`. Affects: `RoutePattern.{match,href,search,ast.search}`

Previously, `RoutePattern` treated `?q` and `?q=` as **different** constraints:

```ts
// Before: `?q` and `?q=` are different

let url = new URL('https://example.com?q')

// Matches "key only" constraint?
new RoutePattern('?q').match(url) // ✅ match

// Matches "key and value" constraint?
new RoutePattern('?q=').match(url) // ❌ no match (`null`)

// Different constraints serialized to different strings
new RoutePattern('?q').search // -> 'q'
new RoutePattern('?q=').search // -> 'q='
```

There were two main problems with that approach:

**Unintuitive matching**

```ts
// URL search looks like `?q=`
let url = new URL('https://example.com?q=')

// Pattern search looks like `?q=`
let pattern = new RoutePattern('?q=')

// But "key and value" constraint doesn't match!
pattern.match(url) // ❌ no match (`null`)
```


**Parsing and serialization**

For consistency with `URLSearchParams`, search param patterns should be parsed according to the [WHATWG `application/x-www-form-urlencoded` parsing spec](https://url.spec.whatwg.org/#application/x-www-form-urlencoded-parsing) and should also [encode spaces as `+`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#percent_encoding).

Now, we use `URLSearchParams` to parse search param patterns to guarantee decodings are consistent:

```ts
let url = new URL('https://example.com?q=a+b')
// Decodes `+` to ` `
url.searchParams.getAll('q') // -> ['a b']

// Before
let pattern = new RoutePattern('?q=a+b')
// Does not decode `+` to ` `
pattern.ast.search.get('q') // -> ❌ Set { 'a+b' }

// After
let pattern = new RoutePattern('?q=a+b')
// Decodes `+` to ` `
pattern.ast.search.get('q') // -> ✅ Set { 'a b' }
```

Similarly, now that `?q` and `?q=` are semantically equivalent, they should serialize to the same thing:

```ts
new URLSearchParams('q=').toString() // 'q='

// Before
new RoutePattern('?q=').search // ❌ 'q'

// After
new RoutePattern('?q=').search // ✅ 'q='
```

As a result, `RoutePattern`s can no longer represent a "key and any value" constraint.
In practice, this was a niche use-case so we chose correctness and consistency with `URLSearchParams`.
If the need for "key and any value" constraints arises, we can later introduce a separate syntax for that without the unintuitive shortcoming of `?q=`.

With "key and any value" constraints removed, the `missing-search-param` error type thrown by `RoutePattern.href` was made obsolete and was removed.