### PR TITLE
fix(tar-parser): handle body chunk boundaries

### DIFF
--- a/packages/tar-parser/.changes/patch.body-chunk-boundary.md
+++ b/packages/tar-parser/.changes/patch.body-chunk-boundary.md
@@ -1,0 +1,1 @@
+Fix parsing tar entries whose file body ends exactly at a chunk boundary.

--- a/packages/tar-parser/src/lib/tar.test.ts
+++ b/packages/tar-parser/src/lib/tar.test.ts
@@ -192,6 +192,24 @@ describe('tar-stream test cases', () => {
     ])
   })
 
+  it('parses a file body that ends at a chunk boundary', async () => {
+    let archive = await bufferBytes(readFixture(fixtures.multiFile))
+    let chunkBoundary = 512 + 'i am file-1\n'.length
+
+    let entries: [string, string][] = []
+    await parseTar(
+      [archive.subarray(0, chunkBoundary), archive.subarray(chunkBoundary)],
+      async (entry) => {
+        entries.push([entry.name, await bufferString(entry.body)])
+      },
+    )
+
+    assert.deepEqual(entries, [
+      ['file-1.txt', 'i am file-1\n'],
+      ['file-2.txt', 'i am file-2\n'],
+    ])
+  })
+
   it('parses pax.tar', async () => {
     let entries: [TarHeader, string][] = []
     await parseTar(readFixture(fixtures.pax), async (entry) => {

--- a/packages/tar-parser/src/lib/tar.ts
+++ b/packages/tar-parser/src/lib/tar.ts
@@ -468,16 +468,17 @@ export class TarParser {
   }
 
   #parseBody(): void {
-    if (this.#missing >= this.#buffer!.length) {
+    if (this.#missing > this.#buffer!.length) {
       this.#bodyController!.enqueue(this.#buffer!)
       this.#missing -= this.#buffer!.length
       this.#buffer = null
-    } else {
-      this.#bodyController!.enqueue(this.#read(this.#missing))
-      this.#bodyController!.close()
-      this.#bodyController = null
-      this.#missing = overflow(this.#header!.size)
+      return
     }
+
+    this.#bodyController!.enqueue(this.#read(this.#missing))
+    this.#bodyController!.close()
+    this.#bodyController = null
+    this.#missing = overflow(this.#header!.size)
   }
 
   #read(size: number): Uint8Array {


### PR DESCRIPTION
Fixes a tar parser boundary case where a file body ends exactly at the current chunk boundary. Previously the parser could enqueue the final body bytes without closing the entry body stream or advancing into tar padding, which left body consumers hanging or caused padding to be parsed as a header.

- Treat exact body/chunk alignment as a completed body and close the entry stream before padding handling.
- Add a deterministic regression that splits the existing multi-file fixture at the first body boundary and consumes both entry bodies.
- Add a patch change file for @remix-run/tar-parser.

Supersedes #10723.
