### PR TITLE
Simplify context entry helper types

### DIFF
--- a/demos/bookstore/app/middleware/asset-entry.ts
+++ b/demos/bookstore/app/middleware/asset-entry.ts
@@ -1,6 +1,5 @@
 import * as path from 'node:path'
-import { createContextKey } from 'remix/fetch-router'
-import type { ContextEntry, Middleware } from 'remix/fetch-router'
+import { createContextKey, type Middleware } from 'remix/fetch-router'
 import { getContext } from 'remix/async-context-middleware'
 
 import { assetServer } from '../utils/assets.ts'
@@ -15,12 +14,10 @@ const assetsEntryKey = createContextKey<AssetEntry>()
 const defaultScriptEntry = path.resolve(import.meta.dirname, '../assets/entry.tsx')
 const defaultStylesheetEntry = path.resolve(import.meta.dirname, '../assets/app.css')
 
-type AssetEntryContextEntry = ContextEntry<typeof assetsEntryKey, AssetEntry>
-
 export function loadAssetEntry(
   scriptEntry = defaultScriptEntry,
   stylesheetEntry = defaultStylesheetEntry,
-): Middleware<AssetEntryContextEntry> {
+): Middleware<readonly [typeof assetsEntryKey, AssetEntry]> {
   return async (context, next) => {
     let [scriptSrc, scriptPreloads, stylesheetHref] = await Promise.all([
       assetServer.getHref(scriptEntry),

--- a/demos/bookstore/app/middleware/auth.ts
+++ b/demos/bookstore/app/middleware/auth.ts
@@ -2,7 +2,7 @@ import type { Route } from 'remix/routes'
 import { createCredentialsAuthProvider } from 'remix/auth'
 import { Auth, auth, createSessionAuthScheme, type GoodAuth } from 'remix/auth-middleware'
 import { Database } from 'remix/data-table'
-import type { ContextEntry, Middleware } from 'remix/fetch-router'
+import type { Middleware } from 'remix/fetch-router'
 import { redirect } from 'remix/response/redirect'
 
 import { users } from '../data/schema.ts'
@@ -70,9 +70,9 @@ export interface RequireAuthOptions {
   redirectTo?: Route
 }
 
-type BookstoreUserContextEntry = ContextEntry<typeof Auth, GoodAuth<User>>
-
-export function requireAuth(options?: RequireAuthOptions): Middleware<BookstoreUserContextEntry> {
+export function requireAuth(
+  options?: RequireAuthOptions,
+): Middleware<readonly [typeof Auth, GoodAuth<User>]> {
   let redirectTo = options?.redirectTo ?? routes.auth.login.index
 
   return (context, next) => {

--- a/demos/bookstore/app/middleware/database.ts
+++ b/demos/bookstore/app/middleware/database.ts
@@ -1,11 +1,9 @@
-import type { ContextEntry, Middleware } from 'remix/fetch-router'
+import type { Middleware } from 'remix/fetch-router'
 import { Database } from 'remix/data-table'
 
 import { db } from '../data/setup.ts'
 
-type DatabaseContextEntry = ContextEntry<typeof Database, Database>
-
-export function loadDatabase(): Middleware<DatabaseContextEntry> {
+export function loadDatabase(): Middleware<readonly [typeof Database, Database]> {
   return async (context, next) => {
     context.set(Database, db)
     return next()

--- a/demos/social-auth/app/middleware/database.ts
+++ b/demos/social-auth/app/middleware/database.ts
@@ -1,11 +1,9 @@
-import type { ContextEntry, Middleware } from 'remix/fetch-router'
+import type { Middleware } from 'remix/fetch-router'
 import { Database } from 'remix/data-table'
 
 import { db } from '../data/setup.ts'
 
-type DatabaseContextEntry = ContextEntry<typeof Database, Database>
-
-export function loadDatabase(): Middleware<DatabaseContextEntry> {
+export function loadDatabase(): Middleware<readonly [typeof Database, Database]> {
   return async (context, next) => {
     context.set(Database, db)
     return next()

--- a/packages/async-context-middleware/README.md
+++ b/packages/async-context-middleware/README.md
@@ -47,21 +47,22 @@ This middleware requires support for `node:async_hooks`, so it is intended for N
 `getContext()` is global and out-of-band, so it reuses your fetch-router `RouterTypes.context` by default.
 
 ```ts
-import type { AnyParams, MiddlewareContext, ContextWithParams } from 'remix/fetch-router'
-import type { ContextWithRequiredAuth } from 'remix/auth-middleware'
+import { requireAuth } from 'remix/auth-middleware'
+import type { AnyParams, ContextWithParams, MiddlewareContext } from 'remix/fetch-router'
 import { loadAuth } from './middleware/auth.ts'
 import { loadSession } from './middleware/session.ts'
 
 export type RootMiddleware = [ReturnType<typeof loadSession>, ReturnType<typeof loadAuth>]
+export const authenticatedMiddleware = [requireAuth<{ id: string }>()] as const
 
 export type AppContext<params extends AnyParams = {}> = ContextWithParams<
   MiddlewareContext<RootMiddleware>,
   params
 >
 
-export type AuthenticatedAppContext<params extends AnyParams = {}> = ContextWithRequiredAuth<
-  AppContext<params>,
-  { id: string }
+export type AuthenticatedAppContext<params extends AnyParams = {}> = ContextWithParams<
+  MiddlewareContext<typeof authenticatedMiddleware, AppContext>,
+  params
 >
 
 declare module 'remix/fetch-router' {

--- a/packages/async-context-middleware/src/lib/async-context.test.ts
+++ b/packages/async-context-middleware/src/lib/async-context.test.ts
@@ -5,7 +5,7 @@ import {
   createContextKey,
   createRouter,
   type AnyParams,
-  type ContextWithValues,
+  type ContextWithEntries,
   type RequestContext,
 } from '@remix-run/fetch-router'
 import { route } from '@remix-run/routes'
@@ -14,7 +14,10 @@ import { asyncContext, getContext } from './async-context.ts'
 
 const CurrentUser = createContextKey<unknown>()
 
-type AppContext = ContextWithValues<RequestContext, [readonly [typeof CurrentUser, { id: string }]]>
+type AppContext = ContextWithEntries<
+  RequestContext,
+  [readonly [typeof CurrentUser, { id: string }]]
+>
 
 declare module '@remix-run/fetch-router' {
   interface RouterTypes {

--- a/packages/async-context-middleware/src/lib/async-context.ts
+++ b/packages/async-context-middleware/src/lib/async-context.ts
@@ -8,7 +8,7 @@ import type {
   RouterTypes,
 } from '@remix-run/fetch-router'
 
-type ContextWithAnyParams<context> =
+type RequestContextWithAnyParams<context> =
   context extends RequestContext<any, infer entries extends ContextEntries>
     ? RequestContext<AnyParams, entries>
     : RequestContext<AnyParams>
@@ -16,7 +16,7 @@ type ContextWithAnyParams<context> =
 export type AsyncRequestContext = RouterTypes extends {
   context: infer context extends RequestContext<any, any>
 }
-  ? ContextWithAnyParams<context>
+  ? RequestContextWithAnyParams<context>
   : RequestContext<AnyParams>
 
 const storage = new AsyncLocalStorage<RequestContext<any, any>>()

--- a/packages/auth-middleware/.changes/minor.context-helper-renames.md
+++ b/packages/auth-middleware/.changes/minor.context-helper-renames.md
@@ -1,9 +1,9 @@
-BREAKING CHANGE: Renamed the auth context helper types from `WithAuth` and `WithRequiredAuth` to `ContextWithAuth` and `ContextWithRequiredAuth` so auth middleware follows the `ContextWith*` naming pattern for helpers that produce refined `RequestContext` types.
+BREAKING CHANGE: Removed the `ContextWithAuth` and `ContextWithRequiredAuth` helper types. Derive auth-aware request context from the actual auth middleware tuple with `MiddlewareContext`, or use the core `ContextWithEntry` helper when manually composing context types without a middleware tuple.
 
 ```ts
-// before
-type AppAuthContext = WithRequiredAuth<AppContext, AuthIdentity>
+import { requireAuth } from 'remix/auth-middleware'
+import type { MiddlewareContext } from 'remix/fetch-router'
 
-// after
-type AppAuthContext = ContextWithRequiredAuth<AppContext, AuthIdentity>
+let protectedMiddleware = [requireAuth<AuthIdentity>()] as const
+type AppAuthContext = MiddlewareContext<typeof protectedMiddleware, AppContext>
 ```

--- a/packages/auth-middleware/src/index.ts
+++ b/packages/auth-middleware/src/index.ts
@@ -18,7 +18,5 @@ export type {
   AuthSchemeSuccess,
   GoodAuth,
   BadAuth,
-  ContextWithAuth,
-  ContextWithRequiredAuth,
 } from './lib/auth.ts'
 export type { RequireAuthOptions } from './lib/require-auth.ts'

--- a/packages/auth-middleware/src/lib/auth-types.test.ts
+++ b/packages/auth-middleware/src/lib/auth-types.test.ts
@@ -6,18 +6,10 @@ import {
   createRouter,
   type GetContextValue,
   type MiddlewareContext,
-  type RequestContext,
 } from '@remix-run/fetch-router'
 import { route } from '@remix-run/routes'
 
-import {
-  Auth,
-  auth,
-  type AuthState,
-  type ContextWithAuth,
-  type ContextWithRequiredAuth,
-  type GoodAuth,
-} from './auth.ts'
+import { Auth, auth, type AuthState, type GoodAuth } from './auth.ts'
 import { requireAuth } from './require-auth.ts'
 import { createAPIAuthScheme } from './schemes/api-key.ts'
 import { createBearerTokenAuthScheme } from './schemes/bearer.ts'
@@ -56,11 +48,12 @@ const routes = route({
 })
 
 const routerMiddleware = [typedAuth] as const
+const protectedMiddleware = [requireAuth<APIIdentity>()] as const
 
 type AppContext = MiddlewareContext<typeof routerMiddleware>
-type ProtectedAppContext = ContextWithRequiredAuth<AppContext, APIIdentity>
+type ProtectedAppContext = MiddlewareContext<typeof protectedMiddleware, AppContext>
 
-type AuthContext = ContextWithAuth<RequestContext, APIIdentity>
+type AuthContext = MiddlewareContext<[typeof typedAuth]>
 
 const router = createRouter({ middleware: routerMiddleware })
 const fallbackRouter = createRouter()
@@ -96,7 +89,7 @@ router.get(routes.public, (context) => {
 })
 
 const privateAction = createAction<typeof routes.private, ProtectedAppContext>(routes.private, {
-  middleware: [requireAuth<APIIdentity>()] as const,
+  middleware: protectedMiddleware,
   handler(context) {
     let currentAuth = context.get(Auth)
     let id: string = context.params.id
@@ -113,7 +106,7 @@ const privateAction = createAction<typeof routes.private, ProtectedAppContext>(r
 })
 
 const adminController = createController<typeof routes.admin, ProtectedAppContext>(routes.admin, {
-  middleware: [requireAuth<APIIdentity>()] as const,
+  middleware: protectedMiddleware,
   actions: {
     dashboard(context) {
       let currentAuth = context.get(Auth)
@@ -130,10 +123,11 @@ const adminController = createController<typeof routes.admin, ProtectedAppContex
 })
 
 type SessionIdentity = { kind: 'session'; id: string }
-type SessionAuthContext = ContextWithRequiredAuth<RequestContext, SessionIdentity>
+const sessionAuthMiddleware = [requireAuth<SessionIdentity>()] as const
+type SessionAuthContext = MiddlewareContext<typeof sessionAuthMiddleware>
 
 const sessionAction = createAction<'/session/:id', SessionAuthContext>('/session/:id', {
-  middleware: [requireAuth<SessionIdentity>()] as const,
+  middleware: sessionAuthMiddleware,
   handler(context) {
     let currentAuth = context.get(Auth)
     let id: string = context.params.id

--- a/packages/auth-middleware/src/lib/auth.ts
+++ b/packages/auth-middleware/src/lib/auth.ts
@@ -1,10 +1,4 @@
-import {
-  createContextKey,
-  type ContextEntry,
-  type ContextWithValues,
-  type Middleware,
-  type RequestContext,
-} from '@remix-run/fetch-router'
+import { createContextKey, type Middleware, type RequestContext } from '@remix-run/fetch-router'
 
 /**
  * Failure details for an unauthenticated request.
@@ -51,30 +45,6 @@ export type AuthState<identity = unknown> = GoodAuth<identity> | BadAuth
  * Context key used to read auth state with `context.get(Auth)`.
  */
 export const Auth = createContextKey<AuthState>()
-
-type AuthContextEntry<auth> = ContextEntry<typeof Auth, auth>
-
-/**
- * Adds the {@link Auth} context key — typed as the full {@link AuthState}
- * union — onto an existing router `RequestContext`. Use this on handlers
- * mounted under {@link auth} where the request may be either authenticated
- * ({@link GoodAuth}) or unauthenticated ({@link BadAuth}).
- */
-export type ContextWithAuth<
-  context extends RequestContext<any, any>,
-  identity = unknown,
-> = ContextWithValues<context, [AuthContextEntry<AuthState<identity>>]>
-
-/**
- * Adds the {@link Auth} context key — typed as a {@link GoodAuth} only —
- * onto an existing router `RequestContext`. Use this on handlers mounted
- * under {@link requireAuth} where the request is guaranteed to be
- * authenticated.
- */
-export type ContextWithRequiredAuth<
-  context extends RequestContext<any, any>,
-  identity = unknown,
-> = ContextWithValues<context, [AuthContextEntry<GoodAuth<identity>>]>
 
 /**
  * Successful result returned by an auth scheme.
@@ -148,7 +118,7 @@ export interface AuthOptions<schemes extends readonly AuthScheme<any>[] = AuthSc
  */
 export function auth<schemes extends readonly AuthScheme<any>[]>(
   options: AuthOptions<schemes>,
-): Middleware<AuthContextEntry<AuthForSchemes<schemes>>> {
+): Middleware<readonly [typeof Auth, AuthForSchemes<schemes>]> {
   if (options.schemes.length === 0) {
     throw new Error('auth() requires at least one authentication scheme')
   }

--- a/packages/auth-middleware/src/lib/require-auth.ts
+++ b/packages/auth-middleware/src/lib/require-auth.ts
@@ -2,7 +2,7 @@ import type {
   GetContextValue,
   Middleware,
   RequestContext,
-  ContextWithValue,
+  ContextWithEntry,
 } from '@remix-run/fetch-router'
 
 import { Auth, type BadAuth, type GoodAuth } from './auth.ts'
@@ -28,7 +28,7 @@ type ResolvedGoodAuth<context extends RequestContext<any, any>, identity> = [
 
 type RequireAuthContextTransform<identity> = <context extends RequestContext<any, any>>(
   context: context,
-) => ContextWithValue<context, typeof Auth, ResolvedGoodAuth<context, identity>>
+) => ContextWithEntry<context, readonly [typeof Auth, ResolvedGoodAuth<context, identity>]>
 
 /**
  * Options for enforcing authentication on a route.

--- a/packages/auth-middleware/src/lib/schemes/session.test.ts
+++ b/packages/auth-middleware/src/lib/schemes/session.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@remix-run/test'
 
 import { createCookie } from '@remix-run/cookie'
 import { createRouter } from '@remix-run/fetch-router'
-import type { ContextEntry, Middleware } from '@remix-run/fetch-router'
+import type { Middleware } from '@remix-run/fetch-router'
 import { createSession, Session } from '@remix-run/session'
 import { createMemorySessionStorage } from '@remix-run/session/memory-storage'
 import { session as sessionMiddleware } from '@remix-run/session-middleware'
@@ -12,8 +12,6 @@ import { auth } from '../auth.ts'
 import { requireAuth } from '../require-auth.ts'
 import { Auth } from '../auth.ts'
 import { createSessionAuthScheme } from './session.ts'
-
-type SessionContextEntry = ContextEntry<typeof Session, Session>
 
 describe('createSessionAuthScheme scheme', () => {
   it('throws when Session is not available in request context', async () => {
@@ -109,7 +107,7 @@ describe('createSessionAuthScheme scheme', () => {
 
   it('fails and invalidates when verify() returns null', async () => {
     let invalidated = false
-    let setSession: Middleware<SessionContextEntry> = (context, next) => {
+    let setSession: Middleware<readonly [typeof Session, Session]> = (context, next) => {
       let session = createSession()
       session.set('auth', { userId: 'u1' })
       context.set(Session, session)

--- a/packages/fetch-router/.changes/minor.action-route-entry-types.md
+++ b/packages/fetch-router/.changes/minor.action-route-entry-types.md
@@ -1,4 +1,4 @@
-BREAKING CHANGE: Simplified route action, controller, request handler, and middleware helper types. `Action` now accepts a route pattern, `RoutePattern`, or `Route` object as its first generic and the full request context as its optional second generic. It describes either a plain request handler function or an action object with optional inline middleware. `Controller` now accepts the route map as its first generic and the full request context as its optional second generic. `RequestHandler` now accepts the full request context as its only generic. `Middleware` now accepts one context effect generic, which can be a single `ContextEntry`, a `ContextEntries` tuple, or a context transform function. `BuildAction` is no longer exported.
+BREAKING CHANGE: Simplified route action, controller, request handler, and middleware helper types. `Action` now accepts a route pattern, `RoutePattern`, or `Route` object as its first generic and the full request context as its optional second generic. It describes either a plain request handler function or an action object with optional inline middleware. `Controller` now accepts the route map as its first generic and the full request context as its optional second generic. `RequestHandler` now accepts the full request context as its only generic. `Middleware` now accepts one context effect generic, which can be a single readonly `[key, value]` tuple, a `ContextEntries` tuple, or a context transform function. `BuildAction` is no longer exported.
 
 For most apps, augment `RouterTypes.context` once and use `createAction()`/`createController()` to type stored handlers without `satisfies` clauses:
 
@@ -39,10 +39,10 @@ let controller = createController(routes, {
 If you manually type actions or controllers in advanced multi-router code, compose the full context type first and pass it as the second generic:
 
 ```ts
-import type { Action, ContextWithMiddleware } from 'remix/fetch-router'
+import type { Action, MiddlewareContext } from 'remix/fetch-router'
 
 let accountMiddleware = [requireAuth<AuthIdentity>()] as const
-type AccountContext = ContextWithMiddleware<AppContext, typeof accountMiddleware>
+type AccountContext = MiddlewareContext<typeof accountMiddleware, AppContext>
 
 let action: Action<typeof routes.account, AccountContext> = {
   middleware: accountMiddleware,
@@ -95,13 +95,12 @@ If you manually annotate middleware, pass only the context transform type:
 let middleware: Middleware<{}, SetDatabaseContextTransform>
 
 // after
-type DatabaseContextEntry = ContextEntry<typeof Database, Database>
-let middleware: Middleware<DatabaseContextEntry>
+let middleware: Middleware<readonly [typeof Database, Database]>
 ```
 
-Simplified the public middleware context helper types. `MiddlewareContext` is now the exported helper for deriving the request context produced by a middleware chain, and it accepts an optional base context as its second type parameter. `ContextWithMiddleware` is available when code reads more naturally by naming the base context first. Middleware that provides one context value can use `ContextEntry<typeof Key, Value>` directly instead of wrapping the entry in a one-item tuple. The lower-level `MiddlewareContextTransform`, `ContextTransform`, `ApplyContextTransform`, `ApplyMiddleware`, and `ApplyMiddlewareTuple` helpers are no longer exported.
+Simplified the public middleware context helper types. `MiddlewareContext` is now the exported helper for deriving the request context produced by a middleware chain, and it accepts an optional base context as its second type parameter. Middleware that provides one context value can use a readonly `[key, value]` tuple directly instead of wrapping the entry in a one-item tuple. The lower-level `MiddlewareContextTransform`, `ContextTransform`, `ApplyContextTransform`, `ApplyMiddleware`, and `ApplyMiddlewareTuple` helpers are no longer exported.
 
-`MiddlewareContext` and `ContextWithMiddleware` accept middleware values, not middleware factory function types. Use `ReturnType<typeof factory>` when a middleware is created by a factory function:
+`MiddlewareContext` accepts middleware values, not middleware factory function types. Use `ReturnType<typeof factory>` when a middleware is created by a factory function:
 
 ```ts
 // before
@@ -124,7 +123,7 @@ type AppContext = MiddlewareContext<typeof middleware>
 type ActionContext = ApplyMiddlewareTuple<AppContext, typeof actionMiddleware>
 
 // after
-type ActionContext = ContextWithMiddleware<AppContext, typeof actionMiddleware>
+type ActionContext = MiddlewareContext<typeof actionMiddleware, AppContext>
 ```
 
 Renamed request context helper types so their names describe the `RequestContext` type they produce. Use `ContextWithParams` when deriving an app context that includes route params:
@@ -143,32 +142,27 @@ type AppContext<params extends AnyParams = {}> = ContextWithParams<
 >
 ```
 
-Use `ContextWithValues` when a middleware package provides one or more context values. Third-party middleware packages that augment request context should prefer exported helper names like `ContextWithCurrentUser` so their package-specific helpers match the built-in `ContextWith...` naming pattern:
+Use `ContextWithEntries` when manually composing one or more context entries without a middleware tuple:
 
 ```ts
 // before
-export type WithCurrentUser<context extends RequestContext<any, any>> = MergeContext<
-  context,
-  [readonly [typeof CurrentUser, User | null]]
->
+type CurrentUserContext = MergeContext<AppContext, [readonly [typeof CurrentUser, User | null]]>
 
 // after
-type CurrentUserContextEntry = ContextEntry<typeof CurrentUser, User | null>
-
-export type ContextWithCurrentUser<context extends RequestContext<any, any>> = ContextWithValues<
-  context,
-  [CurrentUserContextEntry]
+type CurrentUserContext = ContextWithEntries<
+  AppContext,
+  [readonly [typeof CurrentUser, User | null]]
 >
 ```
 
-Use `ContextWithValue` when refining a single context value for a specific handler or middleware result:
+Use `ContextWithEntry` when refining a single context entry for a specific handler or middleware result:
 
 ```ts
 // before
 type AdminContext = SetContextValue<AppContext, typeof CurrentRole, 'admin'>
 
 // after
-type AdminContext = ContextWithValue<AppContext, typeof CurrentRole, 'admin'>
+type AdminContext = ContextWithEntry<AppContext, readonly [typeof CurrentRole, 'admin']>
 ```
 
 Stored action objects and controllers no longer derive handler context from their local middleware tuple. If local middleware adds context values that a handler requires, compose the full handler context explicitly and pass it to `Action`, `Controller`, `createAction()`, or `createController()`:
@@ -187,7 +181,7 @@ let controller = createController(routes, {
 
 // after
 let accountMiddleware = [requireAuth<AuthIdentity>()] as const
-type AuthenticatedAppContext = ContextWithMiddleware<AppContext, typeof accountMiddleware>
+type AuthenticatedAppContext = MiddlewareContext<typeof accountMiddleware, AppContext>
 
 let controller = createController<typeof routes, AuthenticatedAppContext>(routes, {
   middleware: accountMiddleware,

--- a/packages/fetch-router/README.md
+++ b/packages/fetch-router/README.md
@@ -635,7 +635,6 @@ import {
   createController,
   type AnyParams,
   type ContextWithParams,
-  type ContextWithMiddleware,
   type MiddlewareContext,
 } from 'remix/fetch-router'
 import { route } from 'remix/routes'
@@ -661,7 +660,7 @@ declare module 'remix/fetch-router' {
 }
 
 let accountMiddleware = [requireAuth<AuthIdentity>()] as const
-type AccountContext = ContextWithMiddleware<AppContext, typeof accountMiddleware>
+type AccountContext = MiddlewareContext<typeof accountMiddleware, AppContext>
 
 let accountAction = createAction<typeof routes.account, AccountContext>(routes.account, {
   middleware: accountMiddleware,
@@ -695,38 +694,26 @@ When manually annotating stored handlers, use `Action<typeof route, Context>` fo
 If you're authoring a middleware package that stores values in request context, treat that context contract as part of the package API. A good provider should usually export:
 
 - the context key consumers read with `context.get(...)`
-- the middleware that populates that key at runtime
-- one or more `ContextWith...` helper types that let applications describe the resulting request context without touching raw context entries directly
+- the middleware that populates that key at runtime, with a `Middleware` context transform that describes the value it provides
 
-Prefer `ContextWith...` names for third-party middleware packages that augment request context. This matches the built-in `ContextWithParams`, `ContextWithValues`, and `ContextWithValue` helpers and makes it clear that the type produces a new `RequestContext` type with additional context available.
+Apps can derive request context from the middleware tuple with `MiddlewareContext`. If they need to describe a context shape without a middleware tuple, they can use the core `ContextWithEntry` and `ContextWithEntries` helpers directly.
 
 ```ts
-import {
-  createContextKey,
-  type ContextEntry,
-  type ContextWithValues,
-  type Middleware,
-  type RequestContext,
-} from 'remix/fetch-router'
+import { createContextKey, type Middleware, type MiddlewareContext } from 'remix/fetch-router'
 
 // The context key that consumers will need to read from `context.get(...)`
 export const CurrentUser = createContextKey<User | null>()
 
 // The context effect carried by middleware that sets one context value
-type CurrentUserContextEntry = ContextEntry<typeof CurrentUser, User | null>
-
-export function loadCurrentUser(): Middleware<CurrentUserContextEntry> {
+export function loadCurrentUser(): Middleware<readonly [typeof CurrentUser, User | null]> {
   return async (context, next) => {
     context.set(CurrentUser, await getCurrentUser(context.request))
     return next()
   }
 }
 
-// One or more ContextWith* helper types that apps can use to describe the request context
-export type ContextWithCurrentUser<context extends RequestContext<any, any>> = ContextWithValues<
-  context,
-  [CurrentUserContextEntry]
->
+let middleware = [loadCurrentUser()] as const
+type AppContext = MiddlewareContext<typeof middleware>
 ```
 
 ### Additional Topics

--- a/packages/fetch-router/src/index.ts
+++ b/packages/fetch-router/src/index.ts
@@ -5,9 +5,8 @@ export type {
   ContextValue,
   GetContextValue,
   ContextEntries,
-  ContextEntry,
-  ContextWithValues,
-  ContextWithValue,
+  ContextWithEntries,
+  ContextWithEntry,
   ContextWithParams,
 } from './lib/request-context.ts'
 
@@ -16,12 +15,7 @@ export type { RouterTypes } from './lib/router-types.ts'
 export { createAction, createController } from './lib/controller.ts'
 export type { RequestHandler, Action, Controller } from './lib/controller.ts'
 
-export type {
-  ContextWithMiddleware,
-  Middleware,
-  MiddlewareContext,
-  NextFunction,
-} from './lib/middleware.ts'
+export type { Middleware, MiddlewareContext, NextFunction } from './lib/middleware.ts'
 
 export { RequestMethods, isRequestMethod } from './lib/request-methods.ts'
 export type { RequestMethod } from './lib/request-methods.ts'

--- a/packages/fetch-router/src/lib/middleware.ts
+++ b/packages/fetch-router/src/lib/middleware.ts
@@ -2,8 +2,8 @@ import type { RequestHandler } from './controller.ts'
 import { raceRequestAbort } from './request-abort.ts'
 import type {
   ContextEntries,
-  ContextEntry,
-  ContextWithValues,
+  ContextWithEntries,
+  ContextWithEntry,
   RequestContext,
 } from './request-context.ts'
 
@@ -13,7 +13,7 @@ import type {
 export type AnyMiddleware = Middleware<ContextTransform>
 
 type ContextTransform =
-  | ContextEntry
+  | readonly [object, unknown]
   | ContextEntries
   | (<context extends RequestContext<any, any>>(context: context) => RequestContext<any, any>)
 
@@ -28,9 +28,9 @@ type ContextWithTransform<
   context extends RequestContext<any, any>,
   transform,
 > = transform extends ContextEntries
-  ? ContextWithValues<context, transform>
-  : transform extends ContextEntry
-    ? ContextWithValues<context, [transform]>
+  ? ContextWithEntries<context, transform>
+  : transform extends readonly [object, unknown]
+    ? ContextWithEntry<context, transform>
     : transform extends {
           <inputContext extends context>(context: inputContext): infer output
         }
@@ -55,17 +55,6 @@ export type MiddlewareContext<
     : context
 
 /**
- * Resolves the request-context type produced by applying middleware to an existing context.
- *
- * This is useful for router helpers and third-party libraries that need to describe the context
- * available after a known tuple of middleware runs.
- */
-export type ContextWithMiddleware<
-  context extends RequestContext<any, any>,
-  middleware extends readonly AnyMiddleware[],
-> = MiddlewareContext<middleware, context>
-
-/**
  * A special kind of request handler that either returns a response or passes control
  * to the next middleware or request handler in the chain.
  *
@@ -73,8 +62,9 @@ export type ContextWithMiddleware<
  * @param next A function that invokes the next middleware or request handler in the chain
  * @returns A response to short-circuit the chain, or `undefined`/`void` to continue
  *
- * The generic describes the context effect this middleware has. Use a {@link ContextEntry}
- * for middleware that provides one context value, or {@link ContextEntries} for multiple values.
+ * The generic describes the context effect this middleware has. Use a readonly `[key, value]`
+ * tuple for middleware that provides one context value, or {@link ContextEntries} for multiple
+ * values.
  */
 export interface Middleware<transform extends ContextTransform = EmptyContextTransform> {
   /**

--- a/packages/fetch-router/src/lib/request-context.ts
+++ b/packages/fetch-router/src/lib/request-context.ts
@@ -32,14 +32,9 @@ export interface ContextKey<value> {
 export type AnyParams = Record<string, string>
 
 /**
- * A single request-context entry that associates a context key with its stored value type.
- */
-export type ContextEntry<key extends object = object, value = unknown> = readonly [key, value]
-
-/**
  * An ordered list of request-context entries. Later entries override earlier ones for the same key.
  */
-export type ContextEntries = readonly ContextEntry[]
+export type ContextEntries = readonly (readonly [object, unknown])[]
 
 /**
  * Resolves the value type associated with a request-context key.
@@ -88,16 +83,19 @@ export type ContextWithParams<context, params extends Record<string, any>> =
       : never
     : RequestContext<params>
 
-type ResolveContextEntryValue<
+type ResolveEntryValue<
   entries extends ContextEntries,
   key extends object,
   fallback,
-> = entries extends readonly [...infer rest extends ContextEntries, infer last extends ContextEntry]
+> = entries extends readonly [
+  ...infer rest extends ContextEntries,
+  infer last extends readonly [object, unknown],
+]
   ? [key] extends [last[0]]
     ? [last[0]] extends [key]
       ? last[1]
-      : ResolveContextEntryValue<rest, key, fallback>
-    : ResolveContextEntryValue<rest, key, fallback>
+      : ResolveEntryValue<rest, key, fallback>
+    : ResolveEntryValue<rest, key, fallback>
   : fallback
 
 /**
@@ -105,16 +103,14 @@ type ResolveContextEntryValue<
  */
 export type GetContextValue<context, key extends object> =
   context extends RequestContext<any, infer entries extends ContextEntries>
-    ? ResolveContextEntryValue<entries, key, ContextFallbackValue<key>>
+    ? ResolveEntryValue<entries, key, ContextFallbackValue<key>>
     : ContextFallbackValue<key>
 
 /**
- * Appends context values to an existing {@link RequestContext}.
- *
- * Third-party middleware packages that add multiple values should expose their own
- * `ContextWith*` helper built on this type.
+ * Appends context entries to an existing {@link RequestContext}.
+ * This is useful when deriving a context shape without a middleware tuple.
  */
-export type ContextWithValues<context, additions extends ContextEntries> =
+export type ContextWithEntries<context, additions extends ContextEntries> =
   context extends RequestContext<
     infer params extends Record<string, any>,
     infer entries extends ContextEntries
@@ -123,15 +119,13 @@ export type ContextWithValues<context, additions extends ContextEntries> =
     : never
 
 /**
- * Replaces or adds the value type for a single context key in a {@link RequestContext}.
- *
- * Third-party middleware packages that add one value should expose their own
- * `ContextWith*` helper built on this type.
+ * Replaces or adds the value type for a single context entry in a {@link RequestContext}.
+ * This is useful when deriving a context shape without a middleware tuple.
  */
-export type ContextWithValue<context, key extends object, value> = ContextWithValues<
+export type ContextWithEntry<
   context,
-  [readonly [key, value]]
->
+  entry extends readonly [object, unknown],
+> = ContextWithEntries<context, [entry]>
 
 /**
  * A context object that contains information about the current request. Every request

--- a/packages/fetch-router/src/lib/router-types.test.ts
+++ b/packages/fetch-router/src/lib/router-types.test.ts
@@ -3,8 +3,8 @@ import { describe, it } from '@remix-run/test'
 import { createRoutes as route } from '@remix-run/routes'
 
 import { createAction, createController, type Action, type Controller } from './controller.ts'
-import type { ContextWithMiddleware, Middleware, MiddlewareContext } from './middleware.ts'
-import { createContextKey, type ContextEntry, type ContextWithValue } from './request-context.ts'
+import type { Middleware, MiddlewareContext } from './middleware.ts'
+import { createContextKey, type ContextWithEntry } from './request-context.ts'
 import { createRouter } from './router.ts'
 import type { IsEqual } from './type-utils.ts'
 
@@ -13,20 +13,16 @@ function expectTypeEquality<_check extends true>() {}
 const CurrentUser = createContextKey<{ id: string } | null>(null)
 const CurrentRole = createContextKey<'viewer' | 'admin' | null>(null)
 
-type CurrentUserContextEntry = ContextEntry<typeof CurrentUser, { id: string }>
-
-type RoleContextEntry<role extends 'viewer' | 'admin'> = ContextEntry<typeof CurrentRole, role>
-
-type FormDataContextEntry = ContextEntry<typeof FormData, FormData>
-
-function requireUser(): Middleware<CurrentUserContextEntry> {
+function requireUser(): Middleware<readonly [typeof CurrentUser, { id: string }]> {
   return async (context, next) => {
     context.set(CurrentUser, { id: 'user-1' })
     return next()
   }
 }
 
-function setRole<role extends 'viewer' | 'admin'>(role: role): Middleware<RoleContextEntry<role>> {
+function setRole<role extends 'viewer' | 'admin'>(
+  role: role,
+): Middleware<readonly [typeof CurrentRole, role]> {
   return async (context, next) => {
     context.set(CurrentRole, role)
     return next()
@@ -37,7 +33,7 @@ function loadAdminRole() {
   return setRole('admin')
 }
 
-function setFormData(): Middleware<FormDataContextEntry> {
+function setFormData(): Middleware<readonly [typeof FormData, FormData]> {
   return async (context, next) => {
     context.set(FormData, new FormData())
     return next()
@@ -62,10 +58,10 @@ declare module './router-types.ts' {
   }
 }
 
-type AdminAppContext = ContextWithValue<AppContext, typeof CurrentRole, 'admin'>
+type AdminAppContext = ContextWithEntry<AppContext, readonly [typeof CurrentRole, 'admin']>
 
 const elevatedReportMiddleware = [setRole('admin')] as const
-type ElevatedAppContext = ContextWithMiddleware<AppContext, typeof elevatedReportMiddleware>
+type ElevatedAppContext = MiddlewareContext<typeof elevatedReportMiddleware, AppContext>
 
 describe('router type inference', () => {
   it('keeps context values optional when middleware has not provided them', async () => {

--- a/packages/form-data-middleware/src/lib/form-data.ts
+++ b/packages/form-data-middleware/src/lib/form-data.ts
@@ -8,9 +8,7 @@ import {
   type FileUploadHandler,
   type ParseFormDataOptions,
 } from '@remix-run/form-data-parser'
-import type { ContextEntry, Middleware } from '@remix-run/fetch-router'
-
-type FormDataContextEntry = ContextEntry<typeof FormData, FormData>
+import type { Middleware } from '@remix-run/fetch-router'
 
 function isMultipartLimitError(error: unknown): boolean {
   return (
@@ -47,7 +45,9 @@ export interface FormDataOptions extends ParseFormDataOptions {
  * @param options Options for parsing form data
  * @returns A middleware function that parses form data
  */
-export function formData(options?: FormDataOptions): Middleware<FormDataContextEntry> {
+export function formData(
+  options?: FormDataOptions,
+): Middleware<readonly [typeof FormData, FormData]> {
   let suppressErrors = options?.suppressErrors ?? false
   let uploadHandler = options?.uploadHandler
 

--- a/packages/remix/.changes/major.auth-middleware-context-helper-renames.md
+++ b/packages/remix/.changes/major.auth-middleware-context-helper-renames.md
@@ -1,9 +1,9 @@
-BREAKING CHANGE: Renamed the `remix/auth-middleware` auth context helper types from `WithAuth` and `WithRequiredAuth` to `ContextWithAuth` and `ContextWithRequiredAuth` so middleware packages consistently use the `ContextWith*` naming pattern for helpers that produce refined `RequestContext` types.
+BREAKING CHANGE: Removed the `ContextWithAuth` and `ContextWithRequiredAuth` helper types from `remix/auth-middleware`. Derive auth-aware request context from the actual auth middleware tuple with `MiddlewareContext`, or use the core `ContextWithEntry` helper from `remix/fetch-router` when manually composing context types without a middleware tuple.
 
 ```ts
-// before
-type AppAuthContext = WithRequiredAuth<AppContext, AuthIdentity>
+import { requireAuth } from 'remix/auth-middleware'
+import type { MiddlewareContext } from 'remix/fetch-router'
 
-// after
-type AppAuthContext = ContextWithRequiredAuth<AppContext, AuthIdentity>
+let protectedMiddleware = [requireAuth<AuthIdentity>()] as const
+type AppAuthContext = MiddlewareContext<typeof protectedMiddleware, AppContext>
 ```

--- a/packages/remix/.changes/major.fetch-router-action-types.md
+++ b/packages/remix/.changes/major.fetch-router-action-types.md
@@ -1,8 +1,8 @@
-BREAKING CHANGE: Updated the re-exported `remix/fetch-router` helper types to match `@remix-run/fetch-router`: `Action` now describes either a plain request handler function or action object and accepts the full request context as its optional second generic, `Controller` now accepts the full request context as its optional second generic, `RequestHandler` now accepts the full request context as its only generic, `Middleware` now accepts one context effect generic, which can be a single `ContextEntry`, a `ContextEntries` tuple, or a context transform function, `BuildAction` is no longer exported, `createAction()`/`createController()` are the preferred helpers for stored handlers, `RouterTypes.context` configures the default builder context, `MiddlewareContext` now accepts an optional base context, `ContextWithMiddleware` applies middleware to an existing context, the lower-level `MiddlewareContextTransform`, `ContextTransform`, `ApplyContextTransform`, `ApplyMiddleware`, and `ApplyMiddlewareTuple` helpers are no longer exported, and custom matcher payloads should use `RouteEntry` instead of `MatchData`.
+BREAKING CHANGE: Updated the re-exported `remix/fetch-router` helper types to match `@remix-run/fetch-router`: `Action` now describes either a plain request handler function or action object and accepts the full request context as its optional second generic, `Controller` now accepts the full request context as its optional second generic, `RequestHandler` now accepts the full request context as its only generic, `Middleware` now accepts one context effect generic, which can be a single readonly `[key, value]` tuple, a `ContextEntries` tuple, or a context transform function, `BuildAction` is no longer exported, `createAction()`/`createController()` are the preferred helpers for stored handlers, `RouterTypes.context` configures the default builder context, `MiddlewareContext` now accepts an optional base context, the lower-level `MiddlewareContextTransform`, `ContextTransform`, `ApplyContextTransform`, `ApplyMiddleware`, and `ApplyMiddlewareTuple` helpers are no longer exported, and custom matcher payloads should use `RouteEntry` instead of `MatchData`.
 
 The request context helper type renames also apply to imports from `remix/fetch-router`.
 
-`MiddlewareContext` and `ContextWithMiddleware` accept middleware values, not middleware factory function types. Use `ReturnType<typeof factory>` when a middleware is created by a factory function:
+`MiddlewareContext` accepts middleware values, not middleware factory function types. Use `ReturnType<typeof factory>` when a middleware is created by a factory function:
 
 ```ts
 // before
@@ -28,21 +28,16 @@ type AppContext<params extends AnyParams = {}> = ContextWithParams<
 >
 ```
 
-Use `ContextWithValues` when a middleware package provides one or more context values:
+Use `ContextWithEntries` when manually composing one or more context entries without a middleware tuple:
 
 ```ts
 // before
-export type WithCurrentUser<context extends RequestContext<any, any>> = MergeContext<
-  context,
-  [readonly [typeof CurrentUser, User | null]]
->
+type CurrentUserContext = MergeContext<AppContext, [readonly [typeof CurrentUser, User | null]]>
 
 // after
-type CurrentUserContextEntry = ContextEntry<typeof CurrentUser, User | null>
-
-export type ContextWithCurrentUser<context extends RequestContext<any, any>> = ContextWithValues<
-  context,
-  [CurrentUserContextEntry]
+type CurrentUserContext = ContextWithEntries<
+  AppContext,
+  [readonly [typeof CurrentUser, User | null]]
 >
 ```
 
@@ -78,25 +73,27 @@ If you manually annotate middleware, pass only the context transform type:
 let middleware: Middleware<{}, SetDatabaseContextTransform>
 
 // after
-type DatabaseContextEntry = ContextEntry<typeof Database, Database>
-let middleware: Middleware<DatabaseContextEntry>
+let middleware: Middleware<readonly [typeof Database, Database]>
 ```
 
-Use `ContextWithValue` when refining a single context value for a specific handler or middleware result:
+Use `ContextWithEntry` when refining a single context entry for a specific handler or middleware result:
 
 ```ts
 // before
 type AdminContext = SetContextValue<AppContext, typeof CurrentRole, 'admin'>
 
 // after
-type AdminContext = ContextWithValue<AppContext, typeof CurrentRole, 'admin'>
+type AdminContext = ContextWithEntry<AppContext, readonly [typeof CurrentRole, 'admin']>
 ```
 
 For most apps, augment `RouterTypes.context` once and use `createController()` instead of repeating a `satisfies Controller<...>` clause on every controller:
 
 ```ts
 // before
-type AuthenticatedAppContext = WithRequiredAuth<AppContext, AuthIdentity>
+type AuthenticatedAppContext = ContextWithEntry<
+  AppContext,
+  readonly [typeof Auth, GoodAuth<AuthIdentity>]
+>
 
 let controller = {
   middleware: [requireAuth<AuthIdentity>()],

--- a/packages/remix/.changes/major.render-middleware-remove-context-helper.md
+++ b/packages/remix/.changes/major.render-middleware-remove-context-helper.md
@@ -1,0 +1,9 @@
+BREAKING CHANGE: Removed the `ContextWithRenderer` helper type from `remix/render-middleware`. Derive renderer-aware request context from the `renderWith()` middleware tuple with `MiddlewareContext`, or use the core `ContextWithEntry` helper from `remix/fetch-router` when manually composing context types without a middleware tuple.
+
+```ts
+import { renderWith } from 'remix/render-middleware'
+import type { MiddlewareContext } from 'remix/fetch-router'
+
+let render = renderWith(() => (value: string) => new Response(value))
+type AppContext = MiddlewareContext<[typeof render]>
+```

--- a/packages/render-middleware/.changes/minor.initial-release.md
+++ b/packages/render-middleware/.changes/minor.initial-release.md
@@ -1,1 +1,1 @@
-Initial release of `@remix-run/render-middleware`, which provides the `Renderer` context key, `Renderer` type, `ContextWithRenderer` helper, and `renderWith()` middleware for adding request-scoped renderers to `fetch-router` request context.
+Initial release of `@remix-run/render-middleware`, which provides the `Renderer` context key, `Renderer` type, and `renderWith()` middleware for adding request-scoped renderers to `fetch-router` request context.

--- a/packages/render-middleware/src/index.ts
+++ b/packages/render-middleware/src/index.ts
@@ -1,2 +1,2 @@
 export { Renderer, renderWith } from './lib/render.ts'
-export type { AnyRenderer, ContextWithRenderer } from './lib/render.ts'
+export type { AnyRenderer } from './lib/render.ts'

--- a/packages/render-middleware/src/lib/render.test.ts
+++ b/packages/render-middleware/src/lib/render.test.ts
@@ -1,15 +1,9 @@
 import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
-import { createRouter, type MiddlewareContext, type RequestContext } from '@remix-run/fetch-router'
+import { createRouter, type MiddlewareContext } from '@remix-run/fetch-router'
 
-import {
-  Renderer,
-  renderWith,
-  type AnyRenderer,
-  type ContextWithRenderer,
-  type Renderer as RendererType,
-} from '../index.ts'
+import { Renderer, renderWith, type AnyRenderer, type Renderer as RendererType } from '../index.ts'
 
 type IsEqual<left, right> =
   (<type>() => type extends left ? 1 : 2) extends <type>() => type extends right ? 1 : 2
@@ -87,14 +81,19 @@ describe('renderWith', () => {
     assert.equal(await response.text(), '{\n  "ok": true\n}')
   })
 
-  it('exports context helpers for explicit context composition', () => {
-    type JsonRenderer = (value: { ok: boolean }) => Response
-    type JsonContext = ContextWithRenderer<RequestContext, JsonRenderer>
+  it('derives renderer context from middleware', () => {
+    let json = renderWith(
+      () =>
+        function render(value: { ok: boolean }) {
+          return Response.json(value)
+        },
+    )
+    type JsonContext = MiddlewareContext<[typeof json]>
 
     function assertContext(context: JsonContext) {
       let renderer = context.get(Renderer)
 
-      expectTypeEquality<IsEqual<typeof renderer, JsonRenderer>>()
+      expectTypeEquality<IsEqual<typeof renderer, (value: { ok: boolean }) => Response>>()
 
       renderer({ ok: true })
 

--- a/packages/render-middleware/src/lib/render.ts
+++ b/packages/render-middleware/src/lib/render.ts
@@ -1,10 +1,4 @@
-import {
-  createContextKey,
-  type ContextEntry,
-  type ContextWithValue,
-  type Middleware,
-  type RequestContext,
-} from '@remix-run/fetch-router'
+import { createContextKey, type Middleware, type RequestContext } from '@remix-run/fetch-router'
 
 /**
  * A function that converts application data into a `Response`.
@@ -30,14 +24,6 @@ export type AnyRenderer = Renderer<never, never>
  */
 export const Renderer = createContextKey<AnyRenderer>()
 
-/**
- * Adds a renderer to an existing request context type.
- */
-export type ContextWithRenderer<
-  context extends RequestContext<any, any>,
-  renderer extends AnyRenderer,
-> = ContextWithValue<context, typeof Renderer, renderer>
-
 type RendererFactory<renderer extends AnyRenderer> = (context: RequestContext<any, any>) => renderer
 
 /**
@@ -48,7 +34,7 @@ type RendererFactory<renderer extends AnyRenderer> = (context: RequestContext<an
  */
 export function renderWith<const renderer extends AnyRenderer>(
   createRenderer: RendererFactory<renderer>,
-): Middleware<ContextEntry<typeof Renderer, renderer>> {
+): Middleware<readonly [typeof Renderer, renderer]> {
   return (context) => {
     context.set(Renderer, createRenderer(context))
   }

--- a/packages/session-middleware/src/lib/session.ts
+++ b/packages/session-middleware/src/lib/session.ts
@@ -1,8 +1,6 @@
 import type { Cookie } from '@remix-run/cookie'
-import type { ContextEntry, Middleware } from '@remix-run/fetch-router'
+import type { Middleware } from '@remix-run/fetch-router'
 import { Session, type SessionStorage } from '@remix-run/session'
-
-type SessionContextEntry = ContextEntry<typeof Session, Session>
 
 /**
  * Middleware that manages request session state on request context.
@@ -14,7 +12,7 @@ type SessionContextEntry = ContextEntry<typeof Session, Session>
 export function session(
   sessionCookie: Cookie,
   sessionStorage: SessionStorage,
-): Middleware<SessionContextEntry> {
+): Middleware<readonly [typeof Session, Session]> {
   if (!sessionCookie.signed) {
     throw new Error('Session cookie must be signed')
   }


### PR DESCRIPTION
This simplifies request-context type composition around the tuple shape middleware already uses for context effects.

- Renames `ContextWithValue` to `ContextWithEntry` and `ContextWithValues` to `ContextWithEntries`
- Removes the exported `ContextEntry` alias in favor of direct readonly `[key, value]` tuples
- Uses `MiddlewareContext<middleware, baseContext>` directly for middleware-chain composition instead of a second helper alias
- Removes middleware-package-specific `ContextWith*` aliases from auth and render middleware, keeping `MiddlewareContext` as the preferred derivation path
- Updates README guidance, demos, type tests, and unpublished change files to steer apps toward middleware-derived context types

```ts
// before
type AdminContext = ContextWithValue<AppContext, typeof CurrentRole, 'admin'>

// after
type AdminContext = ContextWithEntry<
  AppContext,
  readonly [typeof CurrentRole, 'admin']
>
```

```ts
const protectedMiddleware = [requireAuth<AuthIdentity>()] as const

type ProtectedContext = MiddlewareContext<typeof protectedMiddleware, AppContext>
```
