### PR TITLE
Add SuperHeaders apply method

### DIFF
--- a/packages/headers/.changes/minor.apply-super-headers-init.md
+++ b/packages/headers/.changes/minor.apply-super-headers-init.md
@@ -1,0 +1,1 @@
+Add `SuperHeaders#apply(init)` to apply `SuperHeadersInit` values to an existing instance with header-aware behavior, replacing singleton headers while preserving additive headers like `Cookie`, `Set-Cookie`, and `Vary`.

--- a/packages/headers/.changes/minor.apply-super-headers-init.md
+++ b/packages/headers/.changes/minor.apply-super-headers-init.md
@@ -1,1 +1,1 @@
-Add `SuperHeaders#apply(init)` to apply `SuperHeadersInit` values to an existing instance with header-aware behavior, replacing singleton headers while preserving additive headers like `Cookie`, `Set-Cookie`, and `Vary`.
+Add `SuperHeaders#apply(init)` to apply `SuperHeadersInit` values to an existing instance with header-aware behavior, replacing singleton headers while preserving additive headers like `Cookie`, `Set-Cookie`, and `Vary` (see #11398).

--- a/packages/headers/README.md
+++ b/packages/headers/README.md
@@ -53,6 +53,26 @@ headers.get('Content-Type') // no typed parse needed
 headers.contentType.mediaType // parses Content-Type lazily
 ```
 
+Use `apply()` to apply a `SuperHeadersInit` value to an existing instance with header-aware semantics:
+
+```ts
+let headers = new Headers({
+  contentType: 'text/html',
+  setCookie: { name: 'session', value: 'abc' },
+  vary: 'Accept-Encoding',
+})
+
+headers.apply({
+  contentType: 'application/json',
+  setCookie: { name: 'theme', value: 'dark' },
+  vary: ['Accept-Encoding', 'Accept-Language'],
+})
+
+headers.get('Content-Type') // 'application/json'
+headers.get('Vary') // 'accept-encoding, accept-language'
+headers.getSetCookie() // ['session=abc', 'theme=dark']
+```
+
 ## Individual Header Utilities
 
 Each supported header has a class that represents the header value. Use the static `from()` method to parse header values. Each class has a `toString()` method that returns the header value as a string, which you can either call manually, or will be called automatically when the header class is used in a context that expects a string.

--- a/packages/headers/src/lib/super-headers.test.ts
+++ b/packages/headers/src/lib/super-headers.test.ts
@@ -70,6 +70,84 @@ describe('SuperHeaders', () => {
     assert.deepEqual(headers.getSetCookie(), ['session=abc; Path=/', 'theme=dark'])
   })
 
+  it('applies typed property values to existing headers', () => {
+    let headers = new SuperHeaders({
+      allow: 'GET',
+      contentType: 'text/html',
+      cookie: 'session=abc',
+      setCookie: { name: 'session', value: 'abc' },
+      vary: 'Accept-Encoding',
+    })
+
+    let result = headers.apply({
+      allow: ['POST'],
+      contentType: { mediaType: 'application/json', charset: 'utf-8' },
+      cookie: { theme: 'dark' },
+      setCookie: { name: 'theme', value: 'dark' },
+      vary: ['Accept-Encoding', 'Accept-Language'],
+    })
+
+    assert.equal(result, headers)
+    assert.equal(headers.get('Allow'), 'GET, POST')
+    assert.equal(headers.get('Content-Type'), 'application/json; charset=utf-8')
+    assert.equal(headers.get('Cookie'), 'session=abc; theme=dark')
+    assert.deepEqual(headers.getSetCookie(), ['session=abc', 'theme=dark'])
+    assert.equal(headers.get('Vary'), 'accept-encoding, accept-language')
+  })
+
+  it('applies raw header values with header-specific semantics', () => {
+    let headers = new SuperHeaders({
+      'Content-Type': 'text/html',
+      Link: '</style.css>; rel=preload',
+      'Set-Cookie': 'session=abc',
+      Vary: 'Accept-Encoding',
+      'X-Test': 'old',
+    })
+
+    headers.apply(
+      new Headers([
+        ['Content-Type', 'application/json'],
+        ['Link', '</script.js>; rel=preload'],
+        ['Set-Cookie', 'theme=dark'],
+        ['Vary', 'Accept-Language'],
+        ['X-Test', 'new'],
+      ]),
+    )
+
+    headers.apply({
+      Link: '</image.png>; rel=preload',
+      'Set-Cookie': 'locale=en',
+      Vary: 'User-Agent',
+    })
+
+    assert.equal(headers.get('Content-Type'), 'application/json')
+    assert.equal(
+      headers.get('Link'),
+      '</style.css>; rel=preload, </script.js>; rel=preload, </image.png>; rel=preload',
+    )
+    assert.deepEqual(headers.getSetCookie(), ['session=abc', 'theme=dark', 'locale=en'])
+    assert.equal(headers.get('Vary'), 'accept-encoding, accept-language, user-agent')
+    assert.equal(headers.get('X-Test'), 'new')
+  })
+
+  it('deletes headers from nullish applied values', () => {
+    let headers = new SuperHeaders({
+      contentType: 'text/html',
+      setCookie: { name: 'session', value: 'abc' },
+      'X-Test': 'yes',
+    })
+
+    headers.apply({
+      contentType: null,
+      setCookie: null,
+      'X-Test': null,
+    })
+
+    assert.equal(headers.has('Content-Type'), false)
+    assert.deepEqual(headers.getSetCookie(), [])
+    assert.equal(headers.has('X-Test'), false)
+  })
+
   it('does not parse raw header strings', () => {
     assert.throws(() => Reflect.construct(SuperHeaders, ['Content-Type: text/html']), TypeError)
   })

--- a/packages/headers/src/lib/super-headers.ts
+++ b/packages/headers/src/lib/super-headers.ts
@@ -333,6 +333,24 @@ const HeaderDescriptorByProperty = new Map(
   HeaderDescriptors.map((descriptor) => [descriptor.property, descriptor]),
 )
 
+const ApplyAppendObjectHeaderProperties = new Set([
+  'accept',
+  'acceptEncoding',
+  'acceptLanguage',
+  'cacheControl',
+  'ifMatch',
+  'ifNoneMatch',
+])
+
+const ApplyAppendHeaderNames = new Set(
+  [
+    ...ObjectHeaderDescriptors.filter((descriptor) =>
+      ApplyAppendObjectHeaderProperties.has(descriptor.property),
+    ),
+    ...StringHeaderDescriptors.filter((descriptor) => descriptor.list),
+  ].map((descriptor) => descriptor.name.toLowerCase()),
+)
+
 /**
  * An enhanced JavaScript `Headers` interface with lazy, type-safe property accessors.
  */
@@ -364,6 +382,44 @@ export class SuperHeaders extends Headers {
     this.#invalidate(name)
   }
 
+  /**
+   * Applies header values to this instance using header-aware merge semantics.
+   *
+   * @param init Header values to apply.
+   * @returns This `SuperHeaders` instance.
+   */
+  apply(init: SuperHeadersInit): this {
+    if (typeof init === 'string') {
+      throw new TypeError('SuperHeaders does not parse raw header strings; use parse() instead')
+    }
+
+    if (isIterable<[string, string]>(init)) {
+      for (let [name, value] of init) {
+        this.#applyHeaderValue(name, value)
+      }
+      return this
+    }
+
+    for (let name of Object.getOwnPropertyNames(init)) {
+      let value = init[name]
+      let descriptor = HeaderDescriptorByProperty.get(name)
+
+      if (value == null) {
+        this.delete(descriptor?.name ?? name)
+      } else if (descriptor && this.#shouldSetHeaderDescriptorValue(descriptor)) {
+        this.#setHeaderDescriptorValue(descriptor, value)
+      } else if (descriptor) {
+        for (let [headerName, headerValue] of new SuperHeaders({ [name]: value })) {
+          this.#applyHeaderValue(headerName, headerValue)
+        }
+      } else {
+        this.#applyHeaderValue(name, String(value))
+      }
+    }
+
+    return this
+  }
+
   #initialize(init: SuperHeadersInit): void {
     if (typeof init === 'string') {
       throw new TypeError('SuperHeaders does not parse raw header strings; use parse() instead')
@@ -386,6 +442,54 @@ export class SuperHeaders extends Headers {
         Headers.prototype.set.call(this, name, String(value))
       }
     }
+  }
+
+  #applyHeaderValue(name: string, value: string): void {
+    let key = name.toLowerCase()
+
+    if (key === SetCookieKey) {
+      if (value !== '') this.append(name, value)
+      return
+    }
+
+    if (key === 'cookie') {
+      let incoming = Cookie.from(value)
+      if (incoming.size === 0) return
+
+      let current = Cookie.from(this.get(name))
+      for (let [cookieName, cookieValue] of incoming) {
+        current.append(cookieName, cookieValue)
+      }
+
+      this.set(name, current.toString())
+      return
+    }
+
+    if (key === 'vary') {
+      let incoming = Vary.from(value)
+      if (incoming.size === 0) return
+
+      let current = Vary.from(this.get(name))
+      for (let headerName of incoming) {
+        current.add(headerName)
+      }
+
+      this.set(name, current.toString())
+      return
+    }
+
+    if (ApplyAppendHeaderNames.has(key)) {
+      if (value !== '') this.append(name, value)
+    } else {
+      this.set(name, value)
+    }
+  }
+
+  #shouldSetHeaderDescriptorValue(descriptor: HeaderDescriptor): boolean {
+    let key = descriptor.name.toLowerCase()
+    return (
+      key !== SetCookieKey && key !== 'cookie' && key !== 'vary' && !ApplyAppendHeaderNames.has(key)
+    )
   }
 
   #getHeaderDescriptorValue(descriptor: HeaderDescriptor): unknown {

--- a/packages/remix/.changes/minor.headers.apply-super-headers-init.md
+++ b/packages/remix/.changes/minor.headers.apply-super-headers-init.md
@@ -1,0 +1,1 @@
+Expose `SuperHeaders#apply(init)` through `remix/headers` so apps can apply `SuperHeadersInit` values to an existing instance with header-aware behavior.

--- a/packages/remix/.changes/minor.headers.apply-super-headers-init.md
+++ b/packages/remix/.changes/minor.headers.apply-super-headers-init.md
@@ -1,1 +1,1 @@
-Expose `SuperHeaders#apply(init)` through `remix/headers` so apps can apply `SuperHeadersInit` values to an existing instance with header-aware behavior.
+Expose `SuperHeaders#apply(init)` through `remix/headers` so apps can apply `SuperHeadersInit` values to an existing instance with header-aware behavior (see #11398).

--- a/packages/remix/src/headers/README.md
+++ b/packages/remix/src/headers/README.md
@@ -53,6 +53,26 @@ headers.get('Content-Type') // no typed parse needed
 headers.contentType.mediaType // parses Content-Type lazily
 ```
 
+Use `apply()` to apply a `SuperHeadersInit` value to an existing instance with header-aware semantics:
+
+```ts
+let headers = new Headers({
+  contentType: 'text/html',
+  setCookie: { name: 'session', value: 'abc' },
+  vary: 'Accept-Encoding',
+})
+
+headers.apply({
+  contentType: 'application/json',
+  setCookie: { name: 'theme', value: 'dark' },
+  vary: ['Accept-Encoding', 'Accept-Language'],
+})
+
+headers.get('Content-Type') // 'application/json'
+headers.get('Vary') // 'accept-encoding, accept-language'
+headers.getSetCookie() // ['session=abc', 'theme=dark']
+```
+
 ## Individual Header Utilities
 
 Each supported header has a class that represents the header value. Use the static `from()` method to parse header values. Each class has a `toString()` method that returns the header value as a string, which you can either call manually, or will be called automatically when the header class is used in a context that expects a string.


### PR DESCRIPTION
Add `SuperHeaders#apply(init)` so callers can apply a `SuperHeadersInit` object, iterable, or `Headers` to an existing `SuperHeaders` instance without re-implementing header-specific merge behavior.

Closes #11398.

- Normalizes typed property init values through the existing `SuperHeaders` descriptor pipeline
- Replaces singleton headers like `Content-Type` while preserving additive headers like `Cookie`, `Set-Cookie`, `Vary`, and list-like headers
- Documents the method for both `@remix-run/headers` and `remix/headers`, with release notes for both packages

```ts
import Headers from 'remix/headers'

let headers = new Headers({
  contentType: 'text/html',
  vary: 'Accept-Encoding',
})

headers.apply({
  contentType: 'application/json',
  setCookie: { name: 'theme', value: 'dark' },
  vary: ['Accept-Encoding', 'Accept-Language'],
})

headers.get('Content-Type') // 'application/json'
headers.get('Vary') // 'accept-encoding, accept-language'
headers.getSetCookie() // ['theme=dark']
```
