### PR TITLE
Require middleware to explicitly continue

### DIFF
--- a/demos/bookstore/app/middleware/admin.ts
+++ b/demos/bookstore/app/middleware/admin.ts
@@ -8,11 +8,13 @@ import { getCurrentUser } from '../utils/context.ts'
  * Must be used after requireAuth middleware.
  */
 export function requireAdmin(): Middleware {
-  return () => {
+  return (_, next) => {
     let user = getCurrentUser()
 
     if (user.role !== 'admin') {
       return new Response('Forbidden', { status: 403 })
     }
+
+    return next()
   }
 }

--- a/demos/bookstore/app/middleware/database.ts
+++ b/demos/bookstore/app/middleware/database.ts
@@ -8,7 +8,8 @@ export function loadDatabase(): Middleware<{
   value: Database
   property: 'db'
 }> {
-  return (context) => {
+  return (context, next) => {
     context.set(Database, db, { property: 'db' })
+    return next()
   }
 }

--- a/demos/social-auth/app/middleware/database.ts
+++ b/demos/social-auth/app/middleware/database.ts
@@ -8,7 +8,8 @@ export function loadDatabase(): Middleware<{
   value: Database
   property: 'db'
 }> {
-  return (context) => {
+  return (context, next) => {
     context.set(Database, db, { property: 'db' })
+    return next()
   }
 }

--- a/packages/auth-middleware/src/lib/require-auth.test.ts
+++ b/packages/auth-middleware/src/lib/require-auth.test.ts
@@ -38,12 +38,14 @@ describe('requireAuth middleware', () => {
   it('installs context.auth when auth state was set without a direct property', async () => {
     let loadAuth: Middleware<{ key: typeof Auth; value: AuthState<{ id: number }> }> = (
       context,
+      next,
     ) => {
       context.set(Auth, {
         ok: true,
         identity: { id: 123 },
         method: 'custom',
       })
+      return next()
     }
     let router = createRouter({
       middleware: [loadAuth, requireAuth<{ id: number }>()] as const,

--- a/packages/fetch-router/.changes/minor.require-middleware-next.md
+++ b/packages/fetch-router/.changes/minor.require-middleware-next.md
@@ -1,0 +1,32 @@
+BREAKING CHANGE: Middleware must now explicitly continue the request chain by calling `next()` or return a `Response`. The router no longer calls `next()` automatically when middleware returns `undefined`; instead, it throws an error to catch missing continuation bugs early.
+
+Middleware that only mutates context should return the downstream response:
+
+```ts
+// Before
+function loadUser(): Middleware {
+  return (context) => {
+    context.set(CurrentUser, user)
+  }
+}
+
+// After
+function loadUser(): Middleware {
+  return (context, next) => {
+    context.set(CurrentUser, user)
+    return next()
+  }
+}
+```
+
+Middleware that needs to inspect or modify the downstream response should `await next()` and return a `Response`:
+
+```ts
+function logger(): Middleware {
+  return async (context, next) => {
+    let response = await next()
+    console.log(context.request.url, response.status)
+    return response
+  }
+}
+```

--- a/packages/fetch-router/README.md
+++ b/packages/fetch-router/README.md
@@ -504,6 +504,8 @@ type Routes = typeof routes
 
 Middleware functions run code before and/or after actions. They are a powerful way to add functionality to your app.
 
+Every middleware must either return a `Response`, return the response from `next()`, or call `await next()` before it returns. Middleware that returns without calling `next()` throws at runtime.
+
 A basic logging middleware might look like this:
 
 ```ts
@@ -567,8 +569,9 @@ function loadDatabase(): Middleware<{
   value: Database
   property: 'db'
 }> {
-  return async (context) => {
+  return async (context, next) => {
     context.set(Database, await connectDatabase(), { property: 'db' })
+    return next()
   }
 }
 

--- a/packages/fetch-router/demos/cf-workers/app/router.ts
+++ b/packages/fetch-router/demos/cf-workers/app/router.ts
@@ -31,8 +31,9 @@ const sessionStorage = createCookieSessionStorage()
 const Database = createContextKey<D1Database>()
 
 function loadDatabase(): Middleware<{ key: typeof Database; value: D1Database; property: 'db' }> {
-  return (context) => {
+  return (context, next) => {
     context.set(Database, env.DB, { property: 'db' })
+    return next()
   }
 }
 

--- a/packages/fetch-router/src/lib/middleware.test.ts
+++ b/packages/fetch-router/src/lib/middleware.test.ts
@@ -71,19 +71,19 @@ describe('runMiddleware', () => {
     assert.deepEqual(requestLog, ['one'])
   })
 
-  it('invokes downstream automatically when a middleware does not call next()', async () => {
+  it('uses the downstream response when middleware calls next()', async () => {
     let requestLog: string[] = []
 
     let middleware = [
-      () => {
+      async (_: any, next: NextFunction) => {
         requestLog.push('one')
-        // no next()
+        await next()
       },
-      () => {
+      async (_: any, next: NextFunction) => {
         requestLog.push('two')
-        // no next()
+        await next()
       },
-    ]
+    ] as any
     let context = mockContext('https://remix.run')
     let handler = () => new Response('Hello, world!')
 
@@ -94,13 +94,27 @@ describe('runMiddleware', () => {
     assert.deepEqual(requestLog, ['one', 'two'])
   })
 
+  it('rejects when a middleware neither returns a response nor calls next()', async () => {
+    let middleware = [
+      () => {
+        // no response, no next()
+      },
+    ] as any
+    let context = mockContext('https://remix.run')
+    let handler = () => new Response('Hello, world!')
+
+    await assert.rejects(async () => {
+      await runMiddleware(middleware, context, handler)
+    }, new Error('Middleware must return a Response or call next()'))
+  })
+
   it('rejects when a middleware calls next() multiple times', async () => {
     let middleware = [
       async (_: any, next: NextFunction) => {
         await next()
         await next() // error
       },
-    ]
+    ] as any
     let context = mockContext('https://remix.run')
     let handler = () => new Response('Hello, world!')
 
@@ -110,7 +124,7 @@ describe('runMiddleware', () => {
   })
 
   it('rejects when a handler throws an error', async () => {
-    let middleware = [() => {}]
+    let middleware = [(_: any, next: NextFunction) => next()]
     let context = mockContext('https://remix.run')
     let handler = () => {
       throw new Error('Handler error!')

--- a/packages/fetch-router/src/lib/middleware.ts
+++ b/packages/fetch-router/src/lib/middleware.ts
@@ -61,7 +61,7 @@ export type MiddlewareContext<
  *
  * @param context The request context
  * @param next A function that invokes the next middleware or request handler in the chain
- * @returns A response to short-circuit the chain, or `undefined`/`void` to continue
+ * @returns A response to short-circuit the chain, or the response from `next()` to continue
  *
  * The generic describes the context effect this middleware has. Use a `{ key, value }` object for
  * middleware that provides one context value, add a `property` field to install a direct context
@@ -74,7 +74,7 @@ export interface Middleware<transform extends ContextTransform = EmptyContextTra
   (
     context: RequestContext<any>,
     next: NextFunction,
-  ): Response | undefined | void | Promise<Response | undefined | void>
+  ): Response | Promise<Response>
 
   /**
    * Type-only metadata that carries the middleware's declared context effect.
@@ -127,8 +127,7 @@ export function runMiddleware(
       return nextPromise
     }
 
-    // If it did not call next(), invoke downstream automatically
-    return next()
+    throw new Error('Middleware must return a Response or call next()')
   }
 
   return dispatch(0)

--- a/packages/fetch-router/src/lib/router-abort.test.ts
+++ b/packages/fetch-router/src/lib/router-abort.test.ts
@@ -153,7 +153,7 @@ describe('abort signal support', () => {
           controller.abort()
           await sleep(10)
         },
-      ],
+      ] as any,
     })
 
     router.get('/', () => new Response('Home'))
@@ -185,7 +185,7 @@ describe('abort signal support', () => {
         async () => {
           downstreamMiddlewareCalled = true
         },
-      ],
+      ] as any,
     })
 
     // Handler that should NOT be called

--- a/packages/fetch-router/src/lib/router.test.ts
+++ b/packages/fetch-router/src/lib/router.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from '@remix-run/test'
 
 import { createRoutes as route } from '../routes.ts'
 import type { Action, Controller } from './controller.ts'
+import type { NextFunction } from './middleware.ts'
 import type { RequestContext } from './request-context.ts'
 import { createRouter, type MatchData } from './router.ts'
 
@@ -43,8 +44,9 @@ describe('router.fetch()', () => {
 
     router.get(routes.home, {
       middleware: [
-        () => {
+        (_, next) => {
           requestLog.push('middleware')
+          return next()
         },
       ],
       handler() {
@@ -69,16 +71,18 @@ describe('router.fetch()', () => {
     let requestLog: string[] = []
     let router = createRouter({
       middleware: [
-        () => {
+        (_, next) => {
           requestLog.push('router middleware')
+          return next()
         },
       ],
     })
 
     router.get(routes.home, {
       middleware: [
-        () => {
+        (_, next) => {
           requestLog.push('route middleware')
+          return next()
         },
       ],
       handler() {
@@ -120,8 +124,9 @@ describe('router.fetch()', () => {
 
     router.get('/', {
       middleware: [
-        ({ headers }) => {
+        ({ headers }, next) => {
           requestLog.push(headers.get('From'))
+          return next()
         },
       ],
       handler() {
@@ -142,8 +147,9 @@ describe('router.fetch()', () => {
     let requestLog: string[] = []
     let router = createRouter({
       middleware: [
-        () => {
+        (_, next) => {
           requestLog.push('middleware')
+          return next()
         },
       ],
     })
@@ -158,8 +164,9 @@ describe('router.fetch()', () => {
     let requestLog: string[] = []
     let router = createRouter({
       middleware: [
-        () => {
+        (_, next) => {
           requestLog.push('middleware')
+          return next()
         },
       ],
     })
@@ -197,8 +204,9 @@ describe('router.map() with single routes', () => {
     let requestLog: string[] = []
     let router = createRouter()
 
-    function middleware(context: RequestContext<{ id: string }>) {
+    function middleware(context: RequestContext<{ id: string }>, next: NextFunction) {
       requestLog.push(`middleware ${context.params.id}`)
+      return next()
     }
 
     router.map(routes.profile, {
@@ -289,8 +297,9 @@ describe('router.map()', () => {
     let requestLog: string[] = []
     let router = createRouter()
 
-    function middleware() {
+    function middleware(_: RequestContext, next: NextFunction) {
       requestLog.push('middleware')
+      return next()
     }
 
     router.map(routes, {
@@ -454,8 +463,9 @@ describe('router.map()', () => {
 
     router.map(routes, {
       middleware: [
-        () => {
+        (_, next) => {
           requestLog.push('outer middleware')
+          return next()
         },
       ],
       actions: {
@@ -509,8 +519,9 @@ describe('router.map()', () => {
     // Admin routes - with auth middleware
     router.map(routes.admin, {
       middleware: [
-        () => {
+        (_, next) => {
           requestLog.push('auth')
+          return next()
         },
       ],
       actions: {
@@ -551,16 +562,18 @@ describe('router.map()', () => {
     let requestLog: string[] = []
     let router = createRouter({
       middleware: [
-        () => {
+        (_, next) => {
           requestLog.push('global')
+          return next()
         },
       ],
     })
 
     router.map(routes, {
       middleware: [
-        () => {
+        (_, next) => {
           requestLog.push('inline')
+          return next()
         },
       ],
       actions: {
@@ -594,8 +607,9 @@ describe('router.get()', () => {
     let router = createRouter()
     router.get('/', {
       middleware: [
-        () => {
+        (_, next) => {
           requestLog.push('middleware')
+          return next()
         },
       ],
       handler() {
@@ -614,19 +628,22 @@ describe('inline middleware', () => {
     let requestLog: string[] = []
     let router = createRouter({
       middleware: [
-        () => {
+        (_, next) => {
           requestLog.push('global')
+          return next()
         },
       ],
     })
 
     router.get('/', {
       middleware: [
-        () => {
+        (_, next) => {
           requestLog.push('inline-1')
+          return next()
         },
-        () => {
+        (_, next) => {
           requestLog.push('inline-2')
+          return next()
         },
       ],
       handler() {
@@ -646,8 +663,9 @@ describe('inline middleware', () => {
 
     router.get('/a', {
       middleware: [
-        () => {
+        (_, next) => {
           requestLog.push('inline-a')
+          return next()
         },
       ],
       handler() {
@@ -712,15 +730,17 @@ describe('inline middleware', () => {
 
     router.get('/', {
       middleware: [
-        () => {
+        (_, next) => {
           requestLog.push('m1')
+          return next()
         },
         () => {
           requestLog.push('m2-short-circuit')
           return new Response('Blocked', { status: 403 })
         },
-        () => {
+        (_, next) => {
           requestLog.push('m3')
+          return next()
         },
       ],
       handler() {
@@ -748,11 +768,13 @@ describe('inline middleware', () => {
 
     router.map(routes.admin, {
       middleware: [
-        () => {
+        (_, next) => {
           requestLog.push('auth')
+          return next()
         },
-        () => {
+        (_, next) => {
           requestLog.push('admin')
+          return next()
         },
       ],
       actions: {
@@ -762,8 +784,9 @@ describe('inline middleware', () => {
         },
         users: {
           middleware: [
-            () => {
+            (_, next) => {
               requestLog.push('users-middleware')
+              return next()
             },
           ],
           handler() {

--- a/packages/form-data-middleware/src/lib/form-data.test.ts
+++ b/packages/form-data-middleware/src/lib/form-data.test.ts
@@ -545,8 +545,9 @@ describe('formData middleware', () => {
     let parsedFormData = new FormData()
     parsedFormData.set('name', 'test')
 
-    let setFormData: Middleware<{ key: typeof FormData; value: FormData }> = (context) => {
+    let setFormData: Middleware<{ key: typeof FormData; value: FormData }> = (context, next) => {
       context.set(FormData, parsedFormData)
+      return next()
     }
 
     let router = createRouter({

--- a/packages/form-data-middleware/src/lib/form-data.ts
+++ b/packages/form-data-middleware/src/lib/form-data.ts
@@ -51,19 +51,19 @@ export function formData(
   let suppressErrors = options?.suppressErrors ?? false
   let uploadHandler = options?.uploadHandler
 
-  return async (context) => {
+  return async (context, next) => {
     if (context.has(FormData)) {
       let formData = context.get(FormData)
       if (formData != null) {
         context.set(FormData, formData, { property: 'formData' })
       }
 
-      return
+      return next()
     }
 
     if (context.method === 'GET' || context.method === 'HEAD') {
       context.set(FormData, new FormData(), { property: 'formData' })
-      return
+      return next()
     }
 
     let contentType = context.headers.get('Content-Type')
@@ -73,7 +73,7 @@ export function formData(
         !contentType.startsWith('application/x-www-form-urlencoded'))
     ) {
       context.set(FormData, new FormData(), { property: 'formData' })
-      return
+      return next()
     }
 
     try {
@@ -87,5 +87,7 @@ export function formData(
 
       context.set(FormData, new FormData(), { property: 'formData' })
     }
+
+    return next()
   }
 }

--- a/packages/method-override-middleware/src/lib/method-override.ts
+++ b/packages/method-override-middleware/src/lib/method-override.ts
@@ -1,5 +1,5 @@
 import { isRequestMethod } from '@remix-run/fetch-router'
-import type { Middleware, RequestContext } from '@remix-run/fetch-router'
+import type { Middleware } from '@remix-run/fetch-router'
 
 /**
  * Options for the {@link methodOverride} middleware.
@@ -26,16 +26,17 @@ export interface MethodOverrideOptions {
 export function methodOverride(options?: MethodOverrideOptions): Middleware {
   let fieldName = options?.fieldName ?? '_method'
 
-  return (context: RequestContext) => {
+  return (context, next) => {
     let method = context.get(FormData)?.get(fieldName)
-    if (typeof method !== 'string') {
-      return
+
+    if (typeof method === 'string') {
+      let requestMethod = method.toUpperCase()
+
+      if (isRequestMethod(requestMethod)) {
+        context.method = requestMethod
+      }
     }
 
-    let requestMethod = method.toUpperCase()
-
-    if (isRequestMethod(requestMethod)) {
-      context.method = requestMethod
-    }
+    return next()
   }
 }

--- a/packages/remix/.changes/minor.fetch-router.require-middleware-next.md
+++ b/packages/remix/.changes/minor.fetch-router.require-middleware-next.md
@@ -1,0 +1,12 @@
+BREAKING CHANGE: Middleware consumed through `remix/router` and `remix/fetch-router` must now explicitly continue the request chain by calling `next()` or return a `Response`. Middleware that returned `undefined` without calling `next()` now throws at runtime instead of implicitly continuing.
+
+Update context-loading middleware to return the downstream response:
+
+```ts
+function loadUser(): Middleware {
+  return (context, next) => {
+    context.set(CurrentUser, user)
+    return next()
+  }
+}
+```

--- a/packages/remix/src/fetch-router/README.md
+++ b/packages/remix/src/fetch-router/README.md
@@ -504,6 +504,8 @@ type Routes = typeof routes
 
 Middleware functions run code before and/or after actions. They are a powerful way to add functionality to your app.
 
+Every middleware must either return a `Response`, return the response from `next()`, or call `await next()` before it returns. Middleware that returns without calling `next()` throws at runtime.
+
 A basic logging middleware might look like this:
 
 ```ts
@@ -567,8 +569,9 @@ function loadDatabase(): Middleware<{
   value: Database
   property: 'db'
 }> {
-  return async (context) => {
+  return async (context, next) => {
     context.set(Database, await connectDatabase(), { property: 'db' })
+    return next()
   }
 }
 

--- a/packages/render-middleware/src/lib/render.ts
+++ b/packages/render-middleware/src/lib/render.ts
@@ -36,7 +36,8 @@ type RendererFactory<renderer extends AnyRenderer> = (context: RequestContext<an
 export function renderWith<const renderer extends AnyRenderer>(
   createRenderer: RendererFactory<renderer>,
 ): Middleware<{ key: typeof Renderer; value: renderer; property: 'render' }> {
-  return (context) => {
+  return (context, next) => {
     context.set(Renderer, createRenderer(context), { property: 'render' })
+    return next()
   }
 }


### PR DESCRIPTION
This changes fetch-router middleware from implicit continuation to explicit continuation. Middleware must now return a `Response` or call `next()`; middleware that returns without calling `next()` throws so missing continuation bugs fail loudly.

- Narrows the public `Middleware` type to `Response | Promise<Response>` and removes the runtime auto-`next()` fallback.
- Updates built-in middleware and demos that only populated context to explicitly `return next()`.
- Updates router docs and release notes with the migration pattern.

```ts
// Before
function loadUser(): Middleware {
  return (context) => {
    context.set(CurrentUser, user)
  }
}

// After
function loadUser(): Middleware {
  return (context, next) => {
    context.set(CurrentUser, user)
    return next()
  }
}
```

Middleware that needs to observe the downstream response should keep returning the response after awaiting it:

```ts
function logger(): Middleware {
  return async (context, next) => {
    let response = await next()
    console.log(context.request.url, response.status)
    return response
  }
}
```
