### PR TITLE
Expand frames demo

### DIFF
--- a/demos/frames/app/actions/frames/controller.tsx
+++ b/demos/frames/app/actions/frames/controller.tsx
@@ -174,6 +174,30 @@ export const framesController = createController(routes.frames, {
       )
     },
 
+    async rootReloadEntryFrame(context) {
+      await delay(700)
+
+      return render(
+        context,
+        <div
+          style={{
+            border: '1px solid rgba(255,255,255,0.10)',
+            borderRadius: 10,
+            padding: 10,
+            background: 'rgba(255,255,255,0.02)',
+          }}
+        >
+          <div style={{ fontSize: 12, color: '#b9c6ff' }}>Frame inside preserved client entry</div>
+          <div style={{ fontSize: 16, fontVariantNumeric: 'tabular-nums', marginTop: 2 }}>
+            {new Date().toLocaleTimeString()}
+          </div>
+          <div style={{ marginTop: 8 }}>
+            <Counter initialCount={10} label="Nested frame" />
+          </div>
+        </div>,
+      )
+    },
+
     async time(context) {
       await delay(1200)
 
@@ -208,18 +232,13 @@ export const framesController = createController(routes.frames, {
     async reloadScope(context) {
       await delay(700)
 
-      let now = new Date()
+      return renderReloadScopeFrame(context, 'Non-blocking frame server time')
+    },
 
-      return render(
-        context,
-        <div>
-          <div style={{ fontSize: 13, color: '#b9c6ff' }}>Frame server time</div>
-          <div style={{ fontSize: 18, fontVariantNumeric: 'tabular-nums', marginBottom: 10 }}>
-            {now.toLocaleTimeString()}
-          </div>
-          <ReloadScope />
-        </div>,
-      )
+    async reloadScopeBlocking(context) {
+      await delay(500)
+
+      return renderReloadScopeFrame(context, 'Blocking frame server time')
     },
 
     async stateSearchResults(context) {
@@ -253,6 +272,21 @@ export const framesController = createController(routes.frames, {
 
 function render(context: RouterTypes['context'], node: RemixNode, init?: ResponseInit) {
   return context.render(node, init)
+}
+
+function renderReloadScopeFrame(context: RouterTypes['context'], label: string) {
+  let now = new Date()
+
+  return render(
+    context,
+    <div>
+      <div style={{ fontSize: 13, color: '#b9c6ff' }}>{label}</div>
+      <div style={{ fontSize: 18, fontVariantNumeric: 'tabular-nums', marginBottom: 10 }}>
+        {now.toLocaleTimeString()}
+      </div>
+      <ReloadScope />
+    </div>,
+  )
 }
 
 function delay(ms: number) {

--- a/demos/frames/app/actions/reload-scope.tsx
+++ b/demos/frames/app/actions/reload-scope.tsx
@@ -1,6 +1,7 @@
 import { Frame, type Handle } from 'remix/ui'
 
 import { Counter } from '../assets/counter.tsx'
+import { ReloadTopFrame } from '../assets/reload-scope.tsx'
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
 
@@ -14,7 +15,8 @@ export function ReloadScopePage(handle: Handle<{ pageNow: Date }>) {
         Frame reload vs top reload
       </h1>
       <p style={{ marginTop: 0, color: '#b9c6ff' }}>
-        Reload only this frame, or reload the entire runtime tree from inside the same client entry.
+        Compare blocking and non-blocking child frames while reloading either a child frame or the
+        entire runtime tree.
       </p>
       <div
         style={{
@@ -28,7 +30,10 @@ export function ReloadScopePage(handle: Handle<{ pageNow: Date }>) {
         <div style={{ fontSize: 13, color: '#b9c6ff', marginBottom: 8 }}>
           Root client entry state
         </div>
-        <Counter initialCount={0} label="Root" />
+        <div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+          <Counter initialCount={0} label="Root" />
+          <ReloadTopFrame />
+        </div>
       </div>
       <div style={{ marginBottom: 10 }}>
         <div style={{ fontSize: 13, color: '#b9c6ff' }}>Page server time</div>
@@ -38,16 +43,37 @@ export function ReloadScopePage(handle: Handle<{ pageNow: Date }>) {
       </div>
       <div
         style={{
-          border: '1px solid rgba(255,255,255,0.12)',
-          borderRadius: 12,
-          padding: 16,
-          background: 'rgba(255,255,255,0.04)',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+          gap: 16,
         }}
       >
-        <Frame
-          src={routes.frames.reloadScope.href()}
-          fallback={<div style={{ color: '#9aa8e8' }}>Loading reload controls…</div>}
-        />
+        <section
+          style={{
+            border: '1px solid rgba(255,255,255,0.12)',
+            borderRadius: 12,
+            padding: 16,
+            background: 'rgba(255,255,255,0.04)',
+          }}
+        >
+          <h2 style={{ marginTop: 0, fontSize: 16 }}>Non-blocking child frame</h2>
+          <Frame
+            name="reload-scope-non-blocking"
+            src={routes.frames.reloadScope.href()}
+            fallback={<div style={{ color: '#9aa8e8' }}>Loading non-blocking frame…</div>}
+          />
+        </section>
+        <section
+          style={{
+            border: '1px solid rgba(255,255,255,0.12)',
+            borderRadius: 12,
+            padding: 16,
+            background: 'rgba(255,255,255,0.04)',
+          }}
+        >
+          <h2 style={{ marginTop: 0, fontSize: 16 }}>Blocking child frame</h2>
+          <Frame name="reload-scope-blocking" src={routes.frames.reloadScopeBlocking.href()} />
+        </section>
       </div>
     </Document>
   )

--- a/demos/frames/app/assets/reload-scope.tsx
+++ b/demos/frames/app/assets/reload-scope.tsx
@@ -4,30 +4,33 @@ export const ReloadScope = clientEntry(
   '/assets/reload-scope.js#ReloadScope',
   function ReloadScope(handle: Handle) {
     let framePending = false
-    let topPending = false
+
+    handle.frame.addEventListener(
+      'reloadStart',
+      () => {
+        framePending = true
+        handle.update()
+      },
+      { signal: handle.signal },
+    )
+
+    handle.frame.addEventListener(
+      'reloadComplete',
+      () => {
+        framePending = false
+        handle.update()
+      },
+      { signal: handle.signal },
+    )
 
     return () => (
       <div mix={css({ display: 'flex', gap: 8, flexWrap: 'wrap' })}>
         <button
           type="button"
           mix={[
-            css({
-              padding: '6px 10px',
-              borderRadius: 10,
-              border: '1px solid rgba(255,255,255,0.18)',
-              background: framePending ? 'rgba(255,255,255,0.04)' : 'rgba(255,255,255,0.06)',
-              color: '#e9eefc',
-              cursor: framePending ? 'default' : 'pointer',
-              '&:hover': { background: 'var(--frame-bg)' },
-            }),
-            on('click', async () => {
-              if (framePending || topPending) return
-              framePending = true
-              handle.update()
-              let signal = await handle.frame.reload()
-              if (signal.aborted) return
-              framePending = false
-              handle.update()
+            reloadButtonStyle(framePending),
+            on('click', () => {
+              void handle.frame.reload()
             }),
           ]}
           style={{
@@ -36,35 +39,61 @@ export const ReloadScope = clientEntry(
         >
           {framePending ? 'Reloading frame…' : 'Reload this frame'}
         </button>
-        <button
-          type="button"
-          mix={[
-            css({
-              padding: '6px 10px',
-              borderRadius: 10,
-              border: '1px solid rgba(255,255,255,0.18)',
-              background: topPending ? 'rgba(255,255,255,0.04)' : 'rgba(255,255,255,0.06)',
-              color: '#e9eefc',
-              cursor: topPending ? 'default' : 'pointer',
-              '&:hover': { background: 'var(--top-bg)' },
-            }),
-            on('click', async () => {
-              if (topPending || framePending) return
-              topPending = true
-              handle.update()
-              let signal = await handle.frames.top.reload()
-              if (signal.aborted) return
-              topPending = false
-              handle.update()
-            }),
-          ]}
-          style={{
-            '--top-bg': topPending ? undefined : 'rgba(255,255,255,0.10)',
-          }}
-        >
-          {topPending ? 'Reloading page…' : 'Reload top frame'}
-        </button>
       </div>
     )
   },
 )
+
+export const ReloadTopFrame = clientEntry(
+  '/assets/reload-scope.js#ReloadTopFrame',
+  function ReloadTopFrame(handle: Handle) {
+    let pending = false
+
+    handle.frames.top.addEventListener(
+      'reloadStart',
+      () => {
+        pending = true
+        handle.update()
+      },
+      { signal: handle.signal },
+    )
+
+    handle.frames.top.addEventListener(
+      'reloadComplete',
+      () => {
+        pending = false
+        handle.update()
+      },
+      { signal: handle.signal },
+    )
+
+    return () => (
+      <button
+        type="button"
+        mix={[
+          reloadButtonStyle(pending),
+          on('click', () => {
+            void handle.frames.top.reload()
+          }),
+        ]}
+        style={{
+          '--frame-bg': pending ? undefined : 'rgba(255,255,255,0.10)',
+        }}
+      >
+        {pending ? 'Reloading page…' : 'Reload top frame'}
+      </button>
+    )
+  },
+)
+
+function reloadButtonStyle(pending: boolean) {
+  return css({
+    padding: '6px 10px',
+    borderRadius: 10,
+    border: '1px solid rgba(255,255,255,0.18)',
+    background: pending ? 'rgba(255,255,255,0.04)' : 'rgba(255,255,255,0.06)',
+    color: '#e9eefc',
+    cursor: 'pointer',
+    '&:hover': { background: 'var(--frame-bg)' },
+  })
+}

--- a/demos/frames/app/assets/reload-time.tsx
+++ b/demos/frames/app/assets/reload-time.tsx
@@ -5,6 +5,24 @@ export const ReloadTime = clientEntry(
   function ReloadTime(handle: Handle) {
     let pending = false
 
+    handle.frame.addEventListener(
+      'reloadStart',
+      () => {
+        pending = true
+        handle.update()
+      },
+      { signal: handle.signal },
+    )
+
+    handle.frame.addEventListener(
+      'reloadComplete',
+      () => {
+        pending = false
+        handle.update()
+      },
+      { signal: handle.signal },
+    )
+
     return () => (
       <button
         type="button"
@@ -15,16 +33,11 @@ export const ReloadTime = clientEntry(
             border: '1px solid rgba(255,255,255,0.18)',
             background: pending ? 'rgba(255,255,255,0.04)' : 'rgba(255,255,255,0.06)',
             color: '#e9eefc',
-            cursor: pending ? 'default' : 'pointer',
+            cursor: 'pointer',
             '&:hover': { background: 'var(--bg)' },
           }),
-          on('click', async () => {
-            pending = true
-            handle.update()
-            let reloadSignal = await handle.frame.reload()
-            if (reloadSignal.aborted) return
-            pending = false
-            handle.update()
+          on('click', () => {
+            void handle.frame.reload()
           }),
         ]}
         style={{

--- a/demos/frames/app/assets/root-reload-client-entries.tsx
+++ b/demos/frames/app/assets/root-reload-client-entries.tsx
@@ -1,4 +1,6 @@
-import { clientEntry, css, on, type Handle } from 'remix/ui'
+import { Frame, clientEntry, css, on, type Handle } from 'remix/ui'
+
+import { routes } from '../routes.ts'
 
 type RootReloadControlsProps = {
   includeRemoved: boolean
@@ -27,17 +29,27 @@ export const RootReloadControls = clientEntry(
       })
     }
 
-    async function reloadTopFrame(src: string) {
-      if (pendingHref) return
-      pendingHref = src
-      await handle.update()
+    handle.frames.top.addEventListener(
+      'reloadStart',
+      () => {
+        pendingHref = handle.frames.top.src
+        handle.update()
+      },
+      { signal: handle.signal },
+    )
 
+    handle.frames.top.addEventListener(
+      'reloadComplete',
+      () => {
+        pendingHref = null
+        handle.update()
+      },
+      { signal: handle.signal },
+    )
+
+    function reloadTopFrame(src: string) {
       handle.frames.top.src = src
-      let signal = await handle.frames.top.reload()
-      if (signal.aborted) return
-
-      pendingHref = null
-      handle.update()
+      handle.frames.top.reload()
     }
 
     return () => (
@@ -77,7 +89,6 @@ export const RootReloadControls = clientEntry(
           <button
             type="button"
             mix={[buttonStyle(), on('click', () => reloadTopFrame(handle.props.withRemovedHref))]}
-            disabled={pendingHref !== null}
           >
             {pendingHref === handle.props.withRemovedHref
               ? 'Reloading with entry…'
@@ -89,7 +100,6 @@ export const RootReloadControls = clientEntry(
               buttonStyle(),
               on('click', () => reloadTopFrame(handle.props.withoutRemovedHref)),
             ]}
-            disabled={pendingHref !== null}
           >
             {pendingHref === handle.props.withoutRemovedHref
               ? 'Reloading without entry…'
@@ -136,6 +146,11 @@ export const PersistentRootReloadEntry = clientEntry(
         >
           Increment persistent count
         </button>
+        <EntryFrame
+          entryLabel="persistent"
+          frameName="persistent-root-reload-entry-frame"
+          fallbackLabel="Loading persistent entry frame…"
+        />
       </section>
     )
   },
@@ -180,10 +195,40 @@ export const RemovableRootReloadEntry = clientEntry(
         >
           Increment removable count
         </button>
+        <EntryFrame
+          entryLabel="removable"
+          frameName="removable-root-reload-entry-frame"
+          fallbackLabel="Loading removable entry frame…"
+        />
       </section>
     )
   },
 )
+
+function EntryFrame(
+  handle: Handle<{
+    entryLabel: 'persistent' | 'removable'
+    frameName: string
+    fallbackLabel: string
+  }>,
+) {
+  return () => (
+    <div mix={css({ marginTop: 16 })}>
+      <h3 mix={css({ margin: '0 0 6px', fontSize: 14 })}>
+        Frame inside {handle.props.entryLabel} entry
+      </h3>
+      <p mix={css({ margin: '0 0 10px', color: '#b9c6ff' })}>
+        This frame has a stable name and src while its containing client entry remains mounted
+        across root reloads.
+      </p>
+      <Frame
+        name={handle.props.frameName}
+        src={routes.frames.rootReloadEntryFrame.href()}
+        fallback={<div mix={css({ color: '#9aa8e8' })}>{handle.props.fallbackLabel}</div>}
+      />
+    </div>
+  )
+}
 
 function EntryDetails(
   handle: Handle<{ setupId: number; localCount: number; serverVersion: string }>,
@@ -222,10 +267,6 @@ function buttonStyle() {
     color: '#e9eefc',
     cursor: 'pointer',
     '&:hover': { background: 'rgba(255,255,255,0.10)' },
-    '&:disabled': {
-      cursor: 'default',
-      opacity: 0.65,
-    },
   })
 }
 

--- a/demos/frames/app/routes.ts
+++ b/demos/frames/app/routes.ts
@@ -12,11 +12,13 @@ export const routes = route({
     clientFrameExampleNested: get('/client-frame-example/nested'),
     clientMountedOuter: get('/client-mounted-outer'),
     clientMountedNested: get('/client-mounted-nested'),
+    rootReloadEntryFrame: get('/root-reload-entry-frame'),
     sidebar: get('/sidebar'),
     activity: get('/activity'),
     activityDetail: get('/activity/detail'),
     time: get('/time'),
     reloadScope: get('/reload-scope'),
+    reloadScopeBlocking: get('/reload-scope/blocking'),
     stateSearchResults: get('/state-search-results'),
   }),
 })


### PR DESCRIPTION
In the process of experimenting with HMR support for the `assets` package, I found a few issues when reloading the root frame. This PR updates the `frames` demo to better surface these bugs so it's easier to discuss them and compare any behaviour changes or fixes.

- **Issue:** Reloading the root frame causes non-blocking child frames to briefly show their fallback again.

  **Reproduction:** Go to http://localhost:44100/reload-scope, then wait for the non-blocking child frame to finish loading before clicking `Reload top frame`. You'll see the non-blocking child frame briefly show its fallback again, while the blocking child frame resolves normally.

- **Issue:** Reloading the root frame while a blocking child frame is still resolving aborts the first reload request and crashes the server with an uncaught `DOMException [AbortError]`.

  **Reproduction:** Go to http://localhost:44100/reload-scope, then double-click `Reload top frame` so the first reload request is aborted while the blocking child frame is still resolving. You'll see the server crash with an uncaught `DOMException [AbortError]`.

- **Issue:** Reloading a non-blocking frame when it's still resolving aborts the first reload request and logs an uncaught `DOMException [AbortError]` to the console.

  **Reproduction:** Go to http://localhost:44100/, then double-click the "Refresh" button so that another request is made while the frame is still reloading. You'll see the server log an uncaught `DOMException [AbortError]` to the console. Note that the server is still running after this, it just adds noise to the terminal and/or error reporting.

- **Issue:** Reloading the root frame causes nested frames to reload, but any frames rendered within client entries are not reloaded and continue to show the same server content. In this case, I'm not sure if this is a bug or expected behaviour, but I personally found it surprising.

  **Reproduction:** Go to http://localhost:44100/root-reload-client-entries, then click either of the reload buttons at the top of the page. You'll see the "Server props" content update, but the server times displayed in the nested frames do not change.
