### PR TITLE
Make uWebSockets.js required for node-serve

### DIFF
--- a/packages/node-serve/.changes/patch.require-uwebsockets-dependency.md
+++ b/packages/node-serve/.changes/patch.require-uwebsockets-dependency.md
@@ -1,0 +1,1 @@
+Install `uWebSockets.js` as a required dependency so `remix/node-serve` works when package managers omit optional dependencies.

--- a/packages/node-serve/README.md
+++ b/packages/node-serve/README.md
@@ -18,7 +18,7 @@ Build high-performance Node.js servers with web-standard Fetch API primitives. U
 npm i remix
 ```
 
-`node-serve` includes a native high-performance transport as an optional dependency. Standard installs include optional dependencies; if your install disables them, enable optional dependencies before using `remix/node-serve`.
+`node-serve` includes uWebSockets.js as its native high-performance transport.
 
 ## Usage
 

--- a/packages/node-serve/package.json
+++ b/packages/node-serve/package.json
@@ -37,7 +37,7 @@
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:"
   },
-  "optionalDependencies": {
+  "dependencies": {
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.66.0"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1339,6 +1339,10 @@ importers:
         version: 7.0.0-dev.20251125.1
 
   packages/node-serve:
+    dependencies:
+      uWebSockets.js:
+        specifier: github:uNetworking/uWebSockets.js#v20.66.0
+        version: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/a63031f40f76dc2422e8da736c04217053e9db2b
     devDependencies:
       '@remix-run/assert':
         specifier: workspace:*
@@ -1352,10 +1356,6 @@ importers:
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20251125.1
-    optionalDependencies:
-      uWebSockets.js:
-        specifier: github:uNetworking/uWebSockets.js#v20.66.0
-        version: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/a63031f40f76dc2422e8da736c04217053e9db2b
 
   packages/remix:
     dependencies:
@@ -8539,8 +8539,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/a63031f40f76dc2422e8da736c04217053e9db2b:
-    optional: true
+  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/a63031f40f76dc2422e8da736c04217053e9db2b: {}
 
   uc.micro@2.1.0: {}
 


### PR DESCRIPTION
`node-serve` imports `uWebSockets.js` at module load and `serve()` creates a uWebSockets app directly, so the transport is required for the package to work.

- Moves `uWebSockets.js` from `optionalDependencies` to `dependencies` for `@remix-run/node-serve`
- Updates the lockfile so installs treat the native transport as required
- Removes the optional-dependency install warning from the README
- Adds a patch change file for the corrected install behavior
