### PR TITLE
Fix SQLite transaction token checks

### DIFF
--- a/packages/data-table-sqlite/.changes/patch.reject-stale-transaction-execute.md
+++ b/packages/data-table-sqlite/.changes/patch.reject-stale-transaction-execute.md
@@ -1,0 +1,1 @@
+Reject stale or unknown transaction tokens before executing SQLite data operations.

--- a/packages/data-table-sqlite/src/lib/adapter.test.ts
+++ b/packages/data-table-sqlite/src/lib/adapter.test.ts
@@ -196,6 +196,22 @@ describe('sqlite adapter', () => {
       /Unknown transaction token: tx_missing/,
     )
     await assert.rejects(
+      () =>
+        adapter.execute({
+          operation: {
+            kind: 'insert',
+            table: accounts,
+            values: {
+              id: 1,
+              email: 'a@example.com',
+              status: 'active',
+            },
+          },
+          transaction: { id: 'tx_missing' },
+        }),
+      /Unknown transaction token: tx_missing/,
+    )
+    await assert.rejects(
       () => adapter.hasTable({ name: 'users' }, { id: 'tx_missing' }),
       /Unknown transaction token: tx_missing/,
     )

--- a/packages/data-table-sqlite/src/lib/adapter.ts
+++ b/packages/data-table-sqlite/src/lib/adapter.ts
@@ -96,6 +96,10 @@ export class SqliteDatabaseAdapter implements DatabaseAdapter {
       }
     }
 
+    if (request.transaction) {
+      this.#assertTransaction(request.transaction)
+    }
+
     let statement = this.compileSql(request.operation)[0]
     let prepared = this.#database.prepare(statement.text)
     let values = normalizeStatementValues(statement.values)


### PR DESCRIPTION
SQLite transaction-bound data operations should reject stale or unknown transaction tokens before preparing and running statements. The adapter already enforced this for commit, rollback, savepoints, and introspection, but `execute()` skipped the guard and could run real SQLite work with a closed token.

- Assert provided transaction tokens before executing non-empty SQLite data operations
- Add regression coverage for the `execute()` unknown-token path
- Add a patch change file for `@remix-run/data-table-sqlite`
