### PR TITLE
data-table: remove database adapter options

### DIFF
--- a/packages/data-table-mysql/.changes/minor.remove-adapter-options.md
+++ b/packages/data-table-mysql/.changes/minor.remove-adapter-options.md
@@ -1,0 +1,20 @@
+BREAKING CHANGE: Removed adapter options
+
+**Affected APIs**
+
+- `MysqlDatabaseAdapterOptions` type: removed
+- `createMysqlDatabaseAdapter` function: `options` arg removed
+- `MysqlDatabaseAdapter` constructor: `options` arg removed
+
+**Why**
+
+Adapter options existed solely for tests to override adapter capabilities.
+If you must override capabilities, you can do so directly via mutation:
+
+```ts
+let adapter = createMysqlDatabaseAdapter(mysql)
+adapter.capabilities = {
+  ...adapter.capabilities,
+  upsert: false,
+}
+```

--- a/packages/data-table-mysql/README.md
+++ b/packages/data-table-mysql/README.md
@@ -48,21 +48,6 @@ Import any driver-specific types you need directly from `mysql2/promise`.
 
 ## Advanced Usage
 
-### Capability Overrides For Testing
-
-Capability overrides are mainly for tests where you want to force or disable specific behavior
-checks. In production, keep defaults so adapter behavior matches MySQL behavior.
-
-```ts
-import { createMysqlDatabaseAdapter } from 'remix/data-table-mysql'
-
-let adapter = createMysqlDatabaseAdapter(pool, {
-  capabilities: {
-    upsert: false,
-  },
-})
-```
-
 ### `returning` On MySQL
 
 MySQL does not natively support SQL `RETURNING`. In this adapter, using `returning` on write

--- a/packages/data-table-mysql/src/index.ts
+++ b/packages/data-table-mysql/src/index.ts
@@ -1,2 +1,1 @@
-export type { MysqlDatabaseAdapterOptions } from './lib/adapter.ts'
 export { createMysqlDatabaseAdapter, MysqlDatabaseAdapter } from './lib/adapter.ts'

--- a/packages/data-table-mysql/src/lib/adapter.test.ts
+++ b/packages/data-table-mysql/src/lib/adapter.test.ts
@@ -41,26 +41,23 @@ const accountProjects = table({
 })
 
 describe('mysql adapter', () => {
-  it('applies explicit capability overrides', () => {
-    let adapter = createMysqlDatabaseAdapter(
-      {
-        async query() {
-          return [[], []]
-        },
-        async beginTransaction() {},
-        async commit() {},
-        async rollback() {},
-      } as never,
-      {
-        capabilities: {
-          returning: true,
-          savepoints: false,
-          upsert: false,
-          transactionalDdl: true,
-          migrationLock: false,
-        },
+  it('supports capability mutation for fallback tests', () => {
+    let adapter = createMysqlDatabaseAdapter({
+      async query() {
+        return [[], []]
       },
-    )
+      async beginTransaction() {},
+      async commit() {},
+      async rollback() {},
+    } as never)
+
+    adapter.capabilities = {
+      returning: true,
+      savepoints: false,
+      upsert: false,
+      transactionalDdl: true,
+      migrationLock: false,
+    }
 
     assert.deepEqual(adapter.capabilities, {
       returning: true,

--- a/packages/data-table-mysql/src/lib/adapter.test.ts
+++ b/packages/data-table-mysql/src/lib/adapter.test.ts
@@ -41,33 +41,6 @@ const accountProjects = table({
 })
 
 describe('mysql adapter', () => {
-  it('supports capability mutation for fallback tests', () => {
-    let adapter = createMysqlDatabaseAdapter({
-      async query() {
-        return [[], []]
-      },
-      async beginTransaction() {},
-      async commit() {},
-      async rollback() {},
-    } as never)
-
-    adapter.capabilities = {
-      returning: true,
-      savepoints: false,
-      upsert: false,
-      transactionalDdl: true,
-      migrationLock: false,
-    }
-
-    assert.deepEqual(adapter.capabilities, {
-      returning: true,
-      savepoints: false,
-      upsert: false,
-      transactionalDdl: true,
-      migrationLock: false,
-    })
-  })
-
   it('checks table and column existence through adapter introspection hooks', async () => {
     let statements: Array<{ text: string; values: unknown[] | undefined }> = []
 

--- a/packages/data-table-mysql/src/lib/adapter.ts
+++ b/packages/data-table-mysql/src/lib/adapter.ts
@@ -1,5 +1,4 @@
 import type {
-  AdapterCapabilityOverrides,
   DataManipulationRequest,
   DataMigrationRequest,
   DataMigrationResult,
@@ -28,13 +27,6 @@ import type {
 } from 'mysql2/promise'
 
 import { compileMysqlOperation } from './sql-compiler.ts'
-
-/**
- * Mysql adapter configuration.
- */
-export type MysqlDatabaseAdapterOptions = {
-  capabilities?: AdapterCapabilityOverrides
-}
 
 type TransactionState = {
   connection: MysqlTransactionConnection
@@ -67,14 +59,14 @@ export class MysqlDatabaseAdapter implements DatabaseAdapter {
   #transactions = new Map<string, TransactionState>()
   #transactionCounter = 0
 
-  constructor(client: MysqlQueryable, options?: MysqlDatabaseAdapterOptions) {
+  constructor(client: MysqlQueryable) {
     this.#client = client
     this.capabilities = {
-      returning: options?.capabilities?.returning ?? false,
-      savepoints: options?.capabilities?.savepoints ?? true,
-      upsert: options?.capabilities?.upsert ?? true,
-      transactionalDdl: options?.capabilities?.transactionalDdl ?? false,
-      migrationLock: options?.capabilities?.migrationLock ?? true,
+      returning: false,
+      savepoints: true,
+      upsert: true,
+      transactionalDdl: false,
+      migrationLock: true,
     }
   }
 
@@ -367,9 +359,8 @@ export class MysqlDatabaseAdapter implements DatabaseAdapter {
  */
 export function createMysqlDatabaseAdapter(
   client: MysqlQueryable,
-  options?: MysqlDatabaseAdapterOptions,
 ): MysqlDatabaseAdapter {
-  return new MysqlDatabaseAdapter(client, options)
+  return new MysqlDatabaseAdapter(client)
 }
 
 function isMysqlPool(client: MysqlQueryable): client is MysqlPool {

--- a/packages/data-table-postgres/.changes/minor.remove-adapter-options.md
+++ b/packages/data-table-postgres/.changes/minor.remove-adapter-options.md
@@ -1,0 +1,20 @@
+BREAKING CHANGE: Removed adapter options
+
+**Affected APIs**
+
+- `PostgresDatabaseAdapterOptions` type: removed
+- `createPostgresDatabaseAdapter` function: `options` arg removed
+- `PostgresDatabaseAdapter` constructor: `options` arg removed
+
+**Why**
+
+Adapter options existed solely for tests to override adapter capabilities.
+If you must override capabilities, you can do so directly via mutation:
+
+```ts
+let adapter = createPostgresDatabaseAdapter(postgres)
+adapter.capabilities = {
+  ...adapter.capabilities,
+  returning: false,
+}
+```

--- a/packages/data-table-postgres/README.md
+++ b/packages/data-table-postgres/README.md
@@ -62,20 +62,6 @@ await db.transaction(async (txDb) => txDb.exec('select 1'), {
 })
 ```
 
-### Capability Overrides For Testing
-
-You can override capabilities to verify fallback paths in tests.
-
-```ts
-import { createPostgresDatabaseAdapter } from 'remix/data-table-postgres'
-
-let adapter = createPostgresDatabaseAdapter(pool, {
-  capabilities: {
-    returning: false,
-  },
-})
-```
-
 ## Related Packages
 
 - [`data-table`](https://github.com/remix-run/remix/tree/main/packages/data-table) - Core query/relations API

--- a/packages/data-table-postgres/src/index.ts
+++ b/packages/data-table-postgres/src/index.ts
@@ -1,2 +1,1 @@
-export type { PostgresDatabaseAdapterOptions } from './lib/adapter.ts'
 export { createPostgresDatabaseAdapter, PostgresDatabaseAdapter } from './lib/adapter.ts'

--- a/packages/data-table-postgres/src/lib/adapter.test.ts
+++ b/packages/data-table-postgres/src/lib/adapter.test.ts
@@ -41,29 +41,26 @@ const accountProjects = table({
 })
 
 describe('postgres adapter', () => {
-  it('applies explicit capability overrides', () => {
-    let adapter = createPostgresDatabaseAdapter(
-      {
-        async query() {
-          return {
-            rows: [],
-            rowCount: 0,
-            command: 'SELECT',
-            oid: 0,
-            fields: [],
-          }
-        },
-      } as never,
-      {
-        capabilities: {
-          returning: false,
-          savepoints: false,
-          upsert: false,
-          transactionalDdl: false,
-          migrationLock: false,
-        },
+  it('supports capability mutation for fallback tests', () => {
+    let adapter = createPostgresDatabaseAdapter({
+      async query() {
+        return {
+          rows: [],
+          rowCount: 0,
+          command: 'SELECT',
+          oid: 0,
+          fields: [],
+        }
       },
-    )
+    } as never)
+
+    adapter.capabilities = {
+      returning: false,
+      savepoints: false,
+      upsert: false,
+      transactionalDdl: false,
+      migrationLock: false,
+    }
 
     assert.deepEqual(adapter.capabilities, {
       returning: false,

--- a/packages/data-table-postgres/src/lib/adapter.test.ts
+++ b/packages/data-table-postgres/src/lib/adapter.test.ts
@@ -41,36 +41,6 @@ const accountProjects = table({
 })
 
 describe('postgres adapter', () => {
-  it('supports capability mutation for fallback tests', () => {
-    let adapter = createPostgresDatabaseAdapter({
-      async query() {
-        return {
-          rows: [],
-          rowCount: 0,
-          command: 'SELECT',
-          oid: 0,
-          fields: [],
-        }
-      },
-    } as never)
-
-    adapter.capabilities = {
-      returning: false,
-      savepoints: false,
-      upsert: false,
-      transactionalDdl: false,
-      migrationLock: false,
-    }
-
-    assert.deepEqual(adapter.capabilities, {
-      returning: false,
-      savepoints: false,
-      upsert: false,
-      transactionalDdl: false,
-      migrationLock: false,
-    })
-  })
-
   it('checks table and column existence through adapter introspection hooks', async () => {
     let statements: Array<{ text: string; values: unknown[] | undefined }> = []
 

--- a/packages/data-table-postgres/src/lib/adapter.ts
+++ b/packages/data-table-postgres/src/lib/adapter.ts
@@ -1,5 +1,4 @@
 import type {
-  AdapterCapabilityOverrides,
   DataMigrationRequest,
   DataManipulationRequest,
   DataMigrationResult,
@@ -22,13 +21,6 @@ import {
 import type { Pool as PostgresPool, PoolClient as PostgresPoolClient } from 'pg'
 
 import { compilePostgresOperation } from './sql-compiler.ts'
-
-/**
- * Postgres adapter configuration.
- */
-export type PostgresDatabaseAdapterOptions = {
-  capabilities?: AdapterCapabilityOverrides
-}
 
 type TransactionState = {
   client: PostgresPoolClient
@@ -55,14 +47,14 @@ export class PostgresDatabaseAdapter implements DatabaseAdapter {
   #transactions = new Map<string, TransactionState>()
   #transactionCounter = 0
 
-  constructor(client: PostgresQueryable, options?: PostgresDatabaseAdapterOptions) {
+  constructor(client: PostgresQueryable) {
     this.#client = client
     this.capabilities = {
-      returning: options?.capabilities?.returning ?? true,
-      savepoints: options?.capabilities?.savepoints ?? true,
-      upsert: options?.capabilities?.upsert ?? true,
-      transactionalDdl: options?.capabilities?.transactionalDdl ?? true,
-      migrationLock: options?.capabilities?.migrationLock ?? true,
+      returning: true,
+      savepoints: true,
+      upsert: true,
+      transactionalDdl: true,
+      migrationLock: true,
     }
   }
 
@@ -327,11 +319,8 @@ export class PostgresDatabaseAdapter implements DatabaseAdapter {
  * let db = createDatabase(adapter)
  * ```
  */
-export function createPostgresDatabaseAdapter(
-  client: PostgresQueryable,
-  options?: PostgresDatabaseAdapterOptions,
-): PostgresDatabaseAdapter {
-  return new PostgresDatabaseAdapter(client, options)
+export function createPostgresDatabaseAdapter(client: PostgresQueryable): PostgresDatabaseAdapter {
+  return new PostgresDatabaseAdapter(client)
 }
 
 function isPostgresPool(client: PostgresQueryable): client is PostgresPool {

--- a/packages/data-table-sqlite/.changes/minor.remove-adapter-options.md
+++ b/packages/data-table-sqlite/.changes/minor.remove-adapter-options.md
@@ -1,0 +1,20 @@
+BREAKING CHANGE: Removed adapter options
+
+**Affected APIs**
+
+- `SqliteDatabaseAdapterOptions` type: removed
+- `createSqliteDatabaseAdapter` function: `options` arg removed
+- `SqliteDatabaseAdapter` constructor: `options` arg removed
+
+**Why**
+
+Adapter options existed solely for tests to override adapter capabilities.
+If you must override capabilities, you can do so directly via mutation:
+
+```ts
+let adapter = createSqliteDatabaseAdapter(sqlite)
+adapter.capabilities = {
+  ...adapter.capabilities,
+  returning: false,
+}
+```

--- a/packages/data-table-sqlite/README.md
+++ b/packages/data-table-sqlite/README.md
@@ -59,18 +59,6 @@ let sqlite = new Database(':memory:')
 let db = createDatabase(createSqliteDatabaseAdapter(sqlite))
 ```
 
-### Capability Overrides For Fallback Testing
-
-```ts
-import { createSqliteDatabaseAdapter } from 'remix/data-table-sqlite'
-
-let adapter = createSqliteDatabaseAdapter(sqlite, {
-  capabilities: {
-    returning: false,
-  },
-})
-```
-
 ## Related Packages
 
 - [`data-table`](https://github.com/remix-run/remix/tree/main/packages/data-table) - Core query/relations API

--- a/packages/data-table-sqlite/src/index.ts
+++ b/packages/data-table-sqlite/src/index.ts
@@ -1,2 +1,1 @@
-export type { SqliteDatabaseAdapterOptions } from './lib/adapter.ts'
 export { createSqliteDatabaseAdapter, SqliteDatabaseAdapter } from './lib/adapter.ts'

--- a/packages/data-table-sqlite/src/lib/adapter.ts
+++ b/packages/data-table-sqlite/src/lib/adapter.ts
@@ -1,5 +1,4 @@
 import type {
-  AdapterCapabilityOverrides,
   DataManipulationRequest,
   DataMigrationRequest,
   DataMigrationResult,
@@ -24,13 +23,6 @@ import type { Database as BetterSqliteDatabase, RunResult } from 'better-sqlite3
 import { compileSqliteOperation } from './sql-compiler.ts'
 
 /**
- * Sqlite adapter configuration.
- */
-export type SqliteDatabaseAdapterOptions = {
-  capabilities?: AdapterCapabilityOverrides
-}
-
-/**
  * `DatabaseAdapter` implementation for Better SQLite3.
  */
 export class SqliteDatabaseAdapter implements DatabaseAdapter {
@@ -48,14 +40,14 @@ export class SqliteDatabaseAdapter implements DatabaseAdapter {
   #transactions = new Set<string>()
   #transactionCounter = 0
 
-  constructor(database: BetterSqliteDatabase, options?: SqliteDatabaseAdapterOptions) {
+  constructor(database: BetterSqliteDatabase) {
     this.#database = database
     this.capabilities = {
-      returning: options?.capabilities?.returning ?? true,
-      savepoints: options?.capabilities?.savepoints ?? true,
-      upsert: options?.capabilities?.upsert ?? true,
-      transactionalDdl: options?.capabilities?.transactionalDdl ?? true,
-      migrationLock: options?.capabilities?.migrationLock ?? false,
+      returning: true,
+      savepoints: true,
+      upsert: true,
+      transactionalDdl: true,
+      migrationLock: false,
     }
   }
 
@@ -275,9 +267,8 @@ export class SqliteDatabaseAdapter implements DatabaseAdapter {
  */
 export function createSqliteDatabaseAdapter(
   database: BetterSqliteDatabase,
-  options?: SqliteDatabaseAdapterOptions,
 ): SqliteDatabaseAdapter {
-  return new SqliteDatabaseAdapter(database, options)
+  return new SqliteDatabaseAdapter(database)
 }
 
 function normalizeRows(rows: unknown[]): Record<string, unknown>[] {

--- a/packages/data-table/test/sqlite-adapter.ts
+++ b/packages/data-table/test/sqlite-adapter.ts
@@ -1,5 +1,4 @@
 // Test-only bridge to the sqlite adapter source package.
 // We intentionally avoid a `@remix-run/data-table-sqlite` devDependency here because it creates
 // a cyclic workspace dependency warning in pnpm (`data-table` <-> `data-table-sqlite`).
-export type { SqliteDatabaseAdapterOptions } from '../../data-table-sqlite/src/lib/adapter.ts'
 export { createSqliteDatabaseAdapter } from '../../data-table-sqlite/src/lib/adapter.ts'

--- a/packages/data-table/test/sqlite-test-database.ts
+++ b/packages/data-table/test/sqlite-test-database.ts
@@ -1,7 +1,6 @@
 import BetterSqlite3, { type Database as BetterSqliteDatabase } from 'better-sqlite3'
 
 import type { DatabaseAdapter } from '../src/lib/adapter.ts'
-import type { SqliteDatabaseAdapterOptions } from './sqlite-adapter.ts'
 import { createSqliteDatabaseAdapter } from './sqlite-adapter.ts'
 
 export type SqliteTestSeed = Record<string, Array<Record<string, unknown>>>
@@ -22,18 +21,19 @@ export function createSqliteTestAdapter(
   let sqlite = new BetterSqlite3(':memory:')
   initializeSchema(sqlite)
   seedDatabase(sqlite, seed)
+  let adapter = createSqliteDatabaseAdapter(sqlite)
 
-  let adapterOptions: SqliteDatabaseAdapterOptions | undefined = options
-    ? {
-        capabilities: {
-          returning: options.returning,
-          savepoints: options.savepoints,
-          upsert: options.upsert,
-        },
-      }
-    : undefined
+  if (options?.returning !== undefined) {
+    adapter.capabilities.returning = options.returning
+  }
 
-  let adapter = createSqliteDatabaseAdapter(sqlite, adapterOptions)
+  if (options?.savepoints !== undefined) {
+    adapter.capabilities.savepoints = options.savepoints
+  }
+
+  if (options?.upsert !== undefined) {
+    adapter.capabilities.upsert = options.upsert
+  }
 
   return {
     adapter,


### PR DESCRIPTION
BREAKING CHANGE: Removed adapter options for Mysql, Postgres, Sqlite

**Affected APIs**

- `*DatabaseAdapterOptions` types: removed
- `create*DatabaseAdapter` functions: `options` arg removed
- `*DatabaseAdapter` constructors: `options` arg removed

**Why**

Adapter options existed solely for tests to override adapter capabilities.
If you must override capabilities, you can do so directly via mutation:

```ts
let adapter = createSqliteDatabaseAdapter(sqlite)
adapter.capabilities = {
  ...adapter.capabilities,
  returning: false,
}
```