### PR TITLE
Clarify Remix UI context identity semantics

### DIFF
--- a/packages/ui/docs/context.md
+++ b/packages/ui/docs/context.md
@@ -7,12 +7,12 @@ Context enables components to communicate without direct prop passing.
 Use `handle.context.set()` to provide values and `handle.context.get()` to consume them:
 
 ```tsx
-function ThemeProvider(handle: Handle<{ theme: 'light' | 'dark' }>) {
+function ThemeProvider(handle: Handle<{ children?: RemixNode }, { theme: 'light' | 'dark' }>) {
   let theme: 'light' | 'dark' = 'light'
 
   handle.context.set({ theme })
 
-  return (props: { children: RemixNode }) => (
+  return () => (
     <div>
       <button
         mix={[
@@ -25,7 +25,7 @@ function ThemeProvider(handle: Handle<{ theme: 'light' | 'dark' }>) {
       >
         Toggle Theme
       </button>
-      {props.children}
+      {handle.props.children}
     </div>
   )
 }
@@ -42,6 +42,38 @@ function ThemedContent(handle: Handle) {
 ```
 
 **Important:** `handle.context.set()` does not cause any updates—it simply stores a value. If you want the component tree to update when context changes, you must call `handle.update()` after setting the context (as shown above).
+
+## Component Identity
+
+Context lookup is keyed by component identity. `handle.context.get(Component)` reads the nearest ancestor instance whose component function is exactly `Component`, and the returned value is inferred from that component's `Handle<Props, ContextValue>` type.
+
+This keeps component relationships explicit and avoids accidental collisions between unrelated providers. Nested instances of the same provider component shadow outer instances, but different component types remain independent even when their context values have the same shape.
+
+When multiple public components should provide the same logical scope, create a shared provider component and render it from each public component:
+
+```tsx
+type MenuScopeValue = {
+  id: string
+}
+
+function MenuScope(handle: Handle<{ children?: RemixNode }, MenuScopeValue>) {
+  handle.context.set({ id: handle.id })
+  return () => handle.props.children
+}
+
+function MenuRoot(handle: Handle<{ children?: RemixNode }>) {
+  return () => <MenuScope>{handle.props.children}</MenuScope>
+}
+
+function MenuGroup(handle: Handle<{ children?: RemixNode }>) {
+  return () => <MenuScope>{handle.props.children}</MenuScope>
+}
+
+function MenuTrigger(handle: Handle) {
+  let scope = handle.context.get(MenuScope)
+  return () => <button aria-controls={scope.id}>Open</button>
+}
+```
 
 ## TypedEventTarget for Granular Updates
 
@@ -63,11 +95,11 @@ class Theme extends TypedEventTarget<{ change: Event }> {
   }
 }
 
-function ThemeProvider(handle: Handle<Theme>) {
+function ThemeProvider(handle: Handle<{ children?: RemixNode }, Theme>) {
   let theme = new Theme()
   handle.context.set(theme)
 
-  return (props: { children: RemixNode }) => (
+  return () => (
     <div>
       <button
         mix={[
@@ -79,7 +111,7 @@ function ThemeProvider(handle: Handle<Theme>) {
       >
         Toggle Theme
       </button>
-      {props.children}
+      {handle.props.children}
     </div>
   )
 }
@@ -136,11 +168,11 @@ class AppContext extends TypedEventTarget<{ userChange: Event; settingsChange: E
   }
 }
 
-function AppProvider(handle: Handle<AppContext>) {
+function AppProvider(handle: Handle<{ children?: RemixNode }, AppContext>) {
   let context = new AppContext()
   handle.context.set(context)
 
-  return (props: { children: RemixNode }) => props.children
+  return () => handle.props.children
 }
 
 // Components can subscribe to only the events they care about

--- a/packages/ui/src/runtime/component.ts
+++ b/packages/ui/src/runtime/component.ts
@@ -118,13 +118,18 @@ export type ContextFrom<ComponentType> =
 
 /**
  * Context storage API exposed on component handles.
+ *
+ * Context values are keyed by provider component identity. `get(Component)`
+ * reads the nearest ancestor instance whose component function is exactly
+ * `Component`, so nested instances of the same provider shadow outer instances
+ * while different component types remain independent.
  */
 export interface Context<C> {
   /** Replaces the current context value for this component instance. */
   set(values: C): void
-  /** Reads the context value associated with the given component type. */
+  /** Reads the context value from the nearest ancestor instance of the given component type. */
   get<ComponentType>(component: ComponentType): ContextFrom<ComponentType>
-  /** Reads the context value associated with the given component key. */
+  /** Reads an unknown context value for an untyped lookup. */
   get(component: ElementType | symbol): unknown | undefined
 }
 


### PR DESCRIPTION
Clarifies that Remix UI context lookup is keyed by provider component identity. This documents the intentional behavior raised in #11348: `get(Component)` reads the nearest ancestor instance of that exact component type, while unrelated provider types remain independent.

Closes #11348.

- Updates the exported `Context` JSDoc to describe exact component identity lookup.
- Adds a Component Identity section to the UI context guide.
- Corrects the guide examples to pass context values through the second `Handle` type parameter.
