### PR TITLE
mime: prefer video/mp4 for .mp4 extension

### DIFF
--- a/packages/mime/.changes/patch.prefer-video-mp4.md
+++ b/packages/mime/.changes/patch.prefer-video-mp4.md
@@ -1,0 +1,1 @@
+Prefer video/mp4 over application/mp4 when detecting MIME type for .mp4 extensions.

--- a/packages/mime/scripts/codegen.ts
+++ b/packages/mime/scripts/codegen.ts
@@ -12,6 +12,10 @@ interface MimeDbEntry {
 
 type MimeDb = Record<string, MimeDbEntry>
 
+const extensionMimeTypeOverrides: Record<string, string> = {
+  mp4: 'video/mp4',
+}
+
 // Generates the content for compressible-mime-types.ts from mime-db
 export function generateCompressibleMimeTypesContent(): string {
   let mimeDbPath = fileURLToPath(import.meta.resolve('mime-db/db.json'))
@@ -79,6 +83,11 @@ export function generateMimeTypesContent(): string {
         }
       }
     }
+  }
+
+  // Sort by extension for consistent output
+  for (let [extension, mimeType] of Object.entries(extensionMimeTypeOverrides)) {
+    extensionMap[extension] = mimeType
   }
 
   // Sort by extension for consistent output

--- a/packages/mime/src/generated/mime-types.ts
+++ b/packages/mime/src/generated/mime-types.ts
@@ -598,7 +598,7 @@ export const mimeTypes: Record<string, string> = {
   mp21: 'application/mp21',
   mp2a: 'audio/mpeg',
   mp3: 'audio/mpeg',
-  mp4: 'application/mp4',
+  mp4: 'video/mp4',
   mp4a: 'audio/mp4',
   mp4s: 'application/mp4',
   mp4v: 'video/mp4',

--- a/packages/mime/src/lib/detect-mime-type.test.ts
+++ b/packages/mime/src/lib/detect-mime-type.test.ts
@@ -77,7 +77,7 @@ describe('detectMimeType()', () => {
   })
 
   it('returns MIME type for common video formats', () => {
-    assert.equal(detectMimeType('mp4'), 'application/mp4')
+    assert.equal(detectMimeType('mp4'), 'video/mp4')
     assert.equal(detectMimeType('webm'), 'video/webm')
     assert.equal(detectMimeType('mov'), 'video/quicktime')
   })


### PR DESCRIPTION
Issue link id: #11106

Description:
This updates MIME extension selection so .mp4 resolves to video/mp4 instead of application/mp4, matching expected behavior for common video files.
Includes test updates and a package change file.