### PR TITLE
Prevent doctor --fix writes through external symlinks

### DIFF
--- a/packages/cli/.changes/patch.doctor-fix-symlink-writes.md
+++ b/packages/cli/.changes/patch.doctor-fix-symlink-writes.md
@@ -1,0 +1,1 @@
+Prevent `remix doctor --fix` from creating or updating files outside the project root when fix paths traverse symlinks (see #11532).

--- a/packages/cli/src/lib/doctor/fixes.test.ts
+++ b/packages/cli/src/lib/doctor/fixes.test.ts
@@ -61,4 +61,92 @@ describe('doctor fix plans', () => {
       await fs.rm(escapedPath, { force: true })
     }
   })
+
+  it('rejects fix plans that would create files through symlinked ancestors outside the app root', async () => {
+    let appRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'remix-doctor-fixes-'))
+    let externalAppRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'remix-doctor-fixes-external-'))
+    let externalFile = path.join(externalAppRoot, 'routes.ts')
+
+    try {
+      await fs.symlink(externalAppRoot, path.join(appRoot, 'app'), 'dir')
+
+      await assert.rejects(
+        () =>
+          applyDoctorFixPlans(appRoot, [
+            {
+              code: 'routes-file-missing',
+              contents: 'export const routes = {}\n',
+              kind: 'create-file',
+              path: 'app/routes.ts',
+              suite: 'project',
+            },
+          ]),
+        /outside the app root/,
+      )
+
+      await assert.rejects(() => fs.access(externalFile))
+    } finally {
+      await fs.rm(appRoot, { recursive: true, force: true })
+      await fs.rm(externalAppRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects fix plans that would create directories through symlinked ancestors outside the app root', async () => {
+    let appRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'remix-doctor-fixes-'))
+    let externalAppRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'remix-doctor-fixes-external-'))
+    let externalDirectory = path.join(externalAppRoot, 'actions')
+
+    try {
+      await fs.symlink(externalAppRoot, path.join(appRoot, 'app'), 'dir')
+
+      await assert.rejects(
+        () =>
+          applyDoctorFixPlans(appRoot, [
+            {
+              code: 'routes-file-missing',
+              kind: 'create-directory',
+              path: 'app/actions',
+              suite: 'project',
+            },
+          ]),
+        /outside the app root/,
+      )
+
+      await assert.rejects(() => fs.access(externalDirectory))
+    } finally {
+      await fs.rm(appRoot, { recursive: true, force: true })
+      await fs.rm(externalAppRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects fix plans that would update files through symlinks outside the app root', async () => {
+    let appRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'remix-doctor-fixes-'))
+    let externalDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remix-doctor-fixes-external-'))
+    let externalFile = path.join(externalDir, 'package.json')
+
+    try {
+      await fs.mkdir(path.join(appRoot, 'app'))
+      await fs.writeFile(externalFile, '{"name":"external"}\n')
+      await fs.symlink(externalFile, path.join(appRoot, 'app', 'package.json'), 'file')
+
+      await assert.rejects(
+        () =>
+          applyDoctorFixPlans(appRoot, [
+            {
+              code: 'node-engine-missing',
+              contents: '{"name":"internal"}\n',
+              kind: 'update-file',
+              path: 'app/package.json',
+              suite: 'environment',
+            },
+          ]),
+        /outside the app root/,
+      )
+
+      assert.equal(await fs.readFile(externalFile, 'utf8'), '{"name":"external"}\n')
+    } finally {
+      await fs.rm(appRoot, { recursive: true, force: true })
+      await fs.rm(externalDir, { recursive: true, force: true })
+    }
+  })
 })

--- a/packages/cli/src/lib/doctor/fixes.ts
+++ b/packages/cli/src/lib/doctor/fixes.ts
@@ -11,7 +11,7 @@ export async function applyDoctorFixPlans(
   let appliedFixes: DoctorAppliedFix[] = []
 
   for (let fixPlan of dedupeDoctorFixPlans(fixPlans)) {
-    let absolutePath = resolveDoctorFixPath(appRoot, fixPlan.path)
+    let absolutePath = await resolveDoctorFixPath(appRoot, fixPlan.path)
 
     if (fixPlan.kind === 'create-directory') {
       await fs.mkdir(absolutePath, { recursive: true })
@@ -30,8 +30,7 @@ export async function applyDoctorFixPlans(
     try {
       await fs.writeFile(absolutePath, fixPlan.contents ?? '', { encoding: 'utf8', flag: 'wx' })
     } catch (error) {
-      let nodeError = error as NodeJS.ErrnoException
-      if (nodeError.code !== 'EEXIST') {
+      if (!isErrorWithCode(error, 'EEXIST')) {
         throw error
       }
 
@@ -71,14 +70,64 @@ function toAppliedDoctorFix(fixPlan: DoctorFixPlan): DoctorAppliedFix {
   }
 }
 
-function resolveDoctorFixPath(appRoot: string, fixPath: string): string {
+async function resolveDoctorFixPath(appRoot: string, fixPath: string): Promise<string> {
+  let absolutePath: string
+
   try {
-    return resolveContainedPath(appRoot, fixPath)
+    absolutePath = resolveContainedPath(appRoot, fixPath)
   } catch (error) {
     if (error instanceof Error && error.message.includes('escapes the allowed root')) {
-      throw new Error(`Doctor fix path resolves outside the app root: ${fixPath}`)
+      throwDoctorFixPathOutsideRoot(fixPath)
     }
 
     throw error
   }
+
+  let rootPath = path.resolve(appRoot)
+  let rootRealPath = await fs.realpath(rootPath)
+  let relativePath = path.relative(rootPath, absolutePath)
+  let pathParts = relativePath === '' ? [] : relativePath.split(path.sep)
+  let currentPath = rootPath
+  let currentRealPath = rootRealPath
+
+  for (let [index, pathPart] of pathParts.entries()) {
+    currentPath = path.join(currentPath, pathPart)
+
+    let stats = await lstatIfExists(currentPath)
+    if (stats == null) {
+      return path.join(currentRealPath, ...pathParts.slice(index))
+    }
+
+    currentRealPath = await fs.realpath(currentPath)
+    if (!isPathInsideRoot(rootRealPath, currentRealPath)) {
+      throwDoctorFixPathOutsideRoot(fixPath)
+    }
+  }
+
+  return currentRealPath
+}
+
+async function lstatIfExists(filePath: string) {
+  try {
+    return await fs.lstat(filePath)
+  } catch (error) {
+    if (isErrorWithCode(error, 'ENOENT')) {
+      return null
+    }
+
+    throw error
+  }
+}
+
+function isPathInsideRoot(rootPath: string, filePath: string): boolean {
+  let relativePath = path.relative(rootPath, filePath)
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+}
+
+function isErrorWithCode(error: unknown, code: string): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === code
+}
+
+function throwDoctorFixPathOutsideRoot(fixPath: string): never {
+  throw new Error(`Doctor fix path resolves outside the app root: ${fixPath}`)
 }


### PR DESCRIPTION
`remix doctor --fix` checked proposed fix paths lexically before writing them, which meant filesystem writes could still follow symlinked path components outside the project root. This makes doctor fix writes resolve existing components through realpaths before mutating anything, so external symlink targets are rejected.

Closes #11532.

- Rejects doctor fix paths whose existing filesystem components resolve outside the real project root.
- Keeps valid fixes writing through a contained real path, including symlinks that remain inside the project root.
- Adds regression coverage for `create-file`, `create-directory`, and `update-file` fixes through symlinked paths.
