### PR TITLE
Fix createHref optional param values

### DIFF
--- a/packages/route-pattern/.changes/patch.create-href-optional-values.md
+++ b/packages/route-pattern/.changes/patch.create-href-optional-values.md
@@ -1,0 +1,1 @@
+Fixed `createHref()` so optional route params set to `null` are omitted instead of serialized as `"null"`, and empty pathname variables throw instead of generating hrefs that cannot match their pattern.

--- a/packages/route-pattern/src/lib/href.test.ts
+++ b/packages/route-pattern/src/lib/href.test.ts
@@ -154,6 +154,13 @@ describe('createHref', () => {
         assert.equal(createHref('/posts/:id', { id: 123 }), '/posts/123')
       })
 
+      it('throws when provided an empty string', () => {
+        assert.throws(
+          () => createHref('/posts/:id', { id: '' }),
+          hrefError('invalid-pathname-variable'),
+        )
+      })
+
       it('ignores extra params', () => {
         assert.equal(createHref('/posts/:id', { id: '123', page: '2', sort: 'desc' }), '/posts/123')
       })
@@ -194,6 +201,10 @@ describe('createHref', () => {
 
     it('supports wildcard with number param', () => {
       assert.equal(createHref('/files/*path', { path: 123 }), '/files/123')
+    })
+
+    it('supports wildcard with empty string param', () => {
+      assert.equal(createHref('/files/*path', { path: '' }), '/files/')
     })
 
     it('throws for unnamed wildcard', () => {
@@ -244,6 +255,14 @@ describe('createHref', () => {
       assert.equal(createHref(pattern, {}), '/posts')
       assert.equal(createHref(pattern, null), '/posts')
       assert.equal(createHref(pattern, undefined), '/posts')
+      assert.equal(createHref(pattern, { id: null }), '/posts')
+    })
+
+    it('throws for empty optional variable when provided', () => {
+      assert.throws(
+        () => createHref('/posts(/:id)', { id: '' }),
+        hrefError('invalid-pathname-variable'),
+      )
     })
 
     it('includes optional with wildcard when provided', () => {
@@ -259,6 +278,7 @@ describe('createHref', () => {
       assert.equal(createHref(pattern, {}), '/files')
       assert.equal(createHref(pattern, null), '/files')
       assert.equal(createHref(pattern, undefined), '/files')
+      assert.equal(createHref(pattern, { path: null }), '/files')
     })
 
     it('omits optional with nameless wildcard', () => {
@@ -291,6 +311,17 @@ describe('createHref', () => {
       it('omits both when only inner provided', () => {
         assert.equal(
           createHref('/blog/:year(/:month(/:day))', { year: '2024', day: '15' }),
+          '/blog/2024',
+        )
+      })
+
+      it('omits nested optionals when outer variable is null', () => {
+        assert.equal(
+          createHref('/blog/:year(/:month(/:day))', {
+            year: '2024',
+            month: null,
+            day: '15',
+          }),
           '/blog/2024',
         )
       })
@@ -468,6 +499,27 @@ describe('CreateHrefError', () => {
           CreateHrefError: pattern contains nameless wildcard
 
           Pattern: https://example.com/api/*/users
+        `,
+      )
+    })
+  })
+
+  describe('invalid-pathname-variable', () => {
+    it('shows param, pattern, and value', () => {
+      let pattern = RoutePattern.parse('/posts/:id')
+      let error = new CreateHrefError({
+        type: 'invalid-pathname-variable',
+        pattern,
+        paramName: 'id',
+        value: '',
+      })
+      assert.equal(
+        error.toString(),
+        dedent`
+          CreateHrefError: invalid pathname variable param: 'id' cannot be empty
+
+          Pattern: /posts/:id
+          Value: ""
         `,
       )
     })

--- a/packages/route-pattern/src/lib/href.ts
+++ b/packages/route-pattern/src/lib/href.ts
@@ -42,7 +42,8 @@ type Optionalize<record extends Record<string, string | undefined>> =
  * @param pattern The parsed route pattern.
  * @param args Path params and optional search params.
  * @returns The generated href string.
- * @throws {CreateHrefError} When the pattern requires a hostname, contains a nameless wildcard, or is missing required params.
+ * @throws {CreateHrefError} When the pattern requires a hostname, contains a nameless wildcard,
+ * is missing required params, or receives invalid params.
  */
 export function createHref<source extends string>(
   pattern: source | RoutePattern<source>,
@@ -112,7 +113,7 @@ function hrefPart(
     }
     if (token.type === ':' || token.type === '*') {
       let value = params[token.name]
-      if (value === undefined) {
+      if (value == null) {
         if (stack.length <= 1) {
           if (token.name === '*') {
             throw new CreateHrefError({ type: 'nameless-wildcard', pattern })
@@ -125,7 +126,7 @@ function hrefPart(
       }
       // prettier-ignore
       stack[stack.length - 1].href +=
-        part.type === 'pathname' && token.type === ':' ? encodePathnameVariable(value) :
+        part.type === 'pathname' && token.type === ':' ? encodePathnameVariableParam(pattern, token.name, value) :
         part.type === 'pathname' && token.type === '*' ? encodePathnameWildcard(value) :
         part.type === 'hostname' && token.type === ':' ? validateHostnameVariable(value) :
         part.type === 'hostname' && token.type === '*' ? validateHostnameWildcard(value) :
@@ -202,6 +203,12 @@ type CreateHrefErrorDetails =
       value: string
       char: string
     }
+  | {
+      type: 'invalid-pathname-variable'
+      pattern: RoutePattern
+      paramName: string
+      value: string
+    }
 
 /** Error thrown when a route pattern cannot generate an href from the supplied args. */
 export class CreateHrefError extends Error {
@@ -235,8 +242,25 @@ export class CreateHrefError extends Error {
       return `invalid hostname wildcard param: ${JSON.stringify(details.value)} contains ${JSON.stringify(details.char)}`
     }
 
+    if (details.type === 'invalid-pathname-variable') {
+      return `invalid pathname variable param: '${details.paramName}' cannot be empty\n\nPattern: ${details.pattern}\nValue: ${JSON.stringify(details.value)}`
+    }
+
     unreachable(details)
   }
+}
+
+function encodePathnameVariableParam(pattern: RoutePattern, paramName: string, value: unknown) {
+  let serialized = String(value)
+  if (serialized.length === 0) {
+    throw new CreateHrefError({
+      type: 'invalid-pathname-variable',
+      pattern,
+      paramName,
+      value: serialized,
+    })
+  }
+  return encodePathnameSegment(serialized)
 }
 
 export function encodePathnameVariable(value: unknown) {


### PR DESCRIPTION
createHref() allowed optional params to be typed as null, but runtime treated null as a concrete value and generated paths like /posts/null. It could also generate empty pathname variables such as /posts/, even though pathname variables compile to non-empty matcher segments.

- Treat null and undefined path params as missing so optional params are omitted consistently
- Reject empty pathname variable params with CreateHrefError instead of generating hrefs that cannot match their pattern
- Preserve empty wildcard params, which can still match wildcard patterns, and add regression coverage plus a route-pattern patch note
