### PR TITLE
Fix bootstrap client entry resolution

### DIFF
--- a/packages/cli/.changes/patch.bootstrap-client-entry-resolution.md
+++ b/packages/cli/.changes/patch.bootstrap-client-entry-resolution.md
@@ -1,0 +1,1 @@
+Fix the scaffolded app template so source-owned client entries resolve through the asset server during server rendering.

--- a/packages/cli/bootstrap/app/ui/prompt-button.tsx
+++ b/packages/cli/bootstrap/app/ui/prompt-button.tsx
@@ -10,7 +10,7 @@ interface PromptButtonProps extends SerializableProps {
 }
 
 export const PromptButton = clientEntry(
-  '/assets/app/ui/prompt-button.tsx#PromptButton',
+  import.meta.url,
   function PromptButton(handle: Handle<PromptButtonProps>) {
     let state: CopyState = 'idle'
 

--- a/packages/cli/bootstrap/app/utils/render.tsx
+++ b/packages/cli/bootstrap/app/utils/render.tsx
@@ -1,11 +1,19 @@
 import type { RemixNode } from 'remix/ui'
 import { renderToStream } from 'remix/ui/server'
 
+import { assets } from '../assets.ts'
 import { router } from '../router.ts'
 
 export function render(node: RemixNode, request: Request, init?: ResponseInit) {
   let stream = renderToStream(node, {
     frameSrc: request.url,
+    async resolveClientEntry(entryId, component) {
+      let { href, exportName } = splitClientEntryId(entryId, component.name)
+      return {
+        href: href.startsWith('file://') ? await assets.getHref(href) : href,
+        exportName,
+      }
+    },
     async resolveFrame(src, target) {
       let headers = new Headers({ accept: 'text/html' })
       let cookie = request.headers.get('cookie')
@@ -23,4 +31,21 @@ export function render(node: RemixNode, request: Request, init?: ResponseInit) {
   }
 
   return new Response(stream, { ...init, headers })
+}
+
+function splitClientEntryId(entryId: string, fallbackExportName: string) {
+  let hashIndex = entryId.lastIndexOf('#')
+  let href = hashIndex === -1 ? entryId : entryId.slice(0, hashIndex)
+  let exportName =
+    hashIndex === -1 ? fallbackExportName : entryId.slice(hashIndex + 1) || fallbackExportName
+
+  if (!href) {
+    throw new Error(`Unable to resolve client entry href for ${entryId}`)
+  }
+
+  if (!exportName) {
+    throw new Error(`Unable to resolve client entry export for ${entryId}`)
+  }
+
+  return { href, exportName }
 }


### PR DESCRIPTION
- Resolve scaffolded app client entries through the bootstrap asset server during server rendering.
- Switch the starter `PromptButton` client entry to use its source module URL instead of hard-coding the public asset path.
- Add a CLI patch change note for the scaffold template fix.
