### PR TITLE
Pin node to 24.15.0 on windows CI tests to avoid libuv issue

### DIFF
--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -186,7 +186,10 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: 'package.json'
+          # Pin Windows to 24.15.0 to avoid libuv 1.52.x assertion bug on file watching.
+          # See https://github.com/libuv/libuv/issues/5010
+          # node-version-file: 'package.json'
+          node-version: '24.15.0'
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -206,7 +206,10 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: 'package.json'
+          # Pin Windows to 24.15.0 to avoid libuv 1.52.x assertion bug on file watching.
+          # See https://github.com/libuv/libuv/issues/5010
+          # node-version-file: 'package.json'
+          node-version: '24.15.0'
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,7 +99,10 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: 'package.json'
+          # Pin Windows to 24.15.0 to avoid libuv 1.52.x assertion bug on file watching.
+          # See https://github.com/libuv/libuv/issues/5010
+          # node-version-file: 'package.json'
+          node-version: '24.15.0'
           cache: pnpm
 
       - name: Install dependencies
@@ -140,7 +143,10 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: 'package.json'
+          # Pin Windows to 24.15.0 to avoid libuv 1.52.x assertion bug on file watching.
+          # See https://github.com/libuv/libuv/issues/5010
+          # node-version-file: 'package.json'
+          node-version: '24.15.0'
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
Fixes CI errors on assets tests on windows:

```
packages/assets test: Error running D:/a/remix/remix/packages/assets/src/lib/asset-server.test.ts: Worker process exited with code 3221226505
packages/assets test: Error: Worker process exited with code 3221226505
packages/assets test:     at file:///D:/a/remix/remix/packages/test/src/lib/runner.ts:335:16
packages/assets test:     at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
```

See https://github.com/libuv/libuv/issues/5010