### PR TITLE
Fix urlencoded form data parser limits

### DIFF
--- a/packages/form-data-parser/.changes/patch.urlencoded-limits.md
+++ b/packages/form-data-parser/.changes/patch.urlencoded-limits.md
@@ -1,0 +1,1 @@
+Apply `maxParts` and `maxTotalSize` limits when parsing `application/x-www-form-urlencoded` requests with `parseFormData()`, so urlencoded submissions can no longer bypass the same field count and total body size protections used for multipart forms.

--- a/packages/form-data-parser/README.md
+++ b/packages/form-data-parser/README.md
@@ -7,7 +7,7 @@ A streaming `multipart/form-data` parser that solves memory issues with file upl
 - **Drop-in replacement** for `request.formData()` with streaming file upload support
 - **Minimal buffering** - processes file upload streams with minimal memory footprint
 - **Standards-based** - built on the [web Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) and [File API](https://developer.mozilla.org/en-US/docs/Web/API/File)
-- **Smart fallback** - automatically uses native `request.formData()` for non-`multipart/form-data` requests
+- **Smart fallback** - parses `application/x-www-form-urlencoded` requests with the same total size and field count limits, and uses native `request.formData()` for other form requests
 - **Storage agnostic** - works with any storage backend (local disk, S3, R2, etc.)
 
 ## Why You Need This
@@ -74,7 +74,7 @@ async function requestHandler(request: Request) {
 
 To validate the resulting `FormData` object with `remix/data-schema`, use the `remix/data-schema/form-data` helpers.
 
-To limit the overall shape of multipart requests, use the `maxHeaderSize`, `maxFileSize`, `maxFiles`, `maxParts`, and `maxTotalSize` options. By default, `parseFormData()` uses `maxFiles = 20`, `maxParts = 1000`, and `maxTotalSize = maxFiles * maxFileSize + 1 MiB`.
+To limit the overall shape of multipart requests, use the `maxHeaderSize`, `maxFileSize`, `maxFiles`, `maxParts`, and `maxTotalSize` options. For `application/x-www-form-urlencoded` requests, `maxParts` limits the number of form fields and `maxTotalSize` limits the raw request body size. By default, `parseFormData()` uses `maxFiles = 20`, `maxParts = 1000`, and `maxTotalSize = maxFiles * maxFileSize + 1 MiB`.
 
 Known limit errors are thrown directly so you can handle them with `instanceof` checks. Other failures while parsing the request body are wrapped in `FormDataParseError`, with the original error available as `error.cause`. Errors thrown or rejected by your `uploadHandler` are not wrapped.
 
@@ -106,9 +106,9 @@ try {
   } else if (error instanceof MaxFileSizeExceededError) {
     console.error(`Files may not be larger than 10 MiB`)
   } else if (error instanceof MaxPartsExceededError) {
-    console.error(`Request may not contain more than 25 multipart parts`)
+    console.error(`Request may not contain more than 25 form fields or multipart parts`)
   } else if (error instanceof MaxTotalSizeExceededError) {
-    console.error(`Multipart request may not exceed 12 MiB of total content`)
+    console.error(`Form data request may not exceed 12 MiB of total content`)
   } else if (error instanceof FormDataParseError) {
     console.error(`Could not parse form data:`, error.cause ?? error)
   } else {

--- a/packages/form-data-parser/src/lib/form-data.test.ts
+++ b/packages/form-data-parser/src/lib/form-data.test.ts
@@ -31,6 +31,50 @@ describe('parseFormData', () => {
     assert.equal(formData.get('text'), 'Hello, World!')
   })
 
+  it('throws when urlencoded form data exceeds maxParts', async () => {
+    let request = new Request('https://remix.run', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'field1=value1&field2=value2',
+    })
+
+    await assert.rejects(
+      async () => await parseFormData(request, { maxParts: 1 }),
+      MaxPartsExceededError,
+    )
+  })
+
+  it('throws when urlencoded form data exceeds maxTotalSize', async () => {
+    let request = new Request('https://remix.run', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'field1=value1&field2=value2',
+    })
+
+    await assert.rejects(
+      async () => await parseFormData(request, { maxTotalSize: 1 }),
+      MaxTotalSizeExceededError,
+    )
+  })
+
+  it('preserves repeated urlencoded form fields', async () => {
+    let request = new Request('https://remix.run', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'tag=red&tag=green&tag=blue',
+    })
+
+    let formData = await parseFormData(request)
+
+    assert.deepEqual(formData.getAll('tag'), ['red', 'green', 'blue'])
+  })
+
   it('parses a multipart/form-data request', async () => {
     let fileType = normalizeFileType('text/plain')
     let request = new Request('https://remix.run', {

--- a/packages/form-data-parser/src/lib/form-data.ts
+++ b/packages/form-data-parser/src/lib/form-data.ts
@@ -71,7 +71,7 @@ const defaultMaxFiles = 20
 const defaultMaxFileSize = 2 * oneMb
 const defaultMaxParts = 1000
 
-function isMultipartLimitError(error: unknown): boolean {
+function isParserLimitError(error: unknown): boolean {
   return (
     error instanceof MaxHeaderSizeExceededError ||
     error instanceof MaxFileSizeExceededError ||
@@ -87,12 +87,100 @@ async function* parseFormDataParts(
   try {
     yield* parseMultipartRequest(request, parserOptions)
   } catch (error) {
-    if (error instanceof FormDataParseError || isMultipartLimitError(error)) {
+    if (error instanceof FormDataParseError || isParserLimitError(error)) {
       throw error
     }
 
     throw new FormDataParseError('Cannot parse form data', { cause: error })
   }
+}
+
+function isUrlEncodedRequest(request: Request): boolean {
+  let contentType = request.headers.get('Content-Type')
+  return contentType != null && contentType.startsWith('application/x-www-form-urlencoded')
+}
+
+function validateUrlEncodedPartCount(partCount: number, maxParts: number): void {
+  if (partCount > maxParts) {
+    throw new MaxPartsExceededError(maxParts)
+  }
+}
+
+async function readUrlEncodedBody(
+  request: Request,
+  maxParts: number,
+  maxTotalSize: number,
+): Promise<Uint8Array> {
+  if (request.body == null) {
+    return new Uint8Array()
+  }
+
+  let reader = request.body.getReader()
+  let chunks: Uint8Array[] = []
+  let partCount = 0
+  let totalSize = 0
+  let hasPartBytes = false
+
+  try {
+    while (true) {
+      let result = await reader.read()
+      if (result.done) break
+
+      totalSize += result.value.length
+      if (totalSize > maxTotalSize) {
+        throw new MaxTotalSizeExceededError(maxTotalSize)
+      }
+
+      for (let byte of result.value) {
+        if (byte === 38) {
+          if (hasPartBytes) {
+            validateUrlEncodedPartCount(++partCount, maxParts)
+            hasPartBytes = false
+          }
+        } else {
+          hasPartBytes = true
+        }
+      }
+
+      chunks.push(result.value)
+    }
+
+    if (hasPartBytes) {
+      validateUrlEncodedPartCount(++partCount, maxParts)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  let body = new Uint8Array(totalSize)
+  let offset = 0
+
+  for (let chunk of chunks) {
+    body.set(chunk, offset)
+    offset += chunk.length
+  }
+
+  return body
+}
+
+let urlEncodedDecoder: TextDecoder | undefined
+
+async function parseUrlEncodedFormData(
+  request: Request,
+  maxParts: number,
+  maxTotalSize: number,
+): Promise<FormData> {
+  let bytes = await readUrlEncodedBody(request, maxParts, maxTotalSize)
+  urlEncodedDecoder ??= new TextDecoder()
+
+  let searchParams = new URLSearchParams(urlEncodedDecoder.decode(bytes as BufferSource))
+  let formData = new FormData()
+
+  for (let [name, value] of searchParams) {
+    formData.append(name, value)
+  }
+
+  return formData
 }
 
 /**
@@ -151,14 +239,6 @@ export async function parseFormData(
     uploadHandler = defaultFileUploadHandler
   }
 
-  if (!isMultipartRequest(request)) {
-    try {
-      return await request.formData()
-    } catch (error) {
-      throw new FormDataParseError('Cannot parse form data', { cause: error })
-    }
-  }
-
   let {
     maxFiles = defaultMaxFiles,
     maxHeaderSize,
@@ -166,6 +246,26 @@ export async function parseFormData(
     maxParts = defaultMaxParts,
     maxTotalSize = maxFiles * maxFileSize + oneMb,
   } = optionsOrUploadHandler
+
+  if (isUrlEncodedRequest(request)) {
+    try {
+      return await parseUrlEncodedFormData(request, maxParts, maxTotalSize)
+    } catch (error) {
+      if (error instanceof FormDataParseError || isParserLimitError(error)) {
+        throw error
+      }
+
+      throw new FormDataParseError('Cannot parse form data', { cause: error })
+    }
+  }
+
+  if (!isMultipartRequest(request)) {
+    try {
+      return await request.formData()
+    } catch (error) {
+      throw new FormDataParseError('Cannot parse form data', { cause: error })
+    }
+  }
 
   let parserOptions: MultipartParserOptions = {
     maxHeaderSize,


### PR DESCRIPTION
`parseFormData()` previously delegated `application/x-www-form-urlencoded` requests to native `request.formData()`, which meant parser limits were only enforced for multipart bodies. This updates urlencoded parsing so configured field count and total body size limits apply consistently.

- Enforces `maxTotalSize` while reading urlencoded request body bytes
- Enforces `maxParts` before decoding into `FormData`
- Preserves successful urlencoded parsing behavior, including repeated fields
- Updates docs and adds a patch change note for the user-visible fix

Closes #11535
