### PR TITLE
Fix Postgres raw placeholder rewriting

### DIFF
--- a/packages/data-table-postgres/.changes/patch.raw-placeholder-scanner.md
+++ b/packages/data-table-postgres/.changes/patch.raw-placeholder-scanner.md
@@ -1,0 +1,1 @@
+Fixed raw SQL placeholder rewriting so `?` characters inside string literals, quoted identifiers, comments, and PostgreSQL dollar-quoted strings are preserved.

--- a/packages/data-table-postgres/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-postgres/src/lib/sql-compiler.test.ts
@@ -613,6 +613,21 @@ describe('postgres sql-compiler', () => {
       })
     })
 
+    it('does not rewrite placeholders inside escape string constants', () => {
+      let compiled = compilePostgresOperation({
+        kind: 'raw',
+        sql: {
+          text: "select E'it\\'s ?' as literal, ? as value",
+          values: [123],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: "select E'it\\'s ?' as literal, $1 as value",
+        values: [123],
+      })
+    })
+
     it('does not rewrite placeholders inside double-quoted identifiers', () => {
       let compiled = compilePostgresOperation({
         kind: 'raw',

--- a/packages/data-table-postgres/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-postgres/src/lib/sql-compiler.test.ts
@@ -567,6 +567,111 @@ describe('postgres sql-compiler', () => {
         values: [],
       })
     })
+
+    it('does not rewrite placeholders inside the reported string literal repro', () => {
+      let compiled = compilePostgresOperation({
+        kind: 'raw',
+        sql: {
+          text: "select '?' as literal, ? as value",
+          values: [123],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: "select '?' as literal, $1 as value",
+        values: [123],
+      })
+    })
+
+    it('does not rewrite placeholders inside single-quoted strings', () => {
+      let compiled = compilePostgresOperation({
+        kind: 'raw',
+        sql: {
+          text: "select 'literal ?' as literal, ? as value",
+          values: [123],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: "select 'literal ?' as literal, $1 as value",
+        values: [123],
+      })
+    })
+
+    it('does not rewrite placeholders inside escaped single quotes', () => {
+      let compiled = compilePostgresOperation({
+        kind: 'raw',
+        sql: {
+          text: "select 'it''s ?' as literal, ? as value",
+          values: [123],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: "select 'it''s ?' as literal, $1 as value",
+        values: [123],
+      })
+    })
+
+    it('does not rewrite placeholders inside double-quoted identifiers', () => {
+      let compiled = compilePostgresOperation({
+        kind: 'raw',
+        sql: {
+          text: 'select "is ? active" from accounts where id = ?',
+          values: [10],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: 'select "is ? active" from accounts where id = $1',
+        values: [10],
+      })
+    })
+
+    it('does not rewrite placeholders inside line comments', () => {
+      let compiled = compilePostgresOperation({
+        kind: 'raw',
+        sql: {
+          text: 'select ? as value -- keep ? in comment\nfrom accounts where id = ?',
+          values: [123, 10],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: 'select $1 as value -- keep ? in comment\nfrom accounts where id = $2',
+        values: [123, 10],
+      })
+    })
+
+    it('does not rewrite placeholders inside block comments', () => {
+      let compiled = compilePostgresOperation({
+        kind: 'raw',
+        sql: {
+          text: 'select ? as value /* keep ? in comment */ from accounts where id = ?',
+          values: [123, 10],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: 'select $1 as value /* keep ? in comment */ from accounts where id = $2',
+        values: [123, 10],
+      })
+    })
+
+    it('does not rewrite placeholders inside PostgreSQL dollar-quoted strings', () => {
+      let compiled = compilePostgresOperation({
+        kind: 'raw',
+        sql: {
+          text: 'select $$literal ?$$ as untagged, $tag$tagged ?$tag$ as tagged, ? as value',
+          values: [123],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: 'select $$literal ?$$ as untagged, $tag$tagged ?$tag$ as tagged, $1 as value',
+        values: [123],
+      })
+    })
   })
 
   describe('error handling', () => {

--- a/packages/data-table-postgres/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-postgres/src/lib/sql-compiler.test.ts
@@ -583,6 +583,21 @@ describe('postgres sql-compiler', () => {
       })
     })
 
+    it('rewrites adjacent placeholders while preserving literal question marks', () => {
+      let compiled = compilePostgresOperation({
+        kind: 'raw',
+        sql: {
+          text: "select ?::text || '?' || ?::text as label where id in (?,?)",
+          values: ['left', 'right', 1, 2],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: "select $1::text || '?' || $2::text as label where id in ($3,$4)",
+        values: ['left', 'right', 1, 2],
+      })
+    })
+
     it('does not rewrite placeholders inside single-quoted strings', () => {
       let compiled = compilePostgresOperation({
         kind: 'raw',
@@ -628,6 +643,21 @@ describe('postgres sql-compiler', () => {
       })
     })
 
+    it('does not rewrite placeholders after unterminated single-quoted strings', () => {
+      let compiled = compilePostgresOperation({
+        kind: 'raw',
+        sql: {
+          text: "select 'unterminated ? literal, ? as value",
+          values: [],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: "select 'unterminated ? literal, ? as value",
+        values: [],
+      })
+    })
+
     it('does not rewrite placeholders inside double-quoted identifiers', () => {
       let compiled = compilePostgresOperation({
         kind: 'raw',
@@ -639,6 +669,21 @@ describe('postgres sql-compiler', () => {
 
       assert.deepEqual(compiled, {
         text: 'select "is ? active" from accounts where id = $1',
+        values: [10],
+      })
+    })
+
+    it('does not rewrite placeholders inside escaped double-quoted identifiers', () => {
+      let compiled = compilePostgresOperation({
+        kind: 'raw',
+        sql: {
+          text: 'select "is ""?"" active" from accounts where id = ?',
+          values: [10],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: 'select "is ""?"" active" from accounts where id = $1',
         values: [10],
       })
     })
@@ -658,6 +703,21 @@ describe('postgres sql-compiler', () => {
       })
     })
 
+    it('does not rewrite placeholders inside CRLF line comments', () => {
+      let compiled = compilePostgresOperation({
+        kind: 'raw',
+        sql: {
+          text: 'select ? as value -- keep ? in comment\r\nfrom accounts where id = ?',
+          values: [123, 10],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: 'select $1 as value -- keep ? in comment\r\nfrom accounts where id = $2',
+        values: [123, 10],
+      })
+    })
+
     it('does not rewrite placeholders inside block comments', () => {
       let compiled = compilePostgresOperation({
         kind: 'raw',
@@ -673,6 +733,36 @@ describe('postgres sql-compiler', () => {
       })
     })
 
+    it('does not rewrite placeholders inside nested block comments', () => {
+      let compiled = compilePostgresOperation({
+        kind: 'raw',
+        sql: {
+          text: 'select ? as value /* keep ? /* nested ? */ still ? */ from accounts where id = ?',
+          values: [123, 10],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: 'select $1 as value /* keep ? /* nested ? */ still ? */ from accounts where id = $2',
+        values: [123, 10],
+      })
+    })
+
+    it('does not rewrite placeholders inside unterminated block comments', () => {
+      let compiled = compilePostgresOperation({
+        kind: 'raw',
+        sql: {
+          text: 'select ? as value /* keep ? in unterminated comment where id = ?',
+          values: [123],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: 'select $1 as value /* keep ? in unterminated comment where id = ?',
+        values: [123],
+      })
+    })
+
     it('does not rewrite placeholders inside PostgreSQL dollar-quoted strings', () => {
       let compiled = compilePostgresOperation({
         kind: 'raw',
@@ -684,6 +774,21 @@ describe('postgres sql-compiler', () => {
 
       assert.deepEqual(compiled, {
         text: 'select $$literal ?$$ as untagged, $tag$tagged ?$tag$ as tagged, $1 as value',
+        values: [123],
+      })
+    })
+
+    it('does not rewrite placeholders inside dollar-quoted strings with digits and underscores in tags', () => {
+      let compiled = compilePostgresOperation({
+        kind: 'raw',
+        sql: {
+          text: 'select $_tag9$literal ?$_tag9$, $tag_2$tagged ?$tag_2$, ? as value',
+          values: [123],
+        },
+      })
+
+      assert.deepEqual(compiled, {
+        text: 'select $_tag9$literal ?$_tag9$, $tag_2$tagged ?$tag_2$, $1 as value',
         values: [123],
       })
     })

--- a/packages/data-table-postgres/src/lib/sql-compiler.ts
+++ b/packages/data-table-postgres/src/lib/sql-compiler.ts
@@ -279,6 +279,13 @@ function rewriteRawPlaceholders(text: string): string {
       continue
     }
 
+    if ((char === 'E' || char === 'e') && text[index + 1] === "'") {
+      let end = scanEscapeSingleQuotedString(text, index + 1)
+      output += text.slice(index, end)
+      index = end
+      continue
+    }
+
     if (char === "'") {
       let end = scanSingleQuotedString(text, index)
       output += text.slice(index, end)
@@ -326,6 +333,30 @@ function scanSingleQuotedString(text: string, start: number): number {
   let index = start + 1
 
   while (index < text.length) {
+    if (text[index] === "'") {
+      if (text[index + 1] === "'") {
+        index += 2
+        continue
+      }
+
+      return index + 1
+    }
+
+    index += 1
+  }
+
+  return text.length
+}
+
+function scanEscapeSingleQuotedString(text: string, start: number): number {
+  let index = start + 1
+
+  while (index < text.length) {
+    if (text[index] === '\\') {
+      index += 2
+      continue
+    }
+
     if (text[index] === "'") {
       if (text[index + 1] === "'") {
         index += 2

--- a/packages/data-table-postgres/src/lib/sql-compiler.ts
+++ b/packages/data-table-postgres/src/lib/sql-compiler.ts
@@ -258,17 +258,205 @@ function compileRawOperation(statement: SqlStatement): SqlStatement {
     }
   }
 
-  let index = 1
-  let text = statement.text.replace(/\?/g, function replaceParameter() {
-    let placeholder = '$' + String(index)
-    index += 1
-    return placeholder
-  })
-
   return {
-    text,
+    text: rewriteRawPlaceholders(statement.text),
     values: [...statement.values],
   }
+}
+
+function rewriteRawPlaceholders(text: string): string {
+  let output = ''
+  let index = 0
+  let placeholderIndex = 1
+
+  while (index < text.length) {
+    let char = text[index]
+
+    if (char === '?') {
+      output += '$' + String(placeholderIndex)
+      placeholderIndex += 1
+      index += 1
+      continue
+    }
+
+    if (char === "'") {
+      let end = scanSingleQuotedString(text, index)
+      output += text.slice(index, end)
+      index = end
+      continue
+    }
+
+    if (char === '"') {
+      let end = scanDoubleQuotedIdentifier(text, index)
+      output += text.slice(index, end)
+      index = end
+      continue
+    }
+
+    if (text.startsWith('--', index)) {
+      let end = scanLineComment(text, index)
+      output += text.slice(index, end)
+      index = end
+      continue
+    }
+
+    if (text.startsWith('/*', index)) {
+      let end = scanBlockComment(text, index)
+      output += text.slice(index, end)
+      index = end
+      continue
+    }
+
+    let dollarQuotedStringEnd = scanDollarQuotedString(text, index)
+
+    if (dollarQuotedStringEnd !== undefined) {
+      output += text.slice(index, dollarQuotedStringEnd)
+      index = dollarQuotedStringEnd
+      continue
+    }
+
+    output += char
+    index += 1
+  }
+
+  return output
+}
+
+function scanSingleQuotedString(text: string, start: number): number {
+  let index = start + 1
+
+  while (index < text.length) {
+    if (text[index] === "'") {
+      if (text[index + 1] === "'") {
+        index += 2
+        continue
+      }
+
+      return index + 1
+    }
+
+    index += 1
+  }
+
+  return text.length
+}
+
+function scanDoubleQuotedIdentifier(text: string, start: number): number {
+  let index = start + 1
+
+  while (index < text.length) {
+    if (text[index] === '"') {
+      if (text[index + 1] === '"') {
+        index += 2
+        continue
+      }
+
+      return index + 1
+    }
+
+    index += 1
+  }
+
+  return text.length
+}
+
+function scanLineComment(text: string, start: number): number {
+  let index = start + 2
+
+  while (index < text.length && text[index] !== '\n' && text[index] !== '\r') {
+    index += 1
+  }
+
+  return index
+}
+
+function scanBlockComment(text: string, start: number): number {
+  let index = start + 2
+  let depth = 1
+
+  while (index < text.length && depth > 0) {
+    if (text.startsWith('/*', index)) {
+      depth += 1
+      index += 2
+      continue
+    }
+
+    if (text.startsWith('*/', index)) {
+      depth -= 1
+      index += 2
+      continue
+    }
+
+    index += 1
+  }
+
+  return index
+}
+
+function scanDollarQuotedString(text: string, start: number): number | undefined {
+  let delimiter = getDollarQuoteDelimiter(text, start)
+
+  if (delimiter === undefined) {
+    return undefined
+  }
+
+  let end = text.indexOf(delimiter, start + delimiter.length)
+
+  return end === -1 ? text.length : end + delimiter.length
+}
+
+function getDollarQuoteDelimiter(text: string, start: number): string | undefined {
+  if (text[start] !== '$') {
+    return undefined
+  }
+
+  let index = start + 1
+
+  if (text[index] === '$') {
+    return '$$'
+  }
+
+  if (!isDollarQuoteTagStart(text[index])) {
+    return undefined
+  }
+
+  index += 1
+
+  while (index < text.length && isDollarQuoteTagPart(text[index])) {
+    index += 1
+  }
+
+  if (text[index] !== '$') {
+    return undefined
+  }
+
+  return text.slice(start, index + 1)
+}
+
+function isDollarQuoteTagStart(char: string | undefined): boolean {
+  if (char === undefined) {
+    return false
+  }
+
+  return isAsciiLetter(char) || char === '_'
+}
+
+function isDollarQuoteTagPart(char: string | undefined): boolean {
+  if (char === undefined) {
+    return false
+  }
+
+  return isDollarQuoteTagStart(char) || isAsciiDigit(char)
+}
+
+function isAsciiLetter(char: string): boolean {
+  let code = char.charCodeAt(0)
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122)
+}
+
+function isAsciiDigit(char: string): boolean {
+  let code = char.charCodeAt(0)
+  return code >= 48 && code <= 57
 }
 
 function compileFromClause(


### PR DESCRIPTION
Fixes #11330.

The Postgres raw SQL compiler now scans raw SQL before translating `?` placeholders. It skips string literals, double-quoted identifiers, line and block comments, and PostgreSQL dollar-quoted strings so literal question marks are preserved while real raw placeholders become `$1`, `$2`, etc.

- Replaces the global regex replacement with a token-aware scanner
- Preserves `?` characters in SQL literal/comment/quoted text
- Adds focused compiler coverage for the reported repro and the supported SQL text forms
