### PR TITLE
fix CI flows on pnpm@11

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           pnpm run setup-installable-branch preview/main
           git push --force --set-upstream origin preview/main
-          echo "💿 pushed installable branch: https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"
+          echo "pushed installable branch: https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"
 
       # Build and force push over the PR preview/pr-{number} branch + comment on the PR
       - name: Build/push branch (pull_request)
@@ -86,7 +86,7 @@ jobs:
           pnpm run setup-installable-branch preview/pr-${{ github.event.pull_request.number }}
           git push --force --set-upstream origin preview/pr-${{ github.event.pull_request.number }}
           echo "pushed installable branch: https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"
-          pnpm run pr-preview comment ${{ github.event.pull_request.number }} preview/pr-${{ github.event.pull_request.number }}
+          node ./scripts/pr-preview.ts comment ${{ github.event.pull_request.number }} preview/pr-${{ github.event.pull_request.number }}
 
       # Build and normal push for experimental releases to avoid unintended force
       # pushes over remote branches in case of a branch name collision
@@ -95,7 +95,7 @@ jobs:
         run: |
           pnpm run setup-installable-branch ${{ inputs.installableBranch }}
           git push --set-upstream origin ${{ inputs.installableBranch }}
-          echo "💿 pushed installable branch: https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"
+          echo "pushed installable branch: https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"
 
       # Cleanup PR preview/pr-{number} branches when the PR is closed
       - name: Cleanup preview branch
@@ -103,4 +103,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          pnpm run pr-preview cleanup ${{ github.event.pull_request.number }} preview/pr-${{ github.event.pull_request.number }}
+          node ./scripts/pr-preview.ts cleanup ${{ github.event.pull_request.number }} preview/pr-${{ github.event.pull_request.number }}

--- a/package.json
+++ b/package.json
@@ -43,13 +43,5 @@
   },
   "workspaces": [
     "packages/*"
-  ],
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@swc/core",
-      "esbuild",
-      "sharp",
-      "workerd"
-    ]
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "generate-remix": "node ./scripts/generate-remix.ts",
     "lint": "oxlint . -A all --quiet",
     "lint:fix": "oxlint . -A all --fix --quiet",
-    "pr-preview": "node ./scripts/pr-preview.ts",
     "setup-installable-branch": "node ./scripts/setup-installable-branch.ts",
     "sync-remix-readmes": "node ./scripts/sync-remix-readmes.ts",
     "validate-remix-package-readmes": "node ./scripts/validate-remix-package-readmes.ts",

--- a/packages/node-tsx/src/index.test.ts
+++ b/packages/node-tsx/src/index.test.ts
@@ -1390,7 +1390,7 @@ async function ensureBuiltNodeTsxPackage(): Promise<void> {
     ROOT_DIR,
   )
   assert.equal(result.exitCode, 0, result.stderr)
-  assert.equal(result.stderr, '')
+  assert.equal(result.stderr, '\x1B[2m$ tsgo -p tsconfig.build.json\x1B[22m\n')
   builtNodeTsxPackage = true
 }
 

--- a/packages/node-tsx/src/index.test.ts
+++ b/packages/node-tsx/src/index.test.ts
@@ -1390,7 +1390,12 @@ async function ensureBuiltNodeTsxPackage(): Promise<void> {
     ROOT_DIR,
   )
   assert.equal(result.exitCode, 0, result.stderr)
-  assert.equal(result.stderr, '\x1B[2m$ tsgo -p tsconfig.build.json\x1B[22m\n')
+  assert.equal(
+    result.stderr,
+    process.env.CI
+      ? '$ tsgo -p tsconfig.build.json\n'
+      : '\x1B[2m$ tsgo -p tsconfig.build.json\x1B[22m\n',
+  )
   builtNodeTsxPackage = true
 }
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true
+
 catalog:
   '@types/node': ^24.6.0
   '@typescript/native-preview': 7.0.0-dev.20251125.1


### PR DESCRIPTION
`postinstall` scripts are automatically skipped in `pnpm@11` and need to be explicitly approved or else `pnpm install` fails.  It also seems to then cause any other `pnpm run *` command to fail with the same error until you run the builds.

```sh
~/me/repos/remix (brophdawg11/codex-rmx-ignore-ui)> pnpm install
Scope: all 96 workspace projects
...
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.25.12, esbuild@0.27.1, esbuild@0.27.3, esbuild@0.27.7, sharp@0.34.5, workerd@1.20260508.1

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```
