### PR TITLE
Add pool option (threads | forks) to remix-test

### DIFF
--- a/packages/test/.changes/minor.pool-forks.md
+++ b/packages/test/.changes/minor.pool-forks.md
@@ -1,0 +1,4 @@
+Add `pool` config option to control how each test file is isolated
+
+- `forks` (the new default) runs each file in a `child_process.fork` subprocess for full process-level isolation
+- `threads` runs each file in a `worker_threads.Worker`, which has lower per-file startup overhead but shares the host process

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -114,6 +114,12 @@ export default {
     },
   },
 
+  // Worker pool implementation: "forks" (default, runs each test file in a
+  // `child_process.fork` subprocess for full process-level isolation) or
+  // "threads" (runs each test file in a `worker_threads.Worker`, which has
+  // lower per-file startup overhead but shares the host process)
+  pool: 'forks',
+
   // Comma-separated list of playwright projects to run E2E tests for
   project: 'chromium',
 
@@ -158,6 +164,7 @@ You may also specify any config field as a CLI flag which will take precedence o
 | `--glob.browser`            |       |
 | `--glob.e2e`                |       |
 | `--playwrightConfig <path>` |       |
+| `--pool <name>`             |       |
 | `--project <name>`          | `-p`  |
 | `--reporter <name>`         | `-r`  |
 | `--setup <path>`            | `-s`  |

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -50,8 +50,12 @@
     "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
-    "test": "node src/cli-entry.ts",
-    "test:bun": "bun --bun src/cli-entry.ts --type server",
+    "test": "pnpm test:forks && pnpm test:threads",
+    "test:forks": "node src/cli-entry.ts --pool forks",
+    "test:threads": "node src/cli-entry.ts --pool threads",
+    "test:bun": "pnpm test:bun:forks && pnpm test:bun:threads",
+    "test:bun:forks": "bun --bun src/cli-entry.ts --type server --pool forks",
+    "test:bun:threads": "bun --bun src/cli-entry.ts --type server --pool threads",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {

--- a/packages/test/src/cli.ts
+++ b/packages/test/src/cli.ts
@@ -135,6 +135,16 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
 
       let { files, serverFiles, browserFiles, e2eFiles } = discoveredTests
 
+      let isPlural = config.concurrency !== 1
+      let concurrencyLabel =
+        config.concurrency > 1 ? `${config.concurrency} concurrent` : 'a single'
+      let workerLabel =
+        config.pool === 'forks'
+          ? `forked process${isPlural ? 'es' : ''}`
+          : `worker thread${isPlural ? 's' : ''}`
+
+      console.log(`Running tests in ${concurrencyLabel} ${workerLabel}`)
+
       if (config.watch) {
         watcher ??= createWatcher((file) => queueRerun(file))
         watcher.update(files)
@@ -175,16 +185,12 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
 
       if (serverFiles.length > 0) {
         reporter.onSectionStart('\nRunning server tests:')
-        let serverResult = await runServerTests(
-          serverFiles,
-          reporter,
-          config.concurrency,
-          'server',
-          {
-            coverage: config.coverage,
-            cwd,
-          },
-        )
+        let serverResult = await runServerTests(serverFiles, reporter, config.concurrency, {
+          type: 'server',
+          coverage: config.coverage,
+          cwd,
+          pool: config.pool,
+        })
         counts.failed += serverResult.failed
         counts.passed += serverResult.passed
         counts.skipped += serverResult.skipped
@@ -235,12 +241,14 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
                 })
               : null,
             e2eFiles.length > 0
-              ? runServerTests(e2eFiles, reporter, config.concurrency, 'e2e', {
-                  open: config.browser?.open,
+              ? runServerTests(e2eFiles, reporter, config.concurrency, {
+                  type: 'e2e',
+                  open: config.browser?.open === true,
                   playwrightUseOpts: project.playwrightUseOpts,
                   projectName: project.name,
                   coverage: config.coverage,
                   cwd,
+                  pool: config.pool,
                 })
               : null,
           ])

--- a/packages/test/src/lib/channel.ts
+++ b/packages/test/src/lib/channel.ts
@@ -1,0 +1,63 @@
+import { parentPort, workerData as threadsWorkerData } from 'node:worker_threads'
+import type { TestResults } from './reporters/results.ts'
+import type { CoverageConfig } from './coverage.ts'
+import type { PlaywrightUseOpts } from './playwright.ts'
+
+/*
+ * Worker entry points (`worker.ts`, `worker-e2e.ts`) run in two modes:
+ * - Inside a `worker_threads.Worker` (pool=threads), using `parentPort` and
+ *   `workerData`.
+ * - Inside a `child_process.fork` subprocess (pool=forks), using `process.send`
+ *   and an initial `process.on('message', ...)` payload from the parent.
+ *
+ * This module hides the difference so the worker bodies can stay pool-agnostic.
+ */
+
+export type WorkerPayload = {
+  file: string
+  type: 'server'
+  coverage: CoverageConfig | undefined
+}
+
+export type E2EWorkerPayload = {
+  file: string
+  type: 'e2e'
+  coverage: CoverageConfig | undefined
+  open: boolean
+  playwrightUseOpts: PlaywrightUseOpts
+}
+
+export const isWorkerThread = parentPort != null
+
+export function receiveData<T>(): T | Promise<T> {
+  if (isWorkerThread) return threadsWorkerData as T
+  return new Promise<T>((resolve) => {
+    process.once('message', (msg) => resolve(msg as T))
+  })
+}
+
+export async function sendResults(results: TestResults): Promise<void> {
+  if (isWorkerThread) {
+    parentPort!.postMessage(results)
+  } else {
+    return new Promise<void>((resolve, reject) => {
+      process.send!(results, undefined, undefined, (error: any) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+}
+
+export function closeWorkerChannel(): void {
+  if (isWorkerThread && process.connected) {
+    process.disconnect()
+  }
+
+  // Force worker shutdown for both pools so leaked handles in test files cannot
+  // keep a worker process/thread alive after results are sent
+  process.exit(0)
+}

--- a/packages/test/src/lib/config.ts
+++ b/packages/test/src/lib/config.ts
@@ -110,6 +110,10 @@ const cliOptions = {
     type: 'string',
     description: 'Path to a Playwright config file',
   },
+  pool: {
+    type: 'string',
+    description: 'Worker pool implementation: forks (default) or threads',
+  },
   project: {
     type: 'string',
     short: 'p',
@@ -153,6 +157,7 @@ const defaultValues: ResolvedRemixTestConfig = {
     e2e: '**/*.test.e2e.{ts,tsx}',
     exclude: 'node_modules/**',
   },
+  pool: 'forks',
   reporter: process.env.CI === 'true' ? 'files' : 'spec',
   type: 'server,browser,e2e',
   setup: undefined,
@@ -211,6 +216,13 @@ export interface RemixTestConfig {
    * PlaywrightTestConfig object. CLI `--playwrightConfig` only accepts a file path.
    */
   playwrightConfig?: string | PlaywrightTestConfig
+  /**
+   * Worker pool implementation (--pool). `forks` (default) runs each test file in
+   * a `child_process.fork` subprocess for full process-level isolation; `threads`
+   * runs each test file in a `worker_threads.Worker`, which has lower per-file
+   * startup overhead but shares the host process.
+   */
+  pool?: 'threads' | 'forks'
   /** Filter tests to a specific playwright project or comma-separated list of projects (--project) */
   project?: string
   /** Test reporter (--reporter) */
@@ -245,6 +257,7 @@ export interface ResolvedRemixTestConfig {
     exclude: string
   }
   playwrightConfig: string | PlaywrightTestConfig | undefined
+  pool: 'threads' | 'forks'
   project: string | undefined
   reporter: string
   setup: string | undefined
@@ -284,6 +297,19 @@ function parseCliArgs(args: string[]) {
   return util.parseArgs({ args, options: cliOptions, allowPositionals: true })
 }
 
+function resolvePool(value: string): 'threads' | 'forks' {
+  if (value === 'threads' || value === 'forks') return value
+  throw new Error(`Invalid pool "${value}" — must be "threads" or "forks"`)
+}
+
+function resolveConcurrency(value: number | string): number {
+  let n = Number(value)
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`Invalid concurrency "${value}" — must be a positive integer`)
+  }
+  return n
+}
+
 function resolveConfig(
   fileConfig: RemixTestConfig,
   { values: cliValues, positionals }: ReturnType<typeof parseCliArgs>,
@@ -304,7 +330,7 @@ function resolveConfig(
       echo: cliValues['browser.echo'] ?? fileConfig.browser?.echo ?? defaultValues.browser.echo,
       open: cliValues['browser.open'] ?? fileConfig.browser?.open ?? defaultValues.browser.open,
     },
-    concurrency: Number(
+    concurrency: resolveConcurrency(
       cliValues.concurrency ?? fileConfig.concurrency ?? defaultValues.concurrency,
     ),
     coverage:
@@ -348,6 +374,7 @@ function resolveConfig(
     setup: cliValues.setup ?? fileConfig.setup ?? defaultValues.setup,
     playwrightConfig:
       cliValues.playwrightConfig ?? fileConfig.playwrightConfig ?? defaultValues.playwrightConfig,
+    pool: resolvePool(cliValues.pool ?? fileConfig.pool ?? defaultValues.pool),
     project: cliValues.project ?? fileConfig.project ?? defaultValues.project,
     reporter: cliValues.reporter ?? fileConfig.reporter ?? defaultValues.reporter,
     type: cliValues.type ?? fileConfig.type ?? defaultValues.type,

--- a/packages/test/src/lib/context.ts
+++ b/packages/test/src/lib/context.ts
@@ -1,5 +1,5 @@
 import type { Browser, Page } from 'playwright'
-import type { V8CoverageEntry } from './coverage.ts'
+import type { CoverageConfig, V8CoverageEntry } from './coverage.ts'
 import { createFakeTimers, type FakeTimers } from './fake-timers.ts'
 import { mock, type MockCall, type MockContext, type MockFunction } from './mock.ts'
 import type { getPlaywrightPageOptions } from './playwright.ts'
@@ -89,7 +89,7 @@ export interface TestContext {
 export interface CreateTestContextOptions {
   addE2ECoverageEntries: (value: { entries: V8CoverageEntry[]; baseUrl: string }) => void
   browser: Browser
-  coverage: boolean
+  coverage: CoverageConfig | undefined
   open: boolean
   playwrightPageOptions: ReturnType<typeof getPlaywrightPageOptions>
 }

--- a/packages/test/src/lib/runner.ts
+++ b/packages/test/src/lib/runner.ts
@@ -1,6 +1,7 @@
+import * as cp from 'node:child_process'
 import * as fsp from 'node:fs/promises'
 import * as path from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { Worker } from 'node:worker_threads'
 import { IS_RUNNING_FROM_SRC } from './config.ts'
 import {
@@ -13,6 +14,7 @@ import {
 import { type PlaywrightUseOpts } from './playwright.ts'
 import type { Reporter } from './reporters/index.ts'
 import type { Counts, TestResults } from './reporters/results.ts'
+import type { E2EWorkerPayload, WorkerPayload } from './channel.ts'
 
 // Ensure we load the right file whether we're running in the monorepo (TS) or
 // from a published package (JS)
@@ -22,29 +24,43 @@ const workerE2EUrl = new URL(`./worker-e2e${ext}`, import.meta.url)
 const DEFAULT_WORKER_SHUTDOWN_TIMEOUT_MS = 10_000
 
 interface WorkerRun {
-  worker: Worker
   finished: Promise<void>
   exited: Promise<number>
+  terminate: () => Promise<void>
 }
+
+type RunTestsOptions =
+  | {
+      type: 'server'
+      coverage: CoverageConfig | undefined
+      cwd: string
+      pool: 'threads' | 'forks'
+      workerShutdownTimeoutMs?: number
+    }
+  | {
+      type: 'e2e'
+      coverage: CoverageConfig | undefined
+      cwd: string
+      open: boolean
+      pool: 'threads' | 'forks'
+      playwrightUseOpts: PlaywrightUseOpts
+      projectName: string | undefined
+      workerShutdownTimeoutMs?: number
+    }
 
 export async function runServerTests(
   files: string[],
   reporter: Reporter,
   concurrency: number,
-  type: 'server' | 'e2e',
-  options: {
-    cwd?: string
-    open?: boolean
-    playwrightUseOpts?: PlaywrightUseOpts
-    projectName?: string
-    coverage?: CoverageConfig
-    workerShutdownTimeoutMs?: number
-  } = {},
+  options: RunTestsOptions,
 ): Promise<Counts & { coverageMap: CoverageMap | null }> {
   let counts: Counts = { passed: 0, failed: 0, skipped: 0, todo: 0 }
   let coverageMap: CoverageMap | null = null
   let cwd = options.cwd ?? process.cwd()
-  let envLabel = options.projectName ? `${type}:${options.projectName}` : type
+  let envLabel =
+    options.type === 'e2e' && options.projectName
+      ? `${options.type}:${options.projectName}`
+      : options.type
 
   function accumulate(results: TestResults, file: string) {
     reporter.onResult(
@@ -57,27 +73,19 @@ export async function runServerTests(
     counts.todo += results.todo
   }
 
-  if (type === 'e2e') {
+  if (options.type === 'e2e') {
     let allBrowserCoverageEntries: Array<{ entries: V8CoverageEntry[]; baseUrl: string }> = []
 
     await runInConcurrentWorkers(
       files,
       concurrency,
       (file) =>
-        runFileInWorker(
-          file,
-          type,
-          (results) => {
-            accumulate(results, file)
-            if (results.e2eBrowserCoverageEntries) {
-              allBrowserCoverageEntries.push(...results.e2eBrowserCoverageEntries)
-            }
-          },
-          {
-            ...options,
-            playwrightUseOpts: options.playwrightUseOpts,
-          },
-        ),
+        runFileInWorkerOrThread(file, options, (results) => {
+          accumulate(results, file)
+          if (results.e2eBrowserCoverageEntries) {
+            allBrowserCoverageEntries.push(...results.e2eBrowserCoverageEntries)
+          }
+        }),
       () => counts.failed++,
       !options.open,
       options.workerShutdownTimeoutMs ?? DEFAULT_WORKER_SHUTDOWN_TIMEOUT_MS,
@@ -102,7 +110,7 @@ export async function runServerTests(
     await runInConcurrentWorkers(
       files,
       concurrency,
-      (file) => runFileInWorker(file, type, (results) => accumulate(results, file), options),
+      (file) => runFileInWorkerOrThread(file, options, (results) => accumulate(results, file)),
       () => counts.failed++,
       true,
       options.workerShutdownTimeoutMs ?? DEFAULT_WORKER_SHUTDOWN_TIMEOUT_MS,
@@ -149,7 +157,7 @@ async function runInConcurrentWorkers(
 
         async function terminate(): Promise<boolean> {
           try {
-            await run.worker.terminate()
+            await run.terminate()
             return true
           } catch (err) {
             console.error(
@@ -207,52 +215,27 @@ function waitForWorkerExit(exited: Promise<number>, timeoutMs: number): Promise<
   })
 }
 
-export function runFileInWorker(
-  file: string,
-  type: 'server' | 'e2e',
+function runFileInWorkerThread(
+  file: URL,
+  payload: WorkerPayload | E2EWorkerPayload,
   onResults: (results: TestResults) => void,
-  options: {
-    cwd?: string
-    coverage?: CoverageConfig
-    open?: boolean
-    playwrightUseOpts?: PlaywrightUseOpts
-  } = {},
 ): WorkerRun {
   let receivedResults = false
-  let worker =
-    type === 'e2e'
-      ? new Worker(workerE2EUrl, {
-          workerData: {
-            file: pathToFileURL(file).href,
-            type,
-            coverage: options.coverage,
-            open: options.open,
-            playwrightUseOpts: options.playwrightUseOpts,
-          },
-        })
-      : new Worker(workerUrl, {
-          workerData: {
-            file: pathToFileURL(file).href,
-            type,
-            coverage: options.coverage,
-          },
-        })
-
+  let worker = new Worker(file, { workerData: payload })
   let exited = new Promise<number>((resolve) => {
     worker.once('exit', (code) => resolve(code))
   })
-
   let finished = new Promise<void>((resolve, reject) => {
     worker.once('message', (msg: TestResults) => {
       receivedResults = true
       try {
         onResults(msg)
+        if (payload.type !== 'e2e' || !payload.open) {
+          resolve()
+        }
       } catch (error) {
         reject(error)
         return
-      }
-      if (!options.open) {
-        resolve()
       }
     })
     worker.once('error', reject)
@@ -266,8 +249,104 @@ export function runFileInWorker(
   })
 
   return {
-    worker,
     finished,
     exited,
+    async terminate() {
+      await worker.terminate()
+    },
+  }
+}
+
+function runFileInForkedProcess(
+  workerScript: URL,
+  payload: WorkerPayload | E2EWorkerPayload,
+  onResults: (results: TestResults) => void,
+): WorkerRun {
+  let receivedResults = false
+  // child_process.fork inherits `execArgv` from the parent by default, so any
+  // TypeScript loader hooks (e.g. tsx, Node's strip-types) keep working in
+  // the child. The IPC channel carries the workerData payload as the first
+  // message and the test results as the reply.
+  let child = cp.fork(fileURLToPath(workerScript), [], {
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+  })
+  let exited = new Promise<number>((resolve, reject) => {
+    child.once('exit', (code, signal) => {
+      if (code === 0) resolve(code)
+      else if (signal) reject(new Error(`Forked process killed by signal ${signal}`))
+      else reject(new Error(`Forked process exited with code ${code}`))
+    })
+  })
+  let finished = new Promise<void>((resolve, reject) => {
+    child.once('message', (msg) => {
+      receivedResults = true
+      try {
+        onResults(msg as TestResults)
+        if (payload.type !== 'e2e' || !payload.open) {
+          resolve()
+        }
+      } catch (error) {
+        reject(error)
+        return
+      }
+    })
+    child.once('error', reject)
+
+    exited.then((code) => {
+      if (receivedResults || code === 0) {
+        resolve()
+      } else {
+        reject(new Error(`Worker exited with code ${code}`))
+      }
+    })
+
+    child.send(payload, (err) => {
+      if (err) reject(err)
+    })
+  })
+
+  return {
+    finished,
+    exited,
+    async terminate() {
+      return new Promise((resolve, reject) => {
+        if (child.kill()) {
+          resolve()
+        } else {
+          reject(new Error('Unable to kill forked process'))
+        }
+      })
+    },
+  }
+}
+
+function runFileInWorkerOrThread(
+  file: string,
+  options: RunTestsOptions,
+  onResults: (results: TestResults) => void,
+): WorkerRun {
+  let runner = options.pool === 'forks' ? runFileInForkedProcess : runFileInWorkerThread
+  if (options.type === 'server') {
+    return runner(
+      workerUrl,
+      {
+        file: pathToFileURL(file).href,
+        type: 'server',
+        coverage: options.coverage,
+      },
+      onResults,
+    )
+  } else {
+    return runner(
+      workerE2EUrl,
+      {
+        file: pathToFileURL(file).href,
+        type: 'e2e',
+        coverage: options.coverage,
+        open: options.open === true,
+        playwrightUseOpts: options.playwrightUseOpts,
+      },
+      onResults,
+    )
   }
 }

--- a/packages/test/src/lib/worker-e2e.ts
+++ b/packages/test/src/lib/worker-e2e.ts
@@ -1,4 +1,3 @@
-import { workerData, parentPort } from 'node:worker_threads'
 import { runTests } from './executor.ts'
 import { importModule } from './import-module.ts'
 import {
@@ -7,6 +6,9 @@ import {
   getPlaywrightPageOptions,
 } from './playwright.ts'
 import type { TestResults } from './reporters/results.ts'
+import { closeWorkerChannel, receiveData, sendResults, type E2EWorkerPayload } from './channel.ts'
+
+const workerData = await receiveData<E2EWorkerPayload>()
 
 try {
   await importModule(workerData.file, import.meta)
@@ -14,29 +16,21 @@ try {
   let launcher = await getBrowserLauncher(workerData.playwrightUseOpts)
   let opts = getPlaywrightLaunchOptions(workerData.playwrightUseOpts)
   let browser = await launcher.launch(opts)
-  let browserClosed = false
   try {
     let results = await runTests({
       browser,
-      open: workerData.open,
+      open: workerData.open ?? false,
       playwrightPageOptions: getPlaywrightPageOptions(workerData.playwrightUseOpts),
       coverage: workerData.coverage,
     })
+    await sendResults(results)
     if (workerData.open) {
-      parentPort!.postMessage(results)
       console.log('\nBrowser is open. Press Ctrl+C to close.')
       await new Promise<void>((resolve) => browser.on('disconnected', () => resolve()))
-    } else {
-      await browser.close()
-      browserClosed = true
-      parentPort!.postMessage(results)
     }
   } finally {
-    if (!browserClosed) {
-      await browser.close()
-    }
+    await browser.close()
   }
-  process.exit(0)
 } catch (e) {
   let results: TestResults = {
     passed: 0,
@@ -56,6 +50,7 @@ try {
       },
     ],
   }
-  parentPort!.postMessage(results)
-  process.exit(0)
+  await sendResults(results)
+} finally {
+  closeWorkerChannel()
 }

--- a/packages/test/src/lib/worker.ts
+++ b/packages/test/src/lib/worker.ts
@@ -1,11 +1,12 @@
 import * as mod from 'node:module'
-import * as path from 'node:path'
-import { parentPort, workerData } from 'node:worker_threads'
 import { runTests } from './executor.ts'
 import { importModule } from './import-module.ts'
 import type { TestResults } from './reporters/results.ts'
 import { IS_BUN } from './runtime.ts'
 import { IS_RUNNING_FROM_SRC } from './config.ts'
+import { closeWorkerChannel, receiveData, sendResults, type WorkerPayload } from './channel.ts'
+
+const workerData = await receiveData<WorkerPayload>()
 
 async function takeCoverage(): Promise<void> {
   if (workerData.coverage && !IS_BUN) {
@@ -32,8 +33,7 @@ try {
 
   let results = await runTests()
   await takeCoverage()
-  parentPort!.postMessage(results)
-  process.exit(0)
+  await sendResults(results)
 } catch (e) {
   try {
     await takeCoverage()
@@ -59,6 +59,7 @@ try {
       },
     ],
   }
-  parentPort!.postMessage(results)
-  process.exit(0)
+  await sendResults(results)
+} finally {
+  closeWorkerChannel()
 }

--- a/packages/test/src/test/worker-cleanup.test.ts
+++ b/packages/test/src/test/worker-cleanup.test.ts
@@ -42,7 +42,11 @@ describe('leaked worker fixture', () => {
     }
 
     try {
-      let counts = await runServerTests([FIXTURE_FILE], reporter, 1, 'server', {
+      let counts = await runServerTests([FIXTURE_FILE], reporter, 1, {
+        type: 'server',
+        coverage: undefined,
+        cwd: FIXTURE_DIR,
+        pool: 'threads',
         workerShutdownTimeoutMs: 50,
       })
       assert.equal(counts.passed, 1)


### PR DESCRIPTION
`pool: 'threads'` (default) keeps the existing `worker_threads.Worker` per test file. `pool: 'forks'` runs each file in a `child_process.fork` for full process-level isolation. Configurable via `pool` in the config file or `--pool` CLI flag.