### PR TITLE
Simplify data-table integration test configuration

### DIFF
--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -454,7 +454,7 @@ jobs:
 
       - name: Run sqlite adapter tests
         env:
-          DATA_TABLE_INTEGRATION: '1'
+          REMIX_DATA_TABLE_SQLITE_TEST: '1'
         run: |
           cd packages/data-table-sqlite
           pnpm test src/lib/adapter.integration.test.ts

--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -391,8 +391,7 @@ jobs:
 
       - name: Run postgres integration tests
         env:
-          DATA_TABLE_INTEGRATION: '1'
-          DATA_TABLE_POSTGRES_URL: postgres://postgres:postgres@127.0.0.1:5432/remix
+          REMIX_DATA_TABLE_POSTGRES_TEST_URL: postgres://postgres:postgres@127.0.0.1:5432/remix
         run: |
           cd packages/data-table-postgres
           pnpm test src/lib/adapter.integration.test.ts
@@ -430,8 +429,7 @@ jobs:
 
       - name: Run mysql integration tests
         env:
-          DATA_TABLE_INTEGRATION: '1'
-          DATA_TABLE_MYSQL_URL: mysql://root:root@127.0.0.1:3306/remix
+          REMIX_DATA_TABLE_MYSQL_TEST_URL: mysql://root:root@127.0.0.1:3306/remix
         run: |
           cd packages/data-table-mysql
           pnpm test src/lib/adapter.integration.test.ts

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -415,8 +415,7 @@ jobs:
 
       - name: Run postgres integration tests
         env:
-          DATA_TABLE_INTEGRATION: '1'
-          DATA_TABLE_POSTGRES_URL: postgres://postgres:postgres@127.0.0.1:5432/remix
+          REMIX_DATA_TABLE_POSTGRES_TEST_URL: postgres://postgres:postgres@127.0.0.1:5432/remix
         run: |
           cd packages/data-table-postgres
           pnpm test src/lib/adapter.integration.test.ts
@@ -454,8 +453,7 @@ jobs:
 
       - name: Run mysql integration tests
         env:
-          DATA_TABLE_INTEGRATION: '1'
-          DATA_TABLE_MYSQL_URL: mysql://root:root@127.0.0.1:3306/remix
+          REMIX_DATA_TABLE_MYSQL_TEST_URL: mysql://root:root@127.0.0.1:3306/remix
         run: |
           cd packages/data-table-mysql
           pnpm test src/lib/adapter.integration.test.ts

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -478,7 +478,7 @@ jobs:
 
       - name: Run sqlite adapter tests
         env:
-          DATA_TABLE_INTEGRATION: '1'
+          REMIX_DATA_TABLE_SQLITE_TEST: '1'
         run: |
           cd packages/data-table-sqlite
           pnpm test src/lib/adapter.integration.test.ts

--- a/packages/data-table-mysql/README.md
+++ b/packages/data-table-mysql/README.md
@@ -94,8 +94,7 @@ podman run --name mysql \
 Then run:
 
 ```sh
-DATA_TABLE_INTEGRATION=1 \
-DATA_TABLE_MYSQL_URL=mysql://root:root@127.0.0.1:3306/remix \
+REMIX_DATA_TABLE_MYSQL_TEST_URL=mysql://root:root@127.0.0.1:3306/remix \
 pnpm test src/lib/adapter.integration.test.ts
 ```
 

--- a/packages/data-table-mysql/README.md
+++ b/packages/data-table-mysql/README.md
@@ -79,6 +79,32 @@ try {
 }
 ```
 
+## Running integration tests locally
+
+To start a local MySQL container matching CI:
+
+```sh
+podman run --name mysql \
+  -e MYSQL_ROOT_PASSWORD=root \
+  -e MYSQL_DATABASE=remix \
+  -p 3306:3306 \
+  -d mysql:8
+```
+
+Then run:
+
+```sh
+DATA_TABLE_INTEGRATION=1 \
+DATA_TABLE_MYSQL_URL=mysql://root:root@127.0.0.1:3306/remix \
+pnpm test src/lib/adapter.integration.test.ts
+```
+
+Remove the container when you are done:
+
+```sh
+podman rm -f mysql
+```
+
 ## Related Packages
 
 - [`data-table`](https://github.com/remix-run/remix/tree/main/packages/data-table) - Core query/relations API

--- a/packages/data-table-mysql/src/lib/adapter.integration.test.ts
+++ b/packages/data-table-mysql/src/lib/adapter.integration.test.ts
@@ -11,8 +11,8 @@ import { runAdapterIntegrationContract } from '../../../data-table/test/adapter-
 
 import { createMysqlDatabaseAdapter } from './adapter.ts'
 
-const integrationEnabled =
-  process.env.DATA_TABLE_INTEGRATION === '1' && typeof process.env.DATA_TABLE_MYSQL_URL === 'string'
+const DATABASE_URL = process.env.REMIX_DATA_TABLE_MYSQL_TEST_URL
+const integrationEnabled = typeof DATABASE_URL === 'string'
 
 describe('mysql adapter integration', () => {
   let pool: Pool
@@ -22,7 +22,7 @@ describe('mysql adapter integration', () => {
       return
     }
 
-    pool = createPool(process.env.DATA_TABLE_MYSQL_URL as string)
+    pool = createPool(DATABASE_URL)
     await setupAdapterIntegrationSchema(async (statement) => {
       await pool.query(statement)
     }, 'mysql')

--- a/packages/data-table-mysql/src/lib/adapter.integration.test.ts
+++ b/packages/data-table-mysql/src/lib/adapter.integration.test.ts
@@ -12,27 +12,18 @@ import { runAdapterIntegrationContract } from '../../../data-table/test/adapter-
 import { createMysqlDatabaseAdapter } from './adapter.ts'
 
 const DATABASE_URL = process.env.REMIX_DATA_TABLE_MYSQL_TEST_URL
-const integrationEnabled = typeof DATABASE_URL === 'string'
 
-describe('mysql adapter integration', () => {
+describe('mysql adapter integration', { skip: typeof DATABASE_URL !== 'string' }, () => {
   let pool: Pool
 
   before(async () => {
-    if (!integrationEnabled) {
-      return
-    }
-
-    pool = createPool(DATABASE_URL)
+    pool = createPool(DATABASE_URL!)
     await setupAdapterIntegrationSchema(async (statement) => {
       await pool.query(statement)
     }, 'mysql')
   })
 
   after(async () => {
-    if (!integrationEnabled) {
-      return
-    }
-
     await teardownAdapterIntegrationSchema(async (statement) => {
       await pool.query(statement)
     }, 'mysql')
@@ -40,7 +31,6 @@ describe('mysql adapter integration', () => {
   })
 
   runAdapterIntegrationContract({
-    integrationEnabled,
     createDatabase: () => createDatabase(createMysqlDatabaseAdapter(pool)),
     resetDatabase: async () => {
       await resetAdapterIntegrationSchema(async (statement) => {

--- a/packages/data-table-postgres/README.md
+++ b/packages/data-table-postgres/README.md
@@ -76,8 +76,7 @@ podman run --name postgres \
 Then run:
 
 ```sh
-DATA_TABLE_INTEGRATION=1 \
-DATA_TABLE_POSTGRES_URL=postgres://postgres:postgres@127.0.0.1:5432/remix \
+REMIX_DATA_TABLE_POSTGRES_TEST_URL=postgres://postgres:postgres@127.0.0.1:5432/remix \
 pnpm test src/lib/adapter.integration.test.ts
 ```
 

--- a/packages/data-table-postgres/README.md
+++ b/packages/data-table-postgres/README.md
@@ -60,6 +60,33 @@ await db.transaction(async (txDb) => txDb.exec('select 1'), {
 })
 ```
 
+## Running integration tests locally
+
+To start a local Postgres container matching CI:
+
+```sh
+podman run --name postgres \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=remix \
+  -p 5432:5432 \
+  -d postgres:16
+```
+
+Then run:
+
+```sh
+DATA_TABLE_INTEGRATION=1 \
+DATA_TABLE_POSTGRES_URL=postgres://postgres:postgres@127.0.0.1:5432/remix \
+pnpm test src/lib/adapter.integration.test.ts
+```
+
+Remove the container when you are done:
+
+```sh
+podman rm -f postgres
+```
+
 ## Related Packages
 
 - [`data-table`](https://github.com/remix-run/remix/tree/main/packages/data-table) - Core query/relations API

--- a/packages/data-table-postgres/src/lib/adapter.integration.test.ts
+++ b/packages/data-table-postgres/src/lib/adapter.integration.test.ts
@@ -12,27 +12,18 @@ import { runAdapterIntegrationContract } from '../../../data-table/test/adapter-
 import { createPostgresDatabaseAdapter } from './adapter.ts'
 
 const DATABASE_URL = process.env.REMIX_DATA_TABLE_POSTGRES_TEST_URL
-const integrationEnabled = typeof DATABASE_URL === 'string'
 
-describe('postgres adapter integration', () => {
+describe('postgres adapter integration', { skip: typeof DATABASE_URL !== 'string' }, () => {
   let pool: Pool
 
   before(async () => {
-    if (!integrationEnabled) {
-      return
-    }
-
-    pool = new Pool({ connectionString: DATABASE_URL })
+    pool = new Pool({ connectionString: DATABASE_URL! })
     await setupAdapterIntegrationSchema(async (statement) => {
       await pool.query(statement)
     }, 'postgres')
   })
 
   after(async () => {
-    if (!integrationEnabled) {
-      return
-    }
-
     await teardownAdapterIntegrationSchema(async (statement) => {
       await pool.query(statement)
     }, 'postgres')
@@ -40,7 +31,6 @@ describe('postgres adapter integration', () => {
   })
 
   runAdapterIntegrationContract({
-    integrationEnabled,
     createDatabase: () => createDatabase(createPostgresDatabaseAdapter(pool)),
     resetDatabase: async () => {
       await resetAdapterIntegrationSchema(async (statement) => {

--- a/packages/data-table-postgres/src/lib/adapter.integration.test.ts
+++ b/packages/data-table-postgres/src/lib/adapter.integration.test.ts
@@ -11,9 +11,8 @@ import { runAdapterIntegrationContract } from '../../../data-table/test/adapter-
 
 import { createPostgresDatabaseAdapter } from './adapter.ts'
 
-const integrationEnabled =
-  process.env.DATA_TABLE_INTEGRATION === '1' &&
-  typeof process.env.DATA_TABLE_POSTGRES_URL === 'string'
+const DATABASE_URL = process.env.REMIX_DATA_TABLE_POSTGRES_TEST_URL
+const integrationEnabled = typeof DATABASE_URL === 'string'
 
 describe('postgres adapter integration', () => {
   let pool: Pool
@@ -23,7 +22,7 @@ describe('postgres adapter integration', () => {
       return
     }
 
-    pool = new Pool({ connectionString: process.env.DATA_TABLE_POSTGRES_URL })
+    pool = new Pool({ connectionString: DATABASE_URL })
     await setupAdapterIntegrationSchema(async (statement) => {
       await pool.query(statement)
     }, 'postgres')

--- a/packages/data-table-sqlite/src/lib/adapter.integration.test.ts
+++ b/packages/data-table-sqlite/src/lib/adapter.integration.test.ts
@@ -14,16 +14,10 @@ import {
 
 import { createSqliteDatabaseAdapter } from './adapter.ts'
 
-const integrationEnabled = process.env.DATA_TABLE_INTEGRATION === '1'
-
-describe('sqlite adapter integration', () => {
+describe('sqlite adapter integration', { skip: process.env.DATA_TABLE_INTEGRATION !== '1' }, () => {
   let sqlite: NativeSqliteDatabase
 
   before(async () => {
-    if (!integrationEnabled) {
-      return
-    }
-
     sqlite = createNativeSqliteDatabase()
     await setupAdapterIntegrationSchema(async (statement) => {
       sqlite.exec(statement)
@@ -31,10 +25,6 @@ describe('sqlite adapter integration', () => {
   })
 
   after(async () => {
-    if (!integrationEnabled) {
-      return
-    }
-
     await teardownAdapterIntegrationSchema(async (statement) => {
       sqlite.exec(statement)
     }, 'sqlite')
@@ -42,7 +32,6 @@ describe('sqlite adapter integration', () => {
   })
 
   runAdapterIntegrationContract({
-    integrationEnabled,
     createDatabase: () => createDatabase(createSqliteDatabaseAdapter(sqlite)),
     resetDatabase: async () => {
       await resetAdapterIntegrationSchema(async (statement) => {

--- a/packages/data-table-sqlite/src/lib/adapter.integration.test.ts
+++ b/packages/data-table-sqlite/src/lib/adapter.integration.test.ts
@@ -14,29 +14,33 @@ import {
 
 import { createSqliteDatabaseAdapter } from './adapter.ts'
 
-describe('sqlite adapter integration', { skip: process.env.DATA_TABLE_INTEGRATION !== '1' }, () => {
-  let sqlite: NativeSqliteDatabase
+describe(
+  'sqlite adapter integration',
+  { skip: process.env.REMIX_DATA_TABLE_SQLITE_TEST !== '1' },
+  () => {
+    let sqlite: NativeSqliteDatabase
 
-  before(async () => {
-    sqlite = createNativeSqliteDatabase()
-    await setupAdapterIntegrationSchema(async (statement) => {
-      sqlite.exec(statement)
-    }, 'sqlite')
-  })
-
-  after(async () => {
-    await teardownAdapterIntegrationSchema(async (statement) => {
-      sqlite.exec(statement)
-    }, 'sqlite')
-    sqlite.close()
-  })
-
-  runAdapterIntegrationContract({
-    createDatabase: () => createDatabase(createSqliteDatabaseAdapter(sqlite)),
-    resetDatabase: async () => {
-      await resetAdapterIntegrationSchema(async (statement) => {
+    before(async () => {
+      sqlite = createNativeSqliteDatabase()
+      await setupAdapterIntegrationSchema(async (statement) => {
         sqlite.exec(statement)
       }, 'sqlite')
-    },
-  })
-})
+    })
+
+    after(async () => {
+      await teardownAdapterIntegrationSchema(async (statement) => {
+        sqlite.exec(statement)
+      }, 'sqlite')
+      sqlite.close()
+    })
+
+    runAdapterIntegrationContract({
+      createDatabase: () => createDatabase(createSqliteDatabaseAdapter(sqlite)),
+      resetDatabase: async () => {
+        await resetAdapterIntegrationSchema(async (statement) => {
+          sqlite.exec(statement)
+        }, 'sqlite')
+      },
+    })
+  },
+)

--- a/packages/data-table/test/adapter-integration-contract.ts
+++ b/packages/data-table/test/adapter-integration-contract.ts
@@ -43,435 +43,401 @@ const accountTasks = hasManyThrough(accounts, tasks, {
 })
 
 export type IntegrationContractOptions = {
-  integrationEnabled: boolean
   createDatabase: () => Database
   resetDatabase: () => Promise<void>
 }
 
 export function runAdapterIntegrationContract(options: IntegrationContractOptions): void {
   beforeEach(async () => {
-    if (!options.integrationEnabled) {
-      return
-    }
-
     await options.resetDatabase()
   })
 
-  it(
-    'supports joined alias select with groupBy/having',
-    { skip: !options.integrationEnabled },
-    async function () {
-      let db = options.createDatabase()
+  it('supports joined alias select with groupBy/having', async function () {
+    let db = options.createDatabase()
 
-      await db.query(accounts).insertMany([
-        {
-          id: 1,
-          email: 'a@example.com',
-          status: 'active',
-          nickname: null,
-        },
-        {
-          id: 2,
-          email: 'b@example.com',
-          status: 'inactive',
-          nickname: 'bee',
-        },
-      ])
-      await db.query(projects).insertMany([
-        {
-          id: 100,
-          account_id: 1,
-          name: 'Alpha',
-          archived: false,
-        },
-        {
-          id: 101,
-          account_id: 1,
-          name: 'Beta',
-          archived: true,
-        },
-        {
-          id: 200,
-          account_id: 2,
-          name: 'Gamma',
-          archived: false,
-        },
-      ])
-
-      let joined = await db
-        .query(accounts)
-        .join(projects, eq('accounts.id', 'projects.account_id'))
-        .where(eq('projects.archived', false))
-        .select({
-          accountId: 'accounts.id',
-          accountEmail: 'accounts.email',
-          projectId: 'projects.id',
-          projectName: 'projects.name',
-        })
-        .orderBy('projects.id', 'asc')
-        .all()
-
-      assert.deepEqual(joined, [
-        {
-          accountId: 1,
-          accountEmail: 'a@example.com',
-          projectId: 100,
-          projectName: 'Alpha',
-        },
-        {
-          accountId: 2,
-          accountEmail: 'b@example.com',
-          projectId: 200,
-          projectName: 'Gamma',
-        },
-      ])
-
-      let groupedCount = await db
-        .query(accounts)
-        .join(projects, eq('accounts.id', 'projects.account_id'))
-        .where(eq('projects.archived', false))
-        .groupBy('accounts.id')
-        .having(eq('accounts.id', 1))
-        .count()
-
-      assert.equal(groupedCount, 1)
-    },
-  )
-
-  it(
-    'supports eager relations with per-parent relation pagination',
-    { skip: !options.integrationEnabled },
-    async function () {
-      let db = options.createDatabase()
-
-      await db.query(accounts).insertMany([
-        { id: 1, email: 'a@example.com', status: 'active', nickname: null },
-        { id: 2, email: 'b@example.com', status: 'active', nickname: null },
-      ])
-      await db.query(projects).insertMany([
-        { id: 100, account_id: 1, name: 'A-1', archived: false },
-        { id: 101, account_id: 1, name: 'A-2', archived: false },
-        { id: 200, account_id: 2, name: 'B-1', archived: false },
-        { id: 201, account_id: 2, name: 'B-2', archived: false },
-      ])
-      await db.query(tasks).insertMany([
-        { id: 1000, project_id: 100, title: 'A1-T1', state: 'open' },
-        { id: 1001, project_id: 101, title: 'A2-T1', state: 'open' },
-        { id: 2000, project_id: 200, title: 'B1-T1', state: 'open' },
-        { id: 2001, project_id: 201, title: 'B2-T1', state: 'open' },
-      ])
-
-      let accountRows = await db
-        .query(accounts)
-        .orderBy('id', 'asc')
-        .with({
-          projects: accountProjects.orderBy('id', 'asc').limit(1),
-          tasks: accountTasks.orderBy('id', 'asc').limit(1),
-        })
-        .all()
-
-      assert.equal(accountRows.length, 2)
-      assert.equal(accountRows[0].projects.length, 1)
-      assert.equal(accountRows[0].projects[0].id, 100)
-      assert.equal(accountRows[1].projects.length, 1)
-      assert.equal(accountRows[1].projects[0].id, 200)
-      assert.equal(accountRows[0].tasks.length, 1)
-      assert.equal(accountRows[0].tasks[0].id, 1000)
-      assert.equal(accountRows[1].tasks.length, 1)
-      assert.equal(accountRows[1].tasks[0].id, 2000)
-    },
-  )
-
-  it(
-    'scopes update/delete writes with orderBy and limit',
-    { skip: !options.integrationEnabled },
-    async function () {
-      let db = options.createDatabase()
-
-      await db.query(accounts).insertMany([
-        { id: 1, email: 'a@example.com', status: 'active', nickname: null },
-        { id: 2, email: 'b@example.com', status: 'active', nickname: null },
-        { id: 3, email: 'c@example.com', status: 'active', nickname: null },
-      ])
-
-      await db
-        .query(accounts)
-        .where({ status: 'active' })
-        .orderBy('id', 'asc')
-        .limit(1)
-        .update({ status: 'paused' })
-
-      await db.query(accounts).where({ status: 'active' }).orderBy('id', 'desc').limit(1).delete()
-
-      let rows = await db.query(accounts).orderBy('id', 'asc').all()
-
-      assert.deepEqual(
-        rows.map((row) => ({ id: row.id, status: row.status })),
-        [
-          { id: 1, status: 'paused' },
-          { id: 2, status: 'active' },
-        ],
-      )
-    },
-  )
-
-  it(
-    'supports transactions and nested savepoints',
-    { skip: !options.integrationEnabled },
-    async function () {
-      let db = options.createDatabase()
-
-      await db.query(accounts).insert({
+    await db.query(accounts).insertMany([
+      {
         id: 1,
         email: 'a@example.com',
         status: 'active',
         nickname: null,
+      },
+      {
+        id: 2,
+        email: 'b@example.com',
+        status: 'inactive',
+        nickname: 'bee',
+      },
+    ])
+    await db.query(projects).insertMany([
+      {
+        id: 100,
+        account_id: 1,
+        name: 'Alpha',
+        archived: false,
+      },
+      {
+        id: 101,
+        account_id: 1,
+        name: 'Beta',
+        archived: true,
+      },
+      {
+        id: 200,
+        account_id: 2,
+        name: 'Gamma',
+        archived: false,
+      },
+    ])
+
+    let joined = await db
+      .query(accounts)
+      .join(projects, eq('accounts.id', 'projects.account_id'))
+      .where(eq('projects.archived', false))
+      .select({
+        accountId: 'accounts.id',
+        accountEmail: 'accounts.email',
+        projectId: 'projects.id',
+        projectName: 'projects.name',
+      })
+      .orderBy('projects.id', 'asc')
+      .all()
+
+    assert.deepEqual(joined, [
+      {
+        accountId: 1,
+        accountEmail: 'a@example.com',
+        projectId: 100,
+        projectName: 'Alpha',
+      },
+      {
+        accountId: 2,
+        accountEmail: 'b@example.com',
+        projectId: 200,
+        projectName: 'Gamma',
+      },
+    ])
+
+    let groupedCount = await db
+      .query(accounts)
+      .join(projects, eq('accounts.id', 'projects.account_id'))
+      .where(eq('projects.archived', false))
+      .groupBy('accounts.id')
+      .having(eq('accounts.id', 1))
+      .count()
+
+    assert.equal(groupedCount, 1)
+  })
+
+  it('supports eager relations with per-parent relation pagination', async function () {
+    let db = options.createDatabase()
+
+    await db.query(accounts).insertMany([
+      { id: 1, email: 'a@example.com', status: 'active', nickname: null },
+      { id: 2, email: 'b@example.com', status: 'active', nickname: null },
+    ])
+    await db.query(projects).insertMany([
+      { id: 100, account_id: 1, name: 'A-1', archived: false },
+      { id: 101, account_id: 1, name: 'A-2', archived: false },
+      { id: 200, account_id: 2, name: 'B-1', archived: false },
+      { id: 201, account_id: 2, name: 'B-2', archived: false },
+    ])
+    await db.query(tasks).insertMany([
+      { id: 1000, project_id: 100, title: 'A1-T1', state: 'open' },
+      { id: 1001, project_id: 101, title: 'A2-T1', state: 'open' },
+      { id: 2000, project_id: 200, title: 'B1-T1', state: 'open' },
+      { id: 2001, project_id: 201, title: 'B2-T1', state: 'open' },
+    ])
+
+    let accountRows = await db
+      .query(accounts)
+      .orderBy('id', 'asc')
+      .with({
+        projects: accountProjects.orderBy('id', 'asc').limit(1),
+        tasks: accountTasks.orderBy('id', 'asc').limit(1),
+      })
+      .all()
+
+    assert.equal(accountRows.length, 2)
+    assert.equal(accountRows[0].projects.length, 1)
+    assert.equal(accountRows[0].projects[0].id, 100)
+    assert.equal(accountRows[1].projects.length, 1)
+    assert.equal(accountRows[1].projects[0].id, 200)
+    assert.equal(accountRows[0].tasks.length, 1)
+    assert.equal(accountRows[0].tasks[0].id, 1000)
+    assert.equal(accountRows[1].tasks.length, 1)
+    assert.equal(accountRows[1].tasks[0].id, 2000)
+  })
+
+  it('scopes update/delete writes with orderBy and limit', async function () {
+    let db = options.createDatabase()
+
+    await db.query(accounts).insertMany([
+      { id: 1, email: 'a@example.com', status: 'active', nickname: null },
+      { id: 2, email: 'b@example.com', status: 'active', nickname: null },
+      { id: 3, email: 'c@example.com', status: 'active', nickname: null },
+    ])
+
+    await db
+      .query(accounts)
+      .where({ status: 'active' })
+      .orderBy('id', 'asc')
+      .limit(1)
+      .update({ status: 'paused' })
+
+    await db.query(accounts).where({ status: 'active' }).orderBy('id', 'desc').limit(1).delete()
+
+    let rows = await db.query(accounts).orderBy('id', 'asc').all()
+
+    assert.deepEqual(
+      rows.map((row) => ({ id: row.id, status: row.status })),
+      [
+        { id: 1, status: 'paused' },
+        { id: 2, status: 'active' },
+      ],
+    )
+  })
+
+  it('supports transactions and nested savepoints', async function () {
+    let db = options.createDatabase()
+
+    await db.query(accounts).insert({
+      id: 1,
+      email: 'a@example.com',
+      status: 'active',
+      nickname: null,
+    })
+
+    await db.transaction(async (outerTransaction) => {
+      await outerTransaction.query(accounts).insert({
+        id: 2,
+        email: 'b@example.com',
+        status: 'active',
+        nickname: null,
       })
 
-      await db.transaction(async (outerTransaction) => {
-        await outerTransaction.query(accounts).insert({
-          id: 2,
-          email: 'b@example.com',
-          status: 'active',
-          nickname: null,
-        })
-
-        await outerTransaction
-          .transaction(async (innerTransaction) => {
-            await innerTransaction.query(accounts).insert({
-              id: 3,
-              email: 'c@example.com',
-              status: 'active',
-              nickname: null,
-            })
-
-            throw new Error('rollback inner')
-          })
-          .catch(() => undefined)
-      })
-
-      await db
-        .transaction(async (transactionDatabase) => {
-          await transactionDatabase.query(accounts).insert({
-            id: 4,
-            email: 'd@example.com',
+      await outerTransaction
+        .transaction(async (innerTransaction) => {
+          await innerTransaction.query(accounts).insert({
+            id: 3,
+            email: 'c@example.com',
             status: 'active',
             nickname: null,
           })
 
-          throw new Error('rollback outer')
+          throw new Error('rollback inner')
         })
         .catch(() => undefined)
+    })
 
-      let rows = await db.query(accounts).orderBy('id', 'asc').all()
+    await db
+      .transaction(async (transactionDatabase) => {
+        await transactionDatabase.query(accounts).insert({
+          id: 4,
+          email: 'd@example.com',
+          status: 'active',
+          nickname: null,
+        })
 
-      assert.deepEqual(
-        rows.map((row) => row.id),
-        [1, 2],
-      )
-    },
-  )
+        throw new Error('rollback outer')
+      })
+      .catch(() => undefined)
 
-  it(
-    'supports upsert with conflict target',
-    { skip: !options.integrationEnabled },
-    async function () {
-      let db = options.createDatabase()
+    let rows = await db.query(accounts).orderBy('id', 'asc').all()
 
-      await db.query(accounts).insert({
+    assert.deepEqual(
+      rows.map((row) => row.id),
+      [1, 2],
+    )
+  })
+
+  it('supports upsert with conflict target', async function () {
+    let db = options.createDatabase()
+
+    await db.query(accounts).insert({
+      id: 1,
+      email: 'a@example.com',
+      status: 'active',
+      nickname: null,
+    })
+
+    await db.query(accounts).upsert(
+      {
         id: 1,
         email: 'a@example.com',
+        status: 'inactive',
+        nickname: 'alpha',
+      },
+      { conflictTarget: ['id'] },
+    )
+    await db.query(accounts).upsert(
+      {
+        id: 2,
+        email: 'b@example.com',
         status: 'active',
         nickname: null,
-      })
+      },
+      { conflictTarget: ['id'] },
+    )
 
-      await db.query(accounts).upsert(
-        {
-          id: 1,
-          email: 'a@example.com',
-          status: 'inactive',
-          nickname: 'alpha',
-        },
-        { conflictTarget: ['id'] },
-      )
-      await db.query(accounts).upsert(
-        {
-          id: 2,
-          email: 'b@example.com',
-          status: 'active',
-          nickname: null,
-        },
-        { conflictTarget: ['id'] },
-      )
+    let rows = await db.query(accounts).orderBy('id', 'asc').all()
 
-      let rows = await db.query(accounts).orderBy('id', 'asc').all()
+    assert.equal(rows.length, 2)
+    assert.equal(rows[0].status, 'inactive')
+    assert.equal(rows[0].nickname, 'alpha')
+    assert.equal(rows[1].id, 2)
+  })
 
-      assert.equal(rows.length, 2)
-      assert.equal(rows[0].status, 'inactive')
-      assert.equal(rows[0].nickname, 'alpha')
-      assert.equal(rows[1].id, 2)
-    },
-  )
+  it('supports null and value operators in real queries', async function () {
+    let db = options.createDatabase()
 
-  it(
-    'supports null and value operators in real queries',
-    { skip: !options.integrationEnabled },
-    async function () {
-      let db = options.createDatabase()
+    await db.query(accounts).insertMany([
+      {
+        id: 1,
+        email: 'A@Example.com',
+        status: 'active',
+        nickname: null,
+      },
+      {
+        id: 2,
+        email: 'b@example.com',
+        status: 'inactive',
+        nickname: 'bee',
+      },
+      {
+        id: 3,
+        email: 'c@example.com',
+        status: 'active',
+        nickname: null,
+      },
+    ])
 
-      await db.query(accounts).insertMany([
-        {
-          id: 1,
-          email: 'A@Example.com',
-          status: 'active',
-          nickname: null,
-        },
-        {
-          id: 2,
-          email: 'b@example.com',
-          status: 'inactive',
-          nickname: 'bee',
-        },
-        {
-          id: 3,
-          email: 'c@example.com',
-          status: 'active',
-          nickname: null,
-        },
-      ])
+    let nullNickname = await db
+      .query(accounts)
+      .where(eq('nickname', null))
+      .orderBy('id', 'asc')
+      .all()
+    let nonNullNickname = await db.query(accounts).where(ne('nickname', null)).all()
+    let inRows = await db
+      .query(accounts)
+      .where(inList('id', [1, 3]))
+      .orderBy('id', 'asc')
+      .all()
+    let betweenRows = await db
+      .query(accounts)
+      .where(between('id', 2, 3))
+      .orderBy('id', 'asc')
+      .all()
+    let ilikeRows = await db
+      .query(accounts)
+      .where(ilike('email', '%@example.com'))
+      .orderBy('id', 'asc')
+      .all()
 
-      let nullNickname = await db
-        .query(accounts)
-        .where(eq('nickname', null))
-        .orderBy('id', 'asc')
-        .all()
-      let nonNullNickname = await db.query(accounts).where(ne('nickname', null)).all()
-      let inRows = await db
-        .query(accounts)
-        .where(inList('id', [1, 3]))
-        .orderBy('id', 'asc')
-        .all()
-      let betweenRows = await db
-        .query(accounts)
-        .where(between('id', 2, 3))
-        .orderBy('id', 'asc')
-        .all()
-      let ilikeRows = await db
-        .query(accounts)
-        .where(ilike('email', '%@example.com'))
-        .orderBy('id', 'asc')
-        .all()
+    assert.deepEqual(
+      nullNickname.map((row) => row.id),
+      [1, 3],
+    )
+    assert.equal(nonNullNickname.length, 1)
+    assert.equal(nonNullNickname[0].id, 2)
+    assert.deepEqual(
+      inRows.map((row) => row.id),
+      [1, 3],
+    )
+    assert.deepEqual(
+      betweenRows.map((row) => row.id),
+      [2, 3],
+    )
+    assert.deepEqual(
+      ilikeRows.map((row) => row.id),
+      [1, 2, 3],
+    )
+  })
 
-      assert.deepEqual(
-        nullNickname.map((row) => row.id),
-        [1, 3],
-      )
-      assert.equal(nonNullNickname.length, 1)
-      assert.equal(nonNullNickname[0].id, 2)
-      assert.deepEqual(
-        inRows.map((row) => row.id),
-        [1, 3],
-      )
-      assert.deepEqual(
-        betweenRows.map((row) => row.id),
-        [2, 3],
-      )
-      assert.deepEqual(
-        ilikeRows.map((row) => row.id),
-        [1, 2, 3],
-      )
-    },
-  )
-
-  it(
-    'supports migration up/down with lifecycle hooks and returned reads',
-    { skip: !options.integrationEnabled },
-    async function () {
-      let db = options.createDatabase()
-      let lifecycleEvents: string[] = []
-      let lifecycleAccounts = table({
-        name: 'lifecycle_accounts',
-        columns: {
-          id: column.integer(),
-          email: column.text(),
-          status: column.text(),
-        },
-        beforeWrite({ value }) {
-          lifecycleEvents.push('beforeWrite')
-          return {
-            value: {
-              ...value,
-              email:
-                typeof value.email === 'string' ? value.email.trim().toLowerCase() : value.email,
-              status:
-                value.status === undefined
-                  ? 'active'
-                  : typeof value.status === 'string'
-                    ? value.status.trim().toLowerCase()
-                    : value.status,
-            },
-          }
-        },
-        validate({ value }) {
-          lifecycleEvents.push('validate')
-          if (typeof value.email !== 'string' || !value.email.includes('@')) {
-            return { issues: [{ message: 'Expected valid email', path: ['email'] }] }
-          }
-          return { value }
-        },
-        afterWrite({ operation, affectedRows }) {
-          lifecycleEvents.push('afterWrite:' + operation + ':' + String(affectedRows))
-        },
-        afterRead({ value }) {
-          if (typeof value.email !== 'string') {
-            return { value }
-          }
-          return {
-            value: {
-              ...value,
-              email: value.email.toUpperCase(),
-            },
-          }
-        },
-      })
-      let runner = createMigrationRunner(
-        db.adapter,
-        [
-          {
-            id: '20260228001000',
-            name: 'create_lifecycle_accounts',
-            up: 'create table if not exists lifecycle_accounts (id integer primary key, email text not null, status text not null)',
-            down: 'drop table if exists lifecycle_accounts',
+  it('supports migration up/down with lifecycle hooks and returned reads', async function () {
+    let db = options.createDatabase()
+    let lifecycleEvents: string[] = []
+    let lifecycleAccounts = table({
+      name: 'lifecycle_accounts',
+      columns: {
+        id: column.integer(),
+        email: column.text(),
+        status: column.text(),
+      },
+      beforeWrite({ value }) {
+        lifecycleEvents.push('beforeWrite')
+        return {
+          value: {
+            ...value,
+            email: typeof value.email === 'string' ? value.email.trim().toLowerCase() : value.email,
+            status:
+              value.status === undefined
+                ? 'active'
+                : typeof value.status === 'string'
+                  ? value.status.trim().toLowerCase()
+                  : value.status,
           },
-        ],
-        { journalTable: 'adapter_contract_migrations' },
-      )
-
-      await runner.up()
-
-      let created = await db.create(
-        lifecycleAccounts,
+        }
+      },
+      validate({ value }) {
+        lifecycleEvents.push('validate')
+        if (typeof value.email !== 'string' || !value.email.includes('@')) {
+          return { issues: [{ message: 'Expected valid email', path: ['email'] }] }
+        }
+        return { value }
+      },
+      afterWrite({ operation, affectedRows }) {
+        lifecycleEvents.push('afterWrite:' + operation + ':' + String(affectedRows))
+      },
+      afterRead({ value }) {
+        if (typeof value.email !== 'string') {
+          return { value }
+        }
+        return {
+          value: {
+            ...value,
+            email: value.email.toUpperCase(),
+          },
+        }
+      },
+    })
+    let runner = createMigrationRunner(
+      db.adapter,
+      [
         {
-          id: 1,
-          email: '  User@Example.com  ',
+          id: '20260228001000',
+          name: 'create_lifecycle_accounts',
+          up: 'create table if not exists lifecycle_accounts (id integer primary key, email text not null, status text not null)',
+          down: 'drop table if exists lifecycle_accounts',
         },
-        { returnRow: true },
-      )
-      let loaded = await db.find(lifecycleAccounts, 1)
-      let statusAfterUp = await runner.status()
+      ],
+      { journalTable: 'adapter_contract_migrations' },
+    )
 
-      assert.equal(created.email, 'USER@EXAMPLE.COM')
-      assert.equal(created.status, 'active')
-      assert.equal(loaded?.email, 'USER@EXAMPLE.COM')
-      assert.deepEqual(lifecycleEvents, ['beforeWrite', 'validate', 'afterWrite:create:1'])
-      assert.equal(statusAfterUp.length, 1)
-      assert.equal(statusAfterUp[0].status, 'applied')
+    await runner.up()
 
-      await runner.down({ step: 1 })
+    let created = await db.create(
+      lifecycleAccounts,
+      {
+        id: 1,
+        email: '  User@Example.com  ',
+      },
+      { returnRow: true },
+    )
+    let loaded = await db.find(lifecycleAccounts, 1)
+    let statusAfterUp = await runner.status()
 
-      let statusAfterDown = await runner.status()
-      assert.equal(statusAfterDown.length, 1)
-      assert.equal(statusAfterDown[0].status, 'pending')
-    },
-  )
+    assert.equal(created.email, 'USER@EXAMPLE.COM')
+    assert.equal(created.status, 'active')
+    assert.equal(loaded?.email, 'USER@EXAMPLE.COM')
+    assert.deepEqual(lifecycleEvents, ['beforeWrite', 'validate', 'afterWrite:create:1'])
+    assert.equal(statusAfterUp.length, 1)
+    assert.equal(statusAfterUp[0].status, 'applied')
+
+    await runner.down({ step: 1 })
+
+    let statusAfterDown = await runner.status()
+    assert.equal(statusAfterDown.length, 1)
+    assert.equal(statusAfterDown[0].status, 'pending')
+  })
 }


### PR DESCRIPTION
Updates the data-table adapter integration test setup to use adapter-specific environment variables and documents how to run the Postgres/MySQL integration databases locally with Podman.

## Changes

- Replaces the shared `DATA_TABLE_INTEGRATION` flag for database-backed adapters with URL-driven test configuration:
  - `REMIX_DATA_TABLE_POSTGRES_TEST_URL`
  - `REMIX_DATA_TABLE_MYSQL_TEST_URL`
- Renames the SQLite integration flag to:
  - `REMIX_DATA_TABLE_SQLITE_TEST`
- Moves adapter integration test skipping to the suite level instead of passing `integrationEnabled` through the shared contract helper.
- Updates CI workflows to use the new env var names.
- Adds local Podman setup instructions to the Postgres and MySQL adapter READMEs.

## Validation

- `REMIX_DATA_TABLE_POSTGRES_TEST_URL=postgres://postgres:postgres@127.0.0.1:5432/remix pnpm --dir packages/data-table-postgres test src/lib/adapter.integration.test.ts`
- `REMIX_DATA_TABLE_MYSQL_TEST_URL=mysql://root:root@127.0.0.1:3306/remix pnpm --dir packages/data-table-mysql test src/lib/adapter.integration.test.ts`
- `REMIX_DATA_TABLE_SQLITE_TEST=1 pnpm --dir packages/data-table-sqlite test src/lib/adapter.integration.test.ts`
