### PR TITLE
Make per-package changes directories optional

### DIFF
--- a/.agents/skills/add-package/SKILL.md
+++ b/.agents/skills/add-package/SKILL.md
@@ -22,7 +22,6 @@ Follow this exactly when creating package files, public exports, tests, and docs
   - `CHANGELOG.md`
   - `README.md`
   - `LICENSE`
-  - `.changes/README.md`
   - `src/`
 - For new packages, start `CHANGELOG.md` with `## Unreleased` as the first section to indicate changes are not released yet.
 
@@ -171,7 +170,7 @@ npm i remix <peer-dependency>
   - `pnpm --filter @remix-run/<package-name> run build`
 - Run repo lint (required):
   - `pnpm run lint`
-- Add or update a change file under `packages/<package-name>/.changes/` when requested by contribution workflow.
+- Create `packages/<package-name>/.changes/` on demand and add or update a change file when requested by contribution workflow.
 - For a brand-new package, the initial change file should use a `minor.` filename (for example, `minor.initial-release.md`) so the first release bumps `0.0.0` to `0.1.0`.
 
 ## Templates

--- a/.agents/skills/fix-issue/SKILL.md
+++ b/.agents/skills/fix-issue/SKILL.md
@@ -100,7 +100,7 @@ pnpm run typecheck
 
 ### 6. Create a Change File
 
-If the fix is user-facing, add a change file under `packages/<package>/.changes/`. Use the `make-change-file` skill at `.agents/skills/make-change-file/SKILL.md` — do not re-derive the naming, bump rules, or content rules here.
+If the fix is user-facing, create `packages/<package>/.changes/` on demand and add a change file there. Use the `make-change-file` skill at `.agents/skills/make-change-file/SKILL.md` — do not re-derive the naming, bump rules, or content rules here.
 
 For `0.x` packages, bug fixes are `patch`. For Remix export-only changes, update `packages/remix/.changes/minor.remix.update-exports.md` in place.
 

--- a/.agents/skills/make-change-file/SKILL.md
+++ b/.agents/skills/make-change-file/SKILL.md
@@ -11,16 +11,18 @@ Write release notes that match this repository's `.changes` conventions. Use it 
 
 ## Workflow
 
-1. Read the package's `package.json`, `.changes/` directory, and any relevant PR diff or commit range before writing anything.
+1. Read the package's `package.json`, existing `.changes/` directory if present, and any relevant PR diff or commit range before writing anything.
 2. Check whether an unpublished change file already exists for the same work. If it does, update it in place instead of creating a duplicate note.
 3. Choose the bump type from the package version and the user-facing impact.
-4. Write concise, user-facing release notes that describe shipped behavior, APIs, or exports.
-5. Run `pnpm changes:preview` to verify the rendered changelog output.
-6. Run `pnpm run lint` before finishing.
+4. Create `packages/<package>/.changes/` on demand if it does not already exist.
+5. Write concise, user-facing release notes that describe shipped behavior, APIs, or exports.
+6. Run `pnpm changes:preview` to verify the rendered changelog output.
+7. Run `pnpm run lint` before finishing.
 
 ## Naming
 
 - Use `packages/<package>/.changes/[major|minor|patch].short-description.md`.
+- The `.changes/` directory is optional until a package has a change file or `.changes/config.json`.
 - Keep the slug short, specific, and stable.
 - Reuse existing deterministic names when the repo already has a pattern for that class of note.
 - For brand-new package releases, prefer `minor.initial-release.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ The changed-workspace commands default to diffing against `origin/main` and incl
 ## Release Notes
 
 - If a change affects published packages, add or update the appropriate change file.
+- Package `.changes/` directories are optional. Create `packages/<package>/.changes/` on demand when adding a change file or prerelease config.
 - Prerelease channels come from `packages/*/.changes/config.json` and control the version suffix such as `alpha` or `beta`; prerelease packages still publish to the npm `next` dist-tag.
 - If you modify release or publish flow code, validate it with the preview or dry-run scripts before finishing.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,17 +38,18 @@ All packages are published with TypeScript types along with both ESM and CJS mod
 
 Packages live in the [`packages` directory](https://github.com/remix-run/remix/tree/v3/packages). At a minimum, each package includes:
 
-- `.changes/`: Directory containing change files for the next release
 - `CHANGELOG.md`: A log of what's changed
 - `package.json`: Package metadata and dependencies
 - `README.md`: Information about the package
 - `src/`: The package's source code
 
-When you make changes to a package, please make sure you add a few relevant tests and run the whole test suite to make sure everything still works. Then, [add a change file](#adding-a-change-file) describing your changes and [make a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request). We will take a look at it as soon as we can.
+Packages may also include a `.changes/` directory when they have unreleased changes or prerelease configuration.
+
+When you make changes to a package, please make sure you add a few relevant tests and run the whole test suite to make sure everything still works. Then, [add a change file](#adding-a-change-file) when the change affects published behavior and [make a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request). We will take a look at it as soon as we can.
 
 ### Adding a Change File
 
-When making changes to a package, create a markdown file in the package's `.changes/` directory following this naming convention:
+When making user-facing changes to a package, create a markdown file in the package's `.changes/` directory following this naming convention. If the package does not already have a `.changes/` directory, create it when you add the change file.
 
 ```
 [major|minor|patch].short-description.md
@@ -57,6 +58,8 @@ When making changes to a package, create a markdown file in the package's `.chan
 - `major` - Breaking changes for v1.x+ packages
 - `minor` - Breaking changes for v0.x packages, new features
 - `patch` - Bug fixes
+
+Do not add change files for internal-only refactors, test-only changes, or packages that are released only because one of their dependencies changed. The release scripts automatically include dependent packages and generate dependency bump changelog entries.
 
 #### Examples
 
@@ -96,7 +99,7 @@ pnpm changes:validate
 
 Releases are automated via the [release-pr workflow](/.github/workflows/release-pr.yaml) and [publish workflow](/.github/workflows/publish.yaml).
 
-1. **You push changes to `main`** with change files in `packages/*/.changes/`
+1. **You push changes to `main`** with change files in `packages/<package>/.changes/`
 
 2. **A "Release" PR is automatically opened** (or updated if one exists)
 
@@ -128,7 +131,7 @@ Tags and GitHub releases are created automatically by the publish workflow after
 
 ### Prerelease Mode
 
-Packages can opt into prerelease mode via an optional `.changes/config.json` file:
+Packages can opt into prerelease mode by creating an optional `.changes/config.json` file:
 
 ```json
 {
@@ -140,7 +143,7 @@ The `prereleaseChannel` field determines the version suffix (e.g. `alpha`, `beta
 
 #### Bumping prerelease versions
 
-While in prerelease mode, add change files as normal. The prerelease counter increments (e.g. `3.0.0-alpha.1` → `3.0.0-alpha.2`). Changelog entries still get proper "Major Changes" / "Minor Changes" / "Patch Changes" sections, but the bump type is otherwise ignored—only the prerelease counter is bumped.
+While in prerelease mode, add change files as normal. The prerelease counter increments (e.g. `3.0.0-alpha.1` → `3.0.0-alpha.2`). Changelog entries are grouped under "Pre-release Changes", and the bump type is otherwise ignored—only the prerelease counter is bumped.
 
 #### Transitioning between prerelease channels
 

--- a/packages/assert/.changes/README.md
+++ b/packages/assert/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/assets/.changes/README.md
+++ b/packages/assets/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/async-context-middleware/.changes/README.md
+++ b/packages/async-context-middleware/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/auth-middleware/.changes/README.md
+++ b/packages/auth-middleware/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/auth/.changes/README.md
+++ b/packages/auth/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/cli/.changes/README.md
+++ b/packages/cli/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/compression-middleware/.changes/README.md
+++ b/packages/compression-middleware/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/cookie/.changes/README.md
+++ b/packages/cookie/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/cop-middleware/.changes/README.md
+++ b/packages/cop-middleware/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/cors-middleware/.changes/README.md
+++ b/packages/cors-middleware/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/csrf-middleware/.changes/README.md
+++ b/packages/csrf-middleware/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/data-schema/.changes/README.md
+++ b/packages/data-schema/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/data-table-mysql/.changes/README.md
+++ b/packages/data-table-mysql/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/data-table-postgres/.changes/README.md
+++ b/packages/data-table-postgres/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/data-table-sqlite/.changes/README.md
+++ b/packages/data-table-sqlite/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/data-table/.changes/README.md
+++ b/packages/data-table/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/fetch-proxy/.changes/README.md
+++ b/packages/fetch-proxy/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/fetch-router/.changes/README.md
+++ b/packages/fetch-router/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/file-storage-s3/.changes/README.md
+++ b/packages/file-storage-s3/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/file-storage/.changes/README.md
+++ b/packages/file-storage/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/form-data-middleware/.changes/README.md
+++ b/packages/form-data-middleware/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/form-data-parser/.changes/README.md
+++ b/packages/form-data-parser/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/fs/.changes/README.md
+++ b/packages/fs/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/headers/.changes/README.md
+++ b/packages/headers/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/html-template/.changes/README.md
+++ b/packages/html-template/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/lazy-file/.changes/README.md
+++ b/packages/lazy-file/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/logger-middleware/.changes/README.md
+++ b/packages/logger-middleware/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/method-override-middleware/.changes/README.md
+++ b/packages/method-override-middleware/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/mime/.changes/README.md
+++ b/packages/mime/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/multipart-parser/.changes/README.md
+++ b/packages/multipart-parser/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/node-fetch-server/.changes/README.md
+++ b/packages/node-fetch-server/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/node-tsx/.changes/README.md
+++ b/packages/node-tsx/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/remix/.changes/README.md
+++ b/packages/remix/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/remix/src/ui/combobox/README.md
+++ b/packages/remix/src/ui/combobox/README.md
@@ -8,7 +8,7 @@ Use it when the user should type draft text, filter a popup list, and still comm
 
 ```tsx
 import { css, type Handle } from 'remix/ui'
-import { Combobox, ComboboxOption, onComboboxChange } from 'remix/ui'
+import { Combobox, ComboboxOption, onComboboxChange } from 'remix/ui/combobox'
 
 let airports = [
   {

--- a/packages/remix/src/ui/server/README.md
+++ b/packages/remix/src/ui/server/README.md
@@ -1,6 +1,6 @@
 # Server
 
-Remix Component can render to HTML on the server using two APIs:
+Remix UI can render to HTML on the server using two APIs:
 
 - `renderToString` - Returns a complete HTML string. Simple, but buffers the entire response.
 - `renderToStream` - Returns a `ReadableStream<Uint8Array>`. Sends the initial HTML immediately and streams frame content as it resolves.
@@ -26,6 +26,7 @@ import { renderToStream } from 'remix/ui/server'
 
 let stream = renderToStream(<App />, {
   frameSrc: request.url,
+  signal: request.signal,
   resolveFrame(src, _target, context) {
     let frameUrl = new URL(src, context?.currentFrameSrc ?? request.url)
     return fetchHtml(frameUrl)
@@ -44,6 +45,7 @@ return new Response(stream, {
 
 - **`frameSrc`** - Seeds SSR frame state for the current render. When provided, server-rendered components can read `handle.frame.src` and `handle.frames.top.src` during SSR.
 - **`topFrameSrc`** - Overrides the root frame URL used for `handle.frames.top.src`. This is mainly useful when calling `renderToStream()` from inside `resolveFrame()` for a nested frame render.
+- **`signal`** - Cancels pending server rendering work. Pass `request.signal` so client disconnects can stop unresolved frame work without invoking `onError` for the disconnect itself.
 - **`resolveFrame(src, target, context)`** - Called when a `<Frame>` needs its content. Return a string of HTML, a `ReadableStream<Uint8Array>`, or a promise of either. `context.currentFrameSrc` is the URL for the frame that contains the `<Frame>`, and `context.topFrameSrc` is the outer document URL. Required if your component tree contains `<Frame>` elements.
 - **`onError(error)`** - Called when a rendering error occurs. If not provided, the stream rejects with the error.
 
@@ -80,7 +82,7 @@ function ProductPage() {
 
 ## CSS
 
-Components using the `css` prop have their styles collected during rendering and emitted as a single `<style>` tag in the `<head>`. No client-side style injection is needed for server-rendered content.
+Components using the `css(...)` mixin through `mix` have their styles collected during rendering and emitted as a single `<style>` tag in the `<head>`. No client-side style injection is needed for server-rendered content.
 
 ## See Also
 

--- a/packages/render-middleware/.changes/README.md
+++ b/packages/render-middleware/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/response/.changes/README.md
+++ b/packages/response/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/route-pattern/.changes/README.md
+++ b/packages/route-pattern/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/session-middleware/.changes/README.md
+++ b/packages/session-middleware/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/session-storage-memcache/.changes/README.md
+++ b/packages/session-storage-memcache/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/session-storage-redis/.changes/README.md
+++ b/packages/session-storage-redis/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/session/.changes/README.md
+++ b/packages/session/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/static-middleware/.changes/README.md
+++ b/packages/static-middleware/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/tar-parser/.changes/README.md
+++ b/packages/tar-parser/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/terminal/.changes/README.md
+++ b/packages/terminal/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/test/.changes/README.md
+++ b/packages/test/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/packages/ui/.changes/README.md
+++ b/packages/ui/.changes/README.md
@@ -1,3 +1,0 @@
-# Changes Directory
-
-See the [Contributing Guide](../../../CONTRIBUTING.md#adding-a-change-file) for documentation on how to add change files.

--- a/scripts/changes-version.ts
+++ b/scripts/changes-version.ts
@@ -58,16 +58,25 @@ function updateChangelog(packageDirName: string, newContent: string) {
 }
 
 /**
- * Deletes all change files (except README.md)
+ * Deletes all pending markdown change files.
  */
 function deleteChangeFiles(packageDirName: string) {
   let changesDir = path.join(getPackagePath(packageDirName), '.changes')
+  if (!fs.existsSync(changesDir)) {
+    console.log('  ✓ No change files to delete')
+    return
+  }
+
   let files = fs.readdirSync(changesDir)
   let changeFiles = files.filter((file) => file !== 'README.md' && file.endsWith('.md'))
 
   for (let file of changeFiles) {
     let filePath = path.join(changesDir, file)
     fs.unlinkSync(filePath)
+  }
+
+  if (fs.readdirSync(changesDir).length === 0) {
+    fs.rmdirSync(changesDir)
   }
 
   console.log(`  ✓ Deleted ${changeFiles.length} change file${changeFiles.length === 1 ? '' : 's'}`)

--- a/scripts/generate-remix.ts
+++ b/scripts/generate-remix.ts
@@ -739,6 +739,8 @@ async function outputExportsChangeFiles(
   let legacyChangeFilePattern = /^(major|minor)\.remix\.update-exports-\d+\.md$/
   let changes = ''
 
+  await fs.mkdir(remixChangesDir, { recursive: true })
+
   // Remove any old timestamped exports change files from prior runs.
   for (let fileName of await fs.readdir(remixChangesDir)) {
     if (!legacyChangeFilePattern.test(fileName)) {

--- a/scripts/utils/changes.test.ts
+++ b/scripts/utils/changes.test.ts
@@ -1,10 +1,10 @@
 import * as fs from 'node:fs'
+import * as os from 'node:os'
 import * as path from 'node:path'
 import assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 import type { PackageRelease } from './changes.ts'
-import { generateChangelogContent, getNextVersion, parseAllChangeFiles } from './changes.ts'
-import { packagesDir } from './packages.ts'
+import { generateChangelogContent, getNextVersion, parsePackageChanges } from './changes.ts'
 
 function makeRelease(overrides: Partial<PackageRelease> = {}): PackageRelease {
   return {
@@ -19,8 +19,11 @@ function makeRelease(overrides: Partial<PackageRelease> = {}): PackageRelease {
   }
 }
 
-function withTemporaryPackage(version: string, callback: (packageDirName: string) => void) {
-  let packagePath = fs.mkdtempSync(path.join(path.resolve(packagesDir), 'changes-test-'))
+function withTemporaryPackage(
+  version: string,
+  callback: (packageDirName: string, packagePath: string) => void,
+) {
+  let packagePath = fs.mkdtempSync(path.join(os.tmpdir(), 'remix-changes-test-'))
   let packageDirName = path.basename(packagePath)
   let packageJsonPath = path.join(packagePath, 'package.json')
 
@@ -38,36 +41,23 @@ function withTemporaryPackage(version: string, callback: (packageDirName: string
   )
 
   try {
-    callback(packageDirName)
+    callback(packageDirName, packagePath)
   } finally {
     fs.rmSync(packagePath, { recursive: true, force: true })
   }
 }
 
-describe('parseAllChangeFiles', () => {
+describe('parsePackageChanges', () => {
   it('allows stable packages without .changes directories', () => {
-    withTemporaryPackage('1.0.0', () => {
-      let result = parseAllChangeFiles()
+    withTemporaryPackage('1.0.0', (packageDirName, packagePath) => {
+      let result = parsePackageChanges(packageDirName, packagePath)
 
       if (!result.valid) {
         assert.fail('Expected a stable package without a .changes directory to validate')
       }
-    })
-  })
 
-  it('requires prerelease packages without .changes directories to configure prerelease mode', () => {
-    withTemporaryPackage('1.0.0-beta.1', (packageDirName) => {
-      let result = parseAllChangeFiles()
-
-      if (result.valid) {
-        assert.fail('Expected a prerelease package without a .changes directory to fail validation')
-      }
-
-      let errors = result.errors.filter((error) => error.packageDirName === packageDirName)
-
-      assert.equal(errors.length, 1)
-      assert.equal(errors[0]?.file, '.changes/config.json')
-      assert.match(errors[0]?.error ?? '', /no \.changes\/config\.json exists/)
+      assert.equal(result.changes.length, 0)
+      assert.equal(result.changesConfig, null)
     })
   })
 })

--- a/scripts/utils/changes.test.ts
+++ b/scripts/utils/changes.test.ts
@@ -1,7 +1,10 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
 import assert from '@remix-run/assert'
-import { test } from '@remix-run/test'
+import { describe, it } from '@remix-run/test'
 import type { PackageRelease } from './changes.ts'
-import { generateChangelogContent, getNextVersion } from './changes.ts'
+import { generateChangelogContent, getNextVersion, parseAllChangeFiles } from './changes.ts'
+import { packagesDir } from './packages.ts'
 
 function makeRelease(overrides: Partial<PackageRelease> = {}): PackageRelease {
   return {
@@ -16,83 +19,140 @@ function makeRelease(overrides: Partial<PackageRelease> = {}): PackageRelease {
   }
 }
 
-test('generateChangelogContent groups prerelease changes into a single section', () => {
-  let content = generateChangelogContent(
-    makeRelease({
-      changes: [
-        {
-          file: 'minor.alpha.md',
-          bump: 'minor',
-          content: 'Alpha change',
-        },
-        {
-          file: 'major.breaking.md',
-          bump: 'major',
-          content: 'BREAKING CHANGE: Breaking change',
-        },
-        {
-          file: 'patch.fix.md',
-          bump: 'patch',
-          content: 'Patch change',
-        },
-      ],
-      dependencyBumps: [
-        {
-          packageName: '@remix-run/router',
-          version: '1.2.3',
-          releaseUrl: 'https://example.com/router',
-        },
-      ],
-    }),
+function withTemporaryPackage(version: string, callback: (packageDirName: string) => void) {
+  let packagePath = fs.mkdtempSync(path.join(path.resolve(packagesDir), 'changes-test-'))
+  let packageDirName = path.basename(packagePath)
+  let packageJsonPath = path.join(packagePath, 'package.json')
+
+  fs.writeFileSync(
+    packageJsonPath,
+    JSON.stringify(
+      {
+        name: `@remix-run/${packageDirName}`,
+        version,
+        type: 'module',
+      },
+      null,
+      2,
+    ) + '\n',
   )
 
-  assert.match(content, /^## v3\.0\.0-alpha\.4/m)
-  assert.match(content, /^### Pre-release Changes$/m)
-  assert.doesNotMatch(content, /^### Major Changes$/m)
-  assert.doesNotMatch(content, /^### Minor Changes$/m)
-  assert.doesNotMatch(content, /^### Patch Changes$/m)
-  assert.match(content, /- BREAKING CHANGE: Breaking change/)
-  assert.match(content, /- Alpha change/)
-  assert.match(content, /- Patch change/)
-  assert.match(content, /- Bumped `@remix-run\/\*` dependencies:/)
-  assert.match(content, /\[`router@1\.2\.3`\]\(https:\/\/example\.com\/router\)/)
+  try {
+    callback(packageDirName)
+  } finally {
+    fs.rmSync(packagePath, { recursive: true, force: true })
+  }
+}
+
+describe('parseAllChangeFiles', () => {
+  it('allows stable packages without .changes directories', () => {
+    withTemporaryPackage('1.0.0', () => {
+      let result = parseAllChangeFiles()
+
+      if (!result.valid) {
+        assert.fail('Expected a stable package without a .changes directory to validate')
+      }
+    })
+  })
+
+  it('requires prerelease packages without .changes directories to configure prerelease mode', () => {
+    withTemporaryPackage('1.0.0-beta.1', (packageDirName) => {
+      let result = parseAllChangeFiles()
+
+      if (result.valid) {
+        assert.fail('Expected a prerelease package without a .changes directory to fail validation')
+      }
+
+      let errors = result.errors.filter((error) => error.packageDirName === packageDirName)
+
+      assert.equal(errors.length, 1)
+      assert.equal(errors[0]?.file, '.changes/config.json')
+      assert.match(errors[0]?.error ?? '', /no \.changes\/config\.json exists/)
+    })
+  })
 })
 
-test('generateChangelogContent keeps stable releases grouped by bump type', () => {
-  let content = generateChangelogContent(
-    makeRelease({
-      currentVersion: '3.0.0',
-      nextVersion: '3.0.1',
-      changes: [
-        {
-          file: 'minor.feature.md',
-          bump: 'minor',
-          content: 'Feature change',
-        },
-      ],
-      dependencyBumps: [
-        {
-          packageName: '@remix-run/router',
-          version: '1.2.3',
-          releaseUrl: 'https://example.com/router',
-        },
-      ],
-    }),
-  )
+describe('generateChangelogContent', () => {
+  it('groups prerelease changes into a single section', () => {
+    let content = generateChangelogContent(
+      makeRelease({
+        changes: [
+          {
+            file: 'minor.alpha.md',
+            bump: 'minor',
+            content: 'Alpha change',
+          },
+          {
+            file: 'major.breaking.md',
+            bump: 'major',
+            content: 'BREAKING CHANGE: Breaking change',
+          },
+          {
+            file: 'patch.fix.md',
+            bump: 'patch',
+            content: 'Patch change',
+          },
+        ],
+        dependencyBumps: [
+          {
+            packageName: '@remix-run/router',
+            version: '1.2.3',
+            releaseUrl: 'https://example.com/router',
+          },
+        ],
+      }),
+    )
 
-  assert.match(content, /^## v3\.0\.1/m)
-  assert.match(content, /^### Minor Changes$/m)
-  assert.match(content, /^### Patch Changes$/m)
-  assert.doesNotMatch(content, /^### Pre-release Changes$/m)
+    assert.match(content, /^## v3\.0\.0-alpha\.4/m)
+    assert.match(content, /^### Pre-release Changes$/m)
+    assert.doesNotMatch(content, /^### Major Changes$/m)
+    assert.doesNotMatch(content, /^### Minor Changes$/m)
+    assert.doesNotMatch(content, /^### Patch Changes$/m)
+    assert.match(content, /- BREAKING CHANGE: Breaking change/)
+    assert.match(content, /- Alpha change/)
+    assert.match(content, /- Patch change/)
+    assert.match(content, /- Bumped `@remix-run\/\*` dependencies:/)
+    assert.match(content, /\[`router@1\.2\.3`\]\(https:\/\/example\.com\/router\)/)
+  })
+
+  it('keeps stable releases grouped by bump type', () => {
+    let content = generateChangelogContent(
+      makeRelease({
+        currentVersion: '3.0.0',
+        nextVersion: '3.0.1',
+        changes: [
+          {
+            file: 'minor.feature.md',
+            bump: 'minor',
+            content: 'Feature change',
+          },
+        ],
+        dependencyBumps: [
+          {
+            packageName: '@remix-run/router',
+            version: '1.2.3',
+            releaseUrl: 'https://example.com/router',
+          },
+        ],
+      }),
+    )
+
+    assert.match(content, /^## v3\.0\.1/m)
+    assert.match(content, /^### Minor Changes$/m)
+    assert.match(content, /^### Patch Changes$/m)
+    assert.doesNotMatch(content, /^### Pre-release Changes$/m)
+  })
 })
 
-test('getNextVersion starts prereleases from the next major version', () => {
-  assert.equal(getNextVersion('2.17.4', 'major', { prereleaseChannel: 'alpha' }), '3.0.0-alpha.0')
-})
+describe('getNextVersion', () => {
+  it('starts prereleases from the next major version', () => {
+    assert.equal(getNextVersion('2.17.4', 'major', { prereleaseChannel: 'alpha' }), '3.0.0-alpha.0')
+  })
 
-test('getNextVersion increments prereleases within the same channel', () => {
-  assert.equal(
-    getNextVersion('3.0.0-alpha.0', 'patch', { prereleaseChannel: 'alpha' }),
-    '3.0.0-alpha.1',
-  )
+  it('increments prereleases within the same channel', () => {
+    assert.equal(
+      getNextVersion('3.0.0-alpha.0', 'patch', { prereleaseChannel: 'alpha' }),
+      '3.0.0-alpha.1',
+    )
+  })
 })

--- a/scripts/utils/changes.ts
+++ b/scripts/utils/changes.ts
@@ -161,30 +161,6 @@ function parsePackageChanges(packageDirName: string): ParsedPackageChanges {
   let changes: ChangeFile[] = []
   let errors: ValidationError[] = []
 
-  // Changes directory should exist (with at least README.md)
-  if (!fs.existsSync(changesDir)) {
-    return {
-      valid: false,
-      errors: [
-        {
-          packageDirName,
-          file: '.changes/',
-          error: 'Changes directory does not exist',
-        },
-      ],
-    }
-  }
-
-  // README.md should exist in .changes directory so it persists between releases
-  let readmePath = path.join(changesDir, 'README.md')
-  if (!fs.existsSync(readmePath)) {
-    errors.push({
-      packageDirName,
-      file: '.changes/README.md',
-      error: 'README.md is missing from .changes directory',
-    })
-  }
-
   // Get package version to determine validation rules
   let packageJsonPath = getPackageFile(packageDirName, 'package.json')
   let packageJson = readJson(packageJsonPath)
@@ -193,6 +169,36 @@ function parsePackageChanges(packageDirName: string): ParsedPackageChanges {
   let isV1Plus = majorVersion >= 1
   let currentVersionPrereleaseId = getPrereleaseIdentifier(currentVersion)
   let isCurrentVersionPrerelease = currentVersionPrereleaseId !== null
+
+  if (!fs.existsSync(changesDir)) {
+    if (isCurrentVersionPrerelease) {
+      return {
+        valid: false,
+        errors: [
+          {
+            packageDirName,
+            file: '.changes/config.json',
+            error: `Version ${currentVersion} is a prerelease but no .changes/config.json exists. Either add .changes/config.json with { "prereleaseChannel": "${currentVersionPrereleaseId}" }, or add a change file to graduate to stable.`,
+          },
+        ],
+      }
+    }
+
+    return { valid: true, changes, changesConfig: null }
+  }
+
+  if (!fs.statSync(changesDir).isDirectory()) {
+    return {
+      valid: false,
+      errors: [
+        {
+          packageDirName,
+          file: '.changes/',
+          error: '.changes exists but is not a directory',
+        },
+      ],
+    }
+  }
 
   // Handle .changes/config.json for packages in prerelease mode
   let changesConfig: ChangesConfig | null = null

--- a/scripts/utils/changes.ts
+++ b/scripts/utils/changes.ts
@@ -29,8 +29,10 @@ export type ParsedChangesConfig =
 /**
  * Reads and validates a package's .changes/config.json.
  */
-export function readChangesConfig(packageDirName: string): ParsedChangesConfig {
-  let packagePath = getPackagePath(packageDirName)
+export function readChangesConfig(
+  packageDirName: string,
+  packagePath = getPackagePath(packageDirName),
+): ParsedChangesConfig {
   let configJsonPath = path.join(packagePath, '.changes', 'config.json')
 
   if (!fs.existsSync(configJsonPath)) {
@@ -155,14 +157,16 @@ type ParsedPackageChanges =
  * Parses and validates all change files for a package.
  * Returns changes if valid, or errors if invalid.
  */
-function parsePackageChanges(packageDirName: string): ParsedPackageChanges {
-  let packagePath = getPackagePath(packageDirName)
+export function parsePackageChanges(
+  packageDirName: string,
+  packagePath = getPackagePath(packageDirName),
+): ParsedPackageChanges {
   let changesDir = path.join(packagePath, '.changes')
   let changes: ChangeFile[] = []
   let errors: ValidationError[] = []
 
   // Get package version to determine validation rules
-  let packageJsonPath = getPackageFile(packageDirName, 'package.json')
+  let packageJsonPath = path.join(packagePath, 'package.json')
   let packageJson = readJson(packageJsonPath)
   let currentVersion = packageJson.version as string
   let majorVersion = major(currentVersion)
@@ -171,19 +175,6 @@ function parsePackageChanges(packageDirName: string): ParsedPackageChanges {
   let isCurrentVersionPrerelease = currentVersionPrereleaseId !== null
 
   if (!fs.existsSync(changesDir)) {
-    if (isCurrentVersionPrerelease) {
-      return {
-        valid: false,
-        errors: [
-          {
-            packageDirName,
-            file: '.changes/config.json',
-            error: `Version ${currentVersion} is a prerelease but no .changes/config.json exists. Either add .changes/config.json with { "prereleaseChannel": "${currentVersionPrereleaseId}" }, or add a change file to graduate to stable.`,
-          },
-        ],
-      }
-    }
-
     return { valid: true, changes, changesConfig: null }
   }
 
@@ -202,7 +193,7 @@ function parsePackageChanges(packageDirName: string): ParsedPackageChanges {
 
   // Handle .changes/config.json for packages in prerelease mode
   let changesConfig: ChangesConfig | null = null
-  let parsedChangesConfig = readChangesConfig(packageDirName)
+  let parsedChangesConfig = readChangesConfig(packageDirName, packagePath)
   if (parsedChangesConfig.exists) {
     if (!parsedChangesConfig.valid) {
       errors.push({


### PR DESCRIPTION
Make release tooling treat `packages/<package>/.changes/` as an on-demand state directory instead of required package metadata.

- Allows stable packages without `.changes/` directories to validate as having no pending changes while preserving prerelease validation for packages already on prerelease versions.
- Updates versioning and Remix export generation so missing `.changes/` directories do not fail and generated change files create the directory when needed.
- Removes the sentinel `.changes/README.md` files now that empty directories are no longer required.
- Updates contributor and agent guidance so change files and prerelease config create `.changes/` on demand.
