### PR TITLE
Prevent static middleware symlink escapes

### DIFF
--- a/packages/static-middleware/.changes/patch.prevent-symlink-root-escape.md
+++ b/packages/static-middleware/.changes/patch.prevent-symlink-root-escape.md
@@ -1,0 +1,1 @@
+Prevent `staticFiles()` from serving files outside its configured root through symlinks.

--- a/packages/static-middleware/src/lib/static.test.ts
+++ b/packages/static-middleware/src/lib/static.test.ts
@@ -395,6 +395,36 @@ describe('staticFiles middleware', () => {
     }
   })
 
+  it('serves symlinked files inside the root using the requested path metadata', async () => {
+    let publicDir = path.join(tmpDir, 'public')
+    fs.mkdirSync(publicDir)
+    fs.writeFileSync(path.join(publicDir, 'asset.txt'), 'console.log("safe")')
+    fs.symlinkSync(path.join(publicDir, 'asset.txt'), path.join(publicDir, 'asset.js'))
+    let files: Array<{ name: string; type: string }> = []
+
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [
+        staticFiles(publicDir, {
+          acceptRanges(file) {
+            files.push({ name: file.name, type: file.type })
+            return false
+          },
+        }),
+      ],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/asset.js')
+
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'console.log("safe")')
+    assert.equal(response.headers.get('Content-Type'), 'text/javascript; charset=utf-8')
+    assert.deepEqual(files, [{ name: 'asset.js', type: 'text/javascript' }])
+  })
+
   it('does not serve symlinked files outside the root', async () => {
     let publicDir = path.join(tmpDir, 'public')
     fs.mkdirSync(publicDir)

--- a/packages/static-middleware/src/lib/static.test.ts
+++ b/packages/static-middleware/src/lib/static.test.ts
@@ -395,6 +395,66 @@ describe('staticFiles middleware', () => {
     }
   })
 
+  it('does not serve symlinked files outside the root', async () => {
+    let publicDir = path.join(tmpDir, 'public')
+    fs.mkdirSync(publicDir)
+    createTestFile('secret.txt', 'Secret content')
+    fs.symlinkSync(path.join(tmpDir, 'secret.txt'), path.join(publicDir, 'leak.txt'))
+
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [staticFiles(publicDir)],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/leak.txt')
+
+    assert.equal(response.status, 404)
+    assert.equal(await response.text(), 'Fallback Handler')
+  })
+
+  it('does not serve files from symlinked directories outside the root', async () => {
+    let publicDir = path.join(tmpDir, 'public')
+    fs.mkdirSync(publicDir)
+    createTestFile('private/secret.txt', 'Secret content')
+    fs.symlinkSync(path.join(tmpDir, 'private'), path.join(publicDir, 'private'), 'dir')
+
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [staticFiles(publicDir)],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/private/secret.txt')
+
+    assert.equal(response.status, 404)
+    assert.equal(await response.text(), 'Fallback Handler')
+  })
+
+  it('does not serve index files from symlinked directories outside the root', async () => {
+    let publicDir = path.join(tmpDir, 'public')
+    fs.mkdirSync(publicDir)
+    createTestFile('private/index.html', 'Secret index')
+    fs.symlinkSync(path.join(tmpDir, 'private'), path.join(publicDir, 'private'), 'dir')
+
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [staticFiles(publicDir)],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/private')
+
+    assert.equal(response.status, 404)
+    assert.equal(await response.text(), 'Fallback Handler')
+  })
+
   describe('filter option', () => {
     it('filters files based on custom filter function', async () => {
       createTestFile('index.html', '<h1>Home</h1>')

--- a/packages/static-middleware/src/lib/static.ts
+++ b/packages/static-middleware/src/lib/static.ts
@@ -2,9 +2,15 @@ import * as path from 'node:path'
 import * as fsp from 'node:fs/promises'
 import { openLazyFile } from '@remix-run/fs'
 import type { Middleware } from '@remix-run/fetch-router'
+import { detectMimeType } from '@remix-run/mime'
 import { createFileResponse as sendFile, type FileResponseOptions } from '@remix-run/response/file'
 
 import { generateDirectoryListing } from './directory-listing.ts'
+
+interface StaticFileMatch {
+  realPath: string
+  requestedPath: string
+}
 
 /**
  * Function that determines if HTTP Range requests should be supported for a given file.
@@ -120,17 +126,20 @@ export function staticFiles(root: string, options: StaticFilesOptions = {}): Mid
       return next()
     }
 
-    let filePath: string | undefined
+    let file: StaticFileMatch | undefined
 
     try {
       let stats = await fsp.stat(containedTargetPath)
 
       if (stats.isFile()) {
-        filePath = containedTargetPath
+        file = {
+          realPath: containedTargetPath,
+          requestedPath: targetPath,
+        }
       } else if (stats.isDirectory()) {
         // Try each index file in turn
         for (let indexFile of index) {
-          let indexPath = path.join(containedTargetPath, indexFile)
+          let indexPath = path.join(targetPath, indexFile)
           let containedIndexPath = await resolveContainedPath(rootRealPath, indexPath)
           if (containedIndexPath == null) {
             continue
@@ -139,7 +148,10 @@ export function staticFiles(root: string, options: StaticFilesOptions = {}): Mid
           try {
             let indexStats = await fsp.stat(containedIndexPath)
             if (indexStats.isFile()) {
-              filePath = containedIndexPath
+              file = {
+                realPath: containedIndexPath,
+                requestedPath: indexPath,
+              }
               break
             }
           } catch {
@@ -148,7 +160,7 @@ export function staticFiles(root: string, options: StaticFilesOptions = {}): Mid
         }
 
         // If no index file found and listFiles is enabled, show directory listing
-        if (!filePath && listFiles) {
+        if (!file && listFiles) {
           return generateDirectoryListing(containedTargetPath, context.url.pathname)
         }
       }
@@ -156,9 +168,12 @@ export function staticFiles(root: string, options: StaticFilesOptions = {}): Mid
       // Path doesn't exist or isn't accessible, fall through
     }
 
-    if (filePath) {
-      let fileName = path.relative(root, filePath)
-      let lazyFile = openLazyFile(filePath, { name: fileName })
+    if (file) {
+      let fileName = path.relative(root, file.requestedPath)
+      let lazyFile = openLazyFile(file.realPath, {
+        name: fileName,
+        type: detectMimeType(file.requestedPath) ?? '',
+      })
 
       let finalFileOptions: FileResponseOptions = { ...fileOptions }
 

--- a/packages/static-middleware/src/lib/static.ts
+++ b/packages/static-middleware/src/lib/static.ts
@@ -107,22 +107,39 @@ export function staticFiles(root: string, options: StaticFilesOptions = {}): Mid
       return next()
     }
 
+    let rootRealPath: string
+    try {
+      rootRealPath = await fsp.realpath(root)
+    } catch {
+      return next()
+    }
+
     let targetPath = path.join(root, relativePath)
+    let containedTargetPath = await resolveContainedPath(rootRealPath, targetPath)
+    if (containedTargetPath == null) {
+      return next()
+    }
+
     let filePath: string | undefined
 
     try {
-      let stats = await fsp.stat(targetPath)
+      let stats = await fsp.stat(containedTargetPath)
 
       if (stats.isFile()) {
-        filePath = targetPath
+        filePath = containedTargetPath
       } else if (stats.isDirectory()) {
         // Try each index file in turn
         for (let indexFile of index) {
-          let indexPath = path.join(targetPath, indexFile)
+          let indexPath = path.join(containedTargetPath, indexFile)
+          let containedIndexPath = await resolveContainedPath(rootRealPath, indexPath)
+          if (containedIndexPath == null) {
+            continue
+          }
+
           try {
-            let indexStats = await fsp.stat(indexPath)
+            let indexStats = await fsp.stat(containedIndexPath)
             if (indexStats.isFile()) {
-              filePath = indexPath
+              filePath = containedIndexPath
               break
             }
           } catch {
@@ -132,7 +149,7 @@ export function staticFiles(root: string, options: StaticFilesOptions = {}): Mid
 
         // If no index file found and listFiles is enabled, show directory listing
         if (!filePath && listFiles) {
-          return generateDirectoryListing(targetPath, context.url.pathname)
+          return generateDirectoryListing(containedTargetPath, context.url.pathname)
         }
       }
     } catch {
@@ -158,4 +175,21 @@ export function staticFiles(root: string, options: StaticFilesOptions = {}): Mid
 
     return next()
   }
+}
+
+async function resolveContainedPath(
+  rootRealPath: string,
+  targetPath: string,
+): Promise<string | null> {
+  try {
+    let realPath = await fsp.realpath(targetPath)
+    return isContainedPath(rootRealPath, realPath) ? realPath : null
+  } catch {
+    return null
+  }
+}
+
+function isContainedPath(rootPath: string, targetPath: string): boolean {
+  let relativePath = path.relative(rootPath, targetPath)
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
 }


### PR DESCRIPTION
staticFiles() resolved request candidates with `stat()`, so a symlink inside the configured root could point outside that root and still be served. This changes file and index resolution to compare real paths and fall through when a candidate escapes the configured root.

- Blocks symlinked files and symlinked directories that resolve outside `staticFiles()` root
- Preserves the existing fallback behavior for missing or inaccessible roots and files
- Adds regression coverage for direct file, nested directory, and directory-index symlink escapes