### PR TITLE
Fix fetch proxy forwarded headers with init headers

### DIFF
--- a/packages/fetch-proxy/.changes/patch.forwarded-init-headers.md
+++ b/packages/fetch-proxy/.changes/patch.forwarded-init-headers.md
@@ -1,0 +1,1 @@
+Preserve generated `X-Forwarded-*` headers when proxied requests include custom `init.headers`.

--- a/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
@@ -452,6 +452,38 @@ describe('fetch proxy (double-arg style)', () => {
     assert.equal(capturedRequest.url, 'https://remix.run:3000/dest/api/resource')
   })
 
+  it('keeps X-Forwarded headers when proxy(url, init) provides custom headers', async () => {
+    let capturedRequest: Request
+    let proxy = createFetchProxy('https://upstream.example/base', {
+      xForwardedHeaders: true,
+      fetch(input, init) {
+        capturedRequest = new Request(input, init)
+        return Promise.resolve(new Response())
+      },
+    })
+
+    await proxy('http://shop.example:8080/orders', {
+      method: 'PATCH',
+      cache: 'reload',
+      credentials: 'same-origin',
+      headers: {
+        'X-Custom': 'present',
+      },
+    })
+
+    assert.ok(capturedRequest!)
+    assert.equal(capturedRequest.method, 'PATCH')
+    // Bun uses its own default Request values for several fields instead of preserving these inputs.
+    if (!isBun) {
+      assert.equal(capturedRequest.cache, 'reload')
+      assert.equal(capturedRequest.credentials, 'same-origin')
+    }
+    assert.equal(capturedRequest.headers.get('X-Custom'), 'present')
+    assert.equal(capturedRequest.headers.get('X-Forwarded-Proto'), 'http')
+    assert.equal(capturedRequest.headers.get('X-Forwarded-Host'), 'shop.example:8080')
+    assert.equal(capturedRequest.headers.get('X-Forwarded-Port'), '8080')
+  })
+
   it('handles proxy(url) with defaults', async () => {
     let capturedRequest: Request
     let proxy = createFetchProxy('https://remix.run:3000/dest', {

--- a/packages/fetch-proxy/src/lib/fetch-proxy.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.ts
@@ -85,7 +85,6 @@ export function createFetchProxy(target: string | URL, options?: FetchProxyOptio
 
     let proxyInit: RequestInit = {
       method: request.method,
-      headers: proxyHeaders,
       cache: request.cache,
       credentials: request.credentials,
       integrity: request.integrity,
@@ -96,6 +95,7 @@ export function createFetchProxy(target: string | URL, options?: FetchProxyOptio
       referrerPolicy: request.referrerPolicy,
       signal: request.signal,
       ...init,
+      headers: proxyHeaders,
     }
     if (request.method !== 'GET' && request.method !== 'HEAD') {
       proxyInit.body = request.body


### PR DESCRIPTION
Fix `createFetchProxy` so generated forwarded headers survive calls that pass custom `init.headers` to `proxy(url, init)`.

- Keeps the computed proxied `Headers` object as the final `RequestInit.headers` value so custom headers and generated `X-Forwarded-*` headers are both sent upstream.
- Preserves other `init` overrides by leaving the existing `init` spread in place.
- Adds focused coverage for `proxy(url, init)` with custom headers and method/cache/credentials overrides.
