### PR TITLE
Add menu.contextTrigger() for right-click context menus

### DIFF
--- a/packages/remix/.changes/minor.ui.anchor-coordinate-target.md
+++ b/packages/remix/.changes/minor.ui.anchor-coordinate-target.md
@@ -1,0 +1,1 @@
+Updated `remix/ui/anchor` `anchor(floating, anchorTarget, options)` to accept either an `HTMLElement` or coordinate target via the new `AnchorPoint`/`AnchorTarget` types.

--- a/packages/remix/.changes/minor.ui.context-menu-trigger.md
+++ b/packages/remix/.changes/minor.ui.context-menu-trigger.md
@@ -1,0 +1,2 @@
+Added `remix/ui/menu` `menu.contextTrigger()` so menus can open from right-click pointer locations while keeping existing keyboard navigation, submenus, and selection behavior.
+Updated `remix/ui/anchor` `anchor(floating, anchorTarget, options)` to accept either an `HTMLElement` or coordinate target via the new `AnchorPoint`/`AnchorTarget` types, and added `remix/ui/menu` `menu.contextTrigger()` so menus can open from right-click pointer locations while keeping existing menu behavior.

--- a/packages/remix/src/ui/anchor/README.md
+++ b/packages/remix/src/ui/anchor/README.md
@@ -1,6 +1,6 @@
 # anchor
 
-`anchor` positions a floating element against an anchor element and keeps it constrained to the viewport. Use it for custom floating surfaces that need placement, flipping, offsets, and optional relative alignment.
+`anchor` positions a floating element against an anchor element or viewport coordinates and keeps it constrained to the viewport. Use it for custom floating surfaces that need placement, flipping, offsets, and optional relative alignment.
 
 ## Usage
 
@@ -49,11 +49,19 @@ popover.addEventListener('beforetoggle', (event) => {
 })
 ```
 
+Anchor to coordinates when the surface should open at a pointer location.
+
+```tsx
+let cleanup = anchor(popover, { x: event.clientX, y: event.clientY }, { placement: 'bottom-start' })
+```
+
 ## `anchor.*`
 
-- `anchor(floatingElement, anchorElement, options)`: positions `floatingElement` against `anchorElement`, starts animation-frame polling for geometry changes, and returns a cleanup function.
+- `anchor(floatingElement, anchorTarget, options)`: positions `floatingElement` against an element or coordinate target, starts animation-frame polling for geometry changes, and returns a cleanup function.
 - `AnchorOptions`: placement, inset, relative alignment, and offset options.
+- `AnchorPoint`: viewport coordinate target with `x`, `y`, and optional `width`/`height`.
 - `AnchorPlacement`: exported placement names for the main sides and top/bottom start/end alignment.
+- `AnchorTarget`: an `HTMLElement` or `AnchorPoint`.
 
 ## Placements
 
@@ -149,5 +157,5 @@ anchor(listbox, trigger, {
 - Oversized inset surfaces with `relativeTo` preserve alignment by scrolling the nearest scrollable descendant when possible.
 - `offset`, `offsetX`, and `offsetY` may be numbers or functions that receive the floating element.
 - `relativeTo` lets a surface align to an inner element, which is useful for selected options inside popovers.
-- `anchor` polls on animation frames for anchor or floating geometry changes and repositions when either changes.
+- `anchor` polls on animation frames for anchor target or floating geometry changes and repositions when either changes.
 - The returned cleanup function cancels animation-frame polling.

--- a/packages/remix/src/ui/menu/README.md
+++ b/packages/remix/src/ui/menu/README.md
@@ -68,6 +68,29 @@ Use `menuLabel` when the menu surface needs a different accessible label from th
 </Menu>
 ```
 
+Use `menu.contextTrigger()` with `menu.Context` and `MenuList` when a menu should open at the right-click location of an element.
+
+```tsx
+import * as menu from 'remix/ui/menu'
+import { MenuItem, MenuList } from 'remix/ui/menu'
+
+export function FileContextMenu(handle: Handle) {
+  return () => (
+    <menu.Context label="File actions">
+      <div mix={menu.contextTrigger()} tabIndex={0}>
+        File.txt
+      </div>
+      <MenuList>
+        <MenuItem name="rename">Rename</MenuItem>
+        <MenuItem name="delete">Delete</MenuItem>
+      </MenuList>
+    </menu.Context>
+  )
+}
+```
+
+Attach `onMenuSelect(...)` to `MenuList` or a shared ancestor when using lower-level context menu composition.
+
 ## `menu.*`
 
 - `Menu`: composed trigger, popover, and list component for the common menu case.
@@ -77,13 +100,14 @@ Use `menuLabel` when the menu surface needs a different accessible label from th
 - `onMenuSelect(...)`: event mixin for the bubbling `MenuSelectEvent`.
 - `MenuSelectEvent`: bubbling event class whose `item` describes the selected item.
 - `MenuSelectItem`: selected item shape with `checked`, `id`, `label`, `name`, `type`, and `value`.
-- `menu.Context`, `menu.trigger()`, `menu.popover()`, `menu.list()`, `menu.item(...)`, and `menu.submenuTrigger(...)`: lower-level composition primitives.
+- `menu.Context`, `menu.trigger()`, `menu.contextTrigger()`, `menu.popover()`, `menu.list()`, `menu.item(...)`, and `menu.submenuTrigger(...)`: lower-level composition primitives.
 - `buttonStyle`, `popoverStyle`, `listStyle`, `itemStyle`, `itemSlotStyle`, `itemLabelStyle`, `itemGlyphStyle`, and `triggerGlyphStyle`: flat style mixins used by the wrappers.
-- `MenuProps`, `MenuItemProps`, `MenuListProps`, `MenuProviderProps`, `MenuTriggerOptions`, `MenuItemOptions`, and `SubmenuProps`: public TypeScript props and option types.
+- `MenuProps`, `MenuItemProps`, `MenuListProps`, `MenuProviderProps`, `MenuTriggerOptions`, `MenuContextTriggerOptions`, `MenuItemOptions`, and `SubmenuProps`: public TypeScript props and option types.
 
 ## Behavior Notes
 
 - Click opens the root menu and focuses the list; clicking the trigger again closes it and restores focus.
+- `menu.contextTrigger()` opens the root menu from a `contextmenu` event at the pointer coordinates and supports keyboard opening with the Context Menu key or Shift+F10.
 - `ArrowDown` opens from the trigger at the first enabled item. `ArrowUp` opens at the last enabled item. Enter and Space open the menu with focus on the list.
 - Keyboard navigation skips disabled items and does not wrap past the first or last enabled item.
 - `Home` and `End` move to the first and last enabled item. Enter and Space activate the highlighted item.

--- a/packages/ui/.changes/minor.anchor-coordinate-target.md
+++ b/packages/ui/.changes/minor.anchor-coordinate-target.md
@@ -1,0 +1,1 @@
+Updated `anchor(floating, anchorTarget, options)` to accept either an `HTMLElement` or coordinate target via the new `AnchorPoint`/`AnchorTarget` types.

--- a/packages/ui/.changes/minor.context-menu-trigger.md
+++ b/packages/ui/.changes/minor.context-menu-trigger.md
@@ -1,0 +1,1 @@
+Added `menu.contextTrigger()` so menus can open from right-click pointer locations while keeping existing keyboard navigation, submenus, and selection behavior.

--- a/packages/ui/demo/app/examples/components/menu-context-trigger.tsx
+++ b/packages/ui/demo/app/examples/components/menu-context-trigger.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../../src/components/menu/demos/context-trigger.demo.tsx'

--- a/packages/ui/demo/app/examples/index.tsx
+++ b/packages/ui/demo/app/examples/index.tsx
@@ -73,6 +73,11 @@ const EXAMPLE_COPY_BY_SLUG = {
       '`onMenuSelect(...)` keeps action handling flexible at the item, menu, or app level.',
     title: 'Item and parent events',
   },
+  'menu-context-trigger': {
+    description:
+      '`menu.contextTrigger()` lets a menu open from right-click coordinates while reusing the existing menu list, items, submenus, and selection events.',
+    title: 'Context menu trigger',
+  },
   'start-here-theme': {
     description:
       'Theme is the shared value contract for spacing, color, typography, surfaces, and control sizing.',

--- a/packages/ui/demo/app/explorer/pages/component-menu.tsx
+++ b/packages/ui/demo/app/explorer/pages/component-menu.tsx
@@ -2,7 +2,11 @@ import { ExplorerExampleCard } from '../example-card.tsx'
 import { exampleGridCss, PageSection, pageStackCss } from '../page-primitives.tsx'
 import { EXAMPLES } from '../../examples/index.tsx'
 
-const menuExamples = [EXAMPLES.menuButtonOverview, EXAMPLES.menuButtonBubbling]
+const menuExamples = [
+  EXAMPLES.menuButtonOverview,
+  EXAMPLES.menuContextTrigger,
+  EXAMPLES.menuButtonBubbling,
+]
 
 export function renderComponentMenuPage() {
   return (

--- a/packages/ui/src/components/anchor/README.md
+++ b/packages/ui/src/components/anchor/README.md
@@ -1,6 +1,6 @@
 # anchor
 
-`anchor` positions a floating element against an anchor element and keeps it constrained to the viewport. Use it for custom floating surfaces that need placement, flipping, offsets, and optional relative alignment.
+`anchor` positions a floating element against an anchor element or viewport coordinates and keeps it constrained to the viewport. Use it for custom floating surfaces that need placement, flipping, offsets, and optional relative alignment.
 
 ## Usage
 
@@ -49,11 +49,19 @@ popover.addEventListener('beforetoggle', (event) => {
 })
 ```
 
+Anchor to coordinates when the surface should open at a pointer location.
+
+```tsx
+let cleanup = anchor(popover, { x: event.clientX, y: event.clientY }, { placement: 'bottom-start' })
+```
+
 ## `anchor.*`
 
-- `anchor(floatingElement, anchorElement, options)`: positions `floatingElement` against `anchorElement`, starts animation-frame polling for geometry changes, and returns a cleanup function.
+- `anchor(floatingElement, anchorTarget, options)`: positions `floatingElement` against an element or coordinate target, starts animation-frame polling for geometry changes, and returns a cleanup function.
 - `AnchorOptions`: placement, inset, relative alignment, and offset options.
+- `AnchorPoint`: viewport coordinate target with `x`, `y`, and optional `width`/`height`.
 - `AnchorPlacement`: exported placement names for the main sides and top/bottom start/end alignment.
+- `AnchorTarget`: an `HTMLElement` or `AnchorPoint`.
 
 ## Placements
 
@@ -149,5 +157,5 @@ anchor(listbox, trigger, {
 - Oversized inset surfaces with `relativeTo` preserve alignment by scrolling the nearest scrollable descendant when possible.
 - `offset`, `offsetX`, and `offsetY` may be numbers or functions that receive the floating element.
 - `relativeTo` lets a surface align to an inner element, which is useful for selected options inside popovers.
-- `anchor` polls on animation frames for anchor or floating geometry changes and repositions when either changes.
+- `anchor` polls on animation frames for anchor target or floating geometry changes and repositions when either changes.
 - The returned cleanup function cancels animation-frame polling.

--- a/packages/ui/src/components/anchor/anchor.test.ts
+++ b/packages/ui/src/components/anchor/anchor.test.ts
@@ -148,6 +148,21 @@ describe('anchor', () => {
     cleanup()
   })
 
+  it('positions a floating element from coordinates', () => {
+    let floating = document.createElement('div')
+    document.body.append(floating)
+
+    mockLayout(floating, { top: 0, left: 0, width: 120, height: 80 })
+
+    let cleanup = anchor(floating, { x: 200, y: 40 }, { placement: 'bottom-start' })
+
+    expect(floating.style.position).toBe('fixed')
+    expect(floating.style.top).toBe('40px')
+    expect(floating.style.left).toBe('200px')
+
+    cleanup()
+  })
+
   it('supports horizontal and vertical offsets independently', () => {
     let floating = document.createElement('div')
     let anchorElement = document.createElement('button')
@@ -339,6 +354,41 @@ describe('anchor', () => {
 
     expect(floating.style.top).toBe('420px')
     expect(floating.style.left).toBe('180px')
+
+    cleanup()
+  })
+
+  it('repositions when a coordinate target changes during animation-frame polling', () => {
+    let pollForPositionChanges: ((time: number) => void) | null = null
+    rafSpy.mock.restore!()
+    rafSpy = mock.method(globalThis, 'requestAnimationFrame', (callback) => {
+      pollForPositionChanges = callback
+      return 1
+    })
+
+    let floating = document.createElement('div')
+    let anchorPoint = { x: 200, y: 40 }
+    document.body.append(floating)
+
+    mockLayout(floating, { top: 0, left: 0, width: 120, height: 80 })
+
+    let cleanup = anchor(floating, anchorPoint, {
+      placement: 'bottom-start',
+    })
+
+    expect(floating.style.top).toBe('40px')
+    expect(floating.style.left).toBe('200px')
+
+    anchorPoint.x = 240
+    anchorPoint.y = 90
+    if (!pollForPositionChanges) {
+      throw new Error('Expected anchor() to schedule polling')
+    }
+
+    ;(pollForPositionChanges as (time: number) => void)(16)
+
+    expect(floating.style.top).toBe('90px')
+    expect(floating.style.left).toBe('240px')
 
     cleanup()
   })

--- a/packages/ui/src/components/anchor/anchor.ts
+++ b/packages/ui/src/components/anchor/anchor.ts
@@ -24,6 +24,15 @@ export type AnchorPlacement =
 
 type AnchorOffsetValue = number | ((floating: HTMLElement) => number)
 
+export interface AnchorPoint {
+  height?: number
+  width?: number
+  x: number
+  y: number
+}
+
+export type AnchorTarget = HTMLElement | AnchorPoint
+
 export type AnchorOptions = {
   placement?: ExtendedAnchorPlacement
   inset?: boolean
@@ -123,6 +132,39 @@ function resolveOffsetValue(offset: AnchorOffsetValue | undefined, floating: HTM
   }
 
   return offset ?? 0
+}
+
+function isAnchorPoint(value: unknown): value is AnchorPoint {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  if (!('x' in value) || !('y' in value)) {
+    return false
+  }
+
+  let width = 'width' in value ? value.width : undefined
+  let height = 'height' in value ? value.height : undefined
+
+  return (
+    typeof value.x === 'number' &&
+    typeof value.y === 'number' &&
+    (width === undefined || typeof width === 'number') &&
+    (height === undefined || typeof height === 'number')
+  )
+}
+
+function readAnchorRect(anchorTarget: AnchorTarget) {
+  if (anchorTarget instanceof HTMLElement) {
+    return anchorTarget.getBoundingClientRect()
+  }
+
+  return new DOMRect(
+    anchorTarget.x,
+    anchorTarget.y,
+    anchorTarget.width ?? 0,
+    anchorTarget.height ?? 0,
+  )
 }
 
 function calculatePosition(
@@ -468,7 +510,7 @@ function getFlippedPlacement(
   placementHeight: number,
   collisionWidth: number,
   collisionHeight: number,
-  anchor: HTMLElement,
+  anchorIsAbsolutePositioned: boolean,
   inset: boolean,
   offset: number,
   offsetX: number,
@@ -476,11 +518,9 @@ function getFlippedPlacement(
   relativeOffsetX?: number | null,
   relativeOffsetY?: number | null,
 ) {
-  let computedStyle = getComputedStyle(anchor)
-  let isAbsolutePositioned = computedStyle.position !== 'fixed'
   let hasScroll = window.scrollY > 0
 
-  if (placement.startsWith('top') && isAbsolutePositioned && hasScroll) {
+  if (placement.startsWith('top') && anchorIsAbsolutePositioned && hasScroll) {
     if (anchorRect.top - placementHeight < 0) {
       return placement
     }
@@ -641,7 +681,7 @@ function solveRelativeAlignmentAxis(options: {
 
 export function anchor(
   floating: HTMLElement,
-  anchorElement: HTMLElement,
+  anchorTarget: AnchorTarget,
   options: AnchorOptions = {},
 ): () => void {
   let lastAnchorRect: DOMRect
@@ -651,8 +691,8 @@ export function anchor(
     throw new TypeError('anchor() expected a floating HTMLElement')
   }
 
-  if (!(anchorElement instanceof HTMLElement)) {
-    throw new TypeError('anchor() expected an anchor HTMLElement')
+  if (!(anchorTarget instanceof HTMLElement) && !isAnchorPoint(anchorTarget)) {
+    throw new TypeError('anchor() expected an anchor HTMLElement or coordinates')
   }
 
   let {
@@ -664,12 +704,13 @@ export function anchor(
     offsetY: rawOffsetY = 0,
   } = options
 
-  let isFixed =
-    floating.hasAttribute('popover') || getComputedStyle(anchorElement).position === 'fixed'
+  let anchorIsAbsolutePositioned =
+    anchorTarget instanceof HTMLElement && getComputedStyle(anchorTarget).position !== 'fixed'
+  let isFixed = floating.hasAttribute('popover') || !anchorIsAbsolutePositioned
   let animationFrameId = 0
 
   function updatePosition(
-    anchorRect = anchorElement.getBoundingClientRect(),
+    anchorRect = readAnchorRect(anchorTarget),
     naturalDimensions = getFloatingDimensions(floating, relativeTo, {
       ignoreInlineMaxSize: true,
     }),
@@ -695,7 +736,7 @@ export function anchor(
       placementHeight,
       naturalDimensions.width,
       naturalDimensions.height,
-      anchorElement,
+      anchorIsAbsolutePositioned,
       inset,
       offset,
       offsetX,
@@ -872,7 +913,7 @@ export function anchor(
   updatePosition()
 
   function pollForPositionChanges() {
-    let currentRect = anchorElement.getBoundingClientRect()
+    let currentRect = readAnchorRect(anchorTarget)
     let currentDimensions = getFloatingDimensions(floating, relativeTo)
     if (
       hasRectChanged(currentRect, lastAnchorRect) ||

--- a/packages/ui/src/components/menu/README.md
+++ b/packages/ui/src/components/menu/README.md
@@ -68,6 +68,29 @@ Use `menuLabel` when the menu surface needs a different accessible label from th
 </Menu>
 ```
 
+Use `menu.contextTrigger()` with `menu.Context` and `MenuList` when a menu should open at the right-click location of an element.
+
+```tsx
+import * as menu from 'remix/ui/menu'
+import { MenuItem, MenuList } from 'remix/ui/menu'
+
+export function FileContextMenu(handle: Handle) {
+  return () => (
+    <menu.Context label="File actions">
+      <div mix={menu.contextTrigger()} tabIndex={0}>
+        File.txt
+      </div>
+      <MenuList>
+        <MenuItem name="rename">Rename</MenuItem>
+        <MenuItem name="delete">Delete</MenuItem>
+      </MenuList>
+    </menu.Context>
+  )
+}
+```
+
+Attach `onMenuSelect(...)` to `MenuList` or a shared ancestor when using lower-level context menu composition.
+
 ## `menu.*`
 
 - `Menu`: composed trigger, popover, and list component for the common menu case.
@@ -77,13 +100,14 @@ Use `menuLabel` when the menu surface needs a different accessible label from th
 - `onMenuSelect(...)`: event mixin for the bubbling `MenuSelectEvent`.
 - `MenuSelectEvent`: bubbling event class whose `item` describes the selected item.
 - `MenuSelectItem`: selected item shape with `checked`, `id`, `label`, `name`, `type`, and `value`.
-- `menu.Context`, `menu.trigger()`, `menu.popover()`, `menu.list()`, `menu.item(...)`, and `menu.submenuTrigger(...)`: lower-level composition primitives.
+- `menu.Context`, `menu.trigger()`, `menu.contextTrigger()`, `menu.popover()`, `menu.list()`, `menu.item(...)`, and `menu.submenuTrigger(...)`: lower-level composition primitives.
 - `buttonStyle`, `popoverStyle`, `listStyle`, `itemStyle`, `itemSlotStyle`, `itemLabelStyle`, `itemGlyphStyle`, and `triggerGlyphStyle`: flat style mixins used by the wrappers.
-- `MenuProps`, `MenuItemProps`, `MenuListProps`, `MenuProviderProps`, `MenuTriggerOptions`, `MenuItemOptions`, and `SubmenuProps`: public TypeScript props and option types.
+- `MenuProps`, `MenuItemProps`, `MenuListProps`, `MenuProviderProps`, `MenuTriggerOptions`, `MenuContextTriggerOptions`, `MenuItemOptions`, and `SubmenuProps`: public TypeScript props and option types.
 
 ## Behavior Notes
 
 - Click opens the root menu and focuses the list; clicking the trigger again closes it and restores focus.
+- `menu.contextTrigger()` opens the root menu from a `contextmenu` event at the pointer coordinates and supports keyboard opening with the Context Menu key or Shift+F10.
 - `ArrowDown` opens from the trigger at the first enabled item. `ArrowUp` opens at the last enabled item. Enter and Space open the menu with focus on the list.
 - Keyboard navigation skips disabled items and does not wrap past the first or last enabled item.
 - `Home` and `End` move to the first and last enabled item. Enter and Space activate the highlighted item.

--- a/packages/ui/src/components/menu/demos/context-trigger.demo.tsx
+++ b/packages/ui/src/components/menu/demos/context-trigger.demo.tsx
@@ -1,0 +1,132 @@
+import { css, type Handle } from '@remix-run/ui'
+import * as menu from '@remix-run/ui/menu'
+import { MenuItem, MenuList, onMenuSelect, Submenu } from '@remix-run/ui/menu'
+import { separatorStyle } from '@remix-run/ui/separator'
+import { theme } from '@remix-run/ui/theme'
+
+type FileAction = 'copyPath' | 'duplicate' | 'move' | 'rename' | 'reveal' | 'trash'
+
+const actionLabelByName: Record<FileAction, string> = {
+  copyPath: 'Copied path',
+  duplicate: 'Duplicated file',
+  move: 'Moved file',
+  rename: 'Renamed file',
+  reveal: 'Revealed in Finder',
+  trash: 'Moved to trash',
+}
+
+/**
+ * @name Context Menu Trigger
+ * @description A lower-level menu composition that opens from right-click coordinates while keeping standard menu selection and submenu behavior.
+ */
+export default function Example(handle: Handle) {
+  let latestAction = 'Right-click the card.'
+
+  return () => (
+    <menu.Context label="File actions">
+      <div mix={layoutCss}>
+        <div tabIndex={0} mix={[fileCardCss, menu.contextTrigger()]}>
+          <span mix={fileIconCss}>TS</span>
+          <span mix={fileTextCss}>
+            <strong mix={fileNameCss}>context-menu.tsx</strong>
+            <span mix={fileMetaCss}>Right-click or press Shift+F10</span>
+          </span>
+        </div>
+
+        <p aria-live="polite" mix={statusCss}>
+          {latestAction}
+        </p>
+      </div>
+
+      <MenuList
+        mix={onMenuSelect((event) => {
+          latestAction =
+            actionLabelByName[event.item.name as FileAction] ?? `Selected ${event.item.label}`
+          void handle.update()
+        })}
+      >
+        <MenuItem name="rename">Rename</MenuItem>
+        <MenuItem name="duplicate">Duplicate</MenuItem>
+        <MenuItem name="copyPath">Copy path</MenuItem>
+        <hr mix={separatorStyle} />
+        <Submenu label="Move to">
+          <MenuItem name="move" value="drafts">
+            Drafts
+          </MenuItem>
+          <MenuItem name="move" value="archive">
+            Archive
+          </MenuItem>
+        </Submenu>
+        <MenuItem name="reveal">Reveal in Finder</MenuItem>
+        <hr mix={separatorStyle} />
+        <MenuItem name="trash">Move to trash</MenuItem>
+      </MenuList>
+    </menu.Context>
+  )
+}
+
+const layoutCss = css({
+  display: 'grid',
+  justifyItems: 'start',
+  gap: theme.space.md,
+})
+
+const fileCardCss = css({
+  display: 'grid',
+  gridTemplateColumns: 'auto minmax(0, 1fr)',
+  alignItems: 'center',
+  gap: theme.space.md,
+  width: 'min(100%, 21rem)',
+  padding: theme.space.md,
+  border: `1px solid ${theme.colors.border.subtle}`,
+  borderRadius: theme.radius.lg,
+  backgroundColor: theme.surface.lvl1,
+  color: theme.colors.text.primary,
+  boxShadow: theme.shadow.xs,
+  cursor: 'context-menu',
+  userSelect: 'none',
+  '&:focus-visible': {
+    outline: `2px solid ${theme.colors.focus.ring}`,
+    outlineOffset: '2px',
+  },
+})
+
+const fileIconCss = css({
+  display: 'inline-grid',
+  placeItems: 'center',
+  width: theme.control.height.lg,
+  height: theme.control.height.lg,
+  borderRadius: theme.radius.md,
+  backgroundColor: theme.colors.action.primary.background,
+  color: theme.colors.action.primary.foreground,
+  fontSize: theme.fontSize.xs,
+  fontWeight: theme.fontWeight.bold,
+})
+
+const fileTextCss = css({
+  display: 'grid',
+  gap: theme.space.px,
+  minWidth: 0,
+})
+
+const fileNameCss = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  fontSize: theme.fontSize.sm,
+  lineHeight: theme.lineHeight.normal,
+})
+
+const fileMetaCss = css({
+  color: theme.colors.text.secondary,
+  fontSize: theme.fontSize.xs,
+  lineHeight: theme.lineHeight.normal,
+})
+
+const statusCss = css({
+  margin: 0,
+  minHeight: theme.lineHeight.normal,
+  color: theme.colors.text.secondary,
+  fontSize: theme.fontSize.sm,
+  lineHeight: theme.lineHeight.normal,
+})

--- a/packages/ui/src/components/menu/menu.test.tsx
+++ b/packages/ui/src/components/menu/menu.test.tsx
@@ -3,7 +3,8 @@ import { afterEach, beforeEach, describe, it, mock, type FakeTimers } from '@rem
 
 import { createRoot, type RemixNode } from '@remix-run/ui'
 
-import { Menu, MenuItem, onMenuSelect, Submenu, type MenuSelectEvent } from './menu.tsx'
+import * as menu from './menu.tsx'
+import { Menu, MenuItem, MenuList, onMenuSelect, Submenu, type MenuSelectEvent } from './menu.tsx'
 
 const flashDurationMs = 60
 let roots: Array<ReturnType<typeof createRoot>> = []
@@ -83,6 +84,20 @@ function renderMenuWithSubmenuSeparator() {
   )
 }
 
+function renderContextMenu() {
+  return renderApp(
+    <menu.Context label="File actions">
+      <div id="context-target" tabIndex={0} mix={menu.contextTrigger()}>
+        File.txt
+      </div>
+      <MenuList>
+        <MenuItem name="rename">Rename</MenuItem>
+        <MenuItem name="delete">Delete</MenuItem>
+      </MenuList>
+    </menu.Context>,
+  )
+}
+
 function normalizeText(text: string | null | undefined) {
   return (text ?? '').replace(/\s+/g, ' ').trim()
 }
@@ -123,8 +138,19 @@ function click(target: HTMLElement) {
   target.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 0 }))
 }
 
-function key(target: HTMLElement, key: string) {
-  let event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key })
+function contextMenu(target: HTMLElement, x: number, y: number) {
+  let event = new MouseEvent('contextmenu', {
+    bubbles: true,
+    cancelable: true,
+    clientX: x,
+    clientY: y,
+  })
+  target.dispatchEvent(event)
+  return event
+}
+
+function key(target: HTMLElement, key: string, init: KeyboardEventInit = {}) {
+  let event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key, ...init })
   target.dispatchEvent(event)
   return event
 }
@@ -227,6 +253,66 @@ describe('menu', () => {
 
     expect(rootSurface.matches(':popover-open')).toBe(false)
     expect(document.activeElement).toBe(trigger)
+  })
+
+  it('opens from contextmenu at the pointer coordinates', async () => {
+    let { container, root } = renderContextMenu()
+    let trigger = container.querySelector('#context-target') as HTMLElement
+    let [rootSurface] = getSurfaces(container)
+    let [rootList] = getLists(container)
+
+    mockRect(rootSurface, 0, 0, 160, 96)
+
+    let event = contextMenu(trigger, 220, 140)
+    await settleFrames(root)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(rootSurface.matches(':popover-open')).toBe(true)
+    expect(rootSurface.style.left).toBe('220px')
+    expect(rootSurface.style.top).toBe('140px')
+    expect(rootSurface.getAttribute('data-anchor-placement')).toBe('bottom-start')
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    expect(document.activeElement).toBe(rootList)
+  })
+
+  it('repositions an open context menu when right-clicked again', async () => {
+    let { container, root } = renderContextMenu()
+    let trigger = container.querySelector('#context-target') as HTMLElement
+    let [rootSurface] = getSurfaces(container)
+
+    mockRect(rootSurface, 0, 0, 160, 96)
+
+    contextMenu(trigger, 220, 140)
+    await settleFrames(root)
+
+    expect(rootSurface.style.left).toBe('220px')
+    expect(rootSurface.style.top).toBe('140px')
+
+    contextMenu(trigger, 260, 180)
+    await settleFrames(root)
+
+    expect(rootSurface.matches(':popover-open')).toBe(true)
+    expect(rootSurface.style.left).toBe('260px')
+    expect(rootSurface.style.top).toBe('180px')
+  })
+
+  it('opens a context menu from the keyboard at the trigger bounds', async () => {
+    let { container, root } = renderContextMenu()
+    let trigger = container.querySelector('#context-target') as HTMLElement
+    let [rootSurface] = getSurfaces(container)
+    let [rootList] = getLists(container)
+
+    mockRect(trigger, 80, 70, 200, 40)
+    mockRect(rootSurface, 0, 0, 160, 96)
+
+    let event = key(trigger, 'F10', { shiftKey: true })
+    await settleFrames(root)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(rootSurface.matches(':popover-open')).toBe(true)
+    expect(rootSurface.style.left).toBe('80px')
+    expect(rootSurface.style.top).toBe('110px')
+    expect(document.activeElement).toBe(rootList)
   })
 
   it('opens from ArrowDown and skips disabled items during keyboard navigation', async () => {

--- a/packages/ui/src/components/menu/menu.tsx
+++ b/packages/ui/src/components/menu/menu.tsx
@@ -13,7 +13,7 @@ import {
   type Props,
   type RemixNode,
 } from '@remix-run/ui'
-import { type AnchorOptions } from '../anchor/anchor.ts'
+import { type AnchorOptions, type AnchorPoint } from '../anchor/anchor.ts'
 import * as button from '../button/button.tsx'
 import { Glyph } from '../glyph/glyph.tsx'
 import * as popover from '../popover/popover.ts'
@@ -249,6 +249,8 @@ export interface MenuProviderProps {
 }
 
 export interface MenuTriggerOptions extends AnchorOptions {}
+
+export interface MenuContextTriggerOptions extends AnchorOptions {}
 
 export interface MenuItemOptions {
   checked?: boolean
@@ -1008,6 +1010,74 @@ const triggerMixin: MixinFactory<HTMLElement, [options?: MenuTriggerOptions], El
     ]
   })
 
+const contextTriggerMixin: MixinFactory<
+  HTMLElement,
+  [options?: MenuContextTriggerOptions],
+  ElementProps
+> = createMixin<HTMLElement, [options?: MenuContextTriggerOptions], ElementProps>((handle) => {
+  let context = handle.context.get(MenuProvider)
+  let popoverContext = handle.context.get(popover.Context)
+  let anchorPoint: AnchorPoint = { x: 0, y: 0, width: 0, height: 0 }
+
+  function setAnchorPoint(
+    { x, y, width = 0, height = 0 }: AnchorPoint,
+    options: MenuContextTriggerOptions,
+  ) {
+    anchorPoint.x = x
+    anchorPoint.y = y
+    anchorPoint.width = width
+    anchorPoint.height = height
+    popoverContext.anchor = {
+      target: anchorPoint,
+      options: {
+        placement: 'bottom-start',
+        ...options,
+      },
+    }
+  }
+
+  return (options = {}) => [
+    attrs({
+      id: handle.id,
+      'aria-controls': context.listId,
+      'aria-expanded': context.isOpen ? 'true' : 'false',
+      'aria-haspopup': 'menu',
+    }),
+    ref((node: HTMLElement, signal) => {
+      context.registerTrigger(node, handle.id)
+      signal.addEventListener('abort', () => {
+        context.unregisterTrigger(node)
+      })
+    }),
+    on('contextmenu', (event) => {
+      event.preventDefault()
+      event.stopPropagation()
+      setAnchorPoint({ x: event.clientX, y: event.clientY }, options)
+      void context.open({ strategy: 'list' })
+    }),
+    on('keydown', (event) => {
+      if (event.key !== 'ContextMenu' && !(event.shiftKey && event.key === 'F10')) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+
+      let rect = event.currentTarget.getBoundingClientRect()
+      setAnchorPoint(
+        {
+          x: rect.left,
+          y: rect.top,
+          width: rect.width,
+          height: rect.height,
+        },
+        options,
+      )
+      void context.open({ strategy: 'list' })
+    }),
+  ]
+})
+
 const popoverMixin: MixinFactory<HTMLElement, [], ElementProps> = createMixin<
   HTMLElement,
   [],
@@ -1394,6 +1464,7 @@ type MenuListChildProps = Omit<
 >
 
 export const Context = MenuProvider
+export const contextTrigger = contextTriggerMixin
 export const item = itemMixin
 export const list = listMixin
 export { popoverMixin as popover }
@@ -1402,6 +1473,7 @@ export const trigger = triggerMixin
 
 const menu = {
   Context,
+  contextTrigger,
   item,
   list,
   popover: popoverMixin,

--- a/packages/ui/src/components/popover/popover.ts
+++ b/packages/ui/src/components/popover/popover.ts
@@ -9,7 +9,11 @@ import {
   type MixinFactory,
   type RemixNode,
 } from '@remix-run/ui'
-import { anchor as positionAnchor, type AnchorOptions } from '../anchor/anchor.ts'
+import {
+  anchor as positionAnchor,
+  type AnchorOptions,
+  type AnchorTarget,
+} from '../anchor/anchor.ts'
 import { onOutsideClick } from '../../interactions/outside-click/outside-click-mixin.ts'
 import { theme } from '../../theme/theme.ts'
 import { lockScroll } from '../../utils/scroll-lock.ts'
@@ -26,7 +30,7 @@ export interface PopoverProps {
 }
 
 interface AnchorRef {
-  node: HTMLElement
+  target: AnchorTarget
   options: AnchorOptions
 }
 
@@ -108,10 +112,14 @@ const anchorMixin: MixinFactory<HTMLElement, [options: AnchorOptions], ElementPr
   let context = handle.context.get(PopoverProvider)
   return (options) => {
     handle.queueTask((node) => {
-      context.anchor = { node, options }
+      context.anchor = { target: node, options }
     })
   }
 })
+
+function anchorContains(anchor: AnchorRef | null, target: Node) {
+  return anchor?.target instanceof HTMLElement && anchor.target.contains(target)
+}
 
 const surfaceMixin: MixinFactory<HTMLElement, [options: PopoverSurfaceOptions], ElementProps> =
   createMixin<HTMLElement, [options: PopoverSurfaceOptions]>((handle) => {
@@ -147,10 +155,15 @@ const surfaceMixin: MixinFactory<HTMLElement, [options: PopoverSurfaceOptions], 
 
         on('beforetoggle', (event) => {
           if (event.newState === 'open') {
+            let anchor = context.anchor
+            if (!anchor) {
+              throw new Error('popover.surface() requires a registered anchor before opening')
+            }
+
             cleanupAnchor = positionAnchor(
               event.currentTarget,
-              context.anchor!.node,
-              context.anchor!.options,
+              anchor.target,
+              anchor.options,
             )
             unlockScroll = lockScroll()
           } else if (event.newState === 'closed') {
@@ -179,8 +192,7 @@ const surfaceMixin: MixinFactory<HTMLElement, [options: PopoverSurfaceOptions], 
           (target) => {
             options.onHide({ reason: 'outside-click', target })
           },
-          (target) =>
-            options.closeOnAnchorClick === false && !!context.anchor?.node.contains(target),
+          (target) => options.closeOnAnchorClick === false && anchorContains(context.anchor, target),
           options.stopOutsideClickPropagation ?? true,
         ),
       ]

--- a/packages/ui/src/components/select/select.tsx
+++ b/packages/ui/src/components/select/select.tsx
@@ -156,7 +156,7 @@ function SelectProvider(handle: Handle<SelectContextProps, SelectContextValue>):
     popoverContextRef.hideFocusTarget = triggerRef ?? null
     popoverContextRef.anchor = triggerRef
       ? {
-          node: triggerRef,
+          target: triggerRef,
           options: getPopoverAnchorOptions(),
         }
       : null

--- a/packages/ui/src/theme/theme.test.ts
+++ b/packages/ui/src/theme/theme.test.ts
@@ -308,6 +308,7 @@ describe('modules', () => {
       'MenuSelectEvent',
       'Submenu',
       'buttonStyle',
+      'contextTrigger',
       'item',
       'itemGlyphStyle',
       'itemLabelStyle',


### PR DESCRIPTION
Right clicking will open the context menu at the cursor's position.

```tsx
export default function Example(handle: Handle) {
  let latestAction = 'Right-click the card.'

  return () => (
    <menu.Context label="File actions">
      <div tabIndex={0} mix={menu.contextTrigger()} />

      <MenuList>
        <MenuItem name="rename">Rename</MenuItem>
        <MenuItem name="duplicate">Duplicate</MenuItem>
        <MenuItem name="copyPath">Copy path</MenuItem>
      </MenuList>
    </menu.Context>
  )
}
```