### PR TITLE
route-pattern: remove redundant exclusion of `.types.bench.ts` files from package.json

### DIFF
--- a/packages/route-pattern/package.json
+++ b/packages/route-pattern/package.json
@@ -18,8 +18,7 @@
     "README.md",
     "dist",
     "src",
-    "!src/**/*.test.ts",
-    "!src/**/*.types.bench.ts"
+    "!src/**/*.test.ts"
   ],
   "type": "module",
   "exports": {


### PR DESCRIPTION
type benchmarks have moved to the `bench/` subpackage