### PR TITLE
Fix Bun assert compatibility test

### DIFF
--- a/packages/assert/src/lib/assert.test.ts
+++ b/packages/assert/src/lib/assert.test.ts
@@ -793,6 +793,11 @@ function assertCompatibleError(
   if (ours && nodes) {
     nodeAssert.equal(ours.name, nodes.name)
     nodeAssert.equal(ours.code, nodes.code)
+    // Bun's node:assert shim omits diagnostic fields for some newer assertions.
+    if (nodes.operator === undefined) {
+      return
+    }
+
     nodeAssert.equal(ours.operator, nodes.operator)
     nodeAssert.equal(ours.generatedMessage, nodes.generatedMessage)
     nodeAssert.deepEqual(ours.actual, nodes.actual)


### PR DESCRIPTION
Bun 1.3.14's `node:assert/strict.partialDeepStrictEqual` shim currently omits diagnostic fields like `operator`, `actual`, and `expected` on its `AssertionError`. Our compatibility test should still verify pass/fail, name, and code in that runtime, but it cannot use Bun's incomplete reference error for deeper diagnostic-field parity.

- Fixes the red Bun lane on `main` in `Check main` and `Test`
- Keeps Node's stricter diagnostic-field comparison intact when `node:assert` provides `operator`
- Leaves `@remix-run/assert` runtime behavior unchanged
