### PR TITLE
file-storage: align API types with File and LazyFile return values

### DIFF
--- a/packages/file-storage/.changes/patch.expose-stored-file-type.md
+++ b/packages/file-storage/.changes/patch.expose-stored-file-type.md
@@ -1,0 +1,1 @@
+Add a `StoredFile` type (`File | LazyFile`) to file-storage so API types match backend runtime behavior.

--- a/packages/file-storage/README.md
+++ b/packages/file-storage/README.md
@@ -2,6 +2,8 @@
 
 Key/value storage interfaces for server-side [`File` objects](https://developer.mozilla.org/en-US/docs/Web/API/File). `file-storage` gives Remix apps one consistent API across local disk and memory backends.
 
+Note: Backends may return either native `File` instances or `LazyFile` instances that are compatible with file APIs like `.stream()`, `.arrayBuffer()`, and `.text()`.
+
 ## Features
 
 - **Simple API** - Intuitive key/value API (like [Web Storage](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API), but for `File`s instead of strings)

--- a/packages/file-storage/src/index.ts
+++ b/packages/file-storage/src/index.ts
@@ -4,4 +4,5 @@ export type {
   FileMetadata,
   ListOptions,
   ListResult,
+  StoredFile,
 } from './lib/file-storage.ts'

--- a/packages/file-storage/src/lib/backends/fs.ts
+++ b/packages/file-storage/src/lib/backends/fs.ts
@@ -3,7 +3,7 @@ import * as fsp from 'node:fs/promises'
 import * as path from 'node:path'
 import { openLazyFile, writeFile } from '@remix-run/fs'
 
-import type { FileStorage, FileMetadata, ListOptions, ListResult } from '../file-storage.ts'
+import type { FileStorage, FileMetadata, ListOptions, ListResult, StoredFile } from '../file-storage.ts'
 
 type MetadataJson = Omit<FileMetadata, 'size'>
 
@@ -51,7 +51,7 @@ export function createFsFileStorage(directory: string): FileStorage {
     }
   }
 
-  async function putFile(key: string, file: File): Promise<File> {
+  async function putFile(key: string, file: StoredFile): Promise<StoredFile> {
     let { directory, filePath, metaPath } = await getPaths(key)
 
     // Ensure directory exists
@@ -77,7 +77,7 @@ export function createFsFileStorage(directory: string): FileStorage {
   }
 
   return {
-    async get(key: string): Promise<File | null> {
+    async get(key: string): Promise<StoredFile | null> {
       let { filePath, metaPath } = await getPaths(key)
 
       try {
@@ -153,7 +153,7 @@ export function createFsFileStorage(directory: string): FileStorage {
         files,
       }
     },
-    put(key: string, file: File): Promise<File> {
+    put(key: string, file: StoredFile): Promise<StoredFile> {
       return putFile(key, file)
     },
     async remove(key: string): Promise<void> {
@@ -173,7 +173,7 @@ export function createFsFileStorage(directory: string): FileStorage {
         }
       }
     },
-    async set(key: string, file: File): Promise<void> {
+    async set(key: string, file: StoredFile): Promise<void> {
       await putFile(key, file)
     },
   }

--- a/packages/file-storage/src/lib/backends/memory.ts
+++ b/packages/file-storage/src/lib/backends/memory.ts
@@ -1,4 +1,4 @@
-import type { FileStorage, ListOptions, ListResult } from '../file-storage.ts'
+import type { FileStorage, ListOptions, ListResult, StoredFile } from '../file-storage.ts'
 
 /**
  * Creates a simple, in-memory implementation of the {@link FileStorage} interface.
@@ -8,7 +8,7 @@ import type { FileStorage, ListOptions, ListResult } from '../file-storage.ts'
 export function createMemoryFileStorage(): FileStorage {
   let map = new Map<string, File>()
 
-  async function putFile(key: string, file: File): Promise<File> {
+  async function putFile(key: string, file: StoredFile): Promise<File> {
     let buffer = await file.arrayBuffer()
     let newFile = new File([buffer], file.name, {
       lastModified: file.lastModified,
@@ -64,13 +64,13 @@ export function createMemoryFileStorage(): FileStorage {
         files,
       }
     },
-    put(key: string, file: File): Promise<File> {
+    put(key: string, file: StoredFile): Promise<File> {
       return putFile(key, file)
     },
     remove(key: string): void {
       map.delete(key)
     },
-    async set(key: string, file: File): Promise<void> {
+    async set(key: string, file: StoredFile): Promise<void> {
       await putFile(key, file)
     },
   }

--- a/packages/file-storage/src/lib/file-storage.ts
+++ b/packages/file-storage/src/lib/file-storage.ts
@@ -1,3 +1,10 @@
+import type { LazyFile } from '@remix-run/lazy-file'
+
+/**
+ * The file-like object stored and returned by file-storage backends.
+ */
+export type StoredFile = File | LazyFile
+
 /**
  * A key/value interface for storing `File` objects.
  */
@@ -8,7 +15,7 @@ export interface FileStorage {
    * @param key The key to look up
    * @returns The file with the given key, or `null` if no such key exists
    */
-  get(key: string): File | null | Promise<File | null>
+  get(key: string): StoredFile | null | Promise<StoredFile | null>
   /**
    * Check if a file with the given key exists.
    *
@@ -84,7 +91,7 @@ export interface FileStorage {
    * @param file The file to store
    * @returns A new `File` object backed by this storage
    */
-  put(key: string, file: File): File | Promise<File>
+  put(key: string, file: StoredFile): StoredFile | Promise<StoredFile>
   /**
    * Remove the file with the given key from storage.
    *
@@ -98,7 +105,7 @@ export interface FileStorage {
    * @param key The key to store the file under
    * @param file The file to store
    */
-  set(key: string, file: File): void | Promise<void>
+  set(key: string, file: StoredFile): void | Promise<void>
 }
 
 /**


### PR DESCRIPTION
Issue link id: #11179


Description:
This introduces a StoredFile union type (File | LazyFile) and updates file-storage API signatures/docs so types match backend runtime behavior, especially where lazy-file-backed values are returned.
Includes API type updates, backend signature alignment, README clarification, and change file.