### PR TITLE
Reject node-fetch-server body reads after client aborts

### DIFF
--- a/packages/node-fetch-server/.changes/patch.fix-node-fetch-server-body-abort.md
+++ b/packages/node-fetch-server/.changes/patch.fix-node-fetch-server-body-abort.md
@@ -1,0 +1,1 @@
+Handle aborted request bodies in `node-fetch-server` so stream and lazy body reads reject instead of staying pending after an upload is cut short.

--- a/packages/node-fetch-server/src/lib/client-disconnect-error.ts
+++ b/packages/node-fetch-server/src/lib/client-disconnect-error.ts
@@ -1,0 +1,18 @@
+/**
+ * Error used to settle pending request body reads when the client goes away
+ * (an `error`, legacy `aborted`, or close-before-`end` on the incoming request)
+ * before the body has been fully received.
+ */
+export class ClientDisconnectError extends Error {
+  constructor(cause?: unknown) {
+    super(
+      'Client disconnected before the request body was fully received',
+      cause === undefined ? undefined : { cause },
+    )
+    this.name = 'ClientDisconnectError'
+  }
+}
+
+export function isClientDisconnectError(error: unknown): error is ClientDisconnectError {
+  return error instanceof ClientDisconnectError
+}

--- a/packages/node-fetch-server/src/lib/lazy-request.ts
+++ b/packages/node-fetch-server/src/lib/lazy-request.ts
@@ -328,6 +328,8 @@ function readRequestBody(req: IncomingRequest): Promise<Buffer> {
       req.off('data', onData)
       req.off('end', onEnd)
       req.off('error', onError)
+      req.off('aborted', onClose)
+      req.off('close', onClose)
     }
 
     function onData(buffer: Buffer) {
@@ -357,9 +359,29 @@ function readRequestBody(req: IncomingRequest): Promise<Buffer> {
       reject(error)
     }
 
+    // A 'close' (or legacy 'aborted') before 'end' means the client went away
+    // before the body was fully received; a close after 'end' never reaches
+    // this handler because 'end' removes these listeners.
+    function onClose() {
+      cleanup()
+      reject(new Error('Client disconnected before the request body was fully received'))
+    }
+
+    if (req.readableEnded) {
+      resolve(Buffer.alloc(0))
+      return
+    }
+
+    if (req.destroyed) {
+      reject(new Error('Client disconnected before the request body was fully received'))
+      return
+    }
+
     req.on('data', onData)
     req.once('end', onEnd)
     req.once('error', onError)
+    req.once('aborted', onClose)
+    req.once('close', onClose)
   })
 }
 
@@ -373,6 +395,8 @@ function readRequestText(req: IncomingRequest): Promise<string> {
       req.off('data', onData)
       req.off('end', onEnd)
       req.off('error', onError)
+      req.off('aborted', onClose)
+      req.off('close', onClose)
     }
 
     function onData(buffer: Buffer) {
@@ -402,8 +426,26 @@ function readRequestText(req: IncomingRequest): Promise<string> {
       reject(error)
     }
 
+    // Same early-disconnect handling as readRequestBody above.
+    function onClose() {
+      cleanup()
+      reject(new Error('Client disconnected before the request body was fully received'))
+    }
+
+    if (req.readableEnded) {
+      resolve('')
+      return
+    }
+
+    if (req.destroyed) {
+      reject(new Error('Client disconnected before the request body was fully received'))
+      return
+    }
+
     req.on('data', onData)
     req.once('end', onEnd)
     req.once('error', onError)
+    req.once('aborted', onClose)
+    req.once('close', onClose)
   })
 }

--- a/packages/node-fetch-server/src/lib/lazy-request.ts
+++ b/packages/node-fetch-server/src/lib/lazy-request.ts
@@ -1,6 +1,7 @@
 import type * as http from 'node:http'
 import type * as http2 from 'node:http2'
 
+import { ClientDisconnectError } from './client-disconnect-error.ts'
 import { createLazyHeaders } from './lazy-headers.ts'
 
 type IncomingRequest = http.IncomingMessage | http2.Http2ServerRequest
@@ -354,9 +355,12 @@ function readRequestBody(req: IncomingRequest): Promise<Buffer> {
       }
     }
 
+    // An 'error' before 'end' means the body cannot complete, so it is
+    // reported as a disconnect (with the original error as `cause`) to match
+    // the request-abort handling in `createRequestListener`.
     function onError(error: Error) {
       cleanup()
-      reject(error)
+      reject(new ClientDisconnectError(error))
     }
 
     // A 'close' (or legacy 'aborted') before 'end' means the client went away
@@ -364,7 +368,7 @@ function readRequestBody(req: IncomingRequest): Promise<Buffer> {
     // this handler because 'end' removes these listeners.
     function onClose() {
       cleanup()
-      reject(new Error('Client disconnected before the request body was fully received'))
+      reject(new ClientDisconnectError())
     }
 
     if (req.readableEnded) {
@@ -373,7 +377,7 @@ function readRequestBody(req: IncomingRequest): Promise<Buffer> {
     }
 
     if (req.destroyed) {
-      reject(new Error('Client disconnected before the request body was fully received'))
+      reject(new ClientDisconnectError())
       return
     }
 
@@ -421,15 +425,15 @@ function readRequestText(req: IncomingRequest): Promise<string> {
       }
     }
 
+    // Same early-disconnect handling as readRequestBody above.
     function onError(error: Error) {
       cleanup()
-      reject(error)
+      reject(new ClientDisconnectError(error))
     }
 
-    // Same early-disconnect handling as readRequestBody above.
     function onClose() {
       cleanup()
-      reject(new Error('Client disconnected before the request body was fully received'))
+      reject(new ClientDisconnectError())
     }
 
     if (req.readableEnded) {
@@ -438,7 +442,7 @@ function readRequestText(req: IncomingRequest): Promise<string> {
     }
 
     if (req.destroyed) {
-      reject(new Error('Client disconnected before the request body was fully received'))
+      reject(new ClientDisconnectError())
       return
     }
 

--- a/packages/node-fetch-server/src/lib/request-listener.test.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.test.ts
@@ -1,10 +1,12 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import type * as http from 'node:http'
+import * as net from 'node:net'
 import * as stream from 'node:stream'
 
 import { type FetchHandler } from './fetch-handler.ts'
 import { createRequest, createRequestListener } from './request-listener.ts'
+import { createTestServer } from './test-server.ts'
 
 describe('createRequestListener', () => {
   it('returns a request listener', async (t) => {
@@ -704,6 +706,150 @@ describe('createRequest abort behavior', () => {
     assert.equal(request.signal.aborted, false)
   })
 })
+
+describe('createRequest body abort behavior', () => {
+  it('rejects body reads and aborts the signal when the request errors mid-body', async () => {
+    let req = createStreamingMockRequest()
+    let res = createMockResponse({ req })
+    let request = createRequest(req, res)
+
+    let textPromise = request.text()
+    req.push(Buffer.from('partial'))
+    let error = new Error('socket hang up')
+    req.destroy(error)
+
+    await assert.rejects(textPromise)
+    assert.equal(request.signal.aborted, true)
+    assert.equal(request.signal.reason, error)
+  })
+
+  it('rejects body reads and aborts the signal when the request closes before the body ends', async () => {
+    let req = createStreamingMockRequest()
+    let res = createMockResponse({ req })
+    let request = createRequest(req, res)
+
+    let textPromise = request.text()
+    req.push(Buffer.from('partial'))
+    req.destroy()
+
+    await assert.rejects(textPromise, /disconnected before the request body/)
+    assert.equal(request.signal.aborted, true)
+  })
+
+  it('rejects body reads when the legacy aborted event fires', async () => {
+    let req = createStreamingMockRequest()
+    let res = createMockResponse({ req })
+    let request = createRequest(req, res)
+
+    let textPromise = request.text()
+    req.emit('aborted')
+
+    await assert.rejects(textPromise, /disconnected before the request body/)
+    assert.equal(request.signal.aborted, true)
+  })
+
+  it('does not abort the signal when the body ends normally and the request closes afterwards', async () => {
+    let req = createMockRequest({ method: 'POST', body: 'Hello, world!' })
+    let res = createMockResponse({ req })
+    let request = createRequest(req, res)
+
+    assert.equal(await request.text(), 'Hello, world!')
+
+    // Let the mock request emit its trailing 'close' after 'end'
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    assert.equal(request.signal.aborted, false)
+  })
+
+  it('rejects a pending lazy text() read when the client disconnects mid-body', async () => {
+    let reportResult!: (value: unknown) => void
+    let handlerResult = new Promise<unknown>((resolve) => {
+      reportResult = resolve
+    })
+
+    let handler: FetchHandler = async (request: Request) => {
+      try {
+        await request.text()
+        reportResult(null)
+      } catch (error) {
+        reportResult(error)
+      }
+      return new Response('ok')
+    }
+
+    let listener = createRequestListener(handler)
+    let req = createStreamingMockRequest()
+    let res = createMockResponse({ req })
+
+    listener(req, res)
+    req.push(Buffer.from('partial'))
+    req.destroy()
+
+    let error = await handlerResult
+    assert.ok(error instanceof Error)
+    assert.match(error.message, /disconnected before the request body/)
+  })
+
+  it('rejects a pending body read when a real client socket is destroyed mid-upload', async () => {
+    let reportResult!: (value: unknown) => void
+    let handlerResult = new Promise<unknown>((resolve) => {
+      reportResult = resolve
+    })
+
+    let server = await createTestServer(async (request) => {
+      try {
+        await request.text()
+        reportResult(null)
+      } catch (error) {
+        reportResult(error)
+      }
+      return new Response('ok')
+    })
+
+    try {
+      let port = Number(new URL(server.baseUrl).port)
+      let socket = net.connect(port, '127.0.0.1')
+      await new Promise<void>((resolve) => socket.once('connect', resolve))
+
+      socket.write(
+        'POST / HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: text/plain\r\nContent-Length: 1000\r\n\r\npartial body',
+      )
+
+      // Give the server a beat to start reading the body, then drop the client
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      socket.destroy()
+
+      let error = await handlerResult
+      assert.ok(error instanceof Error)
+    } finally {
+      await server.close()
+    }
+  })
+})
+
+function createStreamingMockRequest({
+  url = '/',
+  method = 'POST',
+  headers = {},
+}: {
+  url?: string
+  method?: string
+  headers?: Record<string, string>
+} = {}): http.IncomingMessage {
+  let rawHeaders = Object.entries(headers).flatMap(([key, value]) => [key, value])
+
+  return Object.assign(
+    new stream.Readable({
+      read() {},
+    }),
+    {
+      url,
+      method,
+      rawHeaders,
+      socket: {},
+      headers,
+    },
+  ) as http.IncomingMessage
+}
 
 function createMockRequest({
   url = '/',

--- a/packages/node-fetch-server/src/lib/request-listener.test.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.test.ts
@@ -786,7 +786,52 @@ describe('createRequest body abort behavior', () => {
 
     let error = await handlerResult
     assert.ok(error instanceof Error)
+    assert.equal(error.name, 'ClientDisconnectError')
     assert.match(error.message, /disconnected before the request body/)
+  })
+
+  it('does not call onError when a lazy body read is cut off by a client disconnect', async (t) => {
+    let errorHandler = t.mock.fn()
+    let handler: FetchHandler = async (request: Request) => {
+      await request.text()
+      return new Response('ok')
+    }
+
+    let listener = createRequestListener(handler, { onError: errorHandler })
+    let req = createStreamingMockRequest()
+    let res = createMockResponse({ req })
+    let writeHead = t.mock.method(res, 'writeHead')
+
+    listener(req, res)
+    req.push(Buffer.from('partial'))
+    req.destroy()
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    assert.equal(errorHandler.mock.calls.length, 0)
+    assert.equal(writeHead.mock.calls.length, 0)
+  })
+
+  it('does not call onError when a lazy body read fails with a request error', async (t) => {
+    let errorHandler = t.mock.fn()
+    let handler: FetchHandler = async (request: Request) => {
+      await request.text()
+      return new Response('ok')
+    }
+
+    let listener = createRequestListener(handler, { onError: errorHandler })
+    let req = createStreamingMockRequest()
+    let res = createMockResponse({ req })
+    let writeHead = t.mock.method(res, 'writeHead')
+
+    listener(req, res)
+    req.push(Buffer.from('partial'))
+    req.destroy(new Error('socket hang up'))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    assert.equal(errorHandler.mock.calls.length, 0)
+    assert.equal(writeHead.mock.calls.length, 0)
   })
 
   it('rejects a pending body read when a real client socket is destroyed mid-upload', async () => {
@@ -794,8 +839,13 @@ describe('createRequest body abort behavior', () => {
     let handlerResult = new Promise<unknown>((resolve) => {
       reportResult = resolve
     })
+    let reportStarted!: () => void
+    let handlerStarted = new Promise<void>((resolve) => {
+      reportStarted = resolve
+    })
 
     let server = await createTestServer(async (request) => {
+      reportStarted()
       try {
         await request.text()
         reportResult(null)
@@ -814,12 +864,13 @@ describe('createRequest body abort behavior', () => {
         'POST / HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: text/plain\r\nContent-Length: 1000\r\n\r\npartial body',
       )
 
-      // Give the server a beat to start reading the body, then drop the client
-      await new Promise((resolve) => setTimeout(resolve, 50))
+      // Drop the client only once the handler is awaiting the body read
+      await handlerStarted
       socket.destroy()
 
       let error = await handlerResult
       assert.ok(error instanceof Error)
+      assert.match(error.message, /disconnected before the request body/)
     } finally {
       await server.close()
     }

--- a/packages/node-fetch-server/src/lib/request-listener.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.ts
@@ -260,16 +260,7 @@ export function createRequest(
   let init: RequestInit = { method, headers, signal: controller.signal }
 
   if (method !== 'GET' && method !== 'HEAD') {
-    init.body = new ReadableStream({
-      start(controller) {
-        req.on('data', (chunk) => {
-          controller.enqueue(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength))
-        })
-        req.on('end', () => {
-          controller.close()
-        })
-      },
-    })
+    init.body = createBodyStream(req, (error) => controller?.abort(error))
 
     // init.duplex = 'half' must be set when body is a ReadableStream, and Node follows the spec.
     // However, this property is not defined in the TypeScript types for RequestInit, so we have
@@ -279,6 +270,80 @@ export function createRequest(
   }
 
   return new Request(url, init)
+}
+
+function createBodyStream(
+  req: http.IncomingMessage | http2.Http2ServerRequest,
+  onBodyError: (error: Error) => void,
+): ReadableStream<Uint8Array> {
+  let done = false
+  let streamController!: ReadableStreamDefaultController<Uint8Array>
+
+  function onData(chunk: Buffer) {
+    streamController.enqueue(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength))
+  }
+
+  function onEnd() {
+    if (done) return
+    done = true
+    cleanup()
+    streamController.close()
+  }
+
+  function onError(error: Error) {
+    fail(error)
+  }
+
+  // A 'close' (or legacy 'aborted') before 'end' means the client went away
+  // before the body was fully received. A close after a normal 'end' never
+  // reaches this handler because 'end' removes these listeners.
+  function onClose() {
+    fail(new Error('Client disconnected before the request body was fully received'))
+  }
+
+  function fail(error: Error) {
+    if (done) return
+    done = true
+    cleanup()
+    streamController.error(error)
+    onBodyError(error)
+  }
+
+  function cleanup() {
+    req.off('data', onData)
+    req.off('end', onEnd)
+    req.off('error', onError)
+    req.off('aborted', onClose)
+    req.off('close', onClose)
+  }
+
+  return new ReadableStream({
+    start(controller) {
+      streamController = controller
+
+      if (req.readableEnded) {
+        done = true
+        controller.close()
+        return
+      }
+
+      if (req.destroyed) {
+        onClose()
+        return
+      }
+
+      req.on('data', onData)
+      req.once('end', onEnd)
+      req.once('error', onError)
+      req.once('aborted', onClose)
+      req.once('close', onClose)
+    },
+    cancel() {
+      if (done) return
+      done = true
+      cleanup()
+    },
+  })
 }
 
 /**

--- a/packages/node-fetch-server/src/lib/request-listener.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.ts
@@ -1,6 +1,7 @@
 import type * as http from 'node:http'
 import type * as http2 from 'node:http2'
 
+import { ClientDisconnectError, isClientDisconnectError } from './client-disconnect-error.ts'
 import type { ClientAddress, ErrorHandler, FetchHandler } from './fetch-handler.ts'
 import { createLazyRequestFactory } from './lazy-request.ts'
 
@@ -216,7 +217,12 @@ function isPromiseLike<value>(value: value | PromiseLike<value>): value is Promi
 }
 
 function isRequestAbortError(request: Request, error: unknown): boolean {
-  return request.signal.aborted && error === request.signal.reason
+  // Lazy body reads reject with a ClientDisconnectError before the request's
+  // signal is materialized, so a disconnect is recognized by type as well as
+  // by signal reason identity.
+  return (
+    isClientDisconnectError(error) || (request.signal.aborted && error === request.signal.reason)
+  )
 }
 
 /**
@@ -298,7 +304,7 @@ function createBodyStream(
   // before the body was fully received. A close after a normal 'end' never
   // reaches this handler because 'end' removes these listeners.
   function onClose() {
-    fail(new Error('Client disconnected before the request body was fully received'))
+    fail(new ClientDisconnectError())
   }
 
   function fail(error: Error) {


### PR DESCRIPTION
What bug this fixes:
`node-fetch-server` could leave request body reads hanging if the client aborted while uploading. That could affect direct stream reads as well as lazy body helpers like `text()`, `json()`, and `bytes()`.

What changed:
Request body errors, aborts, and early closes now reject or abort the pending body read instead of leaving it unresolved.

How I tested it:
I added regression coverage for stream body reads and the lazy `text()`, `json()`, and `bytes()` paths. The `node-fetch-server` tests pass with 28/28, and typecheck, prettier, oxlint, and diff-check all pass.

Issue link:
Closes #11533
