### PR TITLE
Serve Oxc runtime from asset server, require `basePath`

### DIFF
--- a/demos/assets/app/utils/assets.ts
+++ b/demos/assets/app/utils/assets.ts
@@ -5,10 +5,11 @@ import { assetsBase } from '../routes.ts'
 const isDevelopment = process.env.NODE_ENV === 'development'
 
 export const assetServer = createAssetServer({
+  basePath: assetsBase,
   rootDir: path.resolve(import.meta.dirname, '../..'),
   allow: ['app/client/**'],
   fileMap: {
-    [`${assetsBase}/app/*path`]: 'app/client/*path',
+    '/app/*path': 'app/client/*path',
   },
   watch: isDevelopment,
 })

--- a/demos/bookstore/app/utils/assets.ts
+++ b/demos/bookstore/app/utils/assets.ts
@@ -5,11 +5,12 @@ import { assetsBase } from '../routes.ts'
 const isDevelopment = process.env.NODE_ENV === 'development'
 
 export const assetServer = createAssetServer({
+  basePath: assetsBase,
   rootDir: path.resolve(import.meta.dirname, '../../../..'),
   allow: ['demos/bookstore/app/assets/**', 'demos/bookstore/app/routes.ts', 'packages/*/src/**'],
   fileMap: {
-    [`${assetsBase}/app/*path`]: 'demos/bookstore/app/*path',
-    [`${assetsBase}/packages/*path`]: 'packages/*path',
+    '/app/*path': 'demos/bookstore/app/*path',
+    '/packages/*path': 'packages/*path',
   },
   sourceMaps: isDevelopment ? 'external' : undefined,
   minify: !isDevelopment,

--- a/packages/assets/.changes/minor.require-base-path.md
+++ b/packages/assets/.changes/minor.require-base-path.md
@@ -1,0 +1,22 @@
+BREAKING CHANGE: `createAssetServer()` now requires a `basePath` option, and `fileMap` URL patterns are now relative to that base path.
+
+```ts
+// Before:
+createAssetServer({
+  fileMap: {
+    '/assets/app/*path': 'app/*path',
+    '/assets/npm/*path': 'node_modules/*path',
+  },
+  allow: ['app/**', 'node_modules/**'],
+})
+
+// After:
+createAssetServer({
+  basePath: '/assets',
+  fileMap: {
+    '/app/*path': 'app/*path',
+    '/npm/*path': 'node_modules/*path',
+  },
+  allow: ['app/**', 'node_modules/**'],
+})
+```

--- a/packages/assets/.changes/patch.internal-oxc-runtime-helpers.md
+++ b/packages/assets/.changes/patch.internal-oxc-runtime-helpers.md
@@ -1,0 +1,1 @@
+The `@oxc-project/runtime` package which provides helpers for generated code targeting older browsers is now served automatically by the asset server and doesn't need to be manually installed.

--- a/packages/assets/README.md
+++ b/packages/assets/README.md
@@ -27,9 +27,10 @@ import { createRouter } from 'remix/fetch-router'
 import { createAssetServer } from 'remix/assets'
 
 let assetServer = createAssetServer({
+  basePath: '/assets',
   fileMap: {
-    '/assets/app/*path': 'app/*path',
-    '/assets/npm/*path': 'node_modules/*path',
+    '/app/*path': 'app/*path',
+    '/npm/*path': 'node_modules/*path',
   },
   allow: ['app/assets/**', 'node_modules/**'],
 })
@@ -53,9 +54,10 @@ import { createAssetServer } from 'remix/assets'
 
 let assetServer = createAssetServer({
   rootDir: path.resolve(import.meta.dirname, '..'),
+  basePath: '/assets',
   fileMap: {
-    '/assets/app/*path': 'app/*path',
-    '/assets/npm/*path': 'node_modules/*path',
+    '/app/*path': 'app/*path',
+    '/npm/*path': 'node_modules/*path',
   },
   allow: ['app/assets/**', 'node_modules/**'],
 })
@@ -69,7 +71,8 @@ You must provide an `allow` list to specify which files are allowed to be served
 import { createAssetServer } from 'remix/assets'
 
 let assetServer = createAssetServer({
-  fileMap: { '/assets/app/*path': 'app/*path' },
+  basePath: '/assets',
+  fileMap: { '/app/*path': 'app/*path' },
   allow: ['app/assets/**'],
   deny: ['app/**/*.server.*'],
 })
@@ -79,21 +82,22 @@ Rules for `allow` and `deny` are file paths or globs. Relative values are resolv
 
 ## File Map
 
-Use `fileMap` to map public URLs to file paths on disk. The keys are public URL patterns, and the values are root-relative file path patterns.
+Use `fileMap` to map public URLs to file paths on disk. `basePath` defines the shared public mount point, and the `fileMap` keys are URL patterns relative to that base path. The values are root-relative file path patterns.
 
 ```ts
 import { createAssetServer } from 'remix/assets'
 
 let assetServer = createAssetServer({
+  basePath: '/assets',
   fileMap: {
-    '/assets/app/*path': 'app/*path',
-    '/assets/packages/*path': '../packages/*path',
+    '/app/*path': 'app/*path',
+    '/packages/*path': '../packages/*path',
   },
   allow: ['app/assets/**', '../packages/**'],
 })
 ```
 
-`fileMap` entries use [`route-pattern`](https://github.com/remix-run/remix/tree/main/packages/route-pattern) syntax for both URL and file patterns. Wildcards must be named, and the same params must appear in both patterns so imports can be rewritten back to public URLs.
+`fileMap` entries use [`route-pattern`](https://github.com/remix-run/remix/tree/main/packages/route-pattern) syntax for both URL and file patterns. Wildcards must be named, and the same params must appear in both patterns so imports can be rewritten back to public URLs. For example, with `basePath: '/assets'`, a `fileMap` key of `'/app/*path'` is served at `/assets/app/*path`.
 
 ### File watching
 
@@ -103,7 +107,8 @@ The file system is watched by default so source changes are picked up without re
 import { createAssetServer } from 'remix/assets'
 
 let assetServer = createAssetServer({
-  fileMap: { '/assets/app/*path': 'app/*path' },
+  basePath: '/assets',
+  fileMap: { '/app/*path': 'app/*path' },
   allow: ['app/assets/**', 'app/node_modules/**'],
 })
 ```
@@ -120,7 +125,8 @@ You can disable file watching if the files on disk won't change, or if watching 
 import { createAssetServer } from 'remix/assets'
 
 let assetServer = createAssetServer({
-  fileMap: { '/assets/app/*path': 'app/*path' },
+  basePath: '/assets',
+  fileMap: { '/app/*path': 'app/*path' },
   allow: ['app/assets/**', 'app/node_modules/**'],
   watch: false,
 })
@@ -132,7 +138,8 @@ You can optionally provide an array of glob patterns to the `watch.ignore` optio
 import { createAssetServer } from 'remix/assets'
 
 let assetServer = createAssetServer({
-  fileMap: { '/assets/app/*path': 'app/*path' },
+  basePath: '/assets',
+  fileMap: { '/app/*path': 'app/*path' },
   allow: ['app/assets/**', 'app/node_modules/**'],
   watch: {
     ignore: ['**/node_modules/**'],
@@ -174,7 +181,8 @@ If you want clients to cache assets aggressively without revalidation, you can o
 import { createAssetServer } from 'remix/assets'
 
 let assetServer = createAssetServer({
-  fileMap: { '/assets/app/*path': 'app/*path' },
+  basePath: '/assets',
+  fileMap: { '/app/*path': 'app/*path' },
   allow: ['app/assets/**'],
   watch: false,
   fingerprint: {
@@ -195,7 +203,8 @@ Use `target` to lower emitted syntax to a specific browser support policy and/or
 import { createAssetServer } from 'remix/assets'
 
 let assetServer = createAssetServer({
-  fileMap: { '/assets/app/*path': 'app/*path' },
+  basePath: '/assets',
+  fileMap: { '/app/*path': 'app/*path' },
   allow: ['app/assets/**'],
   target: {
     chrome: '109',
@@ -215,7 +224,8 @@ Enable sourcemaps with either `'external'` or `'inline'` using `sourceMaps`:
 import { createAssetServer } from 'remix/assets'
 
 let assetServer = createAssetServer({
-  fileMap: { '/assets/app/*path': 'app/*path' },
+  basePath: '/assets',
+  fileMap: { '/app/*path': 'app/*path' },
   allow: ['app/assets/**'],
   sourceMaps: 'external',
 })
@@ -227,7 +237,8 @@ By default, sourcemap `sources` use URLs so they're presented alongside the comp
 import { createAssetServer } from 'remix/assets'
 
 let assetServer = createAssetServer({
-  fileMap: { '/assets/app/*path': 'app/*path' },
+  basePath: '/assets',
+  fileMap: { '/app/*path': 'app/*path' },
   allow: ['app/assets/**'],
   sourceMaps: 'inline',
   sourceMapSourcePaths: 'absolute',
@@ -242,7 +253,8 @@ Enable minification with `minify`:
 import { createAssetServer } from 'remix/assets'
 
 let assetServer = createAssetServer({
-  fileMap: { '/assets/app/*path': 'app/*path' },
+  basePath: '/assets',
+  fileMap: { '/app/*path': 'app/*path' },
   allow: ['app/assets/**'],
   minify: true,
 })
@@ -258,7 +270,8 @@ Use `scripts.define` to replace global identifiers with constant expressions.
 import { createAssetServer } from 'remix/assets'
 
 let assetServer = createAssetServer({
-  fileMap: { '/assets/app/*path': 'app/*path' },
+  basePath: '/assets',
+  fileMap: { '/app/*path': 'app/*path' },
   allow: ['app/assets/**', 'app/node_modules/**'],
   scripts: {
     define: {
@@ -278,7 +291,8 @@ Use `scripts.external` to leave specific import specifiers unchanged by providin
 import { createAssetServer } from 'remix/assets'
 
 let assetServer = createAssetServer({
-  fileMap: { '/assets/app/*path': 'app/*path' },
+  basePath: '/assets',
+  fileMap: { '/app/*path': 'app/*path' },
   allow: ['app/assets/**'],
   scripts: {
     external: ['my-external-import'],
@@ -305,7 +319,8 @@ Use `onError` to report unexpected compilation failures and/or return a custom r
 import { createAssetServer } from 'remix/assets'
 
 let assetServer = createAssetServer({
-  fileMap: { '/assets/app/*path': 'app/*path' },
+  basePath: '/assets',
+  fileMap: { '/app/*path': 'app/*path' },
   allow: ['app/assets/**'],
   onError(error) {
     console.error('Failed to build client assets', error)

--- a/packages/assets/bench/fixture.ts
+++ b/packages/assets/bench/fixture.ts
@@ -12,7 +12,7 @@ export interface BenchFixture {
   id: 'basic' | 'deep-graph'
   label: string
   entryPoint: string
-  assetServer: Pick<AssetServerOptions, 'allow' | 'fileMap'>
+  assetServer: Pick<AssetServerOptions, 'allow' | 'basePath' | 'fileMap'>
   entryPointUrl: string
   expectedEntryUrlSubstrings: string[]
   expectedPreloadUrlSubstrings: string[]
@@ -117,10 +117,11 @@ async function createBenchFixture(options: CreateBenchFixtureOptions): Promise<B
     entryPoint,
     assetServer: {
       allow: [options.projectRoot, options.packagesRoot, repoPackagesRoot],
+      basePath: '/assets',
       fileMap: {
-        '/assets/app/*path': createFilePattern(repoRoot, path.join(options.projectRoot, 'app')),
-        '/assets/bench-packages/*path': createFilePattern(repoRoot, options.packagesRoot),
-        '/assets/packages/*path': createFilePattern(repoRoot, repoPackagesRoot),
+        '/app/*path': createFilePattern(repoRoot, path.join(options.projectRoot, 'app')),
+        '/bench-packages/*path': createFilePattern(repoRoot, options.packagesRoot),
+        '/packages/*path': createFilePattern(repoRoot, repoPackagesRoot),
       },
     },
     entryPointUrl: options.entryPointUrl,

--- a/packages/assets/bench/runner.ts
+++ b/packages/assets/bench/runner.ts
@@ -185,14 +185,25 @@ function createBenchAssetServer(
   fixture: BenchFixture,
   overrides: Partial<AssetServerOptions> = {},
 ): AssetServer {
+  let defaultFingerprint: AssetServerOptions['fingerprint'] = {
+    buildId: String(Date.now()),
+  }
   let options: AssetServerOptions = {
-    rootDir: path.resolve(import.meta.dirname, '../../..'),
-    fingerprint: {
-      buildId: String(Date.now()),
-    },
-    watch: false,
-    ...fixture.assetServer,
-    ...overrides,
+    allow: overrides.allow ?? fixture.assetServer.allow,
+    basePath: overrides.basePath ?? fixture.assetServer.basePath,
+    fileMap: overrides.fileMap ?? fixture.assetServer.fileMap,
+    deny: overrides.deny,
+    fingerprint: Object.hasOwn(overrides, 'fingerprint')
+      ? overrides.fingerprint
+      : defaultFingerprint,
+    minify: overrides.minify,
+    onError: overrides.onError,
+    rootDir: overrides.rootDir ?? path.resolve(import.meta.dirname, '../../..'),
+    scripts: overrides.scripts,
+    sourceMaps: overrides.sourceMaps,
+    sourceMapSourcePaths: overrides.sourceMapSourcePaths,
+    target: overrides.target,
+    watch: overrides.watch ?? false,
   }
 
   return createAssetServer(options)

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -32,6 +32,7 @@
     }
   },
   "dependencies": {
+    "@oxc-project/runtime": "^0.121.0",
     "@remix-run/headers": "workspace:*",
     "@remix-run/route-pattern": "workspace:*",
     "chokidar": "^5.0.0",

--- a/packages/assets/src/lib/access.ts
+++ b/packages/assets/src/lib/access.ts
@@ -1,4 +1,5 @@
 import { createFileMatcher } from './file-matcher.ts'
+import { isInjectedPackageFilePath } from './injected-packages.ts'
 
 type AccessPolicy = {
   isAllowed(filePath: string): boolean
@@ -16,6 +17,7 @@ export function createAccessPolicy(options: {
 
   return {
     isAllowed(filePath) {
+      if (isInjectedPackageFilePath(filePath)) return true
       if (!allowMatchers.some((matcher) => matcher(filePath))) return false
       if (denyMatchers.length > 0 && denyMatchers.some((matcher) => matcher(filePath))) return false
       return true

--- a/packages/assets/src/lib/asset-server.test.ts
+++ b/packages/assets/src/lib/asset-server.test.ts
@@ -4,6 +4,7 @@ import * as nodeFs from 'node:fs'
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import { init as esModuleLexerInit, parse as esModuleLexer } from 'es-module-lexer'
 import type { RawSourceMap } from 'source-map-js'
 import { SourceMapConsumer } from 'source-map-js'
 import { isAssetServerCompilationError } from './compilation-error.ts'
@@ -18,9 +19,10 @@ import type { AssetServerOptions } from './asset-server.ts'
 type FingerprintOptions = NonNullable<AssetServerOptions['fingerprint']>
 
 function createAssetServerForTest(
-  options: Parameters<typeof createAssetServer>[0],
+  options: Omit<AssetServerOptions, 'basePath'> & { basePath?: string },
 ): ReturnType<typeof createAssetServer> {
   return createAssetServer({
+    basePath: options.basePath ?? '/assets',
     ...options,
     watch: options.watch ?? false,
   })
@@ -55,9 +57,10 @@ function getLineAndColumn(source: string, search: string): { line: number; colum
 function createTestServer(rootDir: string, overrides: Partial<AssetServerOptions> = {}) {
   return createAssetServerForTest({
     allow: ['app/**', 'app/node_modules/**'],
+    basePath: '/assets',
     fileMap: {
-      '/assets/app/*path': 'app/*path',
-      '/assets/npm/*path': 'app/node_modules/*path',
+      '/app/*path': 'app/*path',
+      '/npm/*path': 'app/node_modules/*path',
     },
     rootDir,
     watch: overrides.watch ?? false,
@@ -140,6 +143,43 @@ async function getCompiledCodeAndSourceMap(
     compiledCode,
     sourceMap: JSON.parse(await sourceMapResponse.text()) as RawSourceMap,
   }
+}
+
+async function getAbsoluteImportSpecifiers(source: string): Promise<string[]> {
+  await esModuleLexerInit
+  let [imports] = esModuleLexer(source)
+
+  return imports
+    .map((imported) => imported.n)
+    .filter((specifier): specifier is string => specifier?.startsWith('/') === true)
+}
+
+async function assertRecursivelyServedImports(
+  assetServer: ReturnType<typeof createAssetServer>,
+  startingUrls: readonly string[],
+): Promise<Set<string>> {
+  let seen = new Set<string>()
+  let queue = [...startingUrls]
+
+  while (queue.length > 0) {
+    let url = queue.shift()!
+    if (seen.has(url)) continue
+    seen.add(url)
+
+    let response = await get(assetServer, url)
+    assert.ok(response)
+    assert.equal(response.status, 200, `Expected ${url} to be served`)
+
+    let body = await response.text()
+    let importSpecifiers = await getAbsoluteImportSpecifiers(body)
+    for (let specifier of importSpecifiers) {
+      if (!seen.has(specifier)) {
+        queue.push(specifier)
+      }
+    }
+  }
+
+  return seen
 }
 
 async function assertCharacterAccurateImportRewriteSourceMap(
@@ -1359,7 +1399,7 @@ describe('asset-server', () => {
       allow: ['app/**'],
       deny: ['app/entry.ts'],
       rootDir: dir,
-      fileMap: { '/assets/app/*path': 'app/*path' },
+      fileMap: { '/app/*path': 'app/*path' },
     })
 
     await assert.rejects(
@@ -1585,8 +1625,9 @@ describe('asset-server', () => {
       await write(caseDir, 'app/entry.ts', 'export const value = 1')
       let assetServer = createAssetServer({
         allow: ['app/**'],
+        basePath: '/assets',
         fileMap: {
-          '/assets/app/*path': 'app/*path',
+          '/app/*path': 'app/*path',
         },
         rootDir: caseDir,
       })
@@ -1624,8 +1665,9 @@ describe('asset-server', () => {
       await fs.mkdir(projectDir, { recursive: true })
       let assetServer = createAssetServer({
         allow: ['../packages/**'],
+        basePath: '/assets',
         fileMap: {
-          '/assets/packages/*path': '../packages/*path',
+          '/packages/*path': '../packages/*path',
         },
         rootDir: projectDir,
       })
@@ -3102,13 +3144,31 @@ describe('asset-server', () => {
     assert.ok(assetServer)
   })
 
+  it('treats an empty basePath as root', async () => {
+    await write(dir, 'app/entry.ts', 'export const value = 1')
+
+    let assetServer = createAssetServer({
+      allow: ['app/**'],
+      basePath: '',
+      fileMap: {
+        '/app/*path': 'app/*path',
+      },
+      rootDir: dir,
+      watch: false,
+    })
+
+    let response = await get(assetServer, '/app/entry.ts')
+    assert.ok(response)
+    assert.equal(response.status, 200)
+  })
+
   it('rethrows unexpected realpath errors for exact file matchers', async () => {
     assert.throws(
       () =>
         createAssetServerForTest({
           allow: ['app/\0allowed-realpath.ts'],
           rootDir: dir,
-          fileMap: { '/assets/app/*path': 'app/*path' },
+          fileMap: { '/app/*path': 'app/*path' },
         }),
       { code: 'ERR_INVALID_ARG_VALUE' },
     )
@@ -3122,7 +3182,7 @@ describe('asset-server', () => {
           allow: [path.join(dir, 'app')],
           rootDir: dir,
           fileMap: {
-            '/assets/app/*path': `${path.join(dir, 'app')}/*path`,
+            '/app/*path': `${path.join(dir, 'app')}/*path`,
           },
           fingerprint: { buildId: 'build' },
           watch: false,
@@ -3139,7 +3199,7 @@ describe('asset-server', () => {
       allow: [allowedPath, path.join(dir, 'app')],
       deny: [path.join(dir, 'app/blocked.ts')],
       rootDir: dir,
-      fileMap: { '/assets/app/*path': 'app/*path' },
+      fileMap: { '/app/*path': 'app/*path' },
     })
 
     let allowedResponse = await get(assetServer, '/assets/app/allowed.ts')
@@ -3158,7 +3218,7 @@ describe('asset-server', () => {
         createAssetServerForTest({
           allow: ['app/**'],
           rootDir: dir,
-          fileMap: { '/assets/app/*': 'app/*path' },
+          fileMap: { '/app/*': 'app/*path' },
         }),
       /must use named wildcards/,
     )
@@ -3171,7 +3231,7 @@ describe('asset-server', () => {
       allow: ['app/**/*.ts'],
       deny: ['app/**/private/**'],
       rootDir: dir,
-      fileMap: { '/assets/app/*path': 'app/*path' },
+      fileMap: { '/app/*path': 'app/*path' },
     })
 
     let allowedResponse = await get(assetServer, '/assets/app/features/allowed.ts')
@@ -3188,8 +3248,8 @@ describe('asset-server', () => {
       allow: ['app/**/*', 'node_modules/**/*'],
       rootDir: dir,
       fileMap: {
-        '/assets/app/*path': 'app/*path',
-        '/assets/npm/*path': 'node_modules/*path',
+        '/app/*path': 'app/*path',
+        '/npm/*path': 'node_modules/*path',
       },
     })
 
@@ -3208,7 +3268,7 @@ describe('asset-server', () => {
       allow: ['app/**'],
       deny: ['app/blocked.ts'],
       rootDir: dir,
-      fileMap: { '/assets/app/*path': 'app/*path' },
+      fileMap: { '/app/*path': 'app/*path' },
       onError(error) {
         receivedError = error
       },
@@ -3274,6 +3334,80 @@ describe('asset-server', () => {
 
     assert.doesNotMatch(body, /\?\?|\?\./)
     assert.match(body, /void 0/)
+  })
+
+  it('serves injected helpers while preserving authored imports of the same package', async () => {
+    await writeJson(dir, 'app/node_modules/@oxc-project/runtime/package.json', {
+      name: '@oxc-project/runtime',
+    })
+    await write(
+      dir,
+      'app/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateMethodInitSpec.js',
+      'export default "user-runtime-helper"',
+    )
+    await write(
+      dir,
+      'app/entry.ts',
+      [
+        'import helper from "@oxc-project/runtime/src/helpers/esm/classPrivateMethodInitSpec.js"',
+        'void helper',
+        'export class Example {',
+        '  #value = 1',
+        '  #getValue() {',
+        '    return this.#value',
+        '  }',
+        '  value() {',
+        '    return this.#getValue()',
+        '  }',
+        '}',
+      ].join('\n'),
+    )
+    let assetServer = createTestServer(dir, {
+      fileMap: {
+        '/npm/*path': 'app/node_modules/*path',
+        '/app/*path': 'app/*path',
+      },
+      target: {
+        es: '2020',
+      },
+    })
+
+    let response = await get(assetServer, '/assets/app/entry.ts')
+    assert.ok(response)
+    assert.equal(response.status, 200)
+
+    let body = await response.text()
+    let entryImportSpecifiers = await getAbsoluteImportSpecifiers(body)
+    let helperPaths = entryImportSpecifiers.filter((specifier) =>
+      specifier.startsWith('/assets/__@remix/injected/@oxc-project/runtime/'),
+    )
+
+    assert.doesNotMatch(body, /from ["']@oxc-project\/runtime/)
+    assert.ok(
+      entryImportSpecifiers.includes(
+        '/assets/npm/@oxc-project/runtime/src/helpers/esm/classPrivateMethodInitSpec.js',
+      ),
+    )
+    assert.ok(helperPaths.length > 0)
+    assert.ok(
+      helperPaths.includes(
+        '/assets/__@remix/injected/@oxc-project/runtime/src/helpers/esm/classPrivateMethodInitSpec.js',
+      ),
+    )
+
+    let servedUrls = await assertRecursivelyServedImports(assetServer, ['/assets/app/entry.ts'])
+    assert.ok(
+      servedUrls.has(
+        '/assets/npm/@oxc-project/runtime/src/helpers/esm/classPrivateMethodInitSpec.js',
+      ),
+      'expected authored runtime imports to use the consumer fileMap path',
+    )
+    assert.ok(
+      servedUrls.has(
+        '/assets/__@remix/injected/@oxc-project/runtime/src/helpers/esm/checkPrivateRedeclaration.js',
+      ),
+      'expected transitive Oxc helper imports to be servable',
+    )
   })
 
   it('does not inherit target from tsconfig', async () => {
@@ -3661,8 +3795,9 @@ describe('asset-server', () => {
       () =>
         createAssetServer({
           allow: ['app/**'],
+          basePath: '/assets',
           fileMap: {
-            '/assets/app/*path': 'app/*path',
+            '/app/*path': 'app/*path',
           },
           rootDir: dir,
           fingerprint: { buildId: 'build' },

--- a/packages/assets/src/lib/asset-server.ts
+++ b/packages/assets/src/lib/asset-server.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs'
 import { createAccessPolicy } from './access.ts'
 import { isAssetServerCompilationError } from './compilation-error.ts'
 import { getFingerprintRequestCacheControl, parseFingerprintSuffix } from './fingerprint.ts'
-import { getInjectedPackageFileMap } from './injected-packages.ts'
+import { getInjectedPackageRouteConfigs } from './injected-packages.ts'
 import { normalizeFilePath, normalizePathname } from './paths.ts'
 import { compileRoutes } from './routes.ts'
 import type { CompiledRoutes } from './routes.ts'
@@ -456,14 +456,13 @@ function resolveAssetServerOptions(options: AssetServerOptions): ResolvedAssetSe
     minify: options.minify ?? false,
     onError: options.onError ?? defaultErrorHandler,
     rootDir,
-    routes: compileRoutes({
-      basePath,
-      fileMap: {
-        ...options.fileMap,
-        ...getInjectedPackageFileMap(rootDir),
+    routes: compileRoutes(basePath, [
+      {
+        fileMap: options.fileMap,
+        rootDir,
       },
-      rootDir,
-    }),
+      ...getInjectedPackageRouteConfigs(),
+    ]),
     sourceMapSourcePaths: options.sourceMapSourcePaths ?? 'url',
     sourceMaps: options.sourceMaps,
     scriptsTarget: resolveScriptTarget(options.target),

--- a/packages/assets/src/lib/asset-server.ts
+++ b/packages/assets/src/lib/asset-server.ts
@@ -3,7 +3,8 @@ import * as fs from 'node:fs'
 import { createAccessPolicy } from './access.ts'
 import { isAssetServerCompilationError } from './compilation-error.ts'
 import { getFingerprintRequestCacheControl, parseFingerprintSuffix } from './fingerprint.ts'
-import { normalizeFilePath } from './paths.ts'
+import { getInjectedPackageFileMap } from './injected-packages.ts'
+import { normalizeFilePath, normalizePathname } from './paths.ts'
 import { compileRoutes } from './routes.ts'
 import type { CompiledRoutes } from './routes.ts'
 import { createResponseForScript, createScriptCompiler } from './scripts/compiler.ts'
@@ -54,7 +55,9 @@ interface AssetServerScriptOptions {
 const scriptExtensionSet = new Set<string>(supportedScriptExtensions)
 
 export interface AssetServerOptions {
-  /** File patterns keyed by public URL patterns. */
+  /** Public mount path for this asset server, e.g. `'/assets'`. */
+  basePath: string
+  /** File patterns keyed by public URL patterns relative to `basePath`. */
   fileMap: Readonly<Record<string, string>>
   /**
    * Root directory used to resolve relative file paths. Defaults to `process.cwd()`.
@@ -135,6 +138,7 @@ export interface AssetServer {
 
 type ResolvedAssetServerOptions = {
   allow: readonly string[]
+  basePath: string
   buildId?: string
   define?: Record<string, string>
   deny?: readonly string[]
@@ -174,8 +178,9 @@ export function getInternalWatchTargets(assetServer: AssetServer): readonly stri
  * @example
  * ```ts
  * let assetServer = createAssetServer({
+ *   basePath: '/assets',
  *   fileMap: {
- *     '/assets/app/*path': 'app/*path',
+ *     '/app/*path': 'app/*path',
  *   },
  *   allow: ['app/**'],
  * })
@@ -433,6 +438,7 @@ function defaultErrorHandler(error: unknown): void {
 
 function resolveAssetServerOptions(options: AssetServerOptions): ResolvedAssetServerOptions {
   let rootDir = normalizeFilePath(fs.realpathSync(path.resolve(options.rootDir ?? process.cwd())))
+  let basePath = normalizeBasePath(options.basePath)
   let scriptOptions = options.scripts ?? {}
   let fingerprintOptions = normalizeFingerprintOptions({
     fingerprint: options.fingerprint,
@@ -441,6 +447,7 @@ function resolveAssetServerOptions(options: AssetServerOptions): ResolvedAssetSe
 
   return {
     allow: options.allow,
+    basePath,
     buildId: fingerprintOptions.buildId,
     define: scriptOptions.define,
     deny: options.deny,
@@ -450,7 +457,11 @@ function resolveAssetServerOptions(options: AssetServerOptions): ResolvedAssetSe
     onError: options.onError ?? defaultErrorHandler,
     rootDir,
     routes: compileRoutes({
-      fileMap: options.fileMap,
+      basePath,
+      fileMap: {
+        ...options.fileMap,
+        ...getInjectedPackageFileMap(rootDir),
+      },
       rootDir,
     }),
     sourceMapSourcePaths: options.sourceMapSourcePaths ?? 'url',
@@ -459,6 +470,14 @@ function resolveAssetServerOptions(options: AssetServerOptions): ResolvedAssetSe
     stylesTarget: resolveStyleTarget(options.target),
     watchOptions: normalizeWatchOptions(options.watch),
   }
+}
+
+function normalizeBasePath(basePath: string): string {
+  if (typeof basePath !== 'string') {
+    throw new TypeError('basePath must be a string')
+  }
+
+  return normalizePathname(basePath || '/').replace(/\/+$/, '') || '/'
 }
 
 function normalizeFingerprintOptions(options: {

--- a/packages/assets/src/lib/injected-packages.ts
+++ b/packages/assets/src/lib/injected-packages.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
-import { getFilePathDirectory, getRelativeFilePath, normalizeFilePath } from './paths.ts'
+import { getFilePathDirectory, normalizeFilePath } from './paths.ts'
 
 type ResolvedInjectedPackage = {
   packageJsonPath: string
@@ -26,13 +26,20 @@ export function isInjectedPackageFilePath(filePath: string): boolean {
   return false
 }
 
-export function getInjectedPackageFileMap(rootDir: string): Record<string, string> {
-  return Object.fromEntries(
-    injectedPackageNames.map((packageName) => [
-      getInjectedPackageRoutePattern(packageName),
-      `${toRelativePattern(rootDir, getResolvedInjectedPackage(packageName).packageRoot)}/*path`,
-    ]),
-  )
+export function getInjectedPackageRouteConfigs(): {
+  fileMap: Record<string, string>
+  rootDir: string
+}[] {
+  return injectedPackageNames.map((packageName) => {
+    let { packageRoot } = getResolvedInjectedPackage(packageName)
+
+    return {
+      fileMap: {
+        [getInjectedPackageRoutePattern(packageName)]: `${packageName}/*path`,
+      },
+      rootDir: getInjectedPackageRouteRoot(packageRoot, packageName),
+    }
+  })
 }
 
 export function getInjectedPackageNameForSpecifier(specifier: string): string | null {
@@ -99,7 +106,12 @@ function getInjectedPackageRoutePattern(packageName: string): string {
   return `${injectedPackagesBasePath}/${packageName}/*path`
 }
 
-function toRelativePattern(rootDir: string, targetDirectory: string): string {
-  let relativePath = getRelativeFilePath(rootDir, targetDirectory)
-  return relativePath === '' ? '.' : relativePath.replace(/\/+$/, '')
+function getInjectedPackageRouteRoot(packageRoot: string, packageName: string): string {
+  let routeRoot = packageRoot
+
+  for (let _segment of packageName.split('/')) {
+    routeRoot = getFilePathDirectory(routeRoot)
+  }
+
+  return routeRoot
 }

--- a/packages/assets/src/lib/injected-packages.ts
+++ b/packages/assets/src/lib/injected-packages.ts
@@ -1,0 +1,105 @@
+import * as fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { getFilePathDirectory, getRelativeFilePath, normalizeFilePath } from './paths.ts'
+
+type ResolvedInjectedPackage = {
+  packageJsonPath: string
+  packageRoot: string
+}
+
+const injectedPackageNames = ['@oxc-project/runtime'] as const
+const injectedPackagesBasePath = '/__@remix/injected'
+
+const resolvedInjectedPackages = new Map<string, ResolvedInjectedPackage>()
+
+export function isInjectedPackageFilePath(filePath: string): boolean {
+  let normalizedFilePath = normalizeFilePath(filePath)
+
+  for (let packageName of injectedPackageNames) {
+    let packageRoot = getResolvedInjectedPackage(packageName).packageRoot
+    if (normalizedFilePath === packageRoot || normalizedFilePath.startsWith(`${packageRoot}/`)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+export function getInjectedPackageFileMap(rootDir: string): Record<string, string> {
+  return Object.fromEntries(
+    injectedPackageNames.map((packageName) => [
+      getInjectedPackageRoutePattern(packageName),
+      `${toRelativePattern(rootDir, getResolvedInjectedPackage(packageName).packageRoot)}/*path`,
+    ]),
+  )
+}
+
+export function getInjectedPackageNameForSpecifier(specifier: string): string | null {
+  for (let packageName of injectedPackageNames) {
+    if (specifier === packageName || specifier.startsWith(`${packageName}/`)) {
+      return packageName
+    }
+  }
+
+  return null
+}
+
+export function mayContainInjectedPackageSpecifier(sourceText: string): boolean {
+  return injectedPackageNames.some((packageName) => sourceText.includes(packageName))
+}
+
+export function maskAuthoredInjectedPackageSpecifier(specifier: string): string | null {
+  let packageName = getInjectedPackageNameForSpecifier(specifier)
+  if (!packageName) return null
+
+  let maskedPackageName = getMaskedInjectedPackageName(packageName)
+  return `${maskedPackageName}${specifier.slice(packageName.length)}`
+}
+
+export function restoreAuthoredInjectedPackageSpecifier(specifier: string): string | null {
+  for (let packageName of injectedPackageNames) {
+    let maskedPackageName = getMaskedInjectedPackageName(packageName)
+    if (specifier === maskedPackageName) {
+      return packageName
+    }
+    if (specifier.startsWith(`${maskedPackageName}/`)) {
+      return `${packageName}${specifier.slice(maskedPackageName.length)}`
+    }
+  }
+
+  return null
+}
+
+function getMaskedInjectedPackageName(packageName: string): string {
+  return `~${packageName.slice(1)}`
+}
+
+export function getInjectedPackageImporterPath(): string {
+  return normalizeFilePath(fileURLToPath(import.meta.url))
+}
+
+function getResolvedInjectedPackage(packageName: string): ResolvedInjectedPackage {
+  let existing = resolvedInjectedPackages.get(packageName)
+  if (existing) return existing
+
+  let packageJsonUrl = import.meta.resolve(`${packageName}/package.json`)
+  let packageJsonPath = normalizeFilePath(fs.realpathSync(fileURLToPath(packageJsonUrl)))
+
+  let resolvedInjectedPackage = {
+    packageJsonPath,
+    packageRoot: normalizeFilePath(fs.realpathSync(getFilePathDirectory(packageJsonPath))),
+  }
+
+  resolvedInjectedPackages.set(packageName, resolvedInjectedPackage)
+  return resolvedInjectedPackage
+}
+
+function getInjectedPackageRoutePattern(packageName: string): string {
+  return `${injectedPackagesBasePath}/${packageName}/*path`
+}
+
+function toRelativePattern(rootDir: string, targetDirectory: string): string {
+  let relativePath = getRelativeFilePath(rootDir, targetDirectory)
+  return relativePath === '' ? '.' : relativePath.replace(/\/+$/, '')
+}

--- a/packages/assets/src/lib/paths.test.ts
+++ b/packages/assets/src/lib/paths.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import {
+  getRelativeFilePath,
   isAbsoluteFilePath,
   normalizeFilePath,
   normalizePathname,
@@ -84,6 +85,27 @@ describe('paths', () => {
     assert.equal(
       resolveFilePath('//./c:/temp/project', './app/../app/entry.ts'),
       '//./c:/temp/project/app/entry.ts',
+    )
+  })
+
+  it('gets relative file paths across normalized roots', () => {
+    assert.equal(
+      getRelativeFilePath('/Users/runner/project', '/Users/runner/project/app/entry.ts'),
+      'app/entry.ts',
+    )
+    assert.equal(
+      getRelativeFilePath(
+        'C:/Users/runner/project',
+        String.raw`C:\Users\runner\project\app\entry.ts`,
+      ),
+      'app/entry.ts',
+    )
+    assert.equal(
+      getRelativeFilePath(
+        '//server/share/project',
+        String.raw`\\server\share\project\app\entry.ts`,
+      ),
+      'app/entry.ts',
     )
   })
 })

--- a/packages/assets/src/lib/paths.ts
+++ b/packages/assets/src/lib/paths.ts
@@ -57,6 +57,34 @@ export function getFilePathDirectory(filePath: string): string {
   return path.posix.dirname(normalizeWindowsPath(filePath))
 }
 
+export function getRelativeFilePath(fromPath: string, toPath: string): string {
+  let normalizedFromPath = normalizeFilePath(fromPath)
+  let normalizedToPath = normalizeFilePath(toPath)
+
+  if (normalizedFromPath.startsWith('//') || normalizedToPath.startsWith('//')) {
+    return normalizeWindowsPath(
+      path.win32.relative(
+        normalizedFromPath.replace(/\//g, '\\'),
+        normalizedToPath.replace(/\//g, '\\'),
+      ),
+    )
+  }
+
+  if (
+    windowsDriveLetterRE.test(normalizedFromPath) ||
+    windowsDriveLetterRE.test(normalizedToPath)
+  ) {
+    return normalizeWindowsPath(
+      path.win32.relative(
+        normalizedFromPath.replace(/\//g, '\\'),
+        normalizedToPath.replace(/\//g, '\\'),
+      ),
+    )
+  }
+
+  return path.posix.relative(normalizedFromPath, normalizedToPath)
+}
+
 export function getFilePathBaseName(filePath: string): string {
   return path.posix.basename(normalizeWindowsPath(filePath))
 }

--- a/packages/assets/src/lib/routes.test.ts
+++ b/packages/assets/src/lib/routes.test.ts
@@ -6,8 +6,9 @@ import { compileRoutes } from './routes.ts'
 describe('compileRoutes', () => {
   it('supports windows-style roots without parsing them as route syntax', () => {
     let routes = compileRoutes({
+      basePath: '/assets',
       fileMap: {
-        '/assets/app/*path': 'app/*path',
+        '/app/*path': 'app/*path',
       },
       rootDir: String.raw`C:\Users\runner\project`,
     })
@@ -22,10 +23,30 @@ describe('compileRoutes', () => {
     )
   })
 
+  it('supports UNC roots when mapping file paths back to URLs', () => {
+    let routes = compileRoutes({
+      basePath: '/assets',
+      fileMap: {
+        '/app/*path': 'app/*path',
+      },
+      rootDir: String.raw`\\server\share\project`,
+    })
+
+    assert.equal(
+      routes.resolveUrlPathname('/assets/app/entry.ts'),
+      '//server/share/project/app/entry.ts',
+    )
+    assert.equal(
+      routes.toUrlPathname(String.raw`\\server\share\project\app\entry.ts`),
+      '/assets/app/entry.ts',
+    )
+  })
+
   it('supports file patterns outside the root directory', () => {
     let routes = compileRoutes({
+      basePath: '/assets',
       fileMap: {
-        '/assets/packages/*path': '../packages/*path',
+        '/packages/*path': '../packages/*path',
       },
       rootDir: '/repo/project',
     })

--- a/packages/assets/src/lib/routes.test.ts
+++ b/packages/assets/src/lib/routes.test.ts
@@ -5,13 +5,14 @@ import { compileRoutes } from './routes.ts'
 
 describe('compileRoutes', () => {
   it('supports windows-style roots without parsing them as route syntax', () => {
-    let routes = compileRoutes({
-      basePath: '/assets',
-      fileMap: {
-        '/app/*path': 'app/*path',
+    let routes = compileRoutes('/assets', [
+      {
+        fileMap: {
+          '/app/*path': 'app/*path',
+        },
+        rootDir: String.raw`C:\Users\runner\project`,
       },
-      rootDir: String.raw`C:\Users\runner\project`,
-    })
+    ])
 
     assert.equal(
       routes.resolveUrlPathname('/assets/app/entry.ts'),
@@ -24,13 +25,14 @@ describe('compileRoutes', () => {
   })
 
   it('supports UNC roots when mapping file paths back to URLs', () => {
-    let routes = compileRoutes({
-      basePath: '/assets',
-      fileMap: {
-        '/app/*path': 'app/*path',
+    let routes = compileRoutes('/assets', [
+      {
+        fileMap: {
+          '/app/*path': 'app/*path',
+        },
+        rootDir: String.raw`\\server\share\project`,
       },
-      rootDir: String.raw`\\server\share\project`,
-    })
+    ])
 
     assert.equal(
       routes.resolveUrlPathname('/assets/app/entry.ts'),
@@ -43,13 +45,14 @@ describe('compileRoutes', () => {
   })
 
   it('supports file patterns outside the root directory', () => {
-    let routes = compileRoutes({
-      basePath: '/assets',
-      fileMap: {
-        '/packages/*path': '../packages/*path',
+    let routes = compileRoutes('/assets', [
+      {
+        fileMap: {
+          '/packages/*path': '../packages/*path',
+        },
+        rootDir: '/repo/project',
       },
-      rootDir: '/repo/project',
-    })
+    ])
 
     assert.equal(
       routes.resolveUrlPathname('/assets/packages/shared/value.ts'),
@@ -58,6 +61,32 @@ describe('compileRoutes', () => {
     assert.equal(
       routes.toUrlPathname('/repo/packages/shared/value.ts'),
       '/assets/packages/shared/value.ts',
+    )
+  })
+
+  it('supports route configs with different root directories', () => {
+    let routes = compileRoutes('/assets', [
+      {
+        fileMap: {
+          '/app/*path': 'app/*path',
+        },
+        rootDir: String.raw`C:\repo\project`,
+      },
+      {
+        fileMap: {
+          '/runtime/*path': '@oxc-project/runtime/*path',
+        },
+        rootDir: String.raw`D:\repo\node_modules`,
+      },
+    ])
+
+    assert.equal(
+      routes.resolveUrlPathname('/assets/runtime/helpers/decorate.js'),
+      'D:/repo/node_modules/@oxc-project/runtime/helpers/decorate.js',
+    )
+    assert.equal(
+      routes.toUrlPathname(String.raw`D:\repo\node_modules\@oxc-project\runtime\helpers\decorate.js`),
+      '/assets/runtime/helpers/decorate.js',
     )
   })
 })

--- a/packages/assets/src/lib/routes.ts
+++ b/packages/assets/src/lib/routes.ts
@@ -1,7 +1,7 @@
-import * as path from 'node:path'
 import { RoutePattern } from '@remix-run/route-pattern'
 
 import {
+  getRelativeFilePath,
   isAbsoluteFilePath,
   normalizeFilePath,
   normalizePathname,
@@ -35,6 +35,7 @@ function normalizeFilePattern(pattern: string): string {
 }
 
 export function compileRoutes(options: {
+  basePath: string
   fileMap: Readonly<Record<string, string>>
   rootDir: string
 }): CompiledRoutes {
@@ -48,7 +49,10 @@ export function compileRoutes(options: {
         urlPattern,
         filePattern,
       },
-      { rootDir: options.rootDir },
+      {
+        basePath: options.basePath,
+        rootDir: options.rootDir,
+      },
     ),
   )
 
@@ -69,8 +73,7 @@ export function compileRoutes(options: {
       let normalizedFilePath = normalizeFilePath(filePath)
 
       for (let route of compiledRoutes) {
-        let relativeFilePath = getRelativeFilePath(normalizedFilePath, route.rootDir)
-        if (relativeFilePath === null) continue
+        let relativeFilePath = getRelativeFilePath(route.rootDir, normalizedFilePath)
         let match = route.filePattern.ast.pathname.match(relativeFilePath)
         if (!match) continue
         return normalizePathname(route.urlPattern.href(getPathnameParams(route.filePattern, match)))
@@ -84,10 +87,15 @@ export function compileRoutes(options: {
 function compileRoute(
   route: AssetRouteDefinition,
   options: {
+    basePath: string
     rootDir: string
   },
 ): CompiledRoute {
-  let urlPatternSource = normalizePathname(route.urlPattern)
+  let basePath = normalizePathname(options.basePath).replace(/\/+$/, '') || '/'
+  let relativeUrlPattern = normalizePathname(route.urlPattern)
+  let urlPatternSource = normalizePathname(
+    `${basePath.replace(/\/+$/, '')}/${relativeUrlPattern.replace(/^\/+/, '')}`,
+  )
   let filePatternSource = normalizeFilePattern(route.filePattern)
 
   let urlPattern = new RoutePattern(urlPatternSource)
@@ -102,11 +110,6 @@ function compileRoute(
     urlPattern,
     filePattern,
   }
-}
-
-function getRelativeFilePath(filePath: string, rootDir: string): string | null {
-  if (filePath[1] === ':' && rootDir[1] === ':' && filePath[0] !== rootDir[0]) return null
-  return path.posix.relative(rootDir, filePath)
 }
 
 function getPathnameParams(

--- a/packages/assets/src/lib/routes.ts
+++ b/packages/assets/src/lib/routes.ts
@@ -8,9 +8,14 @@ import {
   resolveFilePath,
 } from './paths.ts'
 
-export interface AssetRouteDefinition {
+interface AssetRouteDefinition {
   urlPattern: string
   filePattern: string
+}
+
+interface RouteConfig {
+  fileMap: Readonly<Record<string, string>>
+  rootDir: string
 }
 
 interface CompiledRoute {
@@ -34,25 +39,23 @@ function normalizeFilePattern(pattern: string): string {
   return normalizePathname(pattern)
 }
 
-export function compileRoutes(options: {
-  basePath: string
-  fileMap: Readonly<Record<string, string>>
-  rootDir: string
-}): CompiledRoutes {
-  if (Object.keys(options.fileMap).length === 0) {
+export function compileRoutes(basePath: string, routeConfigs: readonly RouteConfig[]): CompiledRoutes {
+  if (routeConfigs.every((routeConfig) => Object.keys(routeConfig.fileMap).length === 0)) {
     throw new Error('createAssetServer() requires at least one configured fileMap entry.')
   }
 
-  let compiledRoutes = Object.entries(options.fileMap).map(([urlPattern, filePattern]) =>
-    compileRoute(
-      {
-        urlPattern,
-        filePattern,
-      },
-      {
-        basePath: options.basePath,
-        rootDir: options.rootDir,
-      },
+  let compiledRoutes = routeConfigs.flatMap((routeConfig) =>
+    Object.entries(routeConfig.fileMap).map(([urlPattern, filePattern]) =>
+      compileRoute(
+        {
+          filePattern,
+          urlPattern,
+        },
+        {
+          basePath,
+          rootDir: routeConfig.rootDir,
+        },
+      ),
     ),
   )
 

--- a/packages/assets/src/lib/scripts/resolve.ts
+++ b/packages/assets/src/lib/scripts/resolve.ts
@@ -7,6 +7,11 @@ import {
   isAssetServerCompilationError,
 } from '../compilation-error.ts'
 import type { AssetServerCompilationError } from '../compilation-error.ts'
+import {
+  getInjectedPackageNameForSpecifier,
+  getInjectedPackageImporterPath,
+  restoreAuthoredInjectedPackageSpecifier,
+} from '../injected-packages.ts'
 import type { ModuleRecord, ModuleTracking } from '../module-store.ts'
 import { normalizeFilePath } from '../paths.ts'
 import type { CompiledRoutes } from '../routes.ts'
@@ -81,6 +86,11 @@ type ResolvedSpec = {
   specifier: string
 }
 
+type NormalizedSpecifierResolution = {
+  importerPath: string
+  specifier: string
+}
+
 export async function resolveModule(
   record: ScriptRecord,
   transformed: TransformedModule,
@@ -109,9 +119,10 @@ export async function resolveModule(
   let deps = new Set<string>()
 
   for (let unresolved of transformed.unresolvedImports) {
+    let displaySpecifier = getDisplayImportSpecifier(unresolved.specifier)
     let trackedResolution = getTrackedRelativeImportResolution(
       transformed.importerDir,
-      unresolved.specifier,
+      displaySpecifier,
       args.isWatchIgnored,
     )
 
@@ -119,7 +130,7 @@ export async function resolveModule(
     if (!resolvedSpec?.absolutePath) {
       return failResolve(
         createAssetServerCompilationError(
-          `Failed to resolve import "${unresolved.specifier}" in ${transformed.resolvedPath}. ` +
+          `Failed to resolve import "${displaySpecifier}" in ${transformed.resolvedPath}. ` +
             `Ensure it resolves to a file within the configured asset server fileMap, or mark it as external.`,
           {
             code: 'IMPORT_RESOLUTION_FAILED',
@@ -136,7 +147,7 @@ export async function resolveModule(
     if (!resolvedImport) {
       return failResolve(
         createAssetServerCompilationError(
-          `Import "${unresolved.specifier}" in ${transformed.resolvedPath}, resolved to "${resolvedSpec.absolutePath}", is not a supported script file. ` +
+          `Import "${displaySpecifier}" in ${transformed.resolvedPath}, resolved to "${resolvedSpec.absolutePath}", is not a supported script file. ` +
             `Supported extensions are ${supportedScriptExtensions.join(', ')}.`,
           {
             code: 'IMPORT_NOT_SUPPORTED',
@@ -152,7 +163,7 @@ export async function resolveModule(
     if (!args.isAllowed(resolvedImport.identityPath)) {
       return failResolve(
         createAssetServerCompilationError(
-          `Import "${unresolved.specifier}" in ${transformed.resolvedPath}, resolved to "${resolvedImport.identityPath}", is not allowed by the asset server allow/deny configuration. ` +
+          `Import "${displaySpecifier}" in ${transformed.resolvedPath}, resolved to "${resolvedImport.identityPath}", is not allowed by the asset server allow/deny configuration. ` +
             `Add a matching allow rule for this file path, remove a conflicting deny rule for this file path, or mark this import as external.`,
           {
             code: 'IMPORT_NOT_ALLOWED',
@@ -169,7 +180,7 @@ export async function resolveModule(
     if (!stableUrlPathname) {
       return failResolve(
         createAssetServerCompilationError(
-          `Import "${unresolved.specifier}" in ${transformed.resolvedPath}, resolved to "${resolvedImport.identityPath}", is outside all configured fileMap entries. ` +
+          `Import "${displaySpecifier}" in ${transformed.resolvedPath}, resolved to "${resolvedImport.identityPath}", is outside all configured fileMap entries. ` +
             `Add a matching fileMap entry for this file path, or mark this import as external.`,
           {
             code: 'IMPORT_OUTSIDE_FILE_MAP',
@@ -323,11 +334,17 @@ async function batchResolveSpecifiers(
 
   try {
     for (let specifier of specifiers) {
-      let resolutionResult = await resolverFactory.resolveFileAsync(importerPath, specifier)
+      let normalizedResolution = normalizeSpecifierResolution(specifier, importerPath)
+      let resolutionResult = await resolverFactory.resolveFileAsync(
+        normalizedResolution.importerPath,
+        normalizedResolution.specifier,
+      )
       if (resolutionResult.error) {
         throw createAssetServerCompilationError(
-          `Failed to resolve import "${specifier}" in ${importerPath}. ` +
-            `Ensure it resolves to a file within the configured asset server fileMap, or mark it as external.`,
+          normalizedResolution.importerPath === getInjectedPackageImporterPath()
+            ? `Failed to resolve injected import "${specifier}" from asset server.`
+            : `Failed to resolve import "${normalizedResolution.specifier}" in ${normalizedResolution.importerPath}. ` +
+                `Ensure it resolves to a file within the configured asset server fileMap, or mark it as external.`,
           {
             code: 'IMPORT_RESOLUTION_FAILED',
           },
@@ -368,6 +385,35 @@ function getUniqueSpecifiers(unresolvedImports: TransformedModule['unresolvedImp
 
 function formatUnknownError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+function normalizeSpecifierResolution(
+  specifier: string,
+  importerPath: string,
+): NormalizedSpecifierResolution {
+  let authoredInjectedPackageSpecifier = restoreAuthoredInjectedPackageSpecifier(specifier)
+  if (authoredInjectedPackageSpecifier) {
+    return {
+      importerPath,
+      specifier: authoredInjectedPackageSpecifier,
+    }
+  }
+
+  if (getInjectedPackageNameForSpecifier(specifier)) {
+    return {
+      importerPath: getInjectedPackageImporterPath(),
+      specifier,
+    }
+  }
+
+  return {
+    importerPath,
+    specifier,
+  }
+}
+
+function getDisplayImportSpecifier(specifier: string): string {
+  return restoreAuthoredInjectedPackageSpecifier(specifier) ?? specifier
 }
 
 function failResolve(

--- a/packages/assets/src/lib/scripts/transform.ts
+++ b/packages/assets/src/lib/scripts/transform.ts
@@ -2,10 +2,13 @@ import * as fs from 'node:fs'
 import * as fsp from 'node:fs/promises'
 import * as path from 'node:path'
 import { getTsconfig } from 'get-tsconfig'
+import MagicString from 'magic-string'
 import { minify } from 'oxc-minify'
+import { parseSync, visitorKeys } from 'oxc-parser'
 import { transform as oxcTransform } from 'oxc-transform'
 import { init as esModuleLexerInit, parse as esModuleLexer } from 'es-module-lexer'
 import type { Cache, TsConfigJsonResolved } from 'get-tsconfig'
+import type { Node, Program } from 'oxc-parser'
 import type { TransformOptions as OxcTransformOptions } from 'oxc-transform'
 
 import { isCommonJS, mayContainCommonJSModuleGlobals } from './cjs-check.ts'
@@ -15,6 +18,11 @@ import {
 } from '../compilation-error.ts'
 import type { AssetServerCompilationError } from '../compilation-error.ts'
 import { generateFingerprint } from '../fingerprint.ts'
+import {
+  maskAuthoredInjectedPackageSpecifier,
+  mayContainInjectedPackageSpecifier,
+  restoreAuthoredInjectedPackageSpecifier,
+} from '../injected-packages.ts'
 import type { ModuleRecord, ModuleTracking } from '../module-store.ts'
 import { normalizeFilePath } from '../paths.ts'
 import type { CompiledRoutes } from '../routes.ts'
@@ -205,7 +213,7 @@ export async function transformModule(
     })
 
     analysis.unresolvedImports = analysis.unresolvedImports.filter(
-      (unresolved) => !args.externalSet.has(unresolved.specifier),
+      (unresolved) => !args.externalSet.has(getDisplayImportSpecifier(unresolved.specifier)),
     )
 
     if (mayContainCommonJSModuleGlobals(sourceText) && isCommonJS(analysis.rawCode)) {
@@ -306,11 +314,12 @@ async function analyzeModuleSource(
     target?: ResolvedScriptTarget
   },
 ) {
+  let maskedSourceText = maskAuthoredInjectedPackageImports(sourceText, resolvedPath)
   let transformResult: { code: string; errors?: Array<{ message?: string }>; map?: unknown }
   try {
     transformResult = await oxcTransform(
       resolvedPath,
-      sourceText,
+      maskedSourceText,
       getTransformOptions(resolvedPath, transformOptions, options),
     )
     assertNoCompilerErrors(transformResult.errors, resolvedPath, 'transform')
@@ -539,6 +548,99 @@ async function getUnresolvedImportsFromLexer(rawCode: string): Promise<Unresolve
   }
 
   return unresolvedImports
+}
+
+function getDisplayImportSpecifier(specifier: string): string {
+  return restoreAuthoredInjectedPackageSpecifier(specifier) ?? specifier
+}
+
+function maskAuthoredInjectedPackageImports(sourceText: string, resolvedPath: string): string {
+  if (!mayContainInjectedPackageSpecifier(sourceText)) {
+    return sourceText
+  }
+
+  let parseResult = parseSync(resolvedPath, sourceText, {
+    lang: getSourceLanguageForPath(resolvedPath),
+    sourceType: 'module',
+  })
+  if (parseResult.errors.length > 0) {
+    return sourceText
+  }
+
+  let replacements: Array<{ end: number; specifier: string; start: number }> = []
+
+  walkAst(parseResult.program, (node) => {
+    if (
+      node.type !== 'ImportDeclaration' &&
+      node.type !== 'ExportAllDeclaration' &&
+      node.type !== 'ExportNamedDeclaration' &&
+      node.type !== 'ImportExpression'
+    ) {
+      return
+    }
+
+    let source = 'source' in node ? node.source : null
+    if (!isStringLiteralNode(source)) return
+
+    let maskedSpecifier = maskAuthoredInjectedPackageSpecifier(source.value)
+    if (maskedSpecifier == null) return
+
+    replacements.push({
+      end: source.end - 1,
+      specifier: maskedSpecifier,
+      start: source.start + 1,
+    })
+  })
+
+  if (replacements.length === 0) return sourceText
+
+  let rewrittenSource = new MagicString(sourceText)
+  for (let replacement of replacements) {
+    rewrittenSource.overwrite(replacement.start, replacement.end, replacement.specifier)
+  }
+
+  return rewrittenSource.toString()
+}
+
+function walkAst(node: Program | Node, visit: (node: Program | Node) => void): void {
+  visit(node)
+
+  let keys = visitorKeys[node.type]
+  if (!keys) return
+
+  let walkableNode = node as unknown as Record<string, unknown>
+  for (let key of keys) {
+    let value = walkableNode[key]
+    if (Array.isArray(value)) {
+      for (let child of value) {
+        if (isAstNode(child)) {
+          walkAst(child, visit)
+        }
+      }
+      continue
+    }
+
+    if (isAstNode(value)) {
+      walkAst(value, visit)
+    }
+  }
+}
+
+function isAstNode(value: unknown): value is Node {
+  return typeof value === 'object' && value !== null && 'type' in value
+}
+
+function isStringLiteralNode(node: Node | null | undefined): node is Node & {
+  end: number
+  start: number
+  value: string
+} {
+  return (
+    node?.type === 'Literal' &&
+    typeof node.start === 'number' &&
+    typeof node.end === 'number' &&
+    typeof node.value === 'string'
+  )
 }
 
 function getStaticImportSpecifier(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,6 +256,9 @@ importers:
 
   packages/assets:
     dependencies:
+      '@oxc-project/runtime':
+        specifier: ^0.121.0
+        version: 0.121.0
       '@remix-run/headers':
         specifier: workspace:*
         version: link:../headers
@@ -3104,6 +3107,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@oxc-project/runtime@0.121.0':
+    resolution: {integrity: sha512-p0bQukD8OEHxzY4T9OlANBbEFGnOnjo1CYi50HES7OD36UO2yPh6T+uOJKLtlg06eclxroipRCpQGMpeH8EJ/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@oxc-project/types@0.121.0':
     resolution: {integrity: sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw==}
@@ -6575,6 +6582,8 @@ snapshots:
 
   '@oxc-parser/binding-win32-x64-msvc@0.121.0':
     optional: true
+
+  '@oxc-project/runtime@0.121.0': {}
 
   '@oxc-project/types@0.121.0': {}
 


### PR DESCRIPTION
This updates `@remix-run/assets` so it can automatically serve `@oxc-project/runtime` helpers when Oxc injects them for lowered output, so apps no longer need to manually install that package just to support generated helper imports.

To support that cleanly, `createAssetServer()` now requires a `basePath` option and treats `fileMap` URL patterns as relative to that mount path. The asset server needs to add its own internal file map entries for injected helpers, but the app still needs one clear public base path to know which requests belong to the asset server in the first place.

- automatically serves injected Oxc runtime helpers so apps do not need to manually install `@oxc-project/runtime`
- preserves consumer-owned imports of the same package instead of routing all `@oxc-project/runtime` specifiers through the internal injected namespace
- requires `basePath` in `createAssetServer()` so the asset server can add its own internal routes while the app still has one clear public mount path
- makes `fileMap` URL patterns relative to that mount path instead of repeating the full public prefix in every key
- updates docs, demos, and benchmarks to use the new API shape

Migration example:

```ts
import { createAssetServer } from 'remix/assets'

let assetServer = createAssetServer({
  basePath: '/assets',
  fileMap: {
    '/app/*path': 'app/*path',
    '/npm/*path': 'node_modules/*path',
  },
  allow: ['app/**', 'node_modules/**'],
})
```

Migration:

```ts
// Before
let assetServer = createAssetServer({
  fileMap: {
    '/assets/app/*path': 'app/*path',
    '/assets/npm/*path': 'node_modules/*path',
  },
  allow: ['app/**', 'node_modules/**'],
})
```

```ts
// After
let assetServer = createAssetServer({
  basePath: '/assets',
  fileMap: {
    '/app/*path': 'app/*path',
    '/npm/*path': 'node_modules/*path',
  },
  allow: ['app/**', 'node_modules/**'],
})
```
