### PR TITLE
cli: consolidate `withEnv` test utility

### DIFF
--- a/packages/cli/src/lib/cli.test.ts
+++ b/packages/cli/src/lib/cli.test.ts
@@ -8,6 +8,7 @@ import { describe, it } from '@remix-run/test'
 
 import { getFixturePath } from '../../test/fixtures.ts'
 import { captureOutput } from '../../test/capture-output.ts'
+import { withEnv } from '../../test/with-env.ts'
 import { runRemix, type RunRemixOptions } from '../index.ts'
 import { getTestCommandHelpText } from './commands/test.ts'
 
@@ -597,7 +598,7 @@ describe('run', () => {
     let tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remix-cli-'))
     try {
       let appDir = path.join(tmpDir, 'my-app')
-      let result = await withEnv('REMIX_VERSION', '4.5.6', () =>
+      let result = await withEnv({ REMIX_VERSION: '4.5.6' }, () =>
         captureOutput(() => run(['new', appDir], { remixVersion: '9.9.9' })),
       )
 
@@ -636,7 +637,7 @@ describe('run', () => {
   })
 
   it('does not let REMIX_VERSION override the reported Remix version', async () => {
-    let result = await withEnv('REMIX_VERSION', '4.5.6', () =>
+    let result = await withEnv({ REMIX_VERSION: '4.5.6' }, () =>
       captureOutput(() => run(['version'], { remixVersion: '9.9.9' })),
     )
 
@@ -652,21 +653,6 @@ describe('run', () => {
     assert.match(result.stderr, /Unknown argument: --remix-version/)
   })
 })
-
-async function withEnv<T>(name: string, value: string, callback: () => Promise<T>): Promise<T> {
-  let previousValue = process.env[name]
-  process.env[name] = value
-
-  try {
-    return await callback()
-  } finally {
-    if (previousValue == null) {
-      delete process.env[name]
-    } else {
-      process.env[name] = previousValue
-    }
-  }
-}
 
 async function withCwd<T>(cwd: string, callback: () => Promise<T>): Promise<T> {
   let previousCwd = testCwd

--- a/packages/cli/src/lib/help-text.test.ts
+++ b/packages/cli/src/lib/help-text.test.ts
@@ -2,6 +2,7 @@ import * as process from 'node:process'
 import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
+import { withEnv } from '../../test/with-env.ts'
 import { formatHelpText } from './help-text.ts'
 import { configureColors } from './terminal.ts'
 
@@ -9,7 +10,7 @@ const ANSI_CSI = `${String.fromCharCode(27)}[`
 
 describe('help text', () => {
   it('renders plain help text with stable section order and alignment', () => {
-    let output = withEnv('NO_COLOR', '1', () =>
+    let output = withEnv({ NO_COLOR: '1' }, () =>
       withTTY(process.stdout, true, () =>
         formatHelpText(
           {
@@ -46,23 +47,21 @@ describe('help text', () => {
   })
 
   it('colors headings and syntax tokens when ansi is enabled', () => {
-    let output = withEnv('NO_COLOR', undefined, () =>
-      withEnv('FORCE_COLOR', '1', () =>
-        withEnv('TERM', 'xterm-256color', () =>
-          withTTY(process.stdout, true, () => {
-            configureColors({ disabled: false })
+    let output = withEnv(
+      { FORCE_COLOR: '1', NO_COLOR: undefined, TERM: 'xterm-256color' },
+      () =>
+        withTTY(process.stdout, true, () => {
+          configureColors({ disabled: false })
 
-            return formatHelpText(
-              {
-                examples: ['remix demo --json'],
-                options: [{ description: 'Print JSON output', label: '--dir <path>' }],
-                usage: ['remix demo [options]'],
-              },
-              process.stdout,
-            )
-          }),
-        ),
-      ),
+          return formatHelpText(
+            {
+              examples: ['remix demo --json'],
+              options: [{ description: 'Print JSON output', label: '--dir <path>' }],
+              usage: ['remix demo [options]'],
+            },
+            process.stdout,
+          )
+        }),
     )
 
     assert.ok(output.includes(`${ANSI_CSI}1m${ANSI_CSI}94mUsage${ANSI_CSI}0m:`))
@@ -72,51 +71,27 @@ describe('help text', () => {
   })
 
   it('colors help for stderr independently of stdout capability', () => {
-    let output = withEnv('NO_COLOR', undefined, () =>
-      withEnv('FORCE_COLOR', '1', () =>
-        withEnv('TERM', 'xterm-256color', () =>
-          withTTY(process.stdout, false, () =>
-            withTTY(process.stderr, true, () => {
-              configureColors({ disabled: false })
+    let output = withEnv(
+      { FORCE_COLOR: '1', NO_COLOR: undefined, TERM: 'xterm-256color' },
+      () =>
+        withTTY(process.stdout, false, () =>
+          withTTY(process.stderr, true, () => {
+            configureColors({ disabled: false })
 
-              return formatHelpText(
-                {
-                  usage: ['remix demo <path>'],
-                },
-                process.stderr,
-              )
-            }),
-          ),
+            return formatHelpText(
+              {
+                usage: ['remix demo <path>'],
+              },
+              process.stderr,
+            )
+          }),
         ),
-      ),
     )
 
     assert.ok(output.includes(`${ANSI_CSI}1m${ANSI_CSI}94mUsage${ANSI_CSI}0m:`))
     assert.ok(output.includes(`remix demo ${ANSI_CSI}93m<path>${ANSI_CSI}0m`))
   })
 })
-
-function withEnv<T>(name: string, value: string | undefined, callback: () => T): T {
-  let previousValue = process.env[name]
-
-  if (value == null) {
-    delete process.env[name]
-  } else {
-    process.env[name] = value
-  }
-
-  try {
-    return callback()
-  } finally {
-    if (previousValue == null) {
-      delete process.env[name]
-    } else {
-      process.env[name] = previousValue
-    }
-
-    configureColors({ disabled: false })
-  }
-}
 
 function withTTY<T>(stream: NodeJS.WriteStream, isTTY: boolean, callback: () => T): T {
   let previous = Object.getOwnPropertyDescriptor(stream, 'isTTY')

--- a/packages/cli/src/lib/reporter.test.ts
+++ b/packages/cli/src/lib/reporter.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url'
 import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
+import { withEnv } from '../../test/with-env.ts'
 import { createCommandReporter } from './reporter.ts'
 import { configureColors } from './terminal.ts'
 
@@ -56,98 +57,109 @@ describe('reporter', () => {
   })
 
   it('renders tables with bold headers and optional omitted headers', async () => {
-    await withEnv('NO_COLOR', undefined, async () =>
-      withEnv('FORCE_COLOR', '1', async () =>
-        withEnv('TERM', 'xterm-256color', async () =>
-          withTTY(process.stdout, true, async () =>
-            withCapturedWrites(process.stdout, async (writes) => {
-              configureColors({ disabled: false })
-              let reporter = createCommandReporter()
+    await withEnv({ FORCE_COLOR: '1', NO_COLOR: undefined, TERM: 'xterm-256color' }, async () =>
+      withTTY(process.stdout, true, async () =>
+        withCapturedWrites(process.stdout, async (writes) => {
+          configureColors({ disabled: false })
+          let reporter = createCommandReporter()
 
-              reporter.out.table({
-                headers: ['Route', 'Method'],
-                rows: [
-                  ['home', 'ANY'],
-                  ['auth.login.action', 'POST'],
-                ],
-              })
-              reporter.out.blank()
-              reporter.out.table({
-                headers: ['Route', 'Method'],
-                noHeaders: true,
-                rows: [['home', 'ANY']],
-              })
-              reporter.finish()
+          reporter.out.table({
+            headers: ['Route', 'Method'],
+            rows: [
+              ['home', 'ANY'],
+              ['auth.login.action', 'POST'],
+            ],
+          })
+          reporter.out.blank()
+          reporter.out.table({
+            headers: ['Route', 'Method'],
+            noHeaders: true,
+            rows: [['home', 'ANY']],
+          })
+          reporter.finish()
 
-              assert.deepEqual(writes, [
-                '\n',
-                '\u001B[1mRoute            \u001B[0m  \u001B[1mMethod\u001B[0m\n',
-                'home               ANY   \n',
-                'auth.login.action  POST  \n',
-                '\n',
-                'home   ANY   \n',
-                '\n',
-              ])
-            }),
-          ),
-        ),
+          assert.deepEqual(writes, [
+            '\n',
+            '\u001B[1mRoute            \u001B[0m  \u001B[1mMethod\u001B[0m\n',
+            'home               ANY   \n',
+            'auth.login.action  POST  \n',
+            '\n',
+            'home   ANY   \n',
+            '\n',
+          ])
+        }),
       ),
     )
   })
 
   it('renders progress to stderr with live tty updates', async () => {
-    await withEnv('NO_COLOR', undefined, async () =>
-      withEnv('FORCE_COLOR', '1', async () =>
-        withEnv('TERM', 'xterm-256color', async () =>
-          withTTY(process.stderr, true, async () =>
-            withCapturedWrites(process.stderr, async (writes) => {
-              configureColors({ disabled: false })
-              let reporter = createCommandReporter({ statusFrameIntervalMs: 5 })
+    await withEnv({ FORCE_COLOR: '1', NO_COLOR: undefined, TERM: 'xterm-256color' }, async () =>
+      withTTY(process.stderr, true, async () =>
+        withCapturedWrites(process.stderr, async (writes) => {
+          configureColors({ disabled: false })
+          let reporter = createCommandReporter({ statusFrameIntervalMs: 5 })
 
-              reporter.status.startStep('Checking environment')
-              await wait(25)
-              reporter.status.succeedStep()
-              reporter.status.summaryGap()
+          reporter.status.startStep('Checking environment')
+          await wait(25)
+          reporter.status.succeedStep()
+          reporter.status.summaryGap()
 
-              assert.equal(writes[0], '\n')
-              assert.equal(writes[1], '\r\u001B[2K\u001B[90m• Checking environment.\u001B[0m')
-              assert.ok(
-                writes.some(
-                  (write) =>
-                    write === '\r\u001B[2K\u001B[90m• Checking environment..\u001B[0m' ||
-                    write === '\r\u001B[2K\u001B[90m• Checking environment...\u001B[0m',
-                ),
-              )
-              assert.deepEqual(writes.slice(-2), [
-                '\r\u001B[2K\u001B[92m✓\u001B[0m \u001B[90mChecking environment\u001B[0m\n',
-                '\n',
-              ])
-            }),
-          ),
-        ),
+          assert.equal(writes[0], '\n')
+          assert.equal(writes[1], '\r\u001B[2K\u001B[90m• Checking environment.\u001B[0m')
+          assert.ok(
+            writes.some(
+              (write) =>
+                write === '\r\u001B[2K\u001B[90m• Checking environment..\u001B[0m' ||
+                write === '\r\u001B[2K\u001B[90m• Checking environment...\u001B[0m',
+            ),
+          )
+          assert.deepEqual(writes.slice(-2), [
+            '\r\u001B[2K\u001B[92m✓\u001B[0m \u001B[90mChecking environment\u001B[0m\n',
+            '\n',
+          ])
+        }),
       ),
     )
   })
 
   it('renders non-interactive progress as stable stderr lines', async () => {
-    await withEnv('NO_COLOR', undefined, async () =>
-      withEnv('TERM', 'xterm-256color', async () =>
-        withTTY(process.stderr, false, async () =>
-          withCapturedWrites(process.stderr, async (writes) => {
+    await withEnv({ NO_COLOR: undefined, TERM: 'xterm-256color' }, async () =>
+      withTTY(process.stderr, false, async () =>
+        withCapturedWrites(process.stderr, async (writes) => {
+          configureColors({ disabled: false })
+          let reporter = createCommandReporter()
+
+          reporter.status.startStep('Checking project')
+          reporter.status.failStep()
+          reporter.status.skipStep('actions', 'Blocked by project warnings.')
+          reporter.finish()
+
+          assert.deepEqual(writes, [
+            '\n',
+            '• Checking project...\n',
+            '✗ Checking project\n',
+            '• actions (skipped: Blocked by project warnings.)\n',
+            '\n',
+          ])
+        }),
+      ),
+    )
+  })
+
+  it('writes the progress command header to stderr and never stdout', async () => {
+    await withEnv({ FORCE_COLOR: '1', NO_COLOR: undefined, TERM: 'xterm-256color' }, async () =>
+      withTTY(process.stderr, true, async () =>
+        withCapturedWrites(process.stdout, async (stdoutWrites) =>
+          withCapturedWrites(process.stderr, async (stderrWrites) => {
             configureColors({ disabled: false })
-            let reporter = createCommandReporter()
+            let reporter = createCommandReporter({ remixVersion: '9.9.9' })
 
-            reporter.status.startStep('Checking project')
-            reporter.status.failStep()
-            reporter.status.skipStep('actions', 'Blocked by project warnings.')
-            reporter.finish()
+            await reporter.status.commandHeader('doctor')
 
-            assert.deepEqual(writes, [
+            assert.deepEqual(stdoutWrites, [])
+            assert.deepEqual(stderrWrites, [
               '\n',
-              '• Checking project...\n',
-              '✗ Checking project\n',
-              '• actions (skipped: Blocked by project warnings.)\n',
-              '\n',
+              '\u001B[94mR\u001B[0m\u001B[92mE\u001B[0m\u001B[93mM\u001B[0m\u001B[95mI\u001B[0m\u001B[91mX\u001B[0m v9.9.9 - doctor\n\n',
             ])
           }),
         ),
@@ -155,55 +167,28 @@ describe('reporter', () => {
     )
   })
 
-  it('writes the progress command header to stderr and never stdout', async () => {
-    await withEnv('NO_COLOR', undefined, async () =>
-      withEnv('FORCE_COLOR', '1', async () =>
-        withEnv('TERM', 'xterm-256color', async () =>
-          withTTY(process.stderr, true, async () =>
-            withCapturedWrites(process.stdout, async (stdoutWrites) =>
-              withCapturedWrites(process.stderr, async (stderrWrites) => {
-                configureColors({ disabled: false })
-                let reporter = createCommandReporter({ remixVersion: '9.9.9' })
-
-                await reporter.status.commandHeader('doctor')
-
-                assert.deepEqual(stdoutWrites, [])
-                assert.deepEqual(stderrWrites, [
-                  '\n',
-                  '\u001B[94mR\u001B[0m\u001B[92mE\u001B[0m\u001B[93mM\u001B[0m\u001B[95mI\u001B[0m\u001B[91mX\u001B[0m v9.9.9 - doctor\n\n',
-                ])
-              }),
-            ),
-          ),
-        ),
-      ),
-    )
-  })
-
   it('does not add a second preamble when progress is on stderr and the summary is on stdout', async () => {
-    await withEnv('NO_COLOR', undefined, async () =>
-      withEnv('TERM', 'xterm-256color', async () =>
-        withTTY(process.stderr, false, async () =>
-          withCapturedWrites(process.stdout, async (stdoutWrites) =>
-            withCapturedWrites(process.stderr, async (stderrWrites) => {
-              configureColors({ disabled: false })
-              let reporter = createCommandReporter()
+    await withEnv({ NO_COLOR: undefined, TERM: 'xterm-256color' }, async () =>
+      withTTY(process.stderr, false, async () =>
+        withCapturedWrites(process.stdout, async (stdoutWrites) =>
+          withCapturedWrites(process.stderr, async (stderrWrites) => {
+            configureColors({ disabled: false })
+            let reporter = createCommandReporter()
 
-              reporter.status.startStep('Checking routes')
-              reporter.status.succeedStep()
-              reporter.status.summaryGap()
-              reporter.out.line('Checked Remix routes: 2 found.')
-              reporter.finish()
+            reporter.status.startStep('Checking routes')
+            reporter.status.succeedStep()
+            reporter.status.summaryGap()
+            reporter.out.line('Checked Remix routes: 2 found.')
+            reporter.finish()
 
-              assert.deepEqual(stderrWrites, [
-                '\n',
-                '• Checking routes...\n',
-                '✓ Checking routes\n',
-                '\n',
-              ])
-              assert.deepEqual(stdoutWrites, ['Checked Remix routes: 2 found.\n', '\n'])
-            }),
-          ),
+            assert.deepEqual(stderrWrites, [
+              '\n',
+              '• Checking routes...\n',
+              '✓ Checking routes\n',
+              '\n',
+            ])
+            assert.deepEqual(stdoutWrites, ['Checked Remix routes: 2 found.\n', '\n'])
+          }),
         ),
       ),
     )
@@ -236,32 +221,6 @@ async function withCapturedWrites<T>(
     return await callback(writes)
   } finally {
     stream.write = originalWrite
-  }
-}
-
-async function withEnv<T>(
-  name: string,
-  value: string | undefined,
-  callback: () => Promise<T> | T,
-): Promise<T> {
-  let previousValue = process.env[name]
-
-  if (value == null) {
-    delete process.env[name]
-  } else {
-    process.env[name] = value
-  }
-
-  try {
-    return await callback()
-  } finally {
-    if (previousValue == null) {
-      delete process.env[name]
-    } else {
-      process.env[name] = previousValue
-    }
-
-    configureColors({ disabled: false })
   }
 }
 

--- a/packages/cli/src/lib/terminal.test.ts
+++ b/packages/cli/src/lib/terminal.test.ts
@@ -2,6 +2,7 @@ import * as process from 'node:process'
 import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
+import { withEnv } from '../../test/with-env.ts'
 import {
   bold,
   clearCurrentLine,
@@ -17,66 +18,54 @@ import {
 
 describe('terminal', () => {
   it('styles stdout when stdout is a tty', async () => {
-    withEnv('NO_COLOR', undefined, () =>
-      withEnv('FORCE_COLOR', '1', () =>
-        withEnv('TERM', 'xterm-256color', () =>
-          withTTY(process.stdout, true, () => {
-            configureColors({ disabled: false })
+    withEnv({ FORCE_COLOR: '1', NO_COLOR: undefined, TERM: 'xterm-256color' }, () =>
+      withTTY(process.stdout, true, () => {
+        configureColors({ disabled: false })
 
-            assert.equal(bold('ok'), '\u001B[1mok\u001B[0m')
-            assert.equal(lightBlue('hi'), '\u001B[94mhi\u001B[0m')
-            assert.equal(lightGreen('yes'), '\u001B[92myes\u001B[0m')
-            assert.equal(lightMagenta('wow'), '\u001B[95mwow\u001B[0m')
-            assert.equal(reset(process.stdout), '\u001B[0m')
-          }),
-        ),
-      ),
+        assert.equal(bold('ok'), '\u001B[1mok\u001B[0m')
+        assert.equal(lightBlue('hi'), '\u001B[94mhi\u001B[0m')
+        assert.equal(lightGreen('yes'), '\u001B[92myes\u001B[0m')
+        assert.equal(lightMagenta('wow'), '\u001B[95mwow\u001B[0m')
+        assert.equal(reset(process.stdout), '\u001B[0m')
+      }),
     )
   })
 
   it('colors stderr when stderr is a tty', async () => {
-    withEnv('NO_COLOR', undefined, () =>
-      withEnv('FORCE_COLOR', '1', () =>
-        withEnv('TERM', 'xterm-256color', () =>
-          withTTY(process.stderr, true, () => {
-            configureColors({ disabled: false })
+    withEnv({ FORCE_COLOR: '1', NO_COLOR: undefined, TERM: 'xterm-256color' }, () =>
+      withTTY(process.stderr, true, () => {
+        configureColors({ disabled: false })
 
-            assert.equal(lightRed('nope', process.stderr), '\u001B[91mnope\u001B[0m')
-            assert.equal(reset(process.stderr), '\u001B[0m')
-          }),
-        ),
-      ),
+        assert.equal(lightRed('nope', process.stderr), '\u001B[91mnope\u001B[0m')
+        assert.equal(reset(process.stderr), '\u001B[0m')
+      }),
     )
   })
 
   it('does not color when stdout is not a tty', async () => {
-    withEnv('NO_COLOR', undefined, () =>
-      withEnv('TERM', 'xterm-256color', () =>
-        withTTY(process.stdout, false, () => {
-          configureColors({ disabled: false })
+    withEnv({ NO_COLOR: undefined, TERM: 'xterm-256color' }, () =>
+      withTTY(process.stdout, false, () => {
+        configureColors({ disabled: false })
 
-          assert.equal(bold('ok'), 'ok')
-          assert.equal(reset(process.stdout), '')
-        }),
-      ),
+        assert.equal(bold('ok'), 'ok')
+        assert.equal(reset(process.stdout), '')
+      }),
     )
   })
 
   it('does not color when stderr is not a tty', async () => {
-    withEnv('NO_COLOR', undefined, () =>
-      withEnv('TERM', 'xterm-256color', () =>
-        withTTY(process.stderr, false, () => {
-          configureColors({ disabled: false })
+    withEnv({ NO_COLOR: undefined, TERM: 'xterm-256color' }, () =>
+      withTTY(process.stderr, false, () => {
+        configureColors({ disabled: false })
 
-          assert.equal(lightRed('nope', process.stderr), 'nope')
-          assert.equal(reset(process.stderr), '')
-        }),
-      ),
+        assert.equal(lightRed('nope', process.stderr), 'nope')
+        assert.equal(reset(process.stderr), '')
+      }),
     )
   })
 
   it('does not color when NO_COLOR is set', async () => {
-    withEnv('NO_COLOR', '1', () =>
+    withEnv({ NO_COLOR: '1' }, () =>
       withTTY(process.stdout, true, () => {
         configureColors({ disabled: false })
 
@@ -87,34 +76,30 @@ describe('terminal', () => {
   })
 
   it('does not color when TERM is dumb', async () => {
-    withEnv('NO_COLOR', undefined, () =>
-      withEnv('TERM', 'dumb', () =>
-        withTTY(process.stdout, true, () => {
-          configureColors({ disabled: false })
+    withEnv({ NO_COLOR: undefined, TERM: 'dumb' }, () =>
+      withTTY(process.stdout, true, () => {
+        configureColors({ disabled: false })
 
-          assert.equal(bold('ok'), 'ok')
-          assert.equal(remixWordmark(), 'REMIX')
-          assert.equal(reset(process.stdout), '')
-        }),
-      ),
+        assert.equal(bold('ok'), 'ok')
+        assert.equal(remixWordmark(), 'REMIX')
+        assert.equal(reset(process.stdout), '')
+      }),
     )
   })
 
   it('does not color when disabled by a global flag', async () => {
-    withEnv('NO_COLOR', undefined, () =>
-      withEnv('TERM', 'xterm-256color', () =>
-        withTTY(process.stdout, true, () => {
-          configureColors({ disabled: true })
+    withEnv({ NO_COLOR: undefined, TERM: 'xterm-256color' }, () =>
+      withTTY(process.stdout, true, () => {
+        configureColors({ disabled: true })
 
-          assert.equal(bold('ok'), 'ok')
-          assert.equal(reset(process.stdout), '')
-        }),
-      ),
+        assert.equal(bold('ok'), 'ok')
+        assert.equal(reset(process.stdout), '')
+      }),
     )
   })
 
   it('restores terminal formatting on stdout when stdout supports ansi', async () => {
-    withEnv('TERM', 'xterm-256color', () =>
+    withEnv({ TERM: 'xterm-256color' }, () =>
       withTTY(process.stdout, true, () =>
         withCapturedWrites(process.stdout, (writes) => {
           configureColors({ disabled: true })
@@ -128,7 +113,7 @@ describe('terminal', () => {
   })
 
   it('restores terminal formatting on stderr when only stderr supports ansi', async () => {
-    withEnv('TERM', 'xterm-256color', () =>
+    withEnv({ TERM: 'xterm-256color' }, () =>
       withTTY(process.stdout, false, () =>
         withTTY(process.stderr, true, () =>
           withCapturedWrites(process.stderr, (writes) => {
@@ -144,7 +129,7 @@ describe('terminal', () => {
   })
 
   it('does not restore terminal formatting when ansi is unavailable', async () => {
-    withEnv('TERM', 'dumb', () =>
+    withEnv({ TERM: 'dumb' }, () =>
       withTTY(process.stdout, true, () =>
         withCapturedWrites(process.stdout, (writes) => {
           restoreTerminalFormatting()
@@ -156,24 +141,20 @@ describe('terminal', () => {
   })
 
   it('renders the Remix wordmark with one color per letter when colors are enabled', async () => {
-    withEnv('NO_COLOR', undefined, () =>
-      withEnv('FORCE_COLOR', '1', () =>
-        withEnv('TERM', 'xterm-256color', () =>
-          withTTY(process.stdout, true, () => {
-            configureColors({ disabled: false })
+    withEnv({ FORCE_COLOR: '1', NO_COLOR: undefined, TERM: 'xterm-256color' }, () =>
+      withTTY(process.stdout, true, () => {
+        configureColors({ disabled: false })
 
-            assert.equal(
-              remixWordmark(),
-              '\u001B[94mR\u001B[0m\u001B[92mE\u001B[0m\u001B[93mM\u001B[0m\u001B[95mI\u001B[0m\u001B[91mX\u001B[0m',
-            )
-          }),
-        ),
-      ),
+        assert.equal(
+          remixWordmark(),
+          '\u001B[94mR\u001B[0m\u001B[92mE\u001B[0m\u001B[93mM\u001B[0m\u001B[95mI\u001B[0m\u001B[91mX\u001B[0m',
+        )
+      }),
     )
   })
 
   it('renders the Remix wordmark without color when colors are disabled', async () => {
-    withEnv('NO_COLOR', '1', () =>
+    withEnv({ NO_COLOR: '1' }, () =>
       withTTY(process.stdout, true, () => {
         configureColors({ disabled: false })
 
@@ -186,28 +167,6 @@ describe('terminal', () => {
     assert.equal(clearCurrentLine(), '\r\u001B[2K')
   })
 })
-
-function withEnv<T>(name: string, value: string | undefined, callback: () => T): T {
-  let previousValue = process.env[name]
-
-  if (value == null) {
-    delete process.env[name]
-  } else {
-    process.env[name] = value
-  }
-
-  try {
-    return callback()
-  } finally {
-    if (previousValue == null) {
-      delete process.env[name]
-    } else {
-      process.env[name] = previousValue
-    }
-
-    configureColors({ disabled: false })
-  }
-}
 
 function withTTY<T>(stream: NodeJS.WriteStream, isTTY: boolean, callback: () => T): T {
   let previous = Object.getOwnPropertyDescriptor(stream, 'isTTY')

--- a/packages/cli/test/with-env.ts
+++ b/packages/cli/test/with-env.ts
@@ -1,0 +1,50 @@
+import * as process from 'node:process'
+
+import { configureColors } from '../src/lib/terminal.ts'
+
+type EnvOverrides = Record<string, string | undefined>
+
+export function withEnv<result>(env: EnvOverrides, callback: () => Promise<result>): Promise<result>
+export function withEnv<result>(env: EnvOverrides, callback: () => result): result
+export function withEnv<result>(
+  env: EnvOverrides,
+  callback: () => Promise<result> | result,
+): Promise<result> | result {
+  let previousValues = new Map<string, string | undefined>()
+
+  for (let [name, value] of Object.entries(env)) {
+    previousValues.set(name, process.env[name])
+
+    if (value === undefined) {
+      delete process.env[name]
+    } else {
+      process.env[name] = value
+    }
+  }
+
+  let restoreEnv = () => {
+    for (let [name, value] of previousValues) {
+      if (value === undefined) {
+        delete process.env[name]
+      } else {
+        process.env[name] = value
+      }
+    }
+
+    configureColors({ disabled: false })
+  }
+
+  try {
+    let result = callback()
+
+    if (result instanceof Promise) {
+      return result.finally(restoreEnv)
+    }
+
+    restoreEnv()
+    return result
+  } catch (error) {
+    restoreEnv()
+    throw error
+  }
+}


### PR DESCRIPTION
also, pass in multiple env vars at once instead of one at a time