### PR TITLE
Warn on non-canonical header names in code

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -76,8 +76,12 @@
     },
     {
       "files": ["**/*.{ts,tsx,js,jsx}"],
-      "jsPlugins": ["./scripts/oxlint-plugins/prefer-let-locals-plugin.ts"],
+      "jsPlugins": [
+        "./scripts/oxlint-plugins/prefer-let-locals-plugin.ts",
+        "./scripts/oxlint-plugins/canonical-header-names-plugin.ts"
+      ],
       "rules": {
+        "remix-headers/canonical-header-name": "warn",
         "remix-style/prefer-const-module-scope": "error",
         "remix-style/prefer-let-locals": "error",
         "no-var": "error",

--- a/demos/bookstore/app/actions/render.tsx
+++ b/demos/bookstore/app/actions/render.tsx
@@ -39,11 +39,11 @@ async function resolveFrame<context extends RequestContext<any, any>>(
   let url = new URL(src, request.url)
 
   let headers = new Headers()
-  headers.set('accept', 'text/html')
-  headers.set('accept-encoding', 'identity')
+  headers.set('Accept', 'text/html')
+  headers.set('Accept-Encoding', 'identity')
 
-  let cookie = request.headers.get('cookie')
-  if (cookie) headers.set('cookie', cookie)
+  let cookie = request.headers.get('Cookie')
+  if (cookie) headers.set('Cookie', cookie)
 
   let res = await router.fetch(
     new Request(url, {

--- a/demos/bookstore/app/assets/entry.tsx
+++ b/demos/bookstore/app/assets/entry.tsx
@@ -10,7 +10,7 @@ const app = run({
     return Component
   },
   async resolveFrame(src, signal) {
-    let response = await fetch(src, { headers: { accept: 'text/html' }, signal })
+    let response = await fetch(src, { headers: { Accept: 'text/html' }, signal })
     if (!response.ok) {
       return `<pre>Frame error: ${response.status} ${response.statusText}</pre>`
     }

--- a/demos/frame-navigation/app/actions/render.tsx
+++ b/demos/frame-navigation/app/actions/render.tsx
@@ -31,15 +31,15 @@ async function resolveFrame(
   let url = new URL(src, frameSrc)
 
   let headers = new Headers()
-  headers.set('accept', 'text/html')
-  headers.set('accept-encoding', 'identity')
-  headers.set('x-remix-frame', 'true')
+  headers.set('Accept', 'text/html')
+  headers.set('Accept-Encoding', 'identity')
+  headers.set('X-Remix-Frame', 'true')
   if (target) {
-    headers.set('x-remix-target', target)
+    headers.set('X-Remix-Target', target)
   }
 
-  let cookie = request.headers.get('cookie')
-  if (cookie) headers.set('cookie', cookie)
+  let cookie = request.headers.get('Cookie')
+  if (cookie) headers.set('Cookie', cookie)
 
   let res = await followFrameRedirects(router, request, url, headers)
   if (!res.ok) {
@@ -62,7 +62,7 @@ async function followFrameRedirects(router: Router, request: Request, url: URL, 
       }),
     )
 
-    let location = res.headers.get('location')
+    let location = res.headers.get('Location')
     if (!location || res.status < 300 || res.status >= 400) {
       return res
     }

--- a/demos/frame-navigation/app/actions/settings/controller.tsx
+++ b/demos/frame-navigation/app/actions/settings/controller.tsx
@@ -68,5 +68,5 @@ function SettingsShellOrFragment(handle: Handle<SettingsPageProps>) {
 }
 
 function isFrameRequest() {
-  return getContext().request.headers.get('x-remix-target') === frames.settings
+  return getContext().request.headers.get('X-Remix-Target') === frames.settings
 }

--- a/demos/frame-navigation/app/assets/entry.tsx
+++ b/demos/frame-navigation/app/assets/entry.tsx
@@ -25,11 +25,11 @@ async function resolveFrameResponse(
   target?: string,
 ): Promise<FrameContent> {
   let headers = new Headers()
-  headers.set('accept', 'text/html')
-  headers.set('x-remix-frame', 'true')
+  headers.set('Accept', 'text/html')
+  headers.set('X-Remix-Frame', 'true')
 
   if (target) {
-    headers.set('x-remix-target', target)
+    headers.set('X-Remix-Target', target)
   }
 
   let res = await fetch(url, { headers, signal })

--- a/demos/frame-navigation/app/middleware/auth.ts
+++ b/demos/frame-navigation/app/middleware/auth.ts
@@ -17,7 +17,7 @@ export const authCookie = createCookie('frame-navigation-auth', {
 const authCookieScheme: AuthScheme<FrameAuthIdentity> = {
   name: 'auth-cookie',
   async authenticate(context) {
-    let cookie = await authCookie.parse(context.headers.get('cookie'))
+    let cookie = await authCookie.parse(context.headers.get('Cookie'))
     if (cookie !== '1') {
       return
     }
@@ -42,7 +42,7 @@ export function isAuthenticated() {
 
 export const requireAuth = requireAuthenticated<FrameAuthIdentity>({
   onFailure(context) {
-    let isFrameRequest = context.request.headers.get('x-remix-frame') === 'true'
+    let isFrameRequest = context.request.headers.get('X-Remix-Frame') === 'true'
     if (isFrameRequest) {
       return new Response(
         '<div><h1>Not authorized</h1><p>Refresh the page to sign in again.</p></div>',

--- a/demos/frames/app/actions/render.ts
+++ b/demos/frames/app/actions/render.ts
@@ -37,8 +37,8 @@ async function resolveFrameViaRouter(router: Router, request: Request, src: stri
   let url = new URL(src, request.url)
   let headers = new Headers(request.headers)
 
-  headers.delete('accept-encoding')
-  headers.set('accept', 'text/html')
+  headers.delete('Accept-Encoding')
+  headers.set('Accept', 'text/html')
 
   let response = await router.fetch(
     new Request(url, {

--- a/demos/frames/app/assets/entry.tsx
+++ b/demos/frames/app/assets/entry.tsx
@@ -10,7 +10,7 @@ const app = run({
     return exp
   },
   async resolveFrame(src, signal) {
-    let res = await fetch(src, { headers: { accept: 'text/html' }, signal })
+    let res = await fetch(src, { headers: { Accept: 'text/html' }, signal })
     if (!res.ok) {
       return `<pre>Frame error: ${res.status} ${res.statusText}</pre>`
     }

--- a/packages/auth-middleware/README.md
+++ b/packages/auth-middleware/README.md
@@ -177,7 +177,7 @@ let authCookie = createCookie('__auth', {
 let authCookieScheme: AuthScheme<'demo-user'> = {
   name: 'auth-cookie',
   async authenticate(context) {
-    let value = await authCookie.parse(context.headers.get('cookie'))
+    let value = await authCookie.parse(context.headers.get('Cookie'))
     if (value !== '1') {
       return
     }
@@ -191,7 +191,7 @@ let authCookieScheme: AuthScheme<'demo-user'> = {
 
 let requireAuthCookie = requireAuth<'demo-user'>({
   onFailure(context) {
-    let isFrameRequest = context.request.headers.get('x-remix-frame') === 'true'
+    let isFrameRequest = context.request.headers.get('X-Remix-Frame') === 'true'
     if (isFrameRequest) {
       return new Response('<p>Not authorized</p>', {
         status: 401,

--- a/packages/auth-middleware/src/lib/schemes/api-key.test.ts
+++ b/packages/auth-middleware/src/lib/schemes/api-key.test.ts
@@ -24,7 +24,7 @@ describe('apiKey scheme', () => {
       },
     })
 
-    let result = await scheme.authenticate(createContext({ 'X-API-Key': 'k_live_123' }))
+    let result = await scheme.authenticate(createContext({ 'X-Api-Key': 'k_live_123' }))
 
     assert.deepEqual(result, {
       status: 'success',
@@ -52,12 +52,12 @@ describe('apiKey scheme', () => {
       },
     })
 
-    let result = await scheme.authenticate(createContext({ 'X-API-Key': '   ' }))
+    let result = await scheme.authenticate(createContext({ 'X-Api-Key': '   ' }))
 
     assert.deepEqual(result, {
       status: 'failure',
       code: 'missing_credentials',
-      message: 'X-API-Key header is empty',
+      message: 'X-Api-Key header is empty',
     })
   })
 
@@ -68,7 +68,7 @@ describe('apiKey scheme', () => {
       },
     })
 
-    let result = await scheme.authenticate(createContext({ 'X-API-Key': 'bad-key' }))
+    let result = await scheme.authenticate(createContext({ 'X-Api-Key': 'bad-key' }))
 
     assert.deepEqual(result, {
       status: 'failure',

--- a/packages/auth-middleware/src/lib/schemes/api-key.ts
+++ b/packages/auth-middleware/src/lib/schemes/api-key.ts
@@ -24,7 +24,7 @@ export function createAPIAuthScheme<identity>(
   options: APIAuthSchemeOptions<identity>,
 ): AuthScheme<identity> {
   let name = options.name ?? 'api-key'
-  let headerName = options.headerName ?? 'X-API-Key'
+  let headerName = options.headerName ?? 'X-Api-Key'
 
   return {
     name,

--- a/packages/csrf-middleware/README.md
+++ b/packages/csrf-middleware/README.md
@@ -49,7 +49,7 @@ router.get('/form', (context) => {
 
 By default, `csrf()` checks token values in this order:
 
-1. Request headers: `x-csrf-token`, `x-xsrf-token`, `csrf-token`
+1. Request headers: `X-Csrf-Token`, `X-Xsrf-Token`, `Csrf-Token`
 2. Form field: `_csrf` (requires `formData()` middleware to parse request bodies)
 3. Query param: `_csrf`
 

--- a/packages/csrf-middleware/src/lib/csrf.test.ts
+++ b/packages/csrf-middleware/src/lib/csrf.test.ts
@@ -67,7 +67,7 @@ describe('csrf middleware', () => {
     let postRequest = createRequest(tokenResponse, {
       method: 'POST',
       headers: {
-        'X-CSRF-Token': token,
+        'X-Csrf-Token': token,
       },
     })
 
@@ -115,7 +115,7 @@ describe('csrf middleware', () => {
     let postRequest = createRequest(tokenResponse, {
       method: 'POST',
       headers: {
-        'X-CSRF-Token': 'invalid-token',
+        'X-Csrf-Token': 'invalid-token',
       },
     })
 
@@ -171,7 +171,7 @@ describe('csrf middleware', () => {
       method: 'POST',
       headers: {
         Origin: 'https://evil.example',
-        'X-CSRF-Token': token,
+        'X-Csrf-Token': token,
       },
     })
 
@@ -199,7 +199,7 @@ describe('csrf middleware', () => {
       method: 'POST',
       headers: {
         Origin: 'https://admin.example.com',
-        'X-CSRF-Token': token,
+        'X-Csrf-Token': token,
       },
     })
 
@@ -218,7 +218,7 @@ describe('csrf middleware', () => {
         session(cookie, storage),
         csrf({
           value(context) {
-            return context.headers.get('X-Custom-CSRF')
+            return context.headers.get('X-Custom-Csrf')
           },
         }),
       ],
@@ -233,7 +233,7 @@ describe('csrf middleware', () => {
     let postRequest = createRequest(tokenResponse, {
       method: 'POST',
       headers: {
-        'X-Custom-CSRF': token,
+        'X-Custom-Csrf': token,
       },
     })
 

--- a/packages/csrf-middleware/src/lib/csrf.ts
+++ b/packages/csrf-middleware/src/lib/csrf.ts
@@ -3,7 +3,7 @@ import type { Middleware, RequestContext, RequestMethod } from '@remix-run/fetch
 import { Session } from '@remix-run/session'
 
 const defaultSafeMethods: RequestMethod[] = ['GET', 'HEAD', 'OPTIONS']
-const defaultTokenHeaderNames = ['x-csrf-token', 'x-xsrf-token', 'csrf-token']
+const defaultTokenHeaderNames = ['X-Csrf-Token', 'X-Xsrf-Token', 'Csrf-Token']
 
 type OriginMatcher = string | RegExp | ReadonlyArray<string | RegExp>
 
@@ -71,7 +71,7 @@ export interface CsrfOptions {
   /**
    * Header names checked (in order) for CSRF tokens.
    *
-   * @default ['x-csrf-token', 'x-xsrf-token', 'csrf-token']
+   * @default ['X-Csrf-Token', 'X-Xsrf-Token', 'Csrf-Token']
    */
   headerNames?: readonly string[]
 

--- a/packages/fetch-router/CHANGELOG.md
+++ b/packages/fetch-router/CHANGELOG.md
@@ -99,7 +99,7 @@ This is the changelog for [`fetch-router`](https://github.com/remix-run/remix/tr
   import { Accept } from '@remix-run/headers'
 
   router.get('/api/users', (context) => {
-    let accept = Accept.from(context.headers.get('accept'))
+    let accept = Accept.from(context.headers.get('Accept'))
     let acceptsJson = accept.accepts('application/json')
     // ...
   })

--- a/packages/fetch-router/src/lib/request-context.test.ts
+++ b/packages/fetch-router/src/lib/request-context.test.ts
@@ -11,7 +11,7 @@ describe('new RequestContext()', () => {
     })
     let context = new RequestContext(req)
 
-    assert.equal(context.headers.get('content-type'), 'application/json')
+    assert.equal(context.headers.get('Content-Type'), 'application/json')
   })
 
   it('lazily creates a mutable copy of request headers', () => {

--- a/packages/file-storage-s3/src/lib/s3.test.ts
+++ b/packages/file-storage-s3/src/lib/s3.test.ts
@@ -213,7 +213,7 @@ function createMockS3Fetch(): typeof globalThis.fetch {
       objects.set(objectKey, {
         body,
         metadata,
-        contentType: request.headers.get('content-type') ?? '',
+        contentType: request.headers.get('Content-Type') ?? '',
         updatedAt: Date.now(),
       })
 
@@ -300,16 +300,16 @@ function listObjects(url: URL, bucket: string, objects: Map<string, StoredObject
   return new Response(xml, {
     status: 200,
     headers: {
-      'content-type': 'application/xml',
+      'Content-Type': 'application/xml',
     },
   })
 }
 
 function createObjectResponse(object: StoredObject, headOnly: boolean): Response {
   let headers = new Headers({
-    'content-type': object.contentType,
-    'content-length': String(object.body.byteLength),
-    'last-modified': new Date(object.updatedAt).toUTCString(),
+    'Content-Type': object.contentType,
+    'Content-Length': String(object.body.byteLength),
+    'Last-Modified': new Date(object.updatedAt).toUTCString(),
   })
 
   for (let [header, value] of Object.entries(object.metadata)) {
@@ -367,7 +367,7 @@ function createErrorResponse(status: number, code: string, message: string): Res
   return new Response(xml, {
     status,
     headers: {
-      'content-type': 'application/xml',
+      'Content-Type': 'application/xml',
     },
   })
 }

--- a/packages/file-storage-s3/src/lib/s3.ts
+++ b/packages/file-storage-s3/src/lib/s3.ts
@@ -93,11 +93,11 @@ export function createS3FileStorage(options: S3FileStorageOptions): FileStorage 
     let headers = new Headers()
 
     if (file.type !== '') {
-      headers.set('content-type', file.type)
+      headers.set('Content-Type', file.type)
     }
 
-    headers.set('x-amz-meta-file-name', encodeMetadataValue(file.name))
-    headers.set('x-amz-meta-file-last-modified', String(file.lastModified))
+    headers.set('X-Amz-Meta-File-Name', encodeMetadataValue(file.name))
+    headers.set('X-Amz-Meta-File-Last-Modified', String(file.lastModified))
 
     let response = await s3Fetch(getObjectUrl(key), {
       method: 'PUT',
@@ -130,13 +130,13 @@ export function createS3FileStorage(options: S3FileStorageOptions): FileStorage 
     return {
       key: object.key,
       lastModified:
-        parseEpochMillis(response.headers.get('x-amz-meta-file-last-modified')) ??
+        parseEpochMillis(response.headers.get('X-Amz-Meta-File-Last-Modified')) ??
         object.lastModified,
       name:
-        decodeMetadataValue(response.headers.get('x-amz-meta-file-name')) ??
+        decodeMetadataValue(response.headers.get('X-Amz-Meta-File-Name')) ??
         getDefaultFileName(object.key),
-      size: parseInteger(response.headers.get('content-length')) ?? object.size,
-      type: response.headers.get('content-type') ?? '',
+      size: parseInteger(response.headers.get('Content-Length')) ?? object.size,
+      type: response.headers.get('Content-Type') ?? '',
     }
   }
 
@@ -154,14 +154,14 @@ export function createS3FileStorage(options: S3FileStorageOptions): FileStorage 
 
       return new File(
         [body],
-        decodeMetadataValue(response.headers.get('x-amz-meta-file-name')) ??
+        decodeMetadataValue(response.headers.get('X-Amz-Meta-File-Name')) ??
           getDefaultFileName(key),
         {
           lastModified:
-            parseEpochMillis(response.headers.get('x-amz-meta-file-last-modified')) ??
-            parseHttpDate(response.headers.get('last-modified')) ??
+            parseEpochMillis(response.headers.get('X-Amz-Meta-File-Last-Modified')) ??
+            parseHttpDate(response.headers.get('Last-Modified')) ??
             0,
-          type: response.headers.get('content-type') ?? '',
+          type: response.headers.get('Content-Type') ?? '',
         },
       )
     },

--- a/packages/headers/CHANGELOG.md
+++ b/packages/headers/CHANGELOG.md
@@ -40,7 +40,7 @@ This is the changelog for [`headers`](https://github.com/remix-run/remix/tree/ma
 
   // After:
   import { ContentType } from '@remix-run/headers'
-  let contentType = ContentType.from(request.headers.get('content-type'))
+  let contentType = ContentType.from(request.headers.get('Content-Type'))
   let mediaType = contentType.mediaType
   ```
 

--- a/packages/headers/README.md
+++ b/packages/headers/README.md
@@ -84,7 +84,7 @@ Implements `Map<mediaType, quality>`.
 import { Accept } from 'remix/headers'
 
 // Parse from headers
-let accept = Accept.from(request.headers.get('accept'))
+let accept = Accept.from(request.headers.get('Accept'))
 
 accept.mediaTypes // ['text/html', 'text/*']
 accept.weights // [1, 0.9]
@@ -127,7 +127,7 @@ Implements `Map<encoding, quality>`.
 import { AcceptEncoding } from 'remix/headers'
 
 // Parse from headers
-let acceptEncoding = AcceptEncoding.from(request.headers.get('accept-encoding'))
+let acceptEncoding = AcceptEncoding.from(request.headers.get('Accept-Encoding'))
 
 acceptEncoding.encodings // ['gzip', 'deflate']
 acceptEncoding.weights // [1, 0.8]
@@ -163,7 +163,7 @@ Implements `Map<language, quality>`.
 import { AcceptLanguage } from 'remix/headers'
 
 // Parse from headers
-let acceptLanguage = AcceptLanguage.from(request.headers.get('accept-language'))
+let acceptLanguage = AcceptLanguage.from(request.headers.get('Accept-Language'))
 
 acceptLanguage.languages // ['en-us', 'en']
 acceptLanguage.weights // [1, 0.9]
@@ -197,7 +197,7 @@ Parse, manipulate and stringify [`Cache-Control` headers](https://developer.mozi
 import { CacheControl } from 'remix/headers'
 
 // Parse from headers
-let cacheControl = CacheControl.from(response.headers.get('cache-control'))
+let cacheControl = CacheControl.from(response.headers.get('Cache-Control'))
 
 cacheControl.public // true
 cacheControl.maxAge // 3600
@@ -233,7 +233,7 @@ Parse, manipulate and stringify [`Content-Disposition` headers](https://develope
 import { ContentDisposition } from 'remix/headers'
 
 // Parse from headers
-let contentDisposition = ContentDisposition.from(response.headers.get('content-disposition'))
+let contentDisposition = ContentDisposition.from(response.headers.get('Content-Disposition'))
 
 contentDisposition.type // 'attachment'
 contentDisposition.filename // 'example.pdf'
@@ -267,7 +267,7 @@ Parse, manipulate and stringify [`Content-Range` headers](https://developer.mozi
 import { ContentRange } from 'remix/headers'
 
 // Parse from headers
-let contentRange = ContentRange.from(response.headers.get('content-range'))
+let contentRange = ContentRange.from(response.headers.get('Content-Range'))
 
 contentRange.unit // "bytes"
 contentRange.start // 200
@@ -299,7 +299,7 @@ Parse, manipulate and stringify [`Content-Type` headers](https://developer.mozil
 import { ContentType } from 'remix/headers'
 
 // Parse from headers
-let contentType = ContentType.from(request.headers.get('content-type'))
+let contentType = ContentType.from(request.headers.get('Content-Type'))
 
 contentType.mediaType // "text/html"
 contentType.charset // "utf-8"
@@ -331,7 +331,7 @@ Implements `Map<name, value>`.
 import { Cookie } from 'remix/headers'
 
 // Parse from headers
-let cookie = Cookie.from(request.headers.get('cookie'))
+let cookie = Cookie.from(request.headers.get('Cookie'))
 
 cookie.get('session_id') // 'abc123'
 cookie.get('theme') // 'dark'
@@ -374,7 +374,7 @@ Implements `Set<etag>`.
 import { IfMatch } from 'remix/headers'
 
 // Parse from headers
-let ifMatch = IfMatch.from(request.headers.get('if-match'))
+let ifMatch = IfMatch.from(request.headers.get('If-Match'))
 
 ifMatch.tags // ['"67ab43"', '"54ed21"']
 ifMatch.has('"67ab43"') // true
@@ -411,7 +411,7 @@ Implements `Set<etag>`.
 import { IfNoneMatch } from 'remix/headers'
 
 // Parse from headers
-let ifNoneMatch = IfNoneMatch.from(request.headers.get('if-none-match'))
+let ifNoneMatch = IfNoneMatch.from(request.headers.get('If-None-Match'))
 
 ifNoneMatch.tags // ['"67ab43"', '"54ed21"']
 ifNoneMatch.has('"67ab43"') // true
@@ -445,7 +445,7 @@ Parse, manipulate and stringify [`If-Range` headers](https://developer.mozilla.o
 import { IfRange } from 'remix/headers'
 
 // Parse from headers
-let ifRange = IfRange.from(request.headers.get('if-range'))
+let ifRange = IfRange.from(request.headers.get('If-Range'))
 
 // With HTTP date
 ifRange.matches({ lastModified: 1609459200000 }) // true
@@ -478,7 +478,7 @@ Parse, manipulate and stringify [`Range` headers](https://developer.mozilla.org/
 import { Range } from 'remix/headers'
 
 // Parse from headers
-let range = Range.from(request.headers.get('range'))
+let range = Range.from(request.headers.get('Range'))
 
 range.unit // "bytes"
 range.ranges // [{ start: 200, end: 1000 }]
@@ -513,7 +513,7 @@ Parse, manipulate and stringify [`Set-Cookie` headers](https://developer.mozilla
 import { SetCookie } from 'remix/headers'
 
 // Parse from headers
-let setCookie = SetCookie.from(response.headers.get('set-cookie'))
+let setCookie = SetCookie.from(response.headers.get('Set-Cookie'))
 
 setCookie.name // "session_id"
 setCookie.value // "abc"
@@ -558,7 +558,7 @@ Implements `Set<headerName>`.
 import { Vary } from 'remix/headers'
 
 // Parse from headers
-let vary = Vary.from(response.headers.get('vary'))
+let vary = Vary.from(response.headers.get('Vary'))
 
 vary.headerNames // ['accept-encoding', 'accept-language']
 vary.has('Accept-Encoding') // true (case-insensitive)
@@ -590,8 +590,8 @@ Parse and stringify raw HTTP header strings.
 import { parse, stringify } from 'remix/headers'
 
 let headers = parse('Content-Type: text/html\r\nCache-Control: no-cache')
-headers.get('content-type') // 'text/html'
-headers.get('cache-control') // 'no-cache'
+headers.get('Content-Type') // 'text/html'
+headers.get('Cache-Control') // 'no-cache'
 
 stringify(headers)
 // 'Content-Type: text/html\r\nCache-Control: no-cache'

--- a/packages/headers/src/lib/raw-headers.test.ts
+++ b/packages/headers/src/lib/raw-headers.test.ts
@@ -6,31 +6,31 @@ import { parse as parseRawHeaders, stringify as stringifyRawHeaders } from './ra
 describe('parseRawHeaders', () => {
   it('parses a single header', () => {
     let headers = parseRawHeaders('Content-Type: text/html')
-    assert.equal(headers.get('content-type'), 'text/html')
+    assert.equal(headers.get('Content-Type'), 'text/html')
   })
 
   it('parses multiple headers', () => {
     let headers = parseRawHeaders('Content-Type: text/html\r\nCache-Control: no-cache')
-    assert.equal(headers.get('content-type'), 'text/html')
-    assert.equal(headers.get('cache-control'), 'no-cache')
+    assert.equal(headers.get('Content-Type'), 'text/html')
+    assert.equal(headers.get('Cache-Control'), 'no-cache')
   })
 
   it('trims whitespace from header names and values', () => {
     let headers = parseRawHeaders('  Content-Type  :  text/html  ')
-    assert.equal(headers.get('content-type'), 'text/html')
+    assert.equal(headers.get('Content-Type'), 'text/html')
   })
 
   it('handles multiple values for the same header', () => {
     let headers = parseRawHeaders('Set-Cookie: a=1\r\nSet-Cookie: b=2')
-    assert.equal(headers.get('set-cookie'), 'a=1, b=2')
+    assert.equal(headers.get('Set-Cookie'), 'a=1, b=2')
   })
 
   it('ignores malformed lines', () => {
     let headers = parseRawHeaders(
       'Content-Type: text/html\r\nmalformed line\r\nCache-Control: no-cache',
     )
-    assert.equal(headers.get('content-type'), 'text/html')
-    assert.equal(headers.get('cache-control'), 'no-cache')
+    assert.equal(headers.get('Content-Type'), 'text/html')
+    assert.equal(headers.get('Cache-Control'), 'no-cache')
   })
 
   it('returns empty Headers for empty string', () => {
@@ -40,7 +40,7 @@ describe('parseRawHeaders', () => {
 
   it('handles headers with colons in values', () => {
     let headers = parseRawHeaders('Location: https://example.com:8080/path')
-    assert.equal(headers.get('location'), 'https://example.com:8080/path')
+    assert.equal(headers.get('Location'), 'https://example.com:8080/path')
   })
 })
 
@@ -72,9 +72,9 @@ describe('stringifyRawHeaders', () => {
 
   it('uses canonical header name casing', () => {
     let headers = new Headers()
-    headers.set('etag', '"abc"')
-    headers.set('www-authenticate', 'Basic')
-    headers.set('x-custom-header', 'value')
+    headers.set('ETag', '"abc"')
+    headers.set('WWW-Authenticate', 'Basic')
+    headers.set('X-Custom-Header', 'value')
     let result = stringifyRawHeaders(headers)
     assert.ok(result.includes('ETag: "abc"'))
     assert.ok(result.includes('WWW-Authenticate: Basic'))
@@ -89,7 +89,7 @@ describe('stringifyRawHeaders', () => {
     let stringified = stringifyRawHeaders(original)
     let parsed = parseRawHeaders(stringified)
 
-    assert.equal(parsed.get('content-type'), 'text/html')
-    assert.equal(parsed.get('cache-control'), 'no-cache')
+    assert.equal(parsed.get('Content-Type'), 'text/html')
+    assert.equal(parsed.get('Cache-Control'), 'no-cache')
   })
 })

--- a/packages/headers/src/lib/raw-headers.ts
+++ b/packages/headers/src/lib/raw-headers.ts
@@ -10,8 +10,8 @@ const CRLF = '\r\n'
  *
  * @example
  * let headers = parse('Content-Type: text/html\r\nCache-Control: no-cache')
- * headers.get('content-type') // 'text/html'
- * headers.get('cache-control') // 'no-cache'
+ * headers.get('Content-Type') // 'text/html'
+ * headers.get('Cache-Control') // 'no-cache'
  */
 export function parse(raw: string): Headers {
   let headers = new Headers()

--- a/packages/headers/src/lib/super-headers.test.ts
+++ b/packages/headers/src/lib/super-headers.test.ts
@@ -222,7 +222,7 @@ describe('SuperHeaders', () => {
     headers.accept.set('text/html')
     headers.accept.set('application/json', 0.8)
     headers.cookie.set('theme', 'dark')
-    headers.vary.add('accept-encoding')
+    headers.vary.add('Accept-Encoding')
 
     assert.equal(headers.get('Accept'), 'text/html,application/json;q=0.8')
     assert.equal(headers.get('Cookie'), 'theme=dark')
@@ -308,7 +308,7 @@ describe('SuperHeaders', () => {
     assert.equal(headers.get('Content-Type'), 'text/html; charset=utf-8')
     assert.equal(headers.contentType, contentType)
 
-    headers.set('content-type', 'application/json')
+    headers.set('Content-Type', 'application/json')
     let updatedContentType = headers.contentType
 
     assert.notEqual(updatedContentType, contentType)
@@ -485,11 +485,11 @@ describe('SuperHeaders', () => {
 
     assert.equal(typeof headers.append, 'function')
     assert.equal(typeof headers.get, 'function')
-    assert.equal(headers.get('append'), 'shadow append')
-    assert.equal(headers.get('get'), 'shadow get')
+    assert.equal(headers.get('Append'), 'shadow append')
+    assert.equal(headers.get('Get'), 'shadow get')
 
-    headers.append('append', 'again')
-    assert.equal(headers.get('append'), 'shadow append, again')
+    headers.append('Append', 'again')
+    assert.equal(headers.get('Append'), 'shadow append, again')
   })
 
   it('keeps Set-Cookie mutations visible to Response', () => {

--- a/packages/headers/src/lib/vary.test.ts
+++ b/packages/headers/src/lib/vary.test.ts
@@ -65,7 +65,7 @@ describe('Vary', () => {
   it('adds a header name', () => {
     let header = new Vary()
     header.add('Accept-Encoding')
-    assert.equal(header.has('accept-encoding'), true)
+    assert.equal(header.has('Accept-Encoding'), true)
     assert.equal(header.size, 1)
   })
 

--- a/packages/multipart-parser/CHANGELOG.md
+++ b/packages/multipart-parser/CHANGELOG.md
@@ -6,7 +6,7 @@ This is the changelog for [`multipart-parser`](https://github.com/remix-run/remi
 
 ### Minor Changes
 
-- BREAKING CHANGE: `MultipartPart.headers` is now a plain decoded object keyed by lower-case header name instead of a native `Headers` instance. Access part headers with bracket notation like `part.headers['content-type']` instead of `part.headers.get('content-type')`.
+- BREAKING CHANGE: `MultipartPart.headers` is now a plain decoded object keyed by lower-case header name instead of a native `Headers` instance. Access part headers with bracket notation like `part.headers['content-type']` instead of `part.headers.get('Content-Type')`.
 
   This lets multipart part headers preserve decoded UTF-8 field names and filenames that native `Headers` cannot store.
 

--- a/packages/node-fetch-server/src/lib/request-listener.test.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.test.ts
@@ -40,8 +40,8 @@ describe('createRequestListener', () => {
           status: 201,
           statusText: 'Created!',
           headers: {
-            'x-a': 'A',
-            'x-b': 'B',
+            'X-A': 'A',
+            'X-B': 'B',
           },
         })
 
@@ -76,8 +76,8 @@ describe('createRequestListener', () => {
           status: 201,
           statusText: 'Created!',
           headers: {
-            'x-a': 'A',
-            'x-b': 'B',
+            'X-A': 'A',
+            'X-B': 'B',
           },
         })
 
@@ -174,7 +174,7 @@ describe('createRequestListener', () => {
       let listener = createRequestListener(handler)
       assert.ok(listener)
 
-      let req = createMockRequest({ headers: { host: 'example.com' } })
+      let req = createMockRequest({ headers: { Host: 'example.com' } })
       let res = createMockResponse({ req })
 
       listener(req, res)
@@ -210,7 +210,7 @@ describe('createRequestListener', () => {
       let listener = createRequestListener(handler, { host: 'remix.run' })
       assert.ok(listener)
 
-      let req = createMockRequest({ headers: { host: 'example.com' } })
+      let req = createMockRequest({ headers: { Host: 'example.com' } })
       let res = createMockResponse({ req })
 
       listener(req, res)
@@ -228,7 +228,7 @@ describe('createRequestListener', () => {
       let listener = createRequestListener(handler, { protocol: 'https:' })
       assert.ok(listener)
 
-      let req = createMockRequest({ headers: { host: 'example.com' } })
+      let req = createMockRequest({ headers: { Host: 'example.com' } })
       let res = createMockResponse({ req })
 
       listener(req, res)
@@ -241,7 +241,7 @@ describe('createRequestListener', () => {
       let handler: FetchHandler = async (request) => {
         assert.ok(request instanceof Request)
         assert.equal(request.method, 'POST')
-        assert.equal(request.headers.get('x-test'), 'yes')
+        assert.equal(request.headers.get('X-Test'), 'yes')
         assert.equal(request.bodyUsed, false)
 
         assert.equal(await request.text(), 'Hello, world!')
@@ -260,7 +260,7 @@ describe('createRequestListener', () => {
 
       let req = createMockRequest({
         method: 'POST',
-        headers: { 'x-test': 'yes' },
+        headers: { 'X-Test': 'yes' },
         body: 'Hello, world!',
       })
       let res = createMockResponse({ req })

--- a/packages/node-serve/src/lib/server.test.ts
+++ b/packages/node-serve/src/lib/server.test.ts
@@ -53,7 +53,7 @@ describeUws('serve', () => {
     let server = serve(
       async (request) => {
         assert.equal(request.method, 'POST')
-        assert.equal(request.headers.get('content-type'), 'text/plain')
+        assert.equal(request.headers.get('Content-Type'), 'text/plain')
         assert.equal(await request.text(), 'hello')
 
         return new Response('ok', {
@@ -79,7 +79,7 @@ describeUws('serve', () => {
       })
 
       assert.equal(response.status, 201)
-      assert.equal(response.headers.get('x-test'), 'yes')
+      assert.equal(response.headers.get('X-Test'), 'yes')
       assert.equal(await response.text(), 'ok')
     } finally {
       server.close()

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -73,7 +73,7 @@ This is the changelog for [`remix`](https://github.com/remix-run/remix/tree/main
 
 ### Pre-release Changes
 
-- BREAKING CHANGE: `MultipartPart.headers` from `remix/multipart-parser` and `remix/multipart-parser/node` is now a plain decoded object keyed by lower-case header name instead of a native `Headers` instance. Access part headers with bracket notation like `part.headers['content-type']` instead of `part.headers.get('content-type')`.
+- BREAKING CHANGE: `MultipartPart.headers` from `remix/multipart-parser` and `remix/multipart-parser/node` is now a plain decoded object keyed by lower-case header name instead of a native `Headers` instance. Access part headers with bracket notation like `part.headers['content-type']` instead of `part.headers.get('Content-Type')`.
 
 - BREAKING CHANGE: Removed the deprecated `remix/component`, `remix/component/jsx-runtime`, `remix/component/jsx-dev-runtime`, and `remix/component/server` package exports. Import the consolidated UI runtime from `remix/ui`, `remix/ui/jsx-runtime`, `remix/ui/jsx-dev-runtime`, and `remix/ui/server` instead.
 

--- a/packages/response/src/lib/compress.test.ts
+++ b/packages/response/src/lib/compress.test.ts
@@ -50,7 +50,7 @@ describe('compressResponse()', () => {
 
     assert.equal(compressed.headers.get('Content-Encoding'), 'gzip')
     assert.equal(compressed.headers.get('Accept-Ranges'), 'none')
-    let vary = Vary.from(compressed.headers.get('vary'))
+    let vary = Vary.from(compressed.headers.get('Vary'))
     assert.ok(vary.has('Accept-Encoding'))
 
     let buffer = Buffer.from(await compressed.arrayBuffer())
@@ -85,7 +85,7 @@ describe('compressResponse()', () => {
 
     assert.equal(compressed.headers.get('Content-Encoding'), 'deflate')
     assert.equal(compressed.headers.get('Accept-Ranges'), 'none')
-    let vary = Vary.from(compressed.headers.get('vary'))
+    let vary = Vary.from(compressed.headers.get('Vary'))
     assert.ok(vary.has('Accept-Encoding'))
 
     let buffer = Buffer.from(await compressed.arrayBuffer())
@@ -642,7 +642,7 @@ describe('compressResponse()', () => {
     assert.equal(compressed.headers.get('Content-Encoding'), 'gzip')
     assert.equal(compressed.headers.get('Accept-Ranges'), 'none')
     assert.equal(compressed.headers.get('Content-Length'), null)
-    let vary = Vary.from(compressed.headers.get('vary'))
+    let vary = Vary.from(compressed.headers.get('Vary'))
     assert.ok(vary.has('Accept-Encoding'))
     assert.equal(compressed.body, null)
   })
@@ -692,7 +692,7 @@ describe('compressResponse()', () => {
     assert.equal(compressed.headers.get('Content-Encoding'), 'gzip')
     assert.equal(compressed.headers.get('Accept-Ranges'), 'none')
     assert.equal(compressed.headers.get('Content-Length'), null)
-    let vary = Vary.from(compressed.headers.get('vary'))
+    let vary = Vary.from(compressed.headers.get('Vary'))
     assert.ok(vary.has('Accept-Encoding'))
     assert.equal(compressed.body, null)
   })

--- a/packages/response/src/lib/compress.ts
+++ b/packages/response/src/lib/compress.ts
@@ -92,11 +92,11 @@ export async function compressResponse(
   let acceptEncodingHeader = request.headers.get('Accept-Encoding')
   let responseHeaders = new Headers(response.headers)
 
-  let contentEncodingHeader = responseHeaders.get('content-encoding')
-  let contentLengthHeader = responseHeaders.get('content-length')
+  let contentEncodingHeader = responseHeaders.get('Content-Encoding')
+  let contentLengthHeader = responseHeaders.get('Content-Length')
   let contentLength = contentLengthHeader != null ? parseInt(contentLengthHeader, 10) : null
-  let acceptRangesHeader = responseHeaders.get('accept-ranges')
-  let cacheControl = CacheControl.from(responseHeaders.get('cache-control'))
+  let acceptRangesHeader = responseHeaders.get('Accept-Ranges')
+  let cacheControl = CacheControl.from(responseHeaders.get('Cache-Control'))
 
   if (
     !acceptEncodingHeader ||
@@ -168,19 +168,19 @@ function negotiateEncoding(
 }
 
 function setCompressionHeaders(headers: Headers, encoding: string): void {
-  headers.set('content-encoding', encoding)
-  headers.set('accept-ranges', 'none')
-  headers.delete('content-length')
+  headers.set('Content-Encoding', encoding)
+  headers.set('Accept-Ranges', 'none')
+  headers.delete('Content-Length')
 
   // Update Vary header to include Accept-Encoding
-  let vary = Vary.from(headers.get('vary'))
+  let vary = Vary.from(headers.get('Vary'))
   vary.add('Accept-Encoding')
-  headers.set('vary', vary.toString())
+  headers.set('Vary', vary.toString())
 
   // Convert strong ETags to weak since compressed representation is byte-different
-  let etagHeader = headers.get('etag')
+  let etagHeader = headers.get('ETag')
   if (etagHeader && !etagHeader.startsWith('W/')) {
-    headers.set('etag', `W/${etagHeader}`)
+    headers.set('ETag', `W/${etagHeader}`)
   }
 }
 

--- a/packages/response/src/lib/file.ts
+++ b/packages/response/src/lib/file.ts
@@ -171,7 +171,7 @@ export async function createFileResponse<file extends FileLike>(
 
   // If-Match support: https://httpwg.org/specs/rfc9110.html#field.if-match
   if (etag && hasIfMatch) {
-    let ifMatch = IfMatch.from(headers.get('if-match'))
+    let ifMatch = IfMatch.from(headers.get('If-Match'))
     if (!ifMatch.matches(etag)) {
       return new Response('Precondition Failed', {
         status: 412,
@@ -186,7 +186,7 @@ export async function createFileResponse<file extends FileLike>(
 
   // If-Unmodified-Since support: https://httpwg.org/specs/rfc9110.html#field.if-unmodified-since
   if (lastModified && !hasIfMatch) {
-    let ifUnmodifiedSinceHeader = headers.get('if-unmodified-since')
+    let ifUnmodifiedSinceHeader = headers.get('If-Unmodified-Since')
     if (ifUnmodifiedSinceHeader != null) {
       let ifUnmodifiedSince = new Date(ifUnmodifiedSinceHeader)
       if (removeMilliseconds(lastModified) > removeMilliseconds(ifUnmodifiedSince)) {
@@ -206,12 +206,12 @@ export async function createFileResponse<file extends FileLike>(
   // If-Modified-Since support: https://httpwg.org/specs/rfc9110.html#field.if-modified-since
   if (etag || lastModified) {
     let shouldReturnNotModified = false
-    let ifNoneMatch = IfNoneMatch.from(headers.get('if-none-match'))
+    let ifNoneMatch = IfNoneMatch.from(headers.get('If-None-Match'))
 
     if (etag && ifNoneMatch.matches(etag)) {
       shouldReturnNotModified = true
     } else if (lastModified && ifNoneMatch.tags.length === 0) {
-      let ifModifiedSinceHeader = headers.get('if-modified-since')
+      let ifModifiedSinceHeader = headers.get('If-Modified-Since')
       if (ifModifiedSinceHeader != null) {
         let ifModifiedSince = new Date(ifModifiedSinceHeader)
         if (removeMilliseconds(lastModified) <= removeMilliseconds(ifModifiedSince)) {
@@ -235,7 +235,7 @@ export async function createFileResponse<file extends FileLike>(
   // Range support: https://httpwg.org/specs/rfc9110.html#field.range
   // If-Range support: https://httpwg.org/specs/rfc9110.html#field.if-range
   if (acceptRanges && request.method === 'GET' && headers.has('Range')) {
-    let range = Range.from(headers.get('range'))
+    let range = Range.from(headers.get('Range'))
 
     // Check if the Range header was sent but parsing resulted in no valid ranges (malformed)
     if (range.ranges.length === 0) {
@@ -245,7 +245,7 @@ export async function createFileResponse<file extends FileLike>(
     }
 
     // If-Range support: https://httpwg.org/specs/rfc9110.html#field.if-range
-    let ifRange = IfRange.from(headers.get('if-range'))
+    let ifRange = IfRange.from(headers.get('If-Range'))
     if (
       ifRange.matches({
         etag,

--- a/packages/ui/demo/app/assets/entry.tsx
+++ b/packages/ui/demo/app/assets/entry.tsx
@@ -23,11 +23,11 @@ async function resolveFrameResponse(
   target?: string,
 ): Promise<FrameContent> {
   let headers = new Headers()
-  headers.set('accept', 'text/html')
-  headers.set('x-remix-frame', 'true')
+  headers.set('Accept', 'text/html')
+  headers.set('X-Remix-Frame', 'true')
 
   if (target) {
-    headers.set('x-remix-target', target)
+    headers.set('X-Remix-Target', target)
   }
 
   let response = await fetch(url, { headers, signal })

--- a/packages/ui/demo/config/render.tsx
+++ b/packages/ui/demo/config/render.tsx
@@ -23,17 +23,17 @@ async function resolveFrame(
 ) {
   let frameUrl = new URL(src, frameContext?.currentFrameSrc ?? context.request.url)
   let headers = new Headers()
-  headers.set('accept', 'text/html')
-  headers.set('accept-encoding', 'identity')
-  headers.set('x-remix-frame', 'true')
+  headers.set('Accept', 'text/html')
+  headers.set('Accept-Encoding', 'identity')
+  headers.set('X-Remix-Frame', 'true')
 
   if (target) {
-    headers.set('x-remix-target', target)
+    headers.set('X-Remix-Target', target)
   }
 
-  let cookie = context.request.headers.get('cookie')
+  let cookie = context.request.headers.get('Cookie')
   if (cookie) {
-    headers.set('cookie', cookie)
+    headers.set('Cookie', cookie)
   }
 
   let response = await followFrameRedirects(context.router, context.request, frameUrl, headers)
@@ -63,7 +63,7 @@ async function followFrameRedirects(
       }),
     )
 
-    let location = response.headers.get('location')
+    let location = response.headers.get('Location')
     if (!location || response.status < 300 || response.status >= 400) {
       return response
     }

--- a/packages/ui/docs/component.md
+++ b/packages/ui/docs/component.md
@@ -48,8 +48,8 @@ function App() {
 
 let stream = renderToStream(<App />, {
   resolveFrame(src, target, context) {
-    let headers = new Headers({ accept: 'text/html' })
-    if (target) headers.set('x-remix-target', target)
+    let headers = new Headers({ Accept: 'text/html' })
+    if (target) headers.set('X-Remix-Target', target)
     return fetch(new URL(src, context?.currentFrameSrc ?? request.url), { headers }).then((res) =>
       res.text(),
     )
@@ -109,8 +109,8 @@ let app = run({
     return mod[exportName]
   },
   async resolveFrame(src, signal, target) {
-    let headers = new Headers({ accept: 'text/html' })
-    if (target) headers.set('x-remix-target', target)
+    let headers = new Headers({ Accept: 'text/html' })
+    if (target) headers.set('X-Remix-Target', target)
     let res = await fetch(src, { headers, signal })
     return res.body ?? (await res.text())
   },

--- a/packages/ui/docs/frames.md
+++ b/packages/ui/docs/frames.md
@@ -164,8 +164,8 @@ On the client, `run` accepts an optional `resolveFrame` implementation:
 let app = run({
   loadModule: ...,
   async resolveFrame(src, signal, target) {
-    let headers = new Headers({ accept: 'text/html' })
-    if (target) headers.set('x-remix-target', target)
+    let headers = new Headers({ Accept: 'text/html' })
+    if (target) headers.set('X-Remix-Target', target)
     let response = await fetch(src, { headers, signal })
     return response.body ?? (await response.text())
   },

--- a/packages/ui/docs/getting-started.md
+++ b/packages/ui/docs/getting-started.md
@@ -122,7 +122,7 @@ let app = run({
     return mod[exportName]
   },
   async resolveFrame(src, signal) {
-    let res = await fetch(src, { headers: { accept: 'text/html' }, signal })
+    let res = await fetch(src, { headers: { Accept: 'text/html' }, signal })
     return res.body ?? (await res.text())
   },
 })

--- a/packages/ui/docs/hydration.md
+++ b/packages/ui/docs/hydration.md
@@ -54,7 +54,7 @@ let app = run({
     return mod[exportName]
   },
   async resolveFrame(src, signal) {
-    let res = await fetch(src, { headers: { accept: 'text/html' }, signal })
+    let res = await fetch(src, { headers: { Accept: 'text/html' }, signal })
     return res.body ?? (await res.text())
   },
 })

--- a/scripts/oxlint-plugins/canonical-header-names-plugin.ts
+++ b/scripts/oxlint-plugins/canonical-header-names-plugin.ts
@@ -1,0 +1,216 @@
+import { definePlugin, defineRule } from '@oxlint/plugins'
+import type { Context, ESTree, Fixer } from '@oxlint/plugins'
+
+const HeaderWordCasingExceptions: Record<string, string> = {
+  ct: 'CT',
+  dpop: 'DPoP',
+  etag: 'ETag',
+  te: 'TE',
+  www: 'WWW',
+  x: 'X',
+  xss: 'XSS',
+}
+
+const headerNamePattern = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/
+const headerMethods = new Set(['append', 'delete', 'get', 'has', 'set'])
+
+function canonicalHeaderName(name: string): string {
+  return name
+    .toLowerCase()
+    .split('-')
+    .map((word) => HeaderWordCasingExceptions[word] || word.charAt(0).toUpperCase() + word.slice(1))
+    .join('-')
+}
+
+function isStringLiteral(node: ESTree.Argument): node is ESTree.StringLiteral {
+  return node.type === 'Literal' && typeof node.value === 'string'
+}
+
+function isStaticMemberExpression(node: ESTree.Expression): node is ESTree.StaticMemberExpression {
+  return node.type === 'MemberExpression' && !node.computed && node.property.type === 'Identifier'
+}
+
+function isIdentifierReference(node: ESTree.Expression): node is ESTree.IdentifierReference {
+  return node.type === 'Identifier'
+}
+
+function isHeadersIdentifierName(name: string): boolean {
+  return name === 'headers' || name.endsWith('Headers')
+}
+
+function isNewHeadersExpression(node: ESTree.Expression): boolean {
+  return (
+    node.type === 'NewExpression' &&
+    isIdentifierReference(node.callee) &&
+    node.callee.name === 'Headers'
+  )
+}
+
+function isLikelyHeadersReceiver(node: ESTree.Expression): boolean {
+  if (isIdentifierReference(node)) {
+    return isHeadersIdentifierName(node.name)
+  }
+
+  if (isStaticMemberExpression(node)) {
+    return node.property.name === 'headers'
+  }
+
+  return isNewHeadersExpression(node)
+}
+
+function quoteLike(raw: string | null, value: string): string {
+  let quote = raw?.startsWith('"') ? '"' : "'"
+  let escaped = value.replace(/\\/g, '\\\\').replaceAll(quote, `\\${quote}`)
+
+  return `${quote}${escaped}${quote}`
+}
+
+function getStaticPropertyName(node: ESTree.ObjectProperty): string | null {
+  if (node.computed) {
+    return null
+  }
+
+  if (node.key.type === 'Identifier') {
+    return node.key.name
+  }
+
+  if (node.key.type === 'Literal' && typeof node.key.value === 'string') {
+    return node.key.value
+  }
+
+  return null
+}
+
+function getHeaderPropertyKeyFixText(
+  node: ESTree.IdentifierName | ESTree.StringLiteral,
+  canonicalName: string,
+): string {
+  if (node.type === 'Literal') {
+    return quoteLike(node.raw, canonicalName)
+  }
+
+  return canonicalName
+}
+
+function isHeaderPropertyKey(
+  node: ESTree.PropertyKey,
+): node is ESTree.IdentifierName | ESTree.StringLiteral {
+  return node.type === 'Identifier' || (node.type === 'Literal' && typeof node.value === 'string')
+}
+
+function reportHeaderName(
+  context: Context,
+  node: ESTree.IdentifierName | ESTree.StringLiteral,
+  name: string,
+): void {
+  if (!headerNamePattern.test(name)) {
+    return
+  }
+
+  let canonicalName = canonicalHeaderName(name)
+  if (name === canonicalName) {
+    return
+  }
+
+  context.report({
+    node,
+    message: `Use canonical HTTP header name '${canonicalName}'.`,
+    fix(fixer: Fixer) {
+      return fixer.replaceText(node, getHeaderPropertyKeyFixText(node, canonicalName))
+    },
+  })
+}
+
+function checkHeadersInitObject(context: Context, node: ESTree.ObjectExpression): void {
+  for (let property of node.properties) {
+    if (property.type !== 'Property') {
+      continue
+    }
+
+    let headerName = getStaticPropertyName(property)
+    if (headerName == null) {
+      continue
+    }
+
+    if (!isHeaderPropertyKey(property.key)) {
+      continue
+    }
+
+    reportHeaderName(context, property.key, headerName)
+  }
+}
+
+function isHeadersInitPropertyValue(node: ESTree.ObjectExpression): boolean {
+  let parent = node.parent
+
+  if (parent.type !== 'Property' || parent.value !== node) {
+    return false
+  }
+
+  return getStaticPropertyName(parent) === 'headers'
+}
+
+const canonicalHeaderNamesRule = defineRule({
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+  },
+  create(context: Context) {
+    return {
+      CallExpression(node: ESTree.CallExpression) {
+        if (!isStaticMemberExpression(node.callee)) {
+          return
+        }
+
+        let methodName = node.callee.property.name
+        if (!headerMethods.has(methodName)) {
+          return
+        }
+
+        if (!isLikelyHeadersReceiver(node.callee.object)) {
+          return
+        }
+
+        let headerName = node.arguments[0]
+        if (headerName == null || !isStringLiteral(headerName)) {
+          return
+        }
+
+        reportHeaderName(context, headerName, headerName.value)
+      },
+      NewExpression(node: ESTree.NewExpression) {
+        if (!isNewHeadersExpression(node)) {
+          return
+        }
+
+        let headersInit = node.arguments[0]
+        if (headersInit?.type !== 'ObjectExpression') {
+          return
+        }
+
+        checkHeadersInitObject(context, headersInit)
+      },
+      ObjectExpression(node: ESTree.ObjectExpression) {
+        if (!isHeadersInitPropertyValue(node)) {
+          return
+        }
+
+        checkHeadersInitObject(context, node)
+      },
+    }
+  },
+})
+
+/**
+ * Encourages canonical HTTP header names in direct `Headers` method calls and
+ * static `HeadersInit` objects, while staying conservative enough to avoid
+ * unrelated `Map`, session, and form data APIs.
+ */
+export default definePlugin({
+  meta: {
+    name: 'remix-headers',
+  },
+  rules: {
+    'canonical-header-name': canonicalHeaderNamesRule,
+  },
+})

--- a/scripts/utils/github.ts
+++ b/scripts/utils/github.ts
@@ -15,7 +15,7 @@ function getToken(): string {
 }
 
 function auth() {
-  return { headers: { authorization: `token ${getToken()}` } }
+  return { headers: { Authorization: `token ${getToken()}` } }
 }
 
 export type CreateReleaseResult =

--- a/template/app/actions/render.tsx
+++ b/template/app/actions/render.tsx
@@ -20,10 +20,10 @@ export function render(node: RemixNode, request: Request, init?: ResponseInit) {
       }
     },
     async resolveFrame(src, target) {
-      let headers = new Headers({ accept: 'text/html' })
-      let cookie = request.headers.get('cookie')
-      if (cookie) headers.set('cookie', cookie)
-      if (target) headers.set('x-remix-target', target)
+      let headers = new Headers({ Accept: 'text/html' })
+      let cookie = request.headers.get('Cookie')
+      if (cookie) headers.set('Cookie', cookie)
+      if (target) headers.set('X-Remix-Target', target)
 
       let response = await router.fetch(new Request(new URL(src, request.url), { headers }))
       return response.body ?? response.text()

--- a/template/app/assets/entry.ts
+++ b/template/app/assets/entry.ts
@@ -6,8 +6,8 @@ run({
     return mod[exportName]
   },
   async resolveFrame(src, signal, target) {
-    let headers = new Headers({ accept: 'text/html' })
-    if (target) headers.set('x-remix-target', target)
+    let headers = new Headers({ Accept: 'text/html' })
+    if (target) headers.set('X-Remix-Target', target)
 
     let response = await fetch(src, {
       credentials: 'same-origin',


### PR DESCRIPTION
This adds an oxlint rule that warns when code uses non-canonical HTTP header names in `Headers` method calls or static `HeadersInit` objects. The rule is autofixable for simple literals, so contributors can keep code examples and runtime code consistent without manual casing sweeps.

- Adds `remix-headers/canonical-header-name` as a warning for JS/TS code.
- Covers direct `Headers` methods like `headers.get(...)`, `response.headers.set(...)`, and static init objects like `new Headers({ ... })` or `{ headers: { ... } }`.
- Canonicalizes existing package, demo, template, and script call sites so the new warning starts clean.

```ts
// Before
headers.get('content-type')
new Headers({ accept: 'text/html' })

// After
headers.get('Content-Type')
new Headers({ Accept: 'text/html' })
```
