### PR TITLE
Handle request aborts in renderToStream and createRequestListener

### DIFF
--- a/demos/assets/server.ts
+++ b/demos/assets/server.ts
@@ -9,7 +9,9 @@ const server = http.createServer(
     try {
       return await router.fetch(request)
     } catch (error) {
-      console.error(error)
+      if (!(request.signal.aborted && error === request.signal.reason)) {
+        console.error(error)
+      }
       return new Response('Internal Server Error', { status: 500 })
     }
   }),

--- a/demos/bookstore/app/middleware/render.tsx
+++ b/demos/bookstore/app/middleware/render.tsx
@@ -13,6 +13,7 @@ export function render() {
     ({ request, router }) =>
       function render(node: RemixNode, init?: ResponseInit) {
         let stream = renderToStream(node, {
+          signal: request.signal,
           resolveFrame: (src) => resolveFrame(router, request, src),
           async resolveClientEntry(entryId, component) {
             if (!entryId.startsWith('file://')) {

--- a/demos/bookstore/server.ts
+++ b/demos/bookstore/server.ts
@@ -13,7 +13,9 @@ const server = http.createServer(
     try {
       return await router.fetch(request)
     } catch (error) {
-      console.error(error)
+      if (!(request.signal.aborted && error === request.signal.reason)) {
+        console.error(error)
+      }
       return new Response('Internal Server Error', { status: 500 })
     }
   }),

--- a/demos/frame-navigation/app/middleware/render.tsx
+++ b/demos/frame-navigation/app/middleware/render.tsx
@@ -12,6 +12,7 @@ export function render() {
     return function render(node: RemixNode, init?: ResponseInit) {
       let stream = renderToStream(node, {
         frameSrc: request.url,
+        signal: request.signal,
         resolveFrame: (src, target, context) => resolveFrame(router, request, src, target, context),
         onError(error) {
           console.error(error)

--- a/demos/frame-navigation/server.ts
+++ b/demos/frame-navigation/server.ts
@@ -8,7 +8,9 @@ const server = http.createServer(
     try {
       return await router.fetch(request)
     } catch (error) {
-      console.error(error)
+      if (!(request.signal.aborted && error === request.signal.reason)) {
+        console.error(error)
+      }
       return new Response('Internal Server Error', { status: 500 })
     }
   }),

--- a/demos/frames/app/middleware/render.ts
+++ b/demos/frames/app/middleware/render.ts
@@ -11,6 +11,7 @@ export function render() {
 
     return function render(node: RemixNode, init?: ResponseInit): Response {
       let stream = renderToStream(node, {
+        signal: request.signal,
         resolveFrame: (src) => resolveFrameViaRouter(router, request, src),
         onError(error) {
           console.error(error)

--- a/demos/frames/server.ts
+++ b/demos/frames/server.ts
@@ -8,7 +8,9 @@ const server = http.createServer(
     try {
       return await router.fetch(request)
     } catch (error) {
-      console.error(error)
+      if (!(request.signal.aborted && error === request.signal.reason)) {
+        console.error(error)
+      }
       return new Response('Internal Server Error', { status: 500 })
     }
   }),

--- a/demos/social-auth/app/middleware/render.tsx
+++ b/demos/social-auth/app/middleware/render.tsx
@@ -5,9 +5,10 @@ import { renderToStream } from 'remix/ui/server'
 
 export function render() {
   return renderWith(
-    () =>
+    ({ request }) =>
       function render(node: RemixNode, init?: ResponseInit) {
         let stream = renderToStream(node, {
+          signal: request.signal,
           onError(error) {
             console.error(error)
           },

--- a/demos/social-auth/server.ts
+++ b/demos/social-auth/server.ts
@@ -19,7 +19,9 @@ const server = http.createServer(
     try {
       return await router.fetch(request)
     } catch (error) {
-      console.error(error)
+      if (!(request.signal.aborted && error === request.signal.reason)) {
+        console.error(error)
+      }
       return new Response('Internal Server Error', { status: 500 })
     }
   }),

--- a/demos/sse/app/middleware/render.ts
+++ b/demos/sse/app/middleware/render.ts
@@ -5,9 +5,9 @@ import { renderToStream } from 'remix/ui/server'
 
 export function render() {
   return renderWith(
-    () =>
+    ({ request }) =>
       function render(node: RemixNode, init?: ResponseInit) {
-        return createHtmlResponse(renderToStream(node), init)
+        return createHtmlResponse(renderToStream(node, { signal: request.signal }), init)
       },
   )
 }

--- a/demos/sse/server.ts
+++ b/demos/sse/server.ts
@@ -8,7 +8,9 @@ const server = http.createServer(
     try {
       return await router.fetch(request)
     } catch (error) {
-      console.error(error)
+      if (!(request.signal.aborted && error === request.signal.reason)) {
+        console.error(error)
+      }
       return new Response('Internal Server Error', { status: 500 })
     }
   }),

--- a/demos/unpkg/server.ts
+++ b/demos/unpkg/server.ts
@@ -8,7 +8,9 @@ const server = http.createServer(
     try {
       return await router.fetch(request)
     } catch (error) {
-      console.error(error)
+      if (!(request.signal.aborted && error === request.signal.reason)) {
+        console.error(error)
+      }
       return new Response('Internal Server Error', { status: 500 })
     }
   }),

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -175,6 +175,7 @@ export function createRouter(versions: Versions) {
 
 function stream(router: Router, request: Request, node: RemixNode, init?: ResponseInit) {
   return renderToStream(node, {
+    signal: request.signal,
     async resolveFrame(src) {
       let url = new URL(src, request.url)
 

--- a/packages/node-fetch-server/.changes/patch.ignore-request-aborts.md
+++ b/packages/node-fetch-server/.changes/patch.ignore-request-aborts.md
@@ -1,0 +1,1 @@
+Drop handler responses when the client has already disconnected, and do not forward request abort errors from handlers or response streams to `onError` or write them to a closed socket.

--- a/packages/node-fetch-server/src/lib/request-listener.test.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.test.ts
@@ -163,6 +163,114 @@ describe('createRequestListener', () => {
     })
   })
 
+  it('does not forward request abort errors to onError when the response closes before the handler returns', async (t) => {
+    let handler: FetchHandler = async (request) => {
+      return await new Promise<Response>((_resolve, reject) => {
+        request.signal.addEventListener('abort', () => reject(request.signal.reason), {
+          once: true,
+        })
+      })
+    }
+    let errorHandler = t.mock.fn()
+
+    let listener = createRequestListener(handler, { onError: errorHandler })
+    assert.ok(listener)
+
+    let req = createMockRequest()
+    let res = createMockResponse({ req })
+    let writeHead = t.mock.method(res, 'writeHead')
+    let end = t.mock.method(res, 'end')
+
+    listener(req, res)
+    res.emit('close')
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    assert.equal(errorHandler.mock.calls.length, 0)
+    assert.equal(writeHead.mock.calls.length, 0)
+    assert.equal(end.mock.calls.length, 0)
+  })
+
+  it('drops the response without writing when the request was aborted before send', async (t) => {
+    let errorHandler = t.mock.fn()
+
+    let handler: FetchHandler = (request) => {
+      return new Promise<Response>((resolve) => {
+        request.signal.addEventListener(
+          'abort',
+          () => {
+            // Resolve with a normal-looking response after the abort fires, as
+            // a consumer's outer try/catch would do.
+            resolve(new Response('Internal Server Error', { status: 500 }))
+          },
+          { once: true },
+        )
+      })
+    }
+
+    let listener = createRequestListener(handler, { onError: errorHandler })
+    assert.ok(listener)
+
+    let req = createMockRequest()
+    let res = createMockResponse({ req })
+    let writeHead = t.mock.method(res, 'writeHead')
+    let write = t.mock.method(res, 'write')
+    let end = t.mock.method(res, 'end')
+
+    listener(req, res)
+    res.emit('close')
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    assert.equal(errorHandler.mock.calls.length, 0)
+    assert.equal(writeHead.mock.calls.length, 0)
+    assert.equal(write.mock.calls.length, 0)
+    assert.equal(end.mock.calls.length, 0)
+  })
+
+  it('does not forward request abort errors to onError while streaming the response body', async (t) => {
+    let encoder = new TextEncoder()
+    let errorHandler = t.mock.fn()
+
+    let handler: FetchHandler = (request) => {
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode('first'))
+            request.signal.addEventListener(
+              'abort',
+              () => {
+                controller.error(request.signal.reason)
+              },
+              { once: true },
+            )
+          },
+        }),
+      )
+    }
+
+    let listener = createRequestListener(handler, { onError: errorHandler })
+    assert.ok(listener)
+
+    let req = createMockRequest()
+    let res = createMockResponse({ req })
+    let writeHead = t.mock.method(res, 'writeHead')
+    let end = t.mock.method(res, 'end')
+
+    t.mock.method(res, 'write', () => {
+      res.emit('close')
+      return true
+    })
+
+    listener(req, res)
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    assert.equal(errorHandler.mock.calls.length, 0)
+    assert.equal(writeHead.mock.calls.length, 1)
+    assert.equal(end.mock.calls.length, 0)
+  })
+
   it('uses the `Host` header to construct the URL by default', async () => {
     await new Promise<void>((resolve) => {
       let handler: FetchHandler = async (request) => {

--- a/packages/node-fetch-server/src/lib/request-listener.test.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.test.ts
@@ -164,13 +164,12 @@ describe('createRequestListener', () => {
   })
 
   it('does not forward request abort errors to onError when the response closes before the handler returns', async (t) => {
-    let handler: FetchHandler = async (request) => {
-      return await new Promise<Response>((_resolve, reject) => {
+    let handler: FetchHandler = async (request) =>
+      await new Promise<Response>((_resolve, reject) => {
         request.signal.addEventListener('abort', () => reject(request.signal.reason), {
           once: true,
         })
       })
-    }
     let errorHandler = t.mock.fn()
 
     let listener = createRequestListener(handler, { onError: errorHandler })
@@ -194,8 +193,8 @@ describe('createRequestListener', () => {
   it('drops the response without writing when the request was aborted before send', async (t) => {
     let errorHandler = t.mock.fn()
 
-    let handler: FetchHandler = (request) => {
-      return new Promise<Response>((resolve) => {
+    let handler: FetchHandler = (request) =>
+      new Promise<Response>((resolve) => {
         request.signal.addEventListener(
           'abort',
           () => {
@@ -206,7 +205,6 @@ describe('createRequestListener', () => {
           { once: true },
         )
       })
-    }
 
     let listener = createRequestListener(handler, { onError: errorHandler })
     assert.ok(listener)
@@ -232,8 +230,8 @@ describe('createRequestListener', () => {
     let encoder = new TextEncoder()
     let errorHandler = t.mock.fn()
 
-    let handler: FetchHandler = (request) => {
-      return new Response(
+    let handler: FetchHandler = (request) =>
+      new Response(
         new ReadableStream({
           start(controller) {
             controller.enqueue(encoder.encode('first'))
@@ -247,7 +245,6 @@ describe('createRequestListener', () => {
           },
         }),
       )
-    }
 
     let listener = createRequestListener(handler, { onError: errorHandler })
     assert.ok(listener)

--- a/packages/node-fetch-server/src/lib/request-listener.test.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.test.ts
@@ -226,6 +226,64 @@ describe('createRequestListener', () => {
     assert.equal(end.mock.calls.length, 0)
   })
 
+  it('drops a late response after close when the handler does not read the request signal', async (t) => {
+    let resolveResponse!: (response: Response) => void
+    let handlerResponse = new Promise<Response>((resolve) => {
+      resolveResponse = resolve
+    })
+    let handler: FetchHandler = (_request) => handlerResponse
+    let errorHandler = t.mock.fn()
+
+    let listener = createRequestListener(handler, { onError: errorHandler })
+    assert.ok(listener)
+
+    let req = createMockRequest()
+    let res = createMockResponse({ req })
+    let writeHead = t.mock.method(res, 'writeHead')
+    let write = t.mock.method(res, 'write')
+    let end = t.mock.method(res, 'end')
+
+    listener(req, res)
+    res.emit('close')
+    resolveResponse(new Response('late'))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    assert.equal(errorHandler.mock.calls.length, 0)
+    assert.equal(writeHead.mock.calls.length, 0)
+    assert.equal(write.mock.calls.length, 0)
+    assert.equal(end.mock.calls.length, 0)
+  })
+
+  it('drops a late zero-argument handler response after close', async (t) => {
+    let resolveResponse!: (response: Response) => void
+    let handlerResponse = new Promise<Response>((resolve) => {
+      resolveResponse = resolve
+    })
+    let handler: FetchHandler = () => handlerResponse
+    let errorHandler = t.mock.fn()
+
+    let listener = createRequestListener(handler, { onError: errorHandler })
+    assert.ok(listener)
+
+    let req = createMockRequest()
+    let res = createMockResponse({ req })
+    let writeHead = t.mock.method(res, 'writeHead')
+    let write = t.mock.method(res, 'write')
+    let end = t.mock.method(res, 'end')
+
+    listener(req, res)
+    res.emit('close')
+    resolveResponse(new Response('late'))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    assert.equal(errorHandler.mock.calls.length, 0)
+    assert.equal(writeHead.mock.calls.length, 0)
+    assert.equal(write.mock.calls.length, 0)
+    assert.equal(end.mock.calls.length, 0)
+  })
+
   it('does not forward request abort errors to onError while streaming the response body', async (t) => {
     let encoder = new TextEncoder()
     let errorHandler = t.mock.fn()

--- a/packages/node-fetch-server/src/lib/request-listener.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.ts
@@ -106,14 +106,15 @@ export function createRequestListener(
       if (isPromiseLike(response)) {
         void response.then(
           (response) => {
-            void sendResponse(res, response)
+            void sendResponseForRequest(res, response, request, onError)
           },
           (error) => {
+            if (isRequestAbortError(request, error)) return
             void sendErrorResponse(res, onError, error)
           },
         )
       } else {
-        void sendResponse(res, response)
+        void sendResponseForRequest(res, response, request, onError)
       }
     }
   }
@@ -130,10 +131,11 @@ export function createRequestListener(
     try {
       response = await handler(request, client)
     } catch (error) {
+      if (isRequestAbortError(request, error)) return
       response = await createErrorResponse(onError, error)
     }
 
-    await sendResponse(res, response)
+    await sendResponseForRequest(res, response, request, onError)
   }
 }
 
@@ -144,6 +146,21 @@ async function sendErrorResponse(
 ): Promise<void> {
   let response = await createErrorResponse(onError, error)
   await sendResponse(res, response)
+}
+
+async function sendResponseForRequest(
+  res: http.ServerResponse | http2.Http2ServerResponse,
+  response: Response,
+  request: Request,
+  onError: ErrorHandler,
+): Promise<void> {
+  if (request.signal.aborted) return
+  try {
+    await sendResponse(res, response)
+  } catch (error) {
+    if (isRequestAbortError(request, error)) return
+    await sendErrorResponse(res, onError, error)
+  }
 }
 
 async function createErrorResponse(onError: ErrorHandler, error: unknown): Promise<Response> {
@@ -171,6 +188,10 @@ function internalServerError(): Response {
 
 function isPromiseLike<value>(value: value | PromiseLike<value>): value is PromiseLike<value> {
   return typeof (value as { then?: unknown }).then === 'function'
+}
+
+function isRequestAbortError(request: Request, error: unknown): boolean {
+  return request.signal.aborted && error === request.signal.reason
 }
 
 /**

--- a/packages/node-fetch-server/src/lib/request-listener.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.ts
@@ -78,6 +78,7 @@ export function createRequestListener(
     let handlerWithoutArgs = handler as () => Response | Promise<Response>
 
     return async (_req, res) => {
+      let isResponseClosed = observeResponseClose(res)
       let response: Response
       try {
         response = await handlerWithoutArgs()
@@ -85,7 +86,7 @@ export function createRequestListener(
         response = await createErrorResponse(onError, error)
       }
 
-      await sendResponse(res, response)
+      await sendResponseIfOpen(res, response, isResponseClosed)
     }
   }
 
@@ -93,33 +94,35 @@ export function createRequestListener(
     let requestHandler = handler as (request: Request) => Response | Promise<Response>
 
     return (req, res) => {
+      let isResponseClosed = observeResponseClose(res)
       let request = createLazyRequest(req, res)
 
       let response: Response | Promise<Response>
       try {
         response = requestHandler(request)
       } catch (error) {
-        void sendErrorResponse(res, onError, error)
+        void sendErrorResponseForRequest(res, request, onError, error, isResponseClosed)
         return
       }
 
       if (isPromiseLike(response)) {
         void response.then(
           (response) => {
-            void sendResponseForRequest(res, response, request, onError)
+            void sendResponseForRequest(res, response, request, onError, isResponseClosed)
           },
           (error) => {
             if (isRequestAbortError(request, error)) return
-            void sendErrorResponse(res, onError, error)
+            void sendErrorResponseForRequest(res, request, onError, error, isResponseClosed)
           },
         )
       } else {
-        void sendResponseForRequest(res, response, request, onError)
+        void sendResponseForRequest(res, response, request, onError, isResponseClosed)
       }
     }
   }
 
   return async (req, res) => {
+    let isResponseClosed = observeResponseClose(res)
     let request = createLazyRequest(req, res)
     let client = {
       address: req.socket.remoteAddress!,
@@ -135,16 +138,38 @@ export function createRequestListener(
       response = await createErrorResponse(onError, error)
     }
 
-    await sendResponseForRequest(res, response, request, onError)
+    await sendResponseForRequest(res, response, request, onError, isResponseClosed)
   }
 }
 
-async function sendErrorResponse(
+function observeResponseClose(
   res: http.ServerResponse | http2.Http2ServerResponse,
+): () => boolean {
+  let responseClosed = false
+  res.once('close', () => {
+    responseClosed = true
+  })
+  return () => responseClosed || res.destroyed
+}
+
+async function sendResponseIfOpen(
+  res: http.ServerResponse | http2.Http2ServerResponse,
+  response: Response,
+  isResponseClosed: () => boolean,
+): Promise<void> {
+  if (isResponseClosed()) return
+  await sendResponse(res, response)
+}
+
+async function sendErrorResponseForRequest(
+  res: http.ServerResponse | http2.Http2ServerResponse,
+  request: Request,
   onError: ErrorHandler,
   error: unknown,
+  isResponseClosed: () => boolean,
 ): Promise<void> {
   let response = await createErrorResponse(onError, error)
+  if (isResponseClosed() || request.signal.aborted) return
   await sendResponse(res, response)
 }
 
@@ -153,13 +178,15 @@ async function sendResponseForRequest(
   response: Response,
   request: Request,
   onError: ErrorHandler,
+  isResponseClosed: () => boolean,
 ): Promise<void> {
-  if (request.signal.aborted) return
+  if (isResponseClosed() || request.signal.aborted) return
   try {
     await sendResponse(res, response)
   } catch (error) {
+    if (isResponseClosed()) return
     if (isRequestAbortError(request, error)) return
-    await sendErrorResponse(res, onError, error)
+    await sendErrorResponseForRequest(res, request, onError, error, isResponseClosed)
   }
 }
 

--- a/packages/ui/.changes/minor.render-stream-signal.md
+++ b/packages/ui/.changes/minor.render-stream-signal.md
@@ -1,0 +1,1 @@
+Add a `signal` option to `renderToStream()` so request aborts can cancel pending frame rendering without invoking `onError`.

--- a/packages/ui/demo/config/render.tsx
+++ b/packages/ui/demo/config/render.tsx
@@ -6,6 +6,7 @@ import type { RequestContext, Router } from 'remix/router'
 export function render(context: RequestContext, node: RemixNode, init?: ResponseInit) {
   let stream = renderToStream(node, {
     frameSrc: context.request.url,
+    signal: context.request.signal,
     resolveFrame: (src, target, frameContext) => resolveFrame(context, src, target, frameContext),
     onError(error) {
       console.error(error)

--- a/packages/ui/src/server/README.md
+++ b/packages/ui/src/server/README.md
@@ -26,6 +26,7 @@ import { renderToStream } from 'remix/ui/server'
 
 let stream = renderToStream(<App />, {
   frameSrc: request.url,
+  signal: request.signal,
   resolveFrame(src, _target, context) {
     let frameUrl = new URL(src, context?.currentFrameSrc ?? request.url)
     return fetchHtml(frameUrl)
@@ -44,6 +45,7 @@ return new Response(stream, {
 
 - **`frameSrc`** - Seeds SSR frame state for the current render. When provided, server-rendered components can read `handle.frame.src` and `handle.frames.top.src` during SSR.
 - **`topFrameSrc`** - Overrides the root frame URL used for `handle.frames.top.src`. This is mainly useful when calling `renderToStream()` from inside `resolveFrame()` for a nested frame render.
+- **`signal`** - Cancels pending server rendering work. Pass `request.signal` so client disconnects can stop unresolved frame work without invoking `onError` for the disconnect itself.
 - **`resolveFrame(src, target, context)`** - Called when a `<Frame>` needs its content. Return a string of HTML, a `ReadableStream<Uint8Array>`, or a promise of either. `context.currentFrameSrc` is the URL for the frame that contains the `<Frame>`, and `context.topFrameSrc` is the outer document URL. Required if your component tree contains `<Frame>` elements.
 - **`onError(error)`** - Called when a rendering error occurs. If not provided, the stream rejects with the error.
 

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -31,6 +31,8 @@ export interface RenderToStreamOptions {
   frameSrc?: string | URL
   /** Source URL for the top-level frame in nested frame renders. */
   topFrameSrc?: string | URL
+  /** Signal that cancels pending server rendering work. */
+  signal?: AbortSignal
   /** Error hook invoked when rendering work throws. */
   onError?: (error: unknown) => void
   /** Callback used to resolve nested frame content during streaming SSR. */
@@ -97,6 +99,7 @@ interface RenderContext {
   unresolvedHydrationData: Map<string, UnresolvedHydrationData>
   frameData: Map<string, FrameData>
   blockingFrameTails: ReadableStream<Uint8Array>[]
+  signal: AbortSignal
   flushKind: FlushKind
   serverIdScope: string
   serverIdCounter: number
@@ -192,6 +195,7 @@ export function renderToStream(
   let currentFrameSrc = normalizeFrameSrc(options?.frameSrc ?? options?.topFrameSrc)
   let topFrameSrc = normalizeFrameSrc(options?.topFrameSrc ?? currentFrameSrc)
   let rootFrameState = createSsrFrameState(currentFrameSrc, topFrameSrc)
+  let renderAbortController = new AbortController()
 
   let context: RenderContext = {
     insideSvg: false,
@@ -204,9 +208,23 @@ export function renderToStream(
     unresolvedHydrationData: new Map(),
     frameData: new Map(),
     blockingFrameTails: [],
+    signal: renderAbortController.signal,
     flushKind: 'fragment',
     serverIdScope: crypto.randomUUID().slice(0, 8),
     serverIdCounter: 0,
+  }
+
+  function cancel(reason: unknown): void {
+    if (!renderAbortController.signal.aborted) {
+      renderAbortController.abort(reason)
+    }
+  }
+
+  let signal = options?.signal
+  if (signal?.aborted) {
+    cancel(signal.reason)
+  } else {
+    signal?.addEventListener('abort', () => cancel(signal.reason), { once: true })
   }
 
   return new ReadableStream({
@@ -214,11 +232,14 @@ export function renderToStream(
       try {
         let root = buildSegment(node, context, rootFrameState)
         await resolveBlocking(root)
+        if (closeIfCancelled(controller, context)) return
         await resolveClientEntries(context, options?.resolveClientEntry)
+        if (closeIfCancelled(controller, context)) return
         validateClientEntriesForHydration(context)
         let html = serializeSegment(root)
         let finalHtml = finalizeHtml(html, context)
         let bytes = encoder.encode(appendFlushMarker(finalHtml, context.flushKind))
+        if (closeIfCancelled(controller, context)) return
         controller.enqueue(bytes)
 
         // If we have any tails from blocking frame streams, stream them now.
@@ -226,7 +247,7 @@ export function renderToStream(
         // that must come after the initial document chunk.
         let tailPromise =
           context.blockingFrameTails.length > 0
-            ? streamByteStreams(context.blockingFrameTails, controller, context.onError)
+            ? streamByteStreams(context.blockingFrameTails, controller, context)
             : Promise.resolve()
 
         // If we have pending non-blocking frames, stream them as they resolve
@@ -237,13 +258,42 @@ export function renderToStream(
 
         await Promise.all([tailPromise, pendingPromise])
 
+        if (closeIfCancelled(controller, context)) return
         controller.close()
       } catch (error) {
+        if (isSignalAbortError(context.signal, error)) {
+          closeStream(controller)
+          return
+        }
         onError(error)
         controller.error(error)
       }
     },
+    cancel(reason) {
+      cancel(reason)
+    },
   })
+}
+
+function isSignalAbortError(signal: AbortSignal, error: unknown): boolean {
+  return signal.aborted && error === signal.reason
+}
+
+function closeIfCancelled(
+  controller: ReadableStreamDefaultController,
+  context: RenderContext,
+): boolean {
+  if (!context.signal.aborted) return false
+  closeStream(controller)
+  return true
+}
+
+function closeStream(controller: ReadableStreamDefaultController): void {
+  try {
+    controller.close()
+  } catch {
+    // The consumer may already have cancelled the stream.
+  }
 }
 
 function defaultResolveFrame(): never {
@@ -428,6 +478,9 @@ function buildFrameSegment(props: any, context: RenderContext, frameState: SsrFr
     let framePromise = Promise.resolve(
       context.resolveFrame(props.src, props.name, resolveFrameContext),
     ).then(async (resolved) => resolveFrameHtml(resolved))
+    // The response stream can be cancelled before pending frames are drained.
+    // Keep the promise observed so request aborts don't become unhandled.
+    framePromise.catch(() => {})
     context.pendingFrames.push({ frameId, promise: framePromise })
   } else {
     seg.pending = Promise.resolve(
@@ -1248,26 +1301,33 @@ async function streamPendingFrames(
   let processedFrames = new Set<string>()
 
   while (true) {
+    if (context.signal.aborted) break
+
     let batch = context.pendingFrames.filter(({ frameId }) => !processedFrames.has(frameId))
     if (batch.length === 0) break
 
     await Promise.all(
       batch.map(async ({ frameId, promise }) => {
+        if (context.signal.aborted) return
         processedFrames.add(frameId)
         try {
           let { html, tail } = await promise
+          if (context.signal.aborted) return
           html = dedupeServerStyleTagsInHtml(html, context.emittedStyles)
 
           // Stream as a template element (first chunk only)
           let templateHtml = `<template id="${frameId}">${escapeTemplateContent(html)}</template>`
+          if (context.signal.aborted) return
           controller.enqueue(encoder.encode(templateHtml))
 
           // Forward any additional chunks from a stream-valued resolveFrame result.
           if (tail) {
-            await streamByteStreams([tail], controller, context.onError)
+            await streamByteStreams([tail], controller, context)
           }
         } catch (error) {
-          context.onError(error)
+          if (!isSignalAbortError(context.signal, error)) {
+            context.onError(error)
+          }
         }
       }),
     )
@@ -1277,19 +1337,23 @@ async function streamPendingFrames(
 async function streamByteStreams(
   streams: ReadableStream<Uint8Array>[],
   controller: ReadableStreamDefaultController,
-  onError: (error: unknown) => void,
+  context: RenderContext,
 ): Promise<void> {
   await Promise.all(
     streams.map(async (stream) => {
       let reader = stream.getReader()
       try {
         while (true) {
+          if (context.signal.aborted) break
           let { done, value } = await reader.read()
           if (done) break
+          if (context.signal.aborted) break
           controller.enqueue(value)
         }
       } catch (error) {
-        onError(error)
+        if (!isSignalAbortError(context.signal, error)) {
+          context.onError(error)
+        }
       } finally {
         reader.releaseLock()
       }

--- a/packages/ui/src/test/stream.test.tsx
+++ b/packages/ui/src/test/stream.test.tsx
@@ -2047,13 +2047,12 @@ describe('stream', () => {
         onError(error) {
           errors.push(error)
         },
-        resolveFrame: () => {
-          return new Promise<string>((_resolve, reject) => {
+        resolveFrame: () =>
+          new Promise<string>((_resolve, reject) => {
             controller.signal.addEventListener('abort', () => reject(controller.signal.reason), {
               once: true,
             })
-          })
-        },
+          }),
         signal: controller.signal,
       })
 
@@ -2077,13 +2076,12 @@ describe('stream', () => {
           onError(error) {
             errors.push(error)
           },
-          resolveFrame: () => {
-            return new Promise<string>((_resolve, reject) => {
+          resolveFrame: () =>
+            new Promise<string>((_resolve, reject) => {
               controller.signal.addEventListener('abort', () => reject(controller.signal.reason), {
                 once: true,
               })
-            })
-          },
+            }),
           signal: controller.signal,
         },
       )
@@ -2127,14 +2125,13 @@ describe('stream', () => {
         onError(error) {
           errors.push(error)
         },
-        resolveFrame: () => {
-          return new Promise<string>((_resolve, reject) => {
+        resolveFrame: () =>
+          new Promise<string>((_resolve, reject) => {
             controller.signal.addEventListener('abort', () => reject(controller.signal.reason), {
               once: true,
             })
             if (controller.signal.aborted) reject(controller.signal.reason)
-          })
-        },
+          }),
         signal: controller.signal,
       })
 

--- a/packages/ui/src/test/stream.test.tsx
+++ b/packages/ui/src/test/stream.test.tsx
@@ -2039,6 +2039,110 @@ describe('stream', () => {
       expect(done.done).toBe(true)
     })
 
+    it('cancels blocking frame rendering when signal aborts without calling onError', async () => {
+      let controller = new AbortController()
+      let errors: unknown[] = []
+
+      let stream = renderToStream(<Frame src="/fragments/product" />, {
+        onError(error) {
+          errors.push(error)
+        },
+        resolveFrame: () => {
+          return new Promise<string>((_resolve, reject) => {
+            controller.signal.addEventListener('abort', () => reject(controller.signal.reason), {
+              once: true,
+            })
+          })
+        },
+        signal: controller.signal,
+      })
+
+      let reader = stream.getReader()
+      let read = reader.read()
+
+      let abortError = new DOMException('This operation was aborted', 'AbortError')
+      controller.abort(abortError)
+
+      await expect(read).resolves.toEqual({ done: true, value: undefined })
+      expect(errors).toEqual([])
+    })
+
+    it('cancels non-blocking frame rendering when signal aborts without calling onError', async () => {
+      let controller = new AbortController()
+      let errors: unknown[] = []
+
+      let stream = renderToStream(
+        <Frame src="/fragments/product" fallback={<div>Loading...</div>} />,
+        {
+          onError(error) {
+            errors.push(error)
+          },
+          resolveFrame: () => {
+            return new Promise<string>((_resolve, reject) => {
+              controller.signal.addEventListener('abort', () => reject(controller.signal.reason), {
+                once: true,
+              })
+            })
+          },
+          signal: controller.signal,
+        },
+      )
+
+      let reader = stream.getReader()
+      let first = await reader.read()
+      expect(first.done).toBe(false)
+
+      let abortError = new DOMException('This operation was aborted', 'AbortError')
+      controller.abort(abortError)
+
+      await expect(reader.read()).resolves.toEqual({ done: true, value: undefined })
+      expect(errors).toEqual([])
+    })
+
+    it('calls onError for AbortError when the request was not canceled', async () => {
+      let abortError = new DOMException('This operation was aborted', 'AbortError')
+      let errors: unknown[] = []
+
+      let stream = renderToStream(<Frame src="/fragments/product" />, {
+        onError(error) {
+          errors.push(error)
+        },
+        resolveFrame() {
+          throw abortError
+        },
+      })
+
+      await expect(drain(stream)).rejects.toThrow('This operation was aborted')
+      expect(errors).toEqual([abortError])
+    })
+
+    it('closes immediately when signal is already aborted before rendering starts', async () => {
+      let controller = new AbortController()
+      let abortError = new DOMException('Already aborted', 'AbortError')
+      controller.abort(abortError)
+
+      let errors: unknown[] = []
+
+      let stream = renderToStream(<Frame src="/fragments/product" />, {
+        onError(error) {
+          errors.push(error)
+        },
+        resolveFrame: () => {
+          return new Promise<string>((_resolve, reject) => {
+            controller.signal.addEventListener('abort', () => reject(controller.signal.reason), {
+              once: true,
+            })
+            if (controller.signal.aborted) reject(controller.signal.reason)
+          })
+        },
+        signal: controller.signal,
+      })
+
+      let reader = stream.getReader()
+      await expect(reader.read()).resolves.toEqual({ done: true, value: undefined })
+      expect(errors).toEqual([])
+    })
+
     it('escapes frame template content to prevent template breakouts', async () => {
       let [promise, resolve] = withResolvers<string>()
       let injectedHtml = '</template><script>alert("xss")</script><template><p>safe</p>'

--- a/template/app/middleware/render.tsx
+++ b/template/app/middleware/render.tsx
@@ -9,9 +9,10 @@ import { assetServer } from '../assets.ts'
 
 export function render() {
   return renderWith(
-    () =>
+    ({ request }) =>
       function render(node: RemixNode, init?: ResponseInit) {
         let stream = renderToStream(node, {
+          signal: request.signal,
           // Server rendering turns client entries into browser module URLs.
           async resolveClientEntry(entryId, component) {
             if (!entryId.startsWith('file://')) {

--- a/template/server.ts
+++ b/template/server.ts
@@ -10,7 +10,9 @@ const server = http.createServer(
     try {
       return await router.fetch(request)
     } catch (error) {
-      console.error(error)
+      if (!(request.signal.aborted && error === request.signal.reason)) {
+        console.error(error)
+      }
       return new Response('Internal Server Error', { status: 500 })
     }
   }),


### PR DESCRIPTION
This PR fixes two issues reported in https://github.com/remix-run/remix/pull/11414 where an aborted request can either crash the server or result in noisy error logs.

In `renderToStream`, an aborted `request.signal` rejects pending frame resolution promises with the signal's reason, which then propagates out as either an uncaught error (crashing the process) or as a call to `onError` (logging the abort as if it were a real failure).

In node-fetch-server, the request listener was still attempting to write to a closed socket after a disconnect, and was forwarding the resulting errors  to `onError`.

In both layers, the fix only suppresses an error if it is strictly identical to `request.signal.reason` while the signal is aborted. Unrelated errors still flow through `onError` as before.

### Changes

- **`remix/ui`:** adds an optional `signal` option to `renderToStream()` so request aborts can cancel pending frame rendering. When the signal aborts, the stream short-circuits between rendering phases, suppresses any rejection that is the signal's `reason`, and closes cleanly instead of invoking `onError` or surfacing the abort to the consumer. Cancelling the returned stream also propagates through to in-flight frame work.
- **`remix/node-fetch-server`:** drops handler responses when the client has already disconnected, and suppresses errors raised by handlers or response-body streams when those errors are the request signal's `reason`. This avoids invoking `onError` for the disconnect itself and prevents follow-on writes to a closed socket. Applies to any fetch handler, not just streaming SSR.
- **`template` and demos:** wires `request.signal` through to `renderToStream()` in every SSR entry point (template, `bookstore`, `frame-navigation`, `frames`, `social-auth`, `sse`, the docs site, and the `ui` package's own demo config) and adds the same `!(request.signal.aborted && error === request.signal.reason)` guard to the top-level `server.ts` catch block in every demo (including `assets` and `unpkg`, which don't render via `renderToStream`) and the template, so a normal client disconnect no longer logs to the console.

## Issues fixed

For context, these are the specific issues from https://github.com/remix-run/remix/pull/11414 so you can reproduce them in `main` and compare to this branch.

- **Issue:** Reloading the root frame while a blocking child frame is still resolving aborts the first reload request and crashes the server with an uncaught `DOMException [AbortError]`.

  **Reproduction:** Go to http://localhost:44100/reload-scope, then double-click `Reload top frame` so the first reload request is aborted while the blocking child frame is still resolving. You'll see the server crash with an uncaught `DOMException [AbortError]`.

- **Issue:** Reloading a non-blocking frame when it's still resolving aborts the first reload request and logs an uncaught `DOMException [AbortError]` to the console.

  **Reproduction:** Go to http://localhost:44100/, then double-click the "Refresh" button so that another request is made while the frame is still reloading. You'll see the server log an uncaught `DOMException [AbortError]` to the console. Note that the server is still running after this, it just adds noise to the terminal and/or error reporting.