### PR TITLE
fix: add fallback if import.meta.resolve is not present in `getResolvedInjectedPackage`

### DIFF
--- a/packages/assets/.changes/patch.asset-server-import-meta-resolve-fallback.md
+++ b/packages/assets/.changes/patch.asset-server-import-meta-resolve-fallback.md
@@ -1,0 +1,1 @@
+Ensure injected package resolution works when `import.meta.resolve` is unavailable by falling back to a `createRequire`-based resolver, so asset server initialization succeeds in CJS or hybrid runtimes (including Electron).

--- a/packages/assets/src/lib/injected-packages.test.ts
+++ b/packages/assets/src/lib/injected-packages.test.ts
@@ -1,0 +1,25 @@
+import * as fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import * as assert from '@remix-run/assert'
+import { describe, it } from '@remix-run/test'
+
+import { resolveInjectedPackageJsonUrl } from './injected-packages.ts'
+
+describe('resolveInjectedPackageJsonUrl', () => {
+  it('uses an explicit resolver when provided', () => {
+    let expectedUrl = 'file:///tmp/example/package.json'
+    let resolved = resolveInjectedPackageJsonUrl('@oxc-project/runtime', () => expectedUrl)
+
+    assert.equal(resolved, expectedUrl)
+  })
+
+  it('falls back to createRequire when import.meta.resolve is unavailable', () => {
+    let resolved = resolveInjectedPackageJsonUrl('@oxc-project/runtime', undefined)
+    let resolvedPath = fileURLToPath(resolved)
+
+    assert.ok(resolved.startsWith('file:'))
+    assert.ok(resolvedPath.endsWith('package.json'))
+    assert.ok(fs.existsSync(resolvedPath))
+  })
+})

--- a/packages/assets/src/lib/injected-packages.ts
+++ b/packages/assets/src/lib/injected-packages.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs'
-import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import { getFilePathDirectory, normalizeFilePath } from './paths.ts'
 
@@ -90,7 +91,7 @@ function getResolvedInjectedPackage(packageName: string): ResolvedInjectedPackag
   let existing = resolvedInjectedPackages.get(packageName)
   if (existing) return existing
 
-  let packageJsonUrl = import.meta.resolve(`${packageName}/package.json`)
+  let packageJsonUrl = resolveInjectedPackageJsonUrl(packageName)
   let packageJsonPath = normalizeFilePath(fs.realpathSync(fileURLToPath(packageJsonUrl)))
 
   let resolvedInjectedPackage = {
@@ -100,6 +101,18 @@ function getResolvedInjectedPackage(packageName: string): ResolvedInjectedPackag
 
   resolvedInjectedPackages.set(packageName, resolvedInjectedPackage)
   return resolvedInjectedPackage
+}
+
+export function resolveInjectedPackageJsonUrl(
+  packageName: string,
+  resolve: ((specifier: string) => string) | undefined = import.meta.resolve,
+): string {
+  if (typeof resolve === 'function') {
+    return resolve(`${packageName}/package.json`)
+  }
+
+  let require = createRequire(import.meta.url)
+  return pathToFileURL(require.resolve(`${packageName}/package.json`)).href
 }
 
 function getInjectedPackageRoutePattern(packageName: string): string {


### PR DESCRIPTION
### Summary
When a Remix Electron app boots (e.g. `electron` + `tsx`), `import.meta.resolve` is undefined in Electron’s Node runtime. Remix assets’ injected package resolution assumes it exists, so the asset server throws before it can initialize.
### Reproduction
Repo: https://github.com/WEEFAA/remix-run-with-electron
Steps:
1. Clone the repo and install deps.
2. Start the Electron app.
```
npm i
npm run seed
npm run dev
```
3. Observe startup failure before the asset server initializes.
Minimal snippet (CJS boot path):
```ts
// electron-main.ts (booted via tsx in Electron)
import { createAssetServer } from '@remix-run/assets'
let assetServer = createAssetServer({
  basePath: '/assets',
  fileMap: { '/app/*path': 'app/*path' },
  allow: ['app/**'],
})

// Somewhere in the stack, injected package resolution calls import.meta.resolve

Expected behavior
Asset server initializes successfully even when import.meta.resolve is unavailable.

Actual behavior
Electron runtime throws because import.meta.resolve is undefined.
```

```
App threw an error during load
TypeError: import_meta.resolve is not a function
```

### Test
```
pnpm --filter @remix-run/assets run test
pnpm run test
```