### PR TITLE
Enforce zero-argument UI render functions

### DIFF
--- a/.agents/skills/make-change-file/SKILL.md
+++ b/.agents/skills/make-change-file/SKILL.md
@@ -67,6 +67,12 @@ Write release notes that match this repository's `.changes` conventions. Use it 
 - Do not manually hard-wrap prose in `.changes/*.md` files. Keep each paragraph or bullet on a single source line and let rendered changelogs wrap naturally.
 - Use flat bullets only when they add clarity. Short paragraphs are usually better.
 
+## Historical Changelogs
+
+- Treat existing `CHANGELOG.md` files and historical changelog docs as records of what was true at the time. Do not rewrite old entries to match current APIs, terminology, or guidance.
+- If current guidance is stale or confusing, update current docs, README files, skills, or add a new `.changes` file instead of editing historical release prose.
+- Only edit historical changelog entries for narrow corrections such as broken links, typos, or clearly invalid references, and prefer doing so only when the user explicitly asks.
+
 ## Remix-Specific Rules
 
 - `packages/remix/src/*` re-export files are generated. Do not hand-edit them unless the task explicitly requires generated output.

--- a/demos/bookstore/app/actions/account/orders/index-page.tsx
+++ b/demos/bookstore/app/actions/account/orders/index-page.tsx
@@ -1,60 +1,65 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { Order } from '../../../data/schema.ts'
 import { routes } from '../../../routes.ts'
 import { Layout } from '../../../ui/layout.tsx'
 
-export function AccountOrdersIndexPage() {
-  return ({ orders }: { orders: Order[] }) => (
-    <Layout>
-      <h1>My Orders</h1>
+export function AccountOrdersIndexPage(handle: Handle<{ orders: Order[] }>) {
+  return () => {
+    let { orders } = handle.props
 
-      <div class="card">
-        {orders.length > 0 ? (
-          <table>
-            <thead>
-              <tr>
-                <th>Order ID</th>
-                <th>Date</th>
-                <th>Items</th>
-                <th>Total</th>
-                <th>Status</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {orders.map((order) => (
+    return (
+      <Layout>
+        <h1>My Orders</h1>
+
+        <div class="card">
+          {orders.length > 0 ? (
+            <table>
+              <thead>
                 <tr>
-                  <td>#{order.id}</td>
-                  <td>{new Date(order.created_at).toLocaleDateString()}</td>
-                  <td>{order.items.length} item(s)</td>
-                  <td>${order.total.toFixed(2)}</td>
-                  <td>
-                    <span class="badge badge-info">{order.status}</span>
-                  </td>
-                  <td>
-                    <a
-                      href={routes.account.orders.show.href({ orderId: order.id })}
-                      class="btn btn-secondary"
-                      mix={css({ fontSize: '0.875rem', padding: '0.25rem 0.5rem' })}
-                    >
-                      View
-                    </a>
-                  </td>
+                  <th>Order ID</th>
+                  <th>Date</th>
+                  <th>Items</th>
+                  <th>Total</th>
+                  <th>Status</th>
+                  <th>Actions</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        ) : (
-          <p>You have no orders yet.</p>
-        )}
-      </div>
+              </thead>
+              <tbody>
+                {orders.map((order) => (
+                  <tr>
+                    <td>#{order.id}</td>
+                    <td>{new Date(order.created_at).toLocaleDateString()}</td>
+                    <td>{order.items.length} item(s)</td>
+                    <td>${order.total.toFixed(2)}</td>
+                    <td>
+                      <span class="badge badge-info">{order.status}</span>
+                    </td>
+                    <td>
+                      <a
+                        href={routes.account.orders.show.href({ orderId: order.id })}
+                        class="btn btn-secondary"
+                        mix={css({ fontSize: '0.875rem', padding: '0.25rem 0.5rem' })}
+                      >
+                        View
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p>You have no orders yet.</p>
+          )}
+        </div>
 
-      <p mix={css({ marginTop: '1.5rem' })}>
-        <a href={routes.account.index.href()} class="btn btn-secondary">
-          Back to Account
-        </a>
-      </p>
-    </Layout>
-  )
+        <p mix={css({ marginTop: '1.5rem' })}>
+          <a href={routes.account.index.href()} class="btn btn-secondary">
+            Back to Account
+          </a>
+        </p>
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/account/orders/show-page.tsx
+++ b/demos/bookstore/app/actions/account/orders/show-page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { Order } from '../../../data/schema.ts'
@@ -26,61 +27,67 @@ export function AccountOrderNotFoundPage() {
   )
 }
 
-export function AccountOrderShowPage() {
-  return ({ order, shippingAddress }: { order: Order; shippingAddress: ShippingAddress }) => (
-    <Layout>
-      <h1>Order #{order.id}</h1>
+export function AccountOrderShowPage(
+  handle: Handle<{ order: Order; shippingAddress: ShippingAddress }>,
+) {
+  return () => {
+    let { order, shippingAddress } = handle.props
 
-      <div class="card">
-        <p>
-          <strong>Order Date:</strong> {new Date(order.created_at).toLocaleDateString()}
-        </p>
-        <p>
-          <strong>Status:</strong> <span class="badge badge-info">{order.status}</span>
-        </p>
+    return (
+      <Layout>
+        <h1>Order #{order.id}</h1>
 
-        <h2 mix={css({ marginTop: '2rem' })}>Items</h2>
-        <table mix={css({ marginTop: '1rem' })}>
-          <thead>
-            <tr>
-              <th>Book</th>
-              <th>Quantity</th>
-              <th>Price</th>
-              <th>Subtotal</th>
-            </tr>
-          </thead>
-          <tbody>
-            {order.items.map((item) => (
+        <div class="card">
+          <p>
+            <strong>Order Date:</strong> {new Date(order.created_at).toLocaleDateString()}
+          </p>
+          <p>
+            <strong>Status:</strong> <span class="badge badge-info">{order.status}</span>
+          </p>
+
+          <h2 mix={css({ marginTop: '2rem' })}>Items</h2>
+          <table mix={css({ marginTop: '1rem' })}>
+            <thead>
               <tr>
-                <td>{item.title}</td>
-                <td>{item.quantity}</td>
-                <td>${item.unit_price.toFixed(2)}</td>
-                <td>${(item.unit_price * item.quantity).toFixed(2)}</td>
+                <th>Book</th>
+                <th>Quantity</th>
+                <th>Price</th>
+                <th>Subtotal</th>
               </tr>
-            ))}
-          </tbody>
-          <tfoot>
-            <tr>
-              <td colSpan={3} mix={css({ textAlign: 'right', fontWeight: 'bold' })}>
-                Total:
-              </td>
-              <td mix={css({ fontWeight: 'bold' })}>${order.total.toFixed(2)}</td>
-            </tr>
-          </tfoot>
-        </table>
+            </thead>
+            <tbody>
+              {order.items.map((item) => (
+                <tr>
+                  <td>{item.title}</td>
+                  <td>{item.quantity}</td>
+                  <td>${item.unit_price.toFixed(2)}</td>
+                  <td>${(item.unit_price * item.quantity).toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr>
+                <td colSpan={3} mix={css({ textAlign: 'right', fontWeight: 'bold' })}>
+                  Total:
+                </td>
+                <td mix={css({ fontWeight: 'bold' })}>${order.total.toFixed(2)}</td>
+              </tr>
+            </tfoot>
+          </table>
 
-        <h2 mix={css({ marginTop: '2rem' })}>Shipping Address</h2>
-        <p>{shippingAddress.street}</p>
-        <p>
-          {shippingAddress.city}, {shippingAddress.state} {shippingAddress.zip}
+          <h2 mix={css({ marginTop: '2rem' })}>Shipping Address</h2>
+          <p>{shippingAddress.street}</p>
+          <p>
+            {shippingAddress.city}, {shippingAddress.state} {shippingAddress.zip}
+          </p>
+        </div>
+
+        <p mix={css({ marginTop: '1.5rem' })}>
+          <a href={routes.account.orders.index.href()} class="btn btn-secondary">
+            Back to Orders
+          </a>
         </p>
-      </div>
-
-      <p mix={css({ marginTop: '1.5rem' })}>
-        <a href={routes.account.orders.index.href()} class="btn btn-secondary">
-          Back to Orders
-        </a>
-      </p>
-    </Layout>
-  )
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/account/page.tsx
+++ b/demos/bookstore/app/actions/account/page.tsx
@@ -1,51 +1,56 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { User } from '../../data/schema.ts'
 import { routes } from '../../routes.ts'
 import { Layout } from '../../ui/layout.tsx'
 
-export function AccountPage() {
-  return ({ user }: { user: User }) => (
-    <Layout>
-      <h1>My Account</h1>
+export function AccountPage(handle: Handle<{ user: User }>) {
+  return () => {
+    let { user } = handle.props
 
-      <div class="card">
-        <h2>Account Information</h2>
-        <p>
-          <strong>Name:</strong> {user.name}
-        </p>
-        <p>
-          <strong>Email:</strong> {user.email}
-        </p>
-        <p>
-          <strong>Role:</strong> {user.role}
-        </p>
-        <p>
-          <strong>Member Since:</strong> {new Date(user.created_at).toLocaleDateString()}
-        </p>
+    return (
+      <Layout>
+        <h1>My Account</h1>
 
-        <p mix={css({ marginTop: '1.5rem' })}>
-          <a href={routes.account.settings.index.href()} class="btn">
-            Edit Settings
-          </a>
-        </p>
-      </div>
+        <div class="card">
+          <h2>Account Information</h2>
+          <p>
+            <strong>Name:</strong> {user.name}
+          </p>
+          <p>
+            <strong>Email:</strong> {user.email}
+          </p>
+          <p>
+            <strong>Role:</strong> {user.role}
+          </p>
+          <p>
+            <strong>Member Since:</strong> {new Date(user.created_at).toLocaleDateString()}
+          </p>
 
-      <div class="card" mix={css({ marginTop: '1.5rem' })}>
-        <h2>Quick Links</h2>
-        <p>
-          <a href={routes.account.orders.index.href()} class="btn btn-secondary">
-            View Orders
-          </a>
-          <a
-            href={routes.books.index.href()}
-            class="btn btn-secondary"
-            mix={css({ marginLeft: '0.5rem' })}
-          >
-            Browse Books
-          </a>
-        </p>
-      </div>
-    </Layout>
-  )
+          <p mix={css({ marginTop: '1.5rem' })}>
+            <a href={routes.account.settings.index.href()} class="btn">
+              Edit Settings
+            </a>
+          </p>
+        </div>
+
+        <div class="card" mix={css({ marginTop: '1.5rem' })}>
+          <h2>Quick Links</h2>
+          <p>
+            <a href={routes.account.orders.index.href()} class="btn btn-secondary">
+              View Orders
+            </a>
+            <a
+              href={routes.books.index.href()}
+              class="btn btn-secondary"
+              mix={css({ marginLeft: '0.5rem' })}
+            >
+              Browse Books
+            </a>
+          </p>
+        </div>
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/account/settings/page.tsx
+++ b/demos/bookstore/app/actions/account/settings/page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { User } from '../../../data/schema.ts'
@@ -5,40 +6,44 @@ import { routes } from '../../../routes.ts'
 import { RestfulForm } from '../../../ui/restful-form.tsx'
 import { Layout } from '../../../ui/layout.tsx'
 
-export function AccountSettingsPage() {
-  return ({ user }: { user: User }) => (
-    <Layout>
-      <h1>Account Settings</h1>
+export function AccountSettingsPage(handle: Handle<{ user: User }>) {
+  return () => {
+    let { user } = handle.props
 
-      <div class="card">
-        <RestfulForm method="PUT" action={routes.account.settings.update.href()}>
-          <div class="form-group">
-            <label for="name">Name</label>
-            <input type="text" id="name" name="name" value={user.name} required />
-          </div>
+    return (
+      <Layout>
+        <h1>Account Settings</h1>
 
-          <div class="form-group">
-            <label for="email">Email</label>
-            <input type="email" id="email" name="email" value={user.email} required />
-          </div>
+        <div class="card">
+          <RestfulForm method="PUT" action={routes.account.settings.update.href()}>
+            <div class="form-group">
+              <label for="name">Name</label>
+              <input type="text" id="name" name="name" value={user.name} required />
+            </div>
 
-          <div class="form-group">
-            <label for="password">New Password (leave blank to keep current)</label>
-            <input type="password" id="password" name="password" autoComplete="new-password" />
-          </div>
+            <div class="form-group">
+              <label for="email">Email</label>
+              <input type="email" id="email" name="email" value={user.email} required />
+            </div>
 
-          <button type="submit" class="btn">
-            Update Settings
-          </button>
-          <a
-            href={routes.account.index.href()}
-            class="btn btn-secondary"
-            mix={css({ marginLeft: '0.5rem' })}
-          >
-            Cancel
-          </a>
-        </RestfulForm>
-      </div>
-    </Layout>
-  )
+            <div class="form-group">
+              <label for="password">New Password (leave blank to keep current)</label>
+              <input type="password" id="password" name="password" autoComplete="new-password" />
+            </div>
+
+            <button type="submit" class="btn">
+              Update Settings
+            </button>
+            <a
+              href={routes.account.index.href()}
+              class="btn btn-secondary"
+              mix={css({ marginLeft: '0.5rem' })}
+            >
+              Cancel
+            </a>
+          </RestfulForm>
+        </div>
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/admin/books/form.tsx
+++ b/demos/bookstore/app/actions/admin/books/form.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { Book } from '../../../data/schema.ts'
@@ -13,111 +14,115 @@ export interface AdminBookFormPageProps {
   book?: Book
 }
 
-export function AdminBookFormPage() {
-  return ({
-    action,
-    book,
-    cancelHref,
-    method = 'POST',
-    submitLabel,
-    title,
-  }: AdminBookFormPageProps) => (
-    <Layout>
-      <h1>{title}</h1>
+export function AdminBookFormPage(handle: Handle<AdminBookFormPageProps>) {
+  return () => {
+    let { action, book, cancelHref, method = 'POST', submitLabel, title } = handle.props
 
-      <div class="card">
-        <RestfulForm method={method} action={action} encType="multipart/form-data">
-          <div class="form-group">
-            <label for="title">Title</label>
-            <input type="text" id="title" name="title" value={book?.title} required />
-          </div>
+    return (
+      <Layout>
+        <h1>{title}</h1>
 
-          <div class="form-group">
-            <label for="author">Author</label>
-            <input type="text" id="author" name="author" value={book?.author} required />
-          </div>
+        <div class="card">
+          <RestfulForm method={method} action={action} encType="multipart/form-data">
+            <div class="form-group">
+              <label for="title">Title</label>
+              <input type="text" id="title" name="title" value={book?.title} required />
+            </div>
 
-          <div class="form-group">
-            <label for="slug">Slug (URL-friendly name)</label>
-            <input type="text" id="slug" name="slug" value={book?.slug} required />
-          </div>
+            <div class="form-group">
+              <label for="author">Author</label>
+              <input type="text" id="author" name="author" value={book?.author} required />
+            </div>
 
-          <div class="form-group">
-            <label for="description">Description</label>
-            <textarea
-              id="description"
-              name="description"
-              required
-              defaultValue={book?.description}
-            />
-          </div>
+            <div class="form-group">
+              <label for="slug">Slug (URL-friendly name)</label>
+              <input type="text" id="slug" name="slug" value={book?.slug} required />
+            </div>
 
-          <div class="form-group">
-            <label for="price">Price</label>
-            <input type="number" id="price" name="price" step="0.01" value={book?.price} required />
-          </div>
+            <div class="form-group">
+              <label for="description">Description</label>
+              <textarea
+                id="description"
+                name="description"
+                required
+                defaultValue={book?.description}
+              />
+            </div>
 
-          <div class="form-group">
-            <label for="genre">Genre</label>
-            <input type="text" id="genre" name="genre" value={book?.genre} required />
-          </div>
+            <div class="form-group">
+              <label for="price">Price</label>
+              <input
+                type="number"
+                id="price"
+                name="price"
+                step="0.01"
+                value={book?.price}
+                required
+              />
+            </div>
 
-          <div class="form-group">
-            <label for="isbn">ISBN</label>
-            <input type="text" id="isbn" name="isbn" value={book?.isbn} required />
-          </div>
+            <div class="form-group">
+              <label for="genre">Genre</label>
+              <input type="text" id="genre" name="genre" value={book?.genre} required />
+            </div>
 
-          <div class="form-group">
-            <label for="publishedYear">Published Year</label>
-            <input
-              type="number"
-              id="publishedYear"
-              name="publishedYear"
-              value={book?.published_year ?? 2024}
-              required
-            />
-          </div>
+            <div class="form-group">
+              <label for="isbn">ISBN</label>
+              <input type="text" id="isbn" name="isbn" value={book?.isbn} required />
+            </div>
 
-          <div class="form-group">
-            <label for="inStock">In Stock</label>
-            <select id="inStock" name="inStock">
-              <option value="true" selected={book?.in_stock ?? true}>
-                Yes
-              </option>
-              <option value="false" selected={book != null ? !book.in_stock : false}>
-                No
-              </option>
-            </select>
-          </div>
+            <div class="form-group">
+              <label for="publishedYear">Published Year</label>
+              <input
+                type="number"
+                id="publishedYear"
+                name="publishedYear"
+                value={book?.published_year ?? 2024}
+                required
+              />
+            </div>
 
-          <div class="form-group">
-            <label for="cover">Book Cover Image</label>
-            {book && book.cover_url !== '/images/placeholder.jpg' ? (
-              <div mix={css({ marginBottom: '0.5rem' })}>
-                <img
-                  src={book.cover_url}
-                  alt={book.title}
-                  mix={css({ maxWidth: '200px', height: 'auto', borderRadius: '4px' })}
-                />
-                <p mix={css({ fontSize: '0.875rem', color: '#666' })}>Current cover image</p>
-              </div>
-            ) : null}
-            <input type="file" id="cover" name="cover" accept="image/*" />
-            <small mix={css({ color: '#666' })}>
-              {book
-                ? 'Optional. Upload a new cover image to replace the current one.'
-                : 'Optional. Upload a cover image for this book.'}
-            </small>
-          </div>
+            <div class="form-group">
+              <label for="inStock">In Stock</label>
+              <select id="inStock" name="inStock">
+                <option value="true" selected={book?.in_stock ?? true}>
+                  Yes
+                </option>
+                <option value="false" selected={book != null ? !book.in_stock : false}>
+                  No
+                </option>
+              </select>
+            </div>
 
-          <button type="submit" class="btn">
-            {submitLabel}
-          </button>
-          <a href={cancelHref} class="btn btn-secondary" mix={css({ marginLeft: '0.5rem' })}>
-            Cancel
-          </a>
-        </RestfulForm>
-      </div>
-    </Layout>
-  )
+            <div class="form-group">
+              <label for="cover">Book Cover Image</label>
+              {book && book.cover_url !== '/images/placeholder.jpg' ? (
+                <div mix={css({ marginBottom: '0.5rem' })}>
+                  <img
+                    src={book.cover_url}
+                    alt={book.title}
+                    mix={css({ maxWidth: '200px', height: 'auto', borderRadius: '4px' })}
+                  />
+                  <p mix={css({ fontSize: '0.875rem', color: '#666' })}>Current cover image</p>
+                </div>
+              ) : null}
+              <input type="file" id="cover" name="cover" accept="image/*" />
+              <small mix={css({ color: '#666' })}>
+                {book
+                  ? 'Optional. Upload a new cover image to replace the current one.'
+                  : 'Optional. Upload a cover image for this book.'}
+              </small>
+            </div>
+
+            <button type="submit" class="btn">
+              {submitLabel}
+            </button>
+            <a href={cancelHref} class="btn btn-secondary" mix={css({ marginLeft: '0.5rem' })}>
+              Cancel
+            </a>
+          </RestfulForm>
+        </div>
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/admin/books/index-page.tsx
+++ b/demos/bookstore/app/actions/admin/books/index-page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { Book } from '../../../data/schema.ts'
@@ -5,75 +6,79 @@ import { routes } from '../../../routes.ts'
 import { RestfulForm } from '../../../ui/restful-form.tsx'
 import { Layout } from '../../../ui/layout.tsx'
 
-export function AdminBooksIndexPage() {
-  return ({ books }: { books: Book[] }) => (
-    <Layout>
-      <h1>Manage Books</h1>
+export function AdminBooksIndexPage(handle: Handle<{ books: Book[] }>) {
+  return () => {
+    let { books } = handle.props
 
-      <p mix={css({ marginBottom: '1rem' })}>
-        <a href={routes.admin.books.new.href()} class="btn">
-          Add New Book
-        </a>
-        <a
-          href={routes.admin.index.href()}
-          class="btn btn-secondary"
-          mix={css({ marginLeft: '0.5rem' })}
-        >
-          Back to Dashboard
-        </a>
-      </p>
+    return (
+      <Layout>
+        <h1>Manage Books</h1>
 
-      <div class="card">
-        <table>
-          <thead>
-            <tr>
-              <th>Title</th>
-              <th>Author</th>
-              <th>Genre</th>
-              <th>Price</th>
-              <th>Stock</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {books.map((book) => (
+        <p mix={css({ marginBottom: '1rem' })}>
+          <a href={routes.admin.books.new.href()} class="btn">
+            Add New Book
+          </a>
+          <a
+            href={routes.admin.index.href()}
+            class="btn btn-secondary"
+            mix={css({ marginLeft: '0.5rem' })}
+          >
+            Back to Dashboard
+          </a>
+        </p>
+
+        <div class="card">
+          <table>
+            <thead>
               <tr>
-                <td>{book.title}</td>
-                <td>{book.author}</td>
-                <td>{book.genre}</td>
-                <td>${book.price.toFixed(2)}</td>
-                <td>
-                  <span class={`badge ${book.in_stock ? 'badge-success' : 'badge-warning'}`}>
-                    {book.in_stock ? 'Yes' : 'No'}
-                  </span>
-                </td>
-                <td class="actions">
-                  <a
-                    href={routes.admin.books.edit.href({ bookId: book.id })}
-                    class="btn btn-secondary"
-                    mix={css({ fontSize: '0.875rem', padding: '0.25rem 0.5rem' })}
-                  >
-                    Edit
-                  </a>
-                  <RestfulForm
-                    method="DELETE"
-                    action={routes.admin.books.destroy.href({ bookId: book.id })}
-                    mix={css({ display: 'inline' })}
-                  >
-                    <button
-                      type="submit"
-                      class="btn btn-danger"
+                <th>Title</th>
+                <th>Author</th>
+                <th>Genre</th>
+                <th>Price</th>
+                <th>Stock</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {books.map((book) => (
+                <tr>
+                  <td>{book.title}</td>
+                  <td>{book.author}</td>
+                  <td>{book.genre}</td>
+                  <td>${book.price.toFixed(2)}</td>
+                  <td>
+                    <span class={`badge ${book.in_stock ? 'badge-success' : 'badge-warning'}`}>
+                      {book.in_stock ? 'Yes' : 'No'}
+                    </span>
+                  </td>
+                  <td class="actions">
+                    <a
+                      href={routes.admin.books.edit.href({ bookId: book.id })}
+                      class="btn btn-secondary"
                       mix={css({ fontSize: '0.875rem', padding: '0.25rem 0.5rem' })}
                     >
-                      Delete
-                    </button>
-                  </RestfulForm>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </Layout>
-  )
+                      Edit
+                    </a>
+                    <RestfulForm
+                      method="DELETE"
+                      action={routes.admin.books.destroy.href({ bookId: book.id })}
+                      mix={css({ display: 'inline' })}
+                    >
+                      <button
+                        type="submit"
+                        class="btn btn-danger"
+                        mix={css({ fontSize: '0.875rem', padding: '0.25rem 0.5rem' })}
+                      >
+                        Delete
+                      </button>
+                    </RestfulForm>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/admin/books/show-page.tsx
+++ b/demos/bookstore/app/actions/admin/books/show-page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { Book } from '../../../data/schema.ts'
@@ -14,56 +15,60 @@ export function AdminBookNotFoundPage() {
   )
 }
 
-export function AdminBookShowPage() {
-  return ({ book }: { book: Book }) => (
-    <Layout>
-      <h1>Book Details</h1>
+export function AdminBookShowPage(handle: Handle<{ book: Book }>) {
+  return () => {
+    let { book } = handle.props
 
-      <div class="card">
-        <p>
-          <strong>Title:</strong> {book.title}
-        </p>
-        <p>
-          <strong>Author:</strong> {book.author}
-        </p>
-        <p>
-          <strong>Slug:</strong> {book.slug}
-        </p>
-        <p>
-          <strong>Description:</strong> {book.description}
-        </p>
-        <p>
-          <strong>Price:</strong> ${book.price.toFixed(2)}
-        </p>
-        <p>
-          <strong>Genre:</strong> {book.genre}
-        </p>
-        <p>
-          <strong>ISBN:</strong> {book.isbn}
-        </p>
-        <p>
-          <strong>Published:</strong> {book.published_year}
-        </p>
-        <p>
-          <strong>In Stock:</strong>{' '}
-          <span class={`badge ${book.in_stock ? 'badge-success' : 'badge-warning'}`}>
-            {book.in_stock ? 'Yes' : 'No'}
-          </span>
-        </p>
+    return (
+      <Layout>
+        <h1>Book Details</h1>
 
-        <div mix={css({ marginTop: '2rem' })}>
-          <a href={routes.admin.books.edit.href({ bookId: book.id })} class="btn">
-            Edit
-          </a>
-          <a
-            href={routes.admin.books.index.href()}
-            class="btn btn-secondary"
-            mix={css({ marginLeft: '0.5rem' })}
-          >
-            Back to List
-          </a>
+        <div class="card">
+          <p>
+            <strong>Title:</strong> {book.title}
+          </p>
+          <p>
+            <strong>Author:</strong> {book.author}
+          </p>
+          <p>
+            <strong>Slug:</strong> {book.slug}
+          </p>
+          <p>
+            <strong>Description:</strong> {book.description}
+          </p>
+          <p>
+            <strong>Price:</strong> ${book.price.toFixed(2)}
+          </p>
+          <p>
+            <strong>Genre:</strong> {book.genre}
+          </p>
+          <p>
+            <strong>ISBN:</strong> {book.isbn}
+          </p>
+          <p>
+            <strong>Published:</strong> {book.published_year}
+          </p>
+          <p>
+            <strong>In Stock:</strong>{' '}
+            <span class={`badge ${book.in_stock ? 'badge-success' : 'badge-warning'}`}>
+              {book.in_stock ? 'Yes' : 'No'}
+            </span>
+          </p>
+
+          <div mix={css({ marginTop: '2rem' })}>
+            <a href={routes.admin.books.edit.href({ bookId: book.id })} class="btn">
+              Edit
+            </a>
+            <a
+              href={routes.admin.books.index.href()}
+              class="btn btn-secondary"
+              mix={css({ marginLeft: '0.5rem' })}
+            >
+              Back to List
+            </a>
+          </div>
         </div>
-      </div>
-    </Layout>
-  )
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/admin/orders/index-page.tsx
+++ b/demos/bookstore/app/actions/admin/orders/index-page.tsx
@@ -1,56 +1,61 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { Order } from '../../../data/schema.ts'
 import { routes } from '../../../routes.ts'
 import { Layout } from '../../../ui/layout.tsx'
 
-export function AdminOrdersIndexPage() {
-  return ({ orders }: { orders: Order[] }) => (
-    <Layout>
-      <h1>Manage Orders</h1>
+export function AdminOrdersIndexPage(handle: Handle<{ orders: Order[] }>) {
+  return () => {
+    let { orders } = handle.props
 
-      <p mix={css({ marginBottom: '1rem' })}>
-        <a href={routes.admin.index.href()} class="btn btn-secondary">
-          Back to Dashboard
-        </a>
-      </p>
+    return (
+      <Layout>
+        <h1>Manage Orders</h1>
 
-      <div class="card">
-        <table>
-          <thead>
-            <tr>
-              <th>Order ID</th>
-              <th>Date</th>
-              <th>Items</th>
-              <th>Total</th>
-              <th>Status</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {orders.map((order) => (
+        <p mix={css({ marginBottom: '1rem' })}>
+          <a href={routes.admin.index.href()} class="btn btn-secondary">
+            Back to Dashboard
+          </a>
+        </p>
+
+        <div class="card">
+          <table>
+            <thead>
               <tr>
-                <td>#{order.id}</td>
-                <td>{new Date(order.created_at).toLocaleDateString()}</td>
-                <td>{order.items.length} item(s)</td>
-                <td>${order.total.toFixed(2)}</td>
-                <td>
-                  <span class="badge badge-info">{order.status}</span>
-                </td>
-                <td>
-                  <a
-                    href={routes.admin.orders.show.href({ orderId: order.id })}
-                    class="btn btn-secondary"
-                    mix={css({ fontSize: '0.875rem', padding: '0.25rem 0.5rem' })}
-                  >
-                    View
-                  </a>
-                </td>
+                <th>Order ID</th>
+                <th>Date</th>
+                <th>Items</th>
+                <th>Total</th>
+                <th>Status</th>
+                <th>Actions</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </Layout>
-  )
+            </thead>
+            <tbody>
+              {orders.map((order) => (
+                <tr>
+                  <td>#{order.id}</td>
+                  <td>{new Date(order.created_at).toLocaleDateString()}</td>
+                  <td>{order.items.length} item(s)</td>
+                  <td>${order.total.toFixed(2)}</td>
+                  <td>
+                    <span class="badge badge-info">{order.status}</span>
+                  </td>
+                  <td>
+                    <a
+                      href={routes.admin.orders.show.href({ orderId: order.id })}
+                      class="btn btn-secondary"
+                      mix={css({ fontSize: '0.875rem', padding: '0.25rem 0.5rem' })}
+                    >
+                      View
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/admin/orders/show-page.tsx
+++ b/demos/bookstore/app/actions/admin/orders/show-page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { Order } from '../../../data/schema.ts'
@@ -21,64 +22,70 @@ export function AdminOrderNotFoundPage() {
   )
 }
 
-export function AdminOrderShowPage() {
-  return ({ order, shippingAddress }: { order: Order; shippingAddress: AdminShippingAddress }) => (
-    <Layout>
-      <h1>Order #{order.id}</h1>
+export function AdminOrderShowPage(
+  handle: Handle<{ order: Order; shippingAddress: AdminShippingAddress }>,
+) {
+  return () => {
+    let { order, shippingAddress } = handle.props
 
-      <div class="card">
-        <p>
-          <strong>Order Date:</strong> {new Date(order.created_at).toLocaleDateString()}
-        </p>
-        <p>
-          <strong>User ID:</strong> {order.user_id}
-        </p>
-        <p>
-          <strong>Status:</strong> <span class="badge badge-info">{order.status}</span>
-        </p>
+    return (
+      <Layout>
+        <h1>Order #{order.id}</h1>
 
-        <h2 mix={css({ marginTop: '2rem' })}>Items</h2>
-        <table mix={css({ marginTop: '1rem' })}>
-          <thead>
-            <tr>
-              <th>Book</th>
-              <th>Quantity</th>
-              <th>Price</th>
-              <th>Subtotal</th>
-            </tr>
-          </thead>
-          <tbody>
-            {order.items.map((item) => (
+        <div class="card">
+          <p>
+            <strong>Order Date:</strong> {new Date(order.created_at).toLocaleDateString()}
+          </p>
+          <p>
+            <strong>User ID:</strong> {order.user_id}
+          </p>
+          <p>
+            <strong>Status:</strong> <span class="badge badge-info">{order.status}</span>
+          </p>
+
+          <h2 mix={css({ marginTop: '2rem' })}>Items</h2>
+          <table mix={css({ marginTop: '1rem' })}>
+            <thead>
               <tr>
-                <td>{item.title}</td>
-                <td>{item.quantity}</td>
-                <td>${item.unit_price.toFixed(2)}</td>
-                <td>${(item.unit_price * item.quantity).toFixed(2)}</td>
+                <th>Book</th>
+                <th>Quantity</th>
+                <th>Price</th>
+                <th>Subtotal</th>
               </tr>
-            ))}
-          </tbody>
-          <tfoot>
-            <tr>
-              <td colSpan={3} mix={css({ textAlign: 'right', fontWeight: 'bold' })}>
-                Total:
-              </td>
-              <td mix={css({ fontWeight: 'bold' })}>${order.total.toFixed(2)}</td>
-            </tr>
-          </tfoot>
-        </table>
+            </thead>
+            <tbody>
+              {order.items.map((item) => (
+                <tr>
+                  <td>{item.title}</td>
+                  <td>{item.quantity}</td>
+                  <td>${item.unit_price.toFixed(2)}</td>
+                  <td>${(item.unit_price * item.quantity).toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr>
+                <td colSpan={3} mix={css({ textAlign: 'right', fontWeight: 'bold' })}>
+                  Total:
+                </td>
+                <td mix={css({ fontWeight: 'bold' })}>${order.total.toFixed(2)}</td>
+              </tr>
+            </tfoot>
+          </table>
 
-        <h2 mix={css({ marginTop: '2rem' })}>Shipping Address</h2>
-        <p>{shippingAddress.street}</p>
-        <p>
-          {shippingAddress.city}, {shippingAddress.state} {shippingAddress.zip}
+          <h2 mix={css({ marginTop: '2rem' })}>Shipping Address</h2>
+          <p>{shippingAddress.street}</p>
+          <p>
+            {shippingAddress.city}, {shippingAddress.state} {shippingAddress.zip}
+          </p>
+        </div>
+
+        <p mix={css({ marginTop: '1.5rem' })}>
+          <a href={routes.admin.orders.index.href()} class="btn btn-secondary">
+            Back to Orders
+          </a>
         </p>
-      </div>
-
-      <p mix={css({ marginTop: '1.5rem' })}>
-        <a href={routes.admin.orders.index.href()} class="btn btn-secondary">
-          Back to Orders
-        </a>
-      </p>
-    </Layout>
-  )
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/admin/users/form.tsx
+++ b/demos/bookstore/app/actions/admin/users/form.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { User } from '../../../data/schema.ts'
@@ -12,43 +13,47 @@ export interface AdminUserFormPageProps {
   user: User
 }
 
-export function AdminUserFormPage() {
-  return ({ action, cancelHref, submitLabel, title, user }: AdminUserFormPageProps) => (
-    <Layout>
-      <h1>{title}</h1>
+export function AdminUserFormPage(handle: Handle<AdminUserFormPageProps>) {
+  return () => {
+    let { action, cancelHref, submitLabel, title, user } = handle.props
 
-      <div class="card">
-        <RestfulForm method="PUT" action={action}>
-          <div class="form-group">
-            <label for="name">Name</label>
-            <input type="text" id="name" name="name" value={user.name} required />
-          </div>
+    return (
+      <Layout>
+        <h1>{title}</h1>
 
-          <div class="form-group">
-            <label for="email">Email</label>
-            <input type="email" id="email" name="email" value={user.email} required />
-          </div>
+        <div class="card">
+          <RestfulForm method="PUT" action={action}>
+            <div class="form-group">
+              <label for="name">Name</label>
+              <input type="text" id="name" name="name" value={user.name} required />
+            </div>
 
-          <div class="form-group">
-            <label for="role">Role</label>
-            <select id="role" name="role">
-              <option value="customer" selected={user.role === 'customer'}>
-                Customer
-              </option>
-              <option value="admin" selected={user.role === 'admin'}>
-                Admin
-              </option>
-            </select>
-          </div>
+            <div class="form-group">
+              <label for="email">Email</label>
+              <input type="email" id="email" name="email" value={user.email} required />
+            </div>
 
-          <button type="submit" class="btn">
-            {submitLabel}
-          </button>
-          <a href={cancelHref} class="btn btn-secondary" mix={css({ marginLeft: '0.5rem' })}>
-            Cancel
-          </a>
-        </RestfulForm>
-      </div>
-    </Layout>
-  )
+            <div class="form-group">
+              <label for="role">Role</label>
+              <select id="role" name="role">
+                <option value="customer" selected={user.role === 'customer'}>
+                  Customer
+                </option>
+                <option value="admin" selected={user.role === 'admin'}>
+                  Admin
+                </option>
+              </select>
+            </div>
+
+            <button type="submit" class="btn">
+              {submitLabel}
+            </button>
+            <a href={cancelHref} class="btn btn-secondary" mix={css({ marginLeft: '0.5rem' })}>
+              Cancel
+            </a>
+          </RestfulForm>
+        </div>
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/admin/users/index-page.tsx
+++ b/demos/bookstore/app/actions/admin/users/index-page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { User } from '../../../data/schema.ts'
@@ -10,68 +11,72 @@ export interface AdminUsersIndexPageProps {
   currentUserId: number
 }
 
-export function AdminUsersIndexPage() {
-  return ({ currentUserId, users }: AdminUsersIndexPageProps) => (
-    <Layout>
-      <h1>Manage Users</h1>
+export function AdminUsersIndexPage(handle: Handle<AdminUsersIndexPageProps>) {
+  return () => {
+    let { currentUserId, users } = handle.props
 
-      <p mix={css({ marginBottom: '1rem' })}>
-        <a href={routes.admin.index.href()} class="btn btn-secondary">
-          Back to Dashboard
-        </a>
-      </p>
+    return (
+      <Layout>
+        <h1>Manage Users</h1>
 
-      <div class="card">
-        <table>
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Email</th>
-              <th>Role</th>
-              <th>Created</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {users.map((user) => (
+        <p mix={css({ marginBottom: '1rem' })}>
+          <a href={routes.admin.index.href()} class="btn btn-secondary">
+            Back to Dashboard
+          </a>
+        </p>
+
+        <div class="card">
+          <table>
+            <thead>
               <tr>
-                <td>{user.name}</td>
-                <td>{user.email}</td>
-                <td>
-                  <span class={`badge ${user.role === 'admin' ? 'badge-info' : 'badge-success'}`}>
-                    {user.role}
-                  </span>
-                </td>
-                <td>{new Date(user.created_at).toLocaleDateString()}</td>
-                <td class="actions">
-                  <a
-                    href={routes.admin.users.edit.href({ userId: user.id })}
-                    class="btn btn-secondary"
-                    mix={css({ fontSize: '0.875rem', padding: '0.25rem 0.5rem' })}
-                  >
-                    Edit
-                  </a>
-                  {user.id !== currentUserId ? (
-                    <RestfulForm
-                      method="DELETE"
-                      action={routes.admin.users.destroy.href({ userId: user.id })}
-                      mix={css({ display: 'inline' })}
-                    >
-                      <button
-                        type="submit"
-                        class="btn btn-danger"
-                        mix={css({ fontSize: '0.875rem', padding: '0.25rem 0.5rem' })}
-                      >
-                        Delete
-                      </button>
-                    </RestfulForm>
-                  ) : null}
-                </td>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Role</th>
+                <th>Created</th>
+                <th>Actions</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </Layout>
-  )
+            </thead>
+            <tbody>
+              {users.map((user) => (
+                <tr>
+                  <td>{user.name}</td>
+                  <td>{user.email}</td>
+                  <td>
+                    <span class={`badge ${user.role === 'admin' ? 'badge-info' : 'badge-success'}`}>
+                      {user.role}
+                    </span>
+                  </td>
+                  <td>{new Date(user.created_at).toLocaleDateString()}</td>
+                  <td class="actions">
+                    <a
+                      href={routes.admin.users.edit.href({ userId: user.id })}
+                      class="btn btn-secondary"
+                      mix={css({ fontSize: '0.875rem', padding: '0.25rem 0.5rem' })}
+                    >
+                      Edit
+                    </a>
+                    {user.id !== currentUserId ? (
+                      <RestfulForm
+                        method="DELETE"
+                        action={routes.admin.users.destroy.href({ userId: user.id })}
+                        mix={css({ display: 'inline' })}
+                      >
+                        <button
+                          type="submit"
+                          class="btn btn-danger"
+                          mix={css({ fontSize: '0.875rem', padding: '0.25rem 0.5rem' })}
+                        >
+                          Delete
+                        </button>
+                      </RestfulForm>
+                    ) : null}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/admin/users/show-page.tsx
+++ b/demos/bookstore/app/actions/admin/users/show-page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { User } from '../../../data/schema.ts'
@@ -14,41 +15,45 @@ export function AdminUserNotFoundPage() {
   )
 }
 
-export function AdminUserShowPage() {
-  return ({ user }: { user: User }) => (
-    <Layout>
-      <h1>User Details</h1>
+export function AdminUserShowPage(handle: Handle<{ user: User }>) {
+  return () => {
+    let { user } = handle.props
 
-      <div class="card">
-        <p>
-          <strong>Name:</strong> {user.name}
-        </p>
-        <p>
-          <strong>Email:</strong> {user.email}
-        </p>
-        <p>
-          <strong>Role:</strong>{' '}
-          <span class={`badge ${user.role === 'admin' ? 'badge-info' : 'badge-success'}`}>
-            {user.role}
-          </span>
-        </p>
-        <p>
-          <strong>Created:</strong> {new Date(user.created_at).toLocaleDateString()}
-        </p>
+    return (
+      <Layout>
+        <h1>User Details</h1>
 
-        <div mix={css({ marginTop: '2rem' })}>
-          <a href={routes.admin.users.edit.href({ userId: user.id })} class="btn">
-            Edit
-          </a>
-          <a
-            href={routes.admin.users.index.href()}
-            class="btn btn-secondary"
-            mix={css({ marginLeft: '0.5rem' })}
-          >
-            Back to List
-          </a>
+        <div class="card">
+          <p>
+            <strong>Name:</strong> {user.name}
+          </p>
+          <p>
+            <strong>Email:</strong> {user.email}
+          </p>
+          <p>
+            <strong>Role:</strong>{' '}
+            <span class={`badge ${user.role === 'admin' ? 'badge-info' : 'badge-success'}`}>
+              {user.role}
+            </span>
+          </p>
+          <p>
+            <strong>Created:</strong> {new Date(user.created_at).toLocaleDateString()}
+          </p>
+
+          <div mix={css({ marginTop: '2rem' })}>
+            <a href={routes.admin.users.edit.href({ userId: user.id })} class="btn">
+              Edit
+            </a>
+            <a
+              href={routes.admin.users.index.href()}
+              class="btn btn-secondary"
+              mix={css({ marginLeft: '0.5rem' })}
+            >
+              Back to List
+            </a>
+          </div>
         </div>
-      </div>
-    </Layout>
-  )
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/auth/forgot-password/page.tsx
+++ b/demos/bookstore/app/actions/auth/forgot-password/page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import { routes } from '../../../routes.ts'
@@ -30,38 +31,42 @@ export function ForgotPasswordPage() {
   )
 }
 
-export function ForgotPasswordSuccessPage() {
-  return ({ token }: { token?: string }) => (
-    <Document>
-      <div class="card" mix={authCardStyle}>
-        <div class="alert alert-success">Password reset link sent! Check your email.</div>
+export function ForgotPasswordSuccessPage(handle: Handle<{ token?: string }>) {
+  return () => {
+    let { token } = handle.props
 
-        {token ? (
-          <div
-            mix={css({
-              marginTop: '1rem',
-              padding: '1rem',
-              background: '#f8f9fa',
-              borderRadius: '4px',
-            })}
-          >
-            <p mix={css({ fontSize: '0.9rem' })}>
-              <strong>Demo Mode:</strong> Click the link below to reset your password
-            </p>
-            <p mix={css({ marginTop: '0.5rem' })}>
-              <a href={routes.auth.resetPassword.index.href({ token })} class="btn btn-secondary">
-                Reset Password
-              </a>
-            </p>
-          </div>
-        ) : null}
+    return (
+      <Document>
+        <div class="card" mix={authCardStyle}>
+          <div class="alert alert-success">Password reset link sent! Check your email.</div>
 
-        <p mix={css({ marginTop: '1.5rem' })}>
-          <a href={routes.auth.login.index.href()} class="btn">
-            Back to Login
-          </a>
-        </p>
-      </div>
-    </Document>
-  )
+          {token ? (
+            <div
+              mix={css({
+                marginTop: '1rem',
+                padding: '1rem',
+                background: '#f8f9fa',
+                borderRadius: '4px',
+              })}
+            >
+              <p mix={css({ fontSize: '0.9rem' })}>
+                <strong>Demo Mode:</strong> Click the link below to reset your password
+              </p>
+              <p mix={css({ marginTop: '0.5rem' })}>
+                <a href={routes.auth.resetPassword.index.href({ token })} class="btn btn-secondary">
+                  Reset Password
+                </a>
+              </p>
+            </div>
+          ) : null}
+
+          <p mix={css({ marginTop: '1.5rem' })}>
+            <a href={routes.auth.login.index.href()} class="btn">
+              Back to Login
+            </a>
+          </p>
+        </div>
+      </Document>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/auth/login/page.tsx
+++ b/demos/bookstore/app/actions/auth/login/page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import { routes } from '../../../routes.ts'
@@ -9,62 +10,66 @@ export interface LoginPageProps {
   error?: string
 }
 
-export function LoginPage() {
-  return ({ error, formAction }: LoginPageProps) => (
-    <Document>
-      <div class="card" mix={authCardStyle}>
-        <h1>Login</h1>
+export function LoginPage(handle: Handle<LoginPageProps>) {
+  return () => {
+    let { error, formAction } = handle.props
 
-        {typeof error === 'string' ? (
-          <div class="alert alert-error" mix={css({ marginBottom: '1.5rem' })}>
-            {error}
-          </div>
-        ) : null}
+    return (
+      <Document>
+        <div class="card" mix={authCardStyle}>
+          <h1>Login</h1>
 
-        <form method="POST" action={formAction}>
-          <div class="form-group">
-            <label for="email">Email</label>
-            <input type="email" id="email" name="email" required autoComplete="email" />
-          </div>
+          {typeof error === 'string' ? (
+            <div class="alert alert-error" mix={css({ marginBottom: '1.5rem' })}>
+              {error}
+            </div>
+          ) : null}
 
-          <div class="form-group">
-            <label for="password">Password</label>
-            <input
-              type="password"
-              id="password"
-              name="password"
-              required
-              autoComplete="current-password"
-            />
-          </div>
+          <form method="POST" action={formAction}>
+            <div class="form-group">
+              <label for="email">Email</label>
+              <input type="email" id="email" name="email" required autoComplete="email" />
+            </div>
 
-          <button type="submit" class="btn">
-            Login
-          </button>
-        </form>
+            <div class="form-group">
+              <label for="password">Password</label>
+              <input
+                type="password"
+                id="password"
+                name="password"
+                required
+                autoComplete="current-password"
+              />
+            </div>
 
-        <p mix={css({ marginTop: '1.5rem' })}>
-          Don't have an account? <a href={routes.auth.register.index.href()}>Register here</a>
-        </p>
-        <p>
-          <a href={routes.auth.forgotPassword.index.href()}>Forgot password?</a>
-        </p>
+            <button type="submit" class="btn">
+              Login
+            </button>
+          </form>
 
-        <div
-          mix={css({
-            marginTop: '2rem',
-            padding: '1rem',
-            background: '#f8f9fa',
-            borderRadius: '4px',
-          })}
-        >
-          <p mix={css({ fontSize: '0.9rem' })}>
-            <strong>Demo Accounts:</strong>
+          <p mix={css({ marginTop: '1.5rem' })}>
+            Don't have an account? <a href={routes.auth.register.index.href()}>Register here</a>
           </p>
-          <p mix={css({ fontSize: '0.9rem' })}>Admin: admin@bookstore.com / admin123</p>
-          <p mix={css({ fontSize: '0.9rem' })}>Customer: customer@example.com / password123</p>
+          <p>
+            <a href={routes.auth.forgotPassword.index.href()}>Forgot password?</a>
+          </p>
+
+          <div
+            mix={css({
+              marginTop: '2rem',
+              padding: '1rem',
+              background: '#f8f9fa',
+              borderRadius: '4px',
+            })}
+          >
+            <p mix={css({ fontSize: '0.9rem' })}>
+              <strong>Demo Accounts:</strong>
+            </p>
+            <p mix={css({ fontSize: '0.9rem' })}>Admin: admin@bookstore.com / admin123</p>
+            <p mix={css({ fontSize: '0.9rem' })}>Customer: customer@example.com / password123</p>
+          </div>
         </div>
-      </div>
-    </Document>
-  )
+      </Document>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/auth/reset-password/page.tsx
+++ b/demos/bookstore/app/actions/auth/reset-password/page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import { routes } from '../../../routes.ts'
@@ -9,49 +10,53 @@ export interface ResetPasswordPageProps {
   error?: string
 }
 
-export function ResetPasswordPage() {
-  return ({ error, token }: ResetPasswordPageProps) => (
-    <Document>
-      <div class="card" mix={authCardStyle}>
-        <h1>Reset Password</h1>
-        <p>Enter your new password below.</p>
+export function ResetPasswordPage(handle: Handle<ResetPasswordPageProps>) {
+  return () => {
+    let { error, token } = handle.props
 
-        {typeof error === 'string' ? (
-          <div class="alert alert-error" mix={css({ marginBottom: '1.5rem' })}>
-            {error}
-          </div>
-        ) : null}
+    return (
+      <Document>
+        <div class="card" mix={authCardStyle}>
+          <h1>Reset Password</h1>
+          <p>Enter your new password below.</p>
 
-        <form method="POST" action={routes.auth.resetPassword.action.href({ token })}>
-          <div class="form-group">
-            <label for="password">New Password</label>
-            <input
-              type="password"
-              id="password"
-              name="password"
-              required
-              autoComplete="new-password"
-            />
-          </div>
+          {typeof error === 'string' ? (
+            <div class="alert alert-error" mix={css({ marginBottom: '1.5rem' })}>
+              {error}
+            </div>
+          ) : null}
 
-          <div class="form-group">
-            <label for="confirmPassword">Confirm Password</label>
-            <input
-              type="password"
-              id="confirmPassword"
-              name="confirmPassword"
-              required
-              autoComplete="new-password"
-            />
-          </div>
+          <form method="POST" action={routes.auth.resetPassword.action.href({ token })}>
+            <div class="form-group">
+              <label for="password">New Password</label>
+              <input
+                type="password"
+                id="password"
+                name="password"
+                required
+                autoComplete="new-password"
+              />
+            </div>
 
-          <button type="submit" class="btn">
-            Reset Password
-          </button>
-        </form>
-      </div>
-    </Document>
-  )
+            <div class="form-group">
+              <label for="confirmPassword">Confirm Password</label>
+              <input
+                type="password"
+                id="confirmPassword"
+                name="confirmPassword"
+                required
+                autoComplete="new-password"
+              />
+            </div>
+
+            <button type="submit" class="btn">
+              Reset Password
+            </button>
+          </form>
+        </div>
+      </Document>
+    )
+  }
 }
 
 export function ResetPasswordSuccessPage() {

--- a/demos/bookstore/app/actions/books/genre-page.tsx
+++ b/demos/bookstore/app/actions/books/genre-page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { Book } from '../../data/schema.ts'
@@ -12,32 +13,36 @@ export interface GenrePageProps {
   cart: Cart
 }
 
-export function GenrePage() {
-  return ({ cart, genre, matchingBooks }: GenrePageProps) => (
-    <Layout>
-      <h1>{genre.charAt(0).toUpperCase() + genre.slice(1)} Books</h1>
-      <p mix={css({ margin: '1rem 0' })}>
-        <a href={routes.books.index.href()} class="btn btn-secondary">
-          View All Books
-        </a>
-      </p>
+export function GenrePage(handle: Handle<GenrePageProps>) {
+  return () => {
+    let { cart, genre, matchingBooks } = handle.props
 
-      <div class="grid" mix={css({ marginTop: '2rem' })}>
-        {matchingBooks.map((book) => {
-          let inCart = cart.items.some((item) => item.slug === book.slug)
-          return <BookCard book={book} inCart={inCart} />
-        })}
-      </div>
-    </Layout>
-  )
+    return (
+      <Layout>
+        <h1>{genre.charAt(0).toUpperCase() + genre.slice(1)} Books</h1>
+        <p mix={css({ margin: '1rem 0' })}>
+          <a href={routes.books.index.href()} class="btn btn-secondary">
+            View All Books
+          </a>
+        </p>
+
+        <div class="grid" mix={css({ marginTop: '2rem' })}>
+          {matchingBooks.map((book) => {
+            let inCart = cart.items.some((item) => item.slug === book.slug)
+            return <BookCard book={book} inCart={inCart} />
+          })}
+        </div>
+      </Layout>
+    )
+  }
 }
 
-export function GenreNotFoundPage() {
-  return ({ genre }: { genre: string }) => (
+export function GenreNotFoundPage(handle: Handle<{ genre: string }>) {
+  return () => (
     <Layout>
       <div class="card">
         <h1>Genre Not Found</h1>
-        <p>No books found in the "{genre}" genre.</p>
+        <p>No books found in the "{handle.props.genre}" genre.</p>
         <p mix={css({ marginTop: '1rem' })}>
           <a href={routes.books.index.href()} class="btn">
             Browse All Books

--- a/demos/bookstore/app/actions/books/index-page.tsx
+++ b/demos/bookstore/app/actions/books/index-page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { Book } from '../../data/schema.ts'
@@ -12,46 +13,50 @@ export interface IndexPageProps {
   cart: Cart
 }
 
-export function IndexPage() {
-  return ({ allBooks, cart, genres }: IndexPageProps) => (
-    <Layout>
-      <h1>Browse Books</h1>
+export function IndexPage(handle: Handle<IndexPageProps>) {
+  return () => {
+    let { allBooks, cart, genres } = handle.props
 
-      <div class="card" mix={css({ marginBottom: '2rem' })}>
-        <form
-          action={routes.search.href()}
-          method="GET"
-          mix={css({ display: 'flex', gap: '0.5rem' })}
-        >
-          <input
-            type="search"
-            name="q"
-            placeholder="Search books by title, author, or description..."
-            mix={css({ flex: 1, padding: '0.5rem' })}
-          />
-          <button type="submit" class="btn">
-            Search
-          </button>
-        </form>
-      </div>
+    return (
+      <Layout>
+        <h1>Browse Books</h1>
 
-      <div class="card" mix={css({ marginBottom: '2rem' })}>
-        <h3>Browse by Genre</h3>
-        <div mix={css({ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginTop: '1rem' })}>
-          {genres.map((genre) => (
-            <a href={routes.books.genre.href({ genre })} class="btn btn-secondary">
-              {genre}
-            </a>
-          ))}
+        <div class="card" mix={css({ marginBottom: '2rem' })}>
+          <form
+            action={routes.search.href()}
+            method="GET"
+            mix={css({ display: 'flex', gap: '0.5rem' })}
+          >
+            <input
+              type="search"
+              name="q"
+              placeholder="Search books by title, author, or description..."
+              mix={css({ flex: 1, padding: '0.5rem' })}
+            />
+            <button type="submit" class="btn">
+              Search
+            </button>
+          </form>
         </div>
-      </div>
 
-      <div class="grid">
-        {allBooks.map((book) => {
-          let inCart = cart.items.some((item) => item.slug === book.slug)
-          return <BookCard book={book} inCart={inCart} />
-        })}
-      </div>
-    </Layout>
-  )
+        <div class="card" mix={css({ marginBottom: '2rem' })}>
+          <h3>Browse by Genre</h3>
+          <div mix={css({ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginTop: '1rem' })}>
+            {genres.map((genre) => (
+              <a href={routes.books.genre.href({ genre })} class="btn btn-secondary">
+                {genre}
+              </a>
+            ))}
+          </div>
+        </div>
+
+        <div class="grid">
+          {allBooks.map((book) => {
+            let inCart = cart.items.some((item) => item.slug === book.slug)
+            return <BookCard book={book} inCart={inCart} />
+          })}
+        </div>
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/books/show-page.tsx
+++ b/demos/bookstore/app/actions/books/show-page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { Frame, css } from 'remix/ui'
 
 import type { Book } from '../../data/schema.ts'
@@ -10,78 +11,82 @@ export interface ShowPageProps {
   imageUrls: string[]
 }
 
-export function ShowPage() {
-  return ({ book, imageUrls }: ShowPageProps) => (
-    <Layout>
-      <div mix={css({ display: 'grid', gridTemplateColumns: '300px 1fr', gap: '2rem' })}>
-        <div
-          mix={css({
-            height: '400px',
-            borderRadius: '8px',
-            boxShadow: '0 4px 8px rgba(0,0,0,0.1)',
-            overflow: 'hidden',
-          })}
-        >
-          <ImageCarousel images={imageUrls} />
-        </div>
+export function ShowPage(handle: Handle<ShowPageProps>) {
+  return () => {
+    let { book, imageUrls } = handle.props
 
-        <div class="card">
-          <h1>{book.title}</h1>
-          <p class="author" mix={css({ fontSize: '1.2rem', margin: '0.5rem 0' })}>
-            by {book.author}
-          </p>
-
-          <p mix={css({ margin: '1rem 0' })}>
-            <span class="badge badge-info">{book.genre}</span>
-            <span
-              class={`badge ${book.in_stock ? 'badge-success' : 'badge-warning'}`}
-              mix={css({ marginLeft: '0.5rem' })}
-            >
-              {book.in_stock ? 'In Stock' : 'Out of Stock'}
-            </span>
-          </p>
-
-          <p class="price" mix={css({ fontSize: '2rem', margin: '1rem 0' })}>
-            ${book.price.toFixed(2)}
-          </p>
-
-          <p mix={css({ margin: '1.5rem 0', lineHeight: 1.8 })}>{book.description}</p>
-
+    return (
+      <Layout>
+        <div mix={css({ display: 'grid', gridTemplateColumns: '300px 1fr', gap: '2rem' })}>
           <div
             mix={css({
-              margin: '1.5rem 0',
-              padding: '1rem',
-              background: '#f8f9fa',
-              borderRadius: '4px',
+              height: '400px',
+              borderRadius: '8px',
+              boxShadow: '0 4px 8px rgba(0,0,0,0.1)',
+              overflow: 'hidden',
             })}
           >
-            <p>
-              <strong>ISBN:</strong> {book.isbn}
-            </p>
-            <p>
-              <strong>Published:</strong> {book.published_year}
-            </p>
+            <ImageCarousel images={imageUrls} />
           </div>
 
-          {book.in_stock ? (
-            <div mix={css({ marginTop: '2rem' })}>
-              <Frame src={routes.fragments.cartButton.href({ bookId: book.id })} />
-            </div>
-          ) : (
-            <p mix={css({ color: '#e74c3c', fontWeight: 500 })}>
-              This book is currently out of stock.
+          <div class="card">
+            <h1>{book.title}</h1>
+            <p class="author" mix={css({ fontSize: '1.2rem', margin: '0.5rem 0' })}>
+              by {book.author}
             </p>
-          )}
 
-          <p mix={css({ marginTop: '1.5rem' })}>
-            <a href={routes.books.index.href()} class="btn btn-secondary">
-              Back to Books
-            </a>
-          </p>
+            <p mix={css({ margin: '1rem 0' })}>
+              <span class="badge badge-info">{book.genre}</span>
+              <span
+                class={`badge ${book.in_stock ? 'badge-success' : 'badge-warning'}`}
+                mix={css({ marginLeft: '0.5rem' })}
+              >
+                {book.in_stock ? 'In Stock' : 'Out of Stock'}
+              </span>
+            </p>
+
+            <p class="price" mix={css({ fontSize: '2rem', margin: '1rem 0' })}>
+              ${book.price.toFixed(2)}
+            </p>
+
+            <p mix={css({ margin: '1.5rem 0', lineHeight: 1.8 })}>{book.description}</p>
+
+            <div
+              mix={css({
+                margin: '1.5rem 0',
+                padding: '1rem',
+                background: '#f8f9fa',
+                borderRadius: '4px',
+              })}
+            >
+              <p>
+                <strong>ISBN:</strong> {book.isbn}
+              </p>
+              <p>
+                <strong>Published:</strong> {book.published_year}
+              </p>
+            </div>
+
+            {book.in_stock ? (
+              <div mix={css({ marginTop: '2rem' })}>
+                <Frame src={routes.fragments.cartButton.href({ bookId: book.id })} />
+              </div>
+            ) : (
+              <p mix={css({ color: '#e74c3c', fontWeight: 500 })}>
+                This book is currently out of stock.
+              </p>
+            )}
+
+            <p mix={css({ marginTop: '1.5rem' })}>
+              <a href={routes.books.index.href()} class="btn btn-secondary">
+                Back to Books
+              </a>
+            </p>
+          </div>
         </div>
-      </div>
-    </Layout>
-  )
+      </Layout>
+    )
+  }
 }
 
 export function BookNotFoundPage() {

--- a/demos/bookstore/app/actions/checkout/checkout-page.tsx
+++ b/demos/bookstore/app/actions/checkout/checkout-page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { Cart } from '../../utils/cart.ts'
@@ -25,78 +26,82 @@ export function EmptyCheckoutPage() {
   )
 }
 
-export function CheckoutPage() {
-  return ({ cart, total }: CheckoutPageProps) => (
-    <Layout>
-      <h1>Checkout</h1>
+export function CheckoutPage(handle: Handle<CheckoutPageProps>) {
+  return () => {
+    let { cart, total } = handle.props
 
-      <div class="card">
-        <h2>Order Summary</h2>
-        <table mix={css({ marginTop: '1rem' })}>
-          <thead>
-            <tr>
-              <th>Book</th>
-              <th>Quantity</th>
-              <th>Price</th>
-              <th>Subtotal</th>
-            </tr>
-          </thead>
-          <tbody>
-            {cart.items.map((item) => (
+    return (
+      <Layout>
+        <h1>Checkout</h1>
+
+        <div class="card">
+          <h2>Order Summary</h2>
+          <table mix={css({ marginTop: '1rem' })}>
+            <thead>
               <tr>
-                <td>{item.title}</td>
-                <td>{item.quantity}</td>
-                <td>${item.price.toFixed(2)}</td>
-                <td>${(item.price * item.quantity).toFixed(2)}</td>
+                <th>Book</th>
+                <th>Quantity</th>
+                <th>Price</th>
+                <th>Subtotal</th>
               </tr>
-            ))}
-          </tbody>
-          <tfoot>
-            <tr>
-              <td colSpan={3} mix={css({ textAlign: 'right', fontWeight: 'bold' })}>
-                Total:
-              </td>
-              <td mix={css({ fontWeight: 'bold' })}>${total.toFixed(2)}</td>
-            </tr>
-          </tfoot>
-        </table>
-      </div>
+            </thead>
+            <tbody>
+              {cart.items.map((item) => (
+                <tr>
+                  <td>{item.title}</td>
+                  <td>{item.quantity}</td>
+                  <td>${item.price.toFixed(2)}</td>
+                  <td>${(item.price * item.quantity).toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr>
+                <td colSpan={3} mix={css({ textAlign: 'right', fontWeight: 'bold' })}>
+                  Total:
+                </td>
+                <td mix={css({ fontWeight: 'bold' })}>${total.toFixed(2)}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
 
-      <div class="card" mix={css({ marginTop: '1.5rem' })}>
-        <h2>Shipping Information</h2>
-        <form method="POST" action={routes.checkout.action.href()}>
-          <div class="form-group">
-            <label for="street">Street Address</label>
-            <input type="text" id="street" name="street" required />
-          </div>
+        <div class="card" mix={css({ marginTop: '1.5rem' })}>
+          <h2>Shipping Information</h2>
+          <form method="POST" action={routes.checkout.action.href()}>
+            <div class="form-group">
+              <label for="street">Street Address</label>
+              <input type="text" id="street" name="street" required />
+            </div>
 
-          <div class="form-group">
-            <label for="city">City</label>
-            <input type="text" id="city" name="city" required />
-          </div>
+            <div class="form-group">
+              <label for="city">City</label>
+              <input type="text" id="city" name="city" required />
+            </div>
 
-          <div class="form-group">
-            <label for="state">State</label>
-            <input type="text" id="state" name="state" required />
-          </div>
+            <div class="form-group">
+              <label for="state">State</label>
+              <input type="text" id="state" name="state" required />
+            </div>
 
-          <div class="form-group">
-            <label for="zip">ZIP Code</label>
-            <input type="text" id="zip" name="zip" required />
-          </div>
+            <div class="form-group">
+              <label for="zip">ZIP Code</label>
+              <input type="text" id="zip" name="zip" required />
+            </div>
 
-          <button type="submit" class="btn">
-            Place Order
-          </button>
-          <a
-            href={routes.cart.index.href()}
-            class="btn btn-secondary"
-            mix={css({ marginLeft: '0.5rem' })}
-          >
-            Back to Cart
-          </a>
-        </form>
-      </div>
-    </Layout>
-  )
+            <button type="submit" class="btn">
+              Place Order
+            </button>
+            <a
+              href={routes.cart.index.href()}
+              class="btn btn-secondary"
+              mix={css({ marginLeft: '0.5rem' })}
+            >
+              Back to Cart
+            </a>
+          </form>
+        </div>
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/checkout/confirmation-page.tsx
+++ b/demos/bookstore/app/actions/checkout/confirmation-page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { Order } from '../../data/schema.ts'
@@ -19,44 +20,48 @@ export function CheckoutOrderNotFoundPage() {
   )
 }
 
-export function CheckoutConfirmationPage() {
-  return ({ order }: { order: Order }) => (
-    <Layout>
-      <div class="alert alert-success">
-        <h1 mix={css({ marginBottom: '0.5rem' })}>Order Confirmed!</h1>
-        <p>Thank you for your purchase. Your order has been placed successfully.</p>
-      </div>
+export function CheckoutConfirmationPage(handle: Handle<{ order: Order }>) {
+  return () => {
+    let { order } = handle.props
 
-      <div class="card">
-        <h2>Order #{order.id}</h2>
-        <p>
-          <strong>Order Date:</strong> {new Date(order.created_at).toLocaleDateString()}
-        </p>
-        <p>
-          <strong>Total:</strong> ${order.total.toFixed(2)}
-        </p>
-        <p>
-          <strong>Status:</strong> <span class="badge badge-info">{order.status}</span>
-        </p>
-
-        <p mix={css({ marginTop: '2rem' })}>
-          We'll send you a confirmation email shortly. You can track your order status in your
-          account.
-        </p>
-
-        <div mix={css({ marginTop: '2rem' })}>
-          <a href={routes.account.orders.show.href({ orderId: order.id })} class="btn">
-            View Order Details
-          </a>
-          <a
-            href={routes.books.index.href()}
-            class="btn btn-secondary"
-            mix={css({ marginLeft: '0.5rem' })}
-          >
-            Continue Shopping
-          </a>
+    return (
+      <Layout>
+        <div class="alert alert-success">
+          <h1 mix={css({ marginBottom: '0.5rem' })}>Order Confirmed!</h1>
+          <p>Thank you for your purchase. Your order has been placed successfully.</p>
         </div>
-      </div>
-    </Layout>
-  )
+
+        <div class="card">
+          <h2>Order #{order.id}</h2>
+          <p>
+            <strong>Order Date:</strong> {new Date(order.created_at).toLocaleDateString()}
+          </p>
+          <p>
+            <strong>Total:</strong> ${order.total.toFixed(2)}
+          </p>
+          <p>
+            <strong>Status:</strong> <span class="badge badge-info">{order.status}</span>
+          </p>
+
+          <p mix={css({ marginTop: '2rem' })}>
+            We'll send you a confirmation email shortly. You can track your order status in your
+            account.
+          </p>
+
+          <div mix={css({ marginTop: '2rem' })}>
+            <a href={routes.account.orders.show.href({ orderId: order.id })} class="btn">
+              View Order Details
+            </a>
+            <a
+              href={routes.books.index.href()}
+              class="btn btn-secondary"
+              mix={css({ marginLeft: '0.5rem' })}
+            >
+              Continue Shopping
+            </a>
+          </div>
+        </div>
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/home.tsx
+++ b/demos/bookstore/app/actions/home.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { Book } from '../data/schema.ts'
@@ -11,29 +12,33 @@ interface HomePageProps {
   cart: Cart
 }
 
-export function HomePage() {
-  return ({ featuredBooks, cart }: HomePageProps) => (
-    <Layout>
-      <div class="card">
-        <h1>Welcome to the Bookstore</h1>
-        <p mix={css({ margin: '1rem 0' })}>
-          Discover your next favorite book from our curated collection of fiction, non-fiction, and
-          more.
-        </p>
-        <p>
-          <a href={routes.books.index.href()} class="btn">
-            Browse Books
-          </a>
-        </p>
-      </div>
+export function HomePage(handle: Handle<HomePageProps>) {
+  return () => {
+    let { featuredBooks, cart } = handle.props
 
-      <h2 mix={css({ margin: '2rem 0 1rem' })}>Featured Books</h2>
-      <div class="grid">
-        {featuredBooks.map((book) => {
-          let inCart = cart.items.some((item) => item.slug === book.slug)
-          return <BookCard book={book} inCart={inCart} />
-        })}
-      </div>
-    </Layout>
-  )
+    return (
+      <Layout>
+        <div class="card">
+          <h1>Welcome to the Bookstore</h1>
+          <p mix={css({ margin: '1rem 0' })}>
+            Discover your next favorite book from our curated collection of fiction, non-fiction,
+            and more.
+          </p>
+          <p>
+            <a href={routes.books.index.href()} class="btn">
+              Browse Books
+            </a>
+          </p>
+        </div>
+
+        <h2 mix={css({ margin: '2rem 0 1rem' })}>Featured Books</h2>
+        <div class="grid">
+          {featuredBooks.map((book) => {
+            let inCart = cart.items.some((item) => item.slug === book.slug)
+            return <BookCard book={book} inCart={inCart} />
+          })}
+        </div>
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/actions/search.tsx
+++ b/demos/bookstore/app/actions/search.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import type { Book } from '../data/schema.ts'
@@ -12,46 +13,50 @@ interface SearchPageProps {
   cart: Cart
 }
 
-export function SearchPage() {
-  return ({ cart, matchingBooks, query }: SearchPageProps) => (
-    <Layout>
-      <h1>Search Results</h1>
+export function SearchPage(handle: Handle<SearchPageProps>) {
+  return () => {
+    let { cart, matchingBooks, query } = handle.props
 
-      <div class="card" mix={css({ marginBottom: '2rem' })}>
-        <form
-          action={routes.search.href()}
-          method="GET"
-          mix={css({ display: 'flex', gap: '0.5rem' })}
-        >
-          <input
-            type="search"
-            name="q"
-            placeholder="Search books..."
-            value={query}
-            mix={css({ flex: 1, padding: '0.5rem' })}
-          />
-          <button type="submit" class="btn">
-            Search
-          </button>
-        </form>
-      </div>
+    return (
+      <Layout>
+        <h1>Search Results</h1>
 
-      {query ? (
-        <p mix={css({ marginBottom: '1rem' })}>
-          Found {matchingBooks.length} result(s) for "{query}"
-        </p>
-      ) : null}
+        <div class="card" mix={css({ marginBottom: '2rem' })}>
+          <form
+            action={routes.search.href()}
+            method="GET"
+            mix={css({ display: 'flex', gap: '0.5rem' })}
+          >
+            <input
+              type="search"
+              name="q"
+              placeholder="Search books..."
+              value={query}
+              mix={css({ flex: 1, padding: '0.5rem' })}
+            />
+            <button type="submit" class="btn">
+              Search
+            </button>
+          </form>
+        </div>
 
-      <div class="grid">
-        {matchingBooks.length > 0 ? (
-          matchingBooks.map((book) => {
-            let inCart = cart.items.some((item) => item.slug === book.slug)
-            return <BookCard book={book} inCart={inCart} />
-          })
-        ) : (
-          <p>No books found matching your search.</p>
-        )}
-      </div>
-    </Layout>
-  )
+        {query ? (
+          <p mix={css({ marginBottom: '1rem' })}>
+            Found {matchingBooks.length} result(s) for "{query}"
+          </p>
+        ) : null}
+
+        <div class="grid">
+          {matchingBooks.length > 0 ? (
+            matchingBooks.map((book) => {
+              let inCart = cart.items.some((item) => item.slug === book.slug)
+              return <BookCard book={book} inCart={inCart} />
+            })
+          ) : (
+            <p>No books found matching your search.</p>
+          )}
+        </div>
+      </Layout>
+    )
+  }
 }

--- a/demos/bookstore/app/assets/cart-button.tsx
+++ b/demos/bookstore/app/assets/cart-button.tsx
@@ -2,35 +2,42 @@ import { type Handle, clientEntry, on } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 
-export const CartButton = clientEntry(import.meta.url, function CartButton(handle: Handle) {
-  let pending = false
+export const CartButton = clientEntry(
+  import.meta.url,
+  function CartButton(handle: Handle<{ inCart: boolean; id: string | number; slug: string }>) {
+    let pending = false
 
-  return ({ inCart, id, slug }: { inCart: boolean; id: string | number; slug: string }) => (
-    <button
-      type="button"
-      mix={on('click', async (_event, signal) => {
-        pending = true
-        handle.update()
+    return () => {
+      let { inCart, id, slug } = handle.props
 
-        let formData = new FormData()
-        formData.set('bookId', String(id))
-        formData.set('slug', slug)
+      return (
+        <button
+          type="button"
+          mix={on('click', async (_event, signal) => {
+            pending = true
+            handle.update()
 
-        await fetch(routes.api.cartToggle.href(), {
-          method: 'POST',
-          body: formData,
-          signal,
-        })
+            let formData = new FormData()
+            formData.set('bookId', String(id))
+            formData.set('slug', slug)
 
-        await handle.frame.reload()
-        await new Promise((resolve) => setTimeout(resolve, 500))
-        if (signal.aborted) return
-        pending = false
-        handle.update()
-      })}
-      class="btn"
-    >
-      {pending ? 'Saving...' : inCart ? 'Remove from Cart' : 'Add to Cart'}
-    </button>
-  )
-})
+            await fetch(routes.api.cartToggle.href(), {
+              method: 'POST',
+              body: formData,
+              signal,
+            })
+
+            await handle.frame.reload()
+            await new Promise((resolve) => setTimeout(resolve, 500))
+            if (signal.aborted) return
+            pending = false
+            handle.update()
+          })}
+          class="btn"
+        >
+          {pending ? 'Saving...' : inCart ? 'Remove from Cart' : 'Add to Cart'}
+        </button>
+      )
+    }
+  },
+)

--- a/demos/bookstore/app/assets/cart-items.tsx
+++ b/demos/bookstore/app/assets/cart-items.tsx
@@ -1,4 +1,5 @@
-import { css, type Handle, clientEntry, on } from 'remix/ui'
+import type { Handle } from 'remix/ui'
+import { css, clientEntry, on } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 
@@ -21,175 +22,181 @@ type PendingAction = {
   bookId: number
 } | null
 
-export const CartItems = clientEntry(import.meta.url, function CartItems(handle: Handle) {
-  let pendingAction: PendingAction = null
+export const CartItems = clientEntry(
+  import.meta.url,
+  function CartItems(handle: Handle<CartItemsProps>) {
+    let pendingAction: PendingAction = null
 
-  let submit = async (form: HTMLFormElement, signal: AbortSignal, nextAction: PendingAction) => {
-    if (pendingAction) return
+    let submit = async (form: HTMLFormElement, signal: AbortSignal, nextAction: PendingAction) => {
+      if (pendingAction) return
 
-    pendingAction = nextAction
-    handle.update()
-
-    try {
-      let formData = new FormData(form)
-      formData.set('redirect', 'none')
-
-      await fetch(form.action, {
-        method: 'POST',
-        body: formData,
-        signal,
-      })
-
-      if (signal.aborted) return
-
-      await handle.frame.reload()
-    } finally {
-      pendingAction = null
+      pendingAction = nextAction
       handle.update()
+
+      try {
+        let formData = new FormData(form)
+        formData.set('redirect', 'none')
+
+        await fetch(form.action, {
+          method: 'POST',
+          body: formData,
+          signal,
+        })
+
+        if (signal.aborted) return
+
+        await handle.frame.reload()
+      } finally {
+        pendingAction = null
+        handle.update()
+      }
     }
-  }
 
-  return ({ items, total, canCheckout }: CartItemsProps) => {
-    let isPending = pendingAction !== null
-    let totalLabel = isPending ? '---' : `$${total.toFixed(2)}`
+    return () => {
+      let { items, total, canCheckout } = handle.props
+      let isPending = pendingAction !== null
+      let totalLabel = isPending ? '---' : `$${total.toFixed(2)}`
 
-    return (
-      <>
-        {isPending ? (
-          <p mix={css({ marginBottom: '1rem', fontSize: '0.9rem', color: '#666' })}>
-            Updating your cart...
-          </p>
-        ) : null}
+      return (
+        <>
+          {isPending ? (
+            <p mix={css({ marginBottom: '1rem', fontSize: '0.9rem', color: '#666' })}>
+              Updating your cart...
+            </p>
+          ) : null}
 
-        <table>
-          <thead>
-            <tr>
-              <th>Book</th>
-              <th>Price</th>
-              <th>Quantity</th>
-              <th>Subtotal</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.map((item) => {
-              let isUpdating =
-                pendingAction?.type === 'update' && pendingAction.bookId === item.bookId
-              let isRemoving =
-                pendingAction?.type === 'remove' && pendingAction.bookId === item.bookId
+          <table>
+            <thead>
+              <tr>
+                <th>Book</th>
+                <th>Price</th>
+                <th>Quantity</th>
+                <th>Subtotal</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item) => {
+                let isUpdating =
+                  pendingAction?.type === 'update' && pendingAction.bookId === item.bookId
+                let isRemoving =
+                  pendingAction?.type === 'remove' && pendingAction.bookId === item.bookId
 
-              return (
-                <tr key={item.bookId}>
-                  <td>
-                    <a href={routes.books.show.href({ slug: item.slug })}>{item.title}</a>
-                  </td>
+                return (
+                  <tr key={item.bookId}>
+                    <td>
+                      <a href={routes.books.show.href({ slug: item.slug })}>{item.title}</a>
+                    </td>
 
-                  <td>${item.price.toFixed(2)}</td>
+                    <td>${item.price.toFixed(2)}</td>
 
-                  <td>
-                    <form
-                      method="POST"
-                      action={routes.cart.api.update.href()}
-                      mix={[
-                        on('submit', async (event, signal) => {
-                          event.preventDefault()
-                          await submit(event.currentTarget, signal, {
-                            type: 'update',
-                            bookId: item.bookId,
-                          })
-                        }),
-                        css({ display: 'inline-flex', gap: '0.5rem', alignItems: 'center' }),
-                      ]}
-                    >
-                      <input type="hidden" name="_method" value="PUT" />
-                      <input type="hidden" name="bookId" value={item.bookId} />
-
-                      <input
-                        type="number"
-                        name="quantity"
-                        defaultValue={item.quantity}
-                        min="1"
-                        disabled={isPending}
-                        mix={css({ width: '70px' })}
-                      />
-
-                      <button
-                        type="submit"
-                        disabled={isPending}
-                        class="btn btn-secondary"
-                        mix={css({
-                          fontSize: '0.875rem',
-                          padding: '0.25rem 0.5rem',
-                          minWidth: '6.25rem',
-                          textAlign: 'center',
-                        })}
+                    <td>
+                      <form
+                        method="POST"
+                        action={routes.cart.api.update.href()}
+                        mix={[
+                          on('submit', async (event, signal) => {
+                            event.preventDefault()
+                            await submit(event.currentTarget, signal, {
+                              type: 'update',
+                              bookId: item.bookId,
+                            })
+                          }),
+                          css({ display: 'inline-flex', gap: '0.5rem', alignItems: 'center' }),
+                        ]}
                       >
-                        {isUpdating ? 'Saving...' : 'Update'}
-                      </button>
-                    </form>
-                  </td>
+                        <input type="hidden" name="_method" value="PUT" />
+                        <input type="hidden" name="bookId" value={item.bookId} />
 
-                  <td>${(item.price * item.quantity).toFixed(2)}</td>
+                        <input
+                          type="number"
+                          name="quantity"
+                          defaultValue={item.quantity}
+                          min="1"
+                          disabled={isPending}
+                          mix={css({ width: '70px' })}
+                        />
 
-                  <td>
-                    <form
-                      method="POST"
-                      action={routes.cart.api.remove.href()}
-                      mix={[
-                        on('submit', async (event, signal) => {
-                          event.preventDefault()
-                          await submit(event.currentTarget, signal, {
-                            type: 'remove',
-                            bookId: item.bookId,
-                          })
-                        }),
-                        css({ display: 'inline' }),
-                      ]}
-                    >
-                      <input type="hidden" name="_method" value="DELETE" />
-                      <input type="hidden" name="bookId" value={item.bookId} />
+                        <button
+                          type="submit"
+                          disabled={isPending}
+                          class="btn btn-secondary"
+                          mix={css({
+                            fontSize: '0.875rem',
+                            padding: '0.25rem 0.5rem',
+                            minWidth: '6.25rem',
+                            textAlign: 'center',
+                          })}
+                        >
+                          {isUpdating ? 'Saving...' : 'Update'}
+                        </button>
+                      </form>
+                    </td>
 
-                      <button
-                        type="submit"
-                        disabled={isPending}
-                        class="btn btn-danger"
-                        mix={css({
-                          fontSize: '0.875rem',
-                          padding: '0.25rem 0.5rem',
-                          minWidth: '7rem',
-                          textAlign: 'center',
-                        })}
+                    <td>${(item.price * item.quantity).toFixed(2)}</td>
+
+                    <td>
+                      <form
+                        method="POST"
+                        action={routes.cart.api.remove.href()}
+                        mix={[
+                          on('submit', async (event, signal) => {
+                            event.preventDefault()
+                            await submit(event.currentTarget, signal, {
+                              type: 'remove',
+                              bookId: item.bookId,
+                            })
+                          }),
+                          css({ display: 'inline' }),
+                        ]}
                       >
-                        {isRemoving ? 'Removing...' : 'Remove'}
-                      </button>
-                    </form>
-                  </td>
-                </tr>
-              )
-            })}
-          </tbody>
-        </table>
+                        <input type="hidden" name="_method" value="DELETE" />
+                        <input type="hidden" name="bookId" value={item.bookId} />
 
-        <div mix={css({ marginTop: '2rem', display: 'flex', alignItems: 'center', gap: '1rem' })}>
-          <p mix={css({ margin: 0, fontSize: '1.25rem', fontWeight: 'bold', marginRight: 'auto' })}>
-            Total: {totalLabel}
-          </p>
+                        <button
+                          type="submit"
+                          disabled={isPending}
+                          class="btn btn-danger"
+                          mix={css({
+                            fontSize: '0.875rem',
+                            padding: '0.25rem 0.5rem',
+                            minWidth: '7rem',
+                            textAlign: 'center',
+                          })}
+                        >
+                          {isRemoving ? 'Removing...' : 'Remove'}
+                        </button>
+                      </form>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
 
-          <a href={routes.books.index.href()} class="btn btn-secondary">
-            Continue Shopping
-          </a>
+          <div mix={css({ marginTop: '2rem', display: 'flex', alignItems: 'center', gap: '1rem' })}>
+            <p
+              mix={css({ margin: 0, fontSize: '1.25rem', fontWeight: 'bold', marginRight: 'auto' })}
+            >
+              Total: {totalLabel}
+            </p>
 
-          {canCheckout ? (
-            <a href={routes.checkout.index.href()} class="btn">
-              Proceed to Checkout
+            <a href={routes.books.index.href()} class="btn btn-secondary">
+              Continue Shopping
             </a>
-          ) : (
-            <a href={routes.auth.login.index.href()} class="btn">
-              Login to Checkout
-            </a>
-          )}
-        </div>
-      </>
-    )
-  }
-})
+
+            {canCheckout ? (
+              <a href={routes.checkout.index.href()} class="btn">
+                Proceed to Checkout
+              </a>
+            ) : (
+              <a href={routes.auth.login.index.href()} class="btn">
+                Login to Checkout
+              </a>
+            )}
+          </div>
+        </>
+      )
+    }
+  },
+)

--- a/demos/bookstore/app/ui/book-card.tsx
+++ b/demos/bookstore/app/ui/book-card.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { Frame, css } from 'remix/ui'
 
 import type { Book } from '../data/schema.ts'
@@ -8,22 +9,26 @@ export interface BookCardProps {
   inCart: boolean
 }
 
-export function BookCard() {
-  return ({ book }: BookCardProps) => (
-    <div class="book-card" data-test-slug={book.slug}>
-      <img src={book.cover_url} alt={book.title} />
-      <div class="book-card-body">
-        <h3>{book.title}</h3>
-        <p class="author">by {book.author}</p>
-        <p class="price">${book.price.toFixed(2)}</p>
-        <div mix={css({ display: 'flex', gap: '0.5rem', alignItems: 'center' })}>
-          <a href={routes.books.show.href({ slug: book.slug })} class="btn">
-            View Details
-          </a>
+export function BookCard(handle: Handle<BookCardProps>) {
+  return () => {
+    let { book } = handle.props
 
-          <Frame src={routes.fragments.cartButton.href({ bookId: book.id })} />
+    return (
+      <div class="book-card" data-test-slug={book.slug}>
+        <img src={book.cover_url} alt={book.title} />
+        <div class="book-card-body">
+          <h3>{book.title}</h3>
+          <p class="author">by {book.author}</p>
+          <p class="price">${book.price.toFixed(2)}</p>
+          <div mix={css({ display: 'flex', gap: '0.5rem', alignItems: 'center' })}>
+            <a href={routes.books.show.href({ slug: book.slug })} class="btn">
+              View Details
+            </a>
+
+            <Frame src={routes.fragments.cartButton.href({ bookId: book.id })} />
+          </div>
         </div>
       </div>
-    </div>
-  )
+    )
+  }
 }

--- a/demos/bookstore/app/ui/document.tsx
+++ b/demos/bookstore/app/ui/document.tsx
@@ -1,4 +1,4 @@
-import type { RemixNode } from 'remix/ui'
+import type { Handle, RemixNode } from 'remix/ui'
 
 import { getAssetEntry } from '../middleware/asset-entry.ts'
 
@@ -7,8 +7,9 @@ export interface DocumentProps {
   children?: RemixNode
 }
 
-export function Document() {
-  return ({ title = 'Bookstore', children }: DocumentProps) => {
+export function Document(handle: Handle<DocumentProps>) {
+  return () => {
+    let { title = 'Bookstore', children } = handle.props
     let { scriptSrc, scriptPreloads, stylesheetHref } = getAssetEntry()
 
     return (

--- a/demos/bookstore/app/ui/layout.tsx
+++ b/demos/bookstore/app/ui/layout.tsx
@@ -1,4 +1,4 @@
-import type { RemixNode } from 'remix/ui'
+import type { Handle, RemixNode } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { getCurrentUserSafely } from '../utils/context.ts'
@@ -9,8 +9,9 @@ export interface LayoutProps {
   children?: RemixNode
 }
 
-export function Layout() {
-  return ({ title, children }: LayoutProps) => {
+export function Layout(handle: Handle<LayoutProps>) {
+  return () => {
+    let { title, children } = handle.props
     let user = getCurrentUserSafely()
 
     return (

--- a/demos/bookstore/app/ui/restful-form.tsx
+++ b/demos/bookstore/app/ui/restful-form.tsx
@@ -1,4 +1,4 @@
-import type { Props } from 'remix/ui'
+import type { Handle, Props } from 'remix/ui'
 
 export interface RestfulFormProps extends Props<'form'> {
   /**
@@ -15,8 +15,9 @@ export interface RestfulFormProps extends Props<'form'> {
  * "method override" value that instructs the server to use the specified method when routing
  * the request.
  */
-export function RestfulForm() {
-  return ({ method = 'GET', methodOverrideField = '_method', ...props }: RestfulFormProps) => {
+export function RestfulForm(handle: Handle<RestfulFormProps>) {
+  return () => {
+    let { method = 'GET', methodOverrideField = '_method', ...props } = handle.props
     let upperMethod = method.toUpperCase()
 
     if (upperMethod === 'GET') {

--- a/demos/social-auth/app/actions/auth/error-page.tsx
+++ b/demos/social-auth/app/actions/auth/error-page.tsx
@@ -1,4 +1,4 @@
-import type { RemixNode } from 'remix/ui'
+import type { Handle, RemixNode } from 'remix/ui'
 
 import { AuthCard } from '../../ui/auth-card.tsx'
 import { Document } from '../../ui/document.tsx'
@@ -11,15 +11,19 @@ interface ErrorPageProps {
   loginHref: string
 }
 
-export function ErrorPage() {
-  return ({ title, message, loginHref }: ErrorPageProps) => (
-    <Document title={title}>
-      <AuthCard title={title} subtitle="This request could not be completed.">
-        <Notice tone="error">{message}</Notice>
-        <a href={loginHref} mix={styles.secondaryButton}>
-          Back to Sign In
-        </a>
-      </AuthCard>
-    </Document>
-  )
+export function ErrorPage(handle: Handle<ErrorPageProps>) {
+  return () => {
+    let { title, message, loginHref } = handle.props
+
+    return (
+      <Document title={title}>
+        <AuthCard title={title} subtitle="This request could not be completed.">
+          <Notice tone="error">{message}</Notice>
+          <a href={loginHref} mix={styles.secondaryButton}>
+            Back to Sign In
+          </a>
+        </AuthCard>
+      </Document>
+    )
+  }
 }

--- a/demos/social-auth/app/actions/auth/footer.tsx
+++ b/demos/social-auth/app/actions/auth/footer.tsx
@@ -1,11 +1,13 @@
+import type { Handle } from 'remix/ui'
+
 import * as styles from '../../ui/styles.ts'
 
-export function Footer() {
-  return ({ prefix, href, label }: { prefix: string; href: string; label: string }) => (
+export function Footer(handle: Handle<{ prefix: string; href: string; label: string }>) {
+  return () => (
     <p mix={styles.footerText}>
-      {prefix}{' '}
-      <a href={href} mix={styles.helperLink}>
-        {label}
+      {handle.props.prefix}{' '}
+      <a href={handle.props.href} mix={styles.helperLink}>
+        {handle.props.label}
       </a>
     </p>
   )

--- a/demos/social-auth/app/actions/auth/forgot-password/page.tsx
+++ b/demos/social-auth/app/actions/auth/forgot-password/page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import { EmailIcon } from '../../../ui/icons.tsx'
@@ -18,36 +19,40 @@ interface ForgotPasswordPageProps {
   email?: string
 }
 
-export function ForgotPasswordPage() {
-  return ({ formAction, loginHref, error, email }: ForgotPasswordPageProps) => (
-    <Document title="Forgot Password">
-      <AuthCard
-        title="Forgot Password"
-        subtitle="Enter your email and we will generate a reset link"
-        footer={<Footer prefix="Remembered it?" href={loginHref} label="Back to sign in" />}
-      >
-        {error ? <Notice tone="error">{error}</Notice> : null}
+export function ForgotPasswordPage(handle: Handle<ForgotPasswordPageProps>) {
+  return () => {
+    let { formAction, loginHref, error, email } = handle.props
 
-        <form method="POST" action={formAction} mix={styles.form}>
-          <TextField
-            id="email"
-            name="email"
-            type="email"
-            label="Email"
-            placeholder="Enter your email"
-            autoComplete="email"
-            defaultValue={email}
-            required
-            icon={<EmailIcon mix={styles.fieldIcon} />}
-          />
+    return (
+      <Document title="Forgot Password">
+        <AuthCard
+          title="Forgot Password"
+          subtitle="Enter your email and we will generate a reset link"
+          footer={<Footer prefix="Remembered it?" href={loginHref} label="Back to sign in" />}
+        >
+          {error ? <Notice tone="error">{error}</Notice> : null}
 
-          <button type="submit" mix={styles.submitButton}>
-            Send Reset Link
-          </button>
-        </form>
-      </AuthCard>
-    </Document>
-  )
+          <form method="POST" action={formAction} mix={styles.form}>
+            <TextField
+              id="email"
+              name="email"
+              type="email"
+              label="Email"
+              placeholder="Enter your email"
+              autoComplete="email"
+              defaultValue={email}
+              required
+              icon={<EmailIcon mix={styles.fieldIcon} />}
+            />
+
+            <button type="submit" mix={styles.submitButton}>
+              Send Reset Link
+            </button>
+          </form>
+        </AuthCard>
+      </Document>
+    )
+  }
 }
 
 interface ForgotPasswordSentPageProps {
@@ -56,42 +61,46 @@ interface ForgotPasswordSentPageProps {
   resetHref?: string
 }
 
-export function ForgotPasswordSentPage() {
-  return ({ email, loginHref, resetHref }: ForgotPasswordSentPageProps) => (
-    <Document title="Reset Link Ready">
-      <AuthCard
-        title="Check Your Email"
-        subtitle={`If ${email} matches a local account, the demo generated a reset link.`}
-      >
-        <Notice tone="success">Password reset instructions are ready.</Notice>
+export function ForgotPasswordSentPage(handle: Handle<ForgotPasswordSentPageProps>) {
+  return () => {
+    let { email, loginHref, resetHref } = handle.props
 
-        <div mix={styles.infoPanel}>
-          <p mix={css({ marginBottom: tokens.space.sm })}>
-            This demo does not send email. If a matching account exists, the reset URL is shown
-            below.
-          </p>
-          {resetHref ? (
-            <p>
-              <a href={resetHref} mix={styles.helperLink}>
-                {resetHref}
-              </a>
+    return (
+      <Document title="Reset Link Ready">
+        <AuthCard
+          title="Check Your Email"
+          subtitle={`If ${email} matches a local account, the demo generated a reset link.`}
+        >
+          <Notice tone="success">Password reset instructions are ready.</Notice>
+
+          <div mix={styles.infoPanel}>
+            <p mix={css({ marginBottom: tokens.space.sm })}>
+              This demo does not send email. If a matching account exists, the reset URL is shown
+              below.
             </p>
-          ) : (
-            <p>No matching local account was found.</p>
-          )}
-        </div>
+            {resetHref ? (
+              <p>
+                <a href={resetHref} mix={styles.helperLink}>
+                  {resetHref}
+                </a>
+              </p>
+            ) : (
+              <p>No matching local account was found.</p>
+            )}
+          </div>
 
-        <div mix={styles.buttonRow}>
-          {resetHref ? (
-            <a href={resetHref} mix={styles.submitButton}>
-              Open Reset Form
+          <div mix={styles.buttonRow}>
+            {resetHref ? (
+              <a href={resetHref} mix={styles.submitButton}>
+                Open Reset Form
+              </a>
+            ) : null}
+            <a href={loginHref} mix={styles.secondaryButton}>
+              Back to Sign In
             </a>
-          ) : null}
-          <a href={loginHref} mix={styles.secondaryButton}>
-            Back to Sign In
-          </a>
-        </div>
-      </AuthCard>
-    </Document>
-  )
+          </div>
+        </AuthCard>
+      </Document>
+    )
+  }
 }

--- a/demos/social-auth/app/actions/auth/reset-password/page.tsx
+++ b/demos/social-auth/app/actions/auth/reset-password/page.tsx
@@ -1,3 +1,5 @@
+import type { Handle } from 'remix/ui'
+
 import { PasswordIcon } from '../../../ui/icons.tsx'
 import { TextField } from '../../../ui/form-field.tsx'
 import { Footer } from '../footer.tsx'
@@ -12,60 +14,64 @@ interface ResetPasswordPageProps {
   error?: string
 }
 
-export function ResetPasswordPage() {
-  return ({ formAction, loginHref, error }: ResetPasswordPageProps) => (
-    <Document title="Reset Password">
-      <AuthCard
-        title="Reset Password"
-        subtitle="Create a new password for your account"
-        footer={<Footer prefix="Changed your mind?" href={loginHref} label="Back to sign in" />}
-      >
-        {error ? <Notice tone="error">{error}</Notice> : null}
+export function ResetPasswordPage(handle: Handle<ResetPasswordPageProps>) {
+  return () => {
+    let { formAction, loginHref, error } = handle.props
 
-        <form method="POST" action={formAction} mix={styles.form}>
-          <TextField
-            id="password"
-            name="password"
-            type="password"
-            label="New Password"
-            placeholder="Enter a new password"
-            autoComplete="new-password"
-            required
-            icon={<PasswordIcon mix={styles.fieldIcon} />}
-          />
+    return (
+      <Document title="Reset Password">
+        <AuthCard
+          title="Reset Password"
+          subtitle="Create a new password for your account"
+          footer={<Footer prefix="Changed your mind?" href={loginHref} label="Back to sign in" />}
+        >
+          {error ? <Notice tone="error">{error}</Notice> : null}
 
-          <TextField
-            id="confirmPassword"
-            name="confirmPassword"
-            type="password"
-            label="Confirm Password"
-            placeholder="Confirm your password"
-            autoComplete="new-password"
-            required
-            icon={<PasswordIcon mix={styles.fieldIcon} />}
-          />
+          <form method="POST" action={formAction} mix={styles.form}>
+            <TextField
+              id="password"
+              name="password"
+              type="password"
+              label="New Password"
+              placeholder="Enter a new password"
+              autoComplete="new-password"
+              required
+              icon={<PasswordIcon mix={styles.fieldIcon} />}
+            />
 
-          <button type="submit" mix={styles.submitButton}>
-            Update Password
-          </button>
-        </form>
-      </AuthCard>
-    </Document>
-  )
+            <TextField
+              id="confirmPassword"
+              name="confirmPassword"
+              type="password"
+              label="Confirm Password"
+              placeholder="Confirm your password"
+              autoComplete="new-password"
+              required
+              icon={<PasswordIcon mix={styles.fieldIcon} />}
+            />
+
+            <button type="submit" mix={styles.submitButton}>
+              Update Password
+            </button>
+          </form>
+        </AuthCard>
+      </Document>
+    )
+  }
 }
 
 interface ResetPasswordCompletePageProps {
   loginHref: string
 }
 
-export function ResetPasswordCompletePage() {
-  return ({ loginHref }: ResetPasswordCompletePageProps) => (
+export function ResetPasswordCompletePage(handle: Handle<ResetPasswordCompletePageProps>) {
+  return () => (
     <Document title="Password Updated">
       <AuthCard title="Password Updated" subtitle="Your password has been changed successfully.">
         <Notice tone="success">You can sign in with your new password now.</Notice>
 
         <div mix={styles.buttonRow}>
-          <a href={loginHref} mix={styles.submitButton}>
+          <a href={handle.props.loginHref} mix={styles.submitButton}>
             Back to Sign In
           </a>
         </div>

--- a/demos/social-auth/app/actions/auth/signup/page.tsx
+++ b/demos/social-auth/app/actions/auth/signup/page.tsx
@@ -1,3 +1,5 @@
+import type { Handle } from 'remix/ui'
+
 import { EmailIcon, PasswordIcon, UserIcon } from '../../../ui/icons.tsx'
 import { TextField } from '../../../ui/form-field.tsx'
 import { Footer } from '../footer.tsx'
@@ -16,57 +18,61 @@ interface SignupPageProps {
   }
 }
 
-export function SignupPage() {
-  return ({ formAction, loginHref, error, values }: SignupPageProps) => (
-    <Document title="Create Account">
-      <AuthCard
-        title="Create Account"
-        subtitle="Sign up with email and password"
-        footer={<Footer prefix="Already have an account?" href={loginHref} label="Sign in" />}
-      >
-        {error ? <Notice tone="error">{error}</Notice> : null}
+export function SignupPage(handle: Handle<SignupPageProps>) {
+  return () => {
+    let { formAction, loginHref, error, values } = handle.props
 
-        <form method="POST" action={formAction} mix={styles.form}>
-          <TextField
-            id="name"
-            name="name"
-            type="text"
-            label="Name"
-            placeholder="Enter your name"
-            autoComplete="name"
-            defaultValue={values?.name}
-            required
-            icon={<UserIcon mix={styles.fieldIcon} />}
-          />
+    return (
+      <Document title="Create Account">
+        <AuthCard
+          title="Create Account"
+          subtitle="Sign up with email and password"
+          footer={<Footer prefix="Already have an account?" href={loginHref} label="Sign in" />}
+        >
+          {error ? <Notice tone="error">{error}</Notice> : null}
 
-          <TextField
-            id="email"
-            name="email"
-            type="email"
-            label="Email"
-            placeholder="Enter your email"
-            autoComplete="email"
-            defaultValue={values?.email}
-            required
-            icon={<EmailIcon mix={styles.fieldIcon} />}
-          />
+          <form method="POST" action={formAction} mix={styles.form}>
+            <TextField
+              id="name"
+              name="name"
+              type="text"
+              label="Name"
+              placeholder="Enter your name"
+              autoComplete="name"
+              defaultValue={values?.name}
+              required
+              icon={<UserIcon mix={styles.fieldIcon} />}
+            />
 
-          <TextField
-            id="password"
-            name="password"
-            type="password"
-            label="Password"
-            placeholder="Create a password"
-            autoComplete="new-password"
-            required
-            icon={<PasswordIcon mix={styles.fieldIcon} />}
-          />
+            <TextField
+              id="email"
+              name="email"
+              type="email"
+              label="Email"
+              placeholder="Enter your email"
+              autoComplete="email"
+              defaultValue={values?.email}
+              required
+              icon={<EmailIcon mix={styles.fieldIcon} />}
+            />
 
-          <button type="submit" mix={styles.submitButton}>
-            Create Account
-          </button>
-        </form>
-      </AuthCard>
-    </Document>
-  )
+            <TextField
+              id="password"
+              name="password"
+              type="password"
+              label="Password"
+              placeholder="Create a password"
+              autoComplete="new-password"
+              required
+              icon={<PasswordIcon mix={styles.fieldIcon} />}
+            />
+
+            <button type="submit" mix={styles.submitButton}>
+              Create Account
+            </button>
+          </form>
+        </AuthCard>
+      </Document>
+    )
+  }
 }

--- a/demos/social-auth/app/ui/account-page.tsx
+++ b/demos/social-auth/app/ui/account-page.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import { AuthCard } from './auth-card.tsx'
@@ -17,8 +18,9 @@ interface AccountPageProps {
   logoutAction: string
 }
 
-export function AccountPage() {
-  return ({ identity, logoutAction }: AccountPageProps) => {
+export function AccountPage(handle: Handle<AccountPageProps>) {
+  return () => {
+    let { identity, logoutAction } = handle.props
     let displayName =
       identity.user.name ??
       identity.authAccount?.display_name ??

--- a/demos/social-auth/app/ui/auth-card.tsx
+++ b/demos/social-auth/app/ui/auth-card.tsx
@@ -1,4 +1,4 @@
-import type { RemixNode } from 'remix/ui'
+import type { Handle, RemixNode } from 'remix/ui'
 
 import * as styles from './styles.ts'
 
@@ -9,15 +9,19 @@ interface AuthCardProps {
   footer?: RemixNode
 }
 
-export function AuthCard() {
-  return ({ title, subtitle, children, footer }: AuthCardProps) => (
-    <div mix={styles.card}>
-      <div mix={styles.cardHeader}>
-        <h1 mix={styles.heading}>{title}</h1>
-        {subtitle ? <p mix={styles.subtitle}>{subtitle}</p> : null}
+export function AuthCard(handle: Handle<AuthCardProps>) {
+  return () => {
+    let { title, subtitle, children, footer } = handle.props
+
+    return (
+      <div mix={styles.card}>
+        <div mix={styles.cardHeader}>
+          <h1 mix={styles.heading}>{title}</h1>
+          {subtitle ? <p mix={styles.subtitle}>{subtitle}</p> : null}
+        </div>
+        {children}
+        {footer}
       </div>
-      {children}
-      {footer}
-    </div>
-  )
+    )
+  }
 }

--- a/demos/social-auth/app/ui/document.tsx
+++ b/demos/social-auth/app/ui/document.tsx
@@ -1,4 +1,4 @@
-import type { RemixNode } from 'remix/ui'
+import type { Handle, RemixNode } from 'remix/ui'
 
 import * as styles from './styles.ts'
 
@@ -7,16 +7,16 @@ interface DocumentProps {
   children: RemixNode
 }
 
-export function Document() {
-  return ({ title, children }: DocumentProps) => (
+export function Document(handle: Handle<DocumentProps>) {
+  return () => (
     <html lang="en">
       <head>
         <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-        <title>{title}</title>
+        <title>{handle.props.title}</title>
       </head>
-      <body mix={[styles.pageReset, styles.page]}>{children}</body>
+      <body mix={[styles.pageReset, styles.page]}>{handle.props.children}</body>
     </html>
   )
 }

--- a/demos/social-auth/app/ui/form-field.tsx
+++ b/demos/social-auth/app/ui/form-field.tsx
@@ -1,4 +1,4 @@
-import type { MixValue, RemixNode } from 'remix/ui'
+import type { Handle, MixValue, RemixNode } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import * as styles from './styles.ts'
@@ -16,8 +16,9 @@ interface TextFieldProps {
   mix?: MixValue<HTMLInputElement>
 }
 
-export function TextField() {
-  return (props: TextFieldProps) => {
+export function TextField(handle: Handle<TextFieldProps>) {
+  return () => {
+    let props = handle.props
     let inputMix =
       props.mix == null
         ? [styles.fieldInput]

--- a/demos/social-auth/app/ui/home/external-auth-section.tsx
+++ b/demos/social-auth/app/ui/home/external-auth-section.tsx
@@ -1,3 +1,4 @@
+import type { Handle } from 'remix/ui'
 import { css } from 'remix/ui'
 
 import { designSystem } from '../design-system.ts'
@@ -8,8 +9,8 @@ import type { ExternalProviderLink } from '../../utils/external-auth.ts'
 
 const { theme } = designSystem
 
-export function ExternalAuthSection() {
-  return ({ providers }: { providers: ExternalProviderLink[] }) => (
+export function ExternalAuthSection(handle: Handle<{ providers: ExternalProviderLink[] }>) {
+  return () => (
     <>
       <div mix={styles.divider}>
         <div mix={css({ flex: '1', borderTop: theme.border.subtle })}></div>
@@ -18,7 +19,7 @@ export function ExternalAuthSection() {
       </div>
 
       <div mix={styles.socialButtons}>
-        {providers.map((provider) => (
+        {handle.props.providers.map((provider) => (
           <SocialProviderButton
             key={provider.name}
             label={formatProviderLabel(provider.name)}

--- a/demos/social-auth/app/ui/home/footer.tsx
+++ b/demos/social-auth/app/ui/home/footer.tsx
@@ -1,10 +1,12 @@
+import type { Handle } from 'remix/ui'
+
 import * as styles from '../styles.ts'
 
-export function LoginFooter() {
-  return ({ signupHref }: { signupHref: string }) => (
+export function LoginFooter(handle: Handle<{ signupHref: string }>) {
+  return () => (
     <p mix={styles.footerText}>
       Don't have an account?{' '}
-      <a href={signupHref} mix={styles.helperLink}>
+      <a href={handle.props.signupHref} mix={styles.helperLink}>
         Sign up
       </a>
     </p>

--- a/demos/social-auth/app/ui/home/page.tsx
+++ b/demos/social-auth/app/ui/home/page.tsx
@@ -1,3 +1,5 @@
+import type { Handle } from 'remix/ui'
+
 import type { ExternalProviderLink } from '../../utils/external-auth.ts'
 import { AuthCard } from '../auth-card.tsx'
 import { Document } from '../document.tsx'
@@ -17,64 +19,61 @@ interface LoginPageProps {
   success?: string
 }
 
-export function LoginPage() {
-  return ({
-    formAction,
-    signupHref,
-    forgotPasswordHref,
-    providers,
-    error,
-    success,
-  }: LoginPageProps) => (
-    <Document title="Social Auth Demo">
-      <AuthCard
-        title="Welcome Back"
-        subtitle="Sign in to your account"
-        footer={<LoginFooter signupHref={signupHref} />}
-      >
-        {error ? <Notice tone="error">{error}</Notice> : null}
-        {success ? <Notice tone="success">{success}</Notice> : null}
+export function LoginPage(handle: Handle<LoginPageProps>) {
+  return () => {
+    let { formAction, signupHref, forgotPasswordHref, providers, error, success } = handle.props
 
-        <form method="POST" action={formAction} mix={styles.form}>
-          <TextField
-            id="email"
-            name="email"
-            type="email"
-            label="Email"
-            placeholder="Enter your email"
-            autoComplete="email"
-            required
-            icon={<EmailIcon mix={styles.fieldIcon} />}
-          />
+    return (
+      <Document title="Social Auth Demo">
+        <AuthCard
+          title="Welcome Back"
+          subtitle="Sign in to your account"
+          footer={<LoginFooter signupHref={signupHref} />}
+        >
+          {error ? <Notice tone="error">{error}</Notice> : null}
+          {success ? <Notice tone="success">{success}</Notice> : null}
 
-          <TextField
-            id="password"
-            name="password"
-            type="password"
-            label="Password"
-            placeholder="Enter your password"
-            autoComplete="current-password"
-            required
-            icon={<PasswordIcon mix={styles.fieldIcon} />}
-          />
+          <form method="POST" action={formAction} mix={styles.form}>
+            <TextField
+              id="email"
+              name="email"
+              type="email"
+              label="Email"
+              placeholder="Enter your email"
+              autoComplete="email"
+              required
+              icon={<EmailIcon mix={styles.fieldIcon} />}
+            />
 
-          <div mix={styles.formOptions}>
-            <label mix={styles.rememberMe}>
-              <input type="checkbox" name="remember" value="yes" mix={styles.rememberCheckbox} />
-              <span>Remember me</span>
-            </label>
-            <a href={forgotPasswordHref} mix={styles.helperLink}>
-              Forgot password?
-            </a>
-          </div>
+            <TextField
+              id="password"
+              name="password"
+              type="password"
+              label="Password"
+              placeholder="Enter your password"
+              autoComplete="current-password"
+              required
+              icon={<PasswordIcon mix={styles.fieldIcon} />}
+            />
 
-          <button type="submit" mix={styles.submitButton}>
-            Sign In
-          </button>
-        </form>
+            <div mix={styles.formOptions}>
+              <label mix={styles.rememberMe}>
+                <input type="checkbox" name="remember" value="yes" mix={styles.rememberCheckbox} />
+                <span>Remember me</span>
+              </label>
+              <a href={forgotPasswordHref} mix={styles.helperLink}>
+                Forgot password?
+              </a>
+            </div>
 
-        <ExternalAuthSection providers={providers} />
-      </AuthCard>
-    </Document>
-  )
+            <button type="submit" mix={styles.submitButton}>
+              Sign In
+            </button>
+          </form>
+
+          <ExternalAuthSection providers={providers} />
+        </AuthCard>
+      </Document>
+    )
+  }
 }

--- a/demos/social-auth/app/ui/home/social-provider-button.tsx
+++ b/demos/social-auth/app/ui/home/social-provider-button.tsx
@@ -1,4 +1,4 @@
-import type { RemixNode } from 'remix/ui'
+import type { Handle, RemixNode } from 'remix/ui'
 
 import * as styles from '../styles.ts'
 
@@ -9,8 +9,10 @@ interface SocialProviderButtonProps {
   disabledReason?: string
 }
 
-export function SocialProviderButton() {
-  return ({ label, icon, href, disabledReason }: SocialProviderButtonProps) => {
+export function SocialProviderButton(handle: Handle<SocialProviderButtonProps>) {
+  return () => {
+    let { label, icon, href, disabledReason } = handle.props
+
     if (href) {
       return (
         <a href={href} mix={styles.socialButton}>

--- a/demos/social-auth/app/ui/icons.tsx
+++ b/demos/social-auth/app/ui/icons.tsx
@@ -1,8 +1,8 @@
-import type { Props } from 'remix/ui'
+import type { Handle, Props } from 'remix/ui'
 
-export function UserIcon() {
-  return (props: Props<'svg'>) => (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...props}>
+export function UserIcon(handle: Handle<Props<'svg'>>) {
+  return () => (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...handle.props}>
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -13,9 +13,9 @@ export function UserIcon() {
   )
 }
 
-export function EmailIcon() {
-  return (props: Props<'svg'>) => (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...props}>
+export function EmailIcon(handle: Handle<Props<'svg'>>) {
+  return () => (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...handle.props}>
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -26,9 +26,9 @@ export function EmailIcon() {
   )
 }
 
-export function PasswordIcon() {
-  return (props: Props<'svg'>) => (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...props}>
+export function PasswordIcon(handle: Handle<Props<'svg'>>) {
+  return () => (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...handle.props}>
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -39,9 +39,9 @@ export function PasswordIcon() {
   )
 }
 
-export function GoogleIcon() {
-  return (props: Props<'svg'>) => (
-    <svg viewBox="0 0 24 24" {...props}>
+export function GoogleIcon(handle: Handle<Props<'svg'>>) {
+  return () => (
+    <svg viewBox="0 0 24 24" {...handle.props}>
       <path
         fill="#4285F4"
         d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
@@ -62,17 +62,17 @@ export function GoogleIcon() {
   )
 }
 
-export function GitHubIcon() {
-  return (props: Props<'svg'>) => (
-    <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+export function GitHubIcon(handle: Handle<Props<'svg'>>) {
+  return () => (
+    <svg viewBox="0 0 24 24" fill="currentColor" {...handle.props}>
       <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
     </svg>
   )
 }
 
-export function XIcon() {
-  return (props: Props<'svg'>) => (
-    <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+export function XIcon(handle: Handle<Props<'svg'>>) {
+  return () => (
+    <svg viewBox="0 0 24 24" fill="currentColor" {...handle.props}>
       <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
     </svg>
   )

--- a/demos/social-auth/app/ui/notice.tsx
+++ b/demos/social-auth/app/ui/notice.tsx
@@ -1,4 +1,4 @@
-import type { RemixNode } from 'remix/ui'
+import type { Handle, RemixNode } from 'remix/ui'
 
 import * as styles from './styles.ts'
 
@@ -7,10 +7,14 @@ interface NoticeProps {
   children: RemixNode
 }
 
-export function Notice() {
-  return ({ tone, children }: NoticeProps) => (
-    <div mix={[styles.notice, tone === 'error' ? styles.errorNotice : styles.successNotice]}>
-      {children}
-    </div>
-  )
+export function Notice(handle: Handle<NoticeProps>) {
+  return () => {
+    let { tone, children } = handle.props
+
+    return (
+      <div mix={[styles.notice, tone === 'error' ? styles.errorNotice : styles.successNotice]}>
+        {children}
+      </div>
+    )
+  }
 }

--- a/demos/sse/app/ui/layout.tsx
+++ b/demos/sse/app/ui/layout.tsx
@@ -1,11 +1,12 @@
-import { css, type RemixNode } from 'remix/ui'
+import type { Handle, RemixNode } from 'remix/ui'
+import { css } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 
 const rawCss = String.raw
 
-export function Layout() {
-  return ({ children }: { children?: RemixNode }) => (
+export function Layout(handle: Handle<{ children?: RemixNode }>) {
+  return () => (
     <html lang="en">
       <head>
         <meta charSet="UTF-8" />
@@ -55,7 +56,7 @@ export function Layout() {
           background: '#f5f5f5',
         })}
       >
-        {children}
+        {handle.props.children}
       </body>
     </html>
   )

--- a/packages/ui/.changes/minor.zero-arg-render-functions.md
+++ b/packages/ui/.changes/minor.zero-arg-render-functions.md
@@ -1,0 +1,1 @@
+BREAKING CHANGE: Remix UI component render functions no longer receive props as an argument. Type component props on `Handle<Props>` and read current values from `handle.props` in both setup and render code.

--- a/packages/ui/src/runtime/client-entries.ts
+++ b/packages/ui/src/runtime/client-entries.ts
@@ -47,7 +47,7 @@ export type EntryMetadata = {
  */
 export type EntryComponent<props extends SerializableProps = {}, context = NoContext> = ((
   handle: Handle<props, context>,
-) => RenderFn<props>) &
+) => RenderFn) &
   EntryMetadata
 
 /**
@@ -85,10 +85,6 @@ export type EntryComponent<props extends SerializableProps = {}, context = NoCon
 export function clientEntry<props extends SerializableProps = {}, context = NoContext>(
   entryId: string,
   component: (handle: Handle<props, context>) => RenderFn,
-): EntryComponent<props, context>
-export function clientEntry<props extends SerializableProps = {}, context = NoContext>(
-  entryId: string,
-  component: (handle: Handle<Record<string, never>, context>) => RenderFn<props>,
 ): EntryComponent<props, context>
 
 // Implementation

--- a/packages/ui/src/runtime/component.ts
+++ b/packages/ui/src/runtime/component.ts
@@ -179,9 +179,9 @@ export type ComponentFn<Props = Record<string, never>, ContextValue = NoContext>
 ) => RenderFn
 
 /**
- * Render function returned by a component factory.
+ * Zero-argument render function returned by a component factory.
  */
-export type RenderFn<Props = ElementProps> = (props: Props) => RemixNode
+export type RenderFn = () => RemixNode
 
 export type { RemixNode } from './jsx.ts'
 
@@ -287,7 +287,7 @@ class ComponentRuntime<C = NoContext> implements ComponentHandle<C> {
       this.#renderFn = renderFn
     }
 
-    return [renderFn(this.#props), this.#dequeueTasks()]
+    return [renderFn(), this.#dequeueTasks()]
   }
 
   remove = (): Array<() => void> => {

--- a/packages/ui/src/runtime/jsx.ts
+++ b/packages/ui/src/runtime/jsx.ts
@@ -77,10 +77,6 @@ type MixinElementType = ((
   __rmxMixinElementType: string
 }
 
-type MergeComponentProps<handleProps, renderProps> = [handleProps] extends [Record<string, never>]
-  ? renderProps
-  : handleProps & renderProps
-
 /**
  * Get the props for a specific element type.
  *
@@ -120,7 +116,7 @@ declare global {
       // host elements
       | keyof IntrinsicElements
       // Factory component
-      | ((handle: Handle<any, any>) => RenderFn<any>)
+      | ((handle: Handle<any, any>) => RenderFn)
       // Mixin element used internally by mixin render callbacks
       | MixinElementType
 
@@ -134,11 +130,11 @@ declare global {
 
     type LibraryManagedAttributes<component, props> = component extends MixinElementType
       ? ExpandMixProp<Parameters<ReturnType<component>>[0]>
-      : component extends (handle: Handle<infer P, any>) => RenderFn<infer R>
-        ? // It's a ComponentFactory - infer props from the handle
-          ExpandMixProp<MergeComponentProps<P, R>>
-        : component extends () => RenderFn<infer P>
-          ? ExpandMixProp<P>
+      : component extends () => RenderFn
+        ? ExpandMixProp<Record<string, never>>
+        : component extends (handle: Handle<infer P, any>) => RenderFn
+          ? // It's a ComponentFactory - infer props from the handle
+            ExpandMixProp<P>
           : // Otherwise use props as-is (simple function component)
             ExpandMixProp<props>
 

--- a/packages/ui/src/test/client-entry.test.tsx
+++ b/packages/ui/src/test/client-entry.test.tsx
@@ -92,7 +92,7 @@ describe('clientEntry', () => {
       expect(typeof renderFn).toBe('function')
 
       if (typeof renderFn === 'function') {
-        let element = renderFn(mockHandle.props)
+        let element = renderFn()
         expect(element).toEqual({
           $rmx: true,
           type: 'button',

--- a/packages/ui/src/test/jsx.test.tsx
+++ b/packages/ui/src/test/jsx.test.tsx
@@ -51,7 +51,7 @@ describe('jsx', () => {
       )
     })
 
-    it('accepts nested mix values for host element JSX while render props still see arrays', () => {
+    it('accepts nested mix values for host element JSX while runtime props still see arrays', () => {
       let passthrough = createMixin((_handle) => {})
       let descriptor = passthrough()
 
@@ -149,7 +149,7 @@ describe('jsx', () => {
       let good = <Counter initialCount={10} label="Count" />
     })
 
-    it('accepts single or array mix values for component JSX while render props see arrays', () => {
+    it('accepts single or array mix values for component JSX while handle props see arrays', () => {
       let passthrough = createMixin((handle) => {})
 
       function Button(handle: Handle<Props<'button'>>) {
@@ -171,6 +171,16 @@ describe('jsx', () => {
       expect(withArray.props.mix).toEqual([descriptor])
       expect(withNested.props.mix).toEqual([descriptor, descriptor])
       expect(withoutMix.props.mix).toBeUndefined()
+    })
+
+    it('rejects component props typed on the render callback', () => {
+      function InvalidComponent(handle: Handle) {
+        void handle
+        return (props: { label: string }) => <div>{props.label}</div>
+      }
+
+      // @ts-expect-error - component props must be typed on Handle<Props>
+      let invalid = <InvalidComponent label="Count" />
     })
   })
 

--- a/packages/ui/src/test/vdom.components.test.tsx
+++ b/packages/ui/src/test/vdom.components.test.tsx
@@ -25,6 +25,24 @@ describe('vnode rendering', () => {
       expect(container.innerHTML).toBe('<div>Hello, world!</div>')
     })
 
+    it('does not pass props to the component render function', () => {
+      let container = document.createElement('div')
+      let renderArg: unknown = 'unset'
+
+      function App(handle: Handle<{ label: string }>) {
+        return (...args: unknown[]) => {
+          renderArg = args[0]
+          return <div>{handle.props.label}</div>
+        }
+      }
+
+      let { render } = createRoot(container)
+      render(<App label="Count" />)
+
+      expect(container.innerHTML).toBe('<div>Count</div>')
+      expect(renderArg).toBeUndefined()
+    })
+
     it('updates a component', () => {
       let container = document.createElement('div')
 

--- a/template/app/ui/document.tsx
+++ b/template/app/ui/document.tsx
@@ -1,4 +1,5 @@
-import { css, type RemixNode } from 'remix/ui'
+import type { Handle, RemixNode } from 'remix/ui'
+import { css } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 
@@ -10,22 +11,26 @@ export interface DocumentProps {
 
 const DEFAULT_TITLE = readAppDisplayName('%%RMX_APP_DISPLAY_NAME_URI_COMPONENT%%')
 
-export function Document() {
-  return ({ children, head, title = DEFAULT_TITLE }: DocumentProps) => (
-    <html lang="en">
-      <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <title>{title}</title>
-        {head}
-      </head>
-      <body mix={css({ margin: 0 })}>
-        {children}
-        <script type="module" src={routes.assets.href({ path: 'app/assets/entry.ts' })}></script>
-      </body>
-    </html>
-  )
+export function Document(handle: Handle<DocumentProps>) {
+  return () => {
+    let { children, head, title = DEFAULT_TITLE } = handle.props
+
+    return (
+      <html lang="en">
+        <head>
+          <meta charSet="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+          <title>{title}</title>
+          {head}
+        </head>
+        <body mix={css({ margin: 0 })}>
+          {children}
+          <script type="module" src={routes.assets.href({ path: 'app/assets/entry.ts' })}></script>
+        </body>
+      </html>
+    )
+  }
 }
 
 function readAppDisplayName(value: string): string {

--- a/template/app/ui/scaffold-home-page.tsx
+++ b/template/app/ui/scaffold-home-page.tsx
@@ -1,5 +1,6 @@
 // Delete this file and put your own home page in app/actions/controller.tsx
-import { css, type RemixNode } from 'remix/ui'
+import type { Handle, RemixNode } from 'remix/ui'
+import { css } from 'remix/ui'
 
 import { PromptButton } from '../assets/prompt-button.tsx'
 import { Document } from './document.tsx'
@@ -203,54 +204,62 @@ function CodingWithAiCard() {
   )
 }
 
-function CardLink() {
-  return ({ href, icon, label }: { href: string; icon: RemixNode; label: string }) => (
-    <a
-      href={href}
-      mix={css({
-        display: 'flex',
-        gap: '16px',
-        alignItems: 'center',
-        padding: '16px',
-        borderRadius: '12px',
-        color: 'var(--text-primary)',
-        textDecoration: 'none',
-        background: 'transparent',
-        transition: 'background-color 150ms ease, color 150ms ease',
-        '&:hover, &:focus-visible': {
-          background: 'var(--surface-4)',
-          color: 'var(--brand-blue)',
-          outline: 'none',
-        },
-      })}
-    >
-      <IconSlot>{icon}</IconSlot>
-      <span mix={css({ fontSize: '14px', lineHeight: 1.5, whiteSpace: 'nowrap' })}>{label}</span>
-    </a>
-  )
+function CardLink(handle: Handle<{ href: string; icon: RemixNode; label: string }>) {
+  return () => {
+    let { href, icon, label } = handle.props
+
+    return (
+      <a
+        href={href}
+        mix={css({
+          display: 'flex',
+          gap: '16px',
+          alignItems: 'center',
+          padding: '16px',
+          borderRadius: '12px',
+          color: 'var(--text-primary)',
+          textDecoration: 'none',
+          background: 'transparent',
+          transition: 'background-color 150ms ease, color 150ms ease',
+          '&:hover, &:focus-visible': {
+            background: 'var(--surface-4)',
+            color: 'var(--brand-blue)',
+            outline: 'none',
+          },
+        })}
+      >
+        <IconSlot>{icon}</IconSlot>
+        <span mix={css({ fontSize: '14px', lineHeight: 1.5, whiteSpace: 'nowrap' })}>{label}</span>
+      </a>
+    )
+  }
 }
 
-function IconSlot() {
-  return ({ children, rotated = false }: { children: RemixNode; rotated?: boolean }) => (
-    <span
-      aria-hidden="true"
-      mix={css({
-        flex: '0 0 24px',
-        width: '24px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: rotated ? 'center' : 'flex-start',
-        '& svg': {
-          width: '20px',
-          height: '20px',
-          display: 'block',
-          ...(rotated ? { transform: 'rotate(180deg)' } : {}),
-        },
-      })}
-    >
-      {children}
-    </span>
-  )
+function IconSlot(handle: Handle<{ children: RemixNode; rotated?: boolean }>) {
+  return () => {
+    let { children, rotated = false } = handle.props
+
+    return (
+      <span
+        aria-hidden="true"
+        mix={css({
+          flex: '0 0 24px',
+          width: '24px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: rotated ? 'center' : 'flex-start',
+          '& svg': {
+            width: '20px',
+            height: '20px',
+            display: 'block',
+            ...(rotated ? { transform: 'rotate(180deg)' } : {}),
+          },
+        })}
+      >
+        {children}
+      </span>
+    )
+  }
 }
 
 function Footer() {


### PR DESCRIPTION
Remix UI components now read JSX props from `handle.props`, but the runtime and public types still allowed the older pattern where props were typed on the returned render function. This tightens the component contract so component render functions are truly zero-argument.

This came up while updating old component conventions in https://github.com/remix-run/remix-website/pull/459.

- Makes `RenderFn` zero-argument and stops passing `handle.props` into component render callbacks.
- Updates JSX and `clientEntry` types so component props are inferred from `Handle<Props>`, while mixin render callbacks still receive host props.
- Updates the repo demos and app template that still used the old props-on-render convention.
- Adds type and runtime coverage for the contract, plus a breaking change note for `@remix-run/ui`.
- Adds guidance to the change-file skill to avoid rewriting historical changelog entries when current docs need updating.