### PR TITLE
Use relative URLs for source-served script imports

### DIFF
--- a/packages/assets/.changes/patch.relative-script-import-urls.md
+++ b/packages/assets/.changes/patch.relative-script-import-urls.md
@@ -1,0 +1,1 @@
+Reduced source-served browser JavaScript by rewriting script import specifiers and external source map comments to relative served URLs while keeping `getHref()` and `getPreloads()` URLs absolute.

--- a/packages/assets/src/lib/asset-server.test.ts
+++ b/packages/assets/src/lib/asset-server.test.ts
@@ -159,13 +159,25 @@ async function getCompiledCodeAndSourceMap(
   }
 }
 
-async function getAbsoluteImportSpecifiers(source: string): Promise<string[]> {
+async function getImportSpecifiers(source: string): Promise<string[]> {
   await esModuleLexerInit
   let [imports] = esModuleLexer(source)
 
   return imports
     .map((imported) => imported.n)
-    .filter((specifier): specifier is string => specifier?.startsWith('/') === true)
+    .filter((specifier): specifier is string => specifier !== undefined)
+}
+
+async function getServedImportUrls(source: string, basePathname: string): Promise<string[]> {
+  let specifiers = await getImportSpecifiers(source)
+
+  return specifiers
+    .filter((specifier) => isServedImportSpecifier(specifier))
+    .map((specifier) => new URL(specifier, `http://localhost${basePathname}`).pathname)
+}
+
+function isServedImportSpecifier(specifier: string): boolean {
+  return specifier.startsWith('/') || specifier.startsWith('./') || specifier.startsWith('../')
 }
 
 async function assertRecursivelyServedImports(
@@ -185,10 +197,10 @@ async function assertRecursivelyServedImports(
     assert.equal(response.status, 200, `Expected ${url} to be served`)
 
     let body = await response.text()
-    let importSpecifiers = await getAbsoluteImportSpecifiers(body)
-    for (let specifier of importSpecifiers) {
-      if (!seen.has(specifier)) {
-        queue.push(specifier)
+    let importUrls = await getServedImportUrls(body, url)
+    for (let importUrl of importUrls) {
+      if (!seen.has(importUrl)) {
+        queue.push(importUrl)
       }
     }
   }
@@ -212,7 +224,7 @@ async function assertCharacterAccurateImportRewriteSourceMap(
     let { compiledCode, sourceMap } = await getCompiledCodeAndSourceMap(assetServer, 'app/entry.ts')
     let consumer = new SourceMapConsumer(sourceMap)
 
-    let rewrittenImport = getLineAndColumn(compiledCode, '/assets/app/dep.@')
+    let rewrittenImport = getLineAndColumn(compiledCode, 'dep.@')
     let originalImport = consumer.originalPositionFor(rewrittenImport)
     let expectedImport = getLineAndColumn(sourceText, '"./dep.ts"')
     assert.equal(originalImport.line, expectedImport.line)
@@ -360,7 +372,7 @@ describe('asset-server', () => {
 
     let response = await get(assetServer, '/assets/app/entry.ts')
     assert.ok(response)
-    assert.match(await response.text(), /\/assets\/app\/dep\.ts/)
+    assert.match(await response.text(), /\.\/dep\.ts/)
   })
 
   it('resolves explicit .js imports to directory indexes when needed', async () => {
@@ -372,7 +384,7 @@ describe('asset-server', () => {
 
       let response = await get(assetServer, '/assets/app/entry.ts')
       assert.ok(response)
-      assert.match(await response.text(), /\/assets\/app\/dep\.js\/index\.js/)
+      assert.match(await response.text(), /\.\/dep\.js\/index\.js/)
     } finally {
       await fs.rm(caseDir, { recursive: true, force: true })
     }
@@ -385,7 +397,7 @@ describe('asset-server', () => {
 
     let response = await get(assetServer, '/assets/app/entry.tsx')
     assert.ok(response)
-    assert.match(await response.text(), /\/assets\/app\/dep\.tsx/)
+    assert.match(await response.text(), /\.\/dep\.tsx/)
   })
 
   it('resolves explicit .mjs imports to .mts files when needed', async () => {
@@ -395,7 +407,7 @@ describe('asset-server', () => {
 
     let response = await get(assetServer, '/assets/app/entry.mts')
     assert.ok(response)
-    assert.match(await response.text(), /\/assets\/app\/dep\.mts/)
+    assert.match(await response.text(), /\.\/dep\.mts/)
   })
 
   it('serves CSS assets directly and ignores unsupported direct requests for other non-compiled files', async () => {
@@ -2078,7 +2090,7 @@ describe('asset-server', () => {
     let entryResponse = await getByFile(assetServer, 'app/entry.ts')
     assert.ok(entryResponse)
     let entryBody = await entryResponse.text()
-    let depMatch = entryBody.match(/\/assets\/app\/dep\.@([A-Za-z0-9_-]+)\.ts/)
+    let depMatch = entryBody.match(/dep\.@([A-Za-z0-9_-]+)\.ts/)
     assert.ok(depMatch)
 
     let depResponse = await get(assetServer, `/assets/app/dep.@${depMatch[1]}.ts`)
@@ -2096,7 +2108,7 @@ describe('asset-server', () => {
     let entryResponse = await get(assetServer, entryHref)
     assert.ok(entryResponse)
     let body = await entryResponse.text()
-    let match = body.match(/\/assets\/app\/dep\.@([A-Za-z0-9_-]+)\.ts/)
+    let match = body.match(/dep\.@([A-Za-z0-9_-]+)\.ts/)
     assert.ok(match, `expected fingerprinted dep import, got:\n${body}`)
     assert.match(entryHref, /\/assets\/app\/entry\.@[A-Za-z0-9_-]+\.ts/)
 
@@ -2142,8 +2154,8 @@ describe('asset-server', () => {
 
     let bodyA = await (await getByFile(serverA, 'app/entry.ts'))!.text()
     let bodyB = await (await getByFile(serverB, 'app/entry.ts'))!.text()
-    let matchA = bodyA.match(/\/assets\/app\/dep\.@([A-Za-z0-9_-]+)\.ts/)
-    let matchB = bodyB.match(/\/assets\/app\/dep\.@([A-Za-z0-9_-]+)\.ts/)
+    let matchA = bodyA.match(/dep\.@([A-Za-z0-9_-]+)\.ts/)
+    let matchB = bodyB.match(/dep\.@([A-Za-z0-9_-]+)\.ts/)
 
     assert.ok(matchA && matchB)
     assert.notEqual(matchA[1], matchB[1])
@@ -2199,7 +2211,7 @@ describe('asset-server', () => {
     let response = await getByFile(assetServer, 'app/a.ts')
     assert.ok(response)
     let body = await response.text()
-    assert.ok(body.includes('/assets/app/b.@'))
+    assert.ok(body.includes('b.@'))
   })
 
   it('supports external source maps for fingerprinted request URLs', async () => {
@@ -2213,16 +2225,18 @@ describe('asset-server', () => {
     let entryResponse = await getByFile(assetServer, 'app/entry.ts')
     assert.ok(entryResponse)
     let entryBody = await entryResponse.text()
-    let entryMapMatch = entryBody.match(/\/assets\/app\/entry\.@([A-Za-z0-9_-]+)\.ts\.map/)
+    let entryMapMatch = entryBody.match(
+      /sourceMappingURL=\.\/entry\.@([A-Za-z0-9_-]+)\.ts\.map/,
+    )
     assert.ok(entryMapMatch)
 
-    let depMatch = entryBody.match(/\/assets\/app\/dep\.@([A-Za-z0-9_-]+)\.ts/)
+    let depMatch = entryBody.match(/dep\.@([A-Za-z0-9_-]+)\.ts/)
     assert.ok(depMatch)
 
     let depResponse = await get(assetServer, `/assets/app/dep.@${depMatch[1]}.ts`)
     assert.ok(depResponse)
     let depBody = await depResponse.text()
-    assert.ok(depBody.includes(`/assets/app/dep.@${depMatch[1]}.ts.map`))
+    assert.ok(depBody.includes(`sourceMappingURL=./dep.@${depMatch[1]}.ts.map`))
 
     let entryMap = await get(assetServer, `/assets/app/entry.@${entryMapMatch[1]}.ts.map`)
     let depMap = await get(assetServer, `/assets/app/dep.@${depMatch[1]}.ts.map`)
@@ -2325,7 +2339,7 @@ describe('asset-server', () => {
     assert.ok(response)
     let body = await response.text()
 
-    assert.match(body, /import\("\/assets\/app\/dep\.@[A-Za-z0-9_-]+\.ts"\)/)
+    assert.match(body, /import\("\.\/dep\.@[A-Za-z0-9_-]+\.ts"\)/)
   })
 
   it('rewrites static template-literal dynamic imports', async () => {
@@ -2341,7 +2355,7 @@ describe('asset-server', () => {
     assert.ok(response)
     let body = await response.text()
 
-    assert.match(body, /import\((["`])\/assets\/app\/dep\.@[A-Za-z0-9_-]+\.ts\1\)/)
+    assert.match(body, /import\((["`])\.\/dep\.@[A-Za-z0-9_-]+\.ts\1\)/)
   })
 
   it('rewrites re-exported package specifiers', async () => {
@@ -2358,7 +2372,7 @@ describe('asset-server', () => {
     assert.ok(response)
     let body = await response.text()
 
-    assert.match(body, /export \* from "\/assets\/app\/node_modules\/example\/index\.ts"/)
+    assert.match(body, /export \* from "\.\/node_modules\/example\/index\.ts"/)
   })
 
   it('leaves variable dynamic imports unchanged', async () => {
@@ -2426,7 +2440,7 @@ describe('asset-server', () => {
     let sourceMap = JSON.parse(await sourceMapResponse.text()) as RawSourceMap
     let consumer = new SourceMapConsumer(sourceMap)
 
-    let rewrittenImport = getLineAndColumn(compiledCode, '/assets/app/dep.@')
+    let rewrittenImport = getLineAndColumn(compiledCode, 'dep.@')
     let originalImport = consumer.originalPositionFor(rewrittenImport)
     assert.equal(originalImport.line, 1)
     assert.equal(originalImport.column, 31)
@@ -2506,8 +2520,8 @@ describe('asset-server', () => {
     let response = await getByFile(assetServer, 'app/entry.ts')
     assert.ok(response)
     let body = await response.text()
-    assert.ok(body.includes('/assets/app/shared/value.@'))
-    assert.ok(!body.includes('/assets/app/alias/value.@'))
+    assert.ok(body.includes('./shared/value.@'))
+    assert.ok(!body.includes('./alias/value.@'))
   })
 
   it('uses one canonical URL when app and package imports resolve to the same pnpm package', async () => {
@@ -2938,7 +2952,7 @@ describe('asset-server', () => {
 
       let before = await get(firstServer, '/assets/app/entry.ts')
       assert.ok(before)
-      assert.match(await before.text(), /\/assets\/app\/dep\/index\.js/)
+      assert.match(await before.text(), /\.\/dep\/index\.js/)
 
       await fs.rm(path.join(caseDir, 'app/dep/index.js'))
       await write(caseDir, 'app/dep/index.ts', 'export const dep = "ts"')
@@ -2947,8 +2961,8 @@ describe('asset-server', () => {
       let afterRestart = await get(secondServer, '/assets/app/entry.ts')
       assert.ok(afterRestart)
       let afterRestartBody = await afterRestart.text()
-      assert.doesNotMatch(afterRestartBody, /\/assets\/app\/dep\/index\.js/)
-      assert.match(afterRestartBody, /\/assets\/app\/dep\/index\.ts/)
+      assert.doesNotMatch(afterRestartBody, /\.\/dep\/index\.js/)
+      assert.match(afterRestartBody, /\.\/dep\/index\.ts/)
     } finally {
       await fs.rm(caseDir, { recursive: true, force: true })
     }
@@ -2965,15 +2979,15 @@ describe('asset-server', () => {
 
       let before = await get(assetServer, '/assets/app/entry.ts')
       assert.ok(before)
-      assert.match(await before.text(), /\/assets\/app\/dep\/index\.js/)
+      assert.match(await before.text(), /\.\/dep\/index\.js/)
 
       await fs.rm(path.join(caseDir, 'app/dep/index.js'))
       await write(caseDir, 'app/dep/index.ts', 'export const dep = "ts"')
       let after = await get(assetServer, '/assets/app/entry.ts')
       assert.ok(after)
       let afterBody = await after.text()
-      assert.match(afterBody, /\/assets\/app\/dep\/index\.js/)
-      assert.doesNotMatch(afterBody, /\/assets\/app\/dep\/index\.ts/)
+      assert.match(afterBody, /\.\/dep\/index\.js/)
+      assert.doesNotMatch(afterBody, /\.\/dep\/index\.ts/)
     } finally {
       await fs.rm(caseDir, { recursive: true, force: true })
     }
@@ -3132,7 +3146,7 @@ describe('asset-server', () => {
         assert.equal(after.status, 200)
         let afterBody = await after.text()
 
-        assert.match(afterBody, /\/assets\/app\/missing\.ts/)
+        assert.match(afterBody, /\.\/missing\.ts/)
       } finally {
         await assetServer.close()
       }
@@ -3470,7 +3484,7 @@ describe('asset-server', () => {
       try {
         let firstResponse = await get(assetServer, '/assets/app/entry.ts')
         assert.ok(firstResponse)
-        assert.match(await firstResponse.text(), /\/assets\/app\/dep-a\.ts/)
+        assert.match(await firstResponse.text(), /\.\/dep-a\.ts/)
 
         let packageJsonPath = await writeJson(caseDir, 'package.json', {
           imports: {
@@ -3485,8 +3499,8 @@ describe('asset-server', () => {
         assert.ok(secondResponse)
         let secondBody = await secondResponse.text()
 
-        assert.match(secondBody, /\/assets\/app\/dep-b\.ts/)
-        assert.doesNotMatch(secondBody, /\/assets\/app\/dep-a\.ts/)
+        assert.match(secondBody, /\.\/dep-b\.ts/)
+        assert.doesNotMatch(secondBody, /\.\/dep-a\.ts/)
       } finally {
         await assetServer.close()
       }
@@ -3517,7 +3531,7 @@ describe('asset-server', () => {
       try {
         let before = await get(assetServer, '/assets/app/entry.ts')
         assert.ok(before)
-        assert.match(await before.text(), /\/assets\/app\/dep-a\.ts/)
+        assert.match(await before.text(), /\.\/dep-a\.ts/)
 
         let packageJsonPath = await writeJson(caseDir, 'package.json', {
           imports: {
@@ -3531,8 +3545,8 @@ describe('asset-server', () => {
         let after = await get(assetServer, '/assets/app/entry.ts')
         assert.ok(after)
         let afterBody = await after.text()
-        assert.match(afterBody, /\/assets\/app\/dep-a\.ts/)
-        assert.doesNotMatch(afterBody, /\/assets\/app\/dep-b\.ts/)
+        assert.match(afterBody, /\.\/dep-a\.ts/)
+        assert.doesNotMatch(afterBody, /\.\/dep-b\.ts/)
       } finally {
         await assetServer.close()
       }
@@ -3570,7 +3584,7 @@ describe('asset-server', () => {
         assert.ok(response)
         let body = await response.text()
 
-        assert.match(body, /\/assets\/app\/dep\.ts/)
+        assert.match(body, /\.\/dep\.ts/)
       } finally {
         await assetServer.close()
       }
@@ -3603,7 +3617,7 @@ describe('asset-server', () => {
       try {
         let before = await get(assetServer, '/assets/app/entry.ts')
         assert.ok(before)
-        assert.match(await before.text(), /\/assets\/app\/dep\.ts/)
+        assert.match(await before.text(), /\.\/dep\.ts/)
 
         let packageJsonPath = path.join(caseDir, 'package.json')
         await fs.rm(packageJsonPath)
@@ -3732,7 +3746,7 @@ describe('asset-server', () => {
       try {
         for (let index = 0; index < 8; index++) {
           let useA = index % 2 === 0
-          let expected = useA ? /\/assets\/app\/dep-a\.ts/ : /\/assets\/app\/dep-b\.ts/
+          let expected = useA ? /\.\/dep-a\.ts/ : /\.\/dep-b\.ts/
           let packageJsonPath = await writeJson(caseDir, 'package.json', {
             imports: {
               '#dep': useA ? './app/dep-a.ts' : './app/dep-b.ts',
@@ -3783,7 +3797,7 @@ describe('asset-server', () => {
         assert.ok(after)
         let afterBody = await after.text()
 
-        assert.match(afterBody, /\/assets\/app\/broken\.ts/)
+        assert.match(afterBody, /\.\/broken\.ts/)
       } finally {
         await assetServer.close()
       }
@@ -3842,7 +3856,7 @@ describe('asset-server', () => {
         assert.ok(recovered)
         let recoveredBody = await recovered.text()
 
-        assert.match(recoveredBody, /\/assets\/app\/broken\.ts/)
+        assert.match(recoveredBody, /\.\/broken\.ts/)
         assert.match(recoveredBody, /entry = true/)
         assert.ok(errorCodes.includes('TRANSFORM_FAILED'))
         assert.ok(errorCodes.includes('IMPORT_RESOLUTION_FAILED'))
@@ -3976,7 +3990,7 @@ describe('asset-server', () => {
       try {
         let before = await get(assetServer, '/assets/app/entry.ts')
         assert.ok(before)
-        assert.match(await before.text(), /\/assets\/app\/dep-a\.ts/)
+        assert.match(await before.text(), /\.\/dep-a\.ts/)
 
         let tsconfigPath = await writeJson(caseDir, 'tsconfig.json', {
           compilerOptions: {
@@ -3992,8 +4006,8 @@ describe('asset-server', () => {
         assert.ok(after)
         let afterBody = await after.text()
 
-        assert.match(afterBody, /\/assets\/app\/dep-b\.ts/)
-        assert.doesNotMatch(afterBody, /\/assets\/app\/dep-a\.ts/)
+        assert.match(afterBody, /\.\/dep-b\.ts/)
+        assert.doesNotMatch(afterBody, /\.\/dep-a\.ts/)
       } finally {
         await assetServer.close()
       }
@@ -4032,7 +4046,7 @@ describe('asset-server', () => {
         assert.ok(response)
         let body = await response.text()
 
-        assert.match(body, /\/assets\/app\/dep\.ts/)
+        assert.match(body, /\.\/dep\.ts/)
       } finally {
         await assetServer.close()
       }
@@ -4066,7 +4080,7 @@ describe('asset-server', () => {
       try {
         let before = await get(assetServer, '/assets/app/entry.ts')
         assert.ok(before)
-        assert.match(await before.text(), /\/assets\/app\/dep\.ts/)
+        assert.match(await before.text(), /\.\/dep\.ts/)
 
         let tsconfigPath = path.join(caseDir, 'tsconfig.json')
         await fs.rm(tsconfigPath)
@@ -4108,7 +4122,7 @@ describe('asset-server', () => {
       try {
         for (let index = 0; index < 8; index++) {
           let useA = index % 2 === 0
-          let expected = useA ? /\/assets\/app\/dep-a\.ts/ : /\/assets\/app\/dep-b\.ts/
+          let expected = useA ? /\.\/dep-a\.ts/ : /\.\/dep-b\.ts/
           let tsconfigPath = await writeJson(caseDir, 'tsconfig.json', {
             compilerOptions: {
               baseUrl: '.',
@@ -4228,7 +4242,7 @@ describe('asset-server', () => {
       try {
         let before = await get(assetServer, '/assets/app/entry.ts')
         assert.ok(before)
-        assert.match(await before.text(), /\/assets\/app\/dep\.js/)
+        assert.match(await before.text(), /\.\/dep\.js/)
 
         let depPath = await write(caseDir, 'app/dep.ts', 'export const dep = "ts"')
         await emitWatchEvent(assetServer, depPath, 'add')
@@ -4237,7 +4251,7 @@ describe('asset-server', () => {
         assert.ok(after)
         let afterBody = await after.text()
 
-        assert.match(afterBody, /\/assets\/app\/dep\.ts/)
+        assert.match(afterBody, /\.\/dep\.ts/)
       } finally {
         await assetServer.close()
       }
@@ -4258,7 +4272,7 @@ describe('asset-server', () => {
       try {
         let before = await get(assetServer, '/assets/app/entry.ts')
         assert.ok(before)
-        assert.match(await before.text(), /\/assets\/app\/dep\.ts/)
+        assert.match(await before.text(), /\.\/dep\.ts/)
 
         let depPath = path.join(caseDir, 'app/dep.ts')
         await fs.rm(depPath)
@@ -4268,7 +4282,7 @@ describe('asset-server', () => {
         assert.ok(after)
         let afterBody = await after.text()
 
-        assert.match(afterBody, /\/assets\/app\/dep\.js/)
+        assert.match(afterBody, /\.\/dep\.js/)
       } finally {
         await assetServer.close()
       }
@@ -4352,7 +4366,7 @@ describe('asset-server', () => {
 
       let before = await getByFile(assetServer, 'app/entry.ts')
       assert.ok(before)
-      assert.match(await before.text(), /\/assets\/app\/dep\/index\.@[A-Za-z0-9_-]+\.js/)
+      assert.match(await before.text(), /\.\/dep\/index\.@[A-Za-z0-9_-]+\.js/)
 
       await fs.rm(path.join(caseDir, 'app/dep/index.js'))
       await write(caseDir, 'app/dep/index.ts', 'export const dep = "ts"')
@@ -4360,8 +4374,8 @@ describe('asset-server', () => {
       let after = await getByFile(assetServer, 'app/entry.ts')
       assert.ok(after)
       let afterBody = await after.text()
-      assert.match(afterBody, /\/assets\/app\/dep\/index\.@[A-Za-z0-9_-]+\.js/)
-      assert.doesNotMatch(afterBody, /\/assets\/app\/dep\/index\.@[A-Za-z0-9_-]+\.ts/)
+      assert.match(afterBody, /\.\/dep\/index\.@[A-Za-z0-9_-]+\.js/)
+      assert.doesNotMatch(afterBody, /\.\/dep\/index\.@[A-Za-z0-9_-]+\.ts/)
     } finally {
       await fs.rm(caseDir, { recursive: true, force: true })
     }
@@ -4377,7 +4391,7 @@ describe('asset-server', () => {
 
       let before = await get(firstServer, '/assets/app/entry.ts')
       assert.ok(before)
-      assert.match(await before.text(), /\/assets\/app\/styles\.css\.js/)
+      assert.match(await before.text(), /\.\/styles\.css\.js/)
 
       await fs.rm(path.join(caseDir, 'app/styles.css.js'))
       await write(caseDir, 'app/styles.css.ts', 'export const styles = "ts"')
@@ -4386,8 +4400,8 @@ describe('asset-server', () => {
       let afterRestart = await get(secondServer, '/assets/app/entry.ts')
       assert.ok(afterRestart)
       let afterRestartBody = await afterRestart.text()
-      assert.doesNotMatch(afterRestartBody, /\/assets\/app\/styles\.css\.js/)
-      assert.match(afterRestartBody, /\/assets\/app\/styles\.css\.ts/)
+      assert.doesNotMatch(afterRestartBody, /\.\/styles\.css\.js/)
+      assert.match(afterRestartBody, /\.\/styles\.css\.ts/)
     } finally {
       await fs.rm(caseDir, { recursive: true, force: true })
     }
@@ -4403,7 +4417,7 @@ describe('asset-server', () => {
 
       let before = await get(assetServer, '/assets/app/entry.ts')
       assert.ok(before)
-      assert.match(await before.text(), /\/assets\/app\/styles\.css\.js/)
+      assert.match(await before.text(), /\.\/styles\.css\.js/)
 
       await fs.rm(path.join(caseDir, 'app/styles.css.js'))
       await write(caseDir, 'app/styles.css.ts', 'export const styles = "ts"')
@@ -4411,8 +4425,8 @@ describe('asset-server', () => {
       let after = await get(assetServer, '/assets/app/entry.ts')
       assert.ok(after)
       let afterBody = await after.text()
-      assert.match(afterBody, /\/assets\/app\/styles\.css\.js/)
-      assert.doesNotMatch(afterBody, /\/assets\/app\/styles\.css\.ts/)
+      assert.match(afterBody, /\.\/styles\.css\.js/)
+      assert.doesNotMatch(afterBody, /\.\/styles\.css\.ts/)
     } finally {
       await fs.rm(caseDir, { recursive: true, force: true })
     }
@@ -4429,7 +4443,7 @@ describe('asset-server', () => {
       try {
         let before = await get(assetServer, '/assets/app/entry.ts')
         assert.ok(before)
-        assert.match(await before.text(), /\/assets\/app\/styles\.css\.js/)
+        assert.match(await before.text(), /\.\/styles\.css\.js/)
 
         let stylesPath = await write(caseDir, 'app/styles.css.ts', 'export const styles = "ts"')
         await emitWatchEvent(assetServer, stylesPath, 'add')
@@ -4438,8 +4452,8 @@ describe('asset-server', () => {
         assert.ok(after)
         let afterBody = await after.text()
 
-        assert.match(afterBody, /\/assets\/app\/styles\.css\.ts/)
-        assert.doesNotMatch(afterBody, /\/assets\/app\/styles\.css\.js/)
+        assert.match(afterBody, /\.\/styles\.css\.ts/)
+        assert.doesNotMatch(afterBody, /\.\/styles\.css\.js/)
       } finally {
         await assetServer.close()
       }
@@ -4460,7 +4474,7 @@ describe('asset-server', () => {
       try {
         let before = await get(assetServer, '/assets/app/entry.ts')
         assert.ok(before)
-        assert.match(await before.text(), /\/assets\/app\/styles\.css\.ts/)
+        assert.match(await before.text(), /\.\/styles\.css\.ts/)
 
         let stylesPath = path.join(caseDir, 'app/styles.css.ts')
         await fs.rm(stylesPath)
@@ -4470,8 +4484,8 @@ describe('asset-server', () => {
         assert.ok(after)
         let afterBody = await after.text()
 
-        assert.match(afterBody, /\/assets\/app\/styles\.css\.js/)
-        assert.doesNotMatch(afterBody, /\/assets\/app\/styles\.css\.ts/)
+        assert.match(afterBody, /\.\/styles\.css\.js/)
+        assert.doesNotMatch(afterBody, /\.\/styles\.css\.ts/)
       } finally {
         await assetServer.close()
       }
@@ -4492,7 +4506,7 @@ describe('asset-server', () => {
 
       let before = await getByFile(assetServer, 'app/entry.ts')
       assert.ok(before)
-      assert.match(await before.text(), /\/assets\/app\/styles\.css\.@[A-Za-z0-9_-]+\.js/)
+      assert.match(await before.text(), /\.\/styles\.css\.@[A-Za-z0-9_-]+\.js/)
 
       await fs.rm(path.join(caseDir, 'app/styles.css.js'))
       await write(caseDir, 'app/styles.css.ts', 'export const styles = "ts"')
@@ -4500,8 +4514,8 @@ describe('asset-server', () => {
       let after = await getByFile(assetServer, 'app/entry.ts')
       assert.ok(after)
       let afterBody = await after.text()
-      assert.match(afterBody, /\/assets\/app\/styles\.css\.@[A-Za-z0-9_-]+\.js/)
-      assert.doesNotMatch(afterBody, /\/assets\/app\/styles\.css\.@[A-Za-z0-9_-]+\.ts/)
+      assert.match(afterBody, /\.\/styles\.css\.@[A-Za-z0-9_-]+\.js/)
+      assert.doesNotMatch(afterBody, /\.\/styles\.css\.@[A-Za-z0-9_-]+\.ts/)
     } finally {
       await fs.rm(caseDir, { recursive: true, force: true })
     }
@@ -4517,7 +4531,7 @@ describe('asset-server', () => {
 
       let before = await get(firstServer, '/assets/app/entry.ts')
       assert.ok(before)
-      assert.match(await before.text(), /\/assets\/app\/dep\.ts/)
+      assert.match(await before.text(), /\.\/dep\.ts/)
 
       await write(caseDir, 'app/dep.js', 'export const dep = "js"')
 
@@ -4525,8 +4539,8 @@ describe('asset-server', () => {
       let afterRestart = await get(secondServer, '/assets/app/entry.ts')
       assert.ok(afterRestart)
       let afterRestartBody = await afterRestart.text()
-      assert.doesNotMatch(afterRestartBody, /\/assets\/app\/dep\.ts/)
-      assert.match(afterRestartBody, /\/assets\/app\/dep\.js/)
+      assert.doesNotMatch(afterRestartBody, /\.\/dep\.ts/)
+      assert.match(afterRestartBody, /\.\/dep\.js/)
     } finally {
       await fs.rm(caseDir, { recursive: true, force: true })
     }
@@ -4542,7 +4556,7 @@ describe('asset-server', () => {
 
       let before = await get(firstServer, '/assets/app/entry.ts')
       assert.ok(before)
-      assert.match(await before.text(), /\/assets\/app\/dep\.ts/)
+      assert.match(await before.text(), /\.\/dep\.ts/)
 
       await fs.rm(path.join(caseDir, 'app/dep.ts'))
       await write(caseDir, 'app/dep.js/index.js', 'export const dep = "dir"')
@@ -4551,8 +4565,8 @@ describe('asset-server', () => {
       let afterRestart = await get(secondServer, '/assets/app/entry.ts')
       assert.ok(afterRestart)
       let afterRestartBody = await afterRestart.text()
-      assert.doesNotMatch(afterRestartBody, /\/assets\/app\/dep\.ts/)
-      assert.match(afterRestartBody, /\/assets\/app\/dep\.js\/index\.js/)
+      assert.doesNotMatch(afterRestartBody, /\.\/dep\.ts/)
+      assert.match(afterRestartBody, /\.\/dep\.js\/index\.js/)
     } finally {
       await fs.rm(caseDir, { recursive: true, force: true })
     }
@@ -4568,15 +4582,15 @@ describe('asset-server', () => {
 
       let before = await get(assetServer, '/assets/app/entry.ts')
       assert.ok(before)
-      assert.match(await before.text(), /\/assets\/app\/dep\.ts/)
+      assert.match(await before.text(), /\.\/dep\.ts/)
 
       await write(caseDir, 'app/dep.js', 'export const dep = "js"')
 
       let after = await get(assetServer, '/assets/app/entry.ts')
       assert.ok(after)
       let afterBody = await after.text()
-      assert.match(afterBody, /\/assets\/app\/dep\.ts/)
-      assert.doesNotMatch(afterBody, /\/assets\/app\/dep\.js/)
+      assert.match(afterBody, /\.\/dep\.ts/)
+      assert.doesNotMatch(afterBody, /\.\/dep\.js/)
     } finally {
       await fs.rm(caseDir, { recursive: true, force: true })
     }
@@ -4593,7 +4607,7 @@ describe('asset-server', () => {
       try {
         let before = await get(assetServer, '/assets/app/entry.ts')
         assert.ok(before)
-        assert.match(await before.text(), /\/assets\/app\/dep\.ts/)
+        assert.match(await before.text(), /\.\/dep\.ts/)
 
         let depPath = await write(caseDir, 'app/dep.js', 'export const dep = "js"')
         await emitWatchEvent(assetServer, depPath, 'add')
@@ -4602,8 +4616,8 @@ describe('asset-server', () => {
         assert.ok(after)
         let afterBody = await after.text()
 
-        assert.match(afterBody, /\/assets\/app\/dep\.js/)
-        assert.doesNotMatch(afterBody, /\/assets\/app\/dep\.ts/)
+        assert.match(afterBody, /\.\/dep\.js/)
+        assert.doesNotMatch(afterBody, /\.\/dep\.ts/)
       } finally {
         await assetServer.close()
       }
@@ -4624,7 +4638,7 @@ describe('asset-server', () => {
       try {
         let before = await get(assetServer, '/assets/app/entry.ts')
         assert.ok(before)
-        assert.match(await before.text(), /\/assets\/app\/dep\.js/)
+        assert.match(await before.text(), /\.\/dep\.js/)
 
         let depPath = path.join(caseDir, 'app/dep.js')
         await fs.rm(depPath)
@@ -4634,8 +4648,8 @@ describe('asset-server', () => {
         assert.ok(after)
         let afterBody = await after.text()
 
-        assert.match(afterBody, /\/assets\/app\/dep\.ts/)
-        assert.doesNotMatch(afterBody, /\/assets\/app\/dep\.js/)
+        assert.match(afterBody, /\.\/dep\.ts/)
+        assert.doesNotMatch(afterBody, /\.\/dep\.js/)
       } finally {
         await assetServer.close()
       }
@@ -4655,7 +4669,7 @@ describe('asset-server', () => {
       try {
         let before = await get(assetServer, '/assets/app/entry.ts')
         assert.ok(before)
-        assert.match(await before.text(), /\/assets\/app\/dep\.ts/)
+        assert.match(await before.text(), /\.\/dep\.ts/)
 
         let depPath = path.join(caseDir, 'app/dep.ts')
         await fs.rm(depPath)
@@ -4667,8 +4681,8 @@ describe('asset-server', () => {
         assert.ok(after)
         let afterBody = await after.text()
 
-        assert.match(afterBody, /\/assets\/app\/dep\.js\/index\.js/)
-        assert.doesNotMatch(afterBody, /\/assets\/app\/dep\.ts/)
+        assert.match(afterBody, /\.\/dep\.js\/index\.js/)
+        assert.doesNotMatch(afterBody, /\.\/dep\.ts/)
       } finally {
         await assetServer.close()
       }
@@ -4689,15 +4703,15 @@ describe('asset-server', () => {
 
       let before = await getByFile(assetServer, 'app/entry.ts')
       assert.ok(before)
-      assert.match(await before.text(), /\/assets\/app\/dep\.@[A-Za-z0-9_-]+\.ts/)
+      assert.match(await before.text(), /\.\/dep\.@[A-Za-z0-9_-]+\.ts/)
 
       await write(caseDir, 'app/dep.js', 'export const dep = "js"')
 
       let after = await getByFile(assetServer, 'app/entry.ts')
       assert.ok(after)
       let afterBody = await after.text()
-      assert.match(afterBody, /\/assets\/app\/dep\.@[A-Za-z0-9_-]+\.ts/)
-      assert.doesNotMatch(afterBody, /\/assets\/app\/dep\.@[A-Za-z0-9_-]+\.js/)
+      assert.match(afterBody, /\.\/dep\.@[A-Za-z0-9_-]+\.ts/)
+      assert.doesNotMatch(afterBody, /\.\/dep\.@[A-Za-z0-9_-]+\.js/)
     } finally {
       await fs.rm(caseDir, { recursive: true, force: true })
     }
@@ -4950,14 +4964,14 @@ describe('asset-server', () => {
     assert.equal(response.status, 200)
 
     let body = await response.text()
-    let entryImportSpecifiers = await getAbsoluteImportSpecifiers(body)
-    let helperPaths = entryImportSpecifiers.filter((specifier) =>
+    let entryImportUrls = await getServedImportUrls(body, '/assets/app/entry.ts')
+    let helperPaths = entryImportUrls.filter((specifier) =>
       specifier.startsWith('/assets/__@remix/injected/@oxc-project/runtime/'),
     )
 
     assert.doesNotMatch(body, /from ["']@oxc-project\/runtime/)
     assert.ok(
-      entryImportSpecifiers.includes(
+      entryImportUrls.includes(
         '/assets/npm/@oxc-project/runtime/src/helpers/esm/classPrivateMethodInitSpec.js',
       ),
     )

--- a/packages/assets/src/lib/scripts/emit.ts
+++ b/packages/assets/src/lib/scripts/emit.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path'
 import MagicString from 'magic-string'
 
 import {
@@ -39,10 +40,21 @@ export async function emitResolvedModule(
   },
 ): Promise<EmitResult> {
   try {
-    let importUrls = await Promise.all(
-      resolvedModule.deps.map((depPath) => options.getServedUrl(depPath)),
+    let servedUrl = await options.getServedUrl(resolvedModule.identityPath)
+    let importUrlEntries = await Promise.all(
+      resolvedModule.deps.map(
+        async (depPath): Promise<[string, string]> => [
+          depPath,
+          await options.getServedUrl(depPath),
+        ],
+      ),
     )
-    let rewriteResult = await rewriteImports(resolvedModule, options)
+    let importUrlByDepPath = new Map(importUrlEntries)
+    let importUrls = importUrlEntries.map(([, url]) => url)
+    let rewriteResult = await rewriteImports(resolvedModule, {
+      importUrlByDepPath,
+      servedUrl,
+    })
     let finalCode = rewriteResult.code
 
     if (rewriteResult.sourceMap) {
@@ -50,7 +62,7 @@ export async function emitResolvedModule(
         let encoded = Buffer.from(rewriteResult.sourceMap).toString('base64')
         finalCode += `\n//# sourceMappingURL=data:application/json;base64,${encoded}`
       } else if (options.sourceMaps === 'external') {
-        finalCode += `\n//# sourceMappingURL=${await options.getServedUrl(resolvedModule.identityPath)}.map`
+        finalCode += `\n//# sourceMappingURL=${toRelativeServedUrl(servedUrl, `${servedUrl}.map`)}`
       }
     }
 
@@ -76,13 +88,18 @@ export async function emitResolvedModule(
 async function rewriteImports(
   resolvedModule: ResolvedModule,
   options: {
-    getServedUrl(identityPath: string): Promise<string>
+    importUrlByDepPath: Map<string, string>
+    servedUrl: string
   },
 ): Promise<{ code: string; sourceMap: string | null }> {
   let rewrittenSource = new MagicString(resolvedModule.rawCode)
 
   for (let imported of resolvedModule.imports) {
-    let url = await options.getServedUrl(imported.depPath)
+    let depUrl = options.importUrlByDepPath.get(imported.depPath)
+    if (depUrl === undefined) {
+      throw new Error(`Missing served URL for resolved import ${imported.depPath}`)
+    }
+    let url = toRelativeServedUrl(options.servedUrl, depUrl)
     rewrittenSource.overwrite(
       imported.start,
       imported.end,
@@ -100,6 +117,21 @@ async function rewriteImports(
       : resolvedModule.sourceMap
 
   return { code, sourceMap }
+}
+
+function toRelativeServedUrl(fromUrl: string, toUrl: string): string {
+  let from = new URL(fromUrl, 'http://remix.local')
+  let to = new URL(toUrl, from)
+
+  if (from.origin !== to.origin) {
+    return toUrl
+  }
+
+  let relative = path.posix.relative(path.posix.dirname(from.pathname), to.pathname)
+  if (relative === '' || (!relative.startsWith('.') && !relative.startsWith('/'))) {
+    relative = `./${relative}`
+  }
+  return `${relative}${to.search}${to.hash}`
 }
 
 async function createEmittedAsset(content: string): Promise<EmittedAsset> {


### PR DESCRIPTION
This splits the asset-server URL shortening piece out of #11507. Source-served script modules currently repeat absolute `/assets/...` prefixes in every rewritten browser import; this keeps the public URLs absolute while shortening same-origin specifiers inside the emitted JavaScript.

- Rewrites served script imports, re-exports, and static dynamic imports to relative served URLs such as `./dep.@abc123.ts`
- Rewrites external script source map comments to relative `.map` URLs
- Keeps `assetServer.getHref()` and `assetServer.getPreloads()` returning absolute URLs for callers and preload tags
- Leaves data, HTTP(S), and configured external imports unchanged

Measured against the Remix UI browser asset graph from #11507 by comparing relative output with equivalent absolute-import output:

| Asset set | Modules | Raw | Gzip | Brotli |
| --- | ---: | ---: | ---: | ---: |
| Absolute import URLs | 60 | 95,449 | 39,840 | 35,175 |
| Relative import URLs | 60 | 92,830 | 38,987 | 34,516 |
| Savings | — | 2,619 | 853 | 659 |

The tradeoff is that relative imports assume served modules are fetched from their canonical asset-server URL layout. Public entry/preload URLs remain absolute, so normal asset-server usage is unchanged; custom proxies that rewrite individual module paths should preserve the path layout so relative dependency resolution still targets the same files.

## Impact on Bookstore Demo

Running `pnpm --filter bookstore-demo run start` and going to the login page (left is `main`, right is this PR):

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/b7a0a7fc-7ec5-4e9b-b0c5-58702f5388ea" />

