### PR TITLE
Fix assets error message test in Bun

### DIFF
--- a/packages/assets/src/lib/asset-server.test.ts
+++ b/packages/assets/src/lib/asset-server.test.ts
@@ -847,6 +847,12 @@ describe('asset-server', () => {
   it('reports anonymous global file transform result errors with the transform index', async () => {
     await write(dir, 'app/content/value.txt', 'hello\n')
     let receivedError: unknown
+    let anonymousTransform = async function () {
+      return undefined
+    }
+    // Force the function name to be empty to simulate truly anonymous function
+    Object.defineProperty(anonymousTransform, 'name', { value: '' })
+
     let assetServer = createTestServer(dir, {
       files: {
         extensions: ['.txt'],
@@ -858,11 +864,7 @@ describe('asset-server', () => {
           },
           {
             // @ts-expect-error - exercise runtime validation for invalid global transform returns
-            transform: [
-              async function () {
-                return undefined
-              },
-            ][0],
+            transform: anonymousTransform,
           },
         ],
       },


### PR DESCRIPTION
This PR fixes the `@remix-run/assets` Bun test failure by making the anonymous global file transform test fixture explicitly anonymous.

Bun infers a function name for the fixture where Node does not, so the test now clears the function `name` before asserting that unnamed global transforms are reported by index.