### PR TITLE
Fix bookstore Windows e2e crash

### DIFF
--- a/demos/bookstore/remix-test.config.ts
+++ b/demos/bookstore/remix-test.config.ts
@@ -1,20 +1,27 @@
 import type { RemixTestConfig } from 'remix/test'
+import type { PlaywrightTestConfig } from 'playwright/test'
+import { platform } from 'node:process'
+
+const projects: NonNullable<PlaywrightTestConfig['projects']> = [
+  {
+    name: 'chromium',
+    use: { browserName: 'chromium' },
+  },
+]
+
+if (platform !== 'win32') {
+  projects.push({
+    name: 'firefox',
+    use: { browserName: 'firefox' },
+  })
+}
 
 export default {
-  // better-sqlite3 may crash on Windows when this demo opens many in-memory
-  // databases across test workers concurrently.
+  // better-sqlite3 may crash on Windows when this demo opens in-memory
+  // databases across multiple test workers or browser project runs.
   concurrency: 1,
   playwrightConfig: {
-    projects: [
-      {
-        name: 'chromium',
-        use: { browserName: 'chromium' },
-      },
-      {
-        name: 'firefox',
-        use: { browserName: 'firefox' },
-      },
-    ],
+    projects,
     use: {
       navigationTimeout: 5_000,
       actionTimeout: 5_000,


### PR DESCRIPTION
The Windows main test job is crashing in the bookstore demo e2e run after the Chromium pass, before the Firefox pass, with native exit status `3221225477`. The demo already isolates its Windows run because `better-sqlite3` can crash under heavier test-worker load, but it still opens multiple browser project runs against the in-memory database.

- Runs the bookstore demo e2e suite with Chromium only on Windows
- Keeps Chromium and Firefox coverage for the bookstore demo on non-Windows platforms
- Leaves the existing Windows main workflow isolation in place
