### PR TITLE
fix(ui-demo): add @ssr false opt-out to prevent server crash on browser-only demos

### DIFF
--- a/packages/ui/demo/README.md
+++ b/packages/ui/demo/README.md
@@ -15,3 +15,7 @@ Then open `http://localhost:44100`.
 The index scans `packages/ui` for `*.demo.ts` and `*.demo.tsx` files on every request.
 Each demo is available at `/demo/*filename`, where `*filename` is the demo file path
 relative to `packages/ui`.
+
+Use JSDoc metadata in the demo file comment to customize behavior. For demos that
+should only run in the browser, add `@ssr false` to disable server rendering for
+that demo route while still hydrating from the browser asset bundle.

--- a/packages/ui/demo/app/demo-runner/controller.tsx
+++ b/packages/ui/demo/app/demo-runner/controller.tsx
@@ -28,7 +28,8 @@ const demosController = createController(routes.demos, {
         })
       }
 
-      let DemoComponent = clientEntry(`${demo.assetHref}#default`, await loadDemoModule(demo))
+      let serverComponent = demo.ssr ? await loadDemoModule(demo) : () => () => null
+      let DemoComponent = clientEntry(`${demo.assetHref}#default`, serverComponent)
 
       return render(context, <DemoDocument DemoComponent={DemoComponent} demo={demo} />, {
         headers: {

--- a/packages/ui/demo/app/demo-runner/discovery.ts
+++ b/packages/ui/demo/app/demo-runner/discovery.ts
@@ -11,6 +11,7 @@ export type DemoFile = {
   layout?: DemoLayout
   order?: number
   relativePath: string
+  ssr: boolean
   title: string
 }
 
@@ -61,6 +62,7 @@ function createDemoFile(absolutePath: string): DemoFile {
     layout: metadata.layout,
     order: metadata.order,
     relativePath,
+    ssr: metadata.ssr ?? true,
     title: metadata.name ?? humanizeDemoPath(relativePath),
   }
 }
@@ -110,6 +112,7 @@ function readDemoMetadata(source: string) {
     layout?: DemoLayout
     name?: string
     order?: number
+    ssr?: boolean
   } = {}
 
   for (let key of ['description', 'layout', 'name', 'order'] as const) {
@@ -129,6 +132,9 @@ function readDemoMetadata(source: string) {
 
     metadata[key] = value
   }
+
+  let ssrValue = comment.match(/@ssr\s+([^\n]+)/)?.[1]?.trim().toLowerCase()
+  if (ssrValue === 'false') metadata.ssr = false
 
   return metadata
 }

--- a/packages/ui/src/animation/demos/animation.demo.tsx
+++ b/packages/ui/src/animation/demos/animation.demo.tsx
@@ -109,6 +109,7 @@ function Tile(handle: Handle<{ title: string; children: RemixNode; notes?: strin
 /**
  * @name Animation Gallery
  * @description A collection of motion and animation experiments adapted from the standalone demos.
+ * @ssr false
  */
 export default function AnimationGallery() {
   return () => (

--- a/packages/ui/src/animation/demos/animation.demo.tsx
+++ b/packages/ui/src/animation/demos/animation.demo.tsx
@@ -116,7 +116,7 @@ export default function AnimationGallery() {
     <>
       <h1 mix={[css({ marginBottom: 0, '& + p': { marginTop: 0 } })]}>Animations</h1>
       <p>
-        Most animations are adapted from <a href="https://www.motion.dev">Motion</a>. Thank you for
+        Most animations are adapted from <a href="https://motion.dev">Motion</a>. Thank you for
         your work <a href="https://motion.dev/@matt">Matt Perry</a>!
       </p>
       <div


### PR DESCRIPTION
The demo runner calls `loadDemoModule()` on the server for every demo, which causes a crash when a demo imports browser-only code that runs side effects at module load time.

The specific failure: `animation.demo.tsx` imports `reordering.tsx`, which calls `scheduleNextShuffle()` during setup. That schedules a `setTimeout` which eventually calls `handle.update()`, which throws `scheduleUpdate not implemented` in the server path. The error is uncaught and kills the Node process.

**Fix:** demos can opt out of server-side rendering by adding `@ssr false` to their JSDoc metadata block,  the same block already used for `@name`, `@description`, `@layout`, and `@order`. When set, the server skips executing the module and uses a no-op component instead. The browser still receives and hydrates the full demo bundle.

```ts
/**
 * @name Animation
 * @ssr false
 */
```

Also fixed the `motion.dev` link in the animations demo, as it was broken.