### PR TITLE
Propagate skip and only from parent describes to nested describes

### DIFF
--- a/packages/test/.changes/patch.describe-skip-only-propagation.md
+++ b/packages/test/.changes/patch.describe-skip-only-propagation.md
@@ -1,0 +1,1 @@
+Fix `describe.skip` and `describe.only` so they propagate to nested `describe` blocks. Previously the skipped/focused state was set only on the outer suite, so tests inside nested describes still ran (or were incorrectly skipped under `only`).

--- a/packages/test/src/lib/framework.ts
+++ b/packages/test/src/lib/framework.ts
@@ -57,6 +57,13 @@ function registerDescribe(
   }
   let suite: TestSuite = { name: fullName, tests: [], ...flags }
 
+  // Children inherit `skip`/`only` from their parent so that
+  // `describe.skip('parent', () => describe('child', () => it(...)))` actually
+  // skips the child's tests. The executor walks `rootSuites` as a flat list and
+  // only inspects each suite's own flag, so the propagation has to happen here.
+  if (currentSuite?.skip) suite.skip = true
+  if (currentSuite?.only) suite.only = true
+
   // Inherit lifecycle hooks from parent suite (or root hooks if at top level)
   let parent = currentSuite ?? rootHooks
   if (parent.beforeEach) suite.beforeEach = parent.beforeEach

--- a/packages/test/src/test/framework.test.ts
+++ b/packages/test/src/test/framework.test.ts
@@ -83,10 +83,64 @@ describe('describe.skip', () => {
   })
 })
 
+describe('describe.skip inheritance', () => {
+  it('propagates skip to nested describes', () => {
+    let captured = captureRegistration(() =>
+      describe.skip('parent', () => {
+        describe('child', () => {
+          it('test', () => {})
+        })
+      }),
+    )
+    let [parent, child] = captured
+    assert.equal(parent.skip, true)
+    assert.equal(child.name, 'parent > child')
+    assert.equal(child.skip, true)
+  })
+
+  it('propagates skip through multiple levels of nesting', () => {
+    let captured = captureRegistration(() =>
+      describe.skip('a', () => {
+        describe('b', () => {
+          describe('c', () => {
+            it('test', () => {})
+          })
+        })
+      }),
+    )
+    for (let suite of captured) {
+      assert.equal(suite.skip, true, `${suite.name} should be skipped`)
+    }
+  })
+
+  it('does not infect sibling describes registered after the skipped one', () => {
+    let captured = captureRegistration(() => {
+      describe.skip('skipped', () => {})
+      describe('not skipped', () => {})
+    })
+    let [skipped, notSkipped] = captured
+    assert.equal(skipped.skip, true)
+    assert.equal(notSkipped.skip, undefined)
+  })
+})
+
 describe('describe.only', () => {
   it('marks the suite as only', () => {
     let [s] = captureRegistration(() => describe.only('suite', () => {}))
     assert.equal(s.only, true)
+  })
+
+  it('propagates only to nested describes', () => {
+    let captured = captureRegistration(() =>
+      describe.only('parent', () => {
+        describe('child', () => {
+          it('test', () => {})
+        })
+      }),
+    )
+    let [parent, child] = captured
+    assert.equal(parent.only, true)
+    assert.equal(child.only, true)
   })
 })
 


### PR DESCRIPTION
## Summary

- `describe.skip('parent', () => describe('child', () => it('x')))` was not actually skipping the inner test — only the parent suite was marked skipped, and since the parent had zero direct `it`s, nothing visible got skipped while the child's tests ran normally.
- Two issues combined: (1) `registerDescribe` created each nested suite with only its own flags, so `skip` set on the parent never reached the child, and (2) the executor walks `rootSuites` as a flat list and only inspects each suite's own `skip`/`only` flag, with no notion of ancestor suites.
- The same bug applied to `describe.only` — a child of an `only` parent was marked not-focused and got skipped by the executor's `hasOnlySuites && !suite.only` branch.
- Fix: inherit `skip` and `only` from `currentSuite` at registration time so the executor's flat walk does the right thing.

## Test plan

- [x] `pnpm --filter @remix-run/test test` — 91 pass / 6 skip / 6 todo (no regressions)
- [x] New regression tests cover:
  - `describe.skip` propagates one level to nested describes
  - `describe.skip` propagates through multiple levels of nesting
  - Sibling describes registered after a skipped sibling at the same scope are *not* infected
  - `describe.only` propagates to nested describes

🤖 Generated with [Claude Code](https://claude.com/claude-code)