### PR TITLE
Add type annotation to fix typedoc generation

### DIFF
--- a/packages/auth-middleware/src/lib/auth.ts
+++ b/packages/auth-middleware/src/lib/auth.ts
@@ -49,7 +49,7 @@ export type AuthState<identity = unknown> = GoodAuth<identity> | BadAuth
 /**
  * Context key used to read auth state with `context.get(Auth)`.
  */
-export const Auth = createContextKey<AuthState>()
+export const Auth: ReturnType<typeof createContextKey<AuthState>> = createContextKey<AuthState>()
 
 export type WithAuth<context extends RequestContext<any, any>, identity = unknown> = MergeContext<
   context,


### PR DESCRIPTION
Typedoc (`pnpm run docs`) is failing with the following error:

```
../packages/auth-middleware/src/lib/auth.ts:52:14 - error TS2742: The inferred type of 'Auth' 
cannot be named without a reference to '../../node_modules/@remix-run/fetch-router/src/lib/request-context'. 
This is likely not portable. A type annotation is necessary.

52 export const Auth = createContextKey<AuthState>()
```

I'm not entirely sure why only typedoc hits this but `pnpm typecheck` doesn't, but as the error suggests adding the annotation does fix it.  If we can't figure out why there's a difference we may want to consider adding a `typedoc` run ahead of publishing to catch these.  Running on PRs feels excessive - maybe we could just run in the release PR and block that from being merged if docs aren't building.