### PR TITLE
route-pattern: remove `compareFn` parameter from `Matcher.{match,matchAll}`

### DIFF
--- a/packages/fetch-router/src/lib/router.test.ts
+++ b/packages/fetch-router/src/lib/router.test.ts
@@ -1092,9 +1092,9 @@ describe('custom matcher', () => {
       ignoreCase: inner.ignoreCase,
       add: inner.add.bind(inner),
       match: inner.match.bind(inner),
-      matchAll(url, compareFn) {
+      matchAll(url) {
         matchAllCalls++
-        return inner.matchAll(url, compareFn)
+        return inner.matchAll(url)
       },
     }
 

--- a/packages/remix/.changes/minor.remix-route-pattern.matcher-remove-compare-fn.md
+++ b/packages/remix/.changes/minor.remix-route-pattern.matcher-remove-compare-fn.md
@@ -1,0 +1,13 @@
+BREAKING CHANGE: In `remix/route-pattern`, remove the `compareFn` parameter from `Matcher.match` and `Matcher.matchAll`.
+
+Matches always sort by specificity (most specific first). If you need a different order, sort the result of `matchAll` yourself.
+
+```ts
+import * as Specificity from "remix/route-pattern/specificity"
+
+// before
+matcher.matchAll(url, Specificity.ascending)
+
+// after
+matcher.matchAll(url).sort(Specificity.ascending)
+```

--- a/packages/route-pattern/.changes/minor.matcher-remove-compare-fn.md
+++ b/packages/route-pattern/.changes/minor.matcher-remove-compare-fn.md
@@ -1,0 +1,13 @@
+BREAKING CHANGE: Remove the `compareFn` parameter from `Matcher.match` and `Matcher.matchAll`.
+
+Matches always sort by specificity (most specific first). If you need a different order, sort the result of `matchAll` yourself.
+
+```ts
+import * as Specificity from "remix/route-pattern/specificity"
+
+// before
+matcher.matchAll(url, Specificity.ascending)
+
+// after
+matcher.matchAll(url).sort(Specificity.ascending)
+```

--- a/packages/route-pattern/bench/src/match/array-matcher.ts
+++ b/packages/route-pattern/bench/src/match/array-matcher.ts
@@ -20,12 +20,12 @@ export class ArrayMatcher<data> implements Matcher<data> {
     this.#patterns.push({ pattern, data })
   }
 
-  match(url: string | URL, compareFn = Specificity.descending): Match<string, data> | null {
+  match(url: string | URL): Match<string, data> | null {
     let bestMatch: Match<string, data> | null = null
     for (let entry of this.#patterns) {
       let match = entry.pattern.match(url, { ignoreCase: this.ignoreCase })
       if (match) {
-        if (bestMatch === null || compareFn(match, bestMatch) < 0) {
+        if (bestMatch === null || Specificity.greaterThan(match, bestMatch)) {
           bestMatch = { ...match, data: entry.data }
         }
       }
@@ -33,7 +33,7 @@ export class ArrayMatcher<data> implements Matcher<data> {
     return bestMatch
   }
 
-  matchAll(url: string | URL, compareFn = Specificity.descending): Array<Match<string, data>> {
+  matchAll(url: string | URL): Array<Match<string, data>> {
     let matches: Array<Match<string, data>> = []
     for (let entry of this.#patterns) {
       let match = entry.pattern.match(url, { ignoreCase: this.ignoreCase })
@@ -41,6 +41,6 @@ export class ArrayMatcher<data> implements Matcher<data> {
         matches.push({ ...match, data: entry.data })
       }
     }
-    return matches.sort(compareFn)
+    return matches.sort(Specificity.descending)
   }
 }

--- a/packages/route-pattern/src/lib/matcher.test.ts
+++ b/packages/route-pattern/src/lib/matcher.test.ts
@@ -3,7 +3,6 @@ import { describe, it } from '@remix-run/test'
 
 import { createMatcher } from './matcher.ts'
 import { RoutePattern } from './route-pattern.ts'
-import * as Specificity from './specificity.ts'
 
 describe('Matcher', () => {
   describe('match', () => {
@@ -972,53 +971,4 @@ describe('Matcher', () => {
     })
   })
 
-  describe('custom compareFn', () => {
-    it('uses custom compareFn for match() to select best', () => {
-      let matcher = createMatcher<null>()
-      matcher.add('://example.com/*path', null)
-      matcher.add('://example.com/users/:id', null)
-      matcher.add('://example.com/users/123', null)
-
-      // Default behavior: static wins
-      let defaultMatch = matcher.match('http://example.com/users/123')
-      assert.ok(defaultMatch)
-      assert.equal(defaultMatch.pattern.source, '://example.com/users/123')
-
-      // Custom: prefer least specific (reverse of default)
-      let customMatch = matcher.match('http://example.com/users/123', Specificity.ascending)
-      assert.ok(customMatch)
-      assert.equal(customMatch.pattern.source, '://example.com/*path')
-    })
-
-    it('uses custom compareFn for matchAll() to sort results', () => {
-      let matcher = createMatcher<null>()
-      matcher.add('://example.com/*path', null)
-      matcher.add('://example.com/users/:id', null)
-      matcher.add('://example.com/users/123', null)
-
-      // Custom: sort by pattern source alphabetically
-      let matches = matcher.matchAll('http://example.com/users/123', (a, b) =>
-        a.pattern.source.localeCompare(b.pattern.source),
-      )
-
-      assert.deepEqual(
-        matches.map((m) => m.pattern.source),
-        ['://example.com/*path', '://example.com/users/:id', '://example.com/users/123'],
-      )
-    })
-
-    it('supports ascending specificity order', () => {
-      let matcher = createMatcher<null>()
-      matcher.add('://example.com/*path', null)
-      matcher.add('://example.com/users/:id', null)
-      matcher.add('://example.com/users/123', null)
-
-      let matches = matcher.matchAll('http://example.com/users/123', Specificity.ascending)
-
-      assert.deepEqual(
-        matches.map((m) => m.pattern.source),
-        ['://example.com/*path', '://example.com/users/:id', '://example.com/users/123'],
-      )
-    })
-  })
 })

--- a/packages/route-pattern/src/lib/matcher.ts
+++ b/packages/route-pattern/src/lib/matcher.ts
@@ -8,8 +8,6 @@ export type Match<source extends string = string, data = unknown> = RoutePattern
   data: data
 }
 
-type CompareFn = (a: RoutePatternMatch, b: RoutePatternMatch) => number
-
 /**
  * A type for matching URLs against patterns.
  */
@@ -33,7 +31,7 @@ export type Matcher<data = unknown> = {
    * @param url The URL to match
    * @returns The match result, or `null` if no match was found
    */
-  match(url: string | URL, compareFn?: CompareFn): Match<string, data> | null
+  match(url: string | URL): Match<string, data> | null
 
   /**
    * Find all matches for a URL.
@@ -41,7 +39,7 @@ export type Matcher<data = unknown> = {
    * @param url The URL to match
    * @returns All matches
    */
-  matchAll(url: string | URL, compareFn?: CompareFn): Array<Match<string, data>>
+  matchAll(url: string | URL): Array<Match<string, data>>
 }
 
 /**

--- a/packages/route-pattern/src/lib/trie-matcher.ts
+++ b/packages/route-pattern/src/lib/trie-matcher.ts
@@ -51,15 +51,14 @@ export class TrieMatcher<data = unknown> implements Matcher<data> {
    * Returns the best matching pattern for a URL.
    *
    * @param url URL to match.
-   * @param compareFn Specificity comparer used to rank matches.
    * @returns The best match, or `null` when nothing matches.
    */
-  match(url: string | URL, compareFn = Specificity.descending): Match<string, data> | null {
+  match(url: string | URL): Match<string, data> | null {
     url = typeof url === 'string' ? new URL(url) : url
     let bestMatch: Match<string, data> | null = null
     for (let result of this.trie.search(url)) {
       let match = toMatch(result, url)
-      if (bestMatch === null || compareFn(match, bestMatch) < 0) {
+      if (bestMatch === null || Specificity.greaterThan(match, bestMatch)) {
         bestMatch = match
       }
     }
@@ -70,13 +69,12 @@ export class TrieMatcher<data = unknown> implements Matcher<data> {
    * Returns every pattern that matches a URL.
    *
    * @param url URL to match.
-   * @param compareFn Specificity comparer used to sort matches.
-   * @returns All matching routes sorted by specificity.
+   * @returns All matching routes sorted by specificity (most specific first).
    */
-  matchAll(url: string | URL, compareFn = Specificity.descending): Array<Match<string, data>> {
+  matchAll(url: string | URL): Array<Match<string, data>> {
     url = typeof url === 'string' ? new URL(url) : url
     let matches = this.trie.search(url)
-    return matches.map((result) => toMatch(result, url)).sort(compareFn)
+    return matches.map((result) => toMatch(result, url)).sort(Specificity.descending)
   }
 }
 


### PR DESCRIPTION
Matches always sort by specificity (most specific first). If you need a different order, sort the result of `matchAll` yourself.

```ts
import * as Specificity from "remix/route-pattern/specificity"

// before
matcher.matchAll(url, Specificity.ascending)

// after
matcher.matchAll(url).sort(Specificity.ascending)
```