### PR TITLE
feat(fetch-proxy): add X-Forwarded-Port header

### DIFF
--- a/packages/fetch-proxy/.changes/minor.x-forwarded-port.md
+++ b/packages/fetch-proxy/.changes/minor.x-forwarded-port.md
@@ -1,0 +1,1 @@
+Add an `X-Forwarded-Port` header when `xForwardedHeaders` is enabled.

--- a/packages/fetch-proxy/README.md
+++ b/packages/fetch-proxy/README.md
@@ -7,7 +7,7 @@ Use `fetch-proxy` to create `fetch` handlers that forward requests to target ser
 
 - **Web Standards** - Built on the standard [JavaScript Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
 - **Cookie Rewriting** - Supports rewriting `Set-Cookie` headers received from target server
-- **Forwarding Headers** - Supports `X-Forwarded-Proto` and `X-Forwarded-Host` headers
+- **Forwarding Headers** - Supports `X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Forwarded-Port` headers
 - **Custom Fetch** - Supports custom `fetch` implementations
 
 ## Installation

--- a/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
@@ -100,7 +100,7 @@ describe('fetch proxy', () => {
     }
   })
 
-  it('does not append X-Forwarded-Proto and X-Forwarded-Host headers by default', async () => {
+  it('does not append X-Forwarded headers by default', async () => {
     let { request } = await testProxy(
       new Request('http://shopify.com:8080/search?q=remix'),
       'https://remix.run:3000/dest',
@@ -108,9 +108,10 @@ describe('fetch proxy', () => {
 
     assert.equal(request.headers.get('X-Forwarded-Proto'), null)
     assert.equal(request.headers.get('X-Forwarded-Host'), null)
+    assert.equal(request.headers.get('X-Forwarded-Port'), null)
   })
 
-  it('appends X-Forwarded-Proto and X-Forwarded-Host headers when desired', async () => {
+  it('appends X-Forwarded headers when desired', async () => {
     let { request } = await testProxy(
       new Request('http://shopify.com:8080/search?q=remix'),
       'https://remix.run:3000/dest',
@@ -121,6 +122,27 @@ describe('fetch proxy', () => {
 
     assert.equal(request.headers.get('X-Forwarded-Proto'), 'http')
     assert.equal(request.headers.get('X-Forwarded-Host'), 'shopify.com:8080')
+    assert.equal(request.headers.get('X-Forwarded-Port'), '8080')
+  })
+
+  it('appends default X-Forwarded-Port values when request URLs omit ports', async () => {
+    let { request: httpRequest } = await testProxy(
+      new Request('http://shopify.com/search?q=remix'),
+      'https://remix.run:3000/dest',
+      {
+        xForwardedHeaders: true,
+      },
+    )
+    let { request: httpsRequest } = await testProxy(
+      new Request('https://shopify.com/search?q=remix'),
+      'https://remix.run:3000/dest',
+      {
+        xForwardedHeaders: true,
+      },
+    )
+
+    assert.equal(httpRequest.headers.get('X-Forwarded-Port'), '80')
+    assert.equal(httpsRequest.headers.get('X-Forwarded-Port'), '443')
   })
 
   it('forwards additional request init options', async () => {

--- a/packages/fetch-proxy/src/lib/fetch-proxy.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.ts
@@ -25,7 +25,8 @@ export interface FetchProxyOptions {
    */
   rewriteCookiePath?: boolean
   /**
-   * Set `true` to add `X-Forwarded-Proto` and `X-Forwarded-Host` headers to the proxied request.
+   * Set `true` to add `X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Forwarded-Port`
+   * headers to the proxied request.
    *
    * @default false
    */
@@ -79,6 +80,7 @@ export function createFetchProxy(target: string | URL, options?: FetchProxyOptio
     if (xForwardedHeaders) {
       proxyHeaders.append('X-Forwarded-Proto', url.protocol.replace(/:$/, ''))
       proxyHeaders.append('X-Forwarded-Host', url.host)
+      proxyHeaders.append('X-Forwarded-Port', getForwardedPort(url))
     }
 
     let proxyInit: RequestInit = {
@@ -138,4 +140,12 @@ export function createFetchProxy(target: string | URL, options?: FetchProxyOptio
       headers: responseHeaders,
     })
   }
+}
+
+function getForwardedPort(url: URL): string {
+  if (url.port !== '') {
+    return url.port
+  }
+
+  return url.protocol === 'https:' ? '443' : '80'
 }


### PR DESCRIPTION
This keeps `X-Forwarded-Host` aligned with the original request `Host` value while adding a separate `X-Forwarded-Port` header when `xForwardedHeaders` is enabled. This follows the shape used by `node-http-proxy` and avoids changing existing consumers that expect the port to remain in `X-Forwarded-Host`.

Supersedes #10762.

- Adds `X-Forwarded-Port` for proxied requests when `xForwardedHeaders: true`
- Preserves the current `X-Forwarded-Host` behavior by continuing to use `url.host`
- Uses explicit request ports when present and falls back to `80` or `443` for default HTTP/HTTPS ports

```ts
let proxy = createFetchProxy('https://backend.example', {
  xForwardedHeaders: true,
})

await proxy(new Request('http://shopify.com:8080/search'))
// X-Forwarded-Proto: http
// X-Forwarded-Host: shopify.com:8080
// X-Forwarded-Port: 8080
```
