### PR TITLE
Handle malformed route-pattern pathnames

### DIFF
--- a/packages/route-pattern/.changes/patch.malformed-pathnames.md
+++ b/packages/route-pattern/.changes/patch.malformed-pathnames.md
@@ -1,0 +1,1 @@
+Fixed route matching so malformed percent-encoded pathnames return no match instead of throwing a `URIError`.

--- a/packages/route-pattern/src/lib/match.test.ts
+++ b/packages/route-pattern/src/lib/match.test.ts
@@ -804,6 +804,22 @@ describe('Matcher', () => {
           assert.deepEqual(match?.params, { path: 'a' })
         })
 
+        it('returns null for malformed percent-encoded pathnames', () => {
+          let matcher = createMultiMatcher<null>()
+          matcher.add('://example.com/files/:name', null)
+
+          assert.equal(matcher.match('https://example.com/files/%E0%A4%A'), null)
+          assert.equal(matcher.match('https://example.com/files/%'), null)
+        })
+
+        it('returns no matches for malformed percent-encoded pathnames', () => {
+          let matcher = createMultiMatcher<null>()
+          matcher.add('://example.com/files/:name', null)
+          matcher.add('://example.com/files/*path', null)
+
+          assert.deepEqual(matcher.matchAll('https://example.com/files/%E0%A4%A'), [])
+        })
+
         it('does not match encoded slashes as pathname separators', () => {
           let matcher = createMultiMatcher<null>()
           matcher.add('://example.com/files/:dir/:name', null)

--- a/packages/route-pattern/src/lib/match/trie.ts
+++ b/packages/route-pattern/src/lib/match/trie.ts
@@ -149,7 +149,8 @@ export class Trie<data = unknown> {
     }
 
     let results: Array<Match<string, data>> = []
-    let urlSegments = url.pathname.slice(1).split('/').map(normalizePathnameText)
+    let urlSegments = normalizePathname(url.pathname)
+    if (urlSegments === null) return results
 
     for (let origin of origins) {
       let stack: Array<{
@@ -276,12 +277,34 @@ export class Trie<data = unknown> {
 // Pathname matching uses canonical percent-encoded text. URL pathnames are split on structural
 // "/" before normalization so encoded slashes like "%2F" remain data within a segment instead of
 // becoming separators. Pattern static text is encoded the same way when variants are generated.
-function normalizePathnameText(text: string): string {
-  return encodeURIComponent(fastDecodeURIComponent(text))
+function normalizePathname(pathname: string): string[] | null {
+  let segments: string[] = []
+
+  for (let segment of pathname.slice(1).split('/')) {
+    let normalized = normalizePathnameText(segment)
+    if (normalized === null) return null
+    segments.push(normalized)
+  }
+
+  return segments
+}
+
+function normalizePathnameText(text: string): string | null {
+  let decoded = safeDecodeURIComponent(text)
+  return decoded === null ? null : encodeURIComponent(decoded)
 }
 
 function fastDecodeURIComponent(text: string): string {
   return text.includes('%') ? decodeURIComponent(text) : text
+}
+
+function safeDecodeURIComponent(text: string): string | null {
+  try {
+    return fastDecodeURIComponent(text)
+  } catch (error) {
+    if (error instanceof URIError) return null
+    throw error
+  }
 }
 
 // Search ------------------------------------------------------------------------------------------


### PR DESCRIPTION
Malformed percent-encoded pathname segments currently throw a raw `URIError` during route matching. This keeps matcher APIs from behaving like ordinary match operations for untrusted request URLs.

This updates pathname normalization so malformed percent encoding returns no route-pattern match instead of throwing. Higher-level routers can then continue through their normal no-match/default-handler paths.

- Return `null` from `match()` and `[]` from `matchAll()` for malformed percent-encoded pathnames
- Preserve existing decoding behavior for valid percent-encoded static segments, variables, wildcards, and encoded slashes
- Add a patch change note for `@remix-run/route-pattern`
