### PR TITLE
Add remix test timeouts

### DIFF
--- a/.github/actions/setup-node-pnpm-cache/action.yaml
+++ b/.github/actions/setup-node-pnpm-cache/action.yaml
@@ -1,0 +1,25 @@
+name: Setup Node.js with best-effort pnpm cache
+description: Setup the repository Node.js version and restore the pnpm store without making cache failures fatal.
+
+runs:
+  using: composite
+  steps:
+    - name: Install Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version-file: 'package.json'
+        package-manager-cache: false
+
+    - name: Get pnpm store path
+      id: pnpm-store
+      shell: bash
+      continue-on-error: true
+      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache pnpm store
+      if: steps.pnpm-store.outputs.path != ''
+      uses: actions/cache@v5
+      continue-on-error: true
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/packages/remix/.changes/minor.test.timeouts.md
+++ b/packages/remix/.changes/minor.test.timeouts.md
@@ -1,3 +1,3 @@
 Expose `remix/test` timeout and abort signal support through the Remix package.
 
-Tests and lifecycle hooks can pass `{ timeout, signal }`, and `t.signal` aborts when a test times out.
+Tests and lifecycle hooks can pass `{ timeout, signal }`, and `t.signal` aborts when a test times out. String `skip`/`todo` reasons now flow through `remix/test` results and reporter output.

--- a/packages/remix/.changes/minor.test.timeouts.md
+++ b/packages/remix/.changes/minor.test.timeouts.md
@@ -1,0 +1,3 @@
+Expose `remix/test` timeout and abort signal support through the Remix package.
+
+Tests and lifecycle hooks can pass `{ timeout, signal }`, and `t.signal` aborts when a test times out.

--- a/packages/test/.changes/minor.timeouts.md
+++ b/packages/test/.changes/minor.timeouts.md
@@ -1,10 +1,12 @@
 Add timeout and abort signal support to `@remix-run/test`.
 
-Tests and lifecycle hooks can now pass `{ timeout, signal }`. Timed-out tests fail and abort `t.signal`, so async work that accepts an `AbortSignal` can cancel promptly.
+Tests and lifecycle hooks can now pass `{ timeout, signal }`. Timed-out tests fail and abort `t.signal`, so async work that accepts an `AbortSignal` can cancel promptly. Tests and suites can also use string `skip`/`todo` reasons, and reporters display those reasons when a pending result is reported.
 
 ```ts
 it('loads data', { timeout: 5_000 }, async (t) => {
   let response = await fetch('/api/data', { signal: t.signal })
   assert.equal(response.status, 200)
 })
+
+it('depends on external credentials', { skip: 'requires API credentials' }, () => {})
 ```

--- a/packages/test/.changes/minor.timeouts.md
+++ b/packages/test/.changes/minor.timeouts.md
@@ -1,0 +1,10 @@
+Add timeout and abort signal support to `@remix-run/test`.
+
+Tests and lifecycle hooks can now pass `{ timeout, signal }`. Timed-out tests fail and abort `t.signal`, so async work that accepts an `AbortSignal` can cancel promptly.
+
+```ts
+it('loads data', { timeout: 5_000 }, async (t) => {
+  let response = await fetch('/api/data', { signal: t.signal })
+  assert.equal(response.status, 200)
+})
+```

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -9,6 +9,7 @@ A test framework for JavaScript and TypeScript projects.
 - Playwright E2E testing via `t.serve`
 - In-browser component testing (pair with `render` from `remix/ui/test`)
 - Mock functions and method spies via `t.mock.fn` / `t.mock.method`
+- Per-test and hook timeouts with `t.signal` abort support
 - Unified code coverage reporting across unit and E2E tests
 - Watch mode
 - Config file support (`remix-test.config.ts`)
@@ -193,6 +194,9 @@ describe('My Test Suite', () => {
   afterEach(() => {})
 
   it('tests something', () => {})
+  it('fails if it takes too long', { timeout: 5_000 }, async (t) => {
+    await fetchSomething({ signal: t.signal })
+  })
   it('tests something else', () => {})
 })
 ```
@@ -229,6 +233,9 @@ Each test callback receives a `TestContext` (`t`) as its first argument with hel
 ```ts
 // from 'remix/test'
 interface TestContext {
+  // Aborts when the test times out or when the user-provided test signal aborts
+  signal: AbortSignal
+
   // Register a cleanup function to run after the test completes
   after(fn: () => void): void
 
@@ -282,6 +289,24 @@ it('cleanup', (t) => {
   t.after(() => conn.close())
   // ...
 })
+```
+
+#### Timeouts and Signals
+
+Pass `{ timeout: ms }` to `it()` or after any lifecycle hook callback to fail that work if it takes too long. Timed-out tests abort `t.signal`, so async code that accepts an `AbortSignal` can cancel promptly.
+
+```ts
+it('loads data', { timeout: 5_000 }, async (t) => {
+  let response = await fetch('/api/data', { signal: t.signal })
+  assert.equal(response.status, 200)
+})
+
+beforeEach(
+  async () => {
+    await resetDatabase()
+  },
+  { timeout: 1_000 },
+)
 ```
 
 #### Fake Timers

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -194,6 +194,8 @@ describe('My Test Suite', () => {
   afterEach(() => {})
 
   it('tests something', () => {})
+  it('skips with a reason', { skip: 'requires API credentials' }, () => {})
+  it('tracks planned work', { todo: 'add retry coverage' }, () => {})
   it('fails if it takes too long', { timeout: 5_000 }, async (t) => {
     await fetchSomething({ signal: t.signal })
   })

--- a/packages/test/src/app/client/entry.ts
+++ b/packages/test/src/app/client/entry.ts
@@ -243,7 +243,11 @@ function buildSuite(suiteName: string, tests: TestResult[], baseDir: string): HT
         ? 'rt-todo'
         : 'rt-passed'
   let icon = suiteFailed ? '✗' : suiteAllSkipped ? '↓' : suiteAllTodo ? '…' : '✓'
-  let suffix = suiteAllSkipped ? ' # skipped' : suiteAllTodo ? ' # todo' : ''
+  let suffix = suiteAllSkipped
+    ? ` ${formatPendingComment('skipped', getCommonReason(tests))}`
+    : suiteAllTodo
+      ? ` ${formatPendingComment('todo', getCommonReason(tests))}`
+      : ''
 
   let details = el('details', { className: 'rt-suite-details' })
   if (suiteFailed) details.open = true
@@ -297,12 +301,33 @@ function buildTestItem(test: TestResult, baseDir: string): HTMLElement | null {
     return row
   }
   if (test.status === 'skipped' && test.name) {
-    return el('div', { className: 'rt-muted', textContent: `↓ ${test.name} # skipped` })
+    return el('div', {
+      className: 'rt-muted',
+      textContent: `↓ ${test.name} ${formatPendingComment('skipped', test.reason)}`,
+    })
   }
   if (test.status === 'todo' && test.name) {
-    return el('div', { className: 'rt-todo', textContent: `… ${test.name} # todo` })
+    return el('div', {
+      className: 'rt-todo',
+      textContent: `… ${test.name} ${formatPendingComment('todo', test.reason)}`,
+    })
   }
   return null
+}
+
+function formatPendingComment(status: 'skipped' | 'todo', reason: string | undefined): string {
+  let comment = status === 'skipped' ? '# skipped' : '# todo'
+  return reason ? `${comment}: ${reason}` : comment
+}
+
+function getCommonReason(tests: TestResult[]): string | undefined {
+  let reason: string | undefined
+  for (let test of tests) {
+    if (!test.reason) return undefined
+    reason ??= test.reason
+    if (reason !== test.reason) return undefined
+  }
+  return reason
 }
 
 function buildStack(stack: string, baseDir: string): DocumentFragment {

--- a/packages/test/src/lib/context.ts
+++ b/packages/test/src/lib/context.ts
@@ -28,6 +28,12 @@ export interface TestServer {
  */
 export interface TestContext {
   /**
+   * An abort signal for the current test. The signal is aborted when the test
+   * times out or when a user-provided test signal aborts.
+   */
+  signal: AbortSignal
+
+  /**
    * Registers a cleanup function to be called after the test completes.
    *
    * @param {() => void} fn - The cleanup function to execute
@@ -87,6 +93,11 @@ export interface TestContext {
 }
 
 export interface CreateTestContextOptions {
+  signal: AbortSignal
+  e2e?: CreateTestContextE2EOptions
+}
+
+export interface CreateTestContextE2EOptions {
   addE2ECoverageEntries: (value: { entries: V8CoverageEntry[]; baseUrl: string }) => void
   browser: Browser
   coverage: boolean
@@ -101,6 +112,7 @@ export function createTestContext(options?: CreateTestContextOptions): {
   let cleanups: Array<() => void | Promise<void>> = []
 
   let testContext: TestContext = {
+    signal: options?.signal ?? new AbortController().signal,
     mock: {
       fn: mock.fn,
       method(obj, methodName, impl) {
@@ -118,27 +130,28 @@ export function createTestContext(options?: CreateTestContextOptions): {
       return timers
     },
     async serve(server) {
-      if (!options || !options.browser) {
+      let e2e = options?.e2e
+      if (!e2e) {
         throw new Error('t.serve() is only available in E2E test suites')
       }
 
-      let page = await options.browser.newPage({
-        ...options.playwrightPageOptions,
+      let page = await e2e.browser.newPage({
+        ...e2e.playwrightPageOptions,
         baseURL: server.baseUrl,
       })
-      if (options.playwrightPageOptions?.navigationTimeout != null) {
-        page.setDefaultNavigationTimeout(options.playwrightPageOptions.navigationTimeout)
+      if (e2e.playwrightPageOptions?.navigationTimeout != null) {
+        page.setDefaultNavigationTimeout(e2e.playwrightPageOptions.navigationTimeout)
       }
-      if (options.playwrightPageOptions?.actionTimeout != null) {
-        page.setDefaultTimeout(options.playwrightPageOptions.actionTimeout)
+      if (e2e.playwrightPageOptions?.actionTimeout != null) {
+        page.setDefaultTimeout(e2e.playwrightPageOptions.actionTimeout)
       }
 
-      let coverageEnabled = options.coverage && options.browser.browserType().name() === 'chromium'
+      let coverageEnabled = e2e.coverage && e2e.browser.browserType().name() === 'chromium'
       if (coverageEnabled) {
         await page.coverage.startJSCoverage({ resetOnNavigation: false })
         cleanups.push(async () => {
           let entries = await page.coverage.stopJSCoverage()
-          options.addE2ECoverageEntries?.({
+          e2e.addE2ECoverageEntries?.({
             entries: entries as unknown as V8CoverageEntry[],
             baseUrl: server.baseUrl,
           })
@@ -146,7 +159,7 @@ export function createTestContext(options?: CreateTestContextOptions): {
       }
 
       cleanups.push(async () => {
-        if (!options.open) {
+        if (!e2e.open) {
           await page.close()
         }
         await server.close()

--- a/packages/test/src/lib/executor.ts
+++ b/packages/test/src/lib/executor.ts
@@ -2,6 +2,8 @@ import { createTestContext, type CreateTestContextE2EOptions, type TestContext }
 import type { V8CoverageEntry } from './coverage.ts'
 import type { TestResult, TestResults } from './reporters/results.ts'
 
+type PendingMeta = boolean | string
+
 interface RunnableOptions {
   timeout?: number
   signal?: AbortSignal
@@ -15,8 +17,8 @@ interface RegisteredSuite {
   name: string
   tests: RegisteredTest[]
   only?: boolean
-  skip?: boolean | string
-  todo?: boolean | string
+  skip?: PendingMeta
+  todo?: PendingMeta
   beforeEach?: LifecycleHook[]
   afterEach?: LifecycleHook[]
   beforeAll?: LifecycleHook[]
@@ -27,8 +29,8 @@ interface RegisteredTest extends RunnableOptions {
   name: string
   fn: (t: TestContext) => void | Promise<void>
   only?: boolean
-  skip?: boolean | string
-  todo?: boolean | string
+  skip?: PendingMeta
+  todo?: PendingMeta
 }
 
 export async function runTests(
@@ -50,27 +52,23 @@ export async function runTests(
     // If any suite uses .only, skip all non-only suites
     if (hasOnlySuites && !suite.only) {
       for (let test of suite.tests) {
-        results.tests.push({
-          name: test.name,
-          suiteName: suite.name,
-          status: 'skipped',
-          duration: 0,
-        })
+        results.tests.push(createPendingResult(test.name, suite.name, 'skipped'))
         results.skipped++
       }
       continue
     }
 
-    if (suite.skip || suite.todo) {
-      let status: 'skipped' | 'todo' = suite.todo ? 'todo' : 'skipped'
+    let suitePendingStatus = getPendingStatus(suite)
+    if (suitePendingStatus) {
+      let reason = getPendingReason(suite, suitePendingStatus)
       for (let test of suite.tests) {
-        results.tests.push({ name: test.name, suiteName: suite.name, status, duration: 0 })
-        results[status]++
+        results.tests.push(createPendingResult(test.name, suite.name, suitePendingStatus, reason))
+        results[suitePendingStatus]++
       }
       // describe.todo('name') with no tests — add placeholder so suite appears in output
       if (suite.tests.length === 0) {
-        results.tests.push({ name: '', suiteName: suite.name, status, duration: 0 })
-        results[status]++
+        results.tests.push(createPendingResult('', suite.name, suitePendingStatus, reason))
+        results[suitePendingStatus]++
       }
       continue
     }
@@ -93,20 +91,22 @@ export async function runTests(
     for (let test of suite.tests) {
       // If any test uses .only, skip all non-only tests in this suite
       if (hasOnlyTests && !test.only) {
-        results.tests.push({
-          name: test.name,
-          suiteName: suite.name,
-          status: 'skipped',
-          duration: 0,
-        })
+        results.tests.push(createPendingResult(test.name, suite.name, 'skipped'))
         results.skipped++
         continue
       }
 
-      if (test.skip || test.todo) {
-        let status: 'skipped' | 'todo' = test.todo ? 'todo' : 'skipped'
-        results.tests.push({ name: test.name, suiteName: suite.name, status, duration: 0 })
-        results[status]++
+      let testPendingStatus = getPendingStatus(test)
+      if (testPendingStatus) {
+        results.tests.push(
+          createPendingResult(
+            test.name,
+            suite.name,
+            testPendingStatus,
+            getPendingReason(test, testPendingStatus),
+          ),
+        )
+        results[testPendingStatus]++
         continue
       }
 
@@ -202,6 +202,43 @@ export async function runTests(
 function getRegisteredSuites(): RegisteredSuite[] {
   let global = globalThis as typeof globalThis & { __testSuites?: RegisteredSuite[] }
   return global.__testSuites ?? []
+}
+
+function getPendingStatus(value: {
+  skip?: PendingMeta
+  todo?: PendingMeta
+}): 'skipped' | 'todo' | undefined {
+  if (isPending(value.todo)) return 'todo'
+  if (isPending(value.skip)) return 'skipped'
+  return undefined
+}
+
+function isPending(value: PendingMeta | undefined): value is true | string {
+  return value === true || typeof value === 'string'
+}
+
+function getPendingReason(
+  value: { skip?: PendingMeta; todo?: PendingMeta },
+  status: 'skipped' | 'todo',
+): string | undefined {
+  let reason = status === 'todo' ? value.todo : value.skip
+  return typeof reason === 'string' && reason.length > 0 ? reason : undefined
+}
+
+function createPendingResult(
+  name: string,
+  suiteName: string,
+  status: 'skipped' | 'todo',
+  reason?: string,
+): TestResult {
+  let result: TestResult = {
+    name,
+    suiteName,
+    status,
+    duration: 0,
+  }
+  if (reason) result.reason = reason
+  return result
 }
 
 async function runLifecycleHooks(

--- a/packages/test/src/lib/executor.ts
+++ b/packages/test/src/lib/executor.ts
@@ -1,31 +1,38 @@
-import { createTestContext, type CreateTestContextOptions, type TestContext } from './context.ts'
+import { createTestContext, type CreateTestContextE2EOptions, type TestContext } from './context.ts'
 import type { V8CoverageEntry } from './coverage.ts'
 import type { TestResult, TestResults } from './reporters/results.ts'
 
-type LifecycleHook = () => void | Promise<void>
+interface RunnableOptions {
+  timeout?: number
+  signal?: AbortSignal
+}
+
+interface LifecycleHook extends RunnableOptions {
+  fn: () => void | Promise<void>
+}
 
 interface RegisteredSuite {
   name: string
   tests: RegisteredTest[]
   only?: boolean
-  skip?: boolean
-  todo?: boolean
-  beforeEach?: LifecycleHook
-  afterEach?: LifecycleHook
-  beforeAll?: LifecycleHook
-  afterAll?: LifecycleHook
+  skip?: boolean | string
+  todo?: boolean | string
+  beforeEach?: LifecycleHook[]
+  afterEach?: LifecycleHook[]
+  beforeAll?: LifecycleHook[]
+  afterAll?: LifecycleHook[]
 }
 
-interface RegisteredTest {
+interface RegisteredTest extends RunnableOptions {
   name: string
   fn: (t: TestContext) => void | Promise<void>
   only?: boolean
-  skip?: boolean
-  todo?: boolean
+  skip?: boolean | string
+  todo?: boolean | string
 }
 
 export async function runTests(
-  options?: Omit<CreateTestContextOptions, 'addE2ECoverageEntries'>,
+  options?: Omit<CreateTestContextE2EOptions, 'addE2ECoverageEntries'>,
 ): Promise<TestResults> {
   let suites = getRegisteredSuites()
   let e2eCoverageEntries: Array<{ entries: V8CoverageEntry[]; baseUrl: string }> = []
@@ -71,7 +78,7 @@ export async function runTests(
     if (suite.beforeAll) {
       let startTime = performance.now()
       try {
-        await suite.beforeAll()
+        await runLifecycleHooks('beforeAll', suite.beforeAll)
       } catch (error) {
         results.tests.push(
           createFailedHookResult('beforeAll', suite.name, error, performance.now() - startTime),
@@ -115,20 +122,29 @@ export async function runTests(
       let testFailed = false
       let afterEachFailed = false
 
-      let contextOpts: CreateTestContextOptions | undefined = options
-        ? {
-            ...options,
-            addE2ECoverageEntries: (e) => e2eCoverageEntries.push(e),
-          }
-        : undefined
-      let { testContext, cleanup } = createTestContext(contextOpts)
+      let testAbortController = new AbortController()
+      let { testContext, cleanup } = createTestContext({
+        signal: testAbortController.signal,
+        e2e: options
+          ? {
+              ...options,
+              addE2ECoverageEntries: (e) => e2eCoverageEntries.push(e),
+            }
+          : undefined,
+      })
 
       try {
         if (suite.beforeEach) {
-          await suite.beforeEach()
+          await runLifecycleHooks('beforeEach', suite.beforeEach, testAbortController, test.signal)
         }
 
-        await test.fn(testContext)
+        await runRunnable(
+          'Test',
+          () => test.fn(testContext),
+          test,
+          testAbortController,
+          test.signal,
+        )
       } catch (error) {
         testFailed = true
         testError = error
@@ -136,7 +152,7 @@ export async function runTests(
         await cleanup()
         if (suite.afterEach) {
           try {
-            await suite.afterEach()
+            await runLifecycleHooks('afterEach', suite.afterEach, undefined, undefined, true)
           } catch (error) {
             afterEachFailed = true
             afterEachError = error
@@ -162,7 +178,7 @@ export async function runTests(
     if (suite.afterAll) {
       let startTime = performance.now()
       try {
-        await suite.afterAll()
+        await runLifecycleHooks('afterAll', suite.afterAll, undefined, undefined, true)
       } catch (error) {
         results.tests.push(
           createFailedHookResult('afterAll', suite.name, error, performance.now() - startTime),
@@ -186,6 +202,90 @@ export async function runTests(
 function getRegisteredSuites(): RegisteredSuite[] {
   let global = globalThis as typeof globalThis & { __testSuites?: RegisteredSuite[] }
   return global.__testSuites ?? []
+}
+
+async function runLifecycleHooks(
+  hookName: string,
+  hooks: LifecycleHook[],
+  abortController?: AbortController,
+  inheritedSignal?: AbortSignal,
+  reverse = false,
+): Promise<void> {
+  let orderedHooks = reverse ? [...hooks].reverse() : hooks
+  for (let hook of orderedHooks) {
+    await runRunnable(hookName, hook.fn, hook, abortController, inheritedSignal, hook.signal)
+  }
+}
+
+async function runRunnable(
+  label: string,
+  fn: () => void | Promise<void>,
+  options: RunnableOptions,
+  abortController?: AbortController,
+  ...signals: Array<AbortSignal | undefined>
+): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  let abortCleanups: Array<() => void> = []
+  let abortSignals = [...new Set([...signals, options.signal])].filter(
+    (signal): signal is AbortSignal => signal != null,
+  )
+
+  for (let signal of abortSignals) {
+    if (signal.aborted) {
+      let error = createAbortError(label, signal.reason)
+      abortController?.abort(error)
+      throw error
+    }
+  }
+
+  let abortPromise = new Promise<never>((_, reject) => {
+    for (let signal of abortSignals) {
+      let onAbort = () => {
+        let error = createAbortError(label, signal.reason)
+        abortController?.abort(error)
+        reject(error)
+      }
+      signal.addEventListener('abort', onAbort, { once: true })
+      abortCleanups.push(() => signal.removeEventListener('abort', onAbort))
+    }
+  })
+
+  let timeout = options.timeout
+  let timeoutPromise =
+    timeout && timeout > 0
+      ? new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            let error = createTimeoutError(label, timeout)
+            reject(error)
+            abortController?.abort(error)
+          }, timeout)
+        })
+      : undefined
+
+  try {
+    await Promise.race([
+      Promise.resolve().then(fn),
+      abortPromise,
+      ...(timeoutPromise ? [timeoutPromise] : []),
+    ])
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId)
+    for (let cleanup of abortCleanups) cleanup()
+  }
+}
+
+function createTimeoutError(label: string, timeout: number): Error {
+  let error = new Error(`${label} timed out after ${timeout}ms`)
+  error.name = 'TimeoutError'
+  return error
+}
+
+function createAbortError(label: string, reason: unknown): Error {
+  let message =
+    reason instanceof Error ? reason.message : String(reason ?? 'This operation was aborted')
+  let error = new Error(`${label} aborted: ${message}`)
+  error.name = 'AbortError'
+  return error
 }
 
 function createFailedHookResult(

--- a/packages/test/src/lib/framework.ts
+++ b/packages/test/src/lib/framework.ts
@@ -1,30 +1,47 @@
 import type { TestContext } from './context.ts'
 
+type LifecycleHookName = 'beforeEach' | 'afterEach' | 'beforeAll' | 'afterAll'
+type LifecycleHookFn = () => void | Promise<void>
+
+interface TestOptions {
+  timeout?: number
+  signal?: AbortSignal
+}
+
+interface HookOptions {
+  timeout?: number
+  signal?: AbortSignal
+}
+
+interface LifecycleHook extends HookOptions {
+  fn: LifecycleHookFn
+}
+
 interface TestSuite {
   name: string
   tests: Test[]
   only?: boolean
-  skip?: boolean
-  todo?: boolean
-  beforeEach?: () => void | Promise<void>
-  afterEach?: () => void | Promise<void>
-  beforeAll?: () => void | Promise<void>
-  afterAll?: () => void | Promise<void>
+  skip?: boolean | string
+  todo?: boolean | string
+  beforeEach?: LifecycleHook[]
+  afterEach?: LifecycleHook[]
+  beforeAll?: LifecycleHook[]
+  afterAll?: LifecycleHook[]
 }
 
-interface Test {
+interface Test extends TestOptions {
   name: string
-  fn: (t?: any) => void | Promise<void>
+  fn: TestFn
   suite: TestSuite
   only?: boolean
-  skip?: boolean
-  todo?: boolean
+  skip?: boolean | string
+  todo?: boolean | string
 }
 
 // Holds lifecycle hooks registered at the top level (outside any describe).
 // Top-level describes inherit these hooks just like nested describes inherit
 // from their parent.
-const rootHooks: Pick<TestSuite, 'beforeEach' | 'afterEach' | 'beforeAll' | 'afterAll'> = {}
+const rootHooks: Pick<TestSuite, LifecycleHookName> = {}
 
 let currentSuite: TestSuite | null = null
 const rootSuites: TestSuite[] = []
@@ -36,7 +53,8 @@ const rootSuites: TestSuite[] = []
 let implicitRootSuite: TestSuite | null = null
 function getImplicitRootSuite(): TestSuite {
   if (!implicitRootSuite || !rootSuites.includes(implicitRootSuite)) {
-    implicitRootSuite = { name: '', tests: [], ...rootHooks }
+    implicitRootSuite = { name: '', tests: [] }
+    copyLifecycleHooks(rootHooks, implicitRootSuite)
     rootSuites.push(implicitRootSuite)
   }
   return implicitRootSuite
@@ -45,11 +63,7 @@ function getImplicitRootSuite(): TestSuite {
 // Expose for executor.ts which reads this global
 ;(globalThis as any).__testSuites = rootSuites
 
-function registerDescribe(
-  name: string,
-  fn: () => void,
-  flags?: { only?: boolean; skip?: boolean },
-) {
+function registerDescribe(name: string, fn: () => void, flags?: SuiteMeta) {
   // Nested describes are flattened: "Parent > Child"
   let fullName = currentSuite ? `${currentSuite.name} > ${name}` : name
   if (rootSuites.some((s) => s.name === fullName)) {
@@ -64,12 +78,7 @@ function registerDescribe(
   if (currentSuite?.skip) suite.skip = true
   if (currentSuite?.only) suite.only = true
 
-  // Inherit lifecycle hooks from parent suite (or root hooks if at top level)
-  let parent = currentSuite ?? rootHooks
-  if (parent.beforeEach) suite.beforeEach = parent.beforeEach
-  if (parent.afterEach) suite.afterEach = parent.afterEach
-  if (parent.beforeAll) suite.beforeAll = parent.beforeAll
-  if (parent.afterAll) suite.afterAll = parent.afterAll
+  copyLifecycleHooks(currentSuite ?? rootHooks, suite)
 
   let insertedAt = rootSuites.length
   rootSuites.push(suite)
@@ -130,14 +139,19 @@ export const describe = Object.assign(describeImpl, {
 })
 
 type SuiteMeta = { skip?: boolean; only?: boolean }
-type TestMeta = { skip?: boolean; only?: boolean }
+type TestMeta = TestOptions & {
+  skip?: boolean | string
+  only?: boolean
+  todo?: boolean | string
+}
 type TestFn = (t: TestContext) => void | Promise<void>
 
-function registerIt(name: string, fn: TestFn, flags?: { only?: boolean; skip?: boolean }) {
+function registerIt(name: string, fn: TestFn, flags?: TestMeta) {
   let suite = currentSuite ?? getImplicitRootSuite()
   if (suite.tests.some((t) => t.name === name)) {
     throw new Error(`Duplicate test name: "${name}" in suite "${suite.name || 'Global'}"`)
   }
+  validateTimeout(flags?.timeout)
   suite.tests.push({ name, fn, suite, ...flags })
 }
 
@@ -166,9 +180,12 @@ function itImpl(name: string, metaOrFn: TestMeta | TestFn, fn?: TestFn): void {
  * it.skip('not ready yet', () => { ... })
  * it.only('focused test', () => { ... })
  * it.todo('coming soon')
+ * it('fails if it takes too long', { timeout: 5_000 }, async (t) => {
+ *   await fetch('/api/data', { signal: t.signal })
+ * })
  *
  * @param name - The test name shown in reporter output.
- * @param meta - Test metadata such as `skip` or `only`.
+ * @param meta - Test metadata such as `skip`, `only`, `todo`, `timeout`, or `signal`.
  * @param fn - The test body, receiving a {@link TestContext} as its first argument.
  */
 export const it = Object.assign(itImpl, {
@@ -188,78 +205,86 @@ export const suite = describe
 /** Alias for {@link it}. */
 export const test = it
 
-function chainBefore(
-  existing: (() => void | Promise<void>) | undefined,
-  fn: () => void | Promise<void>,
-) {
-  return existing
-    ? async () => {
-        await existing()
-        await fn()
-      }
-    : fn
+function copyLifecycleHooks(source: Pick<TestSuite, LifecycleHookName>, target: TestSuite): void {
+  if (source.beforeEach) target.beforeEach = [...source.beforeEach]
+  if (source.afterEach) target.afterEach = [...source.afterEach]
+  if (source.beforeAll) target.beforeAll = [...source.beforeAll]
+  if (source.afterAll) target.afterAll = [...source.afterAll]
 }
 
-function chainAfter(
-  existing: (() => void | Promise<void>) | undefined,
-  fn: () => void | Promise<void>,
-) {
-  // Child/later runs first, then earlier (reverse order)
-  return existing
-    ? async () => {
-        await fn()
-        await existing()
-      }
-    : fn
+function registerLifecycleHook(
+  name: LifecycleHookName,
+  fn?: LifecycleHookFn,
+  options: HookOptions = {},
+): void {
+  if (!fn) {
+    throw new TypeError(`${name} requires a function`)
+  }
+
+  validateTimeout(options.timeout)
+
+  let target = currentSuite ?? rootHooks
+  target[name] ??= []
+  target[name].push({ fn, ...options })
+}
+
+function validateTimeout(timeout: number | undefined): void {
+  if (timeout !== undefined && (!Number.isFinite(timeout) || timeout < 0)) {
+    throw new RangeError('Test timeout must be a non-negative finite number')
+  }
 }
 
 /**
  * Registers a hook that runs before **each** test in the current suite (or
  * globally if called outside a `describe`). Multiple calls are chained in
- * registration order.
+ * registration order. Pass `{ timeout, signal }` after the function to limit
+ * how long the hook may run.
  *
  * @param fn - The setup function to run before each test.
+ * @param options - Optional timeout and abort signal configuration.
  */
-export function beforeEach(fn: () => void | Promise<void>) {
-  let target = currentSuite ?? rootHooks
-  target.beforeEach = chainBefore(target.beforeEach, fn)
+export function beforeEach(fn: LifecycleHookFn, options?: HookOptions): void {
+  registerLifecycleHook('beforeEach', fn, options)
 }
 
 /**
  * Registers a hook that runs after **each** test in the current suite (or
  * globally if called outside a `describe`). Multiple calls are chained in
  * reverse registration order.  To run logic after a singular test, use
- * `t.after()` from the {@link TestContext}
+ * `t.after()` from the {@link TestContext}. Pass `{ timeout, signal }` after
+ * the function to limit how long the hook may run.
  *
  * @param fn - The teardown function to run after each test.
+ * @param options - Optional timeout and abort signal configuration.
  */
-export function afterEach(fn: () => void | Promise<void>) {
-  let target = currentSuite ?? rootHooks
-  target.afterEach = chainAfter(target.afterEach, fn)
+export function afterEach(fn: LifecycleHookFn, options?: HookOptions): void {
+  registerLifecycleHook('afterEach', fn, options)
 }
 
 /**
  * Registers a hook that runs once before **all** tests in the current suite
  * (or globally if called outside a `describe`). Multiple calls are chained in
- * registration order.
+ * registration order. Pass `{ timeout, signal }` after the function to limit
+ * how long the hook may run.
  *
  * @param fn - The setup function to run once before all tests in the suite.
+ * @param options - Optional timeout and abort signal configuration.
  */
-export function beforeAll(fn: () => void | Promise<void>) {
-  let target = currentSuite ?? rootHooks
-  target.beforeAll = chainBefore(target.beforeAll, fn)
+export function beforeAll(fn: LifecycleHookFn, options?: HookOptions): void {
+  registerLifecycleHook('beforeAll', fn, options)
 }
 
 /**
  * Registers a hook that runs once after **all** tests in the current suite (or
  * globally if called outside a `describe`). Multiple calls are chained in
- * reverse registration order.
+ * reverse registration order. Pass `{ timeout, signal }` after the function
+ * to limit how long the hook may run.
  *
  * @param fn - The teardown function to run once after all tests in the suite.
+ * @param options - Optional timeout and abort signal configuration.
  */
-export function afterAll(fn: () => void | Promise<void>) {
-  let target = currentSuite ?? rootHooks
-  target.afterAll = chainAfter(target.afterAll, fn)
+export function afterAll(fn: LifecycleHookFn, options?: HookOptions): void {
+  registerLifecycleHook('afterAll', fn, options)
 }
 
 /** Alias for {@link beforeAll} — matches the `node:test` API. */

--- a/packages/test/src/lib/framework.ts
+++ b/packages/test/src/lib/framework.ts
@@ -2,6 +2,7 @@ import type { TestContext } from './context.ts'
 
 type LifecycleHookName = 'beforeEach' | 'afterEach' | 'beforeAll' | 'afterAll'
 type LifecycleHookFn = () => void | Promise<void>
+type PendingMeta = boolean | string
 
 interface TestOptions {
   timeout?: number
@@ -21,8 +22,8 @@ interface TestSuite {
   name: string
   tests: Test[]
   only?: boolean
-  skip?: boolean | string
-  todo?: boolean | string
+  skip?: PendingMeta
+  todo?: PendingMeta
   beforeEach?: LifecycleHook[]
   afterEach?: LifecycleHook[]
   beforeAll?: LifecycleHook[]
@@ -34,8 +35,8 @@ interface Test extends TestOptions {
   fn: TestFn
   suite: TestSuite
   only?: boolean
-  skip?: boolean | string
-  todo?: boolean | string
+  skip?: PendingMeta
+  todo?: PendingMeta
 }
 
 // Holds lifecycle hooks registered at the top level (outside any describe).
@@ -71,11 +72,12 @@ function registerDescribe(name: string, fn: () => void, flags?: SuiteMeta) {
   }
   let suite: TestSuite = { name: fullName, tests: [], ...flags }
 
-  // Children inherit `skip`/`only` from their parent so that
+  // Children inherit `skip`/`todo`/`only` from their parent so that
   // `describe.skip('parent', () => describe('child', () => it(...)))` actually
   // skips the child's tests. The executor walks `rootSuites` as a flat list and
   // only inspects each suite's own flag, so the propagation has to happen here.
-  if (currentSuite?.skip) suite.skip = true
+  if (isPending(currentSuite?.skip)) suite.skip = currentSuite.skip
+  if (isPending(currentSuite?.todo)) suite.todo = currentSuite.todo
   if (currentSuite?.only) suite.only = true
 
   copyLifecycleHooks(currentSuite ?? rootHooks, suite)
@@ -116,33 +118,30 @@ function describeImpl(name: string, metaOrFn: SuiteMeta | (() => void), fn?: () 
  * describe('auth', () => {
  *   it('logs in', async () => { ... })
  * })
+ * describe('external service', { skip: 'requires API credentials' }, () => { ... })
  *
  * // Modifiers
  * describe.skip('skipped suite', () => { ... })
+ * describe.skip('skipped suite', 'blocked by missing fixture', () => { ... })
  * describe.only('focused suite', () => { ... })
  * describe.todo('planned suite')
+ * describe.todo('planned suite', 'needs design input')
  *
  * @param name - The suite name shown in reporter output.
- * @param meta - Suite metadata such as `skip` or `only`.
+ * @param meta - Suite metadata such as `skip`, `only`, or `todo`.
  * @param fn - A function that registers the tests and lifecycle hooks in this suite.
  */
 export const describe = Object.assign(describeImpl, {
-  skip: (name: string, fn: () => void) => registerDescribe(name, fn, { skip: true }),
+  skip: describeSkip,
   only: (name: string, fn: () => void) => registerDescribe(name, fn, { only: true }),
-  todo: (name: string) => {
-    let fullName = currentSuite ? `${currentSuite.name} > ${name}` : name
-    if (rootSuites.some((s) => s.name === fullName)) {
-      throw new Error(`Duplicate suite name: "${fullName}"`)
-    }
-    rootSuites.push({ name: fullName, tests: [], todo: true })
-  },
+  todo: describeTodo,
 })
 
-type SuiteMeta = { skip?: boolean; only?: boolean }
+type SuiteMeta = { skip?: PendingMeta; only?: boolean; todo?: PendingMeta }
 type TestMeta = TestOptions & {
-  skip?: boolean | string
+  skip?: PendingMeta
   only?: boolean
-  todo?: boolean | string
+  todo?: PendingMeta
 }
 type TestFn = (t: TestContext) => void | Promise<void>
 
@@ -178,8 +177,10 @@ function itImpl(name: string, metaOrFn: TestMeta | TestFn, fn?: TestFn): void {
  *
  * // Modifiers
  * it.skip('not ready yet', () => { ... })
+ * it.skip('not ready yet', 'blocked by missing fixture')
  * it.only('focused test', () => { ... })
  * it.todo('coming soon')
+ * it.todo('coming soon', 'needs retry coverage')
  * it('fails if it takes too long', { timeout: 5_000 }, async (t) => {
  *   await fetch('/api/data', { signal: t.signal })
  * })
@@ -189,15 +190,9 @@ function itImpl(name: string, metaOrFn: TestMeta | TestFn, fn?: TestFn): void {
  * @param fn - The test body, receiving a {@link TestContext} as its first argument.
  */
 export const it = Object.assign(itImpl, {
-  skip: (name: string, fn?: TestFn) => registerIt(name, fn ?? (() => {}), { skip: true }),
+  skip: itSkip,
   only: (name: string, fn: TestFn) => registerIt(name, fn, { only: true }),
-  todo: (name: string) => {
-    let suite = currentSuite ?? getImplicitRootSuite()
-    if (suite.tests.some((t) => t.name === name)) {
-      throw new Error(`Duplicate test name: "${name}" in suite "${suite.name || 'Global'}"`)
-    }
-    suite.tests.push({ name, fn: () => {}, suite, todo: true })
-  },
+  todo: itTodo,
 })
 
 /** Alias for {@link describe}. */
@@ -210,6 +205,39 @@ function copyLifecycleHooks(source: Pick<TestSuite, LifecycleHookName>, target: 
   if (source.afterEach) target.afterEach = [...source.afterEach]
   if (source.beforeAll) target.beforeAll = [...source.beforeAll]
   if (source.afterAll) target.afterAll = [...source.afterAll]
+}
+
+function describeSkip(name: string, fn: () => void): void
+function describeSkip(name: string, reason: string, fn: () => void): void
+function describeSkip(name: string, reasonOrFn: string | (() => void), fn?: () => void): void {
+  let suiteFn = typeof reasonOrFn === 'function' ? reasonOrFn : fn
+  if (!suiteFn) {
+    throw new TypeError('describe.skip requires a function')
+  }
+  registerDescribe(name, suiteFn, { skip: typeof reasonOrFn === 'string' ? reasonOrFn : true })
+}
+
+function describeTodo(name: string, reason?: string): void {
+  registerDescribe(name, () => {}, { todo: reason ?? true })
+}
+
+function itSkip(name: string): void
+function itSkip(name: string, fn: TestFn): void
+function itSkip(name: string, reason: string): void
+function itSkip(name: string, reason: string, fn: TestFn): void
+function itSkip(name: string, reasonOrFn?: string | TestFn, fn?: TestFn): void {
+  let testFn = typeof reasonOrFn === 'function' ? reasonOrFn : fn
+  registerIt(name, testFn ?? (() => {}), {
+    skip: typeof reasonOrFn === 'string' ? reasonOrFn : true,
+  })
+}
+
+function itTodo(name: string, reason?: string): void {
+  registerIt(name, () => {}, { todo: reason ?? true })
+}
+
+function isPending(value: PendingMeta | undefined): value is true | string {
+  return value === true || typeof value === 'string'
 }
 
 function registerLifecycleHook(

--- a/packages/test/src/lib/reporters/dot.ts
+++ b/packages/test/src/lib/reporters/dot.ts
@@ -5,6 +5,7 @@ import type { Counts, TestResult, TestResults } from './results.ts'
 
 export class DotReporter implements Reporter {
   #failures: { name: string; error: TestResult['error'] }[] = []
+  #pending: { name: string; status: 'skipped' | 'todo'; reason: string }[] = []
   #dotCount = 0
   #files = new Set<string>()
   #suites = new Set<string>()
@@ -22,11 +23,25 @@ export class DotReporter implements Reporter {
         process.stdout.write(colors.green('.'))
       } else if (test.status === 'skipped') {
         process.stdout.write(colors.dim('S'))
+        if (test.reason) {
+          this.#pending.push({
+            name: formatFullName(test),
+            status: test.status,
+            reason: test.reason,
+          })
+        }
       } else if (test.status === 'todo') {
         process.stdout.write(colors.dim('T'))
+        if (test.reason) {
+          this.#pending.push({
+            name: formatFullName(test),
+            status: test.status,
+            reason: test.reason,
+          })
+        }
       } else {
         process.stdout.write(colors.red('F'))
-        this.#failures.push({ name: `${test.suiteName} > ${test.name}`, error: test.error })
+        this.#failures.push({ name: formatFullName(test), error: test.error })
       }
       this.#dotCount++
     }
@@ -51,6 +66,12 @@ export class DotReporter implements Reporter {
       }
     }
 
+    for (let pending of this.#pending) {
+      let comment = pending.status === 'skipped' ? '# skipped' : '# todo'
+      let color = pending.status === 'skipped' ? colors.dim : colors.yellow
+      console.log(`\n  ${color(`${pending.name} ${comment}: ${pending.reason}`)}`)
+    }
+
     let { passed, failed, skipped, todo } = counts
     let info = colors.cyan('ℹ')
     console.log()
@@ -64,4 +85,8 @@ export class DotReporter implements Reporter {
     console.log(`${info} duration_ms ${durationMs.toFixed(5)}`)
     console.log()
   }
+}
+
+function formatFullName(test: TestResult): string {
+  return test.name ? `${test.suiteName} > ${test.name}` : test.suiteName
 }

--- a/packages/test/src/lib/reporters/files.ts
+++ b/packages/test/src/lib/reporters/files.ts
@@ -46,6 +46,16 @@ export class FilesReporter implements Reporter {
         this.#failures.push({ suiteName: test.suiteName, name: test.name, error: test.error })
       }
     }
+
+    for (let test of results.tests) {
+      if ((test.status !== 'skipped' && test.status !== 'todo') || !test.reason) continue
+      let fullName = test.name ? `${test.suiteName} > ${test.name}` : test.suiteName
+      let marker =
+        test.status === 'skipped'
+          ? `${colors.dim('↓')} ${colors.dim(`${fullName} # skipped: ${test.reason}`)}`
+          : `${colors.yellow('…')} ${colors.yellow(`${fullName} # todo: ${test.reason}`)}`
+      console.log(`  ${marker}`)
+    }
   }
 
   onSummary(counts: Counts, durationMs: number) {

--- a/packages/test/src/lib/reporters/results.ts
+++ b/packages/test/src/lib/reporters/results.ts
@@ -5,6 +5,7 @@ export interface TestResult {
   suiteName: string
   filePath?: string
   status: 'passed' | 'failed' | 'skipped' | 'todo'
+  reason?: string
   error?: {
     message: string
     stack?: string

--- a/packages/test/src/lib/reporters/spec.ts
+++ b/packages/test/src/lib/reporters/spec.ts
@@ -71,9 +71,9 @@ export class SpecReporter implements Reporter {
                 ? colors.yellow(parts[i])
                 : colors.green(parts[i])
           let suiteComment = suiteAllSkipped
-            ? colors.dim(' # skipped')
+            ? colors.dim(` ${formatPendingComment('skipped', getCommonReason(suiteTests))}`)
             : suiteAllTodo
-              ? colors.yellow(' # todo')
+              ? colors.yellow(` ${formatPendingComment('todo', getCommonReason(suiteTests))}`)
               : ''
           let duration = suiteComment ? '' : ` (${totalDuration.toFixed(2)}ms)`
           let label2 = envLabel
@@ -95,9 +95,9 @@ export class SpecReporter implements Reporter {
                 : colors.green
           let prefixDuration = prefixTestList.reduce((sum, t) => sum + t.duration, 0)
           let prefixComment = prefixAllSkipped
-            ? colors.dim(' # skipped')
+            ? colors.dim(` ${formatPendingComment('skipped', getCommonReason(prefixTestList))}`)
             : prefixAllTodo
-              ? colors.yellow(' # todo')
+              ? colors.yellow(` ${formatPendingComment('todo', getCommonReason(prefixTestList))}`)
               : ''
           let prefixDurationStr = prefixComment ? '' : ` (${prefixDuration.toFixed(2)}ms)`
           console.log(
@@ -134,11 +134,17 @@ export class SpecReporter implements Reporter {
           this.#failures.push({ suiteName: test.suiteName, name: test.name, error: test.error })
         } else if (test.status === 'skipped') {
           if (test.name)
-            console.log(`${testIndent}${colors.dim('↓')} ${colors.dim(`${test.name} # skipped`)}`)
+            console.log(
+              `${testIndent}${colors.dim('↓')} ${colors.dim(
+                `${test.name} ${formatPendingComment('skipped', test.reason)}`,
+              )}`,
+            )
         } else if (test.status === 'todo') {
           if (test.name)
             console.log(
-              `${testIndent}${colors.yellow('…')} ${colors.yellow(`${test.name} # todo`)}`,
+              `${testIndent}${colors.yellow('…')} ${colors.yellow(
+                `${test.name} ${formatPendingComment('todo', test.reason)}`,
+              )}`,
             )
         }
       }
@@ -180,4 +186,19 @@ export class SpecReporter implements Reporter {
     console.log(`${info} duration_ms ${durationMs.toFixed(5)}`)
     console.log()
   }
+}
+
+function formatPendingComment(status: 'skipped' | 'todo', reason: string | undefined): string {
+  let comment = status === 'skipped' ? '# skipped' : '# todo'
+  return reason ? `${comment}: ${reason}` : comment
+}
+
+function getCommonReason(tests: TestResult[]): string | undefined {
+  let reason: string | undefined
+  for (let test of tests) {
+    if (!test.reason) return undefined
+    reason ??= test.reason
+    if (reason !== test.reason) return undefined
+  }
+  return reason
 }

--- a/packages/test/src/lib/reporters/tap.ts
+++ b/packages/test/src/lib/reporters/tap.ts
@@ -32,9 +32,9 @@ export class TapReporter implements Reporter {
       if (test.status === 'passed') {
         console.log(`ok ${this.#counter} - ${fullName}`)
       } else if (test.status === 'skipped') {
-        console.log(`ok ${this.#counter} - ${fullName} # SKIP`)
+        console.log(`ok ${this.#counter} - ${fullName} ${formatDirective('SKIP', test.reason)}`)
       } else if (test.status === 'todo') {
-        console.log(`ok ${this.#counter} - ${fullName} # TODO`)
+        console.log(`ok ${this.#counter} - ${fullName} ${formatDirective('TODO', test.reason)}`)
       } else {
         console.log(`not ok ${this.#counter} - ${fullName}`)
         console.log('  ---')
@@ -64,4 +64,8 @@ export class TapReporter implements Reporter {
     if (todo > 0) console.log(`# todo ${todo}`)
     console.log(`# duration_ms ${durationMs.toFixed(5)}`)
   }
+}
+
+function formatDirective(name: 'SKIP' | 'TODO', reason: string | undefined): string {
+  return reason ? `# ${name} ${reason}` : `# ${name}`
 }

--- a/packages/test/src/test/executor.test.ts
+++ b/packages/test/src/test/executor.test.ts
@@ -9,6 +9,8 @@ interface RunnableOptions {
   signal?: AbortSignal
 }
 
+type PendingMeta = boolean | string
+
 interface LifecycleHook extends RunnableOptions {
   fn: () => void | Promise<void>
 }
@@ -17,8 +19,8 @@ interface SuiteFixture {
   name: string
   tests: TestFixture[]
   only?: boolean
-  skip?: boolean
-  todo?: boolean
+  skip?: PendingMeta
+  todo?: PendingMeta
   beforeEach?: LifecycleHook[]
   afterEach?: LifecycleHook[]
   beforeAll?: LifecycleHook[]
@@ -29,8 +31,8 @@ interface TestFixture extends RunnableOptions {
   name: string
   fn: (t: TestContext) => void | Promise<void>
   only?: boolean
-  skip?: boolean
-  todo?: boolean
+  skip?: PendingMeta
+  todo?: PendingMeta
 }
 
 type TestSuitesGlobal = typeof globalThis & { __testSuites?: SuiteFixture[] }
@@ -293,6 +295,88 @@ describe('runTests timeouts and signals', () => {
     assert.equal(results.tests.length, 1)
     assert.equal(results.tests[0]?.name, 'test')
     assert.match(results.tests[0]?.error?.message ?? '', /afterEach failed: afterEach timed out/)
+  })
+})
+
+describe('runTests skip and todo reasons', () => {
+  it('preserves suite skip reasons on skipped test results', async () => {
+    let results = await runWithSuites([
+      {
+        name: 'suite',
+        skip: 'requires database credentials',
+        tests: [
+          {
+            name: 'test',
+            fn() {},
+          },
+        ],
+      },
+    ])
+
+    assert.equal(results.skipped, 1)
+    assert.equal(results.tests[0]?.status, 'skipped')
+    assert.equal(results.tests[0]?.reason, 'requires database credentials')
+  })
+
+  it('preserves test skip and todo reasons on pending test results', async () => {
+    let results = await runWithSuites([
+      {
+        name: 'suite',
+        tests: [
+          {
+            name: 'skipped test',
+            skip: 'needs a fixture',
+            fn() {},
+          },
+          {
+            name: 'todo test',
+            todo: 'needs retry coverage',
+            fn() {},
+          },
+        ],
+      },
+    ])
+
+    assert.equal(results.skipped, 1)
+    assert.equal(results.todo, 1)
+    assert.equal(results.tests[0]?.status, 'skipped')
+    assert.equal(results.tests[0]?.reason, 'needs a fixture')
+    assert.equal(results.tests[1]?.status, 'todo')
+    assert.equal(results.tests[1]?.reason, 'needs retry coverage')
+  })
+
+  it('preserves todo suite reasons on placeholder results', async () => {
+    let results = await runWithSuites([
+      {
+        name: 'suite',
+        todo: 'waiting on design',
+        tests: [],
+      },
+    ])
+
+    assert.equal(results.todo, 1)
+    assert.equal(results.tests[0]?.name, '')
+    assert.equal(results.tests[0]?.status, 'todo')
+    assert.equal(results.tests[0]?.reason, 'waiting on design')
+  })
+
+  it('treats an empty string skip reason as skipped without a displayed reason', async () => {
+    let results = await runWithSuites([
+      {
+        name: 'suite',
+        tests: [
+          {
+            name: 'skipped test',
+            skip: '',
+            fn() {},
+          },
+        ],
+      },
+    ])
+
+    assert.equal(results.skipped, 1)
+    assert.equal(results.tests[0]?.status, 'skipped')
+    assert.equal(results.tests[0]?.reason, undefined)
   })
 })
 

--- a/packages/test/src/test/executor.test.ts
+++ b/packages/test/src/test/executor.test.ts
@@ -4,7 +4,14 @@ import { runTests } from '../lib/executor.ts'
 import { describe, it } from '../lib/framework.ts'
 import type { TestResults } from '../lib/reporters/results.ts'
 
-type LifecycleHook = () => void | Promise<void>
+interface RunnableOptions {
+  timeout?: number
+  signal?: AbortSignal
+}
+
+interface LifecycleHook extends RunnableOptions {
+  fn: () => void | Promise<void>
+}
 
 interface SuiteFixture {
   name: string
@@ -12,13 +19,13 @@ interface SuiteFixture {
   only?: boolean
   skip?: boolean
   todo?: boolean
-  beforeEach?: LifecycleHook
-  afterEach?: LifecycleHook
-  beforeAll?: LifecycleHook
-  afterAll?: LifecycleHook
+  beforeEach?: LifecycleHook[]
+  afterEach?: LifecycleHook[]
+  beforeAll?: LifecycleHook[]
+  afterAll?: LifecycleHook[]
 }
 
-interface TestFixture {
+interface TestFixture extends RunnableOptions {
   name: string
   fn: (t: TestContext) => void | Promise<void>
   only?: boolean
@@ -35,9 +42,13 @@ describe('runTests lifecycle hook failures', () => {
     let results = await runWithSuites([
       {
         name: 'suite',
-        beforeAll() {
-          throw new Error('setup failed')
-        },
+        beforeAll: [
+          {
+            fn() {
+              throw new Error('setup failed')
+            },
+          },
+        ],
         tests: [
           {
             name: 'test',
@@ -66,9 +77,13 @@ describe('runTests lifecycle hook failures', () => {
     let results = await runWithSuites([
       {
         name: 'suite',
-        afterEach() {
-          throw new Error('teardown failed')
-        },
+        afterEach: [
+          {
+            fn() {
+              throw new Error('teardown failed')
+            },
+          },
+        ],
         tests: [
           {
             name: 'test',
@@ -94,9 +109,13 @@ describe('runTests lifecycle hook failures', () => {
     let results = await runWithSuites([
       {
         name: 'suite',
-        afterAll() {
-          throw new Error('teardown failed')
-        },
+        afterAll: [
+          {
+            fn() {
+              throw new Error('teardown failed')
+            },
+          },
+        ],
         tests: [
           {
             name: 'test',
@@ -120,6 +139,160 @@ describe('runTests lifecycle hook failures', () => {
     assert.equal(failure.suiteName, 'suite')
     assert.equal(failure.status, 'failed')
     assert.match(failure.error?.message ?? '', /afterAll failed: teardown failed/)
+  })
+})
+
+describe('runTests timeouts and signals', () => {
+  it('fails tests that exceed their timeout and aborts the test signal', async () => {
+    let aborted = false
+
+    let results = await runWithSuites([
+      {
+        name: 'suite',
+        tests: [
+          {
+            name: 'slow test',
+            timeout: 5,
+            fn(t) {
+              t.signal.addEventListener(
+                'abort',
+                () => {
+                  aborted = true
+                },
+                { once: true },
+              )
+              return new Promise(() => {})
+            },
+          },
+        ],
+      },
+    ])
+
+    assert.equal(aborted, true)
+    assert.equal(results.passed, 0)
+    assert.equal(results.failed, 1)
+    assert.equal(results.tests.length, 1)
+    assert.equal(results.tests[0]?.status, 'failed')
+    assert.match(results.tests[0]?.error?.message ?? '', /Test timed out after 5ms/)
+  })
+
+  it('exposes a non-aborted signal to regular tests', async () => {
+    let sawSignal = false
+
+    let results = await runWithSuites([
+      {
+        name: 'suite',
+        tests: [
+          {
+            name: 'signal test',
+            fn(t) {
+              sawSignal = t.signal instanceof AbortSignal && !t.signal.aborted
+            },
+          },
+        ],
+      },
+    ])
+
+    assert.equal(sawSignal, true)
+    assert.equal(results.passed, 1)
+    assert.equal(results.failed, 0)
+  })
+
+  it('aborts the test signal when a user-provided signal aborts', async () => {
+    let controller = new AbortController()
+    let testSignalAborted = false
+
+    let resultsPromise = runWithSuites([
+      {
+        name: 'suite',
+        tests: [
+          {
+            name: 'aborted test',
+            signal: controller.signal,
+            fn(t) {
+              t.signal.addEventListener(
+                'abort',
+                () => {
+                  testSignalAborted = true
+                },
+                { once: true },
+              )
+              return new Promise(() => {})
+            },
+          },
+        ],
+      },
+    ])
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    controller.abort(new Error('stop'))
+    let results = await resultsPromise
+
+    assert.equal(testSignalAborted, true)
+    assert.equal(results.passed, 0)
+    assert.equal(results.failed, 1)
+    assert.match(results.tests[0]?.error?.message ?? '', /Test aborted: stop/)
+  })
+
+  it('reports beforeAll timeouts as failed hook results', async () => {
+    let testRan = false
+
+    let results = await runWithSuites([
+      {
+        name: 'suite',
+        beforeAll: [
+          {
+            timeout: 5,
+            fn() {
+              return new Promise(() => {})
+            },
+          },
+        ],
+        tests: [
+          {
+            name: 'test',
+            fn() {
+              testRan = true
+            },
+          },
+        ],
+      },
+    ])
+
+    assert.equal(testRan, false)
+    assert.equal(results.passed, 0)
+    assert.equal(results.failed, 1)
+    assert.equal(results.tests.length, 1)
+    assert.equal(results.tests[0]?.name, 'beforeAll')
+    assert.match(results.tests[0]?.error?.message ?? '', /beforeAll failed: beforeAll timed out/)
+  })
+
+  it('reports afterEach timeouts on the affected test', async () => {
+    let results = await runWithSuites([
+      {
+        name: 'suite',
+        afterEach: [
+          {
+            timeout: 5,
+            fn() {
+              return new Promise(() => {})
+            },
+          },
+        ],
+        tests: [
+          {
+            name: 'test',
+            fn() {},
+          },
+        ],
+      },
+    ])
+
+    assert.equal(results.passed, 0)
+    assert.equal(results.failed, 1)
+    assert.equal(results.tests.length, 1)
+    assert.equal(results.tests[0]?.name, 'test')
+    assert.match(results.tests[0]?.error?.message ?? '', /afterEach failed: afterEach timed out/)
   })
 })
 

--- a/packages/test/src/test/framework.test.ts
+++ b/packages/test/src/test/framework.test.ts
@@ -185,6 +185,29 @@ describe('it', () => {
     assert.equal(s.tests[0].name, 'my test')
     assert.equal(s.tests[0].fn, fn)
   })
+
+  it('registers timeout and signal options', () => {
+    let signal = new AbortController().signal
+    let [s] = captureRegistration(() =>
+      describe('suite', () => {
+        it('my test', { timeout: 100, signal }, () => {})
+      }),
+    )
+    assert.equal(s.tests[0].timeout, 100)
+    assert.equal(s.tests[0].signal, signal)
+  })
+
+  it('throws on invalid timeout values', () => {
+    assert.throws(
+      () =>
+        captureRegistration(() =>
+          describe('suite', () => {
+            it('my test', { timeout: -1 }, () => {})
+          }),
+        ),
+      /Test timeout must be a non-negative finite number/,
+    )
+  })
 })
 
 describe('it.skip', () => {
@@ -318,7 +341,7 @@ describe('lifecycle hooks', () => {
         beforeEach(fn)
       }),
     )
-    assert.equal(s.beforeEach, fn)
+    assert.equal(s.beforeEach[0].fn, fn)
   })
 
   it('afterEach registers on the current suite', () => {
@@ -328,7 +351,7 @@ describe('lifecycle hooks', () => {
         afterEach(fn)
       }),
     )
-    assert.equal(s.afterEach, fn)
+    assert.equal(s.afterEach[0].fn, fn)
   })
 
   it('beforeAll registers on the current suite', () => {
@@ -338,7 +361,7 @@ describe('lifecycle hooks', () => {
         beforeAll(fn)
       }),
     )
-    assert.equal(s.beforeAll, fn)
+    assert.equal(s.beforeAll[0].fn, fn)
   })
 
   it('afterAll registers on the current suite', () => {
@@ -348,7 +371,20 @@ describe('lifecycle hooks', () => {
         afterAll(fn)
       }),
     )
-    assert.equal(s.afterAll, fn)
+    assert.equal(s.afterAll[0].fn, fn)
+  })
+
+  it('registers timeout and signal options for hooks', () => {
+    let signal = new AbortController().signal
+    let fn = () => {}
+    let [s] = captureRegistration(() =>
+      describe('suite', () => {
+        beforeEach(fn, { timeout: 50, signal })
+      }),
+    )
+    assert.equal(s.beforeEach[0].fn, fn)
+    assert.equal(s.beforeEach[0].timeout, 50)
+    assert.equal(s.beforeEach[0].signal, signal)
   })
 
   it('beforeEach can be called outside describe (registers on root hooks)', () => {
@@ -358,7 +394,7 @@ describe('lifecycle hooks', () => {
         beforeEach(() => {})
         describe('suite', () => {})
       })
-      assert.equal(typeof s.beforeEach, 'function')
+      assert.equal(typeof s.beforeEach[0].fn, 'function')
     })
   })
 
@@ -368,7 +404,7 @@ describe('lifecycle hooks', () => {
         afterEach(() => {})
         describe('suite', () => {})
       })
-      assert.equal(typeof s.afterEach, 'function')
+      assert.equal(typeof s.afterEach[0].fn, 'function')
     })
   })
 
@@ -378,7 +414,7 @@ describe('lifecycle hooks', () => {
         beforeAll(() => {})
         describe('suite', () => {})
       })
-      assert.equal(typeof s.beforeAll, 'function')
+      assert.equal(typeof s.beforeAll[0].fn, 'function')
     })
   })
 
@@ -388,7 +424,7 @@ describe('lifecycle hooks', () => {
         afterAll(() => {})
         describe('suite', () => {})
       })
-      assert.equal(typeof s.afterAll, 'function')
+      assert.equal(typeof s.afterAll[0].fn, 'function')
     })
   })
 })

--- a/packages/test/src/test/framework.test.ts
+++ b/packages/test/src/test/framework.test.ts
@@ -56,6 +56,15 @@ describe('describe', () => {
     assert.equal(s.tests[1].name, 'test two')
   })
 
+  it('registers skip and todo reasons from metadata', () => {
+    let [skipped, todo] = captureRegistration(() => {
+      describe('skipped', { skip: 'needs credentials' }, () => {})
+      describe('todo', { todo: 'needs design' }, () => {})
+    })
+    assert.equal(skipped.skip, 'needs credentials')
+    assert.equal(todo.todo, 'needs design')
+  })
+
   it('flattens nested describes into "Outer > Inner" names', () => {
     let [outer, inner] = captureRegistration(() => {
       describe('outer', () => {
@@ -71,6 +80,11 @@ describe('describe.skip', () => {
   it('marks the suite as skipped', () => {
     let [s] = captureRegistration(() => describe.skip('suite', () => {}))
     assert.equal(s.skip, true)
+  })
+
+  it('accepts a reason', () => {
+    let [s] = captureRegistration(() => describe.skip('suite', 'needs credentials', () => {}))
+    assert.equal(s.skip, 'needs credentials')
   })
 
   it('still calls fn to register tests', () => {
@@ -96,6 +110,19 @@ describe('describe.skip inheritance', () => {
     assert.equal(parent.skip, true)
     assert.equal(child.name, 'parent > child')
     assert.equal(child.skip, true)
+  })
+
+  it('propagates skip reasons to nested describes', () => {
+    let captured = captureRegistration(() =>
+      describe.skip('parent', 'needs credentials', () => {
+        describe('child', () => {
+          it('test', () => {})
+        })
+      }),
+    )
+    let [parent, child] = captured
+    assert.equal(parent.skip, 'needs credentials')
+    assert.equal(child.skip, 'needs credentials')
   })
 
   it('propagates skip through multiple levels of nesting', () => {
@@ -150,6 +177,11 @@ describe('describe.todo', () => {
     assert.equal(s.todo, true)
   })
 
+  it('accepts a reason', () => {
+    let [s] = captureRegistration(() => describe.todo('suite', 'needs design'))
+    assert.equal(s.todo, 'needs design')
+  })
+
   it('registers with no tests', () => {
     let [s] = captureRegistration(() => describe.todo('suite'))
     assert.equal(s.tests.length, 0)
@@ -197,6 +229,17 @@ describe('it', () => {
     assert.equal(s.tests[0].signal, signal)
   })
 
+  it('registers skip and todo reasons from metadata', () => {
+    let [s] = captureRegistration(() =>
+      describe('suite', () => {
+        it('skipped test', { skip: 'needs credentials' }, () => {})
+        it('todo test', { todo: 'needs design' }, () => {})
+      }),
+    )
+    assert.equal(s.tests[0].skip, 'needs credentials')
+    assert.equal(s.tests[1].todo, 'needs design')
+  })
+
   it('throws on invalid timeout values', () => {
     assert.throws(
       () =>
@@ -229,6 +272,18 @@ describe('it.skip', () => {
     assert.equal(s.tests[0].skip, true)
     assert.equal(typeof s.tests[0].fn, 'function')
   })
+
+  it('accepts a reason with or without a fn', () => {
+    let [s] = captureRegistration(() =>
+      describe('suite', () => {
+        it.skip('with fn', 'needs credentials', () => {})
+        it.skip('without fn', 'blocked')
+      }),
+    )
+    assert.equal(s.tests[0].skip, 'needs credentials')
+    assert.equal(s.tests[1].skip, 'blocked')
+    assert.equal(typeof s.tests[1].fn, 'function')
+  })
 })
 
 describe('it.only', () => {
@@ -251,6 +306,15 @@ describe('it.todo', () => {
     )
     assert.equal(s.tests[0].todo, true)
     assert.equal(s.tests[0].name, 'todo test')
+  })
+
+  it('accepts a reason', () => {
+    let [s] = captureRegistration(() =>
+      describe('suite', () => {
+        it.todo('todo test', 'needs design')
+      }),
+    )
+    assert.equal(s.tests[0].todo, 'needs design')
   })
 
   it('can be called outside describe (registers on implicit root suite)', () => {

--- a/packages/test/src/test/reporters.test.ts
+++ b/packages/test/src/test/reporters.test.ts
@@ -1,0 +1,72 @@
+import * as assert from '@remix-run/assert'
+import { FilesReporter } from '../lib/reporters/files.ts'
+import { SpecReporter } from '../lib/reporters/spec.ts'
+import { TapReporter } from '../lib/reporters/tap.ts'
+import type { TestResults } from '../lib/reporters/results.ts'
+import { describe, it } from '../lib/framework.ts'
+
+describe('reporters skip and todo reasons', () => {
+  it('prints reasons in the spec reporter', () => {
+    let output = captureConsole(() => new SpecReporter().onResult(createPendingResults()))
+
+    assert.match(output, /skipped test # skipped: needs credentials/)
+    assert.match(output, /todo test # todo: needs design/)
+  })
+
+  it('prints reasons in the files reporter', () => {
+    let output = captureConsole(() => new FilesReporter().onResult(createPendingResults()))
+
+    assert.match(output, /suite > skipped test # skipped: needs credentials/)
+    assert.match(output, /suite > todo test # todo: needs design/)
+  })
+
+  it('prints reasons as TAP directives', () => {
+    let output = captureConsole(() => new TapReporter().onResult(createPendingResults()))
+
+    assert.match(output, /ok 1 - suite > skipped test # SKIP needs credentials/)
+    assert.match(output, /ok 2 - suite > todo test # TODO needs design/)
+  })
+})
+
+function createPendingResults(): TestResults {
+  return {
+    passed: 0,
+    failed: 0,
+    skipped: 1,
+    todo: 1,
+    tests: [
+      {
+        name: 'skipped test',
+        suiteName: 'suite',
+        status: 'skipped',
+        reason: 'needs credentials',
+        duration: 0,
+      },
+      {
+        name: 'todo test',
+        suiteName: 'suite',
+        status: 'todo',
+        reason: 'needs design',
+        duration: 0,
+      },
+    ],
+  }
+}
+
+function captureConsole(fn: () => void): string {
+  let lines: string[] = []
+  let originalLog = console.log
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map(String).join(' '))
+  }
+  try {
+    fn()
+  } finally {
+    console.log = originalLog
+  }
+  return stripAnsi(lines.join('\n'))
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, '')
+}


### PR DESCRIPTION
Add Node-aligned timeout and abort signal support to `@remix-run/test` so tests and lifecycle hooks can fail promptly when async work hangs. Timed-out tests now abort `t.signal`, which lets application code pass the test signal through to APIs like `fetch`.

- Adds `{ timeout, signal }` support to `it()`/`test()` and lifecycle hooks
- Exposes `t.signal` on `TestContext` and aborts it when timeout/user cancellation triggers
- Preserves hook ordering while tracking hooks as runnable records with their own options
- Documents the new API and adds change files for `@remix-run/test` and `remix/test`

```ts
it('loads data', { timeout: 5_000 }, async (t) => {
  let response = await fetch('/api/data', { signal: t.signal })
  assert.equal(response.status, 200)
})

beforeEach(
  async () => {
    await resetDatabase()
  },
  { timeout: 1_000 },
)
```
