### PR TITLE
route-pattern: param encoding and validation

### DIFF
--- a/packages/route-pattern/.changes/minor.normalize-pathname-matching.md
+++ b/packages/route-pattern/.changes/minor.normalize-pathname-matching.md
@@ -1,0 +1,44 @@
+Matchers now normalize percent-encoded pathname during matching
+
+Pathname matching now uses the URL parser's normalized pathname, splits it into segments, and canonicalizes each segment as percent-encoded text before matching. This allows equivalent path text like `a` and `%61`, or `café` and `caf%C3%A9`, to match consistently:
+
+```ts
+let matcher = createMatcher('/a')
+
+matcher.match('https://example.com/%61')
+// before: null
+// after:  { params: {} }
+```
+
+```ts
+let matcher = createMatcher('/café')
+
+matcher.match('https://example.com/caf%C3%A9')
+// before: null
+// after:  { params: {} }
+```
+
+Also keeps encoded path separators like `%2F` inside the segment where they appear instead of treating them as `/` separators during matching:
+
+```ts
+let matcher = createMatcher('/files/:dir/:name')
+
+matcher.match('https://example.com/files/docs/readme.md')
+// before: { params: { dir: 'docs', name: 'readme.md' } }
+// after:  { params: { dir: 'docs', name: 'readme.md' } }
+
+matcher.match('https://example.com/files/docs%2Freadme.md')
+// before: { params: { dir: 'docs', name: 'readme.md' } }
+// after:  null
+```
+
+Matched pathname params are still returned decoded.
+
+```ts
+let matcher = createMatcher('/posts/:slug')
+let href = createHref('/posts/:slug', { slug: 'hello/world?draft=true#preview' })
+
+matcher.match(`https://example.com${href}`)
+// before: null
+// after:  { params: { slug: 'hello/world?draft=true#preview' } }
+```

--- a/packages/route-pattern/.changes/minor.validate-hostname-params.md
+++ b/packages/route-pattern/.changes/minor.validate-hostname-params.md
@@ -1,0 +1,29 @@
+`createHref` now encodes pathname params and validates hostname params
+
+Pathname params now encode characters that would otherwise change URL structure when parsed. Variables encode `/`, `?`, `#`, `%`, and `\\`; wildcards preserve `/` as a path separator but encode the other structural characters.
+
+```ts
+createHref('/posts/:slug', { slug: 'hello/world?draft=true#preview' })
+// before: '/posts/hello/world?draft=true#preview'
+// after:  '/posts/hello%2Fworld%3Fdraft=true%23preview'
+
+createHref('/files/*path', { path: 'docs/@remix-run/ui?raw#v1' })
+// before: '/files/docs/@remix-run/ui?raw#v1'
+// after:  '/files/docs/@remix-run/ui%3Fraw%23v1'
+```
+
+Hostname params are now validated so structural URL characters cannot change the URL authority when parsed. Hostname variables reject `.`, `@`, `:`, `/`, `?`, and `#`; hostname wildcards allow `.` to span labels but reject the other structural characters.
+
+```ts
+createHref('://:tenant.example.com/path', { tenant: 'acme.dev' })
+// before: 'https://acme%2Edev.example.com/path'
+// after:  throws CreateHrefError
+
+createHref('://*tenant.example.com/path', { tenant: 'preview.acme' })
+// before: 'https://preview.acme.example.com/path'
+// after:  'https://preview.acme.example.com/path'
+
+createHref('://*tenant.example.com/path', { tenant: 'preview:acme' })
+// before: 'https://preview%3Aacme.example.com/path'
+// after:  throws CreateHrefError
+```

--- a/packages/route-pattern/.changes/patch.escape-static-text.md
+++ b/packages/route-pattern/.changes/patch.escape-static-text.md
@@ -1,0 +1,27 @@
+Route pattern parsing now stores escaped static text without the escape marker
+
+Escaped pattern characters in static text are now parsed into text tokens that contain the literal character without the leading `\\`. Serialization keeps emitting the escape marker so the pattern string still round-trips as escaped static text.
+
+```ts
+let pattern = RoutePattern.parse('/docs/npm\\:@scope/package')
+
+pattern.pathname.tokens
+// before: [{ type: 'text', text: 'docs' }, { type: 'separator' }, { type: 'text', text: 'npm\\:' }, ...]
+// after:  [{ type: 'text', text: 'docs' }, { type: 'separator' }, { type: 'text', text: 'npm:' }, ...]
+
+pattern.toString()
+// before: '/docs/npm\\:@scope/package'
+// after:  '/docs/npm\\:@scope/package'
+```
+
+```ts
+let pattern = RoutePattern.parse('/files/report-\\(final\\).pdf')
+
+pattern.pathname.tokens
+// before: text tokens included '\\(' and '\\)'
+// after:  text tokens include '(' and ')'
+
+pattern.toString()
+// before: '/files/report-\\(final\\).pdf'
+// after:  '/files/report-\\(final\\).pdf'
+```

--- a/packages/route-pattern/README.md
+++ b/packages/route-pattern/README.md
@@ -55,15 +55,13 @@ createHref('http(s)://:region.cdn.com/assets/*file.:ext', {
 
 ## API at a glance
 
-**remix/route-pattern** - Parse and stringify patterns.
-
-**remix/route-pattern/href** - Generate hrefs for patterns with type safe params.
-
-**remix/route-pattern/match** - Match against one pattern with type inference for params. Or match against many patterns with deterministic ranking and attached data.
-
-**remix/route-pattern/join** - Combine two patterns into one. Override protocol, hostname, port. Join pathnames. Merge search constraints.
-
-**remix/route-pattern/specificity** - Rank matches by [specificity](#ranking-matches-by-specificity).
+| Import | Description |
+| --- | --- |
+| `remix/route-pattern` | Parse and stringify patterns. |
+| `remix/route-pattern/href` | Generate hrefs for patterns with type safe params. |
+| `remix/route-pattern/match` | Match against one pattern with type inference for params, or match against many patterns with deterministic ranking and attached data. |
+| `remix/route-pattern/join` | Combine two patterns into one. Override protocol, hostname, port. Join pathnames. Merge search constraints. |
+| `remix/route-pattern/specificity` | Rank matches by [specificity](#ranking-matches-by-specificity). |
 
 For in-depth reference, visit the [`route-pattern` API docs](https://api.remix.run/api/remix/route-pattern)
 
@@ -111,6 +109,15 @@ While variables, wilcards, and optionals are most prevalent in pathnames, you ca
 '(www.)example.com/blog/:slug(.html)' // matches example.com/blog/hello, www.example.com/blog/hello.html
 '*.example.com/files/*path' // matches cdn.example.com/files/images/logo.png
 '(:locale.)example.com/docs(/:section)' // matches en.example.com/docs, en.example.com/docs/guides
+```
+
+**Escape characters** with `\`:
+
+```ts
+'time/12\\:30' // matches /time/12:30
+'calculator/2\\*3' // matches /calculator/2*3
+'wiki/Mercury_\\(planet\\)' // matches /wiki/Mercury_(planet)
+'wiki/AC\\/DC' // matches /wiki/AC%2FDC
 ```
 
 ### Search

--- a/packages/route-pattern/src/lib/href.test.ts
+++ b/packages/route-pattern/src/lib/href.test.ts
@@ -95,6 +95,28 @@ describe('createHref', () => {
     it('includes optional with static content', () => {
       assert.equal(createHref('://(www.)example.com/path'), 'https://www.example.com/path')
     })
+
+    it('rejects structural URL chars and `.` in hostname variables', () => {
+      assert.throws(
+        () => createHref('://:tenant.example.com/path', { tenant: 'acme.dev' }),
+        hrefError('invalid-hostname-variable'),
+      )
+      assert.throws(
+        () => createHref('://:tenant.example.com/path', { tenant: 'acme:staging' }),
+        hrefError('invalid-hostname-variable'),
+      )
+    })
+
+    it('allows `.` but rejects structural URL chars in hostname wildcards', () => {
+      assert.equal(
+        createHref('://*tenant.example.com/path', { tenant: 'preview.acme' }),
+        'https://preview.acme.example.com/path',
+      )
+      assert.throws(
+        () => createHref('://*tenant.example.com/path', { tenant: 'preview:acme' }),
+        hrefError('invalid-hostname-wildcard'),
+      )
+    })
   })
 
   describe('port', () => {
@@ -188,6 +210,20 @@ describe('createHref', () => {
           postId: '123',
         }),
         '/en/users/42/en/posts/123',
+      )
+    })
+
+    it('encodes structural URL chars including `/` for variables', () => {
+      assert.equal(
+        createHref('/posts/:slug', { slug: 'hello/world?draft=true#preview' }),
+        '/posts/hello%2Fworld%3Fdraft=true%23preview',
+      )
+    })
+
+    it('encodes structural URL chars except `/` for wildcards', () => {
+      assert.equal(
+        createHref('/files/*path', { path: 'docs/@remix-run/ui?raw#v1' }),
+        '/files/docs/@remix-run/ui%3Fraw%23v1',
       )
     })
   })

--- a/packages/route-pattern/src/lib/href.ts
+++ b/packages/route-pattern/src/lib/href.ts
@@ -123,7 +123,13 @@ function hrefPart(
         i = part.optionals.get(frame.begin!)! + 1
         continue
       }
-      stack[stack.length - 1].href += typeof value === 'string' ? value : String(value)
+      // prettier-ignore
+      stack[stack.length - 1].href +=
+        part.type === 'pathname' && token.type === ':' ? encodePathnameVariable(value) :
+        part.type === 'pathname' && token.type === '*' ? encodePathnameWildcard(value) :
+        part.type === 'hostname' && token.type === ':' ? validateHostnameVariable(value) :
+        part.type === 'hostname' && token.type === '*' ? validateHostnameWildcard(value) :
+        unreachable()
       i += 1
       continue
     }
@@ -186,6 +192,16 @@ type CreateHrefErrorDetails =
       params: Record<string, unknown>
     }
   | { type: 'nameless-wildcard'; pattern: RoutePattern }
+  | {
+      type: 'invalid-hostname-variable'
+      value: string
+      char: string
+    }
+  | {
+      type: 'invalid-hostname-wildcard'
+      value: string
+      char: string
+    }
 
 /** Error thrown when a route pattern cannot generate an href from the supplied args. */
 export class CreateHrefError extends Error {
@@ -198,21 +214,99 @@ export class CreateHrefError extends Error {
   }
 
   static message(details: CreateHrefErrorDetails): string {
-    let pattern = details.pattern.toString()
-
     if (details.type === 'missing-hostname') {
-      return `pattern requires hostname\n\nPattern: ${pattern}`
+      return `pattern requires hostname\n\nPattern: ${details.pattern}`
     }
 
     if (details.type === 'nameless-wildcard') {
-      return `pattern contains nameless wildcard\n\nPattern: ${pattern}`
+      return `pattern contains nameless wildcard\n\nPattern: ${details.pattern}`
     }
 
     if (details.type === 'missing-params') {
       let params = details.missingParams.map((p) => `'${p}'`).join(', ')
-      return `missing param(s): ${params}\n\nPattern: ${pattern}\nParams: ${JSON.stringify(details.params)}`
+      return `missing param(s): ${params}\n\nPattern: ${details.pattern}\nParams: ${JSON.stringify(details.params)}`
+    }
+
+    if (details.type === 'invalid-hostname-variable') {
+      return `invalid hostname variable param: ${JSON.stringify(details.value)} contains ${JSON.stringify(details.char)}`
+    }
+
+    if (details.type === 'invalid-hostname-wildcard') {
+      return `invalid hostname wildcard param: ${JSON.stringify(details.value)} contains ${JSON.stringify(details.char)}`
     }
 
     unreachable(details)
   }
+}
+
+export function encodePathnameVariable(value: unknown) {
+  return encodePathnameSegment(String(value))
+}
+
+export function encodePathnameWildcard(value: unknown) {
+  return String(value).split('/').map(encodePathnameSegment).join('/')
+}
+
+/**
+ * Keep pathname params from changing URL structure when parsed. `/`, `?`, and `#` are
+ * path/query/fragment delimiters; `%` begins percent-encoded bytes; and `\\` is treated as a
+ * path separator by special URL parsing.
+ *
+ * @see https://url.spec.whatwg.org/#path-percent-encode-set
+ * @see https://url.spec.whatwg.org/#percent-encoded-bytes
+ */
+const PATHNAME_PARAM_STRUCTURAL_CHARS: Record<string, string> = {
+  '/': '%2F',
+  '?': '%3F',
+  '#': '%23',
+  '%': '%25',
+  '\\': '%5C',
+}
+
+function encodePathnameSegment(value: string): string {
+  let encoded = ''
+  for (let char of value) {
+    let encodedChar = PATHNAME_PARAM_STRUCTURAL_CHARS[char]
+    encoded += encodedChar === undefined ? char : encodedChar
+  }
+  return encoded
+}
+
+/**
+ * Keep hostname params from changing URL authority structure when parsed. `@` ends userinfo,
+ * `:` starts the port, and `/`, `?`, and `#` start the path, query, and fragment. Hostname
+ * variables also reject `.` because dots separate host labels; hostname wildcards allow `.` to
+ * span labels intentionally.
+ *
+ * @see https://url.spec.whatwg.org/#authority-state
+ * @see https://url.spec.whatwg.org/#host-parsing
+ */
+const HOSTNAME_PARAM_STRUCTURAL_CHARS = ['@', ':', '/', '?', '#']
+
+export function validateHostnameVariable(value: unknown): string {
+  let serialized = String(value)
+  for (let char of serialized) {
+    if (char === '.' || HOSTNAME_PARAM_STRUCTURAL_CHARS.includes(char)) {
+      throw new CreateHrefError({
+        type: 'invalid-hostname-variable',
+        value: serialized,
+        char,
+      })
+    }
+  }
+  return serialized
+}
+
+export function validateHostnameWildcard(value: unknown): string {
+  let serialized = String(value)
+  for (let char of serialized) {
+    if (HOSTNAME_PARAM_STRUCTURAL_CHARS.includes(char)) {
+      throw new CreateHrefError({
+        type: 'invalid-hostname-wildcard',
+        value: serialized,
+        char,
+      })
+    }
+  }
+  return serialized
 }

--- a/packages/route-pattern/src/lib/match.test.ts
+++ b/packages/route-pattern/src/lib/match.test.ts
@@ -653,6 +653,30 @@ describe('Matcher', () => {
       })
     })
 
+    describe('escaping', () => {
+      describe('hostname', () => {
+        it('matches escaped special chars in static text', () => {
+          let matcher = createMultiMatcher<null>()
+          matcher.add('://a\\*b.c\\(d\\).example.com/users', null)
+
+          let match = matcher.match('https://a*b.c(d).example.com/users')
+          assert.ok(match)
+          assert.deepEqual(match.params, {})
+        })
+      })
+
+      describe('pathname', () => {
+        it('matches escaped special chars in static text', () => {
+          let matcher = createMultiMatcher<null>()
+          matcher.add('/a\\:b/c\\*d/e\\(f\\)/g\\\\h', null)
+
+          let match = matcher.match('https://example.com/a%3Ab/c*d/e(f)/g%5Ch')
+          assert.ok(match)
+          assert.deepEqual(match.params, {})
+        })
+      })
+    })
+
     describe('codec', () => {
       // Unlike pathname params, hostname labels can't use the emoji, zwj,
       // nbsp, or fullwidth cases; see:

--- a/packages/route-pattern/src/lib/match.test.ts
+++ b/packages/route-pattern/src/lib/match.test.ts
@@ -1,6 +1,7 @@
 import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
+import { createHref } from './href.ts'
 import { createMultiMatcher } from './match.ts'
 
 describe('Matcher', () => {
@@ -308,6 +309,13 @@ describe('Matcher', () => {
         matcher.add('://example.com/users', null)
 
         assert.equal(matcher.match('http://example.com/posts'), null)
+      })
+
+      it('does not match encoded slashes as pathname separators', () => {
+        let matcher = createMultiMatcher<null>()
+        matcher.add('://example.com/files/:dir/:name', null)
+
+        assert.equal(matcher.match('http://example.com/files/docs%2Freadme.md'), null)
       })
 
       it('returns null when URL is shorter than pattern', () => {
@@ -815,6 +823,56 @@ describe('Matcher', () => {
         assert.equal(match.paramsMeta.pathname.length, 1)
         assert.equal(match.paramsMeta.pathname[0].name, 'version')
         assert.equal(match.paramsMeta.pathname[0].value, 'v1')
+      })
+    })
+
+    describe('roundtrip with createHref', () => {
+      it('matches pathname variables with structural URL chars encoded by createHref', () => {
+        let matcher = createMultiMatcher<null>()
+        let pattern = '://example.com/posts/:slug' as const
+        matcher.add(pattern, null)
+
+        let href = createHref(pattern, { slug: 'hello/world?draft=true#preview' })
+        let match = matcher.match(href)
+
+        assert.ok(match)
+        assert.deepEqual(match.params, { slug: 'hello/world?draft=true#preview' })
+      })
+
+      it('matches pathname wildcards with structural URL chars encoded by createHref', () => {
+        let matcher = createMultiMatcher<null>()
+        let pattern = '://example.com/files/*path' as const
+        matcher.add(pattern, null)
+
+        let href = createHref(pattern, { path: 'docs/@remix-run/ui?raw#v1' })
+        let match = matcher.match(href)
+
+        assert.ok(match)
+        assert.deepEqual(match.params, { path: 'docs/@remix-run/ui?raw#v1' })
+      })
+
+      it('matches hostname variables with params validated by createHref', () => {
+        let matcher = createMultiMatcher<null>()
+        let pattern = '://:tenant.example.com/path' as const
+        matcher.add(pattern, null)
+
+        let href = createHref(pattern, { tenant: 'acme-staging' })
+        let match = matcher.match(href)
+
+        assert.ok(match)
+        assert.deepEqual(match.params, { tenant: 'acme-staging' })
+      })
+
+      it('matches hostname wildcards with params validated by createHref', () => {
+        let matcher = createMultiMatcher<null>()
+        let pattern = '://*tenant.example.com/path' as const
+        matcher.add(pattern, null)
+
+        let href = createHref(pattern, { tenant: 'preview.acme' })
+        let match = matcher.match(href)
+
+        assert.ok(match)
+        assert.deepEqual(match.params, { tenant: 'preview.acme' })
       })
     })
 

--- a/packages/route-pattern/src/lib/match.test.ts
+++ b/packages/route-pattern/src/lib/match.test.ts
@@ -166,7 +166,7 @@ describe('Matcher', () => {
         assert.deepEqual(match.params, { sub: 'api', version: 'v2', tld: 'dev' })
       })
 
-      it('matches mixed static/variable/wildcard segments', () => {
+      it('matches mixed static/variable/wildcards', () => {
         let matcher = createMultiMatcher<null>()
         matcher.add('://*prefix.:env.example.com/api', null)
 
@@ -303,7 +303,7 @@ describe('Matcher', () => {
         assert.equal(matcher.match('http://example.com/users/'), null)
       })
 
-      it('matches variable segments', () => {
+      it('matches variables', () => {
         let matcher = createMultiMatcher<null>()
         matcher.add('://example.com/users/:id', null)
 
@@ -330,14 +330,14 @@ describe('Matcher', () => {
         assert.deepEqual(match.params, { filename: 'my-file_v2.txt' })
       })
 
-      it('does not partially match variable segments after a static suffix', () => {
+      it('does not partially match variables after a static suffix', () => {
         let matcher = createMultiMatcher<null>()
         matcher.add('://example.com/files/report-:format.pdf', null)
 
         assert.equal(matcher.match('http://example.com/files/report-json.pdf.backup'), null)
       })
 
-      it('matches wildcard segments', () => {
+      it('matches wildcards', () => {
         let matcher = createMultiMatcher<null>()
         matcher.add('://example.com/files/*path', null)
 
@@ -355,7 +355,7 @@ describe('Matcher', () => {
         assert.deepEqual(match.params, { path: 'docs/api' })
       })
 
-      it('does not partially match wildcard segments before a static suffix', () => {
+      it('does not partially match wildcards before a static suffix', () => {
         let matcher = createMultiMatcher<null>()
         matcher.add('://example.com/files/*path/status', null)
 
@@ -428,7 +428,7 @@ describe('Matcher', () => {
         assert.deepEqual(match2.params, { id: 'doc123', format: undefined })
       })
 
-      it('matches mixed static/variable/wildcard segments', () => {
+      it('matches mixed static/variable/wildcards', () => {
         let matcher = createMultiMatcher<null>()
         matcher.add('://example.com/api/:version/files/*path', null)
 
@@ -708,7 +708,18 @@ describe('Matcher', () => {
           'ｗｉｄｅ', // fullwidth
         ]
 
-        it('decodes percent-encoded Unicode variable segments', () => {
+        it('matches percent-encoded Unicode static segments', () => {
+          for (let value of pathnameCodec) {
+            let matcher = createMultiMatcher<null>()
+            matcher.add(`://example.com/${value}`, null)
+
+            let url = new URL(`https://example.com/${value}`)
+            let match = matcher.match(url.href)
+            assert.deepEqual(match?.params, {})
+          }
+        })
+
+        it('decodes percent-encoded Unicode variables', () => {
           for (let value of pathnameCodec) {
             let matcher = createMultiMatcher<null>()
             matcher.add('://example.com/:value', null)
@@ -719,7 +730,7 @@ describe('Matcher', () => {
           }
         })
 
-        it('decodes percent-encoded Unicode wildcard segments', () => {
+        it('decodes percent-encoded Unicode wildcards', () => {
           for (let value of pathnameCodec) {
             let matcher = createMultiMatcher<null>()
             matcher.add('://example.com/files/*path', null)
@@ -730,11 +741,74 @@ describe('Matcher', () => {
           }
         })
 
+        it('normalizes percent-encoded ASCII in static segments', () => {
+          let matcher = createMultiMatcher<null>()
+          matcher.add('://example.com/a', null)
+
+          let match = matcher.match('https://example.com/%61')
+          assert.deepEqual(match?.params, {})
+        })
+
+        it('treats raw and percent-encoded URL path-safe static text as equivalent', () => {
+          let matcher = createMultiMatcher<null>()
+          matcher.add('/packages/@scope+name,semi;equals=/file', null)
+
+          assert.deepEqual(
+            matcher.match('https://example.com/packages/@scope+name,semi;equals=/file')?.params,
+            {},
+          )
+          assert.deepEqual(
+            matcher.match('https://example.com/packages/%40scope%2Bname%2Csemi%3Bequals%3D/file')
+              ?.params,
+            {},
+          )
+        })
+
+        it('decodes percent-encoded ASCII in variables', () => {
+          let matcher = createMultiMatcher<null>()
+          matcher.add('://example.com/:value', null)
+
+          let match = matcher.match('https://example.com/%61')
+          assert.deepEqual(match?.params, { value: 'a' })
+        })
+
+        it('decodes percent-encoded ASCII in wildcards', () => {
+          let matcher = createMultiMatcher<null>()
+          matcher.add('://example.com/files/*path', null)
+
+          let match = matcher.match('https://example.com/files/%61')
+          assert.deepEqual(match?.params, { path: 'a' })
+        })
+
         it('does not match encoded slashes as pathname separators', () => {
           let matcher = createMultiMatcher<null>()
           matcher.add('://example.com/files/:dir/:name', null)
 
           assert.equal(matcher.match('http://example.com/files/docs%2Freadme.md'), null)
+        })
+
+        it('decodes encoded slashes in variables', () => {
+          let matcher = createMultiMatcher<null>()
+          matcher.add('://example.com/files/:name', null)
+
+          let match = matcher.match('https://example.com/files/docs%2Freadme.md')
+          assert.deepEqual(match?.params, { name: 'docs/readme.md' })
+        })
+
+        it('decodes encoded slashes in wildcards with continuation', () => {
+          let matcher = createMultiMatcher<null>()
+          matcher.add('://example.com/files/*path/status', null)
+
+          let match = matcher.match('https://example.com/files/docs%2Freadme.md/status')
+          assert.deepEqual(match?.params, { path: 'docs/readme.md' })
+        })
+
+        it('decodes structural slashes in wildcards with continuation', () => {
+          let matcher = createMultiMatcher<null>()
+          matcher.add('://example.com/files/*path/status', null)
+
+          let match = matcher.match('https://example.com/files/docs/readme.md/status')
+          assert.deepEqual(match?.params, { path: 'docs/readme.md' })
         })
 
         it('decodes structural URL chars in variables encoded by createHref', () => {

--- a/packages/route-pattern/src/lib/match.test.ts
+++ b/packages/route-pattern/src/lib/match.test.ts
@@ -78,28 +78,6 @@ describe('Matcher', () => {
         assert.deepEqual(match.params, {})
       })
 
-      it('matches non-ASCII hostname param values', () => {
-        let matcher = createMultiMatcher<null>()
-        matcher.add('://:accented.:cjk.:rtl.:combining.example.com/users', null)
-
-        let params = {
-          // Unlike pathname params, hostname labels can't use the emoji, zwj,
-          // nbsp, or fullwidth cases; see:
-          // https://unicode.org/reports/tr46/#Validity_Criteria
-          accented: 'café',
-          cjk: '北京',
-          rtl: 'مرحبا',
-          combining: 'hà-nội',
-        }
-        let url = new URL(
-          `https://${params.accented}.${params.cjk}.${params.rtl}.${params.combining}.example.com/users`,
-        )
-
-        let match = matcher.match(url.href)
-        assert.ok(match)
-        assert.deepEqual(match.params, params)
-      })
-
       it('returns null when static hostname does not match', () => {
         let matcher = createMultiMatcher<null>()
         matcher.add('://example.com/users', null)
@@ -311,13 +289,6 @@ describe('Matcher', () => {
         assert.equal(matcher.match('http://example.com/posts'), null)
       })
 
-      it('does not match encoded slashes as pathname separators', () => {
-        let matcher = createMultiMatcher<null>()
-        matcher.add('://example.com/files/:dir/:name', null)
-
-        assert.equal(matcher.match('http://example.com/files/docs%2Freadme.md'), null)
-      })
-
       it('returns null when URL is shorter than pattern', () => {
         let matcher = createMultiMatcher<null>()
         matcher.add('://example.com/users/list', null)
@@ -364,32 +335,6 @@ describe('Matcher', () => {
         matcher.add('://example.com/files/report-:format.pdf', null)
 
         assert.equal(matcher.match('http://example.com/files/report-json.pdf.backup'), null)
-      })
-
-      it('matches non-ASCII param values', () => {
-        let matcher = createMultiMatcher<null>()
-        matcher.add(
-          '://example.com/:accented/:cjk/:rtl/:combining/:emoji/:zwj/:nbsp/:fullwidth',
-          null,
-        )
-
-        let params = {
-          accented: 'café',
-          cjk: '北京-とうきょう-서울',
-          rtl: 'مرحبا-עולם',
-          combining: 'Hà-Nội',
-          emoji: '💿',
-          zwj: '🧑‍🚀', // 🚀 + zero-width joiner + 👨
-          nbsp: 'acme\u00A0corp',
-          fullwidth: 'ｗｉｄｅ',
-        }
-        let url = new URL(
-          `https://example.com/${params.accented}/${params.cjk}/${params.rtl}/${params.combining}/${params.emoji}/${params.zwj}/${params.nbsp}/${params.fullwidth}`,
-        )
-
-        let match = matcher.match(url.href)
-        assert.ok(match)
-        assert.deepEqual(match.params, params)
       })
 
       it('matches wildcard segments', () => {
@@ -619,14 +564,6 @@ describe('Matcher', () => {
         assert.ok(match)
       })
 
-      it('preserves URL encoding in search parameter values', () => {
-        let matcher = createMultiMatcher<null>()
-        matcher.add('://example.com/search?q=hello%20world', null)
-
-        let match = matcher.match('http://example.com/search?q=hello%20world')
-        assert.ok(match)
-      })
-
       it('matches repeated parameter values', () => {
         let matcher = createMultiMatcher<null>()
         matcher.add('://example.com/filter?tags', null)
@@ -713,6 +650,126 @@ describe('Matcher', () => {
         let matcher = createMultiMatcher<null>()
         matcher.add('/Posts/:id', null)
         assert.equal(matcher.match('https://example.com/posts/123'), null)
+      })
+    })
+
+    describe('codec', () => {
+      // Unlike pathname params, hostname labels can't use the emoji, zwj,
+      // nbsp, or fullwidth cases; see:
+      // https://unicode.org/reports/tr46/#Validity_Criteria
+      let hostnameCodec = [
+        'café', // accented
+        '北京-とうきょう-서울', // cjk
+        /* rtl */ 'مرحبا-עולם',
+        'Hà-Nội', // combining
+      ]
+
+      describe('hostname', () => {
+        it('matches punycode-encoded Unicode static labels', () => {
+          for (let value of Object.values(hostnameCodec)) {
+            let matcher = createMultiMatcher<null>()
+            matcher.add(`://${value}.example.com/users`, null)
+
+            let url = new URL(`https://${value}.example.com/users`)
+            let match = matcher.match(url.href)
+            assert.deepEqual(match?.params, {})
+          }
+        })
+
+        it('decodes punycode-encoded Unicode variable labels', () => {
+          for (let value of Object.values(hostnameCodec)) {
+            let matcher = createMultiMatcher<null>()
+            matcher.add('://:value.example.com/users', null)
+
+            let url = new URL(`https://${value}.example.com/users`)
+            let match = matcher.match(url.href)
+            assert.deepEqual(match?.params, { value: value.toLowerCase() })
+          }
+        })
+
+        it('decodes punycode-encoded Unicode wildcard labels', () => {
+          for (let value of Object.values(hostnameCodec)) {
+            let matcher = createMultiMatcher<null>()
+            matcher.add('://*host.example.com/users', null)
+
+            let url = new URL(`https://${value}.example.com/users`)
+            let match = matcher.match(url.href)
+            assert.deepEqual(match?.params, { host: value.toLowerCase() })
+          }
+        })
+      })
+
+      describe('pathname', () => {
+        let pathnameCodec = [
+          ...hostnameCodec,
+          '💿', // emoji
+          '🧑‍🚀', // zwj (🚀 + zero-width joiner + 👨)
+          'acme\u00A0corp', // nbsp
+          'ｗｉｄｅ', // fullwidth
+        ]
+
+        it('decodes percent-encoded Unicode variable segments', () => {
+          for (let value of pathnameCodec) {
+            let matcher = createMultiMatcher<null>()
+            matcher.add('://example.com/:value', null)
+
+            let url = new URL(`https://example.com/${value}`)
+            let match = matcher.match(url.href)
+            assert.deepEqual(match?.params, { value })
+          }
+        })
+
+        it('decodes percent-encoded Unicode wildcard segments', () => {
+          for (let value of pathnameCodec) {
+            let matcher = createMultiMatcher<null>()
+            matcher.add('://example.com/files/*path', null)
+
+            let url = new URL(`https://example.com/files/${value}`)
+            let match = matcher.match(url.href)
+            assert.deepEqual(match?.params, { path: value })
+          }
+        })
+
+        it('does not match encoded slashes as pathname separators', () => {
+          let matcher = createMultiMatcher<null>()
+          matcher.add('://example.com/files/:dir/:name', null)
+
+          assert.equal(matcher.match('http://example.com/files/docs%2Freadme.md'), null)
+        })
+
+        it('decodes structural URL chars in variables encoded by createHref', () => {
+          let matcher = createMultiMatcher<null>()
+          let pattern = '://example.com/posts/:slug' as const
+          matcher.add(pattern, null)
+
+          let slug = 'hello/world?draft=true#preview'
+          let href = createHref(pattern, { slug })
+          let match = matcher.match(href)
+
+          assert.deepEqual(match?.params, { slug })
+        })
+
+        it('decodes structural URL chars in wildcards encoded by createHref', () => {
+          let matcher = createMultiMatcher<null>()
+          let pattern = '://example.com/files/*path' as const
+          matcher.add(pattern, null)
+
+          let path = 'docs/@remix-run/ui?raw#v1'
+          let href = createHref(pattern, { path })
+          let match = matcher.match(href)
+
+          assert.deepEqual(match?.params, { path })
+        })
+      })
+
+      describe('search', () => {
+        it('preserves URL encoding in parameter values', () => {
+          let matcher = createMultiMatcher<null>()
+          matcher.add('://example.com/search?q=hello%20world', null)
+
+          let match = matcher.match('http://example.com/search?q=hello%20world')
+          assert.ok(match)
+        })
       })
     })
 
@@ -823,56 +880,6 @@ describe('Matcher', () => {
         assert.equal(match.paramsMeta.pathname.length, 1)
         assert.equal(match.paramsMeta.pathname[0].name, 'version')
         assert.equal(match.paramsMeta.pathname[0].value, 'v1')
-      })
-    })
-
-    describe('roundtrip with createHref', () => {
-      it('matches pathname variables with structural URL chars encoded by createHref', () => {
-        let matcher = createMultiMatcher<null>()
-        let pattern = '://example.com/posts/:slug' as const
-        matcher.add(pattern, null)
-
-        let href = createHref(pattern, { slug: 'hello/world?draft=true#preview' })
-        let match = matcher.match(href)
-
-        assert.ok(match)
-        assert.deepEqual(match.params, { slug: 'hello/world?draft=true#preview' })
-      })
-
-      it('matches pathname wildcards with structural URL chars encoded by createHref', () => {
-        let matcher = createMultiMatcher<null>()
-        let pattern = '://example.com/files/*path' as const
-        matcher.add(pattern, null)
-
-        let href = createHref(pattern, { path: 'docs/@remix-run/ui?raw#v1' })
-        let match = matcher.match(href)
-
-        assert.ok(match)
-        assert.deepEqual(match.params, { path: 'docs/@remix-run/ui?raw#v1' })
-      })
-
-      it('matches hostname variables with params validated by createHref', () => {
-        let matcher = createMultiMatcher<null>()
-        let pattern = '://:tenant.example.com/path' as const
-        matcher.add(pattern, null)
-
-        let href = createHref(pattern, { tenant: 'acme-staging' })
-        let match = matcher.match(href)
-
-        assert.ok(match)
-        assert.deepEqual(match.params, { tenant: 'acme-staging' })
-      })
-
-      it('matches hostname wildcards with params validated by createHref', () => {
-        let matcher = createMultiMatcher<null>()
-        let pattern = '://*tenant.example.com/path' as const
-        matcher.add(pattern, null)
-
-        let href = createHref(pattern, { tenant: 'preview.acme' })
-        let match = matcher.match(href)
-
-        assert.ok(match)
-        assert.deepEqual(match.params, { tenant: 'preview.acme' })
       })
     })
 

--- a/packages/route-pattern/src/lib/match/decode.ts
+++ b/packages/route-pattern/src/lib/match/decode.ts
@@ -1,19 +1,1 @@
 export { toUnicode as decodeHostname } from './punycode.ts'
-
-/**
- * Decodes valid percent-escape sequences, or returns the input unchanged when
- * it contains invalid ones.
- *
- * @param source String to decode.
- * @returns Decoded string, or `source` when it contains invalid percent-escape sequences.
- */
-export function decodePathname(source: string): string {
-  // coarse check for percent-encoded sequences; skip if none found.
-  if (!source.includes('%')) return source
-
-  try {
-    return decodeURI(source)
-  } catch {
-    return source
-  }
-}

--- a/packages/route-pattern/src/lib/match/trie.ts
+++ b/packages/route-pattern/src/lib/match/trie.ts
@@ -1,5 +1,5 @@
 import type { RoutePattern } from '../route-pattern.ts'
-import { decodeHostname, decodePathname } from './decode.ts'
+import { decodeHostname } from './decode.ts'
 import { generateVariants, type Param } from './variant.ts'
 import { unreachable } from '../unreachable.ts'
 
@@ -149,7 +149,7 @@ export class Trie<data = unknown> {
     }
 
     let results: Array<Match<string, data>> = []
-    let urlSegments = decodePathname(url.pathname.slice(1)).split('/')
+    let urlSegments = url.pathname.slice(1).split('/')
 
     for (let origin of origins) {
       let stack: Array<{
@@ -173,7 +173,7 @@ export class Trie<data = unknown> {
               pathnameMatch.push({
                 type: param.type,
                 name: param.name,
-                value: cap.value,
+                value: decodeURIComponent(cap.value),
                 begin: cap.begin,
                 end: cap.end,
               })

--- a/packages/route-pattern/src/lib/match/trie.ts
+++ b/packages/route-pattern/src/lib/match/trie.ts
@@ -149,7 +149,7 @@ export class Trie<data = unknown> {
     }
 
     let results: Array<Match<string, data>> = []
-    let urlSegments = url.pathname.slice(1).split('/')
+    let urlSegments = url.pathname.slice(1).split('/').map(normalizePathnameText)
 
     for (let origin of origins) {
       let stack: Array<{
@@ -173,7 +173,7 @@ export class Trie<data = unknown> {
               pathnameMatch.push({
                 type: param.type,
                 name: param.name,
-                value: decodeURIComponent(cap.value),
+                value: fastDecodeURIComponent(cap.value),
                 begin: cap.begin,
                 end: cap.end,
               })
@@ -269,6 +269,19 @@ export class Trie<data = unknown> {
 
     return results
   }
+}
+
+// Pathname codec ----------------------------------------------------------------------------------
+
+// Pathname matching uses canonical percent-encoded text. URL pathnames are split on structural
+// "/" before normalization so encoded slashes like "%2F" remain data within a segment instead of
+// becoming separators. Pattern static text is encoded the same way when variants are generated.
+function normalizePathnameText(text: string): string {
+  return encodeURIComponent(fastDecodeURIComponent(text))
+}
+
+function fastDecodeURIComponent(text: string): string {
+  return text.includes('%') ? decodeURIComponent(text) : text
 }
 
 // Search ------------------------------------------------------------------------------------------

--- a/packages/route-pattern/src/lib/match/types.ts
+++ b/packages/route-pattern/src/lib/match/types.ts
@@ -10,7 +10,9 @@ export type MatchParamMeta = {
   type: ':' | '*'
   name: string
   value: string
+  /** Start offset after pathname is normalized. */
   begin: number
+  /** End offset after pathname is normalized. */
   end: number
 }
 

--- a/packages/route-pattern/src/lib/match/variant.ts
+++ b/packages/route-pattern/src/lib/match/variant.ts
@@ -153,8 +153,10 @@ function generatePathnameVariants(
       }
 
       if (token.type === 'text') {
-        key += token.text
-        reSource += escape(token.text)
+        // Encode to comply with URL pathname normalization in trie matcher
+        let text = encodeURIComponent(token.text)
+        key += text
+        reSource += escape(text)
         continue
       }
 

--- a/packages/route-pattern/src/lib/route-pattern/parse.ts
+++ b/packages/route-pattern/src/lib/route-pattern/parse.ts
@@ -102,9 +102,9 @@ export function parsePart(
       if (i + 1 === span[1]) {
         throw new ParseError('dangling escape', source, i)
       }
-      let text = source.slice(i, i + 2)
+      let text = source.slice(i + 1, i + 2)
       appendText(text)
-      i += text.length
+      i += 2
       continue
     }
 

--- a/packages/route-pattern/src/lib/route-pattern/serialize.test.ts
+++ b/packages/route-pattern/src/lib/route-pattern/serialize.test.ts
@@ -84,6 +84,11 @@ describe('serializeHostname', () => {
   it('preserves hostname structure', () => {
     assert.equal(hostnameOf('://:tenant.example.com'), ':tenant.example.com')
   })
+
+  it('escapes special chars in hostname text', () => {
+    let pattern = 'a\\:b.c\\*d.e\\(f\\).g\\\\h'
+    assert.equal(hostnameOf(`://${pattern}`), pattern)
+  })
 })
 
 describe('serializePort', () => {
@@ -123,6 +128,11 @@ describe('serializePathname', () => {
 
   it('emits nameless wildcard as bare *', () => {
     assert.equal(pathnameOf('*'), '*')
+  })
+
+  it('escapes special chars in pathname text', () => {
+    let pattern = 'a\\:b/c\\*d/e\\(f\\)/g\\\\h'
+    assert.equal(pathnameOf(`/${pattern}`), pattern)
   })
 })
 

--- a/packages/route-pattern/src/lib/route-pattern/serialize.ts
+++ b/packages/route-pattern/src/lib/route-pattern/serialize.ts
@@ -64,6 +64,10 @@ export function serializeSearch(pattern: RoutePattern): string {
   return searchParams.toString()
 }
 
+function escapeText(text: string): string {
+  return text.replaceAll(/[:*()\\]/g, '\\$&')
+}
+
 export function serializePart(part: PartPattern): string {
   let separator = part.type === 'hostname' ? '.' : '/'
   let result = ''
@@ -74,7 +78,7 @@ export function serializePart(part: PartPattern): string {
     }
 
     if (token.type === 'text') {
-      result += token.text
+      result += escapeText(token.text)
       continue
     }
 


### PR DESCRIPTION
# Generating hrefs

`createHref` now encodes pathname params and validates hostname params

Pathname params now encode characters that would otherwise change URL structure when parsed. Variables encode `/`, `?`, `#`, `%`, and `\\`; wildcards preserve `/` as a path separator but encode the other structural characters.

```ts
createHref('/posts/:slug', { slug: 'hello/world?draft=true#preview' })
// before: '/posts/hello/world?draft=true#preview'
// after:  '/posts/hello%2Fworld%3Fdraft=true%23preview'

createHref('/files/*path', { path: 'docs/@remix-run/ui?raw#v1' })
// before: '/files/docs/@remix-run/ui?raw#v1'
// after:  '/files/docs/@remix-run/ui%3Fraw%23v1'
```

Hostname params are now validated so structural URL characters cannot change the URL authority when parsed. Hostname variables reject `.`, `@`, `:`, `/`, `?`, and `#`; hostname wildcards allow `.` to span labels but reject the other structural characters.

```ts
createHref('://:tenant.example.com/path', { tenant: 'acme.dev' })
// before: 'https://acme%2Edev.example.com/path'
// after:  throws CreateHrefError

createHref('://*tenant.example.com/path', { tenant: 'preview.acme' })
// before: 'https://preview.acme.example.com/path'
// after:  'https://preview.acme.example.com/path'

createHref('://*tenant.example.com/path', { tenant: 'preview:acme' })
// before: 'https://preview%3Aacme.example.com/path'
// after:  throws CreateHrefError
```

### Benchmarks

Encoding + validation have overhead, but href generation is still <10µs for p99 and <50µs for p999 which is definitely Fast Enough™.

I tried out a couple different optimizations and had the agent iterate on it for a while, but everything added duplication/complexity. We can always explore optimizations again if this becomes a bottleneck, but seems very far from being a problem currently.

<img width="1789" height="1138" alt="Screenshot 2026-05-22 at 10 47 00 AM" src="https://github.com/user-attachments/assets/efb8fc30-2afe-4c12-aec9-eb8dc5aaf912" />

# Matching

Matchers now normalize percent-encoded pathname during matching

Pathname matching now uses the URL parser's normalized pathname, splits it into segments, and canonicalizes each segment as percent-encoded text before matching. This allows equivalent path text like `a` and `%61`, or `café` and `caf%C3%A9`, to match consistently:

```ts
let matcher = createMatcher('/a')

matcher.match('https://example.com/%61')
// before: null
// after:  { params: {} }
```

```ts
let matcher = createMatcher('/café')

matcher.match('https://example.com/caf%C3%A9')
// before: null
// after:  { params: {} }
```

Also keeps encoded path separators like `%2F` inside the segment where they appear instead of treating them as `/` separators during matching:

```ts
let matcher = createMatcher('/files/:dir/:name')

matcher.match('https://example.com/files/docs/readme.md')
// before: { params: { dir: 'docs', name: 'readme.md' } }
// after:  { params: { dir: 'docs', name: 'readme.md' } }

matcher.match('https://example.com/files/docs%2Freadme.md')
// before: { params: { dir: 'docs', name: 'readme.md' } }
// after:  null
```

Matched pathname params are still returned decoded.

```ts
let matcher = createMatcher('/posts/:slug')
let href = createHref('/posts/:slug', { slug: 'hello/world?draft=true#preview' })

matcher.match(`https://example.com${href}`)
// before: null
// after:  { params: { slug: 'hello/world?draft=true#preview' } }
```

### Benchmarks

Ignoring expected variance from `lambda` tests, there is a minor perf hit `server` matching benchmarks, but still matching well below 1ms:

<img width="747" height="1196" alt="Screenshot 2026-05-22 at 4 07 26 PM" src="https://github.com/user-attachments/assets/c402be73-cd1d-4958-8a9e-9be20587efed" />
