### PR TITLE
route-pattern: `createHref` encodes pathname params and validates hostname params

### DIFF
--- a/packages/route-pattern/.changes/minor.validate-hostname-params.md
+++ b/packages/route-pattern/.changes/minor.validate-hostname-params.md
@@ -1,0 +1,29 @@
+`createHref` now encodes pathname params and validates hostname params
+
+Pathname params now encode characters that would otherwise change URL structure when parsed. Variables encode `/`, `?`, `#`, `%`, and `\\`; wildcards preserve `/` as a path separator but encode the other structural characters.
+
+```ts
+createHref('/posts/:slug', { slug: 'hello/world?draft=true#preview' })
+// before: '/posts/hello/world?draft=true#preview'
+// after:  '/posts/hello%2Fworld%3Fdraft=true%23preview'
+
+createHref('/files/*path', { path: 'docs/@remix-run/ui?raw#v1' })
+// before: '/files/docs/@remix-run/ui?raw#v1'
+// after:  '/files/docs/@remix-run/ui%3Fraw%23v1'
+```
+
+Hostname params are now validated so structural URL characters cannot change the URL authority when parsed. Hostname variables reject `.`, `@`, `:`, `/`, `?`, and `#`; hostname wildcards allow `.` to span labels but reject the other structural characters.
+
+```ts
+createHref('://:tenant.example.com/path', { tenant: 'acme.dev' })
+// before: 'https://acme%2Edev.example.com/path'
+// after:  throws CreateHrefError
+
+createHref('://*tenant.example.com/path', { tenant: 'preview.acme' })
+// before: 'https://preview.acme.example.com/path'
+// after:  'https://preview.acme.example.com/path'
+
+createHref('://*tenant.example.com/path', { tenant: 'preview:acme' })
+// before: 'https://preview%3Aacme.example.com/path'
+// after:  throws CreateHrefError
+```

--- a/packages/route-pattern/src/lib/href.test.ts
+++ b/packages/route-pattern/src/lib/href.test.ts
@@ -95,6 +95,28 @@ describe('createHref', () => {
     it('includes optional with static content', () => {
       assert.equal(createHref('://(www.)example.com/path'), 'https://www.example.com/path')
     })
+
+    it('rejects structural URL chars and `.` in hostname variables', () => {
+      assert.throws(
+        () => createHref('://:tenant.example.com/path', { tenant: 'acme.dev' }),
+        hrefError('invalid-hostname-variable'),
+      )
+      assert.throws(
+        () => createHref('://:tenant.example.com/path', { tenant: 'acme:staging' }),
+        hrefError('invalid-hostname-variable'),
+      )
+    })
+
+    it('allows `.` but rejects structural URL chars in hostname wildcards', () => {
+      assert.equal(
+        createHref('://*tenant.example.com/path', { tenant: 'preview.acme' }),
+        'https://preview.acme.example.com/path',
+      )
+      assert.throws(
+        () => createHref('://*tenant.example.com/path', { tenant: 'preview:acme' }),
+        hrefError('invalid-hostname-wildcard'),
+      )
+    })
   })
 
   describe('port', () => {
@@ -188,6 +210,20 @@ describe('createHref', () => {
           postId: '123',
         }),
         '/en/users/42/en/posts/123',
+      )
+    })
+
+    it('encodes structural URL chars including `/` for variables', () => {
+      assert.equal(
+        createHref('/posts/:slug', { slug: 'hello/world?draft=true#preview' }),
+        '/posts/hello%2Fworld%3Fdraft=true%23preview',
+      )
+    })
+
+    it('encodes structural URL chars except `/` for wildcards', () => {
+      assert.equal(
+        createHref('/files/*path', { path: 'docs/@remix-run/ui?raw#v1' }),
+        '/files/docs/@remix-run/ui%3Fraw%23v1',
       )
     })
   })

--- a/packages/route-pattern/src/lib/href.ts
+++ b/packages/route-pattern/src/lib/href.ts
@@ -123,7 +123,13 @@ function hrefPart(
         i = part.optionals.get(frame.begin!)! + 1
         continue
       }
-      stack[stack.length - 1].href += typeof value === 'string' ? value : String(value)
+      // prettier-ignore
+      stack[stack.length - 1].href +=
+        part.type === 'pathname' && token.type === ':' ? encodePathnameVariable(value) :
+        part.type === 'pathname' && token.type === '*' ? encodePathnameWildcard(value) :
+        part.type === 'hostname' && token.type === ':' ? validateHostnameVariable(value) :
+        part.type === 'hostname' && token.type === '*' ? validateHostnameWildcard(value) :
+        unreachable()
       i += 1
       continue
     }
@@ -186,6 +192,16 @@ type CreateHrefErrorDetails =
       params: Record<string, unknown>
     }
   | { type: 'nameless-wildcard'; pattern: RoutePattern }
+  | {
+      type: 'invalid-hostname-variable'
+      value: string
+      char: string
+    }
+  | {
+      type: 'invalid-hostname-wildcard'
+      value: string
+      char: string
+    }
 
 /** Error thrown when a route pattern cannot generate an href from the supplied args. */
 export class CreateHrefError extends Error {
@@ -198,21 +214,99 @@ export class CreateHrefError extends Error {
   }
 
   static message(details: CreateHrefErrorDetails): string {
-    let pattern = details.pattern.toString()
-
     if (details.type === 'missing-hostname') {
-      return `pattern requires hostname\n\nPattern: ${pattern}`
+      return `pattern requires hostname\n\nPattern: ${details.pattern}`
     }
 
     if (details.type === 'nameless-wildcard') {
-      return `pattern contains nameless wildcard\n\nPattern: ${pattern}`
+      return `pattern contains nameless wildcard\n\nPattern: ${details.pattern}`
     }
 
     if (details.type === 'missing-params') {
       let params = details.missingParams.map((p) => `'${p}'`).join(', ')
-      return `missing param(s): ${params}\n\nPattern: ${pattern}\nParams: ${JSON.stringify(details.params)}`
+      return `missing param(s): ${params}\n\nPattern: ${details.pattern}\nParams: ${JSON.stringify(details.params)}`
+    }
+
+    if (details.type === 'invalid-hostname-variable') {
+      return `invalid hostname variable param: ${JSON.stringify(details.value)} contains ${JSON.stringify(details.char)}`
+    }
+
+    if (details.type === 'invalid-hostname-wildcard') {
+      return `invalid hostname wildcard param: ${JSON.stringify(details.value)} contains ${JSON.stringify(details.char)}`
     }
 
     unreachable(details)
   }
+}
+
+export function encodePathnameVariable(value: unknown) {
+  return encodePathnameSegment(String(value))
+}
+
+export function encodePathnameWildcard(value: unknown) {
+  return String(value).split('/').map(encodePathnameSegment).join('/')
+}
+
+/**
+ * Keep pathname params from changing URL structure when parsed. `/`, `?`, and `#` are
+ * path/query/fragment delimiters; `%` begins percent-encoded bytes; and `\\` is treated as a
+ * path separator by special URL parsing.
+ *
+ * @see https://url.spec.whatwg.org/#path-percent-encode-set
+ * @see https://url.spec.whatwg.org/#percent-encoded-bytes
+ */
+const PATHNAME_PARAM_STRUCTURAL_CHARS: Record<string, string> = {
+  '/': '%2F',
+  '?': '%3F',
+  '#': '%23',
+  '%': '%25',
+  '\\': '%5C',
+}
+
+function encodePathnameSegment(value: string): string {
+  let encoded = ''
+  for (let char of value) {
+    let encodedChar = PATHNAME_PARAM_STRUCTURAL_CHARS[char]
+    encoded += encodedChar === undefined ? char : encodedChar
+  }
+  return encoded
+}
+
+/**
+ * Keep hostname params from changing URL authority structure when parsed. `@` ends userinfo,
+ * `:` starts the port, and `/`, `?`, and `#` start the path, query, and fragment. Hostname
+ * variables also reject `.` because dots separate host labels; hostname wildcards allow `.` to
+ * span labels intentionally.
+ *
+ * @see https://url.spec.whatwg.org/#authority-state
+ * @see https://url.spec.whatwg.org/#host-parsing
+ */
+const HOSTNAME_PARAM_STRUCTURAL_CHARS = ['@', ':', '/', '?', '#']
+
+export function validateHostnameVariable(value: unknown): string {
+  let serialized = String(value)
+  for (let char of serialized) {
+    if (char === '.' || HOSTNAME_PARAM_STRUCTURAL_CHARS.includes(char)) {
+      throw new CreateHrefError({
+        type: 'invalid-hostname-variable',
+        value: serialized,
+        char,
+      })
+    }
+  }
+  return serialized
+}
+
+export function validateHostnameWildcard(value: unknown): string {
+  let serialized = String(value)
+  for (let char of serialized) {
+    if (HOSTNAME_PARAM_STRUCTURAL_CHARS.includes(char)) {
+      throw new CreateHrefError({
+        type: 'invalid-hostname-wildcard',
+        value: serialized,
+        char,
+      })
+    }
+  }
+  return serialized
 }


### PR DESCRIPTION
**NOTE:** Pathname param encoding/decoding for matchers coming in a separate PR.

`createHref` now encodes pathname params and validates hostname params

Pathname params now encode characters that would otherwise change URL structure when parsed. Variables encode `/`, `?`, `#`, `%`, and `\\`; wildcards preserve `/` as a path separator but encode the other structural characters.

```ts
createHref('/posts/:slug', { slug: 'hello/world?draft=true#preview' })
// before: '/posts/hello/world?draft=true#preview'
// after:  '/posts/hello%2Fworld%3Fdraft=true%23preview'

createHref('/files/*path', { path: 'docs/@remix-run/ui?raw#v1' })
// before: '/files/docs/@remix-run/ui?raw#v1'
// after:  '/files/docs/@remix-run/ui%3Fraw%23v1'
```

Hostname params are now validated so structural URL characters cannot change the URL authority when parsed. Hostname variables reject `.`, `@`, `:`, `/`, `?`, and `#`; hostname wildcards allow `.` to span labels but reject the other structural characters.

```ts
createHref('://:tenant.example.com/path', { tenant: 'acme.dev' })
// before: 'https://acme%2Edev.example.com/path'
// after:  throws CreateHrefError

createHref('://*tenant.example.com/path', { tenant: 'preview.acme' })
// before: 'https://preview.acme.example.com/path'
// after:  'https://preview.acme.example.com/path'

createHref('://*tenant.example.com/path', { tenant: 'preview:acme' })
// before: 'https://preview%3Aacme.example.com/path'
// after:  throws CreateHrefError
```

## Benchmarks

Encoding + validation have overhead, but href generation is still <10µs for p99 and <50µs for p999 which is definitely Fast Enough™.

I tried out a couple different optimizations and had the agent iterate on it for a while, but everything added duplication/complexity. We can always explore optimizations again if this becomes a bottleneck, but seems very far from being a problem currently.

<img width="1789" height="1138" alt="Screenshot 2026-05-22 at 10 47 00 AM" src="https://github.com/user-attachments/assets/9d1f43cf-7e1f-48af-a8f6-bfc6e6df7255" />
