### PR TITLE
Support native SQLite and Bun data-table adapter tests

### DIFF
--- a/.github/workflows/data-table-integration.yaml
+++ b/.github/workflows/data-table-integration.yaml
@@ -40,6 +40,9 @@ jobs:
           node-version-file: 'package.json'
           cache: pnpm
 
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -47,18 +50,22 @@ jobs:
         run: |
           pnpm --filter @remix-run/data-table run typecheck
           pnpm --filter @remix-run/data-table run test
+          pnpm --filter @remix-run/data-table run test:bun
           pnpm --filter @remix-run/data-table run test:coverage
           pnpm --filter @remix-run/data-table run build
           pnpm --filter @remix-run/data-table-postgres run typecheck
           pnpm --filter @remix-run/data-table-postgres run test
+          pnpm --filter @remix-run/data-table-postgres run test:bun
           pnpm --filter @remix-run/data-table-postgres run test:coverage
           pnpm --filter @remix-run/data-table-postgres run build
           pnpm --filter @remix-run/data-table-mysql run typecheck
           pnpm --filter @remix-run/data-table-mysql run test
+          pnpm --filter @remix-run/data-table-mysql run test:bun
           pnpm --filter @remix-run/data-table-mysql run test:coverage
           pnpm --filter @remix-run/data-table-mysql run build
           pnpm --filter @remix-run/data-table-sqlite run typecheck
           pnpm --filter @remix-run/data-table-sqlite run test
+          pnpm --filter @remix-run/data-table-sqlite run test:bun
           pnpm --filter @remix-run/data-table-sqlite run test:coverage
           pnpm --filter @remix-run/data-table-sqlite run build
 
@@ -94,14 +101,23 @@ jobs:
           node-version-file: 'package.json'
           cache: pnpm
 
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run postgres integration tests
+      - name: Run postgres integration tests in Node
         env:
           DATA_TABLE_INTEGRATION: '1'
           DATA_TABLE_POSTGRES_URL: postgres://postgres:postgres@127.0.0.1:5432/remix
         run: node --disable-warning=ExperimentalWarning --test './packages/data-table-postgres/src/lib/adapter.integration.test.ts'
+
+      - name: Run postgres integration tests in Bun
+        env:
+          DATA_TABLE_INTEGRATION: '1'
+          DATA_TABLE_POSTGRES_URL: postgres://postgres:postgres@127.0.0.1:5432/remix
+        run: bun --bun ./packages/test/src/cli.ts --glob.test './packages/data-table-postgres/src/lib/adapter.integration.test.ts' --type server
 
   mysql-integration:
     name: MySQL Integration
@@ -134,14 +150,23 @@ jobs:
           node-version-file: 'package.json'
           cache: pnpm
 
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run mysql integration tests
+      - name: Run mysql integration tests in Node
         env:
           DATA_TABLE_INTEGRATION: '1'
           DATA_TABLE_MYSQL_URL: mysql://root:root@127.0.0.1:3306/remix
         run: node --disable-warning=ExperimentalWarning --test './packages/data-table-mysql/src/lib/adapter.integration.test.ts'
+
+      - name: Run mysql integration tests in Bun
+        env:
+          DATA_TABLE_INTEGRATION: '1'
+          DATA_TABLE_MYSQL_URL: mysql://root:root@127.0.0.1:3306/remix
+        run: bun --bun ./packages/test/src/cli.ts --glob.test './packages/data-table-mysql/src/lib/adapter.integration.test.ts' --type server
 
   sqlite-integration:
     name: SQLite Integration

--- a/packages/data-table-mysql/package.json
+++ b/packages/data-table-mysql/package.json
@@ -56,6 +56,7 @@
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix-test",
+    "test:bun": "bun x --bun remix-test",
     "test:coverage": "remix-test --coverage",
     "typecheck": "tsgo --noEmit"
   },

--- a/packages/data-table-postgres/package.json
+++ b/packages/data-table-postgres/package.json
@@ -57,6 +57,7 @@
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix-test",
+    "test:bun": "bun x --bun remix-test",
     "test:coverage": "remix-test --coverage",
     "typecheck": "tsgo --noEmit"
   },

--- a/packages/data-table-sqlite/.changes/minor.native-sqlite-clients.md
+++ b/packages/data-table-sqlite/.changes/minor.native-sqlite-clients.md
@@ -1,0 +1,1 @@
+Widened `createSqliteDatabaseAdapter` to accept synchronous SQLite clients that match the shared `prepare`/`exec` surface used by Node's `node:sqlite`, Bun's `bun:sqlite`, and compatible clients. The package no longer requires `better-sqlite3` as an optional peer dependency.

--- a/packages/data-table-sqlite/README.md
+++ b/packages/data-table-sqlite/README.md
@@ -1,11 +1,11 @@
 # data-table-sqlite
 
 SQLite adapter for [`remix/data-table`](https://github.com/remix-run/remix/tree/main/packages/data-table).
-Use this package when you want `data-table` APIs backed by `better-sqlite3`.
+Use this package when you want `data-table` APIs backed by a synchronous SQLite client.
 
 ## Features
 
-- **Native `better-sqlite3` Integration**: Works well for local and embedded deployments
+- **Native Runtime SQLite Support**: Works with Node's `node:sqlite` `DatabaseSync`, Bun's `bun:sqlite` `Database`, and compatible synchronous SQLite clients
 - **Full `data-table` API Support**: Queries, relations, writes, and transactions
 - **Adapter-Owned Compiler**: SQL compilation lives in this adapter, with optional shared pure helpers from `data-table`
 - **Migration DDL Support**: Compiles and executes `DataMigrationOperation` operations for `remix/data-table/migrations`
@@ -19,13 +19,26 @@ Use this package when you want `data-table` APIs backed by `better-sqlite3`.
 ## Installation
 
 ```sh
-npm i remix better-sqlite3
+npm i remix
 ```
 
 ## Usage
 
+### Node
+
 ```ts
-import Database from 'better-sqlite3'
+import { DatabaseSync } from 'node:sqlite'
+import { createDatabase } from 'remix/data-table'
+import { createSqliteDatabaseAdapter } from 'remix/data-table-sqlite'
+
+let sqlite = new DatabaseSync('app.db')
+let db = createDatabase(createSqliteDatabaseAdapter(sqlite))
+```
+
+### Bun
+
+```ts
+import { Database } from 'bun:sqlite'
 import { createDatabase } from 'remix/data-table'
 import { createSqliteDatabaseAdapter } from 'remix/data-table-sqlite'
 
@@ -34,7 +47,7 @@ let db = createDatabase(createSqliteDatabaseAdapter(sqlite))
 ```
 
 This is a good fit for local development, embedded deployments, and single-node services.
-Import any driver-specific types you need directly from `better-sqlite3`.
+Import any driver-specific types you need directly from your runtime's SQLite module.
 
 ## Adapter Capabilities
 
@@ -51,11 +64,11 @@ Import any driver-specific types you need directly from `better-sqlite3`.
 ### In-Memory Database For Tests
 
 ```ts
-import Database from 'better-sqlite3'
+import { DatabaseSync } from 'node:sqlite'
 import { createDatabase } from 'remix/data-table'
 import { createSqliteDatabaseAdapter } from 'remix/data-table-sqlite'
 
-let sqlite = new Database(':memory:')
+let sqlite = new DatabaseSync(':memory:')
 let db = createDatabase(createSqliteDatabaseAdapter(sqlite))
 ```
 

--- a/packages/data-table-sqlite/package.json
+++ b/packages/data-table-sqlite/package.json
@@ -36,27 +36,18 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/data-table": "workspace:*",
     "@remix-run/test": "workspace:*",
-    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
-    "better-sqlite3": "^12.4.1"
+    "@typescript/native-preview": "catalog:"
   },
   "dependencies": {
     "@remix-run/data-table": "workspace:^"
-  },
-  "peerDependencies": {
-    "better-sqlite3": "^12.4.1"
-  },
-  "peerDependenciesMeta": {
-    "better-sqlite3": {
-      "optional": true
-    }
   },
   "scripts": {
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix-test",
+    "test:bun": "bun x --bun remix-test",
     "test:coverage": "remix-test --coverage",
     "typecheck": "tsgo --noEmit"
   },

--- a/packages/data-table-sqlite/src/index.ts
+++ b/packages/data-table-sqlite/src/index.ts
@@ -1,1 +1,2 @@
 export { createSqliteDatabaseAdapter, SqliteDatabaseAdapter } from './lib/adapter.ts'
+export type { SqliteDatabase, SqliteRunResult, SqliteStatement } from './lib/adapter.ts'

--- a/packages/data-table-sqlite/src/lib/adapter.integration.test.ts
+++ b/packages/data-table-sqlite/src/lib/adapter.integration.test.ts
@@ -1,5 +1,4 @@
 import { after, before, describe } from '@remix-run/test'
-import BetterSqlite3, { type Database as BetterSqliteDatabase } from 'better-sqlite3'
 import { createDatabase } from '@remix-run/data-table'
 
 import {
@@ -8,20 +7,24 @@ import {
   teardownAdapterIntegrationSchema,
 } from '../../../data-table/test/adapter-integration-schema.ts'
 import { runAdapterIntegrationContract } from '../../../data-table/test/adapter-integration-contract.ts'
+import {
+  createNativeSqliteDatabase,
+  type NativeSqliteDatabase,
+} from '../../../data-table/test/native-sqlite.ts'
 
 import { createSqliteDatabaseAdapter } from './adapter.ts'
 
-const integrationEnabled = process.env.DATA_TABLE_INTEGRATION === '1' && canOpenSqliteDatabase()
+const integrationEnabled = process.env.DATA_TABLE_INTEGRATION === '1'
 
 describe('sqlite adapter integration', () => {
-  let sqlite: BetterSqliteDatabase
+  let sqlite: NativeSqliteDatabase
 
   before(async () => {
     if (!integrationEnabled) {
       return
     }
 
-    sqlite = new BetterSqlite3(':memory:')
+    sqlite = createNativeSqliteDatabase()
     await setupAdapterIntegrationSchema(async (statement) => {
       sqlite.exec(statement)
     }, 'sqlite')
@@ -48,13 +51,3 @@ describe('sqlite adapter integration', () => {
     },
   })
 })
-
-function canOpenSqliteDatabase(): boolean {
-  try {
-    let database = new BetterSqlite3(':memory:')
-    database.close()
-    return true
-  } catch {
-    return false
-  }
-}

--- a/packages/data-table-sqlite/src/lib/adapter.test.ts
+++ b/packages/data-table-sqlite/src/lib/adapter.test.ts
@@ -2,6 +2,7 @@ import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 import type { DataMigrationOperation } from '@remix-run/data-table'
 import { column, createDatabase, table, eq } from '@remix-run/data-table'
+
 import { createNativeSqliteDatabase } from '../../../data-table/test/native-sqlite.ts'
 
 import { createSqliteDatabaseAdapter } from './adapter.ts'

--- a/packages/data-table-sqlite/src/lib/adapter.test.ts
+++ b/packages/data-table-sqlite/src/lib/adapter.test.ts
@@ -1,8 +1,8 @@
 import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
-import Database from 'better-sqlite3'
 import type { DataMigrationOperation } from '@remix-run/data-table'
 import { column, createDatabase, table, eq } from '@remix-run/data-table'
+import { createNativeSqliteDatabase } from '../../../data-table/test/native-sqlite.ts'
 
 import { createSqliteDatabaseAdapter } from './adapter.ts'
 
@@ -34,9 +34,7 @@ const accountProjects = table({
   primaryKey: ['account_id', 'project_id'],
 })
 
-const sqliteAvailable = canOpenSqliteDatabase()
-
-describe('sqlite adapter', { skip: !sqliteAvailable }, () => {
+describe('sqlite adapter', () => {
   it('short-circuits insertMany([]) and returns empty rows for returning queries', async () => {
     let prepareCalls = 0
     let sqlite = {
@@ -126,15 +124,11 @@ describe('sqlite adapter', { skip: !sqliteAvailable }, () => {
   })
 
   it('enables read uncommitted pragma for read-uncommitted transactions', async () => {
-    let pragmas: string[] = []
     let execs: string[] = []
 
     let sqlite = {
       prepare() {
         throw new Error('not used')
-      },
-      pragma(statement: string) {
-        pragmas.push(statement)
       },
       exec(statement: string) {
         execs.push(statement)
@@ -145,8 +139,7 @@ describe('sqlite adapter', { skip: !sqliteAvailable }, () => {
     let token = await adapter.beginTransaction({ isolationLevel: 'read uncommitted' })
     await adapter.commitTransaction(token)
 
-    assert.deepEqual(pragmas, ['read_uncommitted = true'])
-    assert.deepEqual(execs, ['begin', 'commit'])
+    assert.deepEqual(execs, ['pragma read_uncommitted = true', 'begin', 'commit'])
   })
 
   it('supports rollback and savepoint lifecycle with escaped names', async () => {
@@ -641,7 +634,7 @@ describe('sqlite adapter', { skip: !sqliteAvailable }, () => {
   })
 
   it('supports typed writes, reads, and nested transactions', async () => {
-    let sqlite = new Database(':memory:')
+    let sqlite = createNativeSqliteDatabase()
     sqlite.exec(
       'create table accounts (id integer primary key, email text not null, status text not null)',
     )
@@ -679,7 +672,7 @@ describe('sqlite adapter', { skip: !sqliteAvailable }, () => {
   })
 
   it('supports upsert and returning', async () => {
-    let sqlite = new Database(':memory:')
+    let sqlite = createNativeSqliteDatabase()
     sqlite.exec(
       'create table accounts (id integer primary key, email text not null, status text not null)',
     )
@@ -704,7 +697,7 @@ describe('sqlite adapter', { skip: !sqliteAvailable }, () => {
   })
 
   it('accepts transaction options as best-effort hints', async () => {
-    let sqlite = new Database(':memory:')
+    let sqlite = createNativeSqliteDatabase()
     sqlite.exec(
       'create table accounts (id integer primary key, email text not null, status text not null)',
     )
@@ -731,7 +724,7 @@ describe('sqlite adapter', { skip: !sqliteAvailable }, () => {
   })
 
   it('supports column-to-column comparisons from string references', async () => {
-    let sqlite = new Database(':memory:')
+    let sqlite = createNativeSqliteDatabase()
     sqlite.exec(
       'create table accounts (id integer primary key, email text not null, status text not null)',
     )
@@ -847,7 +840,7 @@ describe('sqlite adapter', { skip: !sqliteAvailable }, () => {
   })
 
   it('treats dotted select aliases as single identifiers', async () => {
-    let sqlite = new Database(':memory:')
+    let sqlite = createNativeSqliteDatabase()
     sqlite.exec(
       'create table accounts (id integer primary key, email text not null, status text not null)',
     )
@@ -863,13 +856,3 @@ describe('sqlite adapter', { skip: !sqliteAvailable }, () => {
     sqlite.close()
   })
 })
-
-function canOpenSqliteDatabase(): boolean {
-  try {
-    let database = new Database(':memory:')
-    database.close()
-    return true
-  } catch {
-    return false
-  }
-}

--- a/packages/data-table-sqlite/src/lib/adapter.ts
+++ b/packages/data-table-sqlite/src/lib/adapter.ts
@@ -18,12 +18,42 @@ import {
   quoteLiteral as quoteLiteralHelper,
   quoteTableRef as quoteTableRefHelper,
 } from '@remix-run/data-table/sql-helpers'
-import type { Database as BetterSqliteDatabase, RunResult } from 'better-sqlite3'
 
 import { compileSqliteOperation } from './sql-compiler.ts'
 
 /**
- * `DatabaseAdapter` implementation for Better SQLite3.
+ * Synchronous SQLite database client accepted by the sqlite adapter.
+ *
+ * This matches the shared surface of Node's `node:sqlite` `DatabaseSync`, Bun's `bun:sqlite`
+ * `Database`, and `better-sqlite3` database instances.
+ */
+export interface SqliteDatabase {
+  prepare(sql: string): SqliteStatement
+  exec(sql: string): unknown
+}
+
+/**
+ * Prepared statement shape used by {@link SqliteDatabase}.
+ */
+export interface SqliteStatement {
+  all(...values: unknown[]): unknown[]
+  get(...values: unknown[]): unknown
+  run(...values: unknown[]): SqliteRunResult
+  reader?: boolean
+  columns?: () => unknown[]
+  columnNames?: string[]
+}
+
+/**
+ * SQLite write execution metadata.
+ */
+export interface SqliteRunResult {
+  changes: number
+  lastInsertRowid: unknown
+}
+
+/**
+ * `DatabaseAdapter` implementation for synchronous SQLite clients.
  */
 export class SqliteDatabaseAdapter implements DatabaseAdapter {
   /**
@@ -36,11 +66,11 @@ export class SqliteDatabaseAdapter implements DatabaseAdapter {
    */
   capabilities
 
-  #database: BetterSqliteDatabase
+  #database: SqliteDatabase
   #transactions = new Set<string>()
   #transactionCounter = 0
 
-  constructor(database: BetterSqliteDatabase) {
+  constructor(database: SqliteDatabase) {
     this.#database = database
     this.capabilities = {
       returning: true,
@@ -82,7 +112,7 @@ export class SqliteDatabaseAdapter implements DatabaseAdapter {
     let statement = this.compileSql(request.operation)[0]
     let prepared = this.#database.prepare(statement.text)
 
-    if (prepared.reader) {
+    if (shouldReadStatement(request.operation, prepared)) {
       let rows = normalizeRows(prepared.all(...statement.values))
 
       if (request.operation.kind === 'count' || request.operation.kind === 'exists') {
@@ -175,7 +205,7 @@ export class SqliteDatabaseAdapter implements DatabaseAdapter {
    */
   async beginTransaction(options?: TransactionOptions): Promise<TransactionToken> {
     if (options?.isolationLevel === 'read uncommitted') {
-      this.#database.pragma('read_uncommitted = true')
+      this.#database.exec('pragma read_uncommitted = true')
     }
 
     this.#database.exec('begin')
@@ -251,21 +281,20 @@ export class SqliteDatabaseAdapter implements DatabaseAdapter {
 
 /**
  * Creates a sqlite `DatabaseAdapter`.
- * @param database Better SQLite3 database instance.
- * @param options Optional adapter capability overrides.
+ * @param database Synchronous SQLite database client.
  * @returns A configured sqlite adapter.
  * @example
  * ```ts
- * import BetterSqlite3 from 'better-sqlite3'
+ * import { DatabaseSync } from 'node:sqlite'
  * import { createDatabase } from 'remix/data-table'
  * import { createSqliteDatabaseAdapter } from 'remix/data-table-sqlite'
  *
- * let sqlite = new BetterSqlite3('./data/app.db')
+ * let sqlite = new DatabaseSync('./data/app.db')
  * let adapter = createSqliteDatabaseAdapter(sqlite)
  * let db = createDatabase(adapter)
  * ```
  */
-export function createSqliteDatabaseAdapter(database: BetterSqliteDatabase): SqliteDatabaseAdapter {
+export function createSqliteDatabaseAdapter(database: SqliteDatabase): SqliteDatabaseAdapter {
   return new SqliteDatabaseAdapter(database)
 }
 
@@ -339,7 +368,7 @@ function normalizeInsertIdForReader(
 
 function normalizeAffectedRowsForRun(
   kind: DataManipulationRequest['operation']['kind'],
-  result: RunResult,
+  result: SqliteRunResult,
 ): number | undefined {
   if (kind === 'select' || kind === 'count' || kind === 'exists') {
     return undefined
@@ -351,7 +380,7 @@ function normalizeAffectedRowsForRun(
 function normalizeInsertIdForRun(
   kind: DataManipulationRequest['operation']['kind'],
   operation: DataManipulationRequest['operation'],
-  result: RunResult,
+  result: SqliteRunResult,
 ): unknown {
   if (!isInsertOperationKind(kind) || !isInsertOperation(operation)) {
     return undefined
@@ -362,6 +391,33 @@ function normalizeInsertIdForRun(
   }
 
   return result.lastInsertRowid
+}
+
+function shouldReadStatement(
+  operation: DataManipulationRequest['operation'],
+  statement: SqliteStatement,
+): boolean {
+  if (operation.kind === 'select' || operation.kind === 'count' || operation.kind === 'exists') {
+    return true
+  }
+
+  if (operation.kind !== 'raw') {
+    return operation.returning !== undefined
+  }
+
+  if (typeof statement.reader === 'boolean') {
+    return statement.reader
+  }
+
+  if (statement.columns) {
+    return statement.columns().length > 0
+  }
+
+  try {
+    return statement.columnNames !== undefined && statement.columnNames.length > 0
+  } catch {
+    return false
+  }
 }
 
 function quoteIdentifier(value: string): string {

--- a/packages/data-table/README.md
+++ b/packages/data-table/README.md
@@ -28,7 +28,7 @@ npm i pg
 # or
 npm i mysql2
 # or
-npm i better-sqlite3
+# use the SQLite client built into your runtime
 ```
 
 ## Setup

--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -55,10 +55,8 @@
   "devDependencies": {
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
-    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
-    "better-sqlite3": "^12.4.1"
+    "@typescript/native-preview": "catalog:"
   },
   "dependencies": {},
   "scripts": {
@@ -66,6 +64,7 @@
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix-test",
+    "test:bun": "bun x --bun remix-test",
     "test:coverage": "remix-test --coverage",
     "typecheck": "tsgo --noEmit"
   },

--- a/packages/data-table/test/native-sqlite.ts
+++ b/packages/data-table/test/native-sqlite.ts
@@ -1,0 +1,48 @@
+export interface NativeSqliteDatabase {
+  prepare(sql: string): NativeSqliteStatement
+  exec(sql: string): unknown
+  close(): void
+}
+
+export interface NativeSqliteStatement {
+  all(...values: unknown[]): unknown[]
+  get(...values: unknown[]): unknown
+  run(...values: unknown[]): { changes: number; lastInsertRowid: unknown }
+}
+
+interface NativeSqliteDatabaseConstructor {
+  new (path: string): NativeSqliteDatabase
+}
+
+type RuntimeImport = (specifier: string) => Promise<unknown>
+
+const importRuntimeModule = Function('specifier', 'return import(specifier)') as RuntimeImport
+
+const sqliteModule = await importRuntimeModule(isBunRuntime() ? 'bun:sqlite' : 'node:sqlite')
+const NativeSqliteDatabaseConstructor = getNativeSqliteDatabaseConstructor(sqliteModule)
+
+export function createNativeSqliteDatabase(path = ':memory:'): NativeSqliteDatabase {
+  return new NativeSqliteDatabaseConstructor(path)
+}
+
+function isBunRuntime(): boolean {
+  return 'Bun' in globalThis
+}
+
+function getNativeSqliteDatabaseConstructor(value: unknown): NativeSqliteDatabaseConstructor {
+  if (!isRecord(value)) {
+    throw new TypeError('SQLite module did not load')
+  }
+
+  let constructor = isBunRuntime() ? value.Database : value.DatabaseSync
+
+  if (typeof constructor !== 'function') {
+    throw new TypeError('SQLite database constructor did not load')
+  }
+
+  return constructor as NativeSqliteDatabaseConstructor
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/packages/data-table/test/sqlite-test-database.ts
+++ b/packages/data-table/test/sqlite-test-database.ts
@@ -1,7 +1,6 @@
-import BetterSqlite3, { type Database as BetterSqliteDatabase } from 'better-sqlite3'
-
 import type { DatabaseAdapter } from '../src/lib/adapter.ts'
 import { createSqliteDatabaseAdapter } from './sqlite-adapter.ts'
+import { createNativeSqliteDatabase, type NativeSqliteDatabase } from './native-sqlite.ts'
 
 export type SqliteTestSeed = Record<string, Array<Record<string, unknown>>>
 
@@ -18,7 +17,7 @@ export function createSqliteTestAdapter(
   adapter: DatabaseAdapter
   close(): void
 } {
-  let sqlite = new BetterSqlite3(':memory:')
+  let sqlite = createNativeSqliteDatabase()
   initializeSchema(sqlite)
   seedDatabase(sqlite, seed)
   let adapter = createSqliteDatabaseAdapter(sqlite)
@@ -43,7 +42,7 @@ export function createSqliteTestAdapter(
   }
 }
 
-function initializeSchema(database: BetterSqliteDatabase): void {
+function initializeSchema(database: NativeSqliteDatabase): void {
   database.exec(
     [
       'create table accounts (',
@@ -107,7 +106,7 @@ function initializeSchema(database: BetterSqliteDatabase): void {
   )
 }
 
-function seedDatabase(database: BetterSqliteDatabase, seed: SqliteTestSeed): void {
+function seedDatabase(database: NativeSqliteDatabase, seed: SqliteTestSeed): void {
   for (let tableName in seed) {
     if (!Object.prototype.hasOwnProperty.call(seed, tableName)) {
       continue

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1786,7 +1786,7 @@ importers:
         version: 7.0.0-dev.20251125.1
       '@vitest/browser':
         specifier: ^3.2.4
-        version: 3.2.4(playwright@1.59.0)(vite@7.3.0(@types/node@24.10.4)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)
+        version: 3.2.4(playwright@1.59.0)(vite@7.3.0(@types/node@24.10.4)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
@@ -1798,7 +1798,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.10.4)(@vitest/browser@3.2.4)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/node@24.10.4)(@vitest/browser@3.2.4)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/ui/demo:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -701,18 +701,12 @@ importers:
       '@remix-run/test':
         specifier: workspace:*
         version: link:../test
-      '@types/better-sqlite3':
-        specifier: ^7.6.13
-        version: 7.6.13
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20251125.1
-      better-sqlite3:
-        specifier: ^12.4.1
-        version: 12.6.2
 
   packages/data-table-mysql:
     dependencies:
@@ -773,18 +767,12 @@ importers:
       '@remix-run/test':
         specifier: workspace:*
         version: link:../test
-      '@types/better-sqlite3':
-        specifier: ^7.6.13
-        version: 7.6.13
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20251125.1
-      better-sqlite3:
-        specifier: ^12.4.1
-        version: 12.6.2
 
   packages/fetch-proxy:
     dependencies:


### PR DESCRIPTION
This removes the `better-sqlite3` requirement from the data-table SQLite test path and extends Bun coverage across the data-table adapter packages. The SQLite adapter now accepts the shared synchronous SQLite surface used by Node's `node:sqlite`, Bun's `bun:sqlite`, and compatible clients.

- Widen `createSqliteDatabaseAdapter` to accept a structural sync SQLite client and export the related adapter input types.
- Use native runtime SQLite for data-table and data-table-sqlite tests so the same suites run in Node and Bun.
- Add `test:bun` scripts for MySQL and Postgres adapters and run data-table Bun checks in the integration workflow.
- Run MySQL and Postgres integration files in both Node and Bun against the workflow service containers.

```ts
import { DatabaseSync } from 'node:sqlite'
import { createDatabase } from 'remix/data-table'
import { createSqliteDatabaseAdapter } from 'remix/data-table-sqlite'

let sqlite = new DatabaseSync(':memory:')
let db = createDatabase(createSqliteDatabaseAdapter(sqlite))
```
