### PR TITLE
Generate package subpath overview docs

### DIFF
--- a/docs/src/generate/packages.ts
+++ b/docs/src/generate/packages.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
+import * as s from 'remix/data-schema'
 import { info, invariant, warn } from './utils.ts'
 
 type PackageOverview = {
@@ -7,6 +8,13 @@ type PackageOverview = {
   packageDir: string
   readmePath?: string
 }
+
+const PackageJsonSchema = s.object({
+  name: s.string(),
+  exports: s.optional(s.record(s.string(), s.any())),
+})
+
+type PackageJson = s.InferOutput<typeof PackageJsonSchema>
 
 const PACKAGES_DIR = path.resolve('..', 'packages')
 const JAVASCRIPT_CODE_FENCE_LANGUAGES = new Set(['js', 'jsx', 'ts', 'tsx'])
@@ -23,7 +31,8 @@ export async function discoverPackageOverviews(): Promise<PackageOverview[]> {
     let packageJsonPath = path.join(packageDir, 'package.json')
 
     try {
-      let packageName = await readPackageName(packageJsonPath)
+      let packageJson = await readPackageJson(packageJsonPath)
+      let packageName = packageJson.name
 
       let readmePath = path.join(packageDir, 'README.md')
       let hasReadme = await isFile(readmePath)
@@ -40,6 +49,9 @@ export async function discoverPackageOverviews(): Promise<PackageOverview[]> {
         overview.readmePath = readmePath
       }
       overviews.push(overview)
+
+      let subpathOverviews = await discoverPackageSubpathOverviews(packageDir, packageJson)
+      overviews.push(...subpathOverviews)
     } catch (error) {
       if (!isErrnoException(error) || error.code !== 'ENOENT') {
         throw error
@@ -48,6 +60,33 @@ export async function discoverPackageOverviews(): Promise<PackageOverview[]> {
   }
 
   return overviews.sort((a, b) => a.docsPackage.localeCompare(b.docsPackage))
+}
+
+async function discoverPackageSubpathOverviews(
+  packageDir: string,
+  packageJson: PackageJson,
+): Promise<PackageOverview[]> {
+  let exports = packageJson.exports
+  if (!exports) return []
+
+  let overviews: PackageOverview[] = []
+  for (let [exportPath, exportConfig] of Object.entries(exports)) {
+    if (!exportPath.startsWith('./') || exportPath === './package.json') continue
+
+    let entryPath = getExportEntryPath(exportConfig)
+    if (!entryPath) continue
+
+    let readmePath = path.join(packageDir, path.dirname(entryPath), 'README.md')
+    if (!(await isFile(readmePath))) continue
+
+    overviews.push({
+      docsPackage: `${getDocsPackageName(packageJson.name)}/${exportPath.slice(2)}`,
+      packageDir,
+      readmePath,
+    })
+  }
+
+  return overviews
 }
 
 export async function writePackageOverviewFiles(overviews: PackageOverview[], docsDir: string) {
@@ -70,14 +109,27 @@ export async function writePackageOverviewFiles(overviews: PackageOverview[], do
   }
 }
 
-async function readPackageName(packageJsonPath: string): Promise<string> {
+async function readPackageJson(packageJsonPath: string): Promise<PackageJson> {
   let packageJson: unknown = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'))
-  invariant(
-    packageJson !== null && typeof packageJson === 'object' && 'name' in packageJson,
-    `Missing package name: ${packageJsonPath}`,
-  )
-  invariant(typeof packageJson.name === 'string', `Invalid package name: ${packageJsonPath}`)
-  return packageJson.name
+  let result = s.parseSafe(PackageJsonSchema, packageJson)
+  invariant(result.success, `Invalid package.json: ${packageJsonPath}`)
+  return result.value
+}
+
+const ExportConfigSchema = s.union([
+  s.string(),
+  s.object({
+    default: s.optional(s.string()),
+    types: s.optional(s.string()),
+  }),
+])
+
+function getExportEntryPath(exportConfig: unknown): string | undefined {
+  let result = s.parseSafe(ExportConfigSchema, exportConfig)
+  if (!result.success) return undefined
+
+  let config = result.value
+  return typeof config === 'string' ? config : (config.types ?? config.default)
 }
 
 function normalizeReadmeMarkdown(markdown: string): string {


### PR DESCRIPTION
This updates the docs generator so package overview pages can be created for documented subpath exports, not just package roots. Root packages still use their package-level README, while subpath exports only get overview pages when a README exists next to the exported source file.

- Parses package.json with remix/data-schema so package metadata is validated at the boundary
- Discovers subpath READMEs from package exports, skipping `.` and `./package.json`
- Keeps subpath overview generation opt-in: exported subpaths without sibling READMEs do not get overview pages