### PR TITLE
route-pattern: do not allow partial matches for variables and wildcards in pathname

### DIFF
--- a/.agents/skills/make-change-file/SKILL.md
+++ b/.agents/skills/make-change-file/SKILL.md
@@ -23,8 +23,19 @@ Write release notes that match this repository's `.changes` conventions. Use it 
 - Use `packages/<package>/.changes/[major|minor|patch].short-description.md`.
 - Keep the slug short, specific, and stable.
 - Reuse existing deterministic names when the repo already has a pattern for that class of note.
-- For Remix export-only changes, update `packages/remix/.changes/minor.remix.update-exports.md` in place.
 - For brand-new package releases, prefer `minor.initial-release.md`.
+- For Remix export-only changes, update `packages/remix/.changes/minor.remix.update-exports.md` in place.
+- When `packages/remix/.changes` mirrors a change file from a re-exported package, name it `packages/remix/.changes/[major|minor|patch].<package>.short-description.md`, where `<package>` omits the `@remix-run/` scope.
+
+  ```text
+  packages/
+  ├── route-pattern/
+  │   └── .changes/
+  │       └── patch.no-partial-matches-for-dynamic-pathnames.md
+  └── remix/
+      └── .changes/
+          └── patch.route-pattern.no-partial-matches-for-dynamic-pathnames.md
+  ```
 
 ## Bump Rules
 
@@ -40,7 +51,10 @@ Write release notes that match this repository's `.changes` conventions. Use it 
 - Document user-visible behavior, public API changes, exports, migrations, or upgrade work.
 - Do not write release notes for internal refactors unless they surface as real API or behavior changes.
 - Prefer a small number of logically grouped notes over many tiny files.
-- If one package changes internally and another package re-exports the new surface, add notes for both when users can consume the change from both package entrypoints.
+- Add a manual change file to the package that owns the changed API, behavior, or implementation.
+- If another package directly re-exports a newly added, removed, renamed, or otherwise changed public API surface, add a change file for the re-exporting package when users can consume that API through the re-exported entrypoint.
+- Do not add manual change files recursively for packages that only observe a change through dependency updates. The release scripts automatically include transitive dependents in the release set and generate dependency bump changelog entries; see `scripts/utils/changes.ts` (`parseAllChangeFiles` and `generateChangelogContent`).
+- For bug fixes in an underlying package, usually add a change file only to the package that owns the fix. Add a re-export package note only when the re-exporting package's own changelog needs to call out the behavior directly, not merely because the fixed dependency is reachable from that package.
 - Do not manually hard-wrap prose in `.changes/*.md` files. Keep each paragraph or bullet on a single source line and let rendered changelogs wrap naturally.
 - Use flat bullets only when they add clarity. Short paragraphs are usually better.
 

--- a/packages/remix/.changes/patch.route-pattern.no-partial-matches-for-dynamic-pathnames.md
+++ b/packages/remix/.changes/patch.route-pattern.no-partial-matches-for-dynamic-pathnames.md
@@ -1,0 +1,17 @@
+Fix `createMatcher` from `remix/route-pattern` so dynamic pathname segments and wildcard continuations only match when they cover the full pathname range being tested.
+
+```ts
+import { createMatcher } from 'remix/route-pattern'
+
+let matcher = createMatcher<string>()
+matcher.add('/files/:name.md', 'markdown')
+matcher.add('/files/:name.md.backup', 'backup')
+
+// before: matched both patterns because `/files/:name.md` matched a prefix of the segment
+matcher.matchAll('https://example.com/files/readme.md.backup').map((match) => match.data)
+// ['backup', 'markdown']
+
+// after: only matches when the pattern covers the whole segment
+matcher.matchAll('https://example.com/files/readme.md.backup').map((match) => match.data)
+// ['backup']
+```

--- a/packages/route-pattern/.changes/patch.no-partial-matches-for-dynamic-pathnames.md
+++ b/packages/route-pattern/.changes/patch.no-partial-matches-for-dynamic-pathnames.md
@@ -1,0 +1,15 @@
+Do not allow partial matches for variables and wildcards in pathname
+
+```ts
+let matcher = createMatcher<string>()
+matcher.add('/files/:name.md', 'original')
+matcher.add('/files/:name.md.backup', 'backup')
+
+// before: 'original' included since `:name.md` partially matches `readme.md.backup`
+matcher.matchAll('https://example.com/files/readme.md.backup').map((match) => match.data)
+// ❌ ['backup', 'original']
+
+// after: only matches when the pattern covers the whole segment
+matcher.matchAll('https://example.com/files/readme.md.backup').map((match) => match.data)
+// ✅ ['backup']
+```

--- a/packages/route-pattern/src/lib/matcher.test.ts
+++ b/packages/route-pattern/src/lib/matcher.test.ts
@@ -425,6 +425,21 @@ describe('Matcher', () => {
         assert.deepEqual(match.params, { path: 'docs/api' })
       })
 
+      it('does not match wildcard continuations against partial pathnames', () => {
+        let docs = new RoutePattern('/api/*slug/')
+        let markdown = new RoutePattern('/api/*slug.md')
+        let matcher = createMatcher<string>()
+        matcher.add(docs, 'docs')
+        matcher.add(markdown, 'markdown')
+
+        let matches = matcher.matchAll('http://localhost/api/remix/fetch-router/overview.md')
+
+        assert.deepEqual(
+          matches.map((match) => [match.data, match.params]),
+          [['markdown', { slug: 'remix/fetch-router/overview' }]],
+        )
+      })
+
       it('excludes unnamed wildcard from params', () => {
         let matcher = createMatcher<null>()
         matcher.add('://example.com/files/*/download', null)

--- a/packages/route-pattern/src/lib/matcher.test.ts
+++ b/packages/route-pattern/src/lib/matcher.test.ts
@@ -425,18 +425,33 @@ describe('Matcher', () => {
         assert.deepEqual(match.params, { path: 'docs/api' })
       })
 
-      it('does not match wildcard continuations against partial pathnames', () => {
-        let docs = new RoutePattern('/api/*slug/')
-        let markdown = new RoutePattern('/api/*slug.md')
+      it('does not match variable segment continuations against partial segments', () => {
+        let markdown = new RoutePattern('/files/:name.md')
+        let backup = new RoutePattern('/files/:name.md.backup')
         let matcher = createMatcher<string>()
-        matcher.add(docs, 'docs')
         matcher.add(markdown, 'markdown')
+        matcher.add(backup, 'backup')
 
-        let matches = matcher.matchAll('http://localhost/api/remix/fetch-router/overview.md')
+        let matches = matcher.matchAll('http://localhost/files/readme.md.backup')
 
         assert.deepEqual(
           matches.map((match) => [match.data, match.params]),
-          [['markdown', { slug: 'remix/fetch-router/overview' }]],
+          [['backup', { name: 'readme' }]],
+        )
+      })
+
+      it('does not match wildcard continuations against partial remaining pathnames', () => {
+        let editor = new RoutePattern('/api/*slug/edit')
+        let json = new RoutePattern('/api/*slug/edit.json')
+        let matcher = createMatcher<string>()
+        matcher.add(editor, 'editor')
+        matcher.add(json, 'json')
+
+        let matches = matcher.matchAll('http://localhost/api/remix/fetch-router/edit.json')
+
+        assert.deepEqual(
+          matches.map((match) => [match.data, match.params]),
+          [['json', { slug: 'remix/fetch-router' }]],
         )
       })
 

--- a/packages/route-pattern/src/lib/trie-matcher/variant.ts
+++ b/packages/route-pattern/src/lib/trie-matcher/variant.ts
@@ -154,7 +154,7 @@ export class PartPatternVariant {
           continue
         }
         if (type === 'variable') {
-          result.push({ type: 'variable', key, regexp: new RegExp(reSource, reFlags) })
+          result.push({ type: 'variable', key, regexp: new RegExp(`^${reSource}$`, reFlags) })
           key = ''
           reSource = ''
           type = 'static'
@@ -195,7 +195,7 @@ export class PartPatternVariant {
       result.push({ type: 'static', key: ignoreCase ? key.toLowerCase() : key })
     }
     if (type === 'variable' || type === 'wildcard') {
-      result.push({ type, key, regexp: new RegExp(reSource, reFlags) })
+      result.push({ type, key, regexp: new RegExp(`^${reSource}$`, reFlags) })
     }
     return result
   }


### PR DESCRIPTION
Do not allow partial matches for variables and wildcards in pathname

```ts
let matcher = createMatcher<string>()
matcher.add('/files/:name.md', 'original')
matcher.add('/files/:name.md.backup', 'backup')

// before: 'original' included since `:name.md` partially matches `readme.md.backup`
matcher.matchAll('https://example.com/files/readme.md.backup').map((match) => match.data)
// ❌ ['backup', 'original']

// after: only matches when the pattern covers the whole segment
matcher.matchAll('https://example.com/files/readme.md.backup').map((match) => match.data)
// ✅ ['backup']
```