### PR TITLE
Fix booleanish attribute rendering

### DIFF
--- a/packages/ui/.changes/patch.false-valued-enumerated-attributes.md
+++ b/packages/ui/.changes/patch.false-valued-enumerated-attributes.md
@@ -1,0 +1,5 @@
+---
+'@remix-run/ui': patch
+---
+
+Fix rendering and JSX types for booleanish string attributes so `contentEditable={false}`, `draggable={false}`, `spellCheck={false}`, and matching SVG attributes produce explicit `"false"` values instead of being omitted. The `translate` JSX type now accepts the HTML attribute values `"yes"` and `"no"`.

--- a/packages/ui/.changes/patch.false-valued-enumerated-attributes.md
+++ b/packages/ui/.changes/patch.false-valued-enumerated-attributes.md
@@ -1,5 +1,1 @@
----
-'@remix-run/ui': patch
----
-
 Fix rendering and JSX types for booleanish string attributes so `contentEditable={false}`, `draggable={false}`, `spellCheck={false}`, and matching SVG attributes produce explicit `"false"` values instead of being omitted. The `translate` JSX type now accepts the HTML attribute values `"yes"` and `"no"`.

--- a/packages/ui/src/runtime/core/attributes.ts
+++ b/packages/ui/src/runtime/core/attributes.ts
@@ -3,6 +3,9 @@ import { normalizeSvgAttribute } from '../svg-attributes.ts'
 import type { ElementProps } from '../jsx.ts'
 
 const ATTRIBUTE_FALLBACK_NAMES = new Set([
+  'contentEditable',
+  'contenteditable',
+  'draggable',
   'width',
   'height',
   'href',
@@ -14,6 +17,20 @@ const ATTRIBUTE_FALLBACK_NAMES = new Set([
   'colSpan',
   'role',
   'popover',
+  'spellCheck',
+  'spellcheck',
+  'translate',
+])
+
+const BOOLEANISH_STRING_ATTRIBUTES = new Set([
+  'autoReverse',
+  'contenteditable',
+  'draggable',
+  'externalResourcesRequired',
+  'focusable',
+  'preserveAlpha',
+  'spellcheck',
+  'value',
 ])
 
 export const FRAMEWORK_PROPS = new Set(['children', 'mix', 'key', 'animate', 'innerHTML', 'on'])
@@ -66,6 +83,10 @@ export function normalizeAttributeName(
   }
 
   return normalizeSvgAttribute(name)
+}
+
+export function isBooleanishStringAttribute(name: string): boolean {
+  return BOOLEANISH_STRING_ATTRIBUTES.has(name)
 }
 
 export function serializeStyleObject(style: Record<string, unknown>): string {

--- a/packages/ui/src/runtime/core/attributes.ts
+++ b/packages/ui/src/runtime/core/attributes.ts
@@ -3,9 +3,6 @@ import { normalizeSvgAttribute } from '../svg-attributes.ts'
 import type { ElementProps } from '../jsx.ts'
 
 const ATTRIBUTE_FALLBACK_NAMES = new Set([
-  'contentEditable',
-  'contenteditable',
-  'draggable',
   'width',
   'height',
   'href',
@@ -17,8 +14,6 @@ const ATTRIBUTE_FALLBACK_NAMES = new Set([
   'colSpan',
   'role',
   'popover',
-  'spellCheck',
-  'spellcheck',
   'translate',
 ])
 
@@ -30,7 +25,6 @@ const BOOLEANISH_STRING_ATTRIBUTES = new Set([
   'focusable',
   'preserveAlpha',
   'spellcheck',
-  'value',
 ])
 
 export const FRAMEWORK_PROPS = new Set(['children', 'mix', 'key', 'animate', 'innerHTML', 'on'])
@@ -60,9 +54,11 @@ export function canUseProperty(
   element: Element,
   name: string,
   isSvg: boolean,
+  attr: string,
 ): element is Element & Record<string, unknown> {
   if (isSvg) return false
   if (ATTRIBUTE_FALLBACK_NAMES.has(name)) return false
+  if (isBooleanishStringAttribute(attr)) return false
   return name in element
 }
 
@@ -87,6 +83,10 @@ export function normalizeAttributeName(
 
 export function isBooleanishStringAttribute(name: string): boolean {
   return BOOLEANISH_STRING_ATTRIBUTES.has(name)
+}
+
+export function shouldStringifyBooleanAttribute(name: string): boolean {
+  return isBooleanishStringAttribute(name) || name === 'value'
 }
 
 export function serializeStyleObject(style: Record<string, unknown>): string {

--- a/packages/ui/src/runtime/core/props.ts
+++ b/packages/ui/src/runtime/core/props.ts
@@ -69,11 +69,11 @@ export function patchHostProps(curr: ElementProps, next: ElementProps, dom: Elem
     if (name === 'class' || name === 'className') continue
     if (name in next && next[name] != null) continue
 
-    if (canUseProperty(dom, name, isSvg)) {
+    let { ns, attr } = normalizeAttributeName(name, isSvg)
+    if (canUseProperty(dom, name, isSvg, attr)) {
       clearRuntimePropertyOnRemoval(dom, name)
     }
 
-    let { ns, attr } = normalizeAttributeName(name, isSvg)
     if (ns) dom.removeAttributeNS(ns, toLocalName(attr))
     else dom.removeAttribute(attr)
   }
@@ -115,7 +115,7 @@ function patchHostProp(dom: Element, name: string, value: unknown, isSvg: boolea
     return
   }
 
-  if (canUseProperty(dom, name, isSvg)) {
+  if (canUseProperty(dom, name, isSvg, attr)) {
     try {
       dom[name] = value == null ? '' : value
       return

--- a/packages/ui/src/runtime/core/props.ts
+++ b/packages/ui/src/runtime/core/props.ts
@@ -2,6 +2,7 @@ import type { ElementProps } from '../jsx.ts'
 import {
   canUseProperty,
   getMergedClassName,
+  isBooleanishStringAttribute,
   normalizeAttributeName,
   serializeStyleObject,
   toKebabCase,
@@ -124,7 +125,8 @@ function patchHostProp(dom: Element, name: string, value: unknown, isSvg: boolea
   if (typeof value === 'function') return
 
   let isAriaOrData = name.startsWith('aria-') || name.startsWith('data-')
-  if (value != null && (value !== false || isAriaOrData)) {
+  let isBooleanishString = isBooleanishStringAttribute(attr)
+  if (value != null && (value !== false || isAriaOrData || isBooleanishString)) {
     let attrValue = name === 'popover' && value === true ? '' : String(value)
     if (ns) dom.setAttributeNS(ns, attr, attrValue)
     else dom.setAttribute(attr, attrValue)

--- a/packages/ui/src/runtime/dom.ts
+++ b/packages/ui/src/runtime/dom.ts
@@ -9,6 +9,7 @@ import type { MixInput } from './mixins/mixin.ts'
  * - Copyright (c) 2015-present Jason Miller
  */
 type Booleanish = boolean | 'true' | 'false'
+type TranslateValue = 'yes' | 'no'
 
 /**
  * Layout animation configuration for FLIP-based position animations.
@@ -109,6 +110,8 @@ export interface SVGProps<eventTarget extends EventTarget = SVGElement>
   attributeName?: Trackable<string | undefined>
   /** The `attributeType` SVG attribute. */
   attributeType?: Trackable<string | undefined>
+  /** The `autoReverse` SVG attribute. */
+  autoReverse?: Trackable<Booleanish | undefined>
   /** The `azimuth` SVG attribute. */
   azimuth?: Trackable<number | string | undefined>
   /** The `baseFrequency` SVG attribute. */
@@ -212,7 +215,7 @@ export interface SVGProps<eventTarget extends EventTarget = SVGElement>
   /** The `exponent` SVG attribute. */
   exponent?: Trackable<number | string | undefined>
   /** The `externalResourcesRequired` SVG attribute. */
-  externalResourcesRequired?: Trackable<number | string | undefined>
+  externalResourcesRequired?: Trackable<Booleanish | undefined>
   /** The `fill` SVG attribute. */
   fill?: Trackable<string | undefined>
   /** The `fillOpacity` SVG attribute. */
@@ -238,7 +241,7 @@ export interface SVGProps<eventTarget extends EventTarget = SVGElement>
   /** The `flood-opacity` SVG attribute. */
   'flood-opacity'?: Trackable<number | string | undefined>
   /** The `focusable` SVG attribute. */
-  focusable?: Trackable<number | string | undefined>
+  focusable?: Trackable<Booleanish | undefined>
   /** The `fontFamily` SVG attribute. */
   fontFamily?: Trackable<string | undefined>
   /** The `font-family` SVG attribute. */
@@ -446,7 +449,7 @@ export interface SVGProps<eventTarget extends EventTarget = SVGElement>
   /** The `pointsAtZ` SVG attribute. */
   pointsAtZ?: Trackable<number | string | undefined>
   /** The `preserveAlpha` SVG attribute. */
-  preserveAlpha?: Trackable<number | string | undefined>
+  preserveAlpha?: Trackable<Booleanish | undefined>
   /** The `preserveAspectRatio` SVG attribute. */
   preserveAspectRatio?: Trackable<string | undefined>
   /** The `primitiveUnits` SVG attribute. */
@@ -1263,7 +1266,7 @@ export interface AllHTMLProps<eventTarget extends EventTarget = EventTarget>
   /** The `decoding` HTML attribute. */
   decoding?: Trackable<'sync' | 'async' | 'auto' | undefined>
   /** The `draggable` HTML attribute. */
-  draggable?: Trackable<boolean | undefined>
+  draggable?: Trackable<Booleanish | undefined>
   /** The `encType` HTML attribute. */
   encType?: Trackable<string | undefined>
   /** The `enctype` HTML attribute. */
@@ -1487,7 +1490,9 @@ export interface AllHTMLProps<eventTarget extends EventTarget = EventTarget>
   /** The `span` HTML attribute. */
   span?: Trackable<number | undefined>
   /** The `spellcheck` HTML attribute. */
-  spellcheck?: Trackable<boolean | undefined>
+  spellcheck?: Trackable<Booleanish | undefined>
+  /** The `spellCheck` HTML attribute. */
+  spellCheck?: Trackable<Booleanish | undefined>
   /** The `src` HTML attribute. */
   src?: Trackable<string | undefined>
   /** The `srcDoc` HTML attribute. */
@@ -1551,7 +1556,7 @@ export interface AllHTMLProps<eventTarget extends EventTarget = EventTarget>
   /** The `results` HTML attribute. */
   results?: Trackable<number | undefined>
   /** The `translate` HTML attribute. */
-  translate?: Trackable<boolean | undefined>
+  translate?: Trackable<TranslateValue | undefined>
 
   // RDFa Attributes
   /** The `about` HTML attribute. */
@@ -1632,7 +1637,7 @@ export interface HTMLProps<eventTarget extends EventTarget = EventTarget>
   /** The `dir` HTML attribute. */
   dir?: Trackable<'auto' | 'rtl' | 'ltr' | undefined>
   /** The `draggable` HTML attribute. */
-  draggable?: Trackable<boolean | undefined>
+  draggable?: Trackable<Booleanish | undefined>
   /** The `enterkeyhint` HTML attribute. */
   enterkeyhint?: Trackable<
     'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined
@@ -1662,7 +1667,9 @@ export interface HTMLProps<eventTarget extends EventTarget = EventTarget>
   /** The `slot` HTML attribute. */
   slot?: Trackable<string | undefined>
   /** The `spellcheck` HTML attribute. */
-  spellcheck?: Trackable<boolean | undefined>
+  spellcheck?: Trackable<Booleanish | undefined>
+  /** The `spellCheck` HTML attribute. */
+  spellCheck?: Trackable<Booleanish | undefined>
   /** The `style` HTML attribute. */
   style?: Trackable<string | StyleProps | undefined>
   /** The `tabindex` HTML attribute. */
@@ -1672,7 +1679,7 @@ export interface HTMLProps<eventTarget extends EventTarget = EventTarget>
   /** The `title` HTML attribute. */
   title?: Trackable<string | undefined>
   /** The `translate` HTML attribute. */
-  translate?: Trackable<boolean | undefined>
+  translate?: Trackable<TranslateValue | undefined>
 
   // WAI-ARIA Attributes
   // Most elements only allow a subset of roles and so this

--- a/packages/ui/src/runtime/svg-attributes.ts
+++ b/packages/ui/src/runtime/svg-attributes.ts
@@ -5,6 +5,7 @@ const CANONICAL_CAMEL_SVG_ATTRS = new Set([
   'accentHeight',
   'attributeName',
   'attributeType',
+  'autoReverse',
   'baseFrequency',
   'baseProfile',
   'calcMode',

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -5,6 +5,7 @@ import { isEntry, type EntryComponent } from '../runtime/client-entries.ts'
 import {
   FRAMEWORK_PROPS as RUNTIME_FRAMEWORK_PROPS,
   SELF_CLOSING_TAGS,
+  isBooleanishStringAttribute,
   normalizeAttributeName,
   serializeStyleObject,
 } from '../runtime/core/attributes.ts'
@@ -529,11 +530,13 @@ function renderAttributes(props: any, isSvg: boolean, excludedProps?: Set<string
     if (excludedProps?.has(key)) continue
 
     let value = props[key]
-    if (value === undefined || value === null || value === false) continue
-
     let attrName = transformAttributeName(key, isSvg)
+    let isBooleanishString = isBooleanishStringAttribute(attrName)
+    if (value === undefined || value === null || (value === false && !isBooleanishString)) {
+      continue
+    }
 
-    if (value === true) {
+    if (value === true && !isBooleanishString) {
       attrs += ` ${attrName}`
     } else {
       attrs += ` ${attrName}="${escapeHtml(String(value))}"`

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -5,9 +5,9 @@ import { isEntry, type EntryComponent } from '../runtime/client-entries.ts'
 import {
   FRAMEWORK_PROPS as RUNTIME_FRAMEWORK_PROPS,
   SELF_CLOSING_TAGS,
-  isBooleanishStringAttribute,
   normalizeAttributeName,
   serializeStyleObject,
+  shouldStringifyBooleanAttribute,
 } from '../runtime/core/attributes.ts'
 import { appendFlushMarker, type FlushKind, stripFlushMarkers } from '../runtime/stream-protocol.ts'
 import { REMIX_UI_STYLE_LAYER } from '../style/layers.ts'
@@ -531,12 +531,14 @@ function renderAttributes(props: any, isSvg: boolean, excludedProps?: Set<string
 
     let value = props[key]
     let attrName = transformAttributeName(key, isSvg)
-    let isBooleanishString = isBooleanishStringAttribute(attrName)
-    if (value === undefined || value === null || (value === false && !isBooleanishString)) {
+    let shouldStringifyBoolean = shouldStringifyBooleanAttribute(attrName)
+    if (value === undefined || value === null || (value === false && !shouldStringifyBoolean)) {
       continue
     }
 
-    if (value === true && !isBooleanishString) {
+    if (typeof value === 'boolean' && shouldStringifyBoolean) {
+      attrs += ` ${attrName}="${escapeHtml(String(value))}"`
+    } else if (value === true) {
       attrs += ` ${attrName}`
     } else {
       attrs += ` ${attrName}="${escapeHtml(String(value))}"`

--- a/packages/ui/src/test/jsx.test.tsx
+++ b/packages/ui/src/test/jsx.test.tsx
@@ -67,6 +67,24 @@ describe('jsx', () => {
       // @ts-expect-error textarea content should come from value/defaultValue
       let alsoBad = <textarea innerHTML="Hello" />
     })
+
+    it('accepts booleanish string attributes', () => {
+      let contentEditable = <div contentEditable="false" />
+      let draggable = <img alt="" draggable="false" />
+      let spellCheck = <div spellCheck="false" />
+      let spellcheck = <div spellcheck="false" />
+      let svg = (
+        <svg>
+          <animate autoReverse="false" />
+          <rect externalResourcesRequired="false" focusable="false" />
+          <feColorMatrix preserveAlpha="false" />
+        </svg>
+      )
+      let translate = <div translate="no" />
+
+      // @ts-expect-error translate uses yes/no attribute values, not true/false strings
+      let badTranslate = <div translate="false" />
+    })
   })
 
   describe('library managed attributes', () => {

--- a/packages/ui/src/test/stream.test.tsx
+++ b/packages/ui/src/test/stream.test.tsx
@@ -398,6 +398,24 @@ describe('stream', () => {
       )
     })
 
+    it('renders booleanish string attributes as explicit false values', async () => {
+      let stream = renderToStream(
+        <div contentEditable={false} draggable={false} spellCheck={false}>
+          {createElement('input', { value: false })}
+        </div>,
+      )
+      let html = await drain(stream)
+      expect(html).toBe(
+        '<div contenteditable="false" draggable="false" spellcheck="false"><input value="false" /></div>',
+      )
+    })
+
+    it('renders translate with yes/no attribute values', async () => {
+      let stream = renderToStream(<div translate="no" />)
+      let html = await drain(stream)
+      expect(html).toBe('<div translate="no"></div>')
+    })
+
     it('renders input defaultValue as a value attribute', async () => {
       let stream = renderToStream(<input defaultValue={'Hello "Ryan" & friends'} />)
       let html = await drain(stream)
@@ -713,6 +731,21 @@ describe('stream', () => {
       expect(html).not.toContain('gradient-units=')
       expect(html).toContain('stdDeviation="2.5"')
       expect(html).not.toContain('std-deviation=')
+    })
+
+    it('renders SVG booleanish string attributes as explicit values', async () => {
+      let stream = renderToStream(
+        <svg>
+          <animate autoReverse={false} />
+          <rect externalResourcesRequired={false} focusable={false} />
+          <feColorMatrix preserveAlpha={false} />
+        </svg>,
+      )
+      let html = await drain(stream)
+      expect(html).toContain('autoReverse="false"')
+      expect(html).toContain('externalResourcesRequired="false"')
+      expect(html).toContain('focusable="false"')
+      expect(html).toContain('preserveAlpha="false"')
     })
   })
 

--- a/packages/ui/src/test/vdom.props.test.tsx
+++ b/packages/ui/src/test/vdom.props.test.tsx
@@ -35,6 +35,45 @@ describe('vnode rendering', () => {
     it.todo('does not render acceptCharset')
   })
 
+  describe('enumerated attributes', () => {
+    it('sets booleanish string attributes as explicit false values', () => {
+      let container = document.createElement('div')
+      let root = createRoot(container)
+
+      root.render(<img alt="" contentEditable={false} draggable={false} spellCheck={false} />)
+
+      let img = container.querySelector('img')
+      invariant(img instanceof HTMLImageElement)
+      expect(img.getAttribute('contenteditable')).toBe('false')
+      expect(img.getAttribute('draggable')).toBe('false')
+      expect(img.getAttribute('spellcheck')).toBe('false')
+    })
+
+    it('sets translate with yes/no attribute values', () => {
+      let container = document.createElement('div')
+      let root = createRoot(container)
+
+      root.render(<div translate="no" />)
+
+      let div = container.querySelector('div')
+      invariant(div instanceof HTMLDivElement)
+      expect(div.getAttribute('translate')).toBe('no')
+    })
+
+    it('preserves string false values for booleanish string attributes', () => {
+      let container = document.createElement('div')
+      let root = createRoot(container)
+
+      root.render(<img alt="" contentEditable="false" draggable="false" spellcheck="false" />)
+
+      let img = container.querySelector('img')
+      invariant(img instanceof HTMLImageElement)
+      expect(img.getAttribute('contenteditable')).toBe('false')
+      expect(img.getAttribute('draggable')).toBe('false')
+      expect(img.getAttribute('spellcheck')).toBe('false')
+    })
+  })
+
   describe('innerHTML prop', () => {
     it('sets innerHTML on element', () => {
       let container = document.createElement('div')

--- a/packages/ui/src/test/vdom.svg.test.tsx
+++ b/packages/ui/src/test/vdom.svg.test.tsx
@@ -207,6 +207,32 @@ describe('vnode rendering', () => {
       expect(clipPath.clipPathUnits.baseVal).toBe(2)
     })
 
+    it('sets SVG booleanish string attributes as explicit values', () => {
+      let container = document.createElement('div')
+      let root = createRoot(container)
+
+      root.render(
+        <svg>
+          <animate id="a" autoReverse={false} />
+          <rect id="r" externalResourcesRequired={false} focusable={false} />
+          <feColorMatrix id="m" preserveAlpha={false} />
+        </svg>,
+      )
+
+      let animate = container.querySelector('#a')
+      invariant(animate instanceof SVGElement)
+      expect(animate.getAttribute('autoReverse')).toBe('false')
+
+      let rect = container.querySelector('#r')
+      invariant(rect instanceof SVGElement)
+      expect(rect.getAttribute('externalResourcesRequired')).toBe('false')
+      expect(rect.getAttribute('focusable')).toBe('false')
+
+      let matrix = container.querySelector('#m')
+      invariant(matrix instanceof SVGElement)
+      expect(matrix.getAttribute('preserveAlpha')).toBe('false')
+    })
+
     it('attaches events on SVG elements', () => {
       let container = document.createElement('div')
       let root = createRoot(container)


### PR DESCRIPTION
This fixes a mismatch between Remix UI JSX types and runtime rendering for booleanish string attributes. These attributes accept boolean values in JSX, but `false` still needs to render as an explicit string attribute value instead of being omitted.

- Render `contentEditable={false}`, `draggable={false}`, `spellCheck={false}`, and matching SVG booleanish attributes as explicit `"false"` values in both DOM rendering and SSR.
- Add JSX type coverage for booleanish string attributes, including `spellCheck` and SVG attributes like `autoReverse`, `externalResourcesRequired`, `focusable`, and `preserveAlpha`.
- Tighten `translate` to its HTML attribute values, `"yes"` and `"no"`, instead of treating it like a boolean attribute.

This means code like this no longer needs to use a string value or suppress TypeScript just to get the right output:

```tsx
// Before
<img
  alt=""
  // @ts-expect-error boolean did not match the Remix JSX type
  draggable="false"
  src={ticketImage}
/>
```

```tsx
// After
<img alt="" draggable={false} src={ticketImage} />
```

It also fixes server output for false values that must be present as attribute strings:

```tsx
renderToString(
  <div contentEditable={false} draggable={false} spellCheck={false} />,
)
```

```html
<div contenteditable="false" draggable="false" spellcheck="false"></div>
```

SVG booleanish attributes follow the same rendering behavior:

```tsx
<svg>
  <animate autoReverse={false} />
  <rect externalResourcesRequired={false} focusable={false} />
  <feColorMatrix preserveAlpha={false} />
</svg>
```

And `translate` is now modeled as the explicit HTML attribute value:

```tsx
<div translate="no" />
```
