### PR TITLE
Add Atmosphere auth provider

### DIFF
--- a/packages/auth/.changes/minor.atmosphere-provider.md
+++ b/packages/auth/.changes/minor.atmosphere-provider.md
@@ -1,0 +1,5 @@
+Added `createAtmosphereAuthProvider(options)(handleOrDid)` to support atproto OAuth flows against Atmosphere-compatible authorization servers.
+
+The new provider resolves handles and DIDs before redirecting, performs required pushed authorization requests with DPoP, supports both public web clients and localhost loopback development clients, and seals per-session DPoP state into the in-flight OAuth transaction using the required `sessionSecret` option instead of a separate persistent store.
+
+Create the Atmosphere factory once with shared options, then call the returned function with the request-time handle or DID before passing the provider to `startExternalAuth()`, `finishExternalAuth()`, or `refreshExternalAuth()`. Atmosphere callback results preserve the DPoP binding state alongside the returned `accessToken` and `refreshToken`, so callers can reuse the completed token bundle directly for follow-up DPoP-signed requests.

--- a/packages/auth/.changes/minor.refresh-external-auth.md
+++ b/packages/auth/.changes/minor.refresh-external-auth.md
@@ -1,3 +1,3 @@
 Added `refreshExternalAuth()` to `@remix-run/auth` so apps can exchange stored refresh tokens for fresh OAuth and OIDC token bundles.
 
-The built-in OIDC providers and X now implement refresh-token exchange. Refreshed token bundles preserve the existing refresh token when the provider omits a rotated value.
+The built-in OIDC providers, X, and Atmosphere now implement refresh-token exchange. Refreshed token bundles preserve the existing refresh token when the provider omits a rotated value.

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -5,7 +5,7 @@ Composable browser authentication primitives for Remix. Use this package to veri
 ## Features
 
 - Small, composable primitives: `verifyCredentials()`, `startExternalAuth()`, `finishExternalAuth()`, `refreshExternalAuth()`, and `completeAuth()`
-- Built-in provider support for Google, Microsoft, Okta, Auth0, GitHub, Facebook, and X
+- Built-in provider support for Google, Microsoft, Okta, Auth0, GitHub, Facebook, X, and Atmosphere
 - Module-scope provider configuration for boot-time validation and stable callback URLs
 - App-owned session records so you decide what auth data to persist
 - Shared session completion for credentials and external auth flows
@@ -273,7 +273,7 @@ router.get(routes.app.dashboard, {
 
 A typical external auth flow looks like this:
 
-1. Create the provider once at module scope.
+1. Create the provider once at module scope, or for Atmosphere create the shared factory once and call it with the request-time handle or DID.
 2. Call `startExternalAuth()` from the login route.
 3. Call `finishExternalAuth()` from the callback route.
 4. Persist any provider tokens you want to reuse later.
@@ -283,11 +283,12 @@ A typical external auth flow looks like this:
 
 ## Built-in External Auth Providers
 
-When one of the built-in providers matches your auth provider, start there. Google, Microsoft, Okta, and Auth0 use the shared OIDC runtime. GitHub, Facebook, and X use built-in custom OAuth flows.
+When one of the built-in providers matches your auth provider, start there. Google, Microsoft, Okta, and Auth0 use the shared OIDC runtime. GitHub, Facebook, X, and Atmosphere use built-in custom OAuth flows.
 
 ```ts
 import {
   createAuth0AuthProvider,
+  createAtmosphereAuthProvider,
   createFacebookAuthProvider,
   createGitHubAuthProvider,
   createGoogleAuthProvider,
@@ -301,6 +302,12 @@ let auth0Provider = createAuth0AuthProvider({
   clientId: env.AUTH0_CLIENT_ID,
   clientSecret: env.AUTH0_CLIENT_SECRET,
   redirectUri: new URL('/auth/auth0/callback', env.APP_ORIGIN),
+})
+
+let atmosphereProvider = createAtmosphereAuthProvider({
+  clientId: new URL('/oauth/client-metadata.json', env.APP_ORIGIN),
+  redirectUri: new URL('/auth/atmosphere/callback', env.APP_ORIGIN),
+  sessionSecret: env.SESSION_SECRET,
 })
 
 let facebookProvider = createFacebookAuthProvider({
@@ -351,7 +358,10 @@ Notes:
 - `createMicrosoftAuthProvider()` adds the `tenant` option and builds the issuer from it
 - `createOktaAuthProvider()` expects the full Okta issuer URL, usually something like `https://example.okta.com/oauth2/default`
 - `createAuth0AuthProvider()` expects your Auth0 domain and derives the issuer URL for you
-- `refreshExternalAuth()` supports built-in OIDC providers and X when the stored token bundle includes a refresh token
+- `createAtmosphereAuthProvider()` returns a factory so apps can share options globally and resolve a handle or DID at request time with `await atmosphereProvider(handleOrDid)`
+- `createAtmosphereAuthProvider()` requires `sessionSecret` and seals the in-flight DPoP state into the existing OAuth transaction stored in your app session, so you do not need a separate file or database store for the redirect step
+- `createAtmosphereAuthProvider()` returns DPoP-bound token material in `result.tokens`, including `accessToken`, `refreshToken`, and `dpop` JWK state for follow-up DPoP-signed requests
+- `refreshExternalAuth()` supports built-in OIDC providers, X, and Atmosphere when the stored token bundle includes a refresh token
 - Providers only return refresh tokens when configured to request offline access, such as `authorizationParams: { access_type: 'offline' }` for Google or adding `offline.access` to X scopes
 - Use `mapProfile()` with `createOIDCAuthProvider()` when you want `result.profile` to have an app-specific type before it reaches your route code
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -61,6 +61,8 @@
     "authentication",
     "oauth",
     "oidc",
+    "atproto",
+    "bluesky",
     "google",
     "github",
     "facebook",

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,6 +1,7 @@
 export { completeAuth } from './lib/complete-auth.ts'
 export { createCredentialsAuthProvider } from './lib/providers/credentials.ts'
 export { createAuth0AuthProvider } from './lib/providers/auth0.ts'
+export { createAtmosphereAuthProvider } from './lib/providers/atmosphere.ts'
 export { createFacebookAuthProvider } from './lib/providers/facebook.ts'
 export { finishExternalAuth } from './lib/finish-external-auth.ts'
 export { refreshExternalAuth } from './lib/refresh-external-auth.ts'
@@ -15,6 +16,13 @@ export { createXAuthProvider } from './lib/providers/x.ts'
 
 export type { CredentialsAuthProviderOptions } from './lib/providers/credentials.ts'
 export type { Auth0AuthProviderOptions, Auth0AuthProfile } from './lib/providers/auth0.ts'
+export type {
+  AtmosphereAuthProfile,
+  AtmosphereAuthProviderMapProfileInput,
+  AtmosphereAuthProviderOptions,
+  AtmosphereAuthorizationServerMetadata,
+  AtmosphereClientAuthentication,
+} from './lib/providers/atmosphere.ts'
 export type {
   FacebookAuthProviderOptions,
   FacebookAuthProviderPicture,
@@ -44,5 +52,13 @@ export type {
   FinishExternalAuthOptions,
 } from './lib/finish-external-auth.ts'
 export type { RefreshedExternalAuthResult } from './lib/refresh-external-auth.ts'
-export type { OAuthAccount, OAuthProvider, OAuthResult, OAuthTokens } from './lib/provider.ts'
+export type {
+  OAuthAccount,
+  OAuthDpopBinding,
+  OAuthDpopTokens,
+  OAuthProvider,
+  OAuthResult,
+  OAuthStandardTokens,
+  OAuthTokens,
+} from './lib/provider.ts'
 export type { StartExternalAuthOptions } from './lib/start-external-auth.ts'

--- a/packages/auth/src/lib/finish-external-auth.ts
+++ b/packages/auth/src/lib/finish-external-auth.ts
@@ -2,7 +2,7 @@ import type { RequestContext } from '@remix-run/fetch-router'
 import type { Session } from '@remix-run/session'
 
 import { getOAuthProviderRuntime } from './provider.ts'
-import type { OAuthProvider, OAuthResult, OAuthTransaction } from './provider.ts'
+import type { OAuthProvider, OAuthResult, OAuthTokens, OAuthTransaction } from './provider.ts'
 import { getRequiredSearchParam, getSession } from './utils.ts'
 
 /**
@@ -16,9 +16,13 @@ export interface FinishExternalAuthOptions {
 /**
  * Completed result returned from a successful OAuth or OIDC callback flow.
  */
-export interface FinishedExternalAuthResult<profile, provider extends string = string> {
+export interface FinishedExternalAuthResult<
+  profile,
+  provider extends string = string,
+  tokens extends OAuthTokens = OAuthTokens,
+> {
   /** Normalized OAuth or OIDC result returned by the provider runtime. */
-  result: OAuthResult<profile, provider>
+  result: OAuthResult<profile, provider, tokens>
   /** Preserved post-auth redirect target, when one was stored in the transaction. */
   returnTo?: string
 }
@@ -35,11 +39,12 @@ export async function finishExternalAuth<
   context extends RequestContext<any, any> = RequestContext,
   profile = never,
   provider extends string = string,
+  tokens extends OAuthTokens = OAuthTokens,
 >(
-  provider: OAuthProvider<profile, provider>,
+  provider: OAuthProvider<profile, provider, tokens>,
   context: context,
   options: FinishExternalAuthOptions = {},
-): Promise<FinishedExternalAuthResult<profile, provider>> {
+): Promise<FinishedExternalAuthResult<profile, provider, tokens>> {
   let session: Session | undefined
   let transactionKey = options.transactionKey ?? '__auth'
   let transaction: OAuthTransaction | undefined

--- a/packages/auth/src/lib/provider.ts
+++ b/packages/auth/src/lib/provider.ts
@@ -1,15 +1,25 @@
 import type { RequestContext } from '@remix-run/fetch-router'
 
 /**
- * OAuth and OIDC tokens returned from a successful authorization code exchange.
+ * DPoP binding material required to sign follow-up requests for DPoP-bound access tokens.
  */
-export interface OAuthTokens {
+export interface OAuthDpopBinding {
+  /** Public JWK advertised in DPoP proofs. */
+  publicJwk: JsonWebKey
+  /** Private JWK used to sign DPoP proofs. */
+  privateJwk: JsonWebKey
+  /** Latest nonce advertised by the target server, when one is required. */
+  nonce?: string
+}
+
+/**
+ * Shared token fields returned from a successful authorization code exchange.
+ */
+interface OAuthTokenBase {
   /** Access token returned by the provider. */
   accessToken: string
   /** Refresh token returned by the provider, when available. */
   refreshToken?: string
-  /** Token type returned by the provider, such as `Bearer`. */
-  tokenType?: string
   /** Expiration time derived from the provider token response, when available. */
   expiresAt?: Date
   /** Scopes granted to the current access token, when provided by the provider. */
@@ -17,6 +27,31 @@ export interface OAuthTokens {
   /** OpenID Connect ID token returned by the provider, when available. */
   idToken?: string
 }
+
+/**
+ * OAuth tokens that are not bound to DPoP key material.
+ */
+export interface OAuthStandardTokens extends OAuthTokenBase {
+  /** Token type returned by the provider, such as `Bearer`. */
+  tokenType?: string
+  /** DPoP binding data is not present for non-DPoP tokens. */
+  dpop?: undefined
+}
+
+/**
+ * OAuth tokens bound to a DPoP key pair.
+ */
+export interface OAuthDpopTokens extends OAuthTokenBase {
+  /** DPoP-bound access tokens always advertise the `DPoP` token type. */
+  tokenType: 'DPoP'
+  /** DPoP binding material returned for DPoP-bound access tokens, when available. */
+  dpop: OAuthDpopBinding
+}
+
+/**
+ * OAuth and OIDC tokens returned from a successful authorization code exchange.
+ */
+export type OAuthTokens = OAuthStandardTokens | OAuthDpopTokens
 
 /**
  * Stable account identifier for a provider-backed identity.
@@ -31,7 +66,11 @@ export interface OAuthAccount<provider extends string = string> {
 /**
  * Normalized result returned by OAuth and OIDC callback handlers.
  */
-export interface OAuthResult<profile, provider extends string = string> {
+export interface OAuthResult<
+  profile,
+  provider extends string = string,
+  tokens extends OAuthTokens = OAuthTokens,
+> {
   /** Provider name that completed the callback flow. */
   provider: provider
   /** Stable provider-backed account identity for the authenticated user. */
@@ -39,13 +78,17 @@ export interface OAuthResult<profile, provider extends string = string> {
   /** Normalized profile data returned by the provider. */
   profile: profile
   /** Tokens returned by the provider for the completed authorization flow. */
-  tokens: OAuthTokens
+  tokens: tokens
 }
 
 /**
  * Public shape for an OAuth or OIDC provider used by external auth request handlers.
  */
-export interface OAuthProvider<profile, provider extends string = string> {
+export interface OAuthProvider<
+  _profile,
+  provider extends string = string,
+  _tokens extends OAuthTokens = OAuthTokens,
+> {
   /** Provider name used for routing, callbacks, and persisted transactions. */
   name: provider
 }
@@ -55,24 +98,30 @@ export interface OAuthTransaction {
   state: string
   codeVerifier: string
   returnTo?: string
+  providerState?: string
 }
 
-export interface OAuthProviderRuntime<profile, provider extends string = string> {
+export interface OAuthProviderRuntime<
+  profile,
+  provider extends string = string,
+  tokens extends OAuthTokens = OAuthTokens,
+> {
   createAuthorizationURL(transaction: OAuthTransaction): URL | Promise<URL>
   handleCallback(
     context: RequestContext,
     transaction: OAuthTransaction,
-  ): Promise<OAuthResult<profile, provider>>
-  refreshTokens?(tokens: OAuthTokens): Promise<OAuthTokens>
+  ): Promise<OAuthResult<profile, provider, tokens>>
+  refreshTokens?(tokens: tokens): Promise<tokens>
 }
 
 export const oauthProviderRuntime = Symbol('oauth-provider-runtime')
 
-export type InternalOAuthProvider<profile, provider extends string = string> = OAuthProvider<
+export type InternalOAuthProvider<
   profile,
-  provider
-> & {
-  [oauthProviderRuntime]: OAuthProviderRuntime<profile, provider>
+  provider extends string = string,
+  tokens extends OAuthTokens = OAuthTokens,
+> = OAuthProvider<profile, provider, tokens> & {
+  [oauthProviderRuntime]: OAuthProviderRuntime<profile, provider, tokens>
 }
 
 interface ExchangeTokenOptionsBase {
@@ -94,20 +143,28 @@ export interface ExchangeRefreshTokenOptions extends ExchangeTokenOptionsBase {
   scopes?: string[]
 }
 
-export function createOAuthProvider<profile, provider extends string>(
+export function createOAuthProvider<
+  profile,
+  provider extends string,
+  tokens extends OAuthTokens = OAuthTokens,
+>(
   name: provider,
-  runtime: OAuthProviderRuntime<profile, provider>,
-): OAuthProvider<profile, provider> {
+  runtime: OAuthProviderRuntime<profile, provider, tokens>,
+): OAuthProvider<profile, provider, tokens> {
   return {
     name,
     [oauthProviderRuntime]: runtime,
-  } as InternalOAuthProvider<profile, provider>
+  } as InternalOAuthProvider<profile, provider, tokens>
 }
 
-export function getOAuthProviderRuntime<profile, provider extends string>(
-  provider: OAuthProvider<profile, provider>,
-): OAuthProviderRuntime<profile, provider> {
-  let runtime = (provider as InternalOAuthProvider<profile, provider>)[oauthProviderRuntime]
+export function getOAuthProviderRuntime<
+  profile,
+  provider extends string,
+  tokens extends OAuthTokens = OAuthTokens,
+>(
+  provider: OAuthProvider<profile, provider, tokens>,
+): OAuthProviderRuntime<profile, provider, tokens> {
+  let runtime = (provider as InternalOAuthProvider<profile, provider, tokens>)[oauthProviderRuntime]
   if (runtime == null) {
     throw new Error(`Invalid OAuth provider "${provider.name}".`)
   }
@@ -132,7 +189,7 @@ export function createAuthorizationURL(
 
 export async function exchangeAuthorizationCode(
   options: ExchangeAuthorizationCodeOptions,
-): Promise<OAuthTokens> {
+): Promise<OAuthStandardTokens> {
   return exchangeOAuthTokens(
     {
       ...options,
@@ -149,7 +206,7 @@ export async function exchangeAuthorizationCode(
 
 export async function exchangeRefreshToken(
   options: ExchangeRefreshTokenOptions,
-): Promise<OAuthTokens> {
+): Promise<OAuthStandardTokens> {
   let params = new URLSearchParams({
     grant_type: 'refresh_token',
     refresh_token: options.refreshToken,
@@ -168,10 +225,10 @@ export async function exchangeRefreshToken(
   )
 }
 
-export function mergeRefreshedTokens(
-  currentTokens: OAuthTokens,
-  refreshedTokens: OAuthTokens,
-): OAuthTokens {
+export function mergeRefreshedStandardTokens(
+  currentTokens: OAuthStandardTokens,
+  refreshedTokens: OAuthStandardTokens,
+): OAuthStandardTokens {
   return {
     ...currentTokens,
     ...refreshedTokens,
@@ -210,7 +267,7 @@ export function getAuthorizationCode(context: RequestContext): string {
 async function exchangeOAuthTokens(
   options: ExchangeTokenOptionsBase & { fallbackError: string },
   params: URLSearchParams,
-): Promise<OAuthTokens> {
+): Promise<OAuthStandardTokens> {
   let clientAuthentication = options.clientAuthentication ?? 'request-body'
 
   if (clientAuthentication === 'request-body') {
@@ -241,7 +298,7 @@ async function exchangeOAuthTokens(
   return normalizeOAuthTokenResponse(json)
 }
 
-function normalizeOAuthTokenResponse(json: unknown): OAuthTokens {
+function normalizeOAuthTokenResponse(json: unknown): OAuthStandardTokens {
   if (typeof json !== 'object' || json == null || Array.isArray(json)) {
     throw new Error('Expected OAuth provider to return a JSON object.')
   }

--- a/packages/auth/src/lib/providers/atmosphere.test.ts
+++ b/packages/auth/src/lib/providers/atmosphere.test.ts
@@ -1,0 +1,443 @@
+import * as assert from '@remix-run/assert'
+import { describe, it } from '@remix-run/test'
+
+import { createCookie } from '@remix-run/cookie'
+import { createRouter } from '@remix-run/fetch-router'
+import { Session } from '@remix-run/session'
+import { createCookieSessionStorage } from '@remix-run/session/cookie-storage'
+import { createMemorySessionStorage } from '@remix-run/session/memory-storage'
+import { session as sessionMiddleware } from '@remix-run/session-middleware'
+
+import { finishExternalAuth } from '../finish-external-auth.ts'
+import { startExternalAuth } from '../start-external-auth.ts'
+import { createRequest, mockFetch } from '../test-utils.ts'
+import { createAtmosphereAuthProvider } from './atmosphere.ts'
+
+describe('atmosphere provider', () => {
+  it('resolves a handle through DNS-over-HTTPS, performs PAR with DPoP, and completes the callback', async () => {
+    let cookie = createCookie('__session', { secrets: ['secret1'] })
+    let sessionStorage = createCookieSessionStorage()
+    let dnsRequests = 0
+    let parRequests = 0
+    let tokenRequests = 0
+    let restoreFetch = mockFetch(async (input, init) => {
+      let url = toRequestUrl(input)
+
+      if (url.origin === 'https://1.1.1.1' && url.pathname === '/dns-query') {
+        dnsRequests += 1
+        assert.equal(url.searchParams.get('name'), '_atproto.alice.example.com')
+        assert.equal(url.searchParams.get('type'), 'TXT')
+        return Response.json({
+          Answer: [
+            {
+              type: 16,
+              data: '"did=did:plc:alice"',
+            },
+          ],
+        })
+      }
+
+      if (url.toString() === 'https://alice.example.com/.well-known/atproto-did') {
+        return new Response('<!DOCTYPE html><html><body>Not a DID</body></html>', {
+          headers: {
+            'Content-Type': 'text/html; charset=utf-8',
+          },
+        })
+      }
+
+      if (url.toString() === 'https://plc.directory/did%3Aplc%3Aalice') {
+        return Response.json({
+          id: 'did:plc:alice',
+          alsoKnownAs: ['at://alice.example.com'],
+          service: [
+            {
+              id: '#atproto_pds',
+              type: 'AtprotoPersonalDataServer',
+              serviceEndpoint: 'https://pds.example.com',
+            },
+          ],
+        })
+      }
+
+      if (url.toString() === 'https://pds.example.com/.well-known/oauth-protected-resource') {
+        return Response.json({
+          authorization_servers: ['https://auth.example.com'],
+        })
+      }
+
+      if (url.toString() === 'https://auth.example.com/.well-known/oauth-authorization-server') {
+        return Response.json(
+          createAtmosphereAuthorizationServerMetadata('https://auth.example.com'),
+        )
+      }
+
+      if (url.toString() === 'https://auth.example.com/oauth/par') {
+        parRequests += 1
+
+        let body = new URLSearchParams(init?.body as string)
+        let dpop = decodeJwt(new Headers(init?.headers).get('DPoP')!)
+
+        assert.equal(body.get('client_id'), 'https://app.example.com/oauth/client-metadata.json')
+        assert.equal(body.get('redirect_uri'), 'https://app.example.com/auth/atmosphere/callback')
+        assert.equal(body.get('response_type'), 'code')
+        assert.equal(body.get('scope'), 'atproto transition:generic')
+        assert.equal(body.get('login_hint'), 'alice.example.com')
+        assert.equal(body.get('code_challenge_method'), 'S256')
+        assert.equal(typeof body.get('code_challenge'), 'string')
+        assert.equal(dpop.payload.htm, 'POST')
+        assert.equal(dpop.payload.htu, 'https://auth.example.com/oauth/par')
+
+        if (parRequests === 1) {
+          assert.equal(dpop.payload.nonce, undefined)
+          return Response.json(
+            {
+              error: 'use_dpop_nonce',
+            },
+            {
+              status: 400,
+              headers: {
+                'DPoP-Nonce': 'par-nonce-1',
+              },
+            },
+          )
+        }
+
+        assert.equal(dpop.payload.nonce, 'par-nonce-1')
+        return Response.json(
+          {
+            request_uri: 'urn:ietf:params:oauth:request_uri:par-1',
+          },
+          {
+            headers: {
+              'DPoP-Nonce': 'token-nonce-1',
+            },
+          },
+        )
+      }
+
+      if (url.toString() === 'https://auth.example.com/oauth/token') {
+        tokenRequests += 1
+
+        let body = new URLSearchParams(init?.body as string)
+        let dpop = decodeJwt(new Headers(init?.headers).get('DPoP')!)
+
+        assert.equal(body.get('client_id'), 'https://app.example.com/oauth/client-metadata.json')
+        assert.equal(body.get('grant_type'), 'authorization_code')
+        assert.equal(body.get('redirect_uri'), 'https://app.example.com/auth/atmosphere/callback')
+        assert.equal(body.get('code'), 'good-code')
+        assert.equal(typeof body.get('code_verifier'), 'string')
+        assert.equal(dpop.payload.nonce, 'token-nonce-1')
+
+        return Response.json({
+          access_token: 'atmosphere-access-token',
+          refresh_token: 'atmosphere-refresh-token',
+          token_type: 'DPoP',
+          scope: 'atproto transition:generic',
+          sub: 'did:plc:alice',
+        })
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    try {
+      let atmosphereProvider = createAtmosphereAuthProvider({
+        clientId: 'https://app.example.com/oauth/client-metadata.json',
+        redirectUri: 'https://app.example.com/auth/atmosphere/callback',
+        sessionSecret: 'atmosphere-session-secret',
+        scopes: ['atproto', 'transition:generic'],
+      })
+      let router = createRouter({
+        middleware: [sessionMiddleware(cookie, sessionStorage)],
+      })
+
+      router.get('/login/atmosphere', async (context) => {
+        let identifier = context.url.searchParams.get('account')
+        if (identifier == null) {
+          throw new Error('Missing atmosphere account identifier')
+        }
+        context.get(Session).set('atmosphere-account', identifier)
+
+        let provider = await atmosphereProvider(identifier)
+
+        return startExternalAuth(provider, context)
+      })
+      router.get('/inspect', ({ get }) => Response.json(get(Session).get('__auth')))
+      router.get('/auth/atmosphere/callback', async (context) => {
+        let identifier = context.get(Session).get('atmosphere-account') as string
+        let provider = await atmosphereProvider(identifier)
+        let { result } = await finishExternalAuth(provider, context)
+        return Response.json(result)
+      })
+
+      let loginResponse = await router.fetch(
+        'https://app.example.com/login/atmosphere?account=alice.example.com',
+      )
+      let inspectResponse = await router.fetch(
+        createRequest('https://app.example.com/inspect', loginResponse),
+      )
+      let transaction = await inspectResponse.json()
+      let location = new URL(loginResponse.headers.get('Location')!)
+      let cookieHeader = loginResponse.headers
+        .getSetCookie()
+        .map((value) => value.split(';', 1)[0])
+        .join('; ')
+      let serializedSession = await cookie.parse(cookieHeader)
+      let storedSession = JSON.parse(serializedSession!) as {
+        i: string
+        d: [Record<string, unknown>, Record<string, unknown>]
+      }
+      let storedTransaction = storedSession.d[0].__auth as Record<string, unknown>
+
+      assert.equal(loginResponse.status, 302)
+      assert.equal(
+        location.toString(),
+        'https://auth.example.com/oauth/authorize?client_id=https%3A%2F%2Fapp.example.com%2Foauth%2Fclient-metadata.json&request_uri=urn%3Aietf%3Aparams%3Aoauth%3Arequest_uri%3Apar-1',
+      )
+      assert.equal(transaction.provider, 'atmosphere')
+      assert.equal(typeof transaction.codeVerifier, 'string')
+      assert.equal(typeof transaction.providerState, 'string')
+      assert.equal(typeof storedTransaction.providerState, 'string')
+      assert.equal(serializedSession!.includes('did:plc:alice'), false)
+      assert.equal(serializedSession!.includes('authorizationServerNonce'), false)
+      assert.equal(serializedSession!.includes('privateJwk'), false)
+      assert.equal(dnsRequests, 1)
+      assert.equal(parRequests, 2)
+
+      let callbackResponse = await router.fetch(
+        createRequest(
+          `https://app.example.com/auth/atmosphere/callback?code=good-code&state=${transaction.state}&iss=${encodeURIComponent('https://auth.example.com')}`,
+          loginResponse,
+        ),
+      )
+
+      assert.equal(tokenRequests, 1)
+
+      let callbackBody = await callbackResponse.json()
+
+      assert.deepEqual(
+        {
+          provider: callbackBody.provider,
+          account: callbackBody.account,
+          profile: callbackBody.profile,
+          tokens: {
+            accessToken: callbackBody.tokens.accessToken,
+            refreshToken: callbackBody.tokens.refreshToken,
+            tokenType: callbackBody.tokens.tokenType,
+            scope: callbackBody.tokens.scope,
+          },
+        },
+        {
+          provider: 'atmosphere',
+          account: {
+            provider: 'atmosphere',
+            providerAccountId: 'did:plc:alice',
+          },
+          profile: {
+            did: 'did:plc:alice',
+            handle: 'alice.example.com',
+            pdsUrl: 'https://pds.example.com',
+            authorizationServer: 'https://auth.example.com',
+          },
+          tokens: {
+            accessToken: 'atmosphere-access-token',
+            refreshToken: 'atmosphere-refresh-token',
+            tokenType: 'DPoP',
+            scope: ['atproto', 'transition:generic'],
+          },
+        },
+      )
+      assert.deepEqual(callbackBody.tokens.dpop.publicJwk, {
+        crv: 'P-256',
+        kty: 'EC',
+        x: callbackBody.tokens.dpop.publicJwk.x,
+        y: callbackBody.tokens.dpop.publicJwk.y,
+      })
+      assert.equal(typeof callbackBody.tokens.dpop.privateJwk.d, 'string')
+      assert.equal(callbackBody.tokens.dpop.privateJwk.crv, 'P-256')
+      assert.equal(callbackBody.tokens.dpop.privateJwk.kty, 'EC')
+      assert.equal(callbackBody.tokens.dpop.privateJwk.x, callbackBody.tokens.dpop.publicJwk.x)
+      assert.equal(callbackBody.tokens.dpop.privateJwk.y, callbackBody.tokens.dpop.publicJwk.y)
+      assert.equal(callbackBody.tokens.dpop.nonce, undefined)
+    } finally {
+      restoreFetch()
+    }
+  })
+
+  it('supports loopback clients and falls back to HTTPS handle resolution when DNS does not return a DID', async () => {
+    let cookie = createCookie('__session', { secrets: ['secret1'] })
+    let sessionStorage = createMemorySessionStorage()
+    let dnsRequests = 0
+    let httpsHandleRequests = 0
+    let parClientId: string | undefined
+    let restoreFetch = mockFetch(async (input, init) => {
+      let url = toRequestUrl(input)
+
+      if (url.origin === 'https://1.1.1.1' && url.pathname === '/dns-query') {
+        dnsRequests += 1
+        return Response.json({ Answer: [] })
+      }
+
+      if (url.toString() === 'https://bob.example.com/.well-known/atproto-did') {
+        httpsHandleRequests += 1
+        return new Response('did:plc:bob', {
+          headers: {
+            'Content-Type': 'text/plain',
+          },
+        })
+      }
+
+      if (url.toString() === 'https://plc.directory/did%3Aplc%3Abob') {
+        return Response.json({
+          id: 'did:plc:bob',
+          alsoKnownAs: ['at://bob.example.com'],
+          service: [
+            {
+              id: '#atproto_pds',
+              type: 'AtprotoPersonalDataServer',
+              serviceEndpoint: 'https://pds.example.com',
+            },
+          ],
+        })
+      }
+
+      if (url.toString() === 'https://pds.example.com/.well-known/oauth-protected-resource') {
+        return Response.json({
+          authorization_servers: ['https://auth.example.com'],
+        })
+      }
+
+      if (url.toString() === 'https://auth.example.com/.well-known/oauth-authorization-server') {
+        return Response.json(
+          createAtmosphereAuthorizationServerMetadata('https://auth.example.com'),
+        )
+      }
+
+      if (url.toString() === 'https://auth.example.com/oauth/par') {
+        let body = new URLSearchParams(init?.body as string)
+        parClientId = body.get('client_id') ?? undefined
+
+        return Response.json(
+          {
+            request_uri: 'urn:ietf:params:oauth:request_uri:par-loopback',
+          },
+          {
+            headers: {
+              'DPoP-Nonce': 'loopback-token-nonce',
+            },
+          },
+        )
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    try {
+      let atmosphereProvider = createAtmosphereAuthProvider({
+        clientId: 'http://localhost',
+        redirectUri: 'http://127.0.0.1:43123/callback',
+        sessionSecret: 'atmosphere-session-secret',
+        scopes: ['atproto', 'transition:generic'],
+      })
+      let router = createRouter({
+        middleware: [sessionMiddleware(cookie, sessionStorage)],
+      })
+
+      router.get('/login/atmosphere', async (context) => {
+        let identifier = context.url.searchParams.get('account')
+        if (identifier == null) {
+          throw new Error('Missing atmosphere account identifier')
+        }
+
+        let provider = await atmosphereProvider(identifier)
+
+        return startExternalAuth(provider, context)
+      })
+
+      let response = await router.fetch(
+        'https://app.example.com/login/atmosphere?account=bob.example.com',
+      )
+      let location = new URL(response.headers.get('Location')!)
+
+      assert.equal(response.status, 302)
+      assert.equal(dnsRequests, 1)
+      assert.equal(httpsHandleRequests, 1)
+      assert.equal(location.origin, 'https://auth.example.com')
+      assert.equal(location.pathname, '/oauth/authorize')
+      assert.equal(
+        location.searchParams.get('request_uri'),
+        'urn:ietf:params:oauth:request_uri:par-loopback',
+      )
+
+      let normalizedClientId = new URL(parClientId!)
+      assert.equal(normalizedClientId.origin, 'http://localhost')
+      assert.equal(normalizedClientId.searchParams.get('scope'), 'atproto transition:generic')
+      assert.deepEqual(normalizedClientId.searchParams.getAll('redirect_uri'), [
+        'http://127.0.0.1:43123/callback',
+      ])
+    } finally {
+      restoreFetch()
+    }
+  })
+
+  it('rejects localhost loopback redirect URIs', async () => {
+    assert.throws(
+      () =>
+        createAtmosphereAuthProvider({
+          clientId: 'http://localhost',
+          redirectUri: 'http://localhost:3000/callback',
+          sessionSecret: 'atmosphere-session-secret',
+        }),
+      /127\.0\.0\.1 or \[::1\], not localhost/,
+    )
+  })
+})
+
+function createAtmosphereAuthorizationServerMetadata(issuer: string) {
+  return {
+    issuer,
+    authorization_endpoint: `${issuer}/oauth/authorize`,
+    token_endpoint: `${issuer}/oauth/token`,
+    pushed_authorization_request_endpoint: `${issuer}/oauth/par`,
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+    code_challenge_methods_supported: ['S256'],
+    token_endpoint_auth_methods_supported: ['none', 'private_key_jwt'],
+    token_endpoint_auth_signing_alg_values_supported: ['ES256'],
+    scopes_supported: ['atproto', 'transition:generic'],
+    authorization_response_iss_parameter_supported: true,
+    require_pushed_authorization_requests: true,
+    client_id_metadata_document_supported: true,
+    dpop_signing_alg_values_supported: ['ES256'],
+  }
+}
+
+function toRequestUrl(input: RequestInfo | URL): URL {
+  if (typeof input === 'string') {
+    return new URL(input)
+  }
+
+  if (input instanceof URL) {
+    return input
+  }
+
+  return new URL(input.url)
+}
+
+function decodeJwt(token: string): {
+  header: Record<string, unknown>
+  payload: Record<string, unknown>
+} {
+  let [header, payload] = token.split('.')
+  return {
+    header: JSON.parse(decodeBase64Url(header)),
+    payload: JSON.parse(decodeBase64Url(payload)),
+  }
+}
+
+function decodeBase64Url(value: string): string {
+  let padding = value.length % 4 === 0 ? '' : '='.repeat(4 - (value.length % 4))
+  let base64 = value.replace(/-/g, '+').replace(/_/g, '/') + padding
+  let bytes = Uint8Array.from(atob(base64), (char) => char.charCodeAt(0))
+  return new TextDecoder().decode(bytes)
+}

--- a/packages/auth/src/lib/providers/atmosphere.ts
+++ b/packages/auth/src/lib/providers/atmosphere.ts
@@ -1,0 +1,1330 @@
+import type { RequestContext } from '@remix-run/fetch-router'
+
+import type { OAuthDpopTokens, OAuthProvider, OAuthResult, OAuthTransaction } from '../provider.ts'
+import { createAuthorizationURL, createOAuthProvider, getAuthorizationCode } from '../provider.ts'
+import { createCodeChallenge, getRequiredSearchParam } from '../utils.ts'
+
+const ATMOSPHERE_PROVIDER_NAME = 'atmosphere'
+const CLOUDFLARE_DNS_ENDPOINT = 'https://1.1.1.1/dns-query'
+const PLC_DIRECTORY_URL = 'https://plc.directory/'
+const DEFAULT_ATMOSPHERE_SCOPES = ['atproto']
+const ATPROTO_PDS_SERVICE_ID = '#atproto_pds'
+const ATPROTO_PDS_SERVICE_TYPE = 'AtprotoPersonalDataServer'
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '[::1]'])
+const DISALLOWED_HANDLE_TLDS = new Set([
+  'alt',
+  'arpa',
+  'example',
+  'internal',
+  'invalid',
+  'local',
+  'localhost',
+  'onion',
+])
+const DID_REGEX = /^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$/
+const HANDLE_REGEX = /^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]([a-z0-9-]{0,61}[a-z0-9])?$/
+
+/**
+ * Profile returned by the built-in Atmosphere auth provider.
+ */
+export interface AtmosphereAuthProfile {
+  /** Stable DID for the authenticated atproto account. */
+  did: string
+  /** Verified handle claimed by the DID document, when one is available. */
+  handle?: string
+  /** Personal Data Server URL declared in the DID document. */
+  pdsUrl: string
+  /** Authorization server issuer that authorized the current session. */
+  authorizationServer: string
+}
+
+/**
+ * Authorization server metadata used by the Atmosphere provider.
+ */
+export interface AtmosphereAuthorizationServerMetadata {
+  /** Issuer origin for the authorization server. */
+  issuer: string
+  /** Browser authorization endpoint used after PAR completes. */
+  authorization_endpoint: string
+  /** Token endpoint used for authorization-code exchanges. */
+  token_endpoint: string
+  /** Pushed authorization request endpoint required by atproto OAuth. */
+  pushed_authorization_request_endpoint: string
+  /** Scopes advertised by the authorization server. */
+  scopes_supported?: string[] | string
+  /** Token endpoint auth methods accepted by the authorization server. */
+  token_endpoint_auth_methods_supported?: string[]
+  /** Signing algorithms accepted for private-key JWT client authentication. */
+  token_endpoint_auth_signing_alg_values_supported?: string[]
+  /** PKCE challenge methods accepted by the authorization server. */
+  code_challenge_methods_supported?: string[]
+  /** OAuth response types accepted by the authorization server. */
+  response_types_supported?: string[]
+  /** OAuth grant types accepted by the authorization server. */
+  grant_types_supported?: string[]
+  /** Indicates whether the `iss` query parameter is returned in callbacks. */
+  authorization_response_iss_parameter_supported?: boolean
+  /** Indicates whether the authorization server requires PAR. */
+  require_pushed_authorization_requests?: boolean
+  /** Indicates whether the server supports client metadata document lookup. */
+  client_id_metadata_document_supported?: boolean
+  /** DPoP signing algorithms accepted by the authorization server. */
+  dpop_signing_alg_values_supported?: string[]
+}
+
+/**
+ * Client-authentication settings for confidential Atmosphere clients.
+ */
+export interface AtmosphereClientAuthentication {
+  /** Private `ES256` signing key used to generate `private_key_jwt` assertions. */
+  key: CryptoKey
+  /** Key identifier published in the client's JWKS metadata. */
+  keyId: string
+}
+
+/**
+ * Input passed to `mapProfile()` for the Atmosphere provider.
+ */
+export interface AtmosphereAuthProviderMapProfileInput {
+  /** Original handle or DID used to start the authorization flow. */
+  identifier: string
+  /** Stable DID returned by the authorization server token response. */
+  did: string
+  /** Verified handle claimed by the DID document, when one is available. */
+  handle?: string
+  /** Personal Data Server URL declared in the DID document. */
+  pdsUrl: string
+  /** Authorization server metadata resolved for the authenticated account. */
+  authorizationServer: AtmosphereAuthorizationServerMetadata
+  /** OAuth tokens returned by the atproto authorization server. */
+  tokens: OAuthDpopTokens
+  /** Request context for the callback currently being processed. */
+  context: RequestContext
+}
+
+/**
+ * Options for creating an Atmosphere auth provider.
+ */
+export interface AtmosphereAuthProviderOptions<
+  profile extends AtmosphereAuthProfile = AtmosphereAuthProfile,
+> {
+  /** Public client metadata URL, or `http://localhost` for loopback development clients. */
+  clientId: string | URL
+  /** Redirect URI registered for the client metadata document. */
+  redirectUri: string | URL
+  /** Secret used to encrypt per-flow DPoP state stored in the OAuth transaction session value. */
+  sessionSecret: string
+  /** Requested atproto OAuth scopes. Must include `atproto`. */
+  scopes?: string[]
+  /** Additional authorization parameters included in the pushed authorization request. */
+  authorizationParams?: Record<string, string | undefined>
+  /** Optional confidential-client settings for `private_key_jwt` authentication. */
+  clientAuthentication?: AtmosphereClientAuthentication
+  /** Maps the resolved atproto identity into an application-specific profile shape. */
+  mapProfile?(input: AtmosphereAuthProviderMapProfileInput): profile | Promise<profile>
+}
+
+interface AtmosphereIdentifier {
+  input: string
+  normalized: string
+  type: 'did' | 'handle'
+}
+
+interface AtmosphereClientConfiguration {
+  clientId: string
+  redirectUri: string
+  loopback: boolean
+}
+
+interface AtmosphereResolvedIdentity {
+  did: string
+  handle?: string
+  pdsUrl: string
+}
+
+interface AtmosphereProtectedResourceMetadata {
+  authorization_servers?: unknown
+}
+
+interface AtmosphereDidDocument {
+  id?: unknown
+  alsoKnownAs?: unknown
+  service?: unknown
+}
+
+interface AtmosphereSessionState {
+  identifier: string
+  did: string
+  handle?: string
+  pdsUrl: string
+  authorizationServer: string
+  publicJwk: JsonWebKey
+  privateJwk: JsonWebKey
+  authorizationServerNonce?: string
+}
+
+interface AtmosphereParResponse {
+  request_uri: string
+}
+
+interface AtmosphereTokenResponse {
+  access_token: string
+  refresh_token?: string
+  token_type?: string
+  expires_in?: number
+  scope?: string
+  sub: string
+}
+
+/**
+ * Creates an Atmosphere auth provider factory with shared client options.
+ *
+ * Because atproto discovery is account-specific, apps should create the factory
+ * once with shared options, then call it with the request-time handle or DID.
+ *
+ * @param options Atmosphere client configuration, session encryption secret, and optional profile mapping hooks.
+ * @returns A function that resolves a handle or DID into a provider for `startExternalAuth()` and `finishExternalAuth()`.
+ */
+export function createAtmosphereAuthProvider<
+  profile extends AtmosphereAuthProfile = AtmosphereAuthProfile,
+>(
+  options: AtmosphereAuthProviderOptions<profile>,
+): (handleOrDid: string) => Promise<OAuthProvider<profile, 'atmosphere', OAuthDpopTokens>> {
+  let scopes = normalizeAtmosphereScopes(options.scopes)
+  let sessionSecret = normalizeAtmosphereSessionSecret(options.sessionSecret)
+  let client = normalizeAtmosphereClientConfiguration(options.clientId, options.redirectUri, scopes)
+
+  return async function createProviderForIdentifier(
+    handleOrDid: string,
+  ): Promise<OAuthProvider<profile, 'atmosphere', OAuthDpopTokens>> {
+    let identifier = normalizeAtmosphereIdentifier(handleOrDid)
+    let identity = await resolveAtmosphereIdentity(identifier)
+    let authorizationServer = await discoverAuthorizationServer(
+      identity.pdsUrl,
+      options.clientAuthentication != null,
+    )
+
+    return createOAuthProvider(ATMOSPHERE_PROVIDER_NAME, {
+      async createAuthorizationURL(transaction) {
+        let challenge = await createCodeChallenge(transaction.codeVerifier)
+        let dpopKeyPair = await generateDpopKeyPair()
+        let stateFile: AtmosphereSessionState = {
+          identifier: identifier.input,
+          did: identity.did,
+          handle: identity.handle,
+          pdsUrl: identity.pdsUrl,
+          authorizationServer: authorizationServer.issuer,
+          publicJwk: dpopKeyPair.publicJwk,
+          privateJwk: dpopKeyPair.privateJwk,
+        }
+        let params = new URLSearchParams()
+
+        for (let [key, value] of Object.entries(options.authorizationParams ?? {})) {
+          if (value != null) {
+            params.set(key, value)
+          }
+        }
+
+        params.set('client_id', client.clientId)
+        params.set('redirect_uri', client.redirectUri)
+        params.set('response_type', 'code')
+        params.set('scope', scopes.join(' '))
+        params.set('state', transaction.state)
+        params.set('code_challenge', challenge)
+        params.set('code_challenge_method', 'S256')
+        params.set('login_hint', identifier.input)
+
+        if (options.clientAuthentication != null) {
+          params.set(
+            'client_assertion_type',
+            'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+          )
+          params.set(
+            'client_assertion',
+            await createClientAssertion(
+              client.clientId,
+              authorizationServer.issuer,
+              options.clientAuthentication,
+            ),
+          )
+        }
+
+        let parResponse = await sendDpopFormRequest<AtmosphereParResponse>({
+          endpoint: authorizationServer.pushed_authorization_request_endpoint,
+          body: params,
+          dpopKeyPair,
+          fallbackError: 'Atmosphere pushed authorization request failed.',
+        })
+
+        if (
+          typeof parResponse.json.request_uri !== 'string' ||
+          parResponse.json.request_uri.length === 0
+        ) {
+          throw new Error('Atmosphere PAR response did not include a request_uri.')
+        }
+
+        stateFile.authorizationServerNonce = parResponse.nonce
+        transaction.providerState = await writeAtmosphereSessionState(
+          sessionSecret,
+          transaction.state,
+          stateFile,
+        )
+
+        return createAuthorizationURL(authorizationServer.authorization_endpoint, {
+          client_id: client.clientId,
+          request_uri: parResponse.json.request_uri,
+        })
+      },
+      async handleCallback(
+        context,
+        transaction,
+      ): Promise<OAuthResult<profile, 'atmosphere', OAuthDpopTokens>> {
+        let callbackIssuer = getRequiredSearchParam(context, 'iss')
+        let sessionState = await readAtmosphereSessionState(sessionSecret, transaction)
+
+        if (sessionState.did !== identity.did || sessionState.identifier !== identifier.input) {
+          throw new Error(
+            'Atmosphere callback must recreate the provider with the same handle or DID used to start the flow.',
+          )
+        }
+
+        if (
+          callbackIssuer !== authorizationServer.issuer ||
+          sessionState.authorizationServer !== callbackIssuer
+        ) {
+          throw new Error(
+            'Atmosphere callback issuer did not match the resolved authorization server.',
+          )
+        }
+
+        let tokenResponse = await sendDpopFormRequest<AtmosphereTokenResponse>({
+          endpoint: authorizationServer.token_endpoint,
+          body: await createAtmosphereTokenRequestBody({
+            clientId: client.clientId,
+            redirectUri: client.redirectUri,
+            code: getAuthorizationCode(context),
+            codeVerifier: transaction.codeVerifier,
+            clientAuthentication: options.clientAuthentication,
+            issuer: authorizationServer.issuer,
+          }),
+          dpopKeyPair: {
+            publicJwk: sessionState.publicJwk,
+            privateJwk: sessionState.privateJwk,
+          },
+          fallbackError: 'Atmosphere token exchange failed.',
+          nonce: sessionState.authorizationServerNonce,
+        })
+        let tokens = {
+          ...normalizeAtmosphereTokenResponse(tokenResponse.json),
+          dpop: {
+            publicJwk: sessionState.publicJwk,
+            privateJwk: sessionState.privateJwk,
+            nonce: tokenResponse.nonce,
+          },
+        } satisfies OAuthDpopTokens
+
+        if (tokenResponse.json.sub !== sessionState.did) {
+          throw new Error('Atmosphere token response did not match the resolved account DID.')
+        }
+
+        let profile = await mapAtmosphereProfile(options, {
+          identifier: sessionState.identifier,
+          did: sessionState.did,
+          handle: sessionState.handle,
+          pdsUrl: sessionState.pdsUrl,
+          authorizationServer,
+          tokens,
+          context,
+        })
+
+        return {
+          provider: ATMOSPHERE_PROVIDER_NAME,
+          account: {
+            provider: ATMOSPHERE_PROVIDER_NAME,
+            providerAccountId: sessionState.did,
+          },
+          profile,
+          tokens,
+        }
+      },
+      async refreshTokens(currentTokens): Promise<OAuthDpopTokens> {
+        if (currentTokens.refreshToken == null || currentTokens.refreshToken.length === 0) {
+          throw new Error('Atmosphere provider did not receive a refresh token.')
+        }
+
+        let tokenResponse = await sendDpopFormRequest<AtmosphereTokenResponse>({
+          endpoint: authorizationServer.token_endpoint,
+          body: await createAtmosphereRefreshTokenRequestBody({
+            clientId: client.clientId,
+            refreshToken: currentTokens.refreshToken,
+            clientAuthentication: options.clientAuthentication,
+            issuer: authorizationServer.issuer,
+          }),
+          dpopKeyPair: {
+            publicJwk: currentTokens.dpop.publicJwk,
+            privateJwk: currentTokens.dpop.privateJwk,
+          },
+          fallbackError: 'Atmosphere refresh token exchange failed.',
+          nonce: currentTokens.dpop.nonce,
+        })
+        let refreshedTokens = normalizeAtmosphereTokenResponse(tokenResponse.json)
+
+        if (tokenResponse.json.sub !== identity.did) {
+          throw new Error('Atmosphere token response did not match the resolved account DID.')
+        }
+
+        return {
+          ...currentTokens,
+          ...refreshedTokens,
+          refreshToken: refreshedTokens.refreshToken ?? currentTokens.refreshToken,
+          expiresAt: refreshedTokens.expiresAt ?? currentTokens.expiresAt,
+          scope: refreshedTokens.scope ?? currentTokens.scope,
+          dpop: {
+            publicJwk: currentTokens.dpop.publicJwk,
+            privateJwk: currentTokens.dpop.privateJwk,
+            nonce: tokenResponse.nonce ?? currentTokens.dpop.nonce,
+          },
+        }
+      },
+    })
+  }
+}
+
+async function mapAtmosphereProfile<profile extends AtmosphereAuthProfile>(
+  options: AtmosphereAuthProviderOptions<profile>,
+  input: AtmosphereAuthProviderMapProfileInput,
+): Promise<profile> {
+  if (options.mapProfile == null) {
+    return {
+      did: input.did,
+      handle: input.handle,
+      pdsUrl: input.pdsUrl,
+      authorizationServer: input.authorizationServer.issuer,
+    } as profile
+  }
+
+  return options.mapProfile(input)
+}
+
+async function createAtmosphereTokenRequestBody(options: {
+  clientId: string
+  redirectUri: string
+  code: string
+  codeVerifier: string
+  issuer: string
+  clientAuthentication?: AtmosphereClientAuthentication
+}): Promise<URLSearchParams> {
+  let body = new URLSearchParams({
+    client_id: options.clientId,
+    code: options.code,
+    code_verifier: options.codeVerifier,
+    grant_type: 'authorization_code',
+    redirect_uri: options.redirectUri,
+  })
+
+  if (options.clientAuthentication != null) {
+    body.set('client_assertion_type', 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer')
+    body.set(
+      'client_assertion',
+      await createClientAssertion(options.clientId, options.issuer, options.clientAuthentication),
+    )
+  }
+
+  return body
+}
+
+async function createAtmosphereRefreshTokenRequestBody(options: {
+  clientId: string
+  refreshToken: string
+  issuer: string
+  clientAuthentication?: AtmosphereClientAuthentication
+}): Promise<URLSearchParams> {
+  let body = new URLSearchParams({
+    client_id: options.clientId,
+    grant_type: 'refresh_token',
+    refresh_token: options.refreshToken,
+  })
+
+  if (options.clientAuthentication != null) {
+    body.set('client_assertion_type', 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer')
+    body.set(
+      'client_assertion',
+      await createClientAssertion(options.clientId, options.issuer, options.clientAuthentication),
+    )
+  }
+
+  return body
+}
+
+async function sendDpopFormRequest<json>(options: {
+  endpoint: string
+  body: URLSearchParams
+  dpopKeyPair: { publicJwk: JsonWebKey; privateJwk: JsonWebKey }
+  fallbackError: string
+  nonce?: string
+}): Promise<{ json: json; nonce?: string }> {
+  let nonce = options.nonce
+  let privateKey = await importPrivateEcKey(options.dpopKeyPair.privateJwk)
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let response = await fetch(options.endpoint, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        DPoP: await createDpopProof({
+          method: 'POST',
+          url: options.endpoint,
+          nonce,
+          privateKey,
+          publicJwk: options.dpopKeyPair.publicJwk,
+        }),
+      },
+      body: options.body,
+    })
+    let json = (await readJsonResponse(response)) as json
+    let responseNonce = response.headers.get('DPoP-Nonce') ?? undefined
+
+    if (response.ok) {
+      return {
+        json,
+        nonce: responseNonce,
+      }
+    }
+
+    if (isUseDpopNonceError(json) && responseNonce != null && attempt === 0) {
+      nonce = responseNonce
+      continue
+    }
+
+    throw new Error(getOAuthErrorMessage(json, options.fallbackError))
+  }
+
+  throw new Error(options.fallbackError)
+}
+
+async function createClientAssertion(
+  clientId: string,
+  issuer: string,
+  authentication: AtmosphereClientAuthentication,
+): Promise<string> {
+  return createSignedJwt(
+    {
+      alg: 'ES256',
+      kid: authentication.keyId,
+    },
+    {
+      aud: issuer,
+      exp: getUnixTimestamp() + 60,
+      iat: getUnixTimestamp(),
+      iss: clientId,
+      jti: createJwtId(),
+      sub: clientId,
+    },
+    authentication.key,
+  )
+}
+
+async function createDpopProof(options: {
+  method: string
+  url: string
+  nonce?: string
+  privateKey: CryptoKey
+  publicJwk: JsonWebKey
+}): Promise<string> {
+  return createSignedJwt(
+    {
+      alg: 'ES256',
+      jwk: toPublicEcJwk(options.publicJwk),
+      typ: 'dpop+jwt',
+    },
+    {
+      exp: getUnixTimestamp() + 60,
+      htm: options.method.toUpperCase(),
+      htu: options.url,
+      iat: getUnixTimestamp(),
+      jti: createJwtId(),
+      nonce: options.nonce,
+    },
+    options.privateKey,
+  )
+}
+
+async function createSignedJwt(
+  header: Record<string, unknown>,
+  payload: Record<string, unknown>,
+  key: CryptoKey,
+): Promise<string> {
+  let encodedHeader = base64UrlEncodeJson(header)
+  let encodedPayload = base64UrlEncodeJson(
+    Object.fromEntries(Object.entries(payload).filter(([, value]) => value != null)),
+  )
+  let signingInput = `${encodedHeader}.${encodedPayload}`
+  let signature = await crypto.subtle.sign(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    key,
+    textEncoder.encode(signingInput),
+  )
+
+  return `${signingInput}.${toBase64Url(new Uint8Array(signature))}`
+}
+
+function getUnixTimestamp(): number {
+  return Math.floor(Date.now() / 1000)
+}
+
+function createJwtId(): string {
+  let bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  return toBase64Url(bytes)
+}
+
+async function generateDpopKeyPair(): Promise<{ publicJwk: JsonWebKey; privateJwk: JsonWebKey }> {
+  let keyPair = (await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair
+  let publicJwk = (await crypto.subtle.exportKey('jwk', keyPair.publicKey)) as JsonWebKey
+  let privateJwk = (await crypto.subtle.exportKey('jwk', keyPair.privateKey)) as JsonWebKey
+
+  return {
+    publicJwk: toPublicEcJwk(publicJwk),
+    privateJwk,
+  }
+}
+
+async function importPrivateEcKey(jwk: JsonWebKey): Promise<CryptoKey> {
+  return crypto.subtle.importKey('jwk', jwk, { name: 'ECDSA', namedCurve: 'P-256' }, false, [
+    'sign',
+  ])
+}
+
+function toPublicEcJwk(jwk: JsonWebKey): JsonWebKey {
+  return {
+    crv: jwk.crv,
+    kty: jwk.kty,
+    x: jwk.x,
+    y: jwk.y,
+  }
+}
+
+function normalizeAtmosphereTokenResponse(
+  json: AtmosphereTokenResponse,
+): Omit<OAuthDpopTokens, 'dpop'> {
+  if (typeof json.access_token !== 'string' || json.access_token.length === 0) {
+    throw new Error('Atmosphere token response did not include an access token.')
+  }
+
+  if (typeof json.sub !== 'string' || json.sub.length === 0) {
+    throw new Error('Atmosphere token response did not include an account DID in "sub".')
+  }
+
+  let scope = parseScope(json.scope)
+  if (scope == null || !scope.includes('atproto')) {
+    throw new Error('Atmosphere token response did not include the required "atproto" scope.')
+  }
+
+  if (json.token_type !== 'DPoP') {
+    throw new Error('Atmosphere token response did not include the required "DPoP" token type.')
+  }
+
+  return {
+    accessToken: json.access_token,
+    refreshToken: typeof json.refresh_token === 'string' ? json.refresh_token : undefined,
+    tokenType: 'DPoP',
+    expiresAt:
+      typeof json.expires_in === 'number'
+        ? new Date(Date.now() + json.expires_in * 1000)
+        : undefined,
+    scope,
+  }
+}
+
+async function discoverAuthorizationServer(
+  pdsUrl: string,
+  confidential: boolean,
+): Promise<AtmosphereAuthorizationServerMetadata> {
+  let resourceMetadata = await fetchJson<AtmosphereProtectedResourceMetadata>(
+    createWellKnownUrl(pdsUrl, '/.well-known/oauth-protected-resource'),
+    'Failed to load Atmosphere protected resource metadata.',
+  )
+  let authorizationServers = Array.isArray(resourceMetadata.authorization_servers)
+    ? resourceMetadata.authorization_servers.filter(
+        (value): value is string => typeof value === 'string',
+      )
+    : []
+
+  if (authorizationServers.length === 0) {
+    throw new Error(
+      'Atmosphere protected resource metadata did not include an authorization server.',
+    )
+  }
+
+  let issuer = validateAuthorizationServerOrigin(authorizationServers[0])
+  let metadata = await fetchJson<AtmosphereAuthorizationServerMetadata>(
+    createWellKnownUrl(issuer, '/.well-known/oauth-authorization-server'),
+    'Failed to load Atmosphere authorization server metadata.',
+  )
+
+  return validateAtmosphereAuthorizationServerMetadata(metadata, issuer, confidential)
+}
+
+async function resolveAtmosphereIdentity(
+  identifier: AtmosphereIdentifier,
+): Promise<AtmosphereResolvedIdentity> {
+  if (identifier.type === 'did') {
+    let document = await resolveDidDocument(identifier.normalized)
+    return {
+      did: identifier.normalized,
+      handle: getClaimedHandle(document),
+      pdsUrl: getPdsUrl(document, identifier.normalized),
+    }
+  }
+
+  let did = await resolveHandleToDid(identifier.normalized)
+  let document = await resolveDidDocument(did)
+  let claimedHandle = getClaimedHandle(document)
+
+  if (claimedHandle !== identifier.normalized) {
+    throw new Error('Atmosphere handle resolution did not match the DID document handle claim.')
+  }
+
+  return {
+    did,
+    handle: claimedHandle,
+    pdsUrl: getPdsUrl(document, did),
+  }
+}
+
+async function resolveHandleToDid(handle: string): Promise<string> {
+  let [dnsResult, httpsResult] = await Promise.allSettled([
+    resolveHandleViaDns(handle),
+    resolveHandleViaHttps(handle),
+  ])
+
+  if (dnsResult.status === 'fulfilled' && dnsResult.value != null) {
+    return dnsResult.value
+  }
+
+  if (dnsResult.status === 'rejected') {
+    throw dnsResult.reason
+  }
+
+  if (httpsResult.status === 'fulfilled' && httpsResult.value != null) {
+    return httpsResult.value
+  }
+
+  if (httpsResult.status === 'rejected') {
+    throw httpsResult.reason
+  }
+
+  throw new Error(`Atmosphere handle resolution failed for "${handle}".`)
+}
+
+async function resolveHandleViaDns(handle: string): Promise<string | undefined> {
+  let url = new URL(CLOUDFLARE_DNS_ENDPOINT)
+  url.searchParams.set('name', `_atproto.${handle}`)
+  url.searchParams.set('type', 'TXT')
+
+  let response = await fetch(url, {
+    headers: {
+      Accept: 'application/dns-json',
+    },
+  })
+
+  if (!response.ok) {
+    return
+  }
+
+  let json = (await readJsonResponse(response)) as {
+    Answer?: Array<{ data?: unknown; type?: unknown }>
+  }
+  let didValues = new Set<string>()
+
+  for (let answer of json.Answer ?? []) {
+    if (answer.type !== 16 || typeof answer.data !== 'string') {
+      continue
+    }
+
+    let text = decodeDnsTxtRecord(answer.data)
+    if (text.startsWith('did=')) {
+      didValues.add(text.slice(4))
+    }
+  }
+
+  if (didValues.size > 1) {
+    throw new Error(`Atmosphere DNS handle resolution returned multiple DIDs for "${handle}".`)
+  }
+
+  let did = didValues.values().next().value as string | undefined
+  if (did == null) {
+    return
+  }
+
+  validateDid(did)
+  return did
+}
+
+async function resolveHandleViaHttps(handle: string): Promise<string | undefined> {
+  let response = await fetch(`https://${handle}/.well-known/atproto-did`)
+
+  if (!response.ok) {
+    return
+  }
+
+  let did = (await response.text()).trim()
+  if (did.length === 0) {
+    return
+  }
+
+  try {
+    validateDid(did)
+  } catch {
+    return
+  }
+
+  return did
+}
+
+async function resolveDidDocument(did: string): Promise<AtmosphereDidDocument> {
+  validateDid(did)
+
+  let document: AtmosphereDidDocument
+  if (did.startsWith('did:plc:')) {
+    document = await fetchJson<AtmosphereDidDocument>(
+      `${PLC_DIRECTORY_URL}${encodeURIComponent(did)}`,
+      `Failed to resolve DID document for "${did}".`,
+    )
+  } else if (did.startsWith('did:web:')) {
+    let didWebUrl = createDidWebDocumentUrl(did)
+    document = await fetchJson<AtmosphereDidDocument>(
+      didWebUrl,
+      `Failed to resolve DID document for "${did}".`,
+    )
+  } else {
+    throw new Error(`Unsupported Atmosphere DID method in "${did}".`)
+  }
+
+  if (document.id !== did) {
+    throw new Error(`Resolved DID document did not match "${did}".`)
+  }
+
+  return document
+}
+
+function createDidWebDocumentUrl(did: string): string {
+  let host = decodeURIComponent(did.slice('did:web:'.length))
+
+  if (host.length === 0 || host.includes('/')) {
+    throw new Error(`Unsupported did:web identifier "${did}".`)
+  }
+
+  if (host.startsWith('localhost')) {
+    return `http://${host}/.well-known/did.json`
+  }
+
+  return `https://${host}/.well-known/did.json`
+}
+
+function getClaimedHandle(document: AtmosphereDidDocument): string | undefined {
+  let alsoKnownAs = Array.isArray(document.alsoKnownAs) ? document.alsoKnownAs : []
+
+  for (let entry of alsoKnownAs) {
+    if (typeof entry !== 'string' || !entry.startsWith('at://')) {
+      continue
+    }
+
+    let handle = entry.slice('at://'.length)
+
+    try {
+      return normalizeHandle(handle)
+    } catch {
+      continue
+    }
+  }
+}
+
+function getPdsUrl(document: AtmosphereDidDocument, did: string): string {
+  let services = Array.isArray(document.service) ? document.service : []
+
+  for (let service of services) {
+    if (typeof service !== 'object' || service == null || Array.isArray(service)) {
+      continue
+    }
+
+    let entry = service as Record<string, unknown>
+    let id = typeof entry.id === 'string' ? entry.id : undefined
+    let type = typeof entry.type === 'string' ? entry.type : undefined
+    let endpoint = typeof entry.serviceEndpoint === 'string' ? entry.serviceEndpoint : undefined
+
+    if (
+      id != null &&
+      matchesDidFragment(id, did, ATPROTO_PDS_SERVICE_ID) &&
+      type === ATPROTO_PDS_SERVICE_TYPE &&
+      endpoint != null
+    ) {
+      return normalizeHttpsOrigin(endpoint, 'Atmosphere DID document PDS endpoint')
+    }
+  }
+
+  throw new Error(`Atmosphere DID document for "${did}" did not include a PDS endpoint.`)
+}
+
+function matchesDidFragment(value: string, did: string, fragment: string): boolean {
+  return value === fragment || value === `${did}${fragment}`
+}
+
+function validateAtmosphereAuthorizationServerMetadata(
+  metadata: AtmosphereAuthorizationServerMetadata,
+  issuer: string,
+  confidential: boolean,
+): AtmosphereAuthorizationServerMetadata {
+  if (normalizeHttpsOrigin(metadata.issuer, 'Atmosphere authorization server issuer') !== issuer) {
+    throw new Error(
+      'Atmosphere authorization server metadata issuer did not match the resolved origin.',
+    )
+  }
+
+  ensureUrl(metadata.authorization_endpoint, issuer, 'Atmosphere authorization endpoint')
+  ensureUrl(metadata.token_endpoint, issuer, 'Atmosphere token endpoint')
+  ensureUrl(
+    metadata.pushed_authorization_request_endpoint,
+    undefined,
+    'Atmosphere pushed authorization request endpoint',
+  )
+
+  ensureIncludes(metadata.response_types_supported, 'code', 'Atmosphere authorization server')
+  ensureIncludes(
+    metadata.grant_types_supported,
+    'authorization_code',
+    'Atmosphere authorization server',
+  )
+  ensureIncludes(metadata.grant_types_supported, 'refresh_token', 'Atmosphere authorization server')
+  ensureIncludes(
+    metadata.code_challenge_methods_supported,
+    'S256',
+    'Atmosphere authorization server',
+  )
+  ensureIncludes(metadata.scopes_supported, 'atproto', 'Atmosphere authorization server')
+  ensureIncludes(
+    metadata.dpop_signing_alg_values_supported,
+    'ES256',
+    'Atmosphere authorization server',
+  )
+
+  if (metadata.require_pushed_authorization_requests === false) {
+    throw new Error('Atmosphere authorization server must require PAR.')
+  }
+
+  if (metadata.authorization_response_iss_parameter_supported !== true) {
+    throw new Error('Atmosphere authorization server must support the callback iss parameter.')
+  }
+
+  if (metadata.client_id_metadata_document_supported !== true) {
+    throw new Error('Atmosphere authorization server must support client metadata documents.')
+  }
+
+  if (confidential) {
+    ensureIncludes(
+      metadata.token_endpoint_auth_methods_supported,
+      'private_key_jwt',
+      'Atmosphere authorization server',
+    )
+    ensureIncludes(
+      metadata.token_endpoint_auth_signing_alg_values_supported,
+      'ES256',
+      'Atmosphere authorization server',
+    )
+  } else {
+    ensureIncludes(
+      metadata.token_endpoint_auth_methods_supported,
+      'none',
+      'Atmosphere authorization server',
+    )
+  }
+
+  return metadata
+}
+
+function normalizeAtmosphereIdentifier(input: string): AtmosphereIdentifier {
+  let value = input.trim()
+
+  if (value.length === 0) {
+    throw new Error('Atmosphere auth requires a handle or DID.')
+  }
+
+  if (value.startsWith('did:')) {
+    validateDid(value)
+    return {
+      input: value,
+      normalized: value,
+      type: 'did',
+    }
+  }
+
+  return {
+    input: value,
+    normalized: normalizeHandle(value),
+    type: 'handle',
+  }
+}
+
+function normalizeAtmosphereClientConfiguration(
+  clientId: string | URL,
+  redirectUri: string | URL,
+  scopes: string[],
+): AtmosphereClientConfiguration {
+  let redirect = normalizeRedirectUri(redirectUri)
+  let client = new URL(typeof clientId === 'string' ? clientId : clientId.toString())
+
+  if (client.origin === 'http://localhost' && client.port === '') {
+    if (client.pathname !== '/' || client.hash.length > 0) {
+      throw new Error(
+        'Atmosphere loopback client_id must use http://localhost with no path or fragment.',
+      )
+    }
+
+    if (!redirect.loopback) {
+      throw new Error('Atmosphere localhost client_id requires a loopback redirect URI.')
+    }
+
+    if (client.searchParams.getAll('redirect_uri').length === 0) {
+      client.searchParams.append('redirect_uri', redirect.url.toString())
+    }
+
+    let configuredRedirectUris = client.searchParams.getAll('redirect_uri')
+    if (!configuredRedirectUris.some((value) => matchesLoopbackRedirect(value, redirect.url))) {
+      throw new Error(
+        'Atmosphere localhost client_id must declare the configured loopback redirect URI.',
+      )
+    }
+
+    if (client.searchParams.get('scope') == null) {
+      client.searchParams.set('scope', scopes.join(' '))
+    }
+
+    let declaredScopes = parseScope(client.searchParams.get('scope')) ?? []
+    for (let scope of scopes) {
+      if (!declaredScopes.includes(scope)) {
+        throw new Error('Atmosphere localhost client_id scope must include every requested scope.')
+      }
+    }
+
+    return {
+      clientId: client.toString(),
+      redirectUri: redirect.url.toString(),
+      loopback: true,
+    }
+  }
+
+  if (client.protocol !== 'https:' || client.port !== '' || client.hash.length > 0) {
+    throw new Error('Atmosphere client_id must be an https URL with no explicit port or fragment.')
+  }
+
+  if (redirect.loopback) {
+    throw new Error('Atmosphere loopback redirect URIs require a localhost client_id.')
+  }
+
+  return {
+    clientId: client.toString(),
+    redirectUri: redirect.url.toString(),
+    loopback: false,
+  }
+}
+
+function normalizeRedirectUri(value: string | URL): { url: URL; loopback: boolean } {
+  let url = new URL(typeof value === 'string' ? value : value.toString())
+
+  if (url.hostname === 'localhost') {
+    throw new Error('Loopback redirect URIs must use 127.0.0.1 or [::1], not localhost.')
+  }
+
+  if (url.protocol === 'https:') {
+    return {
+      url,
+      loopback: false,
+    }
+  }
+
+  if (url.protocol === 'http:' && LOOPBACK_HOSTS.has(url.hostname)) {
+    return {
+      url,
+      loopback: true,
+    }
+  }
+
+  throw new Error(
+    'Atmosphere redirectUri must be https or an http loopback URL using 127.0.0.1 or [::1].',
+  )
+}
+
+function matchesLoopbackRedirect(candidate: string, expected: URL): boolean {
+  let url = new URL(candidate)
+  return (
+    url.protocol === expected.protocol &&
+    url.hostname === expected.hostname &&
+    url.pathname === expected.pathname
+  )
+}
+
+function normalizeAtmosphereScopes(scopes: string[] | undefined): string[] {
+  let normalized = scopes?.filter((scope) => typeof scope === 'string' && scope.length > 0)
+  let value = normalized == null || normalized.length === 0 ? DEFAULT_ATMOSPHERE_SCOPES : normalized
+
+  if (!value.includes('atproto')) {
+    throw new Error('Atmosphere scopes must include "atproto".')
+  }
+
+  return Array.from(new Set(value))
+}
+
+function normalizeAtmosphereSessionSecret(secret: string): string {
+  let value = secret.trim()
+
+  if (value.length === 0) {
+    throw new Error('Atmosphere sessionSecret must not be empty.')
+  }
+
+  return value
+}
+
+function normalizeHandle(input: string): string {
+  let handle = input.trim().toLowerCase()
+  let parts = handle.split('.')
+
+  if (!HANDLE_REGEX.test(handle)) {
+    throw new Error(`Invalid Atmosphere handle "${input}".`)
+  }
+
+  let tld = parts[parts.length - 1]
+  if (DISALLOWED_HANDLE_TLDS.has(tld)) {
+    throw new Error(`Atmosphere handle "${input}" uses a disallowed top-level domain.`)
+  }
+
+  return handle
+}
+
+function validateDid(value: string): void {
+  if (!DID_REGEX.test(value)) {
+    throw new Error(`Invalid Atmosphere DID "${value}".`)
+  }
+}
+
+function createWellKnownUrl(origin: string, pathname: string): string {
+  let url = new URL(pathname, origin)
+  return url.toString()
+}
+
+function validateAuthorizationServerOrigin(value: string): string {
+  return normalizeHttpsOrigin(value, 'Atmosphere authorization server')
+}
+
+function normalizeHttpsOrigin(value: string, label: string): string {
+  let url = new URL(value)
+
+  if (url.protocol !== 'https:' || url.username.length > 0 || url.password.length > 0) {
+    throw new Error(`${label} must be an https origin.`)
+  }
+
+  if (url.pathname !== '/' || url.search.length > 0 || url.hash.length > 0) {
+    throw new Error(`${label} must not include a path, query string, or fragment.`)
+  }
+
+  return url.origin
+}
+
+function ensureUrl(value: string, issuer: string | undefined, label: string): void {
+  let url = new URL(value)
+
+  if (url.protocol !== 'https:') {
+    throw new Error(`${label} must use https.`)
+  }
+
+  if (issuer != null && url.origin !== issuer) {
+    throw new Error(`${label} must use the resolved authorization server origin.`)
+  }
+}
+
+function ensureIncludes(
+  value: string[] | string | undefined,
+  expected: string,
+  source: string,
+): void {
+  let values = Array.isArray(value) ? value : typeof value === 'string' ? value.split(/\s+/) : []
+
+  if (!values.includes(expected)) {
+    throw new Error(`${source} did not advertise required value "${expected}".`)
+  }
+}
+
+async function fetchJson<json>(input: string | URL, fallbackError: string): Promise<json> {
+  let response = await fetch(input)
+  let json = await readJsonResponse(response)
+
+  if (!response.ok) {
+    throw new Error(getOAuthErrorMessage(json, fallbackError))
+  }
+
+  return json as json
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+  let text = await response.text()
+  if (text.length === 0) {
+    return {}
+  }
+
+  return JSON.parse(text)
+}
+
+function getOAuthErrorMessage(json: unknown, fallback: string): string {
+  if (typeof json !== 'object' || json == null || Array.isArray(json)) {
+    return fallback
+  }
+
+  let data = json as Record<string, unknown>
+
+  if (typeof data.error_description === 'string' && data.error_description.length > 0) {
+    return data.error_description
+  }
+
+  if (typeof data.error === 'string' && data.error.length > 0) {
+    return data.error
+  }
+
+  if (typeof data.message === 'string' && data.message.length > 0) {
+    return data.message
+  }
+
+  return fallback
+}
+
+function isUseDpopNonceError(json: unknown): boolean {
+  return (
+    typeof json === 'object' &&
+    json != null &&
+    !Array.isArray(json) &&
+    (json as Record<string, unknown>).error === 'use_dpop_nonce'
+  )
+}
+
+function parseScope(value: unknown): string[] | undefined {
+  if (typeof value !== 'string' || value.length === 0) {
+    return
+  }
+
+  return value
+    .split(/[\s,]+/)
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0)
+}
+
+function decodeDnsTxtRecord(value: string): string {
+  let matches = value.match(/"((?:[^"\\]|\\.)*)"/g)
+
+  if (matches == null) {
+    return value
+  }
+
+  return matches
+    .map((match) => match.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\'))
+    .join('')
+}
+
+async function writeAtmosphereSessionState(
+  secret: string,
+  state: string,
+  value: AtmosphereSessionState,
+): Promise<string> {
+  let iv = crypto.getRandomValues(new Uint8Array(12))
+  let key = await importAtmosphereSessionKey(secret)
+  let ciphertext = await crypto.subtle.encrypt(
+    {
+      name: 'AES-GCM',
+      iv: toArrayBuffer(iv),
+      additionalData: getAtmosphereSessionAdditionalData(state),
+    },
+    key,
+    textEncoder.encode(JSON.stringify(value)),
+  )
+
+  return `v1.${toBase64Url(iv)}.${toBase64Url(new Uint8Array(ciphertext))}`
+}
+
+async function readAtmosphereSessionState(
+  secret: string,
+  transaction: OAuthTransaction,
+): Promise<AtmosphereSessionState> {
+  if (typeof transaction.providerState !== 'string' || transaction.providerState.length === 0) {
+    throw new Error('Missing Atmosphere session state. Restart the login flow and try again.')
+  }
+
+  let [version, encodedIv, encodedCiphertext, ...rest] = transaction.providerState.split('.')
+
+  if (version !== 'v1' || encodedIv == null || encodedCiphertext == null || rest.length > 0) {
+    throw new Error('Missing Atmosphere session state. Restart the login flow and try again.')
+  }
+
+  let key = await importAtmosphereSessionKey(secret)
+
+  try {
+    let plaintext = await crypto.subtle.decrypt(
+      {
+        name: 'AES-GCM',
+        iv: toArrayBuffer(fromBase64Url(encodedIv)),
+        additionalData: getAtmosphereSessionAdditionalData(transaction.state),
+      },
+      key,
+      toArrayBuffer(fromBase64Url(encodedCiphertext)),
+    )
+
+    return JSON.parse(textDecoder.decode(plaintext)) as AtmosphereSessionState
+  } catch {
+    throw new Error('Invalid Atmosphere session state. Restart the login flow and try again.')
+  }
+}
+
+async function importAtmosphereSessionKey(secret: string): Promise<CryptoKey> {
+  let digest = await crypto.subtle.digest('SHA-256', textEncoder.encode(secret))
+
+  return crypto.subtle.importKey('raw', digest, 'AES-GCM', false, ['encrypt', 'decrypt'])
+}
+
+function getAtmosphereSessionAdditionalData(state: string): ArrayBuffer {
+  return toArrayBuffer(textEncoder.encode(`atmosphere:${state}`))
+}
+
+function base64UrlEncodeJson(value: Record<string, unknown>): string {
+  return toBase64Url(textEncoder.encode(JSON.stringify(value)))
+}
+
+function fromBase64Url(value: string): Uint8Array {
+  let padding = value.length % 4 === 0 ? '' : '='.repeat(4 - (value.length % 4))
+  let base64 = value.replace(/-/g, '+').replace(/_/g, '/') + padding
+
+  return Uint8Array.from(atob(base64), (char) => char.charCodeAt(0))
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  let text = ''
+
+  for (let index = 0; index < bytes.length; index += 3) {
+    let chunk =
+      ((bytes[index] ?? 0) << 16) | ((bytes[index + 1] ?? 0) << 8) | (bytes[index + 2] ?? 0)
+
+    text += base64Chars[(chunk >> 18) & 0x3f]
+    text += base64Chars[(chunk >> 12) & 0x3f]
+    text += index + 1 < bytes.length ? base64Chars[(chunk >> 6) & 0x3f] : '='
+    text += index + 2 < bytes.length ? base64Chars[chunk & 0x3f] : '='
+  }
+
+  return text.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder()
+const base64Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'

--- a/packages/auth/src/lib/providers/oidc.ts
+++ b/packages/auth/src/lib/providers/oidc.ts
@@ -1,6 +1,6 @@
 import type { RequestContext } from '@remix-run/fetch-router'
 
-import type { OAuthProvider, OAuthResult, OAuthTokens } from '../provider.ts'
+import type { OAuthProvider, OAuthResult, OAuthStandardTokens, OAuthTokens } from '../provider.ts'
 import {
   createAuthorizationURL,
   createOAuthProvider,
@@ -8,7 +8,7 @@ import {
   exchangeRefreshToken,
   fetchJson,
   getAuthorizationCode,
-  mergeRefreshedTokens,
+  mergeRefreshedStandardTokens,
 } from '../provider.ts'
 import { createCodeChallenge } from '../utils.ts'
 
@@ -127,7 +127,9 @@ export interface OIDCAuthProviderOptions<
 export function createOIDCAuthProvider<
   profile extends OIDCAuthProfile = OIDCAuthProfile,
   provider extends string = 'oidc',
->(options: OIDCAuthProviderOptions<profile, provider>): OAuthProvider<profile, provider> {
+>(
+  options: OIDCAuthProviderOptions<profile, provider>,
+): OAuthProvider<profile, provider, OAuthStandardTokens> {
   let name = options.name ?? ('oidc' as provider)
   let scopes = options.scopes ?? DEFAULT_OIDC_SCOPES
   let metadataPromise: Promise<OIDCAuthProviderMetadata> | undefined
@@ -163,7 +165,10 @@ export function createOIDCAuthProvider<
         code_challenge_method: 'S256',
       })
     },
-    async handleCallback(context, transaction): Promise<OAuthResult<profile, provider>> {
+    async handleCallback(
+      context,
+      transaction,
+    ): Promise<OAuthResult<profile, provider, OAuthStandardTokens>> {
       let metadata = await getMetadata()
       let tokens = await exchangeAuthorizationCode({
         tokenEndpoint: metadata.token_endpoint,
@@ -186,7 +191,7 @@ export function createOIDCAuthProvider<
         tokens,
       }
     },
-    async refreshTokens(currentTokens): Promise<OAuthTokens> {
+    async refreshTokens(currentTokens): Promise<OAuthStandardTokens> {
       if (currentTokens.refreshToken == null || currentTokens.refreshToken.length === 0) {
         throw new Error(`OIDC provider "${name}" did not receive a refresh token.`)
       }
@@ -199,7 +204,7 @@ export function createOIDCAuthProvider<
         refreshToken: currentTokens.refreshToken,
       })
 
-      return mergeRefreshedTokens(currentTokens, refreshedTokens)
+      return mergeRefreshedStandardTokens(currentTokens, refreshedTokens)
     },
   })
 }

--- a/packages/auth/src/lib/providers/x.ts
+++ b/packages/auth/src/lib/providers/x.ts
@@ -1,4 +1,4 @@
-import type { OAuthAccount, OAuthProvider, OAuthResult, OAuthTokens } from '../provider.ts'
+import type { OAuthAccount, OAuthProvider, OAuthResult, OAuthStandardTokens } from '../provider.ts'
 import {
   createAuthorizationURL,
   createOAuthProvider,
@@ -6,7 +6,7 @@ import {
   exchangeRefreshToken,
   fetchJson,
   getAuthorizationCode,
-  mergeRefreshedTokens,
+  mergeRefreshedStandardTokens,
 } from '../provider.ts'
 import { createCodeChallenge } from '../utils.ts'
 
@@ -62,7 +62,7 @@ interface XProfileResponse {
  */
 export function createXAuthProvider(
   options: XAuthProviderOptions,
-): OAuthProvider<XAuthProfile, 'x'> {
+): OAuthProvider<XAuthProfile, 'x', OAuthStandardTokens> {
   let scopes = options.scopes ?? DEFAULT_X_SCOPES
 
   return createOAuthProvider('x', {
@@ -79,7 +79,10 @@ export function createXAuthProvider(
         code_challenge_method: 'S256',
       })
     },
-    async handleCallback(context, transaction): Promise<OAuthResult<XAuthProfile, 'x'>> {
+    async handleCallback(
+      context,
+      transaction,
+    ): Promise<OAuthResult<XAuthProfile, 'x', OAuthStandardTokens>> {
       let tokens = await exchangeAuthorizationCode({
         tokenEndpoint: X_TOKEN_ENDPOINT,
         clientId: options.clientId,
@@ -108,7 +111,7 @@ export function createXAuthProvider(
         tokens,
       }
     },
-    async refreshTokens(currentTokens): Promise<OAuthTokens> {
+    async refreshTokens(currentTokens): Promise<OAuthStandardTokens> {
       if (currentTokens.refreshToken == null || currentTokens.refreshToken.length === 0) {
         throw new Error('X provider did not receive a refresh token.')
       }
@@ -121,7 +124,7 @@ export function createXAuthProvider(
         clientAuthentication: 'basic',
       })
 
-      return mergeRefreshedTokens(currentTokens, refreshedTokens)
+      return mergeRefreshedStandardTokens(currentTokens, refreshedTokens)
     },
   })
 }

--- a/packages/auth/src/lib/refresh-external-auth.test.ts
+++ b/packages/auth/src/lib/refresh-external-auth.test.ts
@@ -1,8 +1,9 @@
 import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
-import type { OAuthTokens } from './provider.ts'
+import type { OAuthDpopTokens, OAuthStandardTokens } from './provider.ts'
 import { refreshExternalAuth } from './refresh-external-auth.ts'
+import { createAtmosphereAuthProvider } from './providers/atmosphere.ts'
 import { createGitHubAuthProvider } from './providers/github.ts'
 import { createGoogleAuthProvider } from './providers/google.ts'
 import { createXAuthProvider } from './providers/x.ts'
@@ -38,7 +39,7 @@ describe('refreshExternalAuth()', () => {
     })
 
     try {
-      let currentTokens: OAuthTokens = {
+      let currentTokens: OAuthStandardTokens = {
         accessToken: 'google-access-token-1',
         refreshToken: 'google-refresh-token',
         tokenType: 'Bearer',
@@ -88,7 +89,7 @@ describe('refreshExternalAuth()', () => {
     })
 
     try {
-      let currentTokens: OAuthTokens = {
+      let currentTokens: OAuthStandardTokens = {
         accessToken: 'x-access-token-1',
         refreshToken: 'x-refresh-token',
         tokenType: 'bearer',
@@ -101,6 +102,113 @@ describe('refreshExternalAuth()', () => {
       assert.equal(result.tokens.refreshToken, 'x-refresh-token-2')
       assert.equal(result.tokens.tokenType, 'bearer')
       assert.deepEqual(result.tokens.scope, ['tweet.read', 'users.read', 'offline.access'])
+    } finally {
+      restoreFetch()
+    }
+  })
+
+  it('refreshes Atmosphere DPoP tokens and updates the nonce', async () => {
+    let restoreFetch = mockFetch(async (input, init) => {
+      let url = toRequestUrl(input)
+
+      if (url.href === 'https://plc.directory/did%3Aplc%3Aalice') {
+        return Response.json({
+          id: 'did:plc:alice',
+          alsoKnownAs: ['at://alice.example.com'],
+          service: [
+            {
+              id: '#atproto_pds',
+              type: 'AtprotoPersonalDataServer',
+              serviceEndpoint: 'https://pds.example.com',
+            },
+          ],
+        })
+      }
+
+      if (url.href === 'https://pds.example.com/.well-known/oauth-protected-resource') {
+        return Response.json({
+          authorization_servers: ['https://auth.example.com'],
+        })
+      }
+
+      if (url.href === 'https://auth.example.com/.well-known/oauth-authorization-server') {
+        return Response.json({
+          issuer: 'https://auth.example.com',
+          authorization_endpoint: 'https://auth.example.com/oauth/authorize',
+          token_endpoint: 'https://auth.example.com/oauth/token',
+          pushed_authorization_request_endpoint: 'https://auth.example.com/oauth/par',
+          response_types_supported: ['code'],
+          grant_types_supported: ['authorization_code', 'refresh_token'],
+          code_challenge_methods_supported: ['S256'],
+          token_endpoint_auth_methods_supported: ['none'],
+          scopes_supported: ['atproto'],
+          authorization_response_iss_parameter_supported: true,
+          require_pushed_authorization_requests: true,
+          client_id_metadata_document_supported: true,
+          dpop_signing_alg_values_supported: ['ES256'],
+        })
+      }
+
+      if (url.href === 'https://auth.example.com/oauth/token') {
+        let body = new URLSearchParams(String(init?.body ?? ''))
+        let proof = decodeJwt(new Headers(init?.headers).get('DPoP')!)
+
+        assert.equal(body.get('grant_type'), 'refresh_token')
+        assert.equal(body.get('refresh_token'), 'atmosphere-refresh-token')
+        assert.equal(
+          body.get('client_id'),
+          'http://localhost/?redirect_uri=http%3A%2F%2F127.0.0.1%3A44100%2Fauth%2Fatmosphere%2Fcallback&scope=atproto',
+        )
+        assert.equal(proof.payload.nonce, 'old-atmosphere-nonce')
+
+        return Response.json(
+          {
+            access_token: 'atmosphere-access-token-2',
+            token_type: 'DPoP',
+            scope: 'atproto',
+            sub: 'did:plc:alice',
+          },
+          {
+            headers: {
+              'DPoP-Nonce': 'new-atmosphere-nonce',
+            },
+          },
+        )
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    try {
+      let atmosphereProvider = createAtmosphereAuthProvider({
+        clientId: 'http://localhost',
+        redirectUri: 'http://127.0.0.1:44100/auth/atmosphere/callback',
+        sessionSecret: 'atmosphere-session-secret',
+      })
+      let provider = await atmosphereProvider('did:plc:alice')
+      let dpopKeyPair = (await crypto.subtle.generateKey(
+        { name: 'ECDSA', namedCurve: 'P-256' },
+        true,
+        ['sign', 'verify'],
+      )) as CryptoKeyPair
+      let currentTokens: OAuthDpopTokens = {
+        accessToken: 'atmosphere-access-token-1',
+        refreshToken: 'atmosphere-refresh-token',
+        tokenType: 'DPoP',
+        scope: ['atproto'],
+        dpop: {
+          publicJwk: (await crypto.subtle.exportKey('jwk', dpopKeyPair.publicKey)) as JsonWebKey,
+          privateJwk: (await crypto.subtle.exportKey('jwk', dpopKeyPair.privateKey)) as JsonWebKey,
+          nonce: 'old-atmosphere-nonce',
+        },
+      }
+      let result = await refreshExternalAuth(provider, currentTokens)
+
+      assert.equal(result.provider, 'atmosphere')
+      assert.equal(result.tokens.accessToken, 'atmosphere-access-token-2')
+      assert.equal(result.tokens.refreshToken, 'atmosphere-refresh-token')
+      assert.equal(result.tokens.dpop.nonce, 'new-atmosphere-nonce')
+      assert.deepEqual(result.tokens.scope, ['atproto'])
     } finally {
       restoreFetch()
     }
@@ -134,4 +242,20 @@ function toRequestUrl(input: RequestInfo | URL): URL {
   }
 
   return new URL(input.url)
+}
+
+function decodeJwt(token: string): {
+  payload: Record<string, unknown>
+} {
+  let [, payload] = token.split('.')
+  return {
+    payload: JSON.parse(decodeBase64Url(payload)),
+  }
+}
+
+function decodeBase64Url(value: string): string {
+  let padding = value.length % 4 === 0 ? '' : '='.repeat(4 - (value.length % 4))
+  let base64 = value.replace(/-/g, '+').replace(/_/g, '/') + padding
+  let bytes = Uint8Array.from(atob(base64), (char) => char.charCodeAt(0))
+  return new TextDecoder().decode(bytes)
 }

--- a/packages/auth/src/lib/refresh-external-auth.ts
+++ b/packages/auth/src/lib/refresh-external-auth.ts
@@ -4,11 +4,14 @@ import type { OAuthProvider, OAuthTokens } from './provider.ts'
 /**
  * Completed result returned from a successful refresh-token exchange.
  */
-export interface RefreshedExternalAuthResult<provider extends string = string> {
+export interface RefreshedExternalAuthResult<
+  provider extends string = string,
+  tokens extends OAuthTokens = OAuthTokens,
+> {
   /** Provider name whose token bundle was refreshed. */
   provider: provider
   /** Updated token bundle returned by the provider runtime. */
-  tokens: OAuthTokens
+  tokens: tokens
 }
 
 /**
@@ -18,10 +21,14 @@ export interface RefreshedExternalAuthResult<provider extends string = string> {
  * @param tokens The current provider token bundle, including a refresh token when available.
  * @returns The provider name plus the refreshed token bundle.
  */
-export async function refreshExternalAuth<profile = never, provider extends string = string>(
-  provider: OAuthProvider<profile, provider>,
-  tokens: OAuthTokens,
-): Promise<RefreshedExternalAuthResult<provider>> {
+export async function refreshExternalAuth<
+  profile = never,
+  provider extends string = string,
+  tokens extends OAuthTokens = OAuthTokens,
+>(
+  provider: OAuthProvider<profile, provider, tokens>,
+  tokens: tokens,
+): Promise<RefreshedExternalAuthResult<provider, tokens>> {
   let runtime = getOAuthProviderRuntime(provider)
 
   if (runtime.refreshTokens == null) {


### PR DESCRIPTION
Stacks on #11272 and brings the Atmosphere auth provider over from the atmosphere branch without adding a standalone DPoP helper package.

- Adds `createAtmosphereAuthProvider(options)(handleOrDid)` so apps can create one shared factory at module scope and resolve the request-time handle or DID only when starting or finishing a flow.
- Inlines DPoP proof generation, nonce retry handling, and sealed per-flow DPoP state inside the Atmosphere provider implementation.
- Extends the auth token types and refresh flow so Atmosphere returns and refreshes DPoP-bound token bundles while OIDC/X continue using standard token bundles.
- Adds auth package tests for DNS/HTTPS identity resolution, PAR with DPoP nonce retry, callback completion, loopback clients, and Atmosphere refresh-token exchange.

```ts
let atmosphereProvider = createAtmosphereAuthProvider({
  clientId: new URL('/oauth/client-metadata.json', env.APP_ORIGIN),
  redirectUri: new URL('/auth/atmosphere/callback', env.APP_ORIGIN),
  sessionSecret: env.SESSION_SECRET,
})

router.get('/login/atmosphere', async (context) => {
  let handleOrDid = context.url.searchParams.get('handleOrDid')
  if (handleOrDid == null) throw new Error('Missing handle or DID')

  return startExternalAuth(await atmosphereProvider(handleOrDid), context)
})
```
