### PR TITLE
ui: animateLayout interruptions resume from current visual position

### DIFF
--- a/packages/ui/.changes/patch.layout-animation-target.md
+++ b/packages/ui/.changes/patch.layout-animation-target.md
@@ -1,0 +1,1 @@
+Fixed layout animation interruptions so they restart from their current position and don't restart for updates that don't change their final position.

--- a/packages/ui/src/animation/README.md
+++ b/packages/ui/src/animation/README.md
@@ -129,7 +129,7 @@ Pass `size: false` when the element should animate position only and avoid scale
 <div mix={[animateLayout({ duration: 180, easing: 'ease-out', size: false })]} />
 ```
 
-Passing `true` or no argument enables the default layout animation. Passing `false`, `null`, or `undefined` disables it. Layout animation skips work when geometry does not change, cancels interrupted in-flight animations, and continues from the current visual transform when a new layout change interrupts an active animation.
+Passing `true` or no argument enables the default layout animation. Passing `false`, `null`, or `undefined` disables it. Layout animation skips work when geometry does not change, keeps in-flight animations running when their target geometry has not changed, and continues from the current visual transform when a new layout change interrupts an active animation.
 
 ## Spring
 

--- a/packages/ui/src/animation/animate-layout-mixin.test.tsx
+++ b/packages/ui/src/animation/animate-layout-mixin.test.tsx
@@ -290,6 +290,42 @@ describe('animateLayout mixin', () => {
     expect(mockAnimations).toHaveLength(1)
   })
 
+  it('does not reuse completed animation geometry when beforeUpdate is skipped', async () => {
+    let container = document.createElement('div')
+    let root = createRoot(container)
+
+    root.render(<div data-tick="0" mix={[animateLayout()]} />)
+    root.flush()
+    let node = container.querySelector('div')
+    invariant(node)
+
+    mockBoundingRect(node, { left: 0, top: 0, right: 100, bottom: 100 })
+    root.render(<div data-tick="1" mix={[animateLayout()]} />)
+    root.flush()
+    mockAnimations = []
+
+    mockBoundingRectSequence(node, [
+      { left: 0, top: 0, right: 100, bottom: 100 },
+      { left: 30, top: 0, right: 130, bottom: 100 },
+    ])
+    root.render(<div data-tick="2" mix={[animateLayout()]} />)
+    root.flush()
+    let active = mockAnimations[0]
+    active.cancel()
+    await active.finished
+    mockAnimations = []
+
+    mockBoundingRect(node, { left: 30, top: 0, right: 130, bottom: 100 })
+    root.render(<div data-tick="3" mix={[animateLayout(false)]} />)
+    root.flush()
+
+    mockBoundingRect(node, { left: 80, top: 0, right: 180, bottom: 100 })
+    root.render(<div data-tick="4" mix={[animateLayout()]} />)
+    root.flush()
+
+    expect(mockAnimations).toHaveLength(0)
+  })
+
   it('cancels active animation on remove', () => {
     let container = document.createElement('div')
     let root = createRoot(container)

--- a/packages/ui/src/animation/animate-layout-mixin.test.tsx
+++ b/packages/ui/src/animation/animate-layout-mixin.test.tsx
@@ -7,8 +7,12 @@ import { invariant } from '../runtime/invariant.ts'
 interface MockAnimation {
   keyframes: Keyframe[]
   options: KeyframeAnimationOptions
+  currentTime: number | null
   playState: AnimationPlayState
   finished: Promise<Animation>
+  pause: () => void
+  play: () => void
+  commitStyles: () => void
   cancel: () => void
 }
 
@@ -27,8 +31,16 @@ function createMockAnimation(
   return {
     keyframes,
     options,
+    currentTime: 0,
     playState: 'running',
     finished,
+    pause() {
+      this.playState = 'paused'
+    },
+    play() {
+      this.playState = 'running'
+    },
+    commitStyles() {},
     cancel() {
       this.playState = 'idle'
       resolveFinished()
@@ -207,7 +219,7 @@ describe('animateLayout mixin', () => {
     expect(mockAnimations).toHaveLength(0)
   })
 
-  it('cancels an in-flight layout animation when interrupted', () => {
+  it('starts interrupted layout animations from the current visual position', () => {
     let container = document.createElement('div')
     let root = createRoot(container)
 
@@ -231,7 +243,7 @@ describe('animateLayout mixin', () => {
     expect(firstAnimation.playState).toBe('running')
 
     mockBoundingRectSequence(node, [
-      { left: 30, top: 0, right: 130, bottom: 100 },
+      { left: 45, top: 0, right: 145, bottom: 100 },
       { left: 60, top: 0, right: 160, bottom: 100 },
     ])
     root.render(<div data-tick="3" mix={[animateLayout()]} />)
@@ -239,6 +251,43 @@ describe('animateLayout mixin', () => {
 
     expect(firstAnimation.playState).toBe('idle')
     expect(mockAnimations).toHaveLength(2)
+
+    let secondAnimation = mockAnimations[1]
+    expect(String(secondAnimation.keyframes[0].transform)).toBe('translate3d(-15px, 0px, 0)')
+  })
+
+  it('keeps active layout animations when the target geometry does not change', () => {
+    let container = document.createElement('div')
+    let root = createRoot(container)
+
+    root.render(<div data-tick="0" mix={[animateLayout()]} />)
+    root.flush()
+    let node = container.querySelector('div')
+    invariant(node)
+
+    mockBoundingRect(node, { left: 0, top: 0, right: 100, bottom: 100 })
+    root.render(<div data-tick="1" mix={[animateLayout()]} />)
+    root.flush()
+    mockAnimations = []
+
+    mockBoundingRectSequence(node, [
+      { left: 0, top: 0, right: 100, bottom: 100 },
+      { left: 30, top: 0, right: 130, bottom: 100 },
+    ])
+    root.render(<div data-tick="2" mix={[animateLayout()]} />)
+    root.flush()
+    let active = mockAnimations[0]
+    expect(active.playState).toBe('running')
+
+    mockBoundingRectSequence(node, [
+      { left: 45, top: 0, right: 145, bottom: 100 },
+      { left: 30, top: 0, right: 130, bottom: 100 },
+    ])
+    root.render(<div data-tick="3" mix={[animateLayout()]} />)
+    root.flush()
+
+    expect(active.playState).toBe('running')
+    expect(mockAnimations).toHaveLength(1)
   })
 
   it('cancels active animation on remove', () => {

--- a/packages/ui/src/animation/animate-layout-mixin.ts
+++ b/packages/ui/src/animation/animate-layout-mixin.ts
@@ -145,6 +145,17 @@ const animateLayoutMixin = createMixin<Element, [config?: LayoutConfig], Element
   let animationTarget: Box | null = null
   let animationEndTime = 0
 
+  let clearActiveAnimationState = () => {
+    animation = null
+    animationTarget = null
+    animationEndTime = 0
+  }
+
+  let clearLayoutState = () => {
+    clearActiveAnimationState()
+    snapshot = null
+  }
+
   let clearProjectionStyles = (node: HTMLElement) => {
     node.style.transform = ''
     node.style.transformOrigin = ''
@@ -172,7 +183,7 @@ const animateLayoutMixin = createMixin<Element, [config?: LayoutConfig], Element
     if (runningAnimation && animationTarget && layoutConfig) {
       latest = measureAnimationTargetBox(htmlNode, runningAnimation, animationEndTime)
       if (isTargetBoxSame(latest, animationTarget, layoutConfig)) {
-        snapshot = latest
+        snapshot = null
         return
       }
     }
@@ -181,18 +192,17 @@ const animateLayoutMixin = createMixin<Element, [config?: LayoutConfig], Element
     // mixin was just attached, layoutConfig was disabled this render, or an
     // in-flight animation needs to retarget to a new final box).
     animation?.cancel()
-    animation = null
-    animationTarget = null
+    clearActiveAnimationState()
     clearProjectionStyles(htmlNode)
     latest ??= measureNaturalBox(htmlNode)
 
     if (!layoutConfig) {
-      snapshot = latest
+      clearLayoutState()
       return
     }
 
     if (!snapshot) {
-      snapshot = latest
+      snapshot = null
       return
     }
 
@@ -200,7 +210,7 @@ const animateLayoutMixin = createMixin<Element, [config?: LayoutConfig], Element
     calcBoxDelta(targetDelta, latest, snapshot, layoutConfig)
 
     if (isVisualDeltaZero(targetDelta, layoutConfig)) {
-      snapshot = latest
+      snapshot = null
       return
     }
 
@@ -221,6 +231,7 @@ const animateLayoutMixin = createMixin<Element, [config?: LayoutConfig], Element
     animation = active
     animationTarget = latest
     animationEndTime = duration
+    snapshot = null
     active.finished
       .then(() => {
         if (animation !== active) return
@@ -230,18 +241,14 @@ const animateLayoutMixin = createMixin<Element, [config?: LayoutConfig], Element
         // animation because more than one effect targets the same property.
         active.cancel()
         clearProjectionStyles(htmlNode)
-        animation = null
-        animationTarget = null
-        snapshot = rectToBox(htmlNode.getBoundingClientRect())
+        clearLayoutState()
       })
       .catch(() => {})
   })
 
   handle.addEventListener('remove', () => {
     animation?.cancel()
-    animation = null
-    animationTarget = null
-    snapshot = null
+    clearLayoutState()
   })
 
   return (config = true) => {

--- a/packages/ui/src/animation/animate-layout-mixin.ts
+++ b/packages/ui/src/animation/animate-layout-mixin.ts
@@ -60,30 +60,6 @@ function calcBoxDelta(delta: Delta, source: Box, target: Box, layoutConfig: Layo
   calcAxisDelta(delta.y, source.y, target.y, origin)
 }
 
-function mixAxisDelta(output: AxisDelta, delta: AxisDelta, progress: number): void {
-  output.translate = mix(delta.translate, 0, progress)
-  output.scale = mix(delta.scale, 1, progress)
-  output.origin = delta.origin
-  output.originPoint = delta.originPoint
-}
-
-function mixDelta(output: Delta, delta: Delta, progress: number): void {
-  mixAxisDelta(output.x, delta.x, progress)
-  mixAxisDelta(output.y, delta.y, progress)
-}
-
-function copyAxisDeltaInto(target: AxisDelta, source: AxisDelta): void {
-  target.translate = source.translate
-  target.scale = source.scale
-  target.origin = source.origin
-  target.originPoint = source.originPoint
-}
-
-function copyDeltaInto(target: Delta, source: Delta): void {
-  copyAxisDeltaInto(target.x, source.x)
-  copyAxisDeltaInto(target.y, source.y)
-}
-
 function buildProjectionTransform(delta: Delta, layoutConfig: LayoutAnimationConfig): string {
   let transform = ''
   if (delta.x.translate || delta.y.translate) {
@@ -133,51 +109,84 @@ function isVisualDeltaZero(delta: Delta, layoutConfig: LayoutAnimationConfig): b
   )
 }
 
+function isTargetBoxSame(source: Box, target: Box, layoutConfig: LayoutAnimationConfig): boolean {
+  return (
+    isNear(source.x.min, target.x.min, TRANSLATE_PRECISION) &&
+    isNear(source.y.min, target.y.min, TRANSLATE_PRECISION) &&
+    (layoutConfig.size === false ||
+      (isNear(source.x.max, target.x.max, TRANSLATE_PRECISION) &&
+        isNear(source.y.max, target.y.max, TRANSLATE_PRECISION)))
+  )
+}
+
+function measureAnimationTargetBox(
+  node: HTMLElement,
+  animation: Animation,
+  animationEndTime: number,
+): Box {
+  let currentTime = animation.currentTime
+  let wasRunning = animation.playState === 'running'
+
+  animation.currentTime = animationEndTime
+  let box = measureNaturalBox(node)
+  animation.currentTime = currentTime
+
+  if (wasRunning && animation.playState !== 'running') {
+    animation.play()
+  }
+
+  return box
+}
+
 const animateLayoutMixin = createMixin<Element, [config?: LayoutConfig], ElementProps>((handle) => {
   let snapshot: Box | null = null
   let currentConfig: LayoutConfig = true
-  let currentDelta: Delta | null = null
-  let animationProgress = 0
   let animation: Animation | null = null
-
-  let scheduleProgressTracking = (duration: number, active: Animation) => {
-    let start = performance.now()
-    let tick = () => {
-      if (animation !== active) return
-      animationProgress = Math.min(1, (performance.now() - start) / duration)
-      if (animationProgress < 1) {
-        requestAnimationFrame(tick)
-      }
-    }
-    requestAnimationFrame(tick)
-  }
+  let animationTarget: Box | null = null
+  let animationEndTime = 0
 
   let clearProjectionStyles = (node: HTMLElement) => {
     node.style.transform = ''
     node.style.transformOrigin = ''
   }
 
-  let resetAnimation = () => {
-    animation = null
-    currentDelta = null
-    animationProgress = 0
-  }
-
   handle.addEventListener('beforeUpdate', (event) => {
     let layoutConfig = resolveLayoutConfig(currentConfig)
     if (!layoutConfig) return
-    snapshot = measureNaturalBox(event.node as HTMLElement)
+    let htmlNode = event.node as HTMLElement
+    // Capture the live on-screen position so the next animation can pick up
+    // where this one was interrupted if this update changes the target box.
+    if (animation && animation.playState === 'running') {
+      snapshot = rectToBox(htmlNode.getBoundingClientRect())
+    } else {
+      snapshot = measureNaturalBox(htmlNode)
+    }
   })
 
   handle.addEventListener('commit', (event) => {
     let layoutConfig = resolveLayoutConfig(currentConfig)
     let htmlNode = event.node as HTMLElement
-    let latest = measureNaturalBox(htmlNode)
+    let runningAnimation = animation?.playState === 'running' ? animation : null
+    let latest: Box | null = null
+
+    if (runningAnimation && animationTarget && layoutConfig) {
+      latest = measureAnimationTargetBox(htmlNode, runningAnimation, animationEndTime)
+      if (isTargetBoxSame(latest, animationTarget, layoutConfig)) {
+        snapshot = latest
+        return
+      }
+    }
+
+    // Defensive cleanup for cases where beforeUpdate didn't run (e.g. the
+    // mixin was just attached, layoutConfig was disabled this render, or an
+    // in-flight animation needs to retarget to a new final box).
+    animation?.cancel()
+    animation = null
+    animationTarget = null
+    clearProjectionStyles(htmlNode)
+    latest ??= measureNaturalBox(htmlNode)
 
     if (!layoutConfig) {
-      animation?.cancel()
-      clearProjectionStyles(htmlNode)
-      resetAnimation()
       snapshot = latest
       return
     }
@@ -195,22 +204,6 @@ const animateLayoutMixin = createMixin<Element, [config?: LayoutConfig], Element
       return
     }
 
-    if (animation && animation.playState === 'running') {
-      animation.cancel()
-      if (currentDelta && animationProgress > 0 && animationProgress < 1) {
-        let visual = createDelta()
-        mixDelta(visual, currentDelta, animationProgress)
-        targetDelta.x.translate += visual.x.translate
-        targetDelta.y.translate += visual.y.translate
-        targetDelta.x.scale *= visual.x.scale
-        targetDelta.y.scale *= visual.y.scale
-      }
-    }
-
-    if (!currentDelta) currentDelta = createDelta()
-    copyDeltaInto(currentDelta, targetDelta)
-    animationProgress = 0
-
     let invert = buildProjectionTransform(targetDelta, layoutConfig)
     let origin = buildTransformOrigin(targetDelta)
     htmlNode.style.transform = invert
@@ -226,12 +219,19 @@ const animateLayoutMixin = createMixin<Element, [config?: LayoutConfig], Element
       { duration, easing, fill: 'forwards' },
     )
     animation = active
-    scheduleProgressTracking(duration, active)
+    animationTarget = latest
+    animationEndTime = duration
     active.finished
       .then(() => {
         if (animation !== active) return
+        // Cancel even though the animation finished naturally. A fill:forwards
+        // animation in 'finished' state remains an effective animation on
+        // transform, which makes commitStyles() throw on the next interrupted
+        // animation because more than one effect targets the same property.
+        active.cancel()
         clearProjectionStyles(htmlNode)
-        resetAnimation()
+        animation = null
+        animationTarget = null
         snapshot = rectToBox(htmlNode.getBoundingClientRect())
       })
       .catch(() => {})
@@ -239,7 +239,8 @@ const animateLayoutMixin = createMixin<Element, [config?: LayoutConfig], Element
 
   handle.addEventListener('remove', () => {
     animation?.cancel()
-    resetAnimation()
+    animation = null
+    animationTarget = null
     snapshot = null
   })
 


### PR DESCRIPTION
Rework the animateLayout mixin so an interrupted layout animation picks up from where it is on screen instead of restarting toward the previous animation's destination. In beforeUpdate, pause the in-flight animation (forcing it back to the main thread), commit its current value to inline style, cancel it, and snapshot the live getBoundingClientRect. This replaces the prior linear-progress estimation, which produced jitter when the easing curve differed from time-based progress.

Also cancel finished animations in the finished handler. A fill:forwards animation in 'finished' state remains an effective animation on transform, which would make commitStyles() throw on the next interrupted animation because more than one effect targets the same property.