### PR TITLE
Clarify fetch router scoped middleware docs

### DIFF
--- a/packages/fetch-router/README.md
+++ b/packages/fetch-router/README.md
@@ -586,7 +586,7 @@ Global middleware is added to the router when it is created using the `createRou
 
 Controller middleware runs for every direct action in a controller. Action middleware runs only for one action, whether that action is registered in a controller or directly with `router.map()` or one of the method-specific helpers like `router.get()`, `router.post()`, `router.put()`, `router.delete()`, etc. The object form for actions is `{ handler, middleware? }`, so you can omit `middleware` entirely when you do not need it.
 
-A controller's `middleware` applies only to the direct route actions in that controller, and its `actions` object may not include nested route-map keys. Map nested route maps explicitly so each controller owns the direct route actions for one route map.
+A controller's `middleware` applies only to the direct route actions in that controller, and its `actions` object may not include nested route-map keys. This is the router's scoped middleware model: map nested route maps explicitly so each controller owns the direct route actions for one route map, and share middleware arrays between controllers that need the same boundary.
 
 ```tsx
 let routes = route({
@@ -602,11 +602,13 @@ let router = createRouter({
   middleware: [staticFiles('./public')],
 })
 
+let adminMiddleware = [auth({ token: 'secret' })]
+
 router.map(routes.home, () => new Response('Home'))
 
 router.map(routes.admin, {
   // This middleware applies to all actions in this controller.
-  middleware: [auth({ token: 'secret' })],
+  middleware: adminMiddleware,
   actions: {
     dashboard() {
       return new Response('Dashboard')

--- a/packages/remix/src/fetch-router/README.md
+++ b/packages/remix/src/fetch-router/README.md
@@ -586,7 +586,7 @@ Global middleware is added to the router when it is created using the `createRou
 
 Controller middleware runs for every direct action in a controller. Action middleware runs only for one action, whether that action is registered in a controller or directly with `router.map()` or one of the method-specific helpers like `router.get()`, `router.post()`, `router.put()`, `router.delete()`, etc. The object form for actions is `{ handler, middleware? }`, so you can omit `middleware` entirely when you do not need it.
 
-A controller's `middleware` applies only to the direct route actions in that controller, and its `actions` object may not include nested route-map keys. Map nested route maps explicitly so each controller owns the direct route actions for one route map.
+A controller's `middleware` applies only to the direct route actions in that controller, and its `actions` object may not include nested route-map keys. This is the router's scoped middleware model: map nested route maps explicitly so each controller owns the direct route actions for one route map, and share middleware arrays between controllers that need the same boundary.
 
 ```tsx
 let routes = route({
@@ -602,11 +602,13 @@ let router = createRouter({
   middleware: [staticFiles('./public')],
 })
 
+let adminMiddleware = [auth({ token: 'secret' })]
+
 router.map(routes.home, () => new Response('Home'))
 
 router.map(routes.admin, {
   // This middleware applies to all actions in this controller.
-  middleware: [auth({ token: 'secret' })],
+  middleware: adminMiddleware,
   actions: {
     dashboard() {
       return new Response('Dashboard')


### PR DESCRIPTION
This clarifies how controller middleware scopes to direct route actions in the fetch router docs.

- Documents the scoped middleware model for nested route maps.
- Shows sharing a middleware array across controllers when they should use the same boundary.
- Keeps the standalone package README and the mirrored Remix README copy in sync.
