### PR TITLE
Fix browser script abort handling

### DIFF
--- a/packages/test/.changes/patch.browser-script-request-aborts.md
+++ b/packages/test/.changes/patch.browser-script-request-aborts.md
@@ -1,0 +1,1 @@
+Ignore browser-cancelled script requests in `remix-test` browser runs so iframe navigation can finish cleanly on Windows while still reporting real script load failures.

--- a/packages/test/src/lib/runner-browser.ts
+++ b/packages/test/src/lib/runner-browser.ts
@@ -138,7 +138,11 @@ export async function runBrowserTests(options: TestRunOptions): Promise<{
       })
       page!.on('requestfailed', (request) => {
         if (isScriptRequest(request)) {
-          reject(new Error(`Failed to load script: ${request.url()}`))
+          let failureText = request.failure()?.errorText
+          if (failureText === 'net::ERR_ABORTED') return
+
+          let reason = failureText ? ` (${failureText})` : ''
+          reject(new Error(`Failed to load script: ${request.url()}${reason}`))
         }
       })
     })


### PR DESCRIPTION
The release PR is currently blocked by the Windows changed-package test job while running the `@remix-run/ui` browser suite. Playwright reports a failed `/scripts/.../tabs.tsx` request, but the server does not log a transform or rewrite failure, which points to a browser-cancelled module request during iframe navigation rather than a real script-serving error.

- Ignore Chromium `net::ERR_ABORTED` request failures for `/scripts/` modules in `remix-test` browser runs.
- Keep failing on non-OK script responses and other request failures, now with the Playwright failure reason included in the error.
- Add a `@remix-run/test` patch change note so the release PR will pick up the fix after regeneration.

This should let the managed release PR regenerate cleanly after this lands on `main` while preserving the guard for actual script load failures.
