### PR TITLE
Fix frame fallback flicker when reloading ancestor frames

### DIFF
--- a/packages/ui/.changes/patch.nested-frame-inherited-reload-events.md
+++ b/packages/ui/.changes/patch.nested-frame-inherited-reload-events.md
@@ -1,0 +1,1 @@
+Dispatch reload events for nested frames when an ancestor frame reloads

--- a/packages/ui/.changes/patch.preserve-nested-frame-state-on-root-reload.md
+++ b/packages/ui/.changes/patch.preserve-nested-frame-state-on-root-reload.md
@@ -1,0 +1,1 @@
+Prevent non-blocking frames from displaying their fallback when an ancestor frame is reloaded

--- a/packages/ui/src/runtime/diff-dom.ts
+++ b/packages/ui/src/runtime/diff-dom.ts
@@ -122,12 +122,23 @@ function diffNode(current: Node, next: Node, context: FrameContext): ChildNode |
 
           let frame = context.frameInstances.get(current)
           let nextMarkerData = getFrameMarkerData(next, context)
-          if (
-            frame &&
-            nextMarkerData?.status === 'pending' &&
-            frame.isDisplayingResolvedContent()
-          ) {
-            return findFrameEndMarker(next)
+          if (frame && nextMarkerData) {
+            if (nextMarkerData.status === 'resolved') {
+              let nextEnd = findFrameEndMarker(next)
+              let nextContent = collectFrameContentFragment(current.ownerDocument, next, nextEnd)
+              void frame.renderMarkerContent(
+                { ...nextMarkerData, id: getFrameId(next) },
+                nextContent,
+                {
+                  signal: context.signal,
+                },
+              )
+              return nextEnd
+            }
+
+            if (frame.isDisplayingResolvedContent()) {
+              return findFrameEndMarker(next)
+            }
           }
         } else {
           disposeFrameStartMarker(current, context)
@@ -608,6 +619,23 @@ function collectNodeRange(start: Node, end: Node): Node[] {
   }
 
   return nodes
+}
+
+function collectFrameContentFragment(
+  doc: Document,
+  start: Comment,
+  end: Comment,
+): DocumentFragment {
+  let fragment = doc.createDocumentFragment()
+  let node = start.nextSibling
+
+  while (node && node !== end) {
+    let next = node.nextSibling
+    fragment.appendChild(node)
+    node = next
+  }
+
+  return fragment
 }
 
 function removeNode(node: Node, parent: ParentNode, context: FrameContext): void {

--- a/packages/ui/src/runtime/diff-dom.ts
+++ b/packages/ui/src/runtime/diff-dom.ts
@@ -7,6 +7,13 @@ type HydratedVirtualRootStartMarker = Comment & {
   }
 }
 
+type CommentMarkerRangeReplacement = {
+  currentStart: Comment
+  nextStart: Comment
+  currentEndIndex: number
+  nextEndIndex: number
+}
+
 export function diffNodes(curr: Node[], next: Node[], context: FrameContext) {
   let parent = curr[0]?.parentNode ?? context.regionParent ?? null
   invariant(parent, 'Parent node not found')
@@ -17,10 +24,11 @@ export function diffNodes(curr: Node[], next: Node[], context: FrameContext) {
     context.regionTailRef ??
     (curr.length > 0 ? (curr[curr.length - 1].nextSibling as ChildNode | null) : null)
 
-  let max = Math.max(curr.length, next.length)
-  for (let i = 0; i < max; i++) {
-    let c = curr[i]
-    let n = next[i]
+  let currentIndex = 0
+  let nextIndex = 0
+  while (currentIndex < curr.length || nextIndex < next.length) {
+    let c = curr[currentIndex]
+    let n = next[nextIndex]
 
     if (!c && n) {
       if (regionTailRef) {
@@ -28,10 +36,28 @@ export function diffNodes(curr: Node[], next: Node[], context: FrameContext) {
       } else {
         parent.appendChild(n)
       }
+      nextIndex++
     } else if (c && !n) {
       removeNode(c, parent, context)
+      currentIndex++
     } else if (c && n) {
-      // Skip hydrated client-entry boundary ranges; hydration pass re-renders
+      let replacement = getCommentMarkerRangeReplacement(
+        c,
+        n,
+        curr,
+        next,
+        currentIndex,
+        nextIndex,
+        context,
+      )
+      if (replacement) {
+        replaceCommentMarkerRange(replacement, parent, context)
+        currentIndex = replacement.currentEndIndex + 1
+        nextIndex = replacement.nextEndIndex + 1
+        continue
+      }
+
+      // Skip hydrated client-entry marker ranges; hydration pass re-renders
       // roots with new props from incoming payload
       if (isVirtualRootStartMarker(c) && isVirtualRootStartMarker(n)) {
         let currentEnd = findHydrationEndMarker(c)
@@ -41,14 +67,25 @@ export function diffNodes(curr: Node[], next: Node[], context: FrameContext) {
 
         let currentEndIndex = curr.indexOf(currentEnd)
         let nextEndIndex = next.indexOf(nextEnd)
-        i = Math.max(currentEndIndex, nextEndIndex)
+        currentIndex = currentEndIndex + 1
+        nextIndex = nextEndIndex + 1
         continue
       }
 
       let cursor = diffNode(c, n, context)
       if (cursor) {
-        i = next.indexOf(cursor)
+        let nextEndIndex = next.indexOf(cursor)
+        let currentEndIndex =
+          isFrameStartMarker(c) && isFrameEndMarker(cursor)
+            ? findFrameEndIndex(curr, currentIndex)
+            : currentIndex
+        currentIndex = currentEndIndex + 1
+        nextIndex = nextEndIndex + 1
+        continue
       }
+
+      currentIndex++
+      nextIndex++
     }
   }
 }
@@ -61,7 +98,7 @@ function diffNode(current: Node, next: Node, context: FrameContext): ChildNode |
     return
   }
 
-  // Hydration boundary -> Hydration boundary
+  // Hydration marker range -> Hydration marker range
   if (isVirtualRootStartMarker(current) && isVirtualRootStartMarker(next)) {
     let nextData = next.data
     if (current.data !== nextData) {
@@ -77,8 +114,30 @@ function diffNode(current: Node, next: Node, context: FrameContext): ChildNode |
   if (isCommentNode(current) && isCommentNode(next)) {
     let newData = next.data
     if (current.data !== newData) {
-      if (isFrameStartMarker(current)) disposeFrameStartMarker(current, context)
-      current.data = newData
+      let updated = false
+      if (isFrameStartMarker(current)) {
+        if (shouldPreserveFrameStartMarker(current, next, context)) {
+          current.data = newData
+          updated = true
+
+          let frame = context.frameInstances.get(current)
+          let nextMarkerData = getFrameMarkerData(next, context)
+          if (
+            frame &&
+            nextMarkerData?.status === 'pending' &&
+            frame.isDisplayingResolvedContent()
+          ) {
+            return findFrameEndMarker(next)
+          }
+        } else {
+          disposeFrameStartMarker(current, context)
+          current.data = newData
+          updated = true
+        }
+      }
+      if (!updated) {
+        current.data = newData
+      }
     }
     return
   }
@@ -224,7 +283,14 @@ function diffElementChildren(current: Element, next: Element, context: FrameCont
     let nextChild = nextChildren[i]
     let matchIndex = -1
 
-    if (isElement(nextChild)) {
+    if (isFrameEndMarker(nextChild)) {
+      for (let j = 0; j < currentChildren.length; j++) {
+        if (!used[j] && isFrameEndMarker(currentChildren[j])) {
+          matchIndex = j
+          break
+        }
+      }
+    } else if (isElement(nextChild)) {
       let key = nextChild.getAttribute('data-key')
       if (key != null && keyToIndex.has(key)) {
         let idx = keyToIndex.get(key)!
@@ -253,14 +319,42 @@ function diffElementChildren(current: Element, next: Element, context: FrameCont
     let mi = matchIndexForNext[i]
     if (mi !== -1) {
       let curChild = currentChildren[mi]
-      let cursor = diffNode(curChild, nextChildren[i], context)
-      if (cursor) {
-        // Fast-forward across a hydrated virtual root region.
-        let nextEndIdx = nextChildren.indexOf(cursor)
-        let currEndIdx = findHydrationEndIndex(currentChildren, mi)
+      let nextChild = nextChildren[i]
 
-        // Adjacent hydration regions can pre-match into the next region and leave
-        // an orphaned `<!-- /rmx:h -->` behind. Clear those stale matches first.
+      let replacement = getCommentMarkerRangeReplacement(
+        curChild,
+        nextChild,
+        currentChildren,
+        nextChildren,
+        mi,
+        i,
+        context,
+      )
+      if (replacement) {
+        replaceCommentMarkerRange(replacement, current, context)
+
+        for (let k = mi; k <= replacement.currentEndIndex; k++) used[k] = true
+
+        committed[i] = replacement.nextStart
+        committed[replacement.nextEndIndex] = nextChildren[replacement.nextEndIndex]
+        for (let j = i + 1; j < replacement.nextEndIndex; j++) committed[j] = undefined
+
+        i = replacement.nextEndIndex
+        continue
+      }
+
+      let cursor = diffNode(curChild, nextChild, context)
+      if (cursor) {
+        // `diffNode` can preserve hydration and frame marker ranges by returning
+        // the next end marker, so skip the owned interior nodes here.
+        let nextEndIdx = nextChildren.indexOf(cursor)
+        let currEndIdx =
+          isFrameStartMarker(curChild) && isFrameEndMarker(cursor)
+            ? findFrameEndIndex(currentChildren, mi)
+            : findHydrationEndIndex(currentChildren, mi)
+
+        // Adjacent marker ranges can pre-match into the next range and leave an
+        // orphaned end marker behind. Clear those stale matches first.
         for (let j = i + 1; j <= nextEndIdx; j++) {
           let matchedIndex = matchIndexForNext[j]
           if (matchedIndex > currEndIdx) {
@@ -272,7 +366,7 @@ function diffElementChildren(current: Element, next: Element, context: FrameCont
         // Mark the entire current region as used to avoid removals.
         for (let k = mi; k <= currEndIdx; k++) used[k] = true
 
-        // Preserve both boundary markers in committed; skip interior in reorder pass.
+        // Preserve both comment markers in committed; skip interior in reorder pass.
         committed[i] = curChild // start marker
         committed[nextEndIdx] = currentChildren[currEndIdx] // end marker
         for (let j = i + 1; j < nextEndIdx; j++) committed[j] = undefined
@@ -296,9 +390,15 @@ function diffElementChildren(current: Element, next: Element, context: FrameCont
     // Use only an anchor that is actually a child of the current parent
     let ref = anchor && anchor.parentNode === current ? anchor : null
 
-    // Do not move hydration boundary markers; keep region stable.
-    // If a boundary marker is new, ensure it is inserted before using it as an anchor.
-    if (isVirtualRootStartMarker(node) || isVirtualRootEndMarker(node)) {
+    // Existing comment markers delimit live ranges, so do not reorder them
+    // independently from their contents. New markers still need to be inserted
+    // before they can be used as anchors.
+    if (
+      isVirtualRootStartMarker(node) ||
+      isVirtualRootEndMarker(node) ||
+      isFrameStartMarker(node) ||
+      isFrameEndMarker(node)
+    ) {
       if (node.parentNode !== current) {
         current.insertBefore(node, ref)
       }
@@ -372,6 +472,37 @@ function findHydrationEndIndex(nodes: Node[], startIdx: number): number {
   return startIdx
 }
 
+function findFrameEndMarker(start: Comment): Comment {
+  let node: Node | null = start.nextSibling
+  let depth = 1
+
+  while (node) {
+    if (isFrameStartMarker(node)) depth++
+    if (isFrameEndMarker(node)) {
+      depth--
+      if (depth === 0) return node
+    }
+    node = node.nextSibling
+  }
+
+  throw new Error('Frame end marker not found')
+}
+
+function findFrameEndIndex(nodes: Node[], startIdx: number): number {
+  let depth = 1
+
+  for (let j = startIdx + 1; j < nodes.length; j++) {
+    let node = nodes[j]
+    if (isFrameStartMarker(node)) depth++
+    if (isFrameEndMarker(node)) {
+      depth--
+      if (depth === 0) return j
+    }
+  }
+
+  return startIdx
+}
+
 function isTextNode(node: Node): node is Text {
   return node.nodeType === Node.TEXT_NODE
 }
@@ -386,6 +517,97 @@ function isCommentNode(node: Node): node is Comment {
 
 function isFrameStartMarker(node: Node): node is Comment {
   return node instanceof Comment && node.data.trim().startsWith('rmx:f:')
+}
+
+function isFrameEndMarker(node: Node): node is Comment {
+  return node instanceof Comment && node.data.trim() === '/rmx:f'
+}
+
+function shouldPreserveFrameStartMarker(
+  current: Comment,
+  next: Comment,
+  context: FrameContext,
+): boolean {
+  if (!isFrameStartMarker(next)) return false
+
+  let currentData = getFrameMarkerData(current, context)
+  let nextData = getFrameMarkerData(next, context)
+
+  return (
+    currentData !== undefined &&
+    nextData !== undefined &&
+    currentData.src === nextData.src &&
+    currentData.name === nextData.name
+  )
+}
+
+function getCommentMarkerRangeReplacement(
+  current: Node,
+  next: Node,
+  currentNodes: Node[],
+  nextNodes: Node[],
+  currentIndex: number,
+  nextIndex: number,
+  context: FrameContext,
+): CommentMarkerRangeReplacement | undefined {
+  // Comment markers can represent owned DOM ranges, not standalone comments. If
+  // the incoming range no longer has the same identity, replace the whole range
+  // before regular node diffing mutates either marker.
+  if (
+    isFrameStartMarker(current) &&
+    isFrameStartMarker(next) &&
+    !shouldPreserveFrameStartMarker(current, next, context)
+  ) {
+    return {
+      currentStart: current,
+      nextStart: next,
+      currentEndIndex: findFrameEndIndex(currentNodes, currentIndex),
+      nextEndIndex: findFrameEndIndex(nextNodes, nextIndex),
+    }
+  }
+}
+
+function getFrameMarkerData(marker: Comment, context: FrameContext) {
+  let id = getFrameId(marker)
+  return context.data.f?.[id]
+}
+
+function getFrameId(marker: Comment): string {
+  let trimmed = marker.data.trim()
+  invariant(trimmed.startsWith('rmx:f:'), 'Invalid frame start marker')
+  return trimmed.slice('rmx:f:'.length)
+}
+
+function replaceCommentMarkerRange(
+  replacement: CommentMarkerRangeReplacement,
+  parent: ParentNode,
+  context: FrameContext,
+): void {
+  let currentEnd = findFrameEndMarker(replacement.currentStart)
+  let nextEnd = findFrameEndMarker(replacement.nextStart)
+  let nextNodes = collectNodeRange(replacement.nextStart, nextEnd)
+  let currentNodes = collectNodeRange(replacement.currentStart, currentEnd)
+
+  for (let node of nextNodes) {
+    parent.insertBefore(node, replacement.currentStart)
+  }
+
+  for (let node of currentNodes) {
+    removeNode(node, parent, context)
+  }
+}
+
+function collectNodeRange(start: Node, end: Node): Node[] {
+  let nodes: Node[] = []
+  let node: Node | null = start
+
+  while (node) {
+    nodes.push(node)
+    if (node === end) break
+    node = node.nextSibling
+  }
+
+  return nodes
 }
 
 function removeNode(node: Node, parent: ParentNode, context: FrameContext): void {

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -129,6 +129,7 @@ export type FrameContext = {
   namedFrames: Map<string, FrameHandle>
   regionTailRef?: ChildNode | null
   regionParent?: ParentNode | null
+  signal?: AbortSignal
 }
 
 type FrameInit = {
@@ -155,7 +156,13 @@ export type Frame = {
   flush: () => void
   clearPendingTemplateWatch: () => void
   isDisplayingResolvedContent: () => boolean
+  startInheritedReload: (signal?: AbortSignal) => void
   updateMarker: (marker: FrameMarkerData, options?: RenderOptions) => Promise<void>
+  renderMarkerContent: (
+    marker: FrameMarkerData,
+    content: InternalFrameContent,
+    options?: RenderOptions,
+  ) => Promise<void>
   dispose: () => void
   handle: FrameHandle
 }
@@ -177,6 +184,8 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
   let pendingTemplateMarkerId: string | undefined
   let pendingTemplateObserver: MutationObserver | undefined
   let pendingTemplateUnsubscribe: (() => void) | undefined
+  let inheritedReloadPending = false
+  let inheritedReloadAbortUnsubscribe: (() => void) | undefined
 
   // Merge any rmx-data found in the current document once at startup.
   mergeRmxDataFromDocument(init.data, container.doc)
@@ -191,6 +200,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       let controller = new AbortController()
       reloadController = controller
       frame.dispatchEvent(new Event('reloadStart'))
+      startSubFrameInheritedReloads(getContentNodes(), controller.signal)
       try {
         let content = await init.resolveFrame(frame.src, controller.signal, frameName)
         if (reloadController !== controller || controller.signal.aborted) return controller.signal
@@ -298,11 +308,13 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
         ...context,
         regionParent: container.doc.documentElement,
         regionTailRef: null,
+        signal: options?.signal,
       })
       diffNodes([container.doc.body], [parsed.body], {
         ...context,
         regionParent: container.doc.documentElement,
         regionTailRef: null,
+        signal: options?.signal,
       })
 
       let bodyContainer = createElementContainer(container.doc.body)
@@ -329,6 +341,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       ...context,
       regionTailRef: container.regionTailRef,
       regionParent: container.regionParent,
+      signal: options?.signal,
     })
 
     if (options?.signal?.aborted) return
@@ -418,18 +431,107 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     flush: () => context.scheduler.dequeue(),
     clearPendingTemplateWatch: clearPendingFrameTemplateWatch,
     isDisplayingResolvedContent: () => displayedContentStatus === 'resolved',
+    startInheritedReload,
     updateMarker,
+    renderMarkerContent,
     dispose,
     handle: frame,
   }
 
   async function updateMarker(marker: FrameMarkerData, options?: RenderOptions): Promise<void> {
     if (options?.signal?.aborted) return
+    let previousMarker = currentMarker
+    let isInheritedReload = previousMarker !== undefined && previousMarker.id !== marker.id
     currentMarker = marker
+
+    if (isInheritedReload) {
+      startInheritedReload(options?.signal)
+    }
+
     if (marker.status === 'pending') {
-      await watchPendingFrameTemplate(marker, options?.initialHydrationTracker, options?.signal)
+      await watchPendingFrameTemplate(
+        marker,
+        options?.initialHydrationTracker,
+        options?.signal,
+        isInheritedReload
+          ? () => {
+              completeInheritedReload()
+            }
+          : undefined,
+      )
     } else {
       clearPendingFrameTemplateWatch()
+      if (isInheritedReload && !options?.signal?.aborted) {
+        completeInheritedReload()
+      }
+    }
+  }
+
+  async function renderMarkerContent(
+    marker: FrameMarkerData,
+    content: InternalFrameContent,
+    options?: RenderOptions,
+  ): Promise<void> {
+    if (options?.signal?.aborted) return
+    let previousMarker = currentMarker
+    let isInheritedReload = previousMarker !== undefined && previousMarker.id !== marker.id
+    currentMarker = marker
+
+    if (isInheritedReload) {
+      startInheritedReload(options?.signal)
+    }
+
+    clearPendingFrameTemplateWatch()
+    await render(content, { ...options, contentStatus: 'resolved' })
+
+    if (isInheritedReload && !options?.signal?.aborted) {
+      completeInheritedReload()
+    }
+  }
+
+  function startInheritedReload(signal?: AbortSignal): void {
+    if (signal?.aborted) return
+    if (!inheritedReloadPending) {
+      inheritedReloadPending = true
+      frame.dispatchEvent(new Event('reloadStart'))
+      startSubFrameInheritedReloads(getContentNodes(), signal)
+    }
+
+    inheritedReloadAbortUnsubscribe?.()
+    inheritedReloadAbortUnsubscribe = undefined
+    if (signal) {
+      let abort = () => completeInheritedReload()
+      signal.addEventListener('abort', abort, { once: true })
+      inheritedReloadAbortUnsubscribe = () => {
+        signal.removeEventListener('abort', abort)
+      }
+    }
+  }
+
+  function completeInheritedReload(): void {
+    if (!inheritedReloadPending) return
+    inheritedReloadPending = false
+    inheritedReloadAbortUnsubscribe?.()
+    inheritedReloadAbortUnsubscribe = undefined
+    frame.dispatchEvent(new Event('reloadComplete'))
+  }
+
+  function startSubFrameInheritedReloads(nodes: Node[], signal?: AbortSignal): void {
+    for (let i = 0; i < nodes.length; i++) {
+      if (signal?.aborted) break
+
+      let node = nodes[i]
+
+      if (isFrameStart(node)) {
+        let end = findEndMarker(node, isFrameStart, isFrameEnd)
+        context.frameInstances.get(node)?.startInheritedReload(signal)
+        i = nodes.indexOf(end)
+        continue
+      }
+
+      if (node.childNodes && node.childNodes.length > 0) {
+        startSubFrameInheritedReloads(Array.from(node.childNodes), signal)
+      }
     }
   }
 
@@ -445,6 +547,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     marker: FrameMarkerData,
     initialHydrationTracker?: InitialHydrationTracker,
     signal?: AbortSignal,
+    onResolved?: () => void,
   ): Promise<void> {
     if (signal?.aborted) return
     if (pendingTemplateMarkerId === marker.id) return
@@ -456,6 +559,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     if (early) {
       clearPendingFrameTemplateWatch()
       await render(early, { initialHydrationTracker, signal, contentStatus: 'resolved' })
+      if (!signal?.aborted) onResolved?.()
       return
     }
 
@@ -471,6 +575,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       if (pendingTemplateMarkerId !== marker.id) return
       clearPendingFrameTemplateWatch()
       await render(fragment, { signal, contentStatus: 'resolved' })
+      if (!signal?.aborted) onResolved?.()
     })
     pendingTemplateUnsubscribe = unsubscribe
 
@@ -488,6 +593,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     if (buffered) {
       clearPendingFrameTemplateWatch()
       await render(buffered, { initialHydrationTracker, signal, contentStatus: 'resolved' })
+      if (!signal?.aborted) onResolved?.()
     }
   }
 }

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -153,6 +153,9 @@ export type Frame = {
   render: (content: InternalFrameContent, options?: RenderOptions) => Promise<void>
   ready: () => Promise<void>
   flush: () => void
+  clearPendingTemplateWatch: () => void
+  isDisplayingResolvedContent: () => boolean
+  updateMarker: (marker: FrameMarkerData, options?: RenderOptions) => Promise<void>
   dispose: () => void
   handle: FrameHandle
 }
@@ -161,15 +164,19 @@ type RenderOptions = {
   flushKind?: FlushKind
   initialHydrationTracker?: InitialHydrationTracker
   signal?: AbortSignal
+  contentStatus?: 'pending' | 'resolved'
 }
 
 export function createFrame(root: FrameRoot, init: FrameInit): Frame {
   let container = createContainer(root)
-  let observers: MutationObserver[] = []
-  let subscriptions: Array<() => void> = []
   let contentRoot: VirtualRoot | undefined
   let reloadController: AbortController | undefined
   let styleManager = init.styleManager ?? createStyleManager()
+  let currentMarker = init.marker
+  let displayedContentStatus: 'pending' | 'resolved' = init.marker?.status ?? 'resolved'
+  let pendingTemplateMarkerId: string | undefined
+  let pendingTemplateObserver: MutationObserver | undefined
+  let pendingTemplateUnsubscribe: (() => void) | undefined
 
   // Merge any rmx-data found in the current document once at startup.
   mergeRmxDataFromDocument(init.data, container.doc)
@@ -250,6 +257,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
 
       if (options?.signal?.aborted) return
       contentRoot.render(content)
+      displayedContentStatus = options?.contentStatus ?? 'resolved'
       return
     }
 
@@ -300,7 +308,8 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       let bodyContainer = createElementContainer(container.doc.body)
       if (options?.signal?.aborted) return
       scheduleHydrationInContainer(bodyContainer, context, options?.initialHydrationTracker)
-      createSubFrames(bodyContainer.childNodes, context)
+      await createSubFrames(bodyContainer.childNodes, context, options)
+      displayedContentStatus = options?.contentStatus ?? 'resolved'
       return
     }
 
@@ -324,7 +333,8 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
 
     if (options?.signal?.aborted) return
     scheduleHydrationInContainer(container, context, options?.initialHydrationTracker)
-    createSubFrames(container.childNodes, context)
+    await createSubFrames(container.childNodes, context, options)
+    displayedContentStatus = options?.contentStatus ?? 'resolved'
   }
 
   function createFrameContentRoot(): VirtualRoot {
@@ -368,30 +378,11 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     let initialHydrationTracker = createInitialHydrationTracker()
 
     context.styleManager.replaceServerStyles(collectFrameServerStyleTags(container))
-    createSubFrames(container.childNodes, context)
+    await createSubFrames(container.childNodes, context)
     scheduleHydrationInContainer(container, context, initialHydrationTracker)
 
-    if (init.marker?.status === 'pending') {
-      let markerId = init.marker.id
-      let early = consumeFrameTemplate(markerId) ?? getEarlyFrameContent(markerId)
-      if (early) {
-        await render(early, { initialHydrationTracker })
-      } else {
-        let observer = setupTemplateObserver()
-        let unsubscribe = subscribeFrameTemplate(markerId, async (fragment) => {
-          unsubscribe()
-          await render(fragment)
-          observer.disconnect()
-        })
-        subscriptions.push(unsubscribe)
-        let buffered = consumeFrameTemplate(markerId)
-        if (buffered) {
-          unsubscribe()
-          await render(buffered)
-          observer.disconnect()
-        }
-        observers.push(observer)
-      }
+    if (currentMarker?.status === 'pending') {
+      await watchPendingFrameTemplate(currentMarker, initialHydrationTracker)
     }
 
     initialHydrationTracker.finalize()
@@ -403,16 +394,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     reloadController = undefined
     contentRoot?.dispose()
     contentRoot = undefined
-
-    // Disconnect any MutationObservers waiting for templates.
-    for (let observer of observers) {
-      observer.disconnect()
-    }
-    observers.length = 0
-    for (let unsubscribe of subscriptions) {
-      unsubscribe()
-    }
-    subscriptions.length = 0
+    clearPendingFrameTemplateWatch()
 
     // Remove hydrated virtual roots in this frame's region.
     removeVirtualRoots(container.childNodes)
@@ -434,8 +416,79 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     render,
     ready: () => readyPromise,
     flush: () => context.scheduler.dequeue(),
+    clearPendingTemplateWatch: clearPendingFrameTemplateWatch,
+    isDisplayingResolvedContent: () => displayedContentStatus === 'resolved',
+    updateMarker,
     dispose,
     handle: frame,
+  }
+
+  async function updateMarker(marker: FrameMarkerData, options?: RenderOptions): Promise<void> {
+    if (options?.signal?.aborted) return
+    currentMarker = marker
+    if (marker.status === 'pending') {
+      await watchPendingFrameTemplate(marker, options?.initialHydrationTracker, options?.signal)
+    } else {
+      clearPendingFrameTemplateWatch()
+    }
+  }
+
+  function clearPendingFrameTemplateWatch(): void {
+    pendingTemplateUnsubscribe?.()
+    pendingTemplateUnsubscribe = undefined
+    pendingTemplateObserver?.disconnect()
+    pendingTemplateObserver = undefined
+    pendingTemplateMarkerId = undefined
+  }
+
+  async function watchPendingFrameTemplate(
+    marker: FrameMarkerData,
+    initialHydrationTracker?: InitialHydrationTracker,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    if (signal?.aborted) return
+    if (pendingTemplateMarkerId === marker.id) return
+
+    clearPendingFrameTemplateWatch()
+    pendingTemplateMarkerId = marker.id
+
+    let early = consumeFrameTemplate(marker.id) ?? getEarlyFrameContent(marker.id)
+    if (early) {
+      clearPendingFrameTemplateWatch()
+      await render(early, { initialHydrationTracker, signal, contentStatus: 'resolved' })
+      return
+    }
+
+    if (signal?.aborted) {
+      clearPendingFrameTemplateWatch()
+      return
+    }
+
+    let observer = setupTemplateObserver()
+    pendingTemplateObserver = observer
+    let unsubscribe = subscribeFrameTemplate(marker.id, async (fragment) => {
+      if (signal?.aborted) return
+      if (pendingTemplateMarkerId !== marker.id) return
+      clearPendingFrameTemplateWatch()
+      await render(fragment, { signal, contentStatus: 'resolved' })
+    })
+    pendingTemplateUnsubscribe = unsubscribe
+
+    signal?.addEventListener(
+      'abort',
+      () => {
+        if (pendingTemplateMarkerId === marker.id) {
+          clearPendingFrameTemplateWatch()
+        }
+      },
+      { once: true },
+    )
+
+    let buffered = consumeFrameTemplate(marker.id)
+    if (buffered) {
+      clearPendingFrameTemplateWatch()
+      await render(buffered, { initialHydrationTracker, signal, contentStatus: 'resolved' })
+    }
   }
 }
 
@@ -752,16 +805,32 @@ function hydrateRegion(
   root.render(vElement)
 }
 
-function createSubFrames(nodes: Node[], context: FrameContext) {
+async function createSubFrames(
+  nodes: Node[],
+  context: FrameContext,
+  options?: RenderOptions,
+): Promise<void> {
+  let tasks: Promise<void>[] = []
+
   for (let i = 0; i < nodes.length; i++) {
+    if (options?.signal?.aborted) break
+
     let node = nodes[i]
 
     if (isFrameStart(node)) {
       let end = findEndMarker(node, isFrameStart, isFrameEnd)
+      let existingFrame = context.frameInstances.get(node)
+      let id = getFrameId(node)
+      let marker = context.data.f?.[id]
 
-      if (!context.frameInstances.has(node)) {
-        let id = getFrameId(node)
-        let marker = context.data.f?.[id]
+      if (existingFrame) {
+        if (marker) {
+          let frameMarker: FrameMarkerData = { ...marker, id }
+          tasks.push(existingFrame.updateMarker(frameMarker, options))
+        } else {
+          existingFrame.clearPendingTemplateWatch()
+        }
+      } else {
         if (marker) {
           let frameMarker: FrameMarkerData = { ...marker, id }
           let subFrame = createFrame([node, end], {
@@ -788,9 +857,11 @@ function createSubFrames(nodes: Node[], context: FrameContext) {
     }
 
     if (node.childNodes && node.childNodes.length > 0) {
-      createSubFrames(Array.from(node.childNodes), context)
+      tasks.push(createSubFrames(Array.from(node.childNodes), context, options))
     }
   }
+
+  await Promise.all(tasks)
 }
 
 function isHydrationMarkerLive(marker: HydrationMarker, context: FrameContext): boolean {

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -438,7 +438,7 @@ function buildSegment(node: RemixNode, context: RenderContext, frameState: SsrFr
 
     if (typeof type === 'function') {
       if (type === Frame) {
-        return buildFrameSegment(props, context, frameState)
+        return buildFrameSegment(node, context, frameState)
       }
       if (isEntry(type)) {
         return buildEntrySegment(type, props, context, frameState)
@@ -456,7 +456,12 @@ function buildSegment(node: RemixNode, context: RenderContext, frameState: SsrFr
   return staticSeg('')
 }
 
-function buildFrameSegment(props: any, context: RenderContext, frameState: SsrFrameState): Segment {
+function buildFrameSegment(
+  node: RemixElement,
+  context: RenderContext,
+  frameState: SsrFrameState,
+): Segment {
+  let props = node.props
   let frameId = randomId('f')
 
   // Store frame data in context for aggregation

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -1587,6 +1587,131 @@ describe('run', () => {
     app.dispose()
   })
 
+  it('dispatches reloadStart and reloadComplete events for non-blocking child frames during top frame reloads', async () => {
+    let childReloadStartEvents = 0
+    let childReloadCompleteEvents = 0
+    let reloadTopFromChild: undefined | (() => Promise<AbortSignal>)
+
+    let ChildReloadObserver = clientEntry(
+      '/assets/child-reload-observer.js#ChildReloadObserver',
+      function ChildReloadObserver(handle: Handle) {
+        reloadTopFromChild = async () => {
+          handle.frame.addEventListener(
+            'reloadStart',
+            () => {
+              childReloadStartEvents++
+            },
+            { once: true },
+          )
+          handle.frame.addEventListener(
+            'reloadComplete',
+            () => {
+              childReloadCompleteEvents++
+            },
+            { once: true },
+          )
+          return await handle.frames.top.reload()
+        }
+
+        return () => <button id="reload-top-from-child">Reload top</button>
+      },
+    )
+
+    async function renderChildFrame(label: string) {
+      return await drain(
+        renderToStream(
+          <section id="event-child-frame-content">
+            <p id="event-child-frame-label">{label}</p>
+            <ChildReloadObserver />
+          </section>,
+        ),
+      )
+    }
+
+    function renderDocument(childContent: string | Promise<string>) {
+      return renderToStream(
+        <html>
+          <head />
+          <body>
+            <main>
+              <p id="event-top-frame-label">Top frame</p>
+              <Frame
+                name="event-child"
+                src="/event-child"
+                fallback={<span id="event-child-frame-fallback">Loading child...</span>}
+              />
+            </main>
+          </body>
+        </html>,
+        {
+          resolveFrame(src: string) {
+            if (src === '/event-child') return childContent
+            throw new Error(`Unexpected frame src: ${src}`)
+          },
+        },
+      )
+    }
+
+    let initialDocument = new DOMParser().parseFromString(
+      await drainWithProtocol(renderDocument(renderChildFrame('Initial child'))),
+      'text/html',
+    )
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let [childReloadPromise, resolveChildReload] = withResolvers<string>()
+    let streamedReload = renderDocument(childReloadPromise)
+    let streamedChunks = readChunks(streamedReload)
+    let firstChunk = await streamedChunks.next()
+    invariant(!firstChunk.done)
+    resolveChildReload(await renderChildFrame('Reloaded child'))
+    let secondChunk = await streamedChunks.next()
+    invariant(!secondChunk.done)
+    let [secondChunkPromise, releaseSecondChunk] = withResolvers<string>()
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/child-reload-observer.js' &&
+          exportName === 'ChildReloadObserver'
+        ) {
+          return ChildReloadObserver
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      resolveFrame(src: string) {
+        if (src === document.location.href) {
+          return streamFromChunks(['<!DOCTYPE html>', firstChunk.value, secondChunkPromise])
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('event-child-frame-label')?.textContent).toBe('Initial child')
+
+    invariant(reloadTopFromChild)
+    let reloadPromise = reloadTopFromChild()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(childReloadStartEvents).toBe(1)
+    expect(childReloadCompleteEvents).toBe(0)
+    expect(document.getElementById('event-child-frame-fallback')).toBeNull()
+    expect(document.getElementById('event-child-frame-label')?.textContent).toBe('Initial child')
+
+    releaseSecondChunk(secondChunk.value)
+    await reloadPromise
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(childReloadStartEvents).toBe(1)
+    expect(childReloadCompleteEvents).toBe(1)
+    expect(document.getElementById('event-child-frame-fallback')).toBeNull()
+    expect(document.getElementById('event-child-frame-label')?.textContent).toBe('Reloaded child')
+
+    app.dispose()
+  })
+
   it('reloads a frame region when the response uses css mixins', async () => {
     let renderCount = 0
 
@@ -3353,6 +3478,36 @@ describe('run', () => {
   it('diffs pending child frame fallbacks and ignores stale templates during top frame reloads', async () => {
     let [initialChildPromise] = withResolvers<string>()
     let [reloadedChildPromise] = withResolvers<string>()
+    let childReloadStartEvents = 0
+    let childReloadCompleteEvents = 0
+    let reloadTopWithPendingChild: undefined | (() => Promise<AbortSignal>)
+
+    let PendingChildFrameObserver = clientEntry(
+      '/assets/pending-child-frame-observer.js#PendingChildFrameObserver',
+      function PendingChildFrameObserver(handle: Handle) {
+        reloadTopWithPendingChild = async () => {
+          let childFrame = handle.frames.get('child')
+          invariant(childFrame)
+          childFrame.addEventListener(
+            'reloadStart',
+            () => {
+              childReloadStartEvents++
+            },
+            { once: true },
+          )
+          childFrame.addEventListener(
+            'reloadComplete',
+            () => {
+              childReloadCompleteEvents++
+            },
+            { once: true },
+          )
+          return await handle.frames.top.reload()
+        }
+
+        return () => <button id="reload-top-with-pending-child">Reload top</button>
+      },
+    )
 
     function renderDocument(childContent: Promise<string>, fallbackLabel: string) {
       return renderToStream(
@@ -3361,6 +3516,7 @@ describe('run', () => {
           <body>
             <main>
               <p id="top-frame-label">Top frame</p>
+              <PendingChildFrameObserver />
               <Frame
                 name="child"
                 src="/child"
@@ -3396,7 +3552,15 @@ describe('run', () => {
     let reloadedMarkerId = getCommentMarkerId(reloadedChunk.value, 'rmx:f:')
 
     let app = run({
-      loadModule: mock.fn(),
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/pending-child-frame-observer.js' &&
+          exportName === 'PendingChildFrameObserver'
+        ) {
+          return PendingChildFrameObserver
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
       resolveFrame(src: string) {
         if (src === document.location.href) {
           return streamFromChunks(['<!DOCTYPE html>', reloadedChunk.value])
@@ -3413,10 +3577,13 @@ describe('run', () => {
     expect(fallback.textContent).toBe('Initial fallback')
     expect(fallback.getAttribute('data-label')).toBe('Initial fallback')
 
-    let reloadPromise = getTopFrame().reload()
+    invariant(reloadTopWithPendingChild)
+    let reloadPromise = reloadTopWithPendingChild()
     await reloadPromise
     await new Promise((resolve) => setTimeout(resolve, 0))
 
+    expect(childReloadStartEvents).toBe(1)
+    expect(childReloadCompleteEvents).toBe(0)
     expect(document.getElementById('child-frame-fallback')).toBe(fallback)
     expect(fallback.textContent).toBe('Reloaded fallback')
     expect(fallback.getAttribute('data-label')).toBe('Reloaded fallback')
@@ -3440,6 +3607,8 @@ describe('run', () => {
     expect(document.getElementById('stale-child-content')).toBeNull()
     expect(document.getElementById('fresh-child-content')?.textContent).toBe('Fresh child')
     expect(document.getElementById('child-frame-fallback')).toBeNull()
+    expect(childReloadStartEvents).toBe(1)
+    expect(childReloadCompleteEvents).toBe(1)
 
     app.dispose()
   })
@@ -3572,6 +3741,130 @@ describe('run', () => {
     )
     expect(input.value).toBe('typed direct child value')
     expect(document.getElementById('direct-parent-sibling')?.textContent).toBe('Parent sibling')
+
+    app.dispose()
+  })
+
+  it('keeps blocking child frame handles reloadable after top frame reloads', async () => {
+    let childReloadCount = 0
+
+    let ReloadBlockingChild = clientEntry(
+      '/assets/reload-blocking-child.js#ReloadBlockingChild',
+      function ReloadBlockingChild(handle: Handle) {
+        let pending = false
+
+        handle.frame.addEventListener('reloadStart', () => {
+          pending = true
+          handle.update()
+        })
+
+        handle.frame.addEventListener('reloadComplete', () => {
+          pending = false
+          handle.update()
+        })
+
+        return () => (
+          <button
+            id="reload-blocking-child"
+            mix={on('click', () => {
+              void handle.frame.reload()
+            })}
+          >
+            {pending ? 'Reloading child' : 'Reload child'}
+          </button>
+        )
+      },
+    )
+
+    async function renderChildFrame(label: string) {
+      return await drain(
+        renderToStream(
+          <>
+            <p id="blocking-child-frame-label">{label}</p>
+            <ReloadBlockingChild />
+          </>,
+        ),
+      )
+    }
+
+    function renderDocument(childLabel: string) {
+      return renderToStream(
+        <html>
+          <head />
+          <body>
+            <main>
+              <Frame name="blocking-child" src="/blocking-child" />
+            </main>
+          </body>
+        </html>,
+        {
+          resolveFrame(src: string) {
+            if (src === '/blocking-child') return renderChildFrame(childLabel)
+            throw new Error(`Unexpected frame src: ${src}`)
+          },
+        },
+      )
+    }
+
+    let initialDocument = new DOMParser().parseFromString(
+      await drainWithProtocol(renderDocument('Initial blocking child')),
+      'text/html',
+    )
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let [topReloadPromise, resolveTopReload] = withResolvers<ReadableStream<Uint8Array>>()
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/reload-blocking-child.js' &&
+          exportName === 'ReloadBlockingChild'
+        ) {
+          return ReloadBlockingChild
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      resolveFrame(src: string) {
+        if (src === document.location.href) {
+          return topReloadPromise
+        }
+        if (src === '/blocking-child') {
+          childReloadCount++
+          return renderChildFrame(`Reloaded by child frame ${childReloadCount}`)
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('blocking-child-frame-label')?.textContent).toBe(
+      'Initial blocking child',
+    )
+
+    let topReload = getTopFrame().reload()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('reload-blocking-child')?.textContent).toBe('Reloading child')
+
+    resolveTopReload(renderDocument('Reloaded by top frame'))
+    await topReload
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('blocking-child-frame-label')?.textContent).toBe(
+      'Reloaded by top frame',
+    )
+    expect(document.getElementById('reload-blocking-child')?.textContent).toBe('Reload child')
+
+    let reloadChildButton = document.getElementById('reload-blocking-child')
+    invariant(reloadChildButton instanceof HTMLButtonElement)
+    reloadChildButton.click()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('blocking-child-frame-label')?.textContent).toBe(
+      'Reloaded by child frame 1',
+    )
 
     app.dispose()
   })

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -3259,6 +3259,645 @@ describe('run', () => {
     app.dispose()
   })
 
+  it('preserves resolved non-blocking child frame content during top frame reloads', async () => {
+    async function renderChildFrame(label: string) {
+      return await drain(
+        renderToStream(
+          <section id="child-frame-content">
+            <p id="child-frame-label">{label}</p>
+            <input id="child-frame-input" />
+          </section>,
+        ),
+      )
+    }
+
+    function renderDocument(childContent: string | Promise<string>) {
+      return renderToStream(
+        <html>
+          <head />
+          <body>
+            <main>
+              <p id="top-frame-label">Top frame</p>
+              <Frame
+                name="child"
+                src="/child"
+                fallback={<span id="child-frame-fallback">Loading child...</span>}
+              />
+            </main>
+          </body>
+        </html>,
+        {
+          resolveFrame(src: string) {
+            if (src === '/child') return childContent
+            throw new Error(`Unexpected frame src: ${src}`)
+          },
+        },
+      )
+    }
+
+    let initialDocument = new DOMParser().parseFromString(
+      await drainWithProtocol(renderDocument(renderChildFrame('Initial child'))),
+      'text/html',
+    )
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let [childReloadPromise, resolveChildReload] = withResolvers<string>()
+    let streamedReload = renderDocument(childReloadPromise)
+    let streamedChunks = readChunks(streamedReload)
+    let firstChunk = await streamedChunks.next()
+    invariant(!firstChunk.done)
+    resolveChildReload(await renderChildFrame('Reloaded child'))
+    let secondChunk = await streamedChunks.next()
+    invariant(!secondChunk.done)
+    let [secondChunkPromise, releaseSecondChunk] = withResolvers<string>()
+
+    let app = run({
+      loadModule: mock.fn(),
+      resolveFrame(src: string) {
+        if (src === document.location.href) {
+          return streamFromChunks(['<!DOCTYPE html>', firstChunk.value, secondChunkPromise])
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    let input = document.getElementById('child-frame-input')
+    invariant(input instanceof HTMLInputElement)
+    expect(document.getElementById('child-frame-label')?.textContent).toBe('Initial child')
+    input.value = 'typed child value'
+
+    let topFrame = getTopFrame()
+    let reloadPromise = topFrame.reload()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('child-frame-fallback')).toBeNull()
+    expect(document.getElementById('child-frame-input')).toBe(input)
+    expect(document.getElementById('child-frame-label')?.textContent).toBe('Initial child')
+    expect(input.value).toBe('typed child value')
+
+    releaseSecondChunk(secondChunk.value)
+    await reloadPromise
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('child-frame-fallback')).toBeNull()
+    expect(document.getElementById('child-frame-input')).toBe(input)
+    expect(document.getElementById('child-frame-label')?.textContent).toBe('Reloaded child')
+    expect(input.value).toBe('typed child value')
+
+    app.dispose()
+  })
+
+  it('diffs pending child frame fallbacks and ignores stale templates during top frame reloads', async () => {
+    let [initialChildPromise] = withResolvers<string>()
+    let [reloadedChildPromise] = withResolvers<string>()
+
+    function renderDocument(childContent: Promise<string>, fallbackLabel: string) {
+      return renderToStream(
+        <html>
+          <head />
+          <body>
+            <main>
+              <p id="top-frame-label">Top frame</p>
+              <Frame
+                name="child"
+                src="/child"
+                fallback={
+                  <span id="child-frame-fallback" data-label={fallbackLabel}>
+                    {fallbackLabel}
+                  </span>
+                }
+              />
+            </main>
+          </body>
+        </html>,
+        {
+          resolveFrame(src: string) {
+            if (src === '/child') return childContent
+            throw new Error(`Unexpected frame src: ${src}`)
+          },
+        },
+      )
+    }
+
+    let initialChunks = readChunks(renderDocument(initialChildPromise, 'Initial fallback'))
+    let initialChunk = await initialChunks.next()
+    invariant(!initialChunk.done)
+    let initialMarkerId = getCommentMarkerId(initialChunk.value, 'rmx:f:')
+
+    let initialDocument = new DOMParser().parseFromString(initialChunk.value, 'text/html')
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let reloadedChunks = readChunks(renderDocument(reloadedChildPromise, 'Reloaded fallback'))
+    let reloadedChunk = await reloadedChunks.next()
+    invariant(!reloadedChunk.done)
+    let reloadedMarkerId = getCommentMarkerId(reloadedChunk.value, 'rmx:f:')
+
+    let app = run({
+      loadModule: mock.fn(),
+      resolveFrame(src: string) {
+        if (src === document.location.href) {
+          return streamFromChunks(['<!DOCTYPE html>', reloadedChunk.value])
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    let fallback = document.getElementById('child-frame-fallback')
+    invariant(fallback instanceof HTMLSpanElement)
+    expect(fallback.textContent).toBe('Initial fallback')
+    expect(fallback.getAttribute('data-label')).toBe('Initial fallback')
+
+    let reloadPromise = getTopFrame().reload()
+    await reloadPromise
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('child-frame-fallback')).toBe(fallback)
+    expect(fallback.textContent).toBe('Reloaded fallback')
+    expect(fallback.getAttribute('data-label')).toBe('Reloaded fallback')
+
+    let staleTemplate = document.createElement('template')
+    staleTemplate.id = initialMarkerId
+    staleTemplate.innerHTML = '<span id="stale-child-content">Stale child</span>'
+    document.body.appendChild(staleTemplate)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('stale-child-content')).toBeNull()
+    expect(document.getElementById('child-frame-fallback')).toBe(fallback)
+    expect(fallback.textContent).toBe('Reloaded fallback')
+
+    let freshTemplate = document.createElement('template')
+    freshTemplate.id = reloadedMarkerId
+    freshTemplate.innerHTML = '<span id="fresh-child-content">Fresh child</span>'
+    document.body.appendChild(freshTemplate)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('stale-child-content')).toBeNull()
+    expect(document.getElementById('fresh-child-content')?.textContent).toBe('Fresh child')
+    expect(document.getElementById('child-frame-fallback')).toBeNull()
+
+    app.dispose()
+  })
+
+  it('preserves resolved direct child frame content during parent frame reloads', async () => {
+    let reloadParent: undefined | (() => Promise<AbortSignal>)
+
+    let ReloadDirectParent = clientEntry(
+      '/assets/reload-direct-parent.js#ReloadDirectParent',
+      function ReloadDirectParent(handle: Handle) {
+        reloadParent = () => handle.frame.reload()
+        return () => <button id="reload-direct-parent">Reload parent</button>
+      },
+    )
+
+    async function renderChildFrame(label: string) {
+      return await drain(
+        renderToStream(
+          <>
+            <p id="direct-child-frame-label">{label}</p>
+            <input id="direct-child-frame-input" />
+          </>,
+        ),
+      )
+    }
+
+    function renderParentFrame(childContent: string | Promise<string>) {
+      return renderToStream(
+        <>
+          <Frame
+            name="direct-child"
+            src="/direct-child"
+            fallback={<span id="direct-child-frame-fallback">Loading child...</span>}
+          />
+          <p id="direct-parent-sibling">Parent sibling</p>
+          <ReloadDirectParent />
+        </>,
+        {
+          resolveFrame(src: string) {
+            if (src === '/direct-child') return childContent
+            throw new Error(`Unexpected frame src: ${src}`)
+          },
+        },
+      )
+    }
+
+    let initialDocument = new DOMParser().parseFromString(
+      await drainWithProtocol(
+        renderToStream(
+          <html>
+            <head />
+            <body>
+              <main>
+                <Frame name="direct-parent" src="/direct-parent" />
+              </main>
+            </body>
+          </html>,
+          {
+            resolveFrame(src: string) {
+              if (src === '/direct-parent') {
+                return renderParentFrame(renderChildFrame('Initial direct child'))
+              }
+              throw new Error(`Unexpected frame src: ${src}`)
+            },
+          },
+        ),
+      ),
+      'text/html',
+    )
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let [childReloadPromise, resolveChildReload] = withResolvers<string>()
+    let streamedReload = renderParentFrame(childReloadPromise)
+    let streamedChunks = readChunks(streamedReload)
+    let firstChunk = await streamedChunks.next()
+    invariant(!firstChunk.done)
+    resolveChildReload(await renderChildFrame('Reloaded direct child'))
+    let secondChunk = await streamedChunks.next()
+    invariant(!secondChunk.done)
+    let [secondChunkPromise, releaseSecondChunk] = withResolvers<string>()
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/reload-direct-parent.js' &&
+          exportName === 'ReloadDirectParent'
+        ) {
+          return ReloadDirectParent
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      resolveFrame(src: string) {
+        if (src === '/direct-parent') {
+          return streamFromChunks([firstChunk.value, secondChunkPromise])
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    let input = document.getElementById('direct-child-frame-input')
+    invariant(input instanceof HTMLInputElement)
+    expect(document.getElementById('direct-child-frame-label')?.textContent).toBe(
+      'Initial direct child',
+    )
+    input.value = 'typed direct child value'
+
+    invariant(reloadParent)
+    let reloadPromise = reloadParent()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('direct-child-frame-fallback')).toBeNull()
+    expect(document.getElementById('direct-child-frame-input')).toBe(input)
+    expect(document.getElementById('direct-child-frame-label')?.textContent).toBe(
+      'Initial direct child',
+    )
+    expect(input.value).toBe('typed direct child value')
+    expect(document.getElementById('direct-parent-sibling')?.textContent).toBe('Parent sibling')
+
+    releaseSecondChunk(secondChunk.value)
+    await reloadPromise
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('direct-child-frame-fallback')).toBeNull()
+    expect(document.getElementById('direct-child-frame-input')).toBe(input)
+    expect(document.getElementById('direct-child-frame-label')?.textContent).toBe(
+      'Reloaded direct child',
+    )
+    expect(input.value).toBe('typed direct child value')
+    expect(document.getElementById('direct-parent-sibling')?.textContent).toBe('Parent sibling')
+
+    app.dispose()
+  })
+
+  it('removes direct child frame content during parent frame reloads', async () => {
+    let reloadParent: undefined | (() => Promise<AbortSignal>)
+    let showChildFrame = true
+
+    let ReloadDirectParent = clientEntry(
+      '/assets/remove-direct-child-frame.js#RemoveDirectChildFrame',
+      function RemoveDirectChildFrame(handle: Handle) {
+        reloadParent = async () => {
+          showChildFrame = false
+          return await handle.frame.reload()
+        }
+        return () => <button id="remove-direct-child-frame">Remove child</button>
+      },
+    )
+
+    function renderParentFrame() {
+      return renderToStream(
+        <>
+          {showChildFrame ? <Frame name="removed-child" src="/removed-child" /> : null}
+          <p id="remove-direct-parent-sibling">Parent sibling</p>
+          <ReloadDirectParent />
+        </>,
+        {
+          resolveFrame(src: string) {
+            if (src === '/removed-child') {
+              return '<p id="removed-child-content">Child content</p><input id="removed-child-input" />'
+            }
+            throw new Error(`Unexpected frame src: ${src}`)
+          },
+        },
+      )
+    }
+
+    let initialDocument = new DOMParser().parseFromString(
+      await drainWithProtocol(
+        renderToStream(
+          <html>
+            <head />
+            <body>
+              <main>
+                <Frame name="remove-direct-parent" src="/remove-direct-parent" />
+              </main>
+            </body>
+          </html>,
+          {
+            resolveFrame(src: string) {
+              if (src === '/remove-direct-parent') return renderParentFrame()
+              throw new Error(`Unexpected frame src: ${src}`)
+            },
+          },
+        ),
+      ),
+      'text/html',
+    )
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/remove-direct-child-frame.js' &&
+          exportName === 'RemoveDirectChildFrame'
+        ) {
+          return ReloadDirectParent
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      resolveFrame(src: string) {
+        if (src === '/remove-direct-parent') return renderParentFrame()
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('removed-child-content')?.textContent).toBe('Child content')
+    expect(document.getElementById('remove-direct-parent-sibling')?.textContent).toBe(
+      'Parent sibling',
+    )
+
+    invariant(reloadParent)
+    await reloadParent()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('removed-child-content')).toBeNull()
+    expect(document.getElementById('removed-child-input')).toBeNull()
+    expect(document.getElementById('remove-direct-parent-sibling')?.textContent).toBe(
+      'Parent sibling',
+    )
+
+    app.dispose()
+  })
+
+  it('replaces direct child frame content when frame src changes during parent frame reloads', async () => {
+    let reloadParent: undefined | (() => Promise<AbortSignal>)
+    let childSrc = '/direct-src-a'
+
+    let ReloadDirectParent = clientEntry(
+      '/assets/replace-direct-child-frame.js#ReplaceDirectChildFrame',
+      function ReplaceDirectChildFrame(handle: Handle) {
+        reloadParent = async () => {
+          childSrc = '/direct-src-b'
+          return await handle.frame.reload()
+        }
+        return () => <button id="replace-direct-child-frame">Replace child</button>
+      },
+    )
+
+    function renderParentFrame(childContent: string | Promise<string>) {
+      return renderToStream(
+        <>
+          <Frame
+            name="direct-src-child"
+            src={childSrc}
+            fallback={<span id="direct-src-child-fallback">Loading replacement...</span>}
+          />
+          <p id="direct-src-parent-sibling">Parent sibling</p>
+          <ReloadDirectParent />
+        </>,
+        {
+          resolveFrame(src: string) {
+            if (src === childSrc) return childContent
+            throw new Error(`Unexpected frame src: ${src}`)
+          },
+        },
+      )
+    }
+
+    let initialDocument = new DOMParser().parseFromString(
+      await drainWithProtocol(
+        renderToStream(
+          <html>
+            <head />
+            <body>
+              <main>
+                <Frame name="direct-src-parent" src="/direct-src-parent" />
+              </main>
+            </body>
+          </html>,
+          {
+            resolveFrame(src: string) {
+              if (src === '/direct-src-parent') {
+                return renderParentFrame(
+                  '<p id="direct-src-child-content">Initial child</p><input id="direct-src-child-input" />',
+                )
+              }
+              throw new Error(`Unexpected frame src: ${src}`)
+            },
+          },
+        ),
+      ),
+      'text/html',
+    )
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let [childReloadPromise, resolveChildReload] = withResolvers<string>()
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/replace-direct-child-frame.js' &&
+          exportName === 'ReplaceDirectChildFrame'
+        ) {
+          return ReloadDirectParent
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      resolveFrame(src: string) {
+        if (src === '/direct-src-parent') {
+          return renderParentFrame(childReloadPromise)
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    let input = document.getElementById('direct-src-child-input')
+    invariant(input instanceof HTMLInputElement)
+    input.value = 'typed value'
+    expect(document.getElementById('direct-src-child-content')?.textContent).toBe('Initial child')
+
+    invariant(reloadParent)
+    let reloadPromise = reloadParent()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('direct-src-child-content')).toBeNull()
+    expect(document.getElementById('direct-src-child-input')).toBeNull()
+    expect(document.getElementById('direct-src-child-fallback')?.textContent).toBe(
+      'Loading replacement...',
+    )
+    expect(document.getElementById('direct-src-parent-sibling')?.textContent).toBe('Parent sibling')
+
+    resolveChildReload('<p id="direct-src-child-content">Replacement child</p>')
+    await reloadPromise
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('direct-src-child-fallback')).toBeNull()
+    expect(document.getElementById('direct-src-child-content')?.textContent).toBe(
+      'Replacement child',
+    )
+    expect(document.getElementById('direct-src-parent-sibling')?.textContent).toBe('Parent sibling')
+
+    app.dispose()
+  })
+
+  it('replaces nested child frame content when frame src changes during parent frame reloads', async () => {
+    let reloadParent: undefined | (() => Promise<AbortSignal>)
+    let childSrc = '/nested-src-a'
+
+    let ReloadNestedParent = clientEntry(
+      '/assets/replace-nested-child-frame.js#ReplaceNestedChildFrame',
+      function ReplaceNestedChildFrame(handle: Handle) {
+        reloadParent = async () => {
+          childSrc = '/nested-src-b'
+          return await handle.frame.reload()
+        }
+        return () => <button id="replace-nested-child-frame">Replace child</button>
+      },
+    )
+
+    function renderParentFrame(childContent: string | Promise<string>) {
+      return renderToStream(
+        <>
+          <section id="nested-src-child-shell">
+            <Frame
+              name="nested-src-child"
+              src={childSrc}
+              fallback={<span id="nested-src-child-fallback">Loading replacement...</span>}
+            />
+          </section>
+          <p id="nested-src-parent-sibling">Parent sibling</p>
+          <ReloadNestedParent />
+        </>,
+        {
+          resolveFrame(src: string) {
+            if (src === childSrc) return childContent
+            throw new Error(`Unexpected frame src: ${src}`)
+          },
+        },
+      )
+    }
+
+    let initialDocument = new DOMParser().parseFromString(
+      await drainWithProtocol(
+        renderToStream(
+          <html>
+            <head />
+            <body>
+              <main>
+                <Frame name="nested-src-parent" src="/nested-src-parent" />
+              </main>
+            </body>
+          </html>,
+          {
+            resolveFrame(src: string) {
+              if (src === '/nested-src-parent') {
+                return renderParentFrame(
+                  '<p id="nested-src-child-content">Initial child</p><input id="nested-src-child-input" />',
+                )
+              }
+              throw new Error(`Unexpected frame src: ${src}`)
+            },
+          },
+        ),
+      ),
+      'text/html',
+    )
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let [childReloadPromise, resolveChildReload] = withResolvers<string>()
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/replace-nested-child-frame.js' &&
+          exportName === 'ReplaceNestedChildFrame'
+        ) {
+          return ReloadNestedParent
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      resolveFrame(src: string) {
+        if (src === '/nested-src-parent') {
+          return renderParentFrame(childReloadPromise)
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    let input = document.getElementById('nested-src-child-input')
+    invariant(input instanceof HTMLInputElement)
+    input.value = 'typed value'
+    expect(document.getElementById('nested-src-child-content')?.textContent).toBe('Initial child')
+
+    invariant(reloadParent)
+    let reloadPromise = reloadParent()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('nested-src-child-content')).toBeNull()
+    expect(document.getElementById('nested-src-child-input')).toBeNull()
+    expect(document.getElementById('nested-src-child-fallback')?.textContent).toBe(
+      'Loading replacement...',
+    )
+    expect(document.getElementById('nested-src-parent-sibling')?.textContent).toBe('Parent sibling')
+
+    resolveChildReload('<p id="nested-src-child-content">Replacement child</p>')
+    await reloadPromise
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('nested-src-child-fallback')).toBeNull()
+    expect(document.getElementById('nested-src-child-content')?.textContent).toBe(
+      'Replacement child',
+    )
+    expect(document.getElementById('nested-src-child-input')).toBeNull()
+    expect(document.getElementById('nested-src-parent-sibling')?.textContent).toBe('Parent sibling')
+
+    app.dispose()
+  })
+
   it('cancels stale client frame streams when src changes', async () => {
     let rootContainer = document.createElement('div')
     document.body.appendChild(rootContainer)


### PR DESCRIPTION
This fixes an issue raised in https://github.com/remix-run/remix/pull/11414. For context, this is the relevant issue:

> **Issue:** Reloading the root frame causes non-blocking child frames to briefly show their fallback again.
> 
> **Reproduction:** Go to http://localhost:44100/reload-scope, then wait for the non-blocking child frame to finish loading before clicking `Reload top frame`. You'll see the non-blocking child frame briefly show its fallback again, while the blocking child frame resolves normally.

With the changes in this PR, the reproduction above is now fixed. Reloading the root frame keeps the existing non-blocking frame contact intact until the new content arrives rather than showing the fallback again.

While testing this, I also found a couple of related ancestor-reload issues:

- Child frame `reloadStart`/`reloadComplete` events were not consistently dispatched for reloads caused by an ancestor frame reload.
- Those inherited reload events were firing too late to produce a visible pending state, especially for blocking child frames whose new content is available in the ancestor reload payload.
- Resolved blocking child frames could lose their frame ownership after a root reload, causing controls inside the child frame that call `handle.frame.reload()` to stop reloading the child frame.

This PR now treats ancestor reloads as inherited reloads for preserved child frames. Descendant frames receive `reloadStart` when the ancestor reload begins, receive `reloadComplete` when their replacement content is applied, and resolved child frame content is rendered through the existing child frame instance so its `handle.frame` wiring remains intact.
