### PR TITLE
Update generate-remix to lift peer deps

### DIFF
--- a/packages/cli/.changes/patch.lazy-command-loading.md
+++ b/packages/cli/.changes/patch.lazy-command-loading.md
@@ -1,0 +1,1 @@
+Lazy-load command implementations after CLI command dispatch so unrelated commands do not load optional command dependencies during startup.

--- a/packages/cli/src/lib/cli.test.ts
+++ b/packages/cli/src/lib/cli.test.ts
@@ -189,7 +189,7 @@ const SKILLS_LIST_COMMAND_HELP_TEXT = [
   '',
 ].join('\n')
 
-const TEST_COMMAND_HELP_TEXT = getTestCommandHelpText()
+const TEST_COMMAND_HELP_TEXT = await getTestCommandHelpText()
 
 const VERSION_COMMAND_HELP_TEXT = [
   'Usage:',

--- a/packages/cli/src/lib/cli.ts
+++ b/packages/cli/src/lib/cli.ts
@@ -1,13 +1,6 @@
 import * as process from 'node:process'
 
-import { runCompletionCommand } from './commands/completion.ts'
-import { runDoctorCommand } from './commands/doctor.ts'
 import { getCliHelpText, runHelpCommand } from './commands/help.ts'
-import { runNewCommand } from './commands/new.ts'
-import { runRoutesCommand } from './commands/routes.ts'
-import { runSkillsCommand } from './commands/skills.ts'
-import { runTestCommand } from './commands/test.ts'
-import { runVersionCommand } from './commands/version.ts'
 import { resolveCliContext, type CliContext } from './cli-context.ts'
 import { renderCliError, unknownCommand } from './errors.ts'
 import { configureColors, restoreTerminalFormatting } from './terminal.ts'
@@ -56,34 +49,42 @@ async function runCommand(command: string, argv: string[], context: CliContext):
   }
 
   if (command === '-v' || command === '--version') {
+    let { runVersionCommand } = await import('./commands/version.ts')
     return runVersionCommand([], context)
   }
 
   if (command === 'new') {
+    let { runNewCommand } = await import('./commands/new.ts')
     return runNewCommand(argv, context)
   }
 
   if (command === 'completion') {
+    let { runCompletionCommand } = await import('./commands/completion.ts')
     return runCompletionCommand(argv)
   }
 
   if (command === 'doctor') {
+    let { runDoctorCommand } = await import('./commands/doctor.ts')
     return runDoctorCommand(argv, context)
   }
 
   if (command === 'skills') {
+    let { runSkillsCommand } = await import('./commands/skills.ts')
     return runSkillsCommand(argv, context)
   }
 
   if (command === 'routes') {
+    let { runRoutesCommand } = await import('./commands/routes.ts')
     return runRoutesCommand(argv, context)
   }
 
   if (command === 'test') {
+    let { runTestCommand } = await import('./commands/test.ts')
     return runTestCommand(argv, context)
   }
 
   if (command === 'version') {
+    let { runVersionCommand } = await import('./commands/version.ts')
     return runVersionCommand(argv, context)
   }
 

--- a/packages/cli/src/lib/commands/help.ts
+++ b/packages/cli/src/lib/commands/help.ts
@@ -1,18 +1,7 @@
 import * as process from 'node:process'
 
-import { getCompletionCommandHelpText } from './completion.ts'
 import { renderCliError, toCliError, unknownHelpTopic } from '../errors.ts'
 import { formatHelpText } from '../help-text.ts'
-import { getDoctorCommandHelpText } from './doctor.ts'
-import { getNewCommandHelpText } from './new.ts'
-import { getRoutesCommandHelpText } from './routes.ts'
-import {
-  getSkillsCommandHelpText,
-  getSkillsInstallCommandHelpText,
-  getSkillsListCommandHelpText,
-} from './skills.ts'
-import { getTestCommandHelpText } from './test.ts'
-import { getVersionCommandHelpText } from './version.ts'
 
 export async function runHelpCommand(argv: string[]): Promise<number> {
   if (argv.includes('-h') || argv.includes('--help')) {
@@ -21,7 +10,7 @@ export async function runHelpCommand(argv: string[]): Promise<number> {
   }
 
   try {
-    process.stdout.write(getCommandHelpText(argv))
+    process.stdout.write(await getCommandHelpText(argv))
     return 0
   } catch (error) {
     process.stderr.write(
@@ -89,7 +78,7 @@ export function getHelpCommandHelpText(target: NodeJS.WriteStream = process.stdo
   )
 }
 
-function getCommandHelpText(argv: string[]): string {
+async function getCommandHelpText(argv: string[]): Promise<string> {
   if (argv.length === 0) {
     return getCliHelpText()
   }
@@ -101,30 +90,36 @@ function getCommandHelpText(argv: string[]): string {
   }
 
   if (command === 'new' && rest.length === 0) {
+    let { getNewCommandHelpText } = await import('./new.ts')
     return getNewCommandHelpText()
   }
 
   if (command === 'completion' && rest.length === 0) {
+    let { getCompletionCommandHelpText } = await import('./completion.ts')
     return getCompletionCommandHelpText()
   }
 
   if (command === 'doctor' && rest.length === 0) {
+    let { getDoctorCommandHelpText } = await import('./doctor.ts')
     return getDoctorCommandHelpText()
   }
 
   if (command === 'routes' && rest.length === 0) {
+    let { getRoutesCommandHelpText } = await import('./routes.ts')
     return getRoutesCommandHelpText()
   }
 
   if (command === 'skills') {
-    return getSkillsHelpText(rest)
+    return await getSkillsHelpText(rest)
   }
 
   if (command === 'test' && rest.length === 0) {
-    return getTestCommandHelpText()
+    let { getTestCommandHelpText } = await import('./test.ts')
+    return await getTestCommandHelpText()
   }
 
   if (command === 'version' && rest.length === 0) {
+    let { getVersionCommandHelpText } = await import('./version.ts')
     return getVersionCommandHelpText()
   }
 
@@ -135,7 +130,13 @@ function getNestedHelpText(command: string, argv: string[]): string {
   throw unknownHelpTopic(`${command} ${argv.join(' ')}`)
 }
 
-function getSkillsHelpText(argv: string[]): string {
+async function getSkillsHelpText(argv: string[]): Promise<string> {
+  let {
+    getSkillsCommandHelpText,
+    getSkillsInstallCommandHelpText,
+    getSkillsListCommandHelpText,
+  } = await import('./skills.ts')
+
   if (argv.length === 0) {
     return getSkillsCommandHelpText()
   }

--- a/packages/cli/src/lib/commands/test.test.ts
+++ b/packages/cli/src/lib/commands/test.test.ts
@@ -12,7 +12,7 @@ import { getTestCommandHelpText } from './test.ts'
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../..')
 
-const TEST_COMMAND_HELP_TEXT = getTestCommandHelpText()
+const TEST_COMMAND_HELP_TEXT = await getTestCommandHelpText()
 
 describe('test command', () => {
   it('prints test command help', async () => {

--- a/packages/cli/src/lib/commands/test.ts
+++ b/packages/cli/src/lib/commands/test.ts
@@ -1,4 +1,3 @@
-import { getRemixTestHelpText, runRemixTest } from '@remix-run/test/cli'
 import * as process from 'node:process'
 
 import type { CliContext } from '../cli-context.ts'
@@ -6,20 +5,27 @@ import { renderCliError, toCliError } from '../errors.ts'
 
 export async function runTestCommand(argv: string[], context: CliContext): Promise<number> {
   if (argv.includes('-h') || argv.includes('--help')) {
-    process.stdout.write(`${getTestCommandHelpText()}\n`)
+    process.stdout.write(`${await getTestCommandHelpText()}\n`)
     return 0
   }
 
   try {
+    let { runRemixTest } = await import('@remix-run/test/cli')
     return await runRemixTest({ argv, cwd: context.cwd })
   } catch (error) {
+    let helpText = await getTestCommandHelpText(process.stderr)
     process.stderr.write(
-      renderCliError(toCliError(error), { helpText: getTestCommandHelpText(process.stderr) }),
+      renderCliError(toCliError(error), {
+        helpText,
+      }),
     )
     return 1
   }
 }
 
-export function getTestCommandHelpText(target: NodeJS.WriteStream = process.stdout): string {
+export async function getTestCommandHelpText(
+  target: NodeJS.WriteStream = process.stdout,
+): Promise<string> {
+  let { getRemixTestHelpText } = await import('@remix-run/test/cli')
   return getRemixTestHelpText(target)
 }

--- a/packages/remix/.changes/patch.lift-optional-peer-dependencies.md
+++ b/packages/remix/.changes/patch.lift-optional-peer-dependencies.md
@@ -1,0 +1,1 @@
+Added optional peer dependency metadata for feature-specific packages exposed through `remix` exports, including database drivers and Playwright.

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -494,5 +494,25 @@
   },
   "bin": {
     "remix": "./src/cli-entry.ts"
+  },
+  "peerDependencies": {
+    "mysql2": "^3.15.3",
+    "pg": "^8.16.3",
+    "redis": "^5.10.0",
+    "playwright": "^1.59.0"
+  },
+  "peerDependenciesMeta": {
+    "mysql2": {
+      "optional": true
+    },
+    "pg": {
+      "optional": true
+    },
+    "redis": {
+      "optional": true
+    },
+    "playwright": {
+      "optional": true
+    }
   }
 }

--- a/packages/test/.changes/patch.lazy-playwright.md
+++ b/packages/test/.changes/patch.lazy-playwright.md
@@ -1,0 +1,1 @@
+Load Playwright only when browser or E2E tests run, allowing test help and server-only test runs without Playwright installed. Browser and E2E test runs now report a clearer error when Playwright is missing.

--- a/packages/test/src/cli.ts
+++ b/packages/test/src/cli.ts
@@ -1,16 +1,16 @@
 import * as fsp from 'node:fs/promises'
 import type * as http from 'node:http'
 import * as path from 'node:path'
+import type * as browserTestRunner from './lib/runner-browser.ts'
 import {
   getRemixTestHelpText,
   IS_RUNNING_FROM_SRC,
   loadConfig,
   type ResolvedRemixTestConfig,
 } from './lib/config.ts'
+import type * as playwrightSupport from './lib/playwright.ts'
 import { generateCombinedCoverageReport } from './lib/coverage.ts'
-import { loadPlaywrightConfig, resolveProjects } from './lib/playwright.ts'
 import { createReporter } from './lib/reporters/index.ts'
-import { runBrowserTests } from './lib/runner-browser.ts'
 import { runServerTests } from './lib/runner.ts'
 import { createWatcher } from './lib/watcher.ts'
 import { importModule } from './lib/import-module.ts'
@@ -20,10 +20,15 @@ import { isMainThread } from 'node:worker_threads'
 
 export { getRemixTestHelpText }
 
+const MISSING_PLAYWRIGHT_MESSAGE =
+  'Playwright is required to run browser and E2E tests. Install it with `npm i -D playwright`.'
+
 export interface RunRemixTestOptions {
   argv?: string[]
   cwd?: string
 }
+
+type RunBrowserTests = typeof browserTestRunner.runBrowserTests
 
 interface DiscoveredTests {
   files: string[]
@@ -157,11 +162,6 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
         browserPort = result.port
       }
 
-      let playwrightConfig =
-        config.playwrightConfig == null || typeof config.playwrightConfig === 'string'
-          ? await loadPlaywrightConfig(config.playwrightConfig, cwd)
-          : config.playwrightConfig
-
       let reporter = createReporter(config.reporter)
       let startTime = performance.now()
 
@@ -194,7 +194,15 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
 
       // Run browser/e2e tests for all browsers configured by the user
       if (browserFiles.length > 0 || e2eFiles.length > 0) {
+        let { loadPlaywrightConfig, resolveProjects } = await importPlaywrightSupport()
+        let runBrowserTests =
+          browserFiles.length > 0 ? (await importBrowserTestRunner()).runBrowserTests : undefined
+        let playwrightConfig =
+          config.playwrightConfig == null || typeof config.playwrightConfig === 'string'
+            ? await loadPlaywrightConfig(config.playwrightConfig, cwd)
+            : config.playwrightConfig
         let projects = resolveProjects(playwrightConfig)
+
         if (config.project) {
           let projectNames = config.project.split(',').map((project) => project.trim())
           projects = projects.filter(
@@ -205,7 +213,7 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
           }
         }
 
-        let lastBrowserResult: Awaited<ReturnType<typeof runBrowserTests>> | null = null
+        let lastBrowserResult: Awaited<ReturnType<RunBrowserTests>> | null = null
 
         for (let project of projects) {
           reporter.onSectionStart(`\nRunning tests for project \`${project.name}\`:`)
@@ -222,7 +230,7 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
           }
 
           let [browserResult, e2eResult] = await Promise.all([
-            browserFiles.length > 0
+            runBrowserTests != null
               ? runBrowserTests({
                   baseUrl: `http://localhost:${browserPort}`,
                   console: config.browser?.echo,
@@ -310,6 +318,42 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
   }
 
   return await runPromise
+}
+
+async function importPlaywrightSupport(): Promise<typeof playwrightSupport> {
+  try {
+    return await import('./lib/playwright.ts')
+  } catch (error) {
+    throw toPlaywrightImportError(error)
+  }
+}
+
+async function importBrowserTestRunner(): Promise<typeof browserTestRunner> {
+  try {
+    return await import('./lib/runner-browser.ts')
+  } catch (error) {
+    throw toPlaywrightImportError(error)
+  }
+}
+
+function toPlaywrightImportError(error: unknown): unknown {
+  return isMissingPlaywrightImport(error) ? new Error(MISSING_PLAYWRIGHT_MESSAGE) : error
+}
+
+function isMissingPlaywrightImport(error: unknown): boolean {
+  if (!isRecord(error) || typeof error.message !== 'string') {
+    return false
+  }
+
+  return (
+    (error.code === 'ERR_MODULE_NOT_FOUND' || error.code === 'MODULE_NOT_FOUND') &&
+    (error.message.includes("Cannot find package 'playwright'") ||
+      error.message.includes("Cannot find module 'playwright'"))
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
 }
 
 async function resolveCwd(cwd: string): Promise<string> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1454,6 +1454,18 @@ importers:
       '@remix-run/ui':
         specifier: workspace:^
         version: link:../ui
+      mysql2:
+        specifier: ^3.15.3
+        version: 3.16.3
+      pg:
+        specifier: ^8.16.3
+        version: 8.18.0
+      playwright:
+        specifier: ^1.59.0
+        version: 1.59.0
+      redis:
+        specifier: ^5.10.0
+        version: 5.11.0
     devDependencies:
       '@types/dom-navigation':
         specifier: ^1.0.7

--- a/scripts/generate-remix.ts
+++ b/scripts/generate-remix.ts
@@ -29,6 +29,8 @@ type RemixRunPackage = {
   packageJsonPath: string
   exports: ExportEntry[]
   bins: BinEntry[]
+  peerDependencies: Record<string, string>
+  peerDependenciesMeta: Record<string, { optional?: boolean }>
 }
 
 type BinEntry = {
@@ -101,6 +103,8 @@ async function getRemixRunPackages() {
       packageJsonPath,
       exports: [],
       bins,
+      peerDependencies: packageJson.peerDependencies ?? {},
+      peerDependenciesMeta: packageJson.peerDependenciesMeta ?? {},
     }
     remixRunPackages.push(remixRunPackage)
 
@@ -259,6 +263,39 @@ async function updateRemixPackage() {
 
   for (let packageInfo of remixRunPackages) {
     remixPackageJson.dependencies[packageInfo.name] = 'workspace:^'
+  }
+
+  // Lift peerDependencies from sub-packages to the umbrella package, preserving
+  // optional flags from peerDependenciesMeta. A peer is treated as optional in
+  // the umbrella if any sub-package declares it optional, since users of the
+  // umbrella typically only consume a subset of sub-packages.
+  let liftedPeerDeps: Record<string, string> = {}
+  let liftedPeerDepsMeta: Record<string, { optional?: boolean }> = {}
+  for (let packageInfo of remixRunPackages) {
+    for (let [name, version] of Object.entries(packageInfo.peerDependencies)) {
+      let existingVersion = liftedPeerDeps[name]
+      if (existingVersion !== undefined && existingVersion !== version) {
+        throw new Error(
+          `Conflicting peerDependency version for "${name}": ${existingVersion} vs ${version}`,
+        )
+      }
+      liftedPeerDeps[name] = version
+      let optional = packageInfo.peerDependenciesMeta[name]?.optional
+      if (optional) {
+        liftedPeerDepsMeta[name] = { optional: true }
+      }
+    }
+  }
+  if (Object.keys(liftedPeerDeps).length > 0) {
+    remixPackageJson.peerDependencies = liftedPeerDeps
+    if (Object.keys(liftedPeerDepsMeta).length > 0) {
+      remixPackageJson.peerDependenciesMeta = liftedPeerDepsMeta
+    } else {
+      delete remixPackageJson.peerDependenciesMeta
+    }
+  } else {
+    delete remixPackageJson.peerDependencies
+    delete remixPackageJson.peerDependenciesMeta
   }
 
   await fs.writeFile(


### PR DESCRIPTION
When running `remix new` on `alpha.6` we run into pnpm issues which I think are due to the lack of hoisted peer deps from nested @remix-run packages.

```
> remix new my-app   
node:internal/modules/package_json_reader:268
  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
        ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'playwright' imported from /Users/ryan/playground/remix-3-demo/node_modules/.pnpm/@remix-run+test@0.2.0/node_modules/@remix-run/test/dist/lib/playwright.js
    at Object.getPackageJSONURL (node:internal/modules/package_json_reader:268:9)
    at packageResolve (node:internal/modules/esm/resolve:768:81)
    at moduleResolve (node:internal/modules/esm/resolve:858:18)
    at defaultResolve (node:internal/modules/esm/resolve:990:11)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:735:20)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:712:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:310:38)
    at #link (node:internal/modules/esm/module_job:208:49) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v24.6.0
```

Ryan's agent explained the issue as:

> The remix package re-exports its internal @remix-run/* packages, but pnpm’s isolated layout is hiding those transitive packages from TypeScript. I’m going to add a project-local pnpm setting to hoist Remix internals so the documented remix/* imports typecheck under pnpm.
