### PR TITLE
Fix Atmosphere handle resolution race

### DIFF
--- a/packages/auth/.changes/patch.atmosphere-handle-resolution.md
+++ b/packages/auth/.changes/patch.atmosphere-handle-resolution.md
@@ -1,0 +1,1 @@
+Fix `createAtmosphereAuthProvider()` handle resolution so a successful DNS or HTTPS handle lookup can start the OAuth flow immediately instead of waiting for the other lookup branch to finish.

--- a/packages/auth/src/lib/providers/atmosphere.test.ts
+++ b/packages/auth/src/lib/providers/atmosphere.test.ts
@@ -472,9 +472,13 @@ describe('atmosphere provider', () => {
     }
   })
 
-  it('does not wait for slow HTTPS handle resolution after DNS returns a DID', async () => {
-    let releaseHttpsHandleResolution: (() => void) | undefined
-    let restoreFetch = mockFetch(async (input) => {
+  it('aborts slow HTTPS handle resolution after DNS returns a DID', async () => {
+    let httpsHandleRequests = 0
+    let resolveHttpsHandleAbort: (() => void) | undefined
+    let httpsHandleAbortPromise = new Promise<void>((resolve) => {
+      resolveHttpsHandleAbort = resolve
+    })
+    let restoreFetch = mockFetch(async (input, init) => {
       let url = toRequestUrl(input)
 
       if (url.origin === 'https://1.1.1.1' && url.pathname === '/dns-query') {
@@ -489,10 +493,19 @@ describe('atmosphere provider', () => {
       }
 
       if (url.toString() === 'https://dns.example.com/.well-known/atproto-did') {
-        await new Promise<void>((resolve) => {
-          releaseHttpsHandleResolution = resolve
+        httpsHandleRequests += 1
+        let signal = toRequestSignal(input, init)
+
+        if (signal == null) {
+          throw new Error('Expected HTTPS handle resolution to receive an abort signal')
+        }
+
+        return await new Promise<Response>((_, reject) => {
+          signal.addEventListener('abort', () => {
+            resolveHttpsHandleAbort?.()
+            reject(signal.reason)
+          })
         })
-        return new Response('did:plc:https')
       }
 
       if (url.toString() === 'https://plc.directory/did%3Aplc%3Adns') {
@@ -531,15 +544,80 @@ describe('atmosphere provider', () => {
         sessionSecret: 'atmosphere-session-secret',
       })
       let preparePromise = atmosphereProvider.prepare('dns.example.com')
-      let result = await Promise.race([
-        preparePromise.then(() => 'prepared' as const),
-        sleep(25).then(() => 'timed out' as const),
-      ])
 
-      releaseHttpsHandleResolution?.()
       await preparePromise
+      await httpsHandleAbortPromise
 
-      assert.equal(result, 'prepared')
+      assert.equal(httpsHandleRequests, 1)
+    } finally {
+      restoreFetch()
+    }
+  })
+
+  it('prefers DNS handle resolution when HTTPS returns a different DID first', async () => {
+    let resolveDnsHandle: (() => void) | undefined
+    let dnsHandlePromise = new Promise<void>((resolve) => {
+      resolveDnsHandle = resolve
+    })
+    let restoreFetch = mockFetch(async (input) => {
+      let url = toRequestUrl(input)
+
+      if (url.origin === 'https://1.1.1.1' && url.pathname === '/dns-query') {
+        await dnsHandlePromise
+        return Response.json({
+          Answer: [
+            {
+              type: 16,
+              data: '"did=did:plc:dns"',
+            },
+          ],
+        })
+      }
+
+      if (url.toString() === 'https://dns-preferred.example.com/.well-known/atproto-did') {
+        return new Response('did:plc:https')
+      }
+
+      if (url.toString() === 'https://plc.directory/did%3Aplc%3Adns') {
+        return Response.json({
+          id: 'did:plc:dns',
+          alsoKnownAs: ['at://dns-preferred.example.com'],
+          service: [
+            {
+              id: '#atproto_pds',
+              type: 'AtprotoPersonalDataServer',
+              serviceEndpoint: 'https://pds.example.com',
+            },
+          ],
+        })
+      }
+
+      if (url.toString() === 'https://pds.example.com/.well-known/oauth-protected-resource') {
+        return Response.json({
+          authorization_servers: ['https://auth.example.com'],
+        })
+      }
+
+      if (url.toString() === 'https://auth.example.com/.well-known/oauth-authorization-server') {
+        return Response.json(
+          createAtmosphereAuthorizationServerMetadata('https://auth.example.com'),
+        )
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    try {
+      let atmosphereProvider = createAtmosphereAuthProvider({
+        clientId: 'https://app.example.com/oauth/client-metadata.json',
+        redirectUri: 'https://app.example.com/auth/atmosphere/callback',
+        sessionSecret: 'atmosphere-session-secret',
+      })
+      let preparePromise = atmosphereProvider.prepare('dns-preferred.example.com')
+
+      await Promise.resolve()
+      resolveDnsHandle?.()
+      await preparePromise
     } finally {
       restoreFetch()
     }
@@ -681,6 +759,18 @@ function toRequestUrl(input: RequestInfo | URL): URL {
   return new URL(input.url)
 }
 
+function toRequestSignal(input: RequestInfo | URL, init?: RequestInit): AbortSignal | undefined {
+  if (init?.signal != null) {
+    return init.signal
+  }
+
+  if (input instanceof Request) {
+    return input.signal
+  }
+
+  return undefined
+}
+
 function decodeJwt(token: string): {
   header: Record<string, unknown>
   payload: Record<string, unknown>
@@ -697,8 +787,4 @@ function decodeBase64Url(value: string): string {
   let base64 = value.replace(/-/g, '+').replace(/_/g, '/') + padding
   let bytes = Uint8Array.from(atob(base64), (char) => char.charCodeAt(0))
   return new TextDecoder().decode(bytes)
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/packages/auth/src/lib/providers/atmosphere.test.ts
+++ b/packages/auth/src/lib/providers/atmosphere.test.ts
@@ -472,6 +472,79 @@ describe('atmosphere provider', () => {
     }
   })
 
+  it('does not wait for slow HTTPS handle resolution after DNS returns a DID', async () => {
+    let releaseHttpsHandleResolution: (() => void) | undefined
+    let restoreFetch = mockFetch(async (input) => {
+      let url = toRequestUrl(input)
+
+      if (url.origin === 'https://1.1.1.1' && url.pathname === '/dns-query') {
+        return Response.json({
+          Answer: [
+            {
+              type: 16,
+              data: '"did=did:plc:dns"',
+            },
+          ],
+        })
+      }
+
+      if (url.toString() === 'https://dns.example.com/.well-known/atproto-did') {
+        await new Promise<void>((resolve) => {
+          releaseHttpsHandleResolution = resolve
+        })
+        return new Response('did:plc:https')
+      }
+
+      if (url.toString() === 'https://plc.directory/did%3Aplc%3Adns') {
+        return Response.json({
+          id: 'did:plc:dns',
+          alsoKnownAs: ['at://dns.example.com'],
+          service: [
+            {
+              id: '#atproto_pds',
+              type: 'AtprotoPersonalDataServer',
+              serviceEndpoint: 'https://pds.example.com',
+            },
+          ],
+        })
+      }
+
+      if (url.toString() === 'https://pds.example.com/.well-known/oauth-protected-resource') {
+        return Response.json({
+          authorization_servers: ['https://auth.example.com'],
+        })
+      }
+
+      if (url.toString() === 'https://auth.example.com/.well-known/oauth-authorization-server') {
+        return Response.json(
+          createAtmosphereAuthorizationServerMetadata('https://auth.example.com'),
+        )
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    try {
+      let atmosphereProvider = createAtmosphereAuthProvider({
+        clientId: 'https://app.example.com/oauth/client-metadata.json',
+        redirectUri: 'https://app.example.com/auth/atmosphere/callback',
+        sessionSecret: 'atmosphere-session-secret',
+      })
+      let preparePromise = atmosphereProvider.prepare('dns.example.com')
+      let result = await Promise.race([
+        preparePromise.then(() => 'prepared' as const),
+        sleep(25).then(() => 'timed out' as const),
+      ])
+
+      releaseHttpsHandleResolution?.()
+      await preparePromise
+
+      assert.equal(result, 'prepared')
+    } finally {
+      restoreFetch()
+    }
+  })
+
   it('resolves path-based did:web documents', async () => {
     let cookie = createCookie('__session', { secrets: ['secret1'] })
     let sessionStorage = createMemorySessionStorage()
@@ -624,4 +697,8 @@ function decodeBase64Url(value: string): string {
   let base64 = value.replace(/-/g, '+').replace(/_/g, '/') + padding
   let bytes = Uint8Array.from(atob(base64), (char) => char.charCodeAt(0))
   return new TextDecoder().decode(bytes)
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/packages/auth/src/lib/providers/atmosphere.test.ts
+++ b/packages/auth/src/lib/providers/atmosphere.test.ts
@@ -623,6 +623,79 @@ describe('atmosphere provider', () => {
     }
   })
 
+  it('falls back to HTTPS handle resolution when DNS is slow', async (t) => {
+    let timers = t.useFakeTimers()
+    let resolveDnsHandleAbort: (() => void) | undefined
+    let dnsHandleAbortPromise = new Promise<void>((resolve) => {
+      resolveDnsHandleAbort = resolve
+    })
+    let restoreFetch = mockFetch(async (input, init) => {
+      let url = toRequestUrl(input)
+
+      if (url.origin === 'https://1.1.1.1' && url.pathname === '/dns-query') {
+        let signal = toRequestSignal(input, init)
+
+        if (signal == null) {
+          throw new Error('Expected DNS handle resolution to receive an abort signal')
+        }
+
+        return await new Promise<Response>((_, reject) => {
+          signal.addEventListener('abort', () => {
+            resolveDnsHandleAbort?.()
+            reject(signal.reason)
+          })
+        })
+      }
+
+      if (url.toString() === 'https://slow-dns.example.com/.well-known/atproto-did') {
+        return new Response('did:plc:https')
+      }
+
+      if (url.toString() === 'https://plc.directory/did%3Aplc%3Ahttps') {
+        return Response.json({
+          id: 'did:plc:https',
+          alsoKnownAs: ['at://slow-dns.example.com'],
+          service: [
+            {
+              id: '#atproto_pds',
+              type: 'AtprotoPersonalDataServer',
+              serviceEndpoint: 'https://pds.example.com',
+            },
+          ],
+        })
+      }
+
+      if (url.toString() === 'https://pds.example.com/.well-known/oauth-protected-resource') {
+        return Response.json({
+          authorization_servers: ['https://auth.example.com'],
+        })
+      }
+
+      if (url.toString() === 'https://auth.example.com/.well-known/oauth-authorization-server') {
+        return Response.json(
+          createAtmosphereAuthorizationServerMetadata('https://auth.example.com'),
+        )
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    try {
+      let atmosphereProvider = createAtmosphereAuthProvider({
+        clientId: 'https://app.example.com/oauth/client-metadata.json',
+        redirectUri: 'https://app.example.com/auth/atmosphere/callback',
+        sessionSecret: 'atmosphere-session-secret',
+      })
+      let preparePromise = atmosphereProvider.prepare('slow-dns.example.com')
+
+      await timers.advanceAsync(500)
+      await preparePromise
+      await dnsHandleAbortPromise
+    } finally {
+      restoreFetch()
+    }
+  })
+
   it('resolves path-based did:web documents', async () => {
     let cookie = createCookie('__session', { secrets: ['secret1'] })
     let sessionStorage = createMemorySessionStorage()

--- a/packages/auth/src/lib/providers/atmosphere.ts
+++ b/packages/auth/src/lib/providers/atmosphere.ts
@@ -8,6 +8,7 @@ const ATMOSPHERE_PROVIDER_NAME = 'atmosphere'
 const CLOUDFLARE_DNS_ENDPOINT = 'https://1.1.1.1/dns-query'
 const PLC_DIRECTORY_URL = 'https://plc.directory/'
 const DEFAULT_ATMOSPHERE_SCOPES = ['atproto']
+const DNS_HANDLE_RESOLUTION_PREFERENCE_MS = 500
 const ATPROTO_PDS_SERVICE_ID = '#atproto_pds'
 const ATPROTO_PDS_SERVICE_TYPE = 'AtprotoPersonalDataServer'
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', '[::1]'])
@@ -206,6 +207,11 @@ interface AtmosphereTokenResponse {
   expires_in?: number
   scope?: string
   sub: string
+}
+
+interface HandleResolutionAttempt {
+  source: 'dns' | 'https'
+  result: PromiseSettledResult<string | undefined>
 }
 
 /**
@@ -784,40 +790,100 @@ async function resolveAtmosphereIdentity(
 }
 
 async function resolveHandleToDid(handle: string): Promise<string> {
+  let dnsAbortController = new AbortController()
   let httpsAbortController = new AbortController()
-  let httpsResultPromise = resolveHandleViaHttps(handle, httpsAbortController.signal).then(
-    (value): PromiseSettledResult<string | undefined> => ({ status: 'fulfilled', value }),
-    (reason: unknown): PromiseSettledResult<string | undefined> => ({ status: 'rejected', reason }),
+  let dnsAttemptPromise = resolveHandleViaDns(handle, dnsAbortController.signal).then(
+    (value): HandleResolutionAttempt => ({
+      source: 'dns',
+      result: { status: 'fulfilled', value },
+    }),
+    (reason: unknown): HandleResolutionAttempt => ({
+      source: 'dns',
+      result: { status: 'rejected', reason },
+    }),
   )
-  let dnsResult = await resolveHandleViaDns(handle).then(
-    (value): PromiseSettledResult<string | undefined> => ({ status: 'fulfilled', value }),
-    (reason: unknown): PromiseSettledResult<string | undefined> => ({ status: 'rejected', reason }),
+  let httpsAttemptPromise = resolveHandleViaHttps(handle, httpsAbortController.signal).then(
+    (value): HandleResolutionAttempt => ({
+      source: 'https',
+      result: { status: 'fulfilled', value },
+    }),
+    (reason: unknown): HandleResolutionAttempt => ({
+      source: 'https',
+      result: { status: 'rejected', reason },
+    }),
   )
+  let dnsPreferenceTimeout: number | undefined
+  let dnsPreferenceTimeoutPromise = new Promise<undefined>((resolve) => {
+    dnsPreferenceTimeout = setTimeout(resolve, DNS_HANDLE_RESOLUTION_PREFERENCE_MS)
+  })
+  let dnsPreferenceAttempt = await Promise.race([
+    dnsAttemptPromise,
+    dnsPreferenceTimeoutPromise,
+  ])
+  if (dnsPreferenceTimeout != null) {
+    clearTimeout(dnsPreferenceTimeout)
+  }
+  let dnsRejection: PromiseRejectedResult | undefined
+  let httpsRejection: PromiseRejectedResult | undefined
 
-  if (dnsResult.status === 'fulfilled' && dnsResult.value != null) {
-    httpsAbortController.abort()
-    void httpsResultPromise
-    return dnsResult.value
+  if (dnsPreferenceAttempt != null) {
+    if (
+      dnsPreferenceAttempt.result.status === 'fulfilled' &&
+      dnsPreferenceAttempt.result.value != null
+    ) {
+      httpsAbortController.abort()
+      void httpsAttemptPromise
+      return dnsPreferenceAttempt.result.value
+    }
+
+    if (dnsPreferenceAttempt.result.status === 'rejected') {
+      dnsRejection = dnsPreferenceAttempt.result
+    }
   }
 
-  let httpsResult = await httpsResultPromise
+  let pendingAttempts = new Map([
+    ['https' as const, httpsAttemptPromise],
+    ...(dnsPreferenceAttempt == null ? [['dns' as const, dnsAttemptPromise] as const] : []),
+  ])
 
-  if (httpsResult.status === 'fulfilled' && httpsResult.value != null) {
-    return httpsResult.value
+  while (pendingAttempts.size > 0) {
+    let attempt = await Promise.race(pendingAttempts.values())
+    pendingAttempts.delete(attempt.source)
+
+    if (attempt.result.status === 'fulfilled') {
+      if (attempt.result.value != null) {
+        if (attempt.source === 'dns') {
+          httpsAbortController.abort()
+          void httpsAttemptPromise
+        } else {
+          dnsAbortController.abort()
+          void dnsAttemptPromise
+        }
+
+        return attempt.result.value
+      }
+    } else if (attempt.source === 'dns') {
+      dnsRejection = attempt.result
+    } else {
+      httpsRejection = attempt.result
+    }
   }
 
-  if (dnsResult.status === 'rejected') {
-    throw dnsResult.reason
+  if (dnsRejection != null) {
+    throw dnsRejection.reason
   }
 
-  if (httpsResult.status === 'rejected') {
-    throw httpsResult.reason
+  if (httpsRejection != null) {
+    throw httpsRejection.reason
   }
 
   throw new Error(`Atmosphere handle resolution failed for "${handle}".`)
 }
 
-async function resolveHandleViaDns(handle: string): Promise<string | undefined> {
+async function resolveHandleViaDns(
+  handle: string,
+  signal?: AbortSignal,
+): Promise<string | undefined> {
   let url = new URL(CLOUDFLARE_DNS_ENDPOINT)
   url.searchParams.set('name', `_atproto.${handle}`)
   url.searchParams.set('type', 'TXT')
@@ -826,6 +892,7 @@ async function resolveHandleViaDns(handle: string): Promise<string | undefined> 
     headers: {
       Accept: 'application/dns-json',
     },
+    signal,
   })
 
   if (!response.ok) {

--- a/packages/auth/src/lib/providers/atmosphere.ts
+++ b/packages/auth/src/lib/providers/atmosphere.ts
@@ -208,16 +208,6 @@ interface AtmosphereTokenResponse {
   sub: string
 }
 
-interface HandleResolutionBranch {
-  source: 'dns' | 'https'
-  promise: Promise<string | undefined>
-}
-
-interface HandleResolutionAttempt {
-  branch: HandleResolutionBranch
-  result: PromiseSettledResult<string | undefined>
-}
-
 /**
  * Creates an Atmosphere auth provider with shared client options.
  *
@@ -794,44 +784,34 @@ async function resolveAtmosphereIdentity(
 }
 
 async function resolveHandleToDid(handle: string): Promise<string> {
-  let pendingAttempts = new Set([
-    { source: 'dns' as const, promise: resolveHandleViaDns(handle) },
-    { source: 'https' as const, promise: resolveHandleViaHttps(handle) },
-  ])
-  let dnsRejection: PromiseRejectedResult | undefined
-  let httpsRejection: PromiseRejectedResult | undefined
+  let httpsAbortController = new AbortController()
+  let httpsResultPromise = resolveHandleViaHttps(handle, httpsAbortController.signal).then(
+    (value): PromiseSettledResult<string | undefined> => ({ status: 'fulfilled', value }),
+    (reason: unknown): PromiseSettledResult<string | undefined> => ({ status: 'rejected', reason }),
+  )
+  let dnsResult = await resolveHandleViaDns(handle).then(
+    (value): PromiseSettledResult<string | undefined> => ({ status: 'fulfilled', value }),
+    (reason: unknown): PromiseSettledResult<string | undefined> => ({ status: 'rejected', reason }),
+  )
 
-  while (pendingAttempts.size > 0) {
-    let attempt = await Promise.race(
-      Array.from(pendingAttempts, async (branch): Promise<HandleResolutionAttempt> => {
-        let result = await branch.promise.then(
-          (value) => ({ status: 'fulfilled' as const, value }),
-          (reason: unknown) => ({ status: 'rejected' as const, reason }),
-        )
-
-        return { branch, result }
-      }),
-    )
-
-    pendingAttempts.delete(attempt.branch)
-
-    if (attempt.result.status === 'fulfilled') {
-      if (attempt.result.value != null) {
-        return attempt.result.value
-      }
-    } else if (attempt.branch.source === 'dns') {
-      dnsRejection = attempt.result
-    } else {
-      httpsRejection = attempt.result
-    }
+  if (dnsResult.status === 'fulfilled' && dnsResult.value != null) {
+    httpsAbortController.abort()
+    void httpsResultPromise
+    return dnsResult.value
   }
 
-  if (dnsRejection != null) {
-    throw dnsRejection.reason
+  let httpsResult = await httpsResultPromise
+
+  if (httpsResult.status === 'fulfilled' && httpsResult.value != null) {
+    return httpsResult.value
   }
 
-  if (httpsRejection != null) {
-    throw httpsRejection.reason
+  if (dnsResult.status === 'rejected') {
+    throw dnsResult.reason
+  }
+
+  if (httpsResult.status === 'rejected') {
+    throw httpsResult.reason
   }
 
   throw new Error(`Atmosphere handle resolution failed for "${handle}".`)
@@ -881,8 +861,11 @@ async function resolveHandleViaDns(handle: string): Promise<string | undefined> 
   return did
 }
 
-async function resolveHandleViaHttps(handle: string): Promise<string | undefined> {
-  let response = await fetch(`https://${handle}/.well-known/atproto-did`)
+async function resolveHandleViaHttps(
+  handle: string,
+  signal?: AbortSignal,
+): Promise<string | undefined> {
+  let response = await fetch(`https://${handle}/.well-known/atproto-did`, { signal })
 
   if (!response.ok) {
     return

--- a/packages/auth/src/lib/providers/atmosphere.ts
+++ b/packages/auth/src/lib/providers/atmosphere.ts
@@ -208,6 +208,16 @@ interface AtmosphereTokenResponse {
   sub: string
 }
 
+interface HandleResolutionBranch {
+  source: 'dns' | 'https'
+  promise: Promise<string | undefined>
+}
+
+interface HandleResolutionAttempt {
+  branch: HandleResolutionBranch
+  result: PromiseSettledResult<string | undefined>
+}
+
 /**
  * Creates an Atmosphere auth provider with shared client options.
  *
@@ -784,25 +794,44 @@ async function resolveAtmosphereIdentity(
 }
 
 async function resolveHandleToDid(handle: string): Promise<string> {
-  let [dnsResult, httpsResult] = await Promise.allSettled([
-    resolveHandleViaDns(handle),
-    resolveHandleViaHttps(handle),
+  let pendingAttempts = new Set([
+    { source: 'dns' as const, promise: resolveHandleViaDns(handle) },
+    { source: 'https' as const, promise: resolveHandleViaHttps(handle) },
   ])
+  let dnsRejection: PromiseRejectedResult | undefined
+  let httpsRejection: PromiseRejectedResult | undefined
 
-  if (dnsResult.status === 'fulfilled' && dnsResult.value != null) {
-    return dnsResult.value
+  while (pendingAttempts.size > 0) {
+    let attempt = await Promise.race(
+      Array.from(pendingAttempts, async (branch): Promise<HandleResolutionAttempt> => {
+        let result = await branch.promise.then(
+          (value) => ({ status: 'fulfilled' as const, value }),
+          (reason: unknown) => ({ status: 'rejected' as const, reason }),
+        )
+
+        return { branch, result }
+      }),
+    )
+
+    pendingAttempts.delete(attempt.branch)
+
+    if (attempt.result.status === 'fulfilled') {
+      if (attempt.result.value != null) {
+        return attempt.result.value
+      }
+    } else if (attempt.branch.source === 'dns') {
+      dnsRejection = attempt.result
+    } else {
+      httpsRejection = attempt.result
+    }
   }
 
-  if (httpsResult.status === 'fulfilled' && httpsResult.value != null) {
-    return httpsResult.value
+  if (dnsRejection != null) {
+    throw dnsRejection.reason
   }
 
-  if (dnsResult.status === 'rejected') {
-    throw dnsResult.reason
-  }
-
-  if (httpsResult.status === 'rejected') {
-    throw httpsResult.reason
+  if (httpsRejection != null) {
+    throw httpsRejection.reason
   }
 
   throw new Error(`Atmosphere handle resolution failed for "${handle}".`)


### PR DESCRIPTION
Fixes `createAtmosphereAuthProvider()` handle resolution so a fast successful DNS or HTTPS DID lookup can prepare the OAuth flow immediately, even if the other lookup branch is slow or unresponsive.

- Races DNS-over-HTTPS and HTTPS handle resolution by settlement order and returns the first valid DID
- Preserves fallback behavior when the first settled branch fails or returns no DID
- Adds a regression test covering a DNS success with a pending HTTPS lookup

Closes https://github.com/remix-run/remix/issues/11499
