### PR TITLE
Clarify Remix component prop guidance

### DIFF
--- a/.agents/skills/remix/SKILL.md
+++ b/.agents/skills/remix/SKILL.md
@@ -34,7 +34,7 @@ A Remix app has four main pieces:
 - **Middleware** composes request lifecycle behavior and populates typed context via
   `context.set(Key, value)`.
 - **Components** render UI with `remix/ui`. This is not React. A component receives a
-  `handle`, reads current props from `handle.props`, and returns a render function.
+  `handle`, reads current props from `handle.props`, and returns a zero-argument render function.
 
 ## When To Use This Skill
 
@@ -198,9 +198,9 @@ When code could live in multiple places:
   need the harness
 - Outside actions and controllers, only use `getContext()` when `asyncContext()` is in the
   middleware stack
-- Remix Component is not React: read props from `handle.props`, keep state in setup-scope
-  variables, call `handle.update()` explicitly, and do DOM-sensitive work in event handlers or
-  `queueTask(...)`, not in render
+- Remix Component is not React: write `function Name(handle: Handle<Props>) { return () => ... }`,
+  read props from `handle.props`, keep state in setup-scope variables, call `handle.update()`
+  explicitly, and do DOM-sensitive work in event handlers or `queueTask(...)`, not in render
 - Prefer host-element mixins via `mix={mixin(...)}` for behavior and styling instead of inventing
   custom host prop conventions. Use `mix={[...]}` only when composing multiple mixins
 - Hydrated `clientEntry(...)` props must be serializable. Do not pass functions, class instances, or

--- a/.agents/skills/remix/references/component-model.md
+++ b/.agents/skills/remix/references/component-model.md
@@ -20,7 +20,10 @@ For host-element behavior (event handlers, styles, refs, animations), see
 A component has two phases:
 
 1. **Setup phase** — runs once when the component is created
-2. **Render phase** — returned function runs on initial render and every update
+2. **Render phase** — returned zero-argument function runs on initial render and every update
+
+The component shape is `function Component(handle: Handle<Props>) { return () => ... }`. Props are
+available as `handle.props` in setup scope and are updated before every render.
 
 ```tsx
 import { on, type Handle } from 'remix/ui'

--- a/packages/remix/src/ui/README.md
+++ b/packages/remix/src/ui/README.md
@@ -135,13 +135,15 @@ let Theme = createTheme({
 Render the theme once near the top of your document:
 
 ```tsx
-function Layout(props: { children: RemixNode }) {
-  return (
+import type { Handle, RemixNode } from 'remix/ui'
+
+function Layout(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <html>
       <head>
         <Theme />
       </head>
-      <body>{props.children}</body>
+      <body>{handle.props.children}</body>
     </html>
   )
 }
@@ -168,13 +170,13 @@ let card = css({
 Render shared glyphs separately from the theme styles:
 
 ```tsx
-import type { RemixNode } from 'remix/ui'
+import type { Handle, RemixNode } from 'remix/ui'
 import { Button } from 'remix/ui/button'
 import { Glyph } from 'remix/ui/glyph'
 import { RMX_01, RMX_01_GLYPHS } from 'remix/ui/theme'
 
-function Layout(props: { children: RemixNode }) {
-  return (
+function Layout(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <html>
       <head>
         <RMX_01 />
@@ -184,7 +186,7 @@ function Layout(props: { children: RemixNode }) {
         <Button startIcon={<Glyph name="add" />} tone="primary">
           New project
         </Button>
-        {props.children}
+        {handle.props.children}
       </body>
     </html>
   )

--- a/packages/remix/src/ui/animation/README.md
+++ b/packages/remix/src/ui/animation/README.md
@@ -52,12 +52,13 @@ function Toast() {
 `animateExit` keeps a removed keyed element in the DOM long enough to animate from its natural styles to the provided keyframe.
 
 ```tsx
+import type { Handle } from 'remix/ui'
 import { animateExit } from 'remix/ui/animation'
 
-function Item({ id, label }: { id: string; label: string }) {
+function Item(handle: Handle<{ id: string; label: string }>) {
   return () => (
     <li
-      key={id}
+      key={handle.props.id}
       mix={[
         animateExit({
           opacity: 0,
@@ -67,7 +68,7 @@ function Item({ id, label }: { id: string; label: string }) {
         }),
       ]}
     >
-      {label}
+      {handle.props.label}
     </li>
   )
 }
@@ -105,12 +106,13 @@ Exit animations can reclaim a removed keyed node if the same keyed element is re
 `animateLayout` animates layout changes with a FLIP-style transform projection. Use it on elements whose position or size can change between renders.
 
 ```tsx
+import type { Handle } from 'remix/ui'
 import { animateLayout, spring } from 'remix/ui/animation'
 
-function Card({ expanded }: { expanded: boolean }) {
+function Card(handle: Handle<{ expanded: boolean }>) {
   return () => (
     <section
-      class={expanded ? 'card expanded' : 'card'}
+      class={handle.props.expanded ? 'card expanded' : 'card'}
       mix={[
         animateLayout({
           ...spring('smooth'),

--- a/packages/test/src/test/framework.test.browser.tsx
+++ b/packages/test/src/test/framework.test.browser.tsx
@@ -81,9 +81,9 @@ describe('Counter', () => {
 
 describe('FieldLabel (using decamelize)', () => {
   // Demonstrates that ESM third-party libraries are importable from test modules
-  function FieldLabel(_handle: unknown) {
-    return (props: { name: string }) => (
-      <span data-testid="label">{decamelize(props.name, { separator: ' ' })}</span>
+  function FieldLabel(handle: Handle<{ name: string }>) {
+    return () => (
+      <span data-testid="label">{decamelize(handle.props.name, { separator: ' ' })}</span>
     )
   }
 

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -433,8 +433,8 @@ function Header(handle: Handle) {
 The simplest component just returns JSX:
 
 ```tsx
-function Greeting() {
-  return (props: { name: string }) => <div>Hello, {props.name}!</div>
+function Greeting(handle: Handle<{ name: string }>) {
+  return () => <div>Hello, {handle.props.name}!</div>
 }
 
 let el = <Greeting name="World" />
@@ -449,11 +449,11 @@ function Parent() {
   return () => <Child message="Hello from parent" count={42} />
 }
 
-function Child() {
-  return (props: { message: string; count: number }) => (
+function Child(handle: Handle<{ message: string; count: number }>) {
+  return () => (
     <div>
-      <p>{props.message}</p>
-      <p>Count: {props.count}</p>
+      <p>{handle.props.message}</p>
+      <p>Count: {handle.props.count}</p>
     </div>
   )
 }
@@ -823,8 +823,8 @@ function Button() {
 Use `&::before` and `&::after` for pseudo-elements:
 
 ```tsx
-function Badge() {
-  return (props: { count: number }) => (
+function Badge(handle: Handle<{ count: number }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -843,7 +843,7 @@ function Badge() {
         }),
       ]}
     >
-      {props.count > 0 && <span>{props.count}</span>}
+      {handle.props.count > 0 && <span>{handle.props.count}</span>}
     </div>
   )
 }
@@ -854,10 +854,10 @@ function Badge() {
 Use `&[attribute]` for attribute selectors:
 
 ```tsx
-function Input() {
-  return (props: { required?: boolean }) => (
+function Input(handle: Handle<{ required?: boolean }>) {
+  return () => (
     <input
-      required={props.required}
+      required={handle.props.required}
       mix={[
         css({
           padding: '8px',
@@ -882,8 +882,8 @@ function Input() {
 Use class names or element selectors directly for descendant selectors:
 
 ```tsx
-function Card() {
-  return (props: { children: RemixNode }) => (
+function Card(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -913,7 +913,7 @@ function Card() {
         }),
       ]}
     >
-      {props.children}
+      {handle.props.children}
     </div>
   )
 }
@@ -939,10 +939,10 @@ Use nested selectors when **parent state affects children**. Don't nest when you
 
 ```tsx
 // ❌ Avoid: Managing hover state in JavaScript
-function CardWithJSState(handle: Handle) {
+function CardWithJSState(handle: Handle<{ children: RemixNode }>) {
   let isHovered = false
 
-  return (props: { children: RemixNode }) => (
+  return () => (
     <div
       mix={[
         on('mouseenter', () => {
@@ -966,8 +966,8 @@ function CardWithJSState(handle: Handle) {
 }
 
 // ✅ Prefer: CSS nested selectors handle state declaratively
-function Card(handle: Handle) {
-  return (props: { children: RemixNode }) => (
+function Card(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -1075,8 +1075,8 @@ function Navigation() {
 Use `@media` for responsive design:
 
 ```tsx
-function ResponsiveGrid() {
-  return (props: { children: RemixNode }) => (
+function ResponsiveGrid(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -1092,7 +1092,7 @@ function ResponsiveGrid() {
         }),
       ]}
     >
-      {props.children}
+      {handle.props.children}
     </div>
   )
 }
@@ -1103,8 +1103,8 @@ function ResponsiveGrid() {
 Here's a comprehensive example demonstrating parent-state-affecting-children and media queries, with styles applied directly to elements:
 
 ```tsx
-function ProductCard() {
-  return (props: { title: string; price: number; image: string }) => (
+function ProductCard(handle: Handle<{ title: string; price: number; image: string }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -1133,8 +1133,8 @@ function ProductCard() {
       ]}
     >
       <img
-        src={props.image}
-        alt={props.title}
+        src={handle.props.image}
+        alt={handle.props.title}
         mix={[
           css({
             width: '100%',
@@ -1169,7 +1169,7 @@ function ProductCard() {
             }),
           ]}
         >
-          {props.title}
+          {handle.props.title}
         </h3>
         <div
           className="price"
@@ -1181,7 +1181,7 @@ function ProductCard() {
             }),
           ]}
         >
-          ${props.price}
+          ${handle.props.price}
         </div>
         <button
           mix={[
@@ -1358,8 +1358,8 @@ Keys can be any type (string, number, bigint, object, symbol), but should be sta
 Components can compose other components via `children`:
 
 ```tsx
-function Layout() {
-  return (props: { children: RemixNode }) => (
+function Layout(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -1370,7 +1370,7 @@ function Layout() {
       ]}
     >
       <header>My App</header>
-      <main>{props.children}</main>
+      <main>{handle.props.children}</main>
       <footer>© 2024</footer>
     </div>
   )
@@ -1905,19 +1905,19 @@ This ensures only the latest search request completes, preventing stale results 
 Use `handle.queueTask()` in the render function for reactive data loading that responds to prop changes. The signal will be aborted if props change or the component is removed:
 
 ```tsx
-function DataLoader(handle: Handle) {
+function DataLoader(handle: Handle<{ url: string }>) {
   let data: any = null
   let loading = false
   let error: Error | null = null
 
-  return (props: { url: string }) => {
+  return () => {
     // Queue data loading task that responds to prop changes
     handle.queueTask(async (signal) => {
       loading = true
       error = null
       handle.update()
 
-      let response = await fetch(props.url, { signal })
+      let response = await fetch(handle.props.url, { signal })
       let json = await response.json()
       if (signal.aborted) return
       data = json

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -135,13 +135,15 @@ let Theme = createTheme({
 Render the theme once near the top of your document:
 
 ```tsx
-function Layout(props: { children: RemixNode }) {
-  return (
+import type { Handle, RemixNode } from 'remix/ui'
+
+function Layout(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <html>
       <head>
         <Theme />
       </head>
-      <body>{props.children}</body>
+      <body>{handle.props.children}</body>
     </html>
   )
 }
@@ -168,13 +170,13 @@ let card = css({
 Render shared glyphs separately from the theme styles:
 
 ```tsx
-import type { RemixNode } from 'remix/ui'
+import type { Handle, RemixNode } from 'remix/ui'
 import { Button } from 'remix/ui/button'
 import { Glyph } from 'remix/ui/glyph'
 import { RMX_01, RMX_01_GLYPHS } from 'remix/ui/theme'
 
-function Layout(props: { children: RemixNode }) {
-  return (
+function Layout(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <html>
       <head>
         <RMX_01 />
@@ -184,7 +186,7 @@ function Layout(props: { children: RemixNode }) {
         <Button startIcon={<Glyph name="add" />} tone="primary">
           New project
         </Button>
-        {props.children}
+        {handle.props.children}
       </body>
     </html>
   )

--- a/packages/ui/bench/frameworks/remix/index.tsx
+++ b/packages/ui/bench/frameworks/remix/index.tsx
@@ -13,81 +13,80 @@ import type { Handle } from '@remix-run/ui'
 
 export const name = 'remix'
 
-function Button() {
-  return ({ id, text, fn }: { id: string; text: string; fn: () => void }) => (
+function Button(handle: Handle<{ id: string; text: string; fn: () => void }>) {
+  return () => (
     <div class="col-sm-6 smallpad">
-      <button id={id} class="btn btn-primary btn-block" type="button" mix={[on('click', fn)]}>
-        {text}
+      <button
+        id={handle.props.id}
+        class="btn btn-primary btn-block"
+        type="button"
+        mix={[on('click', handle.props.fn)]}
+      >
+        {handle.props.text}
       </button>
     </div>
   )
 }
 
 // Stateful Metric Card Component
-function MetricCard(handle: Handle) {
+function MetricCard(handle: Handle<{ id: number; label: string; value: string; change: string }>) {
   let selected = false
   let hovered = false
 
-  return ({
-    id,
-    label,
-    value,
-    change,
-  }: {
-    id: number
-    label: string
-    value: string
-    change: string
-  }) => (
-    <div
-      class={`metric-card ${selected ? 'selected' : ''}`}
-      mix={[
-        on('click', () => {
-          selected = !selected
-          handle.update()
-        }),
-        on('mouseenter', () => {
-          hovered = true
-          handle.update()
-        }),
-        on('mouseleave', () => {
-          hovered = false
-          handle.update()
-        }),
-        on('focus', (e: any) => {
-          e.currentTarget.style.outline = '2px solid #222'
-          e.currentTarget.style.outlineOffset = '2px'
-        }),
-        on('blur', (e: any) => {
-          e.currentTarget.style.outline = ''
-        }),
-      ]}
-      tabIndex={0}
-      style={{
-        backgroundColor: hovered ? '#f5f5f5' : '#fff',
-        transform: hovered && !selected ? 'translateY(-2px)' : 'translateY(0)',
-        transition: 'all 0.2s',
-        padding: '20px',
-        border: '1px solid #ddd',
-        borderRadius: '8px',
-        cursor: 'pointer',
-        boxShadow: selected ? '0 4px 8px rgba(0,0,0,0.1)' : '0 2px 4px rgba(0,0,0,0.05)',
-      }}
-    >
-      <div style={{ fontSize: '14px', color: '#666', marginBottom: '8px' }}>{label}</div>
-      <div style={{ fontSize: '24px', fontWeight: 'bold', marginBottom: '4px' }}>{value}</div>
-      <div style={{ fontSize: '12px', color: change.startsWith('+') ? '#28a745' : '#dc3545' }}>
-        {change}
+  return () => {
+    let { label, value, change } = handle.props
+
+    return (
+      <div
+        class={`metric-card ${selected ? 'selected' : ''}`}
+        mix={[
+          on('click', () => {
+            selected = !selected
+            handle.update()
+          }),
+          on('mouseenter', () => {
+            hovered = true
+            handle.update()
+          }),
+          on('mouseleave', () => {
+            hovered = false
+            handle.update()
+          }),
+          on('focus', (e: any) => {
+            e.currentTarget.style.outline = '2px solid #222'
+            e.currentTarget.style.outlineOffset = '2px'
+          }),
+          on('blur', (e: any) => {
+            e.currentTarget.style.outline = ''
+          }),
+        ]}
+        tabIndex={0}
+        style={{
+          backgroundColor: hovered ? '#f5f5f5' : '#fff',
+          transform: hovered && !selected ? 'translateY(-2px)' : 'translateY(0)',
+          transition: 'all 0.2s',
+          padding: '20px',
+          border: '1px solid #ddd',
+          borderRadius: '8px',
+          cursor: 'pointer',
+          boxShadow: selected ? '0 4px 8px rgba(0,0,0,0.1)' : '0 2px 4px rgba(0,0,0,0.05)',
+        }}
+      >
+        <div style={{ fontSize: '14px', color: '#666', marginBottom: '8px' }}>{label}</div>
+        <div style={{ fontSize: '24px', fontWeight: 'bold', marginBottom: '4px' }}>{value}</div>
+        <div style={{ fontSize: '12px', color: change.startsWith('+') ? '#28a745' : '#dc3545' }}>
+          {change}
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
 }
 
 // Stateful Chart Bar Component
-function ChartBar(handle: Handle) {
+function ChartBar(handle: Handle<{ value: number; index: number }>) {
   let hovered = false
 
-  return ({ value, index }: { value: number; index: number }) => (
+  return () => (
     <div
       class="chart-bar"
       mix={[
@@ -109,7 +108,7 @@ function ChartBar(handle: Handle) {
         }),
       ]}
       style={{
-        height: `${value}%`,
+        height: `${handle.props.value}%`,
         backgroundColor: hovered ? '#286090' : '#337ab7',
         width: '30px',
         margin: '0 2px',
@@ -124,68 +123,72 @@ function ChartBar(handle: Handle) {
 }
 
 // Stateful Activity Item Component
-function ActivityItem(handle: Handle) {
+function ActivityItem(handle: Handle<{ id: number; title: string; time: string; icon: string }>) {
   let read = false
   let hovered = false
 
-  return ({ id, title, time, icon }: { id: number; title: string; time: string; icon: string }) => (
-    <li
-      class={`activity-item ${read ? 'read' : ''}`}
-      mix={[
-        on('click', () => {
-          read = !read
-          handle.update()
-        }),
-        on('mouseenter', () => {
-          hovered = true
-          handle.update()
-        }),
-        on('mouseleave', () => {
-          hovered = false
-          handle.update()
-        }),
-      ]}
-      style={{
-        padding: '12px',
-        borderBottom: '1px solid #eee',
-        cursor: 'pointer',
-        backgroundColor: hovered ? '#f5f5f5' : read ? 'rgba(245, 245, 245, 0.6)' : '#fff',
-        display: 'flex',
-        alignItems: 'center',
-        gap: '12px',
-      }}
-    >
-      <span
+  return () => {
+    let { title, time, icon } = handle.props
+
+    return (
+      <li
+        class={`activity-item ${read ? 'read' : ''}`}
+        mix={[
+          on('click', () => {
+            read = !read
+            handle.update()
+          }),
+          on('mouseenter', () => {
+            hovered = true
+            handle.update()
+          }),
+          on('mouseleave', () => {
+            hovered = false
+            handle.update()
+          }),
+        ]}
         style={{
-          width: '32px',
-          height: '32px',
-          borderRadius: '50%',
-          backgroundColor: '#337ab7',
-          color: '#fff',
+          padding: '12px',
+          borderBottom: '1px solid #eee',
+          cursor: 'pointer',
+          backgroundColor: hovered ? '#f5f5f5' : read ? 'rgba(245, 245, 245, 0.6)' : '#fff',
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'center',
-          fontWeight: 'bold',
+          gap: '12px',
         }}
       >
-        {icon}
-      </span>
-      <div style={{ flex: 1 }}>
-        <div style={{ fontWeight: read ? 'normal' : 'bold' }}>{title}</div>
-        <div style={{ fontSize: '12px', color: '#666' }}>{time}</div>
-      </div>
-    </li>
-  )
+        <span
+          style={{
+            width: '32px',
+            height: '32px',
+            borderRadius: '50%',
+            backgroundColor: '#337ab7',
+            color: '#fff',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontWeight: 'bold',
+          }}
+        >
+          {icon}
+        </span>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontWeight: read ? 'normal' : 'bold' }}>{title}</div>
+          <div style={{ fontSize: '12px', color: '#666' }}>{time}</div>
+        </div>
+      </li>
+    )
+  }
 }
 
 // Stateful Dropdown Menu Component
-function DropdownMenu(handle: Handle) {
+function DropdownMenu(handle: Handle<{ rowId: number }>) {
   let open = false
   let hovered = false
 
   let actions = ['View Details', 'Edit', 'Duplicate', 'Archive', 'Delete']
 
-  return ({ rowId }: { rowId: number }) => (
+  return () => (
     <div style={{ position: 'relative', display: 'inline-block' }}>
       <button
         class="btn btn-primary"
@@ -272,45 +275,49 @@ function DropdownMenu(handle: Handle) {
 }
 
 // Stateful Dashboard Table Row Component
-function DashboardTableRow(handle: Handle) {
+function DashboardTableRow(handle: Handle<{ row: Row }>) {
   let hovered = false
   let selected = false
 
-  return ({ row }: { row: Row }) => (
-    <tr
-      class={selected ? 'danger' : ''}
-      mix={[
-        on('click', () => {
-          selected = !selected
-          handle.update()
-        }),
-        on('mouseenter', () => {
-          hovered = true
-          handle.update()
-        }),
-        on('mouseleave', () => {
-          hovered = false
-          handle.update()
-        }),
-      ]}
-      style={{
-        backgroundColor: hovered ? '#f5f5f5' : '#fff',
-        cursor: 'pointer',
-      }}
-    >
-      <td style={{ padding: '12px', borderTop: '1px solid #ddd' }}>{row.id}</td>
-      <td style={{ padding: '12px', borderTop: '1px solid #ddd' }}>{row.label}</td>
-      <td style={{ padding: '12px', borderTop: '1px solid #ddd' }}>
-        <span style={{ color: '#28a745' }}>Active</span>
-      </td>
-      <td style={{ padding: '12px', borderTop: '1px solid #ddd' }}>
-        ${(row.id * 10.5).toFixed(2)}
-      </td>
-      <td style={{ padding: '12px', borderTop: '1px solid #ddd' }}>
-        <DropdownMenu rowId={row.id} />
-      </td>
-    </tr>
-  )
+  return () => {
+    let { row } = handle.props
+
+    return (
+      <tr
+        class={selected ? 'danger' : ''}
+        mix={[
+          on('click', () => {
+            selected = !selected
+            handle.update()
+          }),
+          on('mouseenter', () => {
+            hovered = true
+            handle.update()
+          }),
+          on('mouseleave', () => {
+            hovered = false
+            handle.update()
+          }),
+        ]}
+        style={{
+          backgroundColor: hovered ? '#f5f5f5' : '#fff',
+          cursor: 'pointer',
+        }}
+      >
+        <td style={{ padding: '12px', borderTop: '1px solid #ddd' }}>{row.id}</td>
+        <td style={{ padding: '12px', borderTop: '1px solid #ddd' }}>{row.label}</td>
+        <td style={{ padding: '12px', borderTop: '1px solid #ddd' }}>
+          <span style={{ color: '#28a745' }}>Active</span>
+        </td>
+        <td style={{ padding: '12px', borderTop: '1px solid #ddd' }}>
+          ${(row.id * 10.5).toFixed(2)}
+        </td>
+        <td style={{ padding: '12px', borderTop: '1px solid #ddd' }}>
+          <DropdownMenu rowId={row.id} />
+        </td>
+      </tr>
+    )
+  }
 }
 
 // Stateful Search Input Component
@@ -550,7 +557,7 @@ function FormWidgets(handle: Handle) {
   )
 }
 
-function Dashboard(handle: Handle) {
+function Dashboard(handle: Handle<{ onSwitchToTable: () => void }>) {
   let dashboardRows = buildData(300)
 
   let sortDashboardAsc = () => {
@@ -570,7 +577,7 @@ function Dashboard(handle: Handle) {
     icon: ['O', 'P', 'S', 'C', 'U'][i % 5],
   }))
 
-  return ({ onSwitchToTable }: { onSwitchToTable: () => void }) => (
+  return () => (
     <div class="container" style={{ maxWidth: '1400px' }}>
       <div
         style={{
@@ -585,7 +592,7 @@ function Dashboard(handle: Handle) {
           id="switchToTable"
           class="btn btn-primary"
           type="button"
-          mix={[on('click', onSwitchToTable)]}
+          mix={[on('click', handle.props.onSwitchToTable)]}
         >
           Switch to Table
         </button>

--- a/packages/ui/demo/app/examples/components/_ignore.tsx
+++ b/packages/ui/demo/app/examples/components/_ignore.tsx
@@ -5,71 +5,75 @@ import { Menu, MenuItem, onMenuSelect } from '@remix-run/ui/menu'
 
 type State = 'idle' | 'deleting' | 'copying' | 'error'
 
-function Row(handle: Handle) {
+function Row(handle: Handle<SomeFile>) {
   let state: State = 'idle'
   let showCopyConfirmation = false
 
-  return (file: SomeFile) => (
-    <div
-      mix={[
-        link(file.href),
-        ui.flex.row,
-        ui.rounded.md,
-        css({
-          background: theme.surface.lvl1,
-          '&:hover': {
-            background: theme.surface.lvl2,
-          },
-        }),
-      ]}
-    >
-      <div mix={css({ fontWeight: theme.fontWeight.semibold })}>{file.name}</div>
-      <div>{formattedSize(file.size)}</div>
+  return () => {
+    let file = handle.props
 
-      <Menu
-        label="Actions"
-        mix={onMenuSelect(async (event) => {
-          switch (event.item.name) {
-            case 'copy-url':
-              let url = await navigator.clipboard.writeText(file.href)
-              if (handle.signal.aborted) return
-
-              showCopyConfirmation = true
-              await handle.update()
-
-              setTimeout(() => {
-                if (handle.signal.aborted) return
-                handle.update()
-              }, 4000)
-
-              break
-            case 'delete':
-              state = 'deleting'
-              break
-            default:
-              break
-          }
-        })}
+    return (
+      <div
+        mix={[
+          link(file.href),
+          ui.flex.row,
+          ui.rounded.md,
+          css({
+            background: theme.surface.lvl1,
+            '&:hover': {
+              background: theme.surface.lvl2,
+            },
+          }),
+        ]}
       >
-        <MenuItem name="copy-url" value="Copy URL">
-          Copy URL
-        </MenuItem>
-        <MenuItem name="delete" value="Delete">
-          Delete
-        </MenuItem>
-      </Menu>
-    </div>
-  )
+        <div mix={css({ fontWeight: theme.fontWeight.semibold })}>{file.name}</div>
+        <div>{formattedSize(file.size)}</div>
+
+        <Menu
+          label="Actions"
+          mix={onMenuSelect(async (event) => {
+            switch (event.item.name) {
+              case 'copy-url':
+                let url = await navigator.clipboard.writeText(file.href)
+                if (handle.signal.aborted) return
+
+                showCopyConfirmation = true
+                await handle.update()
+
+                setTimeout(() => {
+                  if (handle.signal.aborted) return
+                  handle.update()
+                }, 4000)
+
+                break
+              case 'delete':
+                state = 'deleting'
+                break
+              default:
+                break
+            }
+          })}
+        >
+          <MenuItem name="copy-url" value="Copy URL">
+            Copy URL
+          </MenuItem>
+          <MenuItem name="delete" value="Delete">
+            Delete
+          </MenuItem>
+        </Menu>
+      </div>
+    )
+  }
 }
 
 import { type Handle, on } from 'remix/ui'
 import { ui, Glyph } from 'remix/ui'
 import { tooltip } from 'remix/ui/tooltip'
 
-function CopyToClipboard(handle: Handle) {
+function CopyToClipboard(handle: Handle<{ url: string }>) {
   let state: 'idle' | 'copied' | 'error' = 'idle'
 
-  return (props: { url: string }) => {
+  return () => {
     let label = state === 'idle' ? 'Copy' : state === 'copied' ? 'Copied' : 'Error'
 
     return (
@@ -86,7 +90,7 @@ function CopyToClipboard(handle: Handle) {
           // add the event handler to do the work
           on('click', async (event) => {
             try {
-              await navigator.clipboard.writeText(props.url)
+              await navigator.clipboard.writeText(handle.props.url)
               if (handle.signal.aborted) return
             } catch (error) {
               state = 'error'

--- a/packages/ui/demo/app/examples/foundations/install-theme.tsx
+++ b/packages/ui/demo/app/examples/foundations/install-theme.tsx
@@ -1,18 +1,18 @@
 import { css } from 'remix/ui'
 import { Button } from '@remix-run/ui/button'
-import type { RemixNode } from 'remix/ui'
+import type { Handle, RemixNode } from 'remix/ui'
 import { Glyph } from '@remix-run/ui/glyph'
 import { RMX_01, RMX_01_GLYPHS, theme } from '@remix-run/ui/theme'
 
-export function AppDocument(props: { children: RemixNode }) {
-  return (
+export function AppDocument(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <html>
       <head>
         <RMX_01 />
       </head>
       <body>
         <RMX_01_GLYPHS />
-        {props.children}
+        {handle.props.children}
       </body>
     </html>
   )

--- a/packages/ui/demos/animation/entry.tsx
+++ b/packages/ui/demos/animation/entry.tsx
@@ -20,86 +20,90 @@ import { MultiStateBadge } from './multi-state-badge.tsx'
 import { HoldToConfirm } from './hold-to-confirm.tsx'
 import { MaterialRipple } from './material-ripple.tsx'
 
-function Tile(handle: Handle) {
+function Tile(handle: Handle<{ title: string; children: RemixNode; notes?: string }>) {
   let remountKey = 0
 
-  return ({ title, children, notes }: { title: string; children: RemixNode; notes?: string }) => (
-    <div
-      mix={[
-        css({
-          backgroundColor: 'white',
-          padding: '40px',
-          borderRadius: 12,
-          boxShadow: '0 0 10px 0 rgba(0, 0, 0, 0.1)',
-          display: 'flex',
-          alignItems: 'center',
-          flexDirection: 'column',
-          gap: 12,
-          position: 'relative',
-        }),
-      ]}
-    >
-      <button
-        mix={[
-          css({
-            position: 'absolute',
-            bottom: 8,
-            right: 8,
-            width: 18,
-            height: 18,
-            padding: 0,
-            border: 'none',
-            background: 'transparent',
-            cursor: 'pointer',
-            opacity: 0.4,
-            '&:hover': {
-              opacity: 1,
-            },
-          }),
-          on('click', () => {
-            remountKey++
-            handle.update()
-          }),
-        ]}
-        title="Replay animation"
-      >
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-          <path d="M1 4v6h6M23 20v-6h-6" />
-          <path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15" />
-        </svg>
-      </button>
-      <h3 mix={[css({ margin: 0 })]}>{title}</h3>
+  return () => {
+    let { title, children, notes } = handle.props
+
+    return (
       <div
-        key={remountKey}
         mix={[
           css({
-            flex: 1,
+            backgroundColor: 'white',
+            padding: '40px',
+            borderRadius: 12,
+            boxShadow: '0 0 10px 0 rgba(0, 0, 0, 0.1)',
             display: 'flex',
             alignItems: 'center',
-            justifyContent: 'center',
-            minHeight: 280,
+            flexDirection: 'column',
+            gap: 12,
+            position: 'relative',
           }),
         ]}
       >
-        {children}
-      </div>
-      {notes && (
-        <p
+        <button
           mix={[
             css({
-              margin: 0,
-              fontSize: 12,
-              color: '#666',
-              textAlign: 'center',
-              maxWidth: '200px',
+              position: 'absolute',
+              bottom: 8,
+              right: 8,
+              width: 18,
+              height: 18,
+              padding: 0,
+              border: 'none',
+              background: 'transparent',
+              cursor: 'pointer',
+              opacity: 0.4,
+              '&:hover': {
+                opacity: 1,
+              },
+            }),
+            on('click', () => {
+              remountKey++
+              handle.update()
+            }),
+          ]}
+          title="Replay animation"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M1 4v6h6M23 20v-6h-6" />
+            <path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15" />
+          </svg>
+        </button>
+        <h3 mix={[css({ margin: 0 })]}>{title}</h3>
+        <div
+          key={remountKey}
+          mix={[
+            css({
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              minHeight: 280,
             }),
           ]}
         >
-          {notes}
-        </p>
-      )}
-    </div>
-  )
+          {children}
+        </div>
+        {notes && (
+          <p
+            mix={[
+              css({
+                margin: 0,
+                fontSize: 12,
+                color: '#666',
+                textAlign: 'center',
+                maxWidth: '200px',
+              }),
+            ]}
+          >
+            {notes}
+          </p>
+        )}
+      </div>
+    )
+  }
 }
 
 createRoot(document.body).render(

--- a/packages/ui/demos/animation/hold-to-confirm.tsx
+++ b/packages/ui/demos/animation/hold-to-confirm.tsx
@@ -53,10 +53,10 @@ export function HoldToConfirm(handle: Handle) {
   )
 }
 
-function HoldButton(handle: Handle) {
+function HoldButton(handle: Handle<{ onConfirm: () => void }>) {
   let confirming = false
 
-  return (props: { onConfirm: () => void }) => (
+  return () => (
     <button
       mix={[
         animateExit(buttonExitAnimation),
@@ -93,7 +93,7 @@ function HoldButton(handle: Handle) {
           handle.update()
         }),
         on(confirmPress.end, () => {
-          props.onConfirm()
+          handle.props.onConfirm()
         }),
       ]}
     >
@@ -133,8 +133,8 @@ function HoldButton(handle: Handle) {
   )
 }
 
-function Confirmation() {
-  return (props: { onReset: () => void }) => (
+function Confirmation(handle: Handle<{ onReset: () => void }>) {
+  return () => (
     <div
       mix={[
         animateEntrance(confirmationEnterAnimation),
@@ -178,7 +178,7 @@ function Confirmation() {
               borderColor: '#cbd5e1',
             },
           }),
-          on('click', props.onReset),
+          on('click', () => handle.props.onReset()),
         ]}
       >
         Reset Demo

--- a/packages/ui/demos/animation/multi-state-badge.tsx
+++ b/packages/ui/demos/animation/multi-state-badge.tsx
@@ -73,15 +73,17 @@ export function MultiStateBadge(handle: Handle) {
   )
 }
 
-function Badge(handle: Handle) {
+function Badge(handle: Handle<{ state: State }>) {
   let badgeEl: HTMLDivElement
   let prevState: State | null = null
 
-  return (props: { state: State }) => {
+  return () => {
+    let { state } = handle.props
+
     // Trigger shake/scale animations on state change
-    if (prevState !== null && prevState !== props.state) {
+    if (prevState !== null && prevState !== state) {
       handle.queueTask(() => {
-        if (props.state === 'error') {
+        if (state === 'error') {
           badgeEl.animate(
             {
               transform: [
@@ -94,7 +96,7 @@ function Badge(handle: Handle) {
             },
             { duration: 300, easing: 'ease-in-out', delay: 100 },
           )
-        } else if (props.state === 'success') {
+        } else if (state === 'success') {
           badgeEl.animate(
             { transform: ['scale(1)', 'scale(1.2)', 'scale(1)'] },
             { duration: 300, easing: 'ease-in-out' },
@@ -102,7 +104,7 @@ function Badge(handle: Handle) {
         }
       })
     }
-    prevState = props.state
+    prevState = state
 
     return (
       <div
@@ -122,17 +124,17 @@ function Badge(handle: Handle) {
             transition: `gap ${spring('snappy')}`,
           }),
         ]}
-        style={{ gap: props.state === 'idle' ? '0px' : '8px' }}
+        style={{ gap: state === 'idle' ? '0px' : '8px' }}
       >
-        <Icon state={props.state} />
-        <Label state={props.state} />
+        <Icon state={state} />
+        <Label state={state} />
       </div>
     )
   }
 }
 
-function Icon() {
-  return (props: { state: State }) => (
+function Icon(handle: Handle<{ state: State }>) {
+  return () => (
     <span
       mix={[
         css({
@@ -145,9 +147,9 @@ function Icon() {
           transition: `width ${spring({ duration: 200, bounce: 0.2 })}`,
         }),
       ]}
-      style={{ width: props.state === 'idle' ? 0 : ICON_SIZE }}
+      style={{ width: handle.props.state === 'idle' ? 0 : ICON_SIZE }}
     >
-      {props.state === 'processing' && (
+      {handle.props.state === 'processing' && (
         <span
           key="loader"
           mix={[
@@ -159,7 +161,7 @@ function Icon() {
           <Loader />
         </span>
       )}
-      {props.state === 'success' && (
+      {handle.props.state === 'success' && (
         <span
           key="check"
           mix={[
@@ -171,7 +173,7 @@ function Icon() {
           <Check />
         </span>
       )}
-      {props.state === 'error' && (
+      {handle.props.state === 'error' && (
         <span
           key="x"
           mix={[
@@ -302,7 +304,7 @@ function X() {
   )
 }
 
-function Label(handle: Handle) {
+function Label(handle: Handle<{ state: State }>) {
   let measureEl: HTMLSpanElement
   let labelWidth = 0
   let labelHeight = 0
@@ -313,7 +315,9 @@ function Label(handle: Handle) {
     isFirstRender = false
   })
 
-  return (props: { state: State }) => {
+  return () => {
+    let { state } = handle.props
+
     // Measure label dimensions after render
     handle.queueTask(() => {
       if (measureEl) {
@@ -369,10 +373,10 @@ function Label(handle: Handle) {
             css({ position: 'absolute', visibility: 'hidden', whiteSpace: 'nowrap' }),
           ]}
         >
-          {STATES[props.state]}
+          {STATES[state]}
         </span>
 
-        {props.state === 'idle' && (
+        {state === 'idle' && (
           <span
             key="idle"
             mix={[
@@ -383,7 +387,7 @@ function Label(handle: Handle) {
             {STATES.idle}
           </span>
         )}
-        {props.state === 'processing' && (
+        {state === 'processing' && (
           <span
             key="processing"
             mix={[
@@ -394,7 +398,7 @@ function Label(handle: Handle) {
             {STATES.processing}
           </span>
         )}
-        {props.state === 'success' && (
+        {state === 'success' && (
           <span
             key="success"
             mix={[
@@ -405,7 +409,7 @@ function Label(handle: Handle) {
             {STATES.success}
           </span>
         )}
-        {props.state === 'error' && (
+        {state === 'error' && (
           <span
             key="error"
             mix={[

--- a/packages/ui/demos/animation/shared-layout.tsx
+++ b/packages/ui/demos/animation/shared-layout.tsx
@@ -3,13 +3,14 @@ import { animateEntrance, animateExit } from 'remix/ui/animation'
 
 const ease = 'cubic-bezier(0.26, 0.02, 0.23, 0.94)'
 
-function OverlapExample(handle: Handle) {
+function OverlapExample(handle: Handle<{ state: boolean }>) {
   let shouldAnimate = false
   handle.queueTask(() => {
     shouldAnimate = true
   })
 
-  return ({ state }: { state: boolean }) => {
+  return () => {
+    let { state } = handle.props
     let animationMix = [
       animateExit({
         opacity: 0,
@@ -52,13 +53,14 @@ function OverlapExample(handle: Handle) {
   }
 }
 
-function WaitExample(handle: Handle) {
+function WaitExample(handle: Handle<{ state: boolean }>) {
   let shouldAnimate = false
   handle.queueTask(() => {
     shouldAnimate = true
   })
 
-  return ({ state }: { state: boolean }) => {
+  return () => {
+    let { state } = handle.props
     let animationMix = [
       animateExit({
         opacity: 0,
@@ -148,8 +150,8 @@ export function SharedLayout(handle: Handle) {
   )
 }
 
-function Circle() {
-  return (props: { filled?: boolean; children: RemixNode }) => (
+function Circle(handle: Handle<{ filled?: boolean; children: RemixNode }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -160,13 +162,13 @@ function Circle() {
           alignItems: 'center',
           justifyContent: 'center',
           boxSizing: 'border-box',
-          backgroundColor: props.filled ? '#0f1115' : 'transparent',
-          color: props.filled ? '#f5f5f5' : '#0f1115',
-          border: props.filled ? '2px solid #0f1115' : '2px solid #0f1115',
+          backgroundColor: handle.props.filled ? '#0f1115' : 'transparent',
+          color: handle.props.filled ? '#f5f5f5' : '#0f1115',
+          border: handle.props.filled ? '2px solid #0f1115' : '2px solid #0f1115',
         }),
       ]}
     >
-      {props.children}
+      {handle.props.children}
     </div>
   )
 }

--- a/packages/ui/demos/drummer/components.tsx
+++ b/packages/ui/demos/drummer/components.tsx
@@ -1,8 +1,8 @@
-import type { RemixNode, Props } from 'remix/ui'
+import type { Handle, RemixNode, Props } from 'remix/ui'
 import { css } from 'remix/ui'
 
-export function Layout() {
-  return ({ children }: { children: RemixNode }) => (
+export function Layout(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -54,13 +54,13 @@ export function Layout() {
         </div>
       </header>
 
-      {children}
+      {handle.props.children}
     </div>
   )
 }
 
-export function EqualizerLayout() {
-  return ({ children }: { children: RemixNode }) => (
+export function EqualizerLayout(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -76,13 +76,13 @@ export function EqualizerLayout() {
         }),
       ]}
     >
-      {children}
+      {handle.props.children}
     </div>
   )
 }
 
-export function TempoLayout() {
-  return ({ children }: { children: RemixNode }) => (
+export function TempoLayout(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -94,13 +94,13 @@ export function TempoLayout() {
         }),
       ]}
     >
-      {children}
+      {handle.props.children}
     </div>
   )
 }
 
-export function TempoButtons() {
-  return ({ children }: { children: RemixNode }) => (
+export function TempoButtons(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -113,13 +113,13 @@ export function TempoButtons() {
         }),
       ]}
     >
-      {children}
+      {handle.props.children}
     </div>
   )
 }
 
-export function BPMDisplay() {
-  return ({ bpm }: { bpm: number }) => (
+export function BPMDisplay(handle: Handle<{ bpm: number }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -162,13 +162,13 @@ export function BPMDisplay() {
           }),
         ]}
       >
-        {bpm}
+        {handle.props.bpm}
       </div>
     </div>
   )
 }
 
-export function EqualizerBar() {
+export function EqualizerBar(handle: Handle<{ volume: number }>) {
   let colors = [
     '#FF3000',
     '#FF3000',
@@ -182,8 +182,8 @@ export function EqualizerBar() {
     '#1A72FF',
   ]
 
-  return ({ volume }: { volume: number /* 0-1 */ }) => {
-    let startIndexToShow = 10 - Math.round(volume * 10)
+  return () => {
+    let startIndexToShow = 10 - Math.round(handle.props.volume * 10)
     return (
       <div
         mix={[
@@ -215,70 +215,79 @@ export function EqualizerBar() {
   }
 }
 
-export function ControlGroup() {
-  return ({ children, mix: mixOverride, ...rest }: Props<'div'>) => (
-    <div
-      {...rest}
-      mix={[
-        css({
-          display: 'grid',
-          gridTemplateColumns: '1fr 1fr',
-          gridTemplateRows: '1fr 1fr',
-          gap: '18px',
-          alignItems: 'center',
-          justifyContent: 'center',
-          '& button:focus-visible': {
-            outline: '2px solid #2684FF',
-            outlineOffset: '2px',
-          },
-        }),
-        ...(mixOverride ?? []),
-      ]}
-    >
-      {children}
-    </div>
-  )
-}
+export function ControlGroup(handle: Handle<Props<'div'>>) {
+  return () => {
+    let { children, mix: mixOverride, ...rest } = handle.props
 
-export function Button() {
-  return ({ children, mix, ...rest }: Props<'button'>) => (
-    <button
-      {...rest}
-      mix={[
-        css({
-          all: 'unset',
-          letterSpacing: 0.9,
-          height: 120,
-          display: 'flex',
-          alignItems: 'end',
-          background: '#666',
-          borderRadius: '18px',
-          padding: '32px',
-          fontSize: '18px',
-          fontWeight: 700,
-          '&:disabled': {
-            opacity: 0.25,
-          },
-          '&:active': {
-            background: '#555',
-          },
-          '@media (prefers-color-scheme: light)': {
-            background: '#E0E0E0',
-            '&:active': {
-              background: '#D0D0D0',
+    return (
+      <div
+        {...rest}
+        mix={[
+          css({
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gridTemplateRows: '1fr 1fr',
+            gap: '18px',
+            alignItems: 'center',
+            justifyContent: 'center',
+            '& button:focus-visible': {
+              outline: '2px solid #2684FF',
+              outlineOffset: '2px',
             },
-          },
-        }),
-        ...(mix ?? []),
-      ]}
-    >
-      {children}
-    </button>
-  )
+          }),
+          ...(mixOverride ?? []),
+        ]}
+      >
+        {children}
+      </div>
+    )
+  }
 }
 
-export function Triangle() {
-  return ({ label, orientation }: { label: string; orientation: 'up' | 'down' }) => {
+export function Button(handle: Handle<Props<'button'>>) {
+  return () => {
+    let { children, mix, ...rest } = handle.props
+
+    return (
+      <button
+        {...rest}
+        mix={[
+          css({
+            all: 'unset',
+            letterSpacing: 0.9,
+            height: 120,
+            display: 'flex',
+            alignItems: 'end',
+            background: '#666',
+            borderRadius: '18px',
+            padding: '32px',
+            fontSize: '18px',
+            fontWeight: 700,
+            '&:disabled': {
+              opacity: 0.25,
+            },
+            '&:active': {
+              background: '#555',
+            },
+            '@media (prefers-color-scheme: light)': {
+              background: '#E0E0E0',
+              '&:active': {
+                background: '#D0D0D0',
+              },
+            },
+          }),
+          ...(mix ?? []),
+        ]}
+      >
+        {children}
+      </button>
+    )
+  }
+}
+
+export function Triangle(handle: Handle<{ label: string; orientation: 'up' | 'down' }>) {
+  return () => {
+    let { label, orientation } = handle.props
     let up = '5,1.34 9.33,8.66 0.67,8.66'
     let down = '5,8.66 9.33,1.34 0.67,1.34'
     return (
@@ -300,40 +309,44 @@ interface TempoButtonProps extends Props<'button'> {
   orientation: 'up' | 'down'
 }
 
-export function TempoButton() {
-  return ({ orientation, mix: mixOverride, ...rest }: TempoButtonProps) => (
-    <button
-      {...rest}
-      mix={[
-        css({
-          all: 'unset',
-          flex: 1,
-          background: '#666',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          '&:active': {
-            background: '#555',
-          },
-          '@media (prefers-color-scheme: light)': {
-            background: '#E0E0E0',
+export function TempoButton(handle: Handle<TempoButtonProps>) {
+  return () => {
+    let { orientation, mix: mixOverride, ...rest } = handle.props
+
+    return (
+      <button
+        {...rest}
+        mix={[
+          css({
+            all: 'unset',
+            flex: 1,
+            background: '#666',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
             '&:active': {
-              background: '#D0D0D0',
+              background: '#555',
             },
-          },
-          '&:first-child': {
-            borderTopRightRadius: '18px',
-          },
-          '&:last-child': {
-            borderBottomRightRadius: '18px',
-          },
-        }),
-        ...(mixOverride ?? []),
-      ]}
-    >
-      <Triangle label={orientation} orientation={orientation} />
-    </button>
-  )
+            '@media (prefers-color-scheme: light)': {
+              background: '#E0E0E0',
+              '&:active': {
+                background: '#D0D0D0',
+              },
+            },
+            '&:first-child': {
+              borderTopRightRadius: '18px',
+            },
+            '&:last-child': {
+              borderBottomRightRadius: '18px',
+            },
+          }),
+          ...(mixOverride ?? []),
+        ]}
+      >
+        <Triangle label={orientation} orientation={orientation} />
+      </button>
+    )
+  }
 }
 
 export function Logo() {

--- a/packages/ui/docs/component-changelog.md
+++ b/packages/ui/docs/component-changelog.md
@@ -2,6 +2,9 @@
 
 This is the changelog for [`component`](https://github.com/remix-run/remix/tree/main/packages/ui). It follows [semantic versioning](https://semver.org/).
 
+Historical examples below may show legacy component APIs from the release being described. Current
+components read props from `handle.props` and return a zero-argument render function.
+
 ## v0.7.0
 
 ### Minor Changes

--- a/packages/ui/docs/components.md
+++ b/packages/ui/docs/components.md
@@ -84,11 +84,11 @@ function Parent() {
   return () => <Child message="Hello from parent" count={42} />
 }
 
-function Child() {
-  return (props: { message: string; count: number }) => (
+function Child(handle: Handle<{ message: string; count: number }>) {
+  return () => (
     <div>
-      <p>{props.message}</p>
-      <p>Count: {props.count}</p>
+      <p>{handle.props.message}</p>
+      <p>Count: {handle.props.count}</p>
     </div>
   )
 }

--- a/packages/ui/docs/composition.md
+++ b/packages/ui/docs/composition.md
@@ -11,11 +11,11 @@ function Parent() {
   return () => <Child message="Hello from parent" count={42} />
 }
 
-function Child() {
-  return (props: { message: string; count: number }) => (
+function Child(handle: Handle<{ message: string; count: number }>) {
+  return () => (
     <div>
-      <p>{props.message}</p>
-      <p>Count: {props.count}</p>
+      <p>{handle.props.message}</p>
+      <p>Count: {handle.props.count}</p>
     </div>
   )
 }
@@ -26,11 +26,11 @@ function Child() {
 Components can compose other components via `children`:
 
 ```tsx
-function Layout() {
-  return (props: { children: RemixNode }) => (
+function Layout(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <div mix={[css({ padding: '20px', maxWidth: '1200px', margin: '0 auto' })]}>
       <header>My App</header>
-      <main>{props.children}</main>
+      <main>{handle.props.children}</main>
       <footer>© 2024</footer>
     </div>
   )

--- a/packages/ui/docs/styling.md
+++ b/packages/ui/docs/styling.md
@@ -190,8 +190,8 @@ function Button() {
 Use `&::before` and `&::after` for pseudo-elements:
 
 ```tsx
-function Badge() {
-  return (props: { count: number }) => (
+function Badge(handle: Handle<{ count: number }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -210,7 +210,7 @@ function Badge() {
         }),
       ]}
     >
-      {props.count > 0 && <span>{props.count}</span>}
+      {handle.props.count > 0 && <span>{handle.props.count}</span>}
     </div>
   )
 }
@@ -221,10 +221,10 @@ function Badge() {
 Use `&[attribute]` for attribute selectors:
 
 ```tsx
-function Input() {
-  return (props: { required?: boolean }) => (
+function Input(handle: Handle<{ required?: boolean }>) {
+  return () => (
     <input
-      required={props.required}
+      required={handle.props.required}
       mix={[
         css({
           padding: '8px',
@@ -249,8 +249,8 @@ function Input() {
 Use class names or element selectors directly for descendant selectors:
 
 ```tsx
-function Card() {
-  return (props: { children: RemixNode }) => (
+function Card(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -280,7 +280,7 @@ function Card() {
         }),
       ]}
     >
-      {props.children}
+      {handle.props.children}
     </div>
   )
 }
@@ -306,10 +306,10 @@ Use nested selectors when **parent state affects children**. Don't nest when you
 
 ```tsx
 // ❌ Avoid: Managing hover state in JavaScript
-function CardWithJSState(handle: Handle) {
+function CardWithJSState(handle: Handle<{ children: RemixNode }>) {
   let isHovered = false
 
-  return (props: { children: RemixNode }) => (
+  return () => (
     <div
       mix={[
         on('mouseenter', () => {
@@ -334,8 +334,8 @@ function CardWithJSState(handle: Handle) {
 }
 
 // ✅ Prefer: CSS nested selectors handle state declaratively
-function Card(handle: Handle) {
-  return (props: { children: RemixNode }) => (
+function Card(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -443,8 +443,8 @@ function Navigation() {
 Use `@media` for responsive design:
 
 ```tsx
-function ResponsiveGrid() {
-  return (props: { children: RemixNode }) => (
+function ResponsiveGrid(handle: Handle<{ children: RemixNode }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -460,7 +460,7 @@ function ResponsiveGrid() {
         }),
       ]}
     >
-      {props.children}
+      {handle.props.children}
     </div>
   )
 }
@@ -471,8 +471,8 @@ function ResponsiveGrid() {
 Here's a comprehensive example demonstrating parent-state-affecting-children and media queries:
 
 ```tsx
-function ProductCard() {
-  return (props: { title: string; price: number; image: string }) => (
+function ProductCard(handle: Handle<{ title: string; price: number; image: string }>) {
+  return () => (
     <div
       mix={[
         css({
@@ -501,8 +501,8 @@ function ProductCard() {
       ]}
     >
       <img
-        src={props.image}
-        alt={props.title}
+        src={handle.props.image}
+        alt={handle.props.title}
         mix={[
           css({
             width: '100%',
@@ -537,7 +537,7 @@ function ProductCard() {
             }),
           ]}
         >
-          {props.title}
+          {handle.props.title}
         </h3>
         <div
           className="price"
@@ -549,7 +549,7 @@ function ProductCard() {
             }),
           ]}
         >
-          ${props.price}
+          ${handle.props.price}
         </div>
         <button
           mix={[

--- a/packages/ui/src/animation/README.md
+++ b/packages/ui/src/animation/README.md
@@ -52,12 +52,13 @@ function Toast() {
 `animateExit` keeps a removed keyed element in the DOM long enough to animate from its natural styles to the provided keyframe.
 
 ```tsx
+import type { Handle } from 'remix/ui'
 import { animateExit } from 'remix/ui/animation'
 
-function Item({ id, label }: { id: string; label: string }) {
+function Item(handle: Handle<{ id: string; label: string }>) {
   return () => (
     <li
-      key={id}
+      key={handle.props.id}
       mix={[
         animateExit({
           opacity: 0,
@@ -67,7 +68,7 @@ function Item({ id, label }: { id: string; label: string }) {
         }),
       ]}
     >
-      {label}
+      {handle.props.label}
     </li>
   )
 }
@@ -105,12 +106,13 @@ Exit animations can reclaim a removed keyed node if the same keyed element is re
 `animateLayout` animates layout changes with a FLIP-style transform projection. Use it on elements whose position or size can change between renders.
 
 ```tsx
+import type { Handle } from 'remix/ui'
 import { animateLayout, spring } from 'remix/ui/animation'
 
-function Card({ expanded }: { expanded: boolean }) {
+function Card(handle: Handle<{ expanded: boolean }>) {
   return () => (
     <section
-      class={expanded ? 'card expanded' : 'card'}
+      class={handle.props.expanded ? 'card expanded' : 'card'}
       mix={[
         animateLayout({
           ...spring('smooth'),

--- a/packages/ui/src/runtime/jsx.ts
+++ b/packages/ui/src/runtime/jsx.ts
@@ -44,7 +44,7 @@ export type Renderable = RemixElement | string | number | bigint | boolean | nul
  * Particularly useful for `props.children`.
  *
  * ```tsx
- * function MyComponent({ children }: { children: RemixNode }) {}
+ * function MyComponent(handle: Handle<{ children: RemixNode }>) {}
  * ```
  */
 export type RemixNode = Renderable | RemixNode[]

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -1575,12 +1575,12 @@ describe('run', () => {
 
     let CartItems = clientEntry(
       '/assets/cart-items-css.js#CartItemsCss',
-      function CartItemsCss(handle: Handle) {
+      function CartItemsCss(handle: Handle<{ items: Item[] }>) {
         reload = () => handle.frame.reload()
 
-        return (props: { items: Item[] }) => (
+        return () => (
           <section>
-            {props.items.map((item) => (
+            {handle.props.items.map((item) => (
               <form
                 key={item.id}
                 data-row={item.id}
@@ -1671,7 +1671,7 @@ describe('run', () => {
 
     let CartSummary = clientEntry(
       '/assets/cart-summary-css.js#CartSummaryCss',
-      function CartSummaryCss(handle: Handle) {
+      function CartSummaryCss(handle: Handle<{ itemCount: number }>) {
         let pending = false
 
         startPendingReload = async () => {
@@ -1680,7 +1680,7 @@ describe('run', () => {
           return await handle.frame.reload()
         }
 
-        return (props: { itemCount: number }) => (
+        return () => (
           <section>
             {pending ? (
               <p id="pending-message" mix={[css({ color: 'rgb(200, 0, 0)' })]}>
@@ -1688,7 +1688,7 @@ describe('run', () => {
               </p>
             ) : null}
             <p id="item-count" mix={[css({ color: 'rgb(0, 0, 200)' })]}>
-              Items: {props.itemCount}
+              Items: {handle.props.itemCount}
             </p>
           </section>
         )

--- a/packages/ui/src/test/vdom.dom-order.test.tsx
+++ b/packages/ui/src/test/vdom.dom-order.test.tsx
@@ -405,9 +405,9 @@ describe('vnode rendering', () => {
       let capturedUpdates: (() => void)[] = []
       let showMiddle = false
 
-      function Middle(handle: Handle) {
+      function Middle(handle: Handle<{ id: string }>) {
         capturedUpdates.push(() => handle.update())
-        return ({ id }: { id: string }) => (showMiddle ? <span id={id}>Middle</span> : undefined)
+        return () => (showMiddle ? <span id={handle.props.id}>Middle</span> : undefined)
       }
 
       function App() {


### PR DESCRIPTION
Remix components read JSX props through `handle.props` and return zero-argument render functions. Some agent guidance, docs, and demos still showed component examples where props came from the render callback, so this brings those examples back in line with the current component model.

- Updates the Remix skill and UI agent/docs guidance to describe the current handle-based component shape.
- Rewrites demo and example components to type `Handle<Props>` and read current values from `handle.props`.
- Keeps createMixin callbacks unchanged, since those still receive host props, and marks historical changelog snippets as legacy context.
