### PR TITLE
Add version flag to docs prerender

### DIFF
--- a/docs/src/prerender/crawl.test.ts
+++ b/docs/src/prerender/crawl.test.ts
@@ -328,6 +328,45 @@ describe('crawl(router)', () => {
     assert.deepEqual(visited, ['/'])
   })
 
+  it('follows links on matching pages when page-level nofollow is ignored', async () => {
+    let router = createRouter()
+    router.get('/v1.2.3/', () =>
+      html(`
+        <meta name="robots" content="noindex, nofollow">
+        <a href="/v1.2.3/about">About</a>
+      `),
+    )
+    router.get('/v1.2.3/about', () => html('<html></html>'))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router, {
+      paths: ['/v1.2.3/'],
+      ignorePageNofollow: (pathname) => pathname.startsWith('/v1.2.3/'),
+    })) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/v1.2.3/', '/v1.2.3/about'])
+  })
+
+  it('still honors page-level nofollow when ignorePageNofollow does not match', async () => {
+    let router = createRouter()
+    router.get('/', () =>
+      html(`
+        <meta name="robots" content="noindex, nofollow">
+        <a href="/about">About</a>
+      `),
+    )
+    router.get('/about', () => html('<html></html>'))
+
+    let visited: string[] = []
+    for await (let { pathname } of crawl(router, {
+      ignorePageNofollow: (pathname) => pathname.startsWith('/v1.2.3/'),
+    })) {
+      visited.push(pathname)
+    }
+    assert.deepEqual(visited, ['/'])
+  })
+
   it('does not follow links on pages with <meta name="googlebot" content="nofollow">', async () => {
     let router = createRouter()
     router.get('/', () =>

--- a/docs/src/prerender/crawl.ts
+++ b/docs/src/prerender/crawl.ts
@@ -14,13 +14,14 @@ interface CrawlOptions {
   paths?: string[]
   spider?: boolean
   concurrency?: number
+  ignorePageNofollow?: (pathname: string) => boolean
 }
 
 export async function* crawl(
   router: Router,
   options: CrawlOptions = {},
 ): AsyncIterableIterator<CrawlResult> {
-  let { paths = ['/'], spider = true, concurrency = 1 } = options
+  let { paths = ['/'], spider = true, concurrency = 1, ignorePageNofollow } = options
 
   let queue: string[] = []
   let visited = new Set<string>()
@@ -85,7 +86,7 @@ export async function* crawl(
 
         enqueue(extractAssetPaths(dom.elements, pathname))
 
-        if (spider && shouldCrawlLinks(dom.elements)) {
+        if (spider && (ignorePageNofollow?.(pathname) || shouldCrawlLinks(dom.elements))) {
           enqueue(extractLinkPaths(dom.elements, pathname))
         }
       } else {

--- a/docs/src/prerender/index.ts
+++ b/docs/src/prerender/index.ts
@@ -156,7 +156,5 @@ async function getVersionsForPicker(activeVersion?: string): Promise<Versions> {
     })
   }
 
-  return remixVersions.length > 0
-    ? remixVersions.map((version) => ({ version }))
-    : getDefaultVersions()
+  return remixVersions.length > 0 ? remixVersions : getDefaultVersions()
 }

--- a/docs/src/prerender/index.ts
+++ b/docs/src/prerender/index.ts
@@ -17,8 +17,16 @@ let { values: cliArgs } = util.parseArgs({
       short: 'd',
       default: 'build/site',
     },
+    version: {
+      type: 'string',
+    },
   },
 })
+
+const buildVersion = cliArgs.version
+if (buildVersion != null && (buildVersion.length === 0 || buildVersion.includes('/'))) {
+  throw new Error(`Invalid --version value: ${buildVersion}`)
+}
 
 const publicDir = path.join(process.cwd(), 'build', 'public')
 const outputDir = path.join(process.cwd(), cliArgs.dir)
@@ -26,8 +34,9 @@ const SCRIPT_FILE_EXT = /\.(?:tsx?|jsx|mts)$/
 const SCRIPT_EXT_IN_PATH = /\.(?:tsx?|jsx|mts)(?=[?#]|$)/
 const SCRIPT_EXT_IN_JS_IMPORT = /\.(?:tsx?|jsx|mts)(?=["'?#])/g
 
-const versions = await getVersionsToBuild()
-console.log('Prerendering versions:\n', JSON.stringify(versions, null, 2))
+const versions = await getVersionsForPicker(buildVersion)
+console.log(`Prerendering ${buildVersion ? buildVersion : 'root'} docs`)
+console.log('Version picker options:\n', JSON.stringify(versions, null, 2))
 
 const docsRouter = createRouter(versions)
 
@@ -37,14 +46,8 @@ await fs.cp(publicDir, outputDir, { recursive: true })
 
 // Spider the site
 const paths = [
-  routes.home.href(),
-  routes.lookup.href(),
-  ...(versions
-    ?.filter((v) => v.crawl)
-    .flatMap((v) => [
-      routes.home.href({ version: v.version }),
-      routes.lookup.href({ version: v.version }),
-    ]) || []),
+  routes.home.href({ version: buildVersion }),
+  routes.lookup.href({ version: buildVersion }),
 ]
 
 for await (let { pathname, filepath, response } of crawl(docsRouter, { paths })) {
@@ -61,9 +64,11 @@ async function writeResult(pathname: string, filepath: string, response: Respons
   let outputPath = path.join(outputDir, outputFilepath)
   await fs.mkdir(path.dirname(outputPath), { recursive: true })
 
-  if (response.headers.get('Content-Type')?.includes('text/html')) {
+  let contentType = response.headers.get('Content-Type')
+
+  if (contentType?.includes('text/html')) {
     let html = await response.text()
-    // Update all HTML script references to reference JS files for static HTML hosting
+    // Update script references for static HTML hosting.
     let updated = rewriteExtensionsToJs(html)
     await fs.writeFile(outputPath, updated, 'utf-8')
   } else if (SCRIPT_FILE_EXT.test(filepath)) {
@@ -128,9 +133,9 @@ function rewriteExtensionsToJs(html: string): string {
   return changed ? dom.toString() : html
 }
 
-async function getVersionsToBuild(): Promise<Versions> {
+async function getVersionsForPicker(activeVersion?: string): Promise<Versions> {
   // Get all Remix v3 tags, transform them to vX.Y.Z format, sort newest to oldest
-  const remixVersions = cp
+  let remixVersions = cp
     .execSync('git tag', { encoding: 'utf-8' })
     .trim()
     .split('\n')
@@ -139,8 +144,19 @@ async function getVersionsToBuild(): Promise<Versions> {
     .filter((tag) => semver.valid(tag) && !semver.prerelease(tag))
     .sort((a, b) => semver.rcompare(a, b))
 
-  // Crawl only the most recent tag
+  if (activeVersion && !remixVersions.includes(activeVersion)) {
+    remixVersions.push(activeVersion)
+    remixVersions.sort((a, b) => {
+      let aValid = semver.valid(a)
+      let bValid = semver.valid(b)
+      if (aValid && bValid) return semver.rcompare(a, b)
+      if (aValid) return -1
+      if (bValid) return 1
+      return a.localeCompare(b)
+    })
+  }
+
   return remixVersions.length > 0
-    ? remixVersions.map((tag, i) => ({ version: tag, crawl: i === 0 }))
+    ? remixVersions.map((version) => ({ version }))
     : getDefaultVersions()
 }

--- a/docs/src/prerender/index.ts
+++ b/docs/src/prerender/index.ts
@@ -45,12 +45,16 @@ const docsRouter = createRouter(versions)
 await fs.cp(publicDir, outputDir, { recursive: true })
 
 // Spider the site
-const paths = [
-  routes.home.href({ version: buildVersion }),
-  routes.lookup.href({ version: buildVersion }),
-]
+const homePath = routes.home.href({ version: buildVersion })
+const paths = [homePath, routes.lookup.href({ version: buildVersion })]
 
-for await (let { pathname, filepath, response } of crawl(docsRouter, { paths })) {
+for await (let { pathname, filepath, response } of crawl(docsRouter, {
+  paths,
+  // Versioned pages stay noindex,nofollow for public crawlers, but the
+  // prerender spider needs the versioned home page's sidebar links to seed
+  // the static docs graph.
+  ignorePageNofollow: buildVersion ? (pathname) => pathname === homePath : undefined,
+})) {
   await writeResult(pathname, filepath, response)
 }
 

--- a/docs/src/prerender/index.ts
+++ b/docs/src/prerender/index.ts
@@ -1,14 +1,12 @@
-import * as cp from 'node:child_process'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as util from 'node:util'
-import * as semver from 'semver'
 import { assetServer } from '../server/asset-server.ts'
 import { createRouter, getDefaultVersions } from '../server/router.tsx'
 import { routes } from '../server/routes.ts'
-import type { Versions } from '../server/view.tsx'
 import { crawl } from './crawl.ts'
 import { parse } from './html-parser.ts'
+import { getVersionsForPicker } from './versions.ts'
 
 let { values: cliArgs } = util.parseArgs({
   options: {
@@ -34,7 +32,7 @@ const SCRIPT_FILE_EXT = /\.(?:tsx?|jsx|mts)$/
 const SCRIPT_EXT_IN_PATH = /\.(?:tsx?|jsx|mts)(?=[?#]|$)/
 const SCRIPT_EXT_IN_JS_IMPORT = /\.(?:tsx?|jsx|mts)(?=["'?#])/g
 
-const versions = await getVersionsForPicker(buildVersion)
+const versions = getVersionsForPicker(buildVersion, getDefaultVersions())
 console.log(`Prerendering ${buildVersion ? buildVersion : 'root'} docs`)
 console.log('Version picker options:\n', JSON.stringify(versions, null, 2))
 
@@ -135,30 +133,4 @@ function rewriteExtensionsToJs(html: string): string {
   }
 
   return changed ? dom.toString() : html
-}
-
-async function getVersionsForPicker(activeVersion?: string): Promise<Versions> {
-  // Get all Remix v3 tags, transform them to vX.Y.Z format, sort newest to oldest
-  let remixVersions = cp
-    .execSync('git tag', { encoding: 'utf-8' })
-    .trim()
-    .split('\n')
-    .filter((tag) => tag.startsWith('remix@3'))
-    .map((tag) => tag.replace('remix@', 'v'))
-    .filter((tag) => semver.valid(tag) && !semver.prerelease(tag))
-    .sort((a, b) => semver.rcompare(a, b))
-
-  if (activeVersion && !remixVersions.includes(activeVersion)) {
-    remixVersions.push(activeVersion)
-    remixVersions.sort((a, b) => {
-      let aValid = semver.valid(a)
-      let bValid = semver.valid(b)
-      if (aValid && bValid) return semver.rcompare(a, b)
-      if (aValid) return -1
-      if (bValid) return 1
-      return a.localeCompare(b)
-    })
-  }
-
-  return remixVersions.length > 0 ? remixVersions : getDefaultVersions()
 }

--- a/docs/src/prerender/versions.test.ts
+++ b/docs/src/prerender/versions.test.ts
@@ -1,0 +1,48 @@
+import * as assert from 'remix/assert'
+import { describe, it } from 'remix/test'
+import { getVersionsForPickerFromTags } from './versions.ts'
+
+describe('getVersionsForPickerFromTags()', () => {
+  it('returns stable Remix v3 tags sorted newest first', () => {
+    let versions = getVersionsForPickerFromTags(
+      `
+      remix@2.16.8
+      remix@3.0.0
+      remix@3.2.0-beta.1
+      remix@3.1.2
+      other@3.3.0
+    `,
+      { fallback: ['0.0.0'] },
+    )
+
+    assert.deepEqual(versions, ['v3.1.2', 'v3.0.0'])
+  })
+
+  it('falls back when there are no stable Remix v3 tags', () => {
+    let versions = getVersionsForPickerFromTags('remix@3.0.0-beta.1', {
+      fallback: ['0.0.0'],
+    })
+
+    assert.deepEqual(versions, ['0.0.0'])
+  })
+
+  it('includes the active version when it has a matching prerelease tag', () => {
+    let versions = getVersionsForPickerFromTags('remix@3.0.0-beta.1', {
+      activeVersion: 'v3.0.0-beta.1',
+      fallback: ['0.0.0'],
+    })
+
+    assert.deepEqual(versions, ['v3.0.0-beta.1'])
+  })
+
+  it('throws when the active version has no matching git tag', () => {
+    assert.throws(
+      () =>
+        getVersionsForPickerFromTags('remix@3.0.0', {
+          activeVersion: 'v3.1.2',
+          fallback: ['0.0.0'],
+        }),
+      /No matching git tag found for --version v3\.1\.2 \(expected remix@3\.1\.2\)/,
+    )
+  })
+})

--- a/docs/src/prerender/versions.ts
+++ b/docs/src/prerender/versions.ts
@@ -1,0 +1,57 @@
+import * as cp from 'node:child_process'
+import * as semver from 'semver'
+import type { Versions } from '../server/view.tsx'
+
+export function getVersionsForPicker(
+  activeVersion: string | undefined,
+  fallback: Versions,
+): Versions {
+  return getVersionsForPickerFromTags(cp.execSync('git tag', { encoding: 'utf-8' }), {
+    activeVersion,
+    fallback,
+  })
+}
+
+export function getVersionsForPickerFromTags(
+  tags: string,
+  options: {
+    activeVersion?: string
+    fallback: Versions
+  },
+): Versions {
+  let allRemixVersions = getAllRemixVersions(tags)
+  let remixVersions = allRemixVersions
+    .filter((tag) => !semver.prerelease(tag))
+    .sort((a, b) => semver.rcompare(a, b))
+
+  if (options.activeVersion) {
+    if (!allRemixVersions.includes(options.activeVersion)) {
+      throw new Error(
+        `No matching git tag found for --version ${options.activeVersion} ` +
+          `(expected ${getExpectedTagName(options.activeVersion)}). ` +
+          'Make sure you are running prerender from the matching release checkout with tags fetched.',
+      )
+    }
+
+    if (!remixVersions.includes(options.activeVersion)) {
+      remixVersions.push(options.activeVersion)
+      remixVersions.sort((a, b) => semver.rcompare(a, b))
+    }
+  }
+
+  return remixVersions.length > 0 ? remixVersions : options.fallback
+}
+
+function getAllRemixVersions(tags: string): Versions {
+  return tags
+    .trim()
+    .split('\n')
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.startsWith('remix@3'))
+    .map((tag) => tag.replace('remix@', 'v'))
+    .filter((tag) => semver.valid(tag))
+}
+
+function getExpectedTagName(version: string): string {
+  return `remix@${version.startsWith('v') ? version.slice(1) : version}`
+}

--- a/docs/src/server/lookup.ts
+++ b/docs/src/server/lookup.ts
@@ -1,0 +1,18 @@
+import { routes } from './routes.ts'
+
+export function getVersionedLookupHref(href: string, version: string): string {
+  if (!href.startsWith('/api/')) return href
+
+  let url = new URL(href, 'http://localhost')
+  let slug = url.pathname.slice('/api/'.length)
+  if (slug.length === 0) return href
+
+  let routeHref: string
+  if (slug.endsWith('.md')) {
+    routeHref = routes.markdown.href({ version, slug: slug.slice(0, -'.md'.length) })
+  } else {
+    routeHref = routes.docs.href({ version, slug: slug.replace(/\/$/, '') })
+  }
+
+  return `${routeHref}${url.search}${url.hash}`
+}

--- a/docs/src/server/lookup.ts
+++ b/docs/src/server/lookup.ts
@@ -1,18 +1,5 @@
-import { routes } from './routes.ts'
+import { getDocsRouteHref } from './routes.ts'
 
 export function getVersionedLookupHref(href: string, version: string): string {
-  if (!href.startsWith('/api/')) return href
-
-  let url = new URL(href, 'http://localhost')
-  let slug = url.pathname.slice('/api/'.length)
-  if (slug.length === 0) return href
-
-  let routeHref: string
-  if (slug.endsWith('.md')) {
-    routeHref = routes.markdown.href({ version, slug: slug.slice(0, -'.md'.length) })
-  } else {
-    routeHref = routes.docs.href({ version, slug: slug.replace(/\/$/, '') })
-  }
-
-  return `${routeHref}${url.search}${url.hash}`
+  return getDocsRouteHref(href, version) ?? href
 }

--- a/docs/src/server/markdown.ts
+++ b/docs/src/server/markdown.ts
@@ -105,13 +105,13 @@ export async function renderMarkdownFile(
   filePath: string,
   docFilesLookup: Map<string, DocFile>,
   version: string | undefined,
-  addLinks: boolean,
+  addCodeLinks: boolean,
 ): Promise<{ html: string; source?: string }> {
   try {
     let markdown = fs.readFileSync(filePath, 'utf-8')
     let { attributes, body } = parseFrontmatter(markdown)
     let marked = new Marked(
-      getShikiExtension(attributes.title || '', docFilesLookup, version, addLinks),
+      getShikiExtension(attributes.title || '', docFilesLookup, version, addCodeLinks),
     )
     let html = await marked.parse(body)
     return { html, source: typeof attributes.source === 'string' ? attributes.source : undefined }
@@ -131,7 +131,7 @@ function getShikiExtension(
   apiName: string,
   docFilesLookup: Map<string, DocFile>,
   version: string | undefined,
-  addLinks: boolean,
+  addCodeLinks: boolean,
 ): MarkedExtension {
   return {
     async: true,
@@ -150,7 +150,7 @@ function getShikiExtension(
               // Insert cross-links to known APIs
               {
                 span(node, line, col) {
-                  if (!addLinks) {
+                  if (!addCodeLinks) {
                     return
                   }
 

--- a/docs/src/server/markdown.ts
+++ b/docs/src/server/markdown.ts
@@ -217,6 +217,13 @@ function getShikiExtension(
       code(code) {
         return code.text
       },
+      link(token) {
+        let href = getDocsRouteHref(token.href, version)
+        if (!href) return false
+
+        let title = token.title ? ` title="${escapeHtml(token.title)}"` : ''
+        return `<a href="${escapeHtml(href)}"${title}>${this.parser.parseInline(token.tokens)}</a>`
+      },
     },
   }
 
@@ -246,4 +253,38 @@ function getShikiExtension(
       ],
     }
   }
+}
+
+function getDocsRouteHref(href: string, version: string | undefined): string | undefined {
+  if (!href.startsWith('/api/')) return undefined
+
+  let url = new URL(href, 'http://localhost')
+  let slug = url.pathname.slice('/api/'.length)
+  if (slug.length === 0) return undefined
+
+  let routeHref: string
+  if (slug.endsWith('.md')) {
+    routeHref = routes.markdown.href({ version, slug: slug.slice(0, -'.md'.length) })
+  } else {
+    routeHref = routes.docs.href({ version, slug: slug.replace(/\/$/, '') })
+  }
+
+  return `${routeHref}${url.search}${url.hash}`
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"]/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;'
+      case '<':
+        return '&lt;'
+      case '>':
+        return '&gt;'
+      case '"':
+        return '&quot;'
+      default:
+        return char
+    }
+  })
 }

--- a/docs/src/server/markdown.ts
+++ b/docs/src/server/markdown.ts
@@ -5,7 +5,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { codeToHtml } from 'shiki'
 import { IGNORE_SYMBOLS, MDN_SYMBOLS } from '../generate/symbols.ts'
-import { routes } from './routes.ts'
+import { getDocsRouteHref, routes } from './routes.ts'
 
 // No types exist for the `frontmatter` package
 const parseFrontmatter = frontmatter.default as unknown as (md: string) => {
@@ -253,23 +253,6 @@ function getShikiExtension(
       ],
     }
   }
-}
-
-function getDocsRouteHref(href: string, version: string | undefined): string | undefined {
-  if (!href.startsWith('/api/')) return undefined
-
-  let url = new URL(href, 'http://localhost')
-  let slug = url.pathname.slice('/api/'.length)
-  if (slug.length === 0) return undefined
-
-  let routeHref: string
-  if (slug.endsWith('.md')) {
-    routeHref = routes.markdown.href({ version, slug: slug.slice(0, -'.md'.length) })
-  } else {
-    routeHref = routes.docs.href({ version, slug: slug.replace(/\/$/, '') })
-  }
-
-  return `${routeHref}${url.search}${url.hash}`
 }
 
 function escapeHtml(value: string): string {

--- a/docs/src/server/markdown.ts
+++ b/docs/src/server/markdown.ts
@@ -273,18 +273,5 @@ function getDocsRouteHref(href: string, version: string | undefined): string | u
 }
 
 function escapeHtml(value: string): string {
-  return value.replace(/[&<>"]/g, (char) => {
-    switch (char) {
-      case '&':
-        return '&amp;'
-      case '<':
-        return '&lt;'
-      case '>':
-        return '&gt;'
-      case '"':
-        return '&quot;'
-      default:
-        return char
-    }
-  })
+  return value.replace(/[&<>"]/g, (char) => `&#${char.charCodeAt(0)};`)
 }

--- a/docs/src/server/router.test.tsx
+++ b/docs/src/server/router.test.tsx
@@ -1,0 +1,26 @@
+import * as assert from 'remix/assert'
+import { after, describe, it } from 'remix/test'
+
+import { assetServer } from './asset-server.ts'
+import { createRouter } from './router.tsx'
+
+after(async () => {
+  await assetServer.close()
+})
+
+describe('createRouter()', () => {
+  it('preserves versioned markdown lookup targets', async () => {
+    let router = createRouter(['v1.2.3'])
+    let response = await router.fetch(new Request('http://localhost/v1.2.3/api.json'))
+    assert.equal(response.status, 200)
+
+    let body = await response.text()
+    let href = '/v1.2.3/api/remix/headers/accept/class/Accept.md'
+    assert.equal(body.includes(`"Accept":"${href}"`), true)
+    assert.equal(body.includes(`"Accept":"${href}/"`), false)
+
+    let markdownResponse = await router.fetch(new Request(`http://localhost${href}`))
+    assert.equal(markdownResponse.status, 200)
+    assert.equal(markdownResponse.headers.get('content-type'), 'text/markdown; charset=utf-8')
+  })
+})

--- a/docs/src/server/router.test.tsx
+++ b/docs/src/server/router.test.tsx
@@ -4,6 +4,7 @@ import { after, describe, it } from 'remix/test'
 import { assetServer } from './asset-server.ts'
 import { getVersionedLookupHref } from './lookup.ts'
 import { createRouter } from './router.tsx'
+import { getDocsRouteHref } from './routes.ts'
 
 after(async () => {
   await assetServer.close()
@@ -45,6 +46,19 @@ describe('getVersionedLookupHref()', () => {
     assert.equal(
       getVersionedLookupHref('https://example.com/Accept', 'v1.2.3'),
       'https://example.com/Accept',
+    )
+  })
+})
+
+describe('getDocsRouteHref()', () => {
+  it('returns undefined for non-API hrefs', () => {
+    assert.equal(getDocsRouteHref('https://example.com/Accept', 'v1.2.3'), undefined)
+  })
+
+  it('preserves unversioned docs hrefs when version is undefined', () => {
+    assert.equal(
+      getDocsRouteHref('/api/remix/headers/accept/class/Accept.md?tab=docs#example', undefined),
+      '/api/remix/headers/accept/class/Accept.md?tab=docs#example',
     )
   })
 })

--- a/docs/src/server/router.test.tsx
+++ b/docs/src/server/router.test.tsx
@@ -2,6 +2,7 @@ import * as assert from 'remix/assert'
 import { after, describe, it } from 'remix/test'
 
 import { assetServer } from './asset-server.ts'
+import { getVersionedLookupHref } from './lookup.ts'
 import { createRouter } from './router.tsx'
 
 after(async () => {
@@ -9,18 +10,41 @@ after(async () => {
 })
 
 describe('createRouter()', () => {
-  it('preserves versioned markdown lookup targets', async () => {
+  it('does not load generated docs output while creating the router', () => {
     let router = createRouter(['v1.2.3'])
-    let response = await router.fetch(new Request('http://localhost/v1.2.3/api.json'))
-    assert.equal(response.status, 200)
+    assert.equal(typeof router.fetch, 'function')
+  })
+})
 
-    let body = await response.text()
-    let href = '/v1.2.3/api/remix/headers/accept/class/Accept.md'
-    assert.equal(body.includes(`"Accept":"${href}"`), true)
-    assert.equal(body.includes(`"Accept":"${href}/"`), false)
+describe('getVersionedLookupHref()', () => {
+  it('preserves versioned markdown lookup targets', () => {
+    assert.equal(
+      getVersionedLookupHref('/api/remix/headers/accept/class/Accept.md', 'v1.2.3'),
+      '/v1.2.3/api/remix/headers/accept/class/Accept.md',
+    )
+  })
 
-    let markdownResponse = await router.fetch(new Request(`http://localhost${href}`))
-    assert.equal(markdownResponse.status, 200)
-    assert.equal(markdownResponse.headers.get('content-type'), 'text/markdown; charset=utf-8')
+  it('uses docs routes for HTML lookup targets', () => {
+    assert.equal(
+      getVersionedLookupHref('/api/remix/headers/accept/class/Accept', 'v1.2.3'),
+      '/v1.2.3/api/remix/headers/accept/class/Accept/',
+    )
+  })
+
+  it('preserves query strings and hashes', () => {
+    assert.equal(
+      getVersionedLookupHref(
+        '/api/remix/headers/accept/class/Accept.md?tab=docs#example',
+        'v1.2.3',
+      ),
+      '/v1.2.3/api/remix/headers/accept/class/Accept.md?tab=docs#example',
+    )
+  })
+
+  it('leaves non-API lookup targets unchanged', () => {
+    assert.equal(
+      getVersionedLookupHref('https://example.com/Accept', 'v1.2.3'),
+      'https://example.com/Accept',
+    )
   })
 })

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -9,8 +9,13 @@ import { clientEntry, type RemixNode } from 'remix/ui'
 import { renderToStream } from 'remix/ui/server'
 import { assetServer, entryPreloads } from './asset-server.ts'
 import { discoverDemoFiles, loadDemoComponent, renderDemoSource } from './demos.tsx'
-import { discoverMarkdownFiles, renderMarkdownFile } from './markdown.ts'
-import { buildRegistry, type DocsRegistry } from './registry.ts'
+import { getVersionedLookupHref } from './lookup.ts'
+import {
+  discoverMarkdownFiles,
+  renderMarkdownFile,
+  type DocFile as MarkdownDocFile,
+} from './markdown.ts'
+import { buildRegistry, type DocFile, type DocsRegistry } from './registry.ts'
 import { routes } from './routes.ts'
 import { DemoContent, Document, Home, MarkdownContent, NotFound, type Versions } from './view.tsx'
 
@@ -21,20 +26,10 @@ const MD_DIR = path.join(BUILD_DIR, 'md')
 const PUBLIC_DIR = path.join(BUILD_DIR, 'public')
 const REMIX_PKG_JSON = path.join(REPO_DIR, 'packages', 'remix', 'package.json')
 
-const { docFiles: markdownFiles, docFilesLookup } = await discoverMarkdownFiles(MD_DIR)
-const demoFiles = await discoverDemoFiles()
-const docFiles = [...markdownFiles, ...demoFiles].sort((a, b) => a.urlPath.localeCompare(b.urlPath))
-
-const registryByVersion = new Map<string | undefined, DocsRegistry>()
-registryByVersion.set(undefined, buildRegistry(docFiles))
-
-function getRegistry(version?: string): DocsRegistry {
-  let registry = registryByVersion.get(version)
-  if (!registry) {
-    registry = buildRegistry(docFiles, version)
-    registryByVersion.set(version, registry)
-  }
-  return registry
+type DocsContext = {
+  docFiles: DocFile[]
+  docFilesLookup: Map<string, MarkdownDocFile>
+  getRegistry(version?: string): DocsRegistry
 }
 
 export const getDefaultVersions = (): Versions => {
@@ -43,7 +38,14 @@ export const getDefaultVersions = (): Versions => {
 }
 
 export function createRouter(versions: Versions) {
+  let docsContextPromise: Promise<DocsContext> | undefined
+
   const router = _createRouter({ middleware: [staticFiles(PUBLIC_DIR)] })
+
+  function getDocsContext(): Promise<DocsContext> {
+    docsContextPromise ??= loadDocsContext()
+    return docsContextPromise
+  }
 
   const respond = {
     async file(request: Request, filePath: string, name?: string) {
@@ -66,9 +68,10 @@ export function createRouter(versions: Versions) {
         return response ?? new Response('Not Found', { status: 404 })
       },
       async docs({ request, params }) {
-        let docFile = docFiles.find((file) => file.urlPath === params.slug)
+        let docsContext = await getDocsContext()
+        let docFile = docsContext.docFiles.find((file) => file.urlPath === params.slug)
         let docProps = {
-          registry: getRegistry(params.version),
+          registry: docsContext.getRegistry(params.version),
           versions: versions,
           slug: params.slug,
           activeVersion: params.version,
@@ -94,7 +97,7 @@ export function createRouter(versions: Versions) {
 
           let { html, source } = await renderMarkdownFile(
             docFile.path,
-            docFilesLookup,
+            docsContext.docFilesLookup,
             params.version,
             // Don't auto-link code symbols in README - too many false positives.
             docFile.kind !== 'package',
@@ -116,10 +119,11 @@ export function createRouter(versions: Versions) {
         )
       },
       async home({ request, params }) {
+        let docsContext = await getDocsContext()
         return respond.document(
           request,
           <Document
-            registry={getRegistry(params.version)}
+            registry={docsContext.getRegistry(params.version)}
             versions={versions}
             activeVersion={params.version}
             entryPreloads={entryPreloads}
@@ -136,12 +140,13 @@ export function createRouter(versions: Versions) {
 
         let content = JSON.parse(await fs.promises.readFile(jsonPath, 'utf-8'))
         for (let key in content) {
-          content[key] = getLookupHref(content[key], params.version)
+          content[key] = getVersionedLookupHref(content[key], params.version)
         }
         return Response.json(content)
       },
       async markdown({ request, params }) {
-        let docFile = docFiles.find((file) => file.urlPath === params.slug)
+        let docsContext = await getDocsContext()
+        let docFile = docsContext.docFiles.find((file) => file.urlPath === params.slug)
         if (!docFile) {
           return new Response('Not Found', { status: 404 })
         }
@@ -163,21 +168,28 @@ export function createRouter(versions: Versions) {
 
 // Response helpers
 
-function getLookupHref(href: string, version: string): string {
-  if (!href.startsWith('/api/')) return href
+async function loadDocsContext(): Promise<DocsContext> {
+  let { docFiles: markdownFiles, docFilesLookup } = await discoverMarkdownFiles(MD_DIR)
+  let demoFiles = await discoverDemoFiles()
+  let docFiles = [...markdownFiles, ...demoFiles].sort((a, b) =>
+    a.urlPath.localeCompare(b.urlPath),
+  )
 
-  let url = new URL(href, 'http://localhost')
-  let slug = url.pathname.slice('/api/'.length)
-  if (slug.length === 0) return href
+  let registryByVersion = new Map<string | undefined, DocsRegistry>()
+  registryByVersion.set(undefined, buildRegistry(docFiles))
 
-  let routeHref: string
-  if (slug.endsWith('.md')) {
-    routeHref = routes.markdown.href({ version, slug: slug.slice(0, -'.md'.length) })
-  } else {
-    routeHref = routes.docs.href({ version, slug: slug.replace(/\/$/, '') })
+  return {
+    docFiles,
+    docFilesLookup,
+    getRegistry(version?: string): DocsRegistry {
+      let registry = registryByVersion.get(version)
+      if (!registry) {
+        registry = buildRegistry(docFiles, version)
+        registryByVersion.set(version, registry)
+      }
+      return registry
+    },
   }
-
-  return `${routeHref}${url.search}${url.hash}`
 }
 
 function stream(router: Router, request: Request, node: RemixNode, init?: ResponseInit) {

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -39,7 +39,7 @@ function getRegistry(version?: string): DocsRegistry {
 
 export const getDefaultVersions = (): Versions => {
   let version = JSON.parse(fs.readFileSync(REMIX_PKG_JSON, 'utf-8')).version
-  return [{ version }]
+  return [version]
 }
 
 export function createRouter(versions: Versions) {

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -7,7 +7,6 @@ import { createHtmlResponse } from 'remix/response/html'
 import { createRouter as _createRouter, type Router } from 'remix/router'
 import { clientEntry, type RemixNode } from 'remix/ui'
 import { renderToStream } from 'remix/ui/server'
-import * as semver from 'semver'
 import { assetServer, entryPreloads } from './asset-server.ts'
 import { discoverDemoFiles, loadDemoComponent, renderDemoSource } from './demos.tsx'
 import { discoverMarkdownFiles, renderMarkdownFile } from './markdown.ts'
@@ -40,7 +39,7 @@ function getRegistry(version?: string): DocsRegistry {
 
 export const getDefaultVersions = (): Versions => {
   let version = JSON.parse(fs.readFileSync(REMIX_PKG_JSON, 'utf-8')).version
-  return [{ version, crawl: semver.prerelease(version) === null }]
+  return [{ version }]
 }
 
 export function createRouter(versions: Versions) {
@@ -134,9 +133,10 @@ export function createRouter(versions: Versions) {
         if (!params.version) {
           return respond.file(request, jsonPath)
         }
+
         let content = JSON.parse(await fs.promises.readFile(jsonPath, 'utf-8'))
         for (let key in content) {
-          content[key] = `/${params.version}${content[key]}`
+          content[key] = getLookupHref(content[key], params.version)
         }
         return Response.json(content)
       },
@@ -162,6 +162,15 @@ export function createRouter(versions: Versions) {
 }
 
 // Response helpers
+
+function getLookupHref(href: string, version: string): string {
+  if (!href.startsWith('/api/')) return href
+
+  return routes.docs.href({
+    version,
+    slug: href.slice('/api/'.length).replace(/\/$/, ''),
+  })
+}
 
 function stream(router: Router, request: Request, node: RemixNode, init?: ResponseInit) {
   return renderToStream(node, {

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -166,10 +166,18 @@ export function createRouter(versions: Versions) {
 function getLookupHref(href: string, version: string): string {
   if (!href.startsWith('/api/')) return href
 
-  return routes.docs.href({
-    version,
-    slug: href.slice('/api/'.length).replace(/\/$/, ''),
-  })
+  let url = new URL(href, 'http://localhost')
+  let slug = url.pathname.slice('/api/'.length)
+  if (slug.length === 0) return href
+
+  let routeHref: string
+  if (slug.endsWith('.md')) {
+    routeHref = routes.markdown.href({ version, slug: slug.slice(0, -'.md'.length) })
+  } else {
+    routeHref = routes.docs.href({ version, slug: slug.replace(/\/$/, '') })
+  }
+
+  return `${routeHref}${url.search}${url.hash}`
 }
 
 function stream(router: Router, request: Request, node: RemixNode, init?: ResponseInit) {

--- a/docs/src/server/router.tsx
+++ b/docs/src/server/router.tsx
@@ -96,7 +96,7 @@ export function createRouter(versions: Versions) {
             docFile.path,
             docFilesLookup,
             params.version,
-            // Don't transform links in README - too many false positives
+            // Don't auto-link code symbols in README - too many false positives.
             docFile.kind !== 'package',
           )
           return await respond.document(

--- a/docs/src/server/routes.ts
+++ b/docs/src/server/routes.ts
@@ -7,3 +7,20 @@ export const routes = route({
   lookup: '/(:version/)api.json',
   markdown: '/(:version/)api/*slug.md',
 })
+
+export function getDocsRouteHref(href: string, version: string | undefined): string | undefined {
+  if (!href.startsWith('/api/')) return undefined
+
+  let url = new URL(href, 'http://localhost')
+  let slug = url.pathname.slice('/api/'.length)
+  if (slug.length === 0) return undefined
+
+  let routeHref: string
+  if (slug.endsWith('.md')) {
+    routeHref = routes.markdown.href({ version, slug: slug.slice(0, -'.md'.length) })
+  } else {
+    routeHref = routes.docs.href({ version, slug: slug.replace(/\/$/, '') })
+  }
+
+  return `${routeHref}${url.search}${url.hash}`
+}

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -13,7 +13,7 @@ import type { DocsRegistry, NavGroup, PageDefinition } from './registry.ts'
 import { buildNotFoundPage, getDocPage, getHomePage, isPageActive } from './registry.ts'
 import { routes } from './routes.ts'
 
-export type Versions = { version: string }[]
+export type Versions = string[]
 
 const entryHref = await assetServer.getHref('docs/src/client/entry.tsx')
 
@@ -373,7 +373,7 @@ function VersionSwitcher(
 
     let navVersions = versions
     if (activeVersion) {
-      let idx = versions.findIndex((v) => v.version === activeVersion)
+      let idx = versions.findIndex((version) => version === activeVersion)
       if (idx >= 0) navVersions = versions.slice(idx)
     }
 
@@ -384,21 +384,20 @@ function VersionSwitcher(
         </summary>
         <div mix={sectionContentCss}>
           <nav aria-label="Versions" mix={sidebarNavCss}>
-            {navVersions.map((v) => {
-              let latest =
-                (versions.length === 0 || v.version === versions[0]?.version) && !activeVersion
-              let active = v.version === activeVersion || latest
-              let href = routes.home.href({ version: !latest ? v.version : undefined })
+            {navVersions.map((version) => {
+              let latest = (versions.length === 0 || version === versions[0]) && !activeVersion
+              let active = version === activeVersion || latest
+              let href = routes.home.href({ version: !latest ? version : undefined })
               let rel = active ? undefined : 'nofollow'
               return (
                 <a
-                  key={v.version}
+                  key={version}
                   href={href}
                   rel={rel}
                   aria-current={active ? 'page' : undefined}
                   mix={navItemCss}
                 >
-                  {v.version}
+                  {version}
                   {latest ? ' (latest)' : null}
                 </a>
               )

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -13,7 +13,7 @@ import type { DocsRegistry, NavGroup, PageDefinition } from './registry.ts'
 import { buildNotFoundPage, getDocPage, getHomePage, isPageActive } from './registry.ts'
 import { routes } from './routes.ts'
 
-export type Versions = { version: string; crawl: boolean }[]
+export type Versions = { version: string }[]
 
 const entryHref = await assetServer.getHref('docs/src/client/entry.tsx')
 
@@ -99,6 +99,7 @@ function Head(
 ) {
   return () => {
     let { page, activeVersion, entryPreloads } = handle.props
+    let shouldNofollow = page.docFile?.kind === 'package' || page.docFile?.kind === 'demo'
     return (
       <head>
         <meta charSet="utf-8" />
@@ -107,10 +108,10 @@ function Head(
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" sizes="any" />
         {activeVersion != null ? (
           <>
-            <meta name="robots" content="noindex,nofollow" />
-            <meta name="googlebot" content="noindex,nofollow" />
+            <meta name="robots" content={shouldNofollow ? 'noindex,nofollow' : 'noindex'} />
+            <meta name="googlebot" content={shouldNofollow ? 'noindex,nofollow' : 'noindex'} />
           </>
-        ) : page.docFile?.kind === 'package' || page.docFile?.kind === 'demo' ? (
+        ) : shouldNofollow ? (
           // Overview pages (package READMEs) link densely to every API page
           // in the package; those are already reachable via the sidebar, so
           // tell crawlers — including our prerender spider — not to follow
@@ -261,7 +262,7 @@ function Sidebar(
   handle: Handle<{
     registry: DocsRegistry
     currentPath: string
-    versions: { version: string; crawl: boolean }[]
+    versions: Versions
     activeVersion?: string
   }>,
 ) {
@@ -363,7 +364,7 @@ function RemixLogos() {
 
 function VersionSwitcher(
   handle: Handle<{
-    versions: { version: string; crawl: boolean }[]
+    versions: Versions
     activeVersion?: string
   }>,
 ) {
@@ -388,11 +389,12 @@ function VersionSwitcher(
                 (versions.length === 0 || v.version === versions[0]?.version) && !activeVersion
               let active = v.version === activeVersion || latest
               let href = routes.home.href({ version: !latest ? v.version : undefined })
+              let rel = active ? undefined : 'nofollow'
               return (
                 <a
                   key={v.version}
                   href={href}
-                  rel={!latest && !v.crawl ? 'nofollow' : undefined}
+                  rel={rel}
                   aria-current={active ? 'page' : undefined}
                   mix={navItemCss}
                 >

--- a/docs/src/server/view.tsx
+++ b/docs/src/server/view.tsx
@@ -108,8 +108,8 @@ function Head(
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" sizes="any" />
         {activeVersion != null ? (
           <>
-            <meta name="robots" content={shouldNofollow ? 'noindex,nofollow' : 'noindex'} />
-            <meta name="googlebot" content={shouldNofollow ? 'noindex,nofollow' : 'noindex'} />
+            <meta name="robots" content="noindex,nofollow" />
+            <meta name="googlebot" content="noindex,nofollow" />
           </>
         ) : shouldNofollow ? (
           // Overview pages (package READMEs) link densely to every API page

--- a/packages/ui/src/components/button/demos/basic.demo.tsx
+++ b/packages/ui/src/components/button/demos/basic.demo.tsx
@@ -16,7 +16,7 @@ export default function Example() {
         <Glyph mix={button.iconStyle} name="add" />
         <span mix={button.labelStyle}>Publish</span>
       </button>
-      <a href="/api/remix/ui/button/overview/" mix={[button.baseStyle, button.secondaryStyle]}>
+      <a href="../../overview/" mix={[button.baseStyle, button.secondaryStyle]}>
         <span mix={button.labelStyle}>View button docs</span>
         <Glyph mix={button.iconStyle} name="chevronRight" />
       </a>


### PR DESCRIPTION
## Summary
- add a `--version` option to the docs prerender script
- seed the crawler from only the home and lookup routes, with an optional version prefix
- keep docs hrefs version-aware at render time instead of rewriting them during prerender
- repurpose version discovery for the picker options only

## Verification
- `pnpm --filter remix-the-docs typecheck`
- `pnpm --filter remix-the-docs test`
- `pnpm --filter remix-the-docs build`
- root prerender smoke with no `--version`
- versioned prerender smoke with `--version v3.1.2`
- `git diff --check`