### PR TITLE
Fix pnpm package import resolution in assets

### DIFF
--- a/packages/assets/.changes/patch.resolve-pnpm-package-dependencies.md
+++ b/packages/assets/.changes/patch.resolve-pnpm-package-dependencies.md
@@ -1,0 +1,1 @@
+Resolve bare imports from symlinked packages using the package's real filesystem path so pnpm virtual-store dependencies can be served through the asset server.

--- a/packages/assets/src/lib/asset-server.test.ts
+++ b/packages/assets/src/lib/asset-server.test.ts
@@ -54,6 +54,41 @@ async function symlinkDirectory(target: string, link: string): Promise<void> {
   await fs.symlink(target, link, process.platform === 'win32' ? 'junction' : 'dir')
 }
 
+async function writePnpmSymlinkedPackageFixture(dir: string): Promise<void> {
+  await writeJson(dir, 'app/node_modules/.pnpm/remix@1.0.0/node_modules/remix/package.json', {
+    name: 'remix',
+    type: 'module',
+    exports: {
+      './ui': './dist/ui.js',
+    },
+  })
+  await write(
+    dir,
+    'app/node_modules/.pnpm/remix@1.0.0/node_modules/remix/dist/ui.js',
+    'export * from "@remix-run/ui"',
+  )
+  await writeJson(
+    dir,
+    'app/node_modules/.pnpm/remix@1.0.0/node_modules/@remix-run/ui/package.json',
+    {
+      name: '@remix-run/ui',
+      type: 'module',
+      exports: {
+        '.': './dist/index.js',
+      },
+    },
+  )
+  await write(
+    dir,
+    'app/node_modules/.pnpm/remix@1.0.0/node_modules/@remix-run/ui/dist/index.js',
+    'export const ui = true',
+  )
+  await symlinkDirectory(
+    path.join(dir, 'app/node_modules/.pnpm/remix@1.0.0/node_modules/remix'),
+    path.join(dir, 'app/node_modules/remix'),
+  )
+}
+
 function getLineAndColumn(source: string, search: string): { line: number; column: number } {
   let index = source.indexOf(search)
   assert.notEqual(index, -1, `Expected to find "${search}" in:\n${source}`)
@@ -2552,6 +2587,54 @@ describe('asset-server', () => {
         assert.ok(servedUrls.has('/assets/node_modules/remix/src/ui.ts'))
         assert.ok(servedUrls.has('/assets/node_modules/remix/src/shared.ts'))
         assert.equal(servedUrls.has('/assets/packages/remix/src/ui.ts'), false)
+      } finally {
+        await assetServer.close()
+      }
+    } finally {
+      await fs.rm(caseDir, { recursive: true, force: true })
+    }
+  })
+
+  it('resolves bare package dependencies from pnpm package realpaths', async () => {
+    let caseDir = await makeTmpDir()
+    try {
+      await writePnpmSymlinkedPackageFixture(caseDir)
+
+      let assetServer = createNodeModulesTestServer(caseDir)
+      try {
+        let response = await get(assetServer, '/assets/node_modules/remix/dist/ui.js')
+        assert.ok(response)
+        assert.equal(response.status, 200)
+        let body = await response.text()
+
+        assert.match(
+          body,
+          /\/assets\/node_modules\/\.pnpm\/remix@1\.0\.0\/node_modules\/@remix-run\/ui\/dist\/index\.js/,
+        )
+      } finally {
+        await assetServer.close()
+      }
+    } finally {
+      await fs.rm(caseDir, { recursive: true, force: true })
+    }
+  })
+
+  it('serves app imports through pnpm symlinked package dependencies', async () => {
+    let caseDir = await makeTmpDir()
+    try {
+      await writePnpmSymlinkedPackageFixture(caseDir)
+      await write(caseDir, 'app/entry.ts', 'import { ui } from "remix/ui"\nexport { ui }')
+
+      let assetServer = createNodeModulesTestServer(caseDir)
+      try {
+        let servedUrls = await assertRecursivelyServedImports(assetServer, ['/assets/app/entry.ts'])
+
+        assert.ok(servedUrls.has('/assets/node_modules/remix/dist/ui.js'))
+        assert.ok(
+          servedUrls.has(
+            '/assets/node_modules/.pnpm/remix@1.0.0/node_modules/@remix-run/ui/dist/index.js',
+          ),
+        )
       } finally {
         await assetServer.close()
       }

--- a/packages/assets/src/lib/asset-server.test.ts
+++ b/packages/assets/src/lib/asset-server.test.ts
@@ -2595,31 +2595,7 @@ describe('asset-server', () => {
     }
   })
 
-  it('resolves bare package dependencies from pnpm package realpaths', async () => {
-    let caseDir = await makeTmpDir()
-    try {
-      await writePnpmSymlinkedPackageFixture(caseDir)
-
-      let assetServer = createNodeModulesTestServer(caseDir)
-      try {
-        let response = await get(assetServer, '/assets/node_modules/remix/dist/ui.js')
-        assert.ok(response)
-        assert.equal(response.status, 200)
-        let body = await response.text()
-
-        assert.match(
-          body,
-          /\/assets\/node_modules\/\.pnpm\/remix@1\.0\.0\/node_modules\/@remix-run\/ui\/dist\/index\.js/,
-        )
-      } finally {
-        await assetServer.close()
-      }
-    } finally {
-      await fs.rm(caseDir, { recursive: true, force: true })
-    }
-  })
-
-  it('serves app imports through pnpm symlinked package dependencies', async () => {
+  it('serves pnpm symlinked package dependencies from package realpaths', async () => {
     let caseDir = await makeTmpDir()
     try {
       await writePnpmSymlinkedPackageFixture(caseDir)

--- a/packages/assets/src/lib/scripts/compiler.ts
+++ b/packages/assets/src/lib/scripts/compiler.ts
@@ -34,6 +34,7 @@ import { createTsconfigTransformOptionsResolver, transformModule } from './trans
 import type { ResolveModuleResult, TransformArgs, TransformedModule } from './transform.ts'
 import { ResolverFactory } from 'oxc-resolver'
 import type { EmittedAsset, EmittedModule } from './emit.ts'
+import { isBareImportSpecifier } from './specifiers.ts'
 
 type ScriptRecord = ModuleRecord<TransformedModule, ResolvedModule, EmittedModule>
 type ScriptStore = ModuleStore<TransformedModule, ResolvedModule, EmittedModule>
@@ -613,18 +614,6 @@ function resolveActualPath(identityPath: string): string | null {
     if (isNoEntityError(error)) return null
     throw error
   }
-}
-
-function isBareImportSpecifier(specifier: string): boolean {
-  return (
-    !specifier.startsWith('./') &&
-    !specifier.startsWith('../') &&
-    !specifier.startsWith('/') &&
-    !specifier.startsWith('file:') &&
-    !specifier.startsWith('data:') &&
-    !specifier.startsWith('http://') &&
-    !specifier.startsWith('https://')
-  )
 }
 
 function isNoEntityError(

--- a/packages/assets/src/lib/scripts/resolve.ts
+++ b/packages/assets/src/lib/scripts/resolve.ts
@@ -91,6 +91,11 @@ type NormalizedSpecifierResolution = {
   specifier: string
 }
 
+type SpecifierResolutionImporter = {
+  identityPath: string
+  resolvedPath: string
+}
+
 export async function resolveModule(
   record: ScriptRecord,
   transformed: TransformedModule,
@@ -105,7 +110,10 @@ export async function resolveModule(
       transformed.unresolvedImports.length > 0
         ? await batchResolveSpecifiers(
             getUniqueSpecifiers(transformed.unresolvedImports),
-            transformed.identityPath,
+            {
+              identityPath: transformed.identityPath,
+              resolvedPath: transformed.resolvedPath,
+            },
             args.resolverFactory,
           )
         : new Map<string, ResolvedSpec>()
@@ -358,7 +366,7 @@ function resolveCandidateBasePath(importerDir: string, specifier: string): strin
 
 async function batchResolveSpecifiers(
   specifiers: string[],
-  importerPath: string,
+  importer: SpecifierResolutionImporter,
   resolverFactory: ResolveArgs['resolverFactory'],
 ): Promise<Map<string, ResolvedSpec>> {
   let resolvedBySpecifier = new Map<string, ResolvedSpec>()
@@ -366,7 +374,7 @@ async function batchResolveSpecifiers(
 
   try {
     for (let specifier of specifiers) {
-      let normalizedResolution = normalizeSpecifierResolution(specifier, importerPath)
+      let normalizedResolution = normalizeSpecifierResolution(specifier, importer)
       let resolutionResult = await resolverFactory.resolveFileAsync(
         normalizedResolution.importerPath,
         normalizedResolution.specifier,
@@ -400,7 +408,7 @@ async function batchResolveSpecifiers(
     }
 
     throw createAssetServerCompilationError(
-      `Failed to resolve imports in ${importerPath}. ${formatUnknownError(error)}`,
+      `Failed to resolve imports in ${importer.identityPath}. ${formatUnknownError(error)}`,
       {
         cause: error,
         code: 'IMPORT_RESOLUTION_FAILED',
@@ -421,12 +429,12 @@ function formatUnknownError(error: unknown): string {
 
 function normalizeSpecifierResolution(
   specifier: string,
-  importerPath: string,
+  importer: SpecifierResolutionImporter,
 ): NormalizedSpecifierResolution {
   let authoredInjectedPackageSpecifier = restoreAuthoredInjectedPackageSpecifier(specifier)
   if (authoredInjectedPackageSpecifier) {
     return {
-      importerPath,
+      importerPath: getSpecifierImporterPath(authoredInjectedPackageSpecifier, importer),
       specifier: authoredInjectedPackageSpecifier,
     }
   }
@@ -439,9 +447,28 @@ function normalizeSpecifierResolution(
   }
 
   return {
-    importerPath,
+    importerPath: getSpecifierImporterPath(specifier, importer),
     specifier,
   }
+}
+
+function getSpecifierImporterPath(
+  specifier: string,
+  importer: SpecifierResolutionImporter,
+): string {
+  return isBareImportSpecifier(specifier) ? importer.resolvedPath : importer.identityPath
+}
+
+function isBareImportSpecifier(specifier: string): boolean {
+  return (
+    !specifier.startsWith('./') &&
+    !specifier.startsWith('../') &&
+    !specifier.startsWith('/') &&
+    !specifier.startsWith('file:') &&
+    !specifier.startsWith('data:') &&
+    !specifier.startsWith('http://') &&
+    !specifier.startsWith('https://')
+  )
 }
 
 function getDisplayImportSpecifier(specifier: string): string {

--- a/packages/assets/src/lib/scripts/resolve.ts
+++ b/packages/assets/src/lib/scripts/resolve.ts
@@ -17,6 +17,7 @@ import { normalizeFilePath } from '../paths.ts'
 import type { CompiledRoutes } from '../routes.ts'
 import type { ResolveModuleResult, TransformedModule } from './transform.ts'
 import type { EmittedModule } from './emit.ts'
+import { isBareImportSpecifier } from './specifiers.ts'
 
 type ScriptRecord = ModuleRecord<TransformedModule, ResolvedModule, EmittedModule>
 
@@ -457,18 +458,6 @@ function getSpecifierImporterPath(
   importer: SpecifierResolutionImporter,
 ): string {
   return isBareImportSpecifier(specifier) ? importer.resolvedPath : importer.identityPath
-}
-
-function isBareImportSpecifier(specifier: string): boolean {
-  return (
-    !specifier.startsWith('./') &&
-    !specifier.startsWith('../') &&
-    !specifier.startsWith('/') &&
-    !specifier.startsWith('file:') &&
-    !specifier.startsWith('data:') &&
-    !specifier.startsWith('http://') &&
-    !specifier.startsWith('https://')
-  )
 }
 
 function getDisplayImportSpecifier(specifier: string): string {

--- a/packages/assets/src/lib/scripts/specifiers.ts
+++ b/packages/assets/src/lib/scripts/specifiers.ts
@@ -1,0 +1,11 @@
+export function isBareImportSpecifier(specifier: string): boolean {
+  return (
+    !specifier.startsWith('./') &&
+    !specifier.startsWith('../') &&
+    !specifier.startsWith('/') &&
+    !specifier.startsWith('file:') &&
+    !specifier.startsWith('data:') &&
+    !specifier.startsWith('http://') &&
+    !specifier.startsWith('https://')
+  )
+}

--- a/packages/assets/src/lib/scripts/transform.ts
+++ b/packages/assets/src/lib/scripts/transform.ts
@@ -30,6 +30,7 @@ import { composeSourceMaps, rewriteSourceMapSources, stringifySourceMap } from '
 import type { EmittedModule } from './emit.ts'
 import type { ResolvedScriptTarget } from '../target.ts'
 import type { ResolvedModule } from './resolve.ts'
+import { isBareImportSpecifier } from './specifiers.ts'
 
 type ScriptRecord = ModuleRecord<TransformedModule, ResolvedModule, EmittedModule>
 
@@ -263,7 +264,7 @@ export async function transformModule(
         identityPath: record.identityPath,
         importerDir: path.dirname(record.identityPath),
         packageSpecifiers: analysis.unresolvedImports
-          .filter((unresolved) => isPackageImportSpecifier(unresolved.specifier))
+          .filter((unresolved) => isBareImportSpecifier(unresolved.specifier))
           .map((unresolved) => unresolved.specifier),
         rawCode: analysis.rawCode,
         resolvedPath,
@@ -297,10 +298,6 @@ function findNearestTsconfigPath(directory: string): string | null {
     if (parentDirectory === currentDirectory) return null
     currentDirectory = parentDirectory
   }
-}
-
-function isPackageImportSpecifier(specifier: string): boolean {
-  return !specifier.startsWith('./') && !specifier.startsWith('../') && !specifier.startsWith('/')
 }
 
 async function analyzeModuleSource(


### PR DESCRIPTION
pnpm can serve a package through a public node_modules symlink while storing that package's dependencies beside the package's real virtual-store path. When the asset server preserved the public symlink path as the resolver importer, bare imports inside served package facades could fail before fileMap validation had a chance to allow the real dependency path.

- Adds pnpm-style regression coverage for a served remix package facade that re-exports @remix-run/ui from a nested virtual-store dependency.
- Resolves bare package specifiers from the transformed module's real filesystem path so pnpm package dependencies are visible to the resolver.
- Keeps relative and URL-like specifiers resolving from the public identity path so existing symlink URL identity behavior is preserved.