### PR TITLE
Use route installers in social-auth demo

### DIFF
--- a/demos/social-auth/app/actions/auth/controller.tsx
+++ b/demos/social-auth/app/actions/auth/controller.tsx
@@ -1,12 +1,35 @@
-import { createController } from 'remix/router'
+import { createController, type RouteBuilder, type RouterTypes } from 'remix/router'
 import { completeAuth, verifyCredentials } from 'remix/auth'
 import { redirect } from 'remix/response/redirect'
 
+import { forgotPasswordController } from './forgot-password/controller.tsx'
+import { createGitHubAuthController } from './github/controller.ts'
+import { createGoogleAuthController } from './google/controller.ts'
+import { resetPasswordController } from './reset-password/controller.tsx'
+import { signupController } from './signup/controller.tsx'
+import { createXAuthController } from './x/controller.ts'
 import { getPostAuthRedirect, getReturnToQuery, passwordProvider } from '../../middleware/auth.ts'
-import { routes } from '../../routes.ts'
+import { authRoutes, routes } from '../../routes.ts'
+import {
+  externalProviderRegistry,
+  type ExternalProviderRegistry,
+} from '../../utils/external-auth.ts'
+
+export function installAuthRoutes(
+  router: RouteBuilder<RouterTypes['context']>,
+  registry: ExternalProviderRegistry = externalProviderRegistry,
+) {
+  router.map(authRoutes, createAuthController())
+  router.map(authRoutes.signup, signupController)
+  router.map(authRoutes.forgotPassword, forgotPasswordController)
+  router.map(authRoutes.resetPassword, resetPasswordController)
+  router.map(authRoutes.google, createGoogleAuthController(registry))
+  router.map(authRoutes.github, createGitHubAuthController(registry))
+  router.map(authRoutes.x, createXAuthController(registry))
+}
 
 export function createAuthController() {
-  return createController(routes.auth, {
+  return createController(authRoutes, {
     actions: {
       async login(context) {
         let { session, url } = context

--- a/demos/social-auth/app/actions/auth/forgot-password/controller.tsx
+++ b/demos/social-auth/app/actions/auth/forgot-password/controller.tsx
@@ -6,9 +6,9 @@ import { getIssueMessage, readField } from '../form-utils.ts'
 import { forgotPasswordSchema } from '../schemas.ts'
 import { normalizeEmail, passwordResetTokens, users } from '../../../data/schema.ts'
 import { getReturnToQuery } from '../../../middleware/auth.ts'
-import { routes } from '../../../routes.ts'
+import { authRoutes, routes } from '../../../routes.ts'
 
-export const forgotPasswordController = createController(routes.auth.forgotPassword, {
+export const forgotPasswordController = createController(authRoutes.forgotPassword, {
   actions: {
     index({ render, url }) {
       return render(

--- a/demos/social-auth/app/actions/auth/github/controller.ts
+++ b/demos/social-auth/app/actions/auth/github/controller.ts
@@ -4,7 +4,7 @@ import { redirect } from 'remix/response/redirect'
 
 import { resolveExternalAuth } from '../resolve-external-auth.ts'
 import { getReturnToQuery } from '../../../middleware/auth.ts'
-import { routes } from '../../../routes.ts'
+import { authRoutes, routes } from '../../../routes.ts'
 import {
   externalProviderRegistry,
   getExternalProviderLabel,
@@ -18,7 +18,7 @@ export function createGitHubAuthController(
 ) {
   let provider = registry.github
 
-  return createController(routes.auth.github, {
+  return createController(authRoutes.github, {
     actions: {
       async login(context) {
         let { session, url } = context

--- a/demos/social-auth/app/actions/auth/google/controller.ts
+++ b/demos/social-auth/app/actions/auth/google/controller.ts
@@ -4,7 +4,7 @@ import { redirect } from 'remix/response/redirect'
 
 import { resolveExternalAuth } from '../resolve-external-auth.ts'
 import { getReturnToQuery } from '../../../middleware/auth.ts'
-import { routes } from '../../../routes.ts'
+import { authRoutes, routes } from '../../../routes.ts'
 import {
   externalProviderRegistry,
   getExternalProviderLabel,
@@ -18,7 +18,7 @@ export function createGoogleAuthController(
 ) {
   let provider = registry.google
 
-  return createController(routes.auth.google, {
+  return createController(authRoutes.google, {
     actions: {
       async login(context) {
         let { session, url } = context

--- a/demos/social-auth/app/actions/auth/reset-password/controller.tsx
+++ b/demos/social-auth/app/actions/auth/reset-password/controller.tsx
@@ -8,7 +8,7 @@ import { ResetPasswordCompletePage, ResetPasswordPage } from './page.tsx'
 import { resetPasswordSchema } from '../schemas.ts'
 import { passwordResetTokens, users } from '../../../data/schema.ts'
 import { getReturnToQuery } from '../../../middleware/auth.ts'
-import { routes } from '../../../routes.ts'
+import { authRoutes, routes } from '../../../routes.ts'
 import { hashPassword } from '../../../utils/password-hash.ts'
 
 async function loadResetToken(db: Database, token: string) {
@@ -25,7 +25,7 @@ async function loadResetToken(db: Database, token: string) {
   return resetToken
 }
 
-export const resetPasswordController = createController(routes.auth.resetPassword, {
+export const resetPasswordController = createController(authRoutes.resetPassword, {
   actions: {
     async index(context) {
       let { db, params, render, url } = context

--- a/demos/social-auth/app/actions/auth/signup/controller.tsx
+++ b/demos/social-auth/app/actions/auth/signup/controller.tsx
@@ -7,10 +7,10 @@ import { getIssueMessage, readSignupValues } from '../form-utils.ts'
 import { signupSchema } from '../schemas.ts'
 import { normalizeEmail, normalizeText, users } from '../../../data/schema.ts'
 import { getPostAuthRedirect, getReturnToQuery } from '../../../middleware/auth.ts'
-import { routes } from '../../../routes.ts'
+import { authRoutes, routes } from '../../../routes.ts'
 import { hashPassword } from '../../../utils/password-hash.ts'
 
-export const signupController = createController(routes.auth.signup, {
+export const signupController = createController(authRoutes.signup, {
   actions: {
     index({ render, url }) {
       let returnToQuery = getReturnToQuery(url)

--- a/demos/social-auth/app/actions/auth/x/controller.ts
+++ b/demos/social-auth/app/actions/auth/x/controller.ts
@@ -4,7 +4,7 @@ import { redirect } from 'remix/response/redirect'
 
 import { resolveExternalAuth } from '../resolve-external-auth.ts'
 import { getReturnToQuery } from '../../../middleware/auth.ts'
-import { routes } from '../../../routes.ts'
+import { authRoutes, routes } from '../../../routes.ts'
 import {
   externalProviderRegistry,
   getExternalProviderLabel,
@@ -18,7 +18,7 @@ export function createXAuthController(
 ) {
   let provider = registry.x
 
-  return createController(routes.auth.x, {
+  return createController(authRoutes.x, {
     actions: {
       async login(context) {
         let { session, url } = context

--- a/demos/social-auth/app/router.ts
+++ b/demos/social-auth/app/router.ts
@@ -5,19 +5,13 @@ import type { SessionStorage } from 'remix/session'
 import { session } from 'remix/middleware/session'
 import { staticFiles } from 'remix/middleware/static'
 
-import { createAuthController } from './actions/auth/controller.tsx'
-import { forgotPasswordController } from './actions/auth/forgot-password/controller.tsx'
-import { createGitHubAuthController } from './actions/auth/github/controller.ts'
-import { createGoogleAuthController } from './actions/auth/google/controller.ts'
-import { resetPasswordController } from './actions/auth/reset-password/controller.tsx'
-import { signupController } from './actions/auth/signup/controller.tsx'
-import { createXAuthController } from './actions/auth/x/controller.ts'
+import { installAuthRoutes } from './actions/auth/controller.tsx'
 import { createRootController } from './actions/controller.tsx'
 import { loadAuth } from './middleware/auth.ts'
 import { loadDatabase } from './middleware/database.ts'
 import { render } from './middleware/render.tsx'
 import { sessionCookie, sessionStorage } from './middleware/session.ts'
-import { routes } from './routes.ts'
+import { authBase, routes } from './routes.ts'
 import { externalProviderRegistry, type ExternalProviderRegistry } from './utils/external-auth.ts'
 
 type AppMiddleware = ReturnType<typeof createSocialAuthMiddleware>
@@ -42,13 +36,7 @@ export function createSocialAuthRouter(options?: SocialAuthRouterOptions) {
   let router = createRouter({ middleware: createSocialAuthMiddleware(cookie, storage) })
 
   router.map(routes, createRootController(providers))
-  router.map(routes.auth, createAuthController())
-  router.map(routes.auth.signup, signupController)
-  router.map(routes.auth.forgotPassword, forgotPasswordController)
-  router.map(routes.auth.resetPassword, resetPasswordController)
-  router.map(routes.auth.google, createGoogleAuthController(providers))
-  router.map(routes.auth.github, createGitHubAuthController(providers))
-  router.map(routes.auth.x, createXAuthController(providers))
+  router.mount(authBase, (auth) => installAuthRoutes(auth, providers))
 
   return router
 }

--- a/demos/social-auth/app/routes.ts
+++ b/demos/social-auth/app/routes.ts
@@ -1,25 +1,31 @@
 import { form, get, post, route } from 'remix/routes'
 
+export const authBase = '/auth'
+
+const authRouteDefs = {
+  login: post('/login'),
+  logout: post('/logout'),
+  signup: form('/signup'),
+  forgotPassword: form('/forgot-password'),
+  resetPassword: form('/reset-password/:token'),
+  google: route('/google', {
+    login: get('/login'),
+    callback: get('/callback'),
+  }),
+  github: route('/github', {
+    login: get('/login'),
+    callback: get('/callback'),
+  }),
+  x: route('/x', {
+    login: get('/login'),
+    callback: get('/callback'),
+  }),
+}
+
+export const authRoutes = route(authRouteDefs)
+
 export const routes = route({
   home: get('/'),
   account: get('/account'),
-  auth: {
-    login: post('/auth/login'),
-    logout: post('/auth/logout'),
-    signup: form('/auth/signup'),
-    forgotPassword: form('/auth/forgot-password'),
-    resetPassword: form('/auth/reset-password/:token'),
-    google: route('/auth/google', {
-      login: get('/login'),
-      callback: get('/callback'),
-    }),
-    github: route('/auth/github', {
-      login: get('/login'),
-      callback: get('/callback'),
-    }),
-    x: route('/auth/x', {
-      login: get('/login'),
-      callback: get('/callback'),
-    }),
-  },
+  auth: route(authBase, authRouteDefs),
 })


### PR DESCRIPTION
Use `router.mount()` in the social-auth demo so the auth feature owns its local route registration while the app router only chooses the `/auth` mount point.

- Adds shared local auth route definitions and derives full app auth routes from the same definitions for href generation.
- Moves auth subtree registration behind `installAuthRoutes(...)`, keeping the root router focused on top-level composition.
- Updates auth controllers to register against local `authRoutes` while preserving existing `/auth/...` form actions, redirects, and test URLs.

Supersedes #11508.
