### PR TITLE
Simplify fetch-router action helper types

### DIFF
--- a/demos/frames/app/actions/root-reload-client-entries.tsx
+++ b/demos/frames/app/actions/root-reload-client-entries.tsx
@@ -28,7 +28,7 @@ export const rootReloadClientEntriesAction = {
       { request: context.request, router: context.router },
     )
   },
-} satisfies BuildAction<'GET', typeof routes.rootReloadClientEntries>
+} satisfies BuildAction<typeof routes.rootReloadClientEntries>
 
 type RootReloadClientEntriesPageProps = {
   includeRemoved: boolean

--- a/packages/auth-middleware/src/lib/auth-types.test.ts
+++ b/packages/auth-middleware/src/lib/auth-types.test.ts
@@ -109,7 +109,7 @@ const privateAction = {
 
     return new Response('Private')
   },
-} satisfies BuildAction<'GET', typeof routes.private, ProtectedAppContext>
+} satisfies BuildAction<typeof routes.private, ProtectedAppContext>
 
 const adminController = {
   actions: {

--- a/packages/fetch-router/.changes/minor.action-route-entry-types.md
+++ b/packages/fetch-router/.changes/minor.action-route-entry-types.md
@@ -1,0 +1,27 @@
+BREAKING CHANGE: Simplified route action helper types so `Action` and `BuildAction` no longer accept an unused request method type parameter. If you manually type route actions, pass only the route pattern or route object plus any request context type:
+
+```ts
+// before
+let action = {
+  handler(context) {
+    return new Response(context.params.id)
+  },
+} satisfies BuildAction<'GET', typeof routes.account, AppContext>
+
+// after
+let action = {
+  handler(context) {
+    return new Response(context.params.id)
+  },
+} satisfies BuildAction<typeof routes.account, AppContext>
+```
+
+Renamed the custom router matcher payload type from `MatchData` to `RouteEntry`:
+
+```ts
+// before
+let matcher = createMatcher<MatchData>()
+
+// after
+let matcher = createMatcher<RouteEntry>()
+```

--- a/packages/fetch-router/README.md
+++ b/packages/fetch-router/README.md
@@ -652,7 +652,7 @@ let accountAction = {
     let auth = context.get(Auth)
     return Response.json({ id: auth.identity.id })
   },
-} satisfies BuildAction<'GET', typeof routes.account, AuthenticatedAppContext>
+} satisfies BuildAction<typeof routes.account, AuthenticatedAppContext>
 ```
 
 In this example, the action declares the stronger context it requires, and the action-local middleware makes that contract true at runtime. In a larger app, you can still derive a shared base context from router middleware with `MiddlewareContext<typeof middleware>` and build on top of it the same way.

--- a/packages/fetch-router/src/index.ts
+++ b/packages/fetch-router/src/index.ts
@@ -27,4 +27,4 @@ export { RequestMethods, isRequestMethod } from './lib/request-methods.ts'
 export type { RequestMethod } from './lib/request-methods.ts'
 
 export { createRouter } from './lib/router.ts'
-export type { MatchData, Router, RouterOptions } from './lib/router.ts'
+export type { RouteEntry, Router, RouterOptions } from './lib/router.ts'

--- a/packages/fetch-router/src/lib/controller.ts
+++ b/packages/fetch-router/src/lib/controller.ts
@@ -4,7 +4,6 @@ import type { Route, RouteMap } from '@remix-run/routes'
 import type { AnyMiddleware, ApplyMiddlewareTuple } from './middleware.ts'
 import type { RequestContext } from './request-context.ts'
 import type { WithParams } from './request-context.ts'
-import type { RequestMethod } from './request-methods.ts'
 
 export type ActionObjectWithoutMiddleware<
   params extends Record<string, any>,
@@ -67,7 +66,7 @@ export type Controller<
 type ControllerActions<routes extends RouteMap, context extends RequestContext<any, any>> = routes extends any ?
   {
     [name in keyof routes as routes[name] extends Route<any, any> ? name : never]: (
-      routes[name] extends Route<infer method extends RequestMethod | 'ANY', infer pattern extends string> ? Action<method, pattern, context> :
+      routes[name] extends Route<any, infer pattern extends string> ? Action<pattern, context> :
       never
     )
   } & {
@@ -89,7 +88,6 @@ export type ControllerInput<
  * Actions can be plain handler functions or action objects with optional inline middleware.
  */
 export type Action<
-  _method extends RequestMethod | 'ANY',
   pattern extends string,
   context extends RequestContext<any, any> = RequestContext,
 > = ActionInput<Params<pattern>, WithParams<context, Params<pattern>>, readonly AnyMiddleware[]>
@@ -99,13 +97,12 @@ export type Action<
  */
 // prettier-ignore
 export type BuildAction<
-  method extends RequestMethod | 'ANY',
   route extends string | RoutePattern | Route,
   context extends RequestContext<any, any> = RequestContext,
 > =
-  route extends string ? Action<method, route, context> :
-  route extends RoutePattern<infer pattern> ? Action<method, pattern, context> :
-  route extends Route<infer _, infer pattern> ? Action<method, pattern, context> :
+  route extends string ? Action<route, context> :
+  route extends RoutePattern<infer pattern> ? Action<pattern, context> :
+  route extends Route<infer _, infer pattern> ? Action<pattern, context> :
   never
 
 /**

--- a/packages/fetch-router/src/lib/router-types.test.ts
+++ b/packages/fetch-router/src/lib/router-types.test.ts
@@ -111,7 +111,7 @@ const accountAction = {
 
     return new Response(accountId + ':' + user.id + ':' + role)
   },
-} satisfies BuildAction<'GET', typeof routes.account, AppContext>
+} satisfies BuildAction<typeof routes.account, AppContext>
 
 const adminController = {
   actions: {
@@ -165,7 +165,7 @@ const elevatedReportAction = {
 
     return new Response(role)
   },
-} satisfies BuildAction<'GET', typeof routes.reports, AdminAppContext>
+} satisfies BuildAction<typeof routes.reports, AdminAppContext>
 
 router.get(routes.account, accountAction)
 router.map(routes.admin, adminController)

--- a/packages/fetch-router/src/lib/router.test.ts
+++ b/packages/fetch-router/src/lib/router.test.ts
@@ -5,7 +5,7 @@ import { createRoutes as route } from '@remix-run/routes'
 
 import type { BuildAction } from './controller.ts'
 import type { RequestContext } from './request-context.ts'
-import type { MatchData } from './router.ts'
+import type { RouteEntry } from './router.ts'
 import { createRouter } from './router.ts'
 
 describe('router.fetch()', () => {
@@ -818,7 +818,7 @@ describe('inline middleware', () => {
     })
 
     if (false as boolean) {
-      let action: BuildAction<'GET', typeof routes.home> = {
+      let action: BuildAction<typeof routes.home> = {
         handler() {
           return new Response('Home')
         },
@@ -1087,8 +1087,8 @@ describe('custom matcher', () => {
   it('uses a custom matcher when provided', async () => {
     let matchAllCalls = 0
 
-    let inner = createMatcher<MatchData>()
-    let customMatcher: Matcher<MatchData> = {
+    let inner = createMatcher<RouteEntry>()
+    let customMatcher: Matcher<RouteEntry> = {
       ignoreCase: inner.ignoreCase,
       add: inner.add.bind(inner),
       match: inner.match.bind(inner),
@@ -1109,8 +1109,8 @@ describe('custom matcher', () => {
   it('adds routes to the custom matcher', async () => {
     let addedPatterns: string[] = []
 
-    let inner = createMatcher<MatchData>()
-    let customMatcher: Matcher<MatchData> = {
+    let inner = createMatcher<RouteEntry>()
+    let customMatcher: Matcher<RouteEntry> = {
       ignoreCase: inner.ignoreCase,
       add(pattern, data) {
         let routePattern = typeof pattern === 'string' ? new RoutePattern(pattern) : pattern

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -61,7 +61,7 @@ type RouteMethod<context extends AnyContext> = {
   <method extends RequestMethod | 'ANY', pattern extends string>(
     method: method,
     pattern: RouteTarget<method, pattern>,
-    action: Action<method, pattern, context>,
+    action: Action<pattern, context>,
   ): void
 }
 
@@ -84,7 +84,7 @@ type ActionMapping<context extends AnyContext> = {
   ): void
   <method extends RequestMethod | 'ANY', pattern extends string>(
     target: MapRouteTarget<method, pattern>,
-    action: Action<method, pattern, context>,
+    action: Action<pattern, context>,
   ): void
 }
 
@@ -117,21 +117,19 @@ type VerbMethod<method extends RequestMethod, context extends AnyContext> = {
   ): void
   <pattern extends string>(
     route: RouteTarget<method, pattern>,
-    action: Action<method, pattern, context>,
+    action: Action<pattern, context>,
   ): void
 }
 
-type RouteMatchData = {
+/**
+ * The normalized route entry stored in the router matcher.
+ */
+export type RouteEntry = {
   pattern: RoutePattern<string>
   handler: RequestHandler<any, any>
   method: RequestMethod | 'ANY'
   middleware: AnyMiddleware[] | undefined
 }
-
-/**
- * The normalized route-match payload stored in the router matcher.
- */
-export type MatchData = RouteMatchData
 
 type NormalizedAction = {
   handler: RequestHandler<any, any>
@@ -161,7 +159,7 @@ export interface RouterOptions<
    *
    * @default `createMatcher()`
    */
-  matcher?: Matcher<MatchData>
+  matcher?: Matcher<RouteEntry>
   /**
    * Middleware to run for every request handled by this router.
    *
@@ -332,7 +330,7 @@ export function createRouter<
   const middleware extends readonly AnyMiddleware[] = readonly AnyMiddleware[],
 >(options?: RouterOptions<context, middleware>): Router<ApplyMiddlewareTuple<context, middleware>> {
   let defaultHandler = (options?.defaultHandler ?? noMatchHandler) as RequestHandler<any, any>
-  let matcher = options?.matcher ?? createMatcher<MatchData>()
+  let matcher = options?.matcher ?? createMatcher<RouteEntry>()
   let routerMiddleware = normalizeMiddleware(options?.middleware)
 
   async function dispatchRouter(context: RequestContext): Promise<Response> {
@@ -347,17 +345,19 @@ export function createRouter<
 
   async function dispatchMatches(context: RequestContext): Promise<Response> {
     for (let match of matcher.matchAll(context.url)) {
-      if (match.data.method !== context.method && match.data.method !== 'ANY') {
+      let route = match.data
+
+      if (route.method !== context.method && route.method !== 'ANY') {
         continue
       }
 
       context.params = { ...context.params, ...match.params }
 
-      if (match.data.middleware) {
-        return runMiddleware(match.data.middleware, context, match.data.handler)
+      if (route.middleware) {
+        return runMiddleware(route.middleware, context, route.handler)
       }
 
-      return raceRequestAbort(Promise.resolve(match.data.handler(context)), context.request)
+      return raceRequestAbort(Promise.resolve(route.handler(context)), context.request)
     }
 
     return raceRequestAbort(Promise.resolve(defaultHandler(context)), context.request)
@@ -369,7 +369,7 @@ export function createRouter<
     normalizedAction: NormalizedAction,
   ): void {
     let pattern = getRoutePattern(route)
-    let entry: RouteMatchData = {
+    let entry: RouteEntry = {
       pattern,
       handler: normalizedAction.handler,
       method,
@@ -382,7 +382,7 @@ export function createRouter<
   function addRoute<method extends RequestMethod | 'ANY', pattern extends string>(
     method: method,
     route: RouteTarget<method, pattern>,
-    handler: Action<method, pattern, ApplyMiddlewareTuple<context, middleware>>,
+    handler: Action<pattern, ApplyMiddlewareTuple<context, middleware>>,
   ): void {
     registerRoute(method, route, normalizeAction(handler))
   }
@@ -429,7 +429,7 @@ export function createRouter<
 
         let action = controller.actions[key]
         let normalizedAction = normalizeAction(
-          action as Action<any, any, ApplyMiddlewareTuple<context, middleware>>,
+          action as Action<any, ApplyMiddlewareTuple<context, middleware>>,
         )
         registerRoute(route.method, route.pattern, {
           handler: normalizedAction.handler,
@@ -451,7 +451,7 @@ export function createRouter<
       route: RouteTarget<method, pattern>,
       handler: ActionInput<Params<pattern>, RouteContext<RouterContext, pattern>, actionMiddleware>,
     ): void => {
-      addRoute(method, route, handler as Action<method, pattern, RouterContext>)
+      addRoute(method, route, handler as Action<pattern, RouterContext>)
     }) as VerbMethod<method, RouterContext>
   }
 
@@ -470,7 +470,7 @@ export function createRouter<
       route: RouteTarget<method, pattern>,
       handler: ActionInput<Params<pattern>, RouteContext<RouterContext, pattern>, actionMiddleware>,
     ): void {
-      addRoute(method, route, handler as Action<method, pattern, RouterContext>)
+      addRoute(method, route, handler as Action<pattern, RouterContext>)
     },
     map: mapRoutes,
     get: createVerbMethod('GET'),

--- a/packages/remix/.changes/major.fetch-router-action-types.md
+++ b/packages/remix/.changes/major.fetch-router-action-types.md
@@ -1,0 +1,1 @@
+BREAKING CHANGE: Updated the re-exported `remix/fetch-router` action helper types to match `@remix-run/fetch-router`: `Action` and `BuildAction` no longer accept an unused request method type parameter, and custom matcher payloads should use `RouteEntry` instead of `MatchData`.


### PR DESCRIPTION
This simplifies the fetch-router action type helpers by removing the unused request method generic. Route registration and route maps still keep method information for dispatch, but action helper types now only model the route pattern and request context they actually use.

It also renames the custom matcher payload type from `MatchData` to `RouteEntry`, which better describes the data fetch-router stores in the route-pattern matcher.

- Removes the unused method type parameter from `Action` and `BuildAction`.
- Exports `RouteEntry` instead of `MatchData` for custom router matchers.
- Updates internal matcher dispatch code to read `match.data` as a route entry.
- Updates README examples, type tests, demo action annotations, and release notes.

```ts
// Before
let action = {
  handler(context) {
    return new Response(context.params.id)
  },
} satisfies BuildAction<'GET', typeof routes.account, AppContext>

// After
let action = {
  handler(context) {
    return new Response(context.params.id)
  },
} satisfies BuildAction<typeof routes.account, AppContext>
```

```ts
// Before
let matcher = createMatcher<MatchData>()

// After
let matcher = createMatcher<RouteEntry>()
```
