### PR TITLE
Fix route-pattern default port matching

### DIFF
--- a/packages/route-pattern/.changes/patch.match-default-ports.md
+++ b/packages/route-pattern/.changes/patch.match-default-ports.md
@@ -1,0 +1,1 @@
+Fixed route matching for full URL patterns that include explicit default ports such as `http://example.com:80/path` and `https://example.com:443/path` (see #11510).

--- a/packages/route-pattern/src/lib/match.test.ts
+++ b/packages/route-pattern/src/lib/match.test.ts
@@ -224,6 +224,46 @@ describe('Matcher', () => {
         assert.deepEqual(match.params, {})
       })
 
+      it('matches explicit HTTP default port', () => {
+        let matcher = createMultiMatcher<null>()
+        matcher.add('http://example.com:80/users', null)
+
+        let match = matcher.match('http://example.com:80/users')
+        assert.ok(match)
+        assert.deepEqual(match.params, {})
+      })
+
+      it('matches explicit HTTPS default port', () => {
+        let matcher = createMultiMatcher<null>()
+        matcher.add('https://example.com:443/users', null)
+
+        let match = matcher.match('https://example.com:443/users')
+        assert.ok(match)
+        assert.deepEqual(match.params, {})
+      })
+
+      it('normalizes default ports per protocol variant', () => {
+        let matcher = createMultiMatcher<null>()
+        matcher.add('http(s)://example.com:443/users', null)
+
+        assert.ok(matcher.match('http://example.com:443/users'))
+        assert.ok(matcher.match('https://example.com:443/users'))
+        assert.ok(matcher.match('https://example.com/users'))
+        assert.equal(matcher.match('http://example.com/users'), null)
+      })
+
+      it('matches hrefs generated from patterns with explicit default ports', () => {
+        let matcher = createMultiMatcher<null>()
+        let httpPattern = 'http://example.com:80/users' as const
+        let httpsPattern = 'https://example.com:443/users' as const
+
+        matcher.add(httpPattern, null)
+        matcher.add(httpsPattern, null)
+
+        assert.ok(matcher.match(createHref(httpPattern)))
+        assert.ok(matcher.match(createHref(httpsPattern)))
+      })
+
       it('returns null when explicit port does not match', () => {
         let matcher = createMultiMatcher<null>()
         matcher.add('://example.com:8080/users', null)

--- a/packages/route-pattern/src/lib/match/variant.ts
+++ b/packages/route-pattern/src/lib/match/variant.ts
@@ -12,9 +12,9 @@ export type Variant = {
 
 export function generateVariants(pattern: RoutePattern): ReadonlyArray<Variant> {
   let result: Array<Variant> = []
-  let port = pattern.port ?? ''
 
   for (let protocol of generateProtocolVariants(pattern.protocol)) {
+    let port = normalizePort(protocol, pattern.port)
     for (let hostname of generateHostnameVariants(pattern.hostname)) {
       for (let pathname of generatePathnameVariants(pattern.pathname)) {
         result.push({ protocol, hostname, port, pathname })
@@ -33,6 +33,13 @@ function generateProtocolVariants(
 ): ReadonlyArray<ProtocolVariant> {
   if (protocol === null || protocol === 'http(s)') return ['http', 'https']
   return [protocol]
+}
+
+function normalizePort(protocol: ProtocolVariant, port: string | null): string {
+  if (port === null) return ''
+  if (protocol === 'http' && port === '80') return ''
+  if (protocol === 'https' && port === '443') return ''
+  return port
 }
 
 // Hostname ----------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #11510.

Full URL route patterns with explicit default ports were inserted under the literal pattern port, while matching looks up routes with `URL.port`. Since `URL.port` canonicalizes HTTP `:80` and HTTPS `:443` to an empty string, those patterns could not match their own URLs or hrefs generated from the same pattern.

- Normalize route-pattern ports per generated protocol variant before inserting into the matcher
- Preserve non-default port behavior, including mixed `http(s)` patterns where the port is default for only one protocol
- Add regression coverage for explicit default ports and generated href round-trips
