### PR TITLE
docs: patch on mixin release note

### DIFF
--- a/packages/ui/.changes/patch.on-mixin-type-inference.md
+++ b/packages/ui/.changes/patch.on-mixin-type-inference.md
@@ -3,7 +3,7 @@ Improved type inference for `on` mixin
 When defining a wrapper for `on`, use `target` generic on your handler type:
 
 ```ts
-import { type Dispatched } from '@remix-run/ui'
+import { on, type Dispatched } from '@remix-run/ui'
 
 const ACCORDION_CHANGE_EVENT = 'rmx:accordion-change' as const
 


### PR DESCRIPTION
Patch the release note added in #11385 so the code sample is self-contained. The example calls `on(...)`, so it now imports `on` alongside `Dispatched`.

- Updates only `packages/ui/.changes/patch.on-mixin-type-inference.md`
- Keeps the rendered changelog example complete for readers