### PR TITLE
Use HTML response helper in demo renderers

### DIFF
--- a/demos/bookstore/app/utils/render.tsx
+++ b/demos/bookstore/app/utils/render.tsx
@@ -1,6 +1,7 @@
 import * as path from 'node:path'
 import type { RemixNode } from 'remix/ui'
 import { renderToStream } from 'remix/ui/server'
+import { createHtmlResponse } from 'remix/response/html'
 import { getContext } from 'remix/async-context-middleware'
 import type { RequestContext, Router } from 'remix/fetch-router'
 
@@ -27,12 +28,7 @@ export function render(node: RemixNode, init?: ResponseInit) {
     },
   })
 
-  let headers = new Headers(init?.headers)
-  if (!headers.has('Content-Type')) {
-    headers.set('Content-Type', 'text/html; charset=UTF-8')
-  }
-
-  return new Response(stream, { ...init, headers })
+  return createHtmlResponse(stream, init)
 }
 
 async function resolveFrame<context extends RequestContext<any, any>>(
@@ -61,7 +57,6 @@ async function resolveFrame<context extends RequestContext<any, any>>(
     return `<pre>Frame error: ${res.status} ${res.statusText}</pre>`
   }
 
-  if (res.body) return res.body
   return res.text()
 }
 

--- a/demos/frame-navigation/app/utils/render.tsx
+++ b/demos/frame-navigation/app/utils/render.tsx
@@ -1,5 +1,6 @@
 import type { RemixNode } from 'remix/ui'
 import { renderToStream, type ResolveFrameContext } from 'remix/ui/server'
+import { createHtmlResponse } from 'remix/response/html'
 import { getContext } from 'remix/async-context-middleware'
 import type { Router } from 'remix/fetch-router'
 
@@ -16,12 +17,7 @@ export function render(node: RemixNode, init?: ResponseInit) {
     },
   })
 
-  let headers = new Headers(init?.headers)
-  if (!headers.has('Content-Type')) {
-    headers.set('Content-Type', 'text/html; charset=UTF-8')
-  }
-
-  return new Response(stream, { ...init, headers })
+  return createHtmlResponse(stream, init)
 }
 
 async function resolveFrame(
@@ -46,10 +42,11 @@ async function resolveFrame(
   if (cookie) headers.set('cookie', cookie)
 
   let res = await followFrameRedirects(router, request, url, headers)
-  if (res.body) return res.body
+  if (!res.ok) {
+    return `<pre>Frame error: ${res.status} ${res.statusText}</pre>`
+  }
 
-  if (res.ok) return res.text()
-  return `<pre>Frame error: ${res.status} ${res.statusText}</pre>`
+  return res.text()
 }
 
 async function followFrameRedirects(router: Router, request: Request, url: URL, headers: Headers) {

--- a/demos/frames/app/utils/render.ts
+++ b/demos/frames/app/utils/render.ts
@@ -1,5 +1,6 @@
 import type { RemixNode } from 'remix/ui'
 import { renderToStream } from 'remix/ui/server'
+import { createHtmlResponse } from 'remix/response/html'
 import type { Router } from 'remix/fetch-router'
 
 type RenderOptions = {
@@ -25,15 +26,11 @@ export function render(node: RemixNode, options: RenderOptions = {}): Response {
 
   let headers = new Headers(options.init?.headers)
 
-  if (!headers.has('Content-Type')) {
-    headers.set('Content-Type', 'text/html; charset=utf-8')
-  }
-
   if (!headers.has('Cache-Control')) {
     headers.set('Cache-Control', 'no-store')
   }
 
-  return new Response(stream, { ...options.init, headers })
+  return createHtmlResponse(stream, { ...options.init, headers })
 }
 
 async function resolveFrameViaRouter(router: Router, request: Request, src: string) {
@@ -53,10 +50,6 @@ async function resolveFrameViaRouter(router: Router, request: Request, src: stri
 
   if (!response.ok) {
     return `<pre>Frame error: ${response.status} ${response.statusText}</pre>`
-  }
-
-  if (response.body) {
-    return response.body
   }
 
   return response.text()

--- a/packages/ui/demo/config/render.tsx
+++ b/packages/ui/demo/config/render.tsx
@@ -1,5 +1,6 @@
 import type { RemixNode } from 'remix/ui'
 import { renderToStream, type ResolveFrameContext } from 'remix/ui/server'
+import { createHtmlResponse } from 'remix/response/html'
 import type { RequestContext, Router } from 'remix/fetch-router'
 
 export function render(context: RequestContext, node: RemixNode, init?: ResponseInit) {
@@ -11,12 +12,7 @@ export function render(context: RequestContext, node: RemixNode, init?: Response
     },
   })
 
-  let headers = new Headers(init?.headers)
-  if (!headers.has('Content-Type')) {
-    headers.set('Content-Type', 'text/html; charset=utf-8')
-  }
-
-  return new Response(stream, { ...init, headers })
+  return createHtmlResponse(stream, init)
 }
 
 async function resolveFrame(
@@ -41,10 +37,6 @@ async function resolveFrame(
   }
 
   let response = await followFrameRedirects(context.router, context.request, frameUrl, headers)
-
-  if (response.body) {
-    return response.body
-  }
 
   if (response.ok) {
     return await response.text()


### PR DESCRIPTION
Demo render helpers should rely on the response package HTML helper instead of reconstructing `Response` headers by hand. This updates the remaining JSX demo renderers to wrap `renderToStream(...)` with `createHtmlResponse(...)` so content type and doctype behavior stay centralized.

- Updates the frames, frame-navigation, bookstore, and UI demo render helpers to use `createHtmlResponse(...)`.
- Preserves the frames demo `Cache-Control: no-store` default while delegating HTML response details to the shared helper.
- Reads routed frame responses as text before handing them back to `renderToStream(...)`, which lets the UI renderer strip the helper-added doctype before templating nested frame content.