### PR TITLE
Add package README overviews to API docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -30,7 +30,7 @@
     "docs": "node src/generate/index.ts",
     "docs:debug": "DEBUG=1 node src/generate/index.ts",
     "prerender": "tsx src/server/prerender.ts",
-    "prerender:serve": "npx http-server -p 3000 build/site",
+    "prerender:serve": "npx http-server -p 44100 build/site",
     "serve": "tsx src/server/index.ts",
     "typecheck": "tsc --noEmit"
   }

--- a/docs/src/generate/index.ts
+++ b/docs/src/generate/index.ts
@@ -4,6 +4,7 @@ import util from 'node:util'
 import { getDocumentedAPI } from './documented-api.ts'
 import { writeLookupFile } from './lookup.ts'
 import { writeMarkdownFiles } from './markdown.ts'
+import { discoverPackageOverviews, writePackageOverviewFiles } from './packages.ts'
 import { loadTypeDoc } from './typedoc.ts'
 import { info } from './utils.ts'
 
@@ -57,6 +58,7 @@ let documentedAPIs = [...apisToDocument].map((name) => getDocumentedAPI(name, co
 
 // Write out docs
 await writeMarkdownFiles(documentedAPIs, DOCS_DIR)
+await writePackageOverviewFiles(await discoverPackageOverviews(), DOCS_DIR)
 
 // Write out API name -> URL path lookup file
 await writeLookupFile(documentedAPIs, DOCS_DIR)

--- a/docs/src/generate/packages.ts
+++ b/docs/src/generate/packages.ts
@@ -52,8 +52,9 @@ export async function discoverPackageOverviews(): Promise<PackageOverview[]> {
 
 export async function writePackageOverviewFiles(overviews: PackageOverview[], docsDir: string) {
   for (let overview of overviews) {
-    let mdPath = path.join(docsDir, overview.docsPackage, 'index.md')
+    let mdPath = path.join(docsDir, overview.docsPackage, 'overview.md')
     await fs.mkdir(path.dirname(mdPath), { recursive: true })
+    await fs.rm(path.join(docsDir, overview.docsPackage, 'index.md'), { force: true })
 
     let body: string
     if (overview.readmePath) {

--- a/docs/src/generate/packages.ts
+++ b/docs/src/generate/packages.ts
@@ -1,0 +1,183 @@
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import { info, invariant, warn } from './utils.ts'
+
+type PackageOverview = {
+  docsPackage: string
+  packageDir: string
+  readmePath?: string
+}
+
+const PACKAGES_DIR = path.resolve('..', 'packages')
+const JAVASCRIPT_CODE_FENCE_LANGUAGES = new Set(['js', 'jsx', 'ts', 'tsx'])
+const SHELL_CODE_FENCE_LANGUAGES = new Set(['', 'bash', 'sh', 'shell'])
+
+export async function discoverPackageOverviews(): Promise<PackageOverview[]> {
+  let packageDirs = await fs.readdir(PACKAGES_DIR, { withFileTypes: true })
+  let overviews: PackageOverview[] = []
+
+  for (let entry of packageDirs) {
+    if (!entry.isDirectory()) continue
+
+    let packageDir = path.join(PACKAGES_DIR, entry.name)
+    let packageJsonPath = path.join(packageDir, 'package.json')
+
+    try {
+      let packageName = await readPackageName(packageJsonPath)
+
+      let readmePath = path.join(packageDir, 'README.md')
+      let hasReadme = await isFile(readmePath)
+
+      if (!hasReadme) {
+        warn(`Missing README.md for package: ${packageName}`)
+      }
+
+      let overview: PackageOverview = {
+        docsPackage: getDocsPackageName(packageName),
+        packageDir,
+      }
+      if (hasReadme) {
+        overview.readmePath = readmePath
+      }
+      overviews.push(overview)
+    } catch (error) {
+      if (!isErrnoException(error) || error.code !== 'ENOENT') {
+        throw error
+      }
+    }
+  }
+
+  return overviews.sort((a, b) => a.docsPackage.localeCompare(b.docsPackage))
+}
+
+export async function writePackageOverviewFiles(overviews: PackageOverview[], docsDir: string) {
+  for (let overview of overviews) {
+    let mdPath = path.join(docsDir, overview.docsPackage, 'index.md')
+    await fs.mkdir(path.dirname(mdPath), { recursive: true })
+
+    let body: string
+    if (overview.readmePath) {
+      body = await fs.readFile(overview.readmePath, 'utf-8')
+      warnOnInvalidReadmeSyntax(body, overview.readmePath)
+      body = normalizeReadmeMarkdown(body)
+    } else {
+      body = getMissingReadmeMarkdown(overview.docsPackage, overview.packageDir)
+    }
+
+    info(`Writing package overview file: ${mdPath}`)
+    await fs.writeFile(mdPath, [frontmatter(overview), body.trim(), ''].join('\n\n'))
+  }
+}
+
+async function readPackageName(packageJsonPath: string): Promise<string> {
+  let packageJson: unknown = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'))
+  invariant(
+    packageJson !== null && typeof packageJson === 'object' && 'name' in packageJson,
+    `Missing package name: ${packageJsonPath}`,
+  )
+  invariant(typeof packageJson.name === 'string', `Invalid package name: ${packageJsonPath}`)
+  return packageJson.name
+}
+
+function normalizeReadmeMarkdown(markdown: string): string {
+  return markdown.replace(/\]\((?:\.\/)?README\.md(#[^)]+)?\)/g, (_, hash: string | undefined) => {
+    return `](${hash ?? './'})`
+  })
+}
+
+function warnOnInvalidReadmeSyntax(markdown: string, readmePath: string) {
+  let lines = markdown.split('\n')
+  let codeFence: { lang: string; line: number } | undefined
+  let codeLines: string[] = []
+
+  for (let [index, line] of lines.entries()) {
+    let fenceMatch = line.match(/^```\s*([\w-]*)/)
+
+    if (fenceMatch) {
+      if (codeFence) {
+        warnOnInvalidReadmeCodeFenceSyntax(codeLines.join('\n'), codeFence, readmePath)
+        codeFence = undefined
+        codeLines = []
+      } else {
+        codeFence = { lang: fenceMatch[1]?.toLowerCase() ?? '', line: index + 1 }
+      }
+      continue
+    }
+
+    if (codeFence) {
+      codeLines.push(line)
+    }
+  }
+
+  if (codeFence) {
+    warnOnInvalidReadmeCodeFenceSyntax(codeLines.join('\n'), codeFence, readmePath)
+  }
+}
+
+function warnOnInvalidReadmeCodeFenceSyntax(
+  code: string,
+  codeFence: { lang: string; line: number },
+  readmePath: string,
+) {
+  let relativeReadmePath = path.relative(process.cwd(), readmePath)
+
+  if (
+    JAVASCRIPT_CODE_FENCE_LANGUAGES.has(codeFence.lang) &&
+    (/\bfrom\s+['"]@remix-run\//.test(code) || /\bimport\s*\(\s*['"]@remix-run\//.test(code))
+  ) {
+    warn(
+      `Potential invalid import syntax in ${relativeReadmePath}:${codeFence.line}. ` +
+        `Prefer importing from \`remix/*\` instead of \`@remix-run/*\`.`,
+    )
+  }
+
+  if (
+    SHELL_CODE_FENCE_LANGUAGES.has(codeFence.lang) &&
+    /\b(?:npm\s+(?:i|install)|pnpm\s+add|yarn\s+add|bun\s+add)\s+[^\n]*@remix-run\//.test(code)
+  ) {
+    warn(
+      `Potential invalid install syntax in ${relativeReadmePath}:${codeFence.line}. ` +
+        `Prefer installing \`remix\` instead of \`@remix-run/*\`.`,
+    )
+  }
+}
+
+function getDocsPackageName(packageName: string): string {
+  if (packageName === 'remix') {
+    return 'remix'
+  }
+
+  let match = packageName.match(/^@remix-run\/(.+)$/)
+  invariant(match, `Unexpected package name: ${packageName}`)
+
+  return `remix/${match[1]}`
+}
+
+function frontmatter(overview: PackageOverview): string {
+  return ['---', 'type: package', `title: ${overview.docsPackage}`, '---'].join('\n')
+}
+
+function getMissingReadmeMarkdown(docsPackage: string, packageDir: string): string {
+  let relativePackageDir = path.relative(path.resolve('..'), packageDir)
+  return [
+    `# ${docsPackage}`,
+    '',
+    `This package does not have a README yet. Add one at \`${relativePackageDir}/README.md\`.`,
+  ].join('\n')
+}
+
+async function isFile(filePath: string): Promise<boolean> {
+  try {
+    let stat = await fs.stat(filePath)
+    return stat.isFile()
+  } catch (error) {
+    if (isErrnoException(error) && error.code === 'ENOENT') {
+      return false
+    }
+    throw error
+  }
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error
+}

--- a/docs/src/server/markdown.ts
+++ b/docs/src/server/markdown.ts
@@ -13,13 +13,27 @@ const parseFrontmatter = frontmatter.default as unknown as (md: string) => {
   body: string
 }
 
-export type DocFile = {
+export type ApiTypeKind = 'type' | 'interface' | 'class' | 'function'
+
+export type ApiDocFile = {
+  kind: 'api'
   path: string
-  type: string
+  type: ApiTypeKind
   name: string
   package: string
   urlPath: string
 }
+
+export type PackageDocFile = {
+  kind: 'package'
+  path: string
+  type: 'package'
+  name: string
+  package: string
+  urlPath: string
+}
+
+export type DocFile = ApiDocFile | PackageDocFile
 
 export async function discoverMarkdownFiles(
   baseDir: string,
@@ -42,22 +56,45 @@ export async function discoverMarkdownFiles(
       if (entry.isDirectory()) {
         walk(fullPath)
       } else if (entry.isFile() && entry.name.endsWith('.md')) {
-        let relativePath = path.relative(baseDir, fullPath)
-        let parts = relativePath.split(path.sep)
-        let packageName = parts.slice(0, parts.length - 2).join('/')
-        let type = parts[parts.length - 2]
-        let urlPath = relativePath.replace(/\.md$/, '').replace(/\\/g, '/')
-
-        files.push({
-          path: fullPath,
-          type: type || 'unknown',
-          name: entry.name.replace(/\.md$/, ''),
-          package: packageName,
-          urlPath: urlPath,
-        })
+        files.push(getDocFile(baseDir, fullPath))
       }
     }
   }
+}
+
+function getDocFile(baseDir: string, fullPath: string): DocFile {
+  let relativePath = path.relative(baseDir, fullPath)
+  let parts = relativePath.split(path.sep)
+  let name = path.basename(fullPath, '.md')
+
+  if (name === 'index') {
+    let packageName = parts.slice(0, -1).join('/')
+    return {
+      kind: 'package',
+      path: fullPath,
+      type: 'package',
+      name: packageName,
+      package: packageName,
+      urlPath: packageName,
+    }
+  }
+
+  let packageName = parts.slice(0, -2).join('/')
+  return {
+    kind: 'api',
+    path: fullPath,
+    type: getApiTypeKind(parts.at(-2)),
+    name,
+    package: packageName,
+    urlPath: relativePath.replace(/\.md$/, '').replace(/\\/g, '/'),
+  }
+}
+
+function getApiTypeKind(value: string | undefined): ApiTypeKind {
+  if (value === 'type' || value === 'interface' || value === 'class' || value === 'function') {
+    return value
+  }
+  throw new Error(`Invalid API docs type: ${value ?? '<missing>'}`)
 }
 
 export async function renderMarkdownFile(

--- a/docs/src/server/markdown.ts
+++ b/docs/src/server/markdown.ts
@@ -13,7 +13,7 @@ const parseFrontmatter = frontmatter.default as unknown as (md: string) => {
   body: string
 }
 
-export type ApiTypeKind = 'type' | 'interface' | 'class' | 'function'
+export type ApiTypeKind = 'type' | 'interface' | 'class' | 'function' | 'variable' | 'mixin'
 
 export type ApiDocFile = {
   kind: 'api'
@@ -94,7 +94,14 @@ function getDocFile(baseDir: string, fullPath: string): DocFile {
 }
 
 function getApiTypeKind(value: string | undefined): ApiTypeKind {
-  if (value === 'type' || value === 'interface' || value === 'class' || value === 'function') {
+  if (
+    value === 'type' ||
+    value === 'interface' ||
+    value === 'class' ||
+    value === 'function' ||
+    value === 'variable' ||
+    value === 'mixin'
+  ) {
     return value
   }
   throw new Error(`Invalid API docs type: ${value ?? '<missing>'}`)

--- a/docs/src/server/markdown.ts
+++ b/docs/src/server/markdown.ts
@@ -67,7 +67,10 @@ function getDocFile(baseDir: string, fullPath: string): DocFile {
   let parts = relativePath.split(path.sep)
   let name = path.basename(fullPath, '.md')
 
-  if (name === 'index') {
+  let markdown = fs.readFileSync(fullPath, 'utf-8')
+  let { attributes } = parseFrontmatter(markdown)
+
+  if (attributes.type === 'package') {
     let packageName = parts.slice(0, -1).join('/')
     return {
       kind: 'package',
@@ -75,7 +78,7 @@ function getDocFile(baseDir: string, fullPath: string): DocFile {
       type: 'package',
       name: packageName,
       package: packageName,
-      urlPath: packageName,
+      urlPath: relativePath.replace(/\.md$/, '').replace(/\\/g, '/'),
     }
   }
 

--- a/docs/src/server/markdown.ts
+++ b/docs/src/server/markdown.ts
@@ -13,7 +13,7 @@ const parseFrontmatter = frontmatter.default as unknown as (md: string) => {
   body: string
 }
 
-export type ApiTypeKind = 'type' | 'interface' | 'class' | 'function' | 'variable' | 'mixin'
+export type ApiTypeKind = 'type' | 'interface' | 'class' | 'function'
 
 export type ApiDocFile = {
   kind: 'api'
@@ -94,14 +94,7 @@ function getDocFile(baseDir: string, fullPath: string): DocFile {
 }
 
 function getApiTypeKind(value: string | undefined): ApiTypeKind {
-  if (
-    value === 'type' ||
-    value === 'interface' ||
-    value === 'class' ||
-    value === 'function' ||
-    value === 'variable' ||
-    value === 'mixin'
-  ) {
+  if (value === 'type' || value === 'interface' || value === 'class' || value === 'function') {
     return value
   }
   throw new Error(`Invalid API docs type: ${value ?? '<missing>'}`)

--- a/docs/src/server/markdown.ts
+++ b/docs/src/server/markdown.ts
@@ -103,12 +103,15 @@ function getApiTypeKind(value: string | undefined): ApiTypeKind {
 export async function renderMarkdownFile(
   filePath: string,
   docFilesLookup: Map<string, DocFile>,
-  version?: string,
+  version: string | undefined,
+  addLinks: boolean,
 ): Promise<{ html: string; source?: string }> {
   try {
     let markdown = fs.readFileSync(filePath, 'utf-8')
     let { attributes, body } = parseFrontmatter(markdown)
-    let marked = new Marked(getShikiExtension(attributes.title || '', docFilesLookup, version))
+    let marked = new Marked(
+      getShikiExtension(attributes.title || '', docFilesLookup, version, addLinks),
+    )
     let html = await marked.parse(body)
     return { html, source: typeof attributes.source === 'string' ? attributes.source : undefined }
   } catch (error) {
@@ -126,7 +129,8 @@ export async function renderMarkdownFile(
 function getShikiExtension(
   apiName: string,
   docFilesLookup: Map<string, DocFile>,
-  version?: string,
+  version: string | undefined,
+  addLinks: boolean,
 ): MarkedExtension {
   return {
     async: true,
@@ -145,6 +149,10 @@ function getShikiExtension(
               // Insert cross-links to known APIs
               {
                 span(node, line, col) {
+                  if (!addLinks) {
+                    return
+                  }
+
                   // We only enhance single-symbol spans of word characters,
                   // skipping spans for parens, braces, etc
                   if (

--- a/docs/src/server/prerender.ts
+++ b/docs/src/server/prerender.ts
@@ -78,7 +78,8 @@ async function crawl(router: Router, urlPath: string, outputDir: string) {
     throw error
   }
 
-  let isHtmlFile = response.headers.get('Content-Type')?.includes('text/html')
+  let isMarkdownFile = routes.markdown.match(`http://localhost${urlPath}`) !== null
+  let isHtmlFile = !isMarkdownFile && response.headers.get('Content-Type')?.includes('text/html')
 
   // Always put `index.html` files into directories - this leads to the best
   // support with and without trailing slashes on github pages:

--- a/docs/src/server/prerender.ts
+++ b/docs/src/server/prerender.ts
@@ -28,8 +28,6 @@ console.log('Prerendering versions:\n', JSON.stringify(versions, null, 2))
 const docsRouter = createRouter(versions)
 const crawlableUrls = await getCrawlableUrls(versions)
 
-await fs.rm(outputDir, { recursive: true, force: true })
-
 // Copy static assets to the output directory
 await fs.cp(assetsDir, path.join(outputDir, 'assets'), { recursive: true })
 for (let version of versions || getDefaultVersions()) {

--- a/docs/src/server/prerender.ts
+++ b/docs/src/server/prerender.ts
@@ -7,6 +7,7 @@ import * as semver from 'semver'
 import { type Router } from 'remix/fetch-router'
 import { createRouter, getDefaultVersions } from './router.tsx'
 import type { ServerContext } from './components.tsx'
+import { discoverMarkdownFiles } from './markdown.ts'
 import { routes } from './routes.ts'
 
 let { values: cliArgs } = util.parseArgs({
@@ -25,6 +26,9 @@ const versions = await getVersionsToBuild()
 console.log('Prerendering versions:\n', JSON.stringify(versions, null, 2))
 
 const docsRouter = createRouter(versions)
+const crawlableUrls = await getCrawlableUrls(versions)
+
+await fs.rm(outputDir, { recursive: true, force: true })
 
 // Copy static assets to the output directory
 await fs.cp(assetsDir, path.join(outputDir, 'assets'), { recursive: true })
@@ -108,6 +112,7 @@ async function crawl(router: Router, urlPath: string, outputDir: string) {
         .map((href) => resolveRelativeLink(href!, urlPath))
         .map(stripHash)
         .filter((href) => href !== urlPath)
+        .filter((href) => isCrawlableUrl(href, crawlableUrls))
         .flatMap((href) => {
           let match = routes.docs.match(`http://localhost${href}`)
           return match ? [href, routes.markdown.href(match.params)] : [href]
@@ -126,6 +131,15 @@ function stripHash(urlPath: string): string {
 
 function isAbsoluteUrl(href: string): boolean {
   return href.startsWith('http://') || href.startsWith('https://') || href.startsWith('//')
+}
+
+function isCrawlableUrl(urlPath: string, crawlableUrls: Set<string>): boolean {
+  let url = `http://localhost${urlPath}`
+  return (
+    crawlableUrls.has(urlPath) ||
+    routes.assets.match(url) !== null ||
+    routes.home.match(url) !== null
+  )
 }
 
 function resolveRelativeLink(link: string, url: string): string {
@@ -153,4 +167,26 @@ async function getVersionsToBuild(): Promise<ServerContext['versions']> {
   return remixVersions.length > 0
     ? remixVersions.map((tag, i) => ({ version: tag, crawl: i === 0 }))
     : getDefaultVersions()
+}
+
+async function getCrawlableUrls(versions: ServerContext['versions']): Promise<Set<string>> {
+  let { docFiles } = await discoverMarkdownFiles(path.join(process.cwd(), 'build', 'md'))
+  let urls = new Set<string>(['/', '/api.json'])
+
+  for (let file of docFiles) {
+    urls.add(routes.docs.href({ slug: file.urlPath }))
+    urls.add(routes.markdown.href({ slug: file.urlPath }))
+  }
+
+  for (let version of versions) {
+    urls.add(`/${version.version}/`)
+    urls.add(`/${version.version}/api.json`)
+
+    for (let file of docFiles) {
+      urls.add(routes.docs.href({ version: version.version, slug: file.urlPath }))
+      urls.add(routes.markdown.href({ version: version.version, slug: file.urlPath }))
+    }
+  }
+
+  return urls
 }

--- a/docs/src/server/prerender.ts
+++ b/docs/src/server/prerender.ts
@@ -67,6 +67,8 @@ async function spider(router: Router, outputDir: string, urlQueue = new Set(['/'
 }
 
 async function crawl(router: Router, urlPath: string, outputDir: string) {
+  urlPath = stripHash(urlPath)
+
   let response
   try {
     response = await router.fetch(new Request(`http://localhost${urlPath}`))
@@ -104,6 +106,8 @@ async function crawl(router: Router, urlPath: string, outputDir: string) {
         .map((link) => link.getAttribute('href'))
         .filter((href) => href && !isAbsoluteUrl(href))
         .map((href) => resolveRelativeLink(href!, urlPath))
+        .map(stripHash)
+        .filter((href) => href !== urlPath)
         .flatMap((href) => {
           let match = routes.docs.match(`http://localhost${href}`)
           return match ? [href, routes.markdown.href(match.params)] : [href]
@@ -114,6 +118,10 @@ async function crawl(router: Router, urlPath: string, outputDir: string) {
     await fs.writeFile(outputPath, new Uint8Array(content))
     return { downloadedUrl: urlPath, discoveredUrls: [] }
   }
+}
+
+function stripHash(urlPath: string): string {
+  return urlPath.split('#', 1)[0] || '/'
 }
 
 function isAbsoluteUrl(href: string): boolean {

--- a/docs/src/server/prerender.ts
+++ b/docs/src/server/prerender.ts
@@ -26,7 +26,6 @@ const versions = await getVersionsToBuild()
 console.log('Prerendering versions:\n', JSON.stringify(versions, null, 2))
 
 const docsRouter = createRouter(versions)
-const crawlableUrls = await getCrawlableUrls(versions)
 
 // Copy static assets to the output directory
 await fs.cp(assetsDir, path.join(outputDir, 'assets'), { recursive: true })
@@ -69,8 +68,6 @@ async function spider(router: Router, outputDir: string, urlQueue = new Set(['/'
 }
 
 async function crawl(router: Router, urlPath: string, outputDir: string) {
-  urlPath = stripHash(urlPath)
-
   let response
   try {
     response = await router.fetch(new Request(`http://localhost${urlPath}`))
@@ -99,17 +96,29 @@ async function crawl(router: Router, urlPath: string, outputDir: string) {
     let html = await response.text()
     await fs.writeFile(outputPath, html, 'utf-8')
 
+    let parsedHtml = parse(html)
+
+    // Honor `<meta name="robots" content="nofollow">` (e.g. on package
+    // overview pages) by skipping link discovery. Per-link `rel="nofollow"`
+    // is filtered separately in the selector below.
+    let robots = parsedHtml.querySelector('meta[name="robots"]')?.getAttribute('content') || ''
+    let noFollow = robots
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .includes('nofollow')
+
+    if (noFollow) {
+      return { downloadedUrl: urlPath, discoveredUrls: [] }
+    }
+
     // Parse HTML files for other resources/links to add to queue
     return {
       downloadedUrl: urlPath,
-      discoveredUrls: parse(html)
+      discoveredUrls: parsedHtml
         .querySelectorAll('a:not([rel="nofollow"]),link:not([rel="preload"]):not([rel="prefetch"])')
         .map((link) => link.getAttribute('href'))
         .filter((href) => href && !isAbsoluteUrl(href))
         .map((href) => resolveRelativeLink(href!, urlPath))
-        .map(stripHash)
-        .filter((href) => href !== urlPath)
-        .filter((href) => isCrawlableUrl(href, crawlableUrls))
         .flatMap((href) => {
           let match = routes.docs.match(`http://localhost${href}`)
           return match ? [href, routes.markdown.href(match.params)] : [href]
@@ -122,21 +131,8 @@ async function crawl(router: Router, urlPath: string, outputDir: string) {
   }
 }
 
-function stripHash(urlPath: string): string {
-  return urlPath.split('#', 1)[0] || '/'
-}
-
 function isAbsoluteUrl(href: string): boolean {
   return href.startsWith('http://') || href.startsWith('https://') || href.startsWith('//')
-}
-
-function isCrawlableUrl(urlPath: string, crawlableUrls: Set<string>): boolean {
-  let url = `http://localhost${urlPath}`
-  return (
-    crawlableUrls.has(urlPath) ||
-    routes.assets.match(url) !== null ||
-    routes.home.match(url) !== null
-  )
 }
 
 function resolveRelativeLink(link: string, url: string): string {
@@ -164,26 +160,4 @@ async function getVersionsToBuild(): Promise<ServerContext['versions']> {
   return remixVersions.length > 0
     ? remixVersions.map((tag, i) => ({ version: tag, crawl: i === 0 }))
     : getDefaultVersions()
-}
-
-async function getCrawlableUrls(versions: ServerContext['versions']): Promise<Set<string>> {
-  let { docFiles } = await discoverMarkdownFiles(path.join(process.cwd(), 'build', 'md'))
-  let urls = new Set<string>(['/', '/api.json'])
-
-  for (let file of docFiles) {
-    urls.add(routes.docs.href({ slug: file.urlPath }))
-    urls.add(routes.markdown.href({ slug: file.urlPath }))
-  }
-
-  for (let version of versions) {
-    urls.add(`/${version.version}/`)
-    urls.add(`/${version.version}/api.json`)
-
-    for (let file of docFiles) {
-      urls.add(routes.docs.href({ version: version.version, slug: file.urlPath }))
-      urls.add(routes.markdown.href({ version: version.version, slug: file.urlPath }))
-    }
-  }
-
-  return urls
 }

--- a/docs/src/server/prerender.ts
+++ b/docs/src/server/prerender.ts
@@ -82,8 +82,7 @@ async function crawl(router: Router, urlPath: string, outputDir: string) {
     throw error
   }
 
-  let isMarkdownFile = routes.markdown.match(`http://localhost${urlPath}`) !== null
-  let isHtmlFile = !isMarkdownFile && response.headers.get('Content-Type')?.includes('text/html')
+  let isHtmlFile = response.headers.get('Content-Type')?.includes('text/html')
 
   // Always put `index.html` files into directories - this leads to the best
   // support with and without trailing slashes on github pages:

--- a/docs/src/server/registry.ts
+++ b/docs/src/server/registry.ts
@@ -8,6 +8,8 @@ const TYPE_LABEL: Record<ApiTypeKind, string> = {
   interface: 'Interfaces',
   class: 'Classes',
   function: 'Functions',
+  variable: 'Variables',
+  mixin: 'Mixins',
 }
 
 const TYPE_EYEBROW: Record<ApiTypeKind, string> = {
@@ -15,9 +17,11 @@ const TYPE_EYEBROW: Record<ApiTypeKind, string> = {
   interface: 'Interface',
   class: 'Class',
   function: 'Function',
+  variable: 'Variable',
+  mixin: 'Mixin',
 }
 
-const TYPE_ORDER: ApiTypeKind[] = ['type', 'interface', 'class', 'function']
+const TYPE_ORDER: ApiTypeKind[] = ['type', 'interface', 'class', 'function', 'variable', 'mixin']
 
 export const HOME_PAGE_ID = '__home__'
 export const NOT_FOUND_PAGE_ID = '__not-found__'

--- a/docs/src/server/registry.ts
+++ b/docs/src/server/registry.ts
@@ -1,9 +1,7 @@
 import { css } from 'node_modules/@remix-run/ui/src/style/css-mixin.ts'
 import { theme } from '@remix-run/ui/theme'
-import type { DocFile } from './markdown.ts'
+import type { ApiDocFile, ApiTypeKind, DocFile } from './markdown.ts'
 import { routes } from './routes.ts'
-
-export type ApiTypeKind = 'type' | 'interface' | 'class' | 'function'
 
 const TYPE_LABEL: Record<ApiTypeKind, string> = {
   type: 'Types',
@@ -69,31 +67,43 @@ export function buildRegistry(docFiles: DocFile[], version?: string): DocsRegist
   }
   pages[HOME_PAGE_ID] = homePage
 
-  let packageGroups = new Map<string, Map<ApiTypeKind, DocFile[]>>()
+  let packageGroups = new Map<string, Map<ApiTypeKind, ApiDocFile[]>>()
+  let packageOverviews = new Map<string, DocFile>()
   for (let file of docFiles) {
-    if (!packageGroups.has(file.package)) {
-      packageGroups.set(file.package, new Map())
+    if (file.kind === 'package') {
+      packageOverviews.set(file.package, file)
+      continue
     }
-    let typeMap = packageGroups.get(file.package)!
-    let kind = file.type as ApiTypeKind
-    if (!typeMap.has(kind)) typeMap.set(kind, [])
-    typeMap.get(kind)!.push(file)
+
+    let typeMap = getOrSet(packageGroups, file.package, () => new Map())
+    getOrSet(typeMap, file.type, () => []).push(file)
   }
 
-  let sortedPackages = Array.from(packageGroups.keys()).sort((a, b) => {
-    if (a === 'remix' && b.startsWith('remix/')) return -1
-    if (b === 'remix' && a.startsWith('remix/')) return 1
-    if (a.startsWith('remix/') && b.startsWith('remix/')) return a.localeCompare(b)
-    if (a === 'remix' || a.startsWith('remix/')) return -1
-    if (b === 'remix' || b.startsWith('remix/')) return 1
-    return a.localeCompare(b)
-  })
+  let sortedPackages = Array.from(
+    new Set([...packageGroups.keys(), ...packageOverviews.keys()]),
+  ).sort(comparePackages)
 
   for (let pkg of sortedPackages) {
-    let typeMap = packageGroups.get(pkg)!
+    let typeMap = packageGroups.get(pkg)
     let groups: NavGroup[] = []
+    let overview = packageOverviews.get(pkg)
+    if (overview) {
+      let page: PageDefinition = {
+        id: overview.urlPath,
+        description: '',
+        eyebrow: 'Package',
+        navLabel: 'Overview',
+        path: routes.docs.href({ version, slug: overview.urlPath }),
+        sectionId: pkg,
+        title: pkg,
+        docFile: overview,
+      }
+      pages[overview.urlPath] = page
+      groups.push({ id: `${pkg}::overview`, pageIds: [overview.urlPath] })
+    }
+
     for (let kind of TYPE_ORDER) {
-      let files = typeMap.get(kind)
+      let files = typeMap?.get(kind)
       if (!files || files.length === 0) continue
       let groupId = `${pkg}::${kind}`
       let sortedFiles = [...files].sort((a, b) => a.name.localeCompare(b.name))
@@ -144,6 +154,24 @@ export function buildNotFoundPage(slug: string, version?: string): PageDefinitio
 
 export function isPageActive(page: PageDefinition, currentPath: string) {
   return currentPath === page.path
+}
+
+function comparePackages(a: string, b: string): number {
+  if (a === 'remix' && b.startsWith('remix/')) return -1
+  if (b === 'remix' && a.startsWith('remix/')) return 1
+  if (a.startsWith('remix/') && b.startsWith('remix/')) return a.localeCompare(b)
+  if (a === 'remix' || a.startsWith('remix/')) return -1
+  if (b === 'remix' || b.startsWith('remix/')) return 1
+  return a.localeCompare(b)
+}
+
+function getOrSet<key, value>(map: Map<key, value>, key: key, init: () => value): value {
+  let value = map.get(key)
+  if (value === undefined) {
+    value = init()
+    map.set(key, value)
+  }
+  return value
 }
 
 const homePageCss = css({

--- a/docs/src/server/registry.ts
+++ b/docs/src/server/registry.ts
@@ -8,8 +8,6 @@ const TYPE_LABEL: Record<ApiTypeKind, string> = {
   interface: 'Interfaces',
   class: 'Classes',
   function: 'Functions',
-  variable: 'Variables',
-  mixin: 'Mixins',
 }
 
 const TYPE_EYEBROW: Record<ApiTypeKind, string> = {
@@ -17,11 +15,9 @@ const TYPE_EYEBROW: Record<ApiTypeKind, string> = {
   interface: 'Interface',
   class: 'Class',
   function: 'Function',
-  variable: 'Variable',
-  mixin: 'Mixin',
 }
 
-const TYPE_ORDER: ApiTypeKind[] = ['type', 'interface', 'class', 'function', 'variable', 'mixin']
+const TYPE_ORDER: ApiTypeKind[] = ['type', 'interface', 'class', 'function']
 
 export const HOME_PAGE_ID = '__home__'
 export const NOT_FOUND_PAGE_ID = '__not-found__'

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -62,6 +62,16 @@ export function createRouter(versions: ServerContext['versions']) {
         return respond.file(request, filePath, params.asset)
       },
       async docs({ request, params }) {
+        let markdownMatch = routes.markdown.match(request.url)
+        if (markdownMatch) {
+          let docFile = docFiles.find((file) => file.urlPath === markdownMatch.params.slug)
+          if (!docFile) {
+            return new Response('Not Found', { status: 404 })
+          }
+
+          return respond.file(request, docFile.path)
+        }
+
         // Docs page
         let docFile = docFiles.find((file) => file.urlPath === params.slug)
         let node: RemixNode

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -3,7 +3,8 @@ import * as path from 'node:path'
 import * as semver from 'semver'
 import { type RemixNode } from 'remix/ui'
 import { renderToStream } from 'remix/ui/server'
-import { createRouter as _createRouter, type Router } from 'remix/fetch-router'
+import { createRouter as _createRouter, type RouteEntry, type Router } from 'remix/fetch-router'
+import { createMatcher, type Match, type Matcher } from 'remix/route-pattern'
 import { createHtmlResponse } from 'remix/response/html'
 import { MarkdownContent, ServerPage, NotFound, type ServerContext } from './components.tsx'
 import { discoverMarkdownFiles, renderMarkdownFile } from './markdown.ts'
@@ -27,7 +28,7 @@ export const getDefaultVersions = (): ServerContext['versions'] => {
 }
 
 export function createRouter(versions: ServerContext['versions']) {
-  const router = _createRouter()
+  const router = _createRouter({ matcher: createStrictMatcher() })
 
   const respond = {
     async file(request: Request, filePath: string, name?: string) {
@@ -62,16 +63,6 @@ export function createRouter(versions: ServerContext['versions']) {
         return respond.file(request, filePath, params.asset)
       },
       async docs({ request, params }) {
-        let markdownMatch = routes.markdown.match(request.url)
-        if (markdownMatch) {
-          let docFile = docFiles.find((file) => file.urlPath === markdownMatch.params.slug)
-          if (!docFile) {
-            return new Response('Not Found', { status: 404 })
-          }
-
-          return respond.file(request, docFile.path)
-        }
-
         // Docs page
         let docFile = docFiles.find((file) => file.urlPath === params.slug)
         let node: RemixNode
@@ -213,4 +204,26 @@ function stream(router: Router, request: Request, node: RemixNode, init?: Respon
       return await res.text()
     },
   })
+}
+
+function createStrictMatcher(): Matcher<RouteEntry> {
+  let matcher = createMatcher<RouteEntry>()
+
+  function isStrictMatch(match: Match<string, RouteEntry>) {
+    // Work around a trie matcher bug where `Matcher.matchAll()` can return a
+    // candidate that the candidate's own `RoutePattern.match()` rejects.
+    // See https://github.com/remix-run/remix/pull/11368.
+    return match.data.pattern.match(match.url) !== null
+  }
+
+  return {
+    ignoreCase: matcher.ignoreCase,
+    add: matcher.add.bind(matcher),
+    match(url, compareFn) {
+      return this.matchAll(url, compareFn)[0] ?? null
+    },
+    matchAll(url, compareFn) {
+      return matcher.matchAll(url, compareFn).filter(isStrictMatch)
+    },
+  }
 }

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -3,8 +3,7 @@ import * as path from 'node:path'
 import * as semver from 'semver'
 import { type RemixNode } from 'remix/ui'
 import { renderToStream } from 'remix/ui/server'
-import { createRouter as _createRouter, type RouteEntry, type Router } from 'remix/fetch-router'
-import { createMatcher, type Match, type Matcher } from 'remix/route-pattern'
+import { createRouter as _createRouter, type Router } from 'remix/fetch-router'
 import { createHtmlResponse } from 'remix/response/html'
 import { MarkdownContent, ServerPage, NotFound, type ServerContext } from './components.tsx'
 import { discoverMarkdownFiles, renderMarkdownFile } from './markdown.ts'
@@ -28,7 +27,7 @@ export const getDefaultVersions = (): ServerContext['versions'] => {
 }
 
 export function createRouter(versions: ServerContext['versions']) {
-  const router = _createRouter({ matcher: createStrictMatcher() })
+  const router = _createRouter()
 
   const respond = {
     async file(request: Request, filePath: string, name?: string) {
@@ -204,26 +203,4 @@ function stream(router: Router, request: Request, node: RemixNode, init?: Respon
       return await res.text()
     },
   })
-}
-
-function createStrictMatcher(): Matcher<RouteEntry> {
-  let matcher = createMatcher<RouteEntry>()
-
-  function isStrictMatch(match: Match<string, RouteEntry>) {
-    // Work around a trie matcher bug where `Matcher.matchAll()` can return a
-    // candidate that the candidate's own `RoutePattern.match()` rejects.
-    // See https://github.com/remix-run/remix/pull/11368.
-    return match.data.pattern.match(match.url) !== null
-  }
-
-  return {
-    ignoreCase: matcher.ignoreCase,
-    add: matcher.add.bind(matcher),
-    match(url, compareFn) {
-      return this.matchAll(url, compareFn)[0] ?? null
-    },
-    matchAll(url, compareFn) {
-      return matcher.matchAll(url, compareFn).filter(isStrictMatch)
-    },
-  }
 }

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -75,7 +75,7 @@ export function createRouter(versions: ServerContext['versions']) {
             docFilesLookup,
             params.version,
             // Don't transform links in README - too many false positives
-            docFile.urlPath !== docFile.package + '/overview',
+            docFile.kind !== 'package',
           )
           node = <MarkdownContent html={html} />
           sourceUrl = source

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -74,6 +74,8 @@ export function createRouter(versions: ServerContext['versions']) {
             docFile.path,
             docFilesLookup,
             params.version,
+            // Don't transform links in README - too many false positives
+            docFile.urlPath !== docFile.package + '/overview',
           )
           node = <MarkdownContent html={html} />
           sourceUrl = source

--- a/docs/src/server/routes.ts
+++ b/docs/src/server/routes.ts
@@ -2,8 +2,8 @@ import { route } from 'remix/routes'
 
 export const routes = route({
   assets: '/(:version/)assets/*asset',
-  markdown: '/(:version/)api/*slug.md',
   docs: '/(:version/)api/*slug/',
   home: '/(:version/)',
   lookup: '/(:version/)api.json',
+  markdown: '/(:version/)api/*slug.md',
 })

--- a/docs/src/server/routes.ts
+++ b/docs/src/server/routes.ts
@@ -2,8 +2,8 @@ import { route } from 'remix/routes'
 
 export const routes = route({
   assets: '/(:version/)assets/*asset',
+  markdown: '/(:version/)api/*slug.md',
   docs: '/(:version/)api/*slug/',
   home: '/(:version/)',
   lookup: '/(:version/)api.json',
-  markdown: '/(:version/)api/*slug.md',
 })

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -30,6 +30,12 @@ export function DocsDocument(handle: Handle<DocsViewProps>) {
               <meta name="robots" content="noindex,nofollow" />
               <meta name="googlebot" content="noindex,nofollow" />
             </>
+          ) : page.docFile?.kind === 'package' ? (
+            // Overview pages (package READMEs) link densely to every API page
+            // in the package; those are already reachable via the sidebar, so
+            // tell crawlers — including our prerender spider — not to follow
+            // links from here. The page itself is still indexable.
+            <meta name="robots" content="nofollow" />
           ) : null}
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -1,7 +1,7 @@
 import { css } from 'remix/ui'
 import type { Handle, RemixNode } from 'remix/ui'
 import { RMX_01, RMX_01_GLYPHS, theme } from '@remix-run/ui/theme'
-import type { DocsRegistry, PageDefinition } from './registry.ts'
+import type { DocsRegistry, NavGroup, PageDefinition } from './registry.ts'
 import { isPageActive } from './registry.ts'
 import { bodyTextCss, eyebrowTextCss } from './page-primitives.tsx'
 import { routes } from './routes.ts'
@@ -117,36 +117,49 @@ function Sidebar(
               <span mix={sectionSummaryLabelCss}>{section.label}</span>
             </summary>
             <div mix={sectionContentCss}>
-              {section.groups.map((group) => (
-                <div key={group.id} mix={sidebarGroupCss}>
-                  {group.label ? <p mix={sidebarHeadingCss}>{group.label}</p> : null}
-                  <nav
-                    aria-label={
-                      group.label ? `${section.label} ${group.label}` : `${section.label} pages`
-                    }
-                    mix={sidebarNavCss}
-                  >
-                    {group.pageIds.map((pageId) => {
-                      let navPage = registry.pages[pageId]
-                      return (
-                        <a
-                          key={navPage.path}
-                          href={navPage.path}
-                          aria-current={isPageActive(navPage, currentPath) ? 'page' : undefined}
-                          mix={getNavItemMix(navPage, currentPath)}
-                        >
-                          {navPage.navLabel}
-                        </a>
-                      )
-                    })}
+              {section.groups.map((group) =>
+                group.label ? (
+                  <nav key={group.id} mix={[sidebarGroupCss]}>
+                    <p mix={sidebarHeadingCss}>{group.label}</p>
+                    <nav aria-label={`${section.label} ${group.label}`} mix={sidebarNavCss}>
+                      <SidebarGroup registry={registry} group={group} currentPath={currentPath} />
+                    </nav>
                   </nav>
-                </div>
-              ))}
+                ) : (
+                  <nav
+                    key={group.id}
+                    aria-label={`${section.label} Pages`}
+                    mix={[sidebarGroupCss, css({ paddingLeft: 0 })]}
+                  >
+                    <SidebarGroup registry={registry} group={group} currentPath={currentPath} />
+                  </nav>
+                ),
+              )}
             </div>
           </details>
         ))}
       </div>
     )
+  }
+}
+
+function SidebarGroup(
+  handle: Handle<{ registry: DocsRegistry; group: NavGroup; currentPath: string }>,
+) {
+  return () => {
+    let { registry, group, currentPath } = handle.props
+    return group.pageIds.map((pageId) => {
+      let page = registry.pages[pageId]
+      return (
+        <a
+          href={page.path}
+          aria-current={isPageActive(page, currentPath) ? 'page' : undefined}
+          mix={getNavItemMix(page, currentPath)}
+        >
+          {page.navLabel}
+        </a>
+      )
+    })
   }
 }
 
@@ -500,14 +513,6 @@ const sidebarNavCss = css({
   display: 'flex',
   flexDirection: 'column',
   gap: theme.space.xs,
-})
-
-const sidebarTitleCss = css({
-  margin: 0,
-  fontSize: theme.fontSize.xl,
-  lineHeight: theme.lineHeight.tight,
-  fontWeight: theme.fontWeight.semibold,
-  color: theme.colors.text.primary,
 })
 
 const logoLightCss = css({

--- a/packages/assert/README.md
+++ b/packages/assert/README.md
@@ -74,7 +74,7 @@ import {
 
 ### `expect`
 
-A vitest-/jest-style chainable matcher API on top of the same `AssertionError`. Use `.not` to negate, `.rejects` / `.resolves` to assert on a promise. Mock-aware matchers work with `mock.fn()` / `mock.method()` from `@remix-run/test`.
+A vitest-/jest-style chainable matcher API on top of the same `AssertionError`. Use `.not` to negate, `.rejects` / `.resolves` to assert on a promise. Mock-aware matchers work with `mock.fn()` / `mock.method()` from `remix/test`.
 
 ```ts
 import { expect } from 'remix/assert'

--- a/packages/assets/README.md
+++ b/packages/assets/README.md
@@ -166,7 +166,7 @@ let preloads = await assetServer.getPreloads(['app/assets/entry.tsx', 'app/asset
 //   '/assets/app/assets/entry.tsx',
 //   '/assets/app/assets/search.tsx',
 //   '/assets/app/assets/utils.ts',
-//   '/assets/npm/@remix-run/ui/index.js',
+//   '/assets/npm/remix/ui/index.js',
 //   ...etc
 // ]
 ```

--- a/packages/compression-middleware/README.md
+++ b/packages/compression-middleware/README.md
@@ -94,7 +94,7 @@ let router = createRouter({
 
 ### Filter Media Type
 
-**Default:** Uses `isCompressibleMimeType()` from [`@remix-run/mime`](https://github.com/remix-run/remix/tree/main/packages/mime)
+**Default:** Uses `isCompressibleMimeType()` from [`remix/mime`](https://github.com/remix-run/remix/tree/main/packages/mime)
 
 You can customize this behavior with the `filterMediaType` option:
 
@@ -167,9 +167,9 @@ let router = createRouter({
 
 ## Related Packages
 
-- [`@remix-run/fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router) - Router for the web Fetch API
-- [`@remix-run/mime`](https://github.com/remix-run/remix/tree/main/packages/mime) - MIME type utilities
-- [`@remix-run/response`](https://github.com/remix-run/remix/tree/main/packages/response) - Response helpers
+- [`remix/fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router) - Router for the web Fetch API
+- [`remix/mime`](https://github.com/remix-run/remix/tree/main/packages/mime) - MIME type utilities
+- [`remix/response`](https://github.com/remix-run/remix/tree/main/packages/response) - Response helpers
 
 ## License
 

--- a/packages/data-schema/README.md
+++ b/packages/data-schema/README.md
@@ -9,9 +9,9 @@ Tiny, standards-aligned data validation for Remix and the wider TypeScript ecosy
 ## Quick start
 
 ```ts
-import { enum_, literal, number, object, parse, string, variant } from '@remix-run/data-schema'
-import { email, maxLength, min, minLength } from '@remix-run/data-schema/checks'
-import * as coerce from '@remix-run/data-schema/coerce'
+import { enum_, literal, number, object, parse, string, variant } from 'remix/data-schema'
+import { email, maxLength, min, minLength } from 'remix/data-schema/checks'
+import * as coerce from 'remix/data-schema/coerce'
 
 let User = object({
   id: string(),
@@ -46,7 +46,7 @@ let event = parse(Event, { type: 'created', id: 'evt_1' })
 Use `parse()` when you want a typed value or an exception.
 
 ```ts
-import { object, string, number, parse } from '@remix-run/data-schema'
+import { object, string, number, parse } from 'remix/data-schema'
 
 let User = object({ name: string(), age: number() })
 
@@ -56,7 +56,7 @@ let user = parse(User, { name: 'Ada', age: 37 })
 Use `parseSafe()` when you prefer explicit branching over exceptions.
 
 ```ts
-import { object, string, number, parseSafe } from '@remix-run/data-schema'
+import { object, string, number, parseSafe } from 'remix/data-schema'
 
 let User = object({ name: string(), age: number() })
 
@@ -104,8 +104,8 @@ File helpers are intended for `FormData`; `URLSearchParams` only supports text v
 You can also customize built-in validation messages with `errorMap`:
 
 ```ts
-import { object, parseSafe, string } from '@remix-run/data-schema'
-import { minLength } from '@remix-run/data-schema/checks'
+import { object, parseSafe, string } from 'remix/data-schema'
+import { minLength } from 'remix/data-schema/checks'
 
 let User = object({
   name: string(),
@@ -133,7 +133,7 @@ Return `undefined` to keep the default message.
 ## Primitives
 
 ```ts
-import { string, number, boolean, bigint, symbol, null_, undefined_ } from '@remix-run/data-schema'
+import { string, number, boolean, bigint, symbol, null_, undefined_ } from 'remix/data-schema'
 
 string() // validates typeof === 'string'
 number() // validates finite numbers (rejects NaN, Infinity)
@@ -147,7 +147,7 @@ undefined_() // validates value === undefined
 ## Literals, enums, and unions
 
 ```ts
-import { literal, enum_, union } from '@remix-run/data-schema'
+import { literal, enum_, union } from 'remix/data-schema'
 
 // Exact value match
 let yes = literal('yes')
@@ -162,7 +162,7 @@ let StringOrNumber = union([string(), number()])
 ## Objects
 
 ```ts
-import { object, string, number, optional, defaulted } from '@remix-run/data-schema'
+import { object, string, number, optional, defaulted } from 'remix/data-schema'
 
 let User = object({
   name: string(),
@@ -182,7 +182,7 @@ object({ name: string() }, { unknownKeys: 'error' }) // rejects unknown keys
 ## Collections
 
 ```ts
-import { array, tuple, record, map, set, string, number, boolean } from '@remix-run/data-schema'
+import { array, tuple, record, map, set, string, number, boolean } from 'remix/data-schema'
 
 array(number()) // number[]
 tuple([string(), number(), boolean()]) // [string, number, boolean]
@@ -194,7 +194,7 @@ set(number()) // Set<number>
 ## Modifiers
 
 ```ts
-import { nullable, optional, defaulted, string, number } from '@remix-run/data-schema'
+import { nullable, optional, defaulted, string, number } from 'remix/data-schema'
 
 nullable(string()) // string | null
 optional(number()) // number | undefined
@@ -204,7 +204,7 @@ defaulted(string(), 'n/a') // fills 'n/a' when undefined
 ## Instance checks
 
 ```ts
-import { instanceof_, object } from '@remix-run/data-schema'
+import { instanceof_, object } from 'remix/data-schema'
 
 let Schema = object({
   created: instanceof_(Date),
@@ -217,7 +217,7 @@ let Schema = object({
 Accept any value without validation. Useful when part of a structure is opaque.
 
 ```ts
-import { any, object, string } from '@remix-run/data-schema'
+import { any, object, string } from 'remix/data-schema'
 
 let Envelope = object({
   type: string(),
@@ -230,7 +230,7 @@ let Envelope = object({
 Add domain-specific validation logic inline. The predicate runs after the schema validates.
 
 ```ts
-import { number, string, object } from '@remix-run/data-schema'
+import { number, string, object } from 'remix/data-schema'
 
 let Profile = object({
   username: string().refine((s) => s.length >= 3, 'Too short'),
@@ -243,7 +243,7 @@ let Profile = object({
 Map a validated value into the shape your app wants. The transformer runs after the schema validates and changes the parsed output type.
 
 ```ts
-import { object, parse, string } from '@remix-run/data-schema'
+import { object, parse, string } from 'remix/data-schema'
 
 let Event = object({
   id: string(),
@@ -267,8 +267,8 @@ Use `.refine()` for checks that reject values without changing them. Use `.trans
 Compose reusable `Check` objects for common constraints.
 
 ```ts
-import { object, string, number } from '@remix-run/data-schema'
-import { minLength, maxLength, email, min, max } from '@remix-run/data-schema/checks'
+import { object, string, number } from 'remix/data-schema'
+import { minLength, maxLength, email, min, max } from 'remix/data-schema/checks'
 
 let Credentials = object({
   username: string().pipe(minLength(3), maxLength(20)),
@@ -284,8 +284,8 @@ Built-in checks: `minLength`, `maxLength`, `email`, `url`, `min`, `max`.
 Turn stringly-typed inputs (like form data or query strings) into real types at the schema boundary.
 
 ```ts
-import { object, parse } from '@remix-run/data-schema'
-import * as coerce from '@remix-run/data-schema/coerce'
+import { object, parse } from 'remix/data-schema'
+import * as coerce from 'remix/data-schema/coerce'
 
 let Query = object({
   page: coerce.number(),
@@ -309,7 +309,7 @@ let query = parse(Query, {
 Pick the right schema based on a discriminator property.
 
 ```ts
-import { literal, number, object, string, variant } from '@remix-run/data-schema'
+import { literal, number, object, string, variant } from 'remix/data-schema'
 
 let Event = variant('type', {
   created: object({ type: literal('created'), id: string() }),
@@ -322,9 +322,9 @@ let Event = variant('type', {
 Model trees and self-referencing structures. `lazy()` defers schema resolution to avoid circular references.
 
 ```ts
-import { array, object, string } from '@remix-run/data-schema'
-import { lazy } from '@remix-run/data-schema/lazy'
-import type { Schema } from '@remix-run/data-schema'
+import { array, object, string } from 'remix/data-schema'
+import { lazy } from 'remix/data-schema/lazy'
+import type { Schema } from 'remix/data-schema'
 
 type TreeNode = { id: string; children: TreeNode[] }
 
@@ -336,7 +336,7 @@ let Node: Schema<unknown, TreeNode> = lazy(() => object({ id: string(), children
 By default, validation collects all issues in a single pass. To stop at the first issue, enable `abortEarly`.
 
 ```ts
-import { object, string, number, parseSafe } from '@remix-run/data-schema'
+import { object, string, number, parseSafe } from 'remix/data-schema'
 
 let result = parseSafe(
   object({ name: string(), age: number() }),
@@ -354,8 +354,8 @@ if (!result.success) {
 Extract input and output types from any Standard Schema-compatible schema.
 
 ```ts
-import { object, string, number } from '@remix-run/data-schema'
-import type { InferInput, InferOutput } from '@remix-run/data-schema'
+import { object, string, number } from 'remix/data-schema'
+import type { InferInput, InferOutput } from 'remix/data-schema'
 
 let User = object({ name: string(), age: number() })
 
@@ -368,8 +368,8 @@ type UserOutput = InferOutput<typeof User> // { name: string; age: number }
 Build custom schemas using `createSchema`, `createIssue`, and `fail`. These are the same primitives used internally by every built-in schema.
 
 ```ts
-import { createSchema, createIssue, fail } from '@remix-run/data-schema'
-import type { Schema } from '@remix-run/data-schema'
+import { createSchema, createIssue, fail } from 'remix/data-schema'
+import type { Schema } from 'remix/data-schema'
 
 // A schema that validates a non-empty trimmed string
 function trimmedString(): Schema<unknown, string> {

--- a/packages/html-template/README.md
+++ b/packages/html-template/README.md
@@ -94,7 +94,7 @@ let page = html`<div>${showError ? html`<div class="error">${errorMessage}</div>
 
 ## Related Packages
 
-- [`@remix-run/fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router) - HTTP router that works great with html-template
+- [`remix/fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router) - HTTP router that works great with html-template
 
 ## License
 

--- a/packages/response/README.md
+++ b/packages/response/README.md
@@ -29,7 +29,7 @@ import { compressResponse } from 'remix/response/compress'
 
 ### File Responses
 
-The `createFileResponse` helper creates a response for serving files with full HTTP semantics. It works with both native `File` objects and `LazyFile` from `@remix-run/lazy-file`:
+The `createFileResponse` helper creates a response for serving files with full HTTP semantics. It works with both native `File` objects and `LazyFile` from `remix/lazy-file`:
 
 ```ts
 import { createFileResponse } from 'remix/response/file'
@@ -129,7 +129,7 @@ let response = createHtmlResponse('<h1>Hello, World!</h1>')
 // Body: <!DOCTYPE html><h1>Hello, World!</h1>
 ```
 
-The helper automatically prepends `<!DOCTYPE html>` if not already present. It works with strings, `SafeHtml` [from `@remix-run/html-template`](https://github.com/remix-run/remix/tree/main/packages/html-template), Blobs/Files, ArrayBuffers, and ReadableStreams.
+The helper automatically prepends `<!DOCTYPE html>` if not already present. It works with strings, `SafeHtml` [from `remix/html-template`](https://github.com/remix-run/remix/tree/main/packages/html-template), Blobs/Files, ArrayBuffers, and ReadableStreams.
 
 ```ts
 import { html } from 'remix/html-template'
@@ -226,11 +226,11 @@ Range requests and compression are mutually exclusive. When `Accept-Ranges: byte
 
 ## Related Packages
 
-- [`@remix-run/headers`](https://github.com/remix-run/remix/tree/main/packages/headers) - Type-safe HTTP header manipulation
-- [`@remix-run/html-template`](https://github.com/remix-run/remix/tree/main/packages/html-template) - Safe HTML templating with automatic escaping
-- [`@remix-run/fs`](https://github.com/remix-run/remix/tree/main/packages/fs) - File system utilities including `openFile`
-- [`@remix-run/fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router) - Build HTTP routers using the web fetch API
-- [`@remix-run/mime`](https://github.com/remix-run/remix/tree/main/packages/mime) - MIME type utilities
+- [`remix/headers`](https://github.com/remix-run/remix/tree/main/packages/headers) - Type-safe HTTP header manipulation
+- [`remix/html-template`](https://github.com/remix-run/remix/tree/main/packages/html-template) - Safe HTML templating with automatic escaping
+- [`remix/fs`](https://github.com/remix-run/remix/tree/main/packages/fs) - File system utilities including `openFile`
+- [`remix/fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router) - Build HTTP routers using the web fetch API
+- [`remix/mime`](https://github.com/remix-run/remix/tree/main/packages/mime) - MIME type utilities
 
 ## License
 

--- a/packages/session-storage-memcache/README.md
+++ b/packages/session-storage-memcache/README.md
@@ -1,6 +1,6 @@
 # session-storage-memcache
 
-Memcache session storage for [`@remix-run/session`](https://github.com/remix-run/remix/tree/main/packages/session).
+Memcache session storage for [`remix/session`](https://github.com/remix-run/remix/tree/main/packages/session).
 
 ## Installation
 
@@ -29,8 +29,8 @@ Note: Memcache storage uses TCP sockets and requires a Node.js runtime.
 
 ## Related Packages
 
-- [`@remix-run/session`](https://github.com/remix-run/remix/tree/main/packages/session) - Core session primitives and storage interface
-- [`@remix-run/session-middleware`](https://github.com/remix-run/remix/tree/main/packages/session-middleware) - Middleware for wiring session storage into request handling
+- [`remix/session`](https://github.com/remix-run/remix/tree/main/packages/session) - Core session primitives and storage interface
+- [`remix/session-middleware`](https://github.com/remix-run/remix/tree/main/packages/session-middleware) - Middleware for wiring session storage into request handling
 
 ## License
 

--- a/packages/session-storage-redis/README.md
+++ b/packages/session-storage-redis/README.md
@@ -1,19 +1,19 @@
 # session-storage-redis
 
-Redis-backed session storage for [`@remix-run/session`](https://github.com/remix-run/remix/tree/main/packages/session).
+Redis-backed session storage for [`remix/session`](https://github.com/remix-run/remix/tree/main/packages/session).
 Use this package when app servers need to share session state through Redis.
 
 ## Installation
 
 ```sh
-npm i @remix-run/session @remix-run/session-storage-redis redis
+npm i remix
 ```
 
 ## Usage
 
 ```ts
 import { createClient } from 'redis'
-import { createRedisSessionStorage } from '@remix-run/session-storage-redis'
+import { createRedisSessionStorage } from 'remix/session-storage-redis'
 
 let redis = createClient({ url: process.env.REDIS_URL })
 await redis.connect()

--- a/packages/session/README.md
+++ b/packages/session/README.md
@@ -162,9 +162,9 @@ let sessionStorage = createMemorySessionStorage()
 
 ## Related Packages
 
-- [`@remix-run/cookie`](https://github.com/remix-run/remix/tree/main/packages/cookie) - Cookie parsing and serialization
-- [`@remix-run/fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router) - Router with built-in session middleware
-- [`@remix-run/session-storage-memcache`](https://github.com/remix-run/remix/tree/main/packages/session-storage-memcache) - Memcache-backed session storage
+- [`remix/cookie`](https://github.com/remix-run/remix/tree/main/packages/cookie) - Cookie parsing and serialization
+- [`remix/fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router) - Router with built-in session middleware
+- [`remix/session-storage-memcache`](https://github.com/remix-run/remix/tree/main/packages/session-storage-memcache) - Memcache-backed session storage
 
 ## License
 

--- a/packages/static-middleware/README.md
+++ b/packages/static-middleware/README.md
@@ -33,7 +33,7 @@ router.get('/', () => new Response('Home'))
 
 ### With Cache Control
 
-Internally, the `staticFiles()` middleware uses the [`createFileResponse()` helper from `@remix-run/response`](https://github.com/remix-run/remix/tree/main/packages/response/README.md#file-responses) to send files with full HTTP semantics. This means it also accepts the same options as the `createFileResponse()` helper.
+Internally, the `staticFiles()` middleware uses the [`createFileResponse()` helper from `remix/response`](https://github.com/remix-run/remix/tree/main/packages/response/README.md#file-responses) to send files with full HTTP semantics. This means it also accepts the same options as the `createFileResponse()` helper.
 
 ```ts
 let router = createRouter({

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -209,11 +209,11 @@ suite('My Test Suite', () => {
 
 ### Programmatic runner
 
-`@remix-run/test/cli` exports `runRemixTest()` for tools that want to run the test runner without
+`remix/test/cli` exports `runRemixTest()` for tools that want to run the test runner without
 exiting the current process:
 
 ```ts
-import { runRemixTest } from '@remix-run/test/cli'
+import { runRemixTest } from 'remix/test/cli'
 
 let exitCode = await runRemixTest({
   argv: ['--type', 'server'],

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -169,9 +169,9 @@ Render shared glyphs separately from the theme styles:
 
 ```tsx
 import type { RemixNode } from 'remix/ui'
-import { Button } from '@remix-run/ui/button'
-import { Glyph } from '@remix-run/ui/glyph'
-import { RMX_01, RMX_01_GLYPHS } from '@remix-run/ui/theme'
+import { Button } from 'remix/ui/button'
+import { Glyph } from 'remix/ui/glyph'
+import { RMX_01, RMX_01_GLYPHS } from 'remix/ui/theme'
 
 function Layout(props: { children: RemixNode }) {
   return (


### PR DESCRIPTION
This adds package-level overview pages to the generated API docs by pulling each package README into the docs build. Package READMEs are emitted at package root paths such as `/api/remix/fetch-router/`, and the sidebar now includes an explicit Overview entry before each package API grouping.

- Generate package overview markdown from `packages/*/README.md`, with fallback content and warnings for missing READMEs.
- Warn when README usage examples still show `@remix-run/*` install/import syntax, matching the existing JSDoc warning style without blocking generation.
- Update README examples to use the Remix 3 `remix` import paths where they are public usage guidance.
- Keep markdown mirror URLs from being prerendered as `*.md/index.html` in local previews.

The README pages are intentionally not included in `api.json`; that lookup remains focused on API symbols.


<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/1912bc00-495f-4194-b7fe-d57acef6ea01" />
