### PR TITLE
Fix CLI argument and completion edge cases

### DIFF
--- a/packages/cli/.changes/patch.cli-argument-completion.md
+++ b/packages/cli/.changes/patch.cli-argument-completion.md
@@ -1,0 +1,1 @@
+Fixed CLI argument edge cases so `--` separators still work after global options, completion help can be requested after a shell name, and `remix test` completions no longer duplicate `--help`.

--- a/packages/cli/src/lib/cli.test.ts
+++ b/packages/cli/src/lib/cli.test.ts
@@ -374,6 +374,16 @@ describe('run', () => {
     assert.equal(result.stderr, '')
   })
 
+  it('ignores a double-dash separator after global options', async () => {
+    let result = await captureOutput(() =>
+      run(['--no-color', '--', '--version'], { remixVersion: '9.9.9' }),
+    )
+
+    assert.equal(result.exitCode, 0)
+    assert.equal(result.stdout, '9.9.9\n')
+    assert.equal(result.stderr, '')
+  })
+
   it('fails for unknown commands', async () => {
     let result = await captureOutput(() => run(['unknown']))
 
@@ -536,6 +546,22 @@ describe('run', () => {
         result.stderr,
         new RegExp(`Target directory is not empty: ${escapeRegExp(appDir)}`),
       )
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects app names that cannot become package names before writing files', async () => {
+    let tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remix-cli-'))
+
+    try {
+      let appDir = path.join(tmpDir, 'invalid-name')
+      let result = await captureOutput(() => run(['new', appDir, '--app-name', '!!!']))
+
+      assert.equal(result.exitCode, 1)
+      assert.equal(result.stdout, '')
+      assert.match(result.stderr, /Could not derive a valid package name from "!!!"/)
+      await assertPathMissing(appDir)
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true })
     }

--- a/packages/cli/src/lib/cli.ts
+++ b/packages/cli/src/lib/cli.ts
@@ -17,12 +17,10 @@ export async function runRemix(
   let context = await resolveCliContext(options)
 
   try {
-    while (argv[0] === '--') {
-      argv = argv.slice(1)
-    }
+    argv = stripLeadingSeparators(argv)
 
     let globalOptions = extractGlobalOptions(argv)
-    argv = globalOptions.argv
+    argv = stripLeadingSeparators(globalOptions.argv)
     configureColors({ disabled: globalOptions.noColor })
 
     if (argv.length === 0) {
@@ -41,6 +39,14 @@ export async function runRemix(
   } finally {
     restoreTerminalFormatting()
   }
+}
+
+function stripLeadingSeparators(argv: string[]): string[] {
+  while (argv[0] === '--') {
+    argv = argv.slice(1)
+  }
+
+  return argv
 }
 
 async function runCommand(command: string, argv: string[], context: CliContext): Promise<number> {

--- a/packages/cli/src/lib/commands/completion.test.ts
+++ b/packages/cli/src/lib/commands/completion.test.ts
@@ -35,6 +35,14 @@ describe('completion command', () => {
     assert.equal(result.stderr, '')
   })
 
+  it('prints completion command help when help appears after the shell', async () => {
+    let result = await captureOutput(() => runRemix(['completion', 'bash', '--help']))
+
+    assert.equal(result.exitCode, 0)
+    assert.equal(result.stdout, COMPLETION_COMMAND_HELP_TEXT)
+    assert.equal(result.stderr, '')
+  })
+
   it('prints the same wrapper for bash and zsh', async () => {
     let bashResult = await captureOutput(() => runRemix(['completion', 'bash']))
     let zshResult = await captureOutput(() => runRemix(['completion', 'zsh']))
@@ -54,6 +62,14 @@ describe('completion command', () => {
     assert.equal(result.exitCode, 1)
     assert.equal(result.stdout, '')
     assert.equal(result.stderr, UNKNOWN_COMPLETION_SHELL_ERROR_TEXT)
+  })
+
+  it('keeps plumbing mode active when completed words include help flags', async () => {
+    let result = await captureOutput(() => runRemix(['completion', '--', '2', 'remix', '--help']))
+
+    assert.equal(result.exitCode, 0)
+    assert.equal(result.stdout, 'mode:values\n')
+    assert.equal(result.stderr, '')
   })
 
   it('returns machine-readable completions in plumbing mode', async () => {

--- a/packages/cli/src/lib/commands/completion.ts
+++ b/packages/cli/src/lib/commands/completion.ts
@@ -16,13 +16,18 @@ import { formatHelpText } from '../help-text.ts'
 import { parseArgs } from '../parse-args.ts'
 
 export async function runCompletionCommand(argv: string[]): Promise<number> {
-  if (argv.length === 0 || argv[0] === '-h' || argv[0] === '--help') {
+  if (argv.length === 0) {
     process.stdout.write(getCompletionCommandHelpText())
     return 0
   }
 
   if (argv[0] === '--') {
     return runCompletionPlumbing(argv.slice(1))
+  }
+
+  if (argv.includes('-h') || argv.includes('--help')) {
+    process.stdout.write(getCompletionCommandHelpText())
+    return 0
   }
 
   let [shell, ...rest] = argv

--- a/packages/cli/src/lib/commands/doctor.test.ts
+++ b/packages/cli/src/lib/commands/doctor.test.ts
@@ -892,6 +892,16 @@ describe('doctor command', () => {
     assert.equal(result.stderr, '')
   })
 
+  it('fails fix mode when unfixable action warnings remain', async () => {
+    let result = await runDoctor(['--fix'], getFixturePath('doctor-duplicate-owner'))
+
+    assert.equal(result.status, 1)
+    assert.match(result.stdout, /✗ actions/)
+    assert.match(result.stdout, /has multiple action controller files/)
+    assert.doesNotMatch(result.stdout, /Applied fixes:/)
+    assert.equal(result.stderr, '')
+  })
+
   it('reports incomplete actions when a route-key folder is missing its entry file', async () => {
     let result = await runDoctor([], getFixturePath('doctor-incomplete-controller'))
 

--- a/packages/cli/src/lib/completion.test.ts
+++ b/packages/cli/src/lib/completion.test.ts
@@ -100,6 +100,13 @@ describe('completion engine', () => {
     assert.ok(!nested.values?.includes('-v'))
     assert.ok(!nested.values?.includes('--version'))
   })
+
+  it('does not duplicate help flags for commands with their own help handling', () => {
+    let result = getCompletionResult(['remix', 'test', ''], 2)
+
+    assert.equal(result.mode, 'values')
+    assert.deepEqual(result.values, ['--coverage', '--watch', '-h', '--help', '--no-color'])
+  })
 })
 
 describe('completion script', () => {

--- a/packages/cli/src/lib/completion.ts
+++ b/packages/cli/src/lib/completion.ts
@@ -169,11 +169,7 @@ function completeCommand(
   }
 
   if (command === 'test') {
-    return completeSimpleFlags(tokens, currentWord, usedGlobalFlags, [
-      '--coverage',
-      '--watch',
-      '--help',
-    ])
+    return completeSimpleFlags(tokens, currentWord, usedGlobalFlags, ['--coverage', '--watch'])
   }
 
   if (command === 'completion') {


### PR DESCRIPTION
Adds adversarial coverage for a few CLI edge cases that could silently regress: top-level separators after global flags, completion help/plumbing dispatch, duplicate test completions, invalid scaffold app names, and unfixable `doctor --fix` warnings.

- Normalize leading `--` separators both before and after global option extraction so `remix --no-color -- --version` reaches the version command.
- Treat `-h`/`--help` as completion command help after shell names while keeping `remix completion -- ...` reserved for machine-readable shell plumbing.
- Remove the duplicate `--help` completion for `remix test` and add a CLI patch change note.