### PR TITLE
mime: support custom multi-part extensions

### DIFF
--- a/packages/mime/.changes/patch.detect-multipart-custom-extensions.md
+++ b/packages/mime/.changes/patch.detect-multipart-custom-extensions.md
@@ -1,0 +1,1 @@
+Fix detectMimeType to recognize custom multi-part extensions such as be.pit and fr.pit when passed a filename.

--- a/packages/mime/src/lib/define-mime-type.test.ts
+++ b/packages/mime/src/lib/define-mime-type.test.ts
@@ -83,6 +83,22 @@ describe('defineMimeType()', () => {
       assert.equal(detectMimeType('jpeg'), 'image/jpeg')
       assert.equal(detectMimeType('jpe'), 'image/jpeg')
     })
+
+    it('matches multi-part custom extensions from filenames', () => {
+      defineMimeType({
+        extensions: ['tow'],
+        mimeType: 'application/x-tow-document',
+      })
+      defineMimeType({
+        extensions: ['be.pit', 'fr.pit'],
+        mimeType: 'application/x-pit-document',
+      })
+
+      assert.equal(detectMimeType('filename.tow'), 'application/x-tow-document')
+      assert.equal(detectMimeType('filename.be.pit'), 'application/x-pit-document')
+      assert.equal(detectMimeType('filename.fr.pit'), 'application/x-pit-document')
+      assert.equal(detectMimeType('/path/to/filename.be.pit'), 'application/x-pit-document')
+    })
   })
 
   describe('custom compressibility', () => {

--- a/packages/mime/src/lib/detect-mime-type.ts
+++ b/packages/mime/src/lib/detect-mime-type.ts
@@ -18,6 +18,32 @@ import { customMimeTypeByExtension } from './define-mime-type.ts'
  */
 export function detectMimeType(extension: string): string | undefined {
   let ext = extension.trim().toLowerCase()
+
+  // For custom types, support multi-part extensions (e.g. "be.pit") by
+  // checking dot-separated suffixes from longest to shortest.
+  if (customMimeTypeByExtension != null) {
+    let slashIndex = Math.max(ext.lastIndexOf('/'), ext.lastIndexOf('\\'))
+    let baseName = slashIndex >= 0 ? ext.slice(slashIndex + 1) : ext
+    baseName = baseName.replace(/^\.+/, '')
+
+    if (baseName.length > 0) {
+      let customMimeType = customMimeTypeByExtension.get(baseName)
+      if (customMimeType !== undefined) {
+        return customMimeType
+      }
+
+      let dotIndex = baseName.indexOf('.')
+      while (dotIndex !== -1) {
+        customMimeType = customMimeTypeByExtension.get(baseName.slice(dotIndex + 1))
+        if (customMimeType !== undefined) {
+          return customMimeType
+        }
+
+        dotIndex = baseName.indexOf('.', dotIndex + 1)
+      }
+    }
+  }
+
   let idx = ext.lastIndexOf('.')
   // If no dot found (~idx === -1, so !~idx === true), use ext as-is.
   // Otherwise, skip past the dot (++idx) and extract the extension.


### PR DESCRIPTION
Issue link id: #11099

Description:
This fixes detectMimeType so custom extensions containing dots (for example be.pit, fr.pit) can be resolved correctly when registered via defineMimeType.
Adds focused regression tests and a package change file.