### PR TITLE
fix(form-data-parser): let upload handler errors propagate

### DIFF
--- a/packages/form-data-parser/.changes/minor.upload-handler-errors.md
+++ b/packages/form-data-parser/.changes/minor.upload-handler-errors.md
@@ -1,0 +1,1 @@
+BREAKING CHANGE: Errors thrown or rejected by a `parseFormData()` upload handler now propagate directly instead of being wrapped in a `FormDataParseError`.

--- a/packages/form-data-parser/README.md
+++ b/packages/form-data-parser/README.md
@@ -75,12 +75,13 @@ async function requestHandler(request: Request) {
 To validate the resulting `FormData` object with `remix/data-schema`, use the
 `remix/data-schema/form-data` helpers.
 
-To limit the overall shape of multipart requests, use the `maxHeaderSize`, `maxFileSize`, `maxFiles`,
-`maxParts`, and `maxTotalSize` options. By default, `parseFormData()` uses `maxFiles = 20`,
-`maxParts = 1000`, and `maxTotalSize = maxFiles * maxFileSize + 1 MiB`.
+To limit the overall shape of multipart requests, use the `maxHeaderSize`, `maxFileSize`, `maxFiles`, `maxParts`, and `maxTotalSize` options. By default, `parseFormData()` uses `maxFiles = 20`, `maxParts = 1000`, and `maxTotalSize = maxFiles * maxFileSize + 1 MiB`.
+
+Known limit errors are thrown directly so you can handle them with `instanceof` checks. Other failures while parsing the request body are wrapped in `FormDataParseError`, with the original error available as `error.cause`. Errors thrown or rejected by your `uploadHandler` are not wrapped.
 
 ```ts
 import {
+  FormDataParseError,
   MaxFilesExceededError,
   MaxFileSizeExceededError,
   MaxHeaderSizeExceededError,
@@ -109,8 +110,10 @@ try {
     console.error(`Request may not contain more than 25 multipart parts`)
   } else if (error instanceof MaxTotalSizeExceededError) {
     console.error(`Multipart request may not exceed 12 MiB of total content`)
+  } else if (error instanceof FormDataParseError) {
+    console.error(`Could not parse form data:`, error.cause ?? error)
   } else {
-    console.error(`An unknown error occurred:`, error)
+    throw error
   }
 }
 ```

--- a/packages/form-data-parser/src/lib/form-data.test.ts
+++ b/packages/form-data-parser/src/lib/form-data.test.ts
@@ -7,7 +7,7 @@ import {
   MaxFilesExceededError,
   parseFormData,
 } from './form-data.ts'
-import { MaxPartsExceededError, MaxTotalSizeExceededError } from '../index.ts'
+import { MultipartParseError, MaxPartsExceededError, MaxTotalSizeExceededError } from '../index.ts'
 
 describe('parseFormData', () => {
   it('parses a application/x-www-form-urlencoded request', async () => {
@@ -154,6 +154,32 @@ describe('parseFormData', () => {
     assert.equal(await file.text(), 'This is an example file.')
   })
 
+  it('allows errors thrown by the upload handler to propagate directly', async () => {
+    let request = new Request('https://remix.run', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW',
+      },
+      body: [
+        '------WebKitFormBoundary7MA4YWxkTrZu0gW',
+        'Content-Disposition: form-data; name="file"; filename="example.txt"',
+        'Content-Type: text/plain',
+        '',
+        'This is an example file.',
+        '------WebKitFormBoundary7MA4YWxkTrZu0gW--',
+      ].join('\r\n'),
+    })
+    let uploadError = new Error('Upload failed')
+
+    await assert.rejects(
+      async () =>
+        await parseFormData(request, () => {
+          throw uploadError
+        }),
+      (error: unknown) => error === uploadError,
+    )
+  })
+
   it('throws MaxFilesExceededError when the number of files exceeds the limit', async () => {
     let request = new Request('https://remix.run', {
       method: 'POST',
@@ -266,9 +292,13 @@ describe('parseFormData', () => {
       body: 'invalid',
     })
 
-    await assert.rejects(async () => {
-      await parseFormData(request)
-    }, FormDataParseError)
+    await assert.rejects(
+      async () => {
+        await parseFormData(request)
+      },
+      (error: unknown) =>
+        error instanceof FormDataParseError && error.cause instanceof MultipartParseError,
+    )
   })
 
   it('parses a multipart file without a media type', async () => {

--- a/packages/form-data-parser/src/lib/form-data.ts
+++ b/packages/form-data-parser/src/lib/form-data.ts
@@ -80,6 +80,21 @@ function isMultipartLimitError(error: unknown): boolean {
   )
 }
 
+async function* parseFormDataParts(
+  request: Request,
+  parserOptions: MultipartParserOptions,
+): AsyncGenerator<MultipartPart, void, unknown> {
+  try {
+    yield* parseMultipartRequest(request, parserOptions)
+  } catch (error) {
+    if (error instanceof FormDataParseError || isMultipartLimitError(error)) {
+      throw error
+    }
+
+    throw new FormDataParseError('Cannot parse form data', { cause: error })
+  }
+}
+
 /**
  * Options for parsing form data.
  */
@@ -162,30 +177,22 @@ export async function parseFormData(
   let formData = new FormData()
   let fileCount = 0
 
-  try {
-    for await (let part of parseMultipartRequest(request, parserOptions)) {
-      let fieldName = part.name
-      if (!fieldName) continue
+  for await (let part of parseFormDataParts(request, parserOptions)) {
+    let fieldName = part.name
+    if (!fieldName) continue
 
-      if (part.isFile) {
-        if (++fileCount > maxFiles) {
-          throw new MaxFilesExceededError(maxFiles)
-        }
-
-        let value = await uploadHandler(new FileUpload(part, fieldName))
-        if (value != null) {
-          formData.append(fieldName, value)
-        }
-      } else {
-        formData.append(fieldName, part.text)
+    if (part.isFile) {
+      if (++fileCount > maxFiles) {
+        throw new MaxFilesExceededError(maxFiles)
       }
-    }
-  } catch (error) {
-    if (error instanceof FormDataParseError || isMultipartLimitError(error)) {
-      throw error
-    }
 
-    throw new FormDataParseError('Cannot parse form data', { cause: error })
+      let value = await uploadHandler(new FileUpload(part, fieldName))
+      if (value != null) {
+        formData.append(fieldName, value)
+      }
+    } else {
+      formData.append(fieldName, part.text)
+    }
   }
 
   return formData


### PR DESCRIPTION
Supersedes #11212. Fixes #11180.

This updates `form-data-parser` error handling so the README can describe the actual contract instead of requiring callers to check every specific error both directly and through `FormDataParseError.cause`.

- Lets errors thrown or rejected by an `uploadHandler` propagate directly, since those errors come from app code rather than the parser
- Keeps known multipart limit errors directly catchable while wrapping other parser/body failures in `FormDataParseError` with the original error as `cause`
- Updates the README example and adds a change file for the behavior change