### PR TITLE
Update typedoc to ignore errors covered by typecheck

### DIFF
--- a/docs/src/generate/documented-api.ts
+++ b/docs/src/generate/documented-api.ts
@@ -121,6 +121,7 @@ function getDocumentedFunction(
   fullName: string,
   node: typedoc.SignatureReflection,
 ): DocumentedFunction {
+  let comment = node.comment
   let method = getApiMethod(fullName, node)
   invariant(method, `Failed to get method for function: ${node.getFriendlyFullName()}`)
   let methods = [method]
@@ -129,6 +130,7 @@ function getDocumentedFunction(
 
   // For overloaded functions, collect all signatures and merge parameters
   if (node.parent.signatures && node.parent.signatures.length > 1) {
+    comment = node.parent.signatures.find((s) => s.comment)?.comment || comment
     methods = node.parent.signatures
       .map((s) => getApiMethod(fullName, s))
       .filter((m): m is Method => m != null)
@@ -150,11 +152,11 @@ function getDocumentedFunction(
     path: getApiFilePath(fullName, 'function'),
     source: node.sources?.[0]?.url,
     name: method.name,
-    aliases: node.comment ? getApiAliases(node.comment) : undefined,
-    description: node.comment ? getApiDescription(node.comment) : '',
+    aliases: comment ? getApiAliases(comment) : undefined,
+    description: comment ? getApiDescription(comment) : '',
     signature,
-    example: node.comment?.getTag('@example')?.content
-      ? processApiComment(node.comment.getTag('@example')!.content)
+    example: comment?.getTag('@example')?.content
+      ? processApiComment(comment.getTag('@example')!.content)
       : undefined,
     parameters,
     returns: method.returns,

--- a/docs/src/generate/typedoc.ts
+++ b/docs/src/generate/typedoc.ts
@@ -57,6 +57,7 @@ async function loadTypedocJson(opts: {
         blockTags: [...typedoc.OptionDefaults.blockTags, '@alias'],
         // Tag to use in source code links
         gitRevision: opts.tag,
+        skipErrorChecking: true,
         // exclude test files via the build config
         tsconfig: 'tsconfig.build.json',
         validation: {


### PR DESCRIPTION
There's an error being hit by `typedoc` in the auth package that doesn't occur in `pnpm typecheck`.  Since we already typecheck various times in CI we can skip error checking in `typedoc` via `skipErrorChecking:true ` which will also speed up docs generation a bit.

This also fixes a small issue I found with overridden functions in the test PRs.