### PR TITLE
Improve default template asset and frame defaults

### DIFF
--- a/packages/cli/.changes/patch.default-template-asset-performance.md
+++ b/packages/cli/.changes/patch.default-template-asset-performance.md
@@ -1,0 +1,1 @@
+Improve the default `remix new` app template so production starts with `NODE_ENV=production`, minifies browser assets, resolves frames on the client and server, and uses the dev server watcher instead of the asset server watcher.

--- a/packages/cli/src/lib/cli.test.ts
+++ b/packages/cli/src/lib/cli.test.ts
@@ -488,6 +488,8 @@ describe('run', () => {
       assert.doesNotMatch(assets, /\.\.\/packages/)
       assert.doesNotMatch(assets, /usesWorkspaceRemix/)
       assert.doesNotMatch(assets, /workspacePackagesDir/)
+      assert.doesNotMatch(assets, /deny:/)
+      assert.doesNotMatch(assets, /define:/)
       assert.match(assets, /watch: false/)
       assert.doesNotMatch(router, /compression/)
       assert.doesNotMatch(routes, /auth/)

--- a/packages/cli/src/lib/cli.test.ts
+++ b/packages/cli/src/lib/cli.test.ts
@@ -447,11 +447,13 @@ describe('run', () => {
         devDependencies: Record<string, string>
         engines: Record<string, string>
         name: string
+        scripts: Record<string, string>
       }
       let agentsGuide = await fs.readFile(path.join(appDir, 'AGENTS.md'), 'utf8')
       let readme = await fs.readFile(path.join(appDir, 'README.md'), 'utf8')
       let server = await fs.readFile(path.join(appDir, 'server.ts'), 'utf8')
       let assets = await fs.readFile(path.join(appDir, 'app', 'assets.ts'), 'utf8')
+      let router = await fs.readFile(path.join(appDir, 'app', 'router.ts'), 'utf8')
       let routes = await fs.readFile(path.join(appDir, 'app', 'routes.ts'), 'utf8')
       let entry = await fs.readFile(path.join(appDir, 'app', 'assets', 'entry.ts'), 'utf8')
       let renderMiddleware = await fs.readFile(
@@ -468,6 +470,10 @@ describe('run', () => {
       assert.equal(packageJson.devDependencies['@types/node'], 'latest')
       assert.equal(packageJson.devDependencies.typescript, 'latest')
       assert.equal(packageJson.engines.node, '>=24.3.0')
+      assert.match(packageJson.scripts.dev, /NODE_ENV=development/)
+      assert.match(packageJson.scripts.dev, /node --watch/)
+      assert.match(packageJson.scripts.start, /NODE_ENV=production/)
+      assert.match(packageJson.scripts.test, /NODE_ENV=test/)
       assert.match(agentsGuide, /^# My App Agent Guide/m)
       assert.match(agentsGuide, /This starter intentionally begins small/)
       assert.match(agentsGuide, /Put top-level route actions in `app\/actions\/controller\.tsx`/)
@@ -482,12 +488,15 @@ describe('run', () => {
       assert.doesNotMatch(assets, /\.\.\/packages/)
       assert.doesNotMatch(assets, /usesWorkspaceRemix/)
       assert.doesNotMatch(assets, /workspacePackagesDir/)
+      assert.match(assets, /watch: false/)
+      assert.doesNotMatch(router, /compression/)
       assert.doesNotMatch(routes, /auth/)
       assert.match(entry, /loadModule/)
-      assert.doesNotMatch(entry, /resolveFrame/)
+      assert.match(entry, /resolveFrame/)
       assert.doesNotMatch(entry, /X-Remix-Frame/)
       assert.match(renderMiddleware, /resolveClientEntry/)
-      assert.doesNotMatch(renderMiddleware, /resolveFrame/)
+      assert.match(renderMiddleware, /resolveFrame/)
+      assert.doesNotMatch(renderMiddleware, /Accept-Encoding/)
       assert.doesNotMatch(renderMiddleware, /X-Remix-Frame/)
       assert.match(controller, /context\.render\(<HomePage \/>/)
       assert.doesNotMatch(controller, /AuthPage/)

--- a/template/app/assets.ts
+++ b/template/app/assets.ts
@@ -21,13 +21,7 @@ export const assetServer = createAssetServer({
     '../packages/**',
     /* remix-template:remove-end */
   ],
-  deny: ['app/**/*.server.*'],
   sourceMaps: isDevelopment ? 'external' : undefined,
   minify: !isDevelopment,
   watch: false,
-  scripts: {
-    define: {
-      'process.env.NODE_ENV': JSON.stringify(nodeEnv),
-    },
-  },
 })

--- a/template/app/assets.ts
+++ b/template/app/assets.ts
@@ -1,6 +1,8 @@
 import { createAssetServer } from 'remix/assets'
 
 const rootDir = process.cwd()
+const nodeEnv = process.env.NODE_ENV ?? 'development'
+const isDevelopment = nodeEnv === 'development'
 
 export const assetServer = createAssetServer({
   basePath: '/assets',
@@ -20,10 +22,12 @@ export const assetServer = createAssetServer({
     /* remix-template:remove-end */
   ],
   deny: ['app/**/*.server.*'],
-  sourceMaps: process.env.NODE_ENV === 'development' ? 'external' : undefined,
+  sourceMaps: isDevelopment ? 'external' : undefined,
+  minify: !isDevelopment,
+  watch: false,
   scripts: {
     define: {
-      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV ?? 'development'),
+      'process.env.NODE_ENV': JSON.stringify(nodeEnv),
     },
   },
 })

--- a/template/app/assets/entry.ts
+++ b/template/app/assets/entry.ts
@@ -5,4 +5,13 @@ run({
     let mod = await import(moduleUrl)
     return mod[exportName]
   },
+  async resolveFrame(src, signal) {
+    let response = await fetch(src, { headers: { Accept: 'text/html' }, signal })
+    if (!response.ok) {
+      return `<pre>Frame error: ${response.status} ${response.statusText}</pre>`
+    }
+
+    if (response.body) return response.body
+    return await response.text()
+  },
 })

--- a/template/app/middleware/render.tsx
+++ b/template/app/middleware/render.tsx
@@ -1,5 +1,6 @@
 import * as path from 'node:path'
 
+import type { Router } from 'remix/router'
 import { renderWith } from 'remix/middleware/render'
 import { createHtmlResponse } from 'remix/response/html'
 import type { RemixNode } from 'remix/ui'
@@ -9,10 +10,12 @@ import { assetServer } from '../assets.ts'
 
 export function render() {
   return renderWith(
-    ({ request }) =>
+    ({ request, router }) =>
       function render(node: RemixNode, init?: ResponseInit) {
         let stream = renderToStream(node, {
+          frameSrc: request.url,
           signal: request.signal,
+          resolveFrame: (src) => resolveFrame(router, request, src),
           // Server rendering turns client entries into browser module URLs.
           async resolveClientEntry(entryId, component) {
             if (!entryId.startsWith('file://')) {
@@ -31,6 +34,31 @@ export function render() {
         return createHtmlResponse(stream, init)
       },
   )
+}
+
+async function resolveFrame(router: Router, request: Request, src: string) {
+  let url = new URL(src, request.url)
+
+  let headers = new Headers()
+  headers.set('Accept', 'text/html')
+
+  let cookie = request.headers.get('Cookie')
+  if (cookie) headers.set('Cookie', cookie)
+
+  let response = await router.fetch(
+    new Request(url, {
+      method: 'GET',
+      headers,
+      signal: request.signal,
+    }),
+  )
+
+  if (!response.ok) {
+    return `<pre>Frame error: ${response.status} ${response.statusText}</pre>`
+  }
+
+  if (response.body) return response.body
+  return await response.text()
 }
 
 function titleCaseFileName(fileUrl: string): string {

--- a/template/package.json
+++ b/template/package.json
@@ -3,9 +3,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node --watch --import remix/node-tsx server.ts",
-    "start": "node --import remix/node-tsx server.ts",
-    "test": "node --import remix/node-tsx --test",
+    "dev": "NODE_ENV=development node --watch --import remix/node-tsx server.ts",
+    "start": "NODE_ENV=production node --import remix/node-tsx server.ts",
+    "test": "NODE_ENV=test node --import remix/node-tsx --test",
     "typecheck": "tsc --noEmit"
   },
   "engines": {


### PR DESCRIPTION
This improves the default `remix new` app template so fresh projects start with production-minded asset behavior and basic frame rendering defaults without adding extra middleware.

- Sets `NODE_ENV` explicitly in the template scripts so development, production, and test behavior are predictable
- Uses `node --watch` in the development script so server-rendered modules and browser asset output restart from the same source changes
- Minifies browser assets outside development while preserving external sourcemaps during development
- Disables the asset server watcher so it does not update browser assets independently from the running server modules
- Resolves client and server `<Frame>` content by default

This follows the improvements explored in dwoodwardgb/remix3-demo#1 after a user noticed the starter app was serving non-minified browser modules by default.