### PR TITLE
test: fix worker url for distributed remix test package

### DIFF
--- a/packages/test/src/lib/runner.ts
+++ b/packages/test/src/lib/runner.ts
@@ -1,12 +1,13 @@
 import { Worker } from 'node:worker_threads'
 import { pathToFileURL } from 'node:url'
-import * as fsp from 'node:fs/promises'
-import * as path from 'node:path'
 import type { TestResults } from './executor.ts'
 import type { Reporter } from './reporter.ts'
 import type { Counts } from './utils.ts'
 
-const workerUrl = new URL('./worker.ts', import.meta.url)
+const isInRemixMonorepo = import.meta.url.includes('packages/test')
+const workerUrl = isInRemixMonorepo
+  ? new URL('./worker.ts', import.meta.url)
+  : new URL('./worker.js', import.meta.url)
 
 export async function runServerTests(
   files: string[],

--- a/packages/test/src/lib/runner.ts
+++ b/packages/test/src/lib/runner.ts
@@ -1,13 +1,12 @@
-import { Worker } from 'node:worker_threads'
+import * as path from 'node:path'
 import { pathToFileURL } from 'node:url'
+import { Worker } from 'node:worker_threads'
 import type { TestResults } from './executor.ts'
 import type { Reporter } from './reporter.ts'
 import type { Counts } from './utils.ts'
 
-const isInRemixMonorepo = import.meta.url.includes('packages/test')
-const workerUrl = isInRemixMonorepo
-  ? new URL('./worker.ts', import.meta.url)
-  : new URL('./worker.js', import.meta.url)
+const ext = path.extname(import.meta.url)
+const workerUrl = new URL(`./worker${ext}`, import.meta.url)
 
 export async function runServerTests(
   files: string[],


### PR DESCRIPTION
When `remix-test` is used externally from a published package using `dist` contents we need to point to a `worker.js` file instead of the in-repo `worker.ts` file.