### PR TITLE
Update docs generation to produce an api lookup map

### DIFF
--- a/docs/src/generate/documented-api.ts
+++ b/docs/src/generate/documented-api.ts
@@ -77,8 +77,8 @@ export type DocumentedType = BaseDocumentedAPI & {
   signature: string
 }
 
-// PAth docs are served at on the website
-const WEBSITE_DOCS_PATH = '/api'
+// Path docs are served at on the website
+export const WEBSITE_DOCS_PATH = '/api'
 
 // Convert a typedoc reflection for a given node into a documentable instance
 export function getDocumentedAPI(fullName: string, node: typedoc.Reflection): DocumentedAPI {

--- a/docs/src/generate/index.ts
+++ b/docs/src/generate/index.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import util from 'node:util'
 import { getDocumentedAPI } from './documented-api.ts'
+import { writeLookupFile } from './lookup.ts'
 import { writeMarkdownFiles } from './markdown.ts'
 import { loadTypeDoc } from './typedoc.ts'
 import { info } from './utils.ts'
@@ -56,4 +57,8 @@ let documentedAPIs = [...apisToDocument].map((name) => getDocumentedAPI(name, co
 
 // Write out docs
 await writeMarkdownFiles(documentedAPIs, DOCS_DIR)
+
+// Write out API name -> URL path lookup file
+await writeLookupFile(documentedAPIs, DOCS_DIR)
+
 info('Documentation generation complete!')

--- a/docs/src/generate/lookup.ts
+++ b/docs/src/generate/lookup.ts
@@ -21,5 +21,5 @@ export async function writeLookupFile(apis: DocumentedAPI[], docsDir: string) {
 
   let lookupPath = path.join(docsDir, 'api.json')
   info(`Writing API lookup file: ${lookupPath}`)
-  await fs.writeFile(lookupPath, JSON.stringify(sorted, null, 2) + '\n')
+  await fs.writeFile(lookupPath, JSON.stringify(sorted) + '\n')
 }

--- a/docs/src/generate/lookup.ts
+++ b/docs/src/generate/lookup.ts
@@ -1,0 +1,25 @@
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import { WEBSITE_DOCS_PATH, type DocumentedAPI } from './documented-api.ts'
+import { info, warn } from './utils.ts'
+
+export async function writeLookupFile(apis: DocumentedAPI[], docsDir: string) {
+  let lookup: Record<string, string> = {}
+
+  for (let api of apis) {
+    let urlPath = `${WEBSITE_DOCS_PATH}/${api.path}`
+    if (api.name in lookup) {
+      warn(
+        `Duplicate API name \`${api.name}\` in lookup file; ` +
+          `overwriting \`${lookup[api.name]}\` with \`${urlPath}\``,
+      )
+    }
+    lookup[api.name] = urlPath
+  }
+
+  let sorted = Object.fromEntries(Object.entries(lookup).sort(([a], [b]) => a.localeCompare(b)))
+
+  let lookupPath = path.join(docsDir, 'api.json')
+  info(`Writing API lookup file: ${lookupPath}`)
+  await fs.writeFile(lookupPath, JSON.stringify(sorted, null, 2) + '\n')
+}

--- a/docs/src/server/components.tsx
+++ b/docs/src/server/components.tsx
@@ -43,7 +43,8 @@ export function ServerPage(handle: Handle<ServerContext>, setup: ServerContext) 
 }
 
 function Document(handle: Handle) {
-  let { activeVersion } = handle.context.get(ServerPage)
+  let { activeVersion, slug } = handle.context.get(ServerPage)
+  let apiName = slug?.split('/').slice(-1)[0]
   return ({ children }: { children: RemixNode | RemixNode[] }) => (
     <html lang="en">
       <head>
@@ -57,6 +58,14 @@ function Document(handle: Handle) {
         ) : null}
 
         <title>Remix API Documentation</title>
+        {slug ? (
+          <link
+            rel="alternate"
+            type="text/markdown"
+            href={routes.markdown.href({ version: activeVersion, slug })}
+            title={`Markdown docs for ${apiName}`}
+          />
+        ) : null}
         <link
           href={routes.assets.href({ version: activeVersion, asset: 'docs.css' })}
           rel="stylesheet"

--- a/docs/src/server/prerender.ts
+++ b/docs/src/server/prerender.ts
@@ -37,7 +37,11 @@ for (let version of versions || getDefaultVersions()) {
 await spider(
   docsRouter,
   outputDir,
-  new Set(['/', ...(versions?.filter((v) => v.crawl).map((v) => `/${v.version}/`) || [])]),
+  new Set([
+    '/',
+    '/api.json',
+    ...(versions?.filter((v) => v.crawl).map((v) => `/${v.version}/`) || []),
+  ]),
 )
 
 // Spider the website served by router, beginning at /

--- a/docs/src/server/prerender.ts
+++ b/docs/src/server/prerender.ts
@@ -40,7 +40,9 @@ await spider(
   new Set([
     '/',
     '/api.json',
-    ...(versions?.filter((v) => v.crawl).map((v) => `/${v.version}/`) || []),
+    ...(versions
+      ?.filter((v) => v.crawl)
+      .flatMap((v) => [`/${v.version}/api.json`, `/${v.version}/`]) || []),
   ]),
 )
 

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -95,9 +95,16 @@ export function createRouter(versions: ServerContext['versions']) {
           </ServerPage>,
         )
       },
-      lookup({ request }) {
-        let filename = 'api.json'
-        return respond.file(request, path.join(MD_DIR, filename))
+      async lookup({ request, params }) {
+        let jsonPath = path.join(MD_DIR, 'api.json')
+        if (!params.version) {
+          return respond.file(request, jsonPath)
+        }
+        let content = JSON.parse(await fs.promises.readFile(jsonPath, 'utf-8'))
+        for (let key in content) {
+          content[key] = `/${params.version}${content[key]}`
+        }
+        return Response.json(content)
       },
       async markdown({ request, params }) {
         let docFile = docFiles.find((file) => file.urlPath === params.slug)

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -30,7 +30,8 @@ export function createRouter(versions: ServerContext['versions']) {
   const router = _createRouter()
 
   const respond = {
-    async file(request: Request, filePath: string, name: string) {
+    async file(request: Request, filePath: string, name?: string) {
+      name ??= path.basename(filePath)
       return await createFileResponse(openLazyFile(filePath, { name }), request)
     },
     async document(request: Request, node: RemixNode, init?: ResponseInit) {
@@ -94,13 +95,17 @@ export function createRouter(versions: ServerContext['versions']) {
           </ServerPage>,
         )
       },
+      lookup({ request }) {
+        let filename = 'api.json'
+        return respond.file(request, path.join(MD_DIR, filename))
+      },
       async markdown({ request, params }) {
         let docFile = docFiles.find((file) => file.urlPath === params.slug)
         if (!docFile) {
           return new Response('Not Found', { status: 404 })
         }
 
-        return respond.file(request, docFile.path, params.slug)
+        return respond.file(request, docFile.path)
       },
     },
   })

--- a/docs/src/server/routes.ts
+++ b/docs/src/server/routes.ts
@@ -4,5 +4,6 @@ export const routes = route({
   assets: '/(:version/)assets/*asset',
   docs: '/(:version/)api/*slug/',
   home: '/(:version/)',
+  lookup: '/(:version/)api.json',
   markdown: '/(:version/)api/*slug.md',
 })


### PR DESCRIPTION
Update docs generation to produce a lookup map of API names to website markdown URLs that we could use in a `remix docs <api-name>` CLI:

```
{
  "Accept": "/api/remix/headers/class/Accept.md",
  "AcceptEncoding": "/api/remix/headers/class/AcceptEncoding.md",
  "AcceptEncodingInit": "/api/remix/headers/type/AcceptEncodingInit.md",
  "AcceptInit": "/api/remix/headers/type/AcceptInit.md",
  ...
}
```

This will be available from `https://api.remix.run/api.json` so the CLI can fetch that (and potentially cache) and then fetch the associated markdown content.  

It's versioned in the docs as well so `https://api.remix.run/v3.0.0/api.json` will only reflect APIs in v3.0.0 and will also update the markdown links to include the proper version prefix.

Open Questions
- If we want to skip the up front network request we can also generate and ship this in the remix cli so it doesn't need to query `/api.json` - but it feels like some form of caching would be sufficient too