### PR TITLE
Make GitHub release publishing resilient

### DIFF
--- a/scripts/utils/github.test.ts
+++ b/scripts/utils/github.test.ts
@@ -1,0 +1,113 @@
+import assert from '@remix-run/assert'
+import { describe, it } from '@remix-run/test'
+import { createRelease, type GitHubRequest } from './github.ts'
+
+interface MockCall {
+  route: string
+  options: Record<string, unknown>
+}
+
+function withGitHubToken(callback: () => Promise<void>) {
+  let previousToken = process.env.GITHUB_TOKEN
+  process.env.GITHUB_TOKEN = 'test-token'
+
+  return callback().finally(() => {
+    if (previousToken === undefined) {
+      delete process.env.GITHUB_TOKEN
+    } else {
+      process.env.GITHUB_TOKEN = previousToken
+    }
+  })
+}
+
+function createHttpError(status: number, message: string): Error & { status: number } {
+  return Object.assign(new Error(message), { status })
+}
+
+function createCodeError(code: string, message: string): Error & { code: string } {
+  return Object.assign(new Error(message), { code })
+}
+
+describe('createRelease', () => {
+  it('treats a failed create response as success when the release exists afterward', async () => {
+    await withGitHubToken(async () => {
+      let calls: MockCall[] = []
+      let githubRequest: GitHubRequest = async (route, options) => {
+        calls.push({ route, options })
+
+        if (route === 'GET /repos/{owner}/{repo}/releases/tags/{tag}') {
+          if (calls.length === 1) {
+            throw createHttpError(404, 'Not Found')
+          }
+
+          return {
+            data: {
+              html_url: 'https://github.com/remix-run/remix/releases/tag/test%400.4.2',
+            },
+          }
+        }
+
+        if (route === 'POST /repos/{owner}/{repo}/releases') {
+          throw createCodeError('EPIPE', 'write EPIPE')
+        }
+
+        throw new Error(`Unexpected route: ${route}`)
+      }
+
+      let result = await createRelease('@remix-run/test', '0.4.2', {
+        request: githubRequest,
+        retryDelayMs: 0,
+      })
+
+      assert.deepEqual(result, {
+        status: 'created',
+        url: 'https://github.com/remix-run/remix/releases/tag/test%400.4.2',
+      })
+      assert.deepEqual(
+        calls.map((call) => call.route),
+        [
+          'GET /repos/{owner}/{repo}/releases/tags/{tag}',
+          'POST /repos/{owner}/{repo}/releases',
+          'GET /repos/{owner}/{repo}/releases/tags/{tag}',
+        ],
+      )
+    })
+  })
+
+  it('retries transient create failures before reporting success', async () => {
+    await withGitHubToken(async () => {
+      let postAttempts = 0
+      let githubRequest: GitHubRequest = async (route) => {
+        if (route === 'GET /repos/{owner}/{repo}/releases/tags/{tag}') {
+          throw createHttpError(404, 'Not Found')
+        }
+
+        if (route === 'POST /repos/{owner}/{repo}/releases') {
+          postAttempts++
+          if (postAttempts === 1) {
+            throw createHttpError(502, 'Bad Gateway')
+          }
+
+          return {
+            data: {
+              html_url: 'https://github.com/remix-run/remix/releases/tag/ui%400.3.0',
+            },
+          }
+        }
+
+        throw new Error(`Unexpected route: ${route}`)
+      }
+
+      let result = await createRelease('@remix-run/ui', '0.3.0', {
+        request: githubRequest,
+        retryDelayMs: 0,
+      })
+
+      assert.deepEqual(result, {
+        status: 'created',
+        url: 'https://github.com/remix-run/remix/releases/tag/ui%400.3.0',
+      })
+      assert.equal(postAttempts, 2)
+    })
+  })
+})

--- a/scripts/utils/github.ts
+++ b/scripts/utils/github.ts
@@ -5,6 +5,33 @@ import { getGitTag, getPackageShortName } from './packages.ts'
 
 const owner = 'remix-run'
 const repo = 'remix'
+const transientStatusCodes = new Set([408, 429, 500, 502, 503, 504])
+const transientErrorCodes = new Set([
+  'ECONNRESET',
+  'EPIPE',
+  'ETIMEDOUT',
+  'ENETDOWN',
+  'ENETRESET',
+  'ENETUNREACH',
+  'EAI_AGAIN',
+])
+
+interface GitHubResponse {
+  data: unknown
+}
+
+export interface GitHubRequest {
+  (route: string, options: Record<string, unknown>): Promise<GitHubResponse>
+}
+
+interface RetryOptions {
+  maxAttempts?: number
+  retryDelayMs?: number
+}
+
+interface ReleaseInfo {
+  url: string
+}
 
 function getToken(): string {
   let token = process.env.GITHUB_TOKEN
@@ -18,6 +45,113 @@ function auth() {
   return { headers: { Authorization: `token ${getToken()}` } }
 }
 
+async function defaultRequest(route: string, options: Record<string, unknown>) {
+  let response = await request(route, options)
+  return { data: response.data }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function getErrorStatus(error: unknown): number | null {
+  return isRecord(error) && typeof error.status === 'number' ? error.status : null
+}
+
+function getErrorCode(error: unknown): string | null {
+  return isRecord(error) && typeof error.code === 'string' ? error.code : null
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isTransientError(error: unknown): boolean {
+  let status = getErrorStatus(error)
+  if (status !== null && transientStatusCodes.has(status)) {
+    return true
+  }
+
+  let code = getErrorCode(error)
+  return code !== null && transientErrorCodes.has(code)
+}
+
+function getReleaseUrl(tagName: string): string {
+  return `https://github.com/${owner}/${repo}/releases/tag/${encodeURIComponent(tagName)}`
+}
+
+function getReleaseInfo(data: unknown, tagName: string): ReleaseInfo {
+  if (isRecord(data) && typeof data.html_url === 'string') {
+    return { url: data.html_url }
+  }
+
+  return { url: getReleaseUrl(tagName) }
+}
+
+async function delay(ms: number): Promise<void> {
+  if (ms <= 0) {
+    return
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function requestWithRetries(
+  githubRequest: GitHubRequest,
+  route: string,
+  options: Record<string, unknown>,
+  { maxAttempts = 3, retryDelayMs = 1000 }: RetryOptions = {},
+): Promise<GitHubResponse> {
+  let attempts = Math.max(1, maxAttempts)
+  let lastError: unknown
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await githubRequest(route, options)
+    } catch (error) {
+      lastError = error
+      if (attempt === attempts || !isTransientError(error)) {
+        break
+      }
+
+      await delay(retryDelayMs * 2 ** (attempt - 1))
+    }
+  }
+
+  throw lastError
+}
+
+async function getReleaseByTag(
+  tag: string,
+  {
+    request: githubRequest = defaultRequest,
+    maxAttempts,
+    retryDelayMs,
+  }: {
+    request?: GitHubRequest
+  } & RetryOptions = {},
+): Promise<ReleaseInfo | null> {
+  try {
+    let response = await requestWithRetries(
+      githubRequest,
+      'GET /repos/{owner}/{repo}/releases/tags/{tag}',
+      {
+        ...auth(),
+        owner,
+        repo,
+        tag,
+      },
+      { maxAttempts, retryDelayMs },
+    )
+    return getReleaseInfo(response.data, tag)
+  } catch (error) {
+    if (getErrorStatus(error) === 404) {
+      return null
+    }
+    throw error
+  }
+}
+
 export type CreateReleaseResult =
   | { status: 'created'; url: string }
   | { status: 'skipped'; reason: string }
@@ -26,21 +160,13 @@ export type CreateReleaseResult =
 /**
  * Check if a GitHub release exists for a tag.
  */
-export async function releaseExists(tag: string): Promise<boolean> {
-  try {
-    await request('GET /repos/{owner}/{repo}/releases/tags/{tag}', {
-      ...auth(),
-      owner,
-      repo,
-      tag,
-    })
-    return true
-  } catch (error) {
-    if (error instanceof Error && 'status' in error && error.status === 404) {
-      return false
-    }
-    throw error
-  }
+export async function releaseExists(
+  tag: string,
+  options: {
+    request?: GitHubRequest
+  } & RetryOptions = {},
+): Promise<boolean> {
+  return (await getReleaseByTag(tag, options)) !== null
 }
 
 /**
@@ -52,9 +178,15 @@ export async function createRelease(
   version: string,
   options: {
     preview?: boolean
-  } = {},
+    request?: GitHubRequest
+  } & RetryOptions = {},
 ): Promise<CreateReleaseResult> {
-  let { preview = false } = options
+  let {
+    preview = false,
+    request: githubRequest = defaultRequest,
+    maxAttempts,
+    retryDelayMs,
+  } = options
 
   let tagName = getGitTag(packageName, version)
   let releaseName = `${getPackageShortName(packageName)} v${version}`
@@ -75,29 +207,65 @@ export async function createRelease(
   }
 
   try {
-    if (await releaseExists(tagName)) {
+    if (
+      (await getReleaseByTag(tagName, {
+        request: githubRequest,
+        maxAttempts,
+        retryDelayMs,
+      })) !== null
+    ) {
       return { status: 'skipped', reason: 'Already exists' }
     }
   } catch (error) {
-    let message = error instanceof Error ? error.message : String(error)
-    return { status: 'error', error: message }
+    return { status: 'error', error: getErrorMessage(error) }
   }
 
-  try {
-    let response = await request('POST /repos/{owner}/{repo}/releases', {
-      ...auth(),
-      owner,
-      repo,
-      tag_name: tagName,
-      name: releaseName,
-      body,
-    })
+  let attempts = Math.max(1, maxAttempts ?? 3)
+  let lastError: unknown
 
-    return { status: 'created', url: response.data.html_url }
-  } catch (error) {
-    let message = error instanceof Error ? error.message : String(error)
-    return { status: 'error', error: message }
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      let response = await githubRequest('POST /repos/{owner}/{repo}/releases', {
+        ...auth(),
+        owner,
+        repo,
+        tag_name: tagName,
+        name: releaseName,
+        body,
+      })
+
+      return { status: 'created', url: getReleaseInfo(response.data, tagName).url }
+    } catch (error) {
+      lastError = error
+
+      try {
+        let release = await getReleaseByTag(tagName, {
+          request: githubRequest,
+          maxAttempts,
+          retryDelayMs,
+        })
+
+        if (release !== null) {
+          return getErrorStatus(error) === 422
+            ? { status: 'skipped', reason: 'Already exists' }
+            : { status: 'created', url: release.url }
+        }
+      } catch (releaseCheckError) {
+        lastError = releaseCheckError
+        if (!isTransientError(releaseCheckError)) {
+          break
+        }
+      }
+
+      if (attempt === attempts || !isTransientError(error)) {
+        break
+      }
+
+      await delay((retryDelayMs ?? 1000) * 2 ** (attempt - 1))
+    }
   }
+
+  return { status: 'error', error: getErrorMessage(lastError) }
 }
 
 /**


### PR DESCRIPTION
This makes GitHub release creation in the publish script resilient to transient GitHub API and transport failures. We saw `POST /releases` fail with `write EPIPE` after npm packages and tags had already published, leaving one GitHub release to repair manually.

- Retries transient GitHub/API failures such as `EPIPE`, `ECONNRESET`, `429`, and 5xx responses
- Re-checks the release by tag after a failed create request so a server-side success is treated as success locally
- Keeps real missing-release failures visible while avoiding manual cleanup for already-created releases
- Adds focused script tests for retry and post-error reconciliation behavior
