### PR TITLE
Add fork pool for remix test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -127,7 +127,7 @@ jobs:
 
   test-windows-main:
     name: test (windows-latest)
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -127,7 +127,7 @@ jobs:
 
   test-windows-main:
     name: test (windows-latest)
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: github.event_name == 'push'
     runs-on: windows-latest
 
     steps:

--- a/demos/bookstore/remix-test.config.ts
+++ b/demos/bookstore/remix-test.config.ts
@@ -17,13 +17,6 @@ if (platform !== 'win32') {
 }
 
 export default {
-  ...(platform === 'win32'
-    ? {
-        // node:sqlite currently crashes on Windows when this demo opens SQLite
-        // databases across multiple test workers concurrently.
-        concurrency: 1,
-      }
-    : {}),
   playwrightConfig: {
     projects,
     use: {

--- a/packages/test/.changes/patch.worker-cleanup.md
+++ b/packages/test/.changes/patch.worker-cleanup.md
@@ -1,1 +1,1 @@
-Clean up leaked test worker resources after results are reported while giving normal workers more time to finish shutdown first.
+Run server and E2E test files in forked child processes by default, add `pool: 'threads'`/`--pool threads` to preserve the previous worker-thread behavior, and clean up leaked test worker resources after results are reported.

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -76,6 +76,9 @@ export default {
   // Max number of concurrent test workers (default `os.availableParallelism()`)
   concurrency: 2,
 
+  // Pool for server and E2E test files ("forks", "threads")
+  pool: 'forks',
+
   // Code coverage options
   coverage: {
     // Enable coverage reporting
@@ -158,6 +161,7 @@ You may also specify any config field as a CLI flag which will take precedence o
 | `--glob.browser`            |       |
 | `--glob.e2e`                |       |
 | `--playwrightConfig <path>` |       |
+| `--pool <forks|threads>`    |       |
 | `--project <name>`          | `-p`  |
 | `--reporter <name>`         | `-r`  |
 | `--setup <path>`            | `-s`  |

--- a/packages/test/src/cli.ts
+++ b/packages/test/src/cli.ts
@@ -183,6 +183,7 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
           {
             coverage: config.coverage,
             cwd,
+            pool: config.pool,
           },
         )
         counts.failed += serverResult.failed
@@ -241,6 +242,7 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
                   projectName: project.name,
                   coverage: config.coverage,
                   cwd,
+                  pool: config.pool,
                 })
               : null,
           ])

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -1,4 +1,4 @@
-export type { RemixTestConfig } from './lib/config.ts'
+export type { RemixTestConfig, RemixTestPool } from './lib/config.ts'
 export {
   describe,
   it,

--- a/packages/test/src/lib/config.ts
+++ b/packages/test/src/lib/config.ts
@@ -115,6 +115,10 @@ const cliOptions = {
     short: 'p',
     description: 'Filter to a specific Playwright project (comma-separated)',
   },
+  pool: {
+    type: 'string',
+    description: 'Pool used to run server and E2E test files: forks, threads (default: forks)',
+  },
   reporter: {
     type: 'string',
     short: 'r',
@@ -154,12 +158,15 @@ const defaultValues: ResolvedRemixTestConfig = {
     exclude: 'node_modules/**',
   },
   reporter: process.env.CI === 'true' ? 'files' : 'spec',
+  pool: 'forks',
   type: 'server,browser,e2e',
   setup: undefined,
   playwrightConfig: undefined,
   project: undefined,
   watch: false,
-} as const
+}
+
+export type RemixTestPool = 'forks' | 'threads'
 
 export interface RemixTestConfig {
   /**
@@ -215,6 +222,11 @@ export interface RemixTestConfig {
   project?: string
   /** Test reporter (--reporter) */
   reporter?: string
+  /**
+   * Pool used to run server and E2E test files. Forked child processes are the default,
+   * but worker threads are available for projects that prefer the previous behavior.
+   */
+  pool?: RemixTestPool
   /** Comma-separated list of test types to run (--type) */
   type?: string
   /** Watch mode — re-run tests on file changes (--watch) */
@@ -247,6 +259,7 @@ export interface ResolvedRemixTestConfig {
   playwrightConfig: string | PlaywrightTestConfig | undefined
   project: string | undefined
   reporter: string
+  pool: RemixTestPool
   setup: string | undefined
   type: string
   watch: boolean
@@ -350,9 +363,18 @@ function resolveConfig(
       cliValues.playwrightConfig ?? fileConfig.playwrightConfig ?? defaultValues.playwrightConfig,
     project: cliValues.project ?? fileConfig.project ?? defaultValues.project,
     reporter: cliValues.reporter ?? fileConfig.reporter ?? defaultValues.reporter,
+    pool: resolvePool(cliValues.pool ?? fileConfig.pool ?? defaultValues.pool),
     type: cliValues.type ?? fileConfig.type ?? defaultValues.type,
     watch: cliValues.watch ?? fileConfig.watch ?? defaultValues.watch,
   }
+}
+
+function resolvePool(value: string): RemixTestPool {
+  if (value === 'forks' || value === 'threads') {
+    return value
+  }
+
+  throw new Error(`Unsupported test pool "${value}". Supported pools are: forks, threads`)
 }
 
 async function loadConfigFile(

--- a/packages/test/src/lib/import-module.ts
+++ b/packages/test/src/lib/import-module.ts
@@ -1,3 +1,5 @@
+import * as path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { tsImport } from 'tsx/esm/api'
 import { IS_BUN } from './runtime.ts'
 
@@ -17,13 +19,15 @@ function hasImportMetaResolve(meta: ImportMeta): meta is ImportMetaWithResolve {
  * @returns The imported module namespace.
  */
 export async function importModule(specifier: string, meta: ImportMeta): Promise<any> {
+  let resolvedSpecifier = path.isAbsolute(specifier) ? pathToFileURL(specifier).href : specifier
+
   if (IS_BUN) {
     if (!hasImportMetaResolve(meta)) {
       throw new Error('importModule() requires import.meta.resolve() in Bun')
     }
 
-    return import(meta.resolve(specifier, meta.url))
+    return import(meta.resolve(resolvedSpecifier, meta.url))
   }
 
-  return tsImport(specifier, meta.url)
+  return tsImport(resolvedSpecifier, meta.url)
 }

--- a/packages/test/src/lib/runner.ts
+++ b/packages/test/src/lib/runner.ts
@@ -1,8 +1,9 @@
+import { fork, type ChildProcess } from 'node:child_process'
 import * as fsp from 'node:fs/promises'
 import * as path from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { Worker } from 'node:worker_threads'
-import { IS_RUNNING_FROM_SRC } from './config.ts'
+import { IS_RUNNING_FROM_SRC, type RemixTestPool } from './config.ts'
 import {
   collectCoverageMapFromPlaywright,
   collectServerCoverageMap,
@@ -19,12 +20,21 @@ import type { Counts, TestResults } from './reporters/results.ts'
 const ext = IS_RUNNING_FROM_SRC ? '.ts' : '.js'
 const workerUrl = new URL(`./worker${ext}`, import.meta.url)
 const workerE2EUrl = new URL(`./worker-e2e${ext}`, import.meta.url)
+const workerProcessUrl = new URL(`./worker-process${ext}`, import.meta.url)
 const DEFAULT_WORKER_SHUTDOWN_TIMEOUT_MS = 10_000
 
 interface WorkerRun {
-  worker: Worker
   finished: Promise<void>
-  exited: Promise<number>
+  exited: Promise<number | null>
+  terminate(): Promise<boolean>
+}
+
+interface RunFileOptions {
+  cwd?: string
+  coverage?: CoverageConfig
+  open?: boolean
+  playwrightUseOpts?: PlaywrightUseOpts
+  pool?: RemixTestPool
 }
 
 export async function runServerTests(
@@ -39,12 +49,14 @@ export async function runServerTests(
     projectName?: string
     coverage?: CoverageConfig
     workerShutdownTimeoutMs?: number
+    pool?: RemixTestPool
   } = {},
 ): Promise<Counts & { coverageMap: CoverageMap | null }> {
   let counts: Counts = { passed: 0, failed: 0, skipped: 0, todo: 0 }
   let coverageMap: CoverageMap | null = null
   let cwd = options.cwd ?? process.cwd()
   let envLabel = options.projectName ? `${type}:${options.projectName}` : type
+  let pool = options.pool ?? 'forks'
 
   function accumulate(results: TestResults, file: string) {
     reporter.onResult(
@@ -64,7 +76,7 @@ export async function runServerTests(
       files,
       concurrency,
       (file) =>
-        runFileInWorker(
+        runFileInPool(
           file,
           type,
           (results) => {
@@ -75,6 +87,7 @@ export async function runServerTests(
           },
           {
             ...options,
+            pool,
             playwrightUseOpts: options.playwrightUseOpts,
           },
         ),
@@ -102,7 +115,11 @@ export async function runServerTests(
     await runInConcurrentWorkers(
       files,
       concurrency,
-      (file) => runFileInWorker(file, type, (results) => accumulate(results, file), options),
+      (file) =>
+        runFileInPool(file, type, (results) => accumulate(results, file), {
+          ...options,
+          pool,
+        }),
       () => counts.failed++,
       true,
       options.workerShutdownTimeoutMs ?? DEFAULT_WORKER_SHUTDOWN_TIMEOUT_MS,
@@ -147,27 +164,13 @@ async function runInConcurrentWorkers(
           }
         }
 
-        async function terminate(): Promise<boolean> {
-          try {
-            await run.worker.terminate()
-            return true
-          } catch (err) {
-            console.error(
-              `Error terminating worker for ${file}:`,
-              err instanceof Error ? err.message : err,
-            )
-            console.error(err)
-            return false
-          }
-        }
-
         run.finished.then(
           async () => {
             try {
               if (terminateWhenFinished) {
                 let exited = await waitForWorkerExit(run.exited, workerShutdownTimeoutMs)
                 if (!exited) {
-                  let terminated = await terminate()
+                  let terminated = await run.terminate()
                   if (!terminated) {
                     onError()
                   }
@@ -182,7 +185,7 @@ async function runInConcurrentWorkers(
               console.error(`Error running ${file}:`, err instanceof Error ? err.message : err)
               console.error(err)
               onError()
-              await terminate()
+              await run.terminate()
             } finally {
               complete()
             }
@@ -197,7 +200,10 @@ async function runInConcurrentWorkers(
   })
 }
 
-function waitForWorkerExit(exited: Promise<number>, timeoutMs: number): Promise<boolean> {
+function waitForWorkerExit(
+  exited: Promise<number | null>,
+  timeoutMs: number,
+): Promise<boolean> {
   return new Promise((resolve) => {
     let timeout = setTimeout(() => resolve(false), timeoutMs)
     exited.then(() => {
@@ -207,16 +213,22 @@ function waitForWorkerExit(exited: Promise<number>, timeoutMs: number): Promise<
   })
 }
 
+function runFileInPool(
+  file: string,
+  type: 'server' | 'e2e',
+  onResults: (results: TestResults) => void,
+  options: RunFileOptions,
+): WorkerRun {
+  return options.pool === 'threads'
+    ? runFileInWorker(file, type, onResults, options)
+    : runFileInProcess(file, type, onResults, options)
+}
+
 export function runFileInWorker(
   file: string,
   type: 'server' | 'e2e',
   onResults: (results: TestResults) => void,
-  options: {
-    cwd?: string
-    coverage?: CoverageConfig
-    open?: boolean
-    playwrightUseOpts?: PlaywrightUseOpts
-  } = {},
+  options: RunFileOptions = {},
 ): WorkerRun {
   let receivedResults = false
   let worker =
@@ -266,8 +278,118 @@ export function runFileInWorker(
   })
 
   return {
-    worker,
     finished,
     exited,
+    async terminate() {
+      try {
+        await worker.terminate()
+        return true
+      } catch (err) {
+        console.error(
+          `Error terminating worker for ${file}:`,
+          err instanceof Error ? err.message : err,
+        )
+        console.error(err)
+        return false
+      }
+    },
   }
+}
+
+function runFileInProcess(
+  file: string,
+  type: 'server' | 'e2e',
+  onResults: (results: TestResults) => void,
+  options: RunFileOptions = {},
+): WorkerRun {
+  let receivedResults = false
+  let child = fork(fileURLToPath(workerProcessUrl), [], {
+    serialization: 'advanced',
+    stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+  })
+
+  let exited = new Promise<number | null>((resolve) => {
+    child.once('exit', (code) => resolve(code))
+  })
+
+  let finished = new Promise<void>((resolve, reject) => {
+    child.once('message', (msg: unknown) => {
+      if (!isTestResults(msg)) {
+        reject(new Error('Test worker process sent invalid results'))
+        return
+      }
+
+      receivedResults = true
+      try {
+        onResults(msg)
+      } catch (error) {
+        reject(error)
+        return
+      }
+      if (!options.open) {
+        resolve()
+      }
+    })
+    child.once('error', reject)
+    exited.then((code) => {
+      if (receivedResults || code === 0) {
+        resolve()
+      } else {
+        reject(new Error(`Worker process exited with code ${code}`))
+      }
+    })
+    child.send(
+      {
+        file: pathToFileURL(file).href,
+        type,
+        coverage: options.coverage,
+        open: options.open,
+        playwrightUseOpts: options.playwrightUseOpts,
+      },
+      (error) => {
+        if (error) {
+          reject(error)
+        }
+      },
+    )
+  })
+
+  return {
+    finished,
+    exited,
+    terminate: () => terminateChildProcess(child, exited),
+  }
+}
+
+async function terminateChildProcess(
+  child: ChildProcess,
+  exited: Promise<number | null>,
+): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return true
+  }
+
+  if (!child.kill()) {
+    return false
+  }
+
+  return await waitForWorkerExit(exited, 5_000)
+}
+
+function isTestResults(value: unknown): value is TestResults {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  return (
+    typeof value.passed === 'number' &&
+    typeof value.failed === 'number' &&
+    typeof value.skipped === 'number' &&
+    typeof value.todo === 'number' &&
+    Array.isArray(value.tests)
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
 }

--- a/packages/test/src/lib/worker-e2e-file.ts
+++ b/packages/test/src/lib/worker-e2e-file.ts
@@ -1,0 +1,98 @@
+import { runTests } from './executor.ts'
+import { importModule } from './import-module.ts'
+import {
+  getBrowserLauncher,
+  getPlaywrightLaunchOptions,
+  getPlaywrightPageOptions,
+  type PlaywrightUseOpts,
+} from './playwright.ts'
+import type { CoverageConfig } from './coverage.ts'
+import type { TestResults } from './reporters/results.ts'
+import { createFailedResults } from './worker-results.ts'
+import { isRecord, parseCoverageConfig } from './worker-server.ts'
+
+export interface E2ETestWorkerData {
+  file: string
+  coverage?: CoverageConfig
+  open?: boolean
+  playwrightUseOpts?: PlaywrightUseOpts
+}
+
+export async function runE2ETestFile(
+  value: unknown,
+  onOpenResults?: (results: TestResults) => void | Promise<void>,
+): Promise<TestResults | undefined> {
+  try {
+    let workerData = parseE2ETestWorkerData(value)
+
+    await importModule(workerData.file, import.meta)
+
+    let launcher = await getBrowserLauncher(workerData.playwrightUseOpts)
+    let opts = getPlaywrightLaunchOptions(workerData.playwrightUseOpts)
+    let browser = await launcher.launch(opts)
+    let browserClosed = false
+
+    try {
+      let results = await runTests({
+        browser,
+        open: workerData.open ?? false,
+        playwrightPageOptions: getPlaywrightPageOptions(workerData.playwrightUseOpts),
+        coverage: !!workerData.coverage,
+      })
+
+      if (workerData.open) {
+        await onOpenResults?.(results)
+        console.log('\nBrowser is open. Press Ctrl+C to close.')
+        await new Promise<void>((resolve) => browser.on('disconnected', () => resolve()))
+        return undefined
+      }
+
+      await browser.close()
+      browserClosed = true
+      return results
+    } finally {
+      if (!browserClosed) {
+        await browser.close()
+      }
+    }
+  } catch (error) {
+    return createFailedResults(error)
+  }
+}
+
+function parseE2ETestWorkerData(value: unknown): E2ETestWorkerData {
+  if (!isRecord(value) || typeof value.file !== 'string') {
+    throw new Error('Invalid E2E test worker data')
+  }
+
+  return {
+    file: value.file,
+    coverage: parseCoverageConfig(value.coverage),
+    open: parseBoolean(value.open, 'open'),
+    playwrightUseOpts: parsePlaywrightUseOpts(value.playwrightUseOpts),
+  }
+}
+
+function parseBoolean(value: unknown, name: string): boolean | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (typeof value !== 'boolean') {
+    throw new Error(`Invalid E2E test worker ${name}`)
+  }
+
+  return value
+}
+
+function parsePlaywrightUseOpts(value: unknown): PlaywrightUseOpts | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (!isRecord(value)) {
+    throw new Error('Invalid E2E test worker playwright options')
+  }
+
+  return value as PlaywrightUseOpts
+}

--- a/packages/test/src/lib/worker-e2e.ts
+++ b/packages/test/src/lib/worker-e2e.ts
@@ -1,61 +1,17 @@
-import { workerData, parentPort } from 'node:worker_threads'
-import { runTests } from './executor.ts'
-import { importModule } from './import-module.ts'
-import {
-  getBrowserLauncher,
-  getPlaywrightLaunchOptions,
-  getPlaywrightPageOptions,
-} from './playwright.ts'
-import type { TestResults } from './reporters/results.ts'
+import { parentPort, workerData } from 'node:worker_threads'
+import { runE2ETestFile } from './worker-e2e-file.ts'
 
-try {
-  await importModule(workerData.file, import.meta)
-
-  let launcher = await getBrowserLauncher(workerData.playwrightUseOpts)
-  let opts = getPlaywrightLaunchOptions(workerData.playwrightUseOpts)
-  let browser = await launcher.launch(opts)
-  let browserClosed = false
-  try {
-    let results = await runTests({
-      browser,
-      open: workerData.open,
-      playwrightPageOptions: getPlaywrightPageOptions(workerData.playwrightUseOpts),
-      coverage: workerData.coverage,
-    })
-    if (workerData.open) {
-      parentPort!.postMessage(results)
-      console.log('\nBrowser is open. Press Ctrl+C to close.')
-      await new Promise<void>((resolve) => browser.on('disconnected', () => resolve()))
-    } else {
-      await browser.close()
-      browserClosed = true
-      parentPort!.postMessage(results)
-    }
-  } finally {
-    if (!browserClosed) {
-      await browser.close()
-    }
-  }
-  process.exit(0)
-} catch (e) {
-  let results: TestResults = {
-    passed: 0,
-    failed: 1,
-    skipped: 0,
-    todo: 0,
-    tests: [
-      {
-        name: '',
-        suiteName: '',
-        status: 'failed',
-        duration: 0,
-        error: {
-          message: e instanceof Error ? e.message : String(e),
-          stack: e instanceof Error ? e.stack : undefined,
-        },
-      },
-    ],
-  }
-  parentPort!.postMessage(results)
-  process.exit(0)
+if (!parentPort) {
+  throw new Error('E2E test worker is missing a parent port')
 }
+
+const port = parentPort
+const results = await runE2ETestFile(workerData, (openResults) => {
+  port.postMessage(openResults)
+})
+
+if (results) {
+  port.postMessage(results)
+}
+
+process.exit(0)

--- a/packages/test/src/lib/worker-process.ts
+++ b/packages/test/src/lib/worker-process.ts
@@ -1,0 +1,69 @@
+import { runE2ETestFile } from './worker-e2e-file.ts'
+import type { TestResults } from './reporters/results.ts'
+import { runServerTestFile } from './worker-server.ts'
+import { createFailedResults } from './worker-results.ts'
+
+const workerData = await readWorkerData()
+
+const results = await runWorkerProcessFile(workerData)
+
+if (results) {
+  await sendResults(results)
+}
+
+if (process.connected) {
+  process.disconnect()
+}
+
+process.exitCode = 0
+
+function readWorkerData(): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    function cleanup() {
+      process.off('message', onMessage)
+      process.off('disconnect', onDisconnect)
+    }
+
+    function onMessage(value: unknown) {
+      cleanup()
+      resolve(value)
+    }
+
+    function onDisconnect() {
+      cleanup()
+      reject(new Error('Test worker process disconnected'))
+    }
+
+    process.once('message', onMessage)
+    process.once('disconnect', onDisconnect)
+  })
+}
+
+async function runWorkerProcessFile(value: unknown): Promise<TestResults | undefined> {
+  try {
+    if (!isRecord(value) || (value.type !== 'server' && value.type !== 'e2e')) {
+      throw new Error('Invalid test worker process data')
+    }
+
+    return value.type === 'e2e'
+      ? await runE2ETestFile(value, sendResults)
+      : await runServerTestFile(value)
+  } catch (error) {
+    return createFailedResults(error)
+  }
+}
+
+async function sendResults(results: TestResults): Promise<void> {
+  if (!process.send) {
+    throw new Error('Test worker process is missing an IPC channel')
+  }
+
+  let send = process.send.bind(process)
+  await new Promise<void>((resolve, reject) => {
+    send(results, undefined, undefined, (error) => (error ? reject(error) : resolve()))
+  })
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/packages/test/src/lib/worker-results.ts
+++ b/packages/test/src/lib/worker-results.ts
@@ -1,0 +1,22 @@
+import type { TestResults } from './reporters/results.ts'
+
+export function createFailedResults(error: unknown): TestResults {
+  return {
+    passed: 0,
+    failed: 1,
+    skipped: 0,
+    todo: 0,
+    tests: [
+      {
+        name: '',
+        suiteName: '',
+        status: 'failed',
+        duration: 0,
+        error: {
+          message: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+        },
+      },
+    ],
+  }
+}

--- a/packages/test/src/lib/worker-server.ts
+++ b/packages/test/src/lib/worker-server.ts
@@ -1,0 +1,123 @@
+import * as mod from 'node:module'
+import { IS_RUNNING_FROM_SRC } from './config.ts'
+import { importModule } from './import-module.ts'
+import type { CoverageConfig } from './coverage.ts'
+import type { TestResults } from './reporters/results.ts'
+import { runTests } from './executor.ts'
+import { IS_BUN } from './runtime.ts'
+import { createFailedResults } from './worker-results.ts'
+
+export interface ServerTestWorkerData {
+  file: string
+  coverage?: CoverageConfig
+}
+
+export async function runServerTestFile(value: unknown): Promise<TestResults> {
+  let workerData: ServerTestWorkerData | undefined
+
+  try {
+    workerData = parseServerTestWorkerData(value)
+
+    // When coverage is enabled in Node, we use a coverage-friendly TypeScript loader which
+    // replaces tsx's minified transformation with a non-minified esbuild transform
+    // so V8 coverage byte offsets align with readable source lines. This hook runs
+    // before the inherited tsx hook (hooks are LIFO), so it intercepts .ts imports and
+    // short-circuits before tsx transforms them.
+    if (workerData.coverage && !IS_BUN) {
+      // Ensure we load the right file whether we're running in the monorepo (TS) or
+      // from a published package (JS)
+      let ext = IS_RUNNING_FROM_SRC ? '.ts' : '.js'
+      mod.register(new URL(`./coverage-loader${ext}`, import.meta.url), import.meta.url)
+      await import(workerData.file)
+    } else {
+      await importModule(workerData.file, import.meta)
+    }
+
+    let results = await runTests()
+    await takeCoverage(workerData.coverage)
+    return results
+  } catch (e) {
+    try {
+      await takeCoverage(workerData?.coverage)
+    } catch (coverageError) {
+      e = coverageError
+    }
+
+    return createFailedResults(e)
+  }
+}
+
+function parseServerTestWorkerData(value: unknown): ServerTestWorkerData {
+  if (!isRecord(value) || typeof value.file !== 'string') {
+    throw new Error('Invalid server test worker data')
+  }
+
+  return {
+    file: value.file,
+    coverage: parseCoverageConfig(value.coverage),
+  }
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+export function parseCoverageConfig(value: unknown): CoverageConfig | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (!isRecord(value) || typeof value.dir !== 'string') {
+    throw new Error('Invalid server test worker coverage config')
+  }
+
+  let coverage: CoverageConfig = {
+    dir: value.dir,
+  }
+  let include = parseStringArray(value.include, 'include')
+  let exclude = parseStringArray(value.exclude, 'exclude')
+  let statements = parseNumber(value.statements, 'statements')
+  let lines = parseNumber(value.lines, 'lines')
+  let branches = parseNumber(value.branches, 'branches')
+  let functions = parseNumber(value.functions, 'functions')
+
+  if (include) coverage.include = include
+  if (exclude) coverage.exclude = exclude
+  if (statements !== undefined) coverage.statements = statements
+  if (lines !== undefined) coverage.lines = lines
+  if (branches !== undefined) coverage.branches = branches
+  if (functions !== undefined) coverage.functions = functions
+
+  return coverage
+}
+
+function parseStringArray(value: unknown, name: string): string[] | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`Invalid server test worker coverage ${name}`)
+  }
+
+  return value
+}
+
+function parseNumber(value: unknown, name: string): number | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (typeof value !== 'number') {
+    throw new Error(`Invalid server test worker coverage ${name}`)
+  }
+
+  return value
+}
+
+async function takeCoverage(coverage: CoverageConfig | undefined): Promise<void> {
+  if (coverage && !IS_BUN) {
+    let v8 = await import('node:v8')
+    v8.takeCoverage()
+  }
+}

--- a/packages/test/src/lib/worker.ts
+++ b/packages/test/src/lib/worker.ts
@@ -1,64 +1,10 @@
-import * as mod from 'node:module'
-import * as path from 'node:path'
 import { parentPort, workerData } from 'node:worker_threads'
-import { runTests } from './executor.ts'
-import { importModule } from './import-module.ts'
-import type { TestResults } from './reporters/results.ts'
-import { IS_BUN } from './runtime.ts'
-import { IS_RUNNING_FROM_SRC } from './config.ts'
+import { runServerTestFile } from './worker-server.ts'
 
-async function takeCoverage(): Promise<void> {
-  if (workerData.coverage && !IS_BUN) {
-    let v8 = await import('node:v8')
-    v8.takeCoverage()
-  }
+if (!parentPort) {
+  throw new Error('Server test worker is missing a parent port')
 }
 
-try {
-  // When coverage is enabled in Node, we use a coverage-friendly TypeScript loader which
-  // replaces tsx's minified transformation with a non-minified esbuild transform
-  // so V8 coverage byte offsets align with readable source lines. This hook runs
-  // before the inherited tsx hook (hooks are LIFO), so it intercepts .ts imports and
-  // short-circuits before tsx transforms them.
-  if (workerData.coverage && !IS_BUN) {
-    // Ensure we load the right file whether we're running in the monorepo (TS) or
-    // from a published package (JS)
-    let ext = IS_RUNNING_FROM_SRC ? '.ts' : '.js'
-    mod.register(new URL(`./coverage-loader${ext}`, import.meta.url), import.meta.url)
-    await import(workerData.file)
-  } else {
-    await importModule(workerData.file, import.meta)
-  }
-
-  let results = await runTests()
-  await takeCoverage()
-  parentPort!.postMessage(results)
-  process.exit(0)
-} catch (e) {
-  try {
-    await takeCoverage()
-  } catch (coverageError) {
-    e = coverageError
-  }
-
-  let results: TestResults = {
-    passed: 0,
-    failed: 1,
-    skipped: 0,
-    todo: 0,
-    tests: [
-      {
-        name: '',
-        suiteName: '',
-        status: 'failed',
-        duration: 0,
-        error: {
-          message: e instanceof Error ? e.message : String(e),
-          stack: e instanceof Error ? e.stack : undefined,
-        },
-      },
-    ],
-  }
-  parentPort!.postMessage(results)
-  process.exit(0)
-}
+const results = await runServerTestFile(workerData)
+parentPort.postMessage(results)
+process.exit(0)

--- a/packages/test/src/test/config.test.ts
+++ b/packages/test/src/test/config.test.ts
@@ -1,0 +1,58 @@
+import * as assert from '@remix-run/assert'
+import * as fsp from 'node:fs/promises'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it } from '../lib/framework.ts'
+import { getRemixTestHelpText, loadConfig } from '../lib/config.ts'
+
+const PKG_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+const CONFIG_FIXTURE_DIR = path.join(PKG_DIR, '.tmp', 'config')
+
+describe('config', () => {
+  it('defaults to the forks pool', async () => {
+    let cwd = await createConfigDir('default-pool')
+    let config = await loadConfig([], cwd)
+
+    assert.equal(config.pool, 'forks')
+  })
+
+  it('reads pool from the config file', async () => {
+    let cwd = await createConfigDir('file-pool')
+    await fsp.writeFile(path.join(cwd, 'remix-test.config.ts'), `export default { pool: 'threads' }`)
+
+    let config = await loadConfig([], cwd)
+
+    assert.equal(config.pool, 'threads')
+  })
+
+  it('prefers the CLI pool over the config file', async () => {
+    let cwd = await createConfigDir('cli-pool')
+    await fsp.writeFile(path.join(cwd, 'remix-test.config.ts'), `export default { pool: 'threads' }`)
+
+    let config = await loadConfig(['--pool', 'forks'], cwd)
+
+    assert.equal(config.pool, 'forks')
+  })
+
+  it('rejects unsupported pool values', async () => {
+    let cwd = await createConfigDir('invalid-pool')
+
+    await assert.rejects(
+      () => loadConfig(['--pool', 'workers'], cwd),
+      /Unsupported test pool "workers"/,
+    )
+  })
+
+  it('includes the pool flag in help text', () => {
+    let help = getRemixTestHelpText()
+
+    assert.match(help, /--pool <value>/)
+  })
+})
+
+async function createConfigDir(name: string): Promise<string> {
+  let dir = path.join(CONFIG_FIXTURE_DIR, name)
+  await fsp.rm(dir, { recursive: true, force: true })
+  await fsp.mkdir(dir, { recursive: true })
+  return dir
+}

--- a/packages/test/src/test/worker-cleanup.test.ts
+++ b/packages/test/src/test/worker-cleanup.test.ts
@@ -3,6 +3,7 @@ import * as fsp from 'node:fs/promises'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, it } from '../lib/framework.ts'
+import type { RemixTestPool } from '../lib/config.ts'
 import { runServerTests } from '../lib/runner.ts'
 import { IS_BUN } from '../lib/runtime.ts'
 import type { Reporter } from '../lib/reporters/index.ts'
@@ -14,11 +15,20 @@ const FIXTURE_FILE = path.join(FIXTURE_DIR, 'leaked-worker.test.ts')
 
 describe('worker cleanup', () => {
   it('terminates leaked workers after receiving results', { skip: IS_BUN }, async () => {
-    await fsp.rm(FIXTURE_DIR, { recursive: true, force: true })
-    await fsp.mkdir(FIXTURE_DIR, { recursive: true })
-    await fsp.writeFile(
-      FIXTURE_FILE,
-      `
+    await runLeakedWorkerFixture('threads')
+  })
+
+  it('runs server tests in fork isolation', { skip: IS_BUN }, async () => {
+    await runLeakedWorkerFixture('forks')
+  })
+})
+
+async function runLeakedWorkerFixture(pool: RemixTestPool): Promise<void> {
+  await fsp.rm(FIXTURE_DIR, { recursive: true, force: true })
+  await fsp.mkdir(FIXTURE_DIR, { recursive: true })
+  await fsp.writeFile(
+    FIXTURE_FILE,
+    `
 import { Worker } from 'node:worker_threads'
 import { describe, it } from '../../src/lib/framework.ts'
 
@@ -30,40 +40,40 @@ describe('leaked worker fixture', () => {
   })
 })
 `,
-    )
+  )
 
-    let results: TestResults | undefined
-    let reporter: Reporter = {
-      onResult(testResults) {
-        results = testResults
-      },
-      onSectionStart() {},
-      onSummary() {},
-    }
+  let results: TestResults | undefined
+  let reporter: Reporter = {
+    onResult(testResults) {
+      results = testResults
+    },
+    onSectionStart() {},
+    onSummary() {},
+  }
 
-    try {
-      let counts = await runServerTests([FIXTURE_FILE], reporter, 1, 'server', {
-        workerShutdownTimeoutMs: 50,
-      })
-      assert.equal(counts.passed, 1)
-      assert.equal(counts.failed, 0)
-      assert.equal(counts.skipped, 0)
-      assert.equal(counts.todo, 0)
-    } finally {
-      await fsp.rm(FIXTURE_DIR, { recursive: true, force: true })
-    }
+  try {
+    let counts = await runServerTests([FIXTURE_FILE], reporter, 1, 'server', {
+      pool,
+      workerShutdownTimeoutMs: 50,
+    })
+    assert.equal(counts.passed, 1)
+    assert.equal(counts.failed, 0)
+    assert.equal(counts.skipped, 0)
+    assert.equal(counts.todo, 0)
+  } finally {
+    await fsp.rm(FIXTURE_DIR, { recursive: true, force: true })
+  }
 
-    assert.ok(results)
-    assert.equal(results.passed, 1)
-    assert.equal(results.failed, 0)
-    assert.equal(results.skipped, 0)
-    assert.equal(results.todo, 0)
+  assert.ok(results)
+  assert.equal(results.passed, 1)
+  assert.equal(results.failed, 0)
+  assert.equal(results.skipped, 0)
+  assert.equal(results.todo, 0)
 
-    let { tests } = results
-    assert.equal(tests.length, 1)
-    assert.equal(tests[0].name, 'passes while leaving a worker running')
-    assert.equal(tests[0].suiteName, 'leaked worker fixture')
-    assert.equal(tests[0].status, 'passed')
-    assert.equal(typeof tests[0].duration, 'number')
-  })
-})
+  let { tests } = results
+  assert.equal(tests.length, 1)
+  assert.equal(tests[0].name, 'passes while leaving a worker running')
+  assert.equal(tests[0].suiteName, 'leaked worker fixture')
+  assert.equal(tests[0].status, 'passed')
+  assert.equal(typeof tests[0].duration, 'number')
+}


### PR DESCRIPTION
Closes #11295.

This moves server and E2E test-file execution behind a `pool` option and defaults that pool to forked child processes. Worker threads remain available for projects that want the previous behavior, while bookstore can stay on the normal `remix test` path without custom runner scripts or a Windows-only concurrency workaround.

- Adds `pool: 'forks' | 'threads'` to `RemixTestConfig` plus `--pool forks` and `--pool threads`
- Factors server and E2E worker execution so thread and fork pools share the same test-file logic and `TestResults` payload
- Removes the bookstore Windows test-runner workaround from its Remix test config

```ts
import type { RemixTestConfig } from 'remix/test'

export default {
  pool: 'threads',
} satisfies RemixTestConfig
```

```sh
remix test --pool forks
remix test --pool threads
```
