### PR TITLE
Clarify frame resolver setup and run hook docs

### DIFF
--- a/packages/cli/.changes/patch.template-render-frame-resolver.md
+++ b/packages/cli/.changes/patch.template-render-frame-resolver.md
@@ -1,0 +1,1 @@
+Updated the default `remix new` render middleware so its server-side frame resolver is defined inline with the `renderToStream()` options, matching the browser `run()` setup shape.

--- a/packages/ui/.changes/patch.run-frame-hooks-docs.md
+++ b/packages/ui/.changes/patch.run-frame-hooks-docs.md
@@ -1,0 +1,1 @@
+Document the `run()` `loadModule` and `resolveFrame` hooks so editor hints explain how to hydrate client entries and resolve browser-loaded frames.

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -40,12 +40,31 @@ type FrameMarkerData = FrameData & {
 type PendingClientEntries = Map<Comment, [Comment, RemixElement]>
 
 /**
- * Loads a client entry module for hydration.
+ * Loads a named client-entry export for hydration.
+ *
+ * @param moduleUrl Browser-resolvable URL for the module that contains the client entry.
+ * @param exportName Named export to read from the loaded module.
+ * @returns The exported component function, or a promise for it.
+ *
+ * @example
+ * ```ts
+ * run({
+ *   async loadModule(moduleUrl, exportName) {
+ *     let mod = await import(moduleUrl)
+ *     return mod[exportName]
+ *   },
+ * })
+ * ```
  */
 export type LoadModule = (moduleUrl: string, exportName: string) => Promise<Function> | Function
 
 /**
- * Resolves frame content for the given frame source.
+ * Resolves content for a browser-loaded frame.
+ *
+ * @param src Source string from the `<Frame src>` prop.
+ * @param signal Abort signal for the active frame load or reload.
+ * @param target Optional name of the frame being reloaded.
+ * @returns HTML, a stream of HTML bytes, or Remix node content to render into the frame.
  */
 export type ResolveFrame = (
   src: string,

--- a/packages/ui/src/runtime/run.ts
+++ b/packages/ui/src/runtime/run.ts
@@ -11,8 +11,21 @@ import { TypedEventTarget } from './typed-event-target.ts'
 /**
  * Options for starting the client runtime with {@link run}.
  */
-export type RunInit = {
+export interface RunInit {
+  /**
+   * Loads the named browser module export for a hydrated `clientEntry()`.
+   *
+   * Implementations usually call dynamic `import(moduleUrl)` and return
+   * `mod[exportName]`.
+   */
   loadModule: LoadModule
+
+  /**
+   * Resolves browser-loaded `<Frame>` content.
+   *
+   * Omit this only when the runtime never needs to load or reload frames in the
+   * browser.
+   */
   resolveFrame?: ResolveFrame
 }
 
@@ -27,8 +40,11 @@ export type AppRuntimeEventMap = {
  * Client runtime returned by {@link run}.
  */
 export type AppRuntime = TypedEventTarget<AppRuntimeEventMap> & {
+  /** Resolves after the current document finishes hydrating. */
   ready(): Promise<void>
+  /** Flushes any queued component updates synchronously. */
   flush(): void
+  /** Stops runtime listeners and disposes the top-level frame. */
   dispose(): void
 }
 

--- a/template/app/middleware/render.tsx
+++ b/template/app/middleware/render.tsx
@@ -1,10 +1,9 @@
 import * as path from 'node:path'
 
-import type { Router } from 'remix/router'
 import { renderWith } from 'remix/middleware/render'
 import { createHtmlResponse } from 'remix/response/html'
 import type { RemixNode } from 'remix/ui'
-import { renderToStream, type ResolveFrameContext } from 'remix/ui/server'
+import { renderToStream } from 'remix/ui/server'
 
 import { assetServer } from '../assets.ts'
 
@@ -28,44 +27,36 @@ export function render() {
             exportName: entryId.split('#')[1] || component.name || titleCaseFileName(entryId),
           }
         },
-        resolveFrame: (src, target, context) => resolveFrame(router, request, src, target, context),
+        async resolveFrame(src, target, context) {
+          let frameSrc = context?.currentFrameSrc ?? request.url
+          let url = new URL(src, frameSrc)
+
+          let headers = new Headers()
+          headers.set('Accept', 'text/html')
+          headers.set('Accept-Encoding', 'identity')
+          headers.set('X-Remix-Frame', 'true')
+
+          let cookie = request.headers.get('Cookie')
+          if (cookie) headers.set('Cookie', cookie)
+          if (target) headers.set('X-Remix-Target', target)
+
+          let response = await router.fetch(url, {
+            method: 'GET',
+            headers,
+            signal: request.signal,
+          })
+
+          if (!response.ok) {
+            return `<pre>Frame error: ${response.status} ${response.statusText}</pre>`
+          }
+
+          return response.body ?? response.text()
+        },
       })
 
       return createHtmlResponse(stream, init)
     }
   })
-}
-
-async function resolveFrame(
-  router: Router,
-  request: Request,
-  src: string,
-  target?: string,
-  context?: ResolveFrameContext,
-) {
-  let frameSrc = context?.currentFrameSrc ?? request.url
-  let url = new URL(src, frameSrc)
-
-  let headers = new Headers()
-  headers.set('Accept', 'text/html')
-  headers.set('Accept-Encoding', 'identity')
-  headers.set('X-Remix-Frame', 'true')
-
-  let cookie = request.headers.get('Cookie')
-  if (cookie) headers.set('Cookie', cookie)
-  if (target) headers.set('X-Remix-Target', target)
-
-  let response = await router.fetch(url, {
-    method: 'GET',
-    headers,
-    signal: request.signal,
-  })
-
-  if (!response.ok) {
-    return `<pre>Frame error: ${response.status} ${response.statusText}</pre>`
-  }
-
-  return response.body ?? response.text()
 }
 
 function titleCaseFileName(fileUrl: string): string {


### PR DESCRIPTION
This keeps the default template's frame-loading setup aligned across server and browser, and improves editor guidance for public `remix/ui` runtime hooks.

- Defines the default template's server-side `resolveFrame` inline in the `renderToStream()` options object, matching the shape used by browser `run({ resolveFrame })` setup.
- Documents `LoadModule`, `ResolveFrame`, and `RunInit` so editor hints explain how client entries are loaded and browser-loaded frames are resolved.
- Adds CLI and UI change notes for the template setup and runtime hook documentation.
