### PR TITLE
Harden memcache fake server tests

### DIFF
--- a/packages/session-storage-memcache/src/lib/memcache-client.test.ts
+++ b/packages/session-storage-memcache/src/lib/memcache-client.test.ts
@@ -112,6 +112,12 @@ async function startFakeMemcacheServer(
     let store = new Map<string, Buffer>()
 
     let server = net.createServer((socket) => {
+      socket.on('error', () => {
+        // The client closes each request socket with socket.destroy() after it
+        // reads a response. On Windows, that close can show up here as a reset
+        // on the fake server socket after the test already asserted the response.
+      })
+
       let buffer = Buffer.alloc(0)
       let pendingSet: { key: string; bytes: number } | undefined
 

--- a/packages/session-storage-memcache/src/lib/memcache-storage.test.ts
+++ b/packages/session-storage-memcache/src/lib/memcache-storage.test.ts
@@ -195,6 +195,12 @@ async function startFakeMemcacheServer(): Promise<FakeMemcacheServer> {
     let store = new Map<string, Buffer>()
 
     let server = net.createServer((socket) => {
+      socket.on('error', () => {
+        // The client closes each request socket with socket.destroy() after it
+        // reads a response. On Windows, that close can show up here as a reset
+        // on the fake server socket after the test already asserted the response.
+      })
+
       let buffer = Buffer.alloc(0)
       let pendingSet: { key: string; bytes: number } | undefined
 


### PR DESCRIPTION
This hardens the Memcache package test fakes after the release PR hit a Windows changed-package test crash while running the Memcache session storage tests.

- Handles expected server-side socket reset errors from clients closing after each one-shot Memcache command.
- Keeps the package in the normal Windows test path without reducing package test concurrency.
- Leaves the fake server behavior otherwise unchanged.
