### PR TITLE
Add package meta validation script

### DIFF
--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -231,6 +231,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate package meta
+        run: pnpm validate-package-meta
+
       - name: Lint
         run: pnpm lint
 

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -255,6 +255,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate package meta
+        run: pnpm validate-package-meta
+
       - name: Lint
         run: pnpm lint
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This repository includes the source code for Remix 3, a web framework for buildi
 
 ## Default Development Loop
 
-- **Fast local loop**: `pnpm run lint`, `pnpm run test:changed`, `pnpm run typecheck:changed`
+- **Fast local loop**: `pnpm run validate-package-meta`, `pnpm run lint`, `pnpm run test:changed`, `pnpm run typecheck:changed`
 - **Full CI-style validation**: `pnpm test` and `pnpm run typecheck`
 - **When to use full runs locally**: broad cross-workspace changes, shared root config changes, release/publish flow changes, or anything that could affect the whole repo
 - **Single package commands**: `pnpm --filter @remix-run/<package> run test`, `pnpm --filter @remix-run/<package> run typecheck`, `pnpm --filter @remix-run/<package> run build`

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lint:fix": "oxlint . -A all --fix --quiet",
     "pr-preview": "node ./scripts/pr-preview.ts",
     "setup-installable-branch": "node ./scripts/setup-installable-branch.ts",
+    "validate-package-meta": "node ./scripts/validate-package-meta.ts",
     "test": "pnpm --parallel run test",
     "test:bun": "pnpm --parallel --if-present run test:bun",
     "test:changed": "node ./scripts/run-changed-workspaces.ts test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ catalogs:
       specifier: ^1.59.0
       version: 1.59.0
     tsx:
-      specifier: ^4.20.6
+      specifier: ^4.21.0
       version: 4.21.0
     typescript:
       specifier: ^5.9.3
@@ -2023,6 +2023,9 @@ importers:
       semver:
         specifier: ^7.6.3
         version: 7.6.3
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
   template:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ catalog:
   '@types/node': ^24.6.0
   '@typescript/native-preview': 7.0.0-dev.20251125.1
   playwright: ^1.59.0
-  tsx: ^4.20.6
+  tsx: ^4.21.0
   typescript: ^5.9.3
   typescript-language-server: ^5.1.3
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -9,7 +9,8 @@
     "@types/node": "catalog:",
     "@types/semver": "^7.5.8",
     "@typescript/native-preview": "catalog:",
-    "semver": "^7.6.3"
+    "semver": "^7.6.3",
+    "yaml": "^2.9.0"
   },
   "scripts": {
     "test": "remix-test",

--- a/scripts/validate-package-meta.ts
+++ b/scripts/validate-package-meta.ts
@@ -69,15 +69,13 @@ function main() {
 
     if (issues.length > 0) {
       hasFailures = true
-      console.error(`  ${colorize('✗', colors.red)} ${check.name}\n`)
-      console.error(issues.join('\n\n'))
+      console.error(`${colorize('✗', colors.red)} ${check.name}\n`)
+      console.error(`${formatIssues(issues)}\n`)
       continue
     }
 
-    console.log(`  ${colorize('✓', colors.lightGreen)} ${check.name}`)
+    console.log(`${colorize('✓', colors.lightGreen)} ${check.name}\n`)
   }
-
-  console.log()
 
   if (hasFailures) {
     process.exit(1)
@@ -220,6 +218,15 @@ function formatUsages(usages: DependencyUsage[]): string[] {
     (usage) =>
       `- ${usage.packageDir}/package.json ${usage.field}.${usage.dependencyName}: ${usage.specifier}`,
   )
+}
+
+function formatIssues(issues: string[]): string {
+  return issues.map(formatIssue).join('\n\n')
+}
+
+function formatIssue(issue: string): string {
+  let [firstLine, ...remainingLines] = issue.split('\n')
+  return [`- ${firstLine}`, ...remainingLines.map((line) => `  ${line}`)].join('\n')
 }
 
 main()

--- a/scripts/validate-package-meta.ts
+++ b/scripts/validate-package-meta.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs'
+import { parse } from 'yaml'
 import { colors, colorize } from './utils/color.ts'
 import { getAllPackageDirNames, getPackageFile } from './utils/packages.ts'
 
@@ -45,6 +46,7 @@ interface PackageMetaCheck {
 
 function main() {
   let packageInfos = getPublishedPackageInfos()
+  let catalogDependencies = getCatalogDependencies()
   let checks: PackageMetaCheck[] = [
     {
       name: 'Published package.json files use explicit consumer-facing dependency ranges',
@@ -56,6 +58,12 @@ function main() {
       name: 'Published package.json files use consistent consumer-facing dependency ranges across packages',
       validate() {
         return validateConsistentConsumerDependencyRanges(packageInfos)
+      },
+    },
+    {
+      name: 'Published package.json files match catalog ranges for consumer-facing dependencies',
+      validate() {
+        return validateConsumerDependencyRangesMatchCatalog(packageInfos, catalogDependencies)
       },
     },
   ]
@@ -108,6 +116,24 @@ function getPublishedPackageInfos(): PublishedPackageInfo[] {
   return packageInfos
 }
 
+function getCatalogDependencies(): PackageDependencyMap {
+  let workspaceConfig: unknown = parse(fs.readFileSync('pnpm-workspace.yaml', 'utf8'))
+  if (!isRecord(workspaceConfig)) {
+    throw new Error('Expected pnpm-workspace.yaml to contain an object')
+  }
+
+  let catalog = workspaceConfig.catalog
+  if (catalog === undefined) {
+    return {}
+  }
+
+  if (!isDependencyMap(catalog)) {
+    throw new Error('Expected pnpm-workspace.yaml catalog to be an object of string specifiers')
+  }
+
+  return catalog
+}
+
 function validateExplicitConsumerDependencyRanges(packageInfos: PublishedPackageInfo[]): string[] {
   let violations: string[] = []
 
@@ -124,6 +150,35 @@ function validateExplicitConsumerDependencyRanges(packageInfos: PublishedPackage
             `${packageInfo.dir}/package.json ${field}.${dependencyName} uses ${specifier}, but published consumer-facing dependencies must use explicit ranges.`,
           )
         }
+      }
+    }
+  }
+
+  return violations
+}
+
+function validateConsumerDependencyRangesMatchCatalog(
+  packageInfos: PublishedPackageInfo[],
+  catalogDependencies: PackageDependencyMap,
+): string[] {
+  let violations: string[] = []
+
+  for (let packageInfo of packageInfos) {
+    for (let field of CONSUMER_DEPENDENCY_FIELDS) {
+      let dependencies = packageInfo.packageJson[field]
+      if (!dependencies) {
+        continue
+      }
+
+      for (let [dependencyName, specifier] of Object.entries(dependencies)) {
+        let catalogSpecifier = catalogDependencies[dependencyName]
+        if (catalogSpecifier === undefined || specifier === catalogSpecifier) {
+          continue
+        }
+
+        violations.push(
+          `${packageInfo.dir}/package.json ${field}.${dependencyName} uses ${specifier}, but the catalog range is ${catalogSpecifier}.`,
+        )
       }
     }
   }
@@ -205,6 +260,10 @@ function readConsumerDependencies(
   }
 
   return dependencies
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 function isDependencyMap(value: unknown): value is PackageDependencyMap {

--- a/scripts/validate-package-meta.ts
+++ b/scripts/validate-package-meta.ts
@@ -1,0 +1,225 @@
+import * as fs from 'node:fs'
+import { colors, colorize } from './utils/color.ts'
+import { getAllPackageDirNames, getPackageFile } from './utils/packages.ts'
+
+const CONSUMER_DEPENDENCY_FIELDS = [
+  'dependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const
+
+type ConsumerDependencyField = (typeof CONSUMER_DEPENDENCY_FIELDS)[number]
+type PackageDependencyMap = Record<string, string>
+
+interface PublishedPackageInfo {
+  dir: string
+  packageJson: PublishedPackageJson
+}
+
+interface PublishedPackageJson {
+  name: string
+  dependencies?: PackageDependencyMap
+  optionalDependencies?: PackageDependencyMap
+  peerDependencies?: PackageDependencyMap
+}
+
+interface DependencyUsage {
+  packageDir: string
+  packageName: string
+  field: ConsumerDependencyField
+  dependencyName: string
+  specifier: string
+}
+
+type RawPackageJson = {
+  name?: unknown
+  private?: unknown
+} & {
+  [field in ConsumerDependencyField]?: unknown
+}
+
+interface PackageMetaCheck {
+  name: string
+  validate(): string[]
+}
+
+function main() {
+  let packageInfos = getPublishedPackageInfos()
+  let checks: PackageMetaCheck[] = [
+    {
+      name: 'Published package.json files use explicit consumer-facing dependency ranges',
+      validate() {
+        return validateExplicitConsumerDependencyRanges(packageInfos)
+      },
+    },
+    {
+      name: 'Published package.json files use consistent consumer-facing dependency ranges across packages',
+      validate() {
+        return validateConsistentConsumerDependencyRanges(packageInfos)
+      },
+    },
+  ]
+
+  console.log('Validating package metadata...\n')
+
+  let hasFailures = false
+
+  for (let check of checks) {
+    let issues = check.validate()
+
+    if (issues.length > 0) {
+      hasFailures = true
+      console.error(`  ${colorize('✗', colors.red)} ${check.name}\n`)
+      console.error(issues.join('\n\n'))
+      continue
+    }
+
+    console.log(`  ${colorize('✓', colors.lightGreen)} ${check.name}`)
+  }
+
+  console.log()
+
+  if (hasFailures) {
+    process.exit(1)
+  }
+}
+
+function getPublishedPackageInfos(): PublishedPackageInfo[] {
+  let packageInfos: PublishedPackageInfo[] = []
+
+  for (let dirName of getAllPackageDirNames().sort()) {
+    let packageJsonPath = getPackageFile(dirName, 'package.json')
+    if (!fs.existsSync(packageJsonPath)) {
+      continue
+    }
+
+    let packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as RawPackageJson
+    if (typeof packageJson.name !== 'string' || packageJson.private === true) {
+      continue
+    }
+
+    packageInfos.push({
+      dir: `packages/${dirName}`,
+      packageJson: {
+        name: packageJson.name,
+        ...readConsumerDependencies(packageJson, packageJsonPath),
+      },
+    })
+  }
+
+  return packageInfos
+}
+
+function validateExplicitConsumerDependencyRanges(packageInfos: PublishedPackageInfo[]): string[] {
+  let violations: string[] = []
+
+  for (let packageInfo of packageInfos) {
+    for (let field of CONSUMER_DEPENDENCY_FIELDS) {
+      let dependencies = packageInfo.packageJson[field]
+      if (!dependencies) {
+        continue
+      }
+
+      for (let [dependencyName, specifier] of Object.entries(dependencies)) {
+        if (specifier.startsWith('catalog:')) {
+          violations.push(
+            `${packageInfo.dir}/package.json ${field}.${dependencyName} uses ${specifier}, but published consumer-facing dependencies must use explicit ranges.`,
+          )
+        }
+      }
+    }
+  }
+
+  return violations
+}
+
+function validateConsistentConsumerDependencyRanges(packageInfos: PublishedPackageInfo[]): string[] {
+  let violations: string[] = []
+  let firstPartyPackageNames = new Set(
+    packageInfos.map((packageInfo) => packageInfo.packageJson.name),
+  )
+  let thirdPartyUsagesByName = new Map<string, DependencyUsage[]>()
+
+  for (let packageInfo of packageInfos) {
+    for (let field of CONSUMER_DEPENDENCY_FIELDS) {
+      let dependencies = packageInfo.packageJson[field]
+      if (!dependencies) {
+        continue
+      }
+
+      for (let [dependencyName, specifier] of Object.entries(dependencies)) {
+        if (firstPartyPackageNames.has(dependencyName)) {
+          continue
+        }
+
+        let usages = thirdPartyUsagesByName.get(dependencyName) ?? []
+        usages.push({
+          packageDir: packageInfo.dir,
+          packageName: packageInfo.packageJson.name,
+          field,
+          dependencyName,
+          specifier,
+        })
+        thirdPartyUsagesByName.set(dependencyName, usages)
+      }
+    }
+  }
+
+  for (let [dependencyName, usages] of thirdPartyUsagesByName) {
+    let packageNames = new Set(usages.map((usage) => usage.packageName))
+    if (packageNames.size < 2) {
+      continue
+    }
+
+    let specifiers = new Set(usages.map((usage) => usage.specifier))
+    if (specifiers.size > 1) {
+      violations.push(
+        [
+          `${dependencyName} has inconsistent ranges across published consumer-facing dependencies:`,
+          ...formatUsages(usages),
+        ].join('\n'),
+      )
+    }
+  }
+
+  return violations
+}
+
+function readConsumerDependencies(
+  packageJson: RawPackageJson,
+  packageJsonPath: string,
+): Omit<PublishedPackageJson, 'name'> {
+  let dependencies: Omit<PublishedPackageJson, 'name'> = {}
+
+  for (let field of CONSUMER_DEPENDENCY_FIELDS) {
+    let value = packageJson[field]
+    if (value === undefined) {
+      continue
+    }
+
+    if (!isDependencyMap(value)) {
+      throw new Error(`Expected ${packageJsonPath} ${field} to be an object of string specifiers`)
+    }
+
+    dependencies[field] = value
+  }
+
+  return dependencies
+}
+
+function isDependencyMap(value: unknown): value is PackageDependencyMap {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  return Object.values(value).every((specifier) => typeof specifier === 'string')
+}
+
+function formatUsages(usages: DependencyUsage[]): string[] {
+  return usages.map(
+    (usage) =>
+      `- ${usage.packageDir}/package.json ${usage.field}.${usage.dependencyName}: ${usage.specifier}`,
+  )
+}
+
+main()

--- a/scripts/validate-package-meta.ts
+++ b/scripts/validate-package-meta.ts
@@ -131,7 +131,9 @@ function validateExplicitConsumerDependencyRanges(packageInfos: PublishedPackage
   return violations
 }
 
-function validateConsistentConsumerDependencyRanges(packageInfos: PublishedPackageInfo[]): string[] {
+function validateConsistentConsumerDependencyRanges(
+  packageInfos: PublishedPackageInfo[],
+): string[] {
   let violations: string[] = []
   let firstPartyPackageNames = new Set(
     packageInfos.map((packageInfo) => packageInfo.packageJson.name),


### PR DESCRIPTION
This script validates that all consumer-facing third-party dependencies for Remix packages are explicit (i.e. not `catalog:`), are the same across all packages, and match the catalog entry if present. This ensures that we don't accidentally ship multiple versions of our dependencies under the `remix` package, and makes it clear which packages are changing when third-party dependencies are updated.

I initially wanted to make `catalog:` dependencies work in our consumer-facing dependency fields for preview builds since that's the blocker currently, but I ended up feeling like this obfuscates the impact of changing a catalog dependency version in `pnpm-workspace.yaml`. Since even then I'd likely want to validate that we always use `catalog:` for shared third-party deps, simply validating that they're all the same seemed like the simpler workflow.

Script output on success:

```
> node ./scripts/validate-package-meta.ts

Validating package metadata...

✓ Published package.json files use explicit consumer-facing dependency ranges

✓ Published package.json files use consistent consumer-facing dependency ranges across packages

✓ Published package.json files match catalog ranges for consumer-facing dependencies
```

Script output on error:

```
> node ./scripts/validate-package-meta.ts

Validating package metadata...

✗ Published package.json files use explicit consumer-facing dependency ranges

- packages/test/package.json peerDependencies.playwright uses catalog:, but published consumer-facing dependencies must use explicit ranges.

✗ Published package.json files use consistent consumer-facing dependency ranges across packages

- playwright has inconsistent ranges across published consumer-facing dependencies:
  - packages/remix/package.json peerDependencies.playwright: ^1.59.0
  - packages/test/package.json peerDependencies.playwright: catalog:

✗ Published package.json files match catalog ranges for consumer-facing dependencies

- packages/test/package.json dependencies.tsx uses ^4.20.6, but the catalog range is ^4.21.0.
```