### PR TITLE
Fix bookstore CI on main

### DIFF
--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -209,8 +209,14 @@ jobs:
         if: steps.cache-browsers.outputs.cache-hit != 'true'
         run: pnpm --filter @remix-run/ui exec playwright install --with-deps
 
+      - name: Run bookstore tests
+        run: node ./scripts/run-bookstore-tests-serially.ts
+
       - name: Run tests
-        run: pnpm --parallel --filter "!remix-the-web" run test
+        run: |
+          # node:sqlite currently crashes in the bookstore demo on Windows under
+          # the full workspace test load, so run it serially before this step.
+          pnpm --parallel --filter "!bookstore-demo" --filter "!remix-the-web" run test
 
   lint:
     name: Lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -163,5 +163,11 @@ jobs:
         if: steps.cache-browsers.outputs.cache-hit != 'true'
         run: pnpm --filter @remix-run/ui exec playwright install --with-deps
 
+      - name: Run bookstore tests
+        run: node ./scripts/run-bookstore-tests-serially.ts
+
       - name: Run tests
-        run: pnpm --parallel --filter "!remix-the-web" run test
+        run: |
+          # node:sqlite currently crashes in the bookstore demo on Windows under
+          # the full workspace test load, so run it serially before this step.
+          pnpm --parallel --filter "!bookstore-demo" --filter "!remix-the-web" run test

--- a/demos/bookstore/app/app.test.e2e.ts
+++ b/demos/bookstore/app/app.test.e2e.ts
@@ -1,9 +1,11 @@
 import * as assert from 'remix/assert'
 import { createTestServer } from 'remix/node-fetch-server/test'
 import { describe, it } from 'remix/test'
+import type { Locator, Page } from 'playwright'
 import { createBookstoreRouter } from './router.ts'
 import { books } from './data/schema.ts'
 import { db, initializeBookstoreDatabase } from './data/setup.ts'
+import { routes } from './routes.ts'
 
 const router = createBookstoreRouter()
 
@@ -15,14 +17,14 @@ describe('e2e', () => {
     let page = await t.serve(await createTestServer(router.fetch))
 
     // Load the homepage
-    await page.goto('/', { waitUntil: 'networkidle' })
+    await page.goto('/')
 
     let book = await db.findOne(books, { where: { in_stock: true } })
 
     // Add an item to cart
     let bookCard = page.locator(`[data-test-slug="${book?.slug}"]`)
-    await bookCard.getByRole('button', { name: 'Add to Cart' }).click()
-    await bookCard.getByRole('button', { name: 'Remove from Cart' }).waitFor()
+    await clickCartButton(page, bookCard.getByRole('button', { name: 'Add to Cart' }))
+    await bookCard.getByRole('button', { name: 'Remove from Cart' }).waitFor({ timeout: 10_000 })
 
     // Navigate to cart and validate
     await page.getByRole('link', { name: 'Cart' }).click()
@@ -32,3 +34,27 @@ describe('e2e', () => {
     assert.equal(await cartRow.getByRole('spinbutton').getAttribute('defaultvalue'), '1')
   })
 })
+
+async function clickCartButton(page: Page, button: Locator): Promise<void> {
+  let cartTogglePath = routes.api.cartToggle.href()
+
+  for (let attempt = 0; attempt < 10; attempt++) {
+    let responsePromise = page
+      .waitForResponse((response) => new URL(response.url()).pathname === cartTogglePath, {
+        timeout: 1_000,
+      })
+      .catch(() => null)
+
+    await button.click()
+
+    let response = await responsePromise
+    if (response) {
+      assert.equal(response.ok(), true)
+      return
+    }
+
+    await page.waitForTimeout(100)
+  }
+
+  throw new Error(`Timed out waiting for ${cartTogglePath} request`)
+}

--- a/packages/fetch-router/src/lib/request-abort.test.ts
+++ b/packages/fetch-router/src/lib/request-abort.test.ts
@@ -52,13 +52,14 @@ describe('raceRequestAbort', () => {
   it('throws AbortError when signal is aborted during promise execution', async () => {
     let controller = new AbortController()
     let request = new Request('https://remix.run', { signal: controller.signal })
-    let promise = new Promise((resolve) => setTimeout(() => resolve('success'), 100))
+    let promise = new Promise<string>(() => {})
+    let result = raceRequestAbort(promise, request)
 
-    setTimeout(() => controller.abort(), 10)
+    controller.abort()
 
     await assert.rejects(
       async () => {
-        await raceRequestAbort(promise, request)
+        await result
       },
       (error: any) => {
         assert.equal(error.name, 'AbortError')

--- a/packages/test/.changes/patch.worker-cleanup.md
+++ b/packages/test/.changes/patch.worker-cleanup.md
@@ -1,1 +1,1 @@
-Terminate finished test worker threads after they report results so leaked worker resources in a test file do not keep the test process alive.
+Clean up leaked test worker resources after results are reported while allowing normal workers to finish shutdown first.

--- a/packages/test/src/lib/runner.ts
+++ b/packages/test/src/lib/runner.ts
@@ -19,10 +19,12 @@ import type { Counts, TestResults } from './reporters/results.ts'
 const ext = IS_RUNNING_FROM_SRC ? '.ts' : '.js'
 const workerUrl = new URL(`./worker${ext}`, import.meta.url)
 const workerE2EUrl = new URL(`./worker-e2e${ext}`, import.meta.url)
+const WORKER_EXIT_GRACE_MS = 500
 
 interface WorkerRun {
   worker: Worker
   finished: Promise<void>
+  exited: Promise<number>
 }
 
 export async function runServerTests(
@@ -159,9 +161,12 @@ async function runInConcurrentWorkers(
           async () => {
             try {
               if (terminateWhenFinished) {
-                let terminated = await terminate()
-                if (!terminated) {
-                  onError()
+                let exited = await waitForWorkerExit(run.exited, WORKER_EXIT_GRACE_MS)
+                if (!exited) {
+                  let terminated = await terminate()
+                  if (!terminated) {
+                    onError()
+                  }
                 }
               }
             } finally {
@@ -185,6 +190,16 @@ async function runInConcurrentWorkers(
     }
 
     dispatch()
+  })
+}
+
+function waitForWorkerExit(exited: Promise<number>, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    let timeout = setTimeout(() => resolve(false), timeoutMs)
+    exited.then(() => {
+      clearTimeout(timeout)
+      resolve(true)
+    })
   })
 }
 
@@ -219,6 +234,10 @@ export function runFileInWorker(
           },
         })
 
+  let exited = new Promise<number>((resolve) => {
+    worker.once('exit', (code) => resolve(code))
+  })
+
   let finished = new Promise<void>((resolve, reject) => {
     worker.once('message', (msg: TestResults) => {
       receivedResults = true
@@ -233,7 +252,7 @@ export function runFileInWorker(
       }
     })
     worker.once('error', reject)
-    worker.once('exit', (code) => {
+    exited.then((code) => {
       if (receivedResults || code === 0) {
         resolve()
       } else {
@@ -245,5 +264,6 @@ export function runFileInWorker(
   return {
     worker,
     finished,
+    exited,
   }
 }

--- a/packages/test/src/test/worker-cleanup.test.ts
+++ b/packages/test/src/test/worker-cleanup.test.ts
@@ -3,8 +3,9 @@ import * as fsp from 'node:fs/promises'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, it } from '../lib/framework.ts'
-import { runFileInWorker } from '../lib/runner.ts'
+import { runServerTests } from '../lib/runner.ts'
 import { IS_BUN } from '../lib/runtime.ts'
+import type { Reporter } from '../lib/reporters/index.ts'
 import type { TestResults } from '../lib/reporters/results.ts'
 
 const PKG_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
@@ -12,7 +13,7 @@ const FIXTURE_DIR = path.join(PKG_DIR, '.tmp', 'worker-cleanup')
 const FIXTURE_FILE = path.join(FIXTURE_DIR, 'leaked-worker.test.ts')
 
 describe('worker cleanup', () => {
-  it('lets the callsite terminate a worker after receiving results', { skip: IS_BUN }, async () => {
+  it('terminates leaked workers after receiving results', { skip: IS_BUN }, async () => {
     await fsp.rm(FIXTURE_DIR, { recursive: true, force: true })
     await fsp.mkdir(FIXTURE_DIR, { recursive: true })
     await fsp.writeFile(
@@ -32,13 +33,20 @@ describe('leaked worker fixture', () => {
     )
 
     let results: TestResults | undefined
+    let reporter: Reporter = {
+      onResult(testResults) {
+        results = testResults
+      },
+      onSectionStart() {},
+      onSummary() {},
+    }
 
     try {
-      let run = runFileInWorker(FIXTURE_FILE, 'server', (testResults) => {
-        results = testResults
-      })
-      await run.finished
-      await run.worker.terminate()
+      let counts = await runServerTests([FIXTURE_FILE], reporter, 1, 'server')
+      assert.equal(counts.passed, 1)
+      assert.equal(counts.failed, 0)
+      assert.equal(counts.skipped, 0)
+      assert.equal(counts.todo, 0)
     } finally {
       await fsp.rm(FIXTURE_DIR, { recursive: true, force: true })
     }

--- a/scripts/run-bookstore-server-test-file.ts
+++ b/scripts/run-bookstore-server-test-file.ts
@@ -1,0 +1,77 @@
+import * as path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+type TestResults = {
+  passed: number
+  failed: number
+  skipped: number
+  todo: number
+  tests: Array<{
+    name: string
+    suiteName: string
+    status: 'passed' | 'failed' | 'skipped' | 'todo'
+    duration: number
+    error?: {
+      message: string
+      stack?: string
+    }
+  }>
+}
+
+const testLibDir = '../packages/test/src/lib'
+
+function main(): Promise<void> {
+  let [testFile] = process.argv.slice(2)
+
+  if (!testFile) {
+    throw new Error('Usage: node ./scripts/run-bookstore-server-test-file.ts <test-file>')
+  }
+
+  return runServerTestFile(testFile)
+}
+
+async function runServerTestFile(testFile: string): Promise<void> {
+  let filePath = path.resolve(process.cwd(), testFile)
+  let startTime = performance.now()
+  let { importModule } = (await import(`${testLibDir}/import-module.ts`)) as {
+    importModule(specifier: string, meta: ImportMeta): Promise<unknown>
+  }
+  let { runTests } = (await import(`${testLibDir}/executor.ts`)) as {
+    runTests(): Promise<TestResults>
+  }
+
+  await importModule(pathToFileURL(filePath).href, import.meta)
+
+  let results = await runTests()
+  printResults(testFile, results, performance.now() - startTime)
+
+  if (results.failed > 0) {
+    process.exitCode = 1
+  }
+}
+
+function printResults(testFile: string, results: TestResults, durationMs: number) {
+  console.log(`${testFile} [server]`)
+
+  for (let test of results.tests) {
+    let name = test.name ? `${test.suiteName} > ${test.name}` : test.suiteName
+    console.log(`  ${test.status}: ${name} (${test.duration.toFixed(2)}ms)`)
+
+    if (test.error) {
+      console.log(`    Error: ${test.error.message}`)
+      if (test.error.stack) {
+        console.log(test.error.stack)
+      }
+    }
+  }
+
+  console.log()
+  console.log(`tests ${results.passed + results.failed + results.skipped + results.todo}`)
+  console.log(`pass ${results.passed}`)
+  console.log(`fail ${results.failed}`)
+  if (results.skipped > 0) console.log(`skipped ${results.skipped}`)
+  if (results.todo > 0) console.log(`todo ${results.todo}`)
+  console.log(`duration_ms ${durationMs.toFixed(5)}`)
+}
+
+await main()

--- a/scripts/run-bookstore-tests-serially.ts
+++ b/scripts/run-bookstore-tests-serially.ts
@@ -1,0 +1,124 @@
+import * as cp from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+type TestType = 'server' | 'browser' | 'e2e'
+
+type BookstoreTest = {
+  file: string
+  type: TestType
+}
+
+const repoRoot = process.cwd()
+const bookstoreRoot = path.join(repoRoot, 'demos', 'bookstore')
+const appRoot = path.join(bookstoreRoot, 'app')
+
+function main() {
+  let tests = getBookstoreTests()
+
+  if (tests.length === 0) {
+    throw new Error(`No bookstore tests found in ${appRoot}`)
+  }
+
+  console.log('Running bookstore tests one file at a time:')
+  for (let test of tests) {
+    console.log(`- ${test.type}: ${test.file}`)
+  }
+  console.log()
+
+  for (let test of tests) {
+    runBookstoreTest(test)
+  }
+}
+
+function getBookstoreTests(): BookstoreTest[] {
+  let testFiles = getTestFiles(appRoot)
+
+  return testFiles
+    .map((file) => ({
+      file: toPosixPath(path.relative(bookstoreRoot, file)),
+      type: getTestType(file),
+    }))
+    .sort((a, b) => {
+      let typeOrder = getTypeOrder(a.type) - getTypeOrder(b.type)
+      return typeOrder === 0 ? a.file.localeCompare(b.file) : typeOrder
+    })
+}
+
+function getTestFiles(dir: string): string[] {
+  let entries = fs.readdirSync(dir, { withFileTypes: true })
+  let testFiles: string[] = []
+
+  for (let entry of entries) {
+    let file = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      testFiles.push(...getTestFiles(file))
+      continue
+    }
+
+    if (entry.isFile() && /\.test(?:\.(?:browser|e2e))?\.tsx?$/.test(entry.name)) {
+      testFiles.push(file)
+    }
+  }
+
+  return testFiles
+}
+
+function getTestType(file: string): TestType {
+  if (/\.test\.browser\.tsx?$/.test(file)) {
+    return 'browser'
+  }
+
+  if (/\.test\.e2e\.tsx?$/.test(file)) {
+    return 'e2e'
+  }
+
+  return 'server'
+}
+
+function getTypeOrder(type: TestType): number {
+  switch (type) {
+    case 'server':
+      return 0
+    case 'browser':
+      return 1
+    case 'e2e':
+      return 2
+  }
+}
+
+function toPosixPath(file: string): string {
+  return file.split(path.sep).join('/')
+}
+
+function runBookstoreTest(test: BookstoreTest) {
+  console.log(`\nRunning bookstore ${test.type} test: ${test.file}`)
+
+  let commandArgs =
+    test.type === 'server'
+      ? ['node', '../../scripts/run-bookstore-server-test-file.ts', test.file]
+      : [
+          'node',
+          '../../packages/remix/src/cli-entry.ts',
+          'test',
+          test.file,
+          '--type',
+          test.type,
+          '--concurrency',
+          '1',
+        ]
+
+  let result = cp.spawnSync('pnpm', ['--filter', 'bookstore-demo', 'exec', ...commandArgs], {
+    cwd: repoRoot,
+    env: { ...process.env, NODE_ENV: 'test' },
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  })
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}
+
+main()


### PR DESCRIPTION
PR #11297 exposed two bookstore CI issues after it merged: Windows can crash while running the bookstore demo's `node:sqlite` tests under the full parallel workspace test load, and the cart e2e test can click before the app has hydrated when it no longer waits for `networkidle`.

The first recovery CI run also exposed a timer-dependent `fetch-router` abort test that can resolve before the abort timer fires under full parallel load.

- Runs the bookstore demo test files serially before the Windows workspace test job, then excludes `bookstore-demo` from that parallel run.
- Waits for the cart toggle response in the bookstore e2e test and retries briefly while the client hydrates.
- Gives test workers a short normal-shutdown grace period before terminating leaked worker resources.
- Removes timer ordering from the `raceRequestAbort` test that covers aborting during promise execution.
