### PR TITLE
Make RequestContext.get reflect missing values

### DIFF
--- a/demos/bookstore/app/actions/account/controller.tsx
+++ b/demos/bookstore/app/actions/account/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../router.ts'
 
 import { requireAuth } from '../../middleware/auth.ts'
 import type { routes } from '../../routes.ts'
@@ -15,4 +15,4 @@ export default {
       return render(<AccountPage user={user} />)
     },
   },
-} satisfies Controller<typeof routes.account>
+} satisfies AppController<typeof routes.account>

--- a/demos/bookstore/app/actions/account/orders/controller.tsx
+++ b/demos/bookstore/app/actions/account/orders/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../../router.ts'
 import { Database } from 'remix/data-table'
 
 import { orders, orderItemsWithBook } from '../../../data/schema.ts'
@@ -50,4 +50,4 @@ export default {
       return render(<AccountOrderShowPage order={order} shippingAddress={shippingAddress} />)
     },
   },
-} satisfies Controller<typeof routes.account.orders>
+} satisfies AppController<typeof routes.account.orders>

--- a/demos/bookstore/app/actions/account/settings/controller.tsx
+++ b/demos/bookstore/app/actions/account/settings/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../../router.ts'
 import * as s from 'remix/data-schema'
 import * as f from 'remix/data-schema/form-data'
 import { minLength } from 'remix/data-schema/checks'
@@ -46,4 +46,4 @@ export default {
       return redirect(routes.account.index.href())
     },
   },
-} satisfies Controller<typeof routes.account.settings>
+} satisfies AppController<typeof routes.account.settings>

--- a/demos/bookstore/app/actions/admin/books/controller.tsx
+++ b/demos/bookstore/app/actions/admin/books/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../../router.ts'
 import * as s from 'remix/data-schema'
 import * as f from 'remix/data-schema/form-data'
 import * as coerce from 'remix/data-schema/coerce'
@@ -154,4 +154,4 @@ export default {
       return redirect(routes.admin.books.index.href())
     },
   },
-} satisfies Controller<typeof routes.admin.books>
+} satisfies AppController<typeof routes.admin.books>

--- a/demos/bookstore/app/actions/admin/controller.tsx
+++ b/demos/bookstore/app/actions/admin/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../router.ts'
 
 import { requireAdmin } from '../../middleware/admin.ts'
 import { requireAuth } from '../../middleware/auth.ts'
@@ -13,4 +13,4 @@ export default {
       return render(<AdminDashboardPage />)
     },
   },
-} satisfies Controller<typeof routes.admin>
+} satisfies AppController<typeof routes.admin>

--- a/demos/bookstore/app/actions/admin/orders/controller.tsx
+++ b/demos/bookstore/app/actions/admin/orders/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../../router.ts'
 import { Database } from 'remix/data-table'
 
 import { orders, orderItemsWithBook } from '../../../data/schema.ts'
@@ -47,4 +47,4 @@ export default {
       return render(<AdminOrderShowPage order={order} shippingAddress={shippingAddress} />)
     },
   },
-} satisfies Controller<typeof routes.admin.orders>
+} satisfies AppController<typeof routes.admin.orders>

--- a/demos/bookstore/app/actions/admin/users/controller.tsx
+++ b/demos/bookstore/app/actions/admin/users/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../../router.ts'
 import * as s from 'remix/data-schema'
 import * as f from 'remix/data-schema/form-data'
 import { Database } from 'remix/data-table'
@@ -97,4 +97,4 @@ export default {
       return redirect(routes.admin.users.index.href())
     },
   },
-} satisfies Controller<typeof routes.admin.users>
+} satisfies AppController<typeof routes.admin.users>

--- a/demos/bookstore/app/actions/api/controller.tsx
+++ b/demos/bookstore/app/actions/api/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../router.ts'
 import * as s from 'remix/data-schema'
 import * as f from 'remix/data-schema/form-data'
 import { Database } from 'remix/data-table'
@@ -40,4 +40,4 @@ export default {
       return new Response(null, { status: 204 })
     },
   },
-} satisfies Controller<typeof routes.api>
+} satisfies AppController<typeof routes.api>

--- a/demos/bookstore/app/actions/auth/controller.tsx
+++ b/demos/bookstore/app/actions/auth/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../router.ts'
 import { redirect } from 'remix/response/redirect'
 
 import { Session } from '../../middleware/session.ts'
@@ -13,4 +13,4 @@ export default {
       return redirect(routes.home.href())
     },
   },
-} satisfies Controller<typeof routes.auth>
+} satisfies AppController<typeof routes.auth>

--- a/demos/bookstore/app/actions/auth/forgot-password/controller.tsx
+++ b/demos/bookstore/app/actions/auth/forgot-password/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../../router.ts'
 import * as s from 'remix/data-schema'
 import { Database } from 'remix/data-table'
 
@@ -34,4 +34,4 @@ export default {
       return render(<ForgotPasswordSuccessPage token={token} />)
     },
   },
-} satisfies Controller<typeof routes.auth.forgotPassword>
+} satisfies AppController<typeof routes.auth.forgotPassword>

--- a/demos/bookstore/app/actions/auth/login/controller.tsx
+++ b/demos/bookstore/app/actions/auth/login/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../../router.ts'
 import { completeAuth, verifyCredentials } from 'remix/auth'
 import { redirect } from 'remix/response/redirect'
 
@@ -40,4 +40,4 @@ export default {
       return redirect(getPostAuthRedirect(url))
     },
   },
-} satisfies Controller<typeof routes.auth.login>
+} satisfies AppController<typeof routes.auth.login>

--- a/demos/bookstore/app/actions/auth/register/controller.tsx
+++ b/demos/bookstore/app/actions/auth/register/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../../router.ts'
 import * as s from 'remix/data-schema'
 import { Database } from 'remix/data-table'
 import { redirect } from 'remix/response/redirect'
@@ -44,4 +44,4 @@ export default {
       return redirect(routes.account.index.href())
     },
   },
-} satisfies Controller<typeof routes.auth.register>
+} satisfies AppController<typeof routes.auth.register>

--- a/demos/bookstore/app/actions/auth/reset-password/controller.tsx
+++ b/demos/bookstore/app/actions/auth/reset-password/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../../router.ts'
 import * as s from 'remix/data-schema'
 import { Database } from 'remix/data-table'
 import { redirect } from 'remix/response/redirect'
@@ -59,4 +59,4 @@ export default {
       return render(<ResetPasswordSuccessPage />)
     },
   },
-} satisfies Controller<typeof routes.auth.resetPassword>
+} satisfies AppController<typeof routes.auth.resetPassword>

--- a/demos/bookstore/app/actions/books/controller.tsx
+++ b/demos/bookstore/app/actions/books/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../router.ts'
 import { Database, ilike } from 'remix/data-table'
 
 import { books } from '../../data/schema.ts'
@@ -54,4 +54,4 @@ export default {
       })
     },
   },
-} satisfies Controller<typeof routes.books>
+} satisfies AppController<typeof routes.books>

--- a/demos/bookstore/app/actions/cart/api/controller.tsx
+++ b/demos/bookstore/app/actions/cart/api/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../../router.ts'
 import * as s from 'remix/data-schema'
 import * as f from 'remix/data-schema/form-data'
 import { Database } from 'remix/data-table'
@@ -100,4 +100,4 @@ export default {
       return redirect(routes.cart.index.href())
     },
   },
-} satisfies Controller<typeof routes.cart.api>
+} satisfies AppController<typeof routes.cart.api>

--- a/demos/bookstore/app/actions/cart/controller.tsx
+++ b/demos/bookstore/app/actions/cart/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../router.ts'
 
 import type { routes } from '../../routes.ts'
 import { render } from '../render.tsx'
@@ -10,4 +10,4 @@ export default {
       return render(<CartPage />)
     },
   },
-} satisfies Controller<typeof routes.cart>
+} satisfies AppController<typeof routes.cart>

--- a/demos/bookstore/app/actions/checkout/controller.tsx
+++ b/demos/bookstore/app/actions/checkout/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../router.ts'
 import * as s from 'remix/data-schema'
 import * as f from 'remix/data-schema/form-data'
 import { Database } from 'remix/data-table'
@@ -107,4 +107,4 @@ export default {
       return render(<CheckoutConfirmationPage order={order} />)
     },
   },
-} satisfies Controller<typeof routes.checkout>
+} satisfies AppController<typeof routes.checkout>

--- a/demos/bookstore/app/actions/contact/controller.tsx
+++ b/demos/bookstore/app/actions/contact/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../router.ts'
 
 import type { routes } from '../../routes.ts'
 import { render } from '../render.tsx'
@@ -14,4 +14,4 @@ export default {
       return render(<ContactSuccessPage />)
     },
   },
-} satisfies Controller<typeof routes.contact>
+} satisfies AppController<typeof routes.contact>

--- a/demos/bookstore/app/actions/controller.tsx
+++ b/demos/bookstore/app/actions/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../router.ts'
 import { Database, ilike, inList, or } from 'remix/data-table'
 import { createFileResponse as sendFile } from 'remix/response/file'
 
@@ -67,4 +67,4 @@ export default {
       return render(<SearchPage query={query} matchingBooks={matchingBooks} cart={cart} />)
     },
   },
-} satisfies Controller<typeof routes>
+} satisfies AppController<typeof routes>

--- a/demos/bookstore/app/actions/fragments/controller.tsx
+++ b/demos/bookstore/app/actions/fragments/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import type { AppController } from '../../router.ts'
 import { css } from 'remix/ui'
 import { Database } from 'remix/data-table'
 
@@ -49,4 +49,4 @@ export default {
       return renderFragment(<CartItems items={cart.items} total={total} canCheckout={!!user} />)
     },
   },
-} satisfies Controller<typeof routes.fragments>
+} satisfies AppController<typeof routes.fragments>

--- a/demos/bookstore/app/middleware/asset-entry.ts
+++ b/demos/bookstore/app/middleware/asset-entry.ts
@@ -15,10 +15,12 @@ const assetsEntryKey = createContextKey<AssetEntry>()
 const defaultScriptEntry = path.resolve(import.meta.dirname, '../assets/entry.tsx')
 const defaultStylesheetEntry = path.resolve(import.meta.dirname, '../assets/app.css')
 
+type SetAssetEntryContextTransform = readonly [readonly [typeof assetsEntryKey, AssetEntry]]
+
 export function loadAssetEntry(
   scriptEntry = defaultScriptEntry,
   stylesheetEntry = defaultStylesheetEntry,
-): Middleware {
+): Middleware<any, any, SetAssetEntryContextTransform> {
   return async (context, next) => {
     let [scriptSrc, scriptPreloads, stylesheetHref] = await Promise.all([
       assetServer.getHref(scriptEntry),

--- a/demos/bookstore/app/middleware/auth.ts
+++ b/demos/bookstore/app/middleware/auth.ts
@@ -27,6 +27,10 @@ export function loadAuth() {
         },
         async verify(value, context) {
           let db = context.get(Database)
+          if (db == null) {
+            throw new Error('Expected database middleware before auth middleware')
+          }
+
           return (await db.find(users, value.userId)) ?? null
         },
         invalidate(session) {
@@ -40,6 +44,9 @@ export function loadAuth() {
 export const passwordProvider = createCredentialsAuthProvider({
   parse(context) {
     let formData = context.get(FormData)
+    if (formData == null) {
+      throw new Error('Expected formData() middleware before password auth provider')
+    }
 
     return {
       email: normalizeEmail(formData.get('email')?.toString() ?? ''),
@@ -48,6 +55,10 @@ export const passwordProvider = createCredentialsAuthProvider({
   },
   async verify({ email, password }, context) {
     let db = context.get(Database)
+    if (db == null) {
+      throw new Error('Expected database middleware before password auth provider')
+    }
+
     let user = await db.findOne(users, { where: { email } })
 
     if (!user || !(await verifyPassword(password, user.password_hash))) {

--- a/demos/bookstore/app/router.ts
+++ b/demos/bookstore/app/router.ts
@@ -1,6 +1,7 @@
 import {
   createRouter,
   type AnyParams,
+  type Controller,
   type MiddlewareContext,
   type WithParams,
 } from 'remix/fetch-router'
@@ -10,6 +11,7 @@ import { formData } from 'remix/form-data-middleware'
 import type { Cookie } from 'remix/cookie'
 import { logger } from 'remix/logger-middleware'
 import { methodOverride } from 'remix/method-override-middleware'
+import type { RouteMap } from 'remix/routes'
 import type { SessionStorage } from 'remix/session'
 import { session } from 'remix/session-middleware'
 import { staticFiles } from 'remix/static-middleware'
@@ -45,13 +47,16 @@ export type RootMiddleware = [
   ReturnType<typeof formData>,
   ReturnType<typeof session>,
   ReturnType<typeof loadDatabase>,
+  ReturnType<typeof loadAssetEntry>,
   ReturnType<typeof loadAuth>,
 ]
 
-export type AppContext<params extends AnyParams = AnyParams> = WithParams<
+export type AppContext<params extends AnyParams = {}> = WithParams<
   MiddlewareContext<RootMiddleware>,
   params
 >
+
+export type AppController<routes extends RouteMap> = Controller<routes, AppContext>
 
 export interface BookstoreRouterOptions {
   sessionCookie?: Cookie
@@ -83,7 +88,7 @@ export function createBookstoreRouter(options?: BookstoreRouterOptions) {
   middleware.push(loadAssetEntry())
   middleware.push(loadAuth())
 
-  let router = createRouter({ middleware })
+  let router = createRouter<AppContext>({ middleware })
 
   router.map(routes, rootController)
   router.map(routes.fragments, fragmentsController)

--- a/demos/social-auth/app/middleware/auth.ts
+++ b/demos/social-auth/app/middleware/auth.ts
@@ -29,6 +29,10 @@ export function loadAuth() {
         },
         async verify(value, context) {
           let db = context.get(Database)
+          if (db == null) {
+            throw new Error('Expected database middleware before auth middleware')
+          }
+
           let user = await db.find(users, value.userId)
           if (user == null) {
             return null
@@ -54,7 +58,12 @@ export function loadAuth() {
 
 export const passwordProvider = createCredentialsAuthProvider({
   parse(context) {
-    let { email, password } = s.parse(loginSchema, context.get(FormData))
+    let formData = context.get(FormData)
+    if (formData == null) {
+      throw new Error('Expected formData() middleware before password auth provider')
+    }
+
+    let { email, password } = s.parse(loginSchema, formData)
 
     return {
       email: normalizeEmail(email),
@@ -63,6 +72,10 @@ export const passwordProvider = createCredentialsAuthProvider({
   },
   async verify({ email, password }, context) {
     let db = context.get(Database)
+    if (db == null) {
+      throw new Error('Expected database middleware before password auth provider')
+    }
+
     let user = await db.findOne(users, { where: { email } })
 
     if (user == null) {

--- a/packages/auth-middleware/src/lib/require-auth.ts
+++ b/packages/auth-middleware/src/lib/require-auth.ts
@@ -48,13 +48,12 @@ export function requireAuth<identity = unknown>(
   options: RequireAuthOptions = {},
 ): Middleware<any, any, RequireAuthContextTransform<identity>> {
   return async (context, next) => {
-    if (!context.has(Auth)) {
+    let auth = context.get(Auth)
+    if (auth == null) {
       throw new Error(
         'Auth state not found. Make sure auth() middleware runs before requireAuth().',
       )
     }
-
-    let auth = context.get(Auth)
 
     if (auth.ok) {
       return next()

--- a/packages/auth-middleware/src/lib/schemes/session.test.ts
+++ b/packages/auth-middleware/src/lib/schemes/session.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from '@remix-run/test'
 
 import { createCookie } from '@remix-run/cookie'
 import { createRouter } from '@remix-run/fetch-router'
+import type { Middleware } from '@remix-run/fetch-router'
 import { createSession, Session } from '@remix-run/session'
 import { createMemorySessionStorage } from '@remix-run/session/memory-storage'
 import { session as sessionMiddleware } from '@remix-run/session-middleware'
@@ -11,6 +12,8 @@ import { auth } from '../auth.ts'
 import { requireAuth } from '../require-auth.ts'
 import { Auth } from '../auth.ts'
 import { createSessionAuthScheme } from './session.ts'
+
+type SetSessionContextTransform = readonly [readonly [typeof Session, Session]]
 
 describe('createSessionAuthScheme scheme', () => {
   it('throws when Session is not available in request context', async () => {
@@ -106,15 +109,16 @@ describe('createSessionAuthScheme scheme', () => {
 
   it('fails and invalidates when verify() returns null', async () => {
     let invalidated = false
+    let setSession: Middleware<any, any, SetSessionContextTransform> = (context, next) => {
+      let session = createSession()
+      session.set('auth', { userId: 'u1' })
+      context.set(Session, session)
+      return next()
+    }
 
     let router = createRouter({
       middleware: [
-        (context, next) => {
-          let session = createSession()
-          session.set('auth', { userId: 'u1' })
-          context.set(Session, session)
-          return next()
-        },
+        setSession,
         auth({
           schemes: [
             createSessionAuthScheme({

--- a/packages/auth-middleware/src/lib/schemes/session.ts
+++ b/packages/auth-middleware/src/lib/schemes/session.ts
@@ -35,13 +35,13 @@ export function createSessionAuthScheme<identity, session_value = unknown>(
   return {
     name,
     async authenticate(context) {
-      if (!context.has(Session)) {
+      let session = context.get(Session)
+      if (session == null) {
         throw new Error(
           'Session not found. Make sure session() middleware runs before createSessionAuthScheme().',
         )
       }
 
-      let session = context.get(Session)
       let value = options.read(session, context)
 
       if (value == null) {

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -38,8 +38,8 @@ import { auth, Auth, createSessionAuthScheme, requireAuth } from 'remix/auth-mid
 import { completeAuth, createCredentialsAuthProvider, verifyCredentials } from 'remix/auth'
 import { createCookie } from 'remix/cookie'
 import { createRouter } from 'remix/fetch-router'
+import { formData } from 'remix/form-data-middleware'
 import { form, route } from 'remix/routes'
-import { FormData, formData } from 'remix/form-data-middleware'
 import type { GoodAuth } from 'remix/auth-middleware'
 import { redirect } from 'remix/response/redirect'
 import { Session } from 'remix/session'
@@ -71,6 +71,9 @@ let routes = route({
 let passwordProvider = createCredentialsAuthProvider({
   parse(context) {
     let formData = context.get(FormData)
+    if (formData == null) {
+      throw new Error('Expected formData() middleware before verifyCredentials()')
+    }
 
     return {
       email: String(formData.get('email') ?? ''),

--- a/packages/auth/src/lib/utils.ts
+++ b/packages/auth/src/lib/utils.ts
@@ -47,11 +47,12 @@ export function getSession(
   context: RequestContext,
   source: 'completeAuth()' | 'finishExternalAuth()' | 'startExternalAuth()',
 ): Session {
-  if (!context.has(Session)) {
+  let session = context.get(Session)
+  if (session == null) {
     throw new Error(`Session not found. Make sure session() middleware runs before ${source}.`)
   }
 
-  return context.get(Session)
+  return session
 }
 
 export function resolveRedirectTarget(

--- a/packages/auth/src/lib/verify-credentials.test.ts
+++ b/packages/auth/src/lib/verify-credentials.test.ts
@@ -2,16 +2,26 @@ import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
 import { createRouter } from '@remix-run/fetch-router'
+import type { RequestContext } from '@remix-run/fetch-router'
 import { formData } from '@remix-run/form-data-middleware'
 
 import { createCredentialsAuthProvider } from './providers/credentials.ts'
 import { verifyCredentials } from './verify-credentials.ts'
 
+function getFormData(context: RequestContext): FormData {
+  let formData = context.get(FormData)
+  if (formData == null) {
+    throw new Error('FormData not found in request context')
+  }
+
+  return formData
+}
+
 describe('verifyCredentials()', () => {
   it('returns the authenticated result when credentials are valid', async () => {
     let provider = createCredentialsAuthProvider({
       parse(context) {
-        let formData = context.get(FormData)
+        let formData = getFormData(context)
         return {
           email: String(formData.get('email') ?? ''),
           password: String(formData.get('password') ?? ''),
@@ -56,7 +66,7 @@ describe('verifyCredentials()', () => {
   it('returns null when credentials are rejected', async () => {
     let provider = createCredentialsAuthProvider({
       parse(context) {
-        let formData = context.get(FormData)
+        let formData = getFormData(context)
         return {
           email: String(formData.get('email') ?? ''),
           password: String(formData.get('password') ?? ''),

--- a/packages/csrf-middleware/src/lib/csrf.ts
+++ b/packages/csrf-middleware/src/lib/csrf.ts
@@ -123,7 +123,7 @@ export function csrf(options: CsrfOptions = {}): Middleware {
   let allowMissingOrigin = options.allowMissingOrigin ?? true
 
   return async (context, next) => {
-    if (!context.has(Session)) {
+    if (context.get(Session) == null) {
       throw new Error('csrf middleware requires session() middleware to run before it')
     }
 
@@ -169,11 +169,11 @@ function isSafeMethod(method: string, safeMethods: readonly RequestMethod[]): bo
  * @returns The active CSRF token
  */
 export function getCsrfToken(context: RequestContext, tokenKey = '_csrf'): string {
-  if (!context.has(Session)) {
+  let session = context.get(Session)
+  if (session == null) {
     throw new Error('Session is not started. Use session() middleware before csrf().')
   }
 
-  let session = context.get(Session)
   let token = session.get(tokenKey)
   if (typeof token === 'string' && token !== '') {
     return token
@@ -245,7 +245,7 @@ async function resolveSubmittedToken(
     }
   }
 
-  let formValue = context.has(FormData) ? context.get(FormData).get(fieldName) : undefined
+  let formValue = context.get(FormData)?.get(fieldName)
   if (typeof formValue === 'string') {
     let trimmedFormValue = formValue.trim()
     if (trimmedFormValue !== '') {

--- a/packages/fetch-router/.changes/minor.context-key-availability.md
+++ b/packages/fetch-router/.changes/minor.context-key-availability.md
@@ -1,0 +1,33 @@
+BREAKING CHANGE: `context.get(key)` now returns `undefined` when the requested value is not available in request context and the key does not provide a default value. Constructor keys such as `FormData` and `Session` still infer their instance value type when they are set, but an empty `RequestContext` no longer types `context.get(FormData)` as available by default.
+
+If your code reads a constructor key from a broad `RequestContext`, handle the missing case before using the value:
+
+```ts
+// before
+function readName(context: RequestContext): string {
+  return String(context.get(FormData).get('name') ?? '')
+}
+
+// after
+function readName(context: RequestContext): string {
+  let formData = context.get(FormData)
+  if (formData == null) {
+    return ''
+  }
+
+  return String(formData.get('name') ?? '')
+}
+```
+
+Handlers whose context contract proves that middleware provides the key can keep reading a defined value. Keep middleware arrays tuple-typed when you want that context contribution to flow into handlers:
+
+```ts
+let router = createRouter({
+  middleware: [formData()] as const,
+})
+
+router.post('/profile', (context) => {
+  let formData = context.get(FormData)
+  return Response.json({ name: formData.get('name') })
+})
+```

--- a/packages/fetch-router/.changes/minor.context-key-availability.md
+++ b/packages/fetch-router/.changes/minor.context-key-availability.md
@@ -10,12 +10,7 @@ function readName(context: RequestContext): string {
 
 // after
 function readName(context: RequestContext): string {
-  let formData = context.get(FormData)
-  if (formData == null) {
-    return ''
-  }
-
-  return String(formData.get('name') ?? '')
+  return String(context.get(FormData)?.get('name') ?? '')
 }
 ```
 

--- a/packages/fetch-router/README.md
+++ b/packages/fetch-router/README.md
@@ -615,6 +615,7 @@ router.get('/posts/:id', (context) => {
   // set/get: type-safe request-scoped context data on the context object
   context.set(UserKey, currentUser)
   let user = context.get(UserKey)
+  if (user == null) throw new Error('Expected current user')
   console.log(user.id)
 
   return new Response(`Post ${context.params.id}`)
@@ -657,6 +658,8 @@ let accountAction = {
 In this example, the action declares the stronger context it requires, and the action-local middleware makes that contract true at runtime. In a larger app, you can still derive a shared base context from router middleware with `MiddlewareContext<typeof middleware>` and build on top of it the same way.
 
 #### Middleware Provider Guidance
+
+`context.get(key)` returns a defined value when the context type includes that key or the key was created with a default value. Constructor keys like `FormData` are useful context keys, but the constructor itself is not a guarantee that a value exists. Use middleware context transforms for required values, and handle `undefined` when reading values that may not be present.
 
 If you're authoring a middleware package that stores values in request context, treat that context contract as part of the package API. A good provider should usually export:
 

--- a/packages/fetch-router/demos/bun/app/router.ts
+++ b/packages/fetch-router/demos/bun/app/router.ts
@@ -31,8 +31,12 @@ const sessionCookie = createCookie('__sess', {
 const sessionStorage = createCookieSessionStorage()
 
 function requireAuth(): Middleware {
-  return ({ get }, next) => {
-    let session = get(Session)
+  return (context, next) => {
+    let session = context.get(Session)
+    if (session == null) {
+      throw new Error('Expected session() middleware before requireAuth()')
+    }
+
     let username = session.get('username')
 
     if (!username) {

--- a/packages/fetch-router/demos/cf-workers/app/router.ts
+++ b/packages/fetch-router/demos/cf-workers/app/router.ts
@@ -31,8 +31,12 @@ const sessionCookie = createCookie('__sess', {
 const sessionStorage = createCookieSessionStorage()
 
 function requireAuth(): Middleware {
-  return ({ get }, next) => {
-    let session = get(Session)
+  return (context, next) => {
+    let session = context.get(Session)
+    if (session == null) {
+      throw new Error('Expected session() middleware before requireAuth()')
+    }
+
     let username = session.get('username')
 
     if (!username) {

--- a/packages/fetch-router/demos/node/app/router.ts
+++ b/packages/fetch-router/demos/node/app/router.ts
@@ -31,8 +31,12 @@ const sessionCookie = createCookie('__sess', {
 const sessionStorage = createCookieSessionStorage()
 
 function requireAuth(): Middleware {
-  return ({ get }, next) => {
-    let session = get(Session)
+  return (context, next) => {
+    let session = context.get(Session)
+    if (session == null) {
+      throw new Error('Expected session() middleware before requireAuth()')
+    }
+
     let username = session.get('username')
     if (!username) {
       return redirect(routes.login.index.href())

--- a/packages/fetch-router/src/lib/request-context.test.ts
+++ b/packages/fetch-router/src/lib/request-context.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from '@remix-run/test'
 import assert from '@remix-run/assert'
 import { createContextKey, RequestContext } from './request-context.ts'
+import type { IsEqual } from './type-utils.ts'
+
+function expectTypeEquality<_check extends true>() {}
 
 describe('new RequestContext()', () => {
   it('provides access to request headers', () => {
@@ -73,12 +76,31 @@ describe('new RequestContext()', () => {
     context.set(FormData, formData)
 
     assert.equal(context.has(FormData), true)
-    assert.equal(context.get(FormData).get('name'), 'Jane')
-    let avatar = context.get(FormData).get('avatar')
+    let storedFormData = context.get(FormData)
+    if (storedFormData == null) {
+      throw new Error('Expected FormData in request context')
+    }
+
+    expectTypeEquality<IsEqual<typeof storedFormData, FormData>>()
+
+    assert.equal(storedFormData.get('name'), 'Jane')
+    let avatar = storedFormData.get('avatar')
     assert.ok(avatar instanceof File)
     assert.equal(avatar.name, file.name)
     assert.equal(avatar.type, file.type)
     assert.equal(await avatar.text(), await file.text())
+  })
+
+  it('does not type constructor keys as available unless they are in context', () => {
+    let context = new RequestContext(new Request('https://remix.run/test'))
+    let formData = context.get(FormData)
+
+    expectTypeEquality<IsEqual<typeof formData, FormData | undefined>>()
+
+    if (false as boolean) {
+      // @ts-expect-error - FormData is not available until it is set or provided by middleware
+      context.get(FormData).get('name')
+    }
   })
 
   it('stores arbitrary request methods as strings', () => {
@@ -110,11 +132,20 @@ describe('new RequestContext()', () => {
     assert.equal(context.get(key), null)
   })
 
-  it('throws if a context value is not set and no default value exists', () => {
-    let key = createContextKey()
+  it('allows `undefined` as a valid default value in request context', () => {
+    let key = createContextKey(undefined)
     let context = new RequestContext(new Request('https://remix.run/test'))
 
-    assert.throws(() => context.get(key), Error)
+    assert.equal(context.get(key), undefined)
+  })
+
+  it('returns undefined if a context value is not set and no default value exists', () => {
+    let key = createContextKey<string>()
+    let context = new RequestContext(new Request('https://remix.run/test'))
+    let value = context.get(key)
+
+    expectTypeEquality<IsEqual<typeof value, string | undefined>>()
+    assert.equal(value, undefined)
   })
 
   it('checks if a key has a context value', () => {
@@ -126,17 +157,29 @@ describe('new RequestContext()', () => {
     assert.equal(context.has(key), true)
   })
 
+  it('gets values without a default only when they have been set', () => {
+    let key = createContextKey<string>()
+    let context = new RequestContext(new Request('https://remix.run/test'))
+
+    assert.equal(context.get(key), undefined)
+    context.set(key, 'value')
+    assert.equal(context.get(key), 'value')
+  })
+
   it('supports destructuring get/set/has from request context', () => {
-    let key = createContextKey('default')
+    let defaultKey = createContextKey('default')
+    let key = createContextKey<string>()
     let context = new RequestContext(new Request('https://remix.run/test'))
     let { get, has, set } = context
 
     assert.equal(has(key), false)
-    assert.equal(get(key), 'default')
+    assert.equal(get(defaultKey), 'default')
+    assert.equal(get(key), undefined)
 
     set(key, 'value')
 
     assert.equal(has(key), true)
+    assert.equal(get(defaultKey), 'default')
     assert.equal(get(key), 'value')
   })
 
@@ -155,6 +198,11 @@ describe('new RequestContext()', () => {
     context.set(Value, value)
 
     assert.equal(context.has(Value), true)
-    assert.equal(context.get(Value), value)
+    let storedValue = context.get(Value)
+    if (storedValue == null) {
+      throw new Error('Expected Value in request context')
+    }
+
+    assert.equal(storedValue, value)
   })
 })

--- a/packages/fetch-router/src/lib/request-context.ts
+++ b/packages/fetch-router/src/lib/request-context.ts
@@ -8,8 +8,12 @@ import type { Simplify } from './type-utils.ts'
  * @param defaultValue The default value for the context key
  * @returns The new context key
  */
+export function createContextKey<value>(): ContextKey<value>
+export function createContextKey<value>(
+  defaultValue: value,
+): ContextKey<value> & { defaultValue: value }
 export function createContextKey<value>(defaultValue?: value): ContextKey<value> {
-  return { defaultValue }
+  return arguments.length === 0 ? {} : { defaultValue }
 }
 
 /**
@@ -43,9 +47,15 @@ export type ContextEntries = readonly ContextEntry[]
 export type ContextValue<key> =
   key extends ContextKey<infer value>
     ? value
-    : key extends abstract new (...args: any[]) => infer instance
+    : key extends { prototype: infer instance }
       ? instance
       : never
+
+type ContextDefaultValue<key> = key extends { defaultValue: infer value } ? value : never
+
+type ContextFallbackValue<key> = [ContextDefaultValue<key>] extends [never]
+  ? ContextValue<key> | undefined
+  : ContextDefaultValue<key>
 
 /**
  * Extracts the route params type from a {@link RequestContext}.
@@ -95,8 +105,8 @@ type ResolveContextEntryValue<
  */
 export type GetContextValue<context, key extends object> =
   context extends RequestContext<any, infer entries extends ContextEntries>
-    ? ResolveContextEntryValue<entries, key, ContextValue<key>>
-    : ContextValue<key>
+    ? ResolveContextEntryValue<entries, key, ContextFallbackValue<key>>
+    : ContextFallbackValue<key>
 
 /**
  * Appends context entries to an existing {@link RequestContext}.
@@ -178,13 +188,13 @@ export class RequestContext<
    * Get a value from request context.
    *
    * @param key The key to read
-   * @returns The value for the given key
+   * @returns The value for the given key, or `undefined` if the value is not available
    */
   get = <key extends object>(key: key): GetContextValue<RequestContext<params, entries>, key> => {
     if (!this.#contextMap.has(key)) {
       let contextKey = key as ContextKey<GetContextValue<RequestContext<params, entries>, key>>
-      if (contextKey.defaultValue === undefined) {
-        throw new Error(`Missing default value in context for key ${key}`)
+      if (!Object.hasOwn(contextKey, 'defaultValue')) {
+        return undefined as GetContextValue<RequestContext<params, entries>, key>
       }
 
       return contextKey.defaultValue as GetContextValue<RequestContext<params, entries>, key>

--- a/packages/fetch-router/src/lib/router-types.test.ts
+++ b/packages/fetch-router/src/lib/router-types.test.ts
@@ -19,6 +19,8 @@ type SetRoleTransform<role extends 'viewer' | 'admin'> = readonly [
   readonly [typeof CurrentRole, role],
 ]
 
+type SetFormDataTransform = readonly [readonly [typeof FormData, FormData]]
+
 function requireUser(): Middleware<any, any, RequireUserTransform> {
   return async (context, next) => {
     context.set(CurrentUser, { id: 'user-1' })
@@ -31,6 +33,13 @@ function setRole<role extends 'viewer' | 'admin'>(
 ): Middleware<any, any, SetRoleTransform<role>> {
   return async (context, next) => {
     context.set(CurrentRole, role)
+    return next()
+  }
+}
+
+function setFormData(): Middleware<any, any, SetFormDataTransform> {
+  return async (context, next) => {
+    context.set(FormData, new FormData())
     return next()
   }
 }
@@ -49,6 +58,16 @@ plainRouter.get('/public', (context) => {
   // @ts-expect-error - CurrentUser is nullable without middleware refinement
   void context.get(CurrentUser).id
 
+  // @ts-expect-error - FormData is not available unless context has it
+  context.get(FormData).get('name')
+
+  let optionalFormData = context.get(FormData)
+  expectTypeEquality<IsEqual<typeof optionalFormData, FormData | undefined>>()
+
+  if (optionalFormData != null) {
+    expectTypeEquality<IsEqual<typeof optionalFormData, FormData>>()
+  }
+
   return new Response('Public')
 })
 
@@ -64,6 +83,16 @@ router.get(routes.account, (context) => {
   expectTypeEquality<IsEqual<typeof role, 'viewer'>>()
 
   return new Response(accountId + ':' + user.id + ':' + role)
+})
+
+const formRouter = createRouter({ middleware: [setFormData()] as const })
+
+formRouter.post('/form', (context) => {
+  let formData = context.get(FormData)
+
+  expectTypeEquality<IsEqual<typeof formData, FormData>>()
+
+  return new Response(String(formData.get('name') ?? ''))
 })
 
 type AppContext =
@@ -180,6 +209,7 @@ if (false as boolean) {
 
 void plainRouter
 void router
+void formRouter
 void accountAction
 void adminController
 void elevatedReportsController

--- a/packages/form-data-middleware/.changes/minor.always-provide-form-data.md
+++ b/packages/form-data-middleware/.changes/minor.always-provide-form-data.md
@@ -1,0 +1,1 @@
+BREAKING CHANGE: `formData()` now always stores a `FormData` value when the middleware runs successfully. Requests without a form body, including `GET` and `HEAD` requests, receive an empty `FormData` so downstream handlers can rely on `context.get(FormData)` after the middleware has run.

--- a/packages/form-data-middleware/README.md
+++ b/packages/form-data-middleware/README.md
@@ -19,6 +19,8 @@ npm i remix
 
 Use the `formData()` middleware at the router level to parse `FormData` from the request body and make it available on request context via `context.get(FormData)`.
 
+When `formData()` runs successfully it always provides a `FormData` value. Requests that do not contain a form body, including `GET` and `HEAD` requests, receive an empty `FormData`.
+
 Uploaded files are available in the parsed `FormData` object. For a single file field, use `formData.get(name)`. For repeated file fields, use `formData.getAll(name)`.
 
 ```ts

--- a/packages/form-data-middleware/src/lib/form-data.test.ts
+++ b/packages/form-data-middleware/src/lib/form-data.test.ts
@@ -11,14 +11,38 @@ import {
   type FileUploadHandler,
 } from '@remix-run/form-data-parser'
 import { createRouter } from '@remix-run/fetch-router'
+import type { RequestContext } from '@remix-run/fetch-router'
 
 import { formData } from './form-data.ts'
+
+type FormDataState = {
+  isDefined: boolean
+  isFormData: boolean
+  isEmpty: boolean
+}
 
 // Native File normalizes some MIME types differently across runtimes (for example
 // Bun adds charset for text types and rewrites application/javascript), so derive
 // the input type from the current runtime before asserting the response headers.
 function normalizeFileType(type: string): string {
   return new File([''], '', { type }).type
+}
+
+function getFormDataState(context: RequestContext): FormDataState {
+  let formData = context.get(FormData)
+  if (formData == null) {
+    return {
+      isDefined: false,
+      isFormData: false,
+      isEmpty: false,
+    }
+  }
+
+  return {
+    isDefined: true,
+    isFormData: formData instanceof FormData,
+    isEmpty: formData.entries().next().done === true,
+  }
 }
 
 describe('formData middleware', () => {
@@ -130,6 +154,44 @@ describe('formData middleware', () => {
         name: 'test2.txt',
         type: fileType,
       },
+    })
+  })
+
+  it('provides an empty FormData for GET requests', async () => {
+    let router = createRouter({
+      middleware: [formData()],
+    })
+
+    router.get('/', (context) => Response.json(getFormDataState(context)))
+
+    let response = await router.fetch('https://remix.run/')
+
+    assert.equal(response.status, 200)
+    assert.deepEqual(await response.json(), {
+      isDefined: true,
+      isFormData: true,
+      isEmpty: true,
+    })
+  })
+
+  it('provides an empty FormData for HEAD requests', async () => {
+    let formDataState: FormDataState | undefined
+    let router = createRouter({
+      middleware: [formData()],
+    })
+
+    router.head('/', (context) => {
+      formDataState = getFormDataState(context)
+      return new Response(null)
+    })
+
+    let response = await router.fetch('https://remix.run/', { method: 'HEAD' })
+
+    assert.equal(response.status, 200)
+    assert.deepEqual(formDataState, {
+      isDefined: true,
+      isFormData: true,
+      isEmpty: true,
     })
   })
 

--- a/packages/form-data-middleware/src/lib/form-data.ts
+++ b/packages/form-data-middleware/src/lib/form-data.ts
@@ -59,6 +59,7 @@ export function formData(
     }
 
     if (context.method === 'GET' || context.method === 'HEAD') {
+      context.set(FormData, new FormData())
       return
     }
 

--- a/packages/method-override-middleware/src/lib/method-override.ts
+++ b/packages/method-override-middleware/src/lib/method-override.ts
@@ -27,7 +27,7 @@ export function methodOverride(options?: MethodOverrideOptions): Middleware {
   let fieldName = options?.fieldName ?? '_method'
 
   return (context: RequestContext) => {
-    let method = context.has(FormData) ? context.get(FormData).get(fieldName) : null
+    let method = context.get(FormData)?.get(fieldName)
     if (typeof method !== 'string') {
       return
     }


### PR DESCRIPTION
This makes request context reads line up with the runtime contract: `context.get(key)` now returns `undefined` when the value is not present and the key has no default. Constructor keys like `FormData` and `Session` still infer their instance type when middleware or context typing proves they are present, but an empty `RequestContext` no longer pretends those values exist.

The `formData()` middleware now follows the simple provider rule: when it runs successfully, it always provides `FormData`. Requests without a form body, including `GET` and `HEAD`, receive an empty `FormData` so downstream handlers behind typed middleware can keep using `context.get(FormData)` as a defined value.

- Removes the broad constructor-key assumption from `RequestContext.get()`.
- Preserves clean handler ergonomics when middleware context transforms prove a value exists.
- Updates optional middleware integrations to branch on `undefined` from `context.get(...)`.
- Updates demos to type stored controllers against their app-level router context instead of relying on implicit constructor-key availability.

Broad helpers that accept an unconstrained `RequestContext` now need to handle missing values:

```ts
// Before
function readName(context: RequestContext): string {
  return String(context.get(FormData).get('name') ?? '')
}

// After
function readName(context: RequestContext): string {
  return String(context.get(FormData)?.get('name') ?? '')
}
```

Handlers whose context contract includes the provider middleware can continue using `get()` directly:

```ts
let router = createRouter({
  middleware: [formData()] as const,
})

router.post('/profile', (context) => {
  let formData = context.get(FormData)
  return Response.json({ name: formData.get('name') })
})
```
