### PR TITLE
Fix fetch proxy host header

### DIFF
--- a/packages/fetch-proxy/.changes/patch.host-header.md
+++ b/packages/fetch-proxy/.changes/patch.host-header.md
@@ -1,0 +1,1 @@
+Fix proxied requests so the incoming `Host` header is dropped instead of being forwarded to the proxy target (see #10769).

--- a/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
@@ -113,6 +113,19 @@ describe('fetch proxy', () => {
     assert.equal(request.headers.get('X-Forwarded-Port'), null)
   })
 
+  it('does not forward the incoming Host header', async () => {
+    let { request } = await testProxy(
+      new Request('http://shopify.com/search?q=remix', {
+        headers: {
+          Host: 'shopify.com',
+        },
+      }),
+      'https://remix.run:3000/dest',
+    )
+
+    assert.equal(request.headers.get('Host'), null)
+  })
+
   it('appends X-Forwarded headers when desired', async () => {
     let { request } = await testProxy(
       new Request('http://shopify.com:8080/search?q=remix'),

--- a/packages/fetch-proxy/src/lib/fetch-proxy.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.ts
@@ -77,6 +77,7 @@ export function createFetchProxy(target: string | URL, options?: FetchProxyOptio
     }
 
     let proxyHeaders = new Headers(request.headers)
+    proxyHeaders.delete('Host')
     if (xForwardedHeaders) {
       proxyHeaders.append('X-Forwarded-Proto', url.protocol.replace(/:$/, ''))
       proxyHeaders.append('X-Forwarded-Host', url.host)


### PR DESCRIPTION
`createFetchProxy` now updates the forwarded `Host` header after rewriting a request to the proxy target URL.

- Fixes stale incoming `Host` headers being preserved on proxied requests
- Adds a regression test for the downstream request header value
- Adds a patch change note for `@remix-run/fetch-proxy`

Closes #10769
