### PR TITLE
ci: harden npm publish step

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,9 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check release readiness
@@ -81,10 +84,14 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Prepare CLI package
+        run: node ./scripts/sync-cli-template.ts
+
       - name: Publish to npm and create releases
         run: node ./scripts/publish.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
 
       - name: Output tag
         id: get_tag

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,13 +1,16 @@
 /**
  * Publishes packages to npm and creates tags/releases for what was published.
  *
- * This script uses pnpm publish with --report-summary, reads the summary file,
- * and creates Git tags + GitHub releases. When one or more packages are in
- * prerelease mode (have .changes/config.json with prereleaseChannel), it publishes
- * in two phases: all other packages as "latest", then prerelease packages with
- * the "next" tag.
+ * This script uses pnpm publish with --report-summary and --ignore-scripts,
+ * reads the summary file, and creates Git tags + GitHub releases. When one or
+ * more packages are in prerelease mode (have .changes/config.json with
+ * prereleaseChannel), it publishes in two phases: all other packages as
+ * "latest", then prerelease packages with the "next" tag.
  *
  * This script is designed for CI use. For previewing releases, use `pnpm changes:preview`.
+ * CI must build packages and prepare package contents before running this
+ * script because publish-time lifecycle scripts are disabled while npm trusted
+ * publishing credentials are available.
  *
  * Usage:
  *   node scripts/publish.ts [--skip-ci-check] [--dry-run]
@@ -466,6 +469,7 @@ async function main() {
         ...prereleasePackages.map((pkg) => `--filter "!${pkg.dirName}"`),
         '--access public',
         '--no-git-checks',
+        '--ignore-scripts',
         '--report-summary',
       ].join(' '),
       ...prereleasePackages.map((pkg) =>
@@ -474,6 +478,7 @@ async function main() {
           '--tag next',
           '--access public',
           '--no-git-checks',
+          '--ignore-scripts',
           '--report-summary',
         ].join(' '),
       ),
@@ -494,7 +499,7 @@ async function main() {
   } else {
     // Single-phase publish: everything as latest
     let publishCommand =
-      'pnpm publish --recursive --filter "./packages/*" --access public --no-git-checks --report-summary'
+      'pnpm publish --recursive --filter "./packages/*" --access public --no-git-checks --ignore-scripts --report-summary'
 
     if (dryRun) {
       console.log('Would run:')


### PR DESCRIPTION
This keeps the publish workflow simple while reducing code execution during the npm trusted publishing step.

- Defaults this workflow's `GITHUB_TOKEN` permissions to `contents: read`.
- Keeps `contents: write` and `id-token: write` scoped to the existing publish job.
- Sets `NPM_CONFIG_PROVENANCE=true` for the publish step.
- Runs the CLI template sync explicitly before publishing, since `@remix-run/cli` needs that generated `template` directory in its package.
- Adds `--ignore-scripts` to each `pnpm publish` command so publish lifecycle scripts do not run while npm trusted publishing credentials are available.

The TanStack npm incident showed that trusted publishing can still be abused if malicious code runs inside a workflow with `id-token: write`; their postmortem notes the normal publish step was bypassed and no npm token was stolen: https://tanstack.com/blog/npm-supply-chain-compromise-postmortem
