### PR TITLE
Preserve Frame markers at clientEntry Fragment boundaries

### DIFF
--- a/packages/ui/.changes/patch.fragment-nested-frame-hydration-marker.md
+++ b/packages/ui/.changes/patch.fragment-nested-frame-hydration-marker.md
@@ -1,0 +1,3 @@
+Adopt a Fragment-nested `<Frame>`'s server-rendered hydration marker at `clientEntry` boundaries
+
+A `<Frame>` that is the first child of a bare Fragment returned by a `clientEntry` now adopts its streamed hydration marker instead of taking the fresh-insert path, which previously re-fetched `src` on the client and duplicated the streamed subtree. A `<Frame>` wrapped in a host element already hydrated cleanly.

--- a/packages/ui/src/runtime/reconcile.ts
+++ b/packages/ui/src/runtime/reconcile.ts
@@ -700,10 +700,12 @@ function insert(
     cursor = null
   }
 
-  cursor =
-    node.type === Frame
-      ? skipCommentsExceptFrameStart(cursor ?? null)
-      : skipComments(cursor ?? null)
+  // Preserve frame-start markers for non-Frame nodes too, so a following <Frame>
+  // (e.g. the first child of a bare Fragment at a clientEntry boundary) can still
+  // claim its rmx:f marker during hydration instead of being re-inserted fresh.
+  // A rmx:f marker always belongs to a <Frame>, so no non-Frame node should
+  // consume one.
+  cursor = skipCommentsExceptFrameStart(cursor ?? null)
 
   // Also check after skipComments in case we skipped past the anchor
   if (cursor && anchor && cursor === anchor) {

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -3092,6 +3092,67 @@ describe('run', () => {
     app.dispose()
   })
 
+  it('adopts a Fragment-nested Frame hydration marker at a clientEntry boundary', async () => {
+    // Regression test for #11501: a <Frame> that is the first child of a bare
+    // Fragment returned by a clientEntry must adopt its server-rendered hydration
+    // marker rather than taking the fresh-insert path (which re-fetches src on the
+    // client and duplicates the streamed subtree). A host-element wrapper already
+    // works (see the test above); this covers the bare-Fragment-first-child case,
+    // where the clientEntry boundary's comment-skip would otherwise swallow the
+    // frame-start marker.
+    let FragmentFrame = clientEntry(
+      '/js/fragment-frame.js#FragmentFrame',
+      function FragmentFrame() {
+        return () => (
+          <>
+            <Frame name="frag" src="/frag" fallback={<p id="frag-fallback">Loading frag…</p>} />
+            <span id="frag-sibling">sibling</span>
+          </>
+        )
+      },
+    )
+
+    // Leave the frame pending on the server so the first chunk carries the frame's
+    // fallback and its rmx:f start/end markers.
+    let [framePromise] = withResolvers<string>()
+    let pageStream = renderToStream(<FragmentFrame />, {
+      resolveFrame(src: string) {
+        if (src === '/frag') return framePromise
+        throw new Error(`Unexpected src during page render: ${src}`)
+      },
+    })
+    let pageChunks = readChunks(pageStream)
+    let first = await pageChunks.next()
+    invariant(!first.done)
+    document.body.innerHTML = first.value
+
+    expect(document.querySelectorAll('#frag-fallback')).toHaveLength(1)
+    expect(document.querySelectorAll('#frag-sibling')).toHaveLength(1)
+
+    let clientResolveFrame = mock.fn(async (src: string) => `<p data-client="${src}">client</p>`)
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (moduleUrl === '/js/fragment-frame.js' && exportName === 'FragmentFrame') {
+          return FragmentFrame
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      resolveFrame: clientResolveFrame,
+    })
+
+    await app.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Marker adopted: no client re-fetch, fallback not duplicated, sibling intact.
+    expect(clientResolveFrame).not.toHaveBeenCalled()
+    expect(document.querySelectorAll('#frag-fallback')).toHaveLength(1)
+    expect(document.querySelectorAll('#frag-sibling')).toHaveLength(1)
+    expect(document.querySelectorAll('[data-client]')).toHaveLength(0)
+
+    app.dispose()
+  })
+
   it('renders Frame semantics from entry children during initial hydration', async () => {
     let Card = clientEntry('/js/card.js#Card', function Card(handle: Handle<{ children?: any }>) {
       return () => <section>{handle.props.children}</section>


### PR DESCRIPTION
A `<Frame>` that is the first child of a bare Fragment returned by a `clientEntry` could miss its server-rendered `rmx:f` marker during initial hydration. The insert path skipped all comments while processing the client entry node, which consumed the frame-start marker before the Frame could adopt it. The Frame then took the fresh-insert path, duplicated the streamed subtree, and called client `resolveFrame`.

This preserves frame-start markers while skipping comments for hydration, so the following Frame can claim its initial marker. Host-wrapped Frames already behaved correctly.

Fixes #11501.

Notes:
- This only affects initial hydration marker adoption. After a `clientEntry` is hydrated, it owns its subtree and future Frame resolutions inside it happen from the client runtime.
- Adds a regression test for a Fragment-returning `clientEntry` whose first child is a Frame.