### PR TITLE
Avoid eager Web Encoding globals in multipart parser

### DIFF
--- a/packages/multipart-parser/.changes/patch.lazy-codecs.md
+++ b/packages/multipart-parser/.changes/patch.lazy-codecs.md
@@ -1,0 +1,1 @@
+Avoid using Web Encoding globals while importing the multipart parser and while scanning multipart syntax. Header and text decoding now creates the UTF-8 decoder lazily when decoded part fields are accessed.

--- a/packages/multipart-parser/src/lib/buffer-search.ts
+++ b/packages/multipart-parser/src/lib/buffer-search.ts
@@ -2,8 +2,17 @@ export interface SearchFunction {
   (haystack: Uint8Array, start?: number): number
 }
 
+export function encodeAsciiPattern(pattern: string): Uint8Array {
+  let bytes = new Uint8Array(pattern.length)
+  for (let index = 0; index < pattern.length; ++index) {
+    bytes[index] = pattern.charCodeAt(index) & 0xff
+  }
+
+  return bytes
+}
+
 export function createSearch(pattern: string): SearchFunction {
-  let needle = new TextEncoder().encode(pattern)
+  let needle = encodeAsciiPattern(pattern)
 
   let search: SearchFunction
   // Use the built-in Buffer.indexOf method on Node.js for better perf.
@@ -43,7 +52,7 @@ export interface PartialTailSearchFunction {
 }
 
 export function createPartialTailSearch(pattern: string): PartialTailSearchFunction {
-  let needle = new TextEncoder().encode(pattern)
+  let needle = encodeAsciiPattern(pattern)
 
   let byteIndexes: Record<number, number[]> = {}
   for (let i = 0; i < needle.length; ++i) {

--- a/packages/multipart-parser/src/lib/multipart.test.ts
+++ b/packages/multipart-parser/src/lib/multipart.test.ts
@@ -1,3 +1,6 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
 import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
@@ -11,6 +14,7 @@ import {
 } from './multipart.ts'
 
 const boundary = '----WebKitFormBoundaryPMcT9NSv6M3P8D4Q'
+const execFileAsync = promisify(execFile)
 
 function createChunkedIterable(body: Uint8Array, chunkSize: number): Uint8Array[] {
   let chunks: Uint8Array[] = []
@@ -37,6 +41,75 @@ function createChunkedStream(body: Uint8Array, chunkSize: number): ReadableStrea
 }
 
 describe('parseMultipart', async () => {
+  it('does not eagerly use Web Encoding globals while importing and parsing', async () => {
+    let moduleUrl = new URL('./multipart.ts', import.meta.url).href
+    let script = `
+      await import('@remix-run/headers')
+
+      let TextEncoderConstructor = globalThis.TextEncoder
+      let TextDecoderConstructor = globalThis.TextDecoder
+      globalThis.TextEncoder = class TestTextEncoder extends TextEncoderConstructor {
+        encode(input = '') {
+          if (input === '\\r\\n\\r\\n' || String(input).includes('boundary')) {
+            throw new Error('TextEncoder should not encode parser syntax')
+          }
+          return super.encode(input)
+        }
+      }
+      globalThis.TextDecoder = class TestTextDecoder extends TextDecoderConstructor {
+        constructor(label, options) {
+          if (label === 'utf-8' && options?.fatal === true) {
+            throw new Error('TextDecoder should be created lazily')
+          }
+          super(label, options)
+        }
+      }
+
+      function bytes(input) {
+        let result = new Uint8Array(input.length)
+        for (let index = 0; index < input.length; index += 1) {
+          result[index] = input.charCodeAt(index) & 0xff
+        }
+        return result
+      }
+
+      let { parseMultipart } = await import(${JSON.stringify(moduleUrl)})
+      let message = bytes([
+        '--boundary',
+        'Content-Disposition: form-data; name="field"',
+        '',
+        'value',
+        '--boundary--',
+        '',
+      ].join('\\r\\n'))
+      let parts = Array.from(parseMultipart(message, { boundary: 'boundary' }))
+
+      if (parts.length !== 1) {
+        throw new Error('expected one multipart part')
+      }
+      if (parts[0].size !== 5) {
+        throw new Error('expected parser to read part content without encoding parser syntax')
+      }
+
+      globalThis.TextEncoder = TextEncoderConstructor
+      globalThis.TextDecoder = TextDecoderConstructor
+
+      if (parts[0].name !== 'field') {
+        throw new Error('expected lazy header decoding after TextDecoder is installed')
+      }
+      if (parts[0].text !== 'value') {
+        throw new Error('expected lazy body decoding after TextDecoder is installed')
+      }
+    `
+
+    await execFileAsync(process.execPath, [
+      '--disable-warning=ExperimentalWarning',
+      '--input-type=module',
+      '--eval',
+      script,
+    ])
+  })
+
   it('throws when the number of parts exceeds maxParts', () => {
     let message = createMultipartMessage(boundary, {
       field1: 'value1',

--- a/packages/multipart-parser/src/lib/multipart.ts
+++ b/packages/multipart-parser/src/lib/multipart.ts
@@ -1,6 +1,7 @@
 import { ContentDisposition, ContentType } from '@remix-run/headers'
 
 import {
+  encodeAsciiPattern,
   createSearch,
   createPartialTailSearch,
   type SearchFunction,
@@ -265,7 +266,7 @@ export class MultipartParser {
     this.#findBoundary = createSearch(boundaryPattern)
     this.#findPartialTailBoundary = createPartialTailSearch(boundaryPattern)
     this.#boundaryLength = 4 + boundary.length // length of '\r\n--' + boundary
-    this.#boundaryBytes = new TextEncoder().encode(boundaryPattern)
+    this.#boundaryBytes = encodeAsciiPattern(boundaryPattern)
   }
 
   /**
@@ -499,7 +500,12 @@ export class MultipartParser {
   }
 }
 
-const decoder = new TextDecoder('utf-8', { fatal: true })
+let decoder: TextDecoder | undefined
+
+function decodeUtf8(input: Uint8Array): string {
+  decoder ??= new TextDecoder('utf-8', { fatal: true })
+  return decoder.decode(input as BufferSource)
+}
 
 /**
  * The decoded headers for a multipart part, keyed by lower-case header name.
@@ -573,7 +579,7 @@ export class MultipartPart {
    */
   get headers(): MultipartHeaders {
     if (!this.#headers) {
-      this.#headers = parseMultipartHeaders(decoder.decode(this.#header))
+      this.#headers = parseMultipartHeaders(decodeUtf8(this.#header))
     }
 
     return this.#headers
@@ -634,6 +640,6 @@ export class MultipartPart {
    * Note: Do not use this for binary data, use `part.bytes` or `part.arrayBuffer` instead.
    */
   get text(): string {
-    return decoder.decode(this.bytes)
+    return decodeUtf8(this.bytes)
   }
 }


### PR DESCRIPTION
The multipart parser was constructing Web Encoding objects while the module was being evaluated or while parser syntax was prepared. Multipart boundaries and header separators are ASCII byte patterns, so they do not need `TextEncoder`; decoded part headers/body text still need UTF-8 decoding, but that can wait until those fields are accessed.

This matters for runtimes that import application/bootstrap code before Web Encoding globals have been installed. In those environments, eager `TextEncoder`/`TextDecoder` use can make the package fail during module evaluation even though parsing multipart syntax itself only needs byte comparisons.

- Encodes multipart parser syntax with a small ASCII byte helper instead of `TextEncoder`.
- Creates the fatal UTF-8 decoder lazily when `MultipartPart.headers` or `MultipartPart.text` is accessed.
- Adds a regression test that traps parser-specific Web Encoding usage during import/parsing, then restores `TextDecoder` and verifies decoded headers and text still work.
- Adds a patch change file for `@remix-run/multipart-parser`.

The public API and yielded `MultipartPart` behavior stay the same; this only removes unnecessary eager global dependencies from the parser path.
