### PR TITLE
route-pattern: add lambda benchmark for shopify workload

### DIFF
--- a/packages/route-pattern/bench/src/shopify.bench.ts
+++ b/packages/route-pattern/bench/src/shopify.bench.ts
@@ -1,6 +1,6 @@
 import { bench, describe } from 'vitest'
 import { match } from 'path-to-regexp'
-import { ArrayMatcher, TrieMatcher } from '@remix-run/route-pattern'
+import { ArrayMatcher, TrieMatcher, type Matcher } from '@remix-run/route-pattern'
 
 import { patterns } from '../patterns/shopify.ts'
 
@@ -36,7 +36,7 @@ let urls: Array<URL> = [
   '/pl/blog/123',
 ].map((pathname) => new URL(`https://shopify.com${pathname}`))
 
-describe('match shopify', () => {
+describe('match many', () => {
   let pathToRegexpMatcher: Array<ReturnType<typeof match>> = []
   patterns.forEach((pattern) => {
     let matchFn = match(pattern.replace('(:locale)', '{:locale}').replace('*', '*path'), {
@@ -68,3 +68,24 @@ describe('match shopify', () => {
     urls.forEach((url) => trieMatcher.match(url))
   })
 })
+
+describe('lambda (setup + match one)', () => {
+  benchLambda('array', () => new ArrayMatcher<null>())
+  benchLambda('trie', () => new TrieMatcher<null>())
+})
+
+function benchLambda(name: string, createMatcher: () => Matcher<null>) {
+  let index = 0
+
+  bench(name, () => {
+    let matcher = createMatcher()
+
+    for (let pattern of patterns) {
+      matcher.add(pattern, null)
+    }
+
+    let url = urls[index]!
+    index = (index + 1) % urls.length
+    matcher.match(url)
+  })
+}


### PR DESCRIPTION
Most of our existing benchmarks target long-running server use-cases where setup cost is ignored (since it happens upfront once) and we care about matching many URLs. This PR adds a benchmark for a lambda use-case: setup happens every time and we match against a single URL.

<img width="1054" height="632" alt="Screenshot 2026-03-25 at 2 50 09 PM" src="https://github.com/user-attachments/assets/38a1e865-94f6-4425-89a6-9a4f8aab8d40" />
