### PR TITLE
Reduce Remix UI reconciler browser graph

### DIFF
--- a/packages/ui/.changes/patch.reconciler-mixin-runtime-cleanup.md
+++ b/packages/ui/.changes/patch.reconciler-mixin-runtime-cleanup.md
@@ -1,0 +1,1 @@
+Reduced browser JavaScript for Remix UI reconciler, DOM diffing, and mixin lifecycle helpers without changing public APIs.

--- a/packages/ui/src/runtime/diff-dom.ts
+++ b/packages/ui/src/runtime/diff-dom.ts
@@ -167,7 +167,13 @@ function diffNode(current: Node, next: Node, context: FrameContext): ChildNode |
 
     // Same tag: update attributes then children
     diffElementAttributes(current, next)
-    if (shouldPreserveElementChildren(current, next)) return
+    if (
+      current instanceof HTMLTextAreaElement &&
+      next instanceof HTMLTextAreaElement &&
+      current.value !== next.value
+    ) {
+      return
+    }
     diffElementChildren(current, next, context)
     return
   }
@@ -184,11 +190,9 @@ function diffElementAttributes(current: Element, next: Element): void {
   let prevAttrNames = current.getAttributeNames()
   let nextAttrNames = next.getAttributeNames()
 
-  let nextNameSet = new Set(nextAttrNames)
-
   // Removals
   for (let name of prevAttrNames) {
-    if (!nextNameSet.has(name)) {
+    if (!next.hasAttribute(name)) {
       if (shouldPreserveLiveAttribute(current, next, name)) continue
       current.removeAttribute(name)
     }
@@ -245,14 +249,6 @@ function shouldPreserveLiveAttribute(current: Element, next: Element, name: stri
   return false
 }
 
-function shouldPreserveElementChildren(current: Element, next: Element): boolean {
-  if (current instanceof HTMLTextAreaElement && next instanceof HTMLTextAreaElement) {
-    return current.value !== next.value
-  }
-
-  return false
-}
-
 function shouldPreserveInputValue(input: HTMLInputElement): boolean {
   return (
     input.type !== 'button' &&
@@ -303,20 +299,19 @@ function diffElementChildren(current: Element, next: Element, context: FrameCont
       }
     } else if (isElement(nextChild)) {
       let key = nextChild.getAttribute('data-key')
-      if (key != null && keyToIndex.has(key)) {
-        let idx = keyToIndex.get(key)!
-        if (!used[idx]) matchIndex = idx
+      if (key != null) {
+        let idx = keyToIndex.get(key)
+        if (idx !== undefined && !used[idx]) matchIndex = idx
       }
     }
 
     if (matchIndex === -1) {
-      let candidateIndex = i
       if (
-        candidateIndex < currentChildren.length &&
-        !used[candidateIndex] &&
-        nodeTypesComparable(currentChildren[candidateIndex], nextChild)
+        i < currentChildren.length &&
+        !used[i] &&
+        nodeTypesComparable(currentChildren[i], nextChild)
       ) {
-        matchIndex = candidateIndex
+        matchIndex = i
       }
     }
 
@@ -419,11 +414,8 @@ function diffElementChildren(current: Element, next: Element, context: FrameCont
 
     if (node.parentNode === current) {
       // Node already in parent: move only if its nextSibling is not the desired ref.
-      let targetNext = ref
-      let alreadyInPlace =
-        (targetNext === null && node.nextSibling === null) || node.nextSibling === targetNext
-      if (!alreadyInPlace) {
-        current.insertBefore(node, targetNext)
+      if (node.nextSibling !== ref) {
+        current.insertBefore(node, ref)
       }
     } else {
       // New node: insert relative to a valid ref or append
@@ -448,14 +440,8 @@ function diffElementChildren(current: Element, next: Element, context: FrameCont
 function nodeTypesComparable(a: Node, b: Node): boolean {
   if (isTextNode(a) && isTextNode(b)) return true
   if (isElement(a) && isElement(b)) return a.tagName === b.tagName
-  if (isVirtualRootStartMarker(a) && isVirtualRootStartMarker(b)) return true
-  if (isVirtualRootEndMarker(a) && isVirtualRootEndMarker(b)) return true
   if (isCommentNode(a) && isCommentNode(b)) return true
   return false
-}
-
-function isHydrationEndComment(node: Node): node is Comment {
-  return isCommentNode(node) && node.data.trim() === '/rmx:h'
 }
 
 function findHydrationEndMarker(start: Comment): Comment {
@@ -478,7 +464,8 @@ function findHydrationEndMarker(start: Comment): Comment {
 
 function findHydrationEndIndex(nodes: Node[], startIdx: number): number {
   for (let j = startIdx + 1; j < nodes.length; j++) {
-    if (isHydrationEndComment(nodes[j])) return j
+    let node = nodes[j]
+    if (isCommentNode(node) && node.data.trim() === '/rmx:h') return j
   }
   return startIdx
 }
@@ -596,29 +583,22 @@ function replaceCommentMarkerRange(
 ): void {
   let currentEnd = findFrameEndMarker(replacement.currentStart)
   let nextEnd = findFrameEndMarker(replacement.nextStart)
-  let nextNodes = collectNodeRange(replacement.nextStart, nextEnd)
-  let currentNodes = collectNodeRange(replacement.currentStart, currentEnd)
 
-  for (let node of nextNodes) {
-    parent.insertBefore(node, replacement.currentStart)
-  }
-
-  for (let node of currentNodes) {
-    removeNode(node, parent, context)
-  }
-}
-
-function collectNodeRange(start: Node, end: Node): Node[] {
-  let nodes: Node[] = []
-  let node: Node | null = start
-
+  let node: Node | null = replacement.nextStart
   while (node) {
-    nodes.push(node)
-    if (node === end) break
-    node = node.nextSibling
+    let next: Node | null = node.nextSibling
+    parent.insertBefore(node, replacement.currentStart)
+    if (node === nextEnd) break
+    node = next
   }
 
-  return nodes
+  node = replacement.currentStart
+  while (node) {
+    let next: Node | null = node.nextSibling
+    removeNode(node, parent, context)
+    if (node === currentEnd) break
+    node = next
+  }
 }
 
 function collectFrameContentFragment(
@@ -639,43 +619,31 @@ function collectFrameContentFragment(
 }
 
 function removeNode(node: Node, parent: ParentNode, context: FrameContext): void {
-  disposeRemovedVirtualRoots(node)
-  disposeRemovedSubFrames(node, context)
+  disposeRemovedRuntimeNodes(node, context)
 
   if (node.parentNode === parent) {
     parent.removeChild(node)
   }
 }
 
-function disposeRemovedVirtualRoots(node: Node): void {
-  let stack: Node[] = [node]
+function disposeRemovedRuntimeNodes(node: Node, context: FrameContext): void {
+  let stack: Array<[Node, boolean]> = [[node, false]]
   while (stack.length > 0) {
-    let next = stack.pop()
-    if (!next) continue
+    let item = stack.pop()
+    if (!item) continue
+    let [next, insideDisposedRoot] = item
 
-    if (isHydratedVirtualRootStartMarker(next)) {
+    if (!insideDisposedRoot && isHydratedVirtualRootStartMarker(next)) {
       next.$rmx.dispose()
-      continue
+      insideDisposedRoot = true
     }
-
-    for (let child of Array.from(next.childNodes)) {
-      stack.push(child)
-    }
-  }
-}
-
-function disposeRemovedSubFrames(node: Node, context: FrameContext): void {
-  let stack: Node[] = [node]
-  while (stack.length > 0) {
-    let next = stack.pop()
-    if (!next) continue
 
     if (isFrameStartMarker(next)) {
       disposeFrameStartMarker(next, context)
     }
 
     for (let child of Array.from(next.childNodes)) {
-      stack.push(child)
+      stack.push([child, insideDisposedRoot])
     }
   }
 }

--- a/packages/ui/src/runtime/mixins/mixin.ts
+++ b/packages/ui/src/runtime/mixins/mixin.ts
@@ -262,10 +262,16 @@ export function createMixin<
 }
 
 export function resolveMixedProps(input: ResolveMixedPropsInput): ResolveMixedPropsOutput {
-  let state = input.state ?? createMixinRuntimeState()
+  let state =
+    input.state ??
+    ({
+      id: `m${++mixinHandleId}`,
+      aborted: false,
+      runners: [],
+    } satisfies MixinRuntimeState)
   let handle = state.handle as ScopedAnyMixinHandle | undefined
   if (!handle) {
-    handle = createMixinHandle({
+    handle = new MixinHandleImpl({
       id: state.id,
       hostType: input.hostType,
       frame: input.frame,
@@ -289,7 +295,7 @@ export function resolveMixedProps(input: ResolveMixedPropsInput): ResolveMixedPr
       if (entry) {
         queueMixinRemove(handle, entry.scope)
       }
-      let scope = Symbol('mixin-scope')
+      let scope = Symbol()
       handle.setActiveScope(scope)
       entry = {
         scope,
@@ -303,7 +309,7 @@ export function resolveMixedProps(input: ResolveMixedPropsInput): ResolveMixedPr
       state.runners[index] = entry
       let binding = state.binding
       if (binding?.node) {
-        queueMixinInsert(handle, entry.scope, binding.node, binding.parent, binding.key)
+        queueMixinNodeEvent(handle, entry.scope, 'insert', binding.node, binding.parent, binding.key)
       }
     }
 
@@ -342,16 +348,14 @@ export function resolveMixedProps(input: ResolveMixedPropsInput): ResolveMixedPr
     let nextProps = sanitizeReturnedMixinProps(result.props)
     let nestedDescriptors = resolveMixDescriptors(nextProps)
     for (let nested of nestedDescriptors) descriptors.push(nested)
-    composedProps = composeMixinProps(composedProps, withoutMix(nextProps))
+    composedProps = { ...composedProps, ...withoutMix(nextProps) }
     mixinProps = withoutMixinTreeProps(composedProps)
   }
 
   for (let index = descriptors.length; index < state.runners.length; index++) {
     let entry = state.runners[index]
-    if (entry) {
-      handle.dispatchScopedEvent(entry.scope, new Event('remove'))
-      handle.releaseScope(entry.scope)
-    }
+    handle.dispatchScopedEvent(entry.scope, new Event('remove'))
+    handle.releaseScope(entry.scope)
   }
 
   if (state.runners.length > descriptors.length) {
@@ -394,12 +398,9 @@ export function bindMixinRuntime(
   let nextNode = nextBinding.node
   let handle = state.handle as ScopedAnyMixinHandle | undefined
   if (!handle) return
+  let eventType: 'reclaimed' | 'insert' = options?.dispatchReclaimed ? 'reclaimed' : 'insert'
   for (let entry of state.runners) {
-    if (options?.dispatchReclaimed) {
-      queueMixinReclaimed(handle, entry.scope, nextNode, nextBinding.parent, nextBinding.key)
-    } else {
-      queueMixinInsert(handle, entry.scope, nextNode, nextBinding.parent, nextBinding.key)
-    }
+    queueMixinNodeEvent(handle, entry.scope, eventType, nextNode, nextBinding.parent, nextBinding.key)
   }
 }
 
@@ -447,26 +448,6 @@ export function cancelPendingMixinRemoval(
   state.removePrepared = false
 }
 
-function createMixinRuntimeState(): MixinRuntimeState {
-  return {
-    id: `m${++mixinHandleId}`,
-    aborted: false,
-    runners: [],
-  }
-}
-
-function createMixinHandle(options: {
-  id: string
-  hostType: string
-  frame: FrameHandle
-  scheduler: Scheduler
-  getContext: MixinContext['get']
-  getRuntimeSignal: () => AbortSignal
-  getBinding: () => MixinRuntimeBinding | undefined
-}): AnyMixinHandle {
-  return new MixinHandleImpl(options)
-}
-
 class MixinHandleImpl
   extends TypedEventTarget<MixinHandleEventMap<Element>>
   implements ScopedAnyMixinHandle
@@ -475,25 +456,25 @@ class MixinHandleImpl
   context: MixinContext
   frame: FrameHandle
   element: MixinElement<Element, ElementProps>
-  #options: MixinHandleFactoryOptions
-  #phaseListenerCounts: Record<'beforeUpdate' | 'commit', number> = {
+  #init: MixinHandleFactoryOptions
+  #phases: Record<'beforeUpdate' | 'commit', number> = {
     beforeUpdate: 0,
     commit: 0,
   }
-  #activeScope?: symbol
-  #scopeSignals = new Map<symbol, AbortController>()
-  #scopeTargets = new Map<symbol, TypedEventTarget<MixinHandleEventMap<Element>>>()
-  #scopePhaseCounts = new Map<symbol, Record<'beforeUpdate' | 'commit', number>>()
-  #onSchedulerBeforeUpdate = (event: Event) => {
-    this.#dispatchSchedulerPhaseToHandle('beforeUpdate', event as SchedulerPhaseEvent)
+  #scope?: symbol
+  #signals = new Map<symbol, AbortController>()
+  #targets = new Map<symbol, TypedEventTarget<MixinHandleEventMap<Element>>>()
+  #scopePhases = new Map<symbol, Record<'beforeUpdate' | 'commit', number>>()
+  #onBeforeUpdate = (event: Event) => {
+    this.#dispatchPhase('beforeUpdate', event as SchedulerPhaseEvent)
   }
-  #onSchedulerCommit = (event: Event) => {
-    this.#dispatchSchedulerPhaseToHandle('commit', event as SchedulerPhaseEvent)
+  #onCommit = (event: Event) => {
+    this.#dispatchPhase('commit', event as SchedulerPhaseEvent)
   }
 
   constructor(options: MixinHandleFactoryOptions) {
     super()
-    this.#options = options
+    this.#init = options
     this.id = options.id
     this.context = {
       get: options.getContext,
@@ -512,12 +493,12 @@ class MixinHandleImpl
   }
 
   get signal() {
-    let scope = this.#activeScope
+    let scope = this.#scope
     invariant(
       scope,
       'handle.signal is only available during mixin setup, render, or lifecycle callbacks',
     )
-    return this.#getScopeSignal(scope)
+    return this.#scopeSignal(scope)
   }
 
   addEventListener(
@@ -525,24 +506,24 @@ class MixinHandleImpl
     listener: EventListenerOrEventListenerObject | null,
     options?: AddEventListenerOptions | boolean,
   ): void {
-    let target = this.#getActiveScopeTarget()
+    let target = this.#activeTarget()
     target.addEventListener(
       type as keyof MixinHandleEventMap<Element>,
       listener as EventListener,
       options,
     )
     if (!listener || !isSchedulerPhaseType(type)) return
-    let scope = this.#activeScope
+    let scope = this.#scope
     invariant(scope)
-    let scopePhaseCounts = this.#scopePhaseCounts.get(scope)
+    let scopePhaseCounts = this.#scopePhases.get(scope)
     invariant(scopePhaseCounts)
     scopePhaseCounts[type] += 1
-    this.#phaseListenerCounts[type] += 1
-    if (this.#phaseListenerCounts[type] !== 1) return
+    this.#phases[type] += 1
+    if (this.#phases[type] !== 1) return
     if (type === 'beforeUpdate') {
-      this.#options.scheduler.addEventListener('beforeUpdate', this.#onSchedulerBeforeUpdate)
+      this.#init.scheduler.addEventListener('beforeUpdate', this.#onBeforeUpdate)
     } else {
-      this.#options.scheduler.addEventListener('commit', this.#onSchedulerCommit)
+      this.#init.scheduler.addEventListener('commit', this.#onCommit)
     }
   }
 
@@ -551,35 +532,35 @@ class MixinHandleImpl
     listener: EventListenerOrEventListenerObject | null,
     options?: EventListenerOptions | boolean,
   ): void {
-    let target = this.#getActiveScopeTarget()
+    let target = this.#activeTarget()
     target.removeEventListener(
       type as keyof MixinHandleEventMap<Element>,
       listener as EventListener,
       typeof options === 'boolean' ? { capture: options } : options,
     )
     if (!listener || !isSchedulerPhaseType(type)) return
-    let scope = this.#activeScope
+    let scope = this.#scope
     invariant(scope)
-    let scopePhaseCounts = this.#scopePhaseCounts.get(scope)
+    let scopePhaseCounts = this.#scopePhases.get(scope)
     invariant(scopePhaseCounts)
     scopePhaseCounts[type] = Math.max(0, scopePhaseCounts[type] - 1)
-    this.#phaseListenerCounts[type] = Math.max(0, this.#phaseListenerCounts[type] - 1)
-    if (this.#phaseListenerCounts[type] !== 0) return
+    this.#phases[type] = Math.max(0, this.#phases[type] - 1)
+    if (this.#phases[type] !== 0) return
     if (type === 'beforeUpdate') {
-      this.#options.scheduler.removeEventListener('beforeUpdate', this.#onSchedulerBeforeUpdate)
+      this.#init.scheduler.removeEventListener('beforeUpdate', this.#onBeforeUpdate)
     } else {
-      this.#options.scheduler.removeEventListener('commit', this.#onSchedulerCommit)
+      this.#init.scheduler.removeEventListener('commit', this.#onCommit)
     }
   }
 
   update(): Promise<AbortSignal> {
     return new Promise((resolve) => {
-      let signal = this.#options.getRuntimeSignal()
+      let signal = this.#init.getRuntimeSignal()
       if (signal.aborted) {
         resolve(signal)
         return
       }
-      let binding = this.#options.getBinding()
+      let binding = this.#init.getBinding()
       if (!binding) {
         resolve(signal)
         return
@@ -589,88 +570,88 @@ class MixinHandleImpl
   }
 
   queueTask(task: (node: Element, signal: AbortSignal) => void): void {
-    this.#options.scheduler.enqueueTasks([
+    this.#init.scheduler.enqueueTasks([
       () => {
-        let binding = this.#options.getBinding()
+        let binding = this.#init.getBinding()
         invariant(binding)
-        task(binding.node, this.#options.getRuntimeSignal())
+        task(binding.node, this.#init.getRuntimeSignal())
       },
     ])
   }
 
   queueCommitTask(task: () => void): void {
-    this.#options.scheduler.enqueueCommitPhase([task])
+    this.#init.scheduler.enqueueCommitPhase([task])
   }
 
   setActiveScope(scope?: symbol): void {
-    this.#activeScope = scope
+    this.#scope = scope
     if (!scope) return
-    if (this.#scopeTargets.has(scope)) return
-    this.#scopeTargets.set(scope, new TypedEventTarget<MixinHandleEventMap<Element>>())
-    this.#scopePhaseCounts.set(scope, { beforeUpdate: 0, commit: 0 })
+    if (this.#targets.has(scope)) return
+    this.#targets.set(scope, new TypedEventTarget<MixinHandleEventMap<Element>>())
+    this.#scopePhases.set(scope, { beforeUpdate: 0, commit: 0 })
   }
 
   dispatchScopedEvent(scope: symbol, event: Event): void {
-    let previousScope = this.#activeScope
-    this.#activeScope = scope
-    this.#scopeTargets.get(scope)?.dispatchEvent(event)
-    this.#activeScope = previousScope
+    let previousScope = this.#scope
+    this.#scope = scope
+    this.#targets.get(scope)?.dispatchEvent(event)
+    this.#scope = previousScope
   }
 
   releaseScope(scope: symbol): void {
-    let scopePhaseCounts = this.#scopePhaseCounts.get(scope)
+    let scopePhaseCounts = this.#scopePhases.get(scope)
     if (scopePhaseCounts) {
-      this.#decrementGlobalPhaseCount('beforeUpdate', scopePhaseCounts.beforeUpdate)
-      this.#decrementGlobalPhaseCount('commit', scopePhaseCounts.commit)
+      this.#decrementPhase('beforeUpdate', scopePhaseCounts.beforeUpdate)
+      this.#decrementPhase('commit', scopePhaseCounts.commit)
     }
-    let controller = this.#scopeSignals.get(scope)
+    let controller = this.#signals.get(scope)
     if (controller) {
       controller.abort()
-      this.#scopeSignals.delete(scope)
+      this.#signals.delete(scope)
     }
-    this.#scopePhaseCounts.delete(scope)
-    this.#scopeTargets.delete(scope)
-    if (this.#activeScope === scope) {
-      this.#activeScope = undefined
+    this.#scopePhases.delete(scope)
+    this.#targets.delete(scope)
+    if (this.#scope === scope) {
+      this.#scope = undefined
     }
   }
 
-  #dispatchSchedulerPhaseToHandle(type: 'beforeUpdate' | 'commit', event: SchedulerPhaseEvent) {
-    let binding = this.#options.getBinding()
+  #dispatchPhase(type: 'beforeUpdate' | 'commit', event: SchedulerPhaseEvent) {
+    let binding = this.#init.getBinding()
     if (!binding) return
     if (!isBindingInUpdateScope(binding, event.parents)) return
-    for (let [, target] of this.#scopeTargets) {
+    for (let [, target] of this.#targets) {
       let updateEvent = new Event(type) as MixinUpdateEvent<Element>
       updateEvent.node = binding.node
       target.dispatchEvent(updateEvent)
     }
   }
 
-  #getActiveScopeTarget(): TypedEventTarget<MixinHandleEventMap<Element>> {
-    let scope = this.#activeScope
+  #activeTarget(): TypedEventTarget<MixinHandleEventMap<Element>> {
+    let scope = this.#scope
     invariant(scope)
-    let target = this.#scopeTargets.get(scope)
+    let target = this.#targets.get(scope)
     invariant(target)
     return target
   }
 
-  #getScopeSignal(scope: symbol) {
-    let controller = this.#scopeSignals.get(scope)
+  #scopeSignal(scope: symbol) {
+    let controller = this.#signals.get(scope)
     if (!controller) {
       controller = new AbortController()
-      this.#scopeSignals.set(scope, controller)
+      this.#signals.set(scope, controller)
     }
     return controller.signal
   }
 
-  #decrementGlobalPhaseCount(type: 'beforeUpdate' | 'commit', amount: number) {
+  #decrementPhase(type: 'beforeUpdate' | 'commit', amount: number) {
     if (amount <= 0) return
-    this.#phaseListenerCounts[type] = Math.max(0, this.#phaseListenerCounts[type] - amount)
-    if (this.#phaseListenerCounts[type] !== 0) return
+    this.#phases[type] = Math.max(0, this.#phases[type] - amount)
+    if (this.#phases[type] !== 0) return
     if (type === 'beforeUpdate') {
-      this.#options.scheduler.removeEventListener('beforeUpdate', this.#onSchedulerBeforeUpdate)
+      this.#init.scheduler.removeEventListener('beforeUpdate', this.#onBeforeUpdate)
     } else {
-      this.#options.scheduler.removeEventListener('commit', this.#onSchedulerCommit)
+      this.#init.scheduler.removeEventListener('commit', this.#onCommit)
     }
   }
 }
@@ -687,36 +668,15 @@ export function getMixinRuntimeSignal(state: MixinRuntimeState): AbortSignal {
   return controller.signal
 }
 
-export function dispatchMixinBeforeUpdate(state?: MixinRuntimeState) {
-  dispatchMixinUpdateEvent(state, 'beforeUpdate')
-}
-
-export function dispatchMixinCommit(state?: MixinRuntimeState) {
-  dispatchMixinUpdateEvent(state, 'commit')
-}
-
-function dispatchMixinInsert(
+function dispatchMixinNodeEvent(
   handle: ScopedAnyMixinHandle,
   scope: symbol,
+  type: 'insert' | 'reclaimed',
   node: Element,
   parent: ParentNode,
   key?: string,
 ) {
-  let event = new Event('insert') as MixinInsertEvent<Element>
-  event.node = node
-  event.parent = parent
-  event.key = key
-  handle.dispatchScopedEvent(scope, event)
-}
-
-function dispatchMixinReclaimed(
-  handle: ScopedAnyMixinHandle,
-  scope: symbol,
-  node: Element,
-  parent: ParentNode,
-  key?: string,
-) {
-  let event = new Event('reclaimed') as MixinReclaimedEvent<Element>
+  let event = new Event(type) as MixinInsertEvent<Element> | MixinReclaimedEvent<Element>
   event.node = node
   event.parent = parent
   event.key = key
@@ -733,27 +693,16 @@ function dispatchMixinBeforeRemove(
   handle.dispatchScopedEvent(scope, event)
 }
 
-function queueMixinInsert(
+function queueMixinNodeEvent(
   handle: ScopedAnyMixinHandle,
   scope: symbol,
+  type: 'insert' | 'reclaimed',
   node: Element,
   parent: ParentNode,
   key?: string,
 ) {
   handle.queueCommitTask(() => {
-    dispatchMixinInsert(handle, scope, node, parent, key)
-  })
-}
-
-function queueMixinReclaimed(
-  handle: ScopedAnyMixinHandle,
-  scope: symbol,
-  node: Element,
-  parent: ParentNode,
-  key?: string,
-) {
-  handle.queueCommitTask(() => {
-    dispatchMixinReclaimed(handle, scope, node, parent, key)
+    dispatchMixinNodeEvent(handle, scope, type, node, parent, key)
   })
 }
 
@@ -790,7 +739,7 @@ function finalizeMixinTeardown(state: MixinRuntimeState) {
   state.handle = undefined
 }
 
-function dispatchMixinUpdateEvent(
+export function dispatchMixinUpdateEvent(
   state: MixinRuntimeState | undefined,
   type: 'beforeUpdate' | 'commit',
 ) {
@@ -825,11 +774,7 @@ function isBindingInUpdateScope(binding: MixinRuntimeBinding, parents: ParentNod
 function resolveMixDescriptors(props: ElementProps): AnyMixinDescriptor[] {
   let mix = props.mix
   if (!mix) return []
-  if (Array.isArray(mix)) {
-    if (mix.length === 0) return []
-    return mix.filter(Boolean) as AnyMixinDescriptor[]
-  }
-  return [mix] as AnyMixinDescriptor[]
+  return (Array.isArray(mix) ? mix.filter(Boolean) : [mix]) as AnyMixinDescriptor[]
 }
 
 function withoutMix(props: ElementProps): ElementProps {
@@ -851,10 +796,6 @@ function sanitizeReturnedMixinProps(props: ElementProps): ElementProps {
   if (!('children' in props) && !('innerHTML' in props)) return props
   console.error(new Error('mixins must not return children or innerHTML'))
   return withoutMixinTreeProps(props)
-}
-
-function composeMixinProps(previous: ElementProps, next: ElementProps): ElementProps {
-  return { ...previous, ...next }
 }
 
 function resolveReturnedMixDescriptors(value: unknown): AnyMixinDescriptor[] | null {

--- a/packages/ui/src/runtime/reconcile.ts
+++ b/packages/ui/src/runtime/reconcile.ts
@@ -34,8 +34,7 @@ import { toVNode } from './to-vnode.ts'
 import {
   bindMixinRuntime,
   cancelPendingMixinRemoval,
-  dispatchMixinBeforeUpdate,
-  dispatchMixinCommit,
+  dispatchMixinUpdateEvent,
   getMixinRuntimeSignal,
   prepareMixinRemoval,
   resolveMixedProps,
@@ -52,18 +51,8 @@ let persistedRemovalToken = 0
 const persistedMixinNodes = new Set<CommittedHostNode>()
 let activeSchedulerUpdateParents: ParentNode[] | undefined
 
-// Compute SVG context for a node based on its parent and type.
-// Returns true if the node is within an SVG subtree, false otherwise.
 function getSvgContext(vParent: VNode, nodeType: VNodeType): boolean {
-  // Only host elements (strings) can affect SVG context
-  if (typeof nodeType === 'string') {
-    // svg element creates SVG context
-    if (nodeType === 'svg') return true
-    // foreignObject switches back to HTML context
-    if (nodeType === 'foreignObject') return false
-  }
-  // Otherwise inherit from parent
-  return vParent._svg ?? false
+  return nodeType === 'svg' || (nodeType !== 'foreignObject' && (vParent._svg ?? false))
 }
 
 function getHostProps(node: HostNode | CommittedHostNode): ElementProps {
@@ -92,10 +81,9 @@ function findMatchingPersistedMixinNode(
 ): CommittedHostNode | null {
   if (key == null) return null
   for (let node of persistedMixinNodes) {
-    if (node._persistedParentByMixins !== domParent) continue
-    if (node.type !== type) continue
-    if (node.key !== key) continue
-    return node
+    if (node._persistedParentByMixins === domParent && node.type === type && node.key === key) {
+      return node
+    }
   }
   return null
 }
@@ -336,12 +324,12 @@ function enqueueMixinBindingUpdate(
         return
       }
 
-      dispatchMixinBeforeUpdate(state)
+      dispatchMixinUpdateEvent(state, 'beforeUpdate')
       let prevProps = getHostProps(node)
       let nextProps = resolveNodeMixProps(node, this.frame, this.scheduler, state)
       patchHostProps(prevProps, nextProps, this.node)
 
-      dispatchMixinCommit(state)
+      dispatchMixinUpdateEvent(state, 'commit')
       done(state ? getMixinRuntimeSignal(state) : AbortSignal.abort())
     },
   ])
@@ -351,7 +339,6 @@ function bindNodeMixRuntime(
   node: CommittedHostNode,
   frame: FrameHandle,
   scheduler: Scheduler,
-  styles: StyleManager,
   reclaimed: boolean = false,
   parent?: ParentNode,
 ) {
@@ -372,19 +359,7 @@ function bindNodeMixRuntime(
 }
 
 function isHeadHostNode(node: HostNode): boolean {
-  if (node.type === 'head') return true
-  if (node.type.length !== 4) return false
   return node.type.toLowerCase() === 'head'
-}
-
-function getDocumentHead(domParent: ParentNode): HTMLHeadElement | null {
-  if (domParent instanceof Document) {
-    return domParent.head
-  }
-  if (domParent instanceof Node) {
-    return domParent.ownerDocument?.head ?? null
-  }
-  return null
 }
 
 export function diffVNodes(
@@ -510,7 +485,7 @@ function diffHost(
   let shouldDispatchMixinLifecycle =
     (nextMixState?.runners.length ?? 0) > 0 && shouldDispatchInlineMixinLifecycle(curr._dom)
   if (shouldDispatchMixinLifecycle) {
-    dispatchMixinBeforeUpdate(nextMixState)
+    dispatchMixinUpdateEvent(nextMixState, 'beforeUpdate')
   }
 
   // Handle innerHTML prop BEFORE diffChildren to avoid clearing children
@@ -549,10 +524,10 @@ function diffHost(
   }
 
   if (next._mixState) {
-    bindNodeMixRuntime(next as CommittedHostNode, frame, scheduler, styles)
+    bindNodeMixRuntime(next as CommittedHostNode, frame, scheduler)
   }
   if (shouldDispatchMixinLifecycle) {
-    scheduler.enqueueCommitPhase([() => dispatchMixinCommit(nextMixState)])
+    scheduler.enqueueCommitPhase([() => dispatchMixinUpdateEvent(nextMixState, 'commit')])
   }
 
   return
@@ -571,13 +546,34 @@ function setupHostNode(node: HostNode, dom: Element, scheduler: Scheduler): void
   }
 }
 
+function adoptHostNode(
+  node: HostNode,
+  dom: Element,
+  hostProps: ElementProps,
+  frame: FrameHandle,
+  scheduler: Scheduler,
+  styles: StyleManager,
+  rootTarget: EventTarget,
+  cursor?: Node | null,
+  parent?: ParentNode,
+): void {
+  patchHostProps({}, hostProps, dom)
+
+  if (hostProps.innerHTML != null) {
+    dom.innerHTML = hostProps.innerHTML as string
+  } else {
+    diffChildren(null, node._children, dom, frame, scheduler, styles, node, rootTarget, cursor)
+  }
+
+  setupHostNode(node, dom, scheduler)
+  if (node._mixState) {
+    bindNodeMixRuntime(node as CommittedHostNode, frame, scheduler, false, parent)
+  }
+}
+
 function syncDirectEventListeners(node: CommittedHostNode): void {
   let descriptors = node._directEventDescriptors as OnMixinDescriptor[] | undefined
-  if (!descriptors) {
-    teardownDirectEventListeners(node)
-    return
-  }
-  if (descriptors.length === 0) {
+  if (!descriptors?.length) {
     teardownDirectEventListeners(node)
     return
   }
@@ -622,15 +618,13 @@ function createDirectEventBinding(
   handler: DirectEventBinding['handler'],
   capture: boolean,
 ): DirectEventBinding {
-  let binding: DirectEventBinding = {
+  return {
     type,
     handler,
     capture,
     reentry: null,
     stableHandler: null,
   }
-
-  return binding
 }
 
 function getStableDirectEventHandler(binding: DirectEventBinding): (event: Event) => void {
@@ -749,7 +743,12 @@ function insert(
     let hostProps = resolveNodeMixProps(node, frame, scheduler)
 
     if (isHeadHostNode(node)) {
-      let targetHead = getDocumentHead(domParent)
+      let targetHead =
+        domParent instanceof Document
+          ? domParent.head
+          : domParent instanceof Node
+            ? (domParent.ownerDocument?.head ?? null)
+            : null
       if (targetHead) {
         let childCursor = cursor
         if (cursor instanceof Element && cursor.tagName.toLowerCase() === 'head') {
@@ -779,7 +778,7 @@ function insert(
         patchHostProps({}, hostProps, targetHead)
         setupHostNode(node, targetHead, scheduler)
         if (node._mixState) {
-          bindNodeMixRuntime(node as CommittedHostNode, frame, scheduler, styles)
+          bindNodeMixRuntime(node as CommittedHostNode, frame, scheduler)
         }
         return cursor
       }
@@ -798,31 +797,8 @@ function insert(
       let cursorTag = node._svg ? cursor.tagName : cursor.tagName.toLowerCase()
       if (cursorTag === node.type) {
         let nextCursor = cursor.nextSibling
-        patchHostProps({}, hostProps, cursor)
-
-        // Handle innerHTML prop
-        if (hostProps.innerHTML != null) {
-          cursor.innerHTML = hostProps.innerHTML as string
-        } else {
-          let childCursor = cursor.firstChild
-          // Ignore excess nodes - browser extensions may inject content
-          diffChildren(
-            null,
-            node._children,
-            cursor,
-            frame,
-            scheduler,
-            styles,
-            node,
-            rootTarget,
-            childCursor,
-          )
-        }
-
-        setupHostNode(node, cursor, scheduler)
-        if (node._mixState) {
-          bindNodeMixRuntime(node as CommittedHostNode, frame, scheduler, styles)
-        }
+        // Ignore excess nodes - browser extensions may inject content.
+        adoptHostNode(node, cursor, hostProps, frame, scheduler, styles, rootTarget, cursor.firstChild)
         return nextCursor
       } else {
         // Type mismatch - try single-advance retry to handle browser extension injections
@@ -832,30 +808,17 @@ function insert(
           let nextTag = node._svg ? nextSibling.tagName : nextSibling.tagName.toLowerCase()
           if (nextTag === node.type) {
             let nextCursor = nextSibling.nextSibling
-            // Found a match after skipping - adopt it and leave skipped node in place
-            patchHostProps({}, hostProps, nextSibling)
-
-            if (hostProps.innerHTML != null) {
-              nextSibling.innerHTML = hostProps.innerHTML as string
-            } else {
-              let childCursor = nextSibling.firstChild
-              diffChildren(
-                null,
-                node._children,
-                nextSibling,
-                frame,
-                scheduler,
-                styles,
-                node,
-                rootTarget,
-                childCursor,
-              )
-            }
-
-            setupHostNode(node, nextSibling, scheduler)
-            if (node._mixState) {
-              bindNodeMixRuntime(node as CommittedHostNode, frame, scheduler, styles)
-            }
+            // Found a match after skipping - adopt it and leave skipped node in place.
+            adoptHostNode(
+              node,
+              nextSibling,
+              hostProps,
+              frame,
+              scheduler,
+              styles,
+              rootTarget,
+              nextSibling.firstChild,
+            )
             return nextCursor
           }
         }
@@ -867,19 +830,7 @@ function insert(
     let dom = node._svg
       ? document.createElementNS(SVG_NS, node.type)
       : document.createElement(node.type)
-    patchHostProps({}, hostProps, dom)
-
-    // Handle innerHTML prop
-    if (hostProps.innerHTML != null) {
-      dom.innerHTML = hostProps.innerHTML as string
-    } else {
-      diffChildren(null, node._children, dom, frame, scheduler, styles, node, rootTarget)
-    }
-
-    setupHostNode(node, dom, scheduler)
-    if (node._mixState) {
-      bindNodeMixRuntime(node as CommittedHostNode, frame, scheduler, styles, false, domParent)
-    }
+    adoptHostNode(node, dom, hostProps, frame, scheduler, styles, rootTarget, undefined, domParent)
     doInsert(dom)
     return cursor
   }
@@ -2068,7 +2019,7 @@ function reclaimPersistedMixinNode(
     newNode._mixState as MixinRuntimeState | undefined,
   )
   if (shouldDispatchInlineMixinLifecycle(persistedNode._dom)) {
-    dispatchMixinBeforeUpdate(newNode._mixState as MixinRuntimeState | undefined)
+    dispatchMixinUpdateEvent(newNode._mixState as MixinRuntimeState | undefined, 'beforeUpdate')
   }
   patchHostProps(prevProps, nextProps, persistedNode._dom)
   syncDirectEventListeners(newNode as CommittedHostNode)
@@ -2087,11 +2038,11 @@ function reclaimPersistedMixinNode(
   )
 
   if (newNode._mixState) {
-    bindNodeMixRuntime(newNode as CommittedHostNode, frame, scheduler, styles, true)
+    bindNodeMixRuntime(newNode as CommittedHostNode, frame, scheduler, true)
   }
   if (shouldDispatchInlineMixinLifecycle(persistedNode._dom)) {
     scheduler.enqueueCommitPhase([
-      () => dispatchMixinCommit(newNode._mixState as MixinRuntimeState | undefined),
+      () => dispatchMixinUpdateEvent(newNode._mixState as MixinRuntimeState | undefined, 'commit'),
     ])
   }
 }


### PR DESCRIPTION
This splits the last low-risk browser JS cleanup out of the broader Remix UI optimization work (#11507). The change stays package-local to `@remix-run/ui` and focuses on internal reconciler, DOM diff, and mixin lifecycle helpers without changing public APIs.

- Consolidates mixin lifecycle update dispatch through one internal helper
- Removes small mixin runtime helper indirection and deduplicates insert/reclaimed lifecycle event queuing
- Deduplicates repeated host-node adoption code in the reconciler while preserving the existing patch/diff/setup ordering
- Tightens DOM diff helper code by inlining one-use helpers, avoiding redundant checks, and combining removed-runtime-node cleanup walks
- Reduces the bookstore source-served browser JS graph from `108,647 raw / 43,809 gzip / 38,635 brotli` to `107,273 raw / 43,602 gzip / 38,454 brotli`, while keeping the graph at `62` modules

Per-entry measurements for the bookstore demo stayed module-count neutral and saved about `1.4 kB raw / 207 B gzip / 181 B brotli` for each measured entry.

## Impact on Bookstore Demo

Running `pnpm --filter bookstore-demo run start` and going to the login page (left is `main`, right is this PR):

<img width="2560" height="1440" alt="Screenshot 2026-06-05 at 8 28 21 AM" src="https://github.com/user-attachments/assets/65340b89-f237-4624-8f06-adc77bf18b37" />


