### PR TITLE
Add Pagefind search to prerendered docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -29,7 +29,6 @@
     "docs": "node src/generate/index.ts",
     "docs:debug": "DEBUG=1 node src/generate/index.ts",
     "prerender": "node --import remix/node-tsx src/prerender/index.ts",
-    "postprerender": "pagefind --site build/site",
     "prerender:serve": "npx http-server -p 44100 build/site",
     "serve": "node --import remix/node-tsx src/server/index.ts",
     "test": "remix test",

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,6 +14,7 @@
     "@types/hast": "^3.0.4",
     "@types/node": "catalog:",
     "@types/semver": "^7.5.8",
+    "pagefind": "^1.3.0",
     "shiki": "^3.22.0",
     "typedoc": "^0.28.19",
     "typescript": "catalog:"
@@ -28,6 +29,7 @@
     "docs": "node src/generate/index.ts",
     "docs:debug": "DEBUG=1 node src/generate/index.ts",
     "prerender": "node --import remix/node-tsx src/prerender/index.ts",
+    "postprerender": "pagefind --site build/site",
     "prerender:serve": "npx http-server -p 44100 build/site",
     "serve": "node --import remix/node-tsx src/server/index.ts",
     "test": "remix test",

--- a/docs/src/client/entry.tsx
+++ b/docs/src/client/entry.tsx
@@ -28,26 +28,16 @@ app.ready().catch((error: unknown) => {
   console.error('Frame adoption failed:', error)
 })
 
-// Initialize Pagefind search UI
-let searchEl = document.getElementById('search')
-if (searchEl) {
-  let link = document.createElement('link')
-  link.rel = 'stylesheet'
-  link.href = '/pagefind/pagefind-ui.css'
-  document.head.appendChild(link)
+// Load Pagefind Component UI (modal trigger + modal)
+let link = document.createElement('link')
+link.rel = 'stylesheet'
+link.href = '/pagefind/pagefind-component-ui.css'
+document.head.appendChild(link)
 
-  let script = document.createElement('script')
-  script.src = '/pagefind/pagefind-ui.js'
-  script.onload = () => {
-    new (window as any).PagefindUI({
-      element: '#search',
-      showSubResults: true,
-      showImages: false,
-      resetStyles: false,
-    })
-  }
-  document.head.appendChild(script)
-}
+let script = document.createElement('script')
+script.type = 'module'
+script.src = '/pagefind/pagefind-component-ui.js'
+document.head.appendChild(script)
 
 let navToggle = document.getElementById('nav-toggle')
 if (navToggle instanceof HTMLInputElement) {

--- a/docs/src/client/entry.tsx
+++ b/docs/src/client/entry.tsx
@@ -28,6 +28,27 @@ app.ready().catch((error: unknown) => {
   console.error('Frame adoption failed:', error)
 })
 
+// Initialize Pagefind search UI
+let searchEl = document.getElementById('search')
+if (searchEl) {
+  let link = document.createElement('link')
+  link.rel = 'stylesheet'
+  link.href = '/pagefind/pagefind-ui.css'
+  document.head.appendChild(link)
+
+  let script = document.createElement('script')
+  script.src = '/pagefind/pagefind-ui.js'
+  script.onload = () => {
+    new (window as any).PagefindUI({
+      element: '#search',
+      showSubResults: true,
+      showImages: false,
+      resetStyles: false,
+    })
+  }
+  document.head.appendChild(script)
+}
+
 let navToggle = document.getElementById('nav-toggle')
 if (navToggle instanceof HTMLInputElement) {
   navToggle.addEventListener('change', () => {

--- a/docs/src/client/entry.tsx
+++ b/docs/src/client/entry.tsx
@@ -28,17 +28,6 @@ app.ready().catch((error: unknown) => {
   console.error('Frame adoption failed:', error)
 })
 
-// Load Pagefind Component UI (modal trigger + modal)
-let link = document.createElement('link')
-link.rel = 'stylesheet'
-link.href = '/pagefind/pagefind-component-ui.css'
-document.head.appendChild(link)
-
-let script = document.createElement('script')
-script.type = 'module'
-script.src = '/pagefind/pagefind-component-ui.js'
-document.head.appendChild(script)
-
 let navToggle = document.getElementById('nav-toggle')
 if (navToggle instanceof HTMLInputElement) {
   navToggle.addEventListener('change', () => {

--- a/docs/src/client/entry.tsx
+++ b/docs/src/client/entry.tsx
@@ -31,7 +31,7 @@ app.ready().catch((error: unknown) => {
 let navToggle = document.getElementById('nav-toggle')
 if (navToggle instanceof HTMLInputElement) {
   navToggle.addEventListener('change', () => {
-    if (!navToggle.checked || !isMobileNav()) return
+    if (!navToggle.checked || !window.matchMedia(MOBILE_NAV_MEDIA_QUERY).matches) return
 
     let sidebar = document.getElementById('docs-sidebar')
     let activeLink = sidebar?.querySelector('[data-active-doc="true"]')
@@ -52,8 +52,15 @@ window.navigation.addEventListener('navigate', () => {
   if (navToggle instanceof HTMLInputElement) {
     navToggle.checked = false
   }
-})
 
-function isMobileNav() {
-  return window.matchMedia(MOBILE_NAV_MEDIA_QUERY).matches
-}
+  let pagefindModal = document.querySelector('pagefind-modal')
+  if (pagefindModal && pagefindModal instanceof HTMLElement) {
+    let modal = pagefindModal as HTMLElement & { close: () => void }
+    modal.close()
+  }
+
+  let pagefindButton = document.querySelector('pagefind-modal-trigger button')
+  if (pagefindButton && pagefindButton instanceof HTMLElement) {
+    pagefindButton.blur()
+  }
+})

--- a/docs/src/client/entry.tsx
+++ b/docs/src/client/entry.tsx
@@ -31,7 +31,7 @@ app.ready().catch((error: unknown) => {
 let navToggle = document.getElementById('nav-toggle')
 if (navToggle instanceof HTMLInputElement) {
   navToggle.addEventListener('change', () => {
-    if (!navToggle.checked || !window.matchMedia(MOBILE_NAV_MEDIA_QUERY).matches) return
+    if (!navToggle.checked || !isMobileNav()) return
 
     let sidebar = document.getElementById('docs-sidebar')
     let activeLink = sidebar?.querySelector('[data-active-doc="true"]')
@@ -64,3 +64,7 @@ window.navigation.addEventListener('navigate', () => {
     pagefindButton.blur()
   }
 })
+
+function isMobileNav() {
+  return window.matchMedia(MOBILE_NAV_MEDIA_QUERY).matches
+}

--- a/docs/src/pagefind.d.ts
+++ b/docs/src/pagefind.d.ts
@@ -1,0 +1,7 @@
+// Type declarations for Pagefind Component UI custom elements
+declare namespace JSX {
+  interface IntrinsicElements {
+    'pagefind-modal': { instance?: string; 'reset-on-close'?: boolean; mix?: unknown }
+    'pagefind-modal-trigger': { instance?: string; mix?: unknown }
+  }
+}

--- a/docs/src/pagefind.d.ts
+++ b/docs/src/pagefind.d.ts
@@ -2,6 +2,13 @@
 declare namespace JSX {
   interface IntrinsicElements {
     'pagefind-modal': { instance?: string; 'reset-on-close'?: boolean; mix?: unknown }
-    'pagefind-modal-trigger': { instance?: string; mix?: unknown }
+    'pagefind-modal-trigger': {
+      instance?: string
+      compact?: boolean
+      placeholder?: string
+      shortcut?: string
+      'hide-shortcut'?: boolean
+      mix?: unknown
+    }
   }
 }

--- a/docs/src/pagefind.d.ts
+++ b/docs/src/pagefind.d.ts
@@ -10,6 +10,7 @@ declare namespace JSX {
       'reset-on-close'?: boolean
       'data-key'?: string
       'rmx-preserve-dom'?: boolean | ''
+      style?: string
     }
     'pagefind-modal-trigger': {
       instance?: string
@@ -19,6 +20,7 @@ declare namespace JSX {
       'data-key'?: string
       'hide-shortcut'?: boolean
       'rmx-preserve-dom'?: boolean | ''
+      style?: string
     }
   }
 }

--- a/docs/src/pagefind.d.ts
+++ b/docs/src/pagefind.d.ts
@@ -1,13 +1,21 @@
 // Type declarations for Pagefind Component UI custom elements
 declare namespace JSX {
   interface IntrinsicElements {
-    'pagefind-modal': { instance?: string; 'reset-on-close'?: boolean; mix?: unknown }
+    'pagefind-modal': {
+      instance?: string
+      'reset-on-close'?: boolean
+      'data-key'?: string
+      'rmx-ignore'?: boolean | ''
+      mix?: unknown
+    }
     'pagefind-modal-trigger': {
       instance?: string
       compact?: boolean
       placeholder?: string
       shortcut?: string
+      'data-key'?: string
       'hide-shortcut'?: boolean
+      'rmx-ignore'?: boolean | ''
       mix?: unknown
     }
   }

--- a/docs/src/pagefind.d.ts
+++ b/docs/src/pagefind.d.ts
@@ -1,12 +1,15 @@
 // Type declarations for Pagefind Component UI custom elements
 declare namespace JSX {
   interface IntrinsicElements {
+    'pagefind-config': {
+      'base-url'?: string
+      'bundle-path'?: string
+    }
     'pagefind-modal': {
       instance?: string
       'reset-on-close'?: boolean
       'data-key'?: string
-      'rmx-ignore'?: boolean | ''
-      mix?: unknown
+      'rmx-preserve-dom'?: boolean | ''
     }
     'pagefind-modal-trigger': {
       instance?: string
@@ -15,8 +18,7 @@ declare namespace JSX {
       shortcut?: string
       'data-key'?: string
       'hide-shortcut'?: boolean
-      'rmx-ignore'?: boolean | ''
-      mix?: unknown
+      'rmx-preserve-dom'?: boolean | ''
     }
   }
 }

--- a/docs/src/prerender/index.ts
+++ b/docs/src/prerender/index.ts
@@ -1,3 +1,4 @@
+import * as cp from 'node:child_process'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as util from 'node:util'
@@ -13,7 +14,7 @@ let { values: cliArgs } = util.parseArgs({
     dir: {
       type: 'string',
       short: 'd',
-      default: 'build/site',
+      default: path.join('build', 'site'),
     },
     version: {
       type: 'string',
@@ -57,10 +58,21 @@ for await (let { pathname, filepath, response } of crawl(router, {
   await writeResult(pathname, filepath, response)
 }
 
+// Run pagefind to generate the search index and assets
+let versionedDir = buildVersion ? path.join(outputDir, buildVersion) : outputDir
+let cmd = `pnpm exec pagefind --site ${versionedDir} --output-subdir ${versionedDir}/assets/pagefind`
+console.log(`Running Pagefind:\n  ${cmd}`)
+await cp.execSync(cmd)
+
 // Release the asset server's file watcher so the process can exit cleanly.
 await assetServer.close()
 
 async function writeResult(pathname: string, filepath: string, response: Response) {
+  if (response.status === 204) {
+    console.warn(`Skipped ${pathname}: 204 No Content`)
+    return
+  }
+
   let outputFilepath = SCRIPT_FILE_EXT.test(filepath)
     ? filepath.replace(SCRIPT_FILE_EXT, '.js')
     : filepath

--- a/docs/src/server/asset-server.ts
+++ b/docs/src/server/asset-server.ts
@@ -14,7 +14,8 @@ export function createAssetServer(version?: string): DocsAssetServer {
     basePath: version ? `/${version}/assets` : '/assets',
     fileMap: {
       '/demos/*path': 'docs/build/demos/*path',
-      '/pkg/*path': 'packages/*path',
+      '/pkg/:pkg/src/*path': 'packages/:pkg/src/*path',
+      '/pkg/:pkg/deps/*path': 'packages/:pkg/node_modules/*path',
       '/client/*path': 'docs/src/client/*path',
       '/shared/*path': 'docs/src/shared/*path',
     },

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -24,6 +24,7 @@ const REPO_DIR = path.resolve(DOCS_DIR, '..')
 const BUILD_DIR = path.join(REPO_DIR, 'docs', 'build')
 const MD_DIR = path.join(BUILD_DIR, 'md')
 const PUBLIC_DIR = path.join(BUILD_DIR, 'public')
+const SITE_DIR = path.join(BUILD_DIR, 'site')
 const REMIX_PKG_JSON = path.join(REPO_DIR, 'packages', 'remix', 'package.json')
 
 type DocsContext = {
@@ -51,7 +52,15 @@ export function createRouter(options: DocsRouterOptions): Router {
     ? Promise.resolve(docsContext)
     : undefined
 
-  const router = _createRouter({ middleware: [staticFiles(PUBLIC_DIR)] })
+  const middleware = [staticFiles(PUBLIC_DIR)]
+
+  // Serve pre-built Pagefind bundle if available. Falls back gracefully when
+  // the site hasn't been prerendered yet (search simply won't initialize).
+  if (fs.existsSync(path.join(SITE_DIR, 'pagefind'))) {
+    middleware.push(staticFiles(SITE_DIR, { filter: (p) => p.startsWith('pagefind/') }))
+  }
+
+  const router = _createRouter({ middleware })
 
   function getDocsContext(): Promise<DocsContext> {
     docsContextPromise ??= loadDocsContext(assetServer)

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -24,7 +24,7 @@ const REPO_DIR = path.resolve(DOCS_DIR, '..')
 const BUILD_DIR = path.join(REPO_DIR, 'docs', 'build')
 const MD_DIR = path.join(BUILD_DIR, 'md')
 const PUBLIC_DIR = path.join(BUILD_DIR, 'public')
-const SITE_DIR = path.join(BUILD_DIR, 'site')
+const ASSETS_DIR = path.join(BUILD_DIR, 'site', 'assets')
 const REMIX_PKG_JSON = path.join(REPO_DIR, 'packages', 'remix', 'package.json')
 
 type DocsContext = {
@@ -75,7 +75,7 @@ export function createRouter(options: DocsRouterOptions): Router {
       assets: async ({ request, params }) => {
         // Serve versioned pagefind assets manually
         if (params.asset.startsWith('pagefind/')) {
-          let assetPath = path.resolve(SITE_DIR, params.asset)
+          let assetPath = path.resolve(ASSETS_DIR, params.asset)
 
           try {
             let stats = await fs.promises.stat(assetPath)
@@ -88,10 +88,7 @@ export function createRouter(options: DocsRouterOptions): Router {
           return new Response(null, { status: 204 })
         }
 
-        // Drop the optional version prefix so the asset server sees a stable URL space.
-        let url = new URL(request.url)
-        url.pathname = routes.assets.href({ asset: params.asset })
-        let response = await assetServer.fetch(new Request(url, request))
+        let response = await assetServer.fetch(request)
         return response ?? new Response('Not Found', { status: 404 })
       },
       async docs({ request, params }) {

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -52,15 +52,7 @@ export function createRouter(options: DocsRouterOptions): Router {
     ? Promise.resolve(docsContext)
     : undefined
 
-  const middleware = [staticFiles(PUBLIC_DIR)]
-
-  // Serve pre-built Pagefind bundle if available. Falls back gracefully when
-  // the site hasn't been prerendered yet (search simply won't initialize).
-  if (fs.existsSync(path.join(SITE_DIR, 'pagefind'))) {
-    middleware.push(staticFiles(SITE_DIR, { filter: (p) => p.startsWith('pagefind/') }))
-  }
-
-  const router = _createRouter({ middleware })
+  const router = _createRouter({ middleware: [staticFiles(PUBLIC_DIR)] })
 
   function getDocsContext(): Promise<DocsContext> {
     docsContextPromise ??= loadDocsContext(assetServer)
@@ -80,8 +72,26 @@ export function createRouter(options: DocsRouterOptions): Router {
 
   router.map(routes, {
     actions: {
-      assets: async ({ request }) => {
-        let response = await assetServer.fetch(request)
+      assets: async ({ request, params }) => {
+        // Serve versioned pagefind assets manually
+        if (params.asset.startsWith('pagefind/')) {
+          let assetPath = path.resolve(SITE_DIR, params.asset)
+
+          try {
+            let stats = await fs.promises.stat(assetPath)
+            if (stats.isFile()) {
+              return respond.file(request, assetPath)
+            }
+          } catch {}
+
+          console.warn(`[WARN] Pagefind asset not found: ${new URL(request.url).pathname}`)
+          return new Response(null, { status: 204 })
+        }
+
+        // Drop the optional version prefix so the asset server sees a stable URL space.
+        let url = new URL(request.url)
+        url.pathname = routes.assets.href({ asset: params.asset })
+        let response = await assetServer.fetch(new Request(url, request))
         return response ?? new Response('Not Found', { status: 404 })
       },
       async docs({ request, params }) {

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -40,7 +40,7 @@ export function Document(
           entryHref={entryHref}
           entryPreloads={entryPreloads}
         />
-        <body mix={bodyCss}>
+        <body mix={[bodyCss, pagefindVariables]}>
           <MobileHeader page={page} />
           <div mix={shellCss}>
             <Sidebar
@@ -195,6 +195,25 @@ function Head(
           })}
           type="module"
         />
+        {/*
+          Pagefind resets its custom element hosts with `color-scheme: initial`.
+          We override so dark mode works properly.
+        */}
+        <style>{`
+          pagefind-filter-dropdown,
+          pagefind-filter-pane,
+          pagefind-input,
+          pagefind-keyboard-hints,
+          pagefind-modal,
+          pagefind-modal-body,
+          pagefind-modal-header,
+          pagefind-modal-trigger,
+          pagefind-results,
+          pagefind-searchbox,
+          pagefind-summary {
+            color-scheme: light dark;
+          }
+        `}</style>
       </head>
     )
   }
@@ -654,6 +673,32 @@ const bodyCss = css({
   },
 })
 
+const pagefindVariables = css({
+  '--pf-font': theme.fontFamily.sans,
+  '--pf-input-height': '40px',
+  '--pf-border-radius': theme.radius.md,
+  '--pf-text': theme.colors.text.primary,
+  '--pf-text-secondary': theme.colors.text.secondary,
+  '--pf-text-muted': theme.colors.text.muted,
+  '--pf-background': theme.surface.lvl1,
+  '--pf-border': theme.colors.border.subtle,
+  '--pf-border-focus': theme.colors.border.strong,
+  '--pf-skeleton': theme.surface.lvl3,
+  '--pf-skeleton-shine': theme.surface.lvl4,
+  '--pf-hover': theme.surface.lvl2,
+  '--pf-mark': theme.colors.text.primary,
+  '--pf-scroll-shadow': 'light-dark(rgb(0 0 0 / 8%), rgb(255 255 255 / 10%))',
+  '--pf-shadow-sm': '0 2px 8px light-dark(rgb(0 0 0 / 6%), rgb(0 0 0 / 30%))',
+  '--pf-shadow-md': '0 4px 12px light-dark(rgb(0 0 0 / 10%), rgb(0 0 0 / 40%))',
+  '--pf-shadow-lg': '0 16px 48px light-dark(rgb(0 0 0 / 20%), rgb(0 0 0 / 50%))',
+  '--pf-error-bg': 'light-dark(#fef2f2, #2a1a1a)',
+  '--pf-error-border': 'light-dark(#fecaca, #5c2828)',
+  '--pf-error-text': 'light-dark(#dc2626, #f87171)',
+  '--pf-error-text-secondary': 'light-dark(#b91c1c, #ef4444)',
+  '--pf-outline-focus': theme.colors.text.link,
+  '--pf-modal-backdrop': 'light-dark(rgb(0 0 0 / 50%), rgb(0 0 0 / 72%))',
+})
+
 const shellCss = css({
   minHeight: '100vh',
   display: 'grid',
@@ -696,11 +741,6 @@ const sidebarIntroCss = css({
   marginBottom: theme.space.sm,
   [MOBILE_NAV_MEDIA_RULE]: {
     display: 'none',
-  },
-  // Style the Pagefind trigger button to blend with the sidebar
-  '& pagefind-modal-trigger': {
-    '--pf-background': theme.surface.lvl3,
-    '--pf-border': theme.colors.border.subtle,
   },
 })
 
@@ -991,11 +1031,6 @@ const mobileLogoBannerCss = css({
     padding: `${theme.space.lg}`,
     backgroundColor: theme.surface.lvl3,
     borderBottom: `1px solid ${theme.colors.border.subtle}`,
-  },
-  // Style the Pagefind trigger button to blend with the banner background
-  '& pagefind-modal-trigger': {
-    '--pf-background': theme.surface.lvl3,
-    '--pf-border': theme.colors.border.subtle,
   },
 })
 

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -669,7 +669,7 @@ const sidebarIntroCss = css({
 })
 
 const searchTriggerCss = css({
-  marginBottom: theme.space.sm,
+  marginBottom: theme.space.lg,
   width: '100%',
 })
 

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -80,7 +80,7 @@ function MobileHeader(handle: Handle<{ page: PageDefinition }>) {
           <a href="https://remix.run">
             <RemixLogos />
           </a>
-          <pagefind-modal-trigger compact />
+          <pagefind-modal-trigger compact hide-shortcut />
         </div>
         <label
           for="nav-toggle"
@@ -313,7 +313,7 @@ function Sidebar(
               <a href="https://remix.run" class="logo">
                 <RemixLogos />
               </a>
-              <pagefind-modal-trigger compact />
+              <pagefind-modal-trigger compact hide-shortcut />
             </div>
 
             <VersionSwitcher versions={versions} activeVersion={activeVersion} />

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -699,8 +699,8 @@ const sidebarIntroCss = css({
   },
   // Style the Pagefind trigger button to blend with the sidebar
   '& pagefind-modal-trigger': {
-    '--pf-background': theme.colors.action.secondary.background,
-    '--pf-border': theme.colors.action.secondary.border,
+    '--pf-background': theme.surface.lvl3,
+    '--pf-border': theme.colors.border.subtle,
   },
 })
 
@@ -994,8 +994,8 @@ const mobileLogoBannerCss = css({
   },
   // Style the Pagefind trigger button to blend with the banner background
   '& pagefind-modal-trigger': {
-    '--pf-background': theme.colors.action.secondary.background,
-    '--pf-border': theme.colors.action.secondary.border,
+    '--pf-background': theme.surface.lvl3,
+    '--pf-border': theme.colors.border.subtle,
   },
 })
 

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -172,6 +172,8 @@ function Head(
           <link key={href} rel="modulepreload" href={href} />
         ))}
         <script type="module" src={entryHref} />
+        <link href="/pagefind/pagefind-component-ui.css" rel="stylesheet" />
+        <script src="/pagefind/pagefind-component-ui.js" type="module" />
       </head>
     )
   }

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -671,8 +671,8 @@ const sidebarIntroCss = css({
   },
   // Style the Pagefind trigger button to blend with the sidebar
   '& pagefind-modal-trigger': {
-    '--pf-background': 'transparent',
-    '--pf-border': 'light-dark(#313539, #DEE2E6)',
+    '--pf-background': theme.colors.action.secondary.background,
+    '--pf-border': theme.colors.action.secondary.border,
   },
 })
 
@@ -966,8 +966,8 @@ const mobileLogoBannerCss = css({
   },
   // Style the Pagefind trigger button to blend with the banner background
   '& pagefind-modal-trigger': {
-    '--pf-background': 'transparent',
-    '--pf-border': 'light-dark(#313539, #DEE2E6)',
+    '--pf-background': theme.colors.action.secondary.background,
+    '--pf-border': theme.colors.action.secondary.border,
   },
 })
 

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -209,7 +209,7 @@ function MainContent(
   }>,
 ) {
   return () => (
-    <main mix={mainCss} data-pagefind-body={handle.props.activeVersion == null || undefined}>
+    <main mix={mainCss} data-pagefind-body>
       <div mix={pageWrapCss}>
         <div mix={[pageContentCss, handle.props.page.css]}>
           {handle.props.header}

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -669,6 +669,11 @@ const sidebarIntroCss = css({
   [MOBILE_NAV_MEDIA_RULE]: {
     display: 'none',
   },
+  // Style the Pagefind trigger button to blend with the sidebar
+  '& pagefind-modal-trigger': {
+    '--pf-background': 'transparent',
+    '--pf-border': 'light-dark(#313539, #DEE2E6)',
+  },
 })
 
 const sidebarPanelCss = css({
@@ -958,6 +963,11 @@ const mobileLogoBannerCss = css({
     padding: `${theme.space.lg}`,
     backgroundColor: theme.surface.lvl3,
     borderBottom: `1px solid ${theme.colors.border.subtle}`,
+  },
+  // Style the Pagefind trigger button to blend with the banner background
+  '& pagefind-modal-trigger': {
+    '--pf-background': 'transparent',
+    '--pf-border': 'light-dark(#313539, #DEE2E6)',
   },
 })
 

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -76,9 +76,12 @@ function MobileHeader(handle: Handle<{ page: PageDefinition }>) {
           aria-hidden="true"
           tabIndex={-1}
         />
-        <a href="https://remix.run" mix={mobileLogoBannerCss}>
-          <RemixLogos />
-        </a>
+        <div mix={mobileLogoBannerCss}>
+          <a href="https://remix.run">
+            <RemixLogos />
+          </a>
+          <pagefind-modal-trigger compact />
+        </div>
         <label
           for="nav-toggle"
           mix={mobileTopBarCss}
@@ -310,9 +313,8 @@ function Sidebar(
               <a href="https://remix.run" class="logo">
                 <RemixLogos />
               </a>
+              <pagefind-modal-trigger compact />
             </div>
-
-            <pagefind-modal-trigger mix={searchTriggerCss} />
 
             <VersionSwitcher versions={versions} activeVersion={activeVersion} />
 
@@ -659,18 +661,14 @@ const sidebarStickyCss = css({
 
 const sidebarIntroCss = css({
   display: 'flex',
-  flexDirection: 'column',
-  gap: theme.space.xs,
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
   paddingBottom: theme.space.sm,
   marginBottom: theme.space.sm,
   [MOBILE_NAV_MEDIA_RULE]: {
     display: 'none',
   },
-})
-
-const searchTriggerCss = css({
-  marginBottom: theme.space.lg,
-  width: '100%',
 })
 
 const sidebarPanelCss = css({

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -57,7 +57,11 @@ export function Document(
               {children}
             </MainContent>
           </div>
-          <pagefind-modal data-key="pagefind-modal" rmx-ignore />
+          <pagefind-config
+            base-url={routes.home.href({ version: activeVersion })}
+            bundle-path={routes.assets.href({ version: activeVersion, asset: 'pagefind/' })}
+          ></pagefind-config>
+          <pagefind-modal data-key="pagefind-modal" rmx-preserve-dom reset-on-close />
         </body>
       </html>
     )
@@ -84,7 +88,7 @@ function MobileHeader(handle: Handle<{ page: PageDefinition }>) {
             compact
             data-key="pagefind-modal-trigger-mobile"
             hide-shortcut
-            rmx-ignore
+            rmx-preserve-dom
           />
         </div>
         <label
@@ -177,8 +181,20 @@ function Head(
           <link key={href} rel="modulepreload" href={href} />
         ))}
         <script type="module" src={entryHref} />
-        <link href="/pagefind/pagefind-component-ui.css" rel="stylesheet" />
-        <script src="/pagefind/pagefind-component-ui.js" type="module" />
+        <link
+          href={routes.assets.href({
+            version: activeVersion,
+            asset: 'pagefind/pagefind-component-ui.css',
+          })}
+          rel="stylesheet"
+        />
+        <script
+          src={routes.assets.href({
+            version: activeVersion,
+            asset: 'pagefind/pagefind-component-ui.js',
+          })}
+          type="module"
+        />
       </head>
     )
   }
@@ -324,7 +340,7 @@ function Sidebar(
                 compact
                 data-key="pagefind-modal-trigger-sidebar"
                 hide-shortcut
-                rmx-ignore
+                rmx-preserve-dom
               />
             </div>
 

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -49,11 +49,7 @@ export function Document(
               versions={versions}
               activeVersion={activeVersion}
             />
-            <MainContent
-              page={page}
-              header={<PageHeader page={page} sourceUrl={sourceUrl} />}
-              activeVersion={activeVersion}
-            >
+            <MainContent page={page} header={<PageHeader page={page} sourceUrl={sourceUrl} />}>
               {children}
             </MainContent>
           </div>
@@ -224,7 +220,6 @@ function MainContent(
     page: PageDefinition
     header?: RemixNode
     children: RemixNode | RemixNode[]
-    activeVersion?: string
   }>,
 ) {
   return () => (

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -57,6 +57,7 @@ export function Document(
               {children}
             </MainContent>
           </div>
+          <pagefind-modal />
         </body>
       </html>
     )
@@ -311,7 +312,7 @@ function Sidebar(
               </a>
             </div>
 
-            <div id="search" mix={searchContainerCss} />
+            <pagefind-modal-trigger mix={searchTriggerCss} />
 
             <VersionSwitcher versions={versions} activeVersion={activeVersion} />
 
@@ -667,16 +668,9 @@ const sidebarIntroCss = css({
   },
 })
 
-const searchContainerCss = css({
+const searchTriggerCss = css({
   marginBottom: theme.space.sm,
-  '--pagefind-ui-scale': '0.8',
-  '--pagefind-ui-primary': theme.colors.text.link,
-  '--pagefind-ui-text': theme.colors.text.primary,
-  '--pagefind-ui-background': theme.surface.lvl0,
-  '--pagefind-ui-border': theme.colors.border.subtle,
-  '--pagefind-ui-border-width': '1px',
-  '--pagefind-ui-border-radius': theme.radius.md,
-  '--pagefind-ui-font': theme.fontFamily.sans,
+  width: '100%',
 })
 
 const sidebarPanelCss = css({

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -49,7 +49,11 @@ export function Document(
               versions={versions}
               activeVersion={activeVersion}
             />
-            <MainContent page={page} header={<PageHeader page={page} sourceUrl={sourceUrl} />}>
+            <MainContent
+              page={page}
+              header={<PageHeader page={page} sourceUrl={sourceUrl} />}
+              activeVersion={activeVersion}
+            >
               {children}
             </MainContent>
           </div>
@@ -170,10 +174,15 @@ function Head(
 }
 
 function MainContent(
-  handle: Handle<{ page: PageDefinition; header?: RemixNode; children: RemixNode | RemixNode[] }>,
+  handle: Handle<{
+    page: PageDefinition
+    header?: RemixNode
+    children: RemixNode | RemixNode[]
+    activeVersion?: string
+  }>,
 ) {
   return () => (
-    <main mix={mainCss}>
+    <main mix={mainCss} data-pagefind-body={handle.props.activeVersion == null || undefined}>
       <div mix={pageWrapCss}>
         <div mix={[pageContentCss, handle.props.page.css]}>
           {handle.props.header}
@@ -301,6 +310,8 @@ function Sidebar(
                 <RemixLogos />
               </a>
             </div>
+
+            <div id="search" mix={searchContainerCss} />
 
             <VersionSwitcher versions={versions} activeVersion={activeVersion} />
 
@@ -654,6 +665,18 @@ const sidebarIntroCss = css({
   [MOBILE_NAV_MEDIA_RULE]: {
     display: 'none',
   },
+})
+
+const searchContainerCss = css({
+  marginBottom: theme.space.sm,
+  '--pagefind-ui-scale': '0.8',
+  '--pagefind-ui-primary': theme.colors.text.link,
+  '--pagefind-ui-text': theme.colors.text.primary,
+  '--pagefind-ui-background': theme.surface.lvl0,
+  '--pagefind-ui-border': theme.colors.border.subtle,
+  '--pagefind-ui-border-width': '1px',
+  '--pagefind-ui-border-radius': theme.radius.md,
+  '--pagefind-ui-font': theme.fontFamily.sans,
 })
 
 const sidebarPanelCss = css({

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -57,7 +57,7 @@ export function Document(
               {children}
             </MainContent>
           </div>
-          <pagefind-modal />
+          <pagefind-modal data-key="pagefind-modal" rmx-ignore />
         </body>
       </html>
     )
@@ -80,7 +80,12 @@ function MobileHeader(handle: Handle<{ page: PageDefinition }>) {
           <a href="https://remix.run">
             <RemixLogos />
           </a>
-          <pagefind-modal-trigger compact hide-shortcut />
+          <pagefind-modal-trigger
+            compact
+            data-key="pagefind-modal-trigger-mobile"
+            hide-shortcut
+            rmx-ignore
+          />
         </div>
         <label
           for="nav-toggle"
@@ -315,7 +320,12 @@ function Sidebar(
               <a href="https://remix.run" class="logo">
                 <RemixLogos />
               </a>
-              <pagefind-modal-trigger compact hide-shortcut />
+              <pagefind-modal-trigger
+                compact
+                data-key="pagefind-modal-trigger-sidebar"
+                hide-shortcut
+                rmx-ignore
+              />
             </div>
 
             <VersionSwitcher versions={versions} activeVersion={activeVersion} />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
+      pagefind:
+        specifier: ^1.3.0
+        version: 1.5.2
       shiki:
         specifier: ^3.22.0
         version: 3.23.0
@@ -3693,6 +3696,41 @@ packages:
     resolution: {integrity: sha512-4mAGdfUZNQSZwUbHs0xoUcKjByrdBSJ9iaCI3STn/d1ZVRKhW/82oCA6rdfSzO4vxrWH3/l+qYWh/tyrwPSpag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@pagefind/darwin-arm64@1.5.2':
+    resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pagefind/darwin-x64@1.5.2':
+    resolution: {integrity: sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pagefind/freebsd-x64@1.5.2':
+    resolution: {integrity: sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@pagefind/linux-arm64@1.5.2':
+    resolution: {integrity: sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pagefind/linux-x64@1.5.2':
+    resolution: {integrity: sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pagefind/windows-arm64@1.5.2':
+    resolution: {integrity: sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pagefind/windows-x64@1.5.2':
+    resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
+    cpu: [x64]
+    os: [win32]
+
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -4969,6 +5007,10 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  pagefind@1.5.2:
+    resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
+    hasBin: true
 
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
@@ -6734,6 +6776,27 @@ snapshots:
 
   '@oxlint/plugins@1.57.0': {}
 
+  '@pagefind/darwin-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/darwin-x64@1.5.2':
+    optional: true
+
+  '@pagefind/freebsd-x64@1.5.2':
+    optional: true
+
+  '@pagefind/linux-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/linux-x64@1.5.2':
+    optional: true
+
+  '@pagefind/windows-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/windows-x64@1.5.2':
+    optional: true
+
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -8140,6 +8203,16 @@ snapshots:
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
+  pagefind@1.5.2:
+    optionalDependencies:
+      '@pagefind/darwin-arm64': 1.5.2
+      '@pagefind/darwin-x64': 1.5.2
+      '@pagefind/freebsd-x64': 1.5.2
+      '@pagefind/linux-arm64': 1.5.2
+      '@pagefind/linux-x64': 1.5.2
+      '@pagefind/windows-arm64': 1.5.2
+      '@pagefind/windows-x64': 1.5.2
 
   pako@0.2.9: {}
 


### PR DESCRIPTION
~~**Stacked on #11504**~~

Adds [Pagefind](https://pagefind.app/) full-text search to the prerendered docs site. Pagefind runs as a `postprerender` step, indexing the static HTML output, and the modal UI is loaded in the browser via custom elements (`<pagefind-modal>` / `<pagefind-modal-trigger>`).

To test: `cd docs; pnpm run docs: pnpm run prerender; pnpm run prerender:serve`

- Compact search icon trigger next to the logo opens a search modal on click
- Dev server gracefully serves a pre-built Pagefind index from `build/site/pagefind/` if present, falling back silently if not
