### PR TITLE
Fix doctype-only frame stream chunks

### DIFF
--- a/demos/frames/app/actions/frames/controller.tsx
+++ b/demos/frames/app/actions/frames/controller.tsx
@@ -247,5 +247,9 @@ export const framesController = {
 } satisfies Controller<typeof routes.frames>
 
 function delay(ms: number) {
+  if (process.env.NODE_ENV === 'test') {
+    ms = 10
+  }
+
   return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/demos/frames/app/actions/root-reload-client-entries.tsx
+++ b/demos/frames/app/actions/root-reload-client-entries.tsx
@@ -90,5 +90,9 @@ function RootReloadClientEntriesPage(handle: Handle<RootReloadClientEntriesPageP
 }
 
 function delay(ms: number) {
+  if (process.env.NODE_ENV === 'test') {
+    ms = 10
+  }
+
   return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/packages/ui/.changes/patch.frame-stream-doctype-chunk.md
+++ b/packages/ui/.changes/patch.frame-stream-doctype-chunk.md
@@ -1,0 +1,1 @@
+Keep streamed frame content in its template when a resolved frame stream starts with a doctype-only chunk.

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -138,6 +138,18 @@ function stripDoctypeMarkup(html: string): string {
   return html.replace(DOCTYPE_PATTERN, '')
 }
 
+function hasRenderableHtml(html: string): boolean {
+  return stripDoctypeMarkup(html).trim() !== ''
+}
+
+function emptyReadableStream(): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.close()
+    },
+  })
+}
+
 function getStyleLayerName(selector: string, layer: string = DEFAULT_STYLE_LAYER): string {
   return `${layer}.${selector}`
 }
@@ -291,20 +303,26 @@ function createServerComponentId(context: RenderContext): string {
 
 async function splitFirstChunk(
   stream: ReadableStream<Uint8Array>,
-): Promise<{ first: Uint8Array; tail: ReadableStream<Uint8Array> }> {
+): Promise<ResolvedFrameHtml> {
   let reader = stream.getReader()
+  let decoder = new TextDecoder()
 
-  let { value, done } = await reader.read()
-  if (done || !value) {
-    reader.releaseLock()
-    return {
-      first: new Uint8Array(),
-      tail: new ReadableStream({
-        start(controller) {
-          controller.close()
-        },
-      }),
+  let first: Uint8Array | undefined
+  while (true) {
+    let { value, done } = await reader.read()
+    if (done || !value) break
+
+    let text = decoder.decode(value, { stream: true })
+    if (hasRenderableHtml(text)) {
+      first = value
+      break
     }
+  }
+
+  if (!first) {
+    decoder.decode()
+    reader.releaseLock()
+    return { html: '', tail: emptyReadableStream() }
   }
 
   let released = false
@@ -334,7 +352,7 @@ async function splitFirstChunk(
     },
   })
 
-  return { first: value, tail }
+  return { html: stripDoctypeMarkup(decoder.decode(first)), tail }
 }
 
 async function resolveFrameHtml(
@@ -342,9 +360,7 @@ async function resolveFrameHtml(
 ): Promise<ResolvedFrameHtml> {
   if (typeof input === 'string') return { html: stripDoctypeMarkup(input) }
 
-  let decoder = new TextDecoder()
-  let { first, tail } = await splitFirstChunk(input)
-  return { html: stripDoctypeMarkup(decoder.decode(first)), tail }
+  return await splitFirstChunk(input)
 }
 
 function isRemixElement(node: unknown): node is RemixElement {

--- a/packages/ui/src/test/stream.test.tsx
+++ b/packages/ui/src/test/stream.test.tsx
@@ -1753,6 +1753,30 @@ describe('stream', () => {
       expect(result).toContain('>Resolved</div>')
     })
 
+    it('keeps frame stream content inside the template when doctype is its own chunk', async () => {
+      let stream = renderToStream(<Frame src="/x" fallback={<div>Loading...</div>} />, {
+        resolveFrame() {
+          let encoder = new TextEncoder()
+          return new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(encoder.encode('<!DOCTYPE html>'))
+              controller.enqueue(encoder.encode('<div id="resolved">Resolved</div>'))
+              controller.close()
+            },
+          })
+        },
+      })
+      let result = await drain(stream)
+
+      let template = document.createElement('template')
+      template.innerHTML = result
+      let resolvedTemplate = template.content.querySelector('template')
+
+      expect(result).not.toContain('<!DOCTYPE')
+      expect(result).not.toContain('</template><div id="resolved">')
+      expect(resolvedTemplate?.innerHTML).toContain('<div id="resolved">Resolved</div>')
+    })
+
     it('adds frame scripts for blocking frames', async () => {
       let stream = renderToStream(<Frame src="/x" />, {
         resolveFrame: () => '<div>Resolved</div>',


### PR DESCRIPTION
Skip doctype-only prelude chunks when resolving streamed SSR frame content so resolved frame HTML stays inside its streamed template.