### PR TITLE
docs(lazy-file): clarify LazyFile is not a native File subclass

### DIFF
--- a/packages/lazy-file/.changes/patch.clarify-non-subclass-runtime.md
+++ b/packages/lazy-file/.changes/patch.clarify-non-subclass-runtime.md
@@ -1,0 +1,1 @@
+Clarify in lazy-file README that LazyFile/LazyBlob are API-compatible but not native File/Blob subclasses, and document when to use `.toFile()`/`.toBlob()`.

--- a/packages/lazy-file/README.md
+++ b/packages/lazy-file/README.md
@@ -68,6 +68,8 @@ lazyFile.type // "text/plain"
 
 All file contents are read on-demand and nothing is ever buffered unless you explicitly call `.toFile()` or `.toBlob()`.
 
+Note: `LazyFile` and `LazyBlob` are API-compatible with native `File`/`Blob`, but they are not subclasses of the native implementations. Use `.toFile()`/`.toBlob()` when an API requires a real `File` or `Blob` instance.
+
 ### Streaming Content
 
 Use `.stream()` to get a `ReadableStream` for `Response` and other streaming APIs:


### PR DESCRIPTION
Issue link id: #11179


Description:
This clarifies in lazy-file docs that LazyFile and LazyBlob are API-compatible with File/Blob but not native subclasses, and documents when to use toFile/toBlob for APIs requiring real native objects.
Includes docs update and change file.