### PR TITLE
Fix stale component updates after frame reload

### DIFF
--- a/packages/ui/.changes/patch.ignore-removed-component-updates.md
+++ b/packages/ui/.changes/patch.ignore-removed-component-updates.md
@@ -1,0 +1,1 @@
+Ignore component updates scheduled after a frame reload has already removed that component.

--- a/packages/ui/src/runtime/component.ts
+++ b/packages/ui/src/runtime/component.ts
@@ -240,6 +240,7 @@ class ComponentRuntime<C = NoContext> {
   #props = {} as ElementProps
   #renderController: AbortController | undefined
   #renderFn: RenderFn | undefined
+  #removed = false
   #scheduleUpdate: () => void = () => {
     throw new Error('scheduleUpdate not implemented')
   }
@@ -252,7 +253,7 @@ class ComponentRuntime<C = NoContext> {
   }
 
   render = (nextProps: ElementProps): [RemixNode, Array<() => void>] => {
-    if (this.#connectedController?.signal.aborted) {
+    if (this.#removed) {
       console.warn('render called after component was removed, potential application memory leak')
       return [null, []]
     }
@@ -278,9 +279,11 @@ class ComponentRuntime<C = NoContext> {
   }
 
   remove = (): Array<() => void> => {
+    if (this.#removed) return []
+    this.#removed = true
     this.#connectedController?.abort()
     this.#abortRenderSignal()
-    return this.#dequeueTasks()
+    return this.#dequeueTasks(AbortSignal.abort())
   }
 
   setScheduleUpdate = (nextScheduleUpdate: () => void): void => {
@@ -288,6 +291,8 @@ class ComponentRuntime<C = NoContext> {
   }
 
   getContextValue = (): C | undefined => this.#contextValue
+
+  isRemoved = (): boolean => this.#removed
 
   #createHandle(): Handle<ElementProps, C> {
     let component = this
@@ -303,6 +308,11 @@ class ComponentRuntime<C = NoContext> {
       props: this.#props,
       update: () =>
         new Promise((resolve) => {
+          if (component.#removed) {
+            resolve(AbortSignal.abort())
+            return
+          }
+
           this.#tasks.push((signal) => resolve(signal))
           this.#scheduleUpdate()
         }),
@@ -335,14 +345,14 @@ class ComponentRuntime<C = NoContext> {
     this.#renderController = undefined
   }
 
-  #dequeueTasks(): Array<() => void> {
-    let needsSignal = this.#tasks.some((task) => task.length >= 1)
+  #dequeueTasks(signal?: AbortSignal): Array<() => void> {
+    let needsSignal = signal === undefined && this.#tasks.some((task) => task.length >= 1)
 
     if (needsSignal) {
       this.#renderController ??= new AbortController()
     }
 
-    let signal = this.#renderController?.signal
+    signal ??= this.#renderController?.signal
     let tasks = this.#tasks.splice(0, this.#tasks.length)
     return tasks.map((task) => () => task(signal!))
   }

--- a/packages/ui/src/runtime/reconcile.ts
+++ b/packages/ui/src/runtime/reconcile.ts
@@ -1275,6 +1275,8 @@ export function renderComponent(
   anchor?: Node,
   cursor?: Node | null,
 ): Node | null | undefined {
+  if (handle.isRemoved()) return cursor
+
   let [element, tasks] = handle.render(next.props)
   let content = toVNode(element)
   let newCursor = diffVNodes(

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -1188,6 +1188,93 @@ describe('run', () => {
     clientFrame.dispose()
   })
 
+  it('ignores updates from a client entry removed by a frame reload', async () => {
+    let pending = false
+    let showCartItems = true
+    let removeLastItem: undefined | (() => Promise<void>)
+
+    let CartItems = clientEntry(
+      '/assets/cart-items.js#CartItems',
+      function CartItems(handle: Handle) {
+        removeLastItem = async () => {
+          pending = true
+          await handle.update()
+          showCartItems = false
+          await handle.frame.reload()
+          pending = false
+          handle.update()
+        }
+
+        return () => (
+          <>
+            {pending ? <p id="cart-pending">Updating your cart...</p> : null}
+            <table id="cart-items">
+              <tbody>
+                <tr>
+                  <td>Book</td>
+                  <td>
+                    <button>Remove</button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <div id="cart-total">Total: $16.99</div>
+          </>
+        )
+      },
+    )
+
+    async function renderCartItems(): Promise<string> {
+      return await drain(
+        renderToStream(
+          showCartItems ? <CartItems /> : <p id="empty-cart">Your cart is empty.</p>,
+        ),
+      )
+    }
+
+    let html = await drain(
+      renderToStream(
+        <main>
+          <Frame src="/cart-items" />
+        </main>,
+        { resolveFrame: renderCartItems },
+      ),
+    )
+    document.body.innerHTML = html
+
+    let errors: unknown[] = []
+    let clientFrame = run({
+      loadModule(moduleUrl, exportName) {
+        if (moduleUrl === '/assets/cart-items.js' && exportName === 'CartItems') {
+          return CartItems
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      resolveFrame(src: string) {
+        if (src === '/cart-items') return renderCartItems()
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+    clientFrame.addEventListener('error', (event) => {
+      errors.push(event.error)
+    })
+
+    await clientFrame.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('cart-items')).toBeInstanceOf(HTMLElement)
+    invariant(removeLastItem)
+
+    await removeLastItem()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('cart-items')).toBeNull()
+    expect(document.getElementById('empty-cart')?.textContent).toBe('Your cart is empty.')
+    expect(errors).toEqual([])
+
+    clientFrame.dispose()
+  })
+
   it('looks up named adjacent frames from handle.frames.get(name)', async () => {
     let summaryRenderCount = 0
     let reloadSummary: undefined | (() => Promise<void>)


### PR DESCRIPTION
Frame reloads can remove a hydrated client entry while code in that entry is still awaiting the reload. In the bookstore cart, removing the final item reloads the frame to empty-cart markup and then the stale final update attempted to render against detached DOM, causing `Node.insertBefore` errors.

- Tracks component removal explicitly so `handle.update()` after removal resolves with an aborted signal instead of scheduling work.
- Skips rendering component handles that are already removed.
- Adds a frame regression test matching the pending cart update and empty-cart reload flow.
- Adds a patch change note for `@remix-run/ui`.

Closes #11410