### PR TITLE
docs(form-data-parser): fix typo in `CHANGELOG`

### DIFF
--- a/packages/form-data-parser/.changes/patch.fix-error-name-changelog.md
+++ b/packages/form-data-parser/.changes/patch.fix-error-name-changelog.md
@@ -1,0 +1,1 @@
+Fix wrong error name in this changelog.

--- a/packages/form-data-parser/.changes/patch.fix-error-name-changelog.md
+++ b/packages/form-data-parser/.changes/patch.fix-error-name-changelog.md
@@ -1,1 +1,0 @@
-Fix wrong error name in this changelog.

--- a/packages/form-data-parser/CHANGELOG.md
+++ b/packages/form-data-parser/CHANGELOG.md
@@ -48,7 +48,7 @@ This is the changelog for [`form-data-parser`](https://github.com/remix-run/remi
 
 ## v0.9.1 (2025-06-13)
 
-- Export `FormDataParserError` and `MaxFilesExceededError`
+- Export `FormDataParseError` and `MaxFilesExceededError`
 - Re-export `MultipartParseError`, `MaxHeaderSizeExceededError`, and `MaxFileSizeExceededError` from multipart parser
 
 ## v0.9.0 (2025-06-13)


### PR DESCRIPTION
❌️Wrong: <code>FormDataParse<mark>***r***</mark>Error</code>

https://github.com/search?q=repo%3Aremix-run%2Fremix+FormDataParserError&type=code

✅️Correct: `FormDataParseError`

https://github.com/search?q=repo%3Aremix-run%2Fremix%20FormDataParseError&type=code

https://github.com/remix-run/remix/blob/cb06c44e961698e6a8e590b0ebaa042d773f9bca/packages/form-data-parser/src/lib/form-data.ts#L15

https://github.com/remix-run/remix/blob/cb06c44e961698e6a8e590b0ebaa042d773f9bca/packages/form-data-parser/src/index.ts#L1-L8

Extracted from #10986