### PR TITLE
Fix lint warnings in tests and types

### DIFF
--- a/packages/assert/src/lib/assert.ts
+++ b/packages/assert/src/lib/assert.ts
@@ -95,7 +95,7 @@ export function equal<T>(actual: unknown, expected: T, message?: string): assert
  * @param expected - The value that `actual` must not equal.
  * @param message - Optional failure message.
  */
-export function notEqual<T>(actual: unknown, expected: unknown, message?: string): void {
+export function notEqual<_value>(actual: unknown, expected: unknown, message?: string): void {
   if (actual === expected) {
     throw new AssertionError({
       message: message || `${actual} === ${expected}`,
@@ -138,7 +138,7 @@ export function deepEqual<T>(actual: unknown, expected: T, message?: string): as
  * @param expected - The value that `actual` must not deeply equal.
  * @param message - Optional failure message.
  */
-export function notDeepEqual<T>(actual: unknown, expected: unknown, message?: string): void {
+export function notDeepEqual<_value>(actual: unknown, expected: unknown, message?: string): void {
   if (isDeepEqual(actual, expected)) {
     throw new AssertionError({
       message: message || `Objects are deeply equal`,

--- a/packages/assets/src/lib/asset-server.test.ts
+++ b/packages/assets/src/lib/asset-server.test.ts
@@ -92,10 +92,6 @@ async function getByFile(
   return get(assetServer, await assetServer.getHref(filePath), headers)
 }
 
-async function headByFile(assetServer: ReturnType<typeof createAssetServer>, filePath: string) {
-  return head(assetServer, await assetServer.getHref(filePath))
-}
-
 function post(assetServer: ReturnType<typeof createAssetServer>, pathname: string) {
   return assetServer.fetch(new Request(`http://localhost${pathname}`, { method: 'POST' }))
 }
@@ -3939,10 +3935,11 @@ describe('asset-server', () => {
         chokidarWatcher.emit('error', watchError)
 
         assert.equal(onError.mock.calls.length, 0)
-        assert.equal(
-          (consoleError.mock.calls.at(-1)?.arguments[1] as { code?: string }).code,
-          'EMFILE',
-        )
+        let lastConsoleError = consoleError.mock.calls.at(-1)
+        assert.ok(lastConsoleError)
+        let error = lastConsoleError.arguments[1]
+        assert.ok(error && typeof error === 'object' && 'code' in error)
+        assert.equal(error.code, 'EMFILE')
       } finally {
         consoleError.mock.restore?.()
         await assetServer.close()

--- a/packages/auth/src/lib/provider.ts
+++ b/packages/auth/src/lib/provider.ts
@@ -45,7 +45,7 @@ export interface OAuthResult<profile, provider extends string = string> {
 /**
  * Public shape for an OAuth or OIDC provider used by external auth request handlers.
  */
-export interface OAuthProvider<profile, provider extends string = string> {
+export interface OAuthProvider<_profile, provider extends string = string> {
   /** Provider name used for routing, callbacks, and persisted transactions. */
   name: provider
 }

--- a/packages/component/src/lib/mixin.ts
+++ b/packages/component/src/lib/mixin.ts
@@ -1,5 +1,5 @@
 import type { Context, FrameHandle } from './component.ts'
-import type { ElementProps, ElementType, RemixElement } from './jsx.ts'
+import type { ElementProps, RemixElement } from './jsx.ts'
 import type { Scheduler } from './scheduler.ts'
 import type { SchedulerPhaseEvent } from './scheduler.ts'
 import { jsx } from './jsx.ts'

--- a/packages/component/src/test/stream.test.tsx
+++ b/packages/component/src/test/stream.test.tsx
@@ -477,9 +477,9 @@ describe('stream', () => {
 
         expect(html).toBe('<div data-mode="children">safe</div>')
         expect(errorSpy).toHaveBeenCalledTimes(1)
-        expect((errorSpy.mock.calls[0]?.[0] as Error).message).toBe(
-          'mixin elements must not receive children',
-        )
+        let error = errorSpy.mock.calls[0]?.[0]
+        invariant(error instanceof Error)
+        expect(error.message).toBe('mixin elements must not receive children')
       } finally {
         errorSpy.mockRestore()
       }
@@ -496,9 +496,9 @@ describe('stream', () => {
 
         expect(html).toBe('<div data-mode="innerHTML">safe</div>')
         expect(errorSpy).toHaveBeenCalledTimes(1)
-        expect((errorSpy.mock.calls[0]?.[0] as Error).message).toBe(
-          'mixins must not return children or innerHTML',
-        )
+        let error = errorSpy.mock.calls[0]?.[0]
+        invariant(error instanceof Error)
+        expect(error.message).toBe('mixins must not return children or innerHTML')
       } finally {
         errorSpy.mockRestore()
       }

--- a/packages/component/src/test/vdom.mixins.test.tsx
+++ b/packages/component/src/test/vdom.mixins.test.tsx
@@ -97,9 +97,9 @@ describe('vnode mixins', () => {
       expect(container.querySelector('div')?.dataset.mode).toBe('children')
       expect(container.querySelector('div')?.textContent).toBe('safe')
       expect(errorSpy).toHaveBeenCalledTimes(1)
-      expect((errorSpy.mock.calls[0]?.[0] as Error).message).toBe(
-        'mixin elements must not receive children',
-      )
+      let error = errorSpy.mock.calls[0]?.[0]
+      invariant(error instanceof Error)
+      expect(error.message).toBe('mixin elements must not receive children')
     } finally {
       errorSpy.mockRestore()
     }
@@ -121,9 +121,9 @@ describe('vnode mixins', () => {
       expect(container.querySelector('div')?.dataset.mode).toBe('innerHTML')
       expect(container.querySelector('div')?.textContent).toBe('safe')
       expect(errorSpy).toHaveBeenCalledTimes(1)
-      expect((errorSpy.mock.calls[0]?.[0] as Error).message).toBe(
-        'mixins must not return children or innerHTML',
-      )
+      let error = errorSpy.mock.calls[0]?.[0]
+      invariant(error instanceof Error)
+      expect(error.message).toBe('mixins must not return children or innerHTML')
     } finally {
       errorSpy.mockRestore()
     }

--- a/packages/fetch-router/src/lib/controller.ts
+++ b/packages/fetch-router/src/lib/controller.ts
@@ -87,7 +87,7 @@ export type ControllerInput<
  * Actions can be plain handler functions or action objects with optional inline middleware.
  */
 export type Action<
-  method extends RequestMethod | 'ANY',
+  _method extends RequestMethod | 'ANY',
   pattern extends string,
   context extends RequestContext<any, any> = RequestContext,
 > = ActionInput<Params<pattern>, WithParams<context, Params<pattern>>, readonly AnyMiddleware[]>

--- a/packages/fetch-router/src/lib/middleware.ts
+++ b/packages/fetch-router/src/lib/middleware.ts
@@ -80,7 +80,7 @@ export type MiddlewareContext<middleware extends readonly AnyMiddleware[]> = App
  * @returns A response to short-circuit the chain, or `undefined`/`void` to continue
  */
 export interface Middleware<
-  method extends RequestMethod | 'ANY' = RequestMethod | 'ANY',
+  _method extends RequestMethod | 'ANY' = RequestMethod | 'ANY',
   params extends Record<string, any> = {},
   transform extends MiddlewareContextTransform = IdentityContextTransform,
 > {
@@ -106,7 +106,7 @@ export interface Middleware<
 export type NextFunction = () => Promise<Response>
 
 export function runMiddleware<
-  method extends RequestMethod | 'ANY' = RequestMethod | 'ANY',
+  _method extends RequestMethod | 'ANY' = RequestMethod | 'ANY',
   params extends Record<string, any> = {},
 >(
   middleware: AnyMiddleware[],

--- a/packages/ui/demo/app/theme-builder.tsx
+++ b/packages/ui/demo/app/theme-builder.tsx
@@ -42,11 +42,6 @@ type ThemeTokenGroup = {
 
 const DEFAULT_THEME_VALUES = RMX_01.values
 const THEME_TOKEN_GROUPS = createThemeTokenGroups(DEFAULT_THEME_VALUES)
-const DEFAULT_OPEN_TOKEN_GROUPS = THEME_TOKEN_GROUPS.slice(0, 1).map((group) => group.id)
-const THEME_TOKEN_COUNT = THEME_TOKEN_GROUPS.reduce(
-  (count, group) => count + group.tokens.length,
-  0,
-)
 
 const AIRPORT_OPTIONS = [
   { label: 'Austin Bergstrom', searchValue: ['aus', 'austin'], value: 'aus' },
@@ -823,29 +818,6 @@ const previewPanelCss = css({
   '@media (max-width: 760px)': {
     padding: theme.space.lg,
   },
-})
-
-const previewHeaderCss = css({
-  display: 'grid',
-  gap: theme.space.xs,
-  marginBottom: theme.space.xl,
-})
-
-const previewPageTitleCss = css({
-  margin: 0,
-  color: theme.colors.text.primary,
-  fontSize: 'clamp(24px, 3vw, 36px)',
-  fontWeight: theme.fontWeight.semibold,
-  letterSpacing: theme.letterSpacing.tight,
-  lineHeight: theme.lineHeight.tight,
-})
-
-const previewPageDescriptionCss = css({
-  margin: 0,
-  maxWidth: '56ch',
-  color: theme.colors.text.secondary,
-  fontSize: theme.fontSize.sm,
-  lineHeight: theme.lineHeight.relaxed,
 })
 
 const previewStackCss = css({

--- a/packages/ui/src/lib/accordion/accordion.test.tsx
+++ b/packages/ui/src/lib/accordion/accordion.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { createRoot, on, type Handle, type RemixNode } from '@remix-run/component'
+import { createRoot, type Handle, type RemixNode } from '@remix-run/component'
 import { renderToString } from '@remix-run/component/server'
 
 import {

--- a/packages/ui/src/lib/combobox/combobox.test.tsx
+++ b/packages/ui/src/lib/combobox/combobox.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createRoot, type Handle, type RemixNode } from '@remix-run/component'
+import { createRoot, type RemixNode } from '@remix-run/component'
 
 import {
   Combobox,

--- a/packages/ui/src/lib/menu/menu.test.tsx
+++ b/packages/ui/src/lib/menu/menu.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createRoot, on, type RemixNode } from '@remix-run/component'
+import { createRoot, type RemixNode } from '@remix-run/component'
 
 import { Menu, MenuItem, onMenuSelect, Submenu, type MenuSelectEvent } from './menu.tsx'
 

--- a/packages/ui/src/lib/tabs/tabs.test.tsx
+++ b/packages/ui/src/lib/tabs/tabs.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { createRoot, css, on, type Handle, type RemixNode } from '@remix-run/component'
+import { createRoot, css, type Handle, type RemixNode } from '@remix-run/component'
 import { renderToString } from '@remix-run/component/server'
 
 import {


### PR DESCRIPTION
This cleans up linter warnings in tests and type declarations without changing runtime behavior.

- Checks mocked console calls before reading nested error properties, removing the unsafe optional chaining warnings
- Removes unused test helpers, imports, and demo constants/styles
- Preserves public generic arity while marking intentionally unused type parameters with underscore-prefixed names
