### PR TITLE
Fix Remix CLI scaffold placeholders

### DIFF
--- a/packages/cli/bootstrap/AGENTS.md
+++ b/packages/cli/bootstrap/AGENTS.md
@@ -1,4 +1,4 @@
-# **RMX_APP_DISPLAY_NAME** Agent Guide
+# %%RMX_APP_DISPLAY_NAME%% Agent Guide
 
 This app was scaffolded with `remix new`. Use these conventions when continuing to build it out.
 

--- a/packages/cli/bootstrap/README.md
+++ b/packages/cli/bootstrap/README.md
@@ -1,4 +1,4 @@
-# **RMX_APP_DISPLAY_NAME**
+# %%RMX_APP_DISPLAY_NAME%%
 
 A minimal Remix application starter with a home page and an auth page.
 

--- a/packages/cli/bootstrap/app/controllers/home.tsx
+++ b/packages/cli/bootstrap/app/controllers/home.tsx
@@ -4,7 +4,7 @@ import type { routes } from '../routes.ts'
 import { Layout } from '../ui/layout.tsx'
 import { render } from '../utils/render.tsx'
 
-const APP_DISPLAY_NAME = decodeURIComponent('__RMX_APP_DISPLAY_NAME_URI_COMPONENT__')
+const APP_DISPLAY_NAME = decodeURIComponent('%%RMX_APP_DISPLAY_NAME_URI_COMPONENT%%')
 
 export const home: BuildAction<'GET', typeof routes.home> = {
   handler() {

--- a/packages/cli/bootstrap/app/ui/document.tsx
+++ b/packages/cli/bootstrap/app/ui/document.tsx
@@ -5,7 +5,7 @@ export interface DocumentProps {
   title?: string
 }
 
-const DEFAULT_TITLE = decodeURIComponent('__RMX_APP_DISPLAY_NAME_URI_COMPONENT__')
+const DEFAULT_TITLE = decodeURIComponent('%%RMX_APP_DISPLAY_NAME_URI_COMPONENT%%')
 
 export function Document() {
   return ({ title = DEFAULT_TITLE, children }: DocumentProps) => (

--- a/packages/cli/src/lib/bootstrap-project.ts
+++ b/packages/cli/src/lib/bootstrap-project.ts
@@ -100,8 +100,8 @@ function readDefaultRemixVersion(runtimeVersion: string | undefined): string {
 
 function createTemplateValues(config: BootstrapConfig): TemplateValues {
   return {
-    __RMX_APP_DISPLAY_NAME__: config.appDisplayName,
-    __RMX_APP_DISPLAY_NAME_URI_COMPONENT__: encodeURIComponent(config.appDisplayName),
+    '%%RMX_APP_DISPLAY_NAME%%': config.appDisplayName,
+    '%%RMX_APP_DISPLAY_NAME_URI_COMPONENT%%': encodeURIComponent(config.appDisplayName),
   }
 }
 


### PR DESCRIPTION
This fixes the scaffold placeholder bug that is making release PR #11259 fail. The markdown bootstrap files had placeholders shaped like Markdown emphasis, so they were rewritten to `**RMX_APP_DISPLAY_NAME**` before the CLI replacement step could fill in the app name.

- Switches the Remix CLI bootstrap placeholders to `%%...%%` delimiters that are inert in markdown and TSX string literals
- Updates the replacement map to use the same delimiter syntax across markdown and TSX templates
- Relies on the existing CLI scaffold tests to verify generated `AGENTS.md`, `README.md`, and encoded TSX app names

No extra change file is needed because this repairs the unreleased CLI scaffold covered by the existing initial release note.
