### PR TITLE
route-pattern: faster `TrieMatcher.match`

### DIFF
--- a/packages/route-pattern/.changes/patch.linear-time-trie-match.md
+++ b/packages/route-pattern/.changes/patch.linear-time-trie-match.md
@@ -1,0 +1,7 @@
+Faster `TrieMatcher.match`: `O(m·log(m))` -> `O(m)`
+
+Previously, `TrieMatcher.match` internally called `.matchAll`, then sorted the result to find the best match. For `m` matching route patterns, this took `O(m·log(m))` operations.
+
+Now, `TrieMatcher.match` loops over the `m` matches, keeping track of the best one, resulting in `O(n)` operations.
+
+In our benchmarks, this made our largest workload (~5000 route patterns) 17% faster with negligible or modest improvements to other workloads.

--- a/packages/route-pattern/src/lib/trie-matcher.ts
+++ b/packages/route-pattern/src/lib/trie-matcher.ts
@@ -56,8 +56,14 @@ export class TrieMatcher<data = unknown> implements Matcher<data> {
    */
   match(url: string | URL, compareFn = Specificity.descending): Match<string, data> | null {
     url = typeof url === 'string' ? new URL(url) : url
-    let matches = this.matchAll(url, compareFn)
-    return matches[0] ?? null
+    let bestMatch: Match<string, data> | null = null
+    for (let result of this.trie.search(url)) {
+      let match = toMatch(result, url)
+      if (bestMatch === null || compareFn(match, bestMatch) < 0) {
+        bestMatch = match
+      }
+    }
+    return bestMatch
   }
 
   /**
@@ -70,15 +76,7 @@ export class TrieMatcher<data = unknown> implements Matcher<data> {
   matchAll(url: string | URL, compareFn = Specificity.descending): Array<Match<string, data>> {
     url = typeof url === 'string' ? new URL(url) : url
     let matches = this.trie.search(url)
-    return matches
-      .map((match) => ({
-        pattern: match.pattern,
-        url,
-        params: match.params,
-        paramsMeta: { hostname: match.hostname, pathname: match.pathname },
-        data: match.data,
-      }))
-      .sort(compareFn)
+    return matches.map((result) => toMatch(result, url)).sort(compareFn)
   }
 }
 
@@ -131,6 +129,16 @@ type SearchResult<data> = Array<{
   pathname: PartPatternMatch
   params: Record<string, string | undefined>
 }>
+
+function toMatch<data>(result: SearchResult<data>[number], url: URL): Match<string, data> {
+  return {
+    pattern: result.pattern,
+    url,
+    params: result.params,
+    paramsMeta: { hostname: result.hostname, pathname: result.pathname },
+    data: result.data,
+  }
+}
 
 export class Trie<data = unknown> {
   #ignoreCase: boolean


### PR DESCRIPTION
<img width="1244" height="1122" alt="Screenshot 2026-03-25 at 3 40 38 PM" src="https://github.com/user-attachments/assets/fbc66375-ee1d-4e3b-bf23-1257e6fb0bfa" />
