### PR TITLE
Fix node-tsx built loadModule hook path

### DIFF
--- a/packages/node-tsx/.changes/patch.register-built-hooks.md
+++ b/packages/node-tsx/.changes/patch.register-built-hooks.md
@@ -1,0 +1,1 @@
+Fix `loadModule()` in built packages so it registers the emitted JavaScript hooks file instead of a missing TypeScript source file.

--- a/packages/node-tsx/src/index.test.ts
+++ b/packages/node-tsx/src/index.test.ts
@@ -5,10 +5,12 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import * as process from 'node:process'
 import { describe, it } from 'node:test'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
 const REMIX_PACKAGE_PATH = path.join(ROOT_DIR, 'packages', 'remix')
+const NODE_TSX_PACKAGE_PATH = path.join(ROOT_DIR, 'packages', 'node-tsx')
+let builtNodeTsxPackage = false
 
 describe('node-tsx', () => {
   it('runs ts entrypoints that import tsx modules through remix/node-tsx', async () => {
@@ -757,6 +759,45 @@ describe('node-tsx', () => {
     })
   })
 
+  it('loads ts entrypoints through the built load-module file', async () => {
+    await ensureBuiltNodeTsxPackage()
+
+    await withProject(async (projectPath) => {
+      await writeJsxRuntime(projectPath)
+      let loadModuleURL = pathToFileURL(path.join(NODE_TSX_PACKAGE_PATH, 'dist', 'load-module.js'))
+      await writeProjectFile(
+        projectPath,
+        'start.mjs',
+        [
+          `import { loadModule } from ${JSON.stringify(loadModuleURL.href)}`,
+          '',
+          "let { render } = await loadModule('./server.ts', import.meta.url)",
+          'console.log(JSON.stringify(render()))',
+          '',
+        ].join('\n'),
+      )
+      await writeProjectFile(
+        projectPath,
+        'server.ts',
+        ["import { render } from './view.tsx'", '', 'export { render }', ''].join('\n'),
+      )
+      await writeProjectFile(
+        projectPath,
+        'view.tsx',
+        ['export function render() {', '  return <div>Built</div>', '}', ''].join('\n'),
+      )
+
+      let result = await runNode(['./start.mjs'], projectPath)
+
+      assert.equal(result.exitCode, 0, result.stderr)
+      assert.equal(result.stderr, '')
+      assert.deepEqual(JSON.parse(result.stdout.trim()), {
+        props: { children: 'Built' },
+        type: 'div',
+      })
+    })
+  })
+
   it('loads TypeScript modules with transform-only syntax through remix/node-tsx/load-module', async () => {
     await withProject(async (projectPath) => {
       await linkRemixPackage(projectPath)
@@ -1265,7 +1306,15 @@ async function runNode(
   argv: string[],
   cwd: string,
 ): Promise<{ exitCode: number; stderr: string; stdout: string }> {
-  let child = spawn(process.execPath, argv, {
+  return await runProcess(process.execPath, argv, cwd)
+}
+
+async function runProcess(
+  command: string,
+  argv: string[],
+  cwd: string,
+): Promise<{ exitCode: number; stderr: string; stdout: string }> {
+  let child = spawn(command, argv, {
     cwd,
     stdio: ['ignore', 'pipe', 'pipe'],
   })
@@ -1323,6 +1372,26 @@ async function waitForClose(
 async function linkRemixPackage(projectDir: string): Promise<void> {
   await fs.mkdir(path.join(projectDir, 'node_modules'), { recursive: true })
   await fs.symlink(REMIX_PACKAGE_PATH, path.join(projectDir, 'node_modules', 'remix'))
+}
+
+async function ensureBuiltNodeTsxPackage(): Promise<void> {
+  if (builtNodeTsxPackage) {
+    return
+  }
+
+  let npmExecPath = process.env.npm_execpath
+  if (npmExecPath == null) {
+    throw new Error('Expected npm_execpath to be set while running package tests')
+  }
+
+  let result = await runProcess(
+    process.execPath,
+    [npmExecPath, '--filter', '@remix-run/node-tsx', 'run', 'build'],
+    ROOT_DIR,
+  )
+  assert.equal(result.exitCode, 0, result.stderr)
+  assert.equal(result.stderr, '')
+  builtNodeTsxPackage = true
 }
 
 async function writeJsxRuntime(projectDir: string): Promise<void> {

--- a/packages/node-tsx/src/lib/load-module.ts
+++ b/packages/node-tsx/src/lib/load-module.ts
@@ -10,14 +10,18 @@ export async function loadModule(specifier: string, parent: string | URL): Promi
   let parentURL = toParentURL(parent)
   let resolvedSpecifier = path.isAbsolute(specifier) ? pathToFileURL(specifier).href : specifier
 
-  process.setSourceMapsEnabled(true)
-  register(
-    new URL(`./register-hooks.ts?namespace=${encodeURIComponent(namespace)}`, import.meta.url),
-    {
-      data: { namespace },
-      parentURL: import.meta.url,
-    },
+  let loadModuleURL = new URL(import.meta.url)
+  let registerHooksURL = new URL(
+    loadModuleURL.pathname.endsWith('.ts') ? './register-hooks.ts' : './register-hooks.js',
+    loadModuleURL,
   )
+  registerHooksURL.searchParams.set('namespace', namespace)
+
+  process.setSourceMapsEnabled(true)
+  register(registerHooksURL, {
+    data: { namespace },
+    parentURL: import.meta.url,
+  })
 
   return import(createLoadModuleSpecifier(resolvedSpecifier, parentURL, namespace))
 }


### PR DESCRIPTION
This replaces #11437 with a narrower fix for the built `@remix-run/node-tsx/load-module` hook path.

The bug happened because the built `dist/lib/load-module.js` file still registered `./register-hooks.ts`, but the published build only contains `dist/lib/register-hooks.js`. This keeps source-mode execution pointed at the TypeScript hook while built output registers the emitted JavaScript hook.

- Select the hook file extension from `import.meta.url` instead of adding a source-mode shim file.
- Add a direct built-output smoke test that builds `@remix-run/node-tsx`, imports `dist/load-module.js`, and loads a TS/TSX graph.
- Add a patch change file for `@remix-run/node-tsx`.

Supersedes #11437.
