### PR TITLE
fetch-router: Expose matched route on request context

### DIFF
--- a/packages/fetch-router/.changes/minor.matched-route-context.md
+++ b/packages/fetch-router/.changes/minor.matched-route-context.md
@@ -1,0 +1,1 @@
+Added a `MatchedRoute` request context key that stores the route entry matched by `createRouter()`. Router middleware can read it after `await next()`, and route middleware or handlers can read it during matched route dispatch.

--- a/packages/fetch-router/src/index.ts
+++ b/packages/fetch-router/src/index.ts
@@ -26,5 +26,5 @@ export type {
 export { RequestMethods, isRequestMethod } from './lib/request-methods.ts'
 export type { RequestMethod } from './lib/request-methods.ts'
 
-export { createRouter } from './lib/router.ts'
+export { createRouter, MatchedRoute } from './lib/router.ts'
 export type { RouteEntry, Router, RouterOptions } from './lib/router.ts'

--- a/packages/fetch-router/src/lib/router.test.ts
+++ b/packages/fetch-router/src/lib/router.test.ts
@@ -6,7 +6,7 @@ import { createRoutes as route } from '@remix-run/routes'
 import type { Action } from './controller.ts'
 import type { RequestContext } from './request-context.ts'
 import type { RouteEntry } from './router.ts'
-import { createRouter } from './router.ts'
+import { createRouter, MatchedRoute } from './router.ts'
 
 describe('router.fetch()', () => {
   it('fetches a route', async () => {
@@ -91,6 +91,79 @@ describe('router.fetch()', () => {
     assert.equal(response.status, 200)
     assert.equal(await response.text(), 'Home')
     assert.deepEqual(requestLog, ['router middleware', 'route middleware'])
+  })
+
+  it('stores the matched route in context before route middleware runs', async () => {
+    let routes = route({
+      profile: '/profile/:id',
+    })
+
+    let matchedRoutes: RouteEntry[] = []
+    let router = createRouter()
+
+    router.get(routes.profile, {
+      middleware: [
+        (context) => {
+          let matchedRoute = context.get(MatchedRoute)
+          if (matchedRoute != null) {
+            matchedRoutes.push(matchedRoute)
+          }
+        },
+      ],
+      handler() {
+        return new Response('Profile')
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/profile/123')
+
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'Profile')
+    assert.equal(matchedRoutes.length, 1)
+    assert.equal(matchedRoutes[0]?.pattern.source, '/profile/:id')
+    assert.equal(matchedRoutes[0]?.method, 'GET')
+  })
+
+  it('lets router middleware read the matched route after downstream dispatch', async () => {
+    let matchedRoutes: Array<string | undefined> = []
+    let router = createRouter({
+      middleware: [
+        async (context, next) => {
+          let response = await next()
+          matchedRoutes.push(context.get(MatchedRoute)?.pattern.source)
+          return response
+        },
+      ],
+    })
+
+    router.get('/account/:id', () => new Response('Account'))
+
+    let response = await router.fetch('https://remix.run/account/123')
+
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'Account')
+    assert.deepEqual(matchedRoutes, ['/account/:id'])
+  })
+
+  it('does not store a matched route when no route matches', async () => {
+    let matchedRoutes: Array<string | undefined> = []
+    let router = createRouter({
+      middleware: [
+        async (context, next) => {
+          let response = await next()
+          matchedRoutes.push(context.get(MatchedRoute)?.pattern.source)
+          return response
+        },
+      ],
+    })
+
+    router.get('/', () => new Response('Home'))
+
+    let response = await router.fetch('https://remix.run/missing')
+
+    assert.equal(response.status, 404)
+    assert.equal(await response.text(), 'Not Found: /missing')
+    assert.deepEqual(matchedRoutes, [undefined])
   })
 
   it('fetches a route with specific method actions', async () => {

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -3,7 +3,7 @@ import { type RouteMap, Route } from '@remix-run/routes'
 
 import { type AnyMiddleware, type MiddlewareContext, runMiddleware } from './middleware.ts'
 import { raceRequestAbort } from './request-abort.ts'
-import { RequestContext } from './request-context.ts'
+import { createContextKey, RequestContext } from './request-context.ts'
 import type { RequestMethod } from './request-methods.ts'
 import {
   type RequestHandler,
@@ -49,6 +49,11 @@ export interface RouteEntry {
    */
   middleware: AnyMiddleware[] | undefined
 }
+
+/**
+ * Request context key for the route matched by the router.
+ */
+export const MatchedRoute = createContextKey<RouteEntry>()
 
 type NormalizedAction = {
   handler: RequestHandler<any>
@@ -224,6 +229,7 @@ export function createRouter<
       }
 
       context.params = { ...context.params, ...match.params }
+      context.set(MatchedRoute, route)
 
       if (route.middleware) {
         return runMiddleware(route.middleware, context, route.handler)


### PR DESCRIPTION
This PR proposes a small `fetch-router` API addition that makes the matched route available from request context.

  The motivation is future telemetry and observability work. I do not necessarily expect this exact PR to be accepted as-is; the goal is mostly to suggest a simple shape and ask whether Remix is already exploring telemetry support internally.

  - Adds a `MatchedRoute` context key exported from `@remix-run/fetch-router`
  - Stores the matched `RouteEntry` on the request context once a route and method have matched
  - Makes the matched route readable from route middleware, route handlers, and router middleware after `await next()`

  One telemetry use case is enriching an active OpenTelemetry HTTP span with the low-cardinality route pattern. For example, an instrumentation layer could report `/products/:productId` instead of `/products/123`, avoiding high-cardinality span names and attributes.

  ```ts
  import { MatchedRoute } from '@remix-run/fetch-router'

  async function telemetryMiddleware(context, next) {
    let response = await next()
    let matchedRoute = context.get(MatchedRoute)

    if (matchedRoute) {
      span.setAttribute('http.route', matchedRoute.pattern.source)
      span.updateName(`${context.method} ${matchedRoute.pattern.source}`)
    }

    return response
  }
```

Is telemetry something the Remix team is already working on or planning for? If so, would exposing the matched route through request context fit that direction, or would you prefer a different extension point?