### PR TITLE
Fix easy lint warnings

### DIFF
--- a/packages/cli/src/lib/commands/doctor.test.ts
+++ b/packages/cli/src/lib/commands/doctor.test.ts
@@ -10,6 +10,7 @@ import { runRemix } from '../../index.ts'
 import { getFixturePath } from '../../../test/fixtures.ts'
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../..')
+const ANSI_CSI = `${String.fromCharCode(27)}[`
 const REMIX_PACKAGE_JSON_PATH = path.join(ROOT_DIR, 'packages', 'remix', 'package.json')
 
 const DOCTOR_COMMAND_HELP_TEXT = [
@@ -126,7 +127,7 @@ describe('doctor command', () => {
     let result = await runDoctor([], getFixturePath('doctor-missing'))
 
     assert.equal(result.status, 0, result.stderr)
-    assert.doesNotMatch(result.stdout, /\u001B\[/)
+    assert.equal(result.stdout.includes(ANSI_CSI), false)
     assert.equal(result.stderr, '')
   })
 
@@ -872,7 +873,7 @@ describe('doctor command', () => {
     let result = await runDoctor(['--no-color'], getFixturePath('doctor-missing'))
 
     assert.equal(result.status, 0, result.stderr)
-    assert.doesNotMatch(result.stdout, /\u001B\[/)
+    assert.equal(result.stdout.includes(ANSI_CSI), false)
     assert.equal(result.stderr, '')
   })
 

--- a/packages/cli/src/lib/commands/routes.test.ts
+++ b/packages/cli/src/lib/commands/routes.test.ts
@@ -10,6 +10,7 @@ import { runRemix } from '../../index.ts'
 import { getFixturePath } from '../../../test/fixtures.ts'
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../..')
+const ANSI_CSI = `${String.fromCharCode(27)}[`
 
 const ROUTES_COMMAND_HELP_TEXT = [
   'Usage:',
@@ -54,7 +55,7 @@ describe('routes command', () => {
     let result = await runRoutes([], getFixturePath('routes-basic'))
 
     assert.equal(result.status, 0, result.stderr)
-    assert.doesNotMatch(result.stdout, /\u001B\[/)
+    assert.equal(result.stdout.includes(ANSI_CSI), false)
   })
 
   it('works from a nested directory inside an app', async () => {
@@ -119,7 +120,7 @@ describe('routes command', () => {
     let result = await runRoutes(['--no-color'], getFixturePath('routes-missing'))
 
     assert.equal(result.status, 0, result.stderr)
-    assert.doesNotMatch(result.stdout, /\u001B\[/)
+    assert.equal(result.stdout.includes(ANSI_CSI), false)
   })
 
   it('resolves owner files with js, jsx, and ts extensions', async () => {

--- a/packages/cli/src/lib/help-text.test.ts
+++ b/packages/cli/src/lib/help-text.test.ts
@@ -5,6 +5,8 @@ import { describe, it } from '@remix-run/test'
 import { formatHelpText } from './help-text.ts'
 import { configureColors } from './terminal.ts'
 
+const ANSI_CSI = `${String.fromCharCode(27)}[`
+
 describe('help text', () => {
   it('renders plain help text with stable section order and alignment', () => {
     let output = withEnv('NO_COLOR', '1', () =>
@@ -63,10 +65,10 @@ describe('help text', () => {
       ),
     )
 
-    assert.match(output, /\u001B\[1m\u001B\[94mUsage\u001B\[0m:/)
-    assert.match(output, /remix demo \u001B\[93m\[options\]\u001B\[0m/)
-    assert.match(output, /\u001B\[93m--dir\u001B\[0m \u001B\[93m<path>\u001B\[0m/)
-    assert.match(output, /remix demo \u001B\[93m--json\u001B\[0m/)
+    assert.ok(output.includes(`${ANSI_CSI}1m${ANSI_CSI}94mUsage${ANSI_CSI}0m:`))
+    assert.ok(output.includes(`remix demo ${ANSI_CSI}93m[options]${ANSI_CSI}0m`))
+    assert.ok(output.includes(`${ANSI_CSI}93m--dir${ANSI_CSI}0m ${ANSI_CSI}93m<path>${ANSI_CSI}0m`))
+    assert.ok(output.includes(`remix demo ${ANSI_CSI}93m--json${ANSI_CSI}0m`))
   })
 
   it('colors help for stderr independently of stdout capability', () => {
@@ -89,8 +91,8 @@ describe('help text', () => {
       ),
     )
 
-    assert.match(output, /\u001B\[1m\u001B\[94mUsage\u001B\[0m:/)
-    assert.match(output, /remix demo \u001B\[93m<path>\u001B\[0m/)
+    assert.ok(output.includes(`${ANSI_CSI}1m${ANSI_CSI}94mUsage${ANSI_CSI}0m:`))
+    assert.ok(output.includes(`remix demo ${ANSI_CSI}93m<path>${ANSI_CSI}0m`))
   })
 })
 

--- a/packages/logger-middleware/src/lib/logger.test.ts
+++ b/packages/logger-middleware/src/lib/logger.test.ts
@@ -8,6 +8,7 @@ import { createStyles } from '@remix-run/terminal'
 import { logger } from './logger.ts'
 
 const styles = createStyles({ colors: true, env: {} })
+const ANSI_CSI = `${String.fromCharCode(27)}[`
 
 describe('logger', () => {
   it('logs the request', async () => {
@@ -44,7 +45,15 @@ describe('logger', () => {
 
       assert.equal(method, styles.green('GET'))
       assert.equal(status, styles.green('200'))
-      assert.match(duration, /^\x1b\[(32|33|35|31)m\d+\x1b\[39m$/)
+      let durationColor = ['32', '33', '35', '31'].find((color) =>
+        duration.startsWith(`${ANSI_CSI}${color}m`),
+      )
+      assert.ok(durationColor)
+      assert.ok(duration.endsWith(`${ANSI_CSI}39m`))
+      assert.match(
+        duration.slice(`${ANSI_CSI}${durationColor}m`.length, -`${ANSI_CSI}39m`.length),
+        /^\d+$/,
+      )
       assert.equal(contentLength, styles.cyan('2048'))
     })
   })

--- a/packages/test/src/lib/coverage.ts
+++ b/packages/test/src/lib/coverage.ts
@@ -236,7 +236,7 @@ export async function collectServerCoverageMap(
         let { code } = await transformTypeScript(tsSource, filePath)
         let success = await addV8EntryToCoverageMap(coverageMap, filePath, entry.functions, code)
         if (success) converted++
-      } catch (e) {
+      } catch {
         // Skip files that can't be converted
       }
     }

--- a/packages/test/src/lib/ts-transform.ts
+++ b/packages/test/src/lib/ts-transform.ts
@@ -1,4 +1,4 @@
-import { transform, type TsconfigRaw } from 'esbuild'
+import { transform } from 'esbuild'
 import { getTsconfig, type TsConfigResult } from 'get-tsconfig'
 import * as path from 'node:path'
 

--- a/packages/test/src/lib/worker-server.ts
+++ b/packages/test/src/lib/worker-server.ts
@@ -36,14 +36,16 @@ export async function runServerTestFile(value: unknown): Promise<TestResults> {
     let results = await runTests()
     await takeCoverage(workerData.coverage)
     return results
-  } catch (e) {
+  } catch (error) {
+    let failure = error
+
     try {
       await takeCoverage(workerData?.coverage)
     } catch (coverageError) {
-      e = coverageError
+      failure = coverageError
     }
 
-    return createFailedResults(e)
+    return createFailedResults(failure)
   }
 }
 


### PR DESCRIPTION
This trims the lint output by fixing the straightforward warnings while leaving JSX pragma import warnings for a separate decision.

- Replaces ANSI control-character regex assertions with string-based checks.
- Removes an unused transform type import and unused catch binding.
- Refactors server worker error handling to avoid reassigning the caught error while preserving coverage failure behavior.
