### PR TITLE
fix: don't highlight hyphens in path arguments as single-character flags

### DIFF
--- a/packages/cli/.changes/patch.fix-help-text-syntax-highlight.md
+++ b/packages/cli/.changes/patch.fix-help-text-syntax-highlight.md
@@ -1,0 +1,1 @@
+Fixed help text syntax highlighting to not highlight hyphens in path arguments (e.g. `./my-remix-app`) as single-character flags.

--- a/packages/cli/src/lib/help-text.test.ts
+++ b/packages/cli/src/lib/help-text.test.ts
@@ -53,7 +53,12 @@ describe('help text', () => {
 
         return formatHelpText(
           {
-            examples: ['remix demo --json', 'remix new ./my-remix-app --force'],
+            examples: [
+              'remix demo --json',
+              'remix new ./my-remix-app --force',
+              'remix new ./my-a --force',
+              'remix new ./foo--bar --force',
+            ],
             options: [{ description: 'Print JSON output', label: '--dir <path>' }],
             usage: ['remix demo [options]'],
           },
@@ -66,7 +71,9 @@ describe('help text', () => {
     assert.ok(output.includes(`remix demo ${ANSI_CSI}93m[options]${ANSI_CSI}0m`))
     assert.ok(output.includes(`${ANSI_CSI}93m--dir${ANSI_CSI}0m ${ANSI_CSI}93m<path>${ANSI_CSI}0m`))
     assert.ok(output.includes(`remix demo ${ANSI_CSI}93m--json${ANSI_CSI}0m`))
-    assert.ok(output.includes('./my-remix-app'))
+    assert.ok(output.includes(`remix new ./my-remix-app ${ANSI_CSI}93m--force${ANSI_CSI}0m`))
+    assert.ok(output.includes(`remix new ./my-a ${ANSI_CSI}93m--force${ANSI_CSI}0m`))
+    assert.ok(output.includes(`remix new ./foo--bar ${ANSI_CSI}93m--force${ANSI_CSI}0m`))
   })
 
   it('colors help for stderr independently of stdout capability', () => {

--- a/packages/cli/src/lib/help-text.test.ts
+++ b/packages/cli/src/lib/help-text.test.ts
@@ -53,7 +53,7 @@ describe('help text', () => {
 
         return formatHelpText(
           {
-            examples: ['remix demo --json'],
+            examples: ['remix demo --json', 'remix new ./my-remix-app --force'],
             options: [{ description: 'Print JSON output', label: '--dir <path>' }],
             usage: ['remix demo [options]'],
           },
@@ -66,6 +66,7 @@ describe('help text', () => {
     assert.ok(output.includes(`remix demo ${ANSI_CSI}93m[options]${ANSI_CSI}0m`))
     assert.ok(output.includes(`${ANSI_CSI}93m--dir${ANSI_CSI}0m ${ANSI_CSI}93m<path>${ANSI_CSI}0m`))
     assert.ok(output.includes(`remix demo ${ANSI_CSI}93m--json${ANSI_CSI}0m`))
+    assert.ok(output.includes('./my-remix-app'))
   })
 
   it('colors help for stderr independently of stdout capability', () => {

--- a/packages/cli/src/lib/help-text.ts
+++ b/packages/cli/src/lib/help-text.ts
@@ -83,7 +83,7 @@ function formatHeading(title: string, target: NodeJS.WriteStream): string {
 
 function highlightSyntax(text: string, target: NodeJS.WriteStream): string {
   return text.replace(
-    /(--[A-Za-z0-9-]+|-[A-Za-z](?![A-Za-z0-9])|\[[A-Za-z][A-Za-z0-9-]*\]|<[^>\n]+>)/g,
+    /(?<![^\s[,|])(--[A-Za-z0-9-]+|-[A-Za-z])(?=$|[\s,\]|])|\[[A-Za-z][A-Za-z0-9-]*\]|<[^>\n]+>/g,
     (token) => lightYellow(token, target),
   )
 }

--- a/packages/cli/src/lib/help-text.ts
+++ b/packages/cli/src/lib/help-text.ts
@@ -82,7 +82,8 @@ function formatHeading(title: string, target: NodeJS.WriteStream): string {
 }
 
 function highlightSyntax(text: string, target: NodeJS.WriteStream): string {
-  return text.replace(/(--[A-Za-z0-9-]+|-[A-Za-z]|\[[A-Za-z][A-Za-z0-9-]*\]|<[^>\n]+>)/g, (token) =>
-    lightYellow(token, target),
+  return text.replace(
+    /(--[A-Za-z0-9-]+|-[A-Za-z](?![A-Za-z0-9])|\[[A-Za-z][A-Za-z0-9-]*\]|<[^>\n]+>)/g,
+    (token) => lightYellow(token, target),
   )
 }


### PR DESCRIPTION
The regex used for help text syntax highlighting matched -[A-Za-z] to highlight short flags like -v. However, this also matched hyphens in path arguments like ./my-remix-app, causing -r (from -remix) and -a (from -app) to be incorrectly highlighted.

Fixed by adding a negative lookahead (?![A-Za-z0-9]) to ensure short flags are not followed by more alphanumeric characters.

Before / After
<img width="650" height="561" alt="image" src="https://github.com/user-attachments/assets/281c70e7-0f6c-4b79-b253-3595a81253a0" />

<img width="650" height="553" alt="image" src="https://github.com/user-attachments/assets/80562037-4474-40cf-9f1b-769a657e1c6d" />
