### PR TITLE
Reduce Remix UI style browser graph

### DIFF
--- a/packages/ui/.changes/patch.style-ssr-client-boundary-cleanup.md
+++ b/packages/ui/.changes/patch.style-ssr-client-boundary-cleanup.md
@@ -1,0 +1,1 @@
+Reduced browser JavaScript for Remix UI style and prop patching by sharing CSS property helpers across already-downloaded modules and keeping SSR-only prop/tag tables in the server renderer.

--- a/packages/ui/src/runtime/core/attributes.ts
+++ b/packages/ui/src/runtime/core/attributes.ts
@@ -1,4 +1,4 @@
-import { normalizeCssValue } from '../../style/style.ts'
+import { normalizeCssValue, toCssPropertyName } from '../../style/properties.ts'
 import { normalizeSvgAttribute } from '../svg-attributes.ts'
 import type { ElementProps } from '../jsx.ts'
 
@@ -26,29 +26,6 @@ const BOOLEANISH_STRING_ATTRIBUTES = new Set([
   'preserveAlpha',
   'spellcheck',
 ])
-
-export const FRAMEWORK_PROPS = new Set(['children', 'mix', 'key', 'animate', 'innerHTML', 'on'])
-
-export const SELF_CLOSING_TAGS = new Set([
-  'area',
-  'base',
-  'br',
-  'col',
-  'embed',
-  'hr',
-  'img',
-  'input',
-  'link',
-  'meta',
-  'param',
-  'source',
-  'track',
-  'wbr',
-])
-
-export function isChildlessElement(name: string): boolean {
-  return SELF_CLOSING_TAGS.has(name)
-}
 
 export function canUseProperty(
   element: Element,
@@ -85,20 +62,14 @@ export function isBooleanishStringAttribute(name: string): boolean {
   return BOOLEANISH_STRING_ATTRIBUTES.has(name)
 }
 
-export function shouldStringifyBooleanAttribute(name: string): boolean {
-  return isBooleanishStringAttribute(name) || name === 'value'
-}
-
 export function serializeStyleObject(style: Record<string, unknown>): string {
   let parts: string[] = []
 
   for (let [key, value] of Object.entries(style)) {
-    if (value == null) continue
-    if (typeof value === 'boolean') continue
-    if (typeof value === 'number' && !Number.isFinite(value)) continue
+    let cssValue = styleValueToCss(key, value)
+    if (cssValue === undefined) continue
 
-    let cssKey = toKebabCase(key)
-    let cssValue = Array.isArray(value) ? value.join(', ') : normalizeCssValue(key, value)
+    let cssKey = toCssPropertyName(key)
 
     parts.push(`${cssKey}: ${cssValue};`)
   }
@@ -106,13 +77,21 @@ export function serializeStyleObject(style: Record<string, unknown>): string {
   return parts.join(' ')
 }
 
+export function styleValueToCss(name: string, value: unknown): string | undefined {
+  if (value == null) return undefined
+  if (typeof value === 'boolean') return undefined
+  if (typeof value === 'number' && !Number.isFinite(value)) return undefined
+
+  if (Array.isArray(value)) {
+    return value.join(', ')
+  }
+
+  return normalizeCssValue(name, value)
+}
+
 export function getMergedClassName(props: ElementProps): string | undefined {
   let classAttr = typeof props.class === 'string' ? props.class : ''
   let className = typeof props.className === 'string' ? props.className : ''
   let merged = classAttr && className ? `${classAttr} ${className}` : classAttr || className
   return merged || undefined
-}
-
-export function toKebabCase(value: string): string {
-  return value.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`)
 }

--- a/packages/ui/src/runtime/core/props.ts
+++ b/packages/ui/src/runtime/core/props.ts
@@ -5,20 +5,22 @@ import {
   isBooleanishStringAttribute,
   normalizeAttributeName,
   serializeStyleObject,
-  toKebabCase,
+  styleValueToCss,
 } from './attributes.ts'
-import { normalizeCssValue } from '../../style/style.ts'
+import { toCssPropertyName } from '../../style/properties.ts'
 
 const SVG_NS = 'http://www.w3.org/2000/svg'
 
-function isFrameworkProp(name: string): boolean {
+function isIgnoredProp(name: string): boolean {
   return (
     name === 'children' ||
     name === 'mix' ||
     name === 'key' ||
     name === 'animate' ||
     name === 'innerHTML' ||
-    name === 'on'
+    name === 'on' ||
+    name === 'class' ||
+    name === 'className'
   )
 }
 
@@ -65,8 +67,7 @@ export function patchHostProps(curr: ElementProps, next: ElementProps, dom: Elem
   }
 
   for (let name in curr) {
-    if (isFrameworkProp(name)) continue
-    if (name === 'class' || name === 'className') continue
+    if (isIgnoredProp(name)) continue
     if (name in next && next[name] != null) continue
 
     let { ns, attr } = normalizeAttributeName(name, isSvg)
@@ -79,8 +80,7 @@ export function patchHostProps(curr: ElementProps, next: ElementProps, dom: Elem
   }
 
   for (let name in next) {
-    if (isFrameworkProp(name)) continue
-    if (name === 'class' || name === 'className') continue
+    if (isIgnoredProp(name)) continue
 
     let nextValue = next[name]
     if (nextValue == null) continue
@@ -159,7 +159,7 @@ function patchStyleObject(
       let prevCssValue = styleValueToCss(name, curr[name])
       if (prevCssValue === undefined) continue
 
-      style.removeProperty(toKebabCase(name))
+      style.removeProperty(toCssPropertyName(name))
     }
   }
 
@@ -170,18 +170,6 @@ function patchStyleObject(
     let prevCssValue = curr ? styleValueToCss(name, curr[name]) : undefined
     if (prevCssValue === nextCssValue) continue
 
-    style.setProperty(toKebabCase(name), nextCssValue)
+    style.setProperty(toCssPropertyName(name), nextCssValue)
   }
-}
-
-function styleValueToCss(name: string, value: unknown): string | undefined {
-  if (value == null) return undefined
-  if (typeof value === 'boolean') return undefined
-  if (typeof value === 'number' && !Number.isFinite(value)) return undefined
-
-  if (Array.isArray(value)) {
-    return value.join(', ')
-  }
-
-  return normalizeCssValue(name, value)
 }

--- a/packages/ui/src/runtime/diff-props.ts
+++ b/packages/ui/src/runtime/diff-props.ts
@@ -1,6 +1,5 @@
 import { invariant } from './invariant.ts'
-import { createStyleManager } from '../style/index.ts'
-import type { StyleManager } from '../style/index.ts'
+import { createStyleManager, type StyleManager } from '../style/stylesheet.ts'
 
 let globalStyleManager =
   typeof window !== 'undefined' ? createStyleManager() : (null as unknown as StyleManager)

--- a/packages/ui/src/runtime/dom.ts
+++ b/packages/ui/src/runtime/dom.ts
@@ -1,4 +1,4 @@
-import type { StyleProps } from '../style/style.ts'
+import type { StyleProps } from '../style/properties.ts'
 import type { RemixNode } from './jsx.ts'
 import type { MixInput } from './mixins/mixin.ts'
 

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -7,7 +7,7 @@ import type { FrameHandle } from './component.ts'
 import type { Scheduler, VirtualRoot } from './vdom.ts'
 import { createRangeRoot, createRoot } from './vdom.ts'
 import { diffNodes } from './diff-dom.ts'
-import { createStyleManager, type StyleManager } from '../style/index.ts'
+import { createStyleManager, type StyleManager } from '../style/stylesheet.ts'
 import { findFlushMarker, type FlushKind } from './stream-protocol.ts'
 
 type FrameRoot = [Comment, Comment] | Element | Document | DocumentFragment

--- a/packages/ui/src/runtime/reconcile.ts
+++ b/packages/ui/src/runtime/reconcile.ts
@@ -26,7 +26,7 @@ import {
 } from './vnode.ts'
 import { invariant } from './invariant.ts'
 import { patchHostProps } from './core/props.ts'
-import type { StyleManager } from '../style/index.ts'
+import type { StyleManager } from '../style/stylesheet.ts'
 import type { ElementProps } from './jsx.ts'
 import { skipComments, logHydrationMismatch } from './client-entries.ts'
 import type { Scheduler } from './scheduler.ts'

--- a/packages/ui/src/runtime/run.ts
+++ b/packages/ui/src/runtime/run.ts
@@ -1,6 +1,6 @@
 import { createFrame, type Frame } from './frame.ts'
 import { createScheduler } from './vdom.ts'
-import { createStyleManager } from '../style/index.ts'
+import { createStyleManager } from '../style/stylesheet.ts'
 import type { FrameHandle } from './component.ts'
 import { createComponentErrorEvent } from './error-event.ts'
 import type { ComponentErrorEvent } from './error-event.ts'

--- a/packages/ui/src/runtime/scheduler.ts
+++ b/packages/ui/src/runtime/scheduler.ts
@@ -8,7 +8,7 @@ import {
   setActiveSchedulerUpdateParents,
 } from './reconcile.ts'
 import { defaultStyleManager } from './diff-props.ts'
-import type { StyleManager } from '../style/index.ts'
+import type { StyleManager } from '../style/stylesheet.ts'
 
 type EmptyFn = () => void
 type SchedulerPhaseType = 'beforeUpdate' | 'commit'

--- a/packages/ui/src/runtime/vdom.ts
+++ b/packages/ui/src/runtime/vdom.ts
@@ -13,7 +13,7 @@ import { toVNode } from './to-vnode.ts'
 import { TypedEventTarget } from './typed-event-target.ts'
 import { ROOT_VNODE, type VNode } from './vnode.ts'
 import { resetStyleState, defaultStyleManager } from './diff-props.ts'
-import type { StyleManager } from '../style/index.ts'
+import type { StyleManager } from '../style/stylesheet.ts'
 
 /**
  * Events emitted by virtual roots.

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -3,11 +3,9 @@ import type { ElementType, ElementProps, RemixElement } from '../runtime/jsx.ts'
 import { Fragment, createComponent, createFrameHandle, Frame } from '../runtime/component.ts'
 import { isEntry, type EntryComponent } from '../runtime/client-entries.ts'
 import {
-  FRAMEWORK_PROPS as RUNTIME_FRAMEWORK_PROPS,
-  SELF_CLOSING_TAGS,
   normalizeAttributeName,
   serializeStyleObject,
-  shouldStringifyBooleanAttribute,
+  isBooleanishStringAttribute,
 } from '../runtime/core/attributes.ts'
 import { appendFlushMarker, type FlushKind, stripFlushMarkers } from '../runtime/stream-protocol.ts'
 import { REMIX_UI_STYLE_LAYER } from '../style/layers.ts'
@@ -128,6 +126,23 @@ type Segment =
 
 const TEXTAREA_VALUE_PROPS = new Set(['value', 'defaultValue'])
 const INPUT_DEFAULT_PROPS = new Set(['defaultValue', 'defaultChecked'])
+const SSR_OMITTED_PROPS = new Set(['children', 'mix', 'key', 'animate', 'innerHTML', 'on'])
+const SELF_CLOSING_TAGS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+])
 
 const DOCTYPE_PATTERN = /<!doctype(?:\s[^>]*)?>/gi
 
@@ -150,8 +165,6 @@ function emptyReadableStream(): ReadableStream<Uint8Array> {
 function getStyleLayerName(selector: string, layer: string = REMIX_UI_STYLE_LAYER): string {
   return `${layer}.${selector}`
 }
-
-const SSR_OMITTED_PROPS = RUNTIME_FRAMEWORK_PROPS
 
 const ssrSignal = Object.freeze({
   get aborted() {
@@ -589,7 +602,7 @@ function renderAttributes(props: any, isSvg: boolean, excludedProps?: Set<string
 
     let value = props[key]
     let attrName = transformAttributeName(key, isSvg)
-    let shouldStringifyBoolean = shouldStringifyBooleanAttribute(attrName)
+    let shouldStringifyBoolean = isBooleanishStringAttribute(attrName) || attrName === 'value'
     if (value === undefined || value === null || (value === false && !shouldStringifyBoolean)) {
       continue
     }

--- a/packages/ui/src/style/css-mixin.ts
+++ b/packages/ui/src/style/css-mixin.ts
@@ -3,8 +3,8 @@ import type { MixinFactory } from '../runtime/mixins/mixin.ts'
 import type { MixinDescriptor } from '../runtime/mixins/mixin.ts'
 import type { ElementProps } from '../runtime/jsx.ts'
 import { invariant } from '../runtime/invariant.ts'
-import { processStyleClass } from '../style/index.ts'
-import type { CSSProps } from '../style/style.ts'
+import { processStyleClass } from '../style/style.ts'
+import type { CSSProps } from '../style/properties.ts'
 
 type StyleEntry = { selector: string; css: string }
 type StyleCache = Map<string, StyleEntry>

--- a/packages/ui/src/style/index.ts
+++ b/packages/ui/src/style/index.ts
@@ -1,9 +1,0 @@
-import { createStyleManager } from './stylesheet.ts'
-
-export type {
-  CSSProps as EnhancedStyleProperties,
-  DOMStyleProperties as StyleProperties,
-} from './style.ts'
-export { processStyleClass, normalizeCssValue } from './style.ts'
-export { createStyleManager }
-export type { ServerStyleSource, StyleManager } from './stylesheet.ts'

--- a/packages/ui/src/style/properties.ts
+++ b/packages/ui/src/style/properties.ts
@@ -1,0 +1,54 @@
+export type DOMStyleProperties = {
+  [key in keyof Omit<
+    CSSStyleDeclaration,
+    'item' | 'setProperty' | 'removeProperty' | 'getPropertyValue' | 'getPropertyPriority'
+  >]?: string | number | null | undefined
+}
+
+export type AllStyleProperties = {
+  [key: string]: string | number | null | undefined
+}
+
+export interface StyleProps extends AllStyleProperties, DOMStyleProperties {
+  cssText?: string | null
+}
+
+// allow nesting
+export interface CSSProps extends DOMStyleProperties {
+  [key: string]: CSSProps | string | number | null | undefined
+}
+
+const NUMERIC_CSS_PROPS = new Set([
+  'aspect-ratio',
+  'z-index',
+  'opacity',
+  'flex-grow',
+  'flex-shrink',
+  'flex-order',
+  'grid-area',
+  'grid-row',
+  'grid-column',
+  'font-weight',
+  'line-height',
+  'order',
+  'orphans',
+  'widows',
+  'zoom',
+  'columns',
+  'column-count',
+])
+
+export function toCssPropertyName(value: string): string {
+  return value.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)
+}
+
+export function normalizeCssValue(key: string, value: unknown): string {
+  if (value == null) return String(value)
+  if (typeof value === 'number' && value !== 0) {
+    let cssKey = toCssPropertyName(key)
+    if (!NUMERIC_CSS_PROPS.has(cssKey) && !cssKey.startsWith('--')) {
+      return `${value}px`
+    }
+  }
+  return String(value)
+}

--- a/packages/ui/src/style/style.ts
+++ b/packages/ui/src/style/style.ts
@@ -1,84 +1,15 @@
-export type DOMStyleProperties = {
-  [key in keyof Omit<
-    CSSStyleDeclaration,
-    'item' | 'setProperty' | 'removeProperty' | 'getPropertyValue' | 'getPropertyPriority'
-  >]?: string | number | null | undefined
-}
-export type AllStyleProperties = {
-  [key: string]: string | number | null | undefined
-}
-export interface StyleProps extends AllStyleProperties, DOMStyleProperties {
-  cssText?: string | null
-}
-
-// allow nesting
-export interface CSSProps extends DOMStyleProperties {
-  [key: string]: CSSProps | string | number | null | undefined
-}
+import { normalizeCssValue, toCssPropertyName, type CSSProps } from './properties.ts'
 
 type StyleObject = Record<string, unknown>
 
-// Convert camelCase CSS properties to kebab-case
-function camelToKebab(str: string): string {
-  return str.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)
-}
-
-// Properties that should remain unitless (numeric values without px)
-const NUMERIC_CSS_PROPS = new Set([
-  'aspect-ratio',
-  'z-index',
-  'opacity',
-  'flex-grow',
-  'flex-shrink',
-  'flex-order',
-  'grid-area',
-  'grid-row',
-  'grid-column',
-  'font-weight',
-  'line-height',
-  'order',
-  'orphans',
-  'widows',
-  'zoom',
-  'columns',
-  'column-count',
-])
-
-// Normalize numeric CSS values: append 'px' for properties that need units
-// In Standards Mode, browsers drop numeric values without units when multiple properties
-// are present in insertRule(). We must normalize them ourselves.
-export function normalizeCssValue(key: string, value: unknown): string {
-  if (value == null) return String(value)
-  if (typeof value === 'number' && value !== 0) {
-    let cssKey = camelToKebab(key)
-    if (!NUMERIC_CSS_PROPS.has(cssKey) && !cssKey.startsWith('--')) {
-      return `${value}px`
-    }
-  }
-  return String(value)
-}
-
 // Check if a style property is a nested selector or media query
 function isComplexSelector(key: string): boolean {
-  return (
-    key.startsWith('&') ||
-    key.startsWith('@') ||
-    key.startsWith(':') ||
-    key.startsWith('[') ||
-    key.startsWith('.')
-  )
+  return /^[&@:[.]/.test(key)
 }
 
 // Detect @keyframes (including vendor-prefixed variants)
 function isKeyframesAtRule(key: string): boolean {
-  if (!key.startsWith('@')) return false
-  let lower = key.toLowerCase()
-  return (
-    lower.startsWith('@keyframes') ||
-    lower.startsWith('@-webkit-keyframes') ||
-    lower.startsWith('@-moz-keyframes') ||
-    lower.startsWith('@-o-keyframes')
-  )
+  return /^@(?:-(?:webkit|moz|o)-)?keyframes/i.test(key)
 }
 
 // Generate a hash for style objects to create unique class names
@@ -155,7 +86,7 @@ function styleToCss(styles: StyleObject, selector: string = ''): string {
       // Base declaration
       if (value != null) {
         let normalizedValue = normalizeCssValue(key, value)
-        baseDeclarations.push(`  ${camelToKebab(key)}: ${normalizedValue};`)
+        baseDeclarations.push(`  ${toCssPropertyName(key)}: ${normalizedValue};`)
       }
     }
   }
@@ -201,7 +132,7 @@ function nestedStyleBodyToCss(styles: StyleObject, spaces: number): string {
       }
     } else if (value != null) {
       let normalizedValue = normalizeCssValue(key, value)
-      declarations.push(`${pad}${camelToKebab(key)}: ${normalizedValue};`)
+      declarations.push(`${pad}${toCssPropertyName(key)}: ${normalizedValue};`)
     }
   }
 
@@ -241,7 +172,7 @@ function keyframesBodyToCss(frames: StyleObject): string {
       // Ignore nested selectors/at-rules inside keyframe steps
       if (isComplexSelector(prop)) continue
       let normalizedValue = normalizeCssValue(prop, propValue)
-      declarations.push(`  ${camelToKebab(prop)}: ${normalizedValue};`)
+      declarations.push(`  ${toCssPropertyName(prop)}: ${normalizedValue};`)
     }
 
     if (declarations.length > 0) {
@@ -279,7 +210,7 @@ function atRuleBodyToCss(styles: StyleObject): string {
     } else {
       if (value != null) {
         let normalizedValue = normalizeCssValue(key, value)
-        declarations.push(`  ${camelToKebab(key)}: ${normalizedValue};`)
+        declarations.push(`  ${toCssPropertyName(key)}: ${normalizedValue};`)
       }
     }
   }
@@ -323,9 +254,4 @@ export function processStyleClass(
   styleCache.set(hash, result)
 
   return result
-}
-
-// Clear style cache (useful for testing)
-export function clearStyleCache(styleCache: Map<string, { selector: string; css: string }>): void {
-  styleCache.clear()
 }

--- a/packages/ui/src/test/frame.test.ts
+++ b/packages/ui/src/test/frame.test.ts
@@ -6,7 +6,7 @@ import { createFrame, type LoadModule } from '../runtime/frame.ts'
 import { jsx } from '../runtime/jsx.ts'
 import { createScheduler } from '../runtime/scheduler.ts'
 import { appendFlushMarker } from '../runtime/stream-protocol.ts'
-import { createStyleManager } from '../style/index.ts'
+import { createStyleManager } from '../style/stylesheet.ts'
 
 describe('frame reloads', () => {
   afterEach(() => {


### PR DESCRIPTION
This splits out a focused Remix UI cleanup from the broader browser JS optimization work (https://github.com/remix-run/remix/pull/11507). It keeps style property normalization in a small owning module, removes the internal style barrel from browser-loaded runtime paths, and moves SSR-only prop/tag tables out of the client attributes module.

- Shares CSS property helpers between style class generation, inline style serialization, and DOM style patching through `style/properties.ts`
- Removes the internal `style/index.ts` barrel so browser runtime modules import directly from the owning style modules
- Keeps SSR-only omitted-prop and self-closing-tag tables in `server/stream.ts` instead of the client attributes module
- Reduces the bookstore source-served browser JS graph from `108,647 raw / 43,809 gzip / 38,635 brotli` to `107,738 raw / 43,582 gzip / 38,439 brotli`, with the same `62` module count

This keeps the change package-local to `@remix-run/ui` and avoids adding any package-specific asset compiler behavior.

## Impact on Bookstore Demo
Running `pnpm --filter bookstore-demo run start` and going to the login page (left is `main`, right is this PR):

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/c2c3edaa-6443-4659-8e8e-1628abc28c0d" />
