### PR TITLE
Reduce Remix UI root browser graph

### DIFF
--- a/packages/ui/.changes/patch.root-frame-navigation-graph-cleanup.md
+++ b/packages/ui/.changes/patch.root-frame-navigation-graph-cleanup.md
@@ -1,0 +1,1 @@
+Reduced browser JavaScript for Remix UI root, frame, and navigation runtimes by tightening internal root, frame, SVG attribute, and navigation helpers.

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -188,9 +188,22 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
   let inheritedReloadAbortUnsubscribe: (() => void) | undefined
 
   // Merge any rmx-data found in the current document once at startup.
-  mergeRmxDataFromDocument(init.data, container.doc)
+  mergeRmxDataFromRoot(init.data, container.doc)
 
-  let runtime = createFrameRuntime({ ...init, styleManager })
+  let runtime: FrameRuntime = {
+    topFrame: init.topFrame,
+    errorTarget: init.errorTarget,
+    loadModule: init.loadModule,
+    resolveFrame: init.resolveFrame,
+    pendingClientEntries: init.pendingClientEntries,
+    scheduler: init.scheduler,
+    styleManager,
+    data: init.data,
+    moduleCache: init.moduleCache,
+    moduleLoads: init.moduleLoads,
+    frameInstances: init.frameInstances,
+    namedFrames: init.namedFrames,
+  }
 
   let frame = createFrameHandle({
     src: init.src,
@@ -259,8 +272,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     if (isRemixNodeFrameContent(content)) {
       if (!contentRoot) {
         let currentNodes = getContentNodes()
-        removeVirtualRoots(currentNodes)
-        disposeSubFrames(currentNodes, context)
+        cleanupFrameRuntimeNodes(currentNodes, context)
         clearFrameContent()
         contentRoot = createFrameContentRoot()
       }
@@ -281,7 +293,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
         await render(html, { ...options, flushKind })
       })
       if (flushed.applied) {
-        if (flushed.remainder !== '') {
+        if (flushed.remainder) {
           await render(flushed.remainder, { ...options, flushKind: 'fragment' })
         }
         return
@@ -297,7 +309,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
 
     if (isFullDocumentReload && htmlContent !== undefined) {
       let parsed = new DOMParser().parseFromString(htmlContent, 'text/html')
-      mergeRmxDataFromDocument(context.data, parsed)
+      mergeRmxDataFromRoot(context.data, parsed)
       context.styleManager.replaceServerStyles(
         collectFrameServerStyleTags(createElementContainer(parsed)),
       )
@@ -331,7 +343,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       collectFrameServerStyleTags(createElementContainer(fragment)),
     )
     removeEmptyHeads(fragment)
-    mergeRmxDataFromFragment(context.data, fragment)
+    mergeRmxDataFromRoot(context.data, fragment)
 
     let nextContainer = createContainer(fragment)
 
@@ -409,11 +421,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     contentRoot = undefined
     clearPendingFrameTemplateWatch()
 
-    // Remove hydrated virtual roots in this frame's region.
-    removeVirtualRoots(container.childNodes)
-
-    // Dispose sub-frames recursively.
-    disposeSubFrames(container.childNodes, context)
+    cleanupFrameRuntimeNodes(container.childNodes, context)
     context.styleManager.dispose()
 
     if (frameName) {
@@ -529,7 +537,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
         continue
       }
 
-      if (node.childNodes && node.childNodes.length > 0) {
+      if (node.childNodes.length) {
         startSubFrameInheritedReloads(Array.from(node.childNodes), signal)
       }
     }
@@ -568,16 +576,14 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       return
     }
 
-    let observer = setupTemplateObserver()
-    pendingTemplateObserver = observer
-    let unsubscribe = subscribeFrameTemplate(marker.id, async (fragment) => {
+    pendingTemplateObserver = setupTemplateObserver()
+    pendingTemplateUnsubscribe = subscribeFrameTemplate(marker.id, async (fragment) => {
       if (signal?.aborted) return
       if (pendingTemplateMarkerId !== marker.id) return
       clearPendingFrameTemplateWatch()
       await render(fragment, { signal, contentStatus: 'resolved' })
       if (!signal?.aborted) onResolved?.()
     })
-    pendingTemplateUnsubscribe = unsubscribe
 
     signal?.addEventListener(
       'abort',
@@ -595,36 +601,6 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       await render(buffered, { initialHydrationTracker, signal, contentStatus: 'resolved' })
       if (!signal?.aborted) onResolved?.()
     }
-  }
-}
-
-export function createFrameRuntime(init: {
-  topFrame?: FrameHandle
-  errorTarget: EventTarget
-  loadModule: LoadModule
-  resolveFrame: ResolveFrame
-  pendingClientEntries: PendingClientEntries
-  scheduler: Scheduler
-  styleManager: StyleManager
-  data: RmxData
-  moduleCache: Map<string, Function>
-  moduleLoads: Map<string, Promise<Function | undefined>>
-  frameInstances: WeakMap<Comment, Frame>
-  namedFrames: Map<string, FrameHandle>
-}): FrameRuntime {
-  return {
-    topFrame: init.topFrame,
-    errorTarget: init.errorTarget,
-    loadModule: init.loadModule,
-    resolveFrame: init.resolveFrame,
-    pendingClientEntries: init.pendingClientEntries,
-    scheduler: init.scheduler,
-    styleManager: init.styleManager,
-    data: init.data,
-    moduleCache: init.moduleCache,
-    moduleLoads: init.moduleLoads,
-    frameInstances: init.frameInstances,
-    namedFrames: init.namedFrames,
   }
 }
 
@@ -671,18 +647,8 @@ function createInitialHydrationTracker(): InitialHydrationTracker {
   }
 }
 
-function mergeRmxDataFromDocument(into: RmxData, doc: Document): void {
-  let scripts = Array.from(doc.querySelectorAll('script#rmx-data'))
-  for (let script of scripts) {
-    if (!(script instanceof HTMLScriptElement)) continue
-    mergeRmxData(into, parseRmxDataScript(script))
-    script.remove()
-  }
-}
-
-function mergeRmxDataFromFragment(into: RmxData, fragment: DocumentFragment): void {
-  let scripts = Array.from(fragment.querySelectorAll('script#rmx-data'))
-  for (let script of scripts) {
+function mergeRmxDataFromRoot(into: RmxData, root: Document | DocumentFragment): void {
+  for (let script of root.querySelectorAll('script#rmx-data')) {
     if (!(script instanceof HTMLScriptElement)) continue
     mergeRmxData(into, parseRmxDataScript(script))
     script.remove()
@@ -690,8 +656,7 @@ function mergeRmxDataFromFragment(into: RmxData, fragment: DocumentFragment): vo
 }
 
 function removeEmptyHeads(fragment: DocumentFragment): void {
-  let heads = Array.from(fragment.querySelectorAll('head'))
-  for (let head of heads) {
+  for (let head of fragment.querySelectorAll('head')) {
     if (!head.childNodes.length) {
       head.remove()
     }
@@ -741,20 +706,17 @@ function parseRmxDataScript(script: HTMLScriptElement): RmxData {
 
 function mergeRmxData(into: RmxData, from: RmxData): void {
   if (from.h) {
-    if (!into.h) into.h = {}
-    copyOwnRmxEntries(into.h, from.h)
+    copyOwnRmxEntries((into.h ??= {}), from.h)
   }
 
   if (from.f) {
-    if (!into.f) into.f = {}
-    copyOwnRmxEntries(into.f, from.f)
+    copyOwnRmxEntries((into.f ??= {}), from.f)
   }
 }
 
 function copyOwnRmxEntries<T>(target: Record<string, T>, source: Record<string, T>): void {
   for (let key of Object.keys(source)) {
     if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue
-    if (!Object.hasOwn(source, key)) continue
     target[key] = source[key]!
   }
 }
@@ -765,7 +727,7 @@ function scheduleHydrationInContainer(
   initialHydrationTracker?: InitialHydrationTracker,
 ): void {
   let hydrationMarkers = findHydrationMarkers(container)
-  if (hydrationMarkers.length === 0) return
+  if (!hydrationMarkers.length) return
 
   let hydrationData = context.data.h
   if (!hydrationData) return
@@ -962,7 +924,7 @@ async function createSubFrames(
       continue
     }
 
-    if (node.childNodes && node.childNodes.length > 0) {
+    if (node.childNodes.length) {
       tasks.push(createSubFrames(Array.from(node.childNodes), context, options))
     }
   }
@@ -992,7 +954,7 @@ function isHydrationMarkerLive(marker: HydrationMarker, context: FrameContext): 
   return true
 }
 
-function removeVirtualRoots(nodes: Node[]): void {
+function cleanupFrameRuntimeNodes(nodes: Node[], context: FrameContext): void {
   for (let i = 0; i < nodes.length; i++) {
     let node = nodes[i]
 
@@ -1002,16 +964,6 @@ function removeVirtualRoots(nodes: Node[]): void {
       i = nodes.indexOf(end)
       continue
     }
-
-    if (node.childNodes && node.childNodes.length > 0) {
-      removeVirtualRoots(Array.from(node.childNodes))
-    }
-  }
-}
-
-function disposeSubFrames(nodes: Node[], context: FrameContext): void {
-  for (let i = 0; i < nodes.length; i++) {
-    let node = nodes[i]
 
     if (isFrameStart(node)) {
       let end = findEndMarker(node, isFrameStart, isFrameEnd)
@@ -1024,8 +976,8 @@ function disposeSubFrames(nodes: Node[], context: FrameContext): void {
       continue
     }
 
-    if (node.childNodes && node.childNodes.length > 0) {
-      disposeSubFrames(Array.from(node.childNodes), context)
+    if (node.childNodes.length) {
+      cleanupFrameRuntimeNodes(Array.from(node.childNodes), context)
     }
   }
 }
@@ -1061,8 +1013,7 @@ function collectAndPublishTemplates(node: Node): void {
   }
 
   if (!(node instanceof Element)) return
-  let templates = Array.from(node.querySelectorAll('template'))
-  for (let template of templates) {
+  for (let template of node.querySelectorAll('template')) {
     if (!(template instanceof HTMLTemplateElement)) continue
     publishFrameTemplateElement(template)
   }
@@ -1074,7 +1025,7 @@ function publishFrameTemplateElement(template: HTMLTemplateElement): void {
   publishFrameTemplate(template.id, template.content)
 }
 
-export function publishFrameTemplate(id: string, fragment: DocumentFragment): void {
+function publishFrameTemplate(id: string, fragment: DocumentFragment): void {
   let listeners = frameTemplateListeners.get(id)
   if (!listeners || listeners.size === 0) {
     let queue = bufferedFrameTemplates.get(id)
@@ -1091,7 +1042,7 @@ export function publishFrameTemplate(id: string, fragment: DocumentFragment): vo
   }
 }
 
-export function consumeFrameTemplate(id: string): DocumentFragment | null {
+function consumeFrameTemplate(id: string): DocumentFragment | null {
   let queue = bufferedFrameTemplates.get(id)
   if (!queue || queue.length === 0) return null
 
@@ -1162,7 +1113,7 @@ function extractTemplatesFromBuffer(
   }
 
   let tail = buffer.slice(cursor)
-  if (tail === '') return { html, remainder: '' }
+  if (!tail) return { html, remainder: '' }
 
   let tailStart = tail.toLowerCase().lastIndexOf('<template')
   if (tailStart === -1) {
@@ -1202,7 +1153,7 @@ async function renderFrameStream(
       let parsed = extractTemplatesFromBuffer(doc, buffer, publishFrameTemplate)
       buffer = parsed.remainder
 
-      if (parsed.html !== '') {
+      if (parsed.html) {
         html += parsed.html
         let flushed = await consumeFlushBatches(html, applyHtml)
         appliedOnce = flushed.applied || appliedOnce
@@ -1214,19 +1165,19 @@ async function renderFrameStream(
     let parsed = extractTemplatesFromBuffer(doc, buffer, publishFrameTemplate)
     html += parsed.html
     buffer = parsed.remainder
-    if (buffer !== '') {
+    if (buffer) {
       html += buffer
       buffer = ''
     }
 
-    if (html !== '') {
+    if (html) {
       await applyHtml(html, 'fragment')
       appliedOnce = true
     }
 
     // A frame stream can legitimately resolve to empty content. Ensure the
     // existing frame region is cleared instead of treated as a no-op.
-    if (html === '' && !appliedOnce) {
+    if (!html && !appliedOnce) {
       await applyHtml('', 'fragment')
     }
   } finally {
@@ -1355,7 +1306,7 @@ function walkCommentsInNodes(nodes: Node[], cb: (comment: Comment) => void): voi
     }
 
     if (node.nodeType === Node.COMMENT_NODE) cb(node as Comment)
-    if (node.childNodes && node.childNodes.length > 0) {
+    if (node.childNodes.length) {
       walkCommentsInNodes(Array.from(node.childNodes), cb)
     }
   }
@@ -1382,9 +1333,7 @@ function isFrameEnd(node: Comment): boolean {
 }
 
 function getFrameId(start: Comment): string {
-  let trimmed = start.data.trim()
-  invariant(trimmed.startsWith('rmx:f:'), 'Invalid frame start marker')
-  return trimmed.slice('rmx:f:'.length)
+  return start.data.trim().slice('rmx:f:'.length)
 }
 
 function findEndMarker(

--- a/packages/ui/src/runtime/navigation.ts
+++ b/packages/ui/src/runtime/navigation.ts
@@ -1,4 +1,4 @@
-import { getTopFrame, getNamedFrame } from './run.ts'
+import type { FrameHandle } from './component.ts'
 
 type NavigationState = {
   target: string | undefined
@@ -9,6 +9,11 @@ type NavigationState = {
 
 type SourceElementNavigateEvent = NavigateEvent & {
   sourceElement?: Element | null
+}
+
+type NavigationFrameAccessors = {
+  getTopFrame: () => FrameHandle
+  getNamedFrame: (name: string) => FrameHandle
 }
 
 /**
@@ -42,20 +47,10 @@ export async function navigate(href: string, options?: NavigationOptions) {
  * Starts listening for Navigation API transitions and routes them through frame reloads.
  *
  * @param signal Abort signal used to remove the listener.
+ * @param options Frame accessors used to resolve the navigation target.
  * @returns void
  */
-export function startNavigationListener(signal: AbortSignal) {
-  return startNavigationListenerImpl(signal, { getTopFrame, getNamedFrame })
-}
-
-// Internal version used by unit tests so we can inject stub frames
-export function startNavigationListenerImpl(
-  signal: AbortSignal,
-  options: {
-    getTopFrame: typeof getTopFrame
-    getNamedFrame: typeof getNamedFrame
-  },
-) {
+export function startNavigationListener(signal: AbortSignal, options: NavigationFrameAccessors) {
   let navigation = window.navigation
 
   navigation.updateCurrentEntry({

--- a/packages/ui/src/runtime/run.ts
+++ b/packages/ui/src/runtime/run.ts
@@ -99,7 +99,7 @@ export function run(init: RunInit): AppRuntime {
   })
 
   let appController = new AbortController()
-  startNavigationListener(appController.signal)
+  startNavigationListener(appController.signal, { getTopFrame, getNamedFrame })
   let readyPromise = topFrame.ready().catch((error) => {
     errorTarget.dispatchEvent(createComponentErrorEvent(error))
     throw error

--- a/packages/ui/src/runtime/svg-attributes.ts
+++ b/packages/ui/src/runtime/svg-attributes.ts
@@ -69,43 +69,22 @@ for (let attr of CANONICAL_CAMEL_SVG_ATTRS) {
   SVG_ATTR_ALIASES.set(camelToKebab(attr), attr)
 }
 
-const NAMESPACED_SVG_ALIASES = new Map([
-  ['xlinkHref', { ns: XLINK_NS, attr: 'xlink:href' }],
-  ['xlink:href', { ns: XLINK_NS, attr: 'xlink:href' }],
-  ['xlink-href', { ns: XLINK_NS, attr: 'xlink:href' }],
-  ['xlinkActuate', { ns: XLINK_NS, attr: 'xlink:actuate' }],
-  ['xlink:actuate', { ns: XLINK_NS, attr: 'xlink:actuate' }],
-  ['xlink-actuate', { ns: XLINK_NS, attr: 'xlink:actuate' }],
-  ['xlinkArcrole', { ns: XLINK_NS, attr: 'xlink:arcrole' }],
-  ['xlink:arcrole', { ns: XLINK_NS, attr: 'xlink:arcrole' }],
-  ['xlink-arcrole', { ns: XLINK_NS, attr: 'xlink:arcrole' }],
-  ['xlinkRole', { ns: XLINK_NS, attr: 'xlink:role' }],
-  ['xlink:role', { ns: XLINK_NS, attr: 'xlink:role' }],
-  ['xlink-role', { ns: XLINK_NS, attr: 'xlink:role' }],
-  ['xlinkShow', { ns: XLINK_NS, attr: 'xlink:show' }],
-  ['xlink:show', { ns: XLINK_NS, attr: 'xlink:show' }],
-  ['xlink-show', { ns: XLINK_NS, attr: 'xlink:show' }],
-  ['xlinkTitle', { ns: XLINK_NS, attr: 'xlink:title' }],
-  ['xlink:title', { ns: XLINK_NS, attr: 'xlink:title' }],
-  ['xlink-title', { ns: XLINK_NS, attr: 'xlink:title' }],
-  ['xlinkType', { ns: XLINK_NS, attr: 'xlink:type' }],
-  ['xlink:type', { ns: XLINK_NS, attr: 'xlink:type' }],
-  ['xlink-type', { ns: XLINK_NS, attr: 'xlink:type' }],
-  ['xmlBase', { ns: XML_NS, attr: 'xml:base' }],
-  ['xml:base', { ns: XML_NS, attr: 'xml:base' }],
-  ['xml-base', { ns: XML_NS, attr: 'xml:base' }],
-  ['xmlLang', { ns: XML_NS, attr: 'xml:lang' }],
-  ['xml:lang', { ns: XML_NS, attr: 'xml:lang' }],
-  ['xml-lang', { ns: XML_NS, attr: 'xml:lang' }],
-  ['xmlSpace', { ns: XML_NS, attr: 'xml:space' }],
-  ['xml:space', { ns: XML_NS, attr: 'xml:space' }],
-  ['xml-space', { ns: XML_NS, attr: 'xml:space' }],
-  ['xmlnsXlink', { attr: 'xmlns:xlink' }],
-  ['xmlns:xlink', { attr: 'xmlns:xlink' }],
-  ['xmlns-xlink', { attr: 'xmlns:xlink' }],
-])
+const NAMESPACED_SVG_ALIASES = new Map<string, { ns?: string; attr: string }>()
+addNamespacedSvgAliases('xlink', XLINK_NS, 'href actuate arcrole role show title type')
+addNamespacedSvgAliases('xml', XML_NS, 'base lang space')
+addNamespacedSvgAliases('xmlns', undefined, 'xlink')
 
-export function normalizeSvgAttributeName(name: string): string {
+function addNamespacedSvgAliases(prefix: string, ns: string | undefined, names: string) {
+  for (let name of names.split(' ')) {
+    let attr = `${prefix}:${name}`
+    let alias = ns ? { ns, attr } : { attr }
+    NAMESPACED_SVG_ALIASES.set(`${prefix}${name.charAt(0).toUpperCase()}${name.slice(1)}`, alias)
+    NAMESPACED_SVG_ALIASES.set(attr, alias)
+    NAMESPACED_SVG_ALIASES.set(`${prefix}-${name}`, alias)
+  }
+}
+
+function normalizeSvgAttributeName(name: string): string {
   let alias = SVG_ATTR_ALIASES.get(name)
   if (alias) return alias
 

--- a/packages/ui/src/runtime/vdom.ts
+++ b/packages/ui/src/runtime/vdom.ts
@@ -50,7 +50,6 @@ export type VirtualRootOptions = {
 }
 
 export { createScheduler, type Scheduler }
-export { diffVNodes, toVNode }
 export { resetStyleState }
 
 function getHydrationComponentIdFromRangeStart(start: Node): string | undefined {
@@ -73,15 +72,52 @@ export function createRangeRoot(
   options: VirtualRootOptions = {},
 ): VirtualRoot {
   let [start, end] = boundaries
-  let vroot: VNode | null = null
-  let styles = options.styleManager ?? defaultStyleManager
-
   let container = end.parentNode
   invariant(container, 'Expected parent node')
   invariant(start.parentNode === container, 'Boundaries must share parent')
-  let parent = container
 
-  let hydrationCursor = start.nextSibling
+  return createVirtualRoot(
+    container,
+    options,
+    () => ({
+      type: ROOT_VNODE,
+      _svg: false,
+      _rangeStart: start,
+      _rangeEnd: end,
+      _pendingHydrationComponentId: getHydrationComponentIdFromRangeStart(start),
+    }),
+    end,
+    start.nextSibling,
+  )
+}
+
+/**
+ * Creates a virtual root for a host container element.
+ *
+ * @param container Host element to render into.
+ * @param options Root configuration.
+ * @returns A virtual root controller.
+ */
+export function createRoot(container: HTMLElement, options: VirtualRootOptions = {}): VirtualRoot {
+  return createVirtualRoot(
+    container,
+    options,
+    () => ({ type: ROOT_VNODE, _svg: false }),
+    undefined,
+    container.innerHTML.trim() !== '' ? container.firstChild : undefined,
+  )
+}
+
+function createVirtualRoot(
+  parent: ParentNode & Node,
+  options: VirtualRootOptions,
+  createParentVNode: () => VNode,
+  anchor?: Node,
+  initialHydrationCursor?: Node | null,
+): VirtualRoot {
+  let vroot: VNode | null = null
+  let styles = options.styleManager ?? defaultStyleManager
+  let hydrationCursor = initialHydrationCursor
 
   let eventTarget = new TypedEventTarget<VirtualRootEventMap>()
   let scheduler =
@@ -118,13 +154,6 @@ export function createRangeRoot(
       attachDomErrorForwarding()
 
       let vnode = toVNode(element)
-      let vParent: VNode = {
-        type: ROOT_VNODE,
-        _svg: false,
-        _rangeStart: start,
-        _rangeEnd: end,
-        _pendingHydrationComponentId: getHydrationComponentIdFromRangeStart(start),
-      }
       scheduler.enqueueWork([
         () => {
           diffVNodes(
@@ -134,94 +163,9 @@ export function createRangeRoot(
             frameStub,
             scheduler,
             styles,
-            vParent,
+            createParentVNode(),
             eventTarget,
-            end,
-            hydrationCursor,
-          )
-          vroot = vnode
-          hydrationCursor = null
-        },
-      ])
-      scheduler.dequeue()
-    },
-
-    dispose() {
-      detachDomErrorForwarding()
-
-      if (!vroot) return
-      let current = vroot
-      vroot = null
-      scheduler.enqueueWork([() => removeVNode(current, parent, scheduler, styles)])
-      scheduler.dequeue()
-    },
-
-    flush() {
-      scheduler.dequeue()
-    },
-  })
-}
-
-/**
- * Creates a virtual root for a host container element.
- *
- * @param container Host element to render into.
- * @param options Root configuration.
- * @returns A virtual root controller.
- */
-export function createRoot(container: HTMLElement, options: VirtualRootOptions = {}): VirtualRoot {
-  let vroot: VNode | null = null
-  let styles = options.styleManager ?? defaultStyleManager
-  let hydrationCursor = container.innerHTML.trim() !== '' ? container.firstChild : undefined
-
-  let eventTarget = new TypedEventTarget<VirtualRootEventMap>()
-  let scheduler =
-    options.scheduler ?? createScheduler(container.ownerDocument ?? document, eventTarget, styles)
-  let frameStub =
-    options.frame ??
-    createRootFrameHandle({
-      src: options.frameInit?.src,
-      resolveFrame: options.frameInit?.resolveFrame,
-      loadModule: options.frameInit?.loadModule,
-      errorTarget: eventTarget,
-      scheduler,
-      styleManager: styles,
-    })
-
-  let isErrorForwardingAttached = false
-  function forwardDomError(event: Event) {
-    eventTarget.dispatchEvent(createComponentErrorEvent(getComponentError(event)))
-  }
-  function attachDomErrorForwarding() {
-    if (isErrorForwardingAttached) return
-    container.addEventListener('error', forwardDomError)
-    isErrorForwardingAttached = true
-  }
-  function detachDomErrorForwarding() {
-    if (!isErrorForwardingAttached) return
-    container.removeEventListener('error', forwardDomError)
-    isErrorForwardingAttached = false
-  }
-  attachDomErrorForwarding()
-
-  return Object.assign(eventTarget, {
-    render(element: RemixNode) {
-      attachDomErrorForwarding()
-
-      let vnode = toVNode(element)
-      let vParent: VNode = { type: ROOT_VNODE, _svg: false }
-      scheduler.enqueueWork([
-        () => {
-          diffVNodes(
-            vroot,
-            vnode,
-            container,
-            frameStub,
-            scheduler,
-            styles,
-            vParent,
-            eventTarget,
-            undefined,
+            anchor,
             hydrationCursor,
           )
           vroot = vnode
@@ -237,7 +181,7 @@ export function createRoot(container: HTMLElement, options: VirtualRootOptions =
       if (!vroot) return
       let current = vroot
       vroot = null
-      scheduler.enqueueWork([() => removeVNode(current, container, scheduler, styles)])
+      scheduler.enqueueWork([() => removeVNode(current, parent, scheduler, styles)])
       scheduler.dequeue()
     },
 

--- a/packages/ui/src/test/navigation.test.ts
+++ b/packages/ui/src/test/navigation.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@remix-run/assert'
 import { afterEach, describe, it, mock, type TestContext } from '@remix-run/test'
-import { navigate, startNavigationListenerImpl } from '../runtime/navigation.ts'
+import { navigate, startNavigationListener } from '../runtime/navigation.ts'
 import type { FrameHandle } from '../runtime/component.ts'
 
 // Stand-in frame the navigation handler can call without dragging in the
@@ -80,7 +80,7 @@ describe('navigate', () => {
     stubGlobalField(t, 'navigation', stubNavigation)
 
     let controller = new AbortController()
-    startNavigationListenerImpl(controller.signal, stubFrames)
+    startNavigationListener(controller.signal, stubFrames)
 
     let anchor = document.createElement('a')
     anchor.href = '/login'
@@ -114,7 +114,7 @@ describe('navigate', () => {
     stubGlobalField(t, 'navigation', stubNavigation)
 
     let controller = new AbortController()
-    startNavigationListenerImpl(controller.signal, stubFrames)
+    startNavigationListener(controller.signal, stubFrames)
 
     let anchor = document.createElement('a')
     anchor.href = 'https://example.com/login'
@@ -151,7 +151,7 @@ describe('navigate', () => {
     stubGlobalField(t, 'navigation', stubNavigation)
 
     let controller = new AbortController()
-    startNavigationListenerImpl(controller.signal, stubFrames)
+    startNavigationListener(controller.signal, stubFrames)
 
     let anchor = document.createElement('a')
     anchor.href = '/report.csv'
@@ -185,7 +185,7 @@ describe('navigate', () => {
     stubGlobalField(t, 'navigation', stubNavigation)
 
     let controller = new AbortController()
-    startNavigationListenerImpl(controller.signal, stubFrames)
+    startNavigationListener(controller.signal, stubFrames)
 
     let anchor = document.createElement('a')
     anchor.href = '/logo'


### PR DESCRIPTION
This splits another focused browser JS cleanup out of the broader Remix UI optimization work. The change keeps the scope package-local to `@remix-run/ui` and tightens internal root, frame, navigation, and SVG attribute helpers without changing public API surface.

- Shares the duplicated `createRoot` / `createRangeRoot` setup through an internal `createVirtualRoot` helper
- Removes the `navigation.ts -> run.ts` runtime dependency by having `run()` pass frame accessors into `startNavigationListener()`
- Removes frame helper indirection and combines duplicate frame cleanup/data-merge walks
- Generates the SVG namespace alias map from compact prefix/name lists instead of listing every alias manually
- Reduces the bookstore source-served browser JS graph from `108,647 raw / 43,809 gzip / 38,635 brotli` to `105,974 raw / 43,316 gzip / 38,208 brotli`, while keeping the graph at `62` modules

Per-entry measurements for the bookstore demo stayed module-count neutral and saved about `2.7 kB raw / 493 B gzip / 427 B brotli` for each measured entry.

## Impact on Bookstore Demo

Running `pnpm --filter bookstore-demo run start` and going to the login page (left is `main`, right is this PR):

<img width="2560" height="1440" alt="Screenshot 2026-06-04 at 4 28 26 PM" src="https://github.com/user-attachments/assets/7c053ace-4a6d-4f9e-a70f-793c90487e9a" />
