### PR TITLE
Fix ContentDisposition filename* plus decoding

### DIFF
--- a/packages/headers/.changes/patch.content-disposition-filename-plus.md
+++ b/packages/headers/.changes/patch.content-disposition-filename-plus.md
@@ -1,0 +1,1 @@
+Preserve literal `+` characters when decoding RFC 8187 `filename*` values for `ContentDisposition.preferredFilename`.

--- a/packages/headers/src/lib/content-disposition.test.ts
+++ b/packages/headers/src/lib/content-disposition.test.ts
@@ -163,6 +163,16 @@ describe('ContentDisposition', () => {
       assert.equal(header.preferredFilename, 'special file.txt')
     })
 
+    it('preserves literal plus characters in filename*', () => {
+      let header = new ContentDisposition("attachment; filename*=UTF-8''a+b.txt")
+      assert.equal(header.preferredFilename, 'a+b.txt')
+    })
+
+    it('decodes percent-encoded spaces without treating plus as a space', () => {
+      let header = new ContentDisposition("attachment; filename*=UTF-8''a+b%20c.txt")
+      assert.equal(header.preferredFilename, 'a+b c.txt')
+    })
+
     it('handles UTF-8 encoded filename* with special characters', () => {
       let header = new ContentDisposition("attachment; filename*=UTF-8''%E6%96%87%E4%BB%B6.txt")
       assert.equal(header.preferredFilename, '文件.txt')

--- a/packages/headers/src/lib/content-disposition.ts
+++ b/packages/headers/src/lib/content-disposition.ts
@@ -156,7 +156,7 @@ function decodeFilenameSplat(value: string): string | null {
 }
 
 function percentDecode(value: string): string {
-  return value
-    .replace(/\+/g, ' ')
-    .replace(/%([0-9A-Fa-f]{2})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+  return value.replace(/%([0-9A-Fa-f]{2})/g, (_, hex) =>
+    String.fromCharCode(parseInt(hex, 16)),
+  )
 }


### PR DESCRIPTION
`ContentDisposition.preferredFilename` decodes RFC 8187 `filename*` values with percent decoding. The previous implementation also treated `+` as a form-encoded space, so filenames like `a+b.txt` were returned as `a b.txt`.

- Preserve literal `+` characters while still decoding percent escapes such as `%20`.
- Add focused `preferredFilename` regression coverage for literal `+` and mixed `+`/`%20` filenames.
- Add a patch change file for `@remix-run/headers`.
