### PR TITLE
Simplify frame navigation demo rendering

### DIFF
--- a/demos/frame-navigation/app/actions/main/controller.tsx
+++ b/demos/frame-navigation/app/actions/main/controller.tsx
@@ -1,42 +1,43 @@
 import { createController } from 'remix/fetch-router'
-import type { RemixNode } from 'remix/ui'
-import type { Renderer as Render } from 'remix/render-middleware'
 
 import { requireAuth } from '../../middleware/auth.ts'
 import { routes } from '../../routes.ts'
-import { Layout, type MainNavItem } from '../../ui/layout.tsx'
+import { Layout } from '../../ui/layout.tsx'
 import { MainAccountPage } from './account-page.tsx'
 import { MainCalendarPage } from './calendar-page.tsx'
 import { MainCoursesPage } from './courses-page.tsx'
 import { MainIndexPage } from './index-page.tsx'
 
-function renderMainPage(
-  render: Render<RemixNode>,
-  title: string,
-  activeNav: MainNavItem,
-  content: RemixNode,
-) {
-  return render(
-    <Layout title={title} activeNav={activeNav}>
-      {content}
-    </Layout>,
-  )
-}
-
 export default createController(routes.main, {
   middleware: [requireAuth],
   actions: {
     index({ render }) {
-      return renderMainPage(render, 'Dashboard', 'dashboard', <MainIndexPage />)
+      return render(
+        <Layout title="Dashboard" activeNav="dashboard">
+          <MainIndexPage />
+        </Layout>,
+      )
     },
     courses({ render }) {
-      return renderMainPage(render, 'Courses', 'courses', <MainCoursesPage />)
+      return render(
+        <Layout title="Courses" activeNav="courses">
+          <MainCoursesPage />
+        </Layout>,
+      )
     },
     calendar({ render }) {
-      return renderMainPage(render, 'Calendar', 'calendar', <MainCalendarPage />)
+      return render(
+        <Layout title="Calendar" activeNav="calendar">
+          <MainCalendarPage />
+        </Layout>,
+      )
     },
     account({ render }) {
-      return renderMainPage(render, 'Account', 'account', <MainAccountPage />)
+      return render(
+        <Layout title="Account" activeNav="account">
+          <MainAccountPage />
+        </Layout>,
+      )
     },
   },
 })

--- a/demos/frame-navigation/app/actions/settings/controller.tsx
+++ b/demos/frame-navigation/app/actions/settings/controller.tsx
@@ -1,5 +1,4 @@
 import { createController } from 'remix/fetch-router'
-import type { Renderer as Render } from 'remix/render-middleware'
 import type { Handle, RemixNode } from 'remix/ui'
 import { Frame } from 'remix/ui'
 
@@ -19,22 +18,47 @@ export default createController(routes.settings, {
   middleware: [requireAuth],
   actions: {
     index({ render, request }) {
-      return renderSettingsPage(render, request, 'overview', <Index />)
+      return render(
+        <SettingsPage activeItem="overview" {...getSettingsFrameProps(request)}>
+          <Index />
+        </SettingsPage>,
+      )
     },
     profile({ render, request }) {
-      return renderSettingsPage(render, request, 'profile', <Profile />)
+      return render(
+        <SettingsPage activeItem="profile" {...getSettingsFrameProps(request)}>
+          <Profile />
+        </SettingsPage>,
+      )
     },
     notifications({ render, request }) {
-      return renderSettingsPage(render, request, 'notifications', <Notifications />)
+      return render(
+        <SettingsPage activeItem="notifications" {...getSettingsFrameProps(request)}>
+          <Notifications />
+        </SettingsPage>,
+      )
     },
     privacy({ render, request }) {
-      return renderSettingsPage(render, request, 'privacy', <Privacy />, { status: 500 })
+      return render(
+        <SettingsPage activeItem="privacy" {...getSettingsFrameProps(request)}>
+          <Privacy />
+        </SettingsPage>,
+        { status: 500 },
+      )
     },
     grading({ render, request }) {
-      return renderSettingsPage(render, request, 'grading', <Grading />)
+      return render(
+        <SettingsPage activeItem="grading" {...getSettingsFrameProps(request)}>
+          <Grading />
+        </SettingsPage>,
+      )
     },
     integrations({ render, request }) {
-      return renderSettingsPage(render, request, 'integrations', <Integrations />)
+      return render(
+        <SettingsPage activeItem="integrations" {...getSettingsFrameProps(request)}>
+          <Integrations />
+        </SettingsPage>,
+      )
     },
   },
 })
@@ -42,39 +66,27 @@ export default createController(routes.settings, {
 type SettingsPageProps = {
   activeItem: SettingsNavItem
   children?: RemixNode
-  isSettingsFrameRequest: boolean
-  requestUrl: string
+  frameSrc: string
+  isFrameRequest: boolean
 }
 
-function renderSettingsPage(
-  render: Render<RemixNode>,
-  request: Request,
-  activeItem: SettingsNavItem,
-  content: RemixNode,
-  init?: ResponseInit,
-) {
-  return render(
-    <SettingsShellOrFragment
-      activeItem={activeItem}
-      isSettingsFrameRequest={request.headers.get('X-Remix-Target') === frames.settings}
-      requestUrl={request.url}
-    >
-      {content}
-    </SettingsShellOrFragment>,
-    init,
-  )
+function getSettingsFrameProps(request: Request) {
+  return {
+    frameSrc: request.url,
+    isFrameRequest: request.headers.get('X-Remix-Target') === frames.settings,
+  }
 }
 
-function SettingsShellOrFragment(handle: Handle<SettingsPageProps>) {
+function SettingsPage(handle: Handle<SettingsPageProps>) {
   return () => {
-    let { activeItem, children, isSettingsFrameRequest, requestUrl } = handle.props
-    if (isSettingsFrameRequest) {
+    let { activeItem, children, frameSrc, isFrameRequest } = handle.props
+    if (isFrameRequest) {
       return <SettingsLayout activeItem={activeItem}>{children}</SettingsLayout>
     }
 
     return (
       <Layout title="Settings" activeNav="settings">
-        <Frame name={frames.settings} src={requestUrl} />
+        <Frame name={frames.settings} src={frameSrc} />
       </Layout>
     )
   }


### PR DESCRIPTION
This simplifies the frame-navigation demo so route actions render JSX directly instead of delegating through custom render helper functions.

- Removes the main-page render helper and renders each app-shell page inline with `<Layout>`.
- Replaces the settings render helper with a normal `SettingsPage` component that owns the full-page vs frame-fragment branch.
- Keeps the existing frame navigation behavior and intentional privacy error response unchanged.
