### PR TITLE
fix cli tests so that they pass when run from a tty

### DIFF
--- a/packages/cli/src/lib/commands/test.test.ts
+++ b/packages/cli/src/lib/commands/test.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import { stripVTControlCharacters } from 'node:util'
 import { fileURLToPath } from 'node:url'
 import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
@@ -39,10 +40,12 @@ describe('test command', () => {
         }),
       )
 
+      let stdout = stripVTControlCharacters(result.stdout)
+
       assert.equal(result.exitCode, 0, result.stderr)
-      assert.match(result.stdout, /Found 1 test file\(s\) \(1 server, 0 browser, 0 e2e\)/)
-      assert.match(result.stdout, /✓ passes/)
-      assert.match(result.stdout, /ℹ pass 1/)
+      assert.match(stdout, /Found 1 test file\(s\) \(1 server, 0 browser, 0 e2e\)/)
+      assert.match(stdout, /✓ passes/)
+      assert.match(stdout, /ℹ pass 1/)
       assert.equal(result.stderr, '')
     } finally {
       await fs.rm(projectDir, { recursive: true, force: true })
@@ -61,8 +64,10 @@ describe('test command', () => {
         }),
       )
 
+      let stdout = stripVTControlCharacters(result.stdout)
+
       assert.equal(result.exitCode, 0, result.stderr)
-      assert.match(result.stdout, /✓ passes/)
+      assert.match(stdout, /✓ passes/)
     } finally {
       await fs.rm(projectDir, { recursive: true, force: true })
     }

--- a/packages/cli/test/capture-output.ts
+++ b/packages/cli/test/capture-output.ts
@@ -2,11 +2,24 @@ import * as process from 'node:process'
 
 export async function captureOutput(
   callback: () => Promise<number>,
+  { stderrTTY = false, stdoutTTY = false } = {},
 ): Promise<{ exitCode: number; stderr: string; stdout: string }> {
   let stderr = ''
   let stdout = ''
   let originalStdoutWrite = process.stdout.write
   let originalStderrWrite = process.stderr.write
+  let originalStdoutTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  let originalStderrTTY = Object.getOwnPropertyDescriptor(process.stderr, 'isTTY')
+
+  Object.defineProperty(process.stdout, 'isTTY', {
+    configurable: true,
+    value: stdoutTTY,
+  })
+
+  Object.defineProperty(process.stderr, 'isTTY', {
+    configurable: true,
+    value: stderrTTY,
+  })
 
   process.stdout.write = ((chunk: string | Uint8Array) => {
     stdout += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8')
@@ -24,5 +37,16 @@ export async function captureOutput(
   } finally {
     process.stdout.write = originalStdoutWrite
     process.stderr.write = originalStderrWrite
+    restoreTTY(process.stdout, originalStdoutTTY)
+    restoreTTY(process.stderr, originalStderrTTY)
   }
+}
+
+function restoreTTY(stream: NodeJS.WriteStream, descriptor: PropertyDescriptor | undefined): void {
+  if (descriptor == null) {
+    delete (stream as { isTTY?: boolean }).isTTY
+    return
+  }
+
+  Object.defineProperty(stream, 'isTTY', descriptor)
 }


### PR DESCRIPTION
Tests in `packages/cli` were failing when run locally in a TTY, preventing agents from getting a feedback loop when working on CLI features/tests.

Instead of assuming "no TTY", tests now default to "no TTY" but allow overrides by the caller when testing TTY-specific behavior.