### PR TITLE
Reject unsafe OAuth returnTo redirects

### DIFF
--- a/packages/auth/.changes/patch.reject-backslash-return-to.md
+++ b/packages/auth/.changes/patch.reject-backslash-return-to.md
@@ -1,0 +1,1 @@
+Reject OAuth `returnTo` values that resolve outside the current origin when browsers normalize backslashes in redirect locations.

--- a/packages/auth/src/lib/start-external-auth.test.ts
+++ b/packages/auth/src/lib/start-external-auth.test.ts
@@ -91,4 +91,38 @@ describe('startExternalAuth()', () => {
     assert.equal(typeof transaction.codeVerifier, 'string')
     assert.equal(transaction.returnTo, undefined)
   })
+
+  it('drops backslash returnTo values before persisting the transaction', async () => {
+    let cookie = createCookie('__session', { secrets: ['secret1'] })
+    let storage = createMemorySessionStorage()
+    let provider = createGoogleAuthProvider({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      redirectUri: 'https://app.example.com/auth/google/callback',
+    })
+    let router = createRouter({
+      middleware: [sessionMiddleware(cookie, storage)],
+    })
+
+    router.get('/login/google', (context) =>
+      startExternalAuth(provider, context, {
+        returnTo: context.url.searchParams.get('returnTo'),
+      }),
+    )
+    router.get('/inspect', ({ get }) => Response.json(get(Session).get('__auth')))
+
+    let response = await router.fetch(
+      'https://app.example.com/login/google?returnTo=%2F%5Cevil.example.com',
+    )
+    let inspectResponse = await router.fetch(
+      createRequest('https://app.example.com/inspect', response),
+    )
+    let transaction = await inspectResponse.json()
+
+    assert.equal(response.status, 302)
+    assert.equal(transaction.provider, 'google')
+    assert.equal(typeof transaction.state, 'string')
+    assert.equal(typeof transaction.codeVerifier, 'string')
+    assert.equal(transaction.returnTo, undefined)
+  })
 })

--- a/packages/auth/src/lib/utils.ts
+++ b/packages/auth/src/lib/utils.ts
@@ -5,6 +5,7 @@ import type { OAuthTransaction } from './provider.ts'
 
 const textEncoder = new TextEncoder()
 const base64Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+const returnToBaseURL = 'https://remix.local'
 
 export function createCodeVerifier(): string {
   return createRandomToken(48)
@@ -75,11 +76,22 @@ export function sanitizeReturnTo(value: string | null): string | undefined {
     return
   }
 
-  if (!value.startsWith('/') || value.startsWith('//')) {
+  if (!value.startsWith('/')) {
     return
   }
 
-  return value
+  let url: URL
+  try {
+    url = new URL(value, returnToBaseURL)
+  } catch {
+    return
+  }
+
+  if (url.origin !== returnToBaseURL) {
+    return
+  }
+
+  return url.pathname + url.search + url.hash
 }
 
 function createRandomToken(byteLength: number): string {


### PR DESCRIPTION
OAuth `returnTo` values only checked for a leading slash, which let backslash-normalized redirect targets behave like cross-origin locations in browsers. This resolves stored values against a fixed same-origin base and only keeps path/search/hash output when the resolved URL remains same-origin.

- Rejects backslash-based `returnTo` values such as `/\evil.example.com`
- Keeps normal app-relative redirect targets like `/dashboard`
- Adds regression coverage through `startExternalAuth()` so unsafe values are never persisted in the OAuth transaction