### PR TITLE
Fix node-fetch-server response body cancellation on close

### DIFF
--- a/packages/node-fetch-server/.changes/patch.cancel-response-body-on-close.md
+++ b/packages/node-fetch-server/.changes/patch.cancel-response-body-on-close.md
@@ -1,0 +1,1 @@
+Cancel unfinished streaming response bodies when the client connection closes before the response completes.

--- a/packages/node-fetch-server/src/lib/request-listener.test.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.test.ts
@@ -459,6 +459,65 @@ describe('createRequestListener', () => {
     await end
     assert.equal(Buffer.concat(writtenChunks).toString(), 'firstsecond')
   })
+
+  it('cancels a streaming response body when the response closes before it finishes', async () => {
+    let requestAborted = false
+    let resolveBodyCancelled!: () => void
+    let bodyCancelled = new Promise<void>((resolve) => {
+      resolveBodyCancelled = resolve
+    })
+
+    let handler: FetchHandler = async (request) => {
+      request.signal.addEventListener('abort', () => {
+        requestAborted = true
+      })
+
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('first'))
+          },
+          cancel() {
+            resolveBodyCancelled()
+          },
+        }),
+      )
+    }
+
+    let listener = createRequestListener(handler)
+    assert.ok(listener)
+
+    let req = createMockRequest()
+    req.httpVersionMajor = 1
+
+    let resolveFirstWrite!: () => void
+    let firstWrite = new Promise<void>((resolve) => {
+      resolveFirstWrite = resolve
+    })
+
+    let res = Object.assign(new stream.Writable(), {
+      req,
+      writeHead() {},
+      write(chunk: Uint8Array) {
+        assert.equal(new TextDecoder().decode(chunk), 'first')
+        resolveFirstWrite()
+        return true
+      },
+      end() {},
+    }) as unknown as http.ServerResponse
+
+    listener(req, res)
+    await firstWrite
+
+    res.emit('close')
+
+    assert.equal(requestAborted, true)
+    await waitFor(
+      bodyCancelled,
+      100,
+      'Expected the streaming response body to be cancelled when the response closed',
+    )
+  })
 })
 
 describe('createRequest abort behavior', () => {
@@ -529,4 +588,19 @@ function createMockResponse({
     write() {},
     end() {},
   }) as unknown as http.ServerResponse
+}
+
+async function waitFor(promise: Promise<void>, ms: number, message: string): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), ms)
+      }),
+    ])
+  } finally {
+    if (timeout != null) clearTimeout(timeout)
+  }
 }

--- a/packages/node-fetch-server/src/lib/request-listener.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.ts
@@ -295,34 +295,59 @@ export async function sendResponse(
 
   if (response.body != null && res.req.method !== 'HEAD') {
     let reader = response.body.getReader()
-    let first = await reader.read()
-    if (first.done) {
-      reader.releaseLock()
-    } else {
-      try {
-        // @ts-expect-error - Node typings for http2 require a 2nd parameter to write but it's optional
-        if (res.write(first.value) === false) {
-          await new Promise<void>((resolve) => {
-            res.once('drain', resolve)
-          })
-        }
+    let responseClosed = false
 
-        while (true) {
-          let result = await reader.read()
-          if (result.done) break
-
-          // @ts-expect-error - Node typings for http2 require a 2nd parameter to write but it's optional
-          if (res.write(result.value) === false) {
-            await new Promise<void>((resolve) => {
-              res.once('drain', resolve)
-            })
-          }
-        }
-      } finally {
-        reader.releaseLock()
-      }
+    function cancelBody() {
+      responseClosed = true
+      void reader.cancel().catch(() => undefined)
     }
+
+    res.once('close', cancelBody)
+
+    try {
+      while (!responseClosed) {
+        let result = await reader.read()
+        if (result.done) break
+
+        // @ts-expect-error - Node typings for http2 require a 2nd parameter to write but it's optional
+        if (res.write(result.value) === false) {
+          await waitForDrainOrClose(res)
+          if (responseClosed || res.destroyed) return
+        }
+      }
+    } finally {
+      res.removeListener('close', cancelBody)
+      reader.releaseLock()
+    }
+
+    if (responseClosed) return
   }
 
   res.end()
+}
+
+async function waitForDrainOrClose(
+  res: http.ServerResponse | http2.Http2ServerResponse,
+): Promise<void> {
+  if (res.destroyed) return
+
+  await new Promise<void>((resolve) => {
+    function cleanup() {
+      res.removeListener('close', onClose)
+      res.removeListener('drain', onDrain)
+    }
+
+    function onClose() {
+      cleanup()
+      resolve()
+    }
+
+    function onDrain() {
+      cleanup()
+      resolve()
+    }
+
+    res.once('close', onClose)
+    res.once('drain', onDrain)
+  })
 }


### PR DESCRIPTION
Fixes #10920.

`createRequestListener` already aborts `request.signal` when the Node response closes early, but `sendResponse` kept the streaming response body reader alive. This cancels the active reader when the client connection closes before streaming finishes, so user-provided `ReadableStream.cancel()` hooks run and pending backpressure waits can stop.

- Cancel unfinished streaming response bodies from the response `close` event
- Stop waiting for `drain` when the response closes before backpressure clears
- Add regression coverage for a client disconnect after the first streamed chunk
