### PR TITLE
Fix docs typecheck for prerender bench workspace

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -17,5 +17,5 @@
       "remix/ui/jsx-dev-runtime": ["../packages/remix/src/ui/jsx-dev-runtime.ts"]
     }
   },
-  "exclude": ["dist"]
+  "exclude": ["dist", "src/prerender/bench"]
 }


### PR DESCRIPTION
The docs app typecheck currently picks up the nested prerender benchmark workspace under `docs/src/prerender/bench`. That benchmark has its own package boundary and bench-only `vitest` dependency, so the parent docs app should not include it in `tsc --noEmit`.

- Excludes `src/prerender/bench` from `docs/tsconfig.json`
- Keeps the benchmark package separate from the docs app typecheck
- Fixes `pnpm --filter remix-the-docs run typecheck` and the docs-only changed-workspace typecheck path
