### PR TITLE
Add data-table D1 adapter

### DIFF
--- a/packages/data-table-d1/.changes/minor.initial-release.md
+++ b/packages/data-table-d1/.changes/minor.initial-release.md
@@ -1,0 +1,1 @@
+Initial release of the Cloudflare D1 adapter for `remix/data-table`.

--- a/packages/data-table-d1/CHANGELOG.md
+++ b/packages/data-table-d1/CHANGELOG.md
@@ -1,0 +1,9 @@
+# `data-table-d1` CHANGELOG
+
+This is the changelog for [`data-table-d1`](https://github.com/remix-run/remix/tree/main/packages/data-table-d1). It follows [semantic versioning](https://semver.org/).
+
+## v0.1.0
+
+### Minor Changes
+
+- Initial release.

--- a/packages/data-table-d1/LICENSE
+++ b/packages/data-table-d1/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/data-table-d1/README.md
+++ b/packages/data-table-d1/README.md
@@ -1,0 +1,64 @@
+# data-table-d1
+
+Cloudflare D1 adapter for [`remix/data-table`](https://github.com/remix-run/remix/tree/main/packages/data-table). Use this package when you want `data-table` APIs backed by a D1 database binding.
+
+## Features
+
+- **Native D1 Binding Integration**: Works with Cloudflare Workers `D1Database` bindings
+- **SQLite-Compatible SQL**: Uses D1's SQLite-compatible query surface
+- **Adapter-Owned Compiler**: SQL compilation lives in this adapter so D1 behavior can evolve independently from the SQLite adapter
+- **D1 Capabilities Enabled By Default**:
+  - `returning: true`
+  - `savepoints: false`
+  - `upsert: true`
+  - `transactionalDdl: false`
+  - `migrationLock: false`
+
+## Installation
+
+```sh
+npm i remix
+```
+
+## Usage
+
+```ts
+import { createDatabase } from 'remix/data-table'
+import { createD1DatabaseAdapter } from 'remix/data-table/d1'
+
+export default {
+  async fetch(request, env) {
+    let db = createDatabase(createD1DatabaseAdapter(env.DB))
+    // Use db.query(...), db.create(...), and other data-table APIs here.
+    return new Response('OK')
+  },
+}
+```
+
+Import any driver-specific types you need from Cloudflare's generated Worker types.
+
+## Adapter Capabilities
+
+`data-table-d1` reports this capability set by default:
+
+- `returning: true`
+- `savepoints: false`
+- `upsert: true`
+- `transactionalDdl: false`
+- `migrationLock: false`
+
+## D1 Transactions
+
+Cloudflare D1 supports atomic batches through `env.DB.batch()`. This adapter does not implement `db.transaction()` because `data-table` transactions are interactive callback transactions, while D1 rejects SQL `BEGIN TRANSACTION` and `SAVEPOINT` statements through Worker bindings.
+
+## Related Packages
+
+- [`data-table`](https://github.com/remix-run/remix/tree/main/packages/data-table) - Core query/relations API
+- [`data-schema`](https://github.com/remix-run/remix/tree/main/packages/data-schema) - Schema parsing and validation
+- [`data-table-postgres`](https://github.com/remix-run/remix/tree/main/packages/data-table-postgres) - PostgreSQL adapter
+- [`data-table-mysql`](https://github.com/remix-run/remix/tree/main/packages/data-table-mysql) - MySQL adapter
+- [`data-table-sqlite`](https://github.com/remix-run/remix/tree/main/packages/data-table-sqlite) - SQLite adapter
+
+## License
+
+See [LICENSE](https://github.com/remix-run/remix/blob/main/LICENSE)

--- a/packages/data-table-d1/package.json
+++ b/packages/data-table-d1/package.json
@@ -15,7 +15,8 @@
     "README.md",
     "dist",
     "src",
-    "!src/**/*.test.ts"
+    "!src/**/*.test.ts",
+    "!src/**/*.test-helper.ts"
   ],
   "type": "module",
   "sideEffects": false,
@@ -37,7 +38,8 @@
     "@remix-run/data-table": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "@typescript/native-preview": "catalog:",
+    "miniflare": "^4.20260603.0"
   },
   "dependencies": {
     "@cloudflare/workers-types": "^4.20260511.1",

--- a/packages/data-table-d1/package.json
+++ b/packages/data-table-d1/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@remix-run/data-table-d1",
+  "version": "0.0.0",
+  "description": "Cloudflare D1 adapter for remix/data-table",
+  "author": "Lucas Castro <lcastro@cloudflare.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/remix-run/remix.git",
+    "directory": "packages/data-table-d1"
+  },
+  "homepage": "https://github.com/remix-run/remix/tree/main/packages/data-table-d1#readme",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "dist",
+    "src",
+    "!src/**/*.test.ts"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "./package.json": "./package.json"
+    }
+  },
+  "devDependencies": {
+    "@remix-run/assert": "workspace:*",
+    "@remix-run/data-table": "workspace:*",
+    "@remix-run/test": "workspace:*",
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:"
+  },
+  "dependencies": {
+    "@cloudflare/workers-types": "^4.20260511.1",
+    "@remix-run/data-table": "workspace:^"
+  },
+  "scripts": {
+    "build": "tsgo -p tsconfig.build.json",
+    "clean": "git clean -fdX",
+    "prepublishOnly": "pnpm run build",
+    "test": "remix-test",
+    "test:bun": "bun x --bun remix-test",
+    "test:coverage": "remix-test --coverage",
+    "typecheck": "tsgo --noEmit"
+  },
+  "keywords": [
+    "remix",
+    "orm",
+    "d1",
+    "cloudflare",
+    "database",
+    "sql"
+  ]
+}

--- a/packages/data-table-d1/package.json
+++ b/packages/data-table-d1/package.json
@@ -42,7 +42,6 @@
     "miniflare": "^4.20260603.0"
   },
   "dependencies": {
-    "@cloudflare/workers-types": "^4.20260511.1",
     "@remix-run/data-table": "workspace:^"
   },
   "scripts": {

--- a/packages/data-table-d1/remix-test.config.ts
+++ b/packages/data-table-d1/remix-test.config.ts
@@ -1,0 +1,14 @@
+import type { RemixTestConfig } from '@remix-run/test'
+
+export default {
+  type: 'server',
+  coverage: process.argv.includes('--coverage')
+    ? {
+        include: ['src/**/*.ts'],
+        lines: 90,
+        branches: 90,
+        functions: 90,
+        statements: 90,
+      }
+    : undefined,
+} satisfies RemixTestConfig

--- a/packages/data-table-d1/src/index.ts
+++ b/packages/data-table-d1/src/index.ts
@@ -1,2 +1,2 @@
 export { createD1DatabaseAdapter, D1DatabaseAdapter } from './lib/adapter.ts'
-export type { D1Value } from './lib/adapter.ts'
+export type { D1Database, D1ExecResult, D1PreparedStatement, D1Result, D1Value } from './lib/adapter.ts'

--- a/packages/data-table-d1/src/index.ts
+++ b/packages/data-table-d1/src/index.ts
@@ -1,0 +1,2 @@
+export { createD1DatabaseAdapter, D1DatabaseAdapter } from './lib/adapter.ts'
+export type { D1Value } from './lib/adapter.ts'

--- a/packages/data-table-d1/src/lib/adapter.integration.test.ts
+++ b/packages/data-table-d1/src/lib/adapter.integration.test.ts
@@ -1,0 +1,41 @@
+import { after, before, describe } from '@remix-run/test'
+import { createDatabase } from '@remix-run/data-table'
+
+import {
+  resetAdapterIntegrationSchema,
+  setupAdapterIntegrationSchema,
+  teardownAdapterIntegrationSchema,
+} from '../../../data-table/test/adapter-integration-schema.ts'
+import { runAdapterIntegrationContract } from '../../../data-table/test/adapter-integration-contract.ts'
+
+import { createD1DatabaseAdapter } from './adapter.ts'
+import { createTestD1Database, type TestD1Database } from './test-d1.test-helper.ts'
+
+const integrationEnabled = true
+
+describe('d1 adapter integration', () => {
+  let database: TestD1Database
+
+  before(async () => {
+    database = await createTestD1Database()
+    await setupAdapterIntegrationSchema(runStatement, 'sqlite')
+  })
+
+  after(async () => {
+    await teardownAdapterIntegrationSchema(runStatement, 'sqlite')
+    await database.dispose()
+  })
+
+  runAdapterIntegrationContract({
+    integrationEnabled,
+    supportsTransactions: false,
+    createDatabase: () => createDatabase(createD1DatabaseAdapter(database)),
+    resetDatabase: async () => {
+      await resetAdapterIntegrationSchema(runStatement, 'sqlite')
+    },
+  })
+
+  async function runStatement(statement: string): Promise<void> {
+    await database.prepare(statement).run()
+  }
+})

--- a/packages/data-table-d1/src/lib/adapter.test.ts
+++ b/packages/data-table-d1/src/lib/adapter.test.ts
@@ -1,0 +1,238 @@
+import * as assert from '@remix-run/assert'
+import { column, createDatabase, table } from '@remix-run/data-table'
+import { describe, it } from '@remix-run/test'
+
+import { createD1DatabaseAdapter } from './adapter.ts'
+import { createTestD1Database } from './test-d1.test-helper.ts'
+
+const accounts = table({
+  name: 'accounts',
+  columns: {
+    id: column.integer(),
+    email: column.text(),
+    status: column.text(),
+    created_at: column.text(),
+  },
+})
+
+const accountProjects = table({
+  name: 'account_projects',
+  columns: {
+    account_id: column.integer(),
+    project_id: column.integer(),
+  },
+  primaryKey: ['account_id', 'project_id'],
+})
+
+describe('d1 adapter', () => {
+  it('reports D1 capabilities', async () => {
+    let database = await createTestD1Database()
+    let adapter = createD1DatabaseAdapter(database)
+
+    assert.equal(adapter.dialect, 'd1')
+    assert.deepEqual(adapter.capabilities, {
+      returning: true,
+      savepoints: false,
+      upsert: true,
+      transactionalDdl: false,
+      migrationLock: false,
+    })
+    await database.dispose()
+  })
+
+  it('short-circuits insertMany([]) and returns empty rows for returning queries', async () => {
+    let database = await createTestD1Database()
+    let adapter = createD1DatabaseAdapter(database)
+
+    let result = await adapter.execute({
+      operation: {
+        kind: 'insertMany',
+        table: accounts,
+        values: [],
+        returning: ['id'],
+      },
+      transaction: undefined,
+    })
+
+    assert.deepEqual(result, {
+      affectedRows: 0,
+      insertId: undefined,
+      rows: [],
+    })
+    assert.equal(database.prepareCalls, 0)
+    await database.dispose()
+  })
+
+  it('runs scripts and introspects tables and columns', async () => {
+    let database = await createTestD1Database()
+    let adapter = createD1DatabaseAdapter(database)
+
+    await adapter.executeScript(
+      'create table accounts (id integer primary key, email text not null, status text not null, created_at text)',
+    )
+
+    assert.equal(await adapter.hasTable({ name: 'accounts' }), true)
+    assert.equal(await adapter.hasTable({ name: 'missing' }), false)
+    assert.equal(await adapter.hasColumn({ name: 'accounts' }, 'email'), true)
+    assert.equal(await adapter.hasColumn({ name: 'accounts' }, 'missing'), false)
+    await database.dispose()
+  })
+
+  it('supports writes, returned rows, count normalization, and insert ids', async () => {
+    let database = await createTestD1Database()
+    let db = createDatabase(createD1DatabaseAdapter(database))
+
+    await database.exec(
+      'create table accounts (id integer primary key autoincrement, email text not null, status text not null, created_at text)',
+    )
+
+    let first = await db.create(
+      accounts,
+      { email: 'a@example.com', status: 'active', created_at: undefined },
+      { returnRow: true },
+    )
+    let second = await db.create(accounts, { email: 'b@example.com', status: 'inactive' })
+    let count = await db.count(accounts)
+
+    assert.deepEqual(first, {
+      id: 1,
+      email: 'a@example.com',
+      status: 'active',
+      created_at: null,
+    })
+    assert.equal(second.insertId, 2)
+    assert.equal(second.affectedRows, 1)
+    assert.equal(count, 2)
+    await database.dispose()
+  })
+
+  it('does not expose insertId for composite primary keys', async () => {
+    let database = await createTestD1Database()
+    let adapter = createD1DatabaseAdapter(database)
+
+    await database.exec('create table account_projects (account_id integer, project_id integer)')
+
+    let result = await adapter.execute({
+      operation: {
+        kind: 'insert',
+        table: accountProjects,
+        values: {
+          account_id: 1,
+          project_id: 2,
+        },
+      },
+      transaction: undefined,
+    })
+
+    assert.equal(result.affectedRows, 1)
+    assert.equal(result.insertId, undefined)
+    await database.dispose()
+  })
+
+  it('normalizes D1 bound values and rejects unsupported values', async () => {
+    let database = await createTestD1Database()
+    let adapter = createD1DatabaseAdapter(database)
+    let createdAt = new Date('2026-06-04T12:00:00.000Z')
+
+    await database.exec(
+      'create table accounts (id integer primary key, email text, status integer, created_at text)',
+    )
+    await adapter.execute({
+      operation: {
+        kind: 'insert',
+        table: accounts,
+        values: {
+          id: 1,
+          email: undefined,
+          status: true,
+          created_at: createdAt,
+        },
+      },
+      transaction: undefined,
+    })
+    let row = await database.prepare('select * from accounts where id = ?').bind(1).first<{
+      id: number
+      email: string | null
+      status: number
+      created_at: string
+    }>()
+
+    assert.deepEqual(row, {
+      id: 1,
+      email: null,
+      status: 1,
+      created_at: '2026-06-04T12:00:00.000Z',
+    })
+    await assert.rejects(
+      () =>
+        adapter.execute({
+          operation: {
+            kind: 'insert',
+            table: accounts,
+            values: {
+              id: 2n,
+            },
+          },
+          transaction: undefined,
+        }),
+      /Unsupported D1 bound value: 2/,
+    )
+    await database.dispose()
+  })
+
+  it('rejects interactive transactions and transaction tokens', async () => {
+    let database = await createTestD1Database()
+    let adapter = createD1DatabaseAdapter(database)
+    let db = createDatabase(adapter)
+
+    await assert.rejects(
+      () => db.transaction(async () => undefined),
+      /D1DatabaseAdapter does not support data-table interactive transactions/,
+    )
+    await assert.rejects(
+      () => adapter.commitTransaction({ id: 'tx_missing' }),
+      /Unknown transaction token: tx_missing/,
+    )
+    await assert.rejects(
+      () => adapter.rollbackTransaction({ id: 'tx_missing' }),
+      /Unknown transaction token: tx_missing/,
+    )
+    await assert.rejects(
+      () => adapter.createSavepoint({ id: 'tx_missing' }, 'sp'),
+      /Unknown transaction token: tx_missing/,
+    )
+    await assert.rejects(() => database.prepare('begin').run(), /BEGIN TRANSACTION|SAVEPOINT/)
+    await assert.rejects(() => database.prepare('savepoint sp').run(), /BEGIN TRANSACTION|SAVEPOINT/)
+    await database.dispose()
+  })
+
+  it('rejects ordered and limited writes that require interactive transactions', async () => {
+    let database = await createTestD1Database()
+    let db = createDatabase(createD1DatabaseAdapter(database))
+
+    await database.exec(
+      'create table accounts (id integer primary key, email text not null, status text not null, created_at text)',
+    )
+    await db.query(accounts).insertMany([
+      { id: 1, email: 'a@example.com', status: 'active' },
+      { id: 2, email: 'b@example.com', status: 'active' },
+    ])
+
+    await assert.rejects(
+      () =>
+        db
+          .query(accounts)
+          .where({ status: 'active' })
+          .orderBy('id', 'asc')
+          .limit(1)
+          .update({ status: 'paused' }),
+      /D1DatabaseAdapter does not support data-table interactive transactions/,
+    )
+    await assert.rejects(
+      () =>
+        db.query(accounts).where({ status: 'active' }).orderBy('id', 'asc').limit(1).delete(),
+      /D1DatabaseAdapter does not support data-table interactive transactions/,
+    )
+    await database.dispose()
+  })
+})

--- a/packages/data-table-d1/src/lib/adapter.ts
+++ b/packages/data-table-d1/src/lib/adapter.ts
@@ -1,0 +1,104 @@
+import type {
+  DataManipulationOperation,
+  DataManipulationRequest,
+  DataManipulationResult,
+  DatabaseAdapter,
+  SqlStatement,
+  TableRef,
+  TransactionOptions,
+  TransactionToken,
+} from '@remix-run/data-table'
+
+export type D1Value = ArrayBuffer | number | string | null
+
+/**
+ * `DatabaseAdapter` implementation for Cloudflare D1 database bindings.
+ */
+export class D1DatabaseAdapter implements DatabaseAdapter {
+  /**
+   * The SQL dialect identifier reported by this adapter.
+   */
+  dialect = 'd1'
+
+  /**
+   * Feature flags describing the D1 behaviors supported by this adapter.
+   */
+  capabilities
+
+  #database: D1Database
+
+  constructor(database: D1Database) {
+    this.#database = database
+    this.capabilities = {
+      returning: true,
+      savepoints: false,
+      upsert: true,
+      transactionalDdl: false,
+      migrationLock: false,
+    }
+  }
+
+  compileSql(_operation: DataManipulationOperation): SqlStatement[] {
+    throw new Error('D1DatabaseAdapter compileSql() is not implemented yet')
+  }
+
+  async execute(_request: DataManipulationRequest): Promise<DataManipulationResult> {
+    throw new Error('D1DatabaseAdapter execute() is not implemented yet')
+  }
+
+  async executeScript(_sql: string, _transaction?: TransactionToken): Promise<void> {
+    throw new Error('D1DatabaseAdapter executeScript() is not implemented yet')
+  }
+
+  async hasTable(_table: TableRef, _transaction?: TransactionToken): Promise<boolean> {
+    throw new Error('D1DatabaseAdapter hasTable() is not implemented yet')
+  }
+
+  async hasColumn(
+    _table: TableRef,
+    _column: string,
+    _transaction?: TransactionToken,
+  ): Promise<boolean> {
+    throw new Error('D1DatabaseAdapter hasColumn() is not implemented yet')
+  }
+
+  async beginTransaction(_options?: TransactionOptions): Promise<TransactionToken> {
+    throw new Error('D1DatabaseAdapter does not support data-table interactive transactions')
+  }
+
+  async commitTransaction(token: TransactionToken): Promise<void> {
+    throw new Error('Unknown transaction token: ' + token.id)
+  }
+
+  async rollbackTransaction(token: TransactionToken): Promise<void> {
+    throw new Error('Unknown transaction token: ' + token.id)
+  }
+
+  async createSavepoint(token: TransactionToken, _name: string): Promise<void> {
+    throw new Error('Unknown transaction token: ' + token.id)
+  }
+
+  async rollbackToSavepoint(token: TransactionToken, _name: string): Promise<void> {
+    throw new Error('Unknown transaction token: ' + token.id)
+  }
+
+  async releaseSavepoint(token: TransactionToken, _name: string): Promise<void> {
+    throw new Error('Unknown transaction token: ' + token.id)
+  }
+}
+
+/**
+ * Creates a Cloudflare D1 `DatabaseAdapter`.
+ * @param database Cloudflare D1 database binding.
+ * @returns A configured D1 adapter.
+ * @example
+ * ```ts
+ * import { createDatabase } from 'remix/data-table'
+ * import { createD1DatabaseAdapter } from 'remix/data-table/d1'
+ *
+ * let db = createDatabase(createD1DatabaseAdapter(env.DB))
+ * ```
+ */
+export function createD1DatabaseAdapter(database: D1Database): D1DatabaseAdapter {
+  return new D1DatabaseAdapter(database)
+}

--- a/packages/data-table-d1/src/lib/adapter.ts
+++ b/packages/data-table-d1/src/lib/adapter.ts
@@ -8,6 +8,9 @@ import type {
   TransactionOptions,
   TransactionToken,
 } from '@remix-run/data-table'
+import { getTablePrimaryKey } from '@remix-run/data-table'
+
+import { compileD1Operation } from './sql-compiler.ts'
 
 export type D1Value = ArrayBuffer | number | string | null
 
@@ -38,28 +41,103 @@ export class D1DatabaseAdapter implements DatabaseAdapter {
     }
   }
 
-  compileSql(_operation: DataManipulationOperation): SqlStatement[] {
-    throw new Error('D1DatabaseAdapter compileSql() is not implemented yet')
+  /**
+   * Compiles a data-manipulation operation to D1 SQL statements.
+   * @param operation Operation to compile.
+   * @returns Compiled SQL statements.
+   */
+  compileSql(operation: DataManipulationOperation): SqlStatement[] {
+    let compiled = compileD1Operation(operation)
+    return [{ text: compiled.text, values: compiled.values }]
   }
 
-  async execute(_request: DataManipulationRequest): Promise<DataManipulationResult> {
-    throw new Error('D1DatabaseAdapter execute() is not implemented yet')
+  /**
+   * Executes a D1 data-manipulation request.
+   * @param request Request to execute.
+   * @returns Execution result.
+   */
+  async execute(request: DataManipulationRequest): Promise<DataManipulationResult> {
+    if (request.transaction) {
+      throwUnknownTransaction(request.transaction)
+    }
+
+    if (request.operation.kind === 'insertMany' && request.operation.values.length === 0) {
+      return {
+        affectedRows: 0,
+        insertId: undefined,
+        rows: request.operation.returning ? [] : undefined,
+      }
+    }
+
+    let statement = this.compileSql(request.operation)[0]
+    let result = await this.#database
+      .prepare(statement.text)
+      .bind(...normalizeStatementValues(statement.values))
+      .run<Record<string, unknown>>()
+    let rows = normalizeRows(result.results)
+
+    if (request.operation.kind === 'count' || request.operation.kind === 'exists') {
+      rows = normalizeCountRows(rows)
+    }
+
+    return {
+      rows: shouldReturnRows(request.operation, rows) ? rows : undefined,
+      affectedRows: normalizeAffectedRows(request.operation.kind, result, rows),
+      insertId: normalizeInsertId(request.operation, result, rows),
+    }
   }
 
-  async executeScript(_sql: string, _transaction?: TransactionToken): Promise<void> {
-    throw new Error('D1DatabaseAdapter executeScript() is not implemented yet')
+  /**
+   * Executes a multi-statement D1 SQL script.
+   * @param sql SQL script to execute.
+   * @param transaction Optional transaction token (unsupported by D1).
+   * @returns A promise that resolves once execution completes.
+   */
+  async executeScript(sql: string, transaction?: TransactionToken): Promise<void> {
+    if (transaction) {
+      throwUnknownTransaction(transaction)
+    }
+
+    await this.#database.exec(sql)
   }
 
-  async hasTable(_table: TableRef, _transaction?: TransactionToken): Promise<boolean> {
-    throw new Error('D1DatabaseAdapter hasTable() is not implemented yet')
+  /**
+   * Checks whether a table exists in D1.
+   * @param table Table reference to inspect.
+   * @param transaction Optional transaction token (unsupported by D1).
+   * @returns `true` when the table exists.
+   */
+  async hasTable(table: TableRef, transaction?: TransactionToken): Promise<boolean> {
+    if (transaction) {
+      throwUnknownTransaction(transaction)
+    }
+
+    let masterTable = table.schema
+      ? quoteIdentifier(table.schema) + '.sqlite_master'
+      : 'sqlite_master'
+    let result = await this.#database
+      .prepare('select 1 from ' + masterTable + ' where type = ? and name = ? limit 1')
+      .bind('table', table.name)
+      .run<Record<string, unknown>>()
+
+    return normalizeRows(result.results).length > 0
   }
 
   async hasColumn(
-    _table: TableRef,
-    _column: string,
-    _transaction?: TransactionToken,
+    table: TableRef,
+    column: string,
+    transaction?: TransactionToken,
   ): Promise<boolean> {
-    throw new Error('D1DatabaseAdapter hasColumn() is not implemented yet')
+    if (transaction) {
+      throwUnknownTransaction(transaction)
+    }
+
+    let schemaPrefix = table.schema ? quoteIdentifier(table.schema) + '.' : ''
+    let result = await this.#database
+      .prepare('pragma ' + schemaPrefix + 'table_info(' + quoteIdentifier(table.name) + ')')
+      .run<Record<string, unknown>>()
+
+    return normalizeRows(result.results).some((row) => row.name === column)
   }
 
   async beginTransaction(_options?: TransactionOptions): Promise<TransactionToken> {
@@ -67,23 +145,23 @@ export class D1DatabaseAdapter implements DatabaseAdapter {
   }
 
   async commitTransaction(token: TransactionToken): Promise<void> {
-    throw new Error('Unknown transaction token: ' + token.id)
+    throwUnknownTransaction(token)
   }
 
   async rollbackTransaction(token: TransactionToken): Promise<void> {
-    throw new Error('Unknown transaction token: ' + token.id)
+    throwUnknownTransaction(token)
   }
 
   async createSavepoint(token: TransactionToken, _name: string): Promise<void> {
-    throw new Error('Unknown transaction token: ' + token.id)
+    throwUnknownTransaction(token)
   }
 
   async rollbackToSavepoint(token: TransactionToken, _name: string): Promise<void> {
-    throw new Error('Unknown transaction token: ' + token.id)
+    throwUnknownTransaction(token)
   }
 
   async releaseSavepoint(token: TransactionToken, _name: string): Promise<void> {
-    throw new Error('Unknown transaction token: ' + token.id)
+    throwUnknownTransaction(token)
   }
 }
 
@@ -101,4 +179,146 @@ export class D1DatabaseAdapter implements DatabaseAdapter {
  */
 export function createD1DatabaseAdapter(database: D1Database): D1DatabaseAdapter {
   return new D1DatabaseAdapter(database)
+}
+
+function normalizeRows(rows: unknown[]): Record<string, unknown>[] {
+  return rows.map((row) => {
+    if (typeof row !== 'object' || row === null) {
+      return {}
+    }
+
+    return { ...(row as Record<string, unknown>) }
+  })
+}
+
+function normalizeStatementValues(values: unknown[]): D1Value[] {
+  return values.map(normalizeStatementValue)
+}
+
+function normalizeStatementValue(value: unknown): D1Value {
+  if (value === undefined) {
+    return null
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  if (value === null || typeof value === 'number' || typeof value === 'string') {
+    return value
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return value
+  }
+
+  throw new TypeError('Unsupported D1 bound value: ' + String(value))
+}
+
+function normalizeCountRows(rows: Record<string, unknown>[]): Record<string, unknown>[] {
+  return rows.map((row) => {
+    let count = row.count
+
+    if (typeof count === 'string') {
+      let numeric = Number(count)
+
+      if (!Number.isNaN(numeric)) {
+        return {
+          ...row,
+          count: numeric,
+        }
+      }
+    }
+
+    return row
+  })
+}
+
+function shouldReturnRows(
+  operation: DataManipulationRequest['operation'],
+  rows: Record<string, unknown>[],
+): boolean {
+  if (operation.kind === 'select' || operation.kind === 'count' || operation.kind === 'exists') {
+    return true
+  }
+
+  if (operation.kind === 'raw') {
+    return rows.length > 0
+  }
+
+  return operation.returning !== undefined
+}
+
+function normalizeAffectedRows(
+  kind: DataManipulationRequest['operation']['kind'],
+  result: D1Result<Record<string, unknown>>,
+  rows: Record<string, unknown>[],
+): number | undefined {
+  if (kind === 'select' || kind === 'count' || kind === 'exists') {
+    return undefined
+  }
+
+  if (isWriteOperationKind(kind) && rows.length > 0) {
+    return rows.length
+  }
+
+  return result.meta.changes
+}
+
+function normalizeInsertId(
+  operation: DataManipulationRequest['operation'],
+  result: D1Result<Record<string, unknown>>,
+  rows: Record<string, unknown>[],
+): unknown {
+  if (!isInsertOperation(operation)) {
+    return undefined
+  }
+
+  let primaryKey = getTablePrimaryKey(operation.table)
+
+  if (primaryKey.length !== 1) {
+    return undefined
+  }
+
+  let key = primaryKey[0]
+  let row = rows[rows.length - 1]
+
+  if (row) {
+    return row[key]
+  }
+
+  return result.meta.last_row_id
+}
+
+function quoteIdentifier(value: string): string {
+  return '"' + value.replace(/"/g, '""') + '"'
+}
+
+function throwUnknownTransaction(token: TransactionToken): never {
+  throw new Error('Unknown transaction token: ' + token.id)
+}
+
+function isWriteOperationKind(kind: DataManipulationRequest['operation']['kind']): boolean {
+  return (
+    kind === 'insert' ||
+    kind === 'insertMany' ||
+    kind === 'update' ||
+    kind === 'delete' ||
+    kind === 'upsert'
+  )
+}
+
+function isInsertOperation(
+  operation: DataManipulationRequest['operation'],
+): operation is Extract<
+  DataManipulationRequest['operation'],
+  { kind: 'insert' | 'insertMany' | 'upsert' }
+> {
+  return (
+    operation.kind === 'insert' || operation.kind === 'insertMany' || operation.kind === 'upsert'
+  )
 }

--- a/packages/data-table-d1/src/lib/adapter.ts
+++ b/packages/data-table-d1/src/lib/adapter.ts
@@ -14,6 +14,35 @@ import { compileD1Operation } from './sql-compiler.ts'
 
 export type D1Value = ArrayBuffer | number | string | null
 
+export interface D1Database {
+  prepare(query: string): D1PreparedStatement
+  batch<row = unknown>(statements: D1PreparedStatement[]): Promise<Array<D1Result<row>>>
+  exec(query: string): Promise<D1ExecResult>
+}
+
+export interface D1PreparedStatement {
+  bind(...values: unknown[]): D1PreparedStatement
+  first<row = unknown>(colName: string): Promise<row | null>
+  first<row = Record<string, unknown>>(): Promise<row | null>
+  run<row = Record<string, unknown>>(): Promise<D1Result<row>>
+  all<row = Record<string, unknown>>(): Promise<D1Result<row>>
+}
+
+export interface D1Result<row = unknown> {
+  results?: row[]
+  meta: D1Meta
+}
+
+export interface D1Meta {
+  changes?: number
+  last_row_id?: number
+}
+
+export interface D1ExecResult {
+  count: number
+  duration: number
+}
+
 /**
  * `DatabaseAdapter` implementation for Cloudflare D1 database bindings.
  */
@@ -74,7 +103,7 @@ export class D1DatabaseAdapter implements DatabaseAdapter {
       .prepare(statement.text)
       .bind(...normalizeStatementValues(statement.values))
       .run<Record<string, unknown>>()
-    let rows = normalizeRows(result.results)
+    let rows = normalizeRows(result.results ?? [])
 
     if (request.operation.kind === 'count' || request.operation.kind === 'exists') {
       rows = normalizeCountRows(rows)
@@ -120,7 +149,7 @@ export class D1DatabaseAdapter implements DatabaseAdapter {
       .bind('table', table.name)
       .run<Record<string, unknown>>()
 
-    return normalizeRows(result.results).length > 0
+    return normalizeRows(result.results ?? []).length > 0
   }
 
   async hasColumn(
@@ -137,7 +166,7 @@ export class D1DatabaseAdapter implements DatabaseAdapter {
       .prepare('pragma ' + schemaPrefix + 'table_info(' + quoteIdentifier(table.name) + ')')
       .run<Record<string, unknown>>()
 
-    return normalizeRows(result.results).some((row) => row.name === column)
+    return normalizeRows(result.results ?? []).some((row) => row.name === column)
   }
 
   async beginTransaction(_options?: TransactionOptions): Promise<TransactionToken> {

--- a/packages/data-table-d1/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-d1/src/lib/sql-compiler.test.ts
@@ -1,0 +1,197 @@
+import * as assert from '@remix-run/assert'
+import {
+  and,
+  column,
+  createDatabase,
+  eq,
+  ilike,
+  inList,
+  notInList,
+  or,
+  table,
+  type DataManipulationOperation,
+  type DatabaseAdapter,
+} from '@remix-run/data-table'
+import { beforeEach, describe, it } from '@remix-run/test'
+
+import { compileD1Operation } from './sql-compiler.ts'
+
+const accounts = table({
+  name: 'accounts',
+  columns: {
+    id: column.integer(),
+    email: column.text(),
+    status: column.text(),
+    deleted: column.boolean(),
+  },
+})
+
+const tasks = table({
+  name: 'tasks',
+  columns: {
+    id: column.integer(),
+    name: column.text(),
+    account_id: column.integer(),
+  },
+})
+
+let operations: DataManipulationOperation[] = []
+
+const adapter = {
+  dialect: 'd1',
+  capabilities: {
+    returning: true,
+    savepoints: false,
+    upsert: true,
+    transactionalDdl: false,
+    migrationLock: false,
+  },
+  compileSql(operation) {
+    return [compileD1Operation(operation)]
+  },
+  async execute(request) {
+    operations.push(request.operation)
+
+    if (request.operation.kind === 'select') {
+      return { rows: [{ id: 1 }] }
+    }
+
+    if (request.operation.kind === 'insert' && request.operation.returning) {
+      return { rows: [{ id: 10 }] }
+    }
+
+    return {}
+  },
+  async executeScript() {},
+  async hasTable() {
+    return false
+  },
+  async hasColumn() {
+    return false
+  },
+  async beginTransaction() {
+    throw new Error('not used')
+  },
+  async commitTransaction() {},
+  async rollbackTransaction() {},
+  async createSavepoint() {},
+  async rollbackToSavepoint() {},
+  async releaseSavepoint() {},
+} satisfies DatabaseAdapter
+
+const db = createDatabase(adapter)
+
+describe('d1 sql-compiler', () => {
+  beforeEach(() => {
+    operations = []
+  })
+
+  it('compiles wildcard and selected reads', async () => {
+    await db.query(accounts).all()
+    await db.query(accounts).select({ accountId: accounts.id, accountEmail: accounts.email }).all()
+
+    assert.deepEqual(compileD1Operation(operations[0]), {
+      text: 'select * from "accounts"',
+      values: [],
+    })
+    assert.deepEqual(compileD1Operation(operations[1]), {
+      text: 'select "accounts"."id" as "accountId", "accounts"."email" as "accountEmail" from "accounts"',
+      values: [],
+    })
+  })
+
+  it('compiles joins and column comparisons', async () => {
+    await db.query(accounts).join(tasks, eq(accounts.id, tasks.account_id)).all()
+
+    assert.deepEqual(compileD1Operation(operations[0]), {
+      text: 'select * from "accounts" inner join "tasks" on "accounts"."id" = "tasks"."account_id"',
+      values: [],
+    })
+  })
+
+  it('compiles predicate values and empty list predicates', async () => {
+    await db
+      .query(accounts)
+      .where(
+        and(
+          eq('status', 'active'),
+          ilike('email', '%@example.com'),
+          inList('id', [1, 2]),
+          notInList('id', []),
+        ),
+      )
+      .all()
+
+    assert.deepEqual(compileD1Operation(operations[0]), {
+      text: 'select * from "accounts" where (("status" = ?) and (lower("email") like lower(?)) and ("id" in (?, ?)) and (1 = 1))',
+      values: ['active', '%@example.com', 1, 2],
+    })
+  })
+
+  it('compiles grouped counts', async () => {
+    await db
+      .query(accounts)
+      .join(tasks, eq(accounts.id, tasks.account_id))
+      .where(or(eq('status', 'active'), eq('status', 'trial')))
+      .groupBy('accounts.id')
+      .having(eq('accounts.id', 1))
+      .count()
+
+    assert.deepEqual(compileD1Operation(operations[0]), {
+      text: 'select count(*) as "count" from (select 1 from "accounts" inner join "tasks" on "accounts"."id" = "tasks"."account_id" where (("status" = ?) or ("status" = ?)) group by "accounts"."id" having ("accounts"."id" = ?)) as "__dt_count"',
+      values: ['active', 'trial', 1],
+    })
+  })
+
+  it('compiles inserts, updates, deletes, and returning clauses', async () => {
+    await db.query(accounts).insert({ id: 1, email: 'a@example.com', status: 'active' })
+    await db
+      .query(accounts)
+      .insert({ id: 2, email: 'b@example.com', status: 'active' }, { returning: ['id'] })
+    await db
+      .query(accounts)
+      .where({ id: 1 })
+      .update({ status: 'inactive' }, { returning: ['id', 'status'] })
+    await db.query(accounts).where({ id: 2 }).delete({ returning: ['id'] })
+
+    assert.deepEqual(compileD1Operation(operations[0]), {
+      text: 'insert into "accounts" ("id", "email", "status") values (?, ?, ?)',
+      values: [1, 'a@example.com', 'active'],
+    })
+    assert.deepEqual(compileD1Operation(operations[1]), {
+      text: 'insert into "accounts" ("id", "email", "status") values (?, ?, ?) returning "id"',
+      values: [2, 'b@example.com', 'active'],
+    })
+    assert.deepEqual(compileD1Operation(operations[2]), {
+      text: 'update "accounts" set "status" = ? where (("id" = ?)) returning "id", "status"',
+      values: ['inactive', 1],
+    })
+    assert.deepEqual(compileD1Operation(operations[3]), {
+      text: 'delete from "accounts" where (("id" = ?)) returning "id"',
+      values: [2],
+    })
+  })
+
+  it('compiles upserts with conflict targets', async () => {
+    await db
+      .query(accounts)
+      .upsert(
+        { id: 1, email: 'a@example.com', status: 'inactive' },
+        { conflictTarget: ['id'], update: { status: 'inactive' }, returning: ['id', 'status'] },
+      )
+
+    assert.deepEqual(compileD1Operation(operations[0]), {
+      text: 'insert into "accounts" ("id", "email", "status") values (?, ?, ?) on conflict ("id") do update set "status" = ? returning "id", "status"',
+      values: ['inactive', 1, 'a@example.com', 'inactive'],
+    })
+  })
+
+  it('normalizes booleans to D1 integer values during compilation', async () => {
+    await db.query(accounts).where(eq('deleted', false)).all()
+
+    assert.deepEqual(compileD1Operation(operations[0]), {
+      text: 'select * from "accounts" where ("deleted" = ?)',
+      values: [0],
+    })
+  })
+})

--- a/packages/data-table-d1/src/lib/sql-compiler.ts
+++ b/packages/data-table-d1/src/lib/sql-compiler.ts
@@ -1,0 +1,486 @@
+import { getTableName, getTablePrimaryKey } from '@remix-run/data-table'
+import type { DataManipulationOperation, Predicate, SqlStatement } from '@remix-run/data-table'
+import {
+  collectColumns as collectColumnsHelper,
+  normalizeJoinType as normalizeJoinTypeHelper,
+  quotePath as quotePathHelper,
+} from '@remix-run/data-table/sql-helpers'
+
+type JoinClause = Extract<DataManipulationOperation, { kind: 'select' }>['joins'][number]
+type UpsertOperation = Extract<DataManipulationOperation, { kind: 'upsert' }>
+type OperationTable = Extract<DataManipulationOperation, { kind: 'select' }>['table']
+
+type CompileContext = {
+  values: unknown[]
+}
+
+export function compileD1Operation(operation: DataManipulationOperation): SqlStatement {
+  if (operation.kind === 'raw') {
+    return {
+      text: operation.sql.text,
+      values: [...operation.sql.values],
+    }
+  }
+
+  let context: CompileContext = { values: [] }
+
+  if (operation.kind === 'select') {
+    let selection = '*'
+
+    if (operation.select !== '*') {
+      selection = operation.select
+        .map((field) => quotePath(field.column) + ' as ' + quoteIdentifier(field.alias))
+        .join(', ')
+    }
+
+    return {
+      text:
+        'select ' +
+        (operation.distinct ? 'distinct ' : '') +
+        selection +
+        compileFromClause(operation.table, operation.joins, context) +
+        compileWhereClause(operation.where, context) +
+        compileGroupByClause(operation.groupBy) +
+        compileHavingClause(operation.having, context) +
+        compileOrderByClause(operation.orderBy) +
+        compileLimitClause(operation.limit) +
+        compileOffsetClause(operation.offset),
+      values: context.values,
+    }
+  }
+
+  if (operation.kind === 'count' || operation.kind === 'exists') {
+    let inner =
+      'select 1' +
+      compileFromClause(operation.table, operation.joins, context) +
+      compileWhereClause(operation.where, context) +
+      compileGroupByClause(operation.groupBy) +
+      compileHavingClause(operation.having, context)
+
+    return {
+      text:
+        'select count(*) as ' +
+        quoteIdentifier('count') +
+        ' from (' +
+        inner +
+        ') as ' +
+        quoteIdentifier('__dt_count'),
+      values: context.values,
+    }
+  }
+
+  if (operation.kind === 'insert') {
+    return compileInsertOperation(operation.table, operation.values, operation.returning, context)
+  }
+
+  if (operation.kind === 'insertMany') {
+    return compileInsertManyOperation(
+      operation.table,
+      operation.values,
+      operation.returning,
+      context,
+    )
+  }
+
+  if (operation.kind === 'update') {
+    let columns = Object.keys(operation.changes)
+
+    return {
+      text:
+        'update ' +
+        quotePath(getTableName(operation.table)) +
+        ' set ' +
+        columns
+          .map(
+            (column) => quotePath(column) + ' = ' + pushValue(context, operation.changes[column]),
+          )
+          .join(', ') +
+        compileWhereClause(operation.where, context) +
+        compileReturningClause(operation.returning),
+      values: context.values,
+    }
+  }
+
+  if (operation.kind === 'delete') {
+    return {
+      text:
+        'delete from ' +
+        quotePath(getTableName(operation.table)) +
+        compileWhereClause(operation.where, context) +
+        compileReturningClause(operation.returning),
+      values: context.values,
+    }
+  }
+
+  if (operation.kind === 'upsert') {
+    return compileUpsertOperation(operation, context)
+  }
+
+  throw new Error('Unsupported operation kind')
+}
+
+function compileInsertOperation(
+  table: OperationTable,
+  values: Record<string, unknown>,
+  returning: '*' | string[] | undefined,
+  context: CompileContext,
+): SqlStatement {
+  let columns = Object.keys(values)
+
+  if (columns.length === 0) {
+    return {
+      text:
+        'insert into ' +
+        quotePath(getTableName(table)) +
+        ' default values' +
+        compileReturningClause(returning),
+      values: context.values,
+    }
+  }
+
+  return {
+    text:
+      'insert into ' +
+      quotePath(getTableName(table)) +
+      ' (' +
+      columns.map((column) => quotePath(column)).join(', ') +
+      ') values (' +
+      columns.map((column) => pushValue(context, values[column])).join(', ') +
+      ')' +
+      compileReturningClause(returning),
+    values: context.values,
+  }
+}
+
+function compileInsertManyOperation(
+  table: OperationTable,
+  rows: Record<string, unknown>[],
+  returning: '*' | string[] | undefined,
+  context: CompileContext,
+): SqlStatement {
+  if (rows.length === 0) {
+    return {
+      text: 'select 0 where 1 = 0',
+      values: context.values,
+    }
+  }
+
+  let columns = collectColumns(rows)
+
+  if (columns.length === 0) {
+    return {
+      text:
+        'insert into ' +
+        quotePath(getTableName(table)) +
+        ' default values' +
+        compileReturningClause(returning),
+      values: context.values,
+    }
+  }
+
+  return {
+    text:
+      'insert into ' +
+      quotePath(getTableName(table)) +
+      ' (' +
+      columns.map((column) => quotePath(column)).join(', ') +
+      ') values ' +
+      rows
+        .map(
+          (row) =>
+            '(' +
+            columns
+              .map((column) => {
+                let value = Object.prototype.hasOwnProperty.call(row, column) ? row[column] : null
+                return pushValue(context, value)
+              })
+              .join(', ') +
+            ')',
+        )
+        .join(', ') +
+      compileReturningClause(returning),
+    values: context.values,
+  }
+}
+
+function compileUpsertOperation(operation: UpsertOperation, context: CompileContext): SqlStatement {
+  let insertColumns = Object.keys(operation.values)
+  let conflictTarget = operation.conflictTarget ?? [...getTablePrimaryKey(operation.table)]
+
+  if (insertColumns.length === 0) {
+    throw new Error('upsert requires at least one value')
+  }
+
+  let updateValues = operation.update ?? operation.values
+  let updateColumns = Object.keys(updateValues)
+  let conflictClause = ''
+
+  if (updateColumns.length === 0) {
+    conflictClause =
+      ' on conflict (' +
+      conflictTarget.map((column: string) => quotePath(column)).join(', ') +
+      ') do nothing'
+  } else {
+    conflictClause =
+      ' on conflict (' +
+      conflictTarget.map((column: string) => quotePath(column)).join(', ') +
+      ') do update set ' +
+      updateColumns
+        .map((column) => quotePath(column) + ' = ' + pushValue(context, updateValues[column]))
+        .join(', ')
+  }
+
+  return {
+    text:
+      'insert into ' +
+      quotePath(getTableName(operation.table)) +
+      ' (' +
+      insertColumns.map((column) => quotePath(column)).join(', ') +
+      ') values (' +
+      insertColumns.map((column) => pushValue(context, operation.values[column])).join(', ') +
+      ')' +
+      conflictClause +
+      compileReturningClause(operation.returning),
+    values: context.values,
+  }
+}
+
+function compileFromClause(
+  table: OperationTable,
+  joins: JoinClause[],
+  context: CompileContext,
+): string {
+  let output = ' from ' + quotePath(getTableName(table))
+
+  for (let join of joins) {
+    output +=
+      ' ' +
+      normalizeJoinType(join.type) +
+      ' join ' +
+      quotePath(getTableName(join.table)) +
+      ' on ' +
+      compilePredicate(join.on, context)
+  }
+
+  return output
+}
+
+function compileWhereClause(predicates: Predicate[], context: CompileContext): string {
+  if (predicates.length === 0) {
+    return ''
+  }
+
+  return (
+    ' where ' +
+    predicates.map((predicate) => '(' + compilePredicate(predicate, context) + ')').join(' and ')
+  )
+}
+
+function compileGroupByClause(columns: string[]): string {
+  if (columns.length === 0) {
+    return ''
+  }
+
+  return ' group by ' + columns.map((column) => quotePath(column)).join(', ')
+}
+
+function compileHavingClause(predicates: Predicate[], context: CompileContext): string {
+  if (predicates.length === 0) {
+    return ''
+  }
+
+  return (
+    ' having ' +
+    predicates.map((predicate) => '(' + compilePredicate(predicate, context) + ')').join(' and ')
+  )
+}
+
+function compileOrderByClause(orderBy: { column: string; direction: 'asc' | 'desc' }[]): string {
+  if (orderBy.length === 0) {
+    return ''
+  }
+
+  return (
+    ' order by ' +
+    orderBy
+      .map((clause) => quotePath(clause.column) + ' ' + clause.direction.toUpperCase())
+      .join(', ')
+  )
+}
+
+function compileLimitClause(limit: number | undefined): string {
+  if (limit === undefined) {
+    return ''
+  }
+
+  return ' limit ' + String(limit)
+}
+
+function compileOffsetClause(offset: number | undefined): string {
+  if (offset === undefined) {
+    return ''
+  }
+
+  return ' offset ' + String(offset)
+}
+
+function compileReturningClause(returning: '*' | string[] | undefined): string {
+  if (!returning) {
+    return ''
+  }
+
+  if (returning === '*') {
+    return ' returning *'
+  }
+
+  return ' returning ' + returning.map((column) => quotePath(column)).join(', ')
+}
+
+function compilePredicate(predicate: Predicate, context: CompileContext): string {
+  if (predicate.type === 'comparison') {
+    let column = quotePath(predicate.column)
+
+    if (predicate.operator === 'eq') {
+      if (
+        predicate.valueType === 'value' &&
+        (predicate.value === null || predicate.value === undefined)
+      ) {
+        return column + ' is null'
+      }
+
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return column + ' = ' + comparisonValue
+    }
+
+    if (predicate.operator === 'ne') {
+      if (
+        predicate.valueType === 'value' &&
+        (predicate.value === null || predicate.value === undefined)
+      ) {
+        return column + ' is not null'
+      }
+
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return column + ' <> ' + comparisonValue
+    }
+
+    if (predicate.operator === 'gt') {
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return column + ' > ' + comparisonValue
+    }
+
+    if (predicate.operator === 'gte') {
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return column + ' >= ' + comparisonValue
+    }
+
+    if (predicate.operator === 'lt') {
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return column + ' < ' + comparisonValue
+    }
+
+    if (predicate.operator === 'lte') {
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return column + ' <= ' + comparisonValue
+    }
+
+    if (predicate.operator === 'in' || predicate.operator === 'notIn') {
+      let values = Array.isArray(predicate.value) ? predicate.value : []
+
+      if (values.length === 0) {
+        return predicate.operator === 'in' ? '1 = 0' : '1 = 1'
+      }
+
+      let keyword = predicate.operator === 'in' ? 'in' : 'not in'
+
+      return (
+        column +
+        ' ' +
+        keyword +
+        ' (' +
+        values.map((value) => pushValue(context, value)).join(', ') +
+        ')'
+      )
+    }
+
+    if (predicate.operator === 'like') {
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return column + ' like ' + comparisonValue
+    }
+
+    if (predicate.operator === 'ilike') {
+      let comparisonValue = compileComparisonValue(predicate, context)
+      return 'lower(' + column + ') like lower(' + comparisonValue + ')'
+    }
+  }
+
+  if (predicate.type === 'between') {
+    return (
+      quotePath(predicate.column) +
+      ' between ' +
+      pushValue(context, predicate.lower) +
+      ' and ' +
+      pushValue(context, predicate.upper)
+    )
+  }
+
+  if (predicate.type === 'null') {
+    return (
+      quotePath(predicate.column) + (predicate.operator === 'isNull' ? ' is null' : ' is not null')
+    )
+  }
+
+  if (predicate.type === 'logical') {
+    if (predicate.predicates.length === 0) {
+      return predicate.operator === 'and' ? '1 = 1' : '1 = 0'
+    }
+
+    let joiner = predicate.operator === 'and' ? ' and ' : ' or '
+
+    return predicate.predicates
+      .map((child) => '(' + compilePredicate(child, context) + ')')
+      .join(joiner)
+  }
+
+  throw new Error('Unsupported predicate')
+}
+
+function compileComparisonValue(
+  predicate: Extract<Predicate, { type: 'comparison' }>,
+  context: CompileContext,
+): string {
+  if (predicate.valueType === 'column') {
+    return quotePath(predicate.value)
+  }
+
+  return pushValue(context, predicate.value)
+}
+
+function normalizeJoinType(type: string): string {
+  return normalizeJoinTypeHelper(type)
+}
+
+function quoteIdentifier(value: string): string {
+  return '"' + value.replace(/"/g, '""') + '"'
+}
+
+function quotePath(path: string): string {
+  return quotePathHelper(path, quoteIdentifier)
+}
+
+function pushValue(context: CompileContext, value: unknown): string {
+  context.values.push(normalizeCompiledValue(value))
+  return '?'
+}
+
+function normalizeCompiledValue(value: unknown): unknown {
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0
+  }
+
+  return value
+}
+
+function collectColumns(rows: Record<string, unknown>[]): string[] {
+  return collectColumnsHelper(rows)
+}

--- a/packages/data-table-d1/src/lib/test-d1.test-helper.ts
+++ b/packages/data-table-d1/src/lib/test-d1.test-helper.ts
@@ -1,5 +1,12 @@
 import { Miniflare } from 'miniflare'
 
+import type {
+  D1Database,
+  D1ExecResult,
+  D1PreparedStatement,
+  D1Result,
+} from './adapter.ts'
+
 export type TestD1Database = D1Database & {
   prepareCalls: number
   dispose(): Promise<void>
@@ -39,14 +46,6 @@ class TestD1DatabaseWrapper implements TestD1Database {
 
   exec(query: string): Promise<D1ExecResult> {
     return this.#database.exec(query)
-  }
-
-  withSession(constraintOrBookmark?: D1SessionBookmark | D1SessionConstraint): D1DatabaseSession {
-    return this.#database.withSession(constraintOrBookmark)
-  }
-
-  dump(): Promise<ArrayBuffer> {
-    return this.#database.dump()
   }
 
   async dispose(): Promise<void> {

--- a/packages/data-table-d1/src/lib/test-d1.test-helper.ts
+++ b/packages/data-table-d1/src/lib/test-d1.test-helper.ts
@@ -1,0 +1,55 @@
+import { Miniflare } from 'miniflare'
+
+export type TestD1Database = D1Database & {
+  prepareCalls: number
+  dispose(): Promise<void>
+}
+
+export async function createTestD1Database(): Promise<TestD1Database> {
+  let miniflare = new Miniflare({
+    modules: true,
+    script: 'export default { fetch() { return new Response("OK") } }',
+    d1Databases: ['DB'],
+    d1Persist: false,
+  })
+  let database = (await miniflare.getD1Database('DB')) as unknown as D1Database
+
+  return new TestD1DatabaseWrapper(database, miniflare)
+}
+
+class TestD1DatabaseWrapper implements TestD1Database {
+  prepareCalls = 0
+
+  #database: D1Database
+  #miniflare: Miniflare
+
+  constructor(database: D1Database, miniflare: Miniflare) {
+    this.#database = database
+    this.#miniflare = miniflare
+  }
+
+  prepare(query: string): D1PreparedStatement {
+    this.prepareCalls += 1
+    return this.#database.prepare(query)
+  }
+
+  batch<row = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<row>[]> {
+    return this.#database.batch<row>(statements)
+  }
+
+  exec(query: string): Promise<D1ExecResult> {
+    return this.#database.exec(query)
+  }
+
+  withSession(constraintOrBookmark?: D1SessionBookmark | D1SessionConstraint): D1DatabaseSession {
+    return this.#database.withSession(constraintOrBookmark)
+  }
+
+  dump(): Promise<ArrayBuffer> {
+    return this.#database.dump()
+  }
+
+  async dispose(): Promise<void> {
+    await this.#miniflare.dispose()
+  }
+}

--- a/packages/data-table-d1/tsconfig.build.json
+++ b/packages/data-table-d1/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "dist"]
+}

--- a/packages/data-table-d1/tsconfig.build.json
+++ b/packages/data-table-d1/tsconfig.build.json
@@ -6,5 +6,5 @@
     "outDir": "./dist"
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.ts", "dist"]
+  "exclude": ["src/**/*.test.ts", "src/**/*.test-helper.ts", "dist"]
 }

--- a/packages/data-table-d1/tsconfig.json
+++ b/packages/data-table-d1/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ESNext",
-    "types": ["node", "@cloudflare/workers-types"],
+    "types": ["node"],
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
     "verbatimModuleSyntax": true,

--- a/packages/data-table-d1/tsconfig.json
+++ b/packages/data-table-d1/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ESNext",
+    "types": ["node", "@cloudflare/workers-types"],
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "isolatedModules": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["vendor", "dist"]
+}

--- a/packages/data-table/test/adapter-integration-contract.ts
+++ b/packages/data-table/test/adapter-integration-contract.ts
@@ -44,6 +44,7 @@ const accountTasks = hasManyThrough(accounts, tasks, {
 
 export type IntegrationContractOptions = {
   integrationEnabled: boolean
+  supportsTransactions?: boolean
   createDatabase: () => Database
   resetDatabase: () => Promise<void>
 }
@@ -184,7 +185,9 @@ export function runAdapterIntegrationContract(options: IntegrationContractOption
 
   it(
     'scopes update/delete writes with orderBy and limit',
-    { skip: !options.integrationEnabled },
+    {
+      skip: !options.integrationEnabled || options.supportsTransactions === false,
+    },
     async function () {
       let db = options.createDatabase()
 
@@ -217,7 +220,10 @@ export function runAdapterIntegrationContract(options: IntegrationContractOption
 
   it(
     'supports transactions and nested savepoints',
-    { skip: !options.integrationEnabled },
+    {
+      // D1 supports atomic batches, but not data-table's interactive transaction contract.
+      skip: !options.integrationEnabled || options.supportsTransactions === false,
+    },
     async function () {
       let db = options.createDatabase()
 

--- a/packages/remix/.changes/minor.remix.update-exports.md
+++ b/packages/remix/.changes/minor.remix.update-exports.md
@@ -1,0 +1,2 @@
+Added `package.json` `exports`:
+ - `remix/data-table/d1` to re-export APIs from `@remix-run/data-table-d1`

--- a/packages/remix/manifest.json
+++ b/packages/remix/manifest.json
@@ -9,6 +9,7 @@
   "remix/data-schema/form-data": "@remix-run/data-schema/form-data",
   "remix/data-schema/lazy": "@remix-run/data-schema/lazy",
   "remix/data-table": "@remix-run/data-table",
+  "remix/data-table/d1": "@remix-run/data-table-d1",
   "remix/data-table/migrations": "@remix-run/data-table/migrations",
   "remix/data-table/migrations/node": "@remix-run/data-table/migrations/node",
   "remix/data-table/mysql": "@remix-run/data-table-mysql",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -41,6 +41,7 @@
     "./data-table-mysql": "./src/data-table-mysql.ts",
     "./data-table-postgres": "./src/data-table-postgres.ts",
     "./data-table-sqlite": "./src/data-table-sqlite.ts",
+    "./data-table/d1": "./src/data-table-d1.ts",
     "./data-table/migrations": "./src/data-table/migrations.ts",
     "./data-table/migrations/node": "./src/data-table/migrations/node.ts",
     "./data-table/mysql": "./src/data-table-mysql.ts",
@@ -229,6 +230,10 @@
       "./data-table-sqlite": {
         "types": "./dist/data-table-sqlite.d.ts",
         "default": "./dist/data-table-sqlite.js"
+      },
+      "./data-table/d1": {
+        "types": "./dist/data-table-d1.d.ts",
+        "default": "./dist/data-table-d1.js"
       },
       "./data-table/migrations": {
         "types": "./dist/data-table/migrations.d.ts",
@@ -705,7 +710,8 @@
     "@remix-run/cli": "workspace:^",
     "@remix-run/test": "workspace:^",
     "@remix-run/terminal": "workspace:^",
-    "@remix-run/render-middleware": "workspace:^"
+    "@remix-run/render-middleware": "workspace:^",
+    "@remix-run/data-table-d1": "workspace:^"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/packages/remix/src/data-table-d1.ts
+++ b/packages/remix/src/data-table-d1.ts
@@ -1,0 +1,2 @@
+// IMPORTANT: This file is auto-generated, please do not edit manually.
+export * from '@remix-run/data-table-d1'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -708,6 +708,9 @@ importers:
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20251125.1
+      miniflare:
+        specifier: ^4.20260603.0
+        version: 4.20260603.0
 
   packages/data-table-mysql:
     dependencies:
@@ -2199,8 +2202,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-64@1.20260603.1':
+    resolution: {integrity: sha512-cEXDWu6V3ZrpmwWkM4OJE9AeXjdAgOY5rh8EHhcBVCuP5rxnzUbPzLtrVOHx0UUUAcCrFq0Xsa6mZKL1VUZsKQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
   '@cloudflare/workerd-darwin-arm64@1.20260508.1':
     resolution: {integrity: sha512-JTVsisOJPcNKw0qovPjqyBWYahfdhUh7/9NICiG5wxaEQ45PYKdoqNq0hOAAIqvqoxsKZBvTgcPTJREPqk7avA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260603.1':
+    resolution: {integrity: sha512-uBPK4LaWJNbbCYwPnUAehlHbbVulhVZPZsdcAhBPfZhHb3QAuAEPAQepO/P67R3V6Cni4YGx1fLbL8A5wwoaNA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -2211,14 +2226,32 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-64@1.20260603.1':
+    resolution: {integrity: sha512-ht9l6/8Tk7Rp6kA4S9oFZ4X8u0VjnnFdmU/6B3fnABYKREYTKh2RdOqXqXxcp5eNJseireKnWik/hQOPK1CutQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
   '@cloudflare/workerd-linux-arm64@1.20260508.1':
     resolution: {integrity: sha512-XhJa780Ia6MNIrtxn/ruZHS79b9pu5EKPfRNReaUqxy8erPT2fs93axMfFoS9kIkcaRRj/1TOUKcTeAMoywY7w==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20260603.1':
+    resolution: {integrity: sha512-LJZ6x00rAjSrobV4m0ZW0TpH5ilBbKcWBzlH+y+KOUsIE/CpTuhAzKV43TbSnFLRX5+jrWKiz2v0hO91lPXy6A==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-windows-64@1.20260508.1':
     resolution: {integrity: sha512-QdDOK3B/Ul1s3QmIwDrFyx9230to6LsNmWcVR8w+TYjNZuRPzqQBgusp78LO7MlqCoEl9dvIcN00jkJnLtBSfw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260603.1':
+    resolution: {integrity: sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -4894,6 +4927,11 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
+  miniflare@4.20260603.0:
+    resolution: {integrity: sha512-+kMQYB82gC8MPOuojHur3icQsUeZUEJ+Sphuo5rVC3Ri9txBLAW/mH33b9OVrpmkogQeaaqPS4tPtugJZhk5Kw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -5626,6 +5664,11 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workerd@1.20260603.1:
+    resolution: {integrity: sha512-NPcbhI1++CS+fnELyXtsIR52en+5kwr/OrKeiQeYXGy10HxmPdsQBv9N+DU7hJIOOmBHhOGAAsoGDjyiQ2YCaA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   wrangler@4.90.1:
     resolution: {integrity: sha512-u2KrieKSMfRM0toTst/CfDtcRraeoVjmcExcMWgILM/ytq3qcDhuOAULoZSyPHzma43lfLJy1BC544drFyqe1A==}
     engines: {node: '>=22.0.0'}
@@ -5645,6 +5688,18 @@ packages:
 
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -5920,16 +5975,31 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20260508.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-64@1.20260603.1':
+    optional: true
+
   '@cloudflare/workerd-darwin-arm64@1.20260508.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260603.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260508.1':
     optional: true
 
+  '@cloudflare/workerd-linux-64@1.20260603.1':
+    optional: true
+
   '@cloudflare/workerd-linux-arm64@1.20260508.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20260603.1':
+    optional: true
+
   '@cloudflare/workerd-windows-64@1.20260508.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260603.1':
     optional: true
 
   '@cloudflare/workers-types@4.20260511.1': {}
@@ -7969,6 +8039,18 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  miniflare@4.20260603.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260603.1
+      ws: 8.20.1
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -8836,6 +8918,14 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260508.1
       '@cloudflare/workerd-windows-64': 1.20260508.1
 
+  workerd@1.20260603.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260603.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260603.1
+      '@cloudflare/workerd-linux-64': 1.20260603.1
+      '@cloudflare/workerd-linux-arm64': 1.20260603.1
+      '@cloudflare/workerd-windows-64': 1.20260603.1
+
   wrangler@4.90.1(@cloudflare/workers-types@4.20260511.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
@@ -8862,6 +8952,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.0: {}
+
+  ws@8.20.1: {}
 
   xtend@4.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -687,6 +687,28 @@ importers:
         specifier: 'catalog:'
         version: 7.0.0-dev.20251125.1
 
+  packages/data-table-d1:
+    dependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260511.1
+        version: 4.20260511.1
+      '@remix-run/data-table':
+        specifier: workspace:^
+        version: link:../data-table
+    devDependencies:
+      '@remix-run/assert':
+        specifier: workspace:*
+        version: link:../assert
+      '@remix-run/test':
+        specifier: workspace:*
+        version: link:../test
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.10.4
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20251125.1
+
   packages/data-table-mysql:
     dependencies:
       '@remix-run/data-table':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -689,9 +689,6 @@ importers:
 
   packages/data-table-d1:
     dependencies:
-      '@cloudflare/workers-types':
-        specifier: ^4.20260511.1
-        version: 4.20260511.1
       '@remix-run/data-table':
         specifier: workspace:^
         version: link:../data-table
@@ -1382,6 +1379,9 @@ importers:
       '@remix-run/data-table':
         specifier: workspace:^
         version: link:../data-table
+      '@remix-run/data-table-d1':
+        specifier: workspace:^
+        version: link:../data-table-d1
       '@remix-run/data-table-mysql':
         specifier: workspace:^
         version: link:../data-table-mysql


### PR DESCRIPTION
Adds a first-party Cloudflare D1 adapter for `remix/data-table`.

- Adds `@remix-run/data-table-d1`
- Exposes the adapter through `remix/data-table/d1`
- Supports D1 reads, writes, upserts, `RETURNING`, schema introspection, and SQL-file migration execution
- Uses current Miniflare for D1 adapter tests

### D1 transaction caveats

D1 supports atomic transactions through `env.DB.batch()`, but `data-table` transactions are currently interactive callback transactions. D1 rejects SQL `BEGIN` and `SAVEPOINT` through Worker bindings, so this adapter intentionally does not implement `db.transaction()` and reports `savepoints: false` and `transactionalDdl: false`.

`data-table` also uses its interactive transaction path internally for ordered/limited scoped writes like `query(...).orderBy(...).limit(...).update()` and `delete()`. The shared adapter integration contract skips those transaction-backed success cases when an adapter sets `supportsTransactions: false`, and D1 has package-level tests asserting those operations reject with the interactive transaction error.

Related discussion: https://github.com/remix-run/remix/pull/11057#issuecomment-3889302432 and https://github.com/remix-run/remix/pull/11057#issuecomment-3894161493

### Validation

- `pnpm run validate-package-meta`
- `pnpm changes:preview`
- `pnpm run lint`
- `pnpm run test:changed`
- `pnpm run typecheck:changed`
- `pnpm test`
- `DATA_TABLE_INTEGRATION=1 pnpm --filter @remix-run/data-table-d1 run test`
