### PR TITLE
Fix SSE demo MessageStream entry ID

### DIFF
--- a/demos/sse/app/assets/message-stream.tsx
+++ b/demos/sse/app/assets/message-stream.tsx
@@ -3,7 +3,7 @@ import { addEventListeners, clientEntry, css, type Handle } from 'remix/ui'
 import { routes } from '../routes.ts'
 
 export const MessageStream = clientEntry(
-  routes.assets.href({ path: 'message-stream.js#MessageStream' }),
+  '/assets/message-stream.js#MessageStream',
   function MessageStream(handle: Handle<{ limit: number | null }>) {
     let { limit } = handle.props
     let messages: Array<{ count: number; message: string }> = []


### PR DESCRIPTION
Just a tiny fix.

I think the problem is that `href` is encoding the `#` used to denote the module export.