### PR TITLE
docs(form-data-parser): Fix error handling example in README

### DIFF
--- a/packages/form-data-parser/README.md
+++ b/packages/form-data-parser/README.md
@@ -81,6 +81,7 @@ To limit the overall shape of multipart requests, use the `maxHeaderSize`, `maxF
 
 ```ts
 import {
+  FormDataParseError,
   MaxFilesExceededError,
   MaxFileSizeExceededError,
   MaxHeaderSizeExceededError,
@@ -99,6 +100,7 @@ try {
     maxTotalSize: 12 * oneMb,
   })
 } catch (error) {
+  // Errors are wrapped in FormDataParseError with the specific error as the cause
   if (error instanceof MaxFilesExceededError) {
     console.error(`Request may not contain more than 5 files`)
   } else if (error instanceof MaxHeaderSizeExceededError) {
@@ -109,6 +111,21 @@ try {
     console.error(`Request may not contain more than 25 multipart parts`)
   } else if (error instanceof MaxTotalSizeExceededError) {
     console.error(`Multipart request may not exceed 12 MiB of total content`)
+  } else if (error instanceof FormDataParseError && error.cause) {
+    // Check the cause for specific error types
+    if (error.cause instanceof MaxFilesExceededError) {
+      console.error(`Request may not contain more than 5 files`)
+    } else if (error.cause instanceof MaxHeaderSizeExceededError) {
+      console.error(`Multipart headers may not exceed the configured size limit`)
+    } else if (error.cause instanceof MaxFileSizeExceededError) {
+      console.error(`Files may not be larger than 10 MiB`)
+    } else if (error.cause instanceof MaxPartsExceededError) {
+      console.error(`Request may not contain more than 25 multipart parts`)
+    } else if (error.cause instanceof MaxTotalSizeExceededError) {
+      console.error(`Multipart request may not exceed 12 MiB of total content`)
+    } else {
+      console.error(`A parsing error occurred:`, error.cause)
+    }
   } else {
     console.error(`An unknown error occurred:`, error)
   }


### PR DESCRIPTION
## Summary

Fixed the broken error handling example in the form-data-parser README.

## Issue

The example for handling file upload errors was not working correctly because it didn't account for the fact that errors are wrapped in FormDataParseError with the specific error as the cause property.

## Changes

Updated the error handling example to:
1. Import FormDataParseError
2. Show how to check error.cause for specific error types
3. Provide proper fallback handling for both direct errors and wrapped errors

## Before
The original example only checked for specific error types directly, which doesn't work because the errors are wrapped in FormDataParseError.

## After
The updated example shows the correct way to handle errors by checking both the direct error type and error.cause for wrapped errors.

Fixes #11180