### PR TITLE
Preserve package symlink identity paths in asset server

### DIFF
--- a/packages/assets/.changes/patch.package-symlink-identity.md
+++ b/packages/assets/.changes/patch.package-symlink-identity.md
@@ -1,0 +1,1 @@
+Preserve `node_modules` package symlink identity paths when rewriting script imports, while still reading, caching, and invalidating modules through their canonical real paths.

--- a/packages/assets/src/lib/access.ts
+++ b/packages/assets/src/lib/access.ts
@@ -2,6 +2,7 @@ import { createFileMatcher } from './file-matcher.ts'
 import { isInjectedPackageFilePath } from './injected-packages.ts'
 
 type AccessPolicy = {
+  isDenied(filePath: string): boolean
   isAllowed(filePath: string): boolean
 }
 
@@ -15,11 +16,17 @@ export function createAccessPolicy(options: {
     createFileMatcher(pattern, options.rootDir),
   )
 
+  function isDenied(filePath: string): boolean {
+    if (isInjectedPackageFilePath(filePath)) return false
+    return denyMatchers.length > 0 && denyMatchers.some((matcher) => matcher(filePath))
+  }
+
   return {
+    isDenied,
     isAllowed(filePath) {
       if (isInjectedPackageFilePath(filePath)) return true
       if (!allowMatchers.some((matcher) => matcher(filePath))) return false
-      if (denyMatchers.length > 0 && denyMatchers.some((matcher) => matcher(filePath))) return false
+      if (isDenied(filePath)) return false
       return true
     },
   }

--- a/packages/assets/src/lib/asset-server.test.ts
+++ b/packages/assets/src/lib/asset-server.test.ts
@@ -48,6 +48,12 @@ function writeJson(dir: string, rel: string, value: unknown): Promise<string> {
   return write(dir, rel, JSON.stringify(value, null, 2))
 }
 
+async function symlinkDirectory(target: string, link: string): Promise<void> {
+  await fs.mkdir(path.dirname(link), { recursive: true })
+  await fs.rm(link, { recursive: true, force: true })
+  await fs.symlink(target, link, process.platform === 'win32' ? 'junction' : 'dir')
+}
+
 function getLineAndColumn(source: string, search: string): { line: number; column: number } {
   let index = source.indexOf(search)
   assert.notEqual(index, -1, `Expected to find "${search}" in:\n${source}`)
@@ -66,6 +72,23 @@ function createTestServer(rootDir: string, overrides: Partial<AssetServerOptions
     fileMap: {
       '/app/*path': 'app/*path',
       '/npm/*path': 'app/node_modules/*path',
+    },
+    rootDir,
+    watch: overrides.watch ?? false,
+    ...overrides,
+  })
+}
+
+function createNodeModulesTestServer(
+  rootDir: string,
+  overrides: Partial<AssetServerOptions<any>> = {},
+) {
+  return createAssetServerForTest({
+    allow: ['app/entry.ts', 'app/node_modules/**'],
+    basePath: '/assets',
+    fileMap: {
+      '/node_modules/*path': 'app/node_modules/*path',
+      '/app/*path': 'app/*path',
     },
     rootDir,
     watch: overrides.watch ?? false,
@@ -2500,6 +2523,173 @@ describe('asset-server', () => {
     assert.ok(!body.includes('/assets/app/alias/value.@'))
   })
 
+  it('preserves package symlink identity paths for imports through node_modules', async () => {
+    let caseDir = await makeTmpDir()
+    try {
+      await writeJson(caseDir, 'packages/remix/package.json', {
+        name: 'remix',
+        type: 'module',
+        exports: {
+          './ui': './src/ui.ts',
+        },
+      })
+      await write(caseDir, 'packages/remix/src/shared.ts', 'export const shared = "shared"')
+      await write(
+        caseDir,
+        'packages/remix/src/ui.ts',
+        'import { shared } from "./shared.ts"\nexport const ui = shared',
+      )
+      await symlinkDirectory(
+        path.join(caseDir, 'packages/remix'),
+        path.join(caseDir, 'app/node_modules/remix'),
+      )
+      await write(caseDir, 'app/entry.ts', 'import { ui } from "remix/ui"\nexport { ui }')
+
+      let assetServer = createNodeModulesTestServer(caseDir)
+      try {
+        let servedUrls = await assertRecursivelyServedImports(assetServer, [
+          '/assets/app/entry.ts',
+        ])
+
+        assert.ok(servedUrls.has('/assets/node_modules/remix/src/ui.ts'))
+        assert.ok(servedUrls.has('/assets/node_modules/remix/src/shared.ts'))
+        assert.equal(servedUrls.has('/assets/packages/remix/src/ui.ts'), false)
+      } finally {
+        await assetServer.close()
+      }
+    } finally {
+      await fs.rm(caseDir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps arbitrary app symlink escapes blocked', async () => {
+    let caseDir = await makeTmpDir()
+    try {
+      await write(caseDir, 'private/secret.ts', 'export const secret = true')
+      await fs.mkdir(path.join(caseDir, 'app/assets'), { recursive: true })
+      await fs.symlink(
+        path.join(caseDir, 'private/secret.ts'),
+        path.join(caseDir, 'app/assets/secret.ts'),
+      )
+      await write(
+        caseDir,
+        'app/entry.ts',
+        'import { secret } from "./assets/secret.ts"\nexport { secret }',
+      )
+
+      let assetServer = createAssetServerForTest({
+        allow: ['app/entry.ts', 'app/assets/**'],
+        basePath: '/assets',
+        fileMap: {
+          '/app/*path': 'app/*path',
+        },
+        onError: () => undefined,
+        rootDir: caseDir,
+      })
+      try {
+        let directResponse = await get(assetServer, '/assets/app/assets/secret.ts')
+        assert.equal(directResponse, null)
+
+        let entryResponse = await get(assetServer, '/assets/app/entry.ts')
+        assert.ok(entryResponse)
+        await assertInternalServerError(entryResponse)
+      } finally {
+        await assetServer.close()
+      }
+    } finally {
+      await fs.rm(caseDir, { recursive: true, force: true })
+    }
+  })
+
+  it('respects absolute deny rules for real package symlink targets', async () => {
+    let caseDir = await makeTmpDir()
+    try {
+      await writeJson(caseDir, 'packages/remix/package.json', {
+        name: 'remix',
+        type: 'module',
+        exports: {
+          './ui': './src/ui.ts',
+        },
+      })
+      let deniedPath = await write(
+        caseDir,
+        'packages/remix/src/ui.ts',
+        'export const ui = "blocked"',
+      )
+      await symlinkDirectory(
+        path.join(caseDir, 'packages/remix'),
+        path.join(caseDir, 'app/node_modules/remix'),
+      )
+      await write(caseDir, 'app/entry.ts', 'import { ui } from "remix/ui"\nexport { ui }')
+
+      let assetServer = createNodeModulesTestServer(caseDir, {
+        allow: ['app/entry.ts', 'app/node_modules/**', 'packages/remix/**'],
+        deny: [deniedPath],
+        fileMap: {
+          '/app/*path': 'app/*path',
+          '/node_modules/*path': 'app/node_modules/*path',
+          '/packages/*path': 'packages/*path',
+        },
+        onError: () => undefined,
+      })
+      try {
+        let response = await get(assetServer, '/assets/app/entry.ts')
+        assert.ok(response)
+        await assertInternalServerError(response)
+      } finally {
+        await assetServer.close()
+      }
+    } finally {
+      await fs.rm(caseDir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps distinct package identities that point to the same real file', async () => {
+    let caseDir = await makeTmpDir()
+    try {
+      await writeJson(caseDir, 'packages/shared/package.json', {
+        name: 'shared',
+        type: 'module',
+        exports: {
+          './ui': './src/ui.ts',
+        },
+      })
+      await write(caseDir, 'packages/shared/src/ui.ts', 'export const ui = "shared"')
+      await symlinkDirectory(
+        path.join(caseDir, 'packages/shared'),
+        path.join(caseDir, 'app/node_modules/package-a'),
+      )
+      await symlinkDirectory(
+        path.join(caseDir, 'packages/shared'),
+        path.join(caseDir, 'app/node_modules/package-b'),
+      )
+      await write(
+        caseDir,
+        'app/entry.ts',
+        [
+          'import { ui as a } from "package-a/ui"',
+          'import { ui as b } from "package-b/ui"',
+          'export const values = [a, b]',
+        ].join('\n'),
+      )
+
+      let assetServer = createNodeModulesTestServer(caseDir)
+      try {
+        let response = await get(assetServer, '/assets/app/entry.ts')
+        assert.ok(response)
+        assert.equal(response.status, 200)
+        let body = await response.text()
+
+        assert.match(body, /\/assets\/node_modules\/package-a\/src\/ui\.ts/)
+        assert.match(body, /\/assets\/node_modules\/package-b\/src\/ui\.ts/)
+      } finally {
+        await assetServer.close()
+      }
+    } finally {
+      await fs.rm(caseDir, { recursive: true, force: true })
+    }
+  })
+
   it('getHref returns fingerprinted URLs for served script files when fingerprinting is enabled', async () => {
     await write(dir, 'app/entry.ts', 'export const entry = true')
     let assetServer = createTestServer(dir, { fingerprint: { buildId: 'build' } })
@@ -2982,6 +3172,51 @@ describe('asset-server', () => {
         let secondBody = await secondResponse.text()
 
         assert.match(secondBody, /value = 2/)
+      } finally {
+        await assetServer.close()
+      }
+    } finally {
+      await fs.rm(caseDir, { recursive: true, force: true })
+    }
+  })
+
+  it('invalidates package symlink modules from real file watch events', async () => {
+    let caseDir = await makeTmpDir()
+    try {
+      await writeJson(caseDir, 'packages/remix/package.json', {
+        name: 'remix',
+        type: 'module',
+        exports: {
+          './ui': './src/ui.ts',
+        },
+      })
+      let packageFilePath = await write(
+        caseDir,
+        'packages/remix/src/ui.ts',
+        'export const ui = "one"',
+      )
+      await symlinkDirectory(
+        path.join(caseDir, 'packages/remix'),
+        path.join(caseDir, 'app/node_modules/remix'),
+      )
+      await write(caseDir, 'app/entry.ts', 'import { ui } from "remix/ui"\nexport { ui }')
+      let assetServer = createNodeModulesTestServer(caseDir, { watch: true })
+
+      try {
+        let entryResponse = await get(assetServer, '/assets/app/entry.ts')
+        assert.ok(entryResponse)
+        assert.equal(entryResponse.status, 200)
+
+        let firstPackageResponse = await get(assetServer, '/assets/node_modules/remix/src/ui.ts')
+        assert.ok(firstPackageResponse)
+        assert.match(await firstPackageResponse.text(), /ui = "one"/)
+
+        await write(caseDir, 'packages/remix/src/ui.ts', 'export const ui = "two"')
+        await emitWatchEvent(assetServer, packageFilePath, 'change')
+
+        let secondPackageResponse = await get(assetServer, '/assets/node_modules/remix/src/ui.ts')
+        assert.ok(secondPackageResponse)
+        assert.match(await secondPackageResponse.text(), /ui = "two"/)
       } finally {
         await assetServer.close()
       }

--- a/packages/assets/src/lib/asset-server.ts
+++ b/packages/assets/src/lib/asset-server.ts
@@ -252,6 +252,7 @@ export function createAssetServer<const transforms extends AssetRequestTransform
     external: resolvedOptions.external,
     fingerprintAssets: resolvedOptions.fingerprintAssets,
     isAllowed: accessPolicy.isAllowed,
+    isDenied: accessPolicy.isDenied,
     minify: resolvedOptions.minify,
     onWatchDirectoriesChange: (delta) => {
       if (!watcher) return

--- a/packages/assets/src/lib/scripts/compiler.ts
+++ b/packages/assets/src/lib/scripts/compiler.ts
@@ -66,6 +66,7 @@ type ScriptCompilerOptions = {
   external: string[]
   fingerprintAssets: boolean
   isAllowed(absolutePath: string): boolean
+  isDenied(absolutePath: string): boolean
   minify: boolean
   onWatchDirectoriesChange?: (delta: { add: string[]; remove: string[] }) => void
   rootDir: string
@@ -117,8 +118,14 @@ export function createScriptCompiler(options: ScriptCompilerOptions): ScriptComp
     extensionAlias: resolverExtensionAlias,
     extensions: resolverExtensions,
     mainFields: ['browser', 'module', 'main'],
+    symlinks: false,
     tsconfig: 'auto',
   })
+  let resolveModulePathOptions = {
+    isAllowed: resolvedOptions.isAllowed,
+    isDenied: resolvedOptions.isDenied,
+    routes: resolvedOptions.routes,
+  }
   let resolveInFlightByCacheKey = new Map<string, Promise<ResolvedModule>>()
   let emitInFlightByCacheKey = new Map<string, Promise<EmittedModule>>()
 
@@ -138,7 +145,9 @@ export function createScriptCompiler(options: ScriptCompilerOptions): ScriptComp
   let resolveArgs: ResolveArgs = {
     isAllowed: resolvedOptions.isAllowed,
     isWatchIgnored,
-    resolveModulePath,
+    resolveModulePath(absolutePath) {
+      return resolveModulePath(absolutePath, resolveModulePathOptions)
+    },
     resolverFactory,
     routes: resolvedOptions.routes,
   }
@@ -253,7 +262,7 @@ export function createScriptCompiler(options: ScriptCompilerOptions): ScriptComp
   }
 
   function resolveServedScriptOrThrow(absolutePath: string): ResolveModuleResult {
-    let resolvedModule = resolveModulePath(absolutePath)
+    let resolvedModule = resolveModulePath(absolutePath, resolveModulePathOptions)
     if (!resolvedModule) {
       throw createAssetServerCompilationError(`File not found: ${absolutePath}`, {
         code: 'FILE_NOT_FOUND',
@@ -548,11 +557,19 @@ function shouldClearResolverCacheForFileEvent(filePath: string, event: ModuleWat
   return event !== 'change' || isPackageJsonPath(filePath) || isTsconfigPath(filePath)
 }
 
-function resolveModulePath(absolutePath: string): ResolveModuleResult | null {
+function resolveModulePath(
+  absolutePath: string,
+  options: {
+    isAllowed(absolutePath: string): boolean
+    isDenied(absolutePath: string): boolean
+    routes: CompiledRoutes
+  },
+): ResolveModuleResult | null {
+  let candidateIdentityPath = normalizeFilePath(absolutePath)
   let resolvedPath: string
 
   try {
-    resolvedPath = normalizeFilePath(fs.realpathSync(normalizeFilePath(absolutePath)))
+    resolvedPath = normalizeFilePath(fs.realpathSync(candidateIdentityPath))
   } catch (error) {
     if (isNoEntityError(error)) return null
     throw error
@@ -563,9 +580,30 @@ function resolveModulePath(absolutePath: string): ResolveModuleResult | null {
   }
 
   return {
-    identityPath: resolvedPath,
+    identityPath: getModuleIdentityPath(candidateIdentityPath, resolvedPath, options),
     resolvedPath,
   }
+}
+
+function getModuleIdentityPath(
+  candidateIdentityPath: string,
+  resolvedPath: string,
+  options: {
+    isAllowed(absolutePath: string): boolean
+    isDenied(absolutePath: string): boolean
+    routes: CompiledRoutes
+  },
+): string {
+  if (candidateIdentityPath === resolvedPath) return resolvedPath
+  if (!containsNodeModulesPathSegment(candidateIdentityPath)) return resolvedPath
+  if (!options.routes.toUrlPathname(candidateIdentityPath)) return resolvedPath
+  if (!options.isAllowed(candidateIdentityPath)) return resolvedPath
+  if (options.isDenied(resolvedPath)) return resolvedPath
+  return candidateIdentityPath
+}
+
+function containsNodeModulesPathSegment(filePath: string): boolean {
+  return filePath.split('/').includes('node_modules')
 }
 
 function resolveActualPath(identityPath: string): string | null {

--- a/packages/assets/src/lib/scripts/resolve.ts
+++ b/packages/assets/src/lib/scripts/resolve.ts
@@ -105,7 +105,7 @@ export async function resolveModule(
       transformed.unresolvedImports.length > 0
         ? await batchResolveSpecifiers(
             getUniqueSpecifiers(transformed.unresolvedImports),
-            transformed.resolvedPath,
+            transformed.identityPath,
             args.resolverFactory,
           )
         : new Map<string, ResolvedSpec>()
@@ -196,8 +196,10 @@ export async function resolveModule(
     deps.add(resolvedImport.identityPath)
 
     if (transformed.packageSpecifiers.includes(unresolved.specifier)) {
-      let packageJsonPath =
-        resolvedSpec.packageJsonPath ?? findNearestPackageJsonPath(resolvedImport.resolvedPath)
+      let packageJsonPath = resolvePackageJsonPath(
+        resolvedSpec.packageJsonPath,
+        resolvedImport.resolvedPath,
+      )
       if (packageJsonPath && !args.isWatchIgnored(packageJsonPath)) {
         trackedFiles.add(packageJsonPath)
       }
@@ -235,6 +237,25 @@ export async function resolveModule(
   }
 }
 
+function resolvePackageJsonPath(
+  packageJsonPath: string | null,
+  resolvedPath: string,
+): string | null {
+  return (
+    (packageJsonPath ? resolveExistingPath(packageJsonPath) : null) ??
+    findNearestPackageJsonPath(resolvedPath)
+  )
+}
+
+function resolveExistingPath(filePath: string): string | null {
+  try {
+    return normalizeFilePath(fs.realpathSync(filePath))
+  } catch (error) {
+    if (isNoEntityError(error)) return null
+    throw error
+  }
+}
+
 function findNearestPackageJsonPath(filePath: string): string | null {
   let directory = path.dirname(filePath)
 
@@ -248,6 +269,17 @@ function findNearestPackageJsonPath(filePath: string): string | null {
     if (parentDirectory === directory) return null
     directory = parentDirectory
   }
+}
+
+function isNoEntityError(
+  error: unknown,
+): error is NodeJS.ErrnoException & { code: 'ENOENT' | 'ENOTDIR' } {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    ((error as NodeJS.ErrnoException).code === 'ENOENT' ||
+      (error as NodeJS.ErrnoException).code === 'ENOTDIR')
+  )
 }
 
 function isRelativeImportSpecifier(specifier: string): boolean {

--- a/packages/assets/src/lib/scripts/transform.ts
+++ b/packages/assets/src/lib/scripts/transform.ts
@@ -261,7 +261,7 @@ export async function transformModule(
                 content: sourceText,
               }),
         identityPath: record.identityPath,
-        importerDir: path.dirname(resolvedPath),
+        importerDir: path.dirname(record.identityPath),
         packageSpecifiers: analysis.unresolvedImports
           .filter((unresolved) => isPackageImportSpecifier(unresolved.specifier))
           .map((unresolved) => unresolved.specifier),

--- a/packages/cli/.changes/patch.template-asset-config.md
+++ b/packages/cli/.changes/patch.template-asset-config.md
@@ -1,0 +1,1 @@
+Simplified the default app template asset server configuration so workspace installs serve package imports through `node_modules` without Remix monorepo-specific `../packages` rules.

--- a/packages/cli/src/lib/cli.test.ts
+++ b/packages/cli/src/lib/cli.test.ts
@@ -442,6 +442,7 @@ describe('run', () => {
       let agentsGuide = await fs.readFile(path.join(appDir, 'AGENTS.md'), 'utf8')
       let readme = await fs.readFile(path.join(appDir, 'README.md'), 'utf8')
       let server = await fs.readFile(path.join(appDir, 'server.ts'), 'utf8')
+      let assets = await fs.readFile(path.join(appDir, 'app', 'assets.ts'), 'utf8')
       let routes = await fs.readFile(path.join(appDir, 'app', 'routes.ts'), 'utf8')
       let entry = await fs.readFile(path.join(appDir, 'app', 'assets', 'entry.ts'), 'utf8')
       let renderMiddleware = await fs.readFile(
@@ -468,6 +469,9 @@ describe('run', () => {
       assert.match(server, /http\.createServer/)
       assert.match(server, /createRequestListener/)
       assert.doesNotMatch(server, /remix\/node-serve/)
+      assert.doesNotMatch(assets, /\.\.\/packages/)
+      assert.doesNotMatch(assets, /usesWorkspaceRemix/)
+      assert.doesNotMatch(assets, /workspacePackagesDir/)
       assert.doesNotMatch(routes, /auth/)
       assert.match(entry, /loadModule/)
       assert.doesNotMatch(entry, /resolveFrame/)

--- a/template/app/assets.ts
+++ b/template/app/assets.ts
@@ -1,11 +1,6 @@
-import * as fs from 'node:fs'
-import * as path from 'node:path'
-
 import { createAssetServer } from 'remix/assets'
 
 const rootDir = process.cwd()
-const workspacePackagesDir = path.resolve(rootDir, '..', 'packages')
-const usesWorkspaceRemix = fs.existsSync(path.join(workspacePackagesDir, 'remix', 'src', 'ui.ts'))
 
 export const assetServer = createAssetServer({
   basePath: '/assets',
@@ -13,9 +8,8 @@ export const assetServer = createAssetServer({
   fileMap: {
     'app/*path': 'app/*path',
     'node_modules/*path': 'node_modules/*path',
-    ...(usesWorkspaceRemix ? { 'packages/*path': '../packages/*path' } : {}),
   },
-  allow: ['app/assets/**', 'node_modules/**', ...(usesWorkspaceRemix ? ['../packages/**'] : [])],
+  allow: ['app/assets/**', 'node_modules/**'],
   deny: ['app/**/*.server.*'],
   sourceMaps: process.env.NODE_ENV === 'development' ? 'external' : undefined,
   scripts: {


### PR DESCRIPTION
Closes #11418.

This updates the asset server so package-manager symlinks resolved through `node_modules` retain their public package identity while the compiler still reads, tracks, caches, and invalidates against canonical real paths. Generated apps can now use normal app-facing `node_modules` asset configuration without knowing where workspace packages live on disk.

- Disable resolver-level symlink realpathing and choose module identity after the asset server canonicalizes the resolved file.
- Preserve only allowed `node_modules` identity paths that map through `fileMap`, while respecting deny rules for real targets.
- Keep arbitrary app symlink escapes canonicalized to their real paths so allow rules cannot expose private files.
- Remove the default template `../packages` asset-server workaround and cover the scaffold output.
