### PR TITLE
Encode route-pattern pathname params

### DIFF
--- a/packages/route-pattern/.changes/patch.encode-pathname-params.md
+++ b/packages/route-pattern/.changes/patch.encode-pathname-params.md
@@ -1,0 +1,1 @@
+Encode pathname params in `createHref` so generated URLs cannot inject extra path segments, dot segments, query strings, or fragments, while preserving slash-separated structure for wildcard params.

--- a/packages/route-pattern/src/lib/href.test.ts
+++ b/packages/route-pattern/src/lib/href.test.ts
@@ -128,6 +128,14 @@ describe('createHref', () => {
         assert.equal(createHref('/posts/:id', { id: '123' }), '/posts/123')
       })
 
+      it('encodes reserved URL syntax in params', () => {
+        assert.equal(createHref('/posts/:id', { id: 'a/b?c#d' }), '/posts/a%2Fb%3Fc%23d')
+      })
+
+      it('encodes dot segment params', () => {
+        assert.equal(createHref('/posts/:id', { id: '..' }), '/posts/%252E%252E')
+      })
+
       it('works with number params', () => {
         assert.equal(createHref('/posts/:id', { id: 123 }), '/posts/123')
       })
@@ -167,6 +175,13 @@ describe('createHref', () => {
       assert.equal(
         createHref('images/*path.png', { path: 'images/hero' }),
         '/images/images/hero.png',
+      )
+    })
+
+    it('encodes each wildcard path segment independently', () => {
+      assert.equal(
+        createHref('/files/*path', { path: '../draft docs/readme.md?raw#intro' }),
+        '/files/%252E%252E/draft%20docs/readme.md%3Fraw%23intro',
       )
     })
 

--- a/packages/route-pattern/src/lib/href.test.ts
+++ b/packages/route-pattern/src/lib/href.test.ts
@@ -143,6 +143,14 @@ describe('createHref', () => {
         assert.equal(createHref('/posts/:id', { id: '..' }), '/posts/%252E%252E')
       })
 
+      it('does not generate scheme-relative URLs from dynamic path params', () => {
+        let href = createHref('/:next', { next: '/evil.example.com' })
+        let url = new URL(href, 'https://app.example.com')
+
+        assert.equal(href, '/%2Fevil.example.com')
+        assert.equal(url.origin, 'https://app.example.com')
+      })
+
       it('works with number params', () => {
         assert.equal(createHref('/posts/:id', { id: 123 }), '/posts/123')
       })
@@ -197,6 +205,14 @@ describe('createHref', () => {
         createHref('/assets/*path', { path: 'node_modules/@remix-run/ui/jsx-runtime.ts' }),
         '/assets/node_modules/@remix-run/ui/jsx-runtime.ts',
       )
+    })
+
+    it('does not generate scheme-relative URLs from leading wildcard separators', () => {
+      let href = createHref('/*path', { path: '/evil.example.com' })
+      let url = new URL(href, 'https://app.example.com')
+
+      assert.equal(href, '/%2Fevil.example.com')
+      assert.equal(url.origin, 'https://app.example.com')
     })
 
     it('supports wildcard with number param', () => {

--- a/packages/route-pattern/src/lib/href.test.ts
+++ b/packages/route-pattern/src/lib/href.test.ts
@@ -132,6 +132,13 @@ describe('createHref', () => {
         assert.equal(createHref('/posts/:id', { id: 'a/b?c#d' }), '/posts/a%2Fb%3Fc%23d')
       })
 
+      it('preserves valid path segment syntax in params', () => {
+        assert.equal(
+          createHref('/packages/:name', { name: '@remix-run:ui' }),
+          '/packages/@remix-run:ui',
+        )
+      })
+
       it('encodes dot segment params', () => {
         assert.equal(createHref('/posts/:id', { id: '..' }), '/posts/%252E%252E')
       })
@@ -182,6 +189,13 @@ describe('createHref', () => {
       assert.equal(
         createHref('/files/*path', { path: '../draft docs/readme.md?raw#intro' }),
         '/files/%252E%252E/draft%20docs/readme.md%3Fraw%23intro',
+      )
+    })
+
+    it('preserves valid wildcard path segment syntax', () => {
+      assert.equal(
+        createHref('/assets/*path', { path: 'node_modules/@remix-run/ui/jsx-runtime.ts' }),
+        '/assets/node_modules/@remix-run/ui/jsx-runtime.ts',
       )
     })
 

--- a/packages/route-pattern/src/lib/href.ts
+++ b/packages/route-pattern/src/lib/href.ts
@@ -160,7 +160,9 @@ function encodePathSegment(segment: string): string {
   if (segment === '.') return '%252E'
   if (segment === '..') return '%252E%252E'
 
-  return encodeURIComponent(segment)
+  return encodeURIComponent(segment).replace(/%(24|26|2B|2C|3A|3B|3D|40)/gi, (encoded) =>
+    String.fromCharCode(Number.parseInt(encoded.slice(1), 16)),
+  )
 }
 
 function hrefSearch(pattern: RoutePattern, searchParams: SearchParams): string | undefined {

--- a/packages/route-pattern/src/lib/href.ts
+++ b/packages/route-pattern/src/lib/href.ts
@@ -123,7 +123,7 @@ function hrefPart(
         i = part.optionals.get(frame.begin!)! + 1
         continue
       }
-      stack[stack.length - 1].href += typeof value === 'string' ? value : String(value)
+      stack[stack.length - 1].href += hrefParam(part, token.type, value)
       i += 1
       continue
     }
@@ -140,6 +140,27 @@ function hrefPart(
   }
   if (stack.length !== 1) unreachable()
   return stack[0].href
+}
+
+function hrefParam(part: PartPattern, tokenType: ':' | '*', value: unknown): string {
+  let stringValue = typeof value === 'string' ? value : String(value)
+
+  if (part.type !== 'pathname') {
+    return stringValue
+  }
+
+  if (tokenType === '*') {
+    return stringValue.split('/').map(encodePathSegment).join('/')
+  }
+
+  return encodePathSegment(stringValue)
+}
+
+function encodePathSegment(segment: string): string {
+  if (segment === '.') return '%252E'
+  if (segment === '..') return '%252E%252E'
+
+  return encodeURIComponent(segment)
 }
 
 function hrefSearch(pattern: RoutePattern, searchParams: SearchParams): string | undefined {

--- a/packages/route-pattern/src/lib/href.ts
+++ b/packages/route-pattern/src/lib/href.ts
@@ -150,10 +150,16 @@ function hrefParam(part: PartPattern, tokenType: ':' | '*', value: unknown): str
   }
 
   if (tokenType === '*') {
-    return stringValue.split('/').map(encodePathSegment).join('/')
+    return encodeWildcardPathParam(stringValue)
   }
 
   return encodePathSegment(stringValue)
+}
+
+function encodeWildcardPathParam(value: string): string {
+  let encoded = value.split('/').map(encodePathSegment).join('/')
+
+  return encoded.replace(/^\/+/, (slashes) => '%2F'.repeat(slashes.length))
 }
 
 function encodePathSegment(segment: string): string {

--- a/packages/route-pattern/src/lib/match.test.ts
+++ b/packages/route-pattern/src/lib/match.test.ts
@@ -1,6 +1,7 @@
 import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
+import { createHref } from './href.ts'
 import { createMultiMatcher } from './match.ts'
 
 describe('Matcher', () => {
@@ -351,6 +352,17 @@ describe('Matcher', () => {
         assert.deepEqual(match.params, { filename: 'my-file_v2.txt' })
       })
 
+      it('decodes reserved URL syntax in variable values', () => {
+        let matcher = createMultiMatcher<null>()
+        matcher.add('/files/:filename', null)
+
+        let href = createHref('/files/:filename', { filename: 'docs/readme?raw#intro' })
+        let match = matcher.match(new URL(href, 'https://example.com'))
+
+        assert.ok(match)
+        assert.deepEqual(match.params, { filename: 'docs/readme?raw#intro' })
+      })
+
       it('does not partially match variable segments after a static suffix', () => {
         let matcher = createMultiMatcher<null>()
         matcher.add('://example.com/files/report-:format.pdf', null)
@@ -400,6 +412,17 @@ describe('Matcher', () => {
         let match = matcher.match('http://example.com/files/docs/api/status')
         assert.ok(match)
         assert.deepEqual(match.params, { path: 'docs/api' })
+      })
+
+      it('decodes reserved URL syntax in wildcard values', () => {
+        let matcher = createMultiMatcher<null>()
+        matcher.add('/files/*path', null)
+
+        let href = createHref('/files/*path', { path: 'draft docs/readme?raw#intro' })
+        let match = matcher.match(new URL(href, 'https://example.com'))
+
+        assert.ok(match)
+        assert.deepEqual(match.params, { path: 'draft docs/readme?raw#intro' })
       })
 
       it('does not partially match wildcard segments before a static suffix', () => {

--- a/packages/route-pattern/src/lib/match/decode.ts
+++ b/packages/route-pattern/src/lib/match/decode.ts
@@ -1,18 +1,21 @@
 export { toUnicode as decodeHostname } from './punycode.ts'
 
-/**
- * Decodes valid percent-escape sequences, or returns the input unchanged when
- * it contains invalid ones.
- *
- * @param source String to decode.
- * @returns Decoded string, or `source` when it contains invalid percent-escape sequences.
- */
-export function decodePathname(source: string): string {
-  // coarse check for percent-encoded sequences; skip if none found.
+const ENCODED_SLASH = /%2f/gi
+const SLASH_PLACEHOLDER = '\uFDD0'
+
+export function decodePathnameSegments(source: string): Array<string> {
+  return source.split('/').map(decodePathnameSegment)
+}
+
+export function restorePathnameParam(value: string): string {
+  return value.replaceAll(SLASH_PLACEHOLDER, '/')
+}
+
+function decodePathnameSegment(source: string): string {
   if (!source.includes('%')) return source
 
   try {
-    return decodeURI(source)
+    return decodeURIComponent(source.replace(ENCODED_SLASH, SLASH_PLACEHOLDER))
   } catch {
     return source
   }

--- a/packages/route-pattern/src/lib/match/trie.ts
+++ b/packages/route-pattern/src/lib/match/trie.ts
@@ -1,5 +1,5 @@
 import type { RoutePattern } from '../route-pattern.ts'
-import { decodeHostname, decodePathname } from './decode.ts'
+import { decodeHostname, decodePathnameSegments, restorePathnameParam } from './decode.ts'
 import { generateVariants, type Param } from './variant.ts'
 import { unreachable } from '../unreachable.ts'
 
@@ -149,7 +149,7 @@ export class Trie<data = unknown> {
     }
 
     let results: Array<Match<string, data>> = []
-    let urlSegments = decodePathname(url.pathname.slice(1)).split('/')
+    let urlSegments = decodePathnameSegments(url.pathname.slice(1))
 
     for (let origin of origins) {
       let stack: Array<{
@@ -230,7 +230,7 @@ export class Trie<data = unknown> {
             let span = m.indices![i]
             if (span === undefined) unreachable()
             captures.push({
-              value: m[i],
+              value: restorePathnameParam(m[i]),
               begin: current.charOffset + span[0],
               end: current.charOffset + span[1],
             })
@@ -252,7 +252,7 @@ export class Trie<data = unknown> {
             let span = m.indices![i]
             if (span === undefined) continue
             captures.push({
-              value: m[i],
+              value: restorePathnameParam(m[i]),
               begin: current.charOffset + span[0],
               end: current.charOffset + span[1],
             })


### PR DESCRIPTION
createHref was interpolating pathname params directly into generated URLs. Values containing `/`, `?`, `#`, or dot segments could change the URL structure instead of staying inside the route param.

- Encode variable pathname params before interpolation.
- Encode wildcard params segment-by-segment so intentional slash structure is preserved.
- Decode encoded reserved characters during matching so href-generated params round-trip through `match()`.
