### PR TITLE
Reload client frames on ancestor frame reload

### DIFF
--- a/demos/frames/app/assets/entry.tsx
+++ b/demos/frames/app/assets/entry.tsx
@@ -10,7 +10,11 @@ const app = run({
     return exp
   },
   async resolveFrame(src, signal) {
-    let res = await fetch(src, { headers: { Accept: 'text/html' }, signal })
+    let res = await fetch(src, {
+      cache: 'no-store',
+      headers: { Accept: 'text/html' },
+      signal,
+    })
     if (!res.ok) {
       return `<pre>Frame error: ${res.status} ${res.statusText}</pre>`
     }

--- a/packages/ui/.changes/patch.reload-client-entry-frames.md
+++ b/packages/ui/.changes/patch.reload-client-entry-frames.md
@@ -1,0 +1,1 @@
+Reload frames rendered within preserved client entries during ancestor frame reloads

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -111,6 +111,8 @@ export type FrameRuntime = {
   moduleLoads: Map<string, Promise<Function | undefined>>
   frameInstances: WeakMap<Comment, Frame>
   namedFrames: Map<string, FrameHandle>
+  serverFrameReloadRenderInProgress: boolean
+  serverFrameReloadSignal: AbortSignal | undefined
 }
 
 export type FrameContext = {
@@ -156,6 +158,7 @@ export type Frame = {
   flush: () => void
   clearPendingTemplateWatch: () => void
   isDisplayingResolvedContent: () => boolean
+  reloadClientFrameForAncestorReload: (signal?: AbortSignal) => Promise<AbortSignal>
   startInheritedReload: (signal?: AbortSignal) => void
   updateMarker: (marker: FrameMarkerData, options?: RenderOptions) => Promise<void>
   renderMarkerContent: (
@@ -198,27 +201,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
   let frame = createFrameHandle({
     src: init.src,
     $runtime: runtime,
-    reload: async () => {
-      reloadController?.abort()
-      let controller = new AbortController()
-      reloadController = controller
-      frame.dispatchEvent(new Event('reloadStart'))
-      startSubFrameInheritedReloads(getContentNodes(), controller.signal)
-      try {
-        let content = await init.resolveFrame(frame.src, controller.signal, frameName)
-        if (reloadController !== controller || controller.signal.aborted) return controller.signal
-        await render(content, { signal: controller.signal })
-        return controller.signal
-      } catch (error) {
-        if (reloadController !== controller || controller.signal.aborted) return controller.signal
-        init.errorTarget.dispatchEvent(createComponentErrorEvent(error))
-        throw error
-      } finally {
-        if (reloadController === controller) {
-          frame.dispatchEvent(new Event('reloadComplete'))
-        }
-      }
-    },
+    reload: () => reload(),
     replace: async (content: FrameContent) => {
       await render(content)
     },
@@ -322,7 +305,12 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
 
       let bodyContainer = createElementContainer(container.doc.body)
       if (options?.signal?.aborted) return
-      scheduleHydrationInContainer(bodyContainer, context, options?.initialHydrationTracker)
+      scheduleHydrationInContainer(
+        bodyContainer,
+        context,
+        options?.initialHydrationTracker,
+        options?.signal,
+      )
       await createSubFrames(bodyContainer.childNodes, context, options)
       displayedContentStatus = options?.contentStatus ?? 'resolved'
       return
@@ -348,7 +336,12 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     })
 
     if (options?.signal?.aborted) return
-    scheduleHydrationInContainer(container, context, options?.initialHydrationTracker)
+    scheduleHydrationInContainer(
+      container,
+      context,
+      options?.initialHydrationTracker,
+      options?.signal,
+    )
     await createSubFrames(container.childNodes, context, options)
     displayedContentStatus = options?.contentStatus ?? 'resolved'
   }
@@ -436,6 +429,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     flush: () => context.scheduler.dequeue(),
     clearPendingTemplateWatch: clearPendingFrameTemplateWatch,
     isDisplayingResolvedContent: () => displayedContentStatus === 'resolved',
+    reloadClientFrameForAncestorReload,
     startInheritedReload,
     updateMarker,
     renderMarkerContent,
@@ -494,6 +488,60 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     }
   }
 
+  async function reload(): Promise<AbortSignal> {
+    let controller = startReload()
+    return await resolveAndRenderReload(controller)
+  }
+
+  async function reloadClientFrameForAncestorReload(signal?: AbortSignal): Promise<AbortSignal> {
+    let controller = startClientFrameReloadForAncestorReload(signal)
+    return await resolveAndRenderReload(controller)
+  }
+
+  function startReload(): AbortController {
+    reloadController?.abort()
+    let controller = new AbortController()
+    reloadController = controller
+    frame.dispatchEvent(new Event('reloadStart'))
+    startSubFrameInheritedReloads(getContentNodes(), controller.signal)
+    return controller
+  }
+
+  function startClientFrameReloadForAncestorReload(signal?: AbortSignal): AbortController {
+    reloadController?.abort()
+    let controller = new AbortController()
+    reloadController = controller
+    if (signal) {
+      if (signal.aborted) {
+        controller.abort()
+      } else {
+        signal.addEventListener('abort', () => controller.abort(), { once: true })
+      }
+    }
+    if (!reuseInheritedReloadStart()) {
+      frame.dispatchEvent(new Event('reloadStart'))
+      startSubFrameInheritedReloads(getContentNodes(), controller.signal)
+    }
+    return controller
+  }
+
+  async function resolveAndRenderReload(controller: AbortController): Promise<AbortSignal> {
+    try {
+      let content = await init.resolveFrame(frame.src, controller.signal, frameName)
+      if (reloadController !== controller || controller.signal.aborted) return controller.signal
+      await render(content, { signal: controller.signal })
+      return controller.signal
+    } catch (error) {
+      if (reloadController !== controller || controller.signal.aborted) return controller.signal
+      init.errorTarget.dispatchEvent(createComponentErrorEvent(error))
+      throw error
+    } finally {
+      if (reloadController === controller) {
+        frame.dispatchEvent(new Event('reloadComplete'))
+      }
+    }
+  }
+
   function startInheritedReload(signal?: AbortSignal): void {
     if (signal?.aborted) return
     if (!inheritedReloadPending) {
@@ -511,6 +559,14 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
         signal.removeEventListener('abort', abort)
       }
     }
+  }
+
+  function reuseInheritedReloadStart(): boolean {
+    if (!inheritedReloadPending) return false
+    inheritedReloadPending = false
+    inheritedReloadAbortUnsubscribe?.()
+    inheritedReloadAbortUnsubscribe = undefined
+    return true
   }
 
   function completeInheritedReload(): void {
@@ -616,6 +672,7 @@ export function createFrameRuntime(init: {
   moduleLoads: Map<string, Promise<Function | undefined>>
   frameInstances: WeakMap<Comment, Frame>
   namedFrames: Map<string, FrameHandle>
+  serverFrameReloadRenderInProgress?: boolean
 }): FrameRuntime {
   return {
     topFrame: init.topFrame,
@@ -630,6 +687,8 @@ export function createFrameRuntime(init: {
     moduleLoads: init.moduleLoads,
     frameInstances: init.frameInstances,
     namedFrames: init.namedFrames,
+    serverFrameReloadRenderInProgress: init.serverFrameReloadRenderInProgress ?? false,
+    serverFrameReloadSignal: undefined,
   }
 }
 
@@ -768,6 +827,7 @@ function scheduleHydrationInContainer(
   container: FrameContainer,
   context: FrameContext,
   initialHydrationTracker?: InitialHydrationTracker,
+  signal?: AbortSignal,
 ): void {
   let hydrationMarkers = findHydrationMarkers(container)
   if (hydrationMarkers.length === 0) return
@@ -778,7 +838,7 @@ function scheduleHydrationInContainer(
   for (let marker of hydrationMarkers) {
     let entry = hydrationData[marker.id]
     if (!entry) continue
-    scheduleHydrationMarker(marker, entry, context, initialHydrationTracker)
+    scheduleHydrationMarker(marker, entry, context, initialHydrationTracker, signal)
   }
 }
 
@@ -787,15 +847,19 @@ function scheduleHydrationMarker(
   entry: HydrationData,
   context: FrameContext,
   initialHydrationTracker?: InitialHydrationTracker,
+  signal?: AbortSignal,
 ): void {
+  if (signal?.aborted) return
+
   let done = initialHydrationTracker?.track()
   let key = `${entry.moduleUrl}#${entry.exportName}`
 
   let hydrateWithComponent = (component: Function) => {
+    if (signal?.aborted) return
     if (!isHydrationMarkerLive(marker, context)) return
     let vElement = createElement(component, entry.props)
     context.pendingClientEntries.set(marker.start, [marker.end, vElement])
-    hydrateRegion(vElement, marker.start, marker.end, context)
+    hydrateRegion(vElement, marker.start, marker.end, context, signal)
   }
 
   let cached = context.moduleCache.get(key)
@@ -891,14 +955,30 @@ function hydrateRegion(
   start: Comment,
   end: Comment,
   context: FrameContext,
+  signal?: AbortSignal,
 ): void {
+  if (signal?.aborted) return
+
   context.pendingClientEntries.delete(start)
 
   // The same marker can be discovered by overlapping hydration passes
   // (for example, document root + nested frame root). Reuse the existing
   // virtual root instead of redefining the marker property.
   if (isHydratedVirtualRootMarker(start)) {
-    start.$rmx.render(vElement)
+    let frameRuntime = context.frame.$runtime as FrameRuntime | undefined
+    invariant(frameRuntime, 'Expected frame runtime while rendering a preserved client entry')
+
+    let previousServerFrameReloadRenderInProgress = frameRuntime.serverFrameReloadRenderInProgress
+    let previousServerFrameReloadSignal = frameRuntime.serverFrameReloadSignal
+
+    frameRuntime.serverFrameReloadRenderInProgress = true
+    frameRuntime.serverFrameReloadSignal = signal
+    try {
+      start.$rmx.render(vElement)
+    } finally {
+      frameRuntime.serverFrameReloadRenderInProgress = previousServerFrameReloadRenderInProgress
+      frameRuntime.serverFrameReloadSignal = previousServerFrameReloadSignal
+    }
     return
   }
 

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -111,8 +111,7 @@ export type FrameRuntime = {
   moduleLoads: Map<string, Promise<Function | undefined>>
   frameInstances: WeakMap<Comment, Frame>
   namedFrames: Map<string, FrameHandle>
-  serverFrameReloadRenderInProgress: boolean
-  serverFrameReloadSignal: AbortSignal | undefined
+  serverFrameReload: { signal: AbortSignal } | undefined
 }
 
 export type FrameContext = {
@@ -158,7 +157,11 @@ export type Frame = {
   flush: () => void
   clearPendingTemplateWatch: () => void
   isDisplayingResolvedContent: () => boolean
-  reloadClientFrameForAncestorReload: (signal?: AbortSignal) => Promise<AbortSignal>
+  beginClientFrameReloadForAncestorReload: (signal: AbortSignal) => {
+    controller: AbortController
+    complete: () => void
+  }
+  cancelReload: () => void
   startInheritedReload: (signal?: AbortSignal) => void
   updateMarker: (marker: FrameMarkerData, options?: RenderOptions) => Promise<void>
   renderMarkerContent: (
@@ -184,6 +187,8 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
   // The style registry is document-level and shared by every frame; only the
   // frame that created it (the runtime root) disposes it.
   let ownsStyleManager = !init.styleManager
+  let reloadAbortUnsubscribe: (() => void) | undefined
+  let reloadKind: 'direct' | 'ancestor' | undefined
   let styleManager = init.styleManager ?? createStyleManager()
   let currentMarker = init.marker
   let displayedContentStatus: 'pending' | 'resolved' = init.marker?.status ?? 'resolved'
@@ -401,6 +406,9 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
   function dispose(): void {
     reloadController?.abort()
     reloadController = undefined
+    reloadAbortUnsubscribe?.()
+    reloadAbortUnsubscribe = undefined
+    reloadKind = undefined
     contentRoot?.dispose()
     contentRoot = undefined
     clearPendingFrameTemplateWatch()
@@ -429,7 +437,8 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     flush: () => context.scheduler.dequeue(),
     clearPendingTemplateWatch: clearPendingFrameTemplateWatch,
     isDisplayingResolvedContent: () => displayedContentStatus === 'resolved',
-    reloadClientFrameForAncestorReload,
+    beginClientFrameReloadForAncestorReload,
+    cancelReload,
     startInheritedReload,
     updateMarker,
     renderMarkerContent,
@@ -493,35 +502,59 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     return await resolveAndRenderReload(controller)
   }
 
-  async function reloadClientFrameForAncestorReload(signal?: AbortSignal): Promise<AbortSignal> {
-    let controller = startClientFrameReloadForAncestorReload(signal)
-    return await resolveAndRenderReload(controller)
-  }
-
   function startReload(): AbortController {
-    reloadController?.abort()
-    let controller = new AbortController()
-    reloadController = controller
+    let controller = replaceReloadController()
+    reloadKind = 'direct'
     frame.dispatchEvent(new Event('reloadStart'))
     startSubFrameInheritedReloads(getContentNodes(), controller.signal)
     return controller
   }
 
-  function startClientFrameReloadForAncestorReload(signal?: AbortSignal): AbortController {
+  function beginClientFrameReloadForAncestorReload(signal: AbortSignal): {
+    controller: AbortController
+    complete: () => void
+  } {
+    let inheritedReloadStarted = reuseInheritedReloadStart()
+    let continuingAncestorReload = reloadKind === 'ancestor'
+    let controller = replaceReloadController(signal)
+    reloadKind = 'ancestor'
+
+    if (!inheritedReloadStarted && !continuingAncestorReload) {
+      frame.dispatchEvent(new Event('reloadStart'))
+      startSubFrameInheritedReloads(getContentNodes(), controller.signal)
+    }
+
+    return {
+      controller,
+      complete: () => completeReload(controller),
+    }
+  }
+
+  function cancelReload(): void {
+    let controller = reloadController
+    if (!controller) return
+    controller.abort()
+    completeReload(controller)
+  }
+
+  function replaceReloadController(signal?: AbortSignal): AbortController {
     reloadController?.abort()
+    reloadAbortUnsubscribe?.()
+    reloadAbortUnsubscribe = undefined
+
     let controller = new AbortController()
     reloadController = controller
+
     if (signal) {
       if (signal.aborted) {
         controller.abort()
       } else {
-        signal.addEventListener('abort', () => controller.abort(), { once: true })
+        let abort = () => controller.abort()
+        signal.addEventListener('abort', abort, { once: true })
+        reloadAbortUnsubscribe = () => signal.removeEventListener('abort', abort)
       }
     }
-    if (!reuseInheritedReloadStart()) {
-      frame.dispatchEvent(new Event('reloadStart'))
-      startSubFrameInheritedReloads(getContentNodes(), controller.signal)
-    }
+
     return controller
   }
 
@@ -536,10 +569,16 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       init.errorTarget.dispatchEvent(createComponentErrorEvent(error))
       throw error
     } finally {
-      if (reloadController === controller) {
-        frame.dispatchEvent(new Event('reloadComplete'))
-      }
+      completeReload(controller)
     }
+  }
+
+  function completeReload(controller: AbortController): void {
+    if (reloadController !== controller || reloadKind === undefined) return
+    reloadAbortUnsubscribe?.()
+    reloadAbortUnsubscribe = undefined
+    reloadKind = undefined
+    frame.dispatchEvent(new Event('reloadComplete'))
   }
 
   function startInheritedReload(signal?: AbortSignal): void {
@@ -672,7 +711,6 @@ export function createFrameRuntime(init: {
   moduleLoads: Map<string, Promise<Function | undefined>>
   frameInstances: WeakMap<Comment, Frame>
   namedFrames: Map<string, FrameHandle>
-  serverFrameReloadRenderInProgress?: boolean
 }): FrameRuntime {
   return {
     topFrame: init.topFrame,
@@ -687,8 +725,7 @@ export function createFrameRuntime(init: {
     moduleLoads: init.moduleLoads,
     frameInstances: init.frameInstances,
     namedFrames: init.namedFrames,
-    serverFrameReloadRenderInProgress: init.serverFrameReloadRenderInProgress ?? false,
-    serverFrameReloadSignal: undefined,
+    serverFrameReload: undefined,
   }
 }
 
@@ -965,19 +1002,21 @@ function hydrateRegion(
   // (for example, document root + nested frame root). Reuse the existing
   // virtual root instead of redefining the marker property.
   if (isHydratedVirtualRootMarker(start)) {
+    if (!signal) {
+      start.$rmx.render(vElement)
+      return
+    }
+
     let frameRuntime = context.frame.$runtime as FrameRuntime | undefined
     invariant(frameRuntime, 'Expected frame runtime while rendering a preserved client entry')
 
-    let previousServerFrameReloadRenderInProgress = frameRuntime.serverFrameReloadRenderInProgress
-    let previousServerFrameReloadSignal = frameRuntime.serverFrameReloadSignal
+    let previousServerFrameReload = frameRuntime.serverFrameReload
 
-    frameRuntime.serverFrameReloadRenderInProgress = true
-    frameRuntime.serverFrameReloadSignal = signal
+    frameRuntime.serverFrameReload = { signal }
     try {
       start.$rmx.render(vElement)
     } finally {
-      frameRuntime.serverFrameReloadRenderInProgress = previousServerFrameReloadRenderInProgress
-      frameRuntime.serverFrameReloadSignal = previousServerFrameReloadSignal
+      frameRuntime.serverFrameReload = previousServerFrameReload
     }
     return
   }

--- a/packages/ui/src/runtime/reconcile.ts
+++ b/packages/ui/src/runtime/reconcile.ts
@@ -1031,15 +1031,28 @@ function diffFrame(
   next._frameResolved = curr._frameResolved
   next._parent = vParent
 
+  let frameRuntime = getFrameRuntime(frame)
+  let frameInstance = next._frameInstance as FrameInstance | undefined
+
   if (currSrc !== nextSrc) {
-    let frameInstance = next._frameInstance as FrameInstance | undefined
     if (frameInstance) {
       frameInstance.handle.src = nextSrc
     }
 
-    let runtime = getFrameRuntime(frame)
-    if (runtime) {
-      resolveClientFrame(next, runtime)
+    if (frameRuntime) {
+      resolveClientFrame(next, frameRuntime)
+    }
+  } else if (next._frameResolved && frameRuntime?.serverFrameReloadRenderInProgress) {
+    // Reload client frames that have the same src during a render triggered by an ancestor frame reload
+    if (frameInstance) {
+      void frameInstance
+        .reloadClientFrameForAncestorReload(frameRuntime.serverFrameReloadSignal)
+        .catch(() => {
+          // Client-created frames are non-blocking from the parent frame's perspective.
+          // Their reload state is observable through their own frame events. The reload
+          // reports failures before rejecting, so observe the promise here to avoid
+          // unhandled rejections from these client-created frame reloads.
+        })
     }
   }
 

--- a/packages/ui/src/runtime/reconcile.ts
+++ b/packages/ui/src/runtime/reconcile.ts
@@ -46,6 +46,7 @@ import {
   type MixinRuntimeState,
 } from './mixins/mixin.ts'
 import { isOnMixinDescriptor, type OnMixinDescriptor } from './mixins/on-mixin.ts'
+import { createComponentErrorEvent } from './error-event.ts'
 
 const SVG_NS = 'http://www.w3.org/2000/svg'
 
@@ -1028,11 +1029,13 @@ function diffFrame(
   next._frameInstance = curr._frameInstance
   next._frameFallbackRoot = curr._frameFallbackRoot
   next._frameResolveToken = curr._frameResolveToken
+  next._frameResolveController = curr._frameResolveController
   next._frameResolved = curr._frameResolved
   next._parent = vParent
 
   let frameRuntime = getFrameRuntime(frame)
   let frameInstance = next._frameInstance as FrameInstance | undefined
+  let serverFrameReload = frameRuntime?.serverFrameReload
 
   if (currSrc !== nextSrc) {
     if (frameInstance) {
@@ -1040,20 +1043,11 @@ function diffFrame(
     }
 
     if (frameRuntime) {
-      resolveClientFrame(next, frameRuntime)
+      resolveClientFrame(next, frameRuntime, serverFrameReload)
     }
-  } else if (next._frameResolved && frameRuntime?.serverFrameReloadRenderInProgress) {
+  } else if (frameRuntime && frameInstance && serverFrameReload) {
     // Reload client frames that have the same src during a render triggered by an ancestor frame reload
-    if (frameInstance) {
-      void frameInstance
-        .reloadClientFrameForAncestorReload(frameRuntime.serverFrameReloadSignal)
-        .catch(() => {
-          // Client-created frames are non-blocking from the parent frame's perspective.
-          // Their reload state is observable through their own frame events. The reload
-          // reports failures before rejecting, so observe the promise here to avoid
-          // unhandled rejections from these client-created frame reloads.
-        })
-    }
+    resolveClientFrame(next, frameRuntime, serverFrameReload)
   }
 
   if (!next._frameResolved && next._frameFallbackRoot) {
@@ -1168,7 +1162,11 @@ function insertFrame(
   return cursor
 }
 
-function resolveClientFrame(node: VNode, runtime: FrameRuntime): void {
+function resolveClientFrame(
+  node: VNode,
+  runtime: FrameRuntime,
+  serverFrameReload?: { signal: AbortSignal },
+): void {
   let frameSrc = getFrameSrc(node)
   let instance = node._frameInstance as FrameInstance | undefined
   if (!instance) return
@@ -1176,10 +1174,17 @@ function resolveClientFrame(node: VNode, runtime: FrameRuntime): void {
   let token = (node._frameResolveToken ?? 0) + 1
   node._frameResolveToken = token
   node._frameResolveController?.abort()
-  let resolveController = new AbortController()
+  let reload = serverFrameReload
+    ? instance.beginClientFrameReloadForAncestorReload(serverFrameReload.signal)
+    : undefined
+  if (!reload) {
+    instance.cancelReload()
+  }
+  let resolveController = reload?.controller ?? new AbortController()
   node._frameResolveController = resolveController
 
-  Promise.resolve(runtime.resolveFrame(frameSrc, resolveController.signal, getFrameName(node)))
+  Promise.resolve()
+    .then(() => runtime.resolveFrame(frameSrc, resolveController.signal, getFrameName(node)))
     .then(async (content) => {
       if (node._frameResolveToken !== token || resolveController.signal.aborted) return
       node._frameFallbackRoot?.dispose()
@@ -1189,8 +1194,13 @@ function resolveClientFrame(node: VNode, runtime: FrameRuntime): void {
       if (node._frameResolveToken !== token || resolveController.signal.aborted) return
       node._frameResolved = true
     })
-    .catch(() => {})
+    .catch((error) => {
+      if (reload && node._frameResolveToken === token && !resolveController.signal.aborted) {
+        runtime.errorTarget.dispatchEvent(createComponentErrorEvent(error))
+      }
+    })
     .finally(() => {
+      reload?.complete()
       if (node._frameResolveController === resolveController) {
         node._frameResolveController = undefined
       }

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -4510,6 +4510,1287 @@ describe('run', () => {
     app.dispose()
   })
 
+  it('reloads frames inside preserved client entries after server-driven entry rerenders', async () => {
+    let reloadTop: undefined | (() => Promise<AbortSignal>)
+    let entryFrameEvents: string[] = []
+    let entryFrameServerResolveCount = 0
+
+    let EntryWithFrame = clientEntry(
+      '/assets/entry-with-frame.js#EntryWithFrame',
+      function EntryWithFrame(handle: Handle<{ label: string }>) {
+        reloadTop = () => handle.frames.top.reload()
+        return () => (
+          <section>
+            <p id="entry-label">{handle.props.label}</p>
+            <Frame
+              name="entry-frame"
+              src="/entry-frame"
+              fallback={<span id="entry-frame">Loading entry frame...</span>}
+            />
+          </section>
+        )
+      },
+    )
+
+    let EntryFrameObserver = clientEntry(
+      '/assets/entry-frame-observer.js#EntryFrameObserver',
+      function EntryFrameObserver(handle: Handle) {
+        let listening = false
+        return () => {
+          handle.queueTask(() => {
+            if (!listening) {
+              let entryFrame = handle.frames.get('entry-frame')
+              invariant(entryFrame, 'Expected entry frame handle')
+              entryFrame.addEventListener('reloadStart', () => entryFrameEvents.push('start'), {
+                signal: handle.signal,
+              })
+              entryFrame.addEventListener(
+                'reloadComplete',
+                () => entryFrameEvents.push('complete'),
+                {
+                  signal: handle.signal,
+                },
+              )
+              listening = true
+            }
+          })
+
+          return null
+        }
+      },
+    )
+
+    async function renderPage(label: string, frameLabel: string): Promise<string> {
+      return await drain(renderPageStream(label, frameLabel))
+    }
+
+    function renderPageStream(label: string, frameLabel: string): ReadableStream<Uint8Array> {
+      return renderToStream(
+        <html>
+          <body>
+            <main>
+              <EntryFrameObserver />
+              <EntryWithFrame label={label} />
+            </main>
+          </body>
+        </html>,
+        {
+          resolveFrame(src: string) {
+            if (src === '/entry-frame') {
+              entryFrameServerResolveCount++
+              return `<span id="entry-frame">${frameLabel}</span>`
+            }
+            throw new Error(`Unexpected frame src during server render: ${src}`)
+          },
+        },
+      )
+    }
+
+    let serverHtml = await renderPage('Initial entry', 'Initial entry frame')
+    let initialDocument = new DOMParser().parseFromString(serverHtml, 'text/html')
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let entryFrameResolveCount = 0
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (moduleUrl === '/assets/entry-with-frame.js' && exportName === 'EntryWithFrame') {
+          return EntryWithFrame
+        }
+        if (
+          moduleUrl === '/assets/entry-frame-observer.js' &&
+          exportName === 'EntryFrameObserver'
+        ) {
+          return EntryFrameObserver
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      async resolveFrame(src: string) {
+        if (src === document.location.href) {
+          return renderPageStream('Reloaded entry', 'Unused streamed entry frame')
+        }
+        if (src === '/entry-frame') {
+          entryFrameResolveCount++
+          return '<span id="entry-frame">Reloaded entry frame</span>'
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('Initial entry')
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Initial entry frame')
+    expect(entryFrameEvents).toEqual([])
+    expect(entryFrameServerResolveCount).toBe(1)
+    expect(entryFrameResolveCount).toBe(0)
+
+    invariant(reloadTop)
+    await reloadTop()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('Reloaded entry')
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Reloaded entry frame')
+    expect(entryFrameEvents).toEqual(['start', 'complete'])
+    expect(entryFrameServerResolveCount).toBe(2)
+    expect(entryFrameResolveCount).toBe(1)
+    app.dispose()
+  })
+
+  it('reloads blocking frames inside preserved client entries after server-driven entry rerenders', async () => {
+    let reloadTop: undefined | (() => Promise<AbortSignal>)
+    let serverFrameResolveCount = 0
+    let clientFrameResolveCount = 0
+
+    let EntryWithFrame = clientEntry(
+      '/assets/entry-with-server-frame.js#EntryWithServerFrame',
+      function EntryWithServerFrame(handle: Handle<{ label: string }>) {
+        reloadTop = () => handle.frames.top.reload()
+        return () => (
+          <section>
+            <p id="entry-label">{handle.props.label}</p>
+            <Frame name="entry-frame" src="/entry-frame" />
+          </section>
+        )
+      },
+    )
+
+    async function renderPage(label: string, frameLabel: string): Promise<string> {
+      return await drain(renderPageStream(label, frameLabel))
+    }
+
+    async function renderPageWithProtocol(label: string, frameLabel: string): Promise<string> {
+      return await drainWithProtocol(renderPageStream(label, frameLabel))
+    }
+
+    function renderPageStream(label: string, frameLabel: string): ReadableStream<Uint8Array> {
+      return renderToStream(
+        <html>
+          <body>
+            <main>
+              <EntryWithFrame label={label} />
+            </main>
+          </body>
+        </html>,
+        {
+          resolveFrame(src: string) {
+            if (src === '/entry-frame') {
+              serverFrameResolveCount++
+              return `<span id="entry-frame">${frameLabel}</span>`
+            }
+            throw new Error(`Unexpected frame src during server render: ${src}`)
+          },
+        },
+      )
+    }
+
+    let serverHtml = await renderPage('Initial entry', 'Initial entry frame')
+    let initialDocument = new DOMParser().parseFromString(serverHtml, 'text/html')
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/entry-with-server-frame.js' &&
+          exportName === 'EntryWithServerFrame'
+        ) {
+          return EntryWithFrame
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      async resolveFrame(src: string) {
+        if (src === document.location.href) {
+          return streamFromChunks([
+            await renderPageWithProtocol('Reloaded entry', 'Server-provided entry frame'),
+          ])
+        }
+        if (src === '/entry-frame') {
+          clientFrameResolveCount++
+          return '<span id="entry-frame">Reloaded entry frame</span>'
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('Initial entry')
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Initial entry frame')
+    expect(serverFrameResolveCount).toBe(1)
+    expect(clientFrameResolveCount).toBe(0)
+
+    invariant(reloadTop)
+    await reloadTop()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('Reloaded entry')
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Reloaded entry frame')
+    expect(serverFrameResolveCount).toBe(2)
+    expect(clientFrameResolveCount).toBe(1)
+    app.dispose()
+  })
+
+  it('reloads nested frames inside blocking frames rendered by preserved client entries', async () => {
+    let reloadTop: undefined | (() => Promise<AbortSignal>)
+    let renderClientOnlyFrame = false
+    let blockingFrameServerResolveCount = 0
+    let blockingFrameClientResolveCount = 0
+    let clientOnlyFrameClientResolveCount = 0
+
+    let ClientOnlyFrameEntry = clientEntry(
+      '/assets/blocking-frame-client-only-entry.js#BlockingFrameClientOnlyEntry',
+      function BlockingFrameClientOnlyEntry(handle: Handle<{ label: string }>) {
+        return () => {
+          handle.queueTask(() => {
+            if (renderClientOnlyFrame) return
+            renderClientOnlyFrame = true
+            void handle.update()
+          })
+
+          return (
+            <section>
+              <p id="blocking-entry-label">{handle.props.label}</p>
+              {renderClientOnlyFrame ? (
+                <Frame
+                  name="blocking-client-only-frame"
+                  src="/blocking-client-only-frame"
+                  fallback={
+                    <span id="blocking-client-only-frame">Loading blocking client frame...</span>
+                  }
+                />
+              ) : null}
+            </section>
+          )
+        }
+      },
+    )
+
+    let EntryWithBlockingFrame = clientEntry(
+      '/assets/entry-with-blocking-frame.js#EntryWithBlockingFrame',
+      function EntryWithBlockingFrame(handle: Handle<{ label: string }>) {
+        reloadTop = () => handle.frames.top.reload()
+        return () => (
+          <section>
+            <p id="entry-label">{handle.props.label}</p>
+            <Frame name="blocking-frame" src="/blocking-frame" />
+          </section>
+        )
+      },
+    )
+
+    async function renderBlockingFrame(label: string): Promise<string> {
+      let previousRenderClientOnlyFrame = renderClientOnlyFrame
+      renderClientOnlyFrame = false
+      return await drain(
+        renderToStream(<ClientOnlyFrameEntry label={label} />, {
+          resolveFrame(src: string) {
+            throw new Error(`Unexpected blocking frame src during server render: ${src}`)
+          },
+        }),
+      ).finally(() => {
+        renderClientOnlyFrame = previousRenderClientOnlyFrame
+      })
+    }
+
+    async function renderPage(label: string, blockingLabel: string): Promise<string> {
+      return await drain(renderPageStream(label, blockingLabel))
+    }
+
+    async function renderPageWithProtocol(label: string, blockingLabel: string): Promise<string> {
+      return await drainWithProtocol(renderPageStream(label, blockingLabel))
+    }
+
+    function renderPageStream(label: string, blockingLabel: string): ReadableStream<Uint8Array> {
+      return renderToStream(
+        <html>
+          <body>
+            <main>
+              <EntryWithBlockingFrame label={label} />
+            </main>
+          </body>
+        </html>,
+        {
+          resolveFrame(src: string) {
+            if (src === '/blocking-frame') {
+              blockingFrameServerResolveCount++
+              return renderBlockingFrame(blockingLabel)
+            }
+            throw new Error(`Unexpected frame src during server render: ${src}`)
+          },
+        },
+      )
+    }
+
+    let serverHtml = await renderPage('Initial entry', 'Initial blocking entry')
+    let initialDocument = new DOMParser().parseFromString(serverHtml, 'text/html')
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/entry-with-blocking-frame.js' &&
+          exportName === 'EntryWithBlockingFrame'
+        ) {
+          return EntryWithBlockingFrame
+        }
+        if (
+          moduleUrl === '/assets/blocking-frame-client-only-entry.js' &&
+          exportName === 'BlockingFrameClientOnlyEntry'
+        ) {
+          return ClientOnlyFrameEntry
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      async resolveFrame(src: string) {
+        if (src === document.location.href) {
+          return streamFromChunks([
+            await renderPageWithProtocol('Reloaded entry', 'Reloaded blocking entry'),
+          ])
+        }
+        if (src === '/blocking-frame') {
+          blockingFrameClientResolveCount++
+          return await renderBlockingFrame('Reloaded blocking entry from browser')
+        }
+        if (src === '/blocking-client-only-frame') {
+          clientOnlyFrameClientResolveCount++
+          return `<span id="blocking-client-only-frame">Blocking client-only frame ${clientOnlyFrameClientResolveCount}</span>`
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    app.flush()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('Initial entry')
+    expect(document.getElementById('blocking-entry-label')?.textContent).toBe(
+      'Initial blocking entry',
+    )
+    expect(document.getElementById('blocking-client-only-frame')?.textContent).toBe(
+      'Blocking client-only frame 1',
+    )
+    expect(blockingFrameServerResolveCount).toBe(1)
+    expect(blockingFrameClientResolveCount).toBe(0)
+    expect(clientOnlyFrameClientResolveCount).toBe(1)
+
+    invariant(reloadTop)
+    await reloadTop()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('Reloaded entry')
+    expect(document.getElementById('blocking-entry-label')?.textContent).toBe(
+      'Reloaded blocking entry from browser',
+    )
+    expect(document.getElementById('blocking-client-only-frame')?.textContent).toBe(
+      'Blocking client-only frame 2',
+    )
+    expect(blockingFrameServerResolveCount).toBe(2)
+    expect(blockingFrameClientResolveCount).toBe(1)
+    expect(clientOnlyFrameClientResolveCount).toBe(2)
+    app.dispose()
+  })
+
+  it('reloads all frames rendered by preserved client entries when they share a src', async () => {
+    let reloadTop: undefined | (() => Promise<AbortSignal>)
+    let renderClientOnlyFrame = false
+    let serverFrameResolveCount = 0
+    let clientFrameResolveCount = 0
+
+    let EntryWithSharedFrame = clientEntry(
+      '/assets/entry-with-shared-frame.js#EntryWithSharedFrame',
+      function EntryWithSharedFrame(handle: Handle<{ label: string }>) {
+        reloadTop = () => handle.frames.top.reload()
+        return () => {
+          handle.queueTask(() => {
+            if (renderClientOnlyFrame) return
+            renderClientOnlyFrame = true
+            void handle.update()
+          })
+
+          return (
+            <section>
+              <p id="entry-label">{handle.props.label}</p>
+              <Frame
+                src="/shared-frame"
+                fallback={<span id="server-shared-frame">Loading server frame...</span>}
+              />
+              {renderClientOnlyFrame ? (
+                <Frame
+                  src="/shared-frame"
+                  fallback={<span id="client-shared-frame">Loading client frame...</span>}
+                />
+              ) : null}
+            </section>
+          )
+        }
+      },
+    )
+
+    async function renderPage(label: string, serverFrameLabel: string): Promise<string> {
+      let previousRenderClientOnlyFrame = renderClientOnlyFrame
+      renderClientOnlyFrame = false
+      try {
+        return await drain(renderPageStream(label, serverFrameLabel))
+      } finally {
+        renderClientOnlyFrame = previousRenderClientOnlyFrame
+      }
+    }
+
+    async function renderPageWithProtocol(
+      label: string,
+      serverFrameLabel: string,
+    ): Promise<string> {
+      let previousRenderClientOnlyFrame = renderClientOnlyFrame
+      renderClientOnlyFrame = false
+      try {
+        return await drainWithProtocol(renderPageStream(label, serverFrameLabel))
+      } finally {
+        renderClientOnlyFrame = previousRenderClientOnlyFrame
+      }
+    }
+
+    function renderPageStream(label: string, serverFrameLabel: string): ReadableStream<Uint8Array> {
+      return renderToStream(
+        <html>
+          <body>
+            <main>
+              <EntryWithSharedFrame label={label} />
+            </main>
+          </body>
+        </html>,
+        {
+          resolveFrame(src: string) {
+            if (src === '/shared-frame') {
+              serverFrameResolveCount++
+              return `<span id="server-shared-frame">${serverFrameLabel}</span>`
+            }
+            throw new Error(`Unexpected frame src during server render: ${src}`)
+          },
+        },
+      )
+    }
+
+    let serverHtml = await renderPage('Initial entry', 'Initial server frame')
+    let initialDocument = new DOMParser().parseFromString(serverHtml, 'text/html')
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/entry-with-shared-frame.js' &&
+          exportName === 'EntryWithSharedFrame'
+        ) {
+          return EntryWithSharedFrame
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      async resolveFrame(src: string) {
+        if (src === document.location.href) {
+          return streamFromChunks([
+            await renderPageWithProtocol('Reloaded entry', 'Reloaded server frame'),
+          ])
+        }
+        if (src === '/shared-frame') {
+          clientFrameResolveCount++
+          return `<span data-shared-frame="client">Client shared frame ${clientFrameResolveCount}</span>`
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    app.flush()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('Initial entry')
+    expect(document.getElementById('server-shared-frame')?.textContent).toBe('Initial server frame')
+    expect(
+      Array.from(document.querySelectorAll('[data-shared-frame="client"]')).map(
+        (node) => node.textContent,
+      ),
+    ).toEqual(['Client shared frame 1'])
+    expect(serverFrameResolveCount).toBe(1)
+    expect(clientFrameResolveCount).toBe(1)
+
+    invariant(reloadTop)
+    await reloadTop()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('Reloaded entry')
+    expect(
+      Array.from(document.querySelectorAll('[data-shared-frame="client"]')).map(
+        (node) => node.textContent,
+      ),
+    ).toEqual(['Client shared frame 2', 'Client shared frame 3'])
+    expect(serverFrameResolveCount).toBe(2)
+    expect(clientFrameResolveCount).toBe(3)
+    app.dispose()
+  })
+
+  it('reloads frames inside nested frames rendered by preserved client entries', async () => {
+    let reloadTop: undefined | (() => Promise<AbortSignal>)
+    let renderClientOnlyFrame = false
+    let outerFrameServerResolveCount = 0
+    let middleFrameServerResolveCount = 0
+    let outerFrameClientResolveCount = 0
+    let middleFrameClientResolveCount = 0
+    let clientOnlyFrameClientResolveCount = 0
+
+    let ClientOnlyFrameEntry = clientEntry(
+      '/assets/nested-client-only-frame-entry.js#NestedClientOnlyFrameEntry',
+      function NestedClientOnlyFrameEntry(handle: Handle<{ label: string }>) {
+        return () => {
+          handle.queueTask(() => {
+            if (renderClientOnlyFrame) return
+            renderClientOnlyFrame = true
+            void handle.update()
+          })
+
+          return (
+            <section>
+              <p id="middle-entry-label">{handle.props.label}</p>
+              {renderClientOnlyFrame ? (
+                <Frame
+                  name="client-only-inner-frame"
+                  src="/client-only-inner-frame"
+                  fallback={<span id="client-only-inner-frame">Loading client-only frame...</span>}
+                />
+              ) : null}
+            </section>
+          )
+        }
+      },
+    )
+
+    let NestedEntryWithMiddleFrame = clientEntry(
+      '/assets/nested-entry-with-middle-frame.js#NestedEntryWithMiddleFrame',
+      function NestedEntryWithMiddleFrame(handle: Handle<{ label: string }>) {
+        return () => (
+          <section>
+            <p id="nested-entry-label">{handle.props.label}</p>
+            <Frame
+              name="middle-frame"
+              src="/middle-frame"
+              fallback={<span id="middle-frame">Loading middle frame...</span>}
+            />
+          </section>
+        )
+      },
+    )
+
+    let EntryWithOuterFrame = clientEntry(
+      '/assets/entry-with-outer-frame.js#EntryWithOuterFrame',
+      function EntryWithOuterFrame(handle: Handle<{ label: string }>) {
+        reloadTop = () => handle.frames.top.reload()
+        return () => (
+          <section>
+            <p id="entry-label">{handle.props.label}</p>
+            <Frame
+              name="outer-frame"
+              src="/outer-frame"
+              fallback={<span id="outer-frame">Loading outer frame...</span>}
+            />
+          </section>
+        )
+      },
+    )
+
+    async function renderMiddleFrame(label: string): Promise<string> {
+      let previousRenderClientOnlyFrame = renderClientOnlyFrame
+      renderClientOnlyFrame = false
+      return await drain(
+        renderToStream(<ClientOnlyFrameEntry label={label} />, {
+          resolveFrame(src: string) {
+            throw new Error(`Unexpected nested frame src during server render: ${src}`)
+          },
+        }),
+      ).finally(() => {
+        renderClientOnlyFrame = previousRenderClientOnlyFrame
+      })
+    }
+
+    async function renderOuterFrame(label: string, middleLabel: string): Promise<string> {
+      return await drain(
+        renderToStream(<NestedEntryWithMiddleFrame label={label} />, {
+          resolveFrame(src: string) {
+            if (src === '/middle-frame') {
+              middleFrameServerResolveCount++
+              return renderMiddleFrame(middleLabel)
+            }
+            throw new Error(`Unexpected outer frame src during server render: ${src}`)
+          },
+        }),
+      )
+    }
+
+    async function renderPage(
+      label: string,
+      nestedLabel: string,
+      middleLabel: string,
+    ): Promise<string> {
+      return await drain(renderPageStream(label, nestedLabel, middleLabel))
+    }
+
+    async function renderPageWithProtocol(
+      label: string,
+      nestedLabel: string,
+      middleLabel: string,
+    ): Promise<string> {
+      return await drainWithProtocol(renderPageStream(label, nestedLabel, middleLabel))
+    }
+
+    function renderPageStream(
+      label: string,
+      nestedLabel: string,
+      middleLabel: string,
+    ): ReadableStream<Uint8Array> {
+      return renderToStream(
+        <html>
+          <body>
+            <main>
+              <EntryWithOuterFrame label={label} />
+            </main>
+          </body>
+        </html>,
+        {
+          resolveFrame(src: string) {
+            if (src === '/outer-frame') {
+              outerFrameServerResolveCount++
+              return renderOuterFrame(nestedLabel, middleLabel)
+            }
+            throw new Error(`Unexpected frame src during server render: ${src}`)
+          },
+        },
+      )
+    }
+
+    let serverHtml = await renderPage(
+      'Initial entry',
+      'Initial nested entry',
+      'Initial middle entry',
+    )
+    let initialDocument = new DOMParser().parseFromString(serverHtml, 'text/html')
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/entry-with-outer-frame.js' &&
+          exportName === 'EntryWithOuterFrame'
+        ) {
+          return EntryWithOuterFrame
+        }
+        if (
+          moduleUrl === '/assets/nested-entry-with-middle-frame.js' &&
+          exportName === 'NestedEntryWithMiddleFrame'
+        ) {
+          return NestedEntryWithMiddleFrame
+        }
+        if (
+          moduleUrl === '/assets/nested-client-only-frame-entry.js' &&
+          exportName === 'NestedClientOnlyFrameEntry'
+        ) {
+          return ClientOnlyFrameEntry
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      async resolveFrame(src: string) {
+        if (src === document.location.href) {
+          return streamFromChunks([
+            await renderPageWithProtocol(
+              'Reloaded entry',
+              'Reloaded nested entry',
+              'Reloaded middle entry',
+            ),
+          ])
+        }
+        if (src === '/outer-frame') {
+          outerFrameClientResolveCount++
+          return await renderOuterFrame(
+            'Reloaded nested entry from browser',
+            'Reloaded middle entry from browser',
+          )
+        }
+        if (src === '/middle-frame') {
+          middleFrameClientResolveCount++
+          return await renderMiddleFrame('Reloaded middle entry from browser')
+        }
+        if (src === '/client-only-inner-frame') {
+          clientOnlyFrameClientResolveCount++
+          return `<span id="client-only-inner-frame">Client-only inner frame ${clientOnlyFrameClientResolveCount}</span>`
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    app.flush()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('Initial entry')
+    expect(document.getElementById('nested-entry-label')?.textContent).toBe('Initial nested entry')
+    expect(document.getElementById('middle-entry-label')?.textContent).toBe('Initial middle entry')
+    expect(document.getElementById('client-only-inner-frame')?.textContent).toBe(
+      'Client-only inner frame 1',
+    )
+    expect(outerFrameServerResolveCount).toBe(1)
+    expect(middleFrameServerResolveCount).toBe(1)
+    expect(outerFrameClientResolveCount).toBe(0)
+    expect(middleFrameClientResolveCount).toBe(0)
+    expect(clientOnlyFrameClientResolveCount).toBe(1)
+
+    invariant(reloadTop)
+    await reloadTop()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('Reloaded entry')
+    expect(document.getElementById('nested-entry-label')?.textContent).toBe(
+      'Reloaded nested entry from browser',
+    )
+    expect(document.getElementById('middle-entry-label')?.textContent).toBe(
+      'Reloaded middle entry from browser',
+    )
+    expect(document.getElementById('client-only-inner-frame')?.textContent).toBe(
+      'Client-only inner frame 2',
+    )
+    expect(outerFrameServerResolveCount).toBe(2)
+    expect(middleFrameServerResolveCount).toBe(3)
+    expect(outerFrameClientResolveCount).toBe(1)
+    expect(middleFrameClientResolveCount).toBe(1)
+    expect(clientOnlyFrameClientResolveCount).toBe(2)
+    app.dispose()
+  })
+
+  it('does not wait for frames inside preserved client entries to finish reloading', async () => {
+    let reloadTop: undefined | (() => Promise<AbortSignal>)
+    let entryFrameEvents: string[] = []
+
+    let EntryWithPendingFrame = clientEntry(
+      '/assets/entry-with-pending-frame.js#EntryWithPendingFrame',
+      function EntryWithPendingFrame(handle: Handle<{ label: string }>) {
+        reloadTop = () => handle.frames.top.reload()
+        handle.queueTask(() => {
+          let entryFrame = handle.frames.get('entry-frame')
+          invariant(entryFrame, 'Expected entry frame handle')
+          entryFrame.addEventListener('reloadStart', () => entryFrameEvents.push('start'), {
+            signal: handle.signal,
+          })
+          entryFrame.addEventListener('reloadComplete', () => entryFrameEvents.push('complete'), {
+            signal: handle.signal,
+          })
+        })
+        return () => (
+          <section>
+            <p id="entry-label">{handle.props.label}</p>
+            <Frame
+              name="entry-frame"
+              src="/entry-frame"
+              fallback={<span id="entry-frame">Loading entry frame...</span>}
+            />
+          </section>
+        )
+      },
+    )
+
+    async function renderPage(label: string, frameLabel: string): Promise<string> {
+      return await drain(renderPageStream(label, frameLabel))
+    }
+
+    async function renderPageWithProtocol(label: string, frameLabel: string): Promise<string> {
+      return await drainWithProtocol(renderPageStream(label, frameLabel))
+    }
+
+    function renderPageStream(label: string, frameLabel: string): ReadableStream<Uint8Array> {
+      return renderToStream(
+        <html>
+          <body>
+            <main>
+              <EntryWithPendingFrame label={label} />
+            </main>
+          </body>
+        </html>,
+        {
+          resolveFrame(src: string) {
+            if (src === '/entry-frame') {
+              return `<span id="entry-frame">${frameLabel}</span>`
+            }
+            throw new Error(`Unexpected frame src during server render: ${src}`)
+          },
+        },
+      )
+    }
+
+    let serverHtml = await renderPage('Initial entry', 'Initial entry frame')
+    let initialDocument = new DOMParser().parseFromString(serverHtml, 'text/html')
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let [entryFrameContentPromise, resolveEntryFrameContent] = withResolvers<string>()
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/entry-with-pending-frame.js' &&
+          exportName === 'EntryWithPendingFrame'
+        ) {
+          return EntryWithPendingFrame
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      async resolveFrame(src: string) {
+        if (src === document.location.href) {
+          return streamFromChunks([
+            await renderPageWithProtocol('Reloaded entry', 'Unused streamed entry frame'),
+          ])
+        }
+        if (src === '/entry-frame') {
+          return entryFrameContentPromise
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    invariant(reloadTop)
+    let topReloadSettled = false
+    let topReloadPromise = reloadTop().then(() => {
+      topReloadSettled = true
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    let topReloadSettledBeforeEntryFrame = topReloadSettled
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('Reloaded entry')
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Initial entry frame')
+    expect(entryFrameEvents).toEqual(['start'])
+
+    resolveEntryFrameContent('<span id="entry-frame">Reloaded entry frame</span>')
+    await topReloadPromise
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(topReloadSettledBeforeEntryFrame).toBe(true)
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Reloaded entry frame')
+    expect(entryFrameEvents).toEqual(['start', 'complete'])
+    app.dispose()
+  })
+
+  it('ignores stale frame reloads from superseded preserved client entry rerenders', async () => {
+    let reloadTop: undefined | (() => Promise<AbortSignal>)
+
+    let EntryWithPendingFrame = clientEntry(
+      '/assets/entry-with-superseded-frame.js#EntryWithSupersededFrame',
+      function EntryWithSupersededFrame(handle: Handle<{ label: string }>) {
+        reloadTop = () => handle.frames.top.reload()
+        return () => (
+          <section>
+            <p id="entry-label">{handle.props.label}</p>
+            <Frame
+              name="entry-frame"
+              src="/entry-frame"
+              fallback={<span id="entry-frame">Loading entry frame...</span>}
+            />
+          </section>
+        )
+      },
+    )
+
+    async function renderPage(label: string, frameLabel: string): Promise<string> {
+      return await drain(renderPageStream(label, frameLabel))
+    }
+
+    async function renderPageWithProtocol(label: string, frameLabel: string): Promise<string> {
+      return await drainWithProtocol(renderPageStream(label, frameLabel))
+    }
+
+    function renderPageStream(label: string, frameLabel: string): ReadableStream<Uint8Array> {
+      return renderToStream(
+        <html>
+          <body>
+            <main>
+              <EntryWithPendingFrame label={label} />
+            </main>
+          </body>
+        </html>,
+        {
+          resolveFrame(src: string) {
+            if (src === '/entry-frame') {
+              return `<span id="entry-frame">${frameLabel}</span>`
+            }
+            throw new Error(`Unexpected frame src during server render: ${src}`)
+          },
+        },
+      )
+    }
+
+    let serverHtml = await renderPage('Initial entry', 'Initial entry frame')
+    let initialDocument = new DOMParser().parseFromString(serverHtml, 'text/html')
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let topReloadCount = 0
+    let [secondTopContentPromise, resolveSecondTopContent] = withResolvers<string>()
+    let entryFrameResolvers: Array<(content: string) => void> = []
+    let entryFrameSignals: AbortSignal[] = []
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/entry-with-superseded-frame.js' &&
+          exportName === 'EntryWithSupersededFrame'
+        ) {
+          return EntryWithPendingFrame
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      async resolveFrame(src: string, signal?: AbortSignal) {
+        if (src === document.location.href) {
+          topReloadCount++
+          if (topReloadCount === 1) {
+            return streamFromChunks([
+              await renderPageWithProtocol('First reload', 'Unused first streamed entry frame'),
+            ])
+          }
+          if (topReloadCount === 2) {
+            return streamFromChunks([secondTopContentPromise])
+          }
+          throw new Error(`Unexpected top reload count: ${topReloadCount}`)
+        }
+        if (src === '/entry-frame') {
+          invariant(signal, 'Expected entry frame reload signal')
+          let [entryFrameContentPromise, resolveEntryFrameContent] = withResolvers<string>()
+          entryFrameSignals.push(signal)
+          entryFrameResolvers.push(resolveEntryFrameContent)
+          return entryFrameContentPromise
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    invariant(reloadTop)
+    let clientReloadTop = reloadTop
+    await clientReloadTop()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('First reload')
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Initial entry frame')
+    expect(entryFrameResolvers).toHaveLength(1)
+
+    let secondReloadPromise = clientReloadTop()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(entryFrameSignals[0]?.aborted).toBe(true)
+    entryFrameResolvers[0]?.('<span id="entry-frame">Stale entry frame</span>')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('First reload')
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Initial entry frame')
+
+    resolveSecondTopContent(
+      await renderPageWithProtocol('Second reload', 'Unused second streamed entry frame'),
+    )
+    await secondReloadPromise
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('Second reload')
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Initial entry frame')
+    expect(entryFrameResolvers).toHaveLength(2)
+
+    entryFrameResolvers[1]?.('<span id="entry-frame">Second entry frame</span>')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Second entry frame')
+    app.dispose()
+  })
+
+  it('reports reload failures for frames inside preserved client entries', async () => {
+    let reloadTop: undefined | (() => Promise<AbortSignal>)
+    let entryFrameEvents: string[] = []
+    let reloadError = new TypeError('Failed to reload entry frame')
+
+    let EntryWithFailingFrame = clientEntry(
+      '/assets/entry-with-failing-frame.js#EntryWithFailingFrame',
+      function EntryWithFailingFrame(handle: Handle<{ label: string }>) {
+        reloadTop = () => handle.frames.top.reload()
+        handle.queueTask(() => {
+          let entryFrame = handle.frames.get('entry-frame')
+          invariant(entryFrame, 'Expected entry frame handle')
+          entryFrame.addEventListener('reloadStart', () => entryFrameEvents.push('start'), {
+            signal: handle.signal,
+          })
+          entryFrame.addEventListener('reloadComplete', () => entryFrameEvents.push('complete'), {
+            signal: handle.signal,
+          })
+        })
+        return () => (
+          <section>
+            <p id="entry-label">{handle.props.label}</p>
+            <Frame
+              name="entry-frame"
+              src="/entry-frame"
+              fallback={<span id="entry-frame">Loading entry frame...</span>}
+            />
+          </section>
+        )
+      },
+    )
+
+    async function renderPage(label: string, frameLabel: string): Promise<string> {
+      return await drain(renderPageStream(label, frameLabel))
+    }
+
+    async function renderPageWithProtocol(label: string, frameLabel: string): Promise<string> {
+      return await drainWithProtocol(renderPageStream(label, frameLabel))
+    }
+
+    function renderPageStream(label: string, frameLabel: string): ReadableStream<Uint8Array> {
+      return renderToStream(
+        <html>
+          <body>
+            <main>
+              <EntryWithFailingFrame label={label} />
+            </main>
+          </body>
+        </html>,
+        {
+          resolveFrame(src: string) {
+            if (src === '/entry-frame') {
+              return `<span id="entry-frame">${frameLabel}</span>`
+            }
+            throw new Error(`Unexpected frame src during server render: ${src}`)
+          },
+        },
+      )
+    }
+
+    let serverHtml = await renderPage('Initial entry', 'Initial entry frame')
+    let initialDocument = new DOMParser().parseFromString(serverHtml, 'text/html')
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/entry-with-failing-frame.js' &&
+          exportName === 'EntryWithFailingFrame'
+        ) {
+          return EntryWithFailingFrame
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      async resolveFrame(src: string) {
+        if (src === document.location.href) {
+          return streamFromChunks([
+            await renderPageWithProtocol('Reloaded entry', 'Unused streamed entry frame'),
+          ])
+        }
+        if (src === '/entry-frame') {
+          throw reloadError
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+    let forwarded: unknown
+    app.addEventListener('error', (event) => {
+      forwarded = event.error
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    invariant(reloadTop)
+    await reloadTop()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(forwarded).toBe(reloadError)
+    expect(document.getElementById('entry-label')?.textContent).toBe('Reloaded entry')
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Initial entry frame')
+    expect(entryFrameEvents).toEqual(['start', 'complete'])
+    app.dispose()
+  })
+
+  it('does not reload client-created frames during ordinary client updates', async () => {
+    let updateEntry: undefined | (() => Promise<AbortSignal>)
+    let renderCount = 0
+    let entryFrameResolveCount = 0
+
+    let EntryWithFrame = clientEntry(
+      '/assets/entry-with-client-update.js#EntryWithClientUpdate',
+      function EntryWithClientUpdate(handle: Handle) {
+        updateEntry = () => handle.update()
+        return () => (
+          <section>
+            <p id="entry-render-count">Entry render: {renderCount++}</p>
+            <Frame
+              name="entry-frame"
+              src="/entry-frame"
+              fallback={<span id="entry-frame">Loading entry frame...</span>}
+            />
+          </section>
+        )
+      },
+    )
+
+    let serverHtml = await drain(
+      renderToStream(
+        <html>
+          <body>
+            <main>
+              <EntryWithFrame />
+            </main>
+          </body>
+        </html>,
+        {
+          resolveFrame(src: string) {
+            if (src === '/entry-frame') {
+              return '<span id="entry-frame">Initial entry frame</span>'
+            }
+            throw new Error(`Unexpected frame src during server render: ${src}`)
+          },
+        },
+      ),
+    )
+    let initialDocument = new DOMParser().parseFromString(serverHtml, 'text/html')
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/entry-with-client-update.js' &&
+          exportName === 'EntryWithClientUpdate'
+        ) {
+          return EntryWithFrame
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      resolveFrame(src: string) {
+        if (src === '/entry-frame') {
+          entryFrameResolveCount++
+          return '<span id="entry-frame">Reloaded entry frame</span>'
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-render-count')?.textContent).toBe('Entry render: 1')
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Initial entry frame')
+    expect(entryFrameResolveCount).toBe(0)
+
+    invariant(updateEntry)
+    await updateEntry()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-render-count')?.textContent).toBe('Entry render: 2')
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Initial entry frame')
+    expect(entryFrameResolveCount).toBe(0)
+    app.dispose()
+  })
+
+  it('loads new client-created frame src values during server-driven entry rerenders', async () => {
+    let reloadTop: undefined | (() => Promise<AbortSignal>)
+    let frameSrc = '/entry-frame-a'
+
+    let EntryWithChangingFrame = clientEntry(
+      '/assets/entry-with-changing-frame.js#EntryWithChangingFrame',
+      function EntryWithChangingFrame(handle: Handle<{ label: string }>) {
+        reloadTop = () => handle.frames.top.reload()
+        return () => (
+          <section>
+            <p id="entry-label">{handle.props.label}</p>
+            <Frame
+              name="entry-frame"
+              src={frameSrc}
+              fallback={<span id="entry-frame">Loading entry frame...</span>}
+            />
+          </section>
+        )
+      },
+    )
+
+    async function renderPage(label: string, frameLabel: string): Promise<string> {
+      return await drain(renderPageStream(label, frameLabel))
+    }
+
+    async function renderPageWithProtocol(label: string, frameLabel: string): Promise<string> {
+      return await drainWithProtocol(renderPageStream(label, frameLabel))
+    }
+
+    function renderPageStream(label: string, frameLabel: string): ReadableStream<Uint8Array> {
+      return renderToStream(
+        <html>
+          <body>
+            <main>
+              <EntryWithChangingFrame label={label} />
+            </main>
+          </body>
+        </html>,
+        {
+          resolveFrame(src: string) {
+            if (src === frameSrc) {
+              return `<span id="entry-frame">${frameLabel}</span>`
+            }
+            throw new Error(`Unexpected frame src during server render: ${src}`)
+          },
+        },
+      )
+    }
+
+    let serverHtml = await renderPage('Initial entry', 'Initial entry frame')
+    let initialDocument = new DOMParser().parseFromString(serverHtml, 'text/html')
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let resolvedClientFrameSrcs: string[] = []
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/entry-with-changing-frame.js' &&
+          exportName === 'EntryWithChangingFrame'
+        ) {
+          return EntryWithChangingFrame
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      async resolveFrame(src: string) {
+        if (src === document.location.href) {
+          frameSrc = '/entry-frame-b'
+          return streamFromChunks([
+            await renderPageWithProtocol('Reloaded entry', 'Unused streamed entry frame'),
+          ])
+        }
+        if (src === '/entry-frame-b') {
+          resolvedClientFrameSrcs.push(src)
+          return '<span id="entry-frame">Reloaded entry frame</span>'
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('Initial entry')
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Initial entry frame')
+    expect(resolvedClientFrameSrcs).toEqual([])
+
+    invariant(reloadTop)
+    await reloadTop()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('Reloaded entry')
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Reloaded entry frame')
+    expect(resolvedClientFrameSrcs).toEqual(['/entry-frame-b'])
+    app.dispose()
+  })
+
+
   it('cancels stale client frame streams when src changes', async () => {
     let rootContainer = document.createElement('div')
     document.body.appendChild(rootContainer)

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -5378,6 +5378,227 @@ describe('run', () => {
     app.dispose()
   })
 
+  it('restarts pending frames inside preserved client entries during ancestor reloads', async () => {
+    let reloadTop: undefined | (() => Promise<AbortSignal>)
+    let renderClientFrame = false
+
+    let EntryWithPendingFrame = clientEntry(
+      '/assets/entry-with-initially-pending-frame.js#EntryWithInitiallyPendingFrame',
+      function EntryWithInitiallyPendingFrame(handle: Handle<{ label: string }>) {
+        reloadTop = () => handle.frames.top.reload()
+        return () => {
+          handle.queueTask(() => {
+            if (renderClientFrame) return
+            renderClientFrame = true
+            void handle.update()
+          })
+
+          return (
+            <section>
+              <p id="entry-label">{handle.props.label}</p>
+              {renderClientFrame ? (
+                <Frame
+                  name="entry-frame"
+                  src="/entry-frame"
+                  fallback={<span id="entry-frame">Loading entry frame...</span>}
+                />
+              ) : null}
+            </section>
+          )
+        }
+      },
+    )
+
+    async function renderPageWithProtocol(label: string): Promise<string> {
+      let previousRenderClientFrame = renderClientFrame
+      renderClientFrame = false
+      try {
+        return await drainWithProtocol(
+          renderToStream(
+            <html>
+              <body>
+                <main>
+                  <EntryWithPendingFrame label={label} />
+                </main>
+              </body>
+            </html>,
+          ),
+        )
+      } finally {
+        renderClientFrame = previousRenderClientFrame
+      }
+    }
+
+    let initialDocument = new DOMParser().parseFromString(
+      await renderPageWithProtocol('Initial entry'),
+      'text/html',
+    )
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let entryFrameSignals: AbortSignal[] = []
+    let entryFrameResolvers: Array<(content: string) => void> = []
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/entry-with-initially-pending-frame.js' &&
+          exportName === 'EntryWithInitiallyPendingFrame'
+        ) {
+          return EntryWithPendingFrame
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      async resolveFrame(src: string, signal?: AbortSignal) {
+        if (src === document.location.href) {
+          return streamFromChunks([await renderPageWithProtocol('Reloaded entry')])
+        }
+        if (src === '/entry-frame') {
+          invariant(signal, 'Expected entry frame resolve signal')
+          let [contentPromise, resolveContent] = withResolvers<string>()
+          entryFrameSignals.push(signal)
+          entryFrameResolvers.push(resolveContent)
+          return contentPromise
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(entryFrameSignals).toHaveLength(1)
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Loading entry frame...')
+
+    invariant(reloadTop)
+    await reloadTop()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(entryFrameSignals).toHaveLength(2)
+    expect(entryFrameSignals[0]?.aborted).toBe(true)
+    expect(entryFrameSignals[1]?.aborted).toBe(false)
+
+    entryFrameResolvers[0]?.('<span id="entry-frame">Stale entry frame</span>')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-label')?.textContent).toBe('Reloaded entry')
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Loading entry frame...')
+
+    entryFrameResolvers[1]?.('<span id="entry-frame">Reloaded entry frame</span>')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Reloaded entry frame')
+    app.dispose()
+  })
+
+  it('cancels an inherited frame reload when a client update changes its src', async () => {
+    let reloadTop: undefined | (() => Promise<AbortSignal>)
+    let changeFrameSrc: undefined | (() => Promise<AbortSignal>)
+    let frameSrc = '/entry-frame-a'
+
+    let EntryWithChangingFrame = clientEntry(
+      '/assets/entry-with-racing-frame.js#EntryWithRacingFrame',
+      function EntryWithRacingFrame(handle: Handle<{ label: string }>) {
+        reloadTop = () => handle.frames.top.reload()
+        changeFrameSrc = async () => {
+          frameSrc = '/entry-frame-b'
+          return await handle.update()
+        }
+        return () => (
+          <section>
+            <p id="entry-label">{handle.props.label}</p>
+            <Frame
+              name="entry-frame"
+              src={frameSrc}
+              fallback={<span id="entry-frame">Loading entry frame...</span>}
+            />
+          </section>
+        )
+      },
+    )
+
+    async function renderPageWithProtocol(label: string, frameLabel: string): Promise<string> {
+      return await drainWithProtocol(
+        renderToStream(
+          <html>
+            <body>
+              <main>
+                <EntryWithChangingFrame label={label} />
+              </main>
+            </body>
+          </html>,
+          {
+            resolveFrame(src: string) {
+              if (src === '/entry-frame-a') {
+                return `<span id="entry-frame">${frameLabel}</span>`
+              }
+              throw new Error(`Unexpected frame src during server render: ${src}`)
+            },
+          },
+        ),
+      )
+    }
+
+    let initialDocument = new DOMParser().parseFromString(
+      await renderPageWithProtocol('Initial entry', 'Initial entry frame'),
+      'text/html',
+    )
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let inheritedFrameSignal: AbortSignal | undefined
+    let [inheritedFrameContentPromise, resolveInheritedFrameContent] = withResolvers<string>()
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (
+          moduleUrl === '/assets/entry-with-racing-frame.js' &&
+          exportName === 'EntryWithRacingFrame'
+        ) {
+          return EntryWithChangingFrame
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      async resolveFrame(src: string, signal?: AbortSignal) {
+        if (src === document.location.href) {
+          return streamFromChunks([
+            await renderPageWithProtocol('Reloaded entry', 'Unused streamed entry frame'),
+          ])
+        }
+        if (src === '/entry-frame-a') {
+          inheritedFrameSignal = signal
+          return inheritedFrameContentPromise
+        }
+        if (src === '/entry-frame-b') {
+          return '<span id="entry-frame">Updated entry frame</span>'
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    invariant(reloadTop)
+    invariant(changeFrameSrc)
+    let clientChangeFrameSrc = changeFrameSrc
+    await reloadTop()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(inheritedFrameSignal?.aborted).toBe(false)
+
+    await clientChangeFrameSrc()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(inheritedFrameSignal?.aborted).toBe(true)
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Updated entry frame')
+
+    resolveInheritedFrameContent('<span id="entry-frame">Stale inherited frame</span>')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.getElementById('entry-frame')?.textContent).toBe('Updated entry frame')
+    app.dispose()
+  })
+
   it('ignores stale frame reloads from superseded preserved client entry rerenders', async () => {
     let reloadTop: undefined | (() => Promise<AbortSignal>)
 
@@ -5571,6 +5792,7 @@ describe('run', () => {
     let serverHtml = await renderPage('Initial entry', 'Initial entry frame')
     let initialDocument = new DOMParser().parseFromString(serverHtml, 'text/html')
     document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+    let reloadedPage = await renderPageWithProtocol('Reloaded entry', 'Unused streamed entry frame')
 
     let app = run({
       loadModule(moduleUrl, exportName) {
@@ -5582,11 +5804,9 @@ describe('run', () => {
         }
         throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
       },
-      async resolveFrame(src: string) {
+      resolveFrame(src: string) {
         if (src === document.location.href) {
-          return streamFromChunks([
-            await renderPageWithProtocol('Reloaded entry', 'Unused streamed entry frame'),
-          ])
+          return streamFromChunks([reloadedPage])
         }
         if (src === '/entry-frame') {
           throw reloadError
@@ -5696,21 +5916,38 @@ describe('run', () => {
   it('loads new client-created frame src values during server-driven entry rerenders', async () => {
     let reloadTop: undefined | (() => Promise<AbortSignal>)
     let frameSrc = '/entry-frame-a'
+    let entryFrameEvents: string[] = []
 
     let EntryWithChangingFrame = clientEntry(
       '/assets/entry-with-changing-frame.js#EntryWithChangingFrame',
       function EntryWithChangingFrame(handle: Handle<{ label: string }>) {
+        let listening = false
         reloadTop = () => handle.frames.top.reload()
-        return () => (
-          <section>
-            <p id="entry-label">{handle.props.label}</p>
-            <Frame
-              name="entry-frame"
-              src={frameSrc}
-              fallback={<span id="entry-frame">Loading entry frame...</span>}
-            />
-          </section>
-        )
+        return () => {
+          handle.queueTask(() => {
+            if (listening) return
+            let entryFrame = handle.frames.get('entry-frame')
+            invariant(entryFrame, 'Expected entry frame handle')
+            entryFrame.addEventListener('reloadStart', () => entryFrameEvents.push('start'), {
+              signal: handle.signal,
+            })
+            entryFrame.addEventListener('reloadComplete', () => entryFrameEvents.push('complete'), {
+              signal: handle.signal,
+            })
+            listening = true
+          })
+
+          return (
+            <section>
+              <p id="entry-label">{handle.props.label}</p>
+              <Frame
+                name="entry-frame"
+                src={frameSrc}
+                fallback={<span id="entry-frame">Loading entry frame...</span>}
+              />
+            </section>
+          )
+        }
       },
     )
 
@@ -5747,6 +5984,7 @@ describe('run', () => {
     document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
 
     let resolvedClientFrameSrcs: string[] = []
+    let topReloadCount = 0
 
     let app = run({
       loadModule(moduleUrl, exportName) {
@@ -5760,12 +5998,13 @@ describe('run', () => {
       },
       async resolveFrame(src: string) {
         if (src === document.location.href) {
-          frameSrc = '/entry-frame-b'
+          topReloadCount++
+          frameSrc = topReloadCount === 1 ? '/entry-frame-b' : '/entry-frame-c'
           return streamFromChunks([
             await renderPageWithProtocol('Reloaded entry', 'Unused streamed entry frame'),
           ])
         }
-        if (src === '/entry-frame-b') {
+        if (src === '/entry-frame-b' || src === '/entry-frame-c') {
           resolvedClientFrameSrcs.push(src)
           return '<span id="entry-frame">Reloaded entry frame</span>'
         }
@@ -5779,17 +6018,25 @@ describe('run', () => {
     expect(document.getElementById('entry-label')?.textContent).toBe('Initial entry')
     expect(document.getElementById('entry-frame')?.textContent).toBe('Initial entry frame')
     expect(resolvedClientFrameSrcs).toEqual([])
+    expect(entryFrameEvents).toEqual([])
 
     invariant(reloadTop)
-    await reloadTop()
+    let clientReloadTop = reloadTop
+    await clientReloadTop()
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(document.getElementById('entry-label')?.textContent).toBe('Reloaded entry')
     expect(document.getElementById('entry-frame')?.textContent).toBe('Reloaded entry frame')
     expect(resolvedClientFrameSrcs).toEqual(['/entry-frame-b'])
+    expect(entryFrameEvents).toEqual(['start', 'complete'])
+
+    await clientReloadTop()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(resolvedClientFrameSrcs).toEqual(['/entry-frame-b', '/entry-frame-c'])
+    expect(entryFrameEvents).toEqual(['start', 'complete', 'start', 'complete'])
     app.dispose()
   })
-
 
   it('cancels stale client frame streams when src changes', async () => {
     let rootContainer = document.createElement('div')


### PR DESCRIPTION
This fixes an issue raised in this PR: https://github.com/remix-run/remix/pull/11414. For context, this is the issue:

> **Issue:** Reloading the root frame causes nested frames to reload, but any frames rendered within client entries are not reloaded and continue to show the same server content. In this case, I'm not sure if this is a bug or expected behaviour, but I personally found it surprising.
>
> **Reproduction:** Go to http://localhost:44100/root-reload-client-entries, then click either of the reload buttons at the top of the page. You'll see the "Server props" content update, but the server times displayed in the nested frames do not change.

I originally wasn't sure if this behaviour was expected or not, but I've since confirmed that this was indeed an issue.