### PR TITLE
Update Remix UI docs for current APIs

### DIFF
--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -1,6 +1,6 @@
-# Remix Component - Agent Guide
+# Remix UI - Agent Guide
 
-This guide provides a comprehensive overview of the Remix Component API, its runtime behavior, and practical use cases for building interactive UIs.
+This guide provides a comprehensive overview of the Remix UI API, its runtime behavior, and practical use cases for building interactive UIs.
 
 > Note: Host-element `on`, `css`, `animate`, and `connect` props were removed. Use `mix={[on('event', handler)]}`, `mix={[css(...)]}`, animation mixins, and `mix={[ref(...)]}` instead.
 
@@ -8,7 +8,7 @@ This guide provides a comprehensive overview of the Remix Component API, its run
 
 ### Creating a Root
 
-To start using Remix Component, create a root and render your top-level component:
+To start using Remix UI, create a root and render your top-level component:
 
 ```tsx
 import { createRoot, on } from 'remix/ui'
@@ -87,16 +87,16 @@ root.dispose()
 
 All components follow a consistent two-phase structure:
 
-1. **Setup Phase** - Runs once when the component is first created
+1. **Component Phase** - Runs once when the component is first created
 2. **Render Phase** - Runs on initial render and every update afterward
 
 ```tsx
-function MyComponent(handle: Handle, setup: SetupType) {
-  // Setup phase: runs once
-  let state = initializeState(setup)
+function MyComponent(handle: Handle<Props>) {
+  // Component phase: runs once
+  let state = initializeState(handle.props)
 
   // Return render function: runs on every update
-  return (props: Props) => {
+  return () => {
     return <div>{/* render content */}</div>
   }
 }
@@ -108,17 +108,16 @@ When a component is rendered:
 
 1. **First Render**:
 
-   - The component function is called with `handle` and the `setup` prop
+   - The component function is called with `handle`
    - The returned render function is stored
-   - The render function is called with regular props
+   - The render function is called after `handle.props` is populated
    - Any tasks queued via `handle.queueTask()` are executed after rendering
 
 2. **Subsequent Updates**:
 
    - Only the render function is called
-   - Setup phase is skipped, setup closure persists for the lifetime of the component instance
-   - Props are passed to the render function
-   - The `setup` prop is stripped from props
+   - Component phase is skipped, and the closure persists for the lifetime of the component instance
+   - `handle.props` is updated before the render function is called
    - Tasks queued during the update are executed after rendering
 
 3. **Component Removal**:
@@ -126,27 +125,25 @@ When a component is rendered:
    - Listeners registered with `addEventListeners(..., handle.signal, ...)` are automatically cleaned up
    - Any queued tasks are executed with an aborted signal
 
-### Setup vs Props
+### Props On The Handle
 
-The `setup` prop is special - it's only available in the setup phase and is automatically excluded from props. This prevents accidental stale captures:
+Props are available on `handle.props`. The object is stable, and its values are updated before each render:
 
 ```tsx
-function Counter(handle: Handle, setup: number) {
-  // setup prop (e.g., initialCount) only available here
-  let count = setup
+function Counter(handle: Handle<{ initialCount: number; label: string }>) {
+  let count = handle.props.initialCount
 
-  return (props: { label: string }) => {
-    // props only receives { label } - setup is excluded
+  return () => {
     return (
       <div>
-        {props.label}: {count}
+        {handle.props.label}: {count}
       </div>
     )
   }
 }
 
 // Usage
-let element = <Counter setup={10} label="Count" />
+let element = <Counter initialCount={10} label="Count" />
 ```
 
 ## Handle API
@@ -399,8 +396,10 @@ Context API for ancestor/descendant communication. Use `handle.context.set()` to
 
 **Important:** `handle.context.set()` does not cause any updates - it simply stores a value. If you need the component tree to update when context changes, call `handle.update()` after setting the context, or use an `EventTarget` on context for descendants to subscribe to changes (see the TypedEventTarget example in the Context section).
 
+Context lookup is keyed by component identity. `handle.context.get(Component)` reads the nearest ancestor instance whose component function is exactly `Component`, so nested instances of the same provider shadow outer instances while different component types remain independent.
+
 ```tsx
-function App(handle: Handle<{ theme: string }>) {
+function App(handle: Handle<Record<string, never>, { theme: string }>) {
   handle.context.set({ theme: 'dark' })
 
   return () => (
@@ -1394,12 +1393,12 @@ Context enables components to communicate without direct prop passing:
 #### Basic Context
 
 ```tsx
-function ThemeProvider(handle: Handle<{ theme: 'light' | 'dark' }>) {
+function ThemeProvider(handle: Handle<{ children?: RemixNode }, { theme: 'light' | 'dark' }>) {
   let theme: 'light' | 'dark' = 'light'
 
   handle.context.set({ theme })
 
-  return (props: { children: RemixNode }) => (
+  return () => (
     <div>
       <button
         mix={[
@@ -1412,7 +1411,7 @@ function ThemeProvider(handle: Handle<{ theme: 'light' | 'dark' }>) {
       >
         Toggle Theme
       </button>
-      {props.children}
+      {handle.props.children}
     </div>
   )
 }
@@ -1436,6 +1435,8 @@ function ThemedContent(handle: Handle) {
 
 **Note:** `handle.context.set()` does not cause any updates - it simply stores a value. If you want the component tree to update when context changes, you must call `handle.update()` after setting the context (as shown above), or use an `EventTarget` on context for descendants to subscribe to changes (as shown in the TypedEventTarget example below).
 
+Context lookup is keyed by component identity. `handle.context.get(Component)` reads the nearest ancestor instance whose component function is exactly `Component`.
+
 #### TypedEventTarget for Granular Updates
 
 For better performance, use `TypedEventTarget` to avoid updating the entire subtree:
@@ -1456,11 +1457,11 @@ class Theme extends TypedEventTarget<{ change: Event }> {
   }
 }
 
-function ThemeProvider(handle: Handle<Theme>) {
+function ThemeProvider(handle: Handle<{ children?: RemixNode }, Theme>) {
   let theme = new Theme()
   handle.context.set(theme)
 
-  return (props: { children: RemixNode }) => (
+  return () => (
     <div>
       <button
         mix={[
@@ -1472,7 +1473,7 @@ function ThemeProvider(handle: Handle<Theme>) {
       >
         Toggle Theme
       </button>
-      {props.children}
+      {handle.props.children}
     </div>
   )
 }
@@ -1503,29 +1504,29 @@ function ThemedContent(handle: Handle) {
 
 ## Common Patterns and Use Cases
 
-### Setup Scope Use Cases
+### Component Scope Use Cases
 
-The setup scope is perfect for one-time initialization:
+The component scope is perfect for one-time initialization:
 
 #### Initializing Instances
 
 ```tsx
-function CacheExample(handle: Handle, setup: { cacheSize: number }) {
+function CacheExample(handle: Handle<{ cacheSize: number; key: string; value: any }>) {
   // Initialize cache once
   let cache = new Map<string, any>()
-  let maxSize = setup.cacheSize
+  let maxSize = handle.props.cacheSize
 
-  return (props: { key: string; value: any }) => {
+  return () => {
     // Use cache in render
-    if (cache.has(props.key)) {
-      return <div>Cached: {cache.get(props.key)}</div>
+    if (cache.has(handle.props.key)) {
+      return <div>Cached: {cache.get(handle.props.key)}</div>
     }
-    cache.set(props.key, props.value)
+    cache.set(handle.props.key, handle.props.value)
     if (cache.size > maxSize) {
       let firstKey = cache.keys().next().value
       cache.delete(firstKey)
     }
-    return <div>New: {props.value}</div>
+    return <div>New: {handle.props.value}</div>
   }
 }
 ```
@@ -1533,18 +1534,18 @@ function CacheExample(handle: Handle, setup: { cacheSize: number }) {
 #### Third-Party SDKs
 
 ```tsx
-function Analytics(handle: Handle, setup: { apiKey: string }) {
+function Analytics(handle: Handle<{ apiKey: string; event: string; data?: any }>) {
   // Initialize SDK once
-  let analytics = new AnalyticsSDK(setup.apiKey)
+  let analytics = new AnalyticsSDK(handle.props.apiKey)
 
   // Cleanup on disconnect
   handle.signal.addEventListener('abort', () => {
     analytics.disconnect()
   })
 
-  return (props: { event: string; data?: any }) => {
+  return () => {
     // SDK is ready to use
-    return <div>Tracking: {props.event}</div>
+    return <div>Tracking: {handle.props.event}</div>
   }
 }
 ```
@@ -1566,9 +1567,9 @@ class DataEmitter extends TypedEventTarget<{ data: DataEvent }> {
   }
 }
 
-function EventListener(handle: Handle, setup: DataEmitter) {
+function EventListener(handle: Handle<{ emitter: DataEmitter }>) {
   // Set up listeners once with automatic cleanup
-  addEventListeners(setup, handle.signal, {
+  addEventListeners(handle.props.emitter, handle.signal, {
     data(event) {
       // Handle data
       handle.update()
@@ -1606,9 +1607,9 @@ function WindowResizeTracker(handle: Handle) {
 #### Initializing State from Props
 
 ```tsx
-function Timer(handle: Handle, setup: { initialSeconds: number }) {
-  // Initialize from setup prop
-  let seconds = setup.initialSeconds
+function Timer(handle: Handle<{ initialSeconds: number; paused?: boolean }>) {
+  // Initialize from props
+  let seconds = handle.props.initialSeconds
   let interval: number | null = null
 
   function start() {
@@ -1632,10 +1633,10 @@ function Timer(handle: Handle, setup: { initialSeconds: number }) {
   // Cleanup on disconnect
   handle.signal.addEventListener('abort', stop)
 
-  return (props: { paused?: boolean }) => {
-    if (!props.paused && !interval) {
+  return () => {
+    if (!handle.props.paused && !interval) {
       start()
-    } else if (props.paused && interval) {
+    } else if (handle.props.paused && interval) {
       stop()
     }
 
@@ -1940,18 +1941,18 @@ The render signal is aborted when:
 
 This ensures only the latest data loading request completes. If the `url` prop changes while a request is in flight, the previous request is automatically cancelled.
 
-#### Using Setup Scope for Initial Data
+#### Using Component Scope for Initial Data
 
-Load initial data in the setup scope:
+Load initial data in the component scope:
 
 ```tsx
-function UserProfile(handle: Handle, setup: { userId: string }) {
+function UserProfile(handle: Handle<{ userId: string; showEmail?: boolean }>) {
   let user: User | null = null
   let loading = true
 
-  // Load initial data in setup scope using queueTask
+  // Load initial data in component scope using queueTask
   handle.queueTask(async (signal) => {
-    let response = await fetch(`/api/users/${setup.userId}`, { signal })
+    let response = await fetch(`/api/users/${handle.props.userId}`, { signal })
     let data = await response.json()
     if (signal.aborted) return
     user = data
@@ -1959,20 +1960,20 @@ function UserProfile(handle: Handle, setup: { userId: string }) {
     handle.update()
   })
 
-  return (props: { showEmail?: boolean }) => {
+  return () => {
     if (loading) return <div>Loading user...</div>
 
     return (
       <div>
         <h1>{user.name}</h1>
-        {props.showEmail && <p>{user.email}</p>}
+        {handle.props.showEmail && <p>{user.email}</p>}
       </div>
     )
   }
 }
 ```
 
-Note that by fetching this data in the setup scope any parent updates that change `setup.userId` will have no effect.
+Note that by fetching this data in the component scope any parent updates that change `handle.props.userId` will have no effect.
 
 ## Testing
 

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -87,12 +87,12 @@ root.dispose()
 
 All components follow a consistent two-phase structure:
 
-1. **Component Phase** - Runs once when the component is first created
+1. **Setup Phase** - Runs once when the component is first created
 2. **Render Phase** - Runs on initial render and every update afterward
 
 ```tsx
 function MyComponent(handle: Handle<Props>) {
-  // Component phase: runs once
+  // Setup phase: runs once
   let state = initializeState(handle.props)
 
   // Return render function: runs on every update
@@ -116,7 +116,7 @@ When a component is rendered:
 2. **Subsequent Updates**:
 
    - Only the render function is called
-   - Component phase is skipped, and the closure persists for the lifetime of the component instance
+   - Setup phase is skipped, and the closure persists for the lifetime of the component instance
    - `handle.props` is updated before the render function is called
    - Tasks queued during the update are executed after rendering
 
@@ -1504,9 +1504,9 @@ function ThemedContent(handle: Handle) {
 
 ## Common Patterns and Use Cases
 
-### Component Scope Use Cases
+### Setup Scope Use Cases
 
-The component scope is perfect for one-time initialization:
+The setup scope is perfect for one-time initialization:
 
 #### Initializing Instances
 
@@ -1941,16 +1941,16 @@ The render signal is aborted when:
 
 This ensures only the latest data loading request completes. If the `url` prop changes while a request is in flight, the previous request is automatically cancelled.
 
-#### Using Component Scope for Initial Data
+#### Using Setup Scope for Initial Data
 
-Load initial data in the component scope:
+Load initial data in the setup scope:
 
 ```tsx
 function UserProfile(handle: Handle<{ userId: string; showEmail?: boolean }>) {
   let user: User | null = null
   let loading = true
 
-  // Load initial data in component scope using queueTask
+  // Load initial data in setup scope using queueTask
   handle.queueTask(async (signal) => {
     let response = await fetch(`/api/users/${handle.props.userId}`, { signal })
     let data = await response.json()
@@ -1973,7 +1973,7 @@ function UserProfile(handle: Handle<{ userId: string; showEmail?: boolean }>) {
 }
 ```
 
-Note that by fetching this data in the component scope any parent updates that change `handle.props.userId` will have no effect.
+Note that by fetching this data in the setup scope any parent updates that change `handle.props.userId` will have no effect.
 
 ## Testing
 
@@ -2020,7 +2020,7 @@ You should also flush after the initial `root.render()` to ensure event listener
 - **Components** have two phases: setup (runs once) and render (runs after setup and on updates)
 - **State** is managed with plain JavaScript variables
 - **Updates** are explicit via `handle.update()`
-- **Setup prop** initialization values and excluded from props
+- **Setup phase** can initialize stable state from initial `handle.props` values
 - **Context** enables indirect composition without prop drilling
 - **TypedEventTarget** provides granular updates for better performance
 - **State management best practices:**

--- a/packages/ui/docs/component.md
+++ b/packages/ui/docs/component.md
@@ -611,7 +611,7 @@ function LabeledInput(handle: Handle) {
 Context API for ancestor/descendant communication. All components are potential context providers and consumers. Use `handle.context.set()` to provide values and `handle.context.get()` to consume them.
 
 ```tsx
-function App(handle: Handle<{ theme: string }>) {
+function App(handle: Handle<Record<string, never>, { theme: string }>) {
   handle.context.set({ theme: 'dark' })
 
   return () => (
@@ -649,7 +649,7 @@ class Theme extends TypedEventTarget<{ change: Event }> {
   }
 }
 
-function App(handle: Handle<Theme>) {
+function App(handle: Handle<Record<string, never>, Theme>) {
   let theme = new Theme()
   handle.context.set(theme)
 
@@ -702,22 +702,22 @@ function List(handle: Handle) {
 
 ## Documentation
 
-- [Getting Started](./docs/getting-started.md)
-- [Components](./docs/components.md)
-- [Handle API](./docs/handle.md)
+- [Getting Started](./getting-started.md)
+- [Components](./components.md)
+- [Handle API](./handle.md)
 - [Server](../src/server/README.md)
-- [Hydration](./docs/hydration.md)
-- [Frames](./docs/frames.md)
-- [Styling](./docs/styling.md)
-- [Events](./docs/events.md)
-- [Interactions](./docs/interactions.md)
-- [Context](./docs/context.md)
-- [Composition](./docs/composition.md)
-- [Patterns](./docs/patterns.md)
+- [Hydration](./hydration.md)
+- [Frames](./frames.md)
+- [Styling](./styling.md)
+- [Events](./events.md)
+- [Interactions](./interactions.md)
+- [Context](./context.md)
+- [Composition](./composition.md)
+- [Patterns](./patterns.md)
 - [Test](../src/test/README.md)
 - Animations
-  - [spring](./docs/spring.md)
-  - [tween](./docs/tween.md)
+  - [spring](./spring.md)
+  - [tween](./tween.md)
 - [Server](../src/server/README.md)
 
 See [LICENSE](https://github.com/remix-run/remix/blob/main/LICENSE)

--- a/packages/ui/docs/components.md
+++ b/packages/ui/docs/components.md
@@ -4,12 +4,12 @@ All components follow a consistent two-phase structure.
 
 ## Component Structure
 
-1. **Component Phase** - Runs once when the component is first created
+1. **Setup Phase** - Runs once when the component is first created
 2. **Render Phase** - Runs on initial render and every update afterward
 
 ```tsx
 function MyComponent(handle: Handle<Props>) {
-  // Component phase: runs once
+  // Setup phase: runs once
   let state = initializeState(handle.props)
 
   // Return render function: runs on every update
@@ -33,7 +33,7 @@ When a component is rendered:
 2. **Subsequent Updates**:
 
    - Only the render function is called
-   - Component phase is skipped, and the closure persists for the lifetime of the component instance
+   - Setup phase is skipped, and the closure persists for the lifetime of the component instance
    - `handle.props` is updated before the render function is called
    - Tasks queued during the update are executed after rendering
 

--- a/packages/ui/docs/context.md
+++ b/packages/ui/docs/context.md
@@ -7,12 +7,12 @@ Context enables components to communicate without direct prop passing.
 Use `handle.context.set()` to provide values and `handle.context.get()` to consume them:
 
 ```tsx
-function ThemeProvider(handle: Handle<{ theme: 'light' | 'dark' }>) {
+function ThemeProvider(handle: Handle<{ children?: RemixNode }, { theme: 'light' | 'dark' }>) {
   let theme: 'light' | 'dark' = 'light'
 
   handle.context.set({ theme })
 
-  return (props: { children: RemixNode }) => (
+  return () => (
     <div>
       <button
         mix={[
@@ -25,7 +25,7 @@ function ThemeProvider(handle: Handle<{ theme: 'light' | 'dark' }>) {
       >
         Toggle Theme
       </button>
-      {props.children}
+      {handle.props.children}
     </div>
   )
 }
@@ -42,6 +42,38 @@ function ThemedContent(handle: Handle) {
 ```
 
 **Important:** `handle.context.set()` does not cause any updates—it simply stores a value. If you want the component tree to update when context changes, you must call `handle.update()` after setting the context (as shown above).
+
+## Component Identity
+
+Context lookup is keyed by component identity. `handle.context.get(Component)` reads the nearest ancestor instance whose component function is exactly `Component`, and the returned value is inferred from that component's `Handle<Props, ContextValue>` type.
+
+This keeps component relationships explicit and avoids accidental collisions between unrelated providers. Nested instances of the same provider component shadow outer instances, but different component types remain independent even when their context values have the same shape.
+
+When multiple public components should provide the same logical scope, create a shared provider component and render it from each public component:
+
+```tsx
+type MenuScopeValue = {
+  id: string
+}
+
+function MenuScope(handle: Handle<{ children?: RemixNode }, MenuScopeValue>) {
+  handle.context.set({ id: handle.id })
+  return () => handle.props.children
+}
+
+function MenuRoot(handle: Handle<{ children?: RemixNode }>) {
+  return () => <MenuScope>{handle.props.children}</MenuScope>
+}
+
+function MenuGroup(handle: Handle<{ children?: RemixNode }>) {
+  return () => <MenuScope>{handle.props.children}</MenuScope>
+}
+
+function MenuTrigger(handle: Handle) {
+  let scope = handle.context.get(MenuScope)
+  return () => <button aria-controls={scope.id}>Open</button>
+}
+```
 
 ## TypedEventTarget for Granular Updates
 
@@ -63,11 +95,11 @@ class Theme extends TypedEventTarget<{ change: Event }> {
   }
 }
 
-function ThemeProvider(handle: Handle<Theme>) {
+function ThemeProvider(handle: Handle<{ children?: RemixNode }, Theme>) {
   let theme = new Theme()
   handle.context.set(theme)
 
-  return (props: { children: RemixNode }) => (
+  return () => (
     <div>
       <button
         mix={[
@@ -79,7 +111,7 @@ function ThemeProvider(handle: Handle<Theme>) {
       >
         Toggle Theme
       </button>
-      {props.children}
+      {handle.props.children}
     </div>
   )
 }
@@ -136,11 +168,11 @@ class AppContext extends TypedEventTarget<{ userChange: Event; settingsChange: E
   }
 }
 
-function AppProvider(handle: Handle<AppContext>) {
+function AppProvider(handle: Handle<{ children?: RemixNode }, AppContext>) {
   let context = new AppContext()
   handle.context.set(context)
 
-  return (props: { children: RemixNode }) => props.children
+  return () => handle.props.children
 }
 
 // Components can subscribe to only the events they care about

--- a/packages/ui/docs/getting-started.md
+++ b/packages/ui/docs/getting-started.md
@@ -1,10 +1,10 @@
 # Getting Started
 
-Create interactive UIs with Remix Component using a two-phase component model: setup runs once, render runs on every update.
+Create interactive UIs with Remix UI using a two-phase component model: the component function runs once, and its render function runs on every update.
 
 ## Client-Only Root
 
-To start using Remix Component on the client, create a root and render your top-level component:
+To start using Remix UI on the client, create a root and render your top-level component:
 
 ```tsx
 import { createRoot } from 'remix/ui'

--- a/packages/ui/docs/getting-started.md
+++ b/packages/ui/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Create interactive UIs with Remix UI using a two-phase component model: the component function runs once, and its render function runs on every update.
+Create interactive UIs with Remix UI using a two-phase component model: setup runs once, and render runs on every update.
 
 ## Client-Only Root
 

--- a/packages/ui/docs/handle.md
+++ b/packages/ui/docs/handle.md
@@ -285,7 +285,7 @@ function LabeledInput(handle: Handle) {
 Context API for ancestor/descendant communication. See [Context](./context.md) for full documentation.
 
 ```tsx
-function App(handle: Handle<{ theme: string }>) {
+function App(handle: Handle<Record<string, never>, { theme: string }>) {
   handle.context.set({ theme: 'dark' })
 
   return () => (

--- a/packages/ui/docs/hydration.md
+++ b/packages/ui/docs/hydration.md
@@ -65,7 +65,7 @@ await app.ready()
 ### `run` options
 
 - **`loadModule(moduleUrl, exportName)`** (required) - Called for each client entry found in the page. Return the component function. Typically uses dynamic `import()`.
-- **`resolveFrame(src, signal, target)`** (optional) - Called when a `<Frame>` needs to load or reload content. The examples here only use `src` and `signal`, but `target` is also available when frame targeting matters. If omitted, Remix Component uses a placeholder HTML response (`<p>resolve frame unimplemented</p>`). See [Frames](./frames.md) for details.
+- **`resolveFrame(src, signal, target)`** (optional) - Called when a `<Frame>` needs to load or reload content. The examples here only use `src` and `signal`, but `target` is also available when frame targeting matters. If omitted, Remix UI uses a placeholder HTML response (`<p>resolve frame unimplemented</p>`). See [Frames](./frames.md) for details.
 
 ### `app` methods
 

--- a/packages/ui/docs/patterns.md
+++ b/packages/ui/docs/patterns.md
@@ -117,9 +117,9 @@ function Toggle(handle: Handle) {
 }
 ```
 
-## Component Scope Use Cases
+## Setup Scope Use Cases
 
-The component scope is perfect for one-time initialization:
+The setup scope is perfect for one-time initialization:
 
 ### Initializing Instances
 
@@ -520,16 +520,16 @@ function DataLoader(handle: Handle<{ url: string }>) {
 }
 ```
 
-### Using Component Scope for Initial Data
+### Using Setup Scope for Initial Data
 
-Load initial data in the component scope:
+Load initial data in the setup scope:
 
 ```tsx
 function UserProfile(handle: Handle<{ userId: string; showEmail?: boolean }>) {
   let user: User | null = null
   let loading = true
 
-  // Load initial data in component scope using queueTask
+  // Load initial data in setup scope using queueTask
   handle.queueTask(async (signal) => {
     let response = await fetch(`/api/users/${handle.props.userId}`, { signal })
     let data = await response.json()
@@ -552,7 +552,7 @@ function UserProfile(handle: Handle<{ userId: string; showEmail?: boolean }>) {
 }
 ```
 
-Note that by fetching this data in the component scope, parent updates that change `userId` will not restart the request unless you add that behavior yourself.
+Note that by fetching this data in the setup scope, parent updates that change `userId` will not restart the request unless you add that behavior yourself.
 
 ## See Also
 

--- a/packages/ui/src/components/combobox/README.md
+++ b/packages/ui/src/components/combobox/README.md
@@ -8,7 +8,7 @@ Use it when the user should type draft text, filter a popup list, and still comm
 
 ```tsx
 import { css, type Handle } from 'remix/ui'
-import { Combobox, ComboboxOption, onComboboxChange } from 'remix/ui'
+import { Combobox, ComboboxOption, onComboboxChange } from 'remix/ui/combobox'
 
 let airports = [
   {

--- a/packages/ui/src/server/README.md
+++ b/packages/ui/src/server/README.md
@@ -1,6 +1,6 @@
 # Server
 
-Remix Component can render to HTML on the server using two APIs:
+Remix UI can render to HTML on the server using two APIs:
 
 - `renderToString` - Returns a complete HTML string. Simple, but buffers the entire response.
 - `renderToStream` - Returns a `ReadableStream<Uint8Array>`. Sends the initial HTML immediately and streams frame content as it resolves.
@@ -80,7 +80,7 @@ function ProductPage() {
 
 ## CSS
 
-Components using the `css` prop have their styles collected during rendering and emitted as a single `<style>` tag in the `<head>`. No client-side style injection is needed for server-rendered content.
+Components using the `css(...)` mixin through `mix` have their styles collected during rendering and emitted as a single `<style>` tag in the `<head>`. No client-side style injection is needed for server-rendered content.
 
 ## See Also
 


### PR DESCRIPTION
Updates Remix UI markdown docs so current examples match the package APIs today.

- Replaces stale `setup` prop guidance in the UI agent guide with `handle.props` examples.
- Corrects context examples to use `Handle<Props, ContextValue>` and documents component-identity context lookup.
- Fixes the combobox README import to use `remix/ui/combobox`.
- Updates package wording from Remix Component to Remix UI, fixes the server CSS mixin wording, and repairs relative links in `component.md`.
