### PR TITLE
Fix lazy-file nested slice ranges

### DIFF
--- a/packages/lazy-file/.changes/patch.slice-existing-slice.md
+++ b/packages/lazy-file/.changes/patch.slice-existing-slice.md
@@ -1,0 +1,1 @@
+Fix `LazyBlob.slice()` and `LazyFile.slice()` so slicing an existing slice is calculated relative to the current slice instead of the original source content.

--- a/packages/lazy-file/src/lib/lazy-file.test.ts
+++ b/packages/lazy-file/src/lib/lazy-file.test.ts
@@ -19,10 +19,10 @@ function createLazyContent(value = ''): LazyContent {
   let buffer = new TextEncoder().encode(value)
   return {
     byteLength: buffer.byteLength,
-    stream() {
+    stream(start = 0, end = buffer.byteLength) {
       return new ReadableStream({
         start(controller) {
-          controller.enqueue(buffer)
+          controller.enqueue(buffer.subarray(start, end))
           controller.close()
         },
       })
@@ -107,6 +107,14 @@ describe('LazyBlob', () => {
       let slice = blob.slice(0, 5)
       assert.equal(slice instanceof LazyBlob, true)
       assert.equal(slice.size, 5)
+    })
+
+    it('slices relative to an existing slice', async () => {
+      let blob = new LazyBlob(createLazyContent('0123456789'), { type: 'text/plain' })
+      let slice = blob.slice(2, 8).slice(1, 4)
+
+      assert.equal(slice.size, 3)
+      assert.equal(await slice.text(), '345')
     })
   })
 
@@ -298,6 +306,15 @@ describe('LazyFile', () => {
       lazyFile.slice(20, 10).stream()
       assert.equal(read.mock.calls.length, 1)
       assert.deepEqual(read.mock.calls[0].arguments, [20, 20])
+    })
+
+    it('calls content.stream() with the correct range when slicing an existing slice', (t) => {
+      let content = createLazyContent('X'.repeat(100))
+      let read = t.mock.method(content, 'stream')
+      let lazyFile = new LazyFile(content, 'example.txt', { type: 'text/plain' })
+      lazyFile.slice(20, 80).slice(-20, -10).stream()
+      assert.equal(read.mock.calls.length, 1)
+      assert.deepEqual(read.mock.calls[0].arguments, [60, 70])
     })
   })
 

--- a/packages/lazy-file/src/lib/lazy-file.ts
+++ b/packages/lazy-file/src/lib/lazy-file.ts
@@ -430,11 +430,21 @@ class BlobContent {
   }
 
   slice(start = 0, end?: number, contentType = ''): LazyBlob {
-    let range: ByteRange =
-      this.range != null
-        ? // file.slice().slice() is additive
-          { start: this.range.start + start, end: this.range.end + (end ?? 0) }
-        : { start, end: end ?? this.size }
+    let sourceStart = 0
+    let sourceEnd = this.totalSize
+
+    if (this.range != null) {
+      let sourceRange = getIndexes(this.range, this.totalSize)
+      sourceStart = sourceRange[0]
+      sourceEnd = sourceRange[1]
+    }
+
+    let sourceSize = sourceEnd - sourceStart
+    let [sliceStart, sliceEnd] = getIndexes({ start, end: end ?? sourceSize }, sourceSize)
+    let range: ByteRange = {
+      start: sourceStart + sliceStart,
+      end: sourceStart + sliceEnd,
+    }
 
     return new LazyBlob(this.source, { range, type: contentType })
   }


### PR DESCRIPTION
Fixes a bug in lazy-file slice composition where calling `slice()` on an existing `LazyBlob` or `LazyFile` slice computed the new range from the original source instead of the current slice. That could expose bytes outside the current slice, and negative indexes could collapse to the wrong range.

- Resolve nested slice ranges against the current visible range before mapping back to source offsets
- Cover nested slicing through both returned text and the underlying lazy stream range
- Add a patch change file for `@remix-run/lazy-file`
