### PR TITLE
feat(data-schema): add Schema.transform()

### DIFF
--- a/packages/data-schema/.changes/minor.schema-transform.md
+++ b/packages/data-schema/.changes/minor.schema-transform.md
@@ -1,0 +1,1 @@
+Add `Schema.transform()` for mapping validated schema outputs to new values and output types.

--- a/packages/data-schema/README.md
+++ b/packages/data-schema/README.md
@@ -238,6 +238,30 @@ let Profile = object({
 })
 ```
 
+## Output transforms with `.transform()`
+
+Map a validated value into the shape your app wants. The transformer runs after the schema validates and changes the parsed output type.
+
+```ts
+import { object, parse, string } from '@remix-run/data-schema'
+
+let Event = object({
+  id: string(),
+  createdAt: string()
+    .refine((value) => !Number.isNaN(Date.parse(value)), 'Expected valid date')
+    .transform((value) => new Date(value)),
+})
+
+let event = parse(Event, {
+  id: 'evt_1',
+  createdAt: '2026-04-25T00:00:00.000Z',
+})
+
+event.createdAt // Date
+```
+
+Use `.refine()` for checks that reject values without changing them. Use `.transform()` for safe, synchronous mappings; thrown errors are propagated instead of converted into validation issues.
+
 ## Validation pipelines with `.pipe()`
 
 Compose reusable `Check` objects for common constraints.

--- a/packages/data-schema/src/lib/schema.test.ts
+++ b/packages/data-schema/src/lib/schema.test.ts
@@ -386,6 +386,16 @@ describe('modifiers', () => {
     assertFailure(result)
     assert.equal(result.issues[0].message, 'Must be positive')
   })
+
+  it('supports transform predicates', () => {
+    let shcmea = number().transform((n) => n.toString())
+
+    let ok = shcmea['~standard'].validate(42)
+    let bad = shcmea['~standard'].validate('not-a-number')
+
+    assertSuccess(ok)
+    assert.equal(ok.value, '42')
+  })
 })
 
 describe('tuple', () => {
@@ -795,6 +805,28 @@ describe('modifiers (additional)', () => {
     assertSuccess(schema['~standard'].validate('abc'))
     assertFailure(schema['~standard'].validate('bcd'))
     assertFailure(schema['~standard'].validate('ab'))
+  })
+
+  it('chains transform then refine', () => {
+    let schema = number()
+      .transform((n) => n.toString())
+      .refine((s) => s.length === 2, 'Must be two digits')
+
+    assertSuccess(schema['~standard'].validate(42))
+    assertFailure(schema['~standard'].validate(7))
+  })
+
+  it('chains refine then transform', () => {
+    let schema = number()
+      .refine((n) => n > 0, 'Must be positive')
+      .transform((n) => n.toString())
+
+    let ok = schema['~standard'].validate(42)
+    let bad = schema['~standard'].validate(-1)
+
+    assertSuccess(ok)
+    assert.equal(ok.value, '42')
+    assertFailure(bad)
   })
 })
 

--- a/packages/data-schema/src/lib/schema.test.ts
+++ b/packages/data-schema/src/lib/schema.test.ts
@@ -387,8 +387,9 @@ describe('modifiers', () => {
     assert.equal(result.issues[0].message, 'Must be positive')
   })
 
-  it('supports transform predicates', () => {
+  it('supports transform functions', () => {
     let schema = number().transform((n) => n.toString())
+    expectType<Equal<InferOutput<typeof schema>, string>>()
 
     let ok = schema['~standard'].validate(42)
     let bad = schema['~standard'].validate('not-a-number')

--- a/packages/data-schema/src/lib/schema.test.ts
+++ b/packages/data-schema/src/lib/schema.test.ts
@@ -388,13 +388,14 @@ describe('modifiers', () => {
   })
 
   it('supports transform predicates', () => {
-    let shcmea = number().transform((n) => n.toString())
+    let schema = number().transform((n) => n.toString())
 
-    let ok = shcmea['~standard'].validate(42)
-    let bad = shcmea['~standard'].validate('not-a-number')
+    let ok = schema['~standard'].validate(42)
+    let bad = schema['~standard'].validate('not-a-number')
 
     assertSuccess(ok)
     assert.equal(ok.value, '42')
+    assertFailure(bad)
   })
 })
 

--- a/packages/data-schema/src/lib/schema.ts
+++ b/packages/data-schema/src/lib/schema.ts
@@ -224,7 +224,7 @@ export function createSchema<input, output>(
         return result
       })
     },
-    transform<newOutput>(predicate: (value: output) => newOutput): Schema<input, newOutput> {
+    transform<newOutput>(transformer: (value: output) => newOutput): Schema<input, newOutput> {
       return createSchema<input, newOutput>(function validate(value, context) {
         let result = schema['~run'](value, context)
 
@@ -232,7 +232,7 @@ export function createSchema<input, output>(
           return result
         }
 
-        return { value: predicate(result.value) }
+        return { value: transformer(result.value) }
       })
     },
   }

--- a/packages/data-schema/src/lib/schema.ts
+++ b/packages/data-schema/src/lib/schema.ts
@@ -101,6 +101,16 @@ export type Schema<input, output = input> = SyncStandardSchema<input, output> & 
    */
   refine: (predicate: (value: output) => boolean, message?: string) => Schema<input, output>
   /**
+   * Transform the output of this schema with a function.
+   *
+   * The transform function runs after the underlying schema has validated and produced an `output` value.
+   * The returned schema has a different output type.
+   *
+   * @param predicate A function that transforms the validated output
+   * @returns A new schema with the transformation applied
+   */
+  transform: <newOutput>(predicate: (value: output) => newOutput) => Schema<input, newOutput>
+  /**
    * Internal validator used to validate nested values while preserving `path`/`options`.
    */
   '~run': (value: unknown, context: ValidationContext) => ValidationResult<output>
@@ -212,6 +222,17 @@ export function createSchema<input, output>(
         }
 
         return result
+      })
+    },
+    transform<newOutput>(predicate: (value: output) => newOutput): Schema<input, newOutput> {
+      return createSchema<input, newOutput>(function validate(value, context) {
+        let result = schema['~run'](value, context)
+
+        if (result.issues) {
+          return result
+        }
+
+        return { value: predicate(result.value) }
       })
     },
   }

--- a/packages/data-schema/src/lib/schema.ts
+++ b/packages/data-schema/src/lib/schema.ts
@@ -106,10 +106,10 @@ export type Schema<input, output = input> = SyncStandardSchema<input, output> & 
    * The transform function runs after the underlying schema has validated and produced an `output` value.
    * The returned schema has a different output type.
    *
-   * @param predicate A function that transforms the validated output
+   * @param transformer A function that transforms the validated output
    * @returns A new schema with the transformation applied
    */
-  transform: <newOutput>(predicate: (value: output) => newOutput) => Schema<input, newOutput>
+  transform: <newOutput>(transformer: (value: output) => newOutput) => Schema<input, newOutput>
   /**
    * Internal validator used to validate nested values while preserving `path`/`options`.
    */


### PR DESCRIPTION
Add `Schema.transform()` to the `data-schema` chainable API so schemas can map a successfully validated output value into a new output value and type.

```ts
let Event = object({
  id: string(),
  createdAt: string()
    .refine((value) => !Number.isNaN(Date.parse(value)), 'Expected valid date')
    .transform((value) => new Date(value)),
})
```

- Runs transformers after the underlying schema succeeds and leaves validation failures untouched.
- Preserves the original input type while changing the schema output type.
- Documents usage and adds a release note for `@remix-run/data-schema`.
