### PR TITLE
Remove remix/test assertion re-export docs

### DIFF
--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -328,24 +328,6 @@ export default {
 
 Set `browser.open: true` to keep the browser open after tests finish — useful for debugging failures.
 
-### Assertions
-
-`remix/test` re-exports `remix/assert`. See the [`@remix-run/assert` README](../assert/README.md) for full API documentation.
-
-```ts
-import * as assert from 'remix/assert'
-
-assert.ok(value)
-assert.equal(actual, expected)
-assert.notEqual(actual, expected)
-assert.deepEqual(actual, expected)
-assert.notDeepEqual(actual, expected)
-assert.match(string, regexp)
-assert.throws(fn)
-await assert.rejects(asyncFn)
-assert.fail('message')
-```
-
 ## License
 
 See [LICENSE](https://github.com/remix-run/remix/blob/main/LICENSE)


### PR DESCRIPTION
The `@remix-run/test` entrypoint no longer documents assertions as part of the `remix/test` surface. On `main`, the package source already only exports test framework APIs, so this removes the stale README section claiming `remix/test` re-exports `remix/assert`.

- Removes the `Assertions` section from `packages/test/README.md`.
- Keeps assertion usage pointed at the dedicated `remix/assert` entrypoint in existing examples.
- Avoids documenting `remix/assert` as part of the `remix/test` API surface.
