### PR TITLE
Optimize @remix-run/ui runtime performance

### DIFF
--- a/packages/ui/.changes/patch.runtime-performance.md
+++ b/packages/ui/.changes/patch.runtime-performance.md
@@ -1,0 +1,1 @@
+Improved runtime rendering performance by reducing child normalization, keyed reconciliation, mixin lifecycle, scheduler phase, and host insertion overhead.

--- a/packages/ui/src/runtime/jsx.ts
+++ b/packages/ui/src/runtime/jsx.ts
@@ -380,19 +380,18 @@ function normalizeElementProps(props: ElementProps | null | undefined): ElementP
 function normalizeMixValue(mix: unknown): unknown[] | undefined {
   if (!mix) return undefined
 
-  let normalizedMix = flattenMixValue(mix)
+  let normalizedMix: unknown[] = []
+  flattenMixValue(mix, normalizedMix)
   return normalizedMix.length === 0 ? undefined : normalizedMix
 }
 
-function flattenMixValue(mix: unknown): unknown[] {
-  if (!mix) return []
-  if (!Array.isArray(mix)) return [mix]
-
-  let flattened: unknown[] = []
-
-  for (let item of mix) {
-    flattened.push(...flattenMixValue(item))
+function flattenMixValue(mix: unknown, out: unknown[]): void {
+  if (!mix) return
+  if (!Array.isArray(mix)) {
+    out.push(mix)
+    return
   }
-
-  return flattened
+  for (let item of mix) {
+    flattenMixValue(item, out)
+  }
 }

--- a/packages/ui/src/runtime/reconcile.ts
+++ b/packages/ui/src/runtime/reconcile.ts
@@ -1426,6 +1426,38 @@ function diffChildren(
     return
   }
 
+  if (currLength === nextLength) {
+    let canDiffByPosition = true
+    for (let i = 0; i < nextLength; i++) {
+      let currentNode = curr[i]
+      let nextNode = next[i]
+      if (!currentNode || currentNode.key !== nextNode.key || currentNode.type !== nextNode.type) {
+        canDiffByPosition = false
+        break
+      }
+    }
+
+    if (canDiffByPosition) {
+      for (let i = 0; i < nextLength; i++) {
+        diffVNodes(
+          curr[i],
+          next[i],
+          domParent,
+          frame,
+          scheduler,
+          styles,
+          vParent,
+          rootTarget,
+          anchor,
+          cursor,
+        )
+      }
+
+      vParent._children = next
+      return
+    }
+  }
+
   // --- O(n + m) keyed diff with Map-based lookup ------------------------------
 
   let oldChildren = curr

--- a/packages/ui/src/runtime/reconcile.ts
+++ b/packages/ui/src/runtime/reconcile.ts
@@ -460,8 +460,11 @@ function diffHost(
   let mixState = curr._mixState as MixinRuntimeState | undefined
   let currProps = getHostProps(curr)
   let nextProps = resolveNodeMixProps(next, frame, scheduler, mixState)
-  if (shouldDispatchInlineMixinLifecycle(curr._dom)) {
-    dispatchMixinBeforeUpdate(next._mixState as MixinRuntimeState | undefined)
+  let nextMixState = next._mixState as MixinRuntimeState | undefined
+  let shouldDispatchMixinLifecycle =
+    (nextMixState?.runners.length ?? 0) > 0 && shouldDispatchInlineMixinLifecycle(curr._dom)
+  if (shouldDispatchMixinLifecycle) {
+    dispatchMixinBeforeUpdate(nextMixState)
   }
 
   // Handle innerHTML prop BEFORE diffChildren to avoid clearing children
@@ -498,10 +501,8 @@ function diffHost(
   }
 
   bindNodeMixRuntime(next as CommittedHostNode, frame, scheduler, styles)
-  if (shouldDispatchInlineMixinLifecycle(curr._dom)) {
-    scheduler.enqueueCommitPhase([
-      () => dispatchMixinCommit(next._mixState as MixinRuntimeState | undefined),
-    ])
+  if (shouldDispatchMixinLifecycle) {
+    scheduler.enqueueCommitPhase([() => dispatchMixinCommit(nextMixState)])
   }
 
   return

--- a/packages/ui/src/runtime/reconcile.ts
+++ b/packages/ui/src/runtime/reconcile.ts
@@ -332,6 +332,8 @@ function bindNodeMixRuntime(
 }
 
 function isHeadHostNode(node: HostNode): boolean {
+  if (node.type === 'head') return true
+  if (node.type.length !== 4) return false
   return node.type.toLowerCase() === 'head'
 }
 

--- a/packages/ui/src/runtime/scheduler.ts
+++ b/packages/ui/src/runtime/scheduler.ts
@@ -49,6 +49,10 @@ export function createScheduler(
   let cascadingUpdateCount = 0
   let resetScheduled = false
   let phaseEvents = new EventTarget()
+  let phaseListenerCounts: Record<SchedulerPhaseType, number> = {
+    beforeUpdate: 0,
+    commit: 0,
+  }
   let scheduler: {
     enqueue(vnode: CommittedComponentNode, domParent: ParentNode): void
     enqueueWork(newTasks: EmptyFn[]): void
@@ -172,6 +176,7 @@ export function createScheduler(
   }
 
   function dispatchPhaseEvent(type: SchedulerPhaseType, parents: ParentNode[]) {
+    if (phaseListenerCounts[type] === 0) return
     let event = new Event(type) as SchedulerPhaseEvent
     event.parents = parents
     phaseEvents.dispatchEvent(event)
@@ -246,10 +251,12 @@ export function createScheduler(
     },
 
     addEventListener(type, listener, options) {
+      if (listener) phaseListenerCounts[type]++
       phaseEvents.addEventListener(type, listener, options)
     },
 
     removeEventListener(type, listener, options) {
+      if (listener) phaseListenerCounts[type] = Math.max(0, phaseListenerCounts[type] - 1)
       phaseEvents.removeEventListener(type, listener, options)
     },
 

--- a/packages/ui/src/runtime/to-vnode.ts
+++ b/packages/ui/src/runtime/to-vnode.ts
@@ -4,22 +4,22 @@ import type { RemixElement, RemixNode } from './jsx.ts'
 import { isRemixElement, TEXT_NODE, type VNode } from './vnode.ts'
 
 function flatMapChildrenToVNodes(node: RemixElement): VNode[] {
-  return 'children' in node.props
-    ? Array.isArray(node.props.children)
-      ? node.props.children.flat(Infinity).map(toVNode)
-      : [toVNode(node.props.children)]
-    : []
+  if (!('children' in node.props)) return []
+  let children = node.props.children
+  if (!Array.isArray(children)) return [toVNode(children)]
+  let vnodes: VNode[] = []
+  flattenChildrenToVNodes(children, vnodes)
+  return vnodes
 }
 
-function flattenRemixNodeArray(nodes: RemixNode[], out: RemixNode[] = []): RemixNode[] {
+function flattenChildrenToVNodes(nodes: RemixNode[], out: VNode[]): void {
   for (let child of nodes) {
     if (Array.isArray(child)) {
-      flattenRemixNodeArray(child, out)
+      flattenChildrenToVNodes(child, out)
     } else {
-      out.push(child)
+      out.push(toVNode(child))
     }
   }
-  return out
 }
 
 export function toVNode(node: RemixNode): VNode {
@@ -32,8 +32,9 @@ export function toVNode(node: RemixNode): VNode {
   }
 
   if (Array.isArray(node)) {
-    let flatChildren = flattenRemixNodeArray(node)
-    return { type: Fragment, _children: flatChildren.map(toVNode) }
+    let children: VNode[] = []
+    flattenChildrenToVNodes(node, children)
+    return { type: Fragment, _children: children }
   }
 
   if (node.type === Fragment) {


### PR DESCRIPTION
This improves `@remix-run/ui` runtime rendering performance in the browser benchmark harness by reducing hot-path work in child normalization, keyed reconciliation, mixin lifecycle dispatch, scheduler phase dispatch, and host insertion checks.

- Flattens children and JSX `mix` values in a single pass to avoid intermediate arrays in common render paths.
- Fast-paths keyed child lists that keep the same key/type order so updates can skip the keyed map placement path.
- Skips mixin lifecycle and scheduler phase dispatch work when there is nothing registered to observe it.
- Avoids lowercasing most host tags while checking for the special `<head>` reconciliation path.

Measured with:

```sh
pnpm --dir packages/ui/bench run build-frameworks >/tmp/remix-ui-build.log && pnpm --dir packages/ui/bench bench --framework remix --benchmark create1k --benchmark update --benchmark selectRow --benchmark removeRow --runs 3 --warmups 1 --headless --table
```

The autoresearch run started from a `344 ms` total median for `create1k + update + selectRow + removeRow` and retained a final `304 ms` total median, a `40 ms` improvement (~11.6% lower). The retained operation medians were:

- `create1k`: `152 ms`
- `update`: `40 ms`
- `selectRow`: `40 ms`
- `removeRow`: `72 ms`

The package guard passed with `pnpm --filter @remix-run/ui run typecheck && pnpm --filter @remix-run/ui run test`.
