### PR TITLE
Gate Codex PR review workflows

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -628,6 +628,7 @@ jobs:
     if: >
       always() &&
       !cancelled() &&
+      vars.ENABLE_CODEX_PR_REVIEW == 'true' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       needs.detect_changes.result == 'success' &&
       needs.build_ubuntu.result == 'success' &&

--- a/.github/workflows/codex-pr-review.yaml
+++ b/.github/workflows/codex-pr-review.yaml
@@ -22,6 +22,7 @@ jobs:
   wait_for_green_checks:
     name: Wait for required PR checks
     if: |
+      vars.ENABLE_CODEX_PR_REVIEW == 'true' &&
       github.repository == 'remix-run/remix' &&
       github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest


### PR DESCRIPTION
Codex PR review is currently failing because the Codex action exits with a quota exceeded error, which leaves no final review message to post. This gates the Codex review jobs behind `ENABLE_CODEX_PR_REVIEW` so regular PR CI stays active while Codex review is paused.

- Adds the `ENABLE_CODEX_PR_REVIEW == true` gate to the fork review workflow.
- Adds the same gate to the embedded same-repo `Check PR` Codex review job.
- Keeps the normal build, test, lint, typecheck, and change-file checks unchanged.

The repository variable is currently set to `false`. To re-enable later, set `ENABLE_CODEX_PR_REVIEW` to `true` and re-enable the standalone Codex workflow in GitHub Actions.