### PR TITLE
Fix frame stream reload batching

### DIFF
--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -8,6 +8,7 @@ import type { Scheduler, VirtualRoot } from './vdom.ts'
 import { createRangeRoot, createRoot } from './vdom.ts'
 import { diffNodes } from './diff-dom.ts'
 import { createStyleManager, type StyleManager } from '../style/index.ts'
+import { findFlushMarker, type FlushKind } from './stream-protocol.ts'
 
 type FrameRoot = [Comment, Comment] | Element | Document | DocumentFragment
 
@@ -62,10 +63,6 @@ const DOCTYPE_PATTERN = /<!doctype(?:\s[^>]*)?>/gi
 
 function stripDoctypeMarkup(html: string): string {
   return html.replace(DOCTYPE_PATTERN, '')
-}
-
-function hasRenderableHtml(html: string): boolean {
-  return stripDoctypeMarkup(html).trim() !== ''
 }
 
 function syncElementAttributes(target: Element, source: Element) {
@@ -142,6 +139,7 @@ export type Frame = {
 }
 
 type RenderOptions = {
+  flushKind?: FlushKind
   initialHydrationTracker?: InitialHydrationTracker
   signal?: AbortSignal
 }
@@ -215,9 +213,9 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     if (options?.signal?.aborted) return
 
     if (content instanceof ReadableStream) {
-      await renderFrameStream(content, container.doc, async (html) => {
+      await renderFrameStream(content, container.doc, async (html, flushKind) => {
         if (options?.signal?.aborted) return
-        await render(html, options)
+        await render(html, { ...options, flushKind })
       })
       return
     }
@@ -241,12 +239,24 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       contentRoot = undefined
     }
 
+    if (typeof content === 'string') {
+      let flushed = await consumeFlushBatches(content, async (html, flushKind) => {
+        await render(html, { ...options, flushKind })
+      })
+      if (flushed.applied) {
+        if (flushed.remainder !== '') {
+          await render(flushed.remainder, { ...options, flushKind: 'fragment' })
+        }
+        return
+      }
+    }
+
     let htmlContent = typeof content === 'string' ? stripDoctypeMarkup(content) : undefined
 
     let isFullDocumentReload =
       container.root instanceof Document &&
       htmlContent !== undefined &&
-      isFullDocumentHtml(htmlContent)
+      options?.flushKind === 'document'
 
     if (isFullDocumentReload && htmlContent !== undefined) {
       let parsed = new DOMParser().parseFromString(htmlContent, 'text/html')
@@ -982,13 +992,12 @@ function extractTemplatesFromBuffer(
 async function renderFrameStream(
   stream: ReadableStream<Uint8Array>,
   doc: Document,
-  applyHtml: (html: string) => Promise<void>,
+  applyHtml: (html: string, flushKind: FlushKind) => Promise<void>,
 ): Promise<void> {
   let reader = stream.getReader()
   let decoder = new TextDecoder()
   let buffer = ''
   let html = ''
-  let appliedLength = 0
   let appliedOnce = false
 
   try {
@@ -1002,19 +1011,9 @@ async function renderFrameStream(
 
       if (parsed.html !== '') {
         html += parsed.html
-        // A doctype or whitespace prelude can arrive in its own chunk. Wait
-        // until there is actual frame content before applying the stream.
-        if (!hasRenderableHtml(html)) {
-          continue
-        }
-
-        let htmlMarkers = collectHtmlMarkerSummary(html)
-        if (!hasBalancedMarkerSummary(htmlMarkers)) {
-          continue
-        }
-        await applyHtml(html)
-        appliedLength = html.length
-        appliedOnce = true
+        let flushed = await consumeFlushBatches(html, applyHtml)
+        appliedOnce = flushed.applied || appliedOnce
+        html = flushed.remainder
       }
     }
 
@@ -1027,21 +1026,38 @@ async function renderFrameStream(
       buffer = ''
     }
 
-    let hasHtmlToApply = hasRenderableHtml(html)
-
-    if (hasHtmlToApply && html.length > appliedLength) {
-      await applyHtml(html)
+    if (html !== '') {
+      await applyHtml(html, 'fragment')
       appliedOnce = true
     }
 
     // A frame stream can legitimately resolve to empty content. Ensure the
     // existing frame region is cleared instead of treated as a no-op.
-    if (!hasHtmlToApply && !appliedOnce) {
-      await applyHtml('')
+    if (html === '' && !appliedOnce) {
+      await applyHtml('', 'fragment')
     }
   } finally {
     reader.releaseLock()
   }
+}
+
+async function consumeFlushBatches(
+  html: string,
+  applyHtml: (html: string, flushKind: FlushKind) => Promise<void>,
+): Promise<{ applied: boolean; remainder: string }> {
+  let applied = false
+  let cursor = 0
+  let marker = findFlushMarker(html, cursor)
+
+  while (marker) {
+    let batch = html.slice(cursor, marker.index)
+    await applyHtml(batch, marker.kind)
+    applied = true
+    cursor = marker.endIndex
+    marker = findFlushMarker(html, cursor)
+  }
+
+  return { applied, remainder: html.slice(cursor) }
 }
 
 type FrameContainer = {
@@ -1106,11 +1122,6 @@ function isRemixNodeFrameContent(content: InternalFrameContent): content is Remi
     content instanceof DocumentFragment ||
     typeof content === 'string'
   )
-}
-
-function isFullDocumentHtml(content: string): boolean {
-  let trimmed = content.trimStart()
-  return /^<!doctype html\b/i.test(trimmed) || /^<html[\s>]/i.test(trimmed)
 }
 
 type HydrationMarker = {
@@ -1206,17 +1217,3 @@ function findEndMarker(
   throw new Error('End marker not found')
 }
 
-function collectHtmlMarkerSummary(html: string): Record<string, number> {
-  return {
-    frameStarts: html.match(/<!--\s*rmx:f:/g)?.length ?? 0,
-    frameEnds: html.match(/<!--\s*\/rmx:f\s*-->/g)?.length ?? 0,
-    hydrationStarts: html.match(/<!--\s*rmx:h:/g)?.length ?? 0,
-    hydrationEnds: html.match(/<!--\s*\/rmx:h\s*-->/g)?.length ?? 0,
-  }
-}
-
-function hasBalancedMarkerSummary(summary: Record<string, number>): boolean {
-  return (
-    summary.frameStarts === summary.frameEnds && summary.hydrationStarts === summary.hydrationEnds
-  )
-}

--- a/packages/ui/src/runtime/stream-protocol.ts
+++ b/packages/ui/src/runtime/stream-protocol.ts
@@ -1,0 +1,27 @@
+export type FlushKind = 'document' | 'fragment'
+
+const FLUSH_MARKER_PATTERN = /<!--\s*rmx:flush\s+(document|fragment)\s*-->/g
+
+export function appendFlushMarker(html: string, kind: FlushKind): string {
+  return `${html}<!-- rmx:flush ${kind} -->`
+}
+
+export function stripFlushMarkers(html: string): string {
+  FLUSH_MARKER_PATTERN.lastIndex = 0
+  return html.replace(FLUSH_MARKER_PATTERN, '')
+}
+
+export function findFlushMarker(
+  html: string,
+  startIndex: number,
+): { index: number; endIndex: number; kind: FlushKind } | undefined {
+  FLUSH_MARKER_PATTERN.lastIndex = startIndex
+  let match = FLUSH_MARKER_PATTERN.exec(html)
+  if (!match) return undefined
+
+  return {
+    index: match.index,
+    endIndex: FLUSH_MARKER_PATTERN.lastIndex,
+    kind: match[1] as FlushKind,
+  }
+}

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -3,6 +3,7 @@ import type { ElementType, ElementProps, RemixElement } from '../runtime/jsx.ts'
 import { Fragment, createComponent, createFrameHandle, Frame } from '../runtime/component.ts'
 import { isEntry, type EntryComponent } from '../runtime/client-entries.ts'
 import { normalizeSvgAttribute } from '../runtime/svg-attributes.ts'
+import { appendFlushMarker, type FlushKind, stripFlushMarkers } from '../runtime/stream-protocol.ts'
 
 interface VNode {
   type: ElementType
@@ -90,6 +91,7 @@ interface RenderContext {
   unresolvedHydrationData: Map<string, UnresolvedHydrationData>
   frameData: Map<string, FrameData>
   blockingFrameTails: ReadableStream<Uint8Array>[]
+  flushKind: FlushKind
   serverIdScope: string
   serverIdCounter: number
 }
@@ -230,6 +232,7 @@ export function renderToStream(
     unresolvedHydrationData: new Map(),
     frameData: new Map(),
     blockingFrameTails: [],
+    flushKind: 'fragment',
     serverIdScope: crypto.randomUUID().slice(0, 8),
     serverIdCounter: 0,
   }
@@ -243,7 +246,7 @@ export function renderToStream(
         validateClientEntriesForHydration(context)
         let html = serializeSegment(root)
         let finalHtml = finalizeHtml(html, context)
-        let bytes = encoder.encode(finalHtml)
+        let bytes = encoder.encode(appendFlushMarker(finalHtml, context.flushKind))
         controller.enqueue(bytes)
 
         // If we have any tails from blocking frame streams, stream them now.
@@ -350,13 +353,13 @@ async function splitFirstChunk(stream: ReadableStream<Uint8Array>): Promise<Reso
     },
   })
 
-  return { html: stripDoctypeMarkup(decoder.decode(first)), tail }
+  return { html: stripFlushMarkers(stripDoctypeMarkup(decoder.decode(first))), tail }
 }
 
 async function resolveFrameHtml(
   input: string | ReadableStream<Uint8Array>,
 ): Promise<ResolvedFrameHtml> {
-  if (typeof input === 'string') return { html: stripDoctypeMarkup(input) }
+  if (typeof input === 'string') return { html: stripFlushMarkers(stripDoctypeMarkup(input)) }
 
   return await splitFirstChunk(input)
 }
@@ -399,6 +402,7 @@ function buildSegment(node: RemixNode, context: RenderContext, frameState: SsrFr
       let tag = type
 
       if (tag === 'html') {
+        context.flushKind = 'document'
         return buildElementSegment(tag, props, context, frameState)
       }
 
@@ -812,7 +816,11 @@ function buildComponentSegment(
   let [renderedNode] = handle.render(props)
   let childContext = { ...context, parentVNode: vnode }
 
-  return buildSegment(renderedNode, childContext, frameState)
+  let rendered = buildSegment(renderedNode, childContext, frameState)
+  if (childContext.flushKind === 'document') {
+    context.flushKind = 'document'
+  }
+  return rendered
 }
 
 function createHydrationPropsReplacer(context: RenderContext, frameState: SsrFrameState) {
@@ -1094,7 +1102,7 @@ function transformAttributeName(name: string, isSvg: boolean): string {
 }
 
 function finalizeHtml(html: string, context: RenderContext): string {
-  let hasHtmlRoot = html.trimStart().toLowerCase().startsWith('<html')
+  let hasHtmlRoot = context.flushKind === 'document'
 
   let styles = collectStyleTags(context)
   if (styles) {
@@ -1351,11 +1359,13 @@ async function drain(stream: ReadableStream<Uint8Array>): Promise<string> {
  * @returns Rendered HTML.
  */
 export async function renderToString(node: RemixNode): Promise<string> {
-  return drain(
-    renderToStream(node, {
-      onError(error) {
-        throw error
-      },
-    }),
+  return stripFlushMarkers(
+    await drain(
+      renderToStream(node, {
+        onError(error) {
+          throw error
+        },
+      }),
+    ),
   )
 }

--- a/packages/ui/src/test/frame.test.ts
+++ b/packages/ui/src/test/frame.test.ts
@@ -1,0 +1,119 @@
+import { expect } from '@remix-run/assert'
+import { afterEach, describe, it } from '@remix-run/test'
+
+import type { Handle } from '../runtime/component.ts'
+import { createFrame, type LoadModule } from '../runtime/frame.ts'
+import { jsx } from '../runtime/jsx.ts'
+import { createScheduler } from '../runtime/scheduler.ts'
+import { appendFlushMarker } from '../runtime/stream-protocol.ts'
+import { createStyleManager } from '../style/index.ts'
+
+describe('frame reloads', () => {
+  afterEach(() => {
+    document.documentElement.innerHTML = '<head></head><body></body>'
+  })
+
+  it('preserves hydrated client entries while streaming a top frame reload', async () => {
+    let setupCount = 0
+    let disconnectCount = 0
+
+    function StreamingEntry(handle: Handle<{ label: string }>) {
+      setupCount++
+      handle.signal.addEventListener('abort', () => {
+        disconnectCount++
+      })
+
+      return () => jsx('section', { 'data-entry': '', children: handle.props.label })
+    }
+
+    document.documentElement.innerHTML = [
+      '<head><title>Initial</title></head>',
+      '<body>',
+      '<main>',
+      '<!-- rmx:h:h1 -->',
+      '<section data-entry="">initial</section>',
+      '<!-- /rmx:h -->',
+      '</main>',
+      rmxDataScript('initial'),
+      '</body>',
+    ].join('')
+
+    let errorTarget = new EventTarget()
+    let styleManager = createStyleManager()
+    let scheduler = createScheduler(document, errorTarget, styleManager)
+    let loadModule = ((moduleUrl: string, exportName: string) => {
+      expect(moduleUrl).toBe('/entry.js')
+      expect(exportName).toBe('StreamingEntry')
+      return StreamingEntry
+    }) satisfies LoadModule
+
+    let frame = createFrame(document, {
+      src: 'https://example.com/initial',
+      errorTarget,
+      loadModule,
+      resolveFrame() {
+        return htmlStream([
+          '<!doctype html><html><head><title>Next</title></head>',
+          [
+            '<body><main>',
+            '<!-- rmx:h:h1 -->',
+            '<section data-entry="">next</section>',
+            '<!-- /rmx:h -->',
+            rmxDataScript('next'),
+            appendFlushMarker('</main></body></html>', 'document'),
+          ].join(''),
+        ])
+      },
+      pendingClientEntries: new Map(),
+      scheduler,
+      styleManager,
+      data: {},
+      moduleCache: new Map(),
+      moduleLoads: new Map(),
+      frameInstances: new WeakMap(),
+      namedFrames: new Map(),
+    })
+
+    try {
+      await frame.ready()
+      expect(document.querySelector('[data-entry]')?.textContent).toBe('initial')
+      let setupCountBeforeReload = setupCount
+      let disconnectCountBeforeReload = disconnectCount
+
+      await frame.handle.reload()
+
+      expect(document.querySelector('[data-entry]')?.textContent).toBe('next')
+      expect(setupCount).toBe(setupCountBeforeReload)
+      expect(disconnectCount).toBe(disconnectCountBeforeReload)
+    } finally {
+      frame.dispose()
+    }
+  })
+})
+
+function rmxDataScript(label: string): string {
+  let data = {
+    h: {
+      h1: {
+        moduleUrl: '/entry.js',
+        exportName: 'StreamingEntry',
+        props: { label },
+      },
+    },
+  }
+
+  return `<script type="application/json" id="rmx-data">${JSON.stringify(data)}</script>`
+}
+
+function htmlStream(chunks: string[]): ReadableStream<Uint8Array> {
+  let encoder = new TextEncoder()
+
+  return new ReadableStream({
+    start(controller) {
+      for (let chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk))
+      }
+      controller.close()
+    },
+  })
+}

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -30,6 +30,19 @@ function streamFromChunks(chunks: Array<string | Promise<string>>): ReadableStre
   })
 }
 
+async function drainWithProtocol(stream: ReadableStream<Uint8Array>): Promise<string> {
+  let chunks = readChunks(stream)
+  let html = ''
+
+  while (true) {
+    let chunk = await chunks.next()
+    if (chunk.done) break
+    html += chunk.value
+  }
+
+  return html
+}
+
 describe('run', () => {
   let container: HTMLDivElement
 
@@ -206,7 +219,7 @@ describe('run', () => {
     }
 
     async function renderReloadDocument() {
-      return await drain(
+      return await drainWithProtocol(
         renderToStream(
           <html>
             <body>
@@ -287,7 +300,7 @@ describe('run', () => {
     )
 
     async function renderDocument(label: string) {
-      return await drain(
+      return await drainWithProtocol(
         renderToStream(
           <html>
             <head />
@@ -364,7 +377,7 @@ describe('run', () => {
     )
 
     async function renderDocument(includeEntry: boolean) {
-      return await drain(
+      return await drainWithProtocol(
         renderToStream(
           <html>
             <head />
@@ -422,7 +435,7 @@ describe('run', () => {
     })
 
     async function renderDocument(includeFrame: boolean) {
-      return await drain(
+      return await drainWithProtocol(
         renderToStream(
           <html>
             <head />

--- a/packages/ui/src/test/stream.test.tsx
+++ b/packages/ui/src/test/stream.test.tsx
@@ -11,6 +11,7 @@ import { Frame } from '../runtime/component.ts'
 import { invariant } from '../runtime/invariant.ts'
 
 const rmxDataScriptSelector = 'script[type="application/json"]#rmx-data'
+const flushMarkerPattern = /<!--\s*rmx:flush\s+(?:document|fragment)\s*-->/g
 
 describe('stream', () => {
   function getLatestRmxDataScript(root: ParentNode): HTMLScriptElement {
@@ -50,6 +51,24 @@ describe('stream', () => {
       let stream = renderToStream(<div>Hello, world!</div>)
       let html = await drain(stream)
       expect(html).toBe('<div>Hello, world!</div>')
+    })
+
+    it('marks stream batches as documents or fragments', async () => {
+      let fragmentChunks = readChunks(renderToStream(<div>Hello, world!</div>))
+      let fragment = await fragmentChunks.next()
+      invariant(!fragment.done)
+      expect(fragment.value).toContain('<!-- rmx:flush fragment -->')
+
+      let documentChunks = readChunks(
+        renderToStream(
+          <html>
+            <body>Hello, world!</body>
+          </html>,
+        ),
+      )
+      let document = await documentChunks.next()
+      invariant(!document.done)
+      expect(document.value).toContain('<!-- rmx:flush document -->')
     })
 
     it('renders string nodes', async () => {
@@ -1880,6 +1899,7 @@ describe('stream', () => {
       // Both outer and inner should be present in first chunk
       expect(content).toContain('Outer')
       expect(content).toContain('<div>Inner</div>')
+      expect(content.match(flushMarkerPattern)?.length).toBe(1)
 
       // Both frames resolved in aggregated data
       let shelf = document.createElement('template')

--- a/packages/ui/src/test/utils.ts
+++ b/packages/ui/src/test/utils.ts
@@ -1,3 +1,5 @@
+import { stripFlushMarkers } from '../runtime/stream-protocol.ts'
+
 export type Assert<T extends true> = T
 
 export type Equal<X, Y> =
@@ -14,7 +16,7 @@ export async function drain(stream: ReadableStream<Uint8Array>): Promise<string>
     html += decoder.decode(value)
   }
 
-  return html
+  return stripFlushMarkers(html)
 }
 
 export function readChunks(stream: ReadableStream<Uint8Array>): AsyncGenerator<string, void, void> {


### PR DESCRIPTION
Emit an explicit flush marker from server-rendered UI streams so client frame reloads only diff complete batches, preserving hydrated entries across arbitrary fetch chunk boundaries.

Stream chunk boundaries are transport details, not UI update boundaries. The server now emits an explicit `<!-- rmx:flush -->` marker when a batch is complete enough to diff. The client buffers arbitrary incoming chunks until that marker, then applies the batch. This preserves hydrated client entries across top-frame reloads even when the browser splits a complete server render into partial fetch chunks.