### PR TITLE
Preserve duplicate Cookie header values

### DIFF
--- a/packages/headers/.changes/patch.preserve-duplicate-cookies.md
+++ b/packages/headers/.changes/patch.preserve-duplicate-cookies.md
@@ -1,0 +1,1 @@
+Fix `Cookie` and `SuperHeaders.cookie` so duplicate cookie names are preserved in order. `Cookie#get(name)` now returns the first matching value, `Cookie#getAll(name)` can be used to read every matching value, and `Cookie#append(name, value)` can be used to add another cookie with the same name.

--- a/packages/headers/README.md
+++ b/packages/headers/README.md
@@ -325,7 +325,7 @@ headers.set('Content-Type', new ContentType({ mediaType: 'text/html', charset: '
 
 Parse, manipulate and stringify [`Cookie` headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie).
 
-Implements `Map<name, value>`.
+Implements an ordered list of name/value pairs. Duplicate cookie names are preserved, such as when cookies with the same name were set for different paths.
 
 ```ts
 import { Cookie } from 'remix/headers'
@@ -334,6 +334,7 @@ import { Cookie } from 'remix/headers'
 let cookie = Cookie.from(request.headers.get('Cookie'))
 
 cookie.get('session_id') // 'abc123'
+cookie.getAll('session_id') // ['abc123']
 cookie.get('theme') // 'dark'
 cookie.has('session_id') // true
 cookie.size // 2
@@ -345,6 +346,7 @@ for (let [name, value] of cookie) {
 
 // Modify and set header
 cookie.set('theme', 'light')
+cookie.append('session_id', 'def456')
 cookie.delete('session_id')
 headers.set('Cookie', cookie)
 

--- a/packages/headers/src/lib/cookie.test.ts
+++ b/packages/headers/src/lib/cookie.test.ts
@@ -15,6 +15,23 @@ describe('Cookie', () => {
     assert.equal(header.get('name2'), 'value2')
   })
 
+  it('preserves duplicate cookie names in order', () => {
+    let header = new Cookie('session=child; session=parent; theme=dark')
+
+    assert.equal(header.get('session'), 'child')
+    assert.deepEqual(header.getAll('session'), ['child', 'parent'])
+    assert.deepEqual(header.getAll('missing'), [])
+    assert.deepEqual(header.names, ['session', 'session', 'theme'])
+    assert.deepEqual(header.values, ['child', 'parent', 'dark'])
+    assert.equal(header.size, 3)
+    assert.deepEqual(Array.from(header), [
+      ['session', 'child'],
+      ['session', 'parent'],
+      ['theme', 'dark'],
+    ])
+    assert.equal(header.toString(), 'session=child; session=parent; theme=dark')
+  })
+
   it('initializes with an array', () => {
     let header = new Cookie([
       ['name1', 'value1'],
@@ -58,16 +75,26 @@ describe('Cookie', () => {
     assert.equal(header.get('name'), 'value')
   })
 
+  it('appends values', () => {
+    let header = new Cookie('name=value1')
+
+    header.append('name', 'value2')
+
+    assert.deepEqual(header.getAll('name'), ['value1', 'value2'])
+    assert.equal(header.toString(), 'name=value1; name=value2')
+  })
+
   it('returns `null` for nonexistent values', () => {
     let header = new Cookie()
     assert.equal(header.get('name'), null)
   })
 
   it('deletes values', () => {
-    let header = new Cookie('name=value')
+    let header = new Cookie('name=value1; other=value; name=value2')
     assert.equal(header.has('name'), true)
     header.delete('name')
     assert.equal(header.has('name'), false)
+    assert.deepEqual(Array.from(header), [['other', 'value']])
   })
 
   it('checks if value exists', () => {
@@ -137,9 +164,14 @@ describe('Cookie', () => {
   })
 
   it('overwrites existing values', () => {
-    let header = new Cookie('name=value1')
+    let header = new Cookie('name=value1; other=value; name=value2')
     header.set('name', 'value2')
     assert.equal(header.get('name'), 'value2')
+    assert.deepEqual(header.getAll('name'), ['value2'])
+    assert.deepEqual(Array.from(header), [
+      ['name', 'value2'],
+      ['other', 'value'],
+    ])
   })
 })
 

--- a/packages/headers/src/lib/cookie.ts
+++ b/packages/headers/src/lib/cookie.ts
@@ -2,6 +2,8 @@ import { type HeaderValue } from './header-value.ts'
 import { parseParams, quote } from './param-values.ts'
 import { isIterable } from './utils.ts'
 
+type CookiePair = [name: string, value: string]
+
 /**
  * Initializer for a {@link Cookie} header value.
  */
@@ -15,61 +17,91 @@ export type CookieInit = Iterable<[string, string]> | Record<string, string>
  * [HTTP/1.1 Specification](https://datatracker.ietf.org/doc/html/rfc6265#section-4.2)
  */
 export class Cookie implements HeaderValue, Iterable<[string, string]> {
-  #map!: Map<string, string>
+  #cookies!: CookiePair[]
 
   constructor(init?: string | CookieInit) {
     if (init) return Cookie.from(init)
-    this.#map = new Map()
+    this.#cookies = []
   }
 
   /**
    * An array of the names of the cookies in the header.
    */
   get names(): string[] {
-    return Array.from(this.#map.keys())
+    return this.#cookies.map(([name]) => name)
   }
 
   /**
    * An array of the values of the cookies in the header.
    */
   get values(): string[] {
-    return Array.from(this.#map.values())
+    return this.#cookies.map(([, value]) => value)
   }
 
   /**
    * The number of cookies in the header.
    */
   get size(): number {
-    return this.#map.size
+    return this.#cookies.length
   }
 
   /**
-   * Gets the value of a cookie with the given name from the header.
+   * Gets the first value of a cookie with the given name from the header.
    *
    * @param name The name of the cookie
-   * @returns The value of the cookie, or `null` if the cookie does not exist
+   * @returns The first value of the cookie, or `null` if the cookie does not exist
    */
   get(name: string): string | null {
-    return this.#map.get(name) ?? null
+    let cookie = this.#cookies.find(([cookieName]) => cookieName === name)
+    return cookie?.[1] ?? null
   }
 
   /**
-   * Sets a cookie with the given name and value in the header.
+   * Gets all values of cookies with the given name from the header.
+   *
+   * @param name The name of the cookie
+   * @returns The values of all matching cookies, or an empty array if none exist
+   */
+  getAll(name: string): string[] {
+    return this.#cookies.filter(([cookieName]) => cookieName === name).map(([, value]) => value)
+  }
+
+  /**
+   * Sets a cookie with the given name and value in the header, replacing any existing values.
    *
    * @param name The name of the cookie
    * @param value The value of the cookie
    */
   set(name: string, value: string): void {
-    this.#map.set(name, value)
+    let index = this.#cookies.findIndex(([cookieName]) => cookieName === name)
+
+    if (index === -1) {
+      this.#cookies.push([name, value])
+    } else {
+      this.#cookies[index] = [name, value]
+      this.#cookies = this.#cookies.filter(
+        ([cookieName], cookieIndex) => cookieName !== name || cookieIndex === index,
+      )
+    }
   }
 
   /**
-   * Removes a cookie with the given name from the header.
+   * Appends a cookie with the given name and value to the header.
+   *
+   * @param name The name of the cookie
+   * @param value The value of the cookie
+   */
+  append(name: string, value: string): void {
+    this.#cookies.push([name, value])
+  }
+
+  /**
+   * Removes all cookies with the given name from the header.
    *
    * @param name The name of the cookie
    */
   delete(name: string): void {
-    this.#map.delete(name)
+    this.#cookies = this.#cookies.filter(([cookieName]) => cookieName !== name)
   }
 
   /**
@@ -79,14 +111,14 @@ export class Cookie implements HeaderValue, Iterable<[string, string]> {
    * @returns `true` if a cookie with the given name exists in the header
    */
   has(name: string): boolean {
-    return this.#map.has(name)
+    return this.#cookies.some(([cookieName]) => cookieName === name)
   }
 
   /**
    * Removes all cookies from the header.
    */
   clear(): void {
-    this.#map.clear()
+    this.#cookies = []
   }
 
   /**
@@ -94,8 +126,10 @@ export class Cookie implements HeaderValue, Iterable<[string, string]> {
    *
    * @returns An iterator of `[name, value]` tuples
    */
-  entries(): IterableIterator<[string, string]> {
-    return this.#map.entries()
+  *entries(): IterableIterator<[string, string]> {
+    for (let [name, value] of this.#cookies) {
+      yield [name, value]
+    }
   }
 
   /**
@@ -127,7 +161,7 @@ export class Cookie implements HeaderValue, Iterable<[string, string]> {
   toString(): string {
     let pairs: string[] = []
 
-    for (let [name, value] of this.#map) {
+    for (let [name, value] of this.#cookies) {
       pairs.push(`${name}=${quote(value)}`)
     }
 
@@ -147,15 +181,15 @@ export class Cookie implements HeaderValue, Iterable<[string, string]> {
       if (typeof value === 'string') {
         let params = parseParams(value)
         for (let [name, val] of params) {
-          header.#map.set(name, val ?? '')
+          header.#cookies.push([name, val ?? ''])
         }
       } else if (isIterable(value)) {
         for (let [name, val] of value) {
-          header.#map.set(name, val)
+          header.#cookies.push([name, val])
         }
       } else {
         for (let name of Object.getOwnPropertyNames(value)) {
-          header.#map.set(name, value[name])
+          header.#cookies.push([name, value[name]])
         }
       }
     }

--- a/packages/headers/src/lib/super-headers.test.ts
+++ b/packages/headers/src/lib/super-headers.test.ts
@@ -222,10 +222,12 @@ describe('SuperHeaders', () => {
     headers.accept.set('text/html')
     headers.accept.set('application/json', 0.8)
     headers.cookie.set('theme', 'dark')
+    headers.cookie.append('theme', 'light')
     headers.vary.add('Accept-Encoding')
 
     assert.equal(headers.get('Accept'), 'text/html,application/json;q=0.8')
-    assert.equal(headers.get('Cookie'), 'theme=dark')
+    assert.equal(headers.get('Cookie'), 'theme=dark; theme=light')
+    assert.deepEqual(headers.cookie.getAll('theme'), ['dark', 'light'])
     assert.equal(headers.get('Vary'), 'accept-encoding')
     assert.equal(getResponseHeaders(headers).get('Accept'), 'text/html,application/json;q=0.8')
 
@@ -362,6 +364,21 @@ describe('SuperHeaders', () => {
 
     assert.deepEqual(Array.from(headers), [['content-type', 'text/html']])
     assert.equal(stringify(headers), 'Content-Type: text/html')
+  })
+
+  it('preserves duplicate Cookie values', () => {
+    let headers = new SuperHeaders({
+      Cookie: 'session=child; session=parent; theme=dark',
+    })
+
+    assert.equal(headers.cookie.get('session'), 'child')
+    assert.deepEqual(headers.cookie.getAll('session'), ['child', 'parent'])
+    assert.deepEqual(Array.from(headers.cookie), [
+      ['session', 'child'],
+      ['session', 'parent'],
+      ['theme', 'dark'],
+    ])
+    assert.equal(headers.get('Cookie'), 'session=child; session=parent; theme=dark')
   })
 
   it('preserves and syncs multiple Set-Cookie values', () => {

--- a/packages/headers/src/lib/super-headers.ts
+++ b/packages/headers/src/lib/super-headers.ts
@@ -220,6 +220,7 @@ const ObjectHeaderDescriptors: readonly ObjectHeaderDescriptor[] = [
     ContentType.from(value),
   ),
   objectHeader<CookieInit, Cookie>('cookie', 'Cookie', (value) => Cookie.from(value), [
+    'append',
     'clear',
     'delete',
     'set',

--- a/packages/remix/.changes/patch.headers.preserve-duplicate-cookies.md
+++ b/packages/remix/.changes/patch.headers.preserve-duplicate-cookies.md
@@ -1,0 +1,1 @@
+Fix `Cookie` and `SuperHeaders.cookie` from `remix/headers` so duplicate cookie names are preserved in order. `Cookie#get(name)` now returns the first matching value, `Cookie#getAll(name)` can be used to read every matching value, and `Cookie#append(name, value)` can be used to add another cookie with the same name.

--- a/packages/remix/src/headers/README.md
+++ b/packages/remix/src/headers/README.md
@@ -325,7 +325,7 @@ headers.set('Content-Type', new ContentType({ mediaType: 'text/html', charset: '
 
 Parse, manipulate and stringify [`Cookie` headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie).
 
-Implements `Map<name, value>`.
+Implements an ordered list of name/value pairs. Duplicate cookie names are preserved, such as when cookies with the same name were set for different paths.
 
 ```ts
 import { Cookie } from 'remix/headers'
@@ -334,6 +334,7 @@ import { Cookie } from 'remix/headers'
 let cookie = Cookie.from(request.headers.get('Cookie'))
 
 cookie.get('session_id') // 'abc123'
+cookie.getAll('session_id') // ['abc123']
 cookie.get('theme') // 'dark'
 cookie.has('session_id') // true
 cookie.size // 2
@@ -345,6 +346,7 @@ for (let [name, value] of cookie) {
 
 // Modify and set header
 cookie.set('theme', 'light')
+cookie.append('session_id', 'def456')
 cookie.delete('session_id')
 headers.set('Cookie', cookie)
 


### PR DESCRIPTION
`Cookie` previously modeled the `Cookie` header as a `Map<name, value>`, so duplicate names from path/domain-specific cookies collapsed to one value. This switches it to ordered name/value pairs while keeping `get(name)` as a convenience for the first matching value.

- Preserves duplicate `Cookie` entries when parsing strings, iterables, and `SuperHeaders.cookie`
- Adds `Cookie#getAll(name)` and `Cookie#append(name, value)` for duplicate-aware reads and writes
- Updates `@remix-run/headers` and `remix/headers` README/change-file coverage

```ts
let cookie = Cookie.from('session=child; session=parent')

cookie.get('session') // 'child'
cookie.getAll('session') // ['child', 'parent']

cookie.append('session', 'other')
```

Closes #11354
