### PR TITLE
Simplify fetch-router context, action, and middleware typing

### DIFF
--- a/demos/assets/app/actions/controller.ts
+++ b/demos/assets/app/actions/controller.ts
@@ -1,12 +1,12 @@
 import * as path from 'node:path'
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 
-import type { routes } from '../routes.ts'
+import { routes } from '../routes.ts'
 import { assetServer } from '../utils/assets.ts'
 
 const entryFilePath = path.resolve(import.meta.dirname, '../client/entry.ts')
 
-export default {
+export default createController(routes, {
   actions: {
     async home() {
       let entryUrl = await assetServer.getHref(entryFilePath)
@@ -84,7 +84,7 @@ export default {
       return assetResponse ?? new Response('Not found', { status: 404 })
     },
   },
-} satisfies Controller<typeof routes>
+})
 
 function escapeHtml(value: string): string {
   return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;')

--- a/demos/bookstore/app/actions/account/controller.tsx
+++ b/demos/bookstore/app/actions/account/controller.tsx
@@ -1,13 +1,13 @@
-import type { AppController } from '../../router.ts'
+import { createController } from 'remix/fetch-router'
 
 import { requireAuth } from '../../middleware/auth.ts'
-import type { routes } from '../../routes.ts'
+import { routes } from '../../routes.ts'
 import { getCurrentUser } from '../../utils/context.ts'
 import { render } from '../render.tsx'
 import { AccountPage } from './page.tsx'
 
-export default {
-  middleware: [requireAuth()],
+export default createController(routes.account, {
+  middleware: [requireAuth()] as const,
   actions: {
     index() {
       let user = getCurrentUser()
@@ -15,4 +15,4 @@ export default {
       return render(<AccountPage user={user} />)
     },
   },
-} satisfies AppController<typeof routes.account>
+})

--- a/demos/bookstore/app/actions/account/orders/controller.tsx
+++ b/demos/bookstore/app/actions/account/orders/controller.tsx
@@ -1,17 +1,17 @@
-import type { AppController } from '../../../router.ts'
+import { createController } from 'remix/fetch-router'
 import { Database } from 'remix/data-table'
 
 import { orders, orderItemsWithBook } from '../../../data/schema.ts'
 import { requireAuth } from '../../../middleware/auth.ts'
-import type { routes } from '../../../routes.ts'
+import { routes } from '../../../routes.ts'
 import { getCurrentUser } from '../../../utils/context.ts'
 import { parseId } from '../../../utils/ids.ts'
 import { render } from '../../render.tsx'
 import { AccountOrdersIndexPage } from './index-page.tsx'
 import { AccountOrderNotFoundPage, AccountOrderShowPage } from './show-page.tsx'
 
-export default {
-  middleware: [requireAuth()],
+export default createController(routes.account.orders, {
+  middleware: [requireAuth()] as const,
   actions: {
     async index({ get }) {
       let db = get(Database)
@@ -50,4 +50,4 @@ export default {
       return render(<AccountOrderShowPage order={order} shippingAddress={shippingAddress} />)
     },
   },
-} satisfies AppController<typeof routes.account.orders>
+})

--- a/demos/bookstore/app/actions/account/settings/controller.tsx
+++ b/demos/bookstore/app/actions/account/settings/controller.tsx
@@ -1,4 +1,4 @@
-import type { AppController } from '../../../router.ts'
+import { createController } from 'remix/fetch-router'
 import * as s from 'remix/data-schema'
 import * as f from 'remix/data-schema/form-data'
 import { minLength } from 'remix/data-schema/checks'
@@ -23,8 +23,8 @@ const accountSettingsSchema = f.object({
   password: passwordField,
 })
 
-export default {
-  middleware: [requireAuth()],
+export default createController(routes.account.settings, {
+  middleware: [requireAuth()] as const,
   actions: {
     index() {
       let user = getCurrentUser()
@@ -46,4 +46,4 @@ export default {
       return redirect(routes.account.index.href())
     },
   },
-} satisfies AppController<typeof routes.account.settings>
+})

--- a/demos/bookstore/app/actions/admin/books/controller.tsx
+++ b/demos/bookstore/app/actions/admin/books/controller.tsx
@@ -1,4 +1,4 @@
-import type { AppController } from '../../../router.ts'
+import { createController } from 'remix/fetch-router'
 import * as s from 'remix/data-schema'
 import * as f from 'remix/data-schema/form-data'
 import * as coerce from 'remix/data-schema/coerce'
@@ -37,8 +37,8 @@ const bookSchema = f.object({
   inStock: inStockField,
 })
 
-export default {
-  middleware: [requireAuth(), requireAdmin()],
+export default createController(routes.admin.books, {
+  middleware: [requireAuth(), requireAdmin()] as const,
   actions: {
     async index({ get }) {
       let db = get(Database)
@@ -154,4 +154,4 @@ export default {
       return redirect(routes.admin.books.index.href())
     },
   },
-} satisfies AppController<typeof routes.admin.books>
+})

--- a/demos/bookstore/app/actions/admin/controller.tsx
+++ b/demos/bookstore/app/actions/admin/controller.tsx
@@ -1,16 +1,16 @@
-import type { AppController } from '../../router.ts'
+import { createController } from 'remix/fetch-router'
 
 import { requireAdmin } from '../../middleware/admin.ts'
 import { requireAuth } from '../../middleware/auth.ts'
-import type { routes } from '../../routes.ts'
+import { routes } from '../../routes.ts'
 import { render } from '../render.tsx'
 import { AdminDashboardPage } from './page.tsx'
 
-export default {
-  middleware: [requireAuth(), requireAdmin()],
+export default createController(routes.admin, {
+  middleware: [requireAuth(), requireAdmin()] as const,
   actions: {
     index() {
       return render(<AdminDashboardPage />)
     },
   },
-} satisfies AppController<typeof routes.admin>
+})

--- a/demos/bookstore/app/actions/admin/orders/controller.tsx
+++ b/demos/bookstore/app/actions/admin/orders/controller.tsx
@@ -1,17 +1,17 @@
-import type { AppController } from '../../../router.ts'
+import { createController } from 'remix/fetch-router'
 import { Database } from 'remix/data-table'
 
 import { orders, orderItemsWithBook } from '../../../data/schema.ts'
 import { requireAdmin } from '../../../middleware/admin.ts'
 import { requireAuth } from '../../../middleware/auth.ts'
-import type { routes } from '../../../routes.ts'
+import { routes } from '../../../routes.ts'
 import { parseId } from '../../../utils/ids.ts'
 import { render } from '../../render.tsx'
 import { AdminOrdersIndexPage } from './index-page.tsx'
 import { AdminOrderNotFoundPage, AdminOrderShowPage } from './show-page.tsx'
 
-export default {
-  middleware: [requireAuth(), requireAdmin()],
+export default createController(routes.admin.orders, {
+  middleware: [requireAuth(), requireAdmin()] as const,
   actions: {
     async index({ get }) {
       let db = get(Database)
@@ -47,4 +47,4 @@ export default {
       return render(<AdminOrderShowPage order={order} shippingAddress={shippingAddress} />)
     },
   },
-} satisfies AppController<typeof routes.admin.orders>
+})

--- a/demos/bookstore/app/actions/admin/users/controller.tsx
+++ b/demos/bookstore/app/actions/admin/users/controller.tsx
@@ -1,4 +1,4 @@
-import type { AppController } from '../../../router.ts'
+import { createController } from 'remix/fetch-router'
 import * as s from 'remix/data-schema'
 import * as f from 'remix/data-schema/form-data'
 import { Database } from 'remix/data-table'
@@ -25,8 +25,8 @@ const userSchema = f.object({
   role: roleField,
 })
 
-export default {
-  middleware: [requireAuth(), requireAdmin()],
+export default createController(routes.admin.users, {
+  middleware: [requireAuth(), requireAdmin()] as const,
   actions: {
     async index({ get }) {
       let db = get(Database)
@@ -97,4 +97,4 @@ export default {
       return redirect(routes.admin.users.index.href())
     },
   },
-} satisfies AppController<typeof routes.admin.users>
+})

--- a/demos/bookstore/app/actions/api/controller.tsx
+++ b/demos/bookstore/app/actions/api/controller.tsx
@@ -1,11 +1,11 @@
-import type { AppController } from '../../router.ts'
+import { createController } from 'remix/fetch-router'
 import * as s from 'remix/data-schema'
 import * as f from 'remix/data-schema/form-data'
 import { Database } from 'remix/data-table'
 
 import { books } from '../../data/schema.ts'
 import { Session } from '../../middleware/session.ts'
-import type { routes } from '../../routes.ts'
+import { routes } from '../../routes.ts'
 import { addToCart, removeFromCart } from '../../utils/cart.ts'
 import { getCurrentCart } from '../../utils/context.ts'
 import { parseId } from '../../utils/ids.ts'
@@ -15,7 +15,7 @@ const bookIdSchema = f.object({
   bookId: bookIdField,
 })
 
-export default {
+export default createController(routes.api, {
   actions: {
     async cartToggle({ get }) {
       let db = get(Database)
@@ -40,4 +40,4 @@ export default {
       return new Response(null, { status: 204 })
     },
   },
-} satisfies AppController<typeof routes.api>
+})

--- a/demos/bookstore/app/actions/auth/controller.tsx
+++ b/demos/bookstore/app/actions/auth/controller.tsx
@@ -1,10 +1,10 @@
-import type { AppController } from '../../router.ts'
+import { createController } from 'remix/fetch-router'
 import { redirect } from 'remix/response/redirect'
 
 import { Session } from '../../middleware/session.ts'
 import { routes } from '../../routes.ts'
 
-export default {
+export default createController(routes.auth, {
   actions: {
     logout({ get }) {
       let session = get(Session)
@@ -13,4 +13,4 @@ export default {
       return redirect(routes.home.href())
     },
   },
-} satisfies AppController<typeof routes.auth>
+})

--- a/demos/bookstore/app/actions/auth/forgot-password/controller.tsx
+++ b/demos/bookstore/app/actions/auth/forgot-password/controller.tsx
@@ -1,14 +1,14 @@
-import type { AppController } from '../../../router.ts'
+import { createController } from 'remix/fetch-router'
 import * as s from 'remix/data-schema'
 import { Database } from 'remix/data-table'
 
 import { passwordResetTokens, users } from '../../../data/schema.ts'
-import type { routes } from '../../../routes.ts'
+import { routes } from '../../../routes.ts'
 import { render } from '../../render.tsx'
 import { forgotPasswordSchema, normalizeEmail } from '../schemas.ts'
 import { ForgotPasswordPage, ForgotPasswordSuccessPage } from './page.tsx'
 
-export default {
+export default createController(routes.auth.forgotPassword, {
   actions: {
     index() {
       return render(<ForgotPasswordPage />)
@@ -34,4 +34,4 @@ export default {
       return render(<ForgotPasswordSuccessPage token={token} />)
     },
   },
-} satisfies AppController<typeof routes.auth.forgotPassword>
+})

--- a/demos/bookstore/app/actions/auth/login/controller.tsx
+++ b/demos/bookstore/app/actions/auth/login/controller.tsx
@@ -1,4 +1,4 @@
-import type { AppController } from '../../../router.ts'
+import { createController } from 'remix/fetch-router'
 import { completeAuth, verifyCredentials } from 'remix/auth'
 import { redirect } from 'remix/response/redirect'
 
@@ -12,7 +12,7 @@ import {
 } from '../../../middleware/auth.ts'
 import { LoginPage } from './page.tsx'
 
-export default {
+export default createController(routes.auth.login, {
   actions: {
     index({ get, url }) {
       let session = get(Session)
@@ -40,4 +40,4 @@ export default {
       return redirect(getPostAuthRedirect(url))
     },
   },
-} satisfies AppController<typeof routes.auth.login>
+})

--- a/demos/bookstore/app/actions/auth/register/controller.tsx
+++ b/demos/bookstore/app/actions/auth/register/controller.tsx
@@ -1,4 +1,4 @@
-import type { AppController } from '../../../router.ts'
+import { createController } from 'remix/fetch-router'
 import * as s from 'remix/data-schema'
 import { Database } from 'remix/data-table'
 import { redirect } from 'remix/response/redirect'
@@ -11,7 +11,7 @@ import { render } from '../../render.tsx'
 import { normalizeEmail, registrationSchema } from '../schemas.ts'
 import { ExistingAccountPage, RegisterPage } from './page.tsx'
 
-export default {
+export default createController(routes.auth.register, {
   actions: {
     index() {
       return render(<RegisterPage />)
@@ -44,4 +44,4 @@ export default {
       return redirect(routes.account.index.href())
     },
   },
-} satisfies AppController<typeof routes.auth.register>
+})

--- a/demos/bookstore/app/actions/auth/reset-password/controller.tsx
+++ b/demos/bookstore/app/actions/auth/reset-password/controller.tsx
@@ -1,4 +1,4 @@
-import type { AppController } from '../../../router.ts'
+import { createController } from 'remix/fetch-router'
 import * as s from 'remix/data-schema'
 import { Database } from 'remix/data-table'
 import { redirect } from 'remix/response/redirect'
@@ -11,7 +11,7 @@ import { render } from '../../render.tsx'
 import { resetPasswordSchema } from '../schemas.ts'
 import { ResetPasswordPage, ResetPasswordSuccessPage } from './page.tsx'
 
-export default {
+export default createController(routes.auth.resetPassword, {
   actions: {
     index({ params, get }) {
       let session = get(Session)
@@ -59,4 +59,4 @@ export default {
       return render(<ResetPasswordSuccessPage />)
     },
   },
-} satisfies AppController<typeof routes.auth.resetPassword>
+})

--- a/demos/bookstore/app/actions/books/controller.tsx
+++ b/demos/bookstore/app/actions/books/controller.tsx
@@ -1,15 +1,15 @@
-import type { AppController } from '../../router.ts'
+import { createController } from 'remix/fetch-router'
 import { Database, ilike } from 'remix/data-table'
 
 import { books } from '../../data/schema.ts'
-import type { routes } from '../../routes.ts'
+import { routes } from '../../routes.ts'
 import { getCurrentCart } from '../../utils/context.ts'
 import { render } from '../render.tsx'
 import { IndexPage } from './index-page.tsx'
 import { GenreNotFoundPage, GenrePage } from './genre-page.tsx'
 import { BookNotFoundPage, ShowPage } from './show-page.tsx'
 
-export default {
+export default createController(routes.books, {
   actions: {
     async index({ get }) {
       let db = get(Database)
@@ -54,4 +54,4 @@ export default {
       })
     },
   },
-} satisfies AppController<typeof routes.books>
+})

--- a/demos/bookstore/app/actions/cart/api/controller.tsx
+++ b/demos/bookstore/app/actions/cart/api/controller.tsx
@@ -1,4 +1,4 @@
-import type { AppController } from '../../../router.ts'
+import { createController } from 'remix/fetch-router'
 import * as s from 'remix/data-schema'
 import * as f from 'remix/data-schema/form-data'
 import { Database } from 'remix/data-table'
@@ -24,7 +24,7 @@ const cartUpdateSchema = f.object({
   redirect: redirectField,
 })
 
-export default {
+export default createController(routes.cart.api, {
   actions: {
     async add({ get }) {
       let db = get(Database)
@@ -100,4 +100,4 @@ export default {
       return redirect(routes.cart.index.href())
     },
   },
-} satisfies AppController<typeof routes.cart.api>
+})

--- a/demos/bookstore/app/actions/cart/controller.tsx
+++ b/demos/bookstore/app/actions/cart/controller.tsx
@@ -1,13 +1,13 @@
-import type { AppController } from '../../router.ts'
+import { createController } from 'remix/fetch-router'
 
-import type { routes } from '../../routes.ts'
+import { routes } from '../../routes.ts'
 import { render } from '../render.tsx'
 import { CartPage } from './page.tsx'
 
-export default {
+export default createController(routes.cart, {
   actions: {
     index() {
       return render(<CartPage />)
     },
   },
-} satisfies AppController<typeof routes.cart>
+})

--- a/demos/bookstore/app/actions/checkout/controller.tsx
+++ b/demos/bookstore/app/actions/checkout/controller.tsx
@@ -1,4 +1,4 @@
-import type { AppController } from '../../router.ts'
+import { createController } from 'remix/fetch-router'
 import * as s from 'remix/data-schema'
 import * as f from 'remix/data-schema/form-data'
 import { Database } from 'remix/data-table'
@@ -23,8 +23,8 @@ const shippingAddressSchema = f.object({
   zip: textField,
 })
 
-export default {
-  middleware: [requireAuth()],
+export default createController(routes.checkout, {
+  middleware: [requireAuth()] as const,
   actions: {
     index() {
       let cart = getCurrentCart()
@@ -107,4 +107,4 @@ export default {
       return render(<CheckoutConfirmationPage order={order} />)
     },
   },
-} satisfies AppController<typeof routes.checkout>
+})

--- a/demos/bookstore/app/actions/contact/controller.tsx
+++ b/demos/bookstore/app/actions/contact/controller.tsx
@@ -1,10 +1,10 @@
-import type { AppController } from '../../router.ts'
+import { createController } from 'remix/fetch-router'
 
-import type { routes } from '../../routes.ts'
+import { routes } from '../../routes.ts'
 import { render } from '../render.tsx'
 import { ContactPage, ContactSuccessPage } from './page.tsx'
 
-export default {
+export default createController(routes.contact, {
   actions: {
     index() {
       return render(<ContactPage />)
@@ -14,4 +14,4 @@ export default {
       return render(<ContactSuccessPage />)
     },
   },
-} satisfies AppController<typeof routes.contact>
+})

--- a/demos/bookstore/app/actions/controller.tsx
+++ b/demos/bookstore/app/actions/controller.tsx
@@ -1,9 +1,9 @@
-import type { AppController } from '../router.ts'
+import { createController } from 'remix/fetch-router'
 import { Database, ilike, inList, or } from 'remix/data-table'
 import { createFileResponse as sendFile } from 'remix/response/file'
 
 import { books } from '../data/schema.ts'
-import type { routes } from '../routes.ts'
+import { routes } from '../routes.ts'
 import { assetServer } from '../utils/assets.ts'
 import { getCurrentCart } from '../utils/context.ts'
 import { render } from './render.tsx'
@@ -12,7 +12,7 @@ import { AboutPage } from './about.tsx'
 import { HomePage } from './home.tsx'
 import { SearchPage } from './search.tsx'
 
-export default {
+export default createController(routes, {
   actions: {
     async assets({ request }) {
       let assetResponse = await assetServer.fetch(request)
@@ -67,4 +67,4 @@ export default {
       return render(<SearchPage query={query} matchingBooks={matchingBooks} cart={cart} />)
     },
   },
-} satisfies AppController<typeof routes>
+})

--- a/demos/bookstore/app/actions/fragments/controller.tsx
+++ b/demos/bookstore/app/actions/fragments/controller.tsx
@@ -1,4 +1,4 @@
-import type { AppController } from '../../router.ts'
+import { createController } from 'remix/fetch-router'
 import { css } from 'remix/ui'
 import { Database } from 'remix/data-table'
 
@@ -11,7 +11,7 @@ import { getCurrentCart, getCurrentUserSafely } from '../../utils/context.ts'
 import { parseId } from '../../utils/ids.ts'
 import { renderFragment } from '../render.tsx'
 
-export default {
+export default createController(routes.fragments, {
   actions: {
     async cartButton({ get, params }) {
       let db = get(Database)
@@ -49,4 +49,4 @@ export default {
       return renderFragment(<CartItems items={cart.items} total={total} canCheckout={!!user} />)
     },
   },
-} satisfies AppController<typeof routes.fragments>
+})

--- a/demos/bookstore/app/middleware/asset-entry.ts
+++ b/demos/bookstore/app/middleware/asset-entry.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path'
 import { createContextKey } from 'remix/fetch-router'
-import type { Middleware } from 'remix/fetch-router'
+import type { ContextEntry, Middleware } from 'remix/fetch-router'
 import { getContext } from 'remix/async-context-middleware'
 
 import { assetServer } from '../utils/assets.ts'
@@ -15,12 +15,12 @@ const assetsEntryKey = createContextKey<AssetEntry>()
 const defaultScriptEntry = path.resolve(import.meta.dirname, '../assets/entry.tsx')
 const defaultStylesheetEntry = path.resolve(import.meta.dirname, '../assets/app.css')
 
-type SetAssetEntryContextTransform = readonly [readonly [typeof assetsEntryKey, AssetEntry]]
+type AssetEntryContextEntry = ContextEntry<typeof assetsEntryKey, AssetEntry>
 
 export function loadAssetEntry(
   scriptEntry = defaultScriptEntry,
   stylesheetEntry = defaultStylesheetEntry,
-): Middleware<SetAssetEntryContextTransform> {
+): Middleware<AssetEntryContextEntry> {
   return async (context, next) => {
     let [scriptSrc, scriptPreloads, stylesheetHref] = await Promise.all([
       assetServer.getHref(scriptEntry),

--- a/demos/bookstore/app/middleware/asset-entry.ts
+++ b/demos/bookstore/app/middleware/asset-entry.ts
@@ -20,7 +20,7 @@ type SetAssetEntryContextTransform = readonly [readonly [typeof assetsEntryKey, 
 export function loadAssetEntry(
   scriptEntry = defaultScriptEntry,
   stylesheetEntry = defaultStylesheetEntry,
-): Middleware<any, SetAssetEntryContextTransform> {
+): Middleware<SetAssetEntryContextTransform> {
   return async (context, next) => {
     let [scriptSrc, scriptPreloads, stylesheetHref] = await Promise.all([
       assetServer.getHref(scriptEntry),

--- a/demos/bookstore/app/middleware/auth.ts
+++ b/demos/bookstore/app/middleware/auth.ts
@@ -74,7 +74,7 @@ type RequireBookstoreUserTransform = readonly [readonly [typeof Auth, GoodAuth<U
 
 export function requireAuth(
   options?: RequireAuthOptions,
-): Middleware<any, RequireBookstoreUserTransform> {
+): Middleware<RequireBookstoreUserTransform> {
   let redirectTo = options?.redirectTo ?? routes.auth.login.index
 
   return (context, next) => {

--- a/demos/bookstore/app/middleware/auth.ts
+++ b/demos/bookstore/app/middleware/auth.ts
@@ -2,7 +2,7 @@ import type { Route } from 'remix/routes'
 import { createCredentialsAuthProvider } from 'remix/auth'
 import { Auth, auth, createSessionAuthScheme, type GoodAuth } from 'remix/auth-middleware'
 import { Database } from 'remix/data-table'
-import type { Middleware } from 'remix/fetch-router'
+import type { ContextEntry, Middleware } from 'remix/fetch-router'
 import { redirect } from 'remix/response/redirect'
 
 import { users } from '../data/schema.ts'
@@ -70,11 +70,9 @@ export interface RequireAuthOptions {
   redirectTo?: Route
 }
 
-type RequireBookstoreUserTransform = readonly [readonly [typeof Auth, GoodAuth<User>]]
+type BookstoreUserContextEntry = ContextEntry<typeof Auth, GoodAuth<User>>
 
-export function requireAuth(
-  options?: RequireAuthOptions,
-): Middleware<RequireBookstoreUserTransform> {
+export function requireAuth(options?: RequireAuthOptions): Middleware<BookstoreUserContextEntry> {
   let redirectTo = options?.redirectTo ?? routes.auth.login.index
 
   return (context, next) => {

--- a/demos/bookstore/app/middleware/auth.ts
+++ b/demos/bookstore/app/middleware/auth.ts
@@ -1,11 +1,8 @@
 import type { Route } from 'remix/routes'
 import { createCredentialsAuthProvider } from 'remix/auth'
-import {
-  auth,
-  requireAuth as requireAuthenticatedUser,
-  createSessionAuthScheme,
-} from 'remix/auth-middleware'
+import { Auth, auth, createSessionAuthScheme, type GoodAuth } from 'remix/auth-middleware'
 import { Database } from 'remix/data-table'
+import type { Middleware } from 'remix/fetch-router'
 import { redirect } from 'remix/response/redirect'
 
 import { users } from '../data/schema.ts'
@@ -73,20 +70,31 @@ export interface RequireAuthOptions {
   redirectTo?: Route
 }
 
-export function requireAuth(options?: RequireAuthOptions) {
+type RequireBookstoreUserTransform = readonly [readonly [typeof Auth, GoodAuth<User>]]
+
+export function requireAuth(
+  options?: RequireAuthOptions,
+): Middleware<any, RequireBookstoreUserTransform> {
   let redirectTo = options?.redirectTo ?? routes.auth.login.index
 
-  return requireAuthenticatedUser({
-    onFailure(context) {
-      return redirect(
-        redirectTo.href(undefined, {
-          returnTo:
-            getSafeReturnTo(context.url.searchParams.get('returnTo')) ??
-            context.url.pathname + context.url.search,
-        }),
-      )
-    },
-  })
+  return (context, next) => {
+    let authState = context.get(Auth)
+    if (authState == null) {
+      throw new Error('Auth state not found. Make sure loadAuth() runs before requireAuth().')
+    }
+
+    if (authState.ok) {
+      return next()
+    }
+
+    return redirect(
+      redirectTo.href(undefined, {
+        returnTo:
+          getSafeReturnTo(context.url.searchParams.get('returnTo')) ??
+          context.url.pathname + context.url.search,
+      }),
+    )
+  }
 }
 
 export function getPostAuthRedirect(url: URL, fallback = routes.account.index.href()): string {

--- a/demos/bookstore/app/middleware/database.ts
+++ b/demos/bookstore/app/middleware/database.ts
@@ -1,11 +1,11 @@
-import type { Middleware } from 'remix/fetch-router'
+import type { ContextEntry, Middleware } from 'remix/fetch-router'
 import { Database } from 'remix/data-table'
 
 import { db } from '../data/setup.ts'
 
-type SetDatabaseContextTransform = readonly [readonly [typeof Database, Database]]
+type DatabaseContextEntry = ContextEntry<typeof Database, Database>
 
-export function loadDatabase(): Middleware<SetDatabaseContextTransform> {
+export function loadDatabase(): Middleware<DatabaseContextEntry> {
   return async (context, next) => {
     context.set(Database, db)
     return next()

--- a/demos/bookstore/app/middleware/database.ts
+++ b/demos/bookstore/app/middleware/database.ts
@@ -5,7 +5,7 @@ import { db } from '../data/setup.ts'
 
 type SetDatabaseContextTransform = readonly [readonly [typeof Database, Database]]
 
-export function loadDatabase(): Middleware<{}, SetDatabaseContextTransform> {
+export function loadDatabase(): Middleware<SetDatabaseContextTransform> {
   return async (context, next) => {
     context.set(Database, db)
     return next()

--- a/demos/bookstore/app/router.ts
+++ b/demos/bookstore/app/router.ts
@@ -1,9 +1,8 @@
 import {
   createRouter,
   type AnyParams,
-  type Controller,
   type MiddlewareContext,
-  type WithParams,
+  type ContextWithParams,
 } from 'remix/fetch-router'
 import { asyncContext } from 'remix/async-context-middleware'
 import { compression } from 'remix/compression-middleware'
@@ -11,7 +10,6 @@ import { formData } from 'remix/form-data-middleware'
 import type { Cookie } from 'remix/cookie'
 import { logger } from 'remix/logger-middleware'
 import { methodOverride } from 'remix/method-override-middleware'
-import type { RouteMap } from 'remix/routes'
 import type { SessionStorage } from 'remix/session'
 import { session } from 'remix/session-middleware'
 import { staticFiles } from 'remix/static-middleware'
@@ -51,12 +49,16 @@ export type RootMiddleware = [
   ReturnType<typeof loadAuth>,
 ]
 
-export type AppContext<params extends AnyParams = {}> = WithParams<
+export type AppContext<params extends AnyParams = {}> = ContextWithParams<
   MiddlewareContext<RootMiddleware>,
   params
 >
 
-export type AppController<routes extends RouteMap> = Controller<routes, AppContext>
+declare module 'remix/fetch-router' {
+  interface RouterTypes {
+    context: AppContext
+  }
+}
 
 export interface BookstoreRouterOptions {
   sessionCookie?: Cookie

--- a/demos/frame-navigation/app/actions/auth/controller.tsx
+++ b/demos/frame-navigation/app/actions/auth/controller.tsx
@@ -1,10 +1,10 @@
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 import { redirect } from 'remix/response/redirect'
 
 import { routes } from '../../routes.ts'
 import { authCookie } from '../../middleware/auth.ts'
 
-export default {
+export default createController(routes.auth, {
   actions: {
     async logout() {
       return redirect(routes.auth.login.index.href(), {
@@ -14,4 +14,4 @@ export default {
       })
     },
   },
-} satisfies Controller<typeof routes.auth>
+})

--- a/demos/frame-navigation/app/actions/auth/login/controller.tsx
+++ b/demos/frame-navigation/app/actions/auth/login/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 import { css } from 'remix/ui'
 import { redirect } from 'remix/response/redirect'
 
@@ -6,7 +6,7 @@ import { routes } from '../../../routes.ts'
 import { render } from '../../render.tsx'
 import { authCookie, isAuthenticated } from '../../../middleware/auth.ts'
 
-export default {
+export default createController(routes.auth.login, {
   actions: {
     async index() {
       if (await isAuthenticated()) {
@@ -50,7 +50,7 @@ export default {
       })
     },
   },
-} satisfies Controller<typeof routes.auth.login>
+})
 
 const cardStyle = css({
   maxWidth: '38rem',

--- a/demos/frame-navigation/app/actions/main/controller.tsx
+++ b/demos/frame-navigation/app/actions/main/controller.tsx
@@ -1,8 +1,8 @@
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 import type { RemixNode } from 'remix/ui'
 
 import { requireAuth } from '../../middleware/auth.ts'
-import type { routes } from '../../routes.ts'
+import { routes } from '../../routes.ts'
 import { Layout, type MainNavItem } from '../../ui/layout.tsx'
 import { render } from '../render.tsx'
 import { MainAccountPage } from './account-page.tsx'
@@ -18,7 +18,7 @@ function renderMainPage(title: string, activeNav: MainNavItem, content: RemixNod
   )
 }
 
-export default {
+export default createController(routes.main, {
   middleware: [requireAuth],
   actions: {
     index() {
@@ -34,4 +34,4 @@ export default {
       return renderMainPage('Account', 'account', <MainAccountPage />)
     },
   },
-} satisfies Controller<typeof routes.main>
+})

--- a/demos/frame-navigation/app/actions/settings/controller.tsx
+++ b/demos/frame-navigation/app/actions/settings/controller.tsx
@@ -1,10 +1,10 @@
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 import type { Handle, RemixNode } from 'remix/ui'
 import { Frame } from 'remix/ui'
 import { getContext } from 'remix/async-context-middleware'
 
 import { requireAuth } from '../../middleware/auth.ts'
-import { frames, type routes } from '../../routes.ts'
+import { frames, routes } from '../../routes.ts'
 import { Layout } from '../../ui/layout.tsx'
 import { render } from '../render.tsx'
 import { SettingsLayout, type SettingsNavItem } from './layout.tsx'
@@ -16,7 +16,7 @@ import { Notifications } from './notifications-page.tsx'
 import { Privacy } from './privacy-page.tsx'
 import { Profile } from './profile-page.tsx'
 
-export default {
+export default createController(routes.settings, {
   middleware: [requireAuth],
   actions: {
     index() {
@@ -38,7 +38,7 @@ export default {
       return renderSettingsPage('integrations', <Integrations />)
     },
   },
-} satisfies Controller<typeof routes.settings>
+})
 
 type SettingsPageProps = {
   activeItem: SettingsNavItem

--- a/demos/frames/app/actions/controller.tsx
+++ b/demos/frames/app/actions/controller.tsx
@@ -1,6 +1,6 @@
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 
-import type { routes } from '../routes.ts'
+import { routes } from '../routes.ts'
 import { render } from './render.ts'
 import { ClientMountedPage } from './client-mounted.tsx'
 import { HomePage } from './home.tsx'
@@ -9,7 +9,7 @@ import { rootReloadClientEntriesAction } from './root-reload-client-entries.tsx'
 import { StateSearchRoutePage } from './state-search.tsx'
 import { TimePage } from './time.tsx'
 
-export default {
+export default createController(routes, {
   actions: {
     home({ request, router }) {
       return render(<HomePage />, { request, router })
@@ -46,4 +46,4 @@ export default {
 
     rootReloadClientEntries: rootReloadClientEntriesAction.handler,
   },
-} satisfies Controller<typeof routes>
+})

--- a/demos/frames/app/actions/frames/controller.tsx
+++ b/demos/frames/app/actions/frames/controller.tsx
@@ -1,5 +1,5 @@
 import { Frame } from 'remix/ui'
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 
 import { Counter } from '../../assets/counter.tsx'
 import { ReloadScope } from '../../assets/reload-scope.tsx'
@@ -8,7 +8,7 @@ import { routes } from '../../routes.ts'
 import { render } from '../render.ts'
 import { searchUnitedStates } from '../../utils/us-states.ts'
 
-export const framesController = {
+export const framesController = createController(routes.frames, {
   actions: {
     async sidebar() {
       await delay(400)
@@ -244,7 +244,7 @@ export const framesController = {
       )
     },
   },
-} satisfies Controller<typeof routes.frames>
+})
 
 function delay(ms: number) {
   if (process.env.NODE_ENV === 'test') {

--- a/demos/frames/app/actions/root-reload-client-entries.tsx
+++ b/demos/frames/app/actions/root-reload-client-entries.tsx
@@ -1,4 +1,4 @@
-import type { Action } from 'remix/fetch-router'
+import { createAction } from 'remix/fetch-router'
 import type { Handle } from 'remix/ui'
 
 import {
@@ -10,7 +10,7 @@ import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
 import { render } from './render.ts'
 
-export const rootReloadClientEntriesAction = {
+export const rootReloadClientEntriesAction = createAction(routes.rootReloadClientEntries, {
   async handler(context) {
     await delay(1000)
 
@@ -28,7 +28,7 @@ export const rootReloadClientEntriesAction = {
       { request: context.request, router: context.router },
     )
   },
-} satisfies Action<typeof routes.rootReloadClientEntries>
+})
 
 type RootReloadClientEntriesPageProps = {
   includeRemoved: boolean

--- a/demos/social-auth/app/actions/auth/controller.tsx
+++ b/demos/social-auth/app/actions/auth/controller.tsx
@@ -1,14 +1,13 @@
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 import { completeAuth, verifyCredentials } from 'remix/auth'
 import { redirect } from 'remix/response/redirect'
 
 import { getPostAuthRedirect, getReturnToQuery, passwordProvider } from '../../middleware/auth.ts'
 import { Session } from '../../middleware/session.ts'
-import type { AppContext } from '../../router.ts'
 import { routes } from '../../routes.ts'
 
 export function createAuthController() {
-  return {
+  return createController(routes.auth, {
     actions: {
       async login(context) {
         let { get, url } = context
@@ -43,5 +42,5 @@ export function createAuthController() {
         return redirect(routes.home.href())
       },
     },
-  } satisfies Controller<typeof routes.auth, AppContext>
+  })
 }

--- a/demos/social-auth/app/actions/auth/forgot-password/controller.tsx
+++ b/demos/social-auth/app/actions/auth/forgot-password/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 import { Database } from 'remix/data-table'
 import * as s from 'remix/data-schema'
 
@@ -7,11 +7,10 @@ import { getIssueMessage, readField } from '../form-utils.ts'
 import { forgotPasswordSchema } from '../schemas.ts'
 import { normalizeEmail, passwordResetTokens, users } from '../../../data/schema.ts'
 import { getReturnToQuery } from '../../../middleware/auth.ts'
-import type { AppContext } from '../../../router.ts'
 import { routes } from '../../../routes.ts'
 import { render } from '../../render.tsx'
 
-export const forgotPasswordController = {
+export const forgotPasswordController = createController(routes.auth.forgotPassword, {
   actions: {
     index({ url }) {
       return render(
@@ -63,4 +62,4 @@ export const forgotPasswordController = {
       )
     },
   },
-} satisfies Controller<typeof routes.auth.forgotPassword, AppContext>
+})

--- a/demos/social-auth/app/actions/auth/github/controller.ts
+++ b/demos/social-auth/app/actions/auth/github/controller.ts
@@ -1,12 +1,11 @@
 import { completeAuth, finishExternalAuth, startExternalAuth } from 'remix/auth'
 import { Database } from 'remix/data-table'
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 import { redirect } from 'remix/response/redirect'
 
 import { resolveExternalAuth } from '../resolve-external-auth.ts'
 import { getReturnToQuery } from '../../../middleware/auth.ts'
 import { Session } from '../../../middleware/session.ts'
-import type { AppContext } from '../../../router.ts'
 import { routes } from '../../../routes.ts'
 import {
   externalProviderRegistry,
@@ -21,7 +20,7 @@ export function createGitHubAuthController(
 ) {
   let provider = registry.github
 
-  return {
+  return createController(routes.auth.github, {
     actions: {
       async login(context) {
         let { get, url } = context
@@ -72,5 +71,5 @@ export function createGitHubAuthController(
         }
       },
     },
-  } satisfies Controller<typeof routes.auth.github, AppContext>
+  })
 }

--- a/demos/social-auth/app/actions/auth/google/controller.ts
+++ b/demos/social-auth/app/actions/auth/google/controller.ts
@@ -1,12 +1,11 @@
 import { completeAuth, finishExternalAuth, startExternalAuth } from 'remix/auth'
 import { Database } from 'remix/data-table'
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 import { redirect } from 'remix/response/redirect'
 
 import { resolveExternalAuth } from '../resolve-external-auth.ts'
 import { getReturnToQuery } from '../../../middleware/auth.ts'
 import { Session } from '../../../middleware/session.ts'
-import type { AppContext } from '../../../router.ts'
 import { routes } from '../../../routes.ts'
 import {
   externalProviderRegistry,
@@ -21,7 +20,7 @@ export function createGoogleAuthController(
 ) {
   let provider = registry.google
 
-  return {
+  return createController(routes.auth.google, {
     actions: {
       async login(context) {
         let { get, url } = context
@@ -72,5 +71,5 @@ export function createGoogleAuthController(
         }
       },
     },
-  } satisfies Controller<typeof routes.auth.google, AppContext>
+  })
 }

--- a/demos/social-auth/app/actions/auth/reset-password/controller.tsx
+++ b/demos/social-auth/app/actions/auth/reset-password/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 import { Database } from 'remix/data-table'
 import * as s from 'remix/data-schema'
 
@@ -31,7 +31,7 @@ async function loadResetToken(context: AppContext<{ token: string }>) {
   return resetToken
 }
 
-export const resetPasswordController = {
+export const resetPasswordController = createController(routes.auth.resetPassword, {
   actions: {
     async index(context) {
       let { params, url } = context
@@ -128,4 +128,4 @@ export const resetPasswordController = {
       )
     },
   },
-} satisfies Controller<typeof routes.auth.resetPassword, AppContext>
+})

--- a/demos/social-auth/app/actions/auth/signup/controller.tsx
+++ b/demos/social-auth/app/actions/auth/signup/controller.tsx
@@ -1,4 +1,4 @@
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 import { Database } from 'remix/data-table'
 import * as s from 'remix/data-schema'
 import { redirect } from 'remix/response/redirect'
@@ -9,12 +9,11 @@ import { signupSchema } from '../schemas.ts'
 import { normalizeEmail, normalizeText, users } from '../../../data/schema.ts'
 import { getPostAuthRedirect, getReturnToQuery } from '../../../middleware/auth.ts'
 import { Session } from '../../../middleware/session.ts'
-import type { AppContext } from '../../../router.ts'
 import { routes } from '../../../routes.ts'
 import { hashPassword } from '../../../utils/password-hash.ts'
 import { render } from '../../render.tsx'
 
-export const signupController = {
+export const signupController = createController(routes.auth.signup, {
   actions: {
     index({ url }) {
       let returnToQuery = getReturnToQuery(url)
@@ -81,4 +80,4 @@ export const signupController = {
       return redirect(getPostAuthRedirect(url))
     },
   },
-} satisfies Controller<typeof routes.auth.signup, AppContext>
+})

--- a/demos/social-auth/app/actions/auth/x/controller.ts
+++ b/demos/social-auth/app/actions/auth/x/controller.ts
@@ -1,12 +1,11 @@
 import { completeAuth, finishExternalAuth, startExternalAuth } from 'remix/auth'
 import { Database } from 'remix/data-table'
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 import { redirect } from 'remix/response/redirect'
 
 import { resolveExternalAuth } from '../resolve-external-auth.ts'
 import { getReturnToQuery } from '../../../middleware/auth.ts'
 import { Session } from '../../../middleware/session.ts'
-import type { AppContext } from '../../../router.ts'
 import { routes } from '../../../routes.ts'
 import {
   externalProviderRegistry,
@@ -21,7 +20,7 @@ export function createXAuthController(
 ) {
   let provider = registry.x
 
-  return {
+  return createController(routes.auth.x, {
     actions: {
       async login(context) {
         let { get, url } = context
@@ -72,5 +71,5 @@ export function createXAuthController(
         }
       },
     },
-  } satisfies Controller<typeof routes.auth.x, AppContext>
+  })
 }

--- a/demos/social-auth/app/actions/controller.tsx
+++ b/demos/social-auth/app/actions/controller.tsx
@@ -1,10 +1,9 @@
 import { Auth } from 'remix/auth-middleware'
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 import { redirect } from 'remix/response/redirect'
 
 import { getReturnToQuery, requireAuth } from '../middleware/auth.ts'
 import { Session } from '../middleware/session.ts'
-import type { AppContext } from '../router.ts'
 import { routes } from '../routes.ts'
 import { AccountPage } from '../ui/account-page.tsx'
 import { LoginPage } from '../ui/home/page.tsx'
@@ -18,7 +17,7 @@ import { render } from './render.tsx'
 export function createRootController(
   registry: ExternalProviderRegistry = externalProviderRegistry,
 ) {
-  return {
+  return createController(routes, {
     actions: {
       home({ get, url }) {
         let auth = get(Auth)
@@ -56,5 +55,5 @@ export function createRootController(
         },
       },
     },
-  } satisfies Controller<typeof routes, AppContext>
+  })
 }

--- a/demos/social-auth/app/middleware/database.ts
+++ b/demos/social-auth/app/middleware/database.ts
@@ -1,11 +1,11 @@
-import type { Middleware } from 'remix/fetch-router'
+import type { ContextEntry, Middleware } from 'remix/fetch-router'
 import { Database } from 'remix/data-table'
 
 import { db } from '../data/setup.ts'
 
-type SetDatabaseContextTransform = readonly [readonly [typeof Database, Database]]
+type DatabaseContextEntry = ContextEntry<typeof Database, Database>
 
-export function loadDatabase(): Middleware<SetDatabaseContextTransform> {
+export function loadDatabase(): Middleware<DatabaseContextEntry> {
   return async (context, next) => {
     context.set(Database, db)
     return next()

--- a/demos/social-auth/app/middleware/database.ts
+++ b/demos/social-auth/app/middleware/database.ts
@@ -5,7 +5,7 @@ import { db } from '../data/setup.ts'
 
 type SetDatabaseContextTransform = readonly [readonly [typeof Database, Database]]
 
-export function loadDatabase(): Middleware<{}, SetDatabaseContextTransform> {
+export function loadDatabase(): Middleware<SetDatabaseContextTransform> {
   return async (context, next) => {
     context.set(Database, db)
     return next()

--- a/demos/social-auth/app/router.ts
+++ b/demos/social-auth/app/router.ts
@@ -1,5 +1,5 @@
 import type { WithRequiredAuth } from 'remix/auth-middleware'
-import { createRouter, type MiddlewareContext, type WithParams } from 'remix/fetch-router'
+import { createRouter, type MiddlewareContext, type ContextWithParams } from 'remix/fetch-router'
 import type { Cookie } from 'remix/cookie'
 import { formData } from 'remix/form-data-middleware'
 import type { SessionStorage } from 'remix/session'
@@ -29,10 +29,16 @@ type RootMiddleware = [
   ReturnType<typeof loadAuth>,
 ]
 
-export type AppContext<params extends Record<string, string> = {}> = WithParams<
+export type AppContext<params extends Record<string, string> = {}> = ContextWithParams<
   MiddlewareContext<RootMiddleware>,
   params
 >
+
+declare module 'remix/fetch-router' {
+  interface RouterTypes {
+    context: AppContext
+  }
+}
 
 export type AuthenticatedAppContext<params extends Record<string, string> = {}> = WithRequiredAuth<
   AppContext<params>,

--- a/demos/social-auth/app/router.ts
+++ b/demos/social-auth/app/router.ts
@@ -1,4 +1,4 @@
-import type { WithRequiredAuth } from 'remix/auth-middleware'
+import type { ContextWithRequiredAuth } from 'remix/auth-middleware'
 import { createRouter, type MiddlewareContext, type ContextWithParams } from 'remix/fetch-router'
 import type { Cookie } from 'remix/cookie'
 import { formData } from 'remix/form-data-middleware'
@@ -40,10 +40,8 @@ declare module 'remix/fetch-router' {
   }
 }
 
-export type AuthenticatedAppContext<params extends Record<string, string> = {}> = WithRequiredAuth<
-  AppContext<params>,
-  AuthIdentity
->
+export type AuthenticatedAppContext<params extends Record<string, string> = {}> =
+  ContextWithRequiredAuth<AppContext<params>, AuthIdentity>
 
 export interface SocialAuthRouterOptions {
   sessionCookie?: Cookie

--- a/demos/sse/app/actions/controller.tsx
+++ b/demos/sse/app/actions/controller.tsx
@@ -1,11 +1,11 @@
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 
-import type { routes } from '../routes.ts'
+import { routes } from '../routes.ts'
 import { getMessageLimit } from '../utils/message-limit.ts'
 import { render } from './render.ts'
 import { HomePage } from './home.tsx'
 
-export default {
+export default createController(routes, {
   actions: {
     assets() {
       return new Response('Not found', { status: 404 })
@@ -66,4 +66,4 @@ export default {
       })
     },
   },
-} satisfies Controller<typeof routes>
+})

--- a/demos/unpkg/app/actions/controller.ts
+++ b/demos/unpkg/app/actions/controller.ts
@@ -1,7 +1,7 @@
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 import { createRedirectResponse as redirect } from 'remix/response/redirect'
 
-import type { routes } from '../routes.ts'
+import { routes } from '../routes.ts'
 import {
   fetchPackageContents,
   fetchPackageMetadata,
@@ -17,7 +17,7 @@ import { render } from './render.ts'
 import { HomePage } from '../ui/home-page.ts'
 import { renderDirectoryListing, renderError, renderFileContent } from './package-browser.ts'
 
-export default {
+export default createController(routes, {
   actions: {
     home() {
       return render('UNPKG - npm package browser', HomePage())
@@ -77,4 +77,4 @@ export default {
       }
     },
   },
-} satisfies Controller<typeof routes>
+})

--- a/packages/async-context-middleware/README.md
+++ b/packages/async-context-middleware/README.md
@@ -48,7 +48,7 @@ This middleware requires support for `node:async_hooks`, so it is intended for N
 
 ```ts
 import type { AnyParams, MiddlewareContext, ContextWithParams } from 'remix/fetch-router'
-import type { WithRequiredAuth } from 'remix/auth-middleware'
+import type { ContextWithRequiredAuth } from 'remix/auth-middleware'
 
 export type RootMiddleware = [ReturnType<typeof loadSession>, ReturnType<typeof loadAuth>]
 
@@ -57,7 +57,7 @@ export type AppContext<params extends AnyParams = AnyParams> = ContextWithParams
   params
 >
 
-export type AuthenticatedAppContext<params extends AnyParams = AnyParams> = WithRequiredAuth<
+export type AuthenticatedAppContext<params extends AnyParams = AnyParams> = ContextWithRequiredAuth<
   AppContext<params>,
   { id: string }
 >

--- a/packages/async-context-middleware/README.md
+++ b/packages/async-context-middleware/README.md
@@ -47,12 +47,12 @@ This middleware requires support for `node:async_hooks`, so it is intended for N
 `getContext()` is global and out-of-band, so apps can augment `AsyncContextTypes` to tell the package what request context lives in async local storage.
 
 ```ts
-import type { AnyParams, MiddlewareContext, WithParams } from 'remix/fetch-router'
+import type { AnyParams, MiddlewareContext, ContextWithParams } from 'remix/fetch-router'
 import type { WithRequiredAuth } from 'remix/auth-middleware'
 
 export type RootMiddleware = [ReturnType<typeof loadSession>, ReturnType<typeof loadAuth>]
 
-export type AppContext<params extends AnyParams = AnyParams> = WithParams<
+export type AppContext<params extends AnyParams = AnyParams> = ContextWithParams<
   MiddlewareContext<RootMiddleware>,
   params
 >

--- a/packages/async-context-middleware/src/lib/async-context.test.ts
+++ b/packages/async-context-middleware/src/lib/async-context.test.ts
@@ -5,7 +5,7 @@ import {
   createContextKey,
   createRouter,
   type AnyParams,
-  type MergeContext,
+  type ContextWithValues,
   type RequestContext,
 } from '@remix-run/fetch-router'
 import { route } from '@remix-run/routes'
@@ -16,7 +16,7 @@ const CurrentUser = createContextKey<unknown>()
 
 declare module './async-context.ts' {
   interface AsyncContextTypes {
-    requestContext: MergeContext<
+    requestContext: ContextWithValues<
       RequestContext<AnyParams>,
       [readonly [typeof CurrentUser, { id: string }]]
     >

--- a/packages/auth-middleware/.changes/minor.context-helper-renames.md
+++ b/packages/auth-middleware/.changes/minor.context-helper-renames.md
@@ -1,0 +1,9 @@
+BREAKING CHANGE: Renamed the auth context helper types from `WithAuth` and `WithRequiredAuth` to `ContextWithAuth` and `ContextWithRequiredAuth` so auth middleware follows the `ContextWith*` naming pattern for helpers that produce refined `RequestContext` types.
+
+```ts
+// before
+type AppAuthContext = WithRequiredAuth<AppContext, AuthIdentity>
+
+// after
+type AppAuthContext = ContextWithRequiredAuth<AppContext, AuthIdentity>
+```

--- a/packages/auth-middleware/src/index.ts
+++ b/packages/auth-middleware/src/index.ts
@@ -18,7 +18,7 @@ export type {
   AuthSchemeSuccess,
   GoodAuth,
   BadAuth,
-  WithAuth,
-  WithRequiredAuth,
+  ContextWithAuth,
+  ContextWithRequiredAuth,
 } from './lib/auth.ts'
 export type { RequireAuthOptions } from './lib/require-auth.ts'

--- a/packages/auth-middleware/src/lib/auth-types.test.ts
+++ b/packages/auth-middleware/src/lib/auth-types.test.ts
@@ -1,9 +1,9 @@
 import { describe, it } from '@remix-run/test'
 
 import {
+  createAction,
+  createController,
   createRouter,
-  type Action,
-  type Controller,
   type GetContextValue,
   type MiddlewareContext,
   type RequestContext,
@@ -95,7 +95,8 @@ router.get(routes.public, (context) => {
   return new Response('Public')
 })
 
-const privateAction = {
+const privateAction = createAction<typeof routes.private, ProtectedAppContext>(routes.private, {
+  middleware: [requireAuth<APIIdentity>()] as const,
   handler(context) {
     let currentAuth = context.get(Auth)
     let id: string = context.params.id
@@ -109,9 +110,10 @@ const privateAction = {
 
     return new Response('Private')
   },
-} satisfies Action<typeof routes.private, ProtectedAppContext>
+})
 
-const adminController = {
+const adminController = createController<typeof routes.admin, ProtectedAppContext>(routes.admin, {
+  middleware: [requireAuth<APIIdentity>()] as const,
   actions: {
     dashboard(context) {
       let currentAuth = context.get(Auth)
@@ -125,10 +127,13 @@ const adminController = {
       return new Response('Admin')
     },
   },
-} satisfies Controller<typeof routes.admin, ProtectedAppContext>
+})
 
-fallbackRouter.get('/session/:id', {
-  middleware: [requireAuth<{ kind: 'session'; id: string }>()] as const,
+type SessionIdentity = { kind: 'session'; id: string }
+type SessionAuthContext = WithRequiredAuth<RequestContext, SessionIdentity>
+
+const sessionAction = createAction<'/session/:id', SessionAuthContext>('/session/:id', {
+  middleware: [requireAuth<SessionIdentity>()] as const,
   handler(context) {
     let currentAuth = context.get(Auth)
     let id: string = context.params.id
@@ -142,15 +147,11 @@ fallbackRouter.get('/session/:id', {
   },
 })
 
-router.get(routes.private, {
-  middleware: [requireAuth<APIIdentity>()] as const,
-  handler: privateAction.handler,
-})
+fallbackRouter.get('/session/:id', sessionAction)
 
-router.map(routes.admin, {
-  middleware: [requireAuth<APIIdentity>()] as const,
-  actions: adminController.actions,
-})
+router.get(routes.private, privateAction)
+
+router.map(routes.admin, adminController)
 
 if (false as boolean) {
   router.get(routes.private, (context) => {
@@ -165,6 +166,7 @@ void router
 void fallbackRouter
 void privateAction
 void adminController
+void sessionAction
 
 describe('auth middleware type inference', () => {
   it('propagates auth state into controller and action contracts', () => {})

--- a/packages/auth-middleware/src/lib/auth-types.test.ts
+++ b/packages/auth-middleware/src/lib/auth-types.test.ts
@@ -14,9 +14,9 @@ import {
   Auth,
   auth,
   type AuthState,
+  type ContextWithAuth,
+  type ContextWithRequiredAuth,
   type GoodAuth,
-  type WithAuth,
-  type WithRequiredAuth,
 } from './auth.ts'
 import { requireAuth } from './require-auth.ts'
 import { createAPIAuthScheme } from './schemes/api-key.ts'
@@ -58,9 +58,9 @@ const routes = route({
 const routerMiddleware = [typedAuth] as const
 
 type AppContext = MiddlewareContext<typeof routerMiddleware>
-type ProtectedAppContext = WithRequiredAuth<AppContext, APIIdentity>
+type ProtectedAppContext = ContextWithRequiredAuth<AppContext, APIIdentity>
 
-type AuthContext = WithAuth<RequestContext, APIIdentity>
+type AuthContext = ContextWithAuth<RequestContext, APIIdentity>
 
 const router = createRouter({ middleware: routerMiddleware })
 const fallbackRouter = createRouter()
@@ -130,7 +130,7 @@ const adminController = createController<typeof routes.admin, ProtectedAppContex
 })
 
 type SessionIdentity = { kind: 'session'; id: string }
-type SessionAuthContext = WithRequiredAuth<RequestContext, SessionIdentity>
+type SessionAuthContext = ContextWithRequiredAuth<RequestContext, SessionIdentity>
 
 const sessionAction = createAction<'/session/:id', SessionAuthContext>('/session/:id', {
   middleware: [requireAuth<SessionIdentity>()] as const,

--- a/packages/auth-middleware/src/lib/auth.ts
+++ b/packages/auth-middleware/src/lib/auth.ts
@@ -135,7 +135,7 @@ export interface AuthOptions<schemes extends readonly AuthScheme<any>[] = AuthSc
  */
 export function auth<schemes extends readonly AuthScheme<any>[]>(
   options: AuthOptions<schemes>,
-): Middleware<any, SetAuthContextTransform<AuthForSchemes<schemes>>> {
+): Middleware<SetAuthContextTransform<AuthForSchemes<schemes>>> {
   if (options.schemes.length === 0) {
     throw new Error('auth() requires at least one authentication scheme')
   }

--- a/packages/auth-middleware/src/lib/auth.ts
+++ b/packages/auth-middleware/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import {
   createContextKey,
+  type ContextEntry,
   type ContextWithValues,
   type Middleware,
   type RequestContext,
@@ -51,15 +52,17 @@ export type AuthState<identity = unknown> = GoodAuth<identity> | BadAuth
  */
 export const Auth = createContextKey<AuthState>()
 
-export type WithAuth<
-  context extends RequestContext<any, any>,
-  identity = unknown,
-> = ContextWithValues<context, [readonly [typeof Auth, AuthState<identity>]]>
+type AuthContextEntry<auth> = ContextEntry<typeof Auth, auth>
 
-export type WithRequiredAuth<
+export type ContextWithAuth<
   context extends RequestContext<any, any>,
   identity = unknown,
-> = ContextWithValues<context, [readonly [typeof Auth, GoodAuth<identity>]]>
+> = ContextWithValues<context, [AuthContextEntry<AuthState<identity>>]>
+
+export type ContextWithRequiredAuth<
+  context extends RequestContext<any, any>,
+  identity = unknown,
+> = ContextWithValues<context, [AuthContextEntry<GoodAuth<identity>>]>
 
 /**
  * Successful result returned by an auth scheme.
@@ -117,8 +120,6 @@ type AuthForSchemes<schemes extends readonly AuthScheme<any>[]> = AuthState<
   AuthSchemeIdentity<schemes[number]>
 >
 
-type SetAuthContextTransform<auth> = readonly [readonly [typeof Auth, auth]]
-
 /**
  * Options for loading auth state for each request.
  */
@@ -135,7 +136,7 @@ export interface AuthOptions<schemes extends readonly AuthScheme<any>[] = AuthSc
  */
 export function auth<schemes extends readonly AuthScheme<any>[]>(
   options: AuthOptions<schemes>,
-): Middleware<SetAuthContextTransform<AuthForSchemes<schemes>>> {
+): Middleware<AuthContextEntry<AuthForSchemes<schemes>>> {
   if (options.schemes.length === 0) {
     throw new Error('auth() requires at least one authentication scheme')
   }

--- a/packages/auth-middleware/src/lib/auth.ts
+++ b/packages/auth-middleware/src/lib/auth.ts
@@ -1,6 +1,6 @@
 import {
   createContextKey,
-  type MergeContext,
+  type ContextWithValues,
   type Middleware,
   type RequestContext,
 } from '@remix-run/fetch-router'
@@ -51,15 +51,15 @@ export type AuthState<identity = unknown> = GoodAuth<identity> | BadAuth
  */
 export const Auth = createContextKey<AuthState>()
 
-export type WithAuth<context extends RequestContext<any, any>, identity = unknown> = MergeContext<
-  context,
-  [readonly [typeof Auth, AuthState<identity>]]
->
+export type WithAuth<
+  context extends RequestContext<any, any>,
+  identity = unknown,
+> = ContextWithValues<context, [readonly [typeof Auth, AuthState<identity>]]>
 
 export type WithRequiredAuth<
   context extends RequestContext<any, any>,
   identity = unknown,
-> = MergeContext<context, [readonly [typeof Auth, GoodAuth<identity>]]>
+> = ContextWithValues<context, [readonly [typeof Auth, GoodAuth<identity>]]>
 
 /**
  * Successful result returned by an auth scheme.

--- a/packages/auth-middleware/src/lib/require-auth.ts
+++ b/packages/auth-middleware/src/lib/require-auth.ts
@@ -46,7 +46,7 @@ export interface RequireAuthOptions {
  */
 export function requireAuth<identity = unknown>(
   options: RequireAuthOptions = {},
-): Middleware<any, RequireAuthContextTransform<identity>> {
+): Middleware<RequireAuthContextTransform<identity>> {
   return async (context, next) => {
     let auth = context.get(Auth)
     if (auth == null) {

--- a/packages/auth-middleware/src/lib/require-auth.ts
+++ b/packages/auth-middleware/src/lib/require-auth.ts
@@ -2,7 +2,7 @@ import type {
   GetContextValue,
   Middleware,
   RequestContext,
-  SetContextValue,
+  ContextWithValue,
 } from '@remix-run/fetch-router'
 
 import { Auth, type BadAuth, type GoodAuth } from './auth.ts'
@@ -28,7 +28,7 @@ type ResolvedGoodAuth<context extends RequestContext<any, any>, identity> = [
 
 type RequireAuthContextTransform<identity> = <context extends RequestContext<any, any>>(
   context: context,
-) => SetContextValue<context, typeof Auth, ResolvedGoodAuth<context, identity>>
+) => ContextWithValue<context, typeof Auth, ResolvedGoodAuth<context, identity>>
 
 /**
  * Options for enforcing authentication on a route.

--- a/packages/auth-middleware/src/lib/schemes/session.test.ts
+++ b/packages/auth-middleware/src/lib/schemes/session.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@remix-run/test'
 
 import { createCookie } from '@remix-run/cookie'
 import { createRouter } from '@remix-run/fetch-router'
-import type { Middleware } from '@remix-run/fetch-router'
+import type { ContextEntry, Middleware } from '@remix-run/fetch-router'
 import { createSession, Session } from '@remix-run/session'
 import { createMemorySessionStorage } from '@remix-run/session/memory-storage'
 import { session as sessionMiddleware } from '@remix-run/session-middleware'
@@ -13,7 +13,7 @@ import { requireAuth } from '../require-auth.ts'
 import { Auth } from '../auth.ts'
 import { createSessionAuthScheme } from './session.ts'
 
-type SetSessionContextTransform = readonly [readonly [typeof Session, Session]]
+type SessionContextEntry = ContextEntry<typeof Session, Session>
 
 describe('createSessionAuthScheme scheme', () => {
   it('throws when Session is not available in request context', async () => {
@@ -109,7 +109,7 @@ describe('createSessionAuthScheme scheme', () => {
 
   it('fails and invalidates when verify() returns null', async () => {
     let invalidated = false
-    let setSession: Middleware<SetSessionContextTransform> = (context, next) => {
+    let setSession: Middleware<SessionContextEntry> = (context, next) => {
       let session = createSession()
       session.set('auth', { userId: 'u1' })
       context.set(Session, session)

--- a/packages/auth-middleware/src/lib/schemes/session.test.ts
+++ b/packages/auth-middleware/src/lib/schemes/session.test.ts
@@ -109,7 +109,7 @@ describe('createSessionAuthScheme scheme', () => {
 
   it('fails and invalidates when verify() returns null', async () => {
     let invalidated = false
-    let setSession: Middleware<any, SetSessionContextTransform> = (context, next) => {
+    let setSession: Middleware<SetSessionContextTransform> = (context, next) => {
       let session = createSession()
       session.set('auth', { userId: 'u1' })
       context.set(Session, session)

--- a/packages/cli/src/lib/commands/doctor.test.ts
+++ b/packages/cli/src/lib/commands/doctor.test.ts
@@ -933,10 +933,9 @@ describe('doctor command', () => {
         'utf8',
       )
 
-      assert.match(contactSource, /import type \{ Controller \} from 'remix\/fetch-router'/)
-      assert.match(contactSource, /import type \{ routes \} from '\.\.\/\.\.\/routes\.ts'/)
-      assert.match(contactSource, /export default \{/)
-      assert.match(contactSource, /\} satisfies Controller<typeof routes\.contact>/)
+      assert.match(contactSource, /import \{ createController \} from 'remix\/fetch-router'/)
+      assert.match(contactSource, /import \{ routes \} from '\.\.\/\.\.\/routes\.ts'/)
+      assert.match(contactSource, /export default createController\(routes\.contact, \{/)
 
       let checkResult = await runDoctor([], projectDir)
 

--- a/packages/cli/src/lib/doctor/controller-placeholders.ts
+++ b/packages/cli/src/lib/doctor/controller-placeholders.ts
@@ -23,12 +23,12 @@ export function renderControllerPlaceholder(
   let routeExpression = getRouteAccessExpression(routeNode.name)
   let routesImportPath = getRelativeImportPath(entryPath, 'app/routes.ts')
 
-  lines.push(`import type { Controller } from 'remix/fetch-router'`, '')
-  lines.push(`import type { routes } from '${routesImportPath}'`)
+  lines.push(`import { createController } from 'remix/fetch-router'`, '')
+  lines.push(`import { routes } from '${routesImportPath}'`)
 
-  lines.push('', 'export default {', '  actions: {')
+  lines.push('', `export default createController(${routeExpression}, {`, '  actions: {')
   lines.push(...actionEntries)
-  lines.push('  },', `} satisfies Controller<typeof ${routeExpression}>`, '')
+  lines.push('  },', '})', '')
 
   return lines.join('\n')
 }

--- a/packages/cli/src/lib/doctor/project.ts
+++ b/packages/cli/src/lib/doctor/project.ts
@@ -344,13 +344,13 @@ function renderDefaultHomeAction(entryPath: string): string {
 
   if (extension === '.ts') {
     return [
-      `import type { Controller } from 'remix/fetch-router'`,
+      `import { createController } from 'remix/fetch-router'`,
       `import { html } from 'remix/html-template'`,
       `import { createHtmlResponse } from 'remix/response/html'`,
       '',
-      `import type { routes } from '../routes.ts'`,
+      `import { routes } from '../routes.ts'`,
       '',
-      `export default {`,
+      `export default createController(routes, {`,
       '  actions: {',
       '    home() {',
       '      let page = html`',
@@ -369,7 +369,7 @@ function renderDefaultHomeAction(entryPath: string): string {
       '      return createHtmlResponse(page)',
       '    },',
       '  },',
-      `} satisfies Controller<typeof routes>`,
+      `})`,
       '',
     ].join('\n')
   }
@@ -408,20 +408,20 @@ function renderDefaultHomeAction(entryPath: string): string {
   }
 
   return [
-    `import type { Controller } from 'remix/fetch-router'`,
+    `import { createController } from 'remix/fetch-router'`,
     `import { renderToStream } from 'remix/ui/server'`,
     `import { createHtmlResponse } from 'remix/response/html'`,
     '',
-    `import type { routes } from '../routes.ts'`,
+    `import { routes } from '../routes.ts'`,
     '',
-    `export default {`,
+    `export default createController(routes, {`,
     '  actions: {',
     '    home() {',
     '      let page = <HomePage />',
     '      return createHtmlResponse(renderToStream(page))',
     '    },',
     '  },',
-    `} satisfies Controller<typeof routes>`,
+    `})`,
     '',
     'function HomePage() {',
     '  return () => (',

--- a/packages/csrf-middleware/.changes/patch.typed-request-contexts.md
+++ b/packages/csrf-middleware/.changes/patch.typed-request-contexts.md
@@ -1,0 +1,1 @@
+Fixed CSRF helper and callback types so they accept request contexts enriched by middleware such as `session()` and `formData()`.

--- a/packages/csrf-middleware/src/lib/csrf.ts
+++ b/packages/csrf-middleware/src/lib/csrf.ts
@@ -1,10 +1,17 @@
 import { isRequestMethod } from '@remix-run/fetch-router'
-import type { Middleware, RequestContext, RequestMethod } from '@remix-run/fetch-router'
+import type {
+  AnyParams,
+  ContextEntries,
+  Middleware,
+  RequestContext,
+  RequestMethod,
+} from '@remix-run/fetch-router'
 import { Session } from '@remix-run/session'
 
 const defaultSafeMethods: RequestMethod[] = ['GET', 'HEAD', 'OPTIONS']
 const defaultTokenHeaderNames = ['X-Csrf-Token', 'X-Xsrf-Token', 'Csrf-Token']
 
+type AnyRequestContext = RequestContext<AnyParams, ContextEntries>
 type OriginMatcher = string | RegExp | ReadonlyArray<string | RegExp>
 
 /**
@@ -21,7 +28,7 @@ export interface CsrfOriginResolver {
    */
   (
     origin: string,
-    context: RequestContext,
+    context: AnyRequestContext,
   ): CsrfOriginResolverResult | Promise<CsrfOriginResolverResult>
 }
 
@@ -42,7 +49,7 @@ export interface CsrfTokenResolver {
   /**
    * Resolves the submitted CSRF token for the current request.
    */
-  (context: RequestContext): CsrfTokenResolverResult | Promise<CsrfTokenResolverResult>
+  (context: AnyRequestContext): CsrfTokenResolverResult | Promise<CsrfTokenResolverResult>
 }
 
 /**
@@ -104,7 +111,7 @@ export interface CsrfOptions {
   /**
    * Optional custom error response for rejected requests.
    */
-  onError?: (reason: CsrfFailureReason, context: RequestContext) => Response | Promise<Response>
+  onError?: (reason: CsrfFailureReason, context: AnyRequestContext) => Response | Promise<Response>
 }
 
 /**
@@ -168,7 +175,7 @@ function isSafeMethod(method: string, safeMethods: readonly RequestMethod[]): bo
  * @param tokenKey Session key that stores the token
  * @returns The active CSRF token
  */
-export function getCsrfToken(context: RequestContext, tokenKey = '_csrf'): string {
+export function getCsrfToken(context: AnyRequestContext, tokenKey = '_csrf'): string {
   let session = context.get(Session)
   if (session == null) {
     throw new Error('Session is not started. Use session() middleware before csrf().')
@@ -200,7 +207,7 @@ function createCsrfToken(): string {
 function getErrorResponse(
   options: CsrfOptions,
   reason: CsrfFailureReason,
-  context: RequestContext,
+  context: AnyRequestContext,
 ): Response | Promise<Response> {
   if (options.onError) {
     return options.onError(reason, context)
@@ -218,7 +225,7 @@ function getErrorResponse(
 }
 
 async function resolveSubmittedToken(
-  context: RequestContext,
+  context: AnyRequestContext,
   valueResolver: CsrfTokenResolver | undefined,
   fieldName: string,
   headerNames: readonly string[],
@@ -263,7 +270,7 @@ async function resolveSubmittedToken(
 }
 
 async function validateRequestOrigin(
-  context: RequestContext,
+  context: AnyRequestContext,
   configuredOrigin: CsrfOrigin | undefined,
   allowMissingOrigin: boolean,
   defaultOrigin: string,
@@ -303,7 +310,7 @@ async function validateRequestOrigin(
   return false
 }
 
-function getRequestOrigin(context: RequestContext): string | null {
+function getRequestOrigin(context: AnyRequestContext): string | null {
   let origin = context.headers.get('Origin')
   if (origin != null && origin.trim() !== '') {
     return origin

--- a/packages/fetch-router/.changes/minor.action-route-entry-types.md
+++ b/packages/fetch-router/.changes/minor.action-route-entry-types.md
@@ -1,4 +1,4 @@
-BREAKING CHANGE: Simplified route action, controller, and middleware helper types so they no longer accept unused request method type parameters. `Action` now accepts a route pattern, `RoutePattern`, or `Route` object as its first generic and the full request context as its optional second generic. `Controller` now accepts the route map as its first generic and the full request context as its optional second generic. `BuildAction` is no longer exported.
+BREAKING CHANGE: Simplified route action, controller, request handler, and middleware helper types. `Action` now accepts a route pattern, `RoutePattern`, or `Route` object as its first generic and the full request context as its optional second generic. `Controller` now accepts the route map as its first generic and the full request context as its optional second generic. `RequestHandler` now accepts the full request context as its only generic. `Middleware` now accepts only the context transform generic. `BuildAction` is no longer exported.
 
 For most apps, augment `RouterTypes.context` once and use `createAction()`/`createController()` to type stored handlers without `satisfies` clauses:
 
@@ -63,14 +63,24 @@ let matcher = createMatcher<MatchData>()
 let matcher = createMatcher<RouteEntry>()
 ```
 
-If you manually annotate middleware, pass only the params type and context transform type:
+If you manually annotate request handlers, pass the full request context type as the only generic:
 
 ```ts
 // before
-let middleware: Middleware<'ANY', {}, SetDatabaseContextTransform>
+let handler: RequestHandler<{ id: string }, RequestContext<{ id: string }>>
 
 // after
+let handler: RequestHandler<RequestContext<{ id: string }>>
+```
+
+If you manually annotate middleware, pass only the context transform type:
+
+```ts
+// before
 let middleware: Middleware<{}, SetDatabaseContextTransform>
+
+// after
+let middleware: Middleware<SetDatabaseContextTransform>
 ```
 
 Simplified the public middleware context helper types. `MiddlewareContext` is now the exported helper for deriving the request context produced by a middleware chain, and it accepts an optional base context as its second type parameter. `ContextWithMiddleware` is available when code reads more naturally by naming the base context first. The lower-level `ApplyContextTransform`, `ApplyMiddleware`, and `ApplyMiddlewareTuple` helpers are no longer exported. `MiddlewareContextTransform` has been renamed to `ContextTransform`.

--- a/packages/fetch-router/.changes/minor.action-route-entry-types.md
+++ b/packages/fetch-router/.changes/minor.action-route-entry-types.md
@@ -1,4 +1,4 @@
-BREAKING CHANGE: Simplified route action, controller, request handler, and middleware helper types. `Action` now accepts a route pattern, `RoutePattern`, or `Route` object as its first generic and the full request context as its optional second generic. It describes either a plain request handler function or an action object with optional inline middleware. `Controller` now accepts the route map as its first generic and the full request context as its optional second generic. `RequestHandler` now accepts the full request context as its only generic. `Middleware` now accepts only the context transform generic. `BuildAction` is no longer exported.
+BREAKING CHANGE: Simplified route action, controller, request handler, and middleware helper types. `Action` now accepts a route pattern, `RoutePattern`, or `Route` object as its first generic and the full request context as its optional second generic. It describes either a plain request handler function or an action object with optional inline middleware. `Controller` now accepts the route map as its first generic and the full request context as its optional second generic. `RequestHandler` now accepts the full request context as its only generic. `Middleware` now accepts one context effect generic, which can be a single `ContextEntry`, a `ContextEntries` tuple, or a context transform function. `BuildAction` is no longer exported.
 
 For most apps, augment `RouterTypes.context` once and use `createAction()`/`createController()` to type stored handlers without `satisfies` clauses:
 
@@ -95,10 +95,11 @@ If you manually annotate middleware, pass only the context transform type:
 let middleware: Middleware<{}, SetDatabaseContextTransform>
 
 // after
-let middleware: Middleware<SetDatabaseContextTransform>
+type DatabaseContextEntry = ContextEntry<typeof Database, Database>
+let middleware: Middleware<DatabaseContextEntry>
 ```
 
-Simplified the public middleware context helper types. `MiddlewareContext` is now the exported helper for deriving the request context produced by a middleware chain, and it accepts an optional base context as its second type parameter. `ContextWithMiddleware` is available when code reads more naturally by naming the base context first. The lower-level `ApplyContextTransform`, `ApplyMiddleware`, and `ApplyMiddlewareTuple` helpers are no longer exported. `MiddlewareContextTransform` has been renamed to `ContextTransform`.
+Simplified the public middleware context helper types. `MiddlewareContext` is now the exported helper for deriving the request context produced by a middleware chain, and it accepts an optional base context as its second type parameter. `ContextWithMiddleware` is available when code reads more naturally by naming the base context first. Middleware that provides one context value can use `ContextEntry<typeof Key, Value>` directly instead of wrapping the entry in a one-item tuple. The lower-level `MiddlewareContextTransform`, `ContextTransform`, `ApplyContextTransform`, `ApplyMiddleware`, and `ApplyMiddlewareTuple` helpers are no longer exported.
 
 ```ts
 // before
@@ -142,9 +143,11 @@ export type WithCurrentUser<context extends RequestContext<any, any>> = MergeCon
 >
 
 // after
+type CurrentUserContextEntry = ContextEntry<typeof CurrentUser, User | null>
+
 export type ContextWithCurrentUser<context extends RequestContext<any, any>> = ContextWithValues<
   context,
-  [readonly [typeof CurrentUser, User | null]]
+  [CurrentUserContextEntry]
 >
 ```
 

--- a/packages/fetch-router/.changes/minor.action-route-entry-types.md
+++ b/packages/fetch-router/.changes/minor.action-route-entry-types.md
@@ -1,4 +1,4 @@
-BREAKING CHANGE: Simplified route action, controller, request handler, and middleware helper types. `Action` now describes object-form route handlers only and accepts a route pattern, `RoutePattern`, or `Route` object as its first generic and the full request context as its optional second generic. Use the new `RouteHandler` type when you need to describe either a plain request handler function or an action object. `Controller` now accepts the route map as its first generic and the full request context as its optional second generic. `RequestHandler` now accepts the full request context as its only generic. `Middleware` now accepts only the context transform generic. `BuildAction` is no longer exported.
+BREAKING CHANGE: Simplified route action, controller, request handler, and middleware helper types. `Action` now accepts a route pattern, `RoutePattern`, or `Route` object as its first generic and the full request context as its optional second generic. It describes either a plain request handler function or an action object with optional inline middleware. `Controller` now accepts the route map as its first generic and the full request context as its optional second generic. `RequestHandler` now accepts the full request context as its only generic. `Middleware` now accepts only the context transform generic. `BuildAction` is no longer exported.
 
 For most apps, augment `RouterTypes.context` once and use `createAction()`/`createController()` to type stored handlers without `satisfies` clauses:
 
@@ -53,16 +53,10 @@ let action: Action<typeof routes.account, AccountContext> = {
 }
 ```
 
-If you used `Action` to annotate a stored route handler function, switch that annotation to `RouteHandler`. `Action` remains available for object-form handlers with optional middleware:
+`Action` can be used to manually annotate either action form:
 
 ```ts
-// before
 let handler: Action<typeof routes.account, AccountContext> = (context) => {
-  return Response.json(context.get(Auth).identity)
-}
-
-// after
-let handler: RouteHandler<typeof routes.account, AccountContext> = (context) => {
   return Response.json(context.get(Auth).identity)
 }
 

--- a/packages/fetch-router/.changes/minor.action-route-entry-types.md
+++ b/packages/fetch-router/.changes/minor.action-route-entry-types.md
@@ -1,19 +1,56 @@
-BREAKING CHANGE: Simplified route action and middleware helper types so they no longer accept unused request method type parameters. If you manually type route actions, pass only the route pattern or route object plus any request context type:
+BREAKING CHANGE: Simplified route action, controller, and middleware helper types so they no longer accept unused request method type parameters. `Action` now accepts a route pattern, `RoutePattern`, or `Route` object as its first generic and the full request context as its optional second generic. `Controller` now accepts the route map as its first generic and the full request context as its optional second generic. `BuildAction` is no longer exported.
+
+For most apps, augment `RouterTypes.context` once and use `createAction()`/`createController()` to type stored handlers without `satisfies` clauses:
 
 ```ts
-// before
-let action = {
-  handler(context) {
-    return new Response(context.params.id)
-  },
-} satisfies BuildAction<'GET', typeof routes.account, AppContext>
+import {
+  createAction,
+  createController,
+  type ContextWithParams,
+  type RequestContext,
+} from 'remix/fetch-router'
 
-// after
-let action = {
+type AppContext<params extends Record<string, string> = {}> = ContextWithParams<
+  RequestContext,
+  params
+>
+
+declare module 'remix/fetch-router' {
+  interface RouterTypes {
+    context: AppContext
+  }
+}
+
+let action = createAction(routes.account, {
   handler(context) {
     return new Response(context.params.id)
   },
-} satisfies Action<typeof routes.account, AppContext>
+})
+
+let controller = createController(routes, {
+  actions: {
+    account(context) {
+      return new Response(context.params.id)
+    },
+  },
+})
+```
+
+If you manually type actions or controllers in advanced multi-router code, compose the full context type first and pass it as the second generic:
+
+```ts
+import type { Action, ContextWithMiddleware } from 'remix/fetch-router'
+
+let accountMiddleware = [requireAuth<AuthIdentity>()] as const
+type AccountContext = ContextWithMiddleware<AppContext, typeof accountMiddleware>
+
+let action: Action<typeof routes.account, AccountContext> = {
+  middleware: accountMiddleware,
+  handler(context) {
+    let auth = context.get(Auth)
+    return Response.json(auth.identity)
+  },
+}
 ```
 
 Renamed the custom router matcher payload type from `MatchData` to `RouteEntry`:
@@ -36,30 +73,91 @@ let middleware: Middleware<'ANY', {}, SetDatabaseContextTransform>
 let middleware: Middleware<{}, SetDatabaseContextTransform>
 ```
 
-`Action` now accepts string patterns, `RoutePattern` objects, and `Route` objects directly. It also owns the optional action middleware tuple generic, so `BuildAction` is no longer exported.
-
-For stored action objects with action-local middleware, the handler context can now be derived from the middleware tuple that actually runs. Previously, the action had to repeat the middleware's type effect with a manually refined context type. That was type-safe only as long as the manual context type and the runtime middleware stayed in sync:
+Simplified the public middleware context helper types. `MiddlewareContext` is now the exported helper for deriving the request context produced by a middleware chain, and it accepts an optional base context as its second type parameter. `ContextWithMiddleware` is available when code reads more naturally by naming the base context first. The lower-level `ApplyContextTransform`, `ApplyMiddleware`, and `ApplyMiddlewareTuple` helpers are no longer exported. `MiddlewareContextTransform` has been renamed to `ContextTransform`.
 
 ```ts
 // before
-type AuthenticatedAppContext = WithRequiredAuth<AppContext, AuthIdentity>
+type AppContext = ApplyMiddlewareTuple<RequestContext, typeof middleware>
 
-let action = {
+// after
+type AppContext = MiddlewareContext<typeof middleware>
+```
+
+```ts
+// before
+type ActionContext = ApplyMiddlewareTuple<AppContext, typeof actionMiddleware>
+
+// after
+type ActionContext = ContextWithMiddleware<AppContext, typeof actionMiddleware>
+```
+
+Renamed request context helper types so their names describe the `RequestContext` type they produce. Use `ContextWithParams` when deriving an app context that includes route params:
+
+```ts
+// before
+type AppContext<params extends AnyParams = {}> = WithParams<
+  MiddlewareContext<typeof middleware>,
+  params
+>
+
+// after
+type AppContext<params extends AnyParams = {}> = ContextWithParams<
+  MiddlewareContext<typeof middleware>,
+  params
+>
+```
+
+Use `ContextWithValues` when a middleware package provides one or more context values. Third-party middleware packages that augment request context should prefer exported helper names like `ContextWithCurrentUser` so their package-specific helpers match the built-in `ContextWith...` naming pattern:
+
+```ts
+// before
+export type WithCurrentUser<context extends RequestContext<any, any>> = MergeContext<
+  context,
+  [readonly [typeof CurrentUser, User | null]]
+>
+
+// after
+export type ContextWithCurrentUser<context extends RequestContext<any, any>> = ContextWithValues<
+  context,
+  [readonly [typeof CurrentUser, User | null]]
+>
+```
+
+Use `ContextWithValue` when refining a single context value for a specific handler or middleware result:
+
+```ts
+// before
+type AdminContext = SetContextValue<AppContext, typeof CurrentRole, 'admin'>
+
+// after
+type AdminContext = ContextWithValue<AppContext, typeof CurrentRole, 'admin'>
+```
+
+Stored action objects and controllers no longer derive handler context from their local middleware tuple. If local middleware adds context values that a handler requires, compose the full handler context explicitly and pass it to `Action`, `Controller`, `createAction()`, or `createController()`:
+
+```ts
+// before
+let controller = createController(routes, {
   middleware: [requireAuth<AuthIdentity>()],
-  handler(context) {
-    let auth = context.get(Auth)
-    return Response.json(auth.identity)
+  actions: {
+    account(context) {
+      let auth = context.get(Auth)
+      return Response.json(auth.identity)
+    },
   },
-} satisfies BuildAction<'GET', typeof routes.account, AuthenticatedAppContext>
+})
 
 // after
 let accountMiddleware = [requireAuth<AuthIdentity>()] as const
+type AuthenticatedAppContext = ContextWithMiddleware<AppContext, typeof accountMiddleware>
 
-let action = {
+let controller = createController<typeof routes, AuthenticatedAppContext>(routes, {
   middleware: accountMiddleware,
-  handler(context) {
-    let auth = context.get(Auth)
-    return Response.json(auth.identity)
+  actions: {
+    account(context) {
+      let auth = context.get(Auth)
+      return Response.json(auth.identity)
+    },
   },
-} satisfies Action<typeof routes.account, AppContext, typeof accountMiddleware>
+})
 ```

--- a/packages/fetch-router/.changes/minor.action-route-entry-types.md
+++ b/packages/fetch-router/.changes/minor.action-route-entry-types.md
@@ -1,4 +1,4 @@
-BREAKING CHANGE: Simplified route action, controller, request handler, and middleware helper types. `Action` now accepts a route pattern, `RoutePattern`, or `Route` object as its first generic and the full request context as its optional second generic. `Controller` now accepts the route map as its first generic and the full request context as its optional second generic. `RequestHandler` now accepts the full request context as its only generic. `Middleware` now accepts only the context transform generic. `BuildAction` is no longer exported.
+BREAKING CHANGE: Simplified route action, controller, request handler, and middleware helper types. `Action` now describes object-form route handlers only and accepts a route pattern, `RoutePattern`, or `Route` object as its first generic and the full request context as its optional second generic. Use the new `RouteHandler` type when you need to describe either a plain request handler function or an action object. `Controller` now accepts the route map as its first generic and the full request context as its optional second generic. `RequestHandler` now accepts the full request context as its only generic. `Middleware` now accepts only the context transform generic. `BuildAction` is no longer exported.
 
 For most apps, augment `RouterTypes.context` once and use `createAction()`/`createController()` to type stored handlers without `satisfies` clauses:
 
@@ -49,6 +49,27 @@ let action: Action<typeof routes.account, AccountContext> = {
   handler(context) {
     let auth = context.get(Auth)
     return Response.json(auth.identity)
+  },
+}
+```
+
+If you used `Action` to annotate a stored route handler function, switch that annotation to `RouteHandler`. `Action` remains available for object-form handlers with optional middleware:
+
+```ts
+// before
+let handler: Action<typeof routes.account, AccountContext> = (context) => {
+  return Response.json(context.get(Auth).identity)
+}
+
+// after
+let handler: RouteHandler<typeof routes.account, AccountContext> = (context) => {
+  return Response.json(context.get(Auth).identity)
+}
+
+let action: Action<typeof routes.account, AccountContext> = {
+  middleware: accountMiddleware,
+  handler(context) {
+    return Response.json(context.get(Auth).identity)
   },
 }
 ```

--- a/packages/fetch-router/.changes/minor.real-request-inputs.md
+++ b/packages/fetch-router/.changes/minor.real-request-inputs.md
@@ -1,0 +1,1 @@
+BREAKING CHANGE: `router.fetch()` no longer clones `Request` inputs or supports `Request` facades that only become native requests through `clone()`. Pass a real `Request` object to `router.fetch()` when dispatching an existing request.

--- a/packages/fetch-router/README.md
+++ b/packages/fetch-router/README.md
@@ -680,6 +680,8 @@ let accountController = createController<typeof routes, AccountContext>(routes, 
 
 In this example, `AccountContext` describes the context the local middleware provides before the handler runs. In a larger app, you can derive a shared base context from router middleware with `MiddlewareContext<typeof middleware>`, or apply middleware to an existing context with `ContextWithMiddleware<AppContext, typeof middleware>`.
 
+When manually annotating stored handlers, use `RouteHandler<typeof route, Context>` for values that may be either a plain handler function or an action object. Use `Action<typeof route, Context>` specifically for object-form handlers with optional middleware.
+
 #### Middleware Provider Guidance
 
 `context.get(key)` returns a defined value when the context type includes that key or the key was created with a default value. Constructor keys like `FormData` are useful context keys, but the constructor itself is not a guarantee that a value exists. Use context transforms for required middleware values, and handle `undefined` when reading values that may not be present.

--- a/packages/fetch-router/README.md
+++ b/packages/fetch-router/README.md
@@ -626,58 +626,84 @@ router.get('/posts/:id', (context) => {
 
 Route params are only half of a handler's type contract. In many apps, handlers also depend on values that middleware loads into request context, like sessions, database connections, or authenticated users.
 
-`fetch-router` now lets you carry that context contract through the router, controller, and action types directly. A common pattern is to derive one app-local context type from your router middleware, then reuse it across stored controllers and actions.
+`fetch-router` lets you carry that context contract through the router and into stored controllers and actions. A common pattern is to derive one app-local context type from your router middleware, augment `RouterTypes.context` with it, then use `createAction()` and `createController()` to type stored handlers.
 
 ```ts
 import { Auth, requireAuth } from 'remix/auth-middleware'
-import { type Action, type RequestContext, type WithParams } from 'remix/fetch-router'
+import {
+  createAction,
+  createController,
+  type ContextWithParams,
+  type ContextWithMiddleware,
+  type RequestContext,
+} from 'remix/fetch-router'
 import { route } from 'remix/routes'
 
 let routes = route({
   account: '/account',
 })
 
-type AppContext<params extends Record<string, string> = {}> = WithParams<RequestContext, params>
+type AppContext<params extends Record<string, string> = {}> = ContextWithParams<
+  RequestContext,
+  params
+>
 
 type AuthIdentity = { id: string }
 
-let accountMiddleware = [requireAuth<AuthIdentity>()] as const
+declare module 'remix/fetch-router' {
+  interface RouterTypes {
+    context: AppContext
+  }
+}
 
-let accountAction = {
+let accountMiddleware = [requireAuth<AuthIdentity>()] as const
+type AccountContext = ContextWithMiddleware<AppContext, typeof accountMiddleware>
+
+let accountAction = createAction<typeof routes.account, AccountContext>(routes.account, {
   middleware: accountMiddleware,
   handler(context) {
     let auth = context.get(Auth)
     return Response.json({ id: auth.identity.id })
   },
-} satisfies Action<typeof routes.account, AppContext, typeof accountMiddleware>
+})
+
+let accountController = createController<typeof routes, AccountContext>(routes, {
+  middleware: accountMiddleware,
+  actions: {
+    account(context) {
+      let auth = context.get(Auth)
+      return Response.json({ id: auth.identity.id })
+    },
+  },
+})
 ```
 
-In this example, the action-local middleware tuple gives the handler the stronger context it requires and makes that contract true at runtime. In a larger app, you can still derive a shared base context from router middleware with `MiddlewareContext<typeof middleware>` and build on top of it the same way.
+In this example, `AccountContext` describes the context the local middleware provides before the handler runs. In a larger app, you can derive a shared base context from router middleware with `MiddlewareContext<typeof middleware>`, or apply middleware to an existing context with `ContextWithMiddleware<AppContext, typeof middleware>`.
 
 #### Middleware Provider Guidance
 
-`context.get(key)` returns a defined value when the context type includes that key or the key was created with a default value. Constructor keys like `FormData` are useful context keys, but the constructor itself is not a guarantee that a value exists. Use middleware context transforms for required values, and handle `undefined` when reading values that may not be present.
+`context.get(key)` returns a defined value when the context type includes that key or the key was created with a default value. Constructor keys like `FormData` are useful context keys, but the constructor itself is not a guarantee that a value exists. Use context transforms for required middleware values, and handle `undefined` when reading values that may not be present.
 
 If you're authoring a middleware package that stores values in request context, treat that context contract as part of the package API. A good provider should usually export:
 
 - the context key consumers read with `context.get(...)`
 - the middleware that populates that key at runtime
-- one or more `With...` helper types (optional) that let applications describe the resulting request context without touching raw context entries directly
+- one or more `ContextWith...` helper types that let applications describe the resulting request context without touching raw context entries directly
+
+Prefer `ContextWith...` names for third-party middleware packages that augment request context. This matches the built-in `ContextWithParams`, `ContextWithValues`, and `ContextWithValue` helpers and makes it clear that the type produces a new `RequestContext` type with additional context available.
 
 ```ts
-import { createContextKey, type MergeContext, type RequestContext } from 'remix/fetch-router'
+import { createContextKey, type ContextWithValues, type RequestContext } from 'remix/fetch-router'
 
 // The context key that consumers will need to read from `context.get(...)`
 export const CurrentUser = createContextKey<User | null>()
 
-// One or more With* helper types that apps can use to describe the request context
-export type WithCurrentUser<context extends RequestContext<any, any>> = MergeContext<
+// One or more ContextWith* helper types that apps can use to describe the request context
+export type ContextWithCurrentUser<context extends RequestContext<any, any>> = ContextWithValues<
   context,
   [readonly [typeof CurrentUser, User | null]]
 >
 ```
-
-Built-in middleware packages may also export `With...` helpers when that makes controller and action contracts clearer, for example `auth-middleware` provides `WithAuth` and `WithRequiredAuth`.
 
 ### Additional Topics
 

--- a/packages/fetch-router/README.md
+++ b/packages/fetch-router/README.md
@@ -695,15 +695,31 @@ If you're authoring a middleware package that stores values in request context, 
 Prefer `ContextWith...` names for third-party middleware packages that augment request context. This matches the built-in `ContextWithParams`, `ContextWithValues`, and `ContextWithValue` helpers and makes it clear that the type produces a new `RequestContext` type with additional context available.
 
 ```ts
-import { createContextKey, type ContextWithValues, type RequestContext } from 'remix/fetch-router'
+import {
+  createContextKey,
+  type ContextEntry,
+  type ContextWithValues,
+  type Middleware,
+  type RequestContext,
+} from 'remix/fetch-router'
 
 // The context key that consumers will need to read from `context.get(...)`
 export const CurrentUser = createContextKey<User | null>()
 
+// The context effect carried by middleware that sets one context value
+type CurrentUserContextEntry = ContextEntry<typeof CurrentUser, User | null>
+
+export function loadCurrentUser(): Middleware<CurrentUserContextEntry> {
+  return async (context, next) => {
+    context.set(CurrentUser, await getCurrentUser(context.request))
+    return next()
+  }
+}
+
 // One or more ContextWith* helper types that apps can use to describe the request context
 export type ContextWithCurrentUser<context extends RequestContext<any, any>> = ContextWithValues<
   context,
-  [readonly [typeof CurrentUser, User | null]]
+  [CurrentUserContextEntry]
 >
 ```
 

--- a/packages/fetch-router/README.md
+++ b/packages/fetch-router/README.md
@@ -680,7 +680,7 @@ let accountController = createController<typeof routes, AccountContext>(routes, 
 
 In this example, `AccountContext` describes the context the local middleware provides before the handler runs. In a larger app, you can derive a shared base context from router middleware with `MiddlewareContext<typeof middleware>`, or apply middleware to an existing context with `ContextWithMiddleware<AppContext, typeof middleware>`.
 
-When manually annotating stored handlers, use `RouteHandler<typeof route, Context>` for values that may be either a plain handler function or an action object. Use `Action<typeof route, Context>` specifically for object-form handlers with optional middleware.
+When manually annotating stored handlers, use `Action<typeof route, Context>` for values that may be either a plain handler function or an action object with optional middleware.
 
 #### Middleware Provider Guidance
 

--- a/packages/fetch-router/src/index.ts
+++ b/packages/fetch-router/src/index.ts
@@ -6,20 +6,20 @@ export type {
   GetContextValue,
   ContextEntries,
   ContextEntry,
-  MergeContext,
-  SetContextValue,
-  WithParams,
+  ContextWithValues,
+  ContextWithValue,
+  ContextWithParams,
+  RouterTypes,
 } from './lib/request-context.ts'
 
-export type { Controller, Action, RequestHandler } from './lib/controller.ts'
+export { createAction, createController } from './lib/controller.ts'
+export type { RequestHandler, Action, Controller } from './lib/controller.ts'
 
 export type {
-  ApplyContextTransform,
-  ApplyMiddleware,
-  ApplyMiddlewareTuple,
+  ContextWithMiddleware,
+  ContextTransform,
   Middleware,
   MiddlewareContext,
-  MiddlewareContextTransform,
   NextFunction,
 } from './lib/middleware.ts'
 

--- a/packages/fetch-router/src/index.ts
+++ b/packages/fetch-router/src/index.ts
@@ -14,7 +14,7 @@ export type {
 export type { RouterTypes } from './lib/router-types.ts'
 
 export { createAction, createController } from './lib/controller.ts'
-export type { RequestHandler, Action, RouteHandler, Controller } from './lib/controller.ts'
+export type { RequestHandler, Action, Controller } from './lib/controller.ts'
 
 export type {
   ContextWithMiddleware,

--- a/packages/fetch-router/src/index.ts
+++ b/packages/fetch-router/src/index.ts
@@ -18,7 +18,6 @@ export type { RequestHandler, Action, Controller } from './lib/controller.ts'
 
 export type {
   ContextWithMiddleware,
-  ContextTransform,
   Middleware,
   MiddlewareContext,
   NextFunction,

--- a/packages/fetch-router/src/index.ts
+++ b/packages/fetch-router/src/index.ts
@@ -9,11 +9,12 @@ export type {
   ContextWithValues,
   ContextWithValue,
   ContextWithParams,
-  RouterTypes,
 } from './lib/request-context.ts'
 
+export type { RouterTypes } from './lib/router-types.ts'
+
 export { createAction, createController } from './lib/controller.ts'
-export type { RequestHandler, Action, Controller } from './lib/controller.ts'
+export type { RequestHandler, Action, RouteHandler, Controller } from './lib/controller.ts'
 
 export type {
   ContextWithMiddleware,

--- a/packages/fetch-router/src/lib/controller.ts
+++ b/packages/fetch-router/src/lib/controller.ts
@@ -73,12 +73,10 @@ export function createAction(route: ActionRoute, action: Action<ActionRoute, Req
   return action
 }
 
-export interface ActionShape {
-  middleware?: readonly AnyMiddleware[]
+export function isAction(obj: unknown): obj is {
+  middleware?: readonly AnyMiddleware[] | undefined
   handler: RequestHandler<any, any>
-}
-
-export function isAction(obj: unknown): obj is ActionShape {
+} {
   return isRecord(obj) && typeof obj.handler === 'function'
 }
 
@@ -134,12 +132,10 @@ export function createController(
   return controller
 }
 
-export interface ControllerShape {
-  middleware?: readonly AnyMiddleware[]
+export function isController(obj: unknown): obj is {
+  middleware?: readonly AnyMiddleware[] | undefined
   actions: Record<string, unknown>
-}
-
-export function isController(obj: unknown): obj is ControllerShape {
+} {
   return isRecord(obj) && isRecord(obj.actions)
 }
 

--- a/packages/fetch-router/src/lib/controller.ts
+++ b/packages/fetch-router/src/lib/controller.ts
@@ -35,8 +35,8 @@ type ActionPattern<route extends ActionRoute> =
  * An individual route action.
  *
  * Actions are object-form route handlers with optional inline middleware.
- * Most app code should use {@link createAction}; use {@link RouteHandler}
- * when a value may be either a handler function or an action object.
+ * Most app code should use {@link createAction}; use this type directly when you need
+ * to describe an action for an explicit RequestContext type.
  */
 export interface Action<
   route extends ActionRoute,
@@ -92,7 +92,7 @@ export function isAction(obj: unknown): obj is Action<any, any> {
  * Controllers let you store related route handlers together while preserving the params
  * and request-context contract for each route handler. Most app code should use
  * {@link createController}; use this type directly when you need to describe a
- * controller for an explicit request-context type.
+ * controller for an explicit RequestContext type.
  */
 export type Controller<
   routes extends RouteMap,

--- a/packages/fetch-router/src/lib/controller.ts
+++ b/packages/fetch-router/src/lib/controller.ts
@@ -10,10 +10,7 @@ import type { ContextWithParams, DefaultContext, RequestContext } from './reques
  * @param context The request context
  * @returns The response
  */
-export interface RequestHandler<
-  params extends Record<string, any> = {},
-  context extends RequestContext<any, any> = RequestContext<params>,
-> {
+export interface RequestHandler<context extends RequestContext<any, any> = RequestContext> {
   /**
    * Handles a matched request and returns the response.
    */
@@ -40,24 +37,18 @@ export type Action<
   route extends ActionRoute,
   context extends RequestContext<any, any> = DefaultContext,
 > =
-  | RequestHandler<
-      Params<ActionPattern<route>>,
-      ContextWithParams<context, Params<ActionPattern<route>>>
-    >
+  | RequestHandler<ContextWithParams<context, Params<ActionPattern<route>>>>
   | {
       middleware?: readonly AnyMiddleware[] | undefined
-      handler: RequestHandler<
-        Params<ActionPattern<route>>,
-        ContextWithParams<context, Params<ActionPattern<route>>>
-      >
+      handler: RequestHandler<ContextWithParams<context, Params<ActionPattern<route>>>>
     }
 
 /**
  * Defines an action with route-aware params and the default router context.
  *
  * This helper returns the action unchanged while giving TypeScript the route pattern it needs to
- * type `context.params`. If an action's local middleware adds context values, compose those values
- * into the action context type before using {@link Action} directly.
+ * type `context.params`. If local middleware adds context values, compose those values into the
+ * action context type and pass it as the second generic.
  *
  * @param route The route pattern or route object this action handles.
  * @param action The handler function or action object to type-check.
@@ -67,30 +58,17 @@ export function createAction<
   route extends ActionRoute,
   context extends RequestContext<any, any> = DefaultContext,
   action extends Action<route, context> = Action<route, context>,
->(route: route, action: action): action
-export function createAction(route: ActionRoute, action: Action<ActionRoute, RequestContext>) {
+>(route: route, action: action): action {
   void route
   return action
 }
 
 export function isAction(obj: unknown): obj is {
   middleware?: readonly AnyMiddleware[] | undefined
-  handler: RequestHandler<any, any>
+  handler: RequestHandler<any>
 } {
   return isRecord(obj) && typeof obj.handler === 'function'
 }
-
-// prettier-ignore
-type ControllerActions<routes extends RouteMap, context extends RequestContext<any, any>> = routes extends any ?
-  {
-    [name in keyof routes as routes[name] extends Route<any, any> ? name : never]: (
-      routes[name] extends Route<any, infer pattern extends string> ? Action<pattern, context> :
-      never
-    )
-  } & {
-    [name in keyof routes as routes[name] extends RouteMap ? name : never]?: never
-  } :
-  never
 
 /**
  * A controller maps route leaves in a route map to actions.
@@ -105,15 +83,25 @@ export type Controller<
   context extends RequestContext<any, any> = DefaultContext,
 > = {
   middleware?: readonly AnyMiddleware[] | undefined
-  actions: ControllerActions<routes, context>
+  actions: routes extends any
+    ? {
+        [name in keyof routes as routes[name] extends Route<any, any>
+          ? name
+          : never]: routes[name] extends Route<any, infer pattern extends string>
+          ? Action<pattern, context>
+          : never
+      } & {
+        [name in keyof routes as routes[name] extends RouteMap ? name : never]?: never
+      }
+    : never
 }
 
 /**
  * Defines a controller whose action keys and params are checked against a route map.
  *
  * This helper returns the controller unchanged while giving TypeScript the route map it needs to
- * type each action's `context.params`. If a controller's local middleware adds context values,
- * compose those values into the controller context type before using {@link Controller} directly.
+ * type each action's `context.params`. If local middleware adds context values, compose those
+ * values into the controller context type and pass it as the second generic.
  *
  * @param routes The route map this controller handles.
  * @param controller The controller object to type-check.
@@ -123,11 +111,7 @@ export function createController<
   routes extends RouteMap,
   context extends RequestContext<any, any> = DefaultContext,
   controller extends Controller<routes, context> = Controller<routes, context>,
->(routes: routes, controller: controller): controller
-export function createController(
-  routes: RouteMap,
-  controller: Controller<RouteMap, RequestContext>,
-) {
+>(routes: routes, controller: controller): controller {
   void routes
   return controller
 }

--- a/packages/fetch-router/src/lib/controller.ts
+++ b/packages/fetch-router/src/lib/controller.ts
@@ -1,88 +1,8 @@
 import type { Params, RoutePattern } from '@remix-run/route-pattern'
 import type { Route, RouteMap } from '@remix-run/routes'
 
-import type { AnyMiddleware, ApplyMiddlewareTuple } from './middleware.ts'
-import type { RequestContext } from './request-context.ts'
-import type { WithParams } from './request-context.ts'
-
-type ActionRoute = string | RoutePattern | Route
-
-// prettier-ignore
-type ActionPattern<route extends ActionRoute> =
-  route extends string ? route :
-  route extends RoutePattern<infer pattern extends string> ? pattern :
-  route extends Route<any, infer pattern extends string> ? pattern :
-  never
-
-export type ControllerWithoutMiddleware<
-  routes extends RouteMap,
-  context extends RequestContext<any, any>,
-> = {
-  middleware?: undefined
-  actions: ControllerActions<routes, context>
-}
-
-export type ControllerWithMiddleware<
-  routes extends RouteMap,
-  context extends RequestContext<any, any>,
-  middleware extends readonly AnyMiddleware[],
-> = {
-  middleware: readonly [...middleware]
-  actions: ControllerActions<routes, ApplyMiddlewareTuple<context, middleware>>
-}
-
-/**
- * A controller object that maps the direct route leaves in a route map to action handlers.
- *
- * Controllers let you store related route handlers in one object while preserving the params
- * and request-context contract for each action. Nested route maps should be mapped with their
- * own controllers.
- */
-export type Controller<
-  routes extends RouteMap,
-  context extends RequestContext<any, any> = RequestContext,
-> =
-  | ControllerWithoutMiddleware<routes, context>
-  | ControllerWithMiddleware<routes, context, readonly AnyMiddleware[]>
-
-// prettier-ignore
-type ControllerActions<routes extends RouteMap, context extends RequestContext<any, any>> = routes extends any ?
-  {
-    [name in keyof routes as routes[name] extends Route<any, any> ? name : never]: (
-      routes[name] extends Route<any, infer pattern extends string> ? Action<pattern, context> :
-      never
-    )
-  } & {
-    [name in keyof routes as routes[name] extends RouteMap ? name : never]?: never
-  } :
-  never
-
-export type ControllerInput<
-  routes extends RouteMap,
-  context extends RequestContext<any, any>,
-  middleware extends readonly AnyMiddleware[] = readonly AnyMiddleware[],
-> =
-  | ControllerWithoutMiddleware<routes, context>
-  | ControllerWithMiddleware<routes, context, middleware>
-
-/**
- * An individual route action.
- *
- * Actions can be plain handler functions or action objects with optional inline middleware.
- */
-export type Action<
-  route extends ActionRoute,
-  context extends RequestContext<any, any> = RequestContext,
-  middleware extends readonly AnyMiddleware[] = readonly AnyMiddleware[],
-> =
-  | RequestHandler<Params<ActionPattern<route>>, WithParams<context, Params<ActionPattern<route>>>>
-  | {
-      middleware?: readonly [...middleware] | undefined
-      handler: RequestHandler<
-        Params<ActionPattern<route>>,
-        ApplyMiddlewareTuple<WithParams<context, Params<ActionPattern<route>>>, middleware>
-      >
-    }
+import type { AnyMiddleware } from './middleware.ts'
+import type { ContextWithParams, DefaultContext, RequestContext } from './request-context.ts'
 
 /**
  * A request handler function that returns some kind of response.
@@ -100,40 +20,127 @@ export interface RequestHandler<
   (context: context): Response | Promise<Response>
 }
 
-/**
- * Runtime shape for a controller.
- */
-export interface ControllerShape {
-  actions: Record<string, unknown>
-  middleware?: AnyMiddleware[]
-}
+type ActionRoute = string | RoutePattern | Route
+
+// prettier-ignore
+type ActionPattern<route extends ActionRoute> =
+  route extends string ? route :
+  route extends RoutePattern<infer pattern extends string> ? pattern :
+  route extends Route<any, infer pattern extends string> ? pattern :
+  never
 
 /**
- * Check if an object has an object `actions` property.
+ * An individual route action.
  *
- * @param obj The object to check
- * @returns `true` if the object is a controller
+ * Actions can be plain handler functions or action objects with optional inline middleware.
+ * Most app code should use {@link createAction}; use this type directly when you need
+ * to describe an action for an explicit request-context type.
  */
-export function isController(obj: unknown): obj is ControllerShape {
-  return isRecord(obj) && isRecord(obj.actions)
-}
+export type Action<
+  route extends ActionRoute,
+  context extends RequestContext<any, any> = DefaultContext,
+> =
+  | RequestHandler<
+      Params<ActionPattern<route>>,
+      ContextWithParams<context, Params<ActionPattern<route>>>
+    >
+  | {
+      middleware?: readonly AnyMiddleware[] | undefined
+      handler: RequestHandler<
+        Params<ActionPattern<route>>,
+        ContextWithParams<context, Params<ActionPattern<route>>>
+      >
+    }
 
 /**
- * Runtime shape for an action object.
+ * Defines an action with route-aware params and the default router context.
+ *
+ * This helper returns the action unchanged while giving TypeScript the route pattern it needs to
+ * type `context.params`. If an action's local middleware adds context values, compose those values
+ * into the action context type before using {@link Action} directly.
+ *
+ * @param route The route pattern or route object this action handles.
+ * @param action The handler function or action object to type-check.
+ * @returns The same action value.
  */
-export interface ActionObjectShape {
-  middleware?: AnyMiddleware[]
+export function createAction<
+  route extends ActionRoute,
+  context extends RequestContext<any, any> = DefaultContext,
+  action extends Action<route, context> = Action<route, context>,
+>(route: route, action: action): action
+export function createAction(route: ActionRoute, action: Action<ActionRoute, RequestContext>) {
+  void route
+  return action
+}
+
+export interface ActionShape {
+  middleware?: readonly AnyMiddleware[]
   handler: RequestHandler<any, any>
 }
 
-/**
- * Check if an object has a function `handler` property.
- *
- * @param obj The object to check
- * @returns `true` if the object is an action object
- */
-export function isActionObject(obj: unknown): obj is ActionObjectShape {
+export function isAction(obj: unknown): obj is ActionShape {
   return isRecord(obj) && typeof obj.handler === 'function'
+}
+
+// prettier-ignore
+type ControllerActions<routes extends RouteMap, context extends RequestContext<any, any>> = routes extends any ?
+  {
+    [name in keyof routes as routes[name] extends Route<any, any> ? name : never]: (
+      routes[name] extends Route<any, infer pattern extends string> ? Action<pattern, context> :
+      never
+    )
+  } & {
+    [name in keyof routes as routes[name] extends RouteMap ? name : never]?: never
+  } :
+  never
+
+/**
+ * A controller maps route leaves in a route map to actions.
+ *
+ * Controllers let you store related actions together while preserving the params
+ * and request-context contract for each action. Most app code should use
+ * {@link createController}; use this type directly when you need to describe a
+ * controller for an explicit request-context type.
+ */
+export type Controller<
+  routes extends RouteMap,
+  context extends RequestContext<any, any> = DefaultContext,
+> = {
+  middleware?: readonly AnyMiddleware[] | undefined
+  actions: ControllerActions<routes, context>
+}
+
+/**
+ * Defines a controller whose action keys and params are checked against a route map.
+ *
+ * This helper returns the controller unchanged while giving TypeScript the route map it needs to
+ * type each action's `context.params`. If a controller's local middleware adds context values,
+ * compose those values into the controller context type before using {@link Controller} directly.
+ *
+ * @param routes The route map this controller handles.
+ * @param controller The controller object to type-check.
+ * @returns The same controller value.
+ */
+export function createController<
+  routes extends RouteMap,
+  context extends RequestContext<any, any> = DefaultContext,
+  controller extends Controller<routes, context> = Controller<routes, context>,
+>(routes: routes, controller: controller): controller
+export function createController(
+  routes: RouteMap,
+  controller: Controller<RouteMap, RequestContext>,
+) {
+  void routes
+  return controller
+}
+
+export interface ControllerShape {
+  middleware?: readonly AnyMiddleware[]
+  actions: Record<string, unknown>
+}
+
+export function isController(obj: unknown): obj is ControllerShape {
+  return isRecord(obj) && isRecord(obj.actions)
 }
 
 function isRecord(obj: unknown): obj is Record<PropertyKey, unknown> {

--- a/packages/fetch-router/src/lib/controller.ts
+++ b/packages/fetch-router/src/lib/controller.ts
@@ -2,7 +2,8 @@ import type { Params, RoutePattern } from '@remix-run/route-pattern'
 import type { Route, RouteMap } from '@remix-run/routes'
 
 import type { AnyMiddleware } from './middleware.ts'
-import type { ContextWithParams, DefaultContext, RequestContext } from './request-context.ts'
+import type { ContextWithParams, RequestContext } from './request-context.ts'
+import type { DefaultContext } from './router-types.ts'
 
 /**
  * A request handler function that returns some kind of response.
@@ -33,22 +34,36 @@ type ActionPattern<route extends ActionRoute> =
 /**
  * An individual route action.
  *
- * Actions can be plain handler functions or action objects with optional inline middleware.
- * Most app code should use {@link createAction}; use this type directly when you need
- * to describe an action for an explicit request-context type.
+ * Actions are object-form route handlers with optional inline middleware.
+ * Most app code should use {@link createAction}; use {@link RouteHandler}
+ * when a value may be either a handler function or an action object.
  */
-export type Action<
+export interface Action<
+  route extends ActionRoute,
+  context extends RequestContext<any, any> = DefaultContext,
+> {
+  /**
+   * Middleware that runs before this action's handler.
+   */
+  middleware?: readonly AnyMiddleware[] | undefined
+  /**
+   * The handler that runs after this action's middleware.
+   */
+  handler: RequestHandler<ContextWithParams<context, Params<ActionPattern<route>>>>
+}
+
+/**
+ * A route handler can be a plain request handler function or an action object.
+ */
+export type RouteHandler<
   route extends ActionRoute,
   context extends RequestContext<any, any> = DefaultContext,
 > =
   | RequestHandler<ContextWithParams<context, Params<ActionPattern<route>>>>
-  | {
-      middleware?: readonly AnyMiddleware[] | undefined
-      handler: RequestHandler<ContextWithParams<context, Params<ActionPattern<route>>>>
-    }
+  | Action<route, context>
 
 /**
- * Defines an action with route-aware params and the default router context.
+ * Defines a route handler with route-aware params and the default router context.
  *
  * This helper returns the action unchanged while giving TypeScript the route pattern it needs to
  * type `context.params`. If local middleware adds context values, compose those values into the
@@ -61,24 +76,21 @@ export type Action<
 export function createAction<
   route extends ActionRoute,
   context extends RequestContext<any, any> = DefaultContext,
-  action extends Action<route, context> = Action<route, context>,
+  action extends RouteHandler<route, context> = RouteHandler<route, context>,
 >(route: route, action: action): action {
   void route
   return action
 }
 
-export function isAction(obj: unknown): obj is {
-  middleware?: readonly AnyMiddleware[] | undefined
-  handler: RequestHandler<any>
-} {
+export function isAction(obj: unknown): obj is Action<any, any> {
   return isRecord(obj) && typeof obj.handler === 'function'
 }
 
 /**
- * A controller maps route leaves in a route map to actions.
+ * A controller maps route leaves in a route map to route handlers.
  *
- * Controllers let you store related actions together while preserving the params
- * and request-context contract for each action. Most app code should use
+ * Controllers let you store related route handlers together while preserving the params
+ * and request-context contract for each route handler. Most app code should use
  * {@link createController}; use this type directly when you need to describe a
  * controller for an explicit request-context type.
  */
@@ -91,8 +103,8 @@ export type Controller<
     ? {
         [name in keyof routes as routes[name] extends Route<any, any>
           ? name
-          : never]: routes[name] extends Route<any, infer pattern extends string>
-          ? Action<pattern, context>
+          : never]: routes[name] extends Route<any, any>
+          ? RouteHandler<routes[name], context>
           : never
       } & {
         [name in keyof routes as routes[name] extends RouteMap ? name : never]?: never

--- a/packages/fetch-router/src/lib/controller.ts
+++ b/packages/fetch-router/src/lib/controller.ts
@@ -31,17 +31,10 @@ type ActionPattern<route extends ActionRoute> =
   route extends Route<any, infer pattern extends string> ? pattern :
   never
 
-/**
- * An individual route action.
- *
- * Actions are object-form route handlers with optional inline middleware.
- * Most app code should use {@link createAction}; use this type directly when you need
- * to describe an action for an explicit RequestContext type.
- */
-export interface Action<
+type ActionObject<
   route extends ActionRoute,
   context extends RequestContext<any, any> = DefaultContext,
-> {
+> = {
   /**
    * Middleware that runs before this action's handler.
    */
@@ -53,14 +46,18 @@ export interface Action<
 }
 
 /**
- * A route handler can be a plain request handler function or an action object.
+ * An individual route action.
+ *
+ * Actions may be plain request handler functions or objects with optional inline middleware.
+ * Most app code should use {@link createAction}; use this type directly when you need
+ * to describe an action for an explicit RequestContext type.
  */
-export type RouteHandler<
+export type Action<
   route extends ActionRoute,
   context extends RequestContext<any, any> = DefaultContext,
 > =
   | RequestHandler<ContextWithParams<context, Params<ActionPattern<route>>>>
-  | Action<route, context>
+  | ActionObject<route, context>
 
 /**
  * Defines a route handler with route-aware params and the default router context.
@@ -76,21 +73,25 @@ export type RouteHandler<
 export function createAction<
   route extends ActionRoute,
   context extends RequestContext<any, any> = DefaultContext,
-  action extends RouteHandler<route, context> = RouteHandler<route, context>,
+  action extends Action<route, context> = Action<route, context>,
 >(route: route, action: action): action {
   void route
   return action
 }
 
 export function isAction(obj: unknown): obj is Action<any, any> {
+  return isRequestHandler(obj) || isActionObject(obj)
+}
+
+export function isActionObject(obj: unknown): obj is ActionObject<any, any> {
   return isRecord(obj) && typeof obj.handler === 'function'
 }
 
 /**
- * A controller maps route leaves in a route map to route handlers.
+ * A controller maps route leaves in a route map to actions.
  *
- * Controllers let you store related route handlers together while preserving the params
- * and request-context contract for each route handler. Most app code should use
+ * Controllers let you store related actions together while preserving the params
+ * and request-context contract for each action. Most app code should use
  * {@link createController}; use this type directly when you need to describe a
  * controller for an explicit RequestContext type.
  */
@@ -103,9 +104,7 @@ export type Controller<
     ? {
         [name in keyof routes as routes[name] extends Route<any, any>
           ? name
-          : never]: routes[name] extends Route<any, any>
-          ? RouteHandler<routes[name], context>
-          : never
+          : never]: routes[name] extends Route<any, any> ? Action<routes[name], context> : never
       } & {
         [name in keyof routes as routes[name] extends RouteMap ? name : never]?: never
       }

--- a/packages/fetch-router/src/lib/controller.ts
+++ b/packages/fetch-router/src/lib/controller.ts
@@ -17,6 +17,10 @@ export interface RequestHandler<context extends RequestContext<any, any> = Reque
   (context: context): Response | Promise<Response>
 }
 
+export function isRequestHandler(object: unknown): object is RequestHandler<any> {
+  return typeof object === 'function'
+}
+
 type ActionRoute = string | RoutePattern | Route
 
 // prettier-ignore

--- a/packages/fetch-router/src/lib/middleware.ts
+++ b/packages/fetch-router/src/lib/middleware.ts
@@ -1,20 +1,19 @@
 import type { RequestHandler } from './controller.ts'
 import { raceRequestAbort } from './request-abort.ts'
-import type { ContextEntries, RequestContext } from './request-context.ts'
+import type {
+  ContextEntries,
+  ContextEntry,
+  ContextWithValues,
+  RequestContext,
+} from './request-context.ts'
 
 /**
  * A middleware of any context transform.
  */
-export type AnyMiddleware = Middleware<any>
+export type AnyMiddleware = Middleware<ContextTransform>
 
-/**
- * The type-level effect a middleware can apply to request context.
- *
- * Middleware authors may provide either context entries or a custom context transform
- * function. Prefer exposing named `ContextWith*` helpers for reusable middleware that
- * adds values to context.
- */
-export type ContextTransform =
+type ContextTransform =
+  | ContextEntry
   | ContextEntries
   | (<context extends RequestContext<any, any>>(context: context) => RequestContext<any, any>)
 
@@ -27,19 +26,16 @@ type ContextWithTransform<
   context extends RequestContext<any, any>,
   transform,
 > = transform extends ContextEntries
-  ? context extends RequestContext<
-      infer params extends Record<string, any>,
-      infer entries extends ContextEntries
-    >
-    ? RequestContext<params, [...entries, ...transform]>
-    : context
-  : transform extends {
-        <inputContext extends context>(context: inputContext): infer output
-      }
-    ? output extends RequestContext<any, any>
-      ? output
+  ? ContextWithValues<context, transform>
+  : transform extends ContextEntry
+    ? ContextWithValues<context, [transform]>
+    : transform extends {
+          <inputContext extends context>(context: inputContext): infer output
+        }
+      ? output extends RequestContext<any, any>
+        ? output
+        : context
       : context
-    : context
 
 /**
  * Resolves the request-context type produced by a middleware array.
@@ -74,6 +70,9 @@ export type ContextWithMiddleware<
  * @param context The request context
  * @param next A function that invokes the next middleware or request handler in the chain
  * @returns A response to short-circuit the chain, or `undefined`/`void` to continue
+ *
+ * The generic describes the context effect this middleware has. Use a {@link ContextEntry}
+ * for middleware that provides one context value, or {@link ContextEntries} for multiple values.
  */
 export interface Middleware<transform extends ContextTransform = EmptyContextTransform> {
   /**

--- a/packages/fetch-router/src/lib/middleware.ts
+++ b/packages/fetch-router/src/lib/middleware.ts
@@ -9,66 +9,63 @@ export type AnyMiddleware = Middleware<any, any>
 
 /**
  * The type-level effect a middleware can apply to request context.
+ *
+ * Middleware authors may provide either context entries or a custom context transform
+ * function. Prefer exposing named `ContextWith*` helpers for reusable middleware that
+ * adds values to context.
  */
-export type MiddlewareContextTransform =
+export type ContextTransform =
   | ContextEntries
   | (<context extends RequestContext<any, any>>(context: context) => RequestContext<any, any>)
 
-type IdentityContextTransform = readonly []
+type EmptyContextTransform = readonly []
 
-type MiddlewareTransform<middleware> =
-  middleware extends Middleware<any, infer transform> ? transform : IdentityContextTransform
+type TransformOf<middleware> =
+  middleware extends Middleware<any, infer transform> ? transform : EmptyContextTransform
 
-/**
- * Applies a middleware context transform to a request-context type.
- */
-export type ApplyContextTransform<
-  currentContext extends RequestContext<any, any>,
+type ContextWithTransform<
+  context extends RequestContext<any, any>,
   transform,
 > = transform extends ContextEntries
-  ? currentContext extends RequestContext<
+  ? context extends RequestContext<
       infer params extends Record<string, any>,
       infer entries extends ContextEntries
     >
     ? RequestContext<params, [...entries, ...transform]>
-    : currentContext
+    : context
   : transform extends {
-        <inputContext extends currentContext>(context: inputContext): infer output
+        <inputContext extends context>(context: inputContext): infer output
       }
     ? output extends RequestContext<any, any>
       ? output
-      : currentContext
-    : currentContext
-
-/**
- * Applies the declared context effect of a single middleware to a request-context type.
- */
-export type ApplyMiddleware<
-  context extends RequestContext<any, any>,
-  middleware,
-> = ApplyContextTransform<context, MiddlewareTransform<middleware>>
-
-/**
- * Applies an ordered middleware array to a request-context type from left to right.
- */
-export type ApplyMiddlewareTuple<
-  context extends RequestContext<any, any>,
-  middleware,
-> = middleware extends readonly AnyMiddleware[]
-  ? number extends middleware['length']
-    ? context
-    : middleware extends readonly [infer first, ...infer rest]
-      ? ApplyMiddlewareTuple<ApplyMiddleware<context, first>, rest>
       : context
-  : context
+    : context
 
 /**
- * Resolves the request-context type produced by a router middleware array.
+ * Resolves the request-context type produced by a middleware array.
  */
-export type MiddlewareContext<middleware extends readonly AnyMiddleware[]> = ApplyMiddlewareTuple<
-  RequestContext,
-  middleware
->
+export type MiddlewareContext<
+  middleware extends readonly AnyMiddleware[],
+  context extends RequestContext<any, any> = RequestContext,
+> = number extends middleware['length']
+  ? context
+  : middleware extends readonly [
+        infer first extends AnyMiddleware,
+        ...infer rest extends readonly AnyMiddleware[],
+      ]
+    ? MiddlewareContext<rest, ContextWithTransform<context, TransformOf<first>>>
+    : context
+
+/**
+ * Resolves the request-context type produced by applying middleware to an existing context.
+ *
+ * This is useful for router helpers and third-party libraries that need to describe
+ * the context available after a known middleware tuple runs.
+ */
+export type ContextWithMiddleware<
+  context extends RequestContext<any, any>,
+  middleware extends readonly AnyMiddleware[],
+> = MiddlewareContext<middleware, context>
 
 /**
  * A special kind of request handler that either returns a response or passes control
@@ -80,7 +77,7 @@ export type MiddlewareContext<middleware extends readonly AnyMiddleware[]> = App
  */
 export interface Middleware<
   params extends Record<string, any> = {},
-  transform extends MiddlewareContextTransform = IdentityContextTransform,
+  transform extends ContextTransform = EmptyContextTransform,
 > {
   /**
    * Handles a request and optionally delegates to the next middleware or handler.

--- a/packages/fetch-router/src/lib/middleware.ts
+++ b/packages/fetch-router/src/lib/middleware.ts
@@ -19,6 +19,8 @@ type ContextTransform =
 
 type EmptyContextTransform = readonly []
 
+declare const contextTransform: unique symbol
+
 type TransformOf<middleware> =
   middleware extends Middleware<infer transform> ? transform : EmptyContextTransform
 
@@ -86,7 +88,7 @@ export interface Middleware<transform extends ContextTransform = EmptyContextTra
   /**
    * Type-only metadata that carries the middleware's declared context effect.
    */
-  readonly '~contextTransform'?: transform | undefined
+  readonly [contextTransform]?: transform | undefined
 }
 
 /**

--- a/packages/fetch-router/src/lib/middleware.ts
+++ b/packages/fetch-router/src/lib/middleware.ts
@@ -3,9 +3,9 @@ import { raceRequestAbort } from './request-abort.ts'
 import type { ContextEntries, RequestContext } from './request-context.ts'
 
 /**
- * A middleware of any params or context transform.
+ * A middleware of any context transform.
  */
-export type AnyMiddleware = Middleware<any, any>
+export type AnyMiddleware = Middleware<any>
 
 /**
  * The type-level effect a middleware can apply to request context.
@@ -21,7 +21,7 @@ export type ContextTransform =
 type EmptyContextTransform = readonly []
 
 type TransformOf<middleware> =
-  middleware extends Middleware<any, infer transform> ? transform : EmptyContextTransform
+  middleware extends Middleware<infer transform> ? transform : EmptyContextTransform
 
 type ContextWithTransform<
   context extends RequestContext<any, any>,
@@ -75,15 +75,12 @@ export type ContextWithMiddleware<
  * @param next A function that invokes the next middleware or request handler in the chain
  * @returns A response to short-circuit the chain, or `undefined`/`void` to continue
  */
-export interface Middleware<
-  params extends Record<string, any> = {},
-  transform extends ContextTransform = EmptyContextTransform,
-> {
+export interface Middleware<transform extends ContextTransform = EmptyContextTransform> {
   /**
    * Handles a request and optionally delegates to the next middleware or handler.
    */
   (
-    context: RequestContext<params>,
+    context: RequestContext<any>,
     next: NextFunction,
   ): Response | undefined | void | Promise<Response | undefined | void>
 
@@ -100,10 +97,10 @@ export interface Middleware<
  */
 export type NextFunction = () => Promise<Response>
 
-export function runMiddleware<params extends Record<string, any> = {}>(
+export function runMiddleware(
   middleware: AnyMiddleware[],
-  context: RequestContext<params>,
-  handler: RequestHandler<params, any>,
+  context: RequestContext<any, any>,
+  handler: RequestHandler<any>,
 ): Promise<Response> {
   let index = -1
 

--- a/packages/fetch-router/src/lib/request-context.ts
+++ b/packages/fetch-router/src/lib/request-context.ts
@@ -3,30 +3,6 @@ import type { Router } from './router.ts'
 import type { Simplify } from './type-utils.ts'
 
 /**
- * Ambient router type configuration for application-wide defaults.
- *
- * Apps may augment this interface to define the default request context used by
- * `createAction()` and `createController()`. Multi-router apps should avoid this
- * global default and pass explicit context types instead.
- *
- * @example
- * ```ts
- * declare module '@remix-run/fetch-router' {
- *   interface RouterTypes {
- *     context: AppContext
- *   }
- * }
- * ```
- */
-export interface RouterTypes {}
-
-export type DefaultContext = RouterTypes extends {
-  context: infer context extends RequestContext<any, any>
-}
-  ? context
-  : RequestContext
-
-/**
  * Create a request context key with an optional default value.
  *
  * @param defaultValue The default value for the context key

--- a/packages/fetch-router/src/lib/request-context.ts
+++ b/packages/fetch-router/src/lib/request-context.ts
@@ -3,6 +3,24 @@ import type { Router } from './router.ts'
 import type { Simplify } from './type-utils.ts'
 
 /**
+ * Ambient router type configuration for application-wide defaults.
+ *
+ * Apps may augment this interface to define the default request context used by
+ * `createAction()` and `createController()`. Multi-router apps should avoid this
+ * global default and pass explicit context types instead.
+ *
+ * @example
+ * ```ts
+ * declare module '@remix-run/fetch-router' {
+ *   interface RouterTypes {
+ *     context: AppContext
+ *   }
+ * }
+ * ```
+ */
+export interface RouterTypes {}
+
+/**
  * Create a request context key with an optional default value.
  *
  * @param defaultValue The default value for the context key
@@ -63,6 +81,12 @@ type ContextFallbackValue<key> = [ContextDefaultValue<key>] extends [never]
 export type ContextParams<context> =
   context extends RequestContext<infer params extends Record<string, any>, any> ? params : {}
 
+export type DefaultContext = RouterTypes extends {
+  context: infer context extends RequestContext<any, any>
+}
+  ? context
+  : RequestContext
+
 type DuplicateParamNames<
   left extends Record<string, any>,
   right extends Record<string, any>,
@@ -77,9 +101,9 @@ export type MergeContextParams<
 > = [DuplicateParamNames<left, right>] extends [never] ? Simplify<left & right> : never
 
 /**
- * Replaces the params type of a {@link RequestContext} while preserving its existing context entries.
+ * Adds route params to a {@link RequestContext} while preserving its existing context values.
  */
-export type WithParams<context, params extends Record<string, any>> =
+export type ContextWithParams<context, params extends Record<string, any>> =
   context extends RequestContext<any, infer entries extends ContextEntries>
     ? MergeContextParams<ContextParams<context>, params> extends infer merged
       ? [merged] extends [never]
@@ -109,9 +133,12 @@ export type GetContextValue<context, key extends object> =
     : ContextFallbackValue<key>
 
 /**
- * Appends context entries to an existing {@link RequestContext}.
+ * Appends context values to an existing {@link RequestContext}.
+ *
+ * Third-party middleware packages that add multiple values should expose their own
+ * `ContextWith*` helper built on this type.
  */
-export type MergeContext<context, additions extends ContextEntries> =
+export type ContextWithValues<context, additions extends ContextEntries> =
   context extends RequestContext<
     infer params extends Record<string, any>,
     infer entries extends ContextEntries
@@ -121,8 +148,11 @@ export type MergeContext<context, additions extends ContextEntries> =
 
 /**
  * Replaces or adds the value type for a single context key in a {@link RequestContext}.
+ *
+ * Third-party middleware packages that add one value should expose their own
+ * `ContextWith*` helper built on this type.
  */
-export type SetContextValue<context, key extends object, value> = MergeContext<
+export type ContextWithValue<context, key extends object, value> = ContextWithValues<
   context,
   [readonly [key, value]]
 >

--- a/packages/fetch-router/src/lib/request-context.ts
+++ b/packages/fetch-router/src/lib/request-context.ts
@@ -20,6 +20,12 @@ import type { Simplify } from './type-utils.ts'
  */
 export interface RouterTypes {}
 
+export type DefaultContext = RouterTypes extends {
+  context: infer context extends RequestContext<any, any>
+}
+  ? context
+  : RequestContext
+
 /**
  * Create a request context key with an optional default value.
  *
@@ -80,12 +86,6 @@ type ContextFallbackValue<key> = [ContextDefaultValue<key>] extends [never]
  */
 export type ContextParams<context> =
   context extends RequestContext<infer params extends Record<string, any>, any> ? params : {}
-
-export type DefaultContext = RouterTypes extends {
-  context: infer context extends RequestContext<any, any>
-}
-  ? context
-  : RequestContext
 
 type DuplicateParamNames<
   left extends Record<string, any>,

--- a/packages/fetch-router/src/lib/router-types.test.ts
+++ b/packages/fetch-router/src/lib/router-types.test.ts
@@ -1,11 +1,17 @@
+import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 import { createRoutes as route } from '@remix-run/routes'
 
-import { createAction, createController, type Action, type Controller } from './controller.ts'
-import type { ContextWithMiddleware, Middleware } from './middleware.ts'
-import { createContextKey, type RequestContext, type ContextWithValue } from './request-context.ts'
+import {
+  createAction,
+  createController,
+  type Action,
+  type Controller,
+  type RouteHandler,
+} from './controller.ts'
+import type { ContextWithMiddleware, Middleware, MiddlewareContext } from './middleware.ts'
+import { createContextKey, type ContextWithValue } from './request-context.ts'
 import { createRouter } from './router.ts'
-import type { Router } from './router.ts'
 import type { IsEqual } from './type-utils.ts'
 
 function expectTypeEquality<_check extends true>() {}
@@ -51,52 +57,10 @@ const routes = route({
   reports: '/reports/:reportId',
 })
 
-const plainRouter = createRouter()
-plainRouter.get('/public', (context) => {
-  // @ts-expect-error - CurrentUser is nullable without middleware refinement
-  void context.get(CurrentUser).id
-
-  // @ts-expect-error - FormData is not available unless context has it
-  context.get(FormData).get('name')
-
-  let optionalFormData = context.get(FormData)
-  expectTypeEquality<IsEqual<typeof optionalFormData, FormData | undefined>>()
-
-  if (optionalFormData != null) {
-    expectTypeEquality<IsEqual<typeof optionalFormData, FormData>>()
-  }
-
-  return new Response('Public')
-})
-
 const appMiddleware = [requireUser(), setRole('viewer')] as const
-const router = createRouter({ middleware: appMiddleware })
+type AppContext = MiddlewareContext<typeof appMiddleware>
 
-router.get(routes.account, (context) => {
-  let user = context.get(CurrentUser)
-  let role = context.get(CurrentRole)
-  let accountId: string = context.params.accountId
-
-  expectTypeEquality<IsEqual<typeof user, { id: string }>>()
-  expectTypeEquality<IsEqual<typeof role, 'viewer'>>()
-
-  return new Response(accountId + ':' + user.id + ':' + role)
-})
-
-const formRouter = createRouter({ middleware: [setFormData()] as const })
-
-formRouter.post('/form', (context) => {
-  let formData = context.get(FormData)
-
-  expectTypeEquality<IsEqual<typeof formData, FormData>>()
-
-  return new Response(String(formData.get('name') ?? ''))
-})
-
-type AppContext =
-  typeof router extends Router<infer context extends RequestContext<any, any>> ? context : never
-
-declare module './request-context.ts' {
+declare module './router-types.ts' {
   interface RouterTypes {
     context: AppContext
   }
@@ -104,112 +68,189 @@ declare module './request-context.ts' {
 
 type AdminAppContext = ContextWithValue<AppContext, typeof CurrentRole, 'admin'>
 
-const accountAction = {
-  handler(context) {
-    let user = context.get(CurrentUser)
-    let role = context.get(CurrentRole)
-    let accountId: string = context.params.accountId
-
-    expectTypeEquality<IsEqual<typeof user, { id: string }>>()
-    expectTypeEquality<IsEqual<typeof role, 'viewer'>>()
-
-    return new Response(accountId + ':' + user.id + ':' + role)
-  },
-} satisfies Action<typeof routes.account, AppContext>
-
-const adminController = {
-  actions: {
-    dashboard(context) {
-      let user = context.get(CurrentUser)
-      let role = context.get(CurrentRole)
-
-      expectTypeEquality<IsEqual<typeof user, { id: string }>>()
-      expectTypeEquality<IsEqual<typeof role, 'viewer'>>()
-
-      return new Response(user.id + ':' + role)
-    },
-    member(context) {
-      let user = context.get(CurrentUser)
-      let role = context.get(CurrentRole)
-      let memberId: string = context.params.memberId
-
-      expectTypeEquality<IsEqual<typeof user, { id: string }>>()
-      expectTypeEquality<IsEqual<typeof role, 'viewer'>>()
-
-      return new Response(user.id + ':' + role + ':' + memberId)
-    },
-  },
-} satisfies Controller<typeof routes.admin, AppContext>
-
-const elevatedReportsController = {
-  actions: {
-    reports(context) {
-      let user = context.get(CurrentUser)
-      let role = context.get(CurrentRole)
-      let reportId: string = context.params.reportId
-      let exactRole: 'admin' = role
-
-      expectTypeEquality<IsEqual<typeof user, { id: string }>>()
-
-      void exactRole
-
-      return new Response(reportId + ':' + user.id + ':' + role)
-    },
-  },
-} satisfies Controller<{ reports: typeof routes.reports }, AdminAppContext>
-
-const elevatedReportAction = {
-  handler(context) {
-    let role = context.get(CurrentRole)
-    let reportId: string = context.params.reportId
-    let exactRole: 'admin' = role
-
-    void reportId
-    void exactRole
-
-    return new Response(role)
-  },
-} satisfies Action<typeof routes.reports, AdminAppContext>
-
 const elevatedReportMiddleware = [setRole('admin')] as const
 type ElevatedAppContext = ContextWithMiddleware<AppContext, typeof elevatedReportMiddleware>
 
-function checkMiddlewareContextBase(context: ElevatedAppContext): void {
-  let user = context.get(CurrentUser)
-  let role = context.get(CurrentRole)
-  let exactRole: 'admin' = role
+describe('router type inference', () => {
+  it('keeps context values optional when middleware has not provided them', async () => {
+    let plainRouter = createRouter()
 
-  expectTypeEquality<IsEqual<typeof user, { id: string }>>()
+    plainRouter.get('/public', (context) => {
+      if (false as boolean) {
+        // @ts-expect-error - CurrentUser is nullable without middleware refinement
+        void context.get(CurrentUser).id
 
-  void exactRole
-}
+        // @ts-expect-error - FormData is not available unless context has it
+        context.get(FormData).get('name')
+      }
 
-const elevatedReportActionWithMiddleware = createAction<typeof routes.reports, ElevatedAppContext>(
-  routes.reports,
-  {
-    middleware: elevatedReportMiddleware,
-    handler(context) {
+      let optionalFormData = context.get(FormData)
+      expectTypeEquality<IsEqual<typeof optionalFormData, FormData | undefined>>()
+
+      if (optionalFormData != null) {
+        expectTypeEquality<IsEqual<typeof optionalFormData, FormData>>()
+      }
+
+      return new Response('Public')
+    })
+
+    let response = await plainRouter.fetch('https://remix.run/public')
+
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'Public')
+  })
+
+  it('propagates router middleware context into route handlers', async () => {
+    let router = createRouter({ middleware: appMiddleware })
+
+    router.get(routes.account, (context) => {
+      let user = context.get(CurrentUser)
+      let role = context.get(CurrentRole)
+      let accountId: string = context.params.accountId
+
+      expectTypeEquality<IsEqual<typeof user, { id: string }>>()
+      expectTypeEquality<IsEqual<typeof role, 'viewer'>>()
+
+      return new Response(accountId + ':' + user.id + ':' + role)
+    })
+
+    let response = await router.fetch('https://remix.run/account/123')
+
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), '123:user-1:viewer')
+  })
+
+  it('types constructor keys as available when middleware provides them', async () => {
+    let formRouter = createRouter({ middleware: [setFormData()] as const })
+
+    formRouter.post('/form', (context) => {
+      let formData = context.get(FormData)
+
+      expectTypeEquality<IsEqual<typeof formData, FormData>>()
+
+      return new Response(String(formData.get('name') ?? ''))
+    })
+
+    let response = await formRouter.fetch('https://remix.run/form', { method: 'POST' })
+
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), '')
+  })
+
+  it('types stored actions with route params and explicit app context', () => {
+    let accountAction = {
+      handler(context) {
+        let user = context.get(CurrentUser)
+        let role = context.get(CurrentRole)
+        let accountId: string = context.params.accountId
+
+        expectTypeEquality<IsEqual<typeof user, { id: string }>>()
+        expectTypeEquality<IsEqual<typeof role, 'viewer'>>()
+
+        return new Response(accountId + ':' + user.id + ':' + role)
+      },
+    } satisfies Action<typeof routes.account, AppContext>
+
+    let reportRouteHandler = ((context) => {
+      let user = context.get(CurrentUser)
       let role = context.get(CurrentRole)
       let reportId: string = context.params.reportId
-      let exactRole: 'admin' = role
 
-      void reportId
-      void exactRole
+      expectTypeEquality<IsEqual<typeof user, { id: string }>>()
+      expectTypeEquality<IsEqual<typeof role, 'viewer'>>()
 
-      return new Response(role)
-    },
-  },
-)
+      return new Response(reportId + ':' + user.id + ':' + role)
+    }) satisfies RouteHandler<typeof routes.reports, AppContext>
 
-const elevatedReportsControllerWithMiddleware = createController<
-  { reports: typeof routes.reports },
-  ElevatedAppContext
->(
-  { reports: routes.reports },
-  {
-    middleware: elevatedReportMiddleware,
-    actions: {
-      reports(context) {
+    void accountAction
+    void reportRouteHandler
+  })
+
+  it('types controllers with route params and explicit app context', () => {
+    let adminController = {
+      actions: {
+        dashboard(context) {
+          let user = context.get(CurrentUser)
+          let role = context.get(CurrentRole)
+
+          expectTypeEquality<IsEqual<typeof user, { id: string }>>()
+          expectTypeEquality<IsEqual<typeof role, 'viewer'>>()
+
+          return new Response(user.id + ':' + role)
+        },
+        member(context) {
+          let user = context.get(CurrentUser)
+          let role = context.get(CurrentRole)
+          let memberId: string = context.params.memberId
+
+          expectTypeEquality<IsEqual<typeof user, { id: string }>>()
+          expectTypeEquality<IsEqual<typeof role, 'viewer'>>()
+
+          return new Response(user.id + ':' + role + ':' + memberId)
+        },
+      },
+    } satisfies Controller<typeof routes.admin, AppContext>
+
+    let elevatedReportsController = {
+      actions: {
+        reports(context) {
+          let user = context.get(CurrentUser)
+          let role = context.get(CurrentRole)
+          let reportId: string = context.params.reportId
+          let exactRole: 'admin' = role
+
+          expectTypeEquality<IsEqual<typeof user, { id: string }>>()
+
+          void exactRole
+
+          return new Response(reportId + ':' + user.id + ':' + role)
+        },
+      },
+    } satisfies Controller<{ reports: typeof routes.reports }, AdminAppContext>
+
+    void adminController
+    void elevatedReportsController
+  })
+
+  it('uses RouterTypes.context as the default builder context', () => {
+    let accountAction = createAction(routes.account, {
+      handler(context) {
+        let user = context.get(CurrentUser)
+        let role = context.get(CurrentRole)
+        let accountId: string = context.params.accountId
+
+        expectTypeEquality<IsEqual<typeof user, { id: string }>>()
+        expectTypeEquality<IsEqual<typeof role, 'viewer'>>()
+
+        return new Response(accountId + ':' + user.id + ':' + role)
+      },
+    })
+
+    let adminController = createController(routes.admin, {
+      actions: {
+        dashboard(context) {
+          let user = context.get(CurrentUser)
+          let role = context.get(CurrentRole)
+
+          expectTypeEquality<IsEqual<typeof user, { id: string }>>()
+          expectTypeEquality<IsEqual<typeof role, 'viewer'>>()
+
+          return new Response(user.id + ':' + role)
+        },
+        member(context) {
+          let memberId: string = context.params.memberId
+          return new Response(memberId)
+        },
+      },
+    })
+
+    void accountAction
+    void adminController
+  })
+
+  it('lets explicit contexts describe local middleware results', () => {
+    let elevatedReportAction = {
+      handler(context) {
         let role = context.get(CurrentRole)
         let reportId: string = context.params.reportId
         let exactRole: 'admin' = role
@@ -219,31 +260,67 @@ const elevatedReportsControllerWithMiddleware = createController<
 
         return new Response(role)
       },
-    },
-  },
-)
+    } satisfies Action<typeof routes.reports, AdminAppContext>
 
-const untypedElevatedReportAction = createAction(routes.reports, {
-  middleware: elevatedReportMiddleware,
-  handler(context) {
-    let role = context.get(CurrentRole)
-    let reportId: string = context.params.reportId
-    // @ts-expect-error - local middleware context is not inferred into the handler
-    let exactRole: 'admin' = role
+    let elevatedReportActionWithMiddleware = createAction<
+      typeof routes.reports,
+      ElevatedAppContext
+    >(routes.reports, {
+      middleware: elevatedReportMiddleware,
+      handler(context) {
+        let role = context.get(CurrentRole)
+        let reportId: string = context.params.reportId
+        let exactRole: 'admin' = role
 
-    void reportId
-    void exactRole
+        void reportId
+        void exactRole
 
-    return new Response(role)
-  },
-})
+        return new Response(role)
+      },
+    })
 
-const untypedElevatedReportsController = createController(
-  { reports: routes.reports },
-  {
-    middleware: elevatedReportMiddleware,
-    actions: {
-      reports(context) {
+    let elevatedReportsControllerWithMiddleware = createController<
+      { reports: typeof routes.reports },
+      ElevatedAppContext
+    >(
+      { reports: routes.reports },
+      {
+        middleware: elevatedReportMiddleware,
+        actions: {
+          reports(context) {
+            let role = context.get(CurrentRole)
+            let reportId: string = context.params.reportId
+            let exactRole: 'admin' = role
+
+            void reportId
+            void exactRole
+
+            return new Response(role)
+          },
+        },
+      },
+    )
+
+    function checkMiddlewareContextBase(context: ElevatedAppContext): void {
+      let user = context.get(CurrentUser)
+      let role = context.get(CurrentRole)
+      let exactRole: 'admin' = role
+
+      expectTypeEquality<IsEqual<typeof user, { id: string }>>()
+
+      void exactRole
+    }
+
+    void elevatedReportAction
+    void elevatedReportActionWithMiddleware
+    void elevatedReportsControllerWithMiddleware
+    void checkMiddlewareContextBase
+  })
+
+  it('does not infer local middleware into handler context without an explicit context', () => {
+    let untypedElevatedReportAction = createAction(routes.reports, {
+      middleware: elevatedReportMiddleware,
+      handler(context) {
         let role = context.get(CurrentRole)
         let reportId: string = context.params.reportId
         // @ts-expect-error - local middleware context is not inferred into the handler
@@ -254,90 +331,122 @@ const untypedElevatedReportsController = createController(
 
         return new Response(role)
       },
-    },
-  },
-)
+    })
 
-router.get(routes.account, accountAction)
-router.get(routes.reports, elevatedReportActionWithMiddleware)
-router.map(routes.admin, adminController)
-if (false as boolean) {
-  let rootController = {
-    actions: {
-      account: accountAction,
-      reports(context) {
-        let reportId: string = context.params.reportId
-        return new Response(reportId)
-      },
-      // @ts-expect-error - nested route maps are mapped with their own controllers
-      admin: adminController,
-    },
-  } satisfies Controller<typeof routes, AppContext>
+    let untypedElevatedReportsController = createController(
+      { reports: routes.reports },
+      {
+        middleware: elevatedReportMiddleware,
+        actions: {
+          reports(context) {
+            let role = context.get(CurrentRole)
+            let reportId: string = context.params.reportId
+            // @ts-expect-error - local middleware context is not inferred into the handler
+            let exactRole: 'admin' = role
 
-  let unknownActionController = {
-    actions: {
-      dashboard() {
-        return new Response('Dashboard')
-      },
-      member() {
-        return new Response('Member')
-      },
-      // @ts-expect-error - controller action keys must exist in the route map
-      missing() {
-        return new Response('Missing')
-      },
-    },
-  } satisfies Controller<typeof routes.admin, AppContext>
+            void reportId
+            void exactRole
 
-  router.get(routes.reports, (context) => {
-    // @ts-expect-error - the base app context still only guarantees the inherited viewer role
-    let adminRole: 'admin' = context.get(CurrentRole)
-    return new Response(adminRole)
-  })
-
-  router.map(
-    { reports: routes.reports },
-    {
-      middleware: elevatedReportMiddleware,
-      actions: {
-        reports(context) {
-          // @ts-expect-error - local middleware context is not inferred into the handler
-          let adminRole: 'admin' = context.get(CurrentRole)
-          return new Response(adminRole)
+            return new Response(role)
+          },
         },
       },
-    },
-  )
+    )
 
-  let controllerWithUntypedMiddleware = {
-    middleware: elevatedReportMiddleware,
-    actions: {
-      reports(context) {
-        // @ts-expect-error - controller context must include values provided by local middleware
+    void untypedElevatedReportAction
+    void untypedElevatedReportsController
+  })
+
+  it('rejects route maps and context contracts that do not line up', () => {
+    let accountAction = {
+      handler(context) {
+        return new Response(context.params.accountId)
+      },
+    } satisfies Action<typeof routes.account, AppContext>
+
+    let adminController = {
+      actions: {
+        dashboard() {
+          return new Response('Dashboard')
+        },
+        member(context) {
+          return new Response(context.params.memberId)
+        },
+      },
+    } satisfies Controller<typeof routes.admin, AppContext>
+
+    if (false as boolean) {
+      let rootController = {
+        actions: {
+          account: accountAction,
+          reports(context) {
+            let reportId: string = context.params.reportId
+            return new Response(reportId)
+          },
+          // @ts-expect-error - nested route maps are mapped with their own controllers
+          admin: adminController,
+        },
+      } satisfies Controller<typeof routes, AppContext>
+
+      let unknownActionController = {
+        actions: {
+          dashboard() {
+            return new Response('Dashboard')
+          },
+          member() {
+            return new Response('Member')
+          },
+          // @ts-expect-error - controller action keys must exist in the route map
+          missing() {
+            return new Response('Missing')
+          },
+        },
+      } satisfies Controller<typeof routes.admin, AppContext>
+
+      // @ts-expect-error - Action is the object form; use RouteHandler for object-or-function values
+      let functionAction: Action<typeof routes.reports, AppContext> = (context) =>
+        new Response(context.params.reportId)
+
+      let router = createRouter({ middleware: appMiddleware })
+
+      router.get(routes.reports, (context) => {
+        // @ts-expect-error - the base app context still only guarantees the inherited viewer role
         let adminRole: 'admin' = context.get(CurrentRole)
         return new Response(adminRole)
-      },
-    },
-  } satisfies Controller<{ reports: typeof routes.reports }, AppContext>
+      })
 
-  void rootController
-  void unknownActionController
-  void controllerWithUntypedMiddleware
-}
+      router.map(
+        { reports: routes.reports },
+        {
+          middleware: elevatedReportMiddleware,
+          actions: {
+            reports(context) {
+              // @ts-expect-error - local middleware context is not inferred into the handler
+              let adminRole: 'admin' = context.get(CurrentRole)
+              return new Response(adminRole)
+            },
+          },
+        },
+      )
 
-void plainRouter
-void router
-void formRouter
-void accountAction
-void adminController
-void elevatedReportsController
-void elevatedReportAction
-void elevatedReportActionWithMiddleware
-void elevatedReportsControllerWithMiddleware
-void untypedElevatedReportAction
-void untypedElevatedReportsController
-void checkMiddlewareContextBase
+      let controllerWithUntypedMiddleware = {
+        middleware: elevatedReportMiddleware,
+        actions: {
+          reports(context) {
+            // @ts-expect-error - controller context must include values provided by local middleware
+            let adminRole: 'admin' = context.get(CurrentRole)
+            return new Response(adminRole)
+          },
+        },
+      } satisfies Controller<{ reports: typeof routes.reports }, AppContext>
 
-describe('router type inference', () => {
-  it('propagates router context into controller and action contracts', () => {})
+      void rootController
+      void unknownActionController
+      void functionAction
+      void controllerWithUntypedMiddleware
+    }
+
+    void accountAction
+    void adminController
+  })
 })

--- a/packages/fetch-router/src/lib/router-types.test.ts
+++ b/packages/fetch-router/src/lib/router-types.test.ts
@@ -4,7 +4,7 @@ import { createRoutes as route } from '@remix-run/routes'
 
 import { createAction, createController, type Action, type Controller } from './controller.ts'
 import type { ContextWithMiddleware, Middleware, MiddlewareContext } from './middleware.ts'
-import { createContextKey, type ContextWithValue } from './request-context.ts'
+import { createContextKey, type ContextEntry, type ContextWithValue } from './request-context.ts'
 import { createRouter } from './router.ts'
 import type { IsEqual } from './type-utils.ts'
 
@@ -13,29 +13,27 @@ function expectTypeEquality<_check extends true>() {}
 const CurrentUser = createContextKey<{ id: string } | null>(null)
 const CurrentRole = createContextKey<'viewer' | 'admin' | null>(null)
 
-type RequireUserTransform = readonly [readonly [typeof CurrentUser, { id: string }]]
+type CurrentUserContextEntry = ContextEntry<typeof CurrentUser, { id: string }>
 
-type SetRoleTransform<role extends 'viewer' | 'admin'> = readonly [
-  readonly [typeof CurrentRole, role],
-]
+type RoleContextEntry<role extends 'viewer' | 'admin'> = ContextEntry<typeof CurrentRole, role>
 
-type SetFormDataTransform = readonly [readonly [typeof FormData, FormData]]
+type FormDataContextEntry = ContextEntry<typeof FormData, FormData>
 
-function requireUser(): Middleware<RequireUserTransform> {
+function requireUser(): Middleware<CurrentUserContextEntry> {
   return async (context, next) => {
     context.set(CurrentUser, { id: 'user-1' })
     return next()
   }
 }
 
-function setRole<role extends 'viewer' | 'admin'>(role: role): Middleware<SetRoleTransform<role>> {
+function setRole<role extends 'viewer' | 'admin'>(role: role): Middleware<RoleContextEntry<role>> {
   return async (context, next) => {
     context.set(CurrentRole, role)
     return next()
   }
 }
 
-function setFormData(): Middleware<SetFormDataTransform> {
+function setFormData(): Middleware<FormDataContextEntry> {
   return async (context, next) => {
     context.set(FormData, new FormData())
     return next()

--- a/packages/fetch-router/src/lib/router-types.test.ts
+++ b/packages/fetch-router/src/lib/router-types.test.ts
@@ -1,9 +1,9 @@
 import { describe, it } from '@remix-run/test'
 import { createRoutes as route } from '@remix-run/routes'
 
-import type { Action, Controller } from './controller.ts'
-import type { Middleware } from './middleware.ts'
-import { createContextKey, type RequestContext, type SetContextValue } from './request-context.ts'
+import { createAction, createController, type Action, type Controller } from './controller.ts'
+import type { ContextWithMiddleware, Middleware } from './middleware.ts'
+import { createContextKey, type RequestContext, type ContextWithValue } from './request-context.ts'
 import { createRouter } from './router.ts'
 import type { Router } from './router.ts'
 import type { IsEqual } from './type-utils.ts'
@@ -98,7 +98,13 @@ formRouter.post('/form', (context) => {
 type AppContext =
   typeof router extends Router<infer context extends RequestContext<any, any>> ? context : never
 
-type AdminAppContext = SetContextValue<AppContext, typeof CurrentRole, 'admin'>
+declare module './request-context.ts' {
+  interface RouterTypes {
+    context: AppContext
+  }
+}
+
+type AdminAppContext = ContextWithValue<AppContext, typeof CurrentRole, 'admin'>
 
 const accountAction = {
   handler(context) {
@@ -168,11 +174,63 @@ const elevatedReportAction = {
 } satisfies Action<typeof routes.reports, AdminAppContext>
 
 const elevatedReportMiddleware = [setRole('admin')] as const
-const elevatedReportActionWithMiddleware = {
+type ElevatedAppContext = ContextWithMiddleware<AppContext, typeof elevatedReportMiddleware>
+
+function checkMiddlewareContextBase(context: ElevatedAppContext): void {
+  let user = context.get(CurrentUser)
+  let role = context.get(CurrentRole)
+  let exactRole: 'admin' = role
+
+  expectTypeEquality<IsEqual<typeof user, { id: string }>>()
+
+  void exactRole
+}
+
+const elevatedReportActionWithMiddleware = createAction<typeof routes.reports, ElevatedAppContext>(
+  routes.reports,
+  {
+    middleware: elevatedReportMiddleware,
+    handler(context) {
+      let role = context.get(CurrentRole)
+      let reportId: string = context.params.reportId
+      let exactRole: 'admin' = role
+
+      void reportId
+      void exactRole
+
+      return new Response(role)
+    },
+  },
+)
+
+const elevatedReportsControllerWithMiddleware = createController<
+  { reports: typeof routes.reports },
+  ElevatedAppContext
+>(
+  { reports: routes.reports },
+  {
+    middleware: elevatedReportMiddleware,
+    actions: {
+      reports(context) {
+        let role = context.get(CurrentRole)
+        let reportId: string = context.params.reportId
+        let exactRole: 'admin' = role
+
+        void reportId
+        void exactRole
+
+        return new Response(role)
+      },
+    },
+  },
+)
+
+const untypedElevatedReportAction = createAction(routes.reports, {
   middleware: elevatedReportMiddleware,
   handler(context) {
     let role = context.get(CurrentRole)
     let reportId: string = context.params.reportId
+    // @ts-expect-error - local middleware context is not inferred into the handler
     let exactRole: 'admin' = role
 
     void reportId
@@ -180,7 +238,27 @@ const elevatedReportActionWithMiddleware = {
 
     return new Response(role)
   },
-} satisfies Action<typeof routes.reports, AppContext, typeof elevatedReportMiddleware>
+})
+
+const untypedElevatedReportsController = createController(
+  { reports: routes.reports },
+  {
+    middleware: elevatedReportMiddleware,
+    actions: {
+      reports(context) {
+        let role = context.get(CurrentRole)
+        let reportId: string = context.params.reportId
+        // @ts-expect-error - local middleware context is not inferred into the handler
+        let exactRole: 'admin' = role
+
+        void reportId
+        void exactRole
+
+        return new Response(role)
+      },
+    },
+  },
+)
 
 router.get(routes.account, accountAction)
 router.get(routes.reports, elevatedReportActionWithMiddleware)
@@ -219,8 +297,34 @@ if (false as boolean) {
     return new Response(adminRole)
   })
 
+  router.map(
+    { reports: routes.reports },
+    {
+      middleware: elevatedReportMiddleware,
+      actions: {
+        reports(context) {
+          // @ts-expect-error - local middleware context is not inferred into the handler
+          let adminRole: 'admin' = context.get(CurrentRole)
+          return new Response(adminRole)
+        },
+      },
+    },
+  )
+
+  let controllerWithUntypedMiddleware = {
+    middleware: elevatedReportMiddleware,
+    actions: {
+      reports(context) {
+        // @ts-expect-error - controller context must include values provided by local middleware
+        let adminRole: 'admin' = context.get(CurrentRole)
+        return new Response(adminRole)
+      },
+    },
+  } satisfies Controller<{ reports: typeof routes.reports }, AppContext>
+
   void rootController
   void unknownActionController
+  void controllerWithUntypedMiddleware
 }
 
 void plainRouter
@@ -231,6 +335,10 @@ void adminController
 void elevatedReportsController
 void elevatedReportAction
 void elevatedReportActionWithMiddleware
+void elevatedReportsControllerWithMiddleware
+void untypedElevatedReportAction
+void untypedElevatedReportsController
+void checkMiddlewareContextBase
 
 describe('router type inference', () => {
   it('propagates router context into controller and action contracts', () => {})

--- a/packages/fetch-router/src/lib/router-types.test.ts
+++ b/packages/fetch-router/src/lib/router-types.test.ts
@@ -21,23 +21,21 @@ type SetRoleTransform<role extends 'viewer' | 'admin'> = readonly [
 
 type SetFormDataTransform = readonly [readonly [typeof FormData, FormData]]
 
-function requireUser(): Middleware<any, RequireUserTransform> {
+function requireUser(): Middleware<RequireUserTransform> {
   return async (context, next) => {
     context.set(CurrentUser, { id: 'user-1' })
     return next()
   }
 }
 
-function setRole<role extends 'viewer' | 'admin'>(
-  role: role,
-): Middleware<any, SetRoleTransform<role>> {
+function setRole<role extends 'viewer' | 'admin'>(role: role): Middleware<SetRoleTransform<role>> {
   return async (context, next) => {
     context.set(CurrentRole, role)
     return next()
   }
 }
 
-function setFormData(): Middleware<any, SetFormDataTransform> {
+function setFormData(): Middleware<SetFormDataTransform> {
   return async (context, next) => {
     context.set(FormData, new FormData())
     return next()

--- a/packages/fetch-router/src/lib/router-types.test.ts
+++ b/packages/fetch-router/src/lib/router-types.test.ts
@@ -2,13 +2,7 @@ import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 import { createRoutes as route } from '@remix-run/routes'
 
-import {
-  createAction,
-  createController,
-  type Action,
-  type Controller,
-  type RouteHandler,
-} from './controller.ts'
+import { createAction, createController, type Action, type Controller } from './controller.ts'
 import type { ContextWithMiddleware, Middleware, MiddlewareContext } from './middleware.ts'
 import { createContextKey, type ContextWithValue } from './request-context.ts'
 import { createRouter } from './router.ts'
@@ -151,7 +145,7 @@ describe('router type inference', () => {
       },
     } satisfies Action<typeof routes.account, AppContext>
 
-    let reportRouteHandler = ((context) => {
+    let reportAction = ((context) => {
       let user = context.get(CurrentUser)
       let role = context.get(CurrentRole)
       let reportId: string = context.params.reportId
@@ -160,10 +154,10 @@ describe('router type inference', () => {
       expectTypeEquality<IsEqual<typeof role, 'viewer'>>()
 
       return new Response(reportId + ':' + user.id + ':' + role)
-    }) satisfies RouteHandler<typeof routes.reports, AppContext>
+    }) satisfies Action<typeof routes.reports, AppContext>
 
     void accountAction
-    void reportRouteHandler
+    void reportAction
   })
 
   it('types controllers with route params and explicit app context', () => {
@@ -403,7 +397,6 @@ describe('router type inference', () => {
         },
       } satisfies Controller<typeof routes.admin, AppContext>
 
-      // @ts-expect-error - Action is the object form; use RouteHandler for object-or-function values
       let functionAction: Action<typeof routes.reports, AppContext> = (context) =>
         new Response(context.params.reportId)
 

--- a/packages/fetch-router/src/lib/router-types.ts
+++ b/packages/fetch-router/src/lib/router-types.ts
@@ -1,0 +1,25 @@
+import type { RequestContext } from './request-context.ts'
+
+/**
+ * Ambient router type configuration for application-wide defaults.
+ *
+ * Apps may augment this interface to define the default request context used by
+ * `createAction()` and `createController()`. Multi-router apps should avoid this
+ * global default and pass explicit context types instead.
+ *
+ * @example
+ * ```ts
+ * declare module '@remix-run/fetch-router' {
+ *   interface RouterTypes {
+ *     context: AppContext
+ *   }
+ * }
+ * ```
+ */
+export interface RouterTypes {}
+
+export type DefaultContext = RouterTypes extends {
+  context: infer context extends RequestContext<any, any>
+}
+  ? context
+  : RequestContext

--- a/packages/fetch-router/src/lib/router.test.ts
+++ b/packages/fetch-router/src/lib/router.test.ts
@@ -19,11 +19,16 @@ describe('router.fetch()', () => {
     assert.equal(await response.text(), 'Home')
   })
 
-  it('fetches a request facade that clones to a real Request', async () => {
+  it('uses a Request input directly', async () => {
     let router = createRouter()
-    router.get('/', () => new Response('Home'))
+    let request = new Request('https://remix.run')
 
-    let response = await router.fetch(createRequestFacade('https://remix.run'))
+    router.get('/', (context) => {
+      assert.equal(context.request, request)
+      return new Response('Home')
+    })
+
+    let response = await router.fetch(request)
 
     assert.equal(response.status, 200)
     assert.equal(await response.text(), 'Home')
@@ -168,19 +173,6 @@ describe('router.fetch()', () => {
     assert.deepEqual(requestLog, ['middleware'])
   })
 })
-
-function createRequestFacade(url: string): Request {
-  let request = new Request(url)
-  let facade = {
-    clone() {
-      return request.clone()
-    },
-  }
-
-  Object.setPrototypeOf(facade, Request.prototype)
-
-  return facade as Request
-}
 
 describe('router.map() with single routes', () => {
   it('maps a single route to a request handler', async () => {

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -8,7 +8,6 @@ import type { RequestMethod } from './request-methods.ts'
 import {
   type Action,
   type Controller,
-  type ControllerShape,
   type RequestHandler,
   isAction,
   isController,
@@ -347,7 +346,13 @@ export function createRouter<
     mapController(target, handler)
   }
 
-  function mapController(routes: RouteMap, controller: ControllerShape): void {
+  function mapController(
+    routes: RouteMap,
+    controller: {
+      middleware?: readonly AnyMiddleware[] | undefined
+      actions: Record<string, unknown>
+    },
+  ): void {
     let controllerMiddleware = normalizeMiddleware(controller.middleware)
 
     for (let key in controller.actions) {

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -7,8 +7,8 @@ import { RequestContext, type ContextWithParams } from './request-context.ts'
 import type { RequestMethod } from './request-methods.ts'
 import {
   type RequestHandler,
+  type Action,
   type Controller,
-  type RouteHandler,
   isRequestHandler,
   isAction,
   isController,
@@ -33,7 +33,7 @@ type VerbMethod<method extends RequestMethod, context extends AnyContext> = {
   ): void
   <pattern extends string, actionContext extends AnyContext = context>(
     route: RouteTarget<pattern, method>,
-    action: RouteHandler<RouteTarget<pattern, method>, actionContext>,
+    action: Action<RouteTarget<pattern, method>, actionContext>,
   ): void
 }
 
@@ -121,7 +121,7 @@ export interface Router<context extends AnyContext = RequestContext> {
   >(
     method: method,
     pattern: RouteTarget<pattern, method>,
-    action: RouteHandler<RouteTarget<pattern, method>, actionContext>,
+    action: Action<RouteTarget<pattern, method>, actionContext>,
   ): void
   /**
    * Maps either a single route target to an action or a route map to a controller.
@@ -132,7 +132,7 @@ export interface Router<context extends AnyContext = RequestContext> {
   ): void
   map<pattern extends string, actionContext extends AnyContext = context>(
     target: RouteTarget<pattern>,
-    action: RouteHandler<RouteTarget<pattern>, actionContext>,
+    action: Action<RouteTarget<pattern>, actionContext>,
   ): void
   map<target extends RouteMap, controllerContext extends AnyContext = context>(
     target: target,
@@ -279,7 +279,7 @@ export function createRouter<
     route: RouteTarget<pattern, method>,
     handler:
       | RequestHandler<RouteContext<RouterContext, pattern>>
-      | RouteHandler<RouteTarget<pattern, method>, AnyContext>,
+      | Action<RouteTarget<pattern, method>, AnyContext>,
   ): void {
     registerRoute(method, route, normalizeRouteHandler(handler))
   }
@@ -356,7 +356,7 @@ export function createRouter<
       route: RouteTarget<pattern, method>,
       handler:
         | RequestHandler<RouteContext<RouterContext, pattern>>
-        | RouteHandler<RouteTarget<pattern, method>, AnyContext>,
+        | Action<RouteTarget<pattern, method>, AnyContext>,
     ): void => {
       addRoute(method, route, handler)
     }) as VerbMethod<method, RouterContext>
@@ -380,7 +380,7 @@ export function createRouter<
       route: RouteTarget<pattern, method>,
       handler:
         | RequestHandler<RouteContext<RouterContext, pattern>>
-        | RouteHandler<RouteTarget<pattern, method>, AnyContext>,
+        | Action<RouteTarget<pattern, method>, AnyContext>,
     ): void {
       addRoute(method, route, handler)
     },

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -21,25 +21,18 @@ type RouteContext<context extends AnyContext, pattern extends string> = ContextW
   Params<pattern>
 >
 
-type RouteTarget<method extends RequestMethod | 'ANY', pattern extends string> =
-  | pattern
-  | RoutePattern<pattern>
-  | Route<method | 'ANY', pattern>
-
-type MapRouteTarget<method extends RequestMethod | 'ANY', pattern extends string> =
-  | pattern
-  | RoutePattern<pattern>
-  | Route<method, pattern>
-
-type SingleRouteTarget = string | RoutePattern<string> | Route<RequestMethod | 'ANY', string>
+type RouteTarget<
+  pattern extends string = string,
+  method extends RequestMethod | 'ANY' = RequestMethod | 'ANY',
+> = pattern | RoutePattern<pattern> | Route<method | 'ANY', pattern>
 
 type VerbMethod<method extends RequestMethod, context extends AnyContext> = {
   <pattern extends string>(
-    route: RouteTarget<method, pattern>,
+    route: RouteTarget<pattern, method>,
     handler: RequestHandler<Params<pattern>, RouteContext<context, pattern>>,
   ): void
   <pattern extends string, actionContext extends AnyContext = context>(
-    route: RouteTarget<method, pattern>,
+    route: RouteTarget<pattern, method>,
     action: Action<pattern, actionContext>,
   ): void
 }
@@ -71,7 +64,7 @@ type NormalizedAction = {
   middleware: AnyMiddleware[] | undefined
 }
 
-type MapTarget = SingleRouteTarget | RouteMap
+type MapTarget = RouteTarget | RouteMap
 
 /**
  * Options for creating a router.
@@ -121,7 +114,7 @@ export interface Router<context extends AnyContext = RequestContext> {
    */
   route<method extends RequestMethod | 'ANY', pattern extends string>(
     method: method,
-    pattern: RouteTarget<method, pattern>,
+    pattern: RouteTarget<pattern, method>,
     handler: RequestHandler<Params<pattern>, RouteContext<context, pattern>>,
   ): void
   route<
@@ -130,22 +123,18 @@ export interface Router<context extends AnyContext = RequestContext> {
     actionContext extends AnyContext = context,
   >(
     method: method,
-    pattern: RouteTarget<method, pattern>,
+    pattern: RouteTarget<pattern, method>,
     action: Action<pattern, actionContext>,
   ): void
   /**
    * Maps either a single route target to an action or a route map to a controller.
    */
-  map<method extends RequestMethod | 'ANY', pattern extends string>(
-    target: MapRouteTarget<method, pattern>,
+  map<pattern extends string>(
+    target: RouteTarget<pattern>,
     handler: RequestHandler<Params<pattern>, RouteContext<context, pattern>>,
   ): void
-  map<
-    method extends RequestMethod | 'ANY',
-    pattern extends string,
-    actionContext extends AnyContext = context,
-  >(
-    target: MapRouteTarget<method, pattern>,
+  map<pattern extends string, actionContext extends AnyContext = context>(
+    target: RouteTarget<pattern>,
     action: Action<pattern, actionContext>,
   ): void
   map<target extends RouteMap, controllerContext extends AnyContext = context>(
@@ -259,11 +248,11 @@ function cloneRequest(input: Request): Request {
   return input.clone() as Request
 }
 
-function isSingleRouteTarget(target: MapTarget): target is SingleRouteTarget {
+function isRouteTarget(target: MapTarget): target is RouteTarget {
   return typeof target === 'string' || target instanceof RoutePattern || target instanceof Route
 }
 
-function getRoutePattern(target: SingleRouteTarget): RoutePattern<string> {
+function getRoutePattern(target: RouteTarget): RoutePattern<string> {
   if (target instanceof Route) {
     return target.pattern
   }
@@ -271,7 +260,7 @@ function getRoutePattern(target: SingleRouteTarget): RoutePattern<string> {
   return typeof target === 'string' ? new RoutePattern(target) : target
 }
 
-function getMappedRouteMethod(target: SingleRouteTarget): RequestMethod | 'ANY' {
+function getMappedRouteMethod(target: RouteTarget): RequestMethod | 'ANY' {
   return target instanceof Route ? target.method : 'ANY'
 }
 
@@ -328,7 +317,7 @@ export function createRouter<
 
   function registerRoute(
     method: RequestMethod | 'ANY',
-    route: SingleRouteTarget,
+    route: RouteTarget,
     normalizedAction: NormalizedAction,
   ): void {
     let pattern = getRoutePattern(route)
@@ -344,7 +333,7 @@ export function createRouter<
 
   function addRoute<method extends RequestMethod | 'ANY', pattern extends string>(
     method: method,
-    route: RouteTarget<method, pattern>,
+    route: RouteTarget<pattern, method>,
     handler:
       | RequestHandler<Params<pattern>, RouteContext<RouterContext, pattern>>
       | Action<pattern, AnyContext>,
@@ -352,12 +341,12 @@ export function createRouter<
     registerRoute(method, route, normalizeAction(handler))
   }
 
-  function mapSingleRoute(target: SingleRouteTarget, handler: unknown): void {
+  function mapSingleRoute(target: RouteTarget, handler: unknown): void {
     registerRoute(getMappedRouteMethod(target), target, normalizeAction(handler))
   }
 
   function mapRoutes(target: MapTarget, handler: unknown): void {
-    if (isSingleRouteTarget(target)) {
+    if (isRouteTarget(target)) {
       mapSingleRoute(target, handler)
       return
     }
@@ -406,7 +395,7 @@ export function createRouter<
     method: method,
   ): VerbMethod<method, RouterContext> {
     return (<pattern extends string>(
-      route: RouteTarget<method, pattern>,
+      route: RouteTarget<pattern, method>,
       handler:
         | RequestHandler<Params<pattern>, RouteContext<RouterContext, pattern>>
         | Action<pattern, AnyContext>,
@@ -423,7 +412,7 @@ export function createRouter<
     },
     route<method extends RequestMethod | 'ANY', pattern extends string>(
       method: method,
-      route: RouteTarget<method, pattern>,
+      route: RouteTarget<pattern, method>,
       handler:
         | RequestHandler<Params<pattern>, RouteContext<RouterContext, pattern>>
         | Action<pattern, AnyContext>,

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -6,9 +6,10 @@ import { raceRequestAbort } from './request-abort.ts'
 import { RequestContext, type ContextWithParams } from './request-context.ts'
 import type { RequestMethod } from './request-methods.ts'
 import {
+  type RequestHandler,
   type Action,
   type Controller,
-  type RequestHandler,
+  isRequestHandler,
   isAction,
   isController,
 } from './controller.ts'
@@ -174,15 +175,7 @@ function noMatchHandler({ url }: RequestContext): Response {
 function normalizeMiddleware(
   middleware: readonly AnyMiddleware[] | undefined,
 ): AnyMiddleware[] | undefined {
-  if (middleware == null || middleware.length === 0) {
-    return undefined
-  }
-
-  return [...middleware]
-}
-
-function isRequestHandler(action: unknown): action is RequestHandler<any> {
-  return typeof action === 'function'
+  return middleware == null || middleware.length === 0 ? undefined : [...middleware]
 }
 
 function normalizeAction(action: unknown): NormalizedAction {
@@ -203,16 +196,6 @@ function normalizeAction(action: unknown): NormalizedAction {
     handler: action,
     middleware: undefined,
   }
-}
-
-function createRequestContext(input: string | URL | Request, init?: RequestInit): RequestContext {
-  let request = input instanceof Request && init == null ? input : new Request(input, init)
-
-  if (request.signal.aborted) {
-    throw request.signal.reason
-  }
-
-  return new RequestContext(request)
 }
 
 function isRouteTarget(target: MapTarget): target is RouteTarget {
@@ -373,8 +356,15 @@ export function createRouter<
 
   let router: Router<RouterContext> = {
     fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
-      let context = createRequestContext(input, init)
+      let request = input instanceof Request && init == null ? input : new Request(input, init)
+
+      if (request.signal.aborted) {
+        throw request.signal.reason
+      }
+
+      let context = new RequestContext(request)
       context.router = router
+
       return dispatchRouter(context)
     },
     route<method extends RequestMethod | 'ANY', pattern extends string>(

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -1,25 +1,20 @@
-import { type Matcher, type Params, createMatcher, RoutePattern } from '@remix-run/route-pattern'
+import { type Matcher, createMatcher, RoutePattern } from '@remix-run/route-pattern'
 import { type RouteMap, Route } from '@remix-run/routes'
 
 import { type AnyMiddleware, type MiddlewareContext, runMiddleware } from './middleware.ts'
 import { raceRequestAbort } from './request-abort.ts'
-import { RequestContext, type ContextWithParams } from './request-context.ts'
+import { RequestContext } from './request-context.ts'
 import type { RequestMethod } from './request-methods.ts'
 import {
   type RequestHandler,
   type Action,
   type Controller,
   isRequestHandler,
-  isAction,
+  isActionObject,
   isController,
 } from './controller.ts'
 
 type AnyContext = RequestContext<any, any>
-
-type RouteContext<context extends AnyContext, pattern extends string> = ContextWithParams<
-  context,
-  Params<pattern>
->
 
 type RouteTarget<
   pattern extends string = string,
@@ -27,10 +22,6 @@ type RouteTarget<
 > = pattern | RoutePattern<pattern> | Route<method | 'ANY', pattern>
 
 type VerbMethod<method extends RequestMethod, context extends AnyContext> = {
-  <pattern extends string>(
-    route: RouteTarget<pattern, method>,
-    handler: RequestHandler<RouteContext<context, pattern>>,
-  ): void
   <pattern extends string, actionContext extends AnyContext = context>(
     route: RouteTarget<pattern, method>,
     action: Action<RouteTarget<pattern, method>, actionContext>,
@@ -59,7 +50,7 @@ export interface RouteEntry {
   middleware: AnyMiddleware[] | undefined
 }
 
-type NormalizedRouteHandler = {
+type NormalizedAction = {
   handler: RequestHandler<any>
   middleware: AnyMiddleware[] | undefined
 }
@@ -109,11 +100,6 @@ export interface Router<context extends AnyContext = RequestContext> {
    *
    * Accepts either a plain request handler or an action object with optional inline middleware.
    */
-  route<method extends RequestMethod | 'ANY', pattern extends string>(
-    method: method,
-    pattern: RouteTarget<pattern, method>,
-    handler: RequestHandler<RouteContext<context, pattern>>,
-  ): void
   route<
     method extends RequestMethod | 'ANY',
     pattern extends string,
@@ -126,10 +112,6 @@ export interface Router<context extends AnyContext = RequestContext> {
   /**
    * Maps either a single route target to an action or a route map to a controller.
    */
-  map<pattern extends string>(
-    target: RouteTarget<pattern>,
-    handler: RequestHandler<RouteContext<context, pattern>>,
-  ): void
   map<pattern extends string, actionContext extends AnyContext = context>(
     target: RouteTarget<pattern>,
     action: Action<RouteTarget<pattern>, actionContext>,
@@ -178,23 +160,23 @@ function normalizeMiddleware(
   return middleware == null || middleware.length === 0 ? undefined : [...middleware]
 }
 
-function normalizeRouteHandler(routeHandler: unknown): NormalizedRouteHandler {
-  if (isAction(routeHandler)) {
+function normalizeAction(action: unknown): NormalizedAction {
+  if (isRequestHandler(action)) {
     return {
-      handler: routeHandler.handler,
-      middleware: normalizeMiddleware(routeHandler.middleware),
+      handler: action,
+      middleware: undefined,
     }
   }
 
-  if (!isRequestHandler(routeHandler)) {
+  if (!isActionObject(action)) {
     throw new TypeError(
       'Expected a request handler function or action object with a function `handler` property',
     )
   }
 
   return {
-    handler: routeHandler,
-    middleware: undefined,
+    handler: action.handler,
+    middleware: normalizeMiddleware(action.middleware),
   }
 }
 
@@ -256,7 +238,7 @@ export function createRouter<
   function registerRoute(
     method: RequestMethod | 'ANY',
     route: RouteTarget,
-    routeHandler: NormalizedRouteHandler,
+    action: NormalizedAction,
   ): void {
     let pattern =
       route instanceof Route
@@ -266,22 +248,24 @@ export function createRouter<
           : route
     let entry: RouteEntry = {
       pattern,
-      handler: routeHandler.handler,
+      handler: action.handler,
       method,
-      middleware: routeHandler.middleware,
+      middleware: action.middleware,
     }
 
     matcher.add(pattern, entry)
   }
 
-  function addRoute<method extends RequestMethod | 'ANY', pattern extends string>(
+  function addRoute<
+    method extends RequestMethod | 'ANY',
+    pattern extends string,
+    actionContext extends AnyContext,
+  >(
     method: method,
     route: RouteTarget<pattern, method>,
-    handler:
-      | RequestHandler<RouteContext<RouterContext, pattern>>
-      | Action<RouteTarget<pattern, method>, AnyContext>,
+    action: Action<RouteTarget<pattern, method>, actionContext>,
   ): void {
-    registerRoute(method, route, normalizeRouteHandler(handler))
+    registerRoute(method, route, normalizeAction(action))
   }
 
   function mapRoutes(target: MapTarget, handler: unknown): void {
@@ -298,11 +282,7 @@ export function createRouter<
   }
 
   function mapSingleRoute(target: RouteTarget, handler: unknown): void {
-    registerRoute(
-      target instanceof Route ? target.method : 'ANY',
-      target,
-      normalizeRouteHandler(handler),
-    )
+    registerRoute(target instanceof Route ? target.method : 'ANY', target, normalizeAction(handler))
   }
 
   function mapController(
@@ -334,15 +314,14 @@ export function createRouter<
           throw new TypeError(`Missing action \`${key}\` in controller`)
         }
 
-        let action = controller.actions[key]
-        let routeHandler = normalizeRouteHandler(action)
-        let middleware = routeHandler.middleware
+        let action = normalizeAction(controller.actions[key])
+        let middleware = action.middleware
         if (controllerMiddleware) {
           middleware = middleware ? controllerMiddleware.concat(middleware) : controllerMiddleware
         }
 
         registerRoute(route.method, route.pattern, {
-          handler: routeHandler.handler,
+          handler: action.handler,
           middleware,
         })
       }
@@ -352,13 +331,11 @@ export function createRouter<
   function createVerbMethod<method extends RequestMethod>(
     method: method,
   ): VerbMethod<method, RouterContext> {
-    return (<pattern extends string>(
+    return (<pattern extends string, actionContext extends AnyContext = RouterContext>(
       route: RouteTarget<pattern, method>,
-      handler:
-        | RequestHandler<RouteContext<RouterContext, pattern>>
-        | Action<RouteTarget<pattern, method>, AnyContext>,
+      action: Action<RouteTarget<pattern, method>, actionContext>,
     ): void => {
-      addRoute(method, route, handler)
+      addRoute(method, route, action)
     }) as VerbMethod<method, RouterContext>
   }
 
@@ -375,14 +352,16 @@ export function createRouter<
 
       return dispatchRouter(context)
     },
-    route<method extends RequestMethod | 'ANY', pattern extends string>(
+    route<
+      method extends RequestMethod | 'ANY',
+      pattern extends string,
+      actionContext extends AnyContext = RouterContext,
+    >(
       method: method,
       route: RouteTarget<pattern, method>,
-      handler:
-        | RequestHandler<RouteContext<RouterContext, pattern>>
-        | Action<RouteTarget<pattern, method>, AnyContext>,
+      action: Action<RouteTarget<pattern, method>, actionContext>,
     ): void {
-      addRoute(method, route, handler)
+      addRoute(method, route, action)
     },
     map: mapRoutes,
     get: createVerbMethod('GET'),

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -240,18 +240,6 @@ function isRouteTarget(target: MapTarget): target is RouteTarget {
   return typeof target === 'string' || target instanceof RoutePattern || target instanceof Route
 }
 
-function getRoutePattern(target: RouteTarget): RoutePattern<string> {
-  if (target instanceof Route) {
-    return target.pattern
-  }
-
-  return typeof target === 'string' ? new RoutePattern(target) : target
-}
-
-function getMappedRouteMethod(target: RouteTarget): RequestMethod | 'ANY' {
-  return target instanceof Route ? target.method : 'ANY'
-}
-
 /**
  * Create a new router.
  *
@@ -308,7 +296,12 @@ export function createRouter<
     route: RouteTarget,
     normalizedAction: NormalizedAction,
   ): void {
-    let pattern = getRoutePattern(route)
+    let pattern =
+      route instanceof Route
+        ? route.pattern
+        : typeof route === 'string'
+          ? new RoutePattern(route)
+          : route
     let entry: RouteEntry = {
       pattern,
       handler: normalizedAction.handler,
@@ -329,10 +322,6 @@ export function createRouter<
     registerRoute(method, route, normalizeAction(handler))
   }
 
-  function mapSingleRoute(target: RouteTarget, handler: unknown): void {
-    registerRoute(getMappedRouteMethod(target), target, normalizeAction(handler))
-  }
-
   function mapRoutes(target: MapTarget, handler: unknown): void {
     if (isRouteTarget(target)) {
       mapSingleRoute(target, handler)
@@ -344,6 +333,10 @@ export function createRouter<
     }
 
     mapController(target, handler)
+  }
+
+  function mapSingleRoute(target: RouteTarget, handler: unknown): void {
+    registerRoute(target instanceof Route ? target.method : 'ANY', target, normalizeAction(handler))
   }
 
   function mapController(

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -33,47 +33,6 @@ type MapRouteTarget<method extends RequestMethod | 'ANY', pattern extends string
 
 type SingleRouteTarget = string | RoutePattern<string> | Route<RequestMethod | 'ANY', string>
 
-type RouteMethod<context extends AnyContext> = {
-  <method extends RequestMethod | 'ANY', pattern extends string>(
-    method: method,
-    pattern: RouteTarget<method, pattern>,
-    handler: RequestHandler<Params<pattern>, RouteContext<context, pattern>>,
-  ): void
-  <
-    method extends RequestMethod | 'ANY',
-    pattern extends string,
-    actionContext extends AnyContext = context,
-  >(
-    method: method,
-    pattern: RouteTarget<method, pattern>,
-    action: Action<pattern, actionContext>,
-  ): void
-}
-
-type ActionMapping<context extends AnyContext> = {
-  <method extends RequestMethod | 'ANY', pattern extends string>(
-    target: MapRouteTarget<method, pattern>,
-    handler: RequestHandler<Params<pattern>, RouteContext<context, pattern>>,
-  ): void
-  <
-    method extends RequestMethod | 'ANY',
-    pattern extends string,
-    actionContext extends AnyContext = context,
-  >(
-    target: MapRouteTarget<method, pattern>,
-    action: Action<pattern, actionContext>,
-  ): void
-}
-
-type ControllerMapping<context extends AnyContext> = {
-  <target extends RouteMap, controllerContext extends AnyContext = context>(
-    target: target,
-    controller: Controller<target, controllerContext>,
-  ): void
-}
-
-type MapMethod<context extends AnyContext> = ActionMapping<context> & ControllerMapping<context>
-
 type VerbMethod<method extends RequestMethod, context extends AnyContext> = {
   <pattern extends string>(
     route: RouteTarget<method, pattern>,
@@ -160,11 +119,39 @@ export interface Router<context extends AnyContext = RequestContext> {
    *
    * Accepts either a plain request handler or an action object with optional inline middleware.
    */
-  route: RouteMethod<context>
+  route<method extends RequestMethod | 'ANY', pattern extends string>(
+    method: method,
+    pattern: RouteTarget<method, pattern>,
+    handler: RequestHandler<Params<pattern>, RouteContext<context, pattern>>,
+  ): void
+  route<
+    method extends RequestMethod | 'ANY',
+    pattern extends string,
+    actionContext extends AnyContext = context,
+  >(
+    method: method,
+    pattern: RouteTarget<method, pattern>,
+    action: Action<pattern, actionContext>,
+  ): void
   /**
    * Maps either a single route target to an action or a route map to a controller.
    */
-  map: MapMethod<context>
+  map<method extends RequestMethod | 'ANY', pattern extends string>(
+    target: MapRouteTarget<method, pattern>,
+    handler: RequestHandler<Params<pattern>, RouteContext<context, pattern>>,
+  ): void
+  map<
+    method extends RequestMethod | 'ANY',
+    pattern extends string,
+    actionContext extends AnyContext = context,
+  >(
+    target: MapRouteTarget<method, pattern>,
+    action: Action<pattern, actionContext>,
+  ): void
+  map<target extends RouteMap, controllerContext extends AnyContext = context>(
+    target: target,
+    controller: Controller<target, controllerContext>,
+  ): void
   /**
    * Shorthand for registering a `GET` route.
    */

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -7,8 +7,8 @@ import { RequestContext, type ContextWithParams } from './request-context.ts'
 import type { RequestMethod } from './request-methods.ts'
 import {
   type RequestHandler,
-  type Action,
   type Controller,
+  type RouteHandler,
   isRequestHandler,
   isAction,
   isController,
@@ -33,7 +33,7 @@ type VerbMethod<method extends RequestMethod, context extends AnyContext> = {
   ): void
   <pattern extends string, actionContext extends AnyContext = context>(
     route: RouteTarget<pattern, method>,
-    action: Action<pattern, actionContext>,
+    action: RouteHandler<RouteTarget<pattern, method>, actionContext>,
   ): void
 }
 
@@ -59,7 +59,7 @@ export interface RouteEntry {
   middleware: AnyMiddleware[] | undefined
 }
 
-type NormalizedAction = {
+type NormalizedRouteHandler = {
   handler: RequestHandler<any>
   middleware: AnyMiddleware[] | undefined
 }
@@ -121,7 +121,7 @@ export interface Router<context extends AnyContext = RequestContext> {
   >(
     method: method,
     pattern: RouteTarget<pattern, method>,
-    action: Action<pattern, actionContext>,
+    action: RouteHandler<RouteTarget<pattern, method>, actionContext>,
   ): void
   /**
    * Maps either a single route target to an action or a route map to a controller.
@@ -132,7 +132,7 @@ export interface Router<context extends AnyContext = RequestContext> {
   ): void
   map<pattern extends string, actionContext extends AnyContext = context>(
     target: RouteTarget<pattern>,
-    action: Action<pattern, actionContext>,
+    action: RouteHandler<RouteTarget<pattern>, actionContext>,
   ): void
   map<target extends RouteMap, controllerContext extends AnyContext = context>(
     target: target,
@@ -178,22 +178,22 @@ function normalizeMiddleware(
   return middleware == null || middleware.length === 0 ? undefined : [...middleware]
 }
 
-function normalizeAction(action: unknown): NormalizedAction {
-  if (isAction(action)) {
+function normalizeRouteHandler(routeHandler: unknown): NormalizedRouteHandler {
+  if (isAction(routeHandler)) {
     return {
-      handler: action.handler,
-      middleware: normalizeMiddleware(action.middleware),
+      handler: routeHandler.handler,
+      middleware: normalizeMiddleware(routeHandler.middleware),
     }
   }
 
-  if (!isRequestHandler(action)) {
+  if (!isRequestHandler(routeHandler)) {
     throw new TypeError(
       'Expected a request handler function or action object with a function `handler` property',
     )
   }
 
   return {
-    handler: action,
+    handler: routeHandler,
     middleware: undefined,
   }
 }
@@ -256,7 +256,7 @@ export function createRouter<
   function registerRoute(
     method: RequestMethod | 'ANY',
     route: RouteTarget,
-    normalizedAction: NormalizedAction,
+    routeHandler: NormalizedRouteHandler,
   ): void {
     let pattern =
       route instanceof Route
@@ -266,9 +266,9 @@ export function createRouter<
           : route
     let entry: RouteEntry = {
       pattern,
-      handler: normalizedAction.handler,
+      handler: routeHandler.handler,
       method,
-      middleware: normalizedAction.middleware,
+      middleware: routeHandler.middleware,
     }
 
     matcher.add(pattern, entry)
@@ -277,9 +277,11 @@ export function createRouter<
   function addRoute<method extends RequestMethod | 'ANY', pattern extends string>(
     method: method,
     route: RouteTarget<pattern, method>,
-    handler: RequestHandler<RouteContext<RouterContext, pattern>> | Action<pattern, AnyContext>,
+    handler:
+      | RequestHandler<RouteContext<RouterContext, pattern>>
+      | RouteHandler<RouteTarget<pattern, method>, AnyContext>,
   ): void {
-    registerRoute(method, route, normalizeAction(handler))
+    registerRoute(method, route, normalizeRouteHandler(handler))
   }
 
   function mapRoutes(target: MapTarget, handler: unknown): void {
@@ -296,7 +298,11 @@ export function createRouter<
   }
 
   function mapSingleRoute(target: RouteTarget, handler: unknown): void {
-    registerRoute(target instanceof Route ? target.method : 'ANY', target, normalizeAction(handler))
+    registerRoute(
+      target instanceof Route ? target.method : 'ANY',
+      target,
+      normalizeRouteHandler(handler),
+    )
   }
 
   function mapController(
@@ -329,14 +335,14 @@ export function createRouter<
         }
 
         let action = controller.actions[key]
-        let normalizedAction = normalizeAction(action as Action<any, RouterContext>)
-        let middleware = normalizedAction.middleware
+        let routeHandler = normalizeRouteHandler(action)
+        let middleware = routeHandler.middleware
         if (controllerMiddleware) {
           middleware = middleware ? controllerMiddleware.concat(middleware) : controllerMiddleware
         }
 
         registerRoute(route.method, route.pattern, {
-          handler: normalizedAction.handler,
+          handler: routeHandler.handler,
           middleware,
         })
       }
@@ -348,7 +354,9 @@ export function createRouter<
   ): VerbMethod<method, RouterContext> {
     return (<pattern extends string>(
       route: RouteTarget<pattern, method>,
-      handler: RequestHandler<RouteContext<RouterContext, pattern>> | Action<pattern, AnyContext>,
+      handler:
+        | RequestHandler<RouteContext<RouterContext, pattern>>
+        | RouteHandler<RouteTarget<pattern, method>, AnyContext>,
     ): void => {
       addRoute(method, route, handler)
     }) as VerbMethod<method, RouterContext>
@@ -370,7 +378,9 @@ export function createRouter<
     route<method extends RequestMethod | 'ANY', pattern extends string>(
       method: method,
       route: RouteTarget<pattern, method>,
-      handler: RequestHandler<RouteContext<RouterContext, pattern>> | Action<pattern, AnyContext>,
+      handler:
+        | RequestHandler<RouteContext<RouterContext, pattern>>
+        | RouteHandler<RouteTarget<pattern, method>, AnyContext>,
     ): void {
       addRoute(method, route, handler)
     },

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -3,7 +3,7 @@ import { type RouteMap, Route } from '@remix-run/routes'
 
 import { type AnyMiddleware, type MiddlewareContext, runMiddleware } from './middleware.ts'
 import { raceRequestAbort } from './request-abort.ts'
-import { type ContextParams, RequestContext, type ContextWithParams } from './request-context.ts'
+import { RequestContext, type ContextWithParams } from './request-context.ts'
 import type { RequestMethod } from './request-methods.ts'
 import {
   type Action,
@@ -28,7 +28,7 @@ type RouteTarget<
 type VerbMethod<method extends RequestMethod, context extends AnyContext> = {
   <pattern extends string>(
     route: RouteTarget<pattern, method>,
-    handler: RequestHandler<Params<pattern>, RouteContext<context, pattern>>,
+    handler: RequestHandler<RouteContext<context, pattern>>,
   ): void
   <pattern extends string, actionContext extends AnyContext = context>(
     route: RouteTarget<pattern, method>,
@@ -47,7 +47,7 @@ export interface RouteEntry {
   /**
    * The handler that runs when this route matches.
    */
-  handler: RequestHandler<any, any>
+  handler: RequestHandler<any>
   /**
    * The request method this route handles, or `ANY` for method-agnostic routes.
    */
@@ -59,7 +59,7 @@ export interface RouteEntry {
 }
 
 type NormalizedAction = {
-  handler: RequestHandler<any, any>
+  handler: RequestHandler<any>
   middleware: AnyMiddleware[] | undefined
 }
 
@@ -76,10 +76,7 @@ export interface RouterOptions<
    * The default request handler that runs when no route matches.
    * Defaults to a 404 `Not Found` response.
    */
-  defaultHandler?: RequestHandler<
-    ContextParams<MiddlewareContext<middleware, context>>,
-    MiddlewareContext<middleware, context>
-  >
+  defaultHandler?: RequestHandler<MiddlewareContext<middleware, context>>
   /**
    * The matcher to use for matching routes.
    * Defaults to `createMatcher()`.
@@ -114,7 +111,7 @@ export interface Router<context extends AnyContext = RequestContext> {
   route<method extends RequestMethod | 'ANY', pattern extends string>(
     method: method,
     pattern: RouteTarget<pattern, method>,
-    handler: RequestHandler<Params<pattern>, RouteContext<context, pattern>>,
+    handler: RequestHandler<RouteContext<context, pattern>>,
   ): void
   route<
     method extends RequestMethod | 'ANY',
@@ -130,7 +127,7 @@ export interface Router<context extends AnyContext = RequestContext> {
    */
   map<pattern extends string>(
     target: RouteTarget<pattern>,
-    handler: RequestHandler<Params<pattern>, RouteContext<context, pattern>>,
+    handler: RequestHandler<RouteContext<context, pattern>>,
   ): void
   map<pattern extends string, actionContext extends AnyContext = context>(
     target: RouteTarget<pattern>,
@@ -184,7 +181,7 @@ function normalizeMiddleware(
   return [...middleware]
 }
 
-function isRequestHandler(action: unknown): action is RequestHandler<any, any> {
+function isRequestHandler(action: unknown): action is RequestHandler<any> {
   return typeof action === 'function'
 }
 
@@ -206,24 +203,6 @@ function normalizeAction(action: unknown): NormalizedAction {
     handler: action,
     middleware: undefined,
   }
-}
-
-function mergeMiddleware(
-  upstream: AnyMiddleware[] | undefined,
-  downstream: AnyMiddleware[] | undefined,
-): AnyMiddleware[] | undefined {
-  let upstreamMiddleware = normalizeMiddleware(upstream)
-  let downstreamMiddleware = normalizeMiddleware(downstream)
-
-  if (!upstreamMiddleware) {
-    return downstreamMiddleware
-  }
-
-  if (!downstreamMiddleware) {
-    return upstreamMiddleware
-  }
-
-  return upstreamMiddleware.concat(downstreamMiddleware)
 }
 
 function createRequestContext(input: string | URL | Request, init?: RequestInit): RequestContext {
@@ -257,7 +236,7 @@ export function createRouter<
 >(options?: RouterOptions<context, middleware>): Router<MiddlewareContext<middleware, context>> {
   type RouterContext = MiddlewareContext<middleware, context>
 
-  let defaultHandler = (options?.defaultHandler ?? noMatchHandler) as RequestHandler<any, any>
+  let defaultHandler = (options?.defaultHandler ?? noMatchHandler) as RequestHandler<any>
   let matcher = options?.matcher ?? createMatcher<RouteEntry>()
   let routerMiddleware = normalizeMiddleware(options?.middleware)
 
@@ -315,9 +294,7 @@ export function createRouter<
   function addRoute<method extends RequestMethod | 'ANY', pattern extends string>(
     method: method,
     route: RouteTarget<pattern, method>,
-    handler:
-      | RequestHandler<Params<pattern>, RouteContext<RouterContext, pattern>>
-      | Action<pattern, AnyContext>,
+    handler: RequestHandler<RouteContext<RouterContext, pattern>> | Action<pattern, AnyContext>,
   ): void {
     registerRoute(method, route, normalizeAction(handler))
   }
@@ -370,9 +347,14 @@ export function createRouter<
 
         let action = controller.actions[key]
         let normalizedAction = normalizeAction(action as Action<any, RouterContext>)
+        let middleware = normalizedAction.middleware
+        if (controllerMiddleware) {
+          middleware = middleware ? controllerMiddleware.concat(middleware) : controllerMiddleware
+        }
+
         registerRoute(route.method, route.pattern, {
           handler: normalizedAction.handler,
-          middleware: mergeMiddleware(controllerMiddleware, normalizedAction.middleware),
+          middleware,
         })
       }
     }
@@ -383,9 +365,7 @@ export function createRouter<
   ): VerbMethod<method, RouterContext> {
     return (<pattern extends string>(
       route: RouteTarget<pattern, method>,
-      handler:
-        | RequestHandler<Params<pattern>, RouteContext<RouterContext, pattern>>
-        | Action<pattern, AnyContext>,
+      handler: RequestHandler<RouteContext<RouterContext, pattern>> | Action<pattern, AnyContext>,
     ): void => {
       addRoute(method, route, handler)
     }) as VerbMethod<method, RouterContext>
@@ -400,9 +380,7 @@ export function createRouter<
     route<method extends RequestMethod | 'ANY', pattern extends string>(
       method: method,
       route: RouteTarget<pattern, method>,
-      handler:
-        | RequestHandler<Params<pattern>, RouteContext<RouterContext, pattern>>
-        | Action<pattern, AnyContext>,
+      handler: RequestHandler<RouteContext<RouterContext, pattern>> | Action<pattern, AnyContext>,
     ): void {
       addRoute(method, route, handler)
     },

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -1,24 +1,22 @@
 import { type Matcher, type Params, createMatcher, RoutePattern } from '@remix-run/route-pattern'
 import { type RouteMap, Route } from '@remix-run/routes'
 
-import { type AnyMiddleware, type ApplyMiddlewareTuple, runMiddleware } from './middleware.ts'
+import { type AnyMiddleware, type MiddlewareContext, runMiddleware } from './middleware.ts'
 import { raceRequestAbort } from './request-abort.ts'
-import { type ContextParams, RequestContext, type WithParams } from './request-context.ts'
+import { type ContextParams, RequestContext, type ContextWithParams } from './request-context.ts'
 import type { RequestMethod } from './request-methods.ts'
 import {
   type Action,
   type Controller,
   type ControllerShape,
-  type ControllerWithMiddleware,
-  type ControllerWithoutMiddleware,
   type RequestHandler,
-  isActionObject,
+  isAction,
   isController,
 } from './controller.ts'
 
 type AnyContext = RequestContext<any, any>
 
-type RouteContext<context extends AnyContext, pattern extends string> = WithParams<
+type RouteContext<context extends AnyContext, pattern extends string> = ContextWithParams<
   context,
   Params<pattern>
 >
@@ -44,11 +42,11 @@ type RouteMethod<context extends AnyContext> = {
   <
     method extends RequestMethod | 'ANY',
     pattern extends string,
-    middleware extends readonly AnyMiddleware[] = readonly AnyMiddleware[],
+    actionContext extends AnyContext = context,
   >(
     method: method,
     pattern: RouteTarget<method, pattern>,
-    action: Action<pattern, context, middleware>,
+    action: Action<pattern, actionContext>,
   ): void
 }
 
@@ -60,23 +58,18 @@ type ActionMapping<context extends AnyContext> = {
   <
     method extends RequestMethod | 'ANY',
     pattern extends string,
-    middleware extends readonly AnyMiddleware[] = readonly AnyMiddleware[],
+    actionContext extends AnyContext = context,
   >(
     target: MapRouteTarget<method, pattern>,
-    action: Action<pattern, context, middleware>,
+    action: Action<pattern, actionContext>,
   ): void
 }
 
 type ControllerMapping<context extends AnyContext> = {
-  <target extends RouteMap>(
+  <target extends RouteMap, controllerContext extends AnyContext = context>(
     target: target,
-    controller: ControllerWithoutMiddleware<target, context>,
+    controller: Controller<target, controllerContext>,
   ): void
-  <target extends RouteMap, middleware extends readonly AnyMiddleware[]>(
-    target: target,
-    controller: ControllerWithMiddleware<target, context, middleware>,
-  ): void
-  <target extends RouteMap>(target: target, controller: Controller<target, context>): void
 }
 
 type MapMethod<context extends AnyContext> = ActionMapping<context> & ControllerMapping<context>
@@ -86,19 +79,31 @@ type VerbMethod<method extends RequestMethod, context extends AnyContext> = {
     route: RouteTarget<method, pattern>,
     handler: RequestHandler<Params<pattern>, RouteContext<context, pattern>>,
   ): void
-  <pattern extends string, middleware extends readonly AnyMiddleware[] = readonly AnyMiddleware[]>(
+  <pattern extends string, actionContext extends AnyContext = context>(
     route: RouteTarget<method, pattern>,
-    action: Action<pattern, context, middleware>,
+    action: Action<pattern, actionContext>,
   ): void
 }
 
 /**
  * The normalized route entry stored in the router matcher.
  */
-export type RouteEntry = {
+export interface RouteEntry {
+  /**
+   * The URL pattern used to match this route.
+   */
   pattern: RoutePattern<string>
+  /**
+   * The handler that runs when this route matches.
+   */
   handler: RequestHandler<any, any>
+  /**
+   * The request method this route handles, or `ANY` for method-agnostic routes.
+   */
   method: RequestMethod | 'ANY'
+  /**
+   * Route-specific middleware that runs before the handler.
+   */
   middleware: AnyMiddleware[] | undefined
 }
 
@@ -118,17 +123,15 @@ export interface RouterOptions<
 > {
   /**
    * The default request handler that runs when no route matches.
-   *
-   * @default A 404 "Not Found" response
+   * Defaults to a 404 `Not Found` response.
    */
   defaultHandler?: RequestHandler<
-    ContextParams<ApplyMiddlewareTuple<context, middleware>>,
-    ApplyMiddlewareTuple<context, middleware>
+    ContextParams<MiddlewareContext<middleware, context>>,
+    MiddlewareContext<middleware, context>
   >
   /**
    * The matcher to use for matching routes.
-   *
-   * @default `createMatcher()`
+   * Defaults to `createMatcher()`.
    */
   matcher?: Matcher<RouteEntry>
   /**
@@ -211,7 +214,7 @@ function isRequestHandler(action: unknown): action is RequestHandler<any, any> {
 }
 
 function normalizeAction(action: unknown): NormalizedAction {
-  if (isActionObject(action)) {
+  if (isAction(action)) {
     return {
       handler: action.handler,
       middleware: normalizeMiddleware(action.middleware),
@@ -295,12 +298,12 @@ export function createRouter<context extends AnyContext = RequestContext>(): Rou
 export function createRouter<
   context extends AnyContext = RequestContext,
   const middleware extends readonly AnyMiddleware[] = readonly AnyMiddleware[],
->(options: RouterOptions<context, middleware>): Router<ApplyMiddlewareTuple<context, middleware>>
+>(options: RouterOptions<context, middleware>): Router<MiddlewareContext<middleware, context>>
 export function createRouter<
   context extends AnyContext = RequestContext,
   const middleware extends readonly AnyMiddleware[] = readonly AnyMiddleware[],
->(options?: RouterOptions<context, middleware>): Router<ApplyMiddlewareTuple<context, middleware>> {
-  type RouterContext = ApplyMiddlewareTuple<context, middleware>
+>(options?: RouterOptions<context, middleware>): Router<MiddlewareContext<middleware, context>> {
+  type RouterContext = MiddlewareContext<middleware, context>
 
   let defaultHandler = (options?.defaultHandler ?? noMatchHandler) as RequestHandler<any, any>
   let matcher = options?.matcher ?? createMatcher<RouteEntry>()
@@ -352,14 +355,12 @@ export function createRouter<
     matcher.add(pattern, entry)
   }
 
-  function addRoute<
-    method extends RequestMethod | 'ANY',
-    pattern extends string,
-    actionMiddleware extends readonly AnyMiddleware[] = readonly AnyMiddleware[],
-  >(
+  function addRoute<method extends RequestMethod | 'ANY', pattern extends string>(
     method: method,
     route: RouteTarget<method, pattern>,
-    handler: Action<pattern, RouterContext, actionMiddleware>,
+    handler:
+      | RequestHandler<Params<pattern>, RouteContext<RouterContext, pattern>>
+      | Action<pattern, AnyContext>,
   ): void {
     registerRoute(method, route, normalizeAction(handler))
   }
@@ -417,12 +418,11 @@ export function createRouter<
   function createVerbMethod<method extends RequestMethod>(
     method: method,
   ): VerbMethod<method, RouterContext> {
-    return (<
-      pattern extends string,
-      actionMiddleware extends readonly AnyMiddleware[] = readonly AnyMiddleware[],
-    >(
+    return (<pattern extends string>(
       route: RouteTarget<method, pattern>,
-      handler: Action<pattern, RouterContext, actionMiddleware>,
+      handler:
+        | RequestHandler<Params<pattern>, RouteContext<RouterContext, pattern>>
+        | Action<pattern, AnyContext>,
     ): void => {
       addRoute(method, route, handler)
     }) as VerbMethod<method, RouterContext>
@@ -434,14 +434,12 @@ export function createRouter<
       context.router = router
       return dispatchRouter(context)
     },
-    route<
-      method extends RequestMethod | 'ANY',
-      pattern extends string,
-      actionMiddleware extends readonly AnyMiddleware[] = readonly AnyMiddleware[],
-    >(
+    route<method extends RequestMethod | 'ANY', pattern extends string>(
       method: method,
       route: RouteTarget<method, pattern>,
-      handler: Action<pattern, RouterContext, actionMiddleware>,
+      handler:
+        | RequestHandler<Params<pattern>, RouteContext<RouterContext, pattern>>
+        | Action<pattern, AnyContext>,
     ): void {
       addRoute(method, route, handler)
     },

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -228,24 +228,13 @@ function mergeMiddleware(
 }
 
 function createRequestContext(input: string | URL | Request, init?: RequestInit): RequestContext {
-  let request: Request
-  if (input instanceof Request) {
-    request = cloneRequest(input)
-    if (init != null) request = new Request(request, init)
-  } else {
-    request = new Request(input, init)
-  }
+  let request = input instanceof Request && init == null ? input : new Request(input, init)
 
   if (request.signal.aborted) {
     throw request.signal.reason
   }
 
   return new RequestContext(request)
-}
-
-function cloneRequest(input: Request): Request {
-  // Cloudflare's generated Request type preserves worker metadata generics through clone().
-  return input.clone() as Request
 }
 
 function isRouteTarget(target: MapTarget): target is RouteTarget {

--- a/packages/form-data-middleware/src/lib/form-data.test.ts
+++ b/packages/form-data-middleware/src/lib/form-data.test.ts
@@ -11,7 +11,7 @@ import {
   type FileUploadHandler,
 } from '@remix-run/form-data-parser'
 import { createRouter } from '@remix-run/fetch-router'
-import type { RequestContext } from '@remix-run/fetch-router'
+import type { ContextEntries, RequestContext } from '@remix-run/fetch-router'
 
 import { formData } from './form-data.ts'
 
@@ -28,7 +28,9 @@ function normalizeFileType(type: string): string {
   return new File([''], '', { type }).type
 }
 
-function getFormDataState(context: RequestContext): FormDataState {
+function getFormDataState<params extends Record<string, any>, entries extends ContextEntries>(
+  context: RequestContext<params, entries>,
+): FormDataState {
   let formData = context.get(FormData)
   if (formData == null) {
     return {

--- a/packages/form-data-middleware/src/lib/form-data.ts
+++ b/packages/form-data-middleware/src/lib/form-data.ts
@@ -47,7 +47,7 @@ export interface FormDataOptions extends ParseFormDataOptions {
  * @param options Options for parsing form data
  * @returns A middleware function that parses form data
  */
-export function formData(options?: FormDataOptions): Middleware<any, SetFormDataContextTransform> {
+export function formData(options?: FormDataOptions): Middleware<SetFormDataContextTransform> {
   let suppressErrors = options?.suppressErrors ?? false
   let uploadHandler = options?.uploadHandler
 

--- a/packages/form-data-middleware/src/lib/form-data.ts
+++ b/packages/form-data-middleware/src/lib/form-data.ts
@@ -8,9 +8,9 @@ import {
   type FileUploadHandler,
   type ParseFormDataOptions,
 } from '@remix-run/form-data-parser'
-import type { Middleware } from '@remix-run/fetch-router'
+import type { ContextEntry, Middleware } from '@remix-run/fetch-router'
 
-type SetFormDataContextTransform = readonly [readonly [typeof FormData, FormData]]
+type FormDataContextEntry = ContextEntry<typeof FormData, FormData>
 
 function isMultipartLimitError(error: unknown): boolean {
   return (
@@ -47,7 +47,7 @@ export interface FormDataOptions extends ParseFormDataOptions {
  * @param options Options for parsing form data
  * @returns A middleware function that parses form data
  */
-export function formData(options?: FormDataOptions): Middleware<SetFormDataContextTransform> {
+export function formData(options?: FormDataOptions): Middleware<FormDataContextEntry> {
   let suppressErrors = options?.suppressErrors ?? false
   let uploadHandler = options?.uploadHandler
 

--- a/packages/node-serve/.changes/patch.native-request-handlers.md
+++ b/packages/node-serve/.changes/patch.native-request-handlers.md
@@ -1,0 +1,1 @@
+Pass native `Request` objects to Fetch handlers instead of lazy request facades.

--- a/packages/node-serve/src/lib/server.test.ts
+++ b/packages/node-serve/src/lib/server.test.ts
@@ -86,6 +86,29 @@ describeUws('serve', () => {
     }
   })
 
+  it('passes a native Request object to handlers', async () => {
+    let server = serve(
+      (request) => {
+        let copy = new Request(request)
+
+        assert.equal(copy.url, request.url)
+        return new Response('ok')
+      },
+      { port: 0 },
+    )
+
+    await server.ready
+
+    try {
+      let response = await fetch(`http://127.0.0.1:${server.port}/test`)
+
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'ok')
+    } finally {
+      server.close()
+    }
+  })
+
   it('uses the host option to override the incoming Host header', async () => {
     let server = serve(
       async (request) => {

--- a/packages/node-serve/src/lib/uws-request.ts
+++ b/packages/node-serve/src/lib/uws-request.ts
@@ -27,208 +27,64 @@ export function createUwsRequest(
   options?: UwsRequestOptions,
   method = req.getCaseSensitiveMethod(),
 ): Request {
-  return new UwsRequest(req, res, state, options, method)
+  let init: RequestInit = {
+    method,
+    headers: createRequestHeaders(req),
+    signal: getAbortSignal(state),
+  }
+
+  if (requestMethodCanHaveBody(method)) {
+    init.body = createBodyStream(readUwsRequestBody(res, state))
+    ;(init as { duplex: 'half' }).duplex = 'half'
+  }
+
+  return new Request(createRequestUrl(req, options), init)
 }
 
-class UwsRequest implements Request {
-  #request: Request | undefined
-  #headers: Headers
-  #bodyPromise: Promise<Buffer> | undefined
-  #bodyUsed = false
-  #method: string
-  #url: string | undefined
-  #protocol: string
-  #host: string
-  #path: string
-  #query: string
-  #state: UwsResponseState
-
-  constructor(
-    req: HttpRequest,
-    res: HttpResponse,
-    state: UwsResponseState,
-    options: UwsRequestOptions | undefined,
-    method: string,
-  ) {
-    this.#state = state
-    this.#method = method
-
-    let entries: [string, string][] = []
-    req.forEach((key, value) => {
-      entries.push([key, value])
-    })
-    this.#headers = createUwsHeaders(entries)
-
-    this.#protocol = options?.protocol ?? 'http:'
-    this.#host = options?.host ?? (req.getHeader('host') || 'localhost')
-    this.#path = req.getUrl()
-    this.#query = req.getQuery()
-
-    if (requestMethodCanHaveBody(this.#method)) {
-      this.#bodyPromise = readUwsRequestBody(res, state)
-    }
-  }
-
-  #materialize(): Request {
-    if (this.#request != null) return this.#request
-
-    let init: RequestInit = {
-      method: this.#method,
-      headers: this.#headers,
-      signal: this.signal,
-    }
-
-    if (requestMethodCanHaveBody(this.#method)) {
-      init.body = this.#createBodyStream()
-      ;(init as { duplex: 'half' }).duplex = 'half'
-    }
-
-    return (this.#request = new Request(this.url, init))
-  }
-
-  #createBodyStream(): ReadableStream<Uint8Array> {
-    let sent = false
-
-    return new ReadableStream({
-      pull: async (controller) => {
-        if (sent) return
-        sent = true
-
-        let body = await this.#readBody()
-        if (body.byteLength !== 0) controller.enqueue(bufferToBytes(body))
-        controller.close()
-      },
-    })
-  }
-
-  get body() {
-    return this.#materialize().body
-  }
-
-  get bodyUsed() {
-    return this.#bodyUsed || this.#request?.bodyUsed === true
-  }
-
-  get cache() {
-    return this.#materialize().cache
-  }
-
-  get credentials() {
-    return this.#materialize().credentials
-  }
-
-  get destination() {
-    return this.#materialize().destination
-  }
-
-  get headers() {
-    return this.#headers
-  }
-
-  get integrity() {
-    return this.#materialize().integrity
-  }
-
-  get keepalive() {
-    return this.#materialize().keepalive
-  }
-
-  get method() {
-    return this.#method
-  }
-
-  get mode() {
-    return this.#materialize().mode
-  }
-
-  get redirect() {
-    return this.#materialize().redirect
-  }
-
-  get referrer() {
-    return this.#materialize().referrer
-  }
-
-  get referrerPolicy() {
-    return this.#materialize().referrerPolicy
-  }
-
-  get signal() {
-    let controller = (this.#state.controller ??= new AbortController())
-    if (this.#state.aborted) controller.abort()
-    return controller.signal
-  }
-
-  get url() {
-    return (this.#url ??= `${this.#protocol}//${this.#host}${this.#path}${
-      this.#query === '' ? '' : `?${this.#query}`
-    }`)
-  }
-
-  arrayBuffer() {
-    if (this.#request != null && !this.#bodyUsed) return this.#request.arrayBuffer()
-    return this.#consumeBody().then(bufferToArrayBuffer)
-  }
-
-  blob() {
-    if (this.#request != null && !this.#bodyUsed) return this.#request.blob()
-    return this.#consumeBody().then((body) => new Blob([bufferToBytes(body)]))
-  }
-
-  bytes() {
-    if (this.#request != null && !this.#bodyUsed) return this.#request.bytes()
-    return this.#consumeBody().then(bufferToBytes)
-  }
-
-  clone() {
-    if (this.bodyUsed) throw bodyUnusable()
-    return this.#materialize().clone()
-  }
-
-  formData() {
-    return this.#materialize().formData()
-  }
-
-  json() {
-    if (this.#request != null && !this.#bodyUsed) return this.#request.json()
-    return this.text().then(JSON.parse)
-  }
-
-  text() {
-    if (this.#request != null && !this.#bodyUsed) return this.#request.text()
-    return this.#consumeBody().then((body) => body.toString())
-  }
-
-  #consumeBody(): Promise<Buffer> {
-    if (!requestMethodCanHaveBody(this.#method)) return Promise.resolve(Buffer.alloc(0))
-    if (this.#bodyUsed) return Promise.reject(bodyUnusable())
-    this.#bodyUsed = true
-    return this.#readBody()
-  }
-
-  #readBody(): Promise<Buffer> {
-    return this.#bodyPromise ?? Promise.resolve(Buffer.alloc(0))
-  }
+function createRequestHeaders(req: HttpRequest): Headers {
+  let entries: [string, string][] = []
+  req.forEach((key, value) => {
+    entries.push([key, value])
+  })
+  return createUwsHeaders(entries)
 }
 
-Object.setPrototypeOf(UwsRequest.prototype, Request.prototype)
+function getAbortSignal(state: UwsResponseState): AbortSignal {
+  let controller = (state.controller ??= new AbortController())
+  if (state.aborted) controller.abort()
+  return controller.signal
+}
+
+function createRequestUrl(req: HttpRequest, options: UwsRequestOptions | undefined): string {
+  let protocol = options?.protocol ?? 'http:'
+  let host = options?.host ?? (req.getHeader('host') || 'localhost')
+  let query = req.getQuery()
+  return `${protocol}//${host}${req.getUrl()}${query === '' ? '' : `?${query}`}`
+}
+
+function createBodyStream(body: Promise<Buffer>): ReadableStream<Uint8Array> {
+  let sent = false
+
+  return new ReadableStream({
+    pull: async (controller) => {
+      if (sent) return
+      sent = true
+
+      let buffer = await body
+      if (buffer.byteLength !== 0) controller.enqueue(bufferToBytes(buffer))
+      controller.close()
+    },
+  })
+}
 
 function requestMethodCanHaveBody(method: string): boolean {
   return method !== 'GET' && method !== 'HEAD'
-}
-
-function bufferToArrayBuffer(buffer: Buffer): ArrayBuffer {
-  return bufferToBytes(buffer).buffer
 }
 
 function bufferToBytes(buffer: Buffer): Uint8Array<ArrayBuffer> {
   let bytes = new Uint8Array(buffer.byteLength)
   bytes.set(buffer)
   return bytes
-}
-
-function bodyUnusable(): TypeError {
-  return new TypeError('Body is unusable: Body has already been read')
 }
 
 function readUwsRequestBody(res: HttpResponse, state: UwsResponseState): Promise<Buffer> {

--- a/packages/remix/.changes/major.auth-middleware-context-helper-renames.md
+++ b/packages/remix/.changes/major.auth-middleware-context-helper-renames.md
@@ -1,0 +1,9 @@
+BREAKING CHANGE: Renamed the `remix/auth-middleware` auth context helper types from `WithAuth` and `WithRequiredAuth` to `ContextWithAuth` and `ContextWithRequiredAuth` so middleware packages consistently use the `ContextWith*` naming pattern for helpers that produce refined `RequestContext` types.
+
+```ts
+// before
+type AppAuthContext = WithRequiredAuth<AppContext, AuthIdentity>
+
+// after
+type AppAuthContext = ContextWithRequiredAuth<AppContext, AuthIdentity>
+```

--- a/packages/remix/.changes/major.fetch-router-action-types.md
+++ b/packages/remix/.changes/major.fetch-router-action-types.md
@@ -1,4 +1,4 @@
-BREAKING CHANGE: Updated the re-exported `remix/fetch-router` helper types to match `@remix-run/fetch-router`: `Action` now describes object-form route handlers only, the new `RouteHandler` type describes either a plain request handler function or action object, `Action` and `Controller` now accept the full request context as their optional second generic, `RequestHandler` now accepts the full request context as its only generic, `Middleware` now accepts only the context transform generic, `BuildAction` is no longer exported, `createAction()`/`createController()` are the preferred helpers for stored handlers, `RouterTypes.context` configures the default builder context, `MiddlewareContext` now accepts an optional base context, `ContextWithMiddleware` applies middleware to an existing context, `ContextTransform` replaces `MiddlewareContextTransform`, the lower-level `ApplyContextTransform`/`ApplyMiddleware`/`ApplyMiddlewareTuple` helpers are no longer exported, and custom matcher payloads should use `RouteEntry` instead of `MatchData`.
+BREAKING CHANGE: Updated the re-exported `remix/fetch-router` helper types to match `@remix-run/fetch-router`: `Action` now describes either a plain request handler function or action object and accepts the full request context as its optional second generic, `Controller` now accepts the full request context as its optional second generic, `RequestHandler` now accepts the full request context as its only generic, `Middleware` now accepts only the context transform generic, `BuildAction` is no longer exported, `createAction()`/`createController()` are the preferred helpers for stored handlers, `RouterTypes.context` configures the default builder context, `MiddlewareContext` now accepts an optional base context, `ContextWithMiddleware` applies middleware to an existing context, `ContextTransform` replaces `MiddlewareContextTransform`, the lower-level `ApplyContextTransform`/`ApplyMiddleware`/`ApplyMiddlewareTuple` helpers are no longer exported, and custom matcher payloads should use `RouteEntry` instead of `MatchData`.
 
 The request context helper type renames also apply to imports from `remix/fetch-router`.
 
@@ -44,16 +44,10 @@ let handler: RequestHandler<{ id: string }, RequestContext<{ id: string }>>
 let handler: RequestHandler<RequestContext<{ id: string }>>
 ```
 
-If you manually annotate stored route handler functions, use `RouteHandler`. Use `Action` for object-form handlers with optional middleware:
+`Action` can be used to manually annotate either action form:
 
 ```ts
-// before
 let handler: Action<typeof routes.account, AccountContext> = (context) => {
-  return Response.json(context.get(Auth).identity)
-}
-
-// after
-let handler: RouteHandler<typeof routes.account, AccountContext> = (context) => {
   return Response.json(context.get(Auth).identity)
 }
 

--- a/packages/remix/.changes/major.fetch-router-action-types.md
+++ b/packages/remix/.changes/major.fetch-router-action-types.md
@@ -1,4 +1,4 @@
-BREAKING CHANGE: Updated the re-exported `remix/fetch-router` helper types to match `@remix-run/fetch-router`: `Action` now describes either a plain request handler function or action object and accepts the full request context as its optional second generic, `Controller` now accepts the full request context as its optional second generic, `RequestHandler` now accepts the full request context as its only generic, `Middleware` now accepts only the context transform generic, `BuildAction` is no longer exported, `createAction()`/`createController()` are the preferred helpers for stored handlers, `RouterTypes.context` configures the default builder context, `MiddlewareContext` now accepts an optional base context, `ContextWithMiddleware` applies middleware to an existing context, `ContextTransform` replaces `MiddlewareContextTransform`, the lower-level `ApplyContextTransform`/`ApplyMiddleware`/`ApplyMiddlewareTuple` helpers are no longer exported, and custom matcher payloads should use `RouteEntry` instead of `MatchData`.
+BREAKING CHANGE: Updated the re-exported `remix/fetch-router` helper types to match `@remix-run/fetch-router`: `Action` now describes either a plain request handler function or action object and accepts the full request context as its optional second generic, `Controller` now accepts the full request context as its optional second generic, `RequestHandler` now accepts the full request context as its only generic, `Middleware` now accepts one context effect generic, which can be a single `ContextEntry`, a `ContextEntries` tuple, or a context transform function, `BuildAction` is no longer exported, `createAction()`/`createController()` are the preferred helpers for stored handlers, `RouterTypes.context` configures the default builder context, `MiddlewareContext` now accepts an optional base context, `ContextWithMiddleware` applies middleware to an existing context, the lower-level `MiddlewareContextTransform`, `ContextTransform`, `ApplyContextTransform`, `ApplyMiddleware`, and `ApplyMiddlewareTuple` helpers are no longer exported, and custom matcher payloads should use `RouteEntry` instead of `MatchData`.
 
 The request context helper type renames also apply to imports from `remix/fetch-router`.
 
@@ -28,9 +28,11 @@ export type WithCurrentUser<context extends RequestContext<any, any>> = MergeCon
 >
 
 // after
+type CurrentUserContextEntry = ContextEntry<typeof CurrentUser, User | null>
+
 export type ContextWithCurrentUser<context extends RequestContext<any, any>> = ContextWithValues<
   context,
-  [readonly [typeof CurrentUser, User | null]]
+  [CurrentUserContextEntry]
 >
 ```
 
@@ -66,7 +68,8 @@ If you manually annotate middleware, pass only the context transform type:
 let middleware: Middleware<{}, SetDatabaseContextTransform>
 
 // after
-let middleware: Middleware<SetDatabaseContextTransform>
+type DatabaseContextEntry = ContextEntry<typeof Database, Database>
+let middleware: Middleware<DatabaseContextEntry>
 ```
 
 Use `ContextWithValue` when refining a single context value for a specific handler or middleware result:

--- a/packages/remix/.changes/major.fetch-router-action-types.md
+++ b/packages/remix/.changes/major.fetch-router-action-types.md
@@ -1,4 +1,4 @@
-BREAKING CHANGE: Updated the re-exported `remix/fetch-router` helper types to match `@remix-run/fetch-router`: `Action` and `Middleware` no longer accept unused request method type parameters, `Action` and `Controller` now accept the full request context as their optional second generic, `BuildAction` is no longer exported, `createAction()`/`createController()` are the preferred helpers for stored handlers, `RouterTypes.context` configures the default builder context, `MiddlewareContext` now accepts an optional base context, `ContextWithMiddleware` applies middleware to an existing context, `ContextTransform` replaces `MiddlewareContextTransform`, the lower-level `ApplyContextTransform`/`ApplyMiddleware`/`ApplyMiddlewareTuple` helpers are no longer exported, and custom matcher payloads should use `RouteEntry` instead of `MatchData`.
+BREAKING CHANGE: Updated the re-exported `remix/fetch-router` helper types to match `@remix-run/fetch-router`: `Action` and `Controller` now accept the full request context as their optional second generic, `RequestHandler` now accepts the full request context as its only generic, `Middleware` now accepts only the context transform generic, `BuildAction` is no longer exported, `createAction()`/`createController()` are the preferred helpers for stored handlers, `RouterTypes.context` configures the default builder context, `MiddlewareContext` now accepts an optional base context, `ContextWithMiddleware` applies middleware to an existing context, `ContextTransform` replaces `MiddlewareContextTransform`, the lower-level `ApplyContextTransform`/`ApplyMiddleware`/`ApplyMiddlewareTuple` helpers are no longer exported, and custom matcher payloads should use `RouteEntry` instead of `MatchData`.
 
 The request context helper type renames also apply to imports from `remix/fetch-router`.
 
@@ -28,10 +28,30 @@ export type WithCurrentUser<context extends RequestContext<any, any>> = MergeCon
 >
 
 // after
-export type WithCurrentUser<context extends RequestContext<any, any>> = ContextWithValues<
+export type ContextWithCurrentUser<context extends RequestContext<any, any>> = ContextWithValues<
   context,
   [readonly [typeof CurrentUser, User | null]]
 >
+```
+
+If you manually annotate request handlers, pass the full request context type as the only generic:
+
+```ts
+// before
+let handler: RequestHandler<{ id: string }, RequestContext<{ id: string }>>
+
+// after
+let handler: RequestHandler<RequestContext<{ id: string }>>
+```
+
+If you manually annotate middleware, pass only the context transform type:
+
+```ts
+// before
+let middleware: Middleware<{}, SetDatabaseContextTransform>
+
+// after
+let middleware: Middleware<SetDatabaseContextTransform>
 ```
 
 Use `ContextWithValue` when refining a single context value for a specific handler or middleware result:

--- a/packages/remix/.changes/major.fetch-router-action-types.md
+++ b/packages/remix/.changes/major.fetch-router-action-types.md
@@ -1,4 +1,4 @@
-BREAKING CHANGE: Updated the re-exported `remix/fetch-router` helper types to match `@remix-run/fetch-router`: `Action` and `Controller` now accept the full request context as their optional second generic, `RequestHandler` now accepts the full request context as its only generic, `Middleware` now accepts only the context transform generic, `BuildAction` is no longer exported, `createAction()`/`createController()` are the preferred helpers for stored handlers, `RouterTypes.context` configures the default builder context, `MiddlewareContext` now accepts an optional base context, `ContextWithMiddleware` applies middleware to an existing context, `ContextTransform` replaces `MiddlewareContextTransform`, the lower-level `ApplyContextTransform`/`ApplyMiddleware`/`ApplyMiddlewareTuple` helpers are no longer exported, and custom matcher payloads should use `RouteEntry` instead of `MatchData`.
+BREAKING CHANGE: Updated the re-exported `remix/fetch-router` helper types to match `@remix-run/fetch-router`: `Action` now describes object-form route handlers only, the new `RouteHandler` type describes either a plain request handler function or action object, `Action` and `Controller` now accept the full request context as their optional second generic, `RequestHandler` now accepts the full request context as its only generic, `Middleware` now accepts only the context transform generic, `BuildAction` is no longer exported, `createAction()`/`createController()` are the preferred helpers for stored handlers, `RouterTypes.context` configures the default builder context, `MiddlewareContext` now accepts an optional base context, `ContextWithMiddleware` applies middleware to an existing context, `ContextTransform` replaces `MiddlewareContextTransform`, the lower-level `ApplyContextTransform`/`ApplyMiddleware`/`ApplyMiddlewareTuple` helpers are no longer exported, and custom matcher payloads should use `RouteEntry` instead of `MatchData`.
 
 The request context helper type renames also apply to imports from `remix/fetch-router`.
 
@@ -42,6 +42,27 @@ let handler: RequestHandler<{ id: string }, RequestContext<{ id: string }>>
 
 // after
 let handler: RequestHandler<RequestContext<{ id: string }>>
+```
+
+If you manually annotate stored route handler functions, use `RouteHandler`. Use `Action` for object-form handlers with optional middleware:
+
+```ts
+// before
+let handler: Action<typeof routes.account, AccountContext> = (context) => {
+  return Response.json(context.get(Auth).identity)
+}
+
+// after
+let handler: RouteHandler<typeof routes.account, AccountContext> = (context) => {
+  return Response.json(context.get(Auth).identity)
+}
+
+let action: Action<typeof routes.account, AccountContext> = {
+  middleware: accountMiddleware,
+  handler(context) {
+    return Response.json(context.get(Auth).identity)
+  },
+}
 ```
 
 If you manually annotate middleware, pass only the context transform type:

--- a/packages/remix/.changes/major.fetch-router-action-types.md
+++ b/packages/remix/.changes/major.fetch-router-action-types.md
@@ -1,1 +1,81 @@
-BREAKING CHANGE: Updated the re-exported `remix/fetch-router` helper types to match `@remix-run/fetch-router`: `Action` and `Middleware` no longer accept unused request method type parameters, `Action` now accepts route objects directly with an optional middleware tuple generic for action-local middleware so stored action handlers can derive context from the middleware tuple that runs, `BuildAction` is no longer exported, and custom matcher payloads should use `RouteEntry` instead of `MatchData`.
+BREAKING CHANGE: Updated the re-exported `remix/fetch-router` helper types to match `@remix-run/fetch-router`: `Action` and `Middleware` no longer accept unused request method type parameters, `Action` and `Controller` now accept the full request context as their optional second generic, `BuildAction` is no longer exported, `createAction()`/`createController()` are the preferred helpers for stored handlers, `RouterTypes.context` configures the default builder context, `MiddlewareContext` now accepts an optional base context, `ContextWithMiddleware` applies middleware to an existing context, `ContextTransform` replaces `MiddlewareContextTransform`, the lower-level `ApplyContextTransform`/`ApplyMiddleware`/`ApplyMiddlewareTuple` helpers are no longer exported, and custom matcher payloads should use `RouteEntry` instead of `MatchData`.
+
+The request context helper type renames also apply to imports from `remix/fetch-router`.
+
+Use `ContextWithParams` when deriving an app context that includes route params:
+
+```ts
+// before
+type AppContext<params extends AnyParams = {}> = WithParams<
+  MiddlewareContext<typeof middleware>,
+  params
+>
+
+// after
+type AppContext<params extends AnyParams = {}> = ContextWithParams<
+  MiddlewareContext<typeof middleware>,
+  params
+>
+```
+
+Use `ContextWithValues` when a middleware package provides one or more context values:
+
+```ts
+// before
+export type WithCurrentUser<context extends RequestContext<any, any>> = MergeContext<
+  context,
+  [readonly [typeof CurrentUser, User | null]]
+>
+
+// after
+export type WithCurrentUser<context extends RequestContext<any, any>> = ContextWithValues<
+  context,
+  [readonly [typeof CurrentUser, User | null]]
+>
+```
+
+Use `ContextWithValue` when refining a single context value for a specific handler or middleware result:
+
+```ts
+// before
+type AdminContext = SetContextValue<AppContext, typeof CurrentRole, 'admin'>
+
+// after
+type AdminContext = ContextWithValue<AppContext, typeof CurrentRole, 'admin'>
+```
+
+For most apps, augment `RouterTypes.context` once and use `createController()` instead of repeating a `satisfies Controller<...>` clause on every controller:
+
+```ts
+// before
+type AuthenticatedAppContext = WithRequiredAuth<AppContext, AuthIdentity>
+
+let controller = {
+  middleware: [requireAuth<AuthIdentity>()],
+  actions: {
+    account(context) {
+      let auth = context.get(Auth)
+      return Response.json(auth.identity)
+    },
+  },
+} satisfies Controller<typeof routes, AuthenticatedAppContext>
+
+// after
+declare module 'remix/fetch-router' {
+  interface RouterTypes {
+    context: AppContext
+  }
+}
+
+let accountMiddleware = [requireAuth<AuthIdentity>()] as const
+
+let controller = createController(routes, {
+  middleware: accountMiddleware,
+  actions: {
+    account(context) {
+      let auth = context.get(Auth)
+      return Response.json(auth.identity)
+    },
+  },
+})
+```

--- a/packages/remix/src/fetch-router.ts
+++ b/packages/remix/src/fetch-router.ts
@@ -1,2 +1,9 @@
 // IMPORTANT: This file is auto-generated, please do not edit manually.
 export * from '@remix-run/fetch-router'
+
+export interface RouterTypes {}
+type RemixRouterTypes = RouterTypes
+
+declare module '@remix-run/fetch-router' {
+  interface RouterTypes extends RemixRouterTypes {}
+}

--- a/packages/session-middleware/src/lib/session.ts
+++ b/packages/session-middleware/src/lib/session.ts
@@ -14,7 +14,7 @@ type SetSessionContextTransform = readonly [readonly [typeof Session, Session]]
 export function session(
   sessionCookie: Cookie,
   sessionStorage: SessionStorage,
-): Middleware<any, SetSessionContextTransform> {
+): Middleware<SetSessionContextTransform> {
   if (!sessionCookie.signed) {
     throw new Error('Session cookie must be signed')
   }

--- a/packages/session-middleware/src/lib/session.ts
+++ b/packages/session-middleware/src/lib/session.ts
@@ -1,8 +1,8 @@
 import type { Cookie } from '@remix-run/cookie'
-import type { Middleware } from '@remix-run/fetch-router'
+import type { ContextEntry, Middleware } from '@remix-run/fetch-router'
 import { Session, type SessionStorage } from '@remix-run/session'
 
-type SetSessionContextTransform = readonly [readonly [typeof Session, Session]]
+type SessionContextEntry = ContextEntry<typeof Session, Session>
 
 /**
  * Middleware that manages request session state on request context.
@@ -14,7 +14,7 @@ type SetSessionContextTransform = readonly [readonly [typeof Session, Session]]
 export function session(
   sessionCookie: Cookie,
   sessionStorage: SessionStorage,
-): Middleware<SetSessionContextTransform> {
+): Middleware<SessionContextEntry> {
   if (!sessionCookie.signed) {
     throw new Error('Session cookie must be signed')
   }

--- a/packages/ui/demo/app/api/controller.ts
+++ b/packages/ui/demo/app/api/controller.ts
@@ -1,6 +1,6 @@
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 
-import type { routes } from '../../config/routes.ts'
+import { routes } from '../../config/routes.ts'
 import { AIRPORTS, searchAirports } from './airports.ts'
 
 function parseLimit(url: URL) {
@@ -17,35 +17,31 @@ function parseLimit(url: URL) {
   return Math.min(limit, 500)
 }
 
-type ApiActions = Controller<typeof routes.api>['actions']
+const apiController = createController(routes.api, {
+  actions: {
+    airports({ url }) {
+      let query = url.searchParams.get('query') ?? url.searchParams.get('q') ?? ''
+      let limit = parseLimit(url)
+      let airports = searchAirports(query)
+      if (limit !== null) {
+        airports = airports.slice(0, limit)
+      }
 
-const actions = {
-  airports({ url }: { url: URL }) {
-    let query = url.searchParams.get('query') ?? url.searchParams.get('q') ?? ''
-    let limit = parseLimit(url)
-    let airports = searchAirports(query)
-    if (limit !== null) {
-      airports = airports.slice(0, limit)
-    }
-
-    return Response.json(
-      {
-        airports,
-        query,
-        returned: airports.length,
-        total: AIRPORTS.length,
-      },
-      {
-        headers: {
-          'Cache-Control': 'public, max-age=300',
+      return Response.json(
+        {
+          airports,
+          query,
+          returned: airports.length,
+          total: AIRPORTS.length,
         },
-      },
-    )
+        {
+          headers: {
+            'Cache-Control': 'public, max-age=300',
+          },
+        },
+      )
+    },
   },
-} satisfies ApiActions
-
-const apiController = {
-  actions,
-} satisfies Controller<typeof routes.api>
+})
 
 export default apiController

--- a/packages/ui/demo/app/examples/controller.tsx
+++ b/packages/ui/demo/app/examples/controller.tsx
@@ -1,14 +1,12 @@
 import { clientEntry } from 'remix/ui'
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 
 import { render } from '../../config/render.tsx'
-import type { routes } from '../../config/routes.ts'
+import { routes } from '../../config/routes.ts'
 import { findExample, loadExampleModule, readExampleSource } from './index.tsx'
 import { ExampleContent, ExampleDocument } from './view.tsx'
 
-type ExampleActions = Controller<typeof routes.examples>['actions']
-
-let examplesController = {
+let examplesController = createController(routes.examples, {
   actions: {
     async content(context) {
       let example = findExample(context.params.slug)
@@ -55,8 +53,8 @@ let examplesController = {
         },
       )
     },
-  } satisfies ExampleActions,
-} satisfies Controller<typeof routes.examples>
+  },
+})
 
 export default examplesController
 

--- a/packages/ui/demo/app/explorer/controller.tsx
+++ b/packages/ui/demo/app/explorer/controller.tsx
@@ -1,8 +1,7 @@
-import type { Controller } from 'remix/fetch-router'
-import type { RequestContext } from 'remix/fetch-router'
+import { createController, type RequestContext } from 'remix/fetch-router'
 
 import { render } from '../../config/render.tsx'
-import type { routes } from '../../config/routes.ts'
+import { routes } from '../../config/routes.ts'
 import { PAGE_LIST } from './registry.tsx'
 import { ExplorerDocument } from './view.tsx'
 
@@ -14,14 +13,15 @@ function renderPage(context: RequestContext, page: (typeof PAGE_LIST)[number]) {
   })
 }
 
-type ExplorerActions = Controller<typeof routes.explorer>['actions']
-
 const actions = Object.fromEntries(
   PAGE_LIST.map((page) => [page.actionKey, (context: RequestContext) => renderPage(context, page)]),
-) as unknown as ExplorerActions
+) as Record<
+  (typeof PAGE_LIST)[number]['actionKey'],
+  (context: RequestContext) => Response | Promise<Response>
+>
 
-const explorerController = {
+const explorerController = createController(routes.explorer, {
   actions,
-} satisfies Controller<typeof routes.explorer>
+})
 
 export default explorerController

--- a/scripts/generate-remix.ts
+++ b/scripts/generate-remix.ts
@@ -314,6 +314,20 @@ function isRemixTestBin(bin: { command: string; packageName: string }): boolean 
 }
 
 function createExportSource(entry: ExportEntry): string {
+  if (entry.reExportFrom === '@remix-run/fetch-router') {
+    return [
+      `// IMPORTANT: This file is auto-generated, please do not edit manually.`,
+      `export * from '${entry.reExportFrom}'`,
+      ``,
+      `export interface RouterTypes {}`,
+      `type RemixRouterTypes = RouterTypes`,
+      ``,
+      `declare module '@remix-run/fetch-router' {`,
+      `  interface RouterTypes extends RemixRouterTypes {}`,
+      `}\n`,
+    ].join('\n')
+  }
+
   return [
     `// IMPORTANT: This file is auto-generated, please do not edit manually.`,
     `export * from '${entry.reExportFrom}'\n`,

--- a/template/.agents/skills/remix/SKILL.md
+++ b/template/.agents/skills/remix/SKILL.md
@@ -441,12 +441,11 @@ export const routes = route({
 ### Type controllers against the route contract
 
 ```typescript
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 
-import type { AppContext } from '../router.ts'
 import { routes } from '../routes.ts'
 
-export default {
+export default createController(routes.books, {
   actions: {
     async index({ get }) {
       let db = get(Database)
@@ -460,7 +459,7 @@ export default {
       return render(<BookShowPage book={book} />)
     },
   },
-} satisfies Controller<typeof routes.books, AppContext>
+})
 ```
 
 ### Register Controllers Explicitly
@@ -514,18 +513,21 @@ let router = createRouter({ middleware })
 ### Validate, mutate, and respond
 
 ```typescript
+import { createController } from 'remix/fetch-router'
 import { redirect } from 'remix/response/redirect'
 import * as s from 'remix/data-schema'
 import * as f from 'remix/data-schema/form-data'
 import { Session } from 'remix/session'
 import { Database } from 'remix/data-table'
 
+import { routes } from '../routes.ts'
+
 let bookSchema = f.object({
   slug: f.field(s.string()),
   title: f.field(s.string()),
 })
 
-export default {
+export default createController(routes.books, {
   actions: {
     async create({ get }) {
       let parsed = s.parseSafe(bookSchema, get(FormData))
@@ -542,7 +544,7 @@ export default {
       return redirect(routes.books.show.href({ slug: book.slug }))
     },
   },
-} satisfies Controller<typeof routes.books, AppContext>
+})
 ```
 
 This shape works without JavaScript, returns a `Response` for every outcome, and is ready for

--- a/template/.agents/skills/remix/references/assets-and-browser-modules.md
+++ b/template/.agents/skills/remix/references/assets-and-browser-modules.md
@@ -28,7 +28,7 @@ preloads, sourcemaps, or fingerprinted URLs.
 
 ```typescript
 import { createAssetServer } from 'remix/assets'
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 import { get, route } from 'remix/routes'
 
 export const routes = route({
@@ -54,13 +54,13 @@ let assetServer = createAssetServer({
   },
 })
 
-export default {
+export default createController(routes, {
   actions: {
     async assets({ request }) {
       return (await assetServer.fetch(request)) ?? new Response('Not Found', { status: 404 })
     },
   },
-} satisfies Controller<typeof routes>
+})
 ```
 
 ## Rules

--- a/template/.agents/skills/remix/references/auth-and-sessions.md
+++ b/template/.agents/skills/remix/references/auth-and-sessions.md
@@ -303,7 +303,9 @@ module-scope provider to `finishExternalAuth(...)` and `refreshExternalAuth(...)
 ### OAuth controller
 
 ```typescript
-export default {
+import { createController } from 'remix/fetch-router'
+
+export default createController(routes.auth.google, {
   actions: {
     // GET /auth/google — redirect to Google
     async index(context) {
@@ -329,7 +331,7 @@ export default {
       return redirect(returnTo ?? routes.account.index.href())
     },
   },
-} satisfies Controller<typeof routes.auth.google>
+})
 ```
 
 ### Refresh stored provider tokens
@@ -359,16 +361,17 @@ async function refreshGoogleTokens({ get }) {
 Apply `requireAuth()` to every action in one controller:
 
 ```typescript
+import { createController } from 'remix/fetch-router'
 import { requireAuth } from 'remix/auth-middleware'
 
-export default {
+export default createController(routes.account, {
   middleware: [requireAuth()],
   actions: {
     index() {
       /* guaranteed authenticated */
     },
   },
-} satisfies Controller<typeof routes.account>
+})
 ```
 
 Nested route maps need their own explicit protection:
@@ -379,7 +382,7 @@ router.map(routes.account, accountController)
 router.map(routes.account.settings, accountSettingsController)
 
 // app/actions/account/settings/controller.tsx
-export default {
+export default createController(routes.account.settings, {
   middleware: [requireAuth()],
   actions: {
     index() {
@@ -389,7 +392,7 @@ export default {
       /* guaranteed authenticated */
     },
   },
-} satisfies Controller<typeof routes.account.settings>
+})
 ```
 
 ### Stacking middleware
@@ -397,14 +400,14 @@ export default {
 Combine auth checks with role checks:
 
 ```typescript
-export default {
+export default createController(routes.admin, {
   middleware: [requireAuth(), requireAdmin()],
   actions: {
     index() {
       /* requires auth + admin */
     },
   },
-} satisfies Controller<typeof routes.admin>
+})
 ```
 
 ### Action-level protection

--- a/template/.agents/skills/remix/references/middleware-and-server.md
+++ b/template/.agents/skills/remix/references/middleware-and-server.md
@@ -204,10 +204,10 @@ Middleware can be applied at three levels:
 2. **Controller-level** — runs for the direct actions in one controller:
 
    ```typescript
-   export default {
+   export default createController(routes.account, {
      middleware: [requireAuth()],
      actions: { ... },
-   } satisfies Controller<typeof routes.account>
+   })
    ```
 
    Controller middleware does not flow into other controllers. Add the middleware to each

--- a/template/.agents/skills/remix/references/routing-and-controllers.md
+++ b/template/.agents/skills/remix/references/routing-and-controllers.md
@@ -97,15 +97,17 @@ Use `Action` only when a reusable helper needs to type one action before it is a
 controller or when you are doing low-level router wiring outside the `app/actions` convention:
 
 ```typescript
-import type { Action } from 'remix/fetch-router'
+import { createAction } from 'remix/fetch-router'
 
-export const search: Action<typeof routes.search> = {
+import { routes } from '../routes.ts'
+
+export const search = createAction(routes.search, {
   async handler({ url }) {
     let query = url.searchParams.get('q') ?? ''
     let results = await searchIndex(query)
     return render(<SearchPage query={query} results={results} />)
   },
-}
+})
 ```
 
 The handler receives a context object with:
@@ -223,14 +225,16 @@ A controller owns the direct leaf routes in one route map. Each key in `actions`
 leaf route key in the route definition passed to `router.map(...)`. Nested route-map keys do not
 belong inside a controller's `actions`; map those route maps with their own controllers.
 
-Pass `AppContext` as the second generic to `Controller` so `get(Database)`, `get(Session)`,
-`get(Auth)`, etc. are typed against your middleware stack.
+Configure `RouterTypes.context` with your app context in the router module, then use
+`createController()` so `get(Database)`, `get(Session)`, `get(Auth)`, etc. are typed against your
+middleware stack without repeating a type clause on every controller.
 
 ```typescript
-import type { Controller } from 'remix/fetch-router'
-import type { AppContext } from '../router.ts'
+import { createController } from 'remix/fetch-router'
 
-export default {
+import { routes } from '../routes.ts'
+
+export default createController(routes.books, {
   actions: {
     async index({ get }) {
       let db = get(Database)
@@ -245,7 +249,7 @@ export default {
       return render(<ShowPage book={book} />)
     },
   },
-} satisfies Controller<typeof routes.books, AppContext>
+})
 ```
 
 ### Root controller
@@ -264,7 +268,7 @@ export const routes = route({
 })
 
 // app/actions/controller.tsx
-export default {
+export default createController(routes, {
   actions: {
     async assets({ request }) {
       return (await assetServer.fetch(request)) ?? new Response('Not Found', { status: 404 })
@@ -273,7 +277,7 @@ export default {
       return render(<HomePage />)
     },
   },
-} satisfies Controller<typeof routes, AppContext>
+})
 ```
 
 Because `account` is a nested route map, it is not an action key in the root controller.
@@ -285,17 +289,17 @@ Directory names under `app/actions/` are route-map keys, not URL path segments.
 
 ```typescript
 // app/actions/account/controller.tsx
-export default {
+export default createController(routes.account, {
   middleware: [requireAuth()],
   actions: {
     index() {
       return render(<AccountPage />)
     },
   },
-} satisfies Controller<typeof routes.account, AppContext>
+})
 
 // app/actions/account/settings/controller.tsx
-export default {
+export default createController(routes.account.settings, {
   middleware: [requireAuth()],
   actions: {
     index() {
@@ -305,7 +309,7 @@ export default {
       return redirect(routes.account.index.href(), 303)
     },
   },
-} satisfies Controller<typeof routes.account.settings, AppContext>
+})
 ```
 
 Then map each route map explicitly:
@@ -328,12 +332,12 @@ The `middleware` array on a controller runs only for the direct actions in that 
 action-level middleware. It does not apply to other controllers.
 
 ```typescript
-export default {
+export default createController(routes.admin, {
   middleware: [requireAuth(), requireAdmin()],
   actions: {
     /* all actions require auth + admin */
   },
-} satisfies Controller<typeof routes.admin, AppContext>
+})
 ```
 
 ## Registering Routes
@@ -359,10 +363,11 @@ router.post(routes.logout, logoutAction)
 
 ## Typed Context
 
-Define an `AppContext` type from your middleware stack for use in actions and controllers:
+Define an `AppContext` type from your middleware stack, then make it the default context used by
+`createAction()` and `createController()`:
 
 ```typescript
-import type { MiddlewareContext, WithParams, AnyParams } from 'remix/fetch-router'
+import type { MiddlewareContext, ContextWithParams, AnyParams } from 'remix/fetch-router'
 
 type RootMiddleware = [
   ReturnType<typeof formData>,
@@ -371,10 +376,16 @@ type RootMiddleware = [
   ReturnType<typeof loadAuth>,
 ]
 
-export type AppContext<params extends AnyParams = AnyParams> = WithParams<
+export type AppContext<params extends AnyParams = {}> = ContextWithParams<
   MiddlewareContext<RootMiddleware>,
   params
 >
+
+declare module 'remix/fetch-router' {
+  interface RouterTypes {
+    context: AppContext
+  }
+}
 ```
 
 This gives typed `context.get(Database)`, `context.get(Session)`, `context.get(Auth)`, etc.

--- a/template/app/actions/controller.tsx
+++ b/template/app/actions/controller.tsx
@@ -2,9 +2,9 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 
 import { createAssetServer } from 'remix/assets'
-import type { Controller } from 'remix/fetch-router'
+import { createController } from 'remix/fetch-router'
 
-import type { routes } from '../routes.ts'
+import { routes } from '../routes.ts'
 import { HomePage } from '../ui/scaffold-home-page.tsx'
 import { Layout } from '../ui/layout.tsx'
 import { render } from './render.tsx'
@@ -31,7 +31,7 @@ export const assetServer = createAssetServer({
   },
 })
 
-const controller = {
+const controller = createController(routes, {
   actions: {
     async assets({ request }) {
       return (await assetServer.fetch(request)) ?? new Response('Not Found', { status: 404 })
@@ -43,7 +43,7 @@ const controller = {
       return render(<AuthPage />, request)
     },
   },
-} satisfies Controller<typeof routes>
+})
 
 export default controller
 


### PR DESCRIPTION
Simplifies fetch-router's request-context, action, controller, and middleware type story around full `RequestContext` types and consistent `ContextWith*` helpers.

- Adds `RouterTypes.context` plus `createAction()`/`createController()` identity builders so app code can type stored handlers without repeated `satisfies` clauses.
- Keeps `Action` as the single route action type for both plain request handler functions and action objects with optional inline middleware, including direct `router.get()`, `router.route()`, and single-route `router.map()` APIs.
- Simplifies `Controller`, `RequestHandler`, and `Middleware` generics around full request context types.
- Makes middleware context effects easier to write: `Middleware<T>` now accepts a single `ContextEntry`, a `ContextEntries` tuple, or a context transform function; `MiddlewareContext` and `ContextWithMiddleware` fold those effects through the chain.
- Keeps the function-form transform so later middleware can derive refinements from earlier middleware and preserve strong typing through chains such as `auth()` followed by `requireAuth()`.
- Renames auth context helper types to `ContextWithAuth` and `ContextWithRequiredAuth` so auth middleware follows the same `ContextWith*` guidance as fetch-router context helpers.
- Tightens context availability: `context.get(key)` returns `undefined` unless the key has a default or the context type proves the value exists; `formData()` now always provides `FormData` when it runs.
- Keeps router dispatch on real `Request` objects, with `node-serve` passing native requests directly, and updates demos, templates, README/change notes, and generated controller placeholders.

```ts
// Before
export default {
  actions: {
    async show({ get, params }) {
      let db = get(Database)
      let book = await db.find(books, params.bookId)
      return render(<BookShowPage book={book} />)
    },
  },
} satisfies Controller<typeof routes.books, AppContext>

// After
declare module 'remix/fetch-router' {
  interface RouterTypes {
    context: AppContext
  }
}

export default createController(routes.books, {
  actions: {
    async show({ get, params }) {
      let db = get(Database)
      let book = await db.find(books, params.bookId)
      return render(<BookShowPage book={book} />)
    },
  },
})
```

```ts
// Single-value middleware can use ContextEntry directly
type DatabaseContextEntry = ContextEntry<typeof Database, Database>

export function loadDatabase(): Middleware<DatabaseContextEntry> {
  return async (context, next) => {
    context.set(Database, db)
    return next()
  }
}

let middleware = [loadDatabase()] as const
type AppContext = MiddlewareContext<typeof middleware>
```

```ts
let accountMiddleware = [requireAuth<AuthIdentity>()] as const
type AccountContext = ContextWithMiddleware<AppContext, typeof accountMiddleware>
type ProtectedContext = ContextWithRequiredAuth<AppContext, AuthIdentity>

export default createController<typeof routes.account, AccountContext>(routes.account, {
  middleware: accountMiddleware,
  actions: {
    index({ get }) {
      return Response.json(get(Auth).identity)
    },
  },
})
```

```ts
// Action describes both plain handler functions and action objects
let handler: Action<typeof routes.account, AccountContext> = ({ get }) => {
  return Response.json(get(Auth).identity)
}

let action: Action<typeof routes.account, AccountContext> = {
  middleware: accountMiddleware,
  handler({ get }) {
    return Response.json(get(Auth).identity)
  },
}

router.get(routes.account, handler)
router.map(routes.account, action)
```

```ts
// Before
let formData = context.get(FormData)
return Response.json({ name: formData.get('name') })

// After, when middleware is not part of the handler's context contract
let formData = context.get(FormData)
return Response.json({ name: formData?.get('name') })

// Still defined when the handler context includes formData() middleware
let router = createRouter({ middleware: [formData()] as const })
```


Closes #10891.
