### PR TITLE
Make public API types explicit

### DIFF
--- a/packages/assert/.changes/patch.explicit-public-types.md
+++ b/packages/assert/.changes/patch.explicit-public-types.md
@@ -1,0 +1,1 @@
+Add explicit public API types for the `expect` helper.

--- a/packages/assert/src/index.ts
+++ b/packages/assert/src/index.ts
@@ -1,5 +1,5 @@
 import * as assertWrapper from './lib/assert.ts'
 
 export * from './lib/assert.ts'
-export { expect, type Expectation } from './lib/expect.ts'
+export { expect, type Expect, type Expectation } from './lib/expect.ts'
 export default assertWrapper

--- a/packages/assert/src/lib/expect.ts
+++ b/packages/assert/src/lib/expect.ts
@@ -191,6 +191,11 @@ export interface Expectation extends Matchers {
   resolves: AsyncMatchers
 }
 
+export interface Expect {
+  (received: unknown): Expectation
+  objectContaining<value extends object>(expected: value): value
+}
+
 function fail(operator: string, message: string, actual: unknown, expected: unknown): never {
   throw new AssertionError({ message, actual, expected, operator })
 }
@@ -578,4 +583,4 @@ function objectContaining<T extends object>(expected: T): T {
  * @returns An {@link Expectation} object exposing matchers, `.not`,
  *          `.rejects`, and `.resolves`.
  */
-export const expect = Object.assign(expectImpl, { objectContaining })
+export const expect: Expect = Object.assign(expectImpl, { objectContaining })

--- a/packages/headers/.changes/patch.explicit-public-types.md
+++ b/packages/headers/.changes/patch.explicit-public-types.md
@@ -1,0 +1,1 @@
+Add explicit public API return types to header value serialization methods.

--- a/packages/headers/src/lib/if-match.ts
+++ b/packages/headers/src/lib/if-match.ts
@@ -84,7 +84,7 @@ export class IfMatch implements HeaderValue, IfMatchInit {
    *
    * @returns The header value as a string
    */
-  toString() {
+  toString(): string {
     return this.tags.join(', ')
   }
 

--- a/packages/headers/src/lib/if-none-match.ts
+++ b/packages/headers/src/lib/if-none-match.ts
@@ -55,7 +55,7 @@ export class IfNoneMatch implements HeaderValue, IfNoneMatchInit {
    *
    * @returns The header value as a string
    */
-  toString() {
+  toString(): string {
     return this.tags.join(', ')
   }
 

--- a/packages/headers/src/lib/if-range.ts
+++ b/packages/headers/src/lib/if-range.ts
@@ -82,7 +82,7 @@ export class IfRange implements HeaderValue {
    *
    * @returns The header value as a string
    */
-  toString() {
+  toString(): string {
     return this.value
   }
 

--- a/packages/headers/src/lib/vary.ts
+++ b/packages/headers/src/lib/vary.ts
@@ -105,7 +105,7 @@ export class Vary implements HeaderValue, VaryInit, Iterable<string> {
    *
    * @returns The header value as a comma-separated string.
    */
-  toString() {
+  toString(): string {
     return Array.from(this.#set).join(', ')
   }
 

--- a/packages/html-template/.changes/patch.explicit-public-types.md
+++ b/packages/html-template/.changes/patch.explicit-public-types.md
@@ -1,0 +1,1 @@
+Add an explicit public API type for the `html` template helper.

--- a/packages/html-template/src/index.ts
+++ b/packages/html-template/src/index.ts
@@ -1,2 +1,2 @@
 export { html, isSafeHtml } from './lib/safe-html.ts'
-export type { SafeHtml } from './lib/safe-html.ts'
+export type { HtmlTemplateTag, SafeHtml } from './lib/safe-html.ts'

--- a/packages/html-template/src/lib/safe-html.ts
+++ b/packages/html-template/src/lib/safe-html.ts
@@ -37,6 +37,11 @@ function escapeHtml(text: string): string {
 
 type Interpolation = SafeHtml | string | number | boolean | null | undefined | Array<Interpolation>
 
+export interface HtmlTemplateTag {
+  (strings: TemplateStringsArray, ...values: Interpolation[]): SafeHtml
+  raw(strings: TemplateStringsArray, ...values: Interpolation[]): SafeHtml
+}
+
 function stringifyInterpolation(value: Interpolation): string {
   if (value == null) return ''
   if (Array.isArray(value)) return value.map(stringifyInterpolation).join('')
@@ -96,7 +101,7 @@ function htmlHelper(strings: TemplateStringsArray, ...values: Interpolation[]): 
  * @param values The values to interpolate
  * @returns A `SafeHtml` value
  */
-export const html = Object.assign(htmlHelper, {
+export const html: HtmlTemplateTag = Object.assign(htmlHelper, {
   raw(strings: TemplateStringsArray, ...values: Interpolation[]): SafeHtml {
     if (!isTemplateStringsArray(strings)) {
       throw new TypeError('html.raw must be used as a template tag')

--- a/packages/remix/.changes/patch.explicit-public-types.md
+++ b/packages/remix/.changes/patch.explicit-public-types.md
@@ -1,0 +1,1 @@
+Carry explicit public type annotations from underlying packages through re-exported Remix package APIs.

--- a/packages/route-pattern/.changes/patch.explicit-public-types.md
+++ b/packages/route-pattern/.changes/patch.explicit-public-types.md
@@ -1,0 +1,1 @@
+Add an explicit public API type for serialized route pattern JSON.

--- a/packages/route-pattern/src/lib/route-pattern.ts
+++ b/packages/route-pattern/src/lib/route-pattern.ts
@@ -35,6 +35,14 @@ type ParsedRoutePattern = {
   readonly search: ReadonlyMap<string, ReadonlySet<string>>
 }
 
+export interface RoutePatternJSON {
+  protocol: string
+  hostname: string
+  port: string
+  pathname: string
+  search: string
+}
+
 /** A parsed route pattern */
 export class RoutePattern<source extends string = string> implements ParsedRoutePattern {
   readonly protocol: ParsedRoutePattern['protocol']
@@ -88,7 +96,7 @@ export class RoutePattern<source extends string = string> implements ParsedRoute
    *
    * @returns The serialized protocol, hostname, port, pathname, and search.
    */
-  toJSON() {
+  toJSON(): RoutePatternJSON {
     return serializePatternParts(this)
   }
 }

--- a/packages/session/.changes/patch.explicit-public-types.md
+++ b/packages/session/.changes/patch.explicit-public-types.md
@@ -1,0 +1,1 @@
+Add explicit public API types to session creation defaults.

--- a/packages/session/src/lib/session.ts
+++ b/packages/session/src/lib/session.ts
@@ -22,7 +22,7 @@ export class Session<valueData extends Data = Data, flashData extends Data = Dat
    * @param id The session ID
    * @param initialData The initial session data
    */
-  constructor(id = createSessionId(), initialData?: SessionData<valueData, flashData>) {
+  constructor(id: string = createSessionId(), initialData?: SessionData<valueData, flashData>) {
     this.#originalId = id
     this.#currentId = id
     this.#valueMap = toMap(initialData?.[0])
@@ -183,7 +183,7 @@ function toMap<data extends Data>(data?: data): Map<keyof data, data[keyof data]
  * @returns The new session
  */
 export function createSession<valueData extends Data = Data, flashData extends Data = Data>(
-  id = createSessionId(),
+  id: string = createSessionId(),
   initialData?: SessionData<valueData, flashData>,
 ): Session<valueData, flashData> {
   return new Session(id, initialData)

--- a/packages/terminal/.changes/patch.explicit-public-types.md
+++ b/packages/terminal/.changes/patch.explicit-public-types.md
@@ -1,0 +1,1 @@
+Add explicit public API types for ANSI helper objects.

--- a/packages/terminal/src/index.ts
+++ b/packages/terminal/src/index.ts
@@ -1,5 +1,7 @@
 export { ansi, stripAnsi } from './lib/ansi.ts'
 export type {
+  Ansi,
+  AnsiStyleCodes,
   TerminalBackgroundColorName,
   TerminalForegroundColorName,
   TerminalModifierName,

--- a/packages/terminal/src/lib/ansi.ts
+++ b/packages/terminal/src/lib/ansi.ts
@@ -64,12 +64,24 @@ export type TerminalStyleName =
   | TerminalForegroundColorName
   | TerminalBackgroundColorName
 
+export type AnsiStyleCodes = Record<TerminalStyleName, string>
+
+export interface Ansi extends AnsiStyleCodes {
+  reset: string
+  clearLine: string
+  eraseDown: string
+  hideCursor: string
+  showCursor: string
+  cursorTo(column: number, row?: number): string
+  moveCursor(columns: number, rows: number): string
+}
+
 /**
  * ANSI reset sequence that clears all active styles.
  */
 export const ansiResetCode = '\x1b[0m'
 
-export const ansiStyleCodes = {
+export const ansiStyleCodes: AnsiStyleCodes = {
   bold: '\x1b[1m',
   dim: '\x1b[2m',
   italic: '\x1b[3m',
@@ -113,12 +125,12 @@ export const ansiStyleCodes = {
   bgMagentaBright: '\x1b[105m',
   bgCyanBright: '\x1b[106m',
   bgWhiteBright: '\x1b[107m',
-} satisfies Record<TerminalStyleName, string>
+}
 
 /**
  * Raw ANSI escape sequences and helpers for terminal controls.
  */
-export const ansi = {
+export const ansi: Ansi = {
   /**
    * Resets all ANSI styles.
    */

--- a/packages/ui/.changes/patch.explicit-public-types.md
+++ b/packages/ui/.changes/patch.explicit-public-types.md
@@ -1,0 +1,1 @@
+Add explicit public API types for UI component, mixin, scheduler, stylesheet, animation, and theme helpers.

--- a/packages/ui/src/animation/spring.ts
+++ b/packages/ui/src/animation/spring.ts
@@ -38,6 +38,17 @@ export interface SpringIterator extends IterableIterator<number> {
   toString(): string
 }
 
+export interface SpringFunction {
+  (preset: SpringPreset, overrides?: Omit<SpringOptions, 'bounce'>): SpringIterator
+  (options?: SpringOptions): SpringIterator
+  transition(
+    property: string | string[],
+    presetOrOptions?: SpringPreset | SpringOptions,
+    overrides?: Omit<SpringOptions, 'bounce'>,
+  ): string
+  presets: Record<SpringPreset, { duration: number; bounce: number }>
+}
+
 const presets: Record<SpringPreset, { duration: number; bounce: number }> = {
   smooth: { duration: 400, bounce: -0.3 },
   snappy: { duration: 200, bounce: 0 },
@@ -74,7 +85,7 @@ const frameMs = 1000 / 60 // ~16.67ms per frame
  * @param overrides Optional preset overrides.
  * @returns A spring iterator.
  */
-export function spring(
+function createSpring(
   preset: SpringPreset,
   overrides?: Omit<SpringOptions, 'bounce'>,
 ): SpringIterator
@@ -84,8 +95,8 @@ export function spring(
  * @param options Spring parameters.
  * @returns A spring iterator.
  */
-export function spring(options?: SpringOptions): SpringIterator
-export function spring(
+function createSpring(options?: SpringOptions): SpringIterator
+function createSpring(
   presetOrOptions?: SpringPreset | SpringOptions,
   overrides?: Omit<SpringOptions, 'bounce'>,
 ): SpringIterator {
@@ -119,23 +130,24 @@ export function spring(
   return iter as unknown as SpringIterator
 }
 
-// Transition helper for CSS transition property
-spring.transition = function transition(
+function transition(
   property: string | string[],
   presetOrOptions?: SpringPreset | SpringOptions,
   overrides?: Omit<SpringOptions, 'bounce'>,
 ): string {
   let s =
     typeof presetOrOptions === 'string'
-      ? spring(presetOrOptions, overrides)
-      : spring(presetOrOptions)
+      ? createSpring(presetOrOptions, overrides)
+      : createSpring(presetOrOptions)
 
   let properties = Array.isArray(property) ? property : [property]
   return properties.map((p) => `${p} ${s}`).join(', ')
 }
 
-// Access preset defaults
-spring.presets = presets
+export const spring: SpringFunction = Object.assign(createSpring, {
+  transition,
+  presets,
+})
 
 function resolveOptions(
   presetOrOptions?: SpringPreset | SpringOptions,

--- a/packages/ui/src/components/accordion/accordion.tsx
+++ b/packages/ui/src/components/accordion/accordion.tsx
@@ -230,7 +230,7 @@ function isMultipleProps(props: AccordionProps | null): props is AccordionMultip
   return props?.type === 'multiple'
 }
 
-function AccordionImpl(handle: Handle<AccordionProps, AccordionContext>) {
+function AccordionImpl(handle: Handle<AccordionProps, AccordionContext>): () => RemixNode {
   let rootNode: HTMLElement | null = null
   let registeredItems: RegisteredItem[] = []
   let uncontrolledSingleValue: string | null = null
@@ -418,13 +418,15 @@ function AccordionImpl(handle: Handle<AccordionProps, AccordionContext>) {
 export function onAccordionChange<target extends HTMLElement>(
   handler: AccordionChangeHandler<target>,
   captureBoolean?: boolean,
-) {
+): ReturnType<typeof on<target, typeof ACCORDION_CHANGE_EVENT>> {
   return on(ACCORDION_CHANGE_EVENT, handler, captureBoolean)
 }
 
 export const Accordion = AccordionImpl
 
-export function AccordionItem(handle: Handle<AccordionItemProps, AccordionItemContext>) {
+export function AccordionItem(
+  handle: Handle<AccordionItemProps, AccordionItemContext>,
+): () => RemixNode {
   let triggerNode: HTMLButtonElement | null = null
   let triggerId = `${handle.id}-trigger`
   let panelId = `${handle.id}-panel`
@@ -468,7 +470,7 @@ export function AccordionItem(handle: Handle<AccordionItemProps, AccordionItemCo
   }
 }
 
-export function AccordionTrigger(handle: Handle<AccordionTriggerProps>) {
+export function AccordionTrigger(handle: Handle<AccordionTriggerProps>): () => RemixNode {
   return () => {
     let accordion = handle.context.get(Accordion)
     let item = handle.context.get(AccordionItem)
@@ -539,7 +541,7 @@ export function AccordionTrigger(handle: Handle<AccordionTriggerProps>) {
   }
 }
 
-export function AccordionContent(handle: Handle<AccordionContentProps>) {
+export function AccordionContent(handle: Handle<AccordionContentProps>): () => RemixNode {
   return () => {
     let item = handle.context.get(AccordionItem)
     let { children, mix, ...panelProps } = handle.props

--- a/packages/ui/src/components/anchor/anchor.ts
+++ b/packages/ui/src/components/anchor/anchor.ts
@@ -643,7 +643,7 @@ export function anchor(
   floating: HTMLElement,
   anchorElement: HTMLElement,
   options: AnchorOptions = {},
-) {
+): () => void {
   let lastAnchorRect: DOMRect
   let lastFloatingDimensions: FloatingDimensions
 

--- a/packages/ui/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/ui/src/components/breadcrumbs/breadcrumbs.tsx
@@ -72,7 +72,7 @@ const textCss = css({
   whiteSpace: 'nowrap',
 })
 
-export function Breadcrumbs(handle: Handle<BreadcrumbsProps>) {
+export function Breadcrumbs(handle: Handle<BreadcrumbsProps>): () => RemixNode {
   return () => {
     let { 'aria-label': ariaLabel, items, separator, mix, ...navProps } = handle.props
     let currentIndex = items.findIndex((item) => item.current)

--- a/packages/ui/src/components/button/button.tsx
+++ b/packages/ui/src/components/button/button.tsx
@@ -1,5 +1,13 @@
 import { attrs, createElement, createMixin, css } from '@remix-run/ui'
-import type { CSSMixinDescriptor, ElementProps, Handle, Props, RemixNode } from '@remix-run/ui'
+import type {
+  CSSMixinDescriptor,
+  ElementProps,
+  Handle,
+  MixinDescriptor,
+  MixinFactory,
+  Props,
+  RemixNode,
+} from '@remix-run/ui'
 
 import { theme } from '../../theme/theme.ts'
 
@@ -74,22 +82,26 @@ const buttonIconCss: CSSMixinDescriptor = css({
   },
 })
 
-const buttonIconAttrsCss = attrs({ 'aria-hidden': true })
+const buttonIconAttrsCss: MixinDescriptor<Element, [Partial<ElementProps>], ElementProps> = attrs({
+  'aria-hidden': true,
+})
 
-const buttonDefaultsMixin = createMixin<Element, [], ElementProps>(
-  (handle, hostType) => (props) => {
-    if (hostType !== 'button' || props.type !== undefined) {
-      return handle.element
-    }
+const buttonDefaultsMixin: MixinFactory<Element, [], ElementProps> = createMixin<
+  Element,
+  [],
+  ElementProps
+>((handle, hostType) => (props) => {
+  if (hostType !== 'button' || props.type !== undefined) {
+    return handle.element
+  }
 
-    return createElement(handle.element as unknown as string, {
-      ...props,
-      type: 'button',
-    })
-  },
-)
+  return createElement(handle.element as unknown as string, {
+    ...props,
+    type: 'button',
+  })
+})
 
-const buttonDefaultsCss = buttonDefaultsMixin()
+const buttonDefaultsCss: MixinDescriptor<Element, [], ElementProps> = buttonDefaultsMixin()
 
 /**
  * Base button styling with the default `type="button"` behavior for `<button>`
@@ -121,7 +133,7 @@ export const labelStyle = buttonLabelCss
  *
  * @category mixin
  */
-export const primaryStyle = createButtonCss(theme.colors.action.primary)
+export const primaryStyle: CSSMixinDescriptor = createButtonCss(theme.colors.action.primary)
 
 /**
  * Secondary visual treatment for buttons. Combine with {@link baseStyle} when
@@ -129,7 +141,7 @@ export const primaryStyle = createButtonCss(theme.colors.action.primary)
  *
  * @category mixin
  */
-export const secondaryStyle = createButtonCss(theme.colors.action.secondary)
+export const secondaryStyle: CSSMixinDescriptor = createButtonCss(theme.colors.action.secondary)
 
 /**
  * Ghost visual treatment for buttons — transparent background with a hover
@@ -146,7 +158,7 @@ export const ghostStyle = ghostButtonToneCss
  *
  * @category mixin
  */
-export const dangerStyle = createButtonCss(theme.colors.action.danger)
+export const dangerStyle: CSSMixinDescriptor = createButtonCss(theme.colors.action.danger)
 
 const toneStyleByTone = {
   primary: primaryStyle,
@@ -203,7 +215,7 @@ export type ButtonProps = Omit<Props<'button'>, 'children'> & {
  * </Button>
  * ```
  */
-export function Button(handle: Handle<ButtonProps>) {
+export function Button(handle: Handle<ButtonProps>): () => RemixNode {
   return () => {
     let { children, endIcon, mix, startIcon, tone = 'secondary', ...buttonProps } = handle.props
 

--- a/packages/ui/src/components/combobox/combobox.tsx
+++ b/packages/ui/src/components/combobox/combobox.tsx
@@ -10,6 +10,7 @@ import {
   type ElementProps,
   type Handle,
   type MixinHandle,
+  type MixinFactory,
   type Props,
   type RemixNode,
 } from '@remix-run/ui'
@@ -213,7 +214,9 @@ function getOptionSearchValue(option: {
   return option.searchValue ?? option.textValue ?? option.label
 }
 
-function ComboboxProvider(handle: Handle<ComboboxContextProps, ComboboxContextValue>) {
+function ComboboxProvider(
+  handle: Handle<ComboboxContextProps, ComboboxContextValue>,
+): () => RemixNode {
   let inputRef: HTMLInputElement | undefined
   let listboxRef: listbox.ListboxRef | undefined
   let surfaceRef: HTMLElement | undefined
@@ -807,7 +810,11 @@ function getComboboxContext(handle: Handle | MixinHandle) {
   return handle.context.get(ComboboxProvider)
 }
 
-const inputMixin = createMixin<HTMLInputElement, [], ElementProps>((handle) => {
+const inputMixin: MixinFactory<HTMLInputElement, [], ElementProps> = createMixin<
+  HTMLInputElement,
+  [],
+  ElementProps
+>((handle) => {
   let context = getComboboxContext(handle)
 
   return (props) => [
@@ -882,7 +889,11 @@ const inputMixin = createMixin<HTMLInputElement, [], ElementProps>((handle) => {
   ]
 })
 
-const popoverMixin = createMixin<HTMLElement, [], ElementProps>((handle) => {
+const popoverMixin: MixinFactory<HTMLElement, [], ElementProps> = createMixin<
+  HTMLElement,
+  [],
+  ElementProps
+>((handle) => {
   let context = getComboboxContext(handle)
 
   return () => [
@@ -908,12 +919,20 @@ const popoverMixin = createMixin<HTMLElement, [], ElementProps>((handle) => {
   ]
 })
 
-const listMixin = createMixin<HTMLElement, [], ElementProps>((handle) => {
+const listMixin: MixinFactory<HTMLElement, [], ElementProps> = createMixin<
+  HTMLElement,
+  [],
+  ElementProps
+>((handle) => {
   let context = getComboboxContext(handle)
   return () => [attrs({ id: context.listId }), listbox.list()]
 })
 
-const hiddenInputMixin = createMixin<HTMLInputElement, [], ElementProps>((handle) => {
+const hiddenInputMixin: MixinFactory<HTMLInputElement, [], ElementProps> = createMixin<
+  HTMLInputElement,
+  [],
+  ElementProps
+>((handle) => {
   let context = getComboboxContext(handle)
   return () =>
     attrs({
@@ -924,8 +943,8 @@ const hiddenInputMixin = createMixin<HTMLInputElement, [], ElementProps>((handle
     })
 })
 
-const optionMixin = createMixin<HTMLElement, [options: ComboboxOptionOptions], ElementProps>(
-  (handle) => {
+const optionMixin: MixinFactory<HTMLElement, [options: ComboboxOptionOptions], ElementProps> =
+  createMixin<HTMLElement, [options: ComboboxOptionOptions], ElementProps>((handle) => {
     let context = getComboboxContext(handle)
 
     return (options) => {
@@ -946,8 +965,7 @@ const optionMixin = createMixin<HTMLElement, [options: ComboboxOptionOptions], E
         }),
       ]
     }
-  },
-)
+  })
 
 export const Context = ComboboxProvider
 export const hiddenInput = hiddenInputMixin
@@ -968,11 +986,11 @@ const combobox = {
 export function onComboboxChange<target extends HTMLElement>(
   handler: ComboboxChangeHandler<target>,
   captureBoolean?: boolean,
-) {
+): ReturnType<typeof on<target, typeof COMBOBOX_CHANGE_EVENT>> {
   return on(COMBOBOX_CHANGE_EVENT, handler, captureBoolean)
 }
 
-export function Combobox(handle: Handle<ComboboxProps>) {
+export function Combobox(handle: Handle<ComboboxProps>): () => RemixNode {
   return () => {
     let { children, defaultValue, disabled, inputId, name, placeholder, ...divProps } = handle.props
 
@@ -995,7 +1013,7 @@ export function Combobox(handle: Handle<ComboboxProps>) {
   }
 }
 
-export function ComboboxOption(handle: Handle<ComboboxOptionProps>) {
+export function ComboboxOption(handle: Handle<ComboboxOptionProps>): () => RemixNode {
   return () => {
     let { children, disabled, label, mix, searchValue, value, ...divProps } = handle.props
 

--- a/packages/ui/src/components/glyph/glyph.tsx
+++ b/packages/ui/src/components/glyph/glyph.tsx
@@ -31,7 +31,7 @@ export function createGlyphSheet(values: GlyphValues): GlyphSheetComponent {
     >,
   )
 
-  function GlyphSheet(handle: Handle<GlyphSheetProps>) {
+  function GlyphSheet(handle: Handle<GlyphSheetProps>): () => RemixElement {
     return () => {
       let { style, ...svgProps } = handle.props
       let hiddenStyle = {
@@ -70,7 +70,7 @@ export function createGlyphSheet(values: GlyphValues): GlyphSheetComponent {
   })
 }
 
-export function Glyph(handle: Handle<GlyphProps>) {
+export function Glyph(handle: Handle<GlyphProps>): () => RemixElement {
   return () => {
     let { fill, name, ...svgProps } = handle.props
     let glyphId = glyphContract[name].id

--- a/packages/ui/src/components/listbox/listbox.ts
+++ b/packages/ui/src/components/listbox/listbox.ts
@@ -4,7 +4,9 @@ import {
   css,
   on,
   type CSSMixinDescriptor,
+  type ElementProps,
   type Handle,
+  type MixinFactory,
   type RemixNode,
 } from '@remix-run/ui'
 import { theme } from '../../theme/theme.ts'
@@ -149,7 +151,7 @@ export const optionStyle = itemCss
 export const glyphStyle = itemGlyphCss
 export const labelStyle = itemLabelCss
 
-function ListboxProvider(handle: Handle<ListboxProviderProps, ListboxContext>) {
+function ListboxProvider(handle: Handle<ListboxProviderProps, ListboxContext>): () => RemixNode {
   let options: RegisteredOption[] = []
   let state: State = 'idle'
 
@@ -336,49 +338,51 @@ function ListboxProvider(handle: Handle<ListboxProviderProps, ListboxContext>) {
   }
 }
 
-const listMixin = createMixin<HTMLElement>((handle) => (props) => {
-  let context = handle.context.get(ListboxProvider)
-  return [
-    attrs({
-      tabIndex: props.tabIndex ?? -1,
-      role: props.role ?? 'listbox',
-    }),
-    on('focus', () => {
-      context.scrollActiveOptionIntoView()
-    }),
-    on('keydown', (event) => {
-      switch (event.key) {
-        case 'ArrowDown':
-          event.preventDefault()
-          context.navigate('next')
-          break
-        case 'ArrowUp':
-          event.preventDefault()
-          context.navigate('previous')
-          break
-        case 'Tab':
-          event.preventDefault()
-          context.navigate('first')
-          break
-        case 'Enter':
-        case ' ':
-          event.preventDefault()
-          void context.select(context.activeValue)
-          break
-        case 'Home':
-          event.preventDefault()
-          context.navigate('first')
-          break
-        case 'End':
-          event.preventDefault()
-          context.navigate('last')
-      }
-    }),
-    hiddenTypeahead((text) => {
-      context.highlightSearchMatch(text)
-    }),
-  ]
-})
+const listMixin: MixinFactory<HTMLElement, [], ElementProps> = createMixin<HTMLElement>(
+  (handle) => (props) => {
+    let context = handle.context.get(ListboxProvider)
+    return [
+      attrs({
+        tabIndex: props.tabIndex ?? -1,
+        role: props.role ?? 'listbox',
+      }),
+      on('focus', () => {
+        context.scrollActiveOptionIntoView()
+      }),
+      on('keydown', (event) => {
+        switch (event.key) {
+          case 'ArrowDown':
+            event.preventDefault()
+            context.navigate('next')
+            break
+          case 'ArrowUp':
+            event.preventDefault()
+            context.navigate('previous')
+            break
+          case 'Tab':
+            event.preventDefault()
+            context.navigate('first')
+            break
+          case 'Enter':
+          case ' ':
+            event.preventDefault()
+            void context.select(context.activeValue)
+            break
+          case 'Home':
+            event.preventDefault()
+            context.navigate('first')
+            break
+          case 'End':
+            event.preventDefault()
+            context.navigate('last')
+        }
+      }),
+      hiddenTypeahead((text) => {
+        context.highlightSearchMatch(text)
+      }),
+    ]
+  },
+)
 
 export interface ListboxOption {
   id: string
@@ -388,50 +392,51 @@ export interface ListboxOption {
   textValue?: SearchValue
 }
 
-const optionMixin = createMixin<HTMLElement, [option: Omit<ListboxOption, 'id'>]>((handle) => {
-  let optionRef: HTMLElement | undefined
+const optionMixin: MixinFactory<HTMLElement, [option: Omit<ListboxOption, 'id'>], ElementProps> =
+  createMixin<HTMLElement, [option: Omit<ListboxOption, 'id'>]>((handle) => {
+    let optionRef: HTMLElement | undefined
 
-  handle.queueTask((node) => {
-    optionRef = node
-  })
-
-  return (option) => {
-    let context = handle.context.get(ListboxProvider)
-    context.registerOption({
-      ...option,
-      id: handle.id,
-      get hidden() {
-        return optionRef?.hidden === true
-      },
-      get node() {
-        return optionRef as HTMLElement
-      },
+    handle.queueTask((node) => {
+      optionRef = node
     })
 
-    return [
-      attrs({
-        role: 'option',
+    return (option) => {
+      let context = handle.context.get(ListboxProvider)
+      context.registerOption({
+        ...option,
         id: handle.id,
-        'aria-selected': context.value === option.value ? 'true' : 'false',
-        'aria-disabled': option.disabled ? 'true' : 'false',
-        'data-highlighted': context.activeValue === option.value ? 'true' : 'false',
-      }),
-      !option.disabled && [
-        on('click', () => {
-          context.select(option.value)
+        get hidden() {
+          return optionRef?.hidden === true
+        },
+        get node() {
+          return optionRef as HTMLElement
+        },
+      })
+
+      return [
+        attrs({
+          role: 'option',
+          id: handle.id,
+          'aria-selected': context.value === option.value ? 'true' : 'false',
+          'aria-disabled': option.disabled ? 'true' : 'false',
+          'data-highlighted': context.activeValue === option.value ? 'true' : 'false',
         }),
-        on('mousemove', () => {
-          if (context.activeValue === option.value) return
-          context.highlight(option.value)
-        }),
-        on('mouseleave', () => {
-          if (context.activeValue !== option.value) return
-          context.highlight(null)
-        }),
-      ],
-    ]
-  }
-})
+        !option.disabled && [
+          on('click', () => {
+            context.select(option.value)
+          }),
+          on('mousemove', () => {
+            if (context.activeValue === option.value) return
+            context.highlight(option.value)
+          }),
+          on('mouseleave', () => {
+            if (context.activeValue !== option.value) return
+            context.highlight(null)
+          }),
+        ],
+      ]
+    }
+  })
 
 export const Context = ListboxProvider
 export const list = listMixin

--- a/packages/ui/src/components/menu/menu.tsx
+++ b/packages/ui/src/components/menu/menu.tsx
@@ -9,6 +9,7 @@ import {
   type Dispatched,
   type ElementProps,
   type Handle,
+  type MixinFactory,
   type Props,
   type RemixNode,
 } from '@remix-run/ui'
@@ -416,7 +417,7 @@ function focusNode(node: HTMLElement | undefined) {
   }
 }
 
-function MenuProvider(handle: Handle<MenuProviderProps, MenuContextValue>) {
+function MenuProvider(handle: Handle<MenuProviderProps, MenuContextValue>): () => RemixNode {
   let parent = handle.context.get(MenuProvider)
 
   let activeId: string | null = null
@@ -957,8 +958,8 @@ function MenuProvider(handle: Handle<MenuProviderProps, MenuContextValue>) {
   }
 }
 
-const triggerMixin = createMixin<HTMLElement, [options?: MenuTriggerOptions], ElementProps>(
-  (handle) => {
+const triggerMixin: MixinFactory<HTMLElement, [options?: MenuTriggerOptions], ElementProps> =
+  createMixin<HTMLElement, [options?: MenuTriggerOptions], ElementProps>((handle) => {
     let context = handle.context.get(MenuProvider)
 
     return (options = {}) => [
@@ -1005,10 +1006,13 @@ const triggerMixin = createMixin<HTMLElement, [options?: MenuTriggerOptions], El
         }
       }),
     ]
-  },
-)
+  })
 
-const popoverMixin = createMixin<HTMLElement, [], ElementProps>((handle) => {
+const popoverMixin: MixinFactory<HTMLElement, [], ElementProps> = createMixin<
+  HTMLElement,
+  [],
+  ElementProps
+>((handle) => {
   let context = handle.context.get(MenuProvider)
 
   return () => [
@@ -1045,7 +1049,11 @@ const popoverMixin = createMixin<HTMLElement, [], ElementProps>((handle) => {
   ]
 })
 
-const listMixin = createMixin<HTMLElement, [], ElementProps>((handle) => {
+const listMixin: MixinFactory<HTMLElement, [], ElementProps> = createMixin<
+  HTMLElement,
+  [],
+  ElementProps
+>((handle) => {
   let context = handle.context.get(MenuProvider)
 
   return () => [
@@ -1146,7 +1154,11 @@ const listMixin = createMixin<HTMLElement, [], ElementProps>((handle) => {
   ]
 })
 
-const itemMixin = createMixin<HTMLElement, [options: MenuItemOptions], ElementProps>((handle) => {
+const itemMixin: MixinFactory<HTMLElement, [options: MenuItemOptions], ElementProps> = createMixin<
+  HTMLElement,
+  [options: MenuItemOptions],
+  ElementProps
+>((handle) => {
   let itemRef: HTMLElement | undefined
 
   handle.queueTask((node) => {
@@ -1226,11 +1238,11 @@ const itemMixin = createMixin<HTMLElement, [options: MenuItemOptions], ElementPr
   }
 })
 
-const submenuTriggerMixin = createMixin<
+const submenuTriggerMixin: MixinFactory<
   HTMLElement,
   [options: SubmenuTriggerOptions],
   ElementProps
->((handle) => {
+> = createMixin<HTMLElement, [options: SubmenuTriggerOptions], ElementProps>((handle) => {
   let itemRef: HTMLElement | undefined
   let openTimeoutId = 0
   let aborted = false
@@ -1400,7 +1412,7 @@ const menu = {
 export function onMenuSelect<target extends HTMLElement>(
   handler: MenuSelectHandler<target>,
   captureBoolean?: boolean,
-) {
+): ReturnType<typeof on<target, typeof MENU_SELECT_EVENT>> {
   return on(MENU_SELECT_EVENT, handler, captureBoolean)
 }
 
@@ -1425,7 +1437,7 @@ export interface SubmenuProps
   menuLabel?: string
 }
 
-export function Menu(handle: Handle<MenuProps>) {
+export function Menu(handle: Handle<MenuProps>): () => RemixNode {
   let buttonRef: HTMLButtonElement | undefined
 
   return () => {
@@ -1472,7 +1484,7 @@ export function Menu(handle: Handle<MenuProps>) {
   }
 }
 
-export function MenuList(handle: Handle<MenuListProps>) {
+export function MenuList(handle: Handle<MenuListProps>): () => RemixNode {
   return () => {
     let { children, mix, ...divProps } = handle.props
 
@@ -1486,7 +1498,7 @@ export function MenuList(handle: Handle<MenuListProps>) {
   }
 }
 
-export function MenuItem(handle: Handle<MenuItemProps>) {
+export function MenuItem(handle: Handle<MenuItemProps>): () => RemixNode {
   return () => {
     let { checked, children, disabled, label, mix, name, searchValue, type, value, ...divProps } =
       handle.props
@@ -1509,7 +1521,7 @@ export function MenuItem(handle: Handle<MenuItemProps>) {
   }
 }
 
-export function Submenu(handle: Handle<SubmenuProps>) {
+export function Submenu(handle: Handle<SubmenuProps>): () => RemixNode {
   return () => {
     let { children, disabled, label, listProps, menuLabel, mix, searchValue, value, ...divProps } =
       handle.props

--- a/packages/ui/src/components/popover/popover.ts
+++ b/packages/ui/src/components/popover/popover.ts
@@ -4,7 +4,9 @@ import {
   css,
   on,
   type CSSMixinDescriptor,
+  type ElementProps,
   type Handle,
+  type MixinFactory,
   type RemixNode,
 } from '@remix-run/ui'
 import { anchor as positionAnchor, type AnchorOptions } from '../anchor/anchor.ts'
@@ -75,7 +77,7 @@ const popoverSurfaceCss: CSSMixinDescriptor = css({
 export const contentStyle = popoverContentCss
 export const surfaceStyle = [popoverSurfaceCss, popoverSurfaceTransitionCss] as const
 
-function PopoverProvider(handle: Handle<PopoverProps, PopoverContext>) {
+function PopoverProvider(handle: Handle<PopoverProps, PopoverContext>): () => RemixNode {
   handle.context.set({
     hideFocusTarget: null,
     showFocusTarget: null,
@@ -99,7 +101,10 @@ export interface PopoverHideRequest {
   target?: Node | null
 }
 
-const anchorMixin = createMixin<HTMLElement, [options: AnchorOptions]>((handle) => {
+const anchorMixin: MixinFactory<HTMLElement, [options: AnchorOptions], ElementProps> = createMixin<
+  HTMLElement,
+  [options: AnchorOptions]
+>((handle) => {
   let context = handle.context.get(PopoverProvider)
   return (options) => {
     handle.queueTask((node) => {
@@ -108,91 +113,97 @@ const anchorMixin = createMixin<HTMLElement, [options: AnchorOptions]>((handle) 
   }
 })
 
-const surfaceMixin = createMixin<HTMLElement, [options: PopoverSurfaceOptions]>((handle) => {
-  let openProp = false
-  let cleanupAnchor = () => {}
-  let unlockScroll = () => {}
-  let context = handle.context.get(PopoverProvider)
+const surfaceMixin: MixinFactory<HTMLElement, [options: PopoverSurfaceOptions], ElementProps> =
+  createMixin<HTMLElement, [options: PopoverSurfaceOptions]>((handle) => {
+    let openProp = false
+    let cleanupAnchor = () => {}
+    let unlockScroll = () => {}
+    let context = handle.context.get(PopoverProvider)
 
-  handle.queueTask((node, signal) => {
-    context.surface = node
+    handle.queueTask((node, signal) => {
+      context.surface = node
 
-    signal.addEventListener('abort', () => {
-      if (context.surface === node) {
-        context.surface = null
-      }
-    })
-  })
-
-  return (options) => {
-    let wasOpen = openProp
-    openProp = options.open
-
-    handle.queueTask(async (node) => {
-      if (openProp && !wasOpen) {
-        node.showPopover()
-      } else if (!openProp && wasOpen) {
-        node.hidePopover()
-      }
+      signal.addEventListener('abort', () => {
+        if (context.surface === node) {
+          context.surface = null
+        }
+      })
     })
 
-    return [
-      attrs({ popover: 'manual' }),
+    return (options) => {
+      let wasOpen = openProp
+      openProp = options.open
 
-      on('beforetoggle', (event) => {
-        if (event.newState === 'open') {
-          cleanupAnchor = positionAnchor(
-            event.currentTarget,
-            context.anchor!.node,
-            context.anchor!.options,
-          )
-          unlockScroll = lockScroll()
-        } else if (event.newState === 'closed') {
-          cleanupAnchor()
-          unlockScroll()
+      handle.queueTask(async (node) => {
+        if (openProp && !wasOpen) {
+          node.showPopover()
+        } else if (!openProp && wasOpen) {
+          node.hidePopover()
         }
-      }),
+      })
 
-      on('toggle', async (event) => {
-        if (event.newState === 'open') {
-          context.showFocusTarget?.focus()
-        } else if (event.newState === 'closed' && options.restoreFocusOnHide !== false) {
-          context.hideFocusTarget?.focus()
-        }
-      }),
+      return [
+        attrs({ popover: 'manual' }),
 
-      on('keydown', (event) => {
-        if (event.key === 'Escape') {
-          event.preventDefault()
-          options.onHide({ reason: 'escape-key' })
-        }
-      }),
+        on('beforetoggle', (event) => {
+          if (event.newState === 'open') {
+            cleanupAnchor = positionAnchor(
+              event.currentTarget,
+              context.anchor!.node,
+              context.anchor!.options,
+            )
+            unlockScroll = lockScroll()
+          } else if (event.newState === 'closed') {
+            cleanupAnchor()
+            unlockScroll()
+          }
+        }),
 
-      onOutsideClick(
-        openProp,
-        (target) => {
-          options.onHide({ reason: 'outside-click', target })
-        },
-        (target) => options.closeOnAnchorClick === false && !!context.anchor?.node.contains(target),
-        options.stopOutsideClickPropagation ?? true,
-      ),
-    ]
-  }
-})
+        on('toggle', async (event) => {
+          if (event.newState === 'open') {
+            context.showFocusTarget?.focus()
+          } else if (event.newState === 'closed' && options.restoreFocusOnHide !== false) {
+            context.hideFocusTarget?.focus()
+          }
+        }),
 
-const focusOnShowMixin = createMixin<HTMLElement, []>((handle) => {
-  handle.addEventListener('insert', (event) => {
-    let context = handle.context.get(PopoverProvider)
-    context.showFocusTarget = event.node
+        on('keydown', (event) => {
+          if (event.key === 'Escape') {
+            event.preventDefault()
+            options.onHide({ reason: 'escape-key' })
+          }
+        }),
+
+        onOutsideClick(
+          openProp,
+          (target) => {
+            options.onHide({ reason: 'outside-click', target })
+          },
+          (target) =>
+            options.closeOnAnchorClick === false && !!context.anchor?.node.contains(target),
+          options.stopOutsideClickPropagation ?? true,
+        ),
+      ]
+    }
   })
-})
 
-const focusOnHideMixin = createMixin<HTMLElement, []>((handle) => {
-  handle.addEventListener('insert', (event) => {
-    let context = handle.context.get(PopoverProvider)
-    context.hideFocusTarget = event.node
-  })
-})
+const focusOnShowMixin: MixinFactory<HTMLElement, [], ElementProps> = createMixin<HTMLElement, []>(
+  (handle) => {
+    handle.addEventListener('insert', (event) => {
+      let context = handle.context.get(PopoverProvider)
+      context.showFocusTarget = event.node
+    })
+  },
+)
+
+const focusOnHideMixin: MixinFactory<HTMLElement, [], ElementProps> = createMixin<HTMLElement, []>(
+  (handle) => {
+    handle.addEventListener('insert', (event) => {
+      let context = handle.context.get(PopoverProvider)
+      context.hideFocusTarget = event.node
+    })
+  },
+)
 
 export const Context = PopoverProvider
 export const anchor = anchorMixin

--- a/packages/ui/src/components/select/select.tsx
+++ b/packages/ui/src/components/select/select.tsx
@@ -10,6 +10,7 @@ import {
   type ElementProps,
   type Handle,
   type MixinHandle,
+  type MixinFactory,
   type Props,
   type RemixNode,
 } from '@remix-run/ui'
@@ -106,7 +107,7 @@ interface SelectContextValue {
   unregisterTrigger: (node: HTMLButtonElement) => void
 }
 
-function SelectProvider(handle: Handle<SelectContextProps, SelectContextValue>) {
+function SelectProvider(handle: Handle<SelectContextProps, SelectContextValue>): () => RemixNode {
   let triggerRef: HTMLButtonElement | undefined
   let listboxRef: listbox.ListboxRef | undefined
   let surfaceRef: HTMLElement | undefined
@@ -396,7 +397,11 @@ function getSelectContext(handle: Handle | MixinHandle) {
   return handle.context.get(SelectProvider)
 }
 
-const triggerMixin = createMixin<HTMLButtonElement, [], ElementProps>((handle) => {
+const triggerMixin: MixinFactory<HTMLButtonElement, [], ElementProps> = createMixin<
+  HTMLButtonElement,
+  [],
+  ElementProps
+>((handle) => {
   let context = getSelectContext(handle)
 
   return (props) => [
@@ -428,7 +433,11 @@ const triggerMixin = createMixin<HTMLButtonElement, [], ElementProps>((handle) =
   ]
 })
 
-const popoverMixin = createMixin<HTMLElement, [], ElementProps>((handle) => {
+const popoverMixin: MixinFactory<HTMLElement, [], ElementProps> = createMixin<
+  HTMLElement,
+  [],
+  ElementProps
+>((handle) => {
   let context = getSelectContext(handle)
   let popoverState = handle.context.get(popover.Context)
 
@@ -453,7 +462,11 @@ const popoverMixin = createMixin<HTMLElement, [], ElementProps>((handle) => {
   ]
 })
 
-const listMixin = createMixin<HTMLElement, [], ElementProps>((handle) => {
+const listMixin: MixinFactory<HTMLElement, [], ElementProps> = createMixin<
+  HTMLElement,
+  [],
+  ElementProps
+>((handle) => {
   let context = getSelectContext(handle)
 
   return () => [
@@ -466,7 +479,11 @@ const listMixin = createMixin<HTMLElement, [], ElementProps>((handle) => {
   ]
 })
 
-const hiddenInputMixin = createMixin<HTMLInputElement, [], ElementProps>((handle) => {
+const hiddenInputMixin: MixinFactory<HTMLInputElement, [], ElementProps> = createMixin<
+  HTMLInputElement,
+  [],
+  ElementProps
+>((handle) => {
   let context = getSelectContext(handle)
 
   return () =>
@@ -532,17 +549,17 @@ const select = {
 export function onSelectChange<target extends HTMLElement>(
   handler: SelectChangeHandler<target>,
   captureBoolean?: boolean,
-) {
+): ReturnType<typeof on<target, typeof SELECT_CHANGE_EVENT>> {
   return on(SELECT_CHANGE_EVENT, handler, captureBoolean)
 }
 
-function SelectLabel(handle: Handle) {
+function SelectLabel(handle: Handle): () => RemixNode {
   let context = getSelectContext(handle)
 
   return () => <span mix={button.labelStyle}>{context.displayedLabel}</span>
 }
 
-export function Select(handle: Handle<SelectProps>) {
+export function Select(handle: Handle<SelectProps>): () => RemixNode {
   return () => {
     let { children, defaultLabel, defaultValue, disabled, name, mix, ...buttonProps } = handle.props
 
@@ -568,7 +585,7 @@ export function Select(handle: Handle<SelectProps>) {
   }
 }
 
-export function Option(handle: Handle<SelectOptionProps>) {
+export function Option(handle: Handle<SelectOptionProps>): () => RemixNode {
   return () => {
     let { label, value, disabled, textValue, children, mix, ...divProps } = handle.props
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -51,6 +51,7 @@ export type { HostProps, LayoutAnimationConfig } from './runtime/dom.ts'
 export { createMixin } from './runtime/mixins/mixin.ts'
 export type {
   MixinDescriptor,
+  MixinFactory,
   MixinHandle,
   MixinType,
   MixInput,

--- a/packages/ui/src/runtime/component.ts
+++ b/packages/ui/src/runtime/component.ts
@@ -223,7 +223,14 @@ type ComponentConfig = {
 /**
  * Runtime handle returned by {@link createComponent}.
  */
-export type ComponentHandle = ReturnType<typeof createComponent>
+export interface ComponentHandle<C = NoContext> {
+  frame: FrameHandle
+  render(nextProps: ElementProps): [RemixNode, Array<() => void>]
+  remove(): Array<() => void>
+  setScheduleUpdate(nextScheduleUpdate: () => void): void
+  getContextValue(): C | undefined
+  isRemoved(): boolean
+}
 
 /**
  * Creates the internal runtime wrapper for a component instance.
@@ -231,11 +238,11 @@ export type ComponentHandle = ReturnType<typeof createComponent>
  * @param config Component runtime configuration.
  * @returns Component runtime helpers used by the reconciler.
  */
-export function createComponent<C = NoContext>(config: ComponentConfig) {
+export function createComponent<C = NoContext>(config: ComponentConfig): ComponentHandle<C> {
   return new ComponentRuntime<C>(config)
 }
 
-class ComponentRuntime<C = NoContext> {
+class ComponentRuntime<C = NoContext> implements ComponentHandle<C> {
   frame: FrameHandle
 
   #config: ComponentConfig
@@ -381,7 +388,7 @@ function syncProps(target: ElementProps, next: ElementProps): void {
  * @param handle Component handle for the frame instance.
  * @returns A placeholder render function handled by the reconciler.
  */
-export function Frame(handle: Handle<FrameProps, FrameHandle>) {
+export function Frame(handle: Handle<FrameProps, FrameHandle>): RenderFn {
   void handle
   return () => null // reconciler renders
 }
@@ -392,7 +399,7 @@ export function Frame(handle: Handle<FrameProps, FrameHandle>) {
  * @param handle Component handle for the fragment instance.
  * @returns A placeholder render function handled by the reconciler.
  */
-export function Fragment(handle: Handle<FragmentProps>) {
+export function Fragment(handle: Handle<FragmentProps>): RenderFn {
   void handle
   return () => null // reconciler renders
 }

--- a/packages/ui/src/runtime/mixins/link-mixin.ts
+++ b/packages/ui/src/runtime/mixins/link-mixin.ts
@@ -1,4 +1,4 @@
-import { createMixin, renderMixinElement } from './mixin.ts'
+import { createMixin, renderMixinElement, type MixinFactory } from './mixin.ts'
 import { navigate } from '../navigation.ts'
 import { on } from './on-mixin.ts'
 import type { ElementProps } from '../jsx.ts'
@@ -21,108 +21,110 @@ const nativeLinkHostTypes = new Set(['a', 'area'])
 /**
  * Adds client-side navigation behavior to anchor-like elements.
  */
-export const link = createMixin<
+export const link: MixinFactory<
   HTMLElement,
   [href: string, options?: NavigationOptions],
   LinkCurrentProps
->((handle, hostType) => {
-  let suppressKeyboardClick = false
+> = createMixin<HTMLElement, [href: string, options?: NavigationOptions], LinkCurrentProps>(
+  (handle, hostType) => {
+    let suppressKeyboardClick = false
 
-  return (href, options, props: LinkCurrentProps) => {
-    if (nativeLinkHostTypes.has(hostType)) {
+    return (href, options, props: LinkCurrentProps) => {
+      if (nativeLinkHostTypes.has(hostType)) {
+        return renderMixinElement(handle.element, {
+          ...(props ?? {}),
+          href,
+          ...(options?.target == null ? {} : { 'rmx-target': options.target }),
+          ...(options?.src == null ? {} : { 'rmx-src': options.src }),
+          ...(options?.resetScroll === false ? { 'rmx-reset-scroll': 'false' } : {}),
+        })
+      }
+
+      let nextProps = { ...props }
+      if (nextProps.role == null) {
+        nextProps.role = 'link'
+      }
+      if (nextProps.disabled === true && nextProps['aria-disabled'] == null) {
+        nextProps['aria-disabled'] = 'true'
+      }
+      if (hostType === 'button' && nextProps.type == null) {
+        nextProps.type = 'button'
+      }
+      if (
+        hostType !== 'button' &&
+        nextProps.tabIndex == null &&
+        nextProps.tabindex == null &&
+        nextProps.contentEditable == null &&
+        nextProps.contenteditable == null
+      ) {
+        nextProps.tabIndex = 0
+      }
+
       return renderMixinElement(handle.element, {
-        ...(props ?? {}),
-        href,
-        ...(options?.target == null ? {} : { 'rmx-target': options.target }),
-        ...(options?.src == null ? {} : { 'rmx-src': options.src }),
-        ...(options?.resetScroll === false ? { 'rmx-reset-scroll': 'false' } : {}),
-      })
-    }
-
-    let nextProps = { ...props }
-    if (nextProps.role == null) {
-      nextProps.role = 'link'
-    }
-    if (nextProps.disabled === true && nextProps['aria-disabled'] == null) {
-      nextProps['aria-disabled'] = 'true'
-    }
-    if (hostType === 'button' && nextProps.type == null) {
-      nextProps.type = 'button'
-    }
-    if (
-      hostType !== 'button' &&
-      nextProps.tabIndex == null &&
-      nextProps.tabindex == null &&
-      nextProps.contentEditable == null &&
-      nextProps.contenteditable == null
-    ) {
-      nextProps.tabIndex = 0
-    }
-
-    return renderMixinElement(handle.element, {
-      ...nextProps,
-      mix: [
-        on('click', (event) => {
-          if (event.detail === 0 && suppressKeyboardClick) {
-            suppressKeyboardClick = false
-            event.preventDefault()
-            return
-          }
-
-          suppressKeyboardClick = false
-          if (isDisabledElement(event.currentTarget)) {
-            event.preventDefault()
-            return
-          }
-          if (event.button !== 0) return
-
-          event.preventDefault()
-          if (event.metaKey || event.ctrlKey) {
-            globalThis.open(href, '_blank')
-            return
-          }
-
-          void navigate(href, options)
-        }),
-        on('auxclick', (event) => {
-          suppressKeyboardClick = false
-          if (isDisabledElement(event.currentTarget)) {
-            event.preventDefault()
-            return
-          }
-          if (event.button !== 1) return
-
-          event.preventDefault()
-          globalThis.open(href, '_blank')
-        }),
-        on('keydown', (event) => {
-          if (event.key === 'Enter') {
-            if (event.repeat) return
-            if (isDisabledElement(event.currentTarget)) {
+        ...nextProps,
+        mix: [
+          on('click', (event) => {
+            if (event.detail === 0 && suppressKeyboardClick) {
+              suppressKeyboardClick = false
               event.preventDefault()
               return
             }
 
-            suppressKeyboardClick = hostType === 'button'
-            event.preventDefault()
-            void navigate(href, options)
-            return
-          }
+            suppressKeyboardClick = false
+            if (isDisabledElement(event.currentTarget)) {
+              event.preventDefault()
+              return
+            }
+            if (event.button !== 0) return
 
-          if (hostType === 'button' && event.key === ' ') {
-            suppressKeyboardClick = true
             event.preventDefault()
-          }
-        }),
-        on('keyup', (event) => {
-          if (hostType === 'button' && event.key === ' ') {
+            if (event.metaKey || event.ctrlKey) {
+              globalThis.open(href, '_blank')
+              return
+            }
+
+            void navigate(href, options)
+          }),
+          on('auxclick', (event) => {
+            suppressKeyboardClick = false
+            if (isDisabledElement(event.currentTarget)) {
+              event.preventDefault()
+              return
+            }
+            if (event.button !== 1) return
+
             event.preventDefault()
-          }
-        }),
-      ],
-    })
-  }
-})
+            globalThis.open(href, '_blank')
+          }),
+          on('keydown', (event) => {
+            if (event.key === 'Enter') {
+              if (event.repeat) return
+              if (isDisabledElement(event.currentTarget)) {
+                event.preventDefault()
+                return
+              }
+
+              suppressKeyboardClick = hostType === 'button'
+              event.preventDefault()
+              void navigate(href, options)
+              return
+            }
+
+            if (hostType === 'button' && event.key === ' ') {
+              suppressKeyboardClick = true
+              event.preventDefault()
+            }
+          }),
+          on('keyup', (event) => {
+            if (hostType === 'button' && event.key === ' ') {
+              event.preventDefault()
+            }
+          }),
+        ],
+      })
+    }
+  },
+)
 
 function isDisabledElement(node: Element) {
   return (

--- a/packages/ui/src/runtime/mixins/mixin.ts
+++ b/packages/ui/src/runtime/mixins/mixin.ts
@@ -130,6 +130,14 @@ export type MixinDescriptor<
   readonly __node?: (node: node) => void
 }
 
+export type MixinFactory<
+  node extends EventTarget = Element,
+  args extends unknown[] = [],
+  props extends ElementProps = ElementProps,
+> = <boundNode extends node = node>(
+  ...args: RebindTuple<args, node, boundNode>
+) => MixinDescriptor<boundNode, RebindTuple<args, node, boundNode>, props>
+
 type PreviousMixDepth = [0, 0, 1, 2, 3, 4]
 type FalsyMixValue = false | 0 | 0n | '' | null | undefined
 type NullableMixValue<descriptor> = descriptor | FalsyMixValue
@@ -244,7 +252,7 @@ export function createMixin<
   node extends EventTarget = Element,
   args extends unknown[] = [],
   props extends ElementProps = ElementProps,
->(type: MixinType<node, args, props>) {
+>(type: MixinType<node, args, props>): MixinFactory<node, args, props> {
   return <boundNode extends node = node>(
     ...args: RebindTuple<args, node, boundNode>
   ): MixinDescriptor<boundNode, RebindTuple<args, node, boundNode>, props> => ({

--- a/packages/ui/src/runtime/mixins/ref-mixin.ts
+++ b/packages/ui/src/runtime/mixins/ref-mixin.ts
@@ -1,4 +1,4 @@
-import { createMixin } from './mixin.ts'
+import { createMixin, type MixinFactory } from './mixin.ts'
 import type { ElementProps } from '../jsx.ts'
 
 /**
@@ -9,8 +9,8 @@ export type RefCallback<node extends EventTarget> = (node: node, signal: AbortSi
 /**
  * Calls a callback when an element is inserted and aborts it when removed.
  */
-export const ref = createMixin<Element, [callback: RefCallback<Element>], ElementProps>(
-  (handle) => {
+export const ref: MixinFactory<Element, [callback: RefCallback<Element>], ElementProps> =
+  createMixin<Element, [callback: RefCallback<Element>], ElementProps>((handle) => {
     let controller: AbortController | undefined
 
     handle.addEventListener('insert', (event) => {
@@ -28,5 +28,4 @@ export const ref = createMixin<Element, [callback: RefCallback<Element>], Elemen
       callback = nextCallback
       return handle.element
     }
-  },
-)
+  })

--- a/packages/ui/src/runtime/scheduler.ts
+++ b/packages/ui/src/runtime/scheduler.ts
@@ -17,7 +17,23 @@ type SchedulerPhaseListener = EventListenerOrEventListenerObject | null
 /**
  * Scheduler API used by the reconciler and frame runtime.
  */
-export type Scheduler = ReturnType<typeof createScheduler>
+export interface Scheduler {
+  enqueue(vnode: CommittedComponentNode, domParent: ParentNode): void
+  enqueueWork(newTasks: EmptyFn[]): void
+  enqueueCommitPhase(newTasks: EmptyFn[]): void
+  enqueueTasks(newTasks: EmptyFn[]): void
+  addEventListener(
+    type: SchedulerPhaseType,
+    listener: SchedulerPhaseListener,
+    options?: AddEventListenerOptions | boolean,
+  ): void
+  removeEventListener(
+    type: SchedulerPhaseType,
+    listener: SchedulerPhaseListener,
+    options?: EventListenerOptions | boolean,
+  ): void
+  dequeue(): void
+}
 
 // Protect against infinite cascading updates (e.g. handle.update() during render)
 const MAX_CASCADING_UPDATES = 50
@@ -38,7 +54,7 @@ export function createScheduler(
   doc: Document,
   rootTarget: EventTarget,
   styles: StyleManager = defaultStyleManager,
-) {
+): Scheduler {
   let documentState = createDocumentState(doc)
   let scheduled = new Map<CommittedComponentNode, ParentNode>()
   let workTasks: EmptyFn[] = []
@@ -53,23 +69,7 @@ export function createScheduler(
     beforeUpdate: 0,
     commit: 0,
   }
-  let scheduler: {
-    enqueue(vnode: CommittedComponentNode, domParent: ParentNode): void
-    enqueueWork(newTasks: EmptyFn[]): void
-    enqueueCommitPhase(newTasks: EmptyFn[]): void
-    enqueueTasks(newTasks: EmptyFn[]): void
-    addEventListener(
-      type: SchedulerPhaseType,
-      listener: SchedulerPhaseListener,
-      options?: AddEventListenerOptions | boolean,
-    ): void
-    removeEventListener(
-      type: SchedulerPhaseType,
-      listener: SchedulerPhaseListener,
-      options?: EventListenerOptions | boolean,
-    ): void
-    dequeue(): void
-  }
+  let scheduler: Scheduler
 
   function dispatchError(error: unknown) {
     console.error(error)

--- a/packages/ui/src/style/css-mixin.ts
+++ b/packages/ui/src/style/css-mixin.ts
@@ -1,4 +1,5 @@
 import { createMixin, renderMixinElement } from '../runtime/mixins/mixin.ts'
+import type { MixinFactory } from '../runtime/mixins/mixin.ts'
 import type { MixinDescriptor } from '../runtime/mixins/mixin.ts'
 import type { ElementProps } from '../runtime/jsx.ts'
 import { invariant } from '../runtime/invariant.ts'
@@ -20,7 +21,11 @@ const clientStyleCache: StyleCache = new Map()
 /**
  * Applies generated class names for CSS object styles.
  */
-export const css = createMixin<Element, [styles: CSSProps], ElementProps>((handle) => {
+export const css: MixinFactory<Element, [styles: CSSProps], ElementProps> = createMixin<
+  Element,
+  [styles: CSSProps],
+  ElementProps
+>((handle) => {
   let activeSelector = ''
   let activeGeneration = -1
   let currentStyles: CSSProps = {}

--- a/packages/ui/src/style/index.ts
+++ b/packages/ui/src/style/index.ts
@@ -6,5 +6,4 @@ export type {
 } from './style.ts'
 export { processStyleClass, normalizeCssValue } from './style.ts'
 export { createStyleManager }
-
-export type StyleManager = ReturnType<typeof createStyleManager>
+export type { ServerStyleSource, StyleManager } from './stylesheet.ts'

--- a/packages/ui/src/style/stylesheet.ts
+++ b/packages/ui/src/style/stylesheet.ts
@@ -1,7 +1,19 @@
 import { REMIX_UI_STYLE_LAYER } from './layers.ts'
 
 type RuleEntry = { count: number; index: number }
-type ServerStyleSource = ParentNode | Iterable<Node>
+export type ServerStyleSource = ParentNode | Iterable<Node>
+
+export interface StyleManager {
+  insert(className: string, rule: string): void
+  remove(className: string): void
+  has(className: string): boolean
+  getGeneration(): number
+  reset(): void
+  adoptServerStyles(source: ServerStyleSource): Set<string>
+  replaceServerStyles(source: ServerStyleSource): void
+  selectors(): IterableIterator<string>
+  dispose(): void
+}
 
 const SERVER_STYLE_SELECTOR = 'style[data-rmx]'
 
@@ -68,7 +80,7 @@ function getStyleSelector(styleEl: HTMLStyleElement): string | null {
   return selector ? selector : null
 }
 
-export function createStyleManager(layer: string = REMIX_UI_STYLE_LAYER) {
+export function createStyleManager(layer: string = REMIX_UI_STYLE_LAYER): StyleManager {
   let stylesheet: CSSStyleSheet | null = null
   let generation = 0
 

--- a/packages/ui/src/theme/contract.ts
+++ b/packages/ui/src/theme/contract.ts
@@ -4,7 +4,38 @@ export interface ThemeVariableTree {
   [key: string]: string | ThemeVariableTree
 }
 
-const themeVariableNames = {
+type ThemeVariableGroup<key extends string> = Readonly<Record<key, string>>
+type ThemeActionVariableGroup = ThemeVariableGroup<
+  'background' | 'backgroundHover' | 'backgroundActive' | 'foreground' | 'border'
+>
+
+type ThemeVariableNames = {
+  readonly space: ThemeVariableGroup<'none' | 'px' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl'>
+  readonly radius: ThemeVariableGroup<'none' | 'sm' | 'md' | 'lg' | 'xl' | 'full'>
+  readonly fontFamily: ThemeVariableGroup<'sans' | 'mono'>
+  readonly fontSize: ThemeVariableGroup<'xxxs' | 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl'>
+  readonly lineHeight: ThemeVariableGroup<'tight' | 'normal' | 'relaxed'>
+  readonly letterSpacing: ThemeVariableGroup<'tight' | 'normal' | 'meta' | 'wide'>
+  readonly fontWeight: ThemeVariableGroup<'normal' | 'medium' | 'semibold' | 'bold'>
+  readonly control: {
+    readonly height: ThemeVariableGroup<'sm' | 'md' | 'lg'>
+  }
+  readonly surface: ThemeVariableGroup<'lvl0' | 'lvl1' | 'lvl2' | 'lvl3' | 'lvl4'>
+  readonly shadow: ThemeVariableGroup<'xs' | 'sm' | 'md' | 'lg' | 'xl'>
+  readonly colors: {
+    readonly text: ThemeVariableGroup<'primary' | 'secondary' | 'muted' | 'link'>
+    readonly border: ThemeVariableGroup<'subtle' | 'default' | 'strong'>
+    readonly focus: ThemeVariableGroup<'ring'>
+    readonly overlay: ThemeVariableGroup<'scrim'>
+    readonly action: {
+      readonly primary: ThemeActionVariableGroup
+      readonly secondary: ThemeActionVariableGroup
+      readonly danger: ThemeActionVariableGroup
+    }
+  }
+}
+
+const themeVariableNamesSource: ThemeVariableNames = {
   space: {
     none: '--rmx-space-none',
     px: '--rmx-space-px',
@@ -117,7 +148,9 @@ const themeVariableNames = {
       },
     },
   },
-} as const satisfies ThemeVariableTree
+} satisfies ThemeVariableTree
+
+export const themeVariableNames: ThemeVariableNames = themeVariableNamesSource
 
 type MapLeaves<source, leaf> = source extends string
   ? leaf
@@ -126,6 +159,7 @@ type MapLeaves<source, leaf> = source extends string
     }
 
 export type ThemeValue = string | number
+export type ThemeContract = MapLeaves<ThemeVariableNames, string>
 export type ThemeValues = MapLeaves<typeof themeVariableNames, ThemeValue>
 export type ThemeVars = Readonly<Record<string, string>>
 export type CreateThemeOptions = {
@@ -146,7 +180,7 @@ export type ThemeComponent = ThemeRenderer & {
   vars: ThemeVars
 }
 
-export const theme = createThemeContract(themeVariableNames)
+export const theme: ThemeContract = createThemeContract(themeVariableNames)
 
 export type ThemeUtility = ReturnType<typeof css>
 
@@ -157,8 +191,6 @@ type NestedThemeMix<value, depth extends number = 4> = depth extends 0
   : value | ReadonlyArray<NestedThemeMix<value, PreviousThemeMixDepth[depth]>>
 
 export type ThemeMix = NestedThemeMix<ThemeMixLeaf>
-
-export { themeVariableNames }
 
 function createThemeContract<tree extends ThemeVariableTree>(tree: tree): MapLeaves<tree, string> {
   return mapTreeLeaves(tree, (variableName) => `var(${variableName})`) as MapLeaves<tree, string>

--- a/packages/ui/src/theme/glyph-contract.ts
+++ b/packages/ui/src/theme/glyph-contract.ts
@@ -32,7 +32,9 @@ export type GlyphContract = Readonly<Record<GlyphName, { id: string }>>
 
 const DEFAULT_GLYPH_ID_PREFIX = 'rmx-glyph'
 
-export const glyphContract = Object.freeze(createGlyphContract(DEFAULT_GLYPH_ID_PREFIX))
+export const glyphContract: GlyphContract = Object.freeze(
+  createGlyphContract(DEFAULT_GLYPH_ID_PREFIX),
+)
 
 function createGlyphIds(idPrefix: string): Record<GlyphName, string> {
   return Object.fromEntries(glyphNames.map((name) => [name, `${idPrefix}-${name}`])) as Record<

--- a/packages/ui/src/theme/presets/rmx-01/index.ts
+++ b/packages/ui/src/theme/presets/rmx-01/index.ts
@@ -1,9 +1,11 @@
 import { createGlyphSheet } from '../../../components/glyph/glyph.tsx'
 import { createTheme } from '../../runtime.ts'
+import type { GlyphSheetComponent } from '../../../components/glyph/glyph.tsx'
+import type { ThemeComponent } from '../../contract.ts'
 
 import { glyphValues } from './glyphs.tsx'
 
-export const RMX_01 = createTheme({
+export const RMX_01: ThemeComponent = createTheme({
   space: {
     none: '0px',
     px: '1px',
@@ -118,4 +120,4 @@ export const RMX_01 = createTheme({
   },
 })
 
-export const RMX_01_GLYPHS = createGlyphSheet(glyphValues)
+export const RMX_01_GLYPHS: GlyphSheetComponent = createGlyphSheet(glyphValues)

--- a/packages/ui/src/utils/scroll-lock.ts
+++ b/packages/ui/src/utils/scroll-lock.ts
@@ -1,4 +1,4 @@
-import { createMixin, on, type ElementProps } from '@remix-run/ui'
+import { createMixin, on, type ElementProps, type MixinFactory } from '@remix-run/ui'
 
 type ScrollLockState = {
   count: number
@@ -10,7 +10,7 @@ type ScrollLockState = {
 
 const scrollLocks = new WeakMap<Document, ScrollLockState>()
 
-export function lockScroll(targetDocument = globalThis.document) {
+export function lockScroll(targetDocument: Document | undefined = globalThis.document): () => void {
   if (!targetDocument?.body || !targetDocument.defaultView) {
     return () => {}
   }
@@ -74,7 +74,11 @@ export function lockScroll(targetDocument = globalThis.document) {
   }
 }
 
-export const lockScrollOnToggle = createMixin<HTMLElement, [], ElementProps>((handle) => {
+export const lockScrollOnToggle: MixinFactory<HTMLElement, [], ElementProps> = createMixin<
+  HTMLElement,
+  [],
+  ElementProps
+>((handle) => {
   let unlockScroll = () => {}
 
   handle.signal.addEventListener('abort', () => {


### PR DESCRIPTION
This makes exported helper objects, component factories, serialization methods, and theme/style utilities describe their public type surfaces directly instead of depending on declaration inference.

- Adds named public types for object-assigned helpers like `expect`, `html`, ANSI helpers, UI mixins, style managers, theme contracts, and `spring`
- Annotates component, provider, factory, scheduler, stylesheet, and serialization return types
- Adds package change files for the affected published packages
