### PR TITLE
Encode route href path params

### DIFF
--- a/packages/route-pattern/.changes/patch.encode-href-path-params.md
+++ b/packages/route-pattern/.changes/patch.encode-href-path-params.md
@@ -1,0 +1,1 @@
+Encode path params in `createHref()` so generated URLs keep params inside their route segment and cannot become scheme-relative redirects.

--- a/packages/route-pattern/src/lib/href.test.ts
+++ b/packages/route-pattern/src/lib/href.test.ts
@@ -139,6 +139,13 @@ describe('createHref', () => {
         )
       })
 
+      it('preserves path-safe characters in dynamic path params', () => {
+        assert.equal(
+          createHref('/packages/:name', { name: '@remix-run/ui' }),
+          '/packages/@remix-run%2Fui',
+        )
+      })
+
       it('does not generate scheme-relative URLs from dynamic path params', () => {
         let href = createHref('/:next', { next: '/evil.example.com' })
         let url = new URL(href, 'https://app.example.com')
@@ -189,6 +196,13 @@ describe('createHref', () => {
       assert.equal(
         createHref('/files/*path', { path: 'docs/read me.md?raw#top' }),
         '/files/docs/read%20me.md%3Fraw%23top',
+      )
+    })
+
+    it('preserves path-safe characters in named wildcard path params', () => {
+      assert.equal(
+        createHref('/assets/*path', { path: '@remix-run/ui/jsx-runtime.js' }),
+        '/assets/@remix-run/ui/jsx-runtime.js',
       )
     })
 

--- a/packages/route-pattern/src/lib/href.test.ts
+++ b/packages/route-pattern/src/lib/href.test.ts
@@ -132,6 +132,21 @@ describe('createHref', () => {
         assert.equal(createHref('/posts/:id', { id: 123 }), '/posts/123')
       })
 
+      it('percent-encodes dynamic path params', () => {
+        assert.equal(
+          createHref('/posts/:id', { id: 'a/b?x#top\\end' }),
+          '/posts/a%2Fb%3Fx%23top%5Cend',
+        )
+      })
+
+      it('does not generate scheme-relative URLs from dynamic path params', () => {
+        let href = createHref('/:next', { next: '/evil.example.com' })
+        let url = new URL(href, 'https://app.example.com')
+
+        assert.equal(href, '/%2Fevil.example.com')
+        assert.equal(url.origin, 'https://app.example.com')
+      })
+
       it('ignores extra params', () => {
         assert.equal(createHref('/posts/:id', { id: '123', page: '2', sort: 'desc' }), '/posts/123')
       })
@@ -168,6 +183,21 @@ describe('createHref', () => {
         createHref('images/*path.png', { path: 'images/hero' }),
         '/images/images/hero.png',
       )
+    })
+
+    it('percent-encodes named wildcard path params while preserving separators', () => {
+      assert.equal(
+        createHref('/files/*path', { path: 'docs/read me.md?raw#top' }),
+        '/files/docs/read%20me.md%3Fraw%23top',
+      )
+    })
+
+    it('does not generate scheme-relative URLs from leading wildcard separators', () => {
+      let href = createHref('/*path', { path: '/evil.example.com' })
+      let url = new URL(href, 'https://app.example.com')
+
+      assert.equal(href, '/%2Fevil.example.com')
+      assert.equal(url.origin, 'https://app.example.com')
     })
 
     it('supports wildcard with number param', () => {

--- a/packages/route-pattern/src/lib/href.ts
+++ b/packages/route-pattern/src/lib/href.ts
@@ -157,16 +157,46 @@ function hrefParamValue(
     return encodeWildcardPathParam(stringValue)
   }
 
-  return encodeURIComponent(stringValue)
+  return encodePathSegment(stringValue)
 }
 
 function encodeWildcardPathParam(value: string): string {
   let encoded = value
     .split('/')
-    .map((segment) => encodeURIComponent(segment))
+    .map((segment) => encodePathSegment(segment))
     .join('/')
 
   return encoded.replace(/^\/+/, (slashes) => '%2F'.repeat(slashes.length))
+}
+
+function encodePathSegment(value: string): string {
+  return encodeURIComponent(value).replace(
+    /%(24|26|2B|2C|3A|3B|3D|40)/g,
+    decodePathSegmentSafeCharacter,
+  )
+}
+
+function decodePathSegmentSafeCharacter(encodedChar: string): string {
+  switch (encodedChar) {
+    case '%24':
+      return '$'
+    case '%26':
+      return '&'
+    case '%2B':
+      return '+'
+    case '%2C':
+      return ','
+    case '%3A':
+      return ':'
+    case '%3B':
+      return ';'
+    case '%3D':
+      return '='
+    case '%40':
+      return '@'
+    default:
+      return encodedChar
+  }
 }
 
 function hrefSearch(pattern: RoutePattern, searchParams: SearchParams): string | undefined {

--- a/packages/route-pattern/src/lib/href.ts
+++ b/packages/route-pattern/src/lib/href.ts
@@ -123,7 +123,7 @@ function hrefPart(
         i = part.optionals.get(frame.begin!)! + 1
         continue
       }
-      stack[stack.length - 1].href += typeof value === 'string' ? value : String(value)
+      stack[stack.length - 1].href += hrefParamValue(part, token, value)
       i += 1
       continue
     }
@@ -140,6 +140,33 @@ function hrefPart(
   }
   if (stack.length !== 1) unreachable()
   return stack[0].href
+}
+
+function hrefParamValue(
+  part: PartPattern,
+  token: { type: ':' | '*'; name: string },
+  value: unknown,
+): string {
+  let stringValue = typeof value === 'string' ? value : String(value)
+
+  if (part.type === 'hostname') {
+    return stringValue
+  }
+
+  if (token.type === '*') {
+    return encodeWildcardPathParam(stringValue)
+  }
+
+  return encodeURIComponent(stringValue)
+}
+
+function encodeWildcardPathParam(value: string): string {
+  let encoded = value
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')
+
+  return encoded.replace(/^\/+/, (slashes) => '%2F'.repeat(slashes.length))
 }
 
 function hrefSearch(pattern: RoutePattern, searchParams: SearchParams): string | undefined {


### PR DESCRIPTION
`createHref()` inserted path params directly into generated URLs, so values containing `/`, `?`, `#`, or leading separators could escape their route segment and even produce scheme-relative URLs. This encodes pathname params while preserving wildcard path separators where they are part of the wildcard value.

- Encodes dynamic `:param` path values with `encodeURIComponent()`
- Encodes wildcard path segments while preserving internal `/` separators
- Encodes leading wildcard separators so generated hrefs remain same-origin relative paths