### PR TITLE
Fix dotfile matching in `assets` globs

### DIFF
--- a/packages/assets/.changes/patch.allow-globs-match-dot-paths.md
+++ b/packages/assets/.changes/patch.allow-globs-match-dot-paths.md
@@ -1,0 +1,1 @@
+Fix matching of dot-prefixed files and directories in `allow` and `deny` globs

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -42,10 +42,12 @@
     "oxc-parser": "^0.121.0",
     "oxc-resolver": "^11.19.1",
     "oxc-transform": "^0.121.0",
+    "picomatch": "^4.0.4",
     "source-map-js": "^1.2.1"
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "@types/picomatch": "^4.0.3",
     "@typescript/native-preview": "catalog:"
   },
   "scripts": {

--- a/packages/assets/src/lib/asset-server.test.ts
+++ b/packages/assets/src/lib/asset-server.test.ts
@@ -2587,7 +2587,7 @@ describe('asset-server', () => {
   it('supports absolute allow rules and deny overrides', async () => {
     let allowedPath = await write(dir, 'app/allowed.ts', 'export const allowed = true')
     await write(dir, 'app/blocked.ts', 'export const blocked = true')
-    await write(dir, 'app/.hidden.ts', 'export const hidden = true')
+    await write(dir, 'app/.dotfile.ts', 'export const dotfile = true')
     let assetServer = createAssetServerForTest({
       allow: [allowedPath, path.join(dir, 'app')],
       deny: [path.join(dir, 'app/blocked.ts')],
@@ -2597,12 +2597,12 @@ describe('asset-server', () => {
 
     let allowedResponse = await get(assetServer, '/assets/app/allowed.ts')
     let blockedResponse = await get(assetServer, '/assets/app/blocked.ts')
-    let hiddenResponse = await get(assetServer, '/assets/app/.hidden.ts')
+    let dotfileResponse = await get(assetServer, '/assets/app/.dotfile.ts')
     assert.ok(allowedResponse)
     assert.equal(allowedResponse.status, 200)
     assert.equal(blockedResponse, null)
-    assert.ok(hiddenResponse)
-    assert.equal(hiddenResponse.status, 200)
+    assert.ok(dotfileResponse)
+    assert.equal(dotfileResponse.status, 200)
   })
 
   it('rejects unnamed route wildcards because fileMap entries must be reversible', async () => {
@@ -2632,6 +2632,26 @@ describe('asset-server', () => {
     assert.ok(allowedResponse)
     assert.equal(allowedResponse.status, 200)
     assert.equal(blockedResponse, null)
+  })
+
+  it('matches dot-prefixed files and directories in glob-style allow rules', async () => {
+    await write(dir, 'app/.dotfile.ts', 'export const dotfile = true')
+    await write(dir, 'node_modules/.dotdir/example/index.ts', 'export const dotdir = true')
+    let assetServer = createAssetServerForTest({
+      allow: ['app/**/*', 'node_modules/**/*'],
+      rootDir: dir,
+      fileMap: {
+        '/assets/app/*path': 'app/*path',
+        '/assets/npm/*path': 'node_modules/*path',
+      },
+    })
+
+    let dotfileResponse = await get(assetServer, '/assets/app/.dotfile.ts')
+    let dotdirResponse = await get(assetServer, '/assets/npm/.dotdir/example/index.ts')
+    assert.ok(dotfileResponse)
+    assert.equal(dotfileResponse.status, 200)
+    assert.ok(dotdirResponse)
+    assert.equal(dotdirResponse.status, 200)
   })
 
   it('does not call onError for denied direct requests', async () => {

--- a/packages/assets/src/lib/file-matcher.ts
+++ b/packages/assets/src/lib/file-matcher.ts
@@ -1,5 +1,5 @@
 import * as fs from 'node:fs'
-import * as path from 'node:path'
+import picomatch from 'picomatch'
 
 import { normalizeFilePath, resolveFilePath } from './paths.ts'
 
@@ -37,7 +37,8 @@ export function createFileMatcher(
     return (filePath) => filePath === resolvedPatternPath
   }
 
-  return (filePath) => path.posix.matchesGlob(filePath, resolvedPatternPath)
+  let globMatcher = picomatch(resolvedPatternPath, { dot: true })
+  return (filePath) => globMatcher(filePath)
 }
 
 function isSameOrDescendantPath(filePath: string, directoryPath: string): boolean {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,9 @@ importers:
       oxc-transform:
         specifier: ^0.121.0
         version: 0.121.0
+      picomatch:
+        specifier: ^4.0.4
+        version: 4.0.4
       source-map-js:
         specifier: ^1.2.1
         version: 1.2.1
@@ -308,6 +311,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
+      '@types/picomatch':
+        specifier: ^4.0.3
+        version: 4.0.3
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20251125.1
@@ -3547,6 +3553,9 @@ packages:
   '@types/pg@8.16.0':
     resolution: {integrity: sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==}
 
+  '@types/picomatch@4.0.3':
+    resolution: {integrity: sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==}
+
   '@types/qs@6.9.15':
     resolution: {integrity: sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==}
 
@@ -4776,6 +4785,10 @@ packages:
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   playwright-core@1.59.0:
@@ -6794,6 +6807,8 @@ snapshots:
       pg-protocol: 1.11.0
       pg-types: 2.2.0
 
+  '@types/picomatch@4.0.3': {}
+
   '@types/qs@6.9.15': {}
 
   '@types/range-parser@1.2.7': {}
@@ -8199,6 +8214,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  picomatch@4.0.4: {}
 
   playwright-core@1.59.0: {}
 


### PR DESCRIPTION
This fixes an inconsistency in `@remix-run/assets` where allowing `node_modules` via an absolute directory path would correctly permit files inside `node_modules/.pnpm`, but an equivalent glob-style rule like `node_modules/**/*` would not.

The package was previously using `path.posix.matchesGlob()`, which doesn't treat dot-prefixed path segments as matches for patterns like `app/**/*` or `node_modules/**/*`. This meant that requests resolving through `node_modules/.pnpm/*` were skipped by glob-based `allow` and `deny` rules, even though the same paths worked when `node_modules` was allowed via an absolute directory path.

This PR:

- Replaces `path.posix.matchesGlob()` with `picomatch` configured with `dot: true`
- Adds a test for dot-prefixed files and directories in glob-style allow rules
