### PR TITLE
Fix non-ASCII multipart filenames with decoded part headers

### DIFF
--- a/packages/form-data-parser/.changes/patch.non-ascii-multipart-names.md
+++ b/packages/form-data-parser/.changes/patch.non-ascii-multipart-names.md
@@ -1,0 +1,1 @@
+Preserve non-ASCII multipart field names and filenames when parsing `multipart/form-data` requests.

--- a/packages/form-data-parser/src/lib/form-data.test.ts
+++ b/packages/form-data-parser/src/lib/form-data.test.ts
@@ -323,4 +323,94 @@ describe('parseFormData', () => {
     assert.equal(file.type, 'application/octet-stream')
     assert.equal(await file.text(), 'This is an example file.')
   })
+
+  it('parses multipart uploads with non-ASCII filenames', async () => {
+    let request = new Request('https://remix.run', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'multipart/form-data; boundary=----BOUNDARY',
+      },
+      body: [
+        '------BOUNDARY',
+        'Content-Disposition: form-data; name="japanese"; filename="テスト画像.png"',
+        'Content-Type: image/png',
+        '',
+        'Japanese file content.',
+        '------BOUNDARY',
+        'Content-Disposition: form-data; name="chinese"; filename="文件.png"',
+        'Content-Type: image/png',
+        '',
+        'Chinese file content.',
+        '------BOUNDARY',
+        'Content-Disposition: form-data; name="korean"; filename="파일.png"',
+        'Content-Type: image/png',
+        '',
+        'Korean file content.',
+        '------BOUNDARY--',
+      ].join('\r\n'),
+    })
+
+    let formData = await parseFormData(request)
+
+    let japaneseFile = formData.get('japanese')
+    assert.ok(japaneseFile instanceof File)
+    assert.equal(japaneseFile.name, 'テスト画像.png')
+    assert.equal(await japaneseFile.text(), 'Japanese file content.')
+
+    let chineseFile = formData.get('chinese')
+    assert.ok(chineseFile instanceof File)
+    assert.equal(chineseFile.name, '文件.png')
+    assert.equal(await chineseFile.text(), 'Chinese file content.')
+
+    let koreanFile = formData.get('korean')
+    assert.ok(koreanFile instanceof File)
+    assert.equal(koreanFile.name, '파일.png')
+    assert.equal(await koreanFile.text(), 'Korean file content.')
+  })
+
+  it('preserves non-ASCII multipart field names and filenames', async () => {
+    let request = new Request('https://remix.run', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'multipart/form-data; boundary=----BOUNDARY',
+      },
+      body: [
+        '------BOUNDARY',
+        'Content-Disposition: form-data; name="名前"; filename="テスト画像.png"',
+        'Content-Type: image/png',
+        '',
+        'This is an example file.',
+        '------BOUNDARY--',
+      ].join('\r\n'),
+    })
+
+    let formData = await parseFormData(request)
+    let file = formData.get('名前')
+    assert.ok(file instanceof File)
+    assert.equal(file.name, 'テスト画像.png')
+    assert.equal(file.type, 'image/png')
+    assert.equal(await file.text(), 'This is an example file.')
+  })
+
+  it('preserves literal percent sequences in multipart filenames', async () => {
+    let request = new Request('https://remix.run', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'multipart/form-data; boundary=----BOUNDARY',
+      },
+      body: [
+        '------BOUNDARY',
+        'Content-Disposition: form-data; name="file"; filename="%2Fetc%2Fpasswd"',
+        'Content-Type: text/plain',
+        '',
+        'This is an example file.',
+        '------BOUNDARY--',
+      ].join('\r\n'),
+    })
+
+    let formData = await parseFormData(request)
+    let file = formData.get('file')
+    assert.ok(file instanceof File)
+    assert.equal(file.name, '%2Fetc%2Fpasswd')
+  })
 })

--- a/packages/multipart-parser/.changes/minor.multipart-part-headers-object.md
+++ b/packages/multipart-parser/.changes/minor.multipart-part-headers-object.md
@@ -1,0 +1,3 @@
+BREAKING CHANGE: `MultipartPart.headers` is now a plain decoded object keyed by lower-case header name instead of a native `Headers` instance. Access part headers with bracket notation like `part.headers['content-type']` instead of `part.headers.get('content-type')`.
+
+This lets multipart part headers preserve decoded UTF-8 field names and filenames that native `Headers` cannot store.

--- a/packages/multipart-parser/README.md
+++ b/packages/multipart-parser/README.md
@@ -33,6 +33,7 @@ async function handleRequest(request: Request): void {
         console.log(`File received: ${part.filename} (${buffer.byteLength} bytes)`)
         console.log(`Content type: ${part.mediaType}`)
         console.log(`Field name: ${part.name}`)
+        console.log(`Content-Type header: ${part.headers['content-type']}`)
 
         // Save to disk, upload to cloud storage, etc.
         await saveFile(part.filename, part.bytes)
@@ -48,6 +49,19 @@ async function handleRequest(request: Request): void {
       console.error('An unexpected error occurred:', error)
     }
   }
+}
+```
+
+## Part Headers
+
+Each `MultipartPart` exposes decoded part headers as a plain object keyed by lower-case header name. Values are strings, and repeated headers are joined with `, `. Multipart part headers are parsed metadata from the request body, not native `Headers` objects, so access them with bracket notation:
+
+```ts
+for await (let part of parseMultipartRequest(request)) {
+  let contentDisposition = part.headers['content-disposition']
+  let contentType = part.headers['content-type']
+
+  console.log(contentDisposition, contentType)
 }
 ```
 
@@ -216,7 +230,7 @@ Deno 2.3.6
 ## Related Packages
 
 - [`form-data-parser`](https://github.com/remix-run/remix/tree/main/packages/form-data-parser) - Uses `multipart-parser` internally to parse multipart requests and generate `FileUpload`s for storage
-- [`headers`](https://github.com/remix-run/remix/tree/main/packages/headers) - Used internally to parse HTTP headers and get metadata (filename, content type) for each `MultipartPart`
+- [`headers`](https://github.com/remix-run/remix/tree/main/packages/headers) - Used internally to parse `Content-Disposition` and `Content-Type` metadata for each `MultipartPart`
 
 ## Credits
 

--- a/packages/multipart-parser/demos/cf-workers/src/index.ts
+++ b/packages/multipart-parser/demos/cf-workers/src/index.ts
@@ -39,7 +39,7 @@ export default {
 
             await bucket.put(uniqueKey, part.bytes, {
               httpMetadata: {
-                contentType: part.headers.get('Content-Type')!,
+                contentType: part.headers['content-type']!,
               },
             })
 

--- a/packages/multipart-parser/src/index.ts
+++ b/packages/multipart-parser/src/index.ts
@@ -1,4 +1,8 @@
-export type { ParseMultipartOptions, MultipartParserOptions } from './lib/multipart.ts'
+export type {
+  ParseMultipartOptions,
+  MultipartParserOptions,
+  MultipartHeaders,
+} from './lib/multipart.ts'
 export {
   MultipartParseError,
   MaxHeaderSizeExceededError,

--- a/packages/multipart-parser/src/lib/multipart-request.test.ts
+++ b/packages/multipart-parser/src/lib/multipart-request.test.ts
@@ -215,6 +215,90 @@ describe('parseMultipartRequest', async () => {
     assert.equal(parts[0].text, 'File content')
   })
 
+  it('exposes decoded part headers as a plain object', async () => {
+    let request = new Request('https://example.com', {
+      method: 'POST',
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${boundary}`,
+      },
+      body: [
+        `--${boundary}`,
+        'Content-Disposition: form-data; name="file"; filename="test.txt"',
+        'Content-Type: text/plain',
+        'X-Custom: one',
+        'X-Custom: two',
+        '',
+        'File content',
+        `--${boundary}--`,
+      ].join(CRLF),
+    })
+
+    let parts: MultipartPart[] = []
+    for await (let part of parseMultipartRequest(request)) {
+      parts.push(part)
+    }
+
+    assert.equal(parts.length, 1)
+    assert.equal(
+      parts[0].headers['content-disposition'],
+      'form-data; name="file"; filename="test.txt"',
+    )
+    assert.equal(parts[0].headers['content-type'], 'text/plain')
+    assert.equal(parts[0].headers['x-custom'], 'one, two')
+    assert.equal(parts[0].headers['Content-Type'], undefined)
+    assert.equal(Object.isFrozen(parts[0].headers), true)
+  })
+
+  it('preserves non-ASCII field names and filenames', async () => {
+    let request = new Request('https://example.com', {
+      method: 'POST',
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${boundary}`,
+      },
+      body: createMultipartMessage(boundary, {
+        名前: {
+          filename: 'テスト画像.png',
+          mediaType: 'image/png',
+          content: 'image content',
+        },
+      }),
+    })
+
+    let parts: MultipartPart[] = []
+    for await (let part of parseMultipartRequest(request)) {
+      parts.push(part)
+    }
+
+    assert.equal(parts.length, 1)
+    assert.equal(parts[0].name, '名前')
+    assert.equal(parts[0].filename, 'テスト画像.png')
+    assert.equal(parts[0].mediaType, 'image/png')
+  })
+
+  it('preserves literal percent-encoded sequences in filenames', async () => {
+    let request = new Request('https://example.com', {
+      method: 'POST',
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${boundary}`,
+      },
+      body: createMultipartMessage(boundary, {
+        file: {
+          filename: '%2Fetc%2Fpasswd',
+          mediaType: 'text/plain',
+          content: 'File content',
+        },
+      }),
+    })
+
+    let parts: MultipartPart[] = []
+    for await (let part of parseMultipartRequest(request)) {
+      parts.push(part)
+    }
+
+    assert.equal(parts.length, 1)
+    assert.equal(parts[0].filename, '%2Fetc%2Fpasswd')
+  })
+
   it('parses multiple fields and a file upload', async () => {
     let request = new Request('https://example.com', {
       method: 'POST',
@@ -484,7 +568,7 @@ describe('parseMultipartRequest', async () => {
     }
 
     assert.equal(parts.length, 1)
-    assert.equal(parts[0].headers.get('Invalid-Header'), null)
+    assert.equal(parts[0].headers['invalid-header'], undefined)
     assert.equal(parts[0].text, 'Some content')
   })
 

--- a/packages/multipart-parser/src/lib/multipart.ts
+++ b/packages/multipart-parser/src/lib/multipart.ts
@@ -1,4 +1,4 @@
-import { ContentDisposition, ContentType, parse as parseRawHeaders } from '@remix-run/headers'
+import { ContentDisposition, ContentType } from '@remix-run/headers'
 
 import {
   createSearch,
@@ -502,6 +502,29 @@ export class MultipartParser {
 const decoder = new TextDecoder('utf-8', { fatal: true })
 
 /**
+ * The decoded headers for a multipart part, keyed by lower-case header name.
+ */
+export interface MultipartHeaders {
+  readonly [name: string]: string | undefined
+}
+
+function parseMultipartHeaders(raw: string): MultipartHeaders {
+  let headers: Record<string, string> = Object.create(null)
+
+  for (let line of raw.split('\r\n')) {
+    let match = line.match(/^([^:]+):(.*)/)
+    if (match) {
+      let name = match[1].trim().toLowerCase()
+      let value = match[2].trim()
+      let existingValue = headers[name]
+      headers[name] = existingValue === undefined ? value : `${existingValue}, ${value}`
+    }
+  }
+
+  return Object.freeze(headers)
+}
+
+/**
  * A part of a `multipart/*` HTTP message.
  */
 export class MultipartPart {
@@ -511,7 +534,7 @@ export class MultipartPart {
   readonly content: Uint8Array[]
 
   #header: Uint8Array
-  #headers?: Headers
+  #headers?: MultipartHeaders
 
   /**
    * @param header The raw header bytes
@@ -546,11 +569,11 @@ export class MultipartPart {
   }
 
   /**
-   * The headers associated with this part.
+   * The decoded headers associated with this part, keyed by lower-case header name.
    */
-  get headers(): Headers {
+  get headers(): MultipartHeaders {
     if (!this.#headers) {
-      this.#headers = parseRawHeaders(decoder.decode(this.#header))
+      this.#headers = parseMultipartHeaders(decoder.decode(this.#header))
     }
 
     return this.#headers
@@ -574,21 +597,21 @@ export class MultipartPart {
    * The filename of the part, if it is a file upload.
    */
   get filename(): string | undefined {
-    return ContentDisposition.from(this.headers.get('content-disposition')).preferredFilename
+    return ContentDisposition.from(this.headers['content-disposition'] ?? null).preferredFilename
   }
 
   /**
    * The media type of the part.
    */
   get mediaType(): string | undefined {
-    return ContentType.from(this.headers.get('content-type')).mediaType
+    return ContentType.from(this.headers['content-type'] ?? null).mediaType
   }
 
   /**
    * The name of the part, usually the `name` of the field in the `<form>` that submitted the request.
    */
   get name(): string | undefined {
-    return ContentDisposition.from(this.headers.get('content-disposition')).name
+    return ContentDisposition.from(this.headers['content-disposition'] ?? null).name
   }
 
   /**

--- a/packages/multipart-parser/src/node.ts
+++ b/packages/multipart-parser/src/node.ts
@@ -1,5 +1,9 @@
 // Re-export all core functionality
-export type { ParseMultipartOptions, MultipartParserOptions } from './lib/multipart.ts'
+export type {
+  ParseMultipartOptions,
+  MultipartParserOptions,
+  MultipartHeaders,
+} from './lib/multipart.ts'
 export {
   MultipartParseError,
   MaxHeaderSizeExceededError,

--- a/packages/multipart-parser/test/utils.ts
+++ b/packages/multipart-parser/test/utils.ts
@@ -1,8 +1,4 @@
-import {
-  ContentDisposition,
-  ContentType,
-  stringify as stringifyRawHeaders,
-} from '@remix-run/headers'
+import { ContentDisposition, ContentType } from '@remix-run/headers'
 
 export type PartValue =
   | string
@@ -32,31 +28,28 @@ export function createMultipartMessage(
       pushLine(`--${boundary}`)
 
       if (typeof value === 'string') {
-        let headers = new Headers({
-          'Content-Disposition': ContentDisposition.from({
+        pushLine(
+          `Content-Disposition: ${ContentDisposition.from({
             type: 'form-data',
             name,
-          }).toString(),
-        })
-
-        pushLine(stringifyRawHeaders(headers))
+          })}`,
+        )
         pushLine()
         pushLine(value)
       } else {
-        let headers = new Headers({
-          'Content-Disposition': ContentDisposition.from({
+        pushLine(
+          `Content-Disposition: ${ContentDisposition.from({
             type: 'form-data',
             name,
             filename: value.filename,
             filenameSplat: value.filenameSplat,
-          }).toString(),
-        })
+          })}`,
+        )
 
         if (value.mediaType) {
-          headers.set('Content-Type', ContentType.from({ mediaType: value.mediaType }).toString())
+          pushLine(`Content-Type: ${ContentType.from({ mediaType: value.mediaType })}`)
         }
 
-        pushLine(stringifyRawHeaders(headers))
         pushLine()
         if (typeof value.content === 'string') {
           pushLine(value.content)

--- a/packages/remix/.changes/minor.multipart-part-headers-object.md
+++ b/packages/remix/.changes/minor.multipart-part-headers-object.md
@@ -1,0 +1,1 @@
+BREAKING CHANGE: `MultipartPart.headers` from `remix/multipart-parser` and `remix/multipart-parser/node` is now a plain decoded object keyed by lower-case header name instead of a native `Headers` instance. Access part headers with bracket notation like `part.headers['content-type']` instead of `part.headers.get('content-type')`.


### PR DESCRIPTION
This takes a different approach to fixing non-ASCII multipart filenames than #11039 and #11139. Instead of trying to squeeze decoded multipart part headers through native `Headers`, `multipart-parser` now exposes part headers as a decoded plain object, because these are metadata from the multipart body and can contain UTF-8 values that native `Headers` rejects.

Fixes #11032. Supersedes #11139 and the earlier closed #11039. Regression context: #10911 replaced `SuperHeaders` with native `Headers`, which exposed the non-ASCII value limitation.

- `MultipartPart.headers` is now a frozen plain object keyed by lower-case header name, so `part.headers['content-type']` replaces `part.headers.get('content-type')`.
- `MultipartPart.name`, `filename`, and `mediaType` parse decoded strings directly, preserving non-ASCII filenames and field names without percent-encoding/decoding ambiguity.
- Repeated part header values are joined with `, `, matching the prior common `Headers.get()` shape for these multipart metadata values.
- Adds `form-data-parser` regression coverage for Japanese, Chinese, and Korean filenames, plus `multipart-parser` coverage for decoded headers and literal percent sequences.

```ts
// Before
let contentType = part.headers.get('content-type')

// After
let contentType = part.headers['content-type']
```