### PR TITLE
Fix node fetch server abort handling

### DIFF
--- a/packages/node-fetch-server/.changes/patch.request-stream-aborts.md
+++ b/packages/node-fetch-server/.changes/patch.request-stream-aborts.md
@@ -1,0 +1,1 @@
+Reject request body reads when clients abort uploads, and avoid writing fallback error responses after streaming response headers are already committed (see #11533 and #11534).

--- a/packages/node-fetch-server/src/lib/lazy-request.ts
+++ b/packages/node-fetch-server/src/lib/lazy-request.ts
@@ -1,7 +1,13 @@
 import type * as http from 'node:http'
 import type * as http2 from 'node:http2'
+import type { RequestLifecycle } from './request-abort.ts'
 
 import { createLazyHeaders } from './lazy-headers.ts'
+import {
+  createRequestAbortError,
+  isRequestAlreadyAborted,
+  markRequestAbortReason,
+} from './request-abort.ts'
 
 type IncomingRequest = http.IncomingMessage | http2.Http2ServerRequest
 type ServerResponse = http.ServerResponse | http2.Http2ServerResponse
@@ -10,7 +16,19 @@ type RequestFactory<requestOptions> = (
   res: ServerResponse,
   options: requestOptions | undefined,
 ) => Request
+type LifecycleRequestFactory<requestOptions> = (
+  req: IncomingRequest,
+  res: ServerResponse,
+  options: requestOptions | undefined,
+  lifecycle: RequestLifecycle,
+) => Request
 type HeadersFactory = (req: IncomingRequest) => Headers
+type RequestLifecycleFactory = () => RequestLifecycle
+type ResponseLifecycleObserver = (res: ServerResponse, lifecycle: RequestLifecycle) => void
+interface RequestLifecycleOptions {
+  createLifecycle: RequestLifecycleFactory
+  observeResponseForLifecycle: ResponseLifecycleObserver
+}
 
 export function createLazyRequest<requestOptions>(
   req: IncomingRequest,
@@ -24,8 +42,9 @@ export function createLazyRequest<requestOptions>(
 
 export function createLazyRequestFactory<requestOptions>(
   options: requestOptions | undefined,
-  createRequest: RequestFactory<requestOptions>,
+  createRequest: LifecycleRequestFactory<requestOptions>,
   createHeaders: HeadersFactory,
+  lifecycleOptions: RequestLifecycleOptions,
 ): (req: IncomingRequest, res: ServerResponse) => Request {
   class BoundLazyRequest implements Request {
     #request: Request | undefined
@@ -34,15 +53,18 @@ export function createLazyRequestFactory<requestOptions>(
     #req: IncomingRequest
     #res: ServerResponse
     #method: string
+    #lifecycle: RequestLifecycle
 
     constructor(req: IncomingRequest, res: ServerResponse) {
       this.#req = req
       this.#res = res
       this.#method = req.method ?? 'GET'
+      this.#lifecycle = lifecycleOptions.createLifecycle()
+      lifecycleOptions.observeResponseForLifecycle(res, this.#lifecycle)
     }
 
     #materialize(): Request {
-      return (this.#request ??= createRequest(this.#req, this.#res, options))
+      return (this.#request ??= createRequest(this.#req, this.#res, options, this.#lifecycle))
     }
 
     get body() {
@@ -98,7 +120,7 @@ export function createLazyRequestFactory<requestOptions>(
     }
 
     get signal() {
-      return this.#materialize().signal
+      return this.#lifecycle.signal
     }
 
     get url() {
@@ -143,14 +165,14 @@ export function createLazyRequestFactory<requestOptions>(
       if (!requestMethodCanHaveBody(this.#method)) return Promise.resolve(Buffer.alloc(0))
       if (this.#bodyUsed) return Promise.reject(bodyUnusable())
       this.#bodyUsed = true
-      return readRequestBody(this.#req)
+      return readRequestBody(this.#req, this.#lifecycle)
     }
 
     #consumeTextBody(): Promise<string> {
       if (!requestMethodCanHaveBody(this.#method)) return Promise.resolve('')
       if (this.#bodyUsed) return Promise.reject(bodyUnusable())
       this.#bodyUsed = true
-      return readRequestText(this.#req)
+      return readRequestText(this.#req, this.#lifecycle)
     }
   }
 
@@ -287,14 +309,14 @@ class LazyRequest<requestOptions> implements Request {
     if (!requestMethodCanHaveBody(this.#method)) return Promise.resolve(Buffer.alloc(0))
     if (this.#bodyUsed) return Promise.reject(bodyUnusable())
     this.#bodyUsed = true
-    return readRequestBody(this.#req)
+    return readRequestBody(this.#req, undefined)
   }
 
   #consumeTextBody(): Promise<string> {
     if (!requestMethodCanHaveBody(this.#method)) return Promise.resolve('')
     if (this.#bodyUsed) return Promise.reject(bodyUnusable())
     this.#bodyUsed = true
-    return readRequestText(this.#req)
+    return readRequestText(this.#req, undefined)
   }
 }
 
@@ -318,19 +340,27 @@ function bodyUnusable(): TypeError {
   return new TypeError('Body is unusable: Body has already been read')
 }
 
-function readRequestBody(req: IncomingRequest): Promise<Buffer> {
+function readRequestBody(
+  req: IncomingRequest,
+  lifecycle: RequestLifecycle | undefined,
+): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     let firstChunk: Buffer | undefined
     let chunks: Buffer[] | undefined
     let length = 0
+    let requestEnded = false
+    let settled = false
 
-    function cleanup() {
+    function cleanup({ keepErrorListener = false }: { keepErrorListener?: boolean } = {}) {
       req.off('data', onData)
       req.off('end', onEnd)
-      req.off('error', onError)
+      if (!keepErrorListener) req.off('error', onError)
+      req.off('aborted', onAborted)
+      req.off('close', onClose)
     }
 
     function onData(buffer: Buffer) {
+      if (settled) return
       length += buffer.byteLength
 
       if (firstChunk == null) {
@@ -342,6 +372,9 @@ function readRequestBody(req: IncomingRequest): Promise<Buffer> {
     }
 
     function onEnd() {
+      if (settled) return
+      requestEnded = true
+      settled = true
       cleanup()
       if (firstChunk == null) {
         resolve(Buffer.alloc(0))
@@ -353,29 +386,68 @@ function readRequestBody(req: IncomingRequest): Promise<Buffer> {
     }
 
     function onError(error: Error) {
+      if (settled) return
+      settled = true
+      markRequestAbortReason(error)
+      lifecycle?.abort(error)
       cleanup()
       reject(error)
     }
 
+    function onAborted() {
+      rejectRequestAbort()
+    }
+
+    function onClose() {
+      if (!requestEnded) rejectRequestAbort()
+    }
+
+    function rejectRequestAbort() {
+      if (settled) return
+      settled = true
+      let error = createRequestAbortError()
+      cleanup({ keepErrorListener: true })
+      lifecycle?.abort(error)
+      reject(error)
+    }
+
+    req.once('error', onError)
+
+    if (isRequestAlreadyAborted(req)) {
+      rejectRequestAbort()
+      return
+    }
+
     req.on('data', onData)
     req.once('end', onEnd)
-    req.once('error', onError)
+    req.once('aborted', onAborted)
+    req.once('close', onClose)
+
+    if (isRequestAlreadyAborted(req)) rejectRequestAbort()
   })
 }
 
-function readRequestText(req: IncomingRequest): Promise<string> {
+function readRequestText(
+  req: IncomingRequest,
+  lifecycle: RequestLifecycle | undefined,
+): Promise<string> {
   return new Promise((resolve, reject) => {
     let firstChunk: Buffer | undefined
     let chunks: Buffer[] | undefined
     let length = 0
+    let requestEnded = false
+    let settled = false
 
-    function cleanup() {
+    function cleanup({ keepErrorListener = false }: { keepErrorListener?: boolean } = {}) {
       req.off('data', onData)
       req.off('end', onEnd)
-      req.off('error', onError)
+      if (!keepErrorListener) req.off('error', onError)
+      req.off('aborted', onAborted)
+      req.off('close', onClose)
     }
 
     function onData(buffer: Buffer) {
+      if (settled) return
       length += buffer.byteLength
 
       if (firstChunk == null) {
@@ -387,6 +459,9 @@ function readRequestText(req: IncomingRequest): Promise<string> {
     }
 
     function onEnd() {
+      if (settled) return
+      requestEnded = true
+      settled = true
       cleanup()
       if (firstChunk == null) {
         resolve('')
@@ -398,12 +473,43 @@ function readRequestText(req: IncomingRequest): Promise<string> {
     }
 
     function onError(error: Error) {
+      if (settled) return
+      settled = true
+      markRequestAbortReason(error)
+      lifecycle?.abort(error)
       cleanup()
       reject(error)
     }
 
+    function onAborted() {
+      rejectRequestAbort()
+    }
+
+    function onClose() {
+      if (!requestEnded) rejectRequestAbort()
+    }
+
+    function rejectRequestAbort() {
+      if (settled) return
+      settled = true
+      let error = createRequestAbortError()
+      cleanup({ keepErrorListener: true })
+      lifecycle?.abort(error)
+      reject(error)
+    }
+
+    req.once('error', onError)
+
+    if (isRequestAlreadyAborted(req)) {
+      rejectRequestAbort()
+      return
+    }
+
     req.on('data', onData)
     req.once('end', onEnd)
-    req.once('error', onError)
+    req.once('aborted', onAborted)
+    req.once('close', onClose)
+
+    if (isRequestAlreadyAborted(req)) rejectRequestAbort()
   })
 }

--- a/packages/node-fetch-server/src/lib/request-abort.ts
+++ b/packages/node-fetch-server/src/lib/request-abort.ts
@@ -1,0 +1,72 @@
+import type * as http from 'node:http'
+import type * as http2 from 'node:http2'
+
+const requestAbortReasons = new WeakSet<object>()
+
+export interface RequestLifecycle {
+  readonly signal: AbortSignal
+  abort(reason?: unknown): void
+  finish(): void
+}
+
+export function createRequestLifecycle(): RequestLifecycle {
+  let controller = new AbortController()
+  let finished = false
+
+  return {
+    get signal() {
+      return controller.signal
+    },
+    abort(reason?: unknown) {
+      if (!finished) controller.abort(reason)
+    },
+    finish() {
+      finished = true
+    },
+  }
+}
+
+export function observeResponseForRequestLifecycle(
+  res: http.ServerResponse | http2.Http2ServerResponse,
+  lifecycle: RequestLifecycle,
+): void {
+  // Abort once we can no longer write a response if we have
+  // not yet sent a response (i.e., `close` without `finish`)
+  // `finish` -> done rendering the response
+  // `close` -> response can no longer be written to
+  res.once('close', () => lifecycle.abort())
+  res.once('finish', () => lifecycle.finish())
+}
+
+export function isRequestAlreadyAborted(
+  req: http.IncomingMessage | http2.Http2ServerRequest,
+): boolean {
+  if ('aborted' in req && req.aborted === true) return true
+  if ('readableAborted' in req && req.readableAborted === true) return true
+  return req.destroyed && !isRequestComplete(req)
+}
+
+function isRequestComplete(req: http.IncomingMessage | http2.Http2ServerRequest): boolean {
+  if ('complete' in req && req.complete === true) return true
+  return req.readableEnded
+}
+
+export function createRequestAbortError(): DOMException {
+  let error = new DOMException('The request was aborted.', 'AbortError')
+  markRequestAbortReason(error)
+  return error
+}
+
+export function markRequestAbortReason(error: unknown): void {
+  if (error != null && (typeof error === 'object' || typeof error === 'function')) {
+    requestAbortReasons.add(error)
+  }
+}
+
+export function isRequestAbortReason(error: unknown): boolean {
+  return (
+    error != null &&
+    (typeof error === 'object' || typeof error === 'function') &&
+    requestAbortReasons.has(error)
+  )
+}

--- a/packages/node-fetch-server/src/lib/request-listener.test.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'node:assert/strict'
+import type { TestContext } from 'node:test'
 import { describe, it } from 'node:test'
 import type * as http from 'node:http'
 import * as stream from 'node:stream'
@@ -324,6 +325,343 @@ describe('createRequestListener', () => {
     assert.equal(errorHandler.mock.calls.length, 0)
     assert.equal(writeHead.mock.calls.length, 1)
     assert.equal(end.mock.calls.length, 0)
+  })
+
+  it('does not send an error response when a response stream errors after headers are sent', async (t) => {
+    let encoder = new TextEncoder()
+    let streamError = new Error('boom after commit')
+    let errorHandler = t.mock.fn(() => new Response('fallback', { status: 500 }))
+    let handler: FetchHandler = (_request) =>
+      new Response(
+        new ReadableStream({
+          pull(controller) {
+            if (chunks.length === 0) {
+              controller.enqueue(encoder.encode('partial'))
+            } else {
+              controller.error(streamError)
+            }
+          },
+        }),
+      )
+
+    let listener = createRequestListener(handler, { onError: errorHandler })
+    assert.ok(listener)
+
+    let req = createMockRequest()
+    req.httpVersionMajor = 1
+
+    let writeHeadCalls = 0
+    let endCalls = 0
+    let destroyedError: Error | undefined
+    let chunks: Uint8Array[] = []
+
+    let responseFinished = new Promise<void>((resolve) => {
+      let res = Object.assign(new stream.Writable(), {
+        req,
+        writeHead() {
+          writeHeadCalls++
+        },
+        write(chunk: Uint8Array) {
+          chunks.push(chunk)
+          return true
+        },
+        end() {
+          endCalls++
+          resolve()
+        },
+        destroy(error?: Error) {
+          destroyedError = error
+          res.emit('close')
+          resolve()
+          return res
+        },
+      }) as unknown as http.ServerResponse
+
+      Object.defineProperty(res, 'headersSent', {
+        get() {
+          return writeHeadCalls > 0
+        },
+      })
+
+      listener(req, res)
+    })
+
+    await waitFor(
+      responseFinished,
+      100,
+      'Expected the response to end or close after the stream error',
+    )
+
+    assert.equal(writeHeadCalls, 1)
+    assert.equal(errorHandler.mock.calls.length, 1)
+    assert.equal(endCalls, 0)
+    assert.equal(destroyedError, streamError)
+    assert.equal(Buffer.concat(chunks).toString(), 'partial')
+  })
+
+  it('destroys the response without waiting for a slow error handler for committed stream errors', async (t) => {
+    let encoder = new TextEncoder()
+    let streamError = new Error('boom after commit')
+    let resolveErrorHandler!: () => void
+    let errorHandlerStarted = false
+    let errorHandlerFinished = false
+    let errorHandler = t.mock.fn(async () => {
+      errorHandlerStarted = true
+      await new Promise<void>((resolve) => {
+        resolveErrorHandler = resolve
+      })
+      errorHandlerFinished = true
+      return new Response('fallback', { status: 500 })
+    })
+    let handler: FetchHandler = (_request) =>
+      new Response(
+        new ReadableStream({
+          pull(controller) {
+            if (chunks.length === 0) {
+              controller.enqueue(encoder.encode('partial'))
+            } else {
+              controller.error(streamError)
+            }
+          },
+        }),
+      )
+
+    let listener = createRequestListener(handler, { onError: errorHandler })
+    assert.ok(listener)
+
+    let req = createMockRequest()
+    req.httpVersionMajor = 1
+
+    let writeHeadCalls = 0
+    let destroyedError: Error | undefined
+    let chunks: Uint8Array[] = []
+
+    let responseDestroyed = new Promise<void>((resolve) => {
+      let res = Object.assign(new stream.Writable(), {
+        req,
+        writeHead() {
+          writeHeadCalls++
+        },
+        write(chunk: Uint8Array) {
+          chunks.push(chunk)
+          return true
+        },
+        end() {},
+        destroy(error?: Error) {
+          destroyedError = error
+          res.emit('close')
+          resolve()
+          return res
+        },
+      }) as unknown as http.ServerResponse
+
+      Object.defineProperty(res, 'headersSent', {
+        get() {
+          return writeHeadCalls > 0
+        },
+      })
+
+      listener(req, res)
+    })
+
+    await waitFor(
+      responseDestroyed,
+      100,
+      'Expected the response to be destroyed before the slow error handler resolved',
+    )
+
+    assert.equal(writeHeadCalls, 1)
+    assert.equal(errorHandler.mock.calls.length, 1)
+    assert.equal(errorHandlerStarted, true)
+    assert.equal(errorHandlerFinished, false)
+    assert.equal(destroyedError, streamError)
+    assert.equal(Buffer.concat(chunks).toString(), 'partial')
+
+    resolveErrorHandler()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    assert.equal(errorHandlerFinished, true)
+  })
+
+  it('rejects lazy request body reads when the request aborts before ending', async (t) => {
+    await assertLazyRequestBodyReadRejects(
+      t,
+      (request) => request.text(),
+      (req) => {
+        req.emit('aborted')
+        req.emit('error', new Error('late socket error'))
+      },
+      (error, signalReason) => {
+        assert.equal(error, signalReason)
+        assert.equal((error as DOMException).name, 'AbortError')
+      },
+    )
+  })
+
+  it('rejects lazy buffered request body reads when the request closes before ending', async (t) => {
+    await assertLazyRequestBodyReadRejects(
+      t,
+      (request) => request.arrayBuffer(),
+      (req) => {
+        req.emit('close')
+      },
+      (error, signalReason) => {
+        assert.equal(error, signalReason)
+        assert.equal((error as DOMException).name, 'AbortError')
+      },
+    )
+  })
+
+  it('treats lazy request body errors as request abort errors', async (t) => {
+    let bodyError = new Error('client upload failed')
+
+    await assertLazyRequestBodyReadRejects(
+      t,
+      (request) => request.bytes(),
+      (req) => {
+        req.emit('error', bodyError)
+      },
+      (error, signalReason) => {
+        assert.equal(error, bodyError)
+        assert.equal(signalReason, bodyError)
+      },
+    )
+  })
+
+  it('treats materialized request body errors as request abort errors after response close', async (t) => {
+    let bodyError = new Error('client upload failed')
+    let handlerFinished!: () => void
+    let handlerDone = new Promise<void>((resolve) => {
+      handlerFinished = resolve
+    })
+    let handler: FetchHandler = async (request) => {
+      try {
+        assert.equal(request.url, 'http://localhost/')
+        await request.text()
+        return new Response('ok')
+      } finally {
+        handlerFinished()
+      }
+    }
+    let errorHandler = t.mock.fn()
+
+    let listener = createRequestListener(handler, { onError: errorHandler })
+    assert.ok(listener)
+
+    let req = createPendingMockRequest()
+    let res = createMockResponse({ req })
+    let writeHead = t.mock.method(res, 'writeHead')
+    let write = t.mock.method(res, 'write')
+    let end = t.mock.method(res, 'end')
+
+    listener(req, res)
+    res.emit('close')
+    req.emit('error', bodyError)
+
+    await waitFor(
+      handlerDone,
+      100,
+      'Expected the materialized request body read to settle when the request failed',
+    )
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    assert.equal(errorHandler.mock.calls.length, 0)
+    assert.equal(writeHead.mock.calls.length, 0)
+    assert.equal(write.mock.calls.length, 0)
+    assert.equal(end.mock.calls.length, 0)
+  })
+
+  it('rejects lazy request body reads when the request already aborted', async (t) => {
+    let continueHandler!: () => void
+    let handlerCanContinue = new Promise<void>((resolve) => {
+      continueHandler = resolve
+    })
+
+    await assertLazyRequestBodyReadRejects(
+      t,
+      async (request) => {
+        await handlerCanContinue
+        return await request.text()
+      },
+      (req) => {
+        markMockRequestAborted(req)
+        req.emit('aborted')
+        continueHandler()
+      },
+      (error, signalReason) => {
+        assert.equal(error, signalReason)
+        assert.equal((error as DOMException).name, 'AbortError')
+      },
+    )
+  })
+
+  it('keeps an error listener after already-aborted lazy request body reads', async (t) => {
+    let continueHandler!: () => void
+    let handlerCanContinue = new Promise<void>((resolve) => {
+      continueHandler = resolve
+    })
+    let handlerFinished!: () => void
+    let handlerDone = new Promise<void>((resolve) => {
+      handlerFinished = resolve
+    })
+    let handler: FetchHandler = async (request) => {
+      await handlerCanContinue
+
+      await assert.rejects(request.text(), (error) => {
+        assert.equal(error, request.signal.reason)
+        assert.equal((error as DOMException).name, 'AbortError')
+        return true
+      })
+
+      handlerFinished()
+      return new Response('ok')
+    }
+    let errorHandler = t.mock.fn()
+
+    let listener = createRequestListener(handler, { onError: errorHandler })
+    assert.ok(listener)
+
+    let req = createPendingMockRequest()
+    let res = createMockResponse({ req })
+    let writeHead = t.mock.method(res, 'writeHead')
+    let write = t.mock.method(res, 'write')
+    let end = t.mock.method(res, 'end')
+
+    listener(req, res)
+    markMockRequestAborted(req)
+    req.emit('aborted')
+    continueHandler()
+
+    await waitFor(
+      handlerDone,
+      100,
+      'Expected the lazy request body read to reject when the request had already aborted',
+    )
+
+    assert.doesNotThrow(() => req.emit('error', new Error('late socket error')))
+    assert.equal(errorHandler.mock.calls.length, 0)
+    assert.equal(writeHead.mock.calls.length, 0)
+    assert.equal(write.mock.calls.length, 0)
+    assert.equal(end.mock.calls.length, 0)
+  })
+
+  it('returns a stable signal after materializing lazy requests', async (t) => {
+    await new Promise<void>((resolve) => {
+      let handler: FetchHandler = async (request) => {
+        let signal = request.signal
+        assert.equal(request.url, 'http://localhost/')
+        assert.equal(request.signal, signal)
+        return new Response('ok')
+      }
+
+      let listener = createRequestListener(handler)
+      assert.ok(listener)
+
+      let req = createMockRequest()
+      let res = createMockResponse({ req })
+      t.mock.method(res, 'end', () => resolve())
+
+      listener(req, res)
+    })
   })
 
   it('uses the `Host` header to construct the URL by default', async () => {
@@ -703,7 +1041,200 @@ describe('createRequest abort behavior', () => {
     res.emit('close')
     assert.equal(request.signal.aborted, false)
   })
+
+  it('aborts the request.signal and rejects body reads when the request aborts before ending', async () => {
+    let req = createPendingMockRequest()
+    let res = createMockResponse({ req })
+    let request = createRequest(req, res)
+    let body = request.text()
+
+    req.emit('data', Buffer.from('partial'))
+    req.emit('aborted')
+
+    await waitFor(
+      assert.rejects(body, (error) => {
+        assert.equal(error, request.signal.reason)
+        assert.equal((error as DOMException).name, 'AbortError')
+        return true
+      }),
+      100,
+      'Expected the request body read to reject when the request aborted',
+    )
+
+    assert.equal(request.signal.aborted, true)
+  })
+
+  it('aborts the request.signal and rejects body reads when the request errors before ending', async () => {
+    let req = createPendingMockRequest()
+    let res = createMockResponse({ req })
+    let request = createRequest(req, res)
+    let bodyError = new Error('client upload failed')
+    let body = request.text()
+
+    req.emit('data', Buffer.from('partial'))
+    req.emit('error', bodyError)
+
+    await waitFor(
+      assert.rejects(body, (error) => {
+        assert.equal(error, bodyError)
+        return true
+      }),
+      100,
+      'Expected the request body read to reject when the request errored',
+    )
+
+    assert.equal(request.signal.aborted, true)
+    assert.equal(request.signal.reason, bodyError)
+  })
+
+  it('aborts the request.signal and rejects body reads when the request closes before ending', async () => {
+    let req = createPendingMockRequest()
+    let res = createMockResponse({ req })
+    let request = createRequest(req, res)
+    let body = request.text()
+
+    req.emit('data', Buffer.from('partial'))
+    req.emit('close')
+
+    await waitFor(
+      assert.rejects(body, (error) => {
+        assert.equal(error, request.signal.reason)
+        assert.equal((error as DOMException).name, 'AbortError')
+        return true
+      }),
+      100,
+      'Expected the request body read to reject when the request closed',
+    )
+
+    assert.equal(request.signal.aborted, true)
+  })
+
+  it('ignores request errors after an abort has already rejected the body', async () => {
+    let req = createPendingMockRequest()
+    let res = createMockResponse({ req })
+    let request = createRequest(req, res)
+    let body = request.text()
+
+    req.emit('aborted')
+    req.emit('error', new Error('late socket error'))
+
+    await assert.rejects(body, (error) => {
+      assert.equal(error, request.signal.reason)
+      assert.equal((error as DOMException).name, 'AbortError')
+      return true
+    })
+  })
+
+  it('aborts the request.signal and rejects body reads when the request already aborted', async () => {
+    let req = createPendingMockRequest()
+    let res = createMockResponse({ req })
+
+    markMockRequestAborted(req)
+
+    let request = createRequest(req, res)
+    let body = request.text()
+
+    await waitFor(
+      assert.rejects(body, (error) => {
+        assert.equal(error, request.signal.reason)
+        assert.equal((error as DOMException).name, 'AbortError')
+        return true
+      }),
+      100,
+      'Expected the request body read to reject when the request had already aborted',
+    )
+
+    assert.equal(request.signal.aborted, true)
+    assert.doesNotThrow(() => req.emit('error', new Error('late socket error')))
+  })
 })
+
+async function assertLazyRequestBodyReadRejects(
+  t: TestContext,
+  readBody: (request: Request) => Promise<unknown>,
+  failRequest: (req: http.IncomingMessage) => void,
+  assertError: (error: unknown, signalReason: unknown) => void,
+): Promise<void> {
+  let bodyReadRejected = false
+  let bodyError: unknown
+  let signalReason: unknown
+  let resolveHandlerFinished!: () => void
+  let handlerFinished = new Promise<void>((resolve) => {
+    resolveHandlerFinished = resolve
+  })
+  let handler: FetchHandler = async (request) => {
+    try {
+      await readBody(request)
+      return new Response('ok')
+    } catch (error) {
+      bodyReadRejected = true
+      bodyError = error
+      signalReason = request.signal.reason
+      throw error
+    } finally {
+      assert.equal(request.signal.aborted, true)
+      resolveHandlerFinished()
+    }
+  }
+  let errorHandler = t.mock.fn()
+
+  let listener = createRequestListener(handler, { onError: errorHandler })
+  assert.ok(listener)
+
+  let req = createPendingMockRequest()
+  let res = createMockResponse({ req })
+  let writeHead = t.mock.method(res, 'writeHead')
+  let write = t.mock.method(res, 'write')
+  let end = t.mock.method(res, 'end')
+
+  listener(req, res)
+  req.emit('data', Buffer.from('partial'))
+  failRequest(req)
+
+  await waitFor(
+    handlerFinished,
+    100,
+    'Expected the lazy request body read to settle when the request failed',
+  )
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  assert.equal(bodyReadRejected, true)
+  assertError(bodyError, signalReason)
+  assert.equal(errorHandler.mock.calls.length, 0)
+  assert.equal(writeHead.mock.calls.length, 0)
+  assert.equal(write.mock.calls.length, 0)
+  assert.equal(end.mock.calls.length, 0)
+}
+
+function markMockRequestAborted(req: http.IncomingMessage): void {
+  Object.defineProperties(req, {
+    aborted: {
+      value: true,
+      configurable: true,
+    },
+    readableAborted: {
+      value: true,
+      configurable: true,
+    },
+  })
+}
+
+function createPendingMockRequest(): http.IncomingMessage {
+  return Object.assign(
+    new stream.Readable({
+      read() {
+        // Keep the request open until the test emits data/end/error events.
+      },
+    }),
+    {
+      url: '/',
+      method: 'POST',
+      rawHeaders: [] as string[],
+      socket: {},
+      headers: {},
+    },
+  ) as http.IncomingMessage
+}
 
 function createMockRequest({
   url = '/',

--- a/packages/node-fetch-server/src/lib/request-listener.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.ts
@@ -2,7 +2,16 @@ import type * as http from 'node:http'
 import type * as http2 from 'node:http2'
 
 import type { ClientAddress, ErrorHandler, FetchHandler } from './fetch-handler.ts'
+import type { RequestLifecycle } from './request-abort.ts'
 import { createLazyRequestFactory } from './lazy-request.ts'
+import {
+  createRequestAbortError,
+  createRequestLifecycle,
+  isRequestAlreadyAborted,
+  isRequestAbortReason,
+  markRequestAbortReason,
+  observeResponseForRequestLifecycle,
+} from './request-abort.ts'
 
 // "Internal Server Error"
 const internalServerErrorBody = [
@@ -72,7 +81,15 @@ export function createRequestListener(
   options?: RequestListenerOptions,
 ): http.RequestListener {
   let onError = options?.onError ?? defaultErrorHandler
-  let createLazyRequest = createLazyRequestFactory(options, createRequest, createHeaders)
+  let createLazyRequest = createLazyRequestFactory(
+    options,
+    createRequestWithLifecycle,
+    createHeaders,
+    {
+      createLifecycle: createRequestLifecycle,
+      observeResponseForLifecycle: observeResponseForRequestLifecycle,
+    },
+  )
 
   if (handler.length === 0) {
     let handlerWithoutArgs = handler as () => Response | Promise<Response>
@@ -167,7 +184,7 @@ async function sendErrorResponseForRequest(
   isResponseClosed: () => boolean,
 ): Promise<void> {
   let response = await createErrorResponse(onError, error)
-  if (isResponseClosed() || request.signal.aborted) return
+  if (isResponseClosed() || request.signal.aborted || hasResponseStarted(res)) return
   await sendResponse(res, response)
 }
 
@@ -184,6 +201,11 @@ async function sendResponseForRequest(
   } catch (error) {
     if (isResponseClosed()) return
     if (isRequestAbortError(request, error)) return
+    if (hasResponseStarted(res)) {
+      destroyResponse(res, error)
+      void createErrorResponse(onError, error)
+      return
+    }
     await sendErrorResponseForRequest(res, request, onError, error, isResponseClosed)
   }
 }
@@ -216,7 +238,108 @@ function isPromiseLike<value>(value: value | PromiseLike<value>): value is Promi
 }
 
 function isRequestAbortError(request: Request, error: unknown): boolean {
-  return request.signal.aborted && error === request.signal.reason
+  return isRequestAbortReason(error) || (request.signal.aborted && error === request.signal.reason)
+}
+
+function hasResponseStarted(res: http.ServerResponse | http2.Http2ServerResponse): boolean {
+  return res.headersSent
+}
+
+function destroyResponse(
+  res: http.ServerResponse | http2.Http2ServerResponse,
+  error: unknown,
+): void {
+  if (res.destroyed) return
+  if (error instanceof Error) {
+    res.destroy(error)
+  } else {
+    res.destroy()
+  }
+}
+
+function createRequestBodyStream(
+  req: http.IncomingMessage | http2.Http2ServerRequest,
+  lifecycle: RequestLifecycle,
+): ReadableStream<Uint8Array> {
+  let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined
+  let requestEnded = false
+  let bodyClosed = false
+
+  function cleanup({ keepErrorListener = false }: { keepErrorListener?: boolean } = {}) {
+    req.removeListener('data', onData)
+    req.removeListener('end', onEnd)
+    if (!keepErrorListener) req.removeListener('error', onError)
+    req.removeListener('aborted', onAborted)
+    req.removeListener('close', onClose)
+  }
+
+  function closeBody() {
+    if (bodyClosed) return
+    bodyClosed = true
+    cleanup()
+    bodyController?.close()
+  }
+
+  function abortBody(error: unknown, { keepErrorListener = false } = {}) {
+    if (bodyClosed) return
+    bodyClosed = true
+    cleanup({ keepErrorListener })
+    lifecycle.abort(error)
+    bodyController?.error(error)
+  }
+
+  function cancelBody() {
+    if (bodyClosed) return
+    bodyClosed = true
+    cleanup()
+  }
+
+  function onData(chunk: Buffer) {
+    bodyController?.enqueue(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength))
+  }
+
+  function onEnd() {
+    requestEnded = true
+    closeBody()
+  }
+
+  function onError(error: Error) {
+    markRequestAbortReason(error)
+    abortBody(error)
+  }
+
+  function onAborted() {
+    abortBody(createRequestAbortError(), { keepErrorListener: true })
+  }
+
+  function onClose() {
+    if (!requestEnded) abortBody(createRequestAbortError(), { keepErrorListener: true })
+  }
+
+  return new ReadableStream({
+    start(controller) {
+      bodyController = controller
+
+      req.once('error', onError)
+
+      if (isRequestAlreadyAborted(req)) {
+        abortBody(createRequestAbortError(), { keepErrorListener: true })
+        return
+      }
+
+      req.on('data', onData)
+      req.once('end', onEnd)
+      req.once('aborted', onAborted)
+      req.once('close', onClose)
+
+      if (isRequestAlreadyAborted(req)) {
+        abortBody(createRequestAbortError(), { keepErrorListener: true })
+      }
+    },
+    cancel() {
+      cancelBody()
+    },
+  })
 }
 
 /**
@@ -240,15 +363,18 @@ export function createRequest(
   res: http.ServerResponse | http2.Http2ServerResponse,
   options?: RequestOptions,
 ): Request {
-  let controller: AbortController | null = new AbortController()
+  let lifecycle = createRequestLifecycle()
+  observeResponseForRequestLifecycle(res, lifecycle)
 
-  // Abort once we can no longer write a response if we have
-  // not yet sent a response (i.e., `close` without `finish`)
-  // `finish` -> done rendering the response
-  // `close` -> response can no longer be written to
-  res.once('close', () => controller?.abort())
-  res.once('finish', () => (controller = null))
+  return createRequestWithLifecycle(req, res, options, lifecycle)
+}
 
+function createRequestWithLifecycle(
+  req: http.IncomingMessage | http2.Http2ServerRequest,
+  res: http.ServerResponse | http2.Http2ServerResponse,
+  options: RequestOptions | undefined,
+  lifecycle: RequestLifecycle,
+): Request {
   let method = req.method ?? 'GET'
   let headers = createHeaders(req)
 
@@ -257,19 +383,10 @@ export function createRequest(
   let host = options?.host ?? headers.get('Host') ?? req.headers[':authority'] ?? 'localhost'
   let url = `${protocol}//${host}${req.url}`
 
-  let init: RequestInit = { method, headers, signal: controller.signal }
+  let init: RequestInit = { method, headers, signal: lifecycle.signal }
 
   if (method !== 'GET' && method !== 'HEAD') {
-    init.body = new ReadableStream({
-      start(controller) {
-        req.on('data', (chunk) => {
-          controller.enqueue(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength))
-        })
-        req.on('end', () => {
-          controller.close()
-        })
-      },
-    })
+    init.body = createRequestBodyStream(req, lifecycle)
 
     // init.duplex = 'half' must be set when body is a ReadableStream, and Node follows the spec.
     // However, this property is not defined in the TypeScript types for RequestInit, so we have

--- a/packages/session-middleware/src/lib/session.test.ts
+++ b/packages/session-middleware/src/lib/session.test.ts
@@ -56,7 +56,7 @@ describe('session middleware', () => {
 
     router.map('/', ({ session }) => {
       session.set('count', Number(session.get('count') ?? 0) + 1)
-      return fetch('http://example.com')
+      return fetch('data:text/plain,ok')
     })
 
     let response = await router.fetch('https://remix.run')


### PR DESCRIPTION
This fixes two `@remix-run/node-fetch-server` failure modes around interrupted request and response streams.

- Closes #11533 by propagating incoming request `error`, `aborted`, and early `close` events into the web request body stream and `Request.signal`, so body consumers reject instead of hanging after aborted uploads.
- Closes #11534 by avoiding fallback error responses once response headers have already been committed; late response stream failures now call `onError` and destroy the response instead of writing a second response.
- Adds regressions for aborted, errored, and early-closed request bodies, late socket errors after aborts, and response body errors after headers are sent.
