### PR TITLE
feat(logger-middleware): colorize logger output

### DIFF
--- a/packages/logger-middleware/.changes/minor.colorize-logger-output.md
+++ b/packages/logger-middleware/.changes/minor.colorize-logger-output.md
@@ -1,0 +1,1 @@
+Colorize high-signal logger tokens in TTY output by default, with a `colors: false` option to opt out and `NO_COLOR` support when the `process` global is defined.

--- a/packages/logger-middleware/README.md
+++ b/packages/logger-middleware/README.md
@@ -7,6 +7,7 @@ HTTP request/response logging middleware for Remix. It logs request metadata and
 - **Request/Response Logging** - Logs method, path, status, and response metadata
 - **Token-Based Formatting** - Customize log output with built-in placeholders
 - **Structured Timing Data** - Includes request duration and timestamps
+- **Colorized Output** - Highlights method, status, duration, and content length in TTY output
 
 ## Installation
 
@@ -72,6 +73,27 @@ let router = createRouter({
   ],
 })
 ```
+
+### Colorized Output
+
+Logger output automatically uses ANSI colors for high-signal tokens when running in a TTY. Set `colors` to `false` to disable colorized output. When the `process` global is defined, the `NO_COLOR` environment variable disables colors regardless of the `colors` option.
+
+```ts
+let router = createRouter({
+  middleware: [
+    logger({
+      colors: false,
+    }),
+  ],
+})
+```
+
+The following tokens are colorized when colors are enabled:
+
+- `%method`
+- `%status`
+- `%duration`
+- `%contentLength`
 
 ### Custom Logger
 

--- a/packages/logger-middleware/src/lib/logger.test.ts
+++ b/packages/logger-middleware/src/lib/logger.test.ts
@@ -6,36 +6,236 @@ import { route } from '@remix-run/fetch-router/routes'
 
 import { logger } from './logger.ts'
 
+const reset = '\x1b[0m'
+const green = (value: string): string => `\x1b[32m${value}${reset}`
+const cyan = (value: string): string => `\x1b[36m${value}${reset}`
+const yellow = (value: string): string => `\x1b[33m${value}${reset}`
+const red = (value: string): string => `\x1b[31m${value}${reset}`
+
 describe('logger', () => {
   it('logs the request', async () => {
-    let routes = route({
-      home: '/',
+    let { message, response } = await logRequest({
+      loggerOptions: { colors: false },
+      response: new Response('Home', {
+        headers: {
+          'Content-Length': '4',
+          'Content-Type': 'text/plain',
+        },
+      }),
     })
-
-    let messages: string[] = []
-
-    let router = createRouter({
-      middleware: [logger({ log: (message) => messages.push(message) })],
-    })
-
-    router.map(
-      routes.home,
-      () =>
-        new Response('Home', {
-          headers: {
-            'Content-Length': '4',
-            'Content-Type': 'text/plain',
-          },
-        }),
-    )
-
-    let response = await router.fetch('https://remix.run')
 
     assert.equal(response.status, 200)
     assert.equal(await response.text(), 'Home')
-
-    assert.equal(messages.length, 1)
-    let message = messages[0]
     assert.match(message, /\[\d{2}\/\w{3}\/\d{4}:\d{2}:\d{2}:\d{2} [+-]\d{4}\] GET \/ \d+ \d+/)
   })
+
+  it('colorizes high-signal tokens when colors are enabled', async () => {
+    await withNoColor(undefined, async () => {
+      let { message } = await logRequest({
+        loggerOptions: {
+          colors: true,
+          format: '%method %status %duration %contentLength',
+        },
+        response: new Response('Home', {
+          headers: {
+            'Content-Length': '2048',
+          },
+        }),
+      })
+
+      let [method, status, duration, contentLength] = message.split(' ')
+
+      assert.equal(method, green('GET'))
+      assert.equal(status, green('200'))
+      assert.match(duration, /^\x1b\[(32|33|35|31)m\d+\x1b\[0m$/)
+      assert.equal(contentLength, cyan('2048'))
+    })
+  })
+
+  it('colorizes methods, statuses, and content lengths by severity', async () => {
+    await withNoColor(undefined, async () => {
+      let { message } = await logRequest({
+        loggerOptions: {
+          colors: true,
+          format: '%method %status %contentLength',
+        },
+        requestInit: {
+          method: 'DELETE',
+        },
+        response: new Response('Nope', {
+          status: 404,
+          headers: {
+            'Content-Length': '204800',
+          },
+        }),
+      })
+
+      assert.equal(message, `${red('DELETE')} ${yellow('404')} ${yellow('204800')}`)
+    })
+  })
+
+  it('opts out of colors with the colors option', async () => {
+    await withNoColor(undefined, async () => {
+      let { message } = await logRequest({
+        loggerOptions: {
+          colors: false,
+          format: '%method %status %contentLength',
+        },
+        response: new Response('Home', {
+          headers: {
+            'Content-Length': '2048',
+          },
+        }),
+      })
+
+      assert.equal(message, 'GET 200 2048')
+    })
+  })
+
+  it('respects NO_COLOR when the process global is defined', async () => {
+    await withNoColor('1', async () => {
+      let { message } = await logRequest({
+        loggerOptions: {
+          colors: true,
+          format: '%method %status %contentLength',
+        },
+        response: new Response('Home', {
+          headers: {
+            'Content-Length': '2048',
+          },
+        }),
+      })
+
+      assert.equal(message, 'GET 200 2048')
+    })
+  })
+
+  it('enables colors by default in TTY environments', async () => {
+    await withNoColor(undefined, async () => {
+      await withTTY(true, async () => {
+        let { message } = await logRequest({
+          loggerOptions: {
+            format: '%method %status',
+          },
+        })
+
+        assert.equal(message, `${green('GET')} ${green('200')}`)
+      })
+    })
+  })
+
+  it('leaves colors off by default outside TTY environments', async () => {
+    await withNoColor(undefined, async () => {
+      await withTTY(false, async () => {
+        let { message } = await logRequest({
+          loggerOptions: {
+            format: '%method %status %contentLength',
+          },
+          response: new Response('Home', {
+            headers: {
+              'Content-Length': '2048',
+            },
+          }),
+        })
+
+        assert.equal(message, 'GET 200 2048')
+      })
+    })
+  })
+
+  it('leaves invalid content lengths uncolored', async () => {
+    await withNoColor(undefined, async () => {
+      let { message } = await logRequest({
+        loggerOptions: {
+          colors: true,
+          format: '%contentLength',
+        },
+        response: new Response('Home', {
+          headers: {
+            'Content-Length': 'bad',
+          },
+        }),
+      })
+
+      assert.equal(message, 'bad')
+    })
+  })
 })
+
+async function logRequest({
+  loggerOptions = {},
+  requestInit,
+  response = new Response('Home'),
+}: {
+  loggerOptions?: Parameters<typeof logger>[0]
+  requestInit?: RequestInit
+  response?: Response
+}): Promise<{ message: string; response: Response }> {
+  let routes = route({
+    home: '/',
+  })
+
+  let messages: string[] = []
+
+  let router = createRouter({
+    middleware: [
+      logger({
+        ...loggerOptions,
+        log: (message) => messages.push(message),
+      }),
+    ],
+  })
+
+  router.map(routes.home, () => response)
+
+  let result = await router.fetch('https://remix.run', requestInit)
+
+  assert.equal(messages.length, 1)
+
+  return {
+    message: messages[0],
+    response: result,
+  }
+}
+
+async function withNoColor<result>(
+  value: string | undefined,
+  callback: () => Promise<result>,
+): Promise<result> {
+  let hadNoColor = Object.hasOwn(process.env, 'NO_COLOR')
+  let previous = process.env.NO_COLOR
+
+  if (value === undefined) {
+    delete process.env.NO_COLOR
+  } else {
+    process.env.NO_COLOR = value
+  }
+
+  try {
+    return await callback()
+  } finally {
+    if (hadNoColor) {
+      process.env.NO_COLOR = previous
+    } else {
+      delete process.env.NO_COLOR
+    }
+  }
+}
+
+async function withTTY<result>(value: boolean, callback: () => Promise<result>): Promise<result> {
+  let descriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  Object.defineProperty(process.stdout, 'isTTY', {
+    configurable: true,
+    value,
+  })
+
+  try {
+    return await callback()
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(process.stdout, 'isTTY', descriptor)
+    } else {
+      Reflect.deleteProperty(process.stdout, 'isTTY')
+    }
+  }
+}

--- a/packages/logger-middleware/src/lib/logger.ts
+++ b/packages/logger-middleware/src/lib/logger.ts
@@ -37,6 +37,23 @@ export interface LoggerOptions {
    * @default console.log
    */
   log?: (message: string) => void
+  /**
+   * Enables ANSI colors for high-signal log tokens.
+   *
+   * By default, colors are enabled when running in a TTY and disabled otherwise. Set this to `false`
+   * to opt out. When the `process` global is defined, the `NO_COLOR` environment variable disables
+   * colors regardless of this option.
+   *
+   * The following tokens are colorized when colors are enabled:
+   *
+   * - `%method`
+   * - `%status`
+   * - `%duration`
+   * - `%contentLength`
+   *
+   * @default undefined
+   */
+  colors?: boolean
 }
 
 /**
@@ -46,22 +63,30 @@ export interface LoggerOptions {
  * @returns The logger middleware
  */
 export function logger(options: LoggerOptions = {}): Middleware {
-  let { format = '[%date] %method %path %status %contentLength', log = console.log } = options
+  let {
+    colors,
+    format = '[%date] %method %path %status %contentLength',
+    log = console.log,
+  } = options
+  let colorizer = getColorizer(colors)
 
   return async ({ request, url }, next) => {
     let start = new Date()
     let response = await next()
     let end = new Date()
+    let duration = end.getTime() - start.getTime()
+    let contentLength = response.headers.get('Content-Length')
+    let contentLengthValue = parseContentLength(contentLength)
 
     let tokens: Record<string, () => string> = {
       date: () => formatApacheDate(start),
       dateISO: () => start.toISOString(),
-      duration: () => String(end.getTime() - start.getTime()),
-      contentLength: () => response.headers.get('Content-Length') ?? '-',
+      duration: () => colorizer.duration(duration),
+      contentLength: () => colorizer.contentLength(contentLength ?? '-', contentLengthValue),
       contentType: () => response.headers.get('Content-Type') ?? '-',
       host: () => url.host,
       hostname: () => url.hostname,
-      method: () => request.method,
+      method: () => colorizer.method(request.method),
       path: () => url.pathname + url.search,
       pathname: () => url.pathname,
       port: () => url.port,
@@ -69,7 +94,7 @@ export function logger(options: LoggerOptions = {}): Middleware {
       query: () => url.search,
       referer: () => request.headers.get('Referer') ?? '-',
       search: () => url.search,
-      status: () => String(response.status),
+      status: () => colorizer.status(response.status),
       statusText: () => response.statusText,
       url: () => url.href,
       userAgent: () => request.headers.get('User-Agent') ?? '-',
@@ -84,6 +109,95 @@ export function logger(options: LoggerOptions = {}): Middleware {
 }
 
 const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+const ansi = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  cyan: '\x1b[36m',
+  yellow: '\x1b[33m',
+  magenta: '\x1b[35m',
+  red: '\x1b[31m',
+}
+
+interface Colorizer {
+  contentLength(value: string, bytes: number | undefined): string
+  duration(ms: number): string
+  method(method: string): string
+  status(status: number): string
+}
+
+function getColorizer(option: boolean | undefined): Colorizer {
+  let enabled = shouldUseColors(option)
+
+  return {
+    contentLength(value, bytes) {
+      if (!enabled || bytes === undefined) return value
+      if (bytes >= 1024 * 1024) return colorize(value, ansi.red)
+      if (bytes >= 100 * 1024) return colorize(value, ansi.yellow)
+      if (bytes >= 1024) return colorize(value, ansi.cyan)
+      return value
+    },
+    duration(ms) {
+      let value = String(ms)
+      if (!enabled) return value
+      if (ms >= 1000) return colorize(value, ansi.red)
+      if (ms >= 500) return colorize(value, ansi.magenta)
+      if (ms >= 100) return colorize(value, ansi.yellow)
+      return colorize(value, ansi.green)
+    },
+    method(method) {
+      if (!enabled) return method
+
+      switch (method.toUpperCase()) {
+        case 'GET':
+        case 'HEAD':
+          return colorize(method, ansi.green)
+        case 'POST':
+          return colorize(method, ansi.cyan)
+        case 'PUT':
+        case 'PATCH':
+          return colorize(method, ansi.yellow)
+        case 'DELETE':
+          return colorize(method, ansi.red)
+        case 'OPTIONS':
+          return colorize(method, ansi.magenta)
+        default:
+          return method
+      }
+    },
+    status(status) {
+      let value = String(status)
+      if (!enabled) return value
+      if (status >= 500) return colorize(value, ansi.red)
+      if (status >= 400) return colorize(value, ansi.yellow)
+      if (status >= 300) return colorize(value, ansi.cyan)
+      if (status >= 200) return colorize(value, ansi.green)
+      return value
+    },
+  }
+}
+
+function shouldUseColors(option: boolean | undefined): boolean {
+  if (typeof process !== 'undefined' && process.env?.NO_COLOR != null) {
+    return false
+  }
+
+  if (option !== undefined) {
+    return option
+  }
+
+  return typeof process !== 'undefined' && process.stdout?.isTTY === true
+}
+
+function colorize(value: string, color: string): string {
+  return `${color}${value}${ansi.reset}`
+}
+
+function parseContentLength(value: string | null): number | undefined {
+  if (value === null) return undefined
+
+  let bytes = Number(value)
+  return Number.isSafeInteger(bytes) && bytes >= 0 ? bytes : undefined
+}
 
 /**
  * Formats a date in Apache/nginx log format: "dd/Mon/yyyy:HH:mm:ss ±zzzz"


### PR DESCRIPTION
This replaces #10862 with a scoped logger colorization change. It keeps the default log format unchanged and colorizes the existing high-signal tokens when output is suitable for ANSI colors.

- Adds a `colors?: boolean` option; TTY output is colorized by default, `colors: false` opts out, and `NO_COLOR` disables colors when the `process` global is defined.
- Colorizes `%method`, `%status`, `%duration`, and `%contentLength` without adding pretty-format tokens.
- Preserves raw token values when colors are disabled, including malformed `Content-Length` values.

Supersedes #10862.

```ts
let router = createRouter({
  middleware: [
    logger({
      colors: false,
    }),
  ],
})
```
