### PR TITLE
mime: prefer image/x-icon for .ico extension

### DIFF
--- a/packages/mime/.changes/patch.prefer-image-x-icon.md
+++ b/packages/mime/.changes/patch.prefer-image-x-icon.md
@@ -1,0 +1,1 @@
+Prefer image/x-icon over image/vnd.microsoft.icon when detecting MIME type for .ico extensions.

--- a/packages/mime/scripts/codegen.ts
+++ b/packages/mime/scripts/codegen.ts
@@ -12,6 +12,10 @@ interface MimeDbEntry {
 
 type MimeDb = Record<string, MimeDbEntry>
 
+const extensionMimeTypeOverrides: Record<string, string> = {
+  ico: 'image/x-icon',
+}
+
 // Generates the content for compressible-mime-types.ts from mime-db
 export function generateCompressibleMimeTypesContent(): string {
   let mimeDbPath = fileURLToPath(import.meta.resolve('mime-db/db.json'))
@@ -79,6 +83,10 @@ export function generateMimeTypesContent(): string {
         }
       }
     }
+  }
+
+  for (let [extension, mimeType] of Object.entries(extensionMimeTypeOverrides)) {
+    extensionMap[extension] = mimeType
   }
 
   // Sort by extension for consistent output

--- a/packages/mime/src/generated/mime-types.ts
+++ b/packages/mime/src/generated/mime-types.ts
@@ -403,7 +403,7 @@ export const mimeTypes: Record<string, string> = {
   icc: 'application/vnd.iccprofile',
   ice: 'x-conference/x-cooltalk',
   icm: 'application/vnd.iccprofile',
-  ico: 'image/vnd.microsoft.icon',
+  ico: 'image/x-icon',
   ics: 'text/calendar',
   ief: 'image/ief',
   ifb: 'text/calendar',

--- a/packages/mime/src/lib/detect-mime-type.test.ts
+++ b/packages/mime/src/lib/detect-mime-type.test.ts
@@ -72,6 +72,7 @@ describe('detectMimeType()', () => {
     assert.equal(detectMimeType('jpg'), 'image/jpeg')
     assert.equal(detectMimeType('jpeg'), 'image/jpeg')
     assert.equal(detectMimeType('gif'), 'image/gif')
+    assert.equal(detectMimeType('ico'), 'image/x-icon')
     assert.equal(detectMimeType('svg'), 'image/svg+xml')
     assert.equal(detectMimeType('webp'), 'image/webp')
   })


### PR DESCRIPTION
Title: mime: prefer image/x-icon for .ico extension
Issue link id: #11107

Description:
This adjusts MIME extension preference so .ico resolves to image/x-icon instead of image/vnd.microsoft.icon, aligning with widespread browser/server expectations.
Includes test updates and a package change file.