### PR TITLE
Speed up slow CI test files

### DIFF
--- a/packages/cli/src/lib/commands/doctor.test.ts
+++ b/packages/cli/src/lib/commands/doctor.test.ts
@@ -9,6 +9,7 @@ import { describe, it } from '@remix-run/test'
 import { runRemix } from '../../index.ts'
 import { getFixturePath } from '../../../test/fixtures.ts'
 import { captureOutput } from '../../../test/capture-output.ts'
+import { checkEnvironment, getEnvironmentFixPlans } from '../doctor/environment.ts'
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../..')
 const ANSI_CSI = `${String.fromCharCode(27)}[`
@@ -268,22 +269,6 @@ describe('doctor command', () => {
     for (let { label, range } of getSupportedNodeRangeCases()) {
       let projectDir = await createTempProject(
         {
-          'app/actions/controller.js': [
-            'export default {',
-            '  actions: {',
-            '    home() {',
-            "      return new Response('ok')",
-            '    },',
-            '  },',
-            '}',
-          ].join('\n'),
-          'app/routes.ts': [
-            "import { route } from 'remix/routes'",
-            '',
-            'export const routes = route({',
-            "  home: '/',",
-            '})',
-          ].join('\n'),
           'package.json': JSON.stringify(
             {
               dependencies: {
@@ -304,26 +289,12 @@ describe('doctor command', () => {
       )
 
       try {
-        let checkResult = await runDoctor([], projectDir)
+        let result = await checkEnvironment(projectDir)
+        let fixPlans = getEnvironmentFixPlans(result, '9.9.9')
 
-        assert.equal(checkResult.exitCode, 0, `${label}: ${checkResult.stderr}`)
-        assert.match(checkResult.stdout, /Doctor found no issues\./, label)
-        assert.equal(checkResult.stderr, '', label)
-
-        let fixResult = await runDoctor(['--fix'], projectDir)
-
-        assert.equal(fixResult.exitCode, 0, `${label}: ${fixResult.stderr}`)
-        assert.doesNotMatch(fixResult.stdout, /Applied fixes:/, label)
-        assert.match(fixResult.stdout, /Doctor found no issues\./, label)
-        assert.equal(fixResult.stderr, '', label)
-
-        let packageJson = JSON.parse(
-          await fs.readFile(path.join(projectDir, 'package.json'), 'utf8'),
-        ) as {
-          engines: Record<string, string>
-        }
-
-        assert.equal(packageJson.engines.node, range, label)
+        assert.equal(result.suite.status, 'ok', label)
+        assert.deepEqual(result.suite.findings, [], label)
+        assert.deepEqual(fixPlans, [], label)
       } finally {
         await fs.rm(projectDir, { recursive: true, force: true })
       }
@@ -396,12 +367,7 @@ describe('doctor command', () => {
 
       assert.equal(packageJson.dependencies.remix, remixPackageJson.version)
       assert.equal(packageJson.engines.node, '>=24.3.0')
-
-      let checkResult = await runDoctor([], projectDir)
-
-      assert.equal(checkResult.exitCode, 0, checkResult.stderr)
-      assert.match(checkResult.stdout, /Doctor found no issues\./)
-      assert.equal(checkResult.stderr, '')
+      assert.match(fixResult.stdout, /Doctor found no issues\./)
     } finally {
       await fs.rm(projectDir, { recursive: true, force: true })
     }
@@ -534,12 +500,7 @@ describe('doctor command', () => {
       }
 
       assert.equal(packageJson.engines.node, '>=24.3.0')
-
-      let checkResult = await runDoctor([], projectDir)
-
-      assert.equal(checkResult.exitCode, 0, checkResult.stderr)
-      assert.match(checkResult.stdout, /Doctor found no issues\./)
-      assert.equal(checkResult.stderr, '')
+      assert.match(fixResult.stdout, /Doctor found no issues\./)
     } finally {
       await fs.rm(projectDir, { recursive: true, force: true })
     }
@@ -609,12 +570,7 @@ describe('doctor command', () => {
       assert.match(controllerSource, /home\(\) \{\n\s+let page = html`/)
       assert.match(controllerSource, /return createHtmlResponse\(page\)/)
       assert.match(controllerSource, /<h1>Home<\/h1>/)
-
-      let checkResult = await runDoctor([], projectDir)
-
-      assert.equal(checkResult.exitCode, 0, checkResult.stderr)
-      assert.match(checkResult.stdout, /Doctor found no issues\./)
-      assert.equal(checkResult.stderr, '')
+      assert.match(fixResult.stdout, /Doctor found no issues\./)
     } finally {
       await fs.rm(projectDir, { recursive: true, force: true })
     }
@@ -662,12 +618,7 @@ describe('doctor command', () => {
       assert.match(routesSource, /home: '\//)
       assert.match(controllerSource, /export default \{/)
       assert.match(controllerSource, /home\(\) \{/)
-
-      let checkResult = await runDoctor([], projectDir)
-
-      assert.equal(checkResult.exitCode, 0, checkResult.stderr)
-      assert.match(checkResult.stdout, /Doctor found no issues\./)
-      assert.equal(checkResult.stderr, '')
+      assert.match(fixResult.stdout, /Doctor found no issues\./)
     } finally {
       await fs.rm(projectDir, { recursive: true, force: true })
     }
@@ -705,12 +656,6 @@ describe('doctor command', () => {
       assert.match(contactSource, /action\(\) \{/)
       assert.match(contactSource, /TODO: implement routes\.contact\.index/)
       assert.match(contactSource, /TODO: implement routes\.contact\.action/)
-
-      let checkResult = await runDoctor([], projectDir)
-
-      assert.equal(checkResult.exitCode, 0, checkResult.stderr)
-      assert.match(checkResult.stdout, /Doctor found no issues\./)
-      assert.equal(checkResult.stderr, '')
     } finally {
       await fs.rm(projectDir, { recursive: true, force: true })
     }
@@ -758,12 +703,7 @@ describe('doctor command', () => {
 
       assert.match(controllerSource, /"sales-report"\(\) \{/)
       assert.match(controllerSource, /TODO: implement routes\.sales-report/)
-
-      let checkResult = await runDoctor([], projectDir)
-
-      assert.equal(checkResult.exitCode, 0, checkResult.stderr)
-      assert.match(checkResult.stdout, /Doctor found no issues\./)
-      assert.equal(checkResult.stderr, '')
+      assert.match(fixResult.stdout, /Doctor found no issues\./)
     } finally {
       await fs.rm(projectDir, { recursive: true, force: true })
     }
@@ -806,12 +746,7 @@ describe('doctor command', () => {
       assert.match(fixResult.stdout, /Created app\/actions\/controller\.js/)
       await assertPathExists(path.join(projectDir, 'app', 'actions', 'controller.js'))
       await assertPathMissing(outsidePath)
-
-      let checkResult = await runDoctor([], projectDir)
-
-      assert.equal(checkResult.exitCode, 0, checkResult.stderr)
-      assert.match(checkResult.stdout, /Doctor found no issues\./)
-      assert.equal(checkResult.stderr, '')
+      assert.match(fixResult.stdout, /Doctor found no issues\./)
     } finally {
       await fs.rm(projectDir, { recursive: true, force: true })
     }
@@ -936,12 +871,7 @@ describe('doctor command', () => {
       assert.match(contactSource, /import \{ createController \} from 'remix\/router'/)
       assert.match(contactSource, /import \{ routes \} from '\.\.\/\.\.\/routes\.ts'/)
       assert.match(contactSource, /export default createController\(routes\.contact, \{/)
-
-      let checkResult = await runDoctor([], projectDir)
-
-      assert.equal(checkResult.exitCode, 0, checkResult.stderr)
-      assert.match(checkResult.stdout, /Doctor found no issues\./)
-      assert.equal(checkResult.stderr, '')
+      assert.match(fixResult.stdout, /Doctor found no issues\./)
     } finally {
       await fs.rm(projectDir, { recursive: true, force: true })
     }
@@ -1066,12 +996,7 @@ describe('doctor command', () => {
 
       assert.match(forgotPasswordSource, /TODO: implement routes\.auth\.forgotPassword\.index/)
       assert.match(forgotPasswordSource, /TODO: implement routes\.auth\.forgotPassword\.action/)
-
-      let checkResult = await runDoctor([], projectDir)
-
-      assert.equal(checkResult.exitCode, 0, checkResult.stderr)
-      assert.match(checkResult.stdout, /Doctor found no issues\./)
-      assert.equal(checkResult.stderr, '')
+      assert.match(fixResult.stdout, /Doctor found no issues\./)
     } finally {
       await fs.rm(projectDir, { recursive: true, force: true })
     }

--- a/packages/cli/src/lib/commands/routes.test.ts
+++ b/packages/cli/src/lib/commands/routes.test.ts
@@ -48,14 +48,8 @@ describe('routes command', () => {
     assert.equal(result.exitCode, 0, result.stderr)
     assert.match(result.stdout, /home\s+ANY\s+\/\s+-> controller\.tsx/)
     assert.match(result.stdout, /auth\s+ANY\s+\/auth\s+-> controller\.tsx/)
-    assert.equal(result.stderr, '')
-  })
-
-  it('does not print color when output is not a tty', async () => {
-    let result = await runRoutes([], getFixturePath('routes-basic'))
-
-    assert.equal(result.exitCode, 0, result.stderr)
     assert.equal(result.stdout.includes(ANSI_CSI), false)
+    assert.equal(result.stderr, '')
   })
 
   it('works from a nested directory inside an app', async () => {
@@ -114,13 +108,6 @@ describe('routes command', () => {
       /auth\.login\.action\s+POST\s+\/login\s+auth\/login\/controller\.tsx/,
     )
     assert.equal(result.stderr, '')
-  })
-
-  it('accepts the global no-color flag', async () => {
-    let result = await runRoutes(['--no-color'], getFixturePath('routes-missing'))
-
-    assert.equal(result.exitCode, 0, result.stderr)
-    assert.equal(result.stdout.includes(ANSI_CSI), false)
   })
 
   it('resolves owner files with js, jsx, and ts extensions', async () => {
@@ -213,9 +200,10 @@ describe('routes command', () => {
   })
 
   it('annotates missing owners without failing the command', async () => {
-    let result = await runRoutes([], getFixturePath('routes-missing'))
+    let result = await runRoutes(['--no-color'], getFixturePath('routes-missing'))
 
     assert.equal(result.exitCode, 0, result.stderr)
+    assert.equal(result.stdout.includes(ANSI_CSI), false)
     assert.match(result.stdout, /home\s+ANY\s+\/\s+-> controller\.tsx \[missing\]/)
     assert.match(result.stdout, /auth -> auth \[missing\]/)
     assert.match(result.stdout, /login -> auth\/login\/controller\.tsx \[missing\]/)

--- a/packages/cli/src/lib/commands/test.test.ts
+++ b/packages/cli/src/lib/commands/test.test.ts
@@ -52,27 +52,6 @@ describe('test command', () => {
     }
   })
 
-  it('returns after running tests even when the project leaves handles open', async () => {
-    let projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remix-cli-test-command-handles-'))
-
-    try {
-      await writeTestProject(projectDir, { leaveHandleOpen: true })
-
-      let result = await captureOutput(() =>
-        runRemix(['test', '--concurrency', '1', '--reporter', 'spec', '--type', 'server'], {
-          cwd: projectDir,
-        }),
-      )
-
-      let stdout = stripVTControlCharacters(result.stdout)
-
-      assert.equal(result.exitCode, 0, result.stderr)
-      assert.match(stdout, /✓ passes/)
-    } finally {
-      await fs.rm(projectDir, { recursive: true, force: true })
-    }
-  })
-
   it('exits watch mode when no test files can be found', async () => {
     let projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remix-cli-test-command-empty-'))
 
@@ -101,10 +80,7 @@ describe('test command', () => {
   })
 })
 
-async function writeTestProject(
-  projectDir: string,
-  options: { leaveHandleOpen?: boolean } = {},
-): Promise<void> {
+async function writeTestProject(projectDir: string): Promise<void> {
   await fs.writeFile(
     path.join(projectDir, 'package.json'),
     `${JSON.stringify({ name: 'test-command-fixture', private: true, type: 'module' }, null, 2)}\n`,
@@ -122,7 +98,6 @@ async function writeTestProject(
       "import { it } from '@remix-run/test'",
       '',
       "it('passes', () => {",
-      options.leaveHandleOpen ? '  setInterval(() => {}, 1_000)' : '',
       '  assert.equal(1 + 1, 2)',
       '})',
       '',

--- a/packages/multipart-parser/src/lib/multipart-request.test.ts
+++ b/packages/multipart-parser/src/lib/multipart-request.test.ts
@@ -18,6 +18,7 @@ import {
 } from './multipart-request.ts'
 
 const CRLF = '\r\n'
+const LARGE_FILE_SIZE = 128 * 1024
 
 describe('getMultipartBoundary', async () => {
   it('returns the boundary from the Content-Type header', async () => {
@@ -333,8 +334,8 @@ describe('parseMultipartRequest', async () => {
   })
 
   it('parses large file uploads correctly', async () => {
-    let maxFileSize = 10 * 1024 * 1024 // 10 MiB
-    let content = getRandomBytes(maxFileSize) // 10 MiB file
+    let maxFileSize = LARGE_FILE_SIZE
+    let content = getRandomBytes(maxFileSize)
     let request = new Request('https://example.com', {
       method: 'POST',
       headers: {
@@ -489,6 +490,7 @@ describe('parseMultipartRequest', async () => {
   })
 
   it('throws when a file exceeds maximum size', async () => {
+    let maxFileSize = LARGE_FILE_SIZE
     let request = new Request('https://example.com', {
       method: 'POST',
       headers: {
@@ -498,13 +500,13 @@ describe('parseMultipartRequest', async () => {
         file1: {
           filename: 'random.dat',
           mediaType: 'application/octet-stream',
-          content: getRandomBytes(11 * 1024 * 1024), // 11 MB file
+          content: getRandomBytes(maxFileSize + 1),
         },
       }),
     })
 
     await assert.rejects(async () => {
-      for await (let _ of parseMultipartRequest(request, { maxFileSize: 10 * 1024 * 1024 })) {
+      for await (let _ of parseMultipartRequest(request, { maxFileSize })) {
         // ...
       }
     }, MaxFileSizeExceededError)

--- a/packages/multipart-parser/src/lib/multipart.node.test.ts
+++ b/packages/multipart-parser/src/lib/multipart.node.test.ts
@@ -8,6 +8,8 @@ import type { MultipartPart } from './multipart.ts'
 import { MaxPartsExceededError, MaxTotalSizeExceededError } from './multipart.ts'
 import { parseMultipartRequest } from './multipart.node.ts'
 
+const LARGE_FILE_SIZE = 128 * 1024
+
 describe('parseMultipartRequest (node)', () => {
   let boundary = '----WebKitFormBoundaryzv5f5B2cY6tjQ0Rn'
 
@@ -38,7 +40,7 @@ describe('parseMultipartRequest (node)', () => {
   })
 
   it('parses large file uploads correctly', async () => {
-    let maxFileSize = 1024 * 1024 * 10 // 10 MiB
+    let maxFileSize = LARGE_FILE_SIZE
     let content = getRandomBytes(maxFileSize)
     let request = createMultipartRequest(boundary, {
       file1: {

--- a/packages/test/src/test/coverage-parity.test.ts
+++ b/packages/test/src/test/coverage-parity.test.ts
@@ -73,13 +73,16 @@ describe('coverage parity', () => {
   it('all three runners produce identical coverage for the fixture', { skip: IS_BUN }, async () => {
     await fsp.rm(PARITY_DIR, { recursive: true, force: true })
 
-    let records = new Map<string, string>()
-    for (let spec of RUNS) {
-      let dir = path.join(PARITY_DIR, spec.type)
-      await runWithCoverage(spec, dir)
-      let lcov = await fsp.readFile(path.join(dir, 'lcov.info'), 'utf-8')
-      records.set(spec.type, extractFixtureRecord(lcov))
-    }
+    let records = new Map(
+      await Promise.all(
+        RUNS.map(async (spec) => {
+          let dir = path.join(PARITY_DIR, spec.type)
+          await runWithCoverage(spec, dir)
+          let lcov = await fsp.readFile(path.join(dir, 'lcov.info'), 'utf-8')
+          return [spec.type, extractFixtureRecord(lcov)] as const
+        }),
+      ),
+    )
 
     let server = records.get('server')!
     let browser = records.get('browser')!


### PR DESCRIPTION
This trims several of the slowest test files surfaced by CI while keeping the same behavioral coverage.

- Removes redundant `remix doctor` command reruns after `--fix` already rechecks and reports the cleaned project
- Tests doctor semver range handling through the environment checker and fix planner instead of repeating the full CLI command path
- Drops a redundant CLI wrapper leaked-worker test covered directly by `@remix-run/test`
- Folds duplicate routes command assertions into existing command tests
- Shrinks multipart large-file fixtures from 10-11 MiB to 128 KiB while still crossing stream chunks and exercising max file size handling
- Runs coverage parity server/browser/e2e subprocesses in parallel because they write to independent coverage directories

CI timing comparison, using file-level durations from GitHub Actions logs:

| Test file | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| `packages/cli/src/lib/commands/doctor.test.ts` (Windows) | 18.60s | 6.03s | 3.1x |
| `packages/cli/src/lib/commands/routes.test.ts` (Windows changed packages) | 8.35s | 1.85s | 4.5x |
| `packages/cli/src/lib/commands/test.test.ts` (Ubuntu) | 11.13s | 0.60s | 18.5x |
| `packages/multipart-parser/src/lib/multipart-request.test.ts` (Ubuntu) | 29.19s | 1.80s | 16.2x |
| `packages/multipart-parser/src/lib/multipart.node.test.ts` (Ubuntu) | 30.04s | 1.38s | 21.8x |
| `packages/test/src/test/coverage-parity.test.ts` (Ubuntu) | 28.54s | 18.71s | 1.5x |

Before values are from the latest `main` Test workflow run `26187259943`, except `routes.test.ts`, which uses the first PR changed-package run `26188459002` where it was the changed-package hotspot. After values are from the latest PR Test workflow run `26190605709`.
