### PR TITLE
Clarify session storage cookie docs

### DIFF
--- a/packages/session/README.md
+++ b/packages/session/README.md
@@ -126,7 +126,7 @@ This will clear all session data from storage the next time it is saved. It also
 
 Several strategies are provided out of the box for storing session data across requests, depending on your needs.
 
-A session storage object must always be initialized with a _signed_ session cookie. This is used to identify the session and to store the session data in the response.
+Session storage objects read and save cookie values. Use the `session` middleware with a signed `Cookie` to parse the incoming `Cookie` header, expose the session on request context, and serialize any saved value back into a `Set-Cookie` response header.
 
 #### Filesystem Storage
 

--- a/packages/session/src/lib/session-storage.ts
+++ b/packages/session/src/lib/session-storage.ts
@@ -1,23 +1,28 @@
 import type { Session } from './session.ts'
 
 /**
- * An interface for storing and retrieving session data.
+ * Stores and retrieves session data using values read from a session cookie.
+ *
+ * Session storage implementations operate on cookie values. Use `remix/cookie` or
+ * `remix/middleware/session` to parse incoming `Cookie` headers and serialize outgoing
+ * `Set-Cookie` headers.
  */
 export interface SessionStorage {
   /**
-   * Retrieve a new session from storage based on the session cookie.
+   * Retrieve a session from storage using a value read from the session cookie.
    *
-   * @param cookie The session cookie value, or `null` if no session cookie is available
+   * @param cookie The stored session cookie value, or `null` if no session cookie is available
    * @returns The session
    */
   read(cookie: string | null): Promise<Session>
   /**
-   * Save session data in storage and return the session cookie.
+   * Save session data in storage and return the value to write to the session cookie.
    *
-   * Note: If no session cookie should be set, this method returns `null`.
+   * Note: If no session cookie should be set, this method returns `null`. If the session
+   * should be destroyed, this method returns an empty string.
    *
    * @param session The session to save
-   * @returns The session cookie value, or `null` if no session cookie should be set
+   * @returns The stored session cookie value, or `null` if no session cookie should be set
    */
   save(session: Session): Promise<string | null>
 }


### PR DESCRIPTION
This clarifies the `SessionStorage` docs around cookie handling. The current API intentionally keeps storage implementations focused on reading and saving cookie values, while `remix/cookie` and `remix/middleware/session` handle parsing incoming `Cookie` headers and serializing outgoing `Set-Cookie` headers.

- Updates the `SessionStorage` JSDoc to describe the cookie value contract more precisely
- Replaces README wording that implied storage objects are initialized with signed cookies
- Closes #10829
