### PR TITLE
Layer Remix UI theme reset

### DIFF
--- a/docs/src/server/registry.ts
+++ b/docs/src/server/registry.ts
@@ -180,8 +180,7 @@ function getOrSet<key, value>(map: Map<key, value>, key: key, init: () => value)
 
 const homePageCss = css({
   '& > p': {
-    marginTop: `${theme.space.sm} !important`,
-    marginBottom: `${theme.space.sm} !important`,
+    margin: `${theme.space.sm} 0`,
   },
   '& > ol > li + li': {
     marginTop: theme.space.md,

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -332,13 +332,6 @@ function DocsFooter() {
 
 // Typography mirrors the `.md-prose` rules from the remix.run blog
 // (`/styles/md.css`) and is applied site-wide.
-//
-// `!important` is required on the margin/decoration overrides below because the
-// RMX_01 theme renders an unlayered `:where(h1, h2, ..., p, ul, ol, ...)
-// { margin: 0 }` reset, while the `css()` mixin always wraps its rules in
-// `@layer rmx.*`. Per the CSS cascade, unlayered author rules beat any layered
-// author rule of equal/lower importance regardless of specificity — so without
-// `!important` our margins are silently dropped.
 const bodyCss = css({
   margin: 0,
   backgroundColor: theme.surface.lvl0,
@@ -349,22 +342,23 @@ const bodyCss = css({
   lineHeight: '1.4',
   letterSpacing: '-0.008em',
 
+  // Headings
   '& :is(h1, h2, h3, h4, h5, h6)': {
     fontFamily: theme.fontFamily.sans,
     fontWeight: theme.fontWeight.bold,
     letterSpacing: '-0.02em',
     lineHeight: '1',
     color: theme.colors.text.primary,
-    marginTop: `${theme.space.lg} !important`,
-    marginBottom: `${theme.space.lg} !important`,
+    margin: `${theme.space.lg} 0`,
   },
   '& h1': {
     fontSize: 'clamp(1.5rem, 4vw, 3.5rem)',
     overflowWrap: 'anywhere',
+    marginTop: theme.space.xxl,
   },
   '& h2': {
     fontSize: 'clamp(1.375rem, 2.5vw, 1.625rem)',
-    marginTop: `calc(${theme.space.xxl} + ${theme.space.lg}) !important`,
+    marginTop: theme.space.xxl,
   },
   '& h3': {
     fontSize: 'clamp(1.125rem, 1.75vw, 1.25rem)',
@@ -379,28 +373,27 @@ const bodyCss = css({
     fontSize: '1rem',
   },
 
+  // Paragraphs
   '& p': {
-    marginTop: `${theme.space.lg} !important`,
-    marginBottom: `${theme.space.lg} !important`,
+    margin: `${theme.space.lg} 0`,
   },
 
+  // Lists
+  '& ol, & ul': {
+    margin: `${theme.space.xxl} 0 ${theme.space.lg}`,
+    paddingInlineStart: theme.space.xxl,
+  },
   '& ul': {
     listStyle: 'disc',
-    marginTop: `${theme.space.xxl} !important`,
-    marginBottom: `${theme.space.lg} !important`,
-    paddingInlineStart: theme.space.xxl,
   },
   '& ol': {
     listStyle: 'decimal',
-    marginTop: `${theme.space.xxl} !important`,
-    marginBottom: `${theme.space.lg} !important`,
-    paddingInlineStart: theme.space.xxl,
   },
   '& li + li': {
     marginTop: theme.space.xs,
   },
   '& li > p': {
-    margin: '0 !important',
+    margin: 0,
   },
 
   '& a': {
@@ -417,7 +410,7 @@ const bodyCss = css({
     border: `1px solid ${theme.colors.border.subtle}`,
     borderRadius: theme.radius.md,
     padding: theme.space.md,
-    margin: `${theme.space.lg} 0 !important`,
+    margin: `${theme.space.lg} 0`,
     overflowX: 'auto',
     lineHeight: theme.lineHeight.relaxed,
     '@media (min-width: 768px)': {
@@ -436,26 +429,26 @@ const bodyCss = css({
   },
 
   '& .shiki': {
-    backgroundColor: `${theme.surface.lvl4} !important`,
+    backgroundColor: theme.surface.lvl4,
     '& a': {
       color: 'inherit',
     },
     '@media (prefers-color-scheme: dark)': {
       '&, & span': {
-        color: 'var(--shiki-dark) !important',
+        color: 'var(--shiki-dark)',
       },
     },
   },
 
   // Sidebar opt-out: the global `& a { underline }` and `& p { margin: 2rem }`
   // would otherwise wreck the nav and group labels. Higher-specificity
-  // descendant selectors win without needing !important fights.
+  // descendant selectors win without needing fights.
   '& aside a': {
     textDecoration: 'none',
   },
   '& aside p': {
-    marginTop: '0 !important',
-    marginBottom: '0 !important',
+    marginTop: 0,
+    marginBottom: 0,
   },
 
   // Mobile nav toggle: the sidebar stays in document flow below the sticky top

--- a/packages/ui/.changes/patch.layer-theme-reset.md
+++ b/packages/ui/.changes/patch.layer-theme-reset.md
@@ -1,0 +1,1 @@
+Emit the built-in theme reset in `rmx-reset` so generated Remix UI component styles can override it. Document where app layers should sit relative to Remix UI layers.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -191,6 +191,27 @@ function Layout(props: { children: RemixNode }) {
 }
 ```
 
+## Cascade Layers
+
+Remix UI emits its built-in theme reset in `rmx-reset` and generated `css(...)` rules under `rmx`. Unlayered CSS outranks layered component CSS, so use explicit layer order when mixing Remix UI with global styles.
+
+Put layers that should lose to Remix UI before `rmx-reset` and `rmx`:
+
+```css
+@layer base, rmx-reset, rmx;
+
+@layer base {
+  button,
+  input,
+  textarea,
+  select {
+    font: inherit;
+    margin: 0;
+    padding: 0;
+  }
+}
+```
+
 ## License
 
 See [LICENSE](https://github.com/remix-run/remix/blob/main/LICENSE)

--- a/packages/ui/docs/styling.md
+++ b/packages/ui/docs/styling.md
@@ -80,6 +80,70 @@ function ProgressBar(handle: Handle) {
 - Dynamic styles that change based on state or props
 - Computed values that update frequently
 
+## Cascade Layers
+
+Generated `css(...)` rules are emitted in native CSS cascade layers under the stable parent layer
+`rmx`. Each generated class gets its own sublayer, so a class such as `rmxc-k4a9f` is emitted as
+`@layer rmx.rmxc-k4a9f { ... }`. This keeps mix ordering stable across roots and frames.
+
+Unlayered author CSS outranks normal layered CSS. That means global styles can override generated
+component styles even when Remix UI inserts its rules later.
+
+The built-in theme reset is emitted in `rmx-reset` and ordered before `rmx`. No extra layer setup is
+needed unless the app adds layers that should sit before or after Remix UI.
+
+Put layers that should lose to Remix UI before `rmx-reset` and `rmx`. The layer can use any
+app-owned name; `base` is a common choice for defaults:
+
+```css
+@layer base, rmx-reset, rmx;
+
+@layer base {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  button,
+  input,
+  select,
+  textarea {
+    font: inherit;
+    margin: 0;
+    padding: 0;
+  }
+
+  code,
+  pre {
+    font-size: 1em;
+  }
+}
+```
+
+Put layers that should override Remix UI after `rmx`:
+
+```css
+@layer base, rmx-reset, rmx, app;
+
+@layer app {
+  .marketing-heading {
+    font-size: clamp(2rem, 6vw, 4rem);
+  }
+}
+```
+
+For imported styles, use an import layer when your build supports it:
+
+```css
+@layer base, rmx-reset, rmx;
+@import './base.css' layer(base);
+```
+
 ## Pseudo-Selectors
 
 Use `&` to reference the current element in pseudo-selectors:

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -9,6 +9,7 @@ import {
   serializeStyleObject,
 } from '../runtime/core/attributes.ts'
 import { appendFlushMarker, type FlushKind, stripFlushMarkers } from '../runtime/stream-protocol.ts'
+import { REMIX_UI_STYLE_LAYER } from '../style/layers.ts'
 
 interface VNode {
   type: ElementType
@@ -124,7 +125,6 @@ type Segment =
 const TEXTAREA_VALUE_PROPS = new Set(['value', 'defaultValue'])
 const INPUT_DEFAULT_PROPS = new Set(['defaultValue', 'defaultChecked'])
 
-const DEFAULT_STYLE_LAYER = 'rmx'
 const DOCTYPE_PATTERN = /<!doctype(?:\s[^>]*)?>/gi
 
 function stripDoctypeMarkup(html: string): string {
@@ -143,7 +143,7 @@ function emptyReadableStream(): ReadableStream<Uint8Array> {
   })
 }
 
-function getStyleLayerName(selector: string, layer: string = DEFAULT_STYLE_LAYER): string {
+function getStyleLayerName(selector: string, layer: string = REMIX_UI_STYLE_LAYER): string {
   return `${layer}.${selector}`
 }
 
@@ -1175,7 +1175,7 @@ function collectStyleTags(context: RenderContext): string {
 function wrapStyleForLayer(
   selector: string,
   css: string,
-  layer: string = DEFAULT_STYLE_LAYER,
+  layer: string = REMIX_UI_STYLE_LAYER,
 ): string {
   let trimmed = css.trim()
   if (!trimmed) return ''
@@ -1185,7 +1185,7 @@ function wrapStyleForLayer(
 function renderStyleTag(
   selector: string,
   css: string,
-  layer: string = DEFAULT_STYLE_LAYER,
+  layer: string = REMIX_UI_STYLE_LAYER,
 ): string {
   let wrappedCss = wrapStyleForLayer(selector, css, layer)
   if (!wrappedCss) return ''

--- a/packages/ui/src/style/layers.ts
+++ b/packages/ui/src/style/layers.ts
@@ -1,0 +1,2 @@
+export const REMIX_UI_STYLE_LAYER = 'rmx'
+export const REMIX_UI_RESET_LAYER = 'rmx-reset'

--- a/packages/ui/src/style/stylesheet.ts
+++ b/packages/ui/src/style/stylesheet.ts
@@ -1,10 +1,11 @@
+import { REMIX_UI_STYLE_LAYER } from './layers.ts'
+
 type RuleEntry = { count: number; index: number }
 type ServerStyleSource = ParentNode | Iterable<Node>
 
 const SERVER_STYLE_SELECTOR = 'style[data-rmx]'
-const DEFAULT_STYLE_LAYER = 'rmx'
 
-function getStyleLayerName(className: string, layer: string = DEFAULT_STYLE_LAYER): string {
+function getStyleLayerName(className: string, layer: string = REMIX_UI_STYLE_LAYER): string {
   return `${layer}.${className}`
 }
 
@@ -67,7 +68,7 @@ function getStyleSelector(styleEl: HTMLStyleElement): string | null {
   return selector ? selector : null
 }
 
-export function createStyleManager(layer: string = 'rmx') {
+export function createStyleManager(layer: string = REMIX_UI_STYLE_LAYER) {
   let stylesheet: CSSStyleSheet | null = null
   let generation = 0
 

--- a/packages/ui/src/theme/README.md
+++ b/packages/ui/src/theme/README.md
@@ -98,6 +98,6 @@ function Layout() {
 - `theme` values are CSS variable references, not raw token values.
 - `createTheme` serializes token values into CSS custom properties and renders a `<style data-rmx-theme>` tag.
 - The default selector is `:root`; pass `selector` for scoped themes.
-- The base reset is included by default and can be disabled with `reset: false`.
+- The base reset is included by default, emitted in `rmx-reset`, and can be disabled with `reset: false`.
 - The built-in components consume this token contract through their style mixins.
 - Render `<RMX_01 />` and `<RMX_01_GLYPHS />` once when using the built-in theme and glyph preset.

--- a/packages/ui/src/theme/runtime.ts
+++ b/packages/ui/src/theme/runtime.ts
@@ -1,5 +1,6 @@
 import { createElement, type Handle } from '@remix-run/ui'
 
+import { REMIX_UI_RESET_LAYER, REMIX_UI_STYLE_LAYER } from '../style/layers.ts'
 import {
   theme,
   themeVariableNames,
@@ -76,7 +77,9 @@ function serializeThemeCss(selector: string, vars: ThemeVars, options: { reset: 
   let blocks = [`${selector} {\n${lines}\n}`]
 
   if (options.reset) {
-    blocks.push(serializeThemeResetCss(selector))
+    let resetCss = serializeThemeResetCss(selector)
+    blocks.push(`@layer ${REMIX_UI_RESET_LAYER}, ${REMIX_UI_STYLE_LAYER};`)
+    blocks.push(`@layer ${REMIX_UI_RESET_LAYER} { ${resetCss} }`)
   }
 
   return blocks.join('\n\n')

--- a/packages/ui/src/theme/theme.test.ts
+++ b/packages/ui/src/theme/theme.test.ts
@@ -1,7 +1,7 @@
 import { expect } from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
-import { createElement } from '@remix-run/ui'
+import { createElement, createRoot, css } from '@remix-run/ui'
 import { renderToString } from '@remix-run/ui/server'
 
 import * as accordion from '../components/accordion/accordion.tsx'
@@ -155,6 +155,8 @@ describe('createTheme', () => {
     expect(Theme.cssText).toMatch(/--rmx-control-height-sm: 28px;/)
     expect(Theme.cssText).toMatch(/--rmx-surface-lvl3: #f1f5f9;/)
     expect(Theme.cssText).toMatch(/--rmx-color-text-primary: #111827;/)
+    expect(Theme.cssText).toMatch(/@layer rmx-reset, rmx;/)
+    expect(Theme.cssText).toMatch(/@layer rmx-reset \{/)
     expect(Theme.cssText).toMatch(/html, body \{/)
     expect(Theme.cssText).toMatch(/font-family: var\(--rmx-font-family-sans\);/)
     expect(Theme.cssText).toMatch(/background-color: var\(--rmx-surface-lvl0\);/)
@@ -184,8 +186,36 @@ describe('createTheme', () => {
     })
 
     expect(Theme.cssText).toMatch(/:root \{/)
+    expect(Theme.cssText).not.toMatch(/@layer rmx-reset \{/)
     expect(Theme.cssText).not.toMatch(/html, body \{/)
     expect(Theme.cssText).not.toMatch(/box-sizing: border-box;/)
+  })
+
+  it('keeps the theme reset below generated styles', () => {
+    let Theme = createTheme(sampleTheme)
+    let container = document.createElement('div')
+    document.body.appendChild(container)
+    let root = createRoot(container)
+
+    try {
+      root.render(
+        createElement(
+          'div',
+          {},
+          createElement(Theme, {}),
+          createElement('h1', { mix: [css({ marginTop: 24, marginBottom: 24 })] }, 'Dashboard'),
+        ),
+      )
+      root.flush()
+
+      let heading = container.querySelector('h1')
+      if (!heading) throw new Error('Expected heading to be rendered')
+      expect(getComputedStyle(heading).marginTop).toBe('24px')
+      expect(getComputedStyle(heading).marginBottom).toBe('24px')
+    } finally {
+      root.dispose()
+      container.remove()
+    }
   })
 
   it('renders a style tag component', async () => {


### PR DESCRIPTION
## Summary

Remix UI generated component styles already live under the native `rmx` cascade layer. This PR moves the built-in theme reset into `rmx-reset` and explicitly orders it before `rmx`, so generated component styles can override the package reset instead of losing to it through layer order.

- Adds shared internal layer-name constants for `rmx` and `rmx-reset` so the client style manager, server renderer, and theme runtime stay aligned.
- Emits `@layer rmx-reset, rmx;` when the theme reset is enabled, then wraps the theme reset in `@layer rmx-reset`.
- Documents where app layers should sit relative to Remix UI layers: before `rmx-reset`/`rmx` for defaults, after `rmx` for overrides.
- Adds a theme regression test showing generated `css(...)` styles override the built-in reset.

## What problem does this solve

The `createTheme` reset is _too powerful_

```tsx
import { createTheme, css } from 'remix/ui'

let Theme = createTheme(themeValues, { reset: true })

function HomepageHero() {
  return (
    <>
      <Theme />

      {/* Previously, the unlayered theme reset could override these generated layered styles. */}
      <h1
        mix={css({
          marginTop: 24,
          fontSize: 48,
          fontWeight: 700,
        })}
      >
        Build faster with Remix
      </h1>
    </>
  )
}
```