### PR TITLE
Fix custom multi-part MIME extension detection

### DIFF
--- a/packages/mime/.changes/patch.detect-multipart-extensions.md
+++ b/packages/mime/.changes/patch.detect-multipart-extensions.md
@@ -1,0 +1,1 @@
+Fixed `detectMimeType()` so custom MIME types registered with multi-part extensions, such as `be.pit`, are detected from filenames like `filename.be.pit` (see #11099).

--- a/packages/mime/README.md
+++ b/packages/mime/README.md
@@ -86,12 +86,19 @@ mimeTypeToContentType('image/png') // 'image/png'
 Registers or overrides a MIME type for one or more file extensions.
 
 ```ts
-import { defineMimeType } from 'remix/mime'
+import { defineMimeType, detectMimeType } from 'remix/mime'
 
 defineMimeType({
   extensions: ['myformat'],
   mimeType: 'application/x-myformat',
 })
+
+defineMimeType({
+  extensions: ['be.pit'],
+  mimeType: 'application/x-be-pit-document',
+})
+
+detectMimeType('filename.be.pit') // 'application/x-be-pit-document'
 ```
 
 You can also optionally configure the charset and whether the MIME type is compressible:

--- a/packages/mime/src/lib/define-mime-type.test.ts
+++ b/packages/mime/src/lib/define-mime-type.test.ts
@@ -53,6 +53,31 @@ describe('defineMimeType()', () => {
       assert.equal(detectMimeType('.mdx'), 'text/mdx')
     })
 
+    it('detects multi-part extensions', () => {
+      defineMimeType({
+        extensions: 'pit',
+        mimeType: 'application/x-pit-document',
+      })
+      defineMimeType({
+        extensions: 'be.pit',
+        mimeType: 'application/x-be-pit-document',
+      })
+      defineMimeType({
+        extensions: 'fr.pit',
+        mimeType: 'application/x-fr-pit-document',
+      })
+
+      assert.equal(detectMimeType('filename.pit'), 'application/x-pit-document')
+      assert.equal(detectMimeType('filename.be.pit'), 'application/x-be-pit-document')
+      assert.equal(detectMimeType('filename.fr.pit'), 'application/x-fr-pit-document')
+      assert.equal(detectMimeType('be.pit'), 'application/x-be-pit-document')
+      assert.equal(detectMimeType('.fr.pit'), 'application/x-fr-pit-document')
+      assert.equal(detectMimeType('path/to/be.pit'), 'application/x-be-pit-document')
+      assert.equal(detectMimeType('path/to/.fr.pit'), 'application/x-fr-pit-document')
+      assert.equal(detectMimeType('path/to/pit'), undefined)
+      assert.equal(detectMimeType('PATH/TO/FILENAME.BE.PIT'), 'application/x-be-pit-document')
+    })
+
     it('trims extension whitespace', () => {
       defineMimeType({
         extensions: '  mdx  ',

--- a/packages/mime/src/lib/detect-mime-type.ts
+++ b/packages/mime/src/lib/detect-mime-type.ts
@@ -18,10 +18,47 @@ import { customMimeTypeByExtension } from './define-mime-type.ts'
  */
 export function detectMimeType(extension: string): string | undefined {
   let ext = extension.trim().toLowerCase()
+
+  let customMimeType = detectCustomMimeType(ext)
+  if (customMimeType !== undefined) {
+    return customMimeType
+  }
+
   let idx = ext.lastIndexOf('.')
   // If no dot found (~idx === -1, so !~idx === true), use ext as-is.
   // Otherwise, skip past the dot (++idx) and extract the extension.
   // Credit to mrmime for this technique.
   ext = !~idx ? ext : ext.substring(++idx)
-  return customMimeTypeByExtension?.get(ext) ?? mimeTypes[ext]
+  return mimeTypes[ext]
+}
+
+function detectCustomMimeType(extension: string): string | undefined {
+  let customMimeTypes = customMimeTypeByExtension
+  if (!customMimeTypes) return undefined
+
+  let ext = extension.startsWith('.') ? extension.slice(1) : extension
+  let mimeType = customMimeTypes.get(ext)
+  if (mimeType !== undefined) {
+    return mimeType
+  }
+
+  let slashIdx = Math.max(extension.lastIndexOf('/'), extension.lastIndexOf('\\'))
+  let filename = ~slashIdx ? extension.slice(slashIdx + 1) : extension
+  if (filename.includes('.')) {
+    ext = filename.startsWith('.') ? filename.slice(1) : filename
+    mimeType = customMimeTypes.get(ext)
+    if (mimeType !== undefined) {
+      return mimeType
+    }
+  }
+
+  let idx = filename.indexOf('.')
+  while (~idx) {
+    mimeType = customMimeTypes.get(filename.substring(idx + 1))
+    if (mimeType !== undefined) {
+      return mimeType
+    }
+
+    idx = filename.indexOf('.', idx + 1)
+  }
 }


### PR DESCRIPTION
Custom MIME registrations could only be detected after `detectMimeType()` reduced a filename to the text after the final dot, so a filename like `filename.be.pit` was treated as `pit` before the custom `be.pit` registration could be checked.

This checks custom registrations against the direct extension and the filename dot suffixes from longest to shortest before falling back to built-in MIME-db lookup.

- Fixes `detectMimeType()` for registered multi-part custom extensions such as `be.pit`
- Keeps single-segment custom extensions and built-in last-dot lookup behavior intact
- Adds regression coverage, docs, and a MIME package patch change note

Closes #11099
