### PR TITLE
Fix UI hydration fragment anchors

### DIFF
--- a/packages/ui/.changes/patch.fix-hydration-fragment-anchors.md
+++ b/packages/ui/.changes/patch.fix-hydration-fragment-anchors.md
@@ -1,0 +1,1 @@
+Fix hydrated `@remix-run/ui` components so non-rendering children inside fragments keep the correct DOM anchor when they later become renderable.

--- a/packages/ui/src/runtime/reconcile.ts
+++ b/packages/ui/src/runtime/reconcile.ts
@@ -20,6 +20,7 @@ import {
   isCommittedTextNode,
   isFragmentNode,
   isHostNode,
+  isNonRenderNode,
   isTextNode,
   findContextFromAncestry,
 } from './vnode.ts'
@@ -421,6 +422,10 @@ export function diffVNodes(
     return rootCursor
   }
 
+  if (isNonRenderNode(curr) && isNonRenderNode(next)) {
+    return rootCursor
+  }
+
   if (isCommittedTextNode(curr) && isTextNode(next)) {
     diffText(curr, next, vParent)
     return rootCursor
@@ -444,7 +449,7 @@ export function diffVNodes(
       frame,
       scheduler,
       styles,
-      vParent,
+      next,
       rootTarget,
       undefined,
       anchor,
@@ -484,7 +489,7 @@ function replace(
     return
   }
 
-  let replacementAnchor = findNextSiblingDomAnchor(curr, vParent) ?? anchor
+  let replacementAnchor = findNextSiblingDomAnchor(curr) ?? anchor
   remove(curr, domParent, scheduler, styles)
   insert(next, domParent, frame, scheduler, styles, vParent, rootTarget, replacementAnchor)
 }
@@ -709,6 +714,10 @@ function insert(
     ? (dom: Node) => domParent.insertBefore(dom, anchor)
     : (dom: Node) => domParent.appendChild(dom)
 
+  if (isNonRenderNode(node)) {
+    return cursor
+  }
+
   if (isTextNode(node)) {
     if (cursor instanceof Text) {
       node._parent = vParent
@@ -878,17 +887,7 @@ function insert(
   if (isFragmentNode(node)) {
     // Insert fragment children in order before the same anchor
     for (let child of node._children) {
-      cursor = insert(
-        child,
-        domParent,
-        frame,
-        scheduler,
-        styles,
-        vParent,
-        rootTarget,
-        anchor,
-        cursor,
-      )
+      cursor = insert(child, domParent, frame, scheduler, styles, node, rootTarget, anchor, cursor)
     }
     return cursor
   }
@@ -2020,15 +2019,23 @@ function shouldDispatchInlineMixinLifecycle(node: Node): boolean {
   return true
 }
 
-export function findNextSiblingDomAnchor(curr: VNode, vParent?: VNode): Node | null {
+export function findNextSiblingDomAnchor(curr: VNode): Node | null {
+  let vParent = curr._parent
   if (!vParent || !Array.isArray(vParent._children)) return null
   let children = vParent._children
+  if (children.length === 0) return findNextSiblingDomAnchor(vParent)
+
   let idx = children.indexOf(curr)
   if (idx === -1) return null
   for (let i = idx + 1; i < children.length; i++) {
     let dom = findFirstDomAnchor(children[i])
     if (dom) return dom
   }
+
+  if (isFragmentNode(vParent)) {
+    return findNextSiblingDomAnchor(vParent)
+  }
+
   return null
 }
 

--- a/packages/ui/src/runtime/scheduler.ts
+++ b/packages/ui/src/runtime/scheduler.ts
@@ -137,7 +137,7 @@ export function createScheduler(
             // Needed for fragment self-updates that add children - without this, new children
             // would be appended after siblings. The keyed diff has placement logic, but unkeyed
             // diff relies on anchor for correct positioning.
-            let anchor = findNextSiblingDomAnchor(vnode, vParent) || undefined
+            let anchor = findNextSiblingDomAnchor(vnode) || undefined
             try {
               let updateStyles = getFrameStyleManager(vnode)
               renderComponent(

--- a/packages/ui/src/runtime/to-vnode.ts
+++ b/packages/ui/src/runtime/to-vnode.ts
@@ -2,7 +2,7 @@ import { Fragment } from './component.ts'
 import { invariant } from './invariant.ts'
 import { isEmptyChild, isPrimitiveChild, normalizeChildren } from './core/children.ts'
 import type { RemixElement, RemixNode } from './jsx.ts'
-import { isRemixElement, TEXT_NODE, type VNode } from './vnode.ts'
+import { isRemixElement, NON_RENDER_NODE, TEXT_NODE, type VNode } from './vnode.ts'
 
 function flatMapChildrenToVNodes(node: RemixElement): VNode[] {
   if (!('children' in node.props)) return []
@@ -21,7 +21,7 @@ function flattenChildrenToVNodes(nodes: RemixNode[], out: VNode[]): void {
 
 export function toVNode(node: RemixNode): VNode {
   if (isEmptyChild(node)) {
-    return { type: TEXT_NODE, _text: '' }
+    return { type: NON_RENDER_NODE }
   }
 
   if (isPrimitiveChild(node)) {

--- a/packages/ui/src/runtime/vnode.ts
+++ b/packages/ui/src/runtime/vnode.ts
@@ -6,6 +6,7 @@ import type { ElementProps, RemixNode } from './jsx.ts'
 export { isRemixElement }
 
 export const TEXT_NODE = Symbol('TEXT_NODE')
+export const NON_RENDER_NODE = Symbol('NON_RENDER_NODE')
 export const ROOT_VNODE = Symbol('ROOT_VNODE')
 
 export type VNodeType =
@@ -13,6 +14,7 @@ export type VNodeType =
   | string // host element
   | Function // component
   | typeof TEXT_NODE
+  | typeof NON_RENDER_NODE
   | typeof Fragment
   | typeof Frame
 
@@ -66,6 +68,10 @@ export type TextNode = VNode & {
   _text: string
 }
 
+export type NonRenderNode = VNode & {
+  type: typeof NON_RENDER_NODE
+}
+
 export type CommittedTextNode = TextNode & {
   _dom: Text
 }
@@ -100,6 +106,10 @@ export function isFragmentNode(node: VNode): node is FragmentNode {
 
 export function isTextNode(node: VNode): node is TextNode {
   return node.type === TEXT_NODE
+}
+
+export function isNonRenderNode(node: VNode): node is NonRenderNode {
+  return node.type === NON_RENDER_NODE
 }
 
 export function isCommittedTextNode(node: VNode): node is CommittedTextNode {

--- a/packages/ui/src/test/hydration.components.test.tsx
+++ b/packages/ui/src/test/hydration.components.test.tsx
@@ -1,6 +1,6 @@
 import { expect } from '@remix-run/assert'
 import { afterEach, beforeEach, describe, it } from '@remix-run/test'
-import type { Handle } from '../runtime/component.ts'
+import type { Handle, RemixNode } from '../runtime/component.ts'
 import { createRoot } from '../runtime/vdom.ts'
 import { renderToString } from '../server/stream.ts'
 import { clientEntry } from '../runtime/client-entries.ts'
@@ -162,6 +162,49 @@ describe('hydration', () => {
       root.flush()
 
       expect(existingButton.textContent).toBe('Count: 6')
+    })
+
+    it('hydrates null elements without breaking sibling ordering when they become renderable', async () => {
+      let secondElement: RemixNode = null
+      let capturedUpdate = () => {}
+      let NullChanging = clientEntry('/with-null.js#WithNull', function WithNull(handle: Handle) {
+        capturedUpdate = () => handle.update()
+        return () => (
+          <div>
+            <span>First</span>
+            {secondElement}
+            <span>Second</span>
+          </div>
+        )
+      })
+
+      let html = await renderToString(<NullChanging />)
+      container.innerHTML = html
+
+      let existingSpans = container.querySelectorAll('span')
+      expect(existingSpans).toHaveLength(2)
+      invariant(existingSpans[0] && existingSpans[1])
+      expect(existingSpans[0].textContent).toBe('First')
+      expect(existingSpans[1].textContent).toBe('Second')
+
+      let root = createRoot(container)
+      root.render(<NullChanging />)
+      root.flush()
+
+      let hydratedSpans = container.querySelectorAll('span')
+      expect(hydratedSpans).toHaveLength(2)
+      expect(hydratedSpans[0]).toBe(existingSpans[0])
+      expect(hydratedSpans[1]).toBe(existingSpans[1])
+
+      secondElement = <span>after First</span>
+      capturedUpdate()
+      root.flush()
+
+      let updatedSpans = container.querySelectorAll('span')
+      expect(updatedSpans).toHaveLength(3)
+      expect(updatedSpans[0]).toBe(existingSpans[0])
+      expect(updatedSpans[1].textContent).toBe('after First')
+      expect(updatedSpans[2]).toBe(existingSpans[1])
     })
   })
 

--- a/packages/ui/src/test/vdom.dom-order.test.tsx
+++ b/packages/ui/src/test/vdom.dom-order.test.tsx
@@ -2,6 +2,7 @@ import { expect } from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 import { createRoot } from '../runtime/vdom.ts'
 import type { Handle } from '../runtime/component.ts'
+import { invariant } from '../runtime/invariant.ts'
 
 describe('vnode rendering', () => {
   describe('conditional rendering and DOM order', () => {
@@ -349,6 +350,135 @@ describe('vnode rendering', () => {
       expect(container.innerHTML).toBe(
         '<main><span>0</span><span>1</span><span>2</span><footer>Footer</footer></main>',
       )
+    })
+
+    it('maintains DOM order when fragment component has multiple renders before changing', () => {
+      let container = document.createElement('div')
+      let root = createRoot(container)
+
+      let showMiddle = false
+      let capturedUpdate = () => {}
+
+      function Dynamic(handle: Handle) {
+        capturedUpdate = () => handle.update()
+        return () => (showMiddle ? <span id="middle">Middle</span> : null)
+      }
+
+      function App() {
+        return () => (
+          <main>
+            <>
+              <Dynamic />
+              <span id="tail">Tail</span>
+            </>
+            <footer id="footer">Footer</footer>
+          </main>
+        )
+      }
+
+      root.render(<App />)
+      let originalTail = container.querySelector('#tail')
+      let originalFooter = container.querySelector('#footer')
+      expect(container.innerHTML).toBe(
+        '<main><span id="tail">Tail</span><footer id="footer">Footer</footer></main>',
+      )
+
+      root.render(<App />)
+      root.flush()
+      expect(container.querySelector('#tail')).toBe(originalTail)
+      expect(container.querySelector('#footer')).toBe(originalFooter)
+
+      showMiddle = true
+      capturedUpdate()
+      root.flush()
+
+      expect(container.innerHTML).toBe(
+        '<main><span id="middle">Middle</span><span id="tail">Tail</span><footer id="footer">Footer</footer></main>',
+      )
+      expect(container.querySelector('#tail')).toBe(originalTail)
+      expect(container.querySelector('#footer')).toBe(originalFooter)
+    })
+
+    it('maintains DOM order with non-render content in nested fragments after self-updates', () => {
+      let container = document.createElement('div')
+      let root = createRoot(container)
+      let capturedUpdates: (() => void)[] = []
+      let showMiddle = false
+
+      function Middle(handle: Handle) {
+        capturedUpdates.push(() => handle.update())
+        return ({ id }: { id: string }) => (showMiddle ? <span id={id}>Middle</span> : undefined)
+      }
+
+      function App() {
+        return () => (
+          <>
+            <span id="first">First</span>
+            <Middle id="middle-1" />
+            <span id="second">Second</span>
+            <>
+              <span id="third">Third</span>
+              <>
+                <>
+                  <Middle id="middle-2" />
+                </>
+              </>
+              <span id="fourth">Fourth</span>
+            </>
+            <div id="div">
+              <>
+                <span id="fifth">Fifth</span>
+                <Middle id="middle-3" />
+                <span id="sixth">Sixth</span>
+              </>
+            </div>
+            <span id="seventh">Seventh</span>
+          </>
+        )
+      }
+
+      root.render(<App />)
+
+      let first = container.querySelector('#first')
+      let second = container.querySelector('#second')
+      invariant(first && second)
+      expect(first.nextSibling).toBe(second)
+
+      let third = container.querySelector('#third')
+      let fourth = container.querySelector('#fourth')
+      invariant(third && fourth)
+      expect(second.nextSibling).toBe(third)
+      expect(third.nextSibling).toBe(fourth)
+
+      let div = container.querySelector('#div')
+      let fifth = container.querySelector('#fifth')
+      let sixth = container.querySelector('#sixth')
+      invariant(div && fifth && sixth)
+      expect(fourth.nextSibling).toBe(div)
+      expect(fifth.parentNode).toBe(div)
+      expect(fifth.nextSibling).toBe(sixth)
+
+      let seventh = container.querySelector('#seventh')
+      invariant(seventh)
+      expect(div.nextSibling).toBe(seventh)
+
+      showMiddle = true
+      for (let update of capturedUpdates) {
+        update()
+      }
+      root.flush()
+
+      let middle1 = container.querySelector('#middle-1')
+      let middle2 = container.querySelector('#middle-2')
+      let middle3 = container.querySelector('#middle-3')
+      invariant(middle1 && middle2 && middle3)
+      expect(middle1.previousSibling).toBe(first)
+      expect(middle1.nextSibling).toBe(second)
+      expect(middle2.previousSibling).toBe(third)
+      expect(middle2.nextSibling).toBe(fourth)
+      expect(middle3.parentNode).toBe(div)
+      expect(middle3.previousSibling).toBe(fifth)
+      expect(middle3.nextSibling).toBe(sixth)
     })
   })
 })


### PR DESCRIPTION
Ports the hydration and DOM-order fix from #11189 to the current `@remix-run/ui` runtime after the component package was consolidated into `packages/ui`.

Hydration currently represents `null`, `undefined`, and boolean children as empty text vnodes even though SSR emits no DOM for them. When those children later become renderable, anchor lookup can fall through fragment boundaries and insert the new DOM after following siblings.

- Tracks non-rendering children with an explicit vnode type instead of an empty text node
- Links fragment children to their fragment parent so sibling anchor lookup can recurse through flattened fragment DOM
- Adds hydration and DOM-order regressions for non-render content becoming renderable inside client entries and nested fragments
- Supersedes #11189
- Fixes #11370