### PR TITLE
Fix fetch-proxy cookie domain rewrites with ports

### DIFF
--- a/packages/fetch-proxy/.changes/patch.cookie-domain-hostname.md
+++ b/packages/fetch-proxy/.changes/patch.cookie-domain-hostname.md
@@ -1,0 +1,1 @@
+Fix `Set-Cookie` domain rewrites so proxied cookies never include the request URL port and `localhost`/IP requests use host-only cookies.

--- a/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
@@ -228,6 +228,106 @@ describe('fetch proxy', () => {
     assert.equal(setCookie[0], 'name=value; Domain=preview.example.com; Path=/search')
   })
 
+  it('omits cookie domains for IPv4 request hosts with ports', async () => {
+    let { response } = await testProxy(
+      new Request('http://127.0.0.1:5173/search?q=remix'),
+      'https://remix.run:3000/dest',
+      {
+        async fetch() {
+          return new Response(null, {
+            headers: [
+              ['Set-Cookie', 'name=value; Domain=remix.run; Path=/dest/search'],
+              ['Set-Cookie', 'name2=value2; Domain=remix.run:3000; Path=/dest'],
+            ],
+          })
+        },
+      },
+    )
+
+    let setCookie = response.headers.getSetCookie()
+    assert.ok(setCookie)
+    assert.equal(setCookie.length, 2)
+    assert.equal(setCookie[0], 'name=value; Path=/search')
+    assert.equal(setCookie[1], 'name2=value2; Path=/')
+  })
+
+  it('omits cookie domains for IPv6 request hosts with ports', async () => {
+    let { response } = await testProxy(
+      new Request('http://[2001:db8::1]:5173/search?q=remix'),
+      'https://remix.run:3000/dest',
+      {
+        async fetch() {
+          return new Response(null, {
+            headers: [['Set-Cookie', 'name=value; Domain=remix.run; Path=/dest/search']],
+          })
+        },
+      },
+    )
+
+    let setCookie = response.headers.getSetCookie()
+    assert.ok(setCookie)
+    assert.equal(setCookie.length, 1)
+    assert.equal(setCookie[0], 'name=value; Path=/search')
+  })
+
+  it('rewrites cookie domains to punycode hostnames without ports', async () => {
+    let { response } = await testProxy(
+      new Request('https://xn--mnich-kva.example:8443/search?q=remix'),
+      'https://remix.run:3000/dest',
+      {
+        async fetch() {
+          return new Response(null, {
+            headers: [['Set-Cookie', 'name=value; Domain=remix.run:3000; Path=/dest/search']],
+          })
+        },
+      },
+    )
+
+    let setCookie = response.headers.getSetCookie()
+    assert.ok(setCookie)
+    assert.equal(setCookie.length, 1)
+    assert.equal(setCookie[0], 'name=value; Domain=xn--mnich-kva.example; Path=/search')
+  })
+
+  it('preserves host-only upstream cookies while rewriting paths', async () => {
+    let { response } = await testProxy(
+      new Request('https://preview.example.com:8443/search?q=remix'),
+      'https://remix.run:3000/dest',
+      {
+        async fetch() {
+          return new Response(null, {
+            headers: [['Set-Cookie', 'name=value; Path=/dest/search; HttpOnly']],
+          })
+        },
+      },
+    )
+
+    let setCookie = response.headers.getSetCookie()
+    assert.ok(setCookie)
+    assert.equal(setCookie.length, 1)
+    assert.equal(setCookie[0], 'name=value; HttpOnly; Path=/search')
+  })
+
+  it('preserves cookie domains when only domain rewriting is disabled', async () => {
+    let { response } = await testProxy(
+      new Request('https://preview.example.com:8443/search?q=remix'),
+      'https://remix.run:3000/dest',
+      {
+        rewriteCookieDomain: false,
+        async fetch() {
+          return new Response(null, {
+            headers: [['Set-Cookie', 'name=value; Domain=remix.run:3000; Path=/dest/search']],
+          })
+        },
+      },
+    )
+
+    let setCookie = response.headers.getSetCookie()
+    assert.ok(setCookie)
+    assert.equal(setCookie.length, 1)
+    assert.equal(setCookie[0], 'name=value; Domain=remix.run:3000; Path=/search')
+  })
+
   it('does not rewrite cookie domain and path when opting-out', async () => {
     let { response } = await testProxy(
       new Request('http://shopify.com/?q=remix'),

--- a/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
@@ -190,6 +190,44 @@ describe('fetch proxy', () => {
     assert.equal(setCookie[1], 'name2=value2; Domain=shopify.com; Path=/')
   })
 
+  it('omits cookie domain for localhost requests with a port and rewrites path', async () => {
+    let { response } = await testProxy(
+      new Request('http://localhost:5173/search?q=remix'),
+      'https://remix.run:3000/dest',
+      {
+        async fetch() {
+          return new Response(null, {
+            headers: [['Set-Cookie', 'name=value; Domain=remix.run; Path=/dest/search']],
+          })
+        },
+      },
+    )
+
+    let setCookie = response.headers.getSetCookie()
+    assert.ok(setCookie)
+    assert.equal(setCookie.length, 1)
+    assert.equal(setCookie[0], 'name=value; Path=/search')
+  })
+
+  it('rewrites cookie domain to hostname for DNS requests with a port and rewrites path', async () => {
+    let { response } = await testProxy(
+      new Request('https://preview.example.com:8443/search?q=remix'),
+      'https://remix.run:3000/dest',
+      {
+        async fetch() {
+          return new Response(null, {
+            headers: [['Set-Cookie', 'name=value; Domain=remix.run; Path=/dest/search']],
+          })
+        },
+      },
+    )
+
+    let setCookie = response.headers.getSetCookie()
+    assert.ok(setCookie)
+    assert.equal(setCookie.length, 1)
+    assert.equal(setCookie[0], 'name=value; Domain=preview.example.com; Path=/search')
+  })
+
   it('does not rewrite cookie domain and path when opting-out', async () => {
     let { response } = await testProxy(
       new Request('http://shopify.com/?q=remix'),

--- a/packages/fetch-proxy/src/lib/fetch-proxy.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.ts
@@ -119,7 +119,7 @@ export function createFetchProxy(target: string | URL, options?: FetchProxyOptio
         let header = new SetCookie(cookie)
 
         if (rewriteCookieDomain && header.domain) {
-          header.domain = url.host
+          header.domain = getCookieDomain(url.hostname)
         }
 
         if (rewriteCookiePath && header.path) {
@@ -140,6 +140,18 @@ export function createFetchProxy(target: string | URL, options?: FetchProxyOptio
       headers: responseHeaders,
     })
   }
+}
+
+function getCookieDomain(hostname: string): string | undefined {
+  if (hostname.toLowerCase() === 'localhost' || isIpAddress(hostname)) {
+    return undefined
+  }
+
+  return hostname
+}
+
+function isIpAddress(hostname: string): boolean {
+  return /^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname) || hostname.includes(':')
 }
 
 function getForwardedPort(url: URL): string {


### PR DESCRIPTION
Fixes #11329.

`createFetchProxy` rewrites upstream `Set-Cookie` `Domain` attributes to match the incoming request host. When the proxy receives a request on an explicit port, using `url.host` leaks the port into `Domain`, producing invalid cookie domains that browsers reject.

- Rewrite cookie domains with the request `hostname` instead of `host`.
- Omit the `Domain` attribute for `localhost` and IP request hosts so those cookies become host-only.
- Keep existing cookie path rewriting behavior while covering localhost and DNS hosts with ports.