### PR TITLE
Run bookstore tests serially on Windows

### DIFF
--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -212,8 +212,11 @@ jobs:
       - name: Run tests
         run: |
           # node:sqlite currently crashes in the bookstore demo on Windows under
-          # the full workspace test load. Ubuntu keeps bookstore coverage.
+          # the full workspace test load, so run it serially below.
           pnpm --parallel --filter "!bookstore-demo" --filter "!remix-the-web" run test
+
+      - name: Run bookstore tests
+        run: node ./scripts/run-bookstore-tests-serially.ts
 
   lint:
     name: Lint

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -236,6 +236,23 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node ./scripts/detect-changed-packages.ts "$PR_BASE_SHA" "$PR_HEAD_SHA"
 
+      - name: Detect bookstore test changes
+        id: bookstore-tests
+        shell: bash
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" | grep -Eq '^(\.github/workflows/(check-main|check-pr|test)\.yaml|demos/bookstore/)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run bookstore tests
+        if: steps.bookstore-tests.outputs.run == 'true'
+        run: node ./scripts/run-bookstore-tests-serially.ts
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -125,6 +125,20 @@ jobs:
       - name: Run changed package tests
         run: node ./scripts/detect-changed-packages.ts origin/${{ github.base_ref }}
 
+      - name: Detect bookstore test changes
+        id: bookstore-tests
+        shell: bash
+        run: |
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -Eq '^(\.github/workflows/(check-main|check-pr|test)\.yaml|demos/bookstore/)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run bookstore tests
+        if: steps.bookstore-tests.outputs.run == 'true'
+        run: node ./scripts/run-bookstore-tests-serially.ts
+
   test-windows-main:
     name: test (windows-latest)
     if: github.event_name == 'push'
@@ -166,5 +180,8 @@ jobs:
       - name: Run tests
         run: |
           # node:sqlite currently crashes in the bookstore demo on Windows under
-          # the full workspace test load. Ubuntu keeps bookstore coverage.
+          # the full workspace test load, so run it serially below.
           pnpm --parallel --filter "!bookstore-demo" --filter "!remix-the-web" run test
+
+      - name: Run bookstore tests
+        run: node ./scripts/run-bookstore-tests-serially.ts

--- a/demos/bookstore/app/app.test.e2e.ts
+++ b/demos/bookstore/app/app.test.e2e.ts
@@ -1,16 +1,14 @@
 import * as assert from 'remix/assert'
 import { createTestServer } from 'remix/node-fetch-server/test'
-import { afterAll, describe, it } from 'remix/test'
+import { describe, it } from 'remix/test'
 import { createBookstoreRouter } from './router.ts'
 import { books } from './data/schema.ts'
-import { closeBookstoreDatabase, db, initializeBookstoreDatabase } from './data/setup.ts'
+import { db, initializeBookstoreDatabase } from './data/setup.ts'
 
 const router = createBookstoreRouter()
 
 // Initialize DB for this worker thread
 await initializeBookstoreDatabase()
-
-afterAll(() => closeBookstoreDatabase())
 
 describe('e2e', () => {
   it('adds to cart', async (t) => {

--- a/demos/bookstore/remix-test.config.ts
+++ b/demos/bookstore/remix-test.config.ts
@@ -19,9 +19,9 @@ if (platform !== 'win32') {
 export default {
   ...(platform === 'win32'
     ? {
-        // node:sqlite crashes after the bookstore e2e worker exits on Windows.
-        // Keep Windows coverage on concurrent server/browser tests until that stabilizes.
-        type: 'server,browser',
+        // node:sqlite currently crashes on Windows when this demo opens SQLite
+        // databases across multiple test workers concurrently.
+        concurrency: 1,
       }
     : {}),
   playwrightConfig: {

--- a/scripts/run-bookstore-tests-serially.ts
+++ b/scripts/run-bookstore-tests-serially.ts
@@ -1,0 +1,126 @@
+import * as cp from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+type TestType = 'server' | 'browser' | 'e2e'
+
+type BookstoreTest = {
+  file: string
+  type: TestType
+}
+
+const repoRoot = process.cwd()
+const bookstoreRoot = path.join(repoRoot, 'demos', 'bookstore')
+const appRoot = path.join(bookstoreRoot, 'app')
+
+function main() {
+  let tests = getBookstoreTests()
+
+  if (tests.length === 0) {
+    throw new Error(`No bookstore tests found in ${appRoot}`)
+  }
+
+  console.log('Running bookstore tests one file at a time:')
+  for (let test of tests) {
+    console.log(`- ${test.type}: ${test.file}`)
+  }
+  console.log()
+
+  for (let test of tests) {
+    runBookstoreTest(test)
+  }
+}
+
+function getBookstoreTests(): BookstoreTest[] {
+  let testFiles = getTestFiles(appRoot)
+
+  return testFiles
+    .map((file) => ({
+      file: toPosixPath(path.relative(bookstoreRoot, file)),
+      type: getTestType(file),
+    }))
+    .sort((a, b) => {
+      let typeOrder = getTypeOrder(a.type) - getTypeOrder(b.type)
+      return typeOrder === 0 ? a.file.localeCompare(b.file) : typeOrder
+    })
+}
+
+function getTestFiles(dir: string): string[] {
+  let entries = fs.readdirSync(dir, { withFileTypes: true })
+  let testFiles: string[] = []
+
+  for (let entry of entries) {
+    let file = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      testFiles.push(...getTestFiles(file))
+      continue
+    }
+
+    if (entry.isFile() && /\.test(?:\.(?:browser|e2e))?\.tsx?$/.test(entry.name)) {
+      testFiles.push(file)
+    }
+  }
+
+  return testFiles
+}
+
+function getTestType(file: string): TestType {
+  if (/\.test\.browser\.tsx?$/.test(file)) {
+    return 'browser'
+  }
+
+  if (/\.test\.e2e\.tsx?$/.test(file)) {
+    return 'e2e'
+  }
+
+  return 'server'
+}
+
+function getTypeOrder(type: TestType): number {
+  switch (type) {
+    case 'server':
+      return 0
+    case 'browser':
+      return 1
+    case 'e2e':
+      return 2
+  }
+}
+
+function toPosixPath(file: string): string {
+  return file.split(path.sep).join('/')
+}
+
+function runBookstoreTest(test: BookstoreTest) {
+  console.log(`\nRunning bookstore ${test.type} test: ${test.file}`)
+
+  let result = cp.spawnSync(
+    'pnpm',
+    [
+      '--filter',
+      'bookstore-demo',
+      'exec',
+      'node',
+      '../../packages/remix/src/cli-entry.ts',
+      'test',
+      test.file,
+      '--type',
+      test.type,
+      '--concurrency',
+      '1',
+    ],
+    {
+      cwd: repoRoot,
+      env: { ...process.env, NODE_ENV: 'test' },
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    },
+  )
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}
+
+main()


### PR DESCRIPTION
This restores Windows coverage for the bookstore demo without putting it back into the full parallel workspace test load.

- keeps the rest of the Windows workspace test job parallelized
- runs bookstore tests from a dedicated script after the parallel workspace pass
- invokes each bookstore test file in its own Remix test process with concurrency 1 so `node:sqlite` is not kept alive across the full server file set on Windows
- runs the same serial bookstore path in PR and main Windows workflows when bookstore or workflow files change