### PR TITLE
Add node-serve setup hook

### DIFF
--- a/packages/node-serve/.changes/minor.setup-hook.md
+++ b/packages/node-serve/.changes/minor.setup-hook.md
@@ -1,0 +1,19 @@
+Add a `setup(app)` option to `serve()` so managed node-serve apps can register native uWebSockets.js WebSocket routes and connection filters before the Fetch fallback route starts listening.
+
+```ts
+import { serve } from 'remix/node-serve'
+
+serve(handler, {
+  setup(app) {
+    app.ws('/ws/chat', {
+      message(ws, message, isBinary) {
+        ws.publish('chat', message, isBinary)
+      },
+    })
+
+    app.filter((_res, count) => {
+      console.log(`Active uWS connections: ${count}`)
+    })
+  },
+})
+```

--- a/packages/node-serve/README.md
+++ b/packages/node-serve/README.md
@@ -10,6 +10,7 @@ Build high-performance Node.js servers with web-standard Fetch API primitives. U
 - **Managed Server Lifecycle**: Start a server with `serve()`, wait for `server.ready`, and close it with `server.close()`
 - **Custom Hostname**: Override the host and protocol used to construct incoming `request.url` values
 - **Client Info**: Access client IP address, address family, and remote port when your handler accepts a second argument
+- **uWebSockets.js Setup**: Register native WebSocket routes and connection filters before the Fetch fallback starts listening
 - **Existing uWebSockets.js App Adapter**: Use `createUwsRequestHandler()` when you already own a uWebSockets.js app
 
 ## Installation
@@ -58,6 +59,84 @@ let server = serve(handler, { port: 3000 })
 await server.ready
 console.log(`Server running at http://localhost:${server.port}`)
 ```
+
+### uWebSockets.js Setup
+
+Use `setup(app)` when `serve()` should still manage the server lifecycle and Fetch fallback, but you need to configure native uWebSockets.js transport features before the server starts listening. The hook runs after the app is created and before `node-serve` registers its catch-all Fetch route.
+
+This example adds a native WebSocket endpoint next to a normal Fetch handler on the same port:
+
+```ts
+import { serve } from 'remix/node-serve'
+
+let server = serve(
+  (request) => {
+    let url = new URL(request.url)
+
+    if (url.pathname === '/') {
+      return new Response('Chat server')
+    }
+
+    return new Response('Not Found', { status: 404 })
+  },
+  {
+    port: 3000,
+    setup(app) {
+      app.ws('/ws/chat', {
+        open(ws) {
+          ws.subscribe('chat')
+        },
+        message(ws, message, isBinary) {
+          ws.publish('chat', message, isBinary)
+        },
+      })
+    },
+  },
+)
+
+await server.ready
+```
+
+`app.ws(pattern, ...)` uses uWebSockets.js route patterns, not Remix `route-pattern` syntax. uWS supports simple path params such as `/rooms/:room`, and those params are available during `upgrade` through `req.getParameter('room')` or `req.getParameter(0)`. If WebSocket handlers need params, copy them into uWS user data during `upgrade`, then read them with `ws.getUserData()`:
+
+```ts
+serve(handler, {
+  setup(app) {
+    app.ws<{ room: string }>('/rooms/:room', {
+      upgrade(res, req, context) {
+        res.upgrade(
+          { room: req.getParameter('room') ?? 'general' },
+          req.getHeader('sec-websocket-key'),
+          req.getHeader('sec-websocket-protocol'),
+          req.getHeader('sec-websocket-extensions'),
+          context,
+        )
+      },
+      open(ws) {
+        ws.subscribe(`room:${ws.getUserData().room}`)
+      },
+    })
+  },
+})
+```
+
+uWS patterns do not support the full `route-pattern` feature set, including partial-segment params like `v:version`, split params like `:file.:ext`, optionals like `/api(/v:version)`, host/protocol/search matching, or named multi-segment wildcard captures like `*path`. You can use a uWS pattern like `/files/*` as a catch-all, but it does not provide Remix-style named wildcard params.
+
+You can also register connection filters for low-level transport metrics or limits:
+
+```ts
+let activeConnections = 0
+
+serve(handler, {
+  setup(app) {
+    app.filter((_res, count) => {
+      activeConnections = Number(count)
+    })
+  },
+})
+```
+
+`app.filter()` observes low-level connection count changes. It is not Fetch response middleware and should not be used to mutate normal `Response` headers or bodies. Use Fetch handlers, middleware, or [`fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router) for normal HTTP routing and response behavior; reserve `setup()` for uWebSockets.js transport features that must be configured before listening.
 
 ### Custom Request URLs
 

--- a/packages/node-serve/src/lib/server.test.ts
+++ b/packages/node-serve/src/lib/server.test.ts
@@ -1,8 +1,10 @@
 import * as https from 'node:https'
+import * as net from 'node:net'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
+import { serve } from '../index.ts'
 
 const describeUws = process.platform === 'win32' ? describe.skip : describe
 const fixturesDir = path.resolve(
@@ -11,8 +13,43 @@ const fixturesDir = path.resolve(
 )
 
 describeUws('serve', () => {
+  it('runs setup before listening and exposes the configured app', async () => {
+    let events: string[] = []
+    let setupApp: unknown
+
+    let server = serve(
+      () => {
+        events.push('handler')
+        return new Response('ok')
+      },
+      {
+        port: 0,
+        setup(app) {
+          events.push('setup')
+          setupApp = app
+          assert.deepEqual(events, ['setup'])
+        },
+      },
+    )
+
+    events.push('returned')
+    assert.equal(setupApp, server.app)
+    assert.deepEqual(events, ['setup', 'returned'])
+
+    await server.ready
+
+    try {
+      let response = await fetch(`http://127.0.0.1:${server.port}/test`)
+
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'ok')
+      assert.deepEqual(events, ['setup', 'returned', 'handler'])
+    } finally {
+      server.close()
+    }
+  })
+
   it('handles fetch requests with the uWebSockets.js transport', async () => {
-    let { serve } = await import('../index.ts')
     let server = serve(
       async (request) => {
         assert.equal(request.method, 'POST')
@@ -50,7 +87,6 @@ describeUws('serve', () => {
   })
 
   it('uses the host option to override the incoming Host header', async () => {
-    let { serve } = await import('../index.ts')
     let server = serve(
       async (request) => {
         assert.equal(request.url, 'http://remix.run/test?value=1')
@@ -71,8 +107,99 @@ describeUws('serve', () => {
     }
   })
 
+  it('lets setup register a WebSocket route before the Fetch fallback', async () => {
+    let server = serve(
+      (request) => {
+        assert.equal(new URL(request.url).pathname, '/fetch')
+        return new Response('fetch ok')
+      },
+      {
+        port: 0,
+        setup(app) {
+          app.ws('/ws/echo', {
+            message(ws, message, isBinary) {
+              ws.send(message, isBinary)
+            },
+          })
+        },
+      },
+    )
+
+    await server.ready
+
+    let socket = await connectWebSocket(`ws://127.0.0.1:${server.port}/ws/echo`)
+
+    try {
+      let message = receiveWebSocketMessage(socket)
+      socket.send('hello')
+
+      assert.equal(await message, 'hello')
+
+      let response = await fetch(`http://127.0.0.1:${server.port}/fetch`)
+
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'fetch ok')
+    } finally {
+      socket.close()
+      server.close()
+    }
+  })
+
+  it('lets setup register a connection filter', async () => {
+    let connectionCounts: number[] = []
+    let server = serve(() => new Response('ok'), {
+      port: 0,
+      setup(app) {
+        app.filter((_res, count) => {
+          connectionCounts.push(Number(count))
+        })
+      },
+    })
+
+    await server.ready
+
+    try {
+      let response = await fetch(`http://127.0.0.1:${server.port}/test`)
+
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'ok')
+
+      await waitFor(
+        () => connectionCounts.some((count) => count > 0),
+        'Timed out waiting for a connection filter callback',
+      )
+    } finally {
+      server.close()
+    }
+  })
+
+  it('throws synchronously and does not listen when setup throws', async () => {
+    let port = await getAvailablePort()
+
+    assert.throws(() => {
+      serve(() => new Response('ok'), {
+        port,
+        setup() {
+          throw new Error('setup failed')
+        },
+      })
+    }, /setup failed/)
+
+    let server = serve(() => new Response('ok'), { port })
+
+    await server.ready
+
+    try {
+      let response = await fetch(`http://127.0.0.1:${server.port}/test`)
+
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'ok')
+    } finally {
+      server.close()
+    }
+  })
+
   it('serves HTTPS requests when TLS options are provided', async () => {
-    let { serve } = await import('../index.ts')
     let server = serve(
       (request) => {
         assert.equal(request.url, 'https://remix.run/secure?value=1')
@@ -100,6 +227,111 @@ describeUws('serve', () => {
     }
   })
 })
+
+function getAvailablePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let server = net.createServer()
+
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      let address = server.address()
+
+      if (address == null || typeof address === 'string') {
+        server.close()
+        reject(new Error('Unable to determine the test server port'))
+        return
+      }
+
+      server.close((error) => {
+        if (error != null) {
+          reject(error)
+        } else {
+          resolve(address.port)
+        }
+      })
+    })
+  })
+}
+
+async function connectWebSocket(url: string): Promise<WebSocket> {
+  let socket = new WebSocket(url)
+
+  try {
+    await withTimeout(
+      new Promise<void>((resolve, reject) => {
+        socket.addEventListener('open', () => resolve(), { once: true })
+        socket.addEventListener('error', () => reject(new Error('Unable to open WebSocket')), {
+          once: true,
+        })
+      }),
+      'Timed out opening WebSocket',
+    )
+  } catch (error: unknown) {
+    socket.close()
+    throw error
+  }
+
+  return socket
+}
+
+function receiveWebSocketMessage(socket: WebSocket): Promise<string> {
+  return withTimeout(
+    new Promise((resolve, reject) => {
+      socket.addEventListener(
+        'message',
+        (event) => {
+          let data: unknown = event.data
+
+          if (typeof data === 'string') {
+            resolve(data)
+            return
+          }
+
+          if (data instanceof ArrayBuffer) {
+            resolve(Buffer.from(data).toString())
+            return
+          }
+
+          if (data instanceof Blob) {
+            void data.text().then(resolve, reject)
+            return
+          }
+
+          reject(new Error('Received an unsupported WebSocket message type'))
+        },
+        { once: true },
+      )
+      socket.addEventListener('error', () => reject(new Error('WebSocket error')), { once: true })
+    }),
+    'Timed out receiving WebSocket message',
+  )
+}
+
+async function waitFor(predicate: () => boolean, message: string): Promise<void> {
+  let deadline = Date.now() + 5_000
+
+  while (Date.now() < deadline) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+
+  throw new Error(message)
+}
+
+async function withTimeout<value>(promise: Promise<value>, message: string): Promise<value> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error(message)), 5_000)
+      }),
+    ])
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+  }
+}
 
 function requestHttps(
   port: number,

--- a/packages/node-serve/src/lib/server.ts
+++ b/packages/node-serve/src/lib/server.ts
@@ -90,6 +90,12 @@ export interface ServeOptions {
    * to the `https:` protocol.
    */
   tls?: ServeTlsOptions
+  /**
+   * Configures the underlying uWebSockets.js app before the Fetch fallback route is registered and
+   * before the server starts listening. Use this for low-level transport features such as native
+   * WebSocket routes and connection filters.
+   */
+  setup?: (app: uWS.TemplatedApp) => void
 }
 
 /**
@@ -228,6 +234,13 @@ export function serve(handler: FetchHandler, options?: ServeOptions): Server {
   let app = createApp(options?.tls)
   let listenSocket: uWS.us_listen_socket | false = false
   let port = 0
+
+  try {
+    options?.setup?.(app)
+  } catch (error) {
+    app.close()
+    throw error
+  }
 
   let ready = new Promise<void>((resolve, reject) => {
     let onListen = (socket: uWS.us_listen_socket | false) => {

--- a/packages/remix/.changes/minor.node-serve-setup-hook.md
+++ b/packages/remix/.changes/minor.node-serve-setup-hook.md
@@ -1,0 +1,15 @@
+Expose the `node-serve` `setup(app)` option through `remix/node-serve` so apps can register native uWebSockets.js WebSocket routes and connection filters before the Fetch fallback route starts listening.
+
+```ts
+import { serve } from 'remix/node-serve'
+
+serve(handler, {
+  setup(app) {
+    app.ws('/ws/chat', {
+      message(ws, message, isBinary) {
+        ws.publish('chat', message, isBinary)
+      },
+    })
+  },
+})
+```


### PR DESCRIPTION
Adds a synchronous `setup(app)` option to `serve()` for configuring native uWebSockets.js features before node-serve registers its Fetch fallback and starts listening. Fixes #11313.

- Passes the created `uWS.TemplatedApp` to `setup` before `app.any("/*", ...)`, then surfaces setup errors synchronously without starting a listener.
- Covers native WebSocket routes, connection filters, normal Fetch fallback behavior, and setup failure behavior in node-serve tests.
- Documents WebSocket and filter usage, including uWS route pattern differences from Remix `route-pattern`.

```ts
serve(handler, {
  setup(app) {
    app.ws("/ws/chat", {
      open(ws) {
        ws.subscribe("chat")
      },
      message(ws, message, isBinary) {
        ws.publish("chat", message, isBinary)
      },
    })
  },
})
```