### PR TITLE
route-pattern: replace `TrieMatcher` and `ArrayMatcher` with `createMatcher` fn

### DIFF
--- a/.agents/skills/make-decision-doc/SKILL.md
+++ b/.agents/skills/make-decision-doc/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: make-decision-doc
+description: Add a numbered decision document under `decisions/` to capture a non-obvious architectural choice. Use when the user asks for a decision doc, ADR, design rationale, or wants to record why we picked one approach over alternatives.
+---
+
+# Make Decision Doc
+
+## Overview
+
+Decision docs live at the repo root in `decisions/NNN-kebab-name.md`. They explain *why* a choice was made — the tradeoff, the alternatives that were actually considered, and (when useful) the conditions under which we'd revisit. They are not feature specs, not how-to guides, and not changelog entries.
+
+## When to write one
+
+- A non-obvious architectural choice was made and a future contributor would reasonably ask "why didn't we do X instead?".
+- A choice has tradeoffs that are easy to second-guess without context (perf vs. simplicity, lock-in vs. flexibility, ergonomics vs. correctness).
+- We diverged from a common default or industry-standard alternative and the reasoning matters.
+
+Skip a decision doc when the choice is obvious, the alternatives weren't seriously considered, or the rationale already lives in code comments / change file / PR description.
+
+## Workflow
+
+1. Read the existing files under `decisions/` (e.g. `decisions/001-*.md`) to match tone and structure.
+2. Pick the next number by counting existing files (`ls decisions/ | wc -l`) and add 1. Filename is `NNN-kebab-slug.md` with a 3-digit zero-padded prefix.
+3. Pick a slug that names the *thing being decided*, not the verb (`single-matcher`, not `pick-single-matcher`).
+4. Draft the doc following the structure below. Keep it grounded — no hypothetical alternatives, no aspirational language.
+5. If the decision relates to other decisions, link them as footnotes (`[NNN]: ./NNN-other.md`).
+
+## Structure
+
+No rigid template — match the style of existing docs. The shape that tends to work:
+
+- **H1 title**: a short statement or question that a reader scanning the folder can grok at a glance.
+- **Opening framing** (1–3 short paragraphs): what the choice was, why it came up, and what the realistic alternatives were. Lead with concrete context, not abstractions.
+- **Tradeoff sections**: typically "What gets simpler / harder", "Why we chose X", or named sections per dimension (perf, complexity, ergonomics). Use H2s.
+- **When to revisit** (optional but encouraged): a numbered list of conditions that would flip the decision. Keeps the doc honest and gives future contributors a clear off-ramp.
+- **Footnote links** to related decisions or external sources cited in the body.
+
+## Content rules
+
+- Ground every claim. Cite benchmarks, blog posts, code references, or measured behavior. If the decision is "feels nicer", say so explicitly rather than dressing it up.
+- Only list alternatives that were actually deliberated. Inventing options to knock down weakens the doc.
+- Past tense for the decision ("we chose X"), present tense for ongoing implications ("X means we don't need Y").
+- Keep prose tight. These docs reward density — readers come looking for a specific answer.
+- Code references use the repo's standard `path/to/file.ts` style; line ranges with backtick fences when illustrating a specific snippet.
+- No marketing tone, no hedging filler ("it's worth noting that…", "in many cases…"). State the call.
+
+## Checklist
+
+- Did you read at least one existing decision doc to match style?
+- Is the filename `NNN-kebab-slug.md` with the next available number?
+- Does the H1 communicate the decision in one line?
+- Are the alternatives ones that were actually considered?
+- Did you cite concrete evidence (benchmarks, sources, code) instead of assertions?
+- Is there a "when to revisit" section if the decision could plausibly flip?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ For work on this repository itself, use the skills in `.agents/skills/`:
 - `fix-issue` at `.agents/skills/fix-issue/SKILL.md`: Fix bugs reported in GitHub issues.
 - `write-tests` at `.agents/skills/write-tests/SKILL.md`: Write, refactor, or review tests with repo runner, fixture, assertion, dependency, and validation conventions.
 - `make-change-file` at `.agents/skills/make-change-file/SKILL.md`: Create or update package change files under `packages/*/.changes`.
+- `make-decision-doc` at `.agents/skills/make-decision-doc/SKILL.md`: Add a numbered decision document under `decisions/` capturing a non-obvious architectural choice.
 - `make-demo` at `.agents/skills/make-demo/SKILL.md`: Create or revise demos in this repository with production-quality Remix patterns.
 - `make-pr` at `.agents/skills/make-pr/SKILL.md`: Prepare and open clear, reviewer-friendly pull requests.
 - `publish-placeholder-package` at `.agents/skills/publish-placeholder-package/SKILL.md`: Publish a `0.0.0` placeholder package to reserve an npm name.

--- a/decisions/005-trie-based-matching.md
+++ b/decisions/005-trie-based-matching.md
@@ -1,0 +1,15 @@
+# Use only trie-based matching for `route-pattern
+
+`@remix-run/route-pattern` ships a single `Matcher` implementation (trie-based) constructed via `createMatcher()`.
+
+Earlier versions exported both `ArrayMatcher` and `TrieMatcher` and asked users to pick based on app size and runtime.
+However, in our benchmarks the trie-based matcher vastly outperformed the array matcher in "long-running server" benchmarks where the setup cost was ignored.
+For "lambda" benchmarks, the array matcher was a bit faster (<2x), but both matchers consistently setup and match in under 10ms for even our [largest benchmark with ~2500 patterns](../packages/route-pattern/bench/patterns/shopify.ts).
+
+While lambda providers don't guarantee warm workers, In practice, warm workers tend to be more common than cold starts anyway. 
+Additionally, lambda providers like Cloudflare have [techniques for starting up your app during the TLS handshake](https://blog.cloudflare.com/eliminating-cold-starts-2-shard-and-conquer/) which mitigate even the negligible differences between the array matcher and trie-matcher startup times.
+
+By eliminating the array matcher, we simplify our API and avoid any issues where competing matcher implementations have behavior drift.
+
+The array matcher implementation has been moved to the benchmark sub-package, so that we can continue to monitor if these performance characteristics ever change. 
+If any real-world scenarios benefit from having an array matcher, we can revisit this decision.

--- a/packages/fetch-router/README.md
+++ b/packages/fetch-router/README.md
@@ -673,7 +673,6 @@ Built-in middleware packages may also export `With...` helpers when that makes c
 
 #### Scaling Your Application
 
-- how to use a TrieMatcher
 - how to spread controllers across multiple files
 
 #### Error Handling and Aborted Requests

--- a/packages/fetch-router/src/lib/router.test.ts
+++ b/packages/fetch-router/src/lib/router.test.ts
@@ -1,6 +1,6 @@
 import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
-import { ArrayMatcher, RoutePattern } from '@remix-run/route-pattern'
+import { createMatcher, type Matcher, RoutePattern } from '@remix-run/route-pattern'
 import { createRoutes as route } from '@remix-run/routes'
 
 import type { BuildAction } from './controller.ts'
@@ -980,15 +980,17 @@ describe('custom matcher', () => {
   it('uses a custom matcher when provided', async () => {
     let matchAllCalls = 0
 
-    // Create a custom matcher that tracks calls
-    class CustomMatcher extends ArrayMatcher<MatchData> {
-      matchAll(url: string | URL) {
+    let inner = createMatcher<MatchData>()
+    let customMatcher: Matcher<MatchData> = {
+      ignoreCase: inner.ignoreCase,
+      add: inner.add.bind(inner),
+      match: inner.match.bind(inner),
+      matchAll(url, compareFn) {
         matchAllCalls++
-        return super.matchAll(url)
-      }
+        return inner.matchAll(url, compareFn)
+      },
     }
 
-    let customMatcher = new CustomMatcher()
     let router = createRouter({ matcher: customMatcher })
     router.get('/', () => new Response('Home'))
 
@@ -1000,15 +1002,18 @@ describe('custom matcher', () => {
   it('adds routes to the custom matcher', async () => {
     let addedPatterns: string[] = []
 
-    class CustomMatcher extends ArrayMatcher<MatchData> {
-      add<P extends string>(pattern: P | RoutePattern<P>, data: MatchData): void {
+    let inner = createMatcher<MatchData>()
+    let customMatcher: Matcher<MatchData> = {
+      ignoreCase: inner.ignoreCase,
+      add(pattern, data) {
         let routePattern = typeof pattern === 'string' ? new RoutePattern(pattern) : pattern
         addedPatterns.push(routePattern.source)
-        super.add(pattern, data)
-      }
+        inner.add(pattern, data)
+      },
+      match: inner.match.bind(inner),
+      matchAll: inner.matchAll.bind(inner),
     }
 
-    let customMatcher = new CustomMatcher()
     let router = createRouter({ matcher: customMatcher })
     router.get('/home', () => new Response('Home'))
     router.get('/about', () => new Response('About'))

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -1,4 +1,4 @@
-import { type Matcher, type Params, ArrayMatcher, RoutePattern } from '@remix-run/route-pattern'
+import { type Matcher, type Params, createMatcher, RoutePattern } from '@remix-run/route-pattern'
 import { type RouteMap, Route } from '@remix-run/routes'
 
 import { type AnyMiddleware, type ApplyMiddlewareTuple, runMiddleware } from './middleware.ts'
@@ -184,7 +184,7 @@ export interface RouterOptions<
   /**
    * The matcher to use for matching routes.
    *
-   * @default `new ArrayMatcher()`
+   * @default `createMatcher()`
    */
   matcher?: Matcher<MatchData>
   /**
@@ -333,7 +333,7 @@ export function createRouter<
   const middleware extends readonly AnyMiddleware[] = readonly AnyMiddleware[],
 >(options?: RouterOptions<context, middleware>): Router<ApplyMiddlewareTuple<context, middleware>> {
   let defaultHandler = (options?.defaultHandler ?? noMatchHandler) as RequestHandler<any, any>
-  let matcher = options?.matcher ?? new ArrayMatcher<MatchData>()
+  let matcher = options?.matcher ?? createMatcher<MatchData>()
   let routerMiddleware = options?.middleware ? [...options.middleware] : undefined
 
   async function dispatchRouter(

--- a/packages/remix/.changes/minor.remix-route-pattern.create-matcher.md
+++ b/packages/remix/.changes/minor.remix-route-pattern.create-matcher.md
@@ -1,0 +1,11 @@
+BREAKING CHANGE: `remix/route-pattern` no longer exports `ArrayMatcher` or `TrieMatcher`. Use the new `createMatcher` function instead.
+
+```ts
+// before
+import { ArrayMatcher } from 'remix/route-pattern'
+let matcher = new ArrayMatcher<string>()
+
+// after
+import { createMatcher } from 'remix/route-pattern'
+let matcher = createMatcher<string>()
+```

--- a/packages/route-pattern/.changes/minor.create-matcher.md
+++ b/packages/route-pattern/.changes/minor.create-matcher.md
@@ -1,0 +1,15 @@
+BREAKING CHANGE: Replace `ArrayMatcher` and `TrieMatcher` exports with a single `createMatcher` function.
+
+The package now ships one matcher implementation. `Matcher` and `Match` types are unchanged.
+
+```ts
+// before
+import { ArrayMatcher, TrieMatcher } from '@remix-run/route-pattern'
+let matcher = new ArrayMatcher<string>()
+// or
+let matcher = new TrieMatcher<string>()
+
+// after
+import { createMatcher } from '@remix-run/route-pattern'
+let matcher = createMatcher<string>()
+```

--- a/packages/route-pattern/.changes/patch.trie-origin-less-port.md
+++ b/packages/route-pattern/.changes/patch.trie-origin-less-port.md
@@ -1,0 +1,1 @@
+Fix matcher to match origin-less patterns (e.g. `/`, `/about`) against URLs that have an explicit port. Previously a pattern like `/` would not match `http://localhost:44199/`, diverging from `RoutePattern.match` which ignores port checks when the pattern has no origin.

--- a/packages/route-pattern/README.md
+++ b/packages/route-pattern/README.md
@@ -81,10 +81,10 @@ new RoutePattern('search?q') // allows additional search params beyond ?q
 Match URLs against multiple patterns. Each pattern can have associated data (handlers, route IDs, metadata, etc.):
 
 ```ts
-import { ArrayMatcher as Matcher } from 'remix/route-pattern'
+import { createMatcher } from 'remix/route-pattern'
 
 // Any data type you want!  👇
-let matcher = new Matcher<string>()
+let matcher = createMatcher<string>()
 
 matcher.add('/', 'home')
 matcher.add('blog/:slug', 'blog-post')
@@ -97,20 +97,6 @@ matcher.match('https://example.com/api/v2/users/profile')
 // { pattern: 'api(/v:version)/*path', params: { version: '2', path: 'users/profile' }, data: 'api' }
 ```
 
-**ArrayMatcher vs TrieMatcher**
-
-- **ArrayMatcher**: Best for small apps (~80 routes or fewer)
-- **TrieMatcher**: Best for large apps (hundreds of routes)
-
-Note: Performance depends on your specific patterns—benchmark both to verify which is faster for your app.
-
-Both implement the `Matcher` API so you can swap them out easily:
-
-```ts
-// import { ArrayMatcher as Matcher } from 'remix/route-pattern'
-import { TrieMatcher as Matcher } from 'remix/route-pattern'
-```
-
 ## Specificity
 
 When multiple patterns match a URL, the most specific pattern wins.
@@ -118,9 +104,9 @@ When multiple patterns match a URL, the most specific pattern wins.
 **Pathname specificity** (left-to-right):
 
 ```ts
-import { ArrayMatcher } from 'remix/route-pattern'
+import { createMatcher } from 'remix/route-pattern'
 
-let matcher = new ArrayMatcher<string>()
+let matcher = createMatcher<string>()
 matcher.add('blog/hello', 'static')
 matcher.add('blog/:slug', 'variable')
 matcher.add('blog/*path', 'wildcard')
@@ -134,12 +120,12 @@ matcher.match('https://example.com/blog/hello')
 **Search parameter specificity**:
 
 ```ts
-let router = new ArrayMatcher<string>()
-router.add('search', 'no-params')
-router.add('search?q', 'has-q')
-router.add('search?q=hello', 'exact-match')
+let matcher = createMatcher<string>()
+matcher.add('search', 'no-params')
+matcher.add('search?q', 'has-q')
+matcher.add('search?q=hello', 'exact-match')
 
-router.match('https://example.com/search?q=hello')
+matcher.match('https://example.com/search?q=hello')
 // { pattern: 'search?q=hello', params: {}, data: 'exact-match' }
 // More constrained search params = more specific (`?q` and `?q=` tie)
 ```

--- a/packages/route-pattern/bench/src/match/array-matcher.ts
+++ b/packages/route-pattern/bench/src/match/array-matcher.ts
@@ -1,43 +1,25 @@
-import { RoutePattern } from './route-pattern.ts'
-import type { Match, Matcher } from './matcher.ts'
-import * as Specificity from './specificity.ts'
+import { RoutePattern, type Match, type Matcher } from '@remix-run/route-pattern'
+import * as Specificity from '@remix-run/route-pattern/specificity'
 
 /**
  * Matcher implementation that checks patterns in insertion order and sorts matches by specificity.
+ *
+ * Kept here in the bench project for benchmark comparison only; the published package now ships
+ * a single trie-based matcher via `createMatcher`.
  */
 export class ArrayMatcher<data> implements Matcher<data> {
-  /**
-   * Whether pathname matching is case-insensitive.
-   */
   readonly ignoreCase: boolean
   #patterns: Array<{ pattern: RoutePattern; data: data }> = []
 
-  /**
-   * @param options Constructor options
-   * @param options.ignoreCase When `true`, pathname matching is case-insensitive for all patterns. Defaults to `false`.
-   */
   constructor(options?: { ignoreCase?: boolean }) {
     this.ignoreCase = options?.ignoreCase ?? false
   }
 
-  /**
-   * Adds a pattern and associated data to the matcher.
-   *
-   * @param pattern Pattern to register.
-   * @param data Data returned when the pattern matches.
-   */
   add(pattern: string | RoutePattern, data: data): void {
     pattern = typeof pattern === 'string' ? new RoutePattern(pattern) : pattern
     this.#patterns.push({ pattern, data })
   }
 
-  /**
-   * Returns the best matching pattern for a URL.
-   *
-   * @param url URL to match.
-   * @param compareFn Specificity comparer used to rank matches.
-   * @returns The best match, or `null` when nothing matches.
-   */
   match(url: string | URL, compareFn = Specificity.descending): Match<string, data> | null {
     let bestMatch: Match<string, data> | null = null
     for (let entry of this.#patterns) {
@@ -51,13 +33,6 @@ export class ArrayMatcher<data> implements Matcher<data> {
     return bestMatch
   }
 
-  /**
-   * Returns every pattern that matches a URL.
-   *
-   * @param url URL to match.
-   * @param compareFn Specificity comparer used to sort matches.
-   * @returns All matching routes sorted by specificity.
-   */
   matchAll(url: string | URL, compareFn = Specificity.descending): Array<Match<string, data>> {
     let matches: Array<Match<string, data>> = []
     for (let entry of this.#patterns) {

--- a/packages/route-pattern/bench/src/match/matchers.ts
+++ b/packages/route-pattern/bench/src/match/matchers.ts
@@ -1,6 +1,8 @@
 import FindMyWay from 'find-my-way'
 import { match } from 'path-to-regexp'
-import { ArrayMatcher, TrieMatcher, type Matcher } from '@remix-run/route-pattern'
+import { createMatcher, type Matcher } from '@remix-run/route-pattern'
+
+import { ArrayMatcher } from './array-matcher.ts'
 
 export let matchers = {
   routePatternArray: {
@@ -9,7 +11,7 @@ export let matchers = {
   },
   routePatternTrie: {
     name: 'route-pattern/trie',
-    createMatcher: () => new TrieMatcher<null>(),
+    createMatcher: () => createMatcher<null>(),
   },
   findMyWay: {
     name: 'find-my-way',

--- a/packages/route-pattern/src/index.ts
+++ b/packages/route-pattern/src/index.ts
@@ -4,6 +4,4 @@ export type { Params } from './lib/route-pattern/params.ts'
 export { ParseError } from './lib/route-pattern/parse.ts'
 export { type HrefArgs, HrefError } from './lib/route-pattern/href.ts'
 
-export { type Matcher, type Match } from './lib/matcher.ts'
-export { ArrayMatcher } from './lib/array-matcher.ts'
-export { TrieMatcher } from './lib/trie-matcher.ts'
+export { type Matcher, type Match, createMatcher } from './lib/matcher.ts'

--- a/packages/route-pattern/src/lib/matcher.test.ts
+++ b/packages/route-pattern/src/lib/matcher.test.ts
@@ -1,21 +1,14 @@
 import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
-import type { Matcher } from './matcher.ts'
+import { createMatcher } from './matcher.ts'
 import * as Specificity from './specificity.ts'
-import { ArrayMatcher } from './array-matcher.ts'
-import { TrieMatcher } from './trie-matcher.ts'
 
-type MatcherConstructor = new (options?: { ignoreCase?: boolean }) => Matcher<null>
-
-describe('ArrayMatcher', () => testSuite(ArrayMatcher))
-describe('TrieMatcher', () => testSuite(TrieMatcher))
-
-function testSuite(MatcherClass: MatcherConstructor): void {
+describe('Matcher', () => {
   describe('match', () => {
     describe('protocol', () => {
       it('matches any protocol when protocol is omitted', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/users', null)
 
         let httpMatch = matcher.match('http://example.com/users')
@@ -26,7 +19,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches http only when protocol is explicit http', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('http://example.com/users', null)
 
         let match = matcher.match('http://example.com/users')
@@ -34,7 +27,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches https only when protocol is explicit https', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('https://example.com/users', null)
 
         let match = matcher.match('https://example.com/users')
@@ -42,7 +35,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches both http and https when protocol is http(s)', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('http(s)://example.com/users', null)
 
         let httpMatch = matcher.match('http://example.com/users')
@@ -53,7 +46,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('returns null when protocol does not match', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('http://example.com/users', null)
 
         let match = matcher.match('https://example.com/users')
@@ -63,7 +56,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
 
     describe('hostname', () => {
       it('matches any hostname when hostname is omitted', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('users', null)
 
         let match1 = matcher.match('https://example.com/users')
@@ -77,7 +70,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches exact static hostname', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/users', null)
 
         let match = matcher.match('https://example.com/users')
@@ -86,7 +79,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches non-ASCII hostname param values', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://:accented.:cjk.:rtl.:combining.example.com/users', null)
 
         let params = {
@@ -108,7 +101,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('returns null when static hostname does not match', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/users', null)
 
         let match = matcher.match('https://other.com/users')
@@ -116,7 +109,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches variable segment in hostname', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://:subdomain.example.com/api', null)
 
         let match = matcher.match('https://api.example.com/api')
@@ -125,7 +118,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches multiple variables in hostname', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://:subdomain.:env.example.com/api', null)
 
         let match = matcher.match('https://api.prod.example.com/api')
@@ -134,7 +127,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches wildcard segment in hostname', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://*host.example.com/api', null)
 
         let match = matcher.match('https://api.v1.example.com/api')
@@ -143,7 +136,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('excludes unnamed wildcard from params', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://*.example.com/api', null)
 
         let match = matcher.match('https://api.v1.example.com/api')
@@ -152,7 +145,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches optional hostname segments when present', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://api(-:version).example.com/users', null)
 
         let match = matcher.match('https://api-v2.example.com/users')
@@ -161,7 +154,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches optional hostname segments when absent', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://api(-:version).example.com/users', null)
 
         let match = matcher.match('https://api.example.com/users')
@@ -170,7 +163,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches nested optionals in hostname', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://api(.:region(-:zone)).example.com/users', null)
 
         let matchAll = matcher.match('https://api.us-east1.example.com/users')
@@ -187,7 +180,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches multiple optionals in hostname', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://:sub(-:version).example(.:tld).com/api', null)
 
         let match = matcher.match('https://api-v2.example.dev.com/api')
@@ -196,7 +189,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches mixed static/variable/wildcard segments', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://*prefix.:env.example.com/api', null)
 
         let match = matcher.match('https://api.v1.prod.example.com/api')
@@ -205,7 +198,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('prefers static over variable hostname', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://:subdomain.example.com/api', null)
         matcher.add('://api.example.com/api', null)
 
@@ -215,7 +208,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('prefers variable over wildcard hostname', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://*host.example.com/api', null)
         matcher.add('://:subdomain.example.com/api', null)
 
@@ -225,7 +218,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('prefers longer static prefix in hostname', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://:subdomain.com/api', null)
         matcher.add('://:subdomain.example.com/api', null)
 
@@ -237,7 +230,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
 
     describe('port', () => {
       it('matches omitted port in URL when port is omitted in pattern', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/users', null)
 
         assert.ok(matcher.match('http://example.com/users'))
@@ -245,7 +238,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches explicit port', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com:8080/users', null)
 
         let match = matcher.match('http://example.com:8080/users')
@@ -254,28 +247,28 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('returns null when explicit port does not match', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com:8080/users', null)
 
         assert.equal(matcher.match('http://example.com:3000/users'), null)
       })
 
       it('returns null when pattern has explicit port but URL omits port', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com:8080/users', null)
 
         assert.equal(matcher.match('http://example.com/users'), null)
       })
 
       it('returns null when pattern omits port but URL has explicit port', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/users', null)
 
         assert.equal(matcher.match('http://example.com:8080/users'), null)
       })
 
       it('matches port with hostname variables', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://:subdomain.example.com:8080/api', null)
 
         let match = matcher.match('https://api.example.com:8080/api')
@@ -286,14 +279,14 @@ function testSuite(MatcherClass: MatcherConstructor): void {
 
     describe('pathname', () => {
       it('matches root pathname when pathname is empty', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com', null)
 
         assert.ok(matcher.match('http://example.com/'))
       })
 
       it('matches static segments', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/users/list', null)
 
         let match = matcher.match('http://example.com/users/list')
@@ -302,28 +295,28 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('returns null when static segment does not match', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/users', null)
 
         assert.equal(matcher.match('http://example.com/posts'), null)
       })
 
       it('returns null when URL is shorter than pattern', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/users/list', null)
 
         assert.equal(matcher.match('http://example.com/users'), null)
       })
 
       it('returns null when trailing slash does not match', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/users', null)
 
         assert.equal(matcher.match('http://example.com/users/'), null)
       })
 
       it('matches variable segments', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/users/:id', null)
 
         let match = matcher.match('http://example.com/users/123')
@@ -332,7 +325,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches multiple variables', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/users/:userId/posts/:postId', null)
 
         let match = matcher.match('http://example.com/users/42/posts/99')
@@ -341,7 +334,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches special characters in variable values', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/files/:filename', null)
 
         let match = matcher.match('http://example.com/files/my-file_v2.txt')
@@ -350,7 +343,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches non-ASCII param values', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add(
           '://example.com/:accented/:cjk/:rtl/:combining/:emoji/:zwj/:nbsp/:fullwidth',
           null,
@@ -376,7 +369,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches wildcard segments', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/files/*path', null)
 
         let match = matcher.match('http://example.com/files/docs/readme.md')
@@ -385,7 +378,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches wildcard with continuation', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/files/*path/status', null)
 
         let match = matcher.match('http://example.com/files/docs/api/status')
@@ -394,7 +387,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('excludes unnamed wildcard from params', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/files/*/download', null)
 
         let match = matcher.match('http://example.com/files/docs/download')
@@ -403,7 +396,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches optional segments when present', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/posts(/:lang)', null)
 
         let match = matcher.match('http://example.com/posts/en')
@@ -412,7 +405,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches optional segments when absent', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/posts(/:lang)', null)
 
         let match = matcher.match('http://example.com/posts')
@@ -421,7 +414,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches nested optionals', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/docs(/:version(/:page))', null)
 
         let match1 = matcher.match('http://example.com/docs/v1/intro')
@@ -438,7 +431,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches multiple optionals', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/api(/:version)/users(/:id)', null)
 
         let match = matcher.match('http://example.com/api/v2/users/123')
@@ -447,7 +440,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches complex optionals for file extensions', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/files/:id(.:format)', null)
 
         let match1 = matcher.match('http://example.com/files/doc123.pdf')
@@ -460,7 +453,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches mixed static/variable/wildcard segments', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/api/:version/files/*path', null)
 
         let match = matcher.match('http://example.com/api/v1/files/docs/guide.pdf')
@@ -469,7 +462,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches deep nesting', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add(
           '://example.com/products/electronics/computers/laptops/gaming/accessories/keyboards',
           null,
@@ -483,7 +476,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('prefers static over variable pathname', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/users/new', null)
         matcher.add('://example.com/users/:id', null)
 
@@ -493,7 +486,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('prefers variable over wildcard pathname', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/files/*path', null)
         matcher.add('://example.com/files/:id', null)
 
@@ -503,7 +496,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('prefers longer static prefix in pathname', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/api/:id', null)
         matcher.add('://example.com/api/v1/:id', null)
 
@@ -515,7 +508,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
 
     describe('search', () => {
       it('matches any query params when no search constraints', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/search', null)
 
         assert.ok(matcher.match('http://example.com/search'))
@@ -524,7 +517,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches bare parameter for presence check', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/search?q', null)
 
         let match = matcher.match('http://example.com/search?q')
@@ -532,7 +525,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches bare parameter with any value', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/search?q', null)
 
         assert.ok(matcher.match('http://example.com/search?q=test'))
@@ -540,7 +533,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches any value constraint with non-empty value', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/search?q=', null)
 
         let match = matcher.match('http://example.com/search?q=test')
@@ -548,7 +541,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches key-only constraint', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/search?q=', null)
 
         assert.ok(matcher.match('http://example.com/search?q'))
@@ -557,7 +550,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches specific value with exact match', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/api?format=json', null)
 
         let match = matcher.match('http://example.com/api?format=json')
@@ -565,14 +558,14 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('returns null when specific value does not match', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/api?format=json', null)
 
         assert.equal(matcher.match('http://example.com/api?format=xml'), null)
       })
 
       it('matches multiple constraints', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/search?q=&lang=en', null)
 
         let match = matcher.match('http://example.com/search?q=test&lang=en')
@@ -580,7 +573,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches constraints regardless of order', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/api?format=json&version=v1', null)
 
         let match = matcher.match('http://example.com/api?version=v1&format=json')
@@ -588,7 +581,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('allows extra params beyond constraints', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/search?q', null)
 
         let match = matcher.match('http://example.com/search?q=test&lang=en&page=2')
@@ -596,7 +589,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('preserves URL encoding in search parameter values', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/search?q=hello%20world', null)
 
         let match = matcher.match('http://example.com/search?q=hello%20world')
@@ -604,7 +597,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches repeated parameter values', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/filter?tags', null)
 
         let match = matcher.match('http://example.com/filter?tags=a&tags=b')
@@ -612,7 +605,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('returns null when constraint is not met', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/api?auth', null)
 
         assert.equal(matcher.match('http://example.com/api'), null)
@@ -620,7 +613,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('prefers more constraints over fewer', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/search?q', null)
         matcher.add('://example.com/search?q&lang', null)
 
@@ -630,7 +623,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('prefers exact value over any value', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/api?format', null)
         matcher.add('://example.com/api?format=json', null)
 
@@ -640,7 +633,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('ties specificity for both forms of key only constraints; tiebreaks using insertion order', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/search?q', null)
         matcher.add('://example.com/search?q=', null)
 
@@ -652,7 +645,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
 
     describe('ignoreCase', () => {
       it('uses case-sensitive pathname matching by default', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('/Posts/:id', null)
 
         assert.equal(matcher.match('https://example.com/posts/123'), null)
@@ -661,7 +654,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('ignores pathname case when ignoreCase is true', () => {
-        let matcher = new MatcherClass({ ignoreCase: true })
+        let matcher = createMatcher<null>({ ignoreCase: true })
         matcher.add('/Posts/:id', null)
 
         assert.ok(matcher.match('https://example.com/posts/123'))
@@ -670,7 +663,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('ignores hostname case regardless of ignoreCase', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://Example.COM/users', null)
 
         assert.ok(matcher.match('https://example.com/users'))
@@ -678,7 +671,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('matches search params case-sensitively regardless of ignoreCase', () => {
-        let matcher = new MatcherClass({ ignoreCase: true })
+        let matcher = createMatcher<null>({ ignoreCase: true })
         matcher.add('/api?Sort', null)
 
         assert.ok(matcher.match('https://example.com/api?Sort'))
@@ -686,7 +679,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('defaults to false', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('/Posts/:id', null)
         assert.equal(matcher.match('https://example.com/posts/123'), null)
       })
@@ -694,7 +687,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
 
     describe('paramsMeta', () => {
       it('returns empty arrays when no params', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/users', null)
 
         let match = matcher.match('http://example.com/users')
@@ -704,7 +697,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('includes wildcard hostname metadata for pathname-only patterns', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('/users/:id', null)
 
         let match = matcher.match('http://example.com/users/123')
@@ -718,7 +711,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('includes hostname params with metadata', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://:subdomain.example.com/api', null)
 
         let match = matcher.match('https://api.example.com/api')
@@ -731,7 +724,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('includes pathname params with metadata', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/users/:id', null)
 
         let match = matcher.match('http://example.com/users/123')
@@ -744,7 +737,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('includes params from both hostname and pathname', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://:subdomain.example.com/users/:id', null)
 
         let match = matcher.match('https://api.example.com/users/123')
@@ -758,7 +751,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('includes wildcard params in metadata', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/files/*path', null)
 
         let match = matcher.match('http://example.com/files/docs/readme.md')
@@ -770,7 +763,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('includes unnamed wildcards in metadata with name "*"', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/files/*/download', null)
 
         let match = matcher.match('http://example.com/files/docs/download')
@@ -782,7 +775,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('excludes undefined optional params from metadata', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/posts(/:lang)', null)
 
         let match = matcher.match('http://example.com/posts')
@@ -791,7 +784,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('includes only matched optional params in metadata', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/docs(/:version(/:page))', null)
 
         let match = matcher.match('http://example.com/docs/v1')
@@ -804,7 +797,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
 
     describe('specificity', () => {
       it('prefers static over variable', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/:segment', null)
         matcher.add('://example.com/users', null)
 
@@ -814,7 +807,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('prefers variable over wildcard', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/*path', null)
         matcher.add('://example.com/:id', null)
 
@@ -824,7 +817,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('prefers longer static prefix over shorter', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/:id', null)
         matcher.add('://example.com/api/:id', null)
 
@@ -834,7 +827,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('prefers hostname specificity over pathname specificity', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/*path', null)
         matcher.add('://:subdomain.example.com/users', null)
 
@@ -844,7 +837,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('increases specificity with search constraints', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/search', null)
         matcher.add('://example.com/search?q', null)
 
@@ -854,7 +847,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       })
 
       it('returns null when no patterns match', () => {
-        let matcher = new MatcherClass()
+        let matcher = createMatcher<null>()
         matcher.add('://example.com/users', null)
         matcher.add('://example.com/posts', null)
 
@@ -865,7 +858,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
 
   describe('matchAll', () => {
     it('returns all matches sorted by specificity', () => {
-      let matcher = new MatcherClass()
+      let matcher = createMatcher<null>()
       matcher.add('://example.com/*path', null)
       matcher.add('://example.com/users/:id', null)
       matcher.add('://example.com/users/new', null)
@@ -878,7 +871,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
     })
 
     it('returns empty array when no matches', () => {
-      let matcher = new MatcherClass()
+      let matcher = createMatcher<null>()
       matcher.add('://example.com/users', null)
       matcher.add('://example.com/posts', null)
 
@@ -887,7 +880,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
     })
 
     it('includes patterns with same specificity', () => {
-      let matcher = new MatcherClass()
+      let matcher = createMatcher<null>()
       matcher.add('://example.com/users/:id', null)
       matcher.add('://example.com/posts/:id', null)
 
@@ -905,7 +898,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
     })
 
     it('orders complex specificity scenarios consistently', () => {
-      let matcher = new MatcherClass()
+      let matcher = createMatcher<null>()
       // Add patterns in random order to ensure ordering is by specificity, not insertion order
       matcher.add('/*path', null)
       matcher.add('://api.example.com/users/:id', null)
@@ -942,7 +935,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
 
   describe('custom compareFn', () => {
     it('uses custom compareFn for match() to select best', () => {
-      let matcher = new MatcherClass()
+      let matcher = createMatcher<null>()
       matcher.add('://example.com/*path', null)
       matcher.add('://example.com/users/:id', null)
       matcher.add('://example.com/users/123', null)
@@ -959,7 +952,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
     })
 
     it('uses custom compareFn for matchAll() to sort results', () => {
-      let matcher = new MatcherClass()
+      let matcher = createMatcher<null>()
       matcher.add('://example.com/*path', null)
       matcher.add('://example.com/users/:id', null)
       matcher.add('://example.com/users/123', null)
@@ -976,7 +969,7 @@ function testSuite(MatcherClass: MatcherConstructor): void {
     })
 
     it('supports ascending specificity order', () => {
-      let matcher = new MatcherClass()
+      let matcher = createMatcher<null>()
       matcher.add('://example.com/*path', null)
       matcher.add('://example.com/users/:id', null)
       matcher.add('://example.com/users/123', null)
@@ -989,4 +982,4 @@ function testSuite(MatcherClass: MatcherConstructor): void {
       )
     })
   })
-}
+})

--- a/packages/route-pattern/src/lib/matcher.test.ts
+++ b/packages/route-pattern/src/lib/matcher.test.ts
@@ -275,6 +275,16 @@ describe('Matcher', () => {
         assert.ok(match)
         assert.deepEqual(match.params, { subdomain: 'api' })
       })
+
+      it('matches origin-less pattern against URL with any port', () => {
+        let matcher = createMatcher<null>()
+        matcher.add('/', null)
+        matcher.add('/about', null)
+
+        assert.ok(matcher.match('http://localhost/'))
+        assert.ok(matcher.match('http://localhost:44199/'))
+        assert.ok(matcher.match('https://example.com:8080/about'))
+      })
     })
 
     describe('pathname', () => {

--- a/packages/route-pattern/src/lib/matcher.ts
+++ b/packages/route-pattern/src/lib/matcher.ts
@@ -1,4 +1,5 @@
 import type { RoutePattern, RoutePatternMatch } from './route-pattern.ts'
+import { TrieMatcher } from './trie-matcher.ts'
 
 /**
  * Successful pattern match paired with matcher-specific data.
@@ -41,4 +42,17 @@ export type Matcher<data = unknown> = {
    * @returns All matches
    */
   matchAll(url: string | URL, compareFn?: CompareFn): Array<Match<string, data>>
+}
+
+/**
+ * Create a new matcher.
+ *
+ * @param options Constructor options
+ * @param options.ignoreCase When `true`, pathname matching is case-insensitive for all patterns. Defaults to `false`.
+ * @returns A new matcher instance.
+ */
+export function createMatcher<data = unknown>(options?: {
+  ignoreCase?: boolean
+}): Matcher<data> {
+  return new TrieMatcher<data>(options)
 }

--- a/packages/route-pattern/src/lib/trie-matcher.ts
+++ b/packages/route-pattern/src/lib/trie-matcher.ts
@@ -242,8 +242,9 @@ export class Trie<data = unknown> {
     if (protocol !== 'http' && protocol !== 'https') return []
     let hostNameNode = this.protocolNode[protocol]
 
-    // any hostname + port -> pathname
-    let anyHostname = hostNameNode.any.get(url.port)
+    // any hostname (no port) -> pathname
+    // port cannot appear without hostname, so always indexed under the empty-port key
+    let anyHostname = hostNameNode.any.get('')
     if (anyHostname) {
       origins.push({
         hostnameMatch: [


### PR DESCRIPTION
TrieMatcher was always faster than ArrayMatcher in our benchmarks, except for a few lambda-style benchmarks.
But for those, the absolute time was tiny and difference was negligible.

In fact, some lambda providers start booting up your request handler while they are still pre-processing the request, which often takes on the order of a few milliseconds. That already covers for the total time taken by TrieMatcher to setup on the `shopify.com` benchmark w/ ~2500 patterns.

Therefore, `createMatcher` uses `TrieMatcher` internally. Moved `ArrayMatcher` into the `bench` subpackage so we can still benchmark against that implementation.

Perf looks the same accounting for noise (reminder, lambda benchmarks are much noisier since their absolute runtimes are much faster):

<img width="573" height="1148" alt="Screenshot 2026-04-30 at 11 39 18 AM" src="https://github.com/user-attachments/assets/d2f4a725-d833-426d-8437-cf0bcda20398" />
