### PR TITLE
Add trusted proxy support

### DIFF
--- a/packages/node-fetch-server/.changes/minor.trust-proxy.md
+++ b/packages/node-fetch-server/.changes/minor.trust-proxy.md
@@ -1,0 +1,1 @@
+Added a `trustProxy` option to `createRequestListener()` and `createRequest()` so apps behind trusted reverse proxies can construct `request.url` from `Forwarded`, `X-Forwarded-Host`, and `X-Forwarded-Proto` headers. `createRequestListener()` also uses trusted `Forwarded` and `X-Forwarded-For` values for handler client address information (see #10874).

--- a/packages/node-fetch-server/README.md
+++ b/packages/node-fetch-server/README.md
@@ -8,7 +8,8 @@ Build Node.js servers with web-standard Fetch API primitives. `node-fetch-server
 - **Node.js HTTP Integration** - Works directly with `node:http`, `node:https`, and `node:http2`
 - **Streaming Support** - Response support with `ReadableStream`
 - **Custom Hostname** - Configuration for deployment flexibility
-- **Client Info** - Access to client connection info (IP address, port)
+- **Proxy Header Support** - Opt in to trusted `Forwarded`, `X-Forwarded-Host`, `X-Forwarded-Proto`, and `X-Forwarded-For` headers
+- **Client Info** - Access to client connection info (IP address, port, and trusted proxy address)
 - **TypeScript** - Full TypeScript support with type definitions
 
 ## Installation
@@ -146,9 +147,34 @@ let server = http.createServer(createRequestListener(handler, { host: hostname }
 server.listen(3000)
 ```
 
+### Trusted Proxy Headers
+
+If your app runs behind a trusted reverse proxy, Node.js sees the proxy connection instead of the original client connection. Enable `trustProxy` to use trusted proxy headers when constructing `request.url` and client information:
+
+- `Forwarded: proto` and `X-Forwarded-Proto` can provide the original request protocol.
+- `Forwarded: host` and `X-Forwarded-Host` can provide the original request host.
+- `Forwarded: for` and `X-Forwarded-For` can provide the original client address.
+
+Only enable this option when your server is reachable exclusively through a trusted proxy that overwrites these headers. Otherwise, clients can spoof the host, protocol, and client address.
+
+```ts
+import * as http from 'node:http'
+import { createRequestListener } from 'remix/node-fetch-server'
+
+let server = http.createServer(
+  createRequestListener(handler, {
+    trustProxy: true,
+  }),
+)
+
+server.listen(3000)
+```
+
+When `host` or `protocol` are set, those fixed options take precedence over trusted proxy headers.
+
 ### Accessing Client Information
 
-Get client connection details (IP address, port) for logging or security:
+Get client connection details (IP address, port) for logging or security. When `trustProxy` is enabled, `client.address` uses trusted `Forwarded` or `X-Forwarded-For` values when present:
 
 ```ts
 import { type FetchHandler } from 'remix/node-fetch-server'

--- a/packages/node-fetch-server/src/lib/fetch-handler.ts
+++ b/packages/node-fetch-server/src/lib/fetch-handler.ts
@@ -5,17 +5,23 @@ export interface ClientAddress {
   /**
    * The IP address of the client that sent the request.
    *
+   * When `trustProxy` is enabled, this may come from trusted proxy headers.
+   *
    * [Node.js Reference](https://nodejs.org/api/net.html#socketremoteaddress)
    */
   address: string
   /**
    * The family of the client IP address.
    *
+   * When `trustProxy` is enabled, this may be inferred from trusted proxy headers.
+   *
    * [Node.js Reference](https://nodejs.org/api/net.html#socketremotefamily)
    */
   family: 'IPv4' | 'IPv6'
   /**
    * The remote port of the client that sent the request.
+   *
+   * When `trustProxy` is enabled, this may come from trusted `Forwarded` headers.
    *
    * [Node.js Reference](https://nodejs.org/api/net.html#socketremoteport)
    */

--- a/packages/node-fetch-server/src/lib/request-listener.test.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'node:test'
 import type * as http from 'node:http'
 import * as stream from 'node:stream'
 
-import { type FetchHandler } from './fetch-handler.ts'
+import { type ClientAddress, type FetchHandler } from './fetch-handler.ts'
 import { createRequest, createRequestListener } from './request-listener.ts'
 
 describe('createRequestListener', () => {
@@ -737,6 +737,193 @@ describe('createRequestListener', () => {
     })
   })
 
+  it('ignores proxy headers by default', async (t) => {
+    let requestUrl = await captureRequestUrl(t, {
+      headers: {
+        Host: 'example.com',
+        Forwarded: 'for=203.0.113.43; proto=https; host=remix.run',
+        'X-Forwarded-Host': 'remix.run',
+        'X-Forwarded-Proto': 'https',
+      },
+    })
+    assert.equal(requestUrl, 'http://example.com/')
+  })
+
+  it('uses the `Forwarded` proto and host parameters when proxies are trusted', async (t) => {
+    let requestUrl = await captureRequestUrl(
+      t,
+      {
+        headers: {
+          Host: 'example.com',
+          Forwarded: 'for=203.0.113.43; proto=https; host=remix.run',
+        },
+      },
+      { trustProxy: true },
+    )
+    assert.equal(requestUrl, 'https://remix.run/')
+  })
+
+  it('uses quoted `Forwarded` proto and host values when proxies are trusted', async (t) => {
+    let requestUrl = await captureRequestUrl(
+      t,
+      {
+        headers: {
+          Host: 'example.com',
+          Forwarded: 'for="[2001:db8:cafe::17]"; proto="https"; host="remix.run"',
+        },
+      },
+      { trustProxy: true },
+    )
+    assert.equal(requestUrl, 'https://remix.run/')
+  })
+
+  it('uses `X-Forwarded-Host` and `X-Forwarded-Proto` when proxies are trusted', async (t) => {
+    let requestUrl = await captureRequestUrl(
+      t,
+      {
+        headers: {
+          Host: 'example.com',
+          'X-Forwarded-Host': 'remix.run',
+          'X-Forwarded-Proto': 'https',
+        },
+      },
+      { trustProxy: true },
+    )
+    assert.equal(requestUrl, 'https://remix.run/')
+  })
+
+  it('uses the first `X-Forwarded-Host` and `X-Forwarded-Proto` values when proxies are trusted', async (t) => {
+    let requestUrl = await captureRequestUrl(
+      t,
+      {
+        headers: {
+          Host: 'example.com',
+          'X-Forwarded-Host': 'remix.run, example.com',
+          'X-Forwarded-Proto': 'https, http',
+        },
+      },
+      { trustProxy: true },
+    )
+    assert.equal(requestUrl, 'https://remix.run/')
+  })
+
+  it('uses the host option before trusted proxy host headers', async (t) => {
+    let requestUrl = await captureRequestUrl(
+      t,
+      {
+        headers: {
+          Host: 'example.com',
+          Forwarded: 'host=remix.run',
+          'X-Forwarded-Host': 'remix.run',
+        },
+      },
+      {
+        host: 'app.example.com',
+        trustProxy: true,
+      },
+    )
+    assert.equal(requestUrl, 'http://app.example.com/')
+  })
+
+  it('ignores invalid forwarded protocol header values when proxies are trusted', async (t) => {
+    let requestUrl = await captureRequestUrl(
+      t,
+      {
+        headers: {
+          Host: 'example.com',
+          Forwarded: 'proto=javascript',
+          'X-Forwarded-Proto': 'file',
+        },
+      },
+      { trustProxy: true },
+    )
+    assert.equal(requestUrl, 'http://example.com/')
+  })
+
+  it('uses the `protocol` option before trusted proxy protocol headers', async (t) => {
+    let requestUrl = await captureRequestUrl(
+      t,
+      {
+        headers: {
+          Host: 'example.com',
+          Forwarded: 'proto=https',
+        },
+      },
+      {
+        protocol: 'http:',
+        trustProxy: true,
+      },
+    )
+    assert.equal(requestUrl, 'http://example.com/')
+  })
+
+  it('uses `X-Forwarded-For` for client address when proxies are trusted', async (t) => {
+    let client = await captureClientAddress(
+      t,
+      {
+        headers: {
+          'X-Forwarded-For': '203.0.113.43, 10.0.0.1',
+        },
+        socket: {
+          remoteAddress: '10.0.0.1',
+          remoteFamily: 'IPv4',
+          remotePort: 12345,
+        },
+      },
+      { trustProxy: true },
+    )
+
+    assert.deepEqual(client, {
+      address: '203.0.113.43',
+      family: 'IPv4',
+      port: 12345,
+    })
+  })
+
+  it('uses the `Forwarded` for parameter for client address when proxies are trusted', async (t) => {
+    let client = await captureClientAddress(
+      t,
+      {
+        headers: {
+          Forwarded: 'for="[2001:db8:cafe::17]:4711"',
+          'X-Forwarded-For': '203.0.113.43',
+        },
+        socket: {
+          remoteAddress: '10.0.0.1',
+          remoteFamily: 'IPv4',
+          remotePort: 12345,
+        },
+      },
+      { trustProxy: true },
+    )
+
+    assert.deepEqual(client, {
+      address: '2001:db8:cafe::17',
+      family: 'IPv6',
+      port: 4711,
+    })
+  })
+
+  it('ignores proxy client address headers by default', async (t) => {
+    let client = await captureClientAddress(t, {
+      headers: {
+        Forwarded: 'for=203.0.113.43',
+        'X-Forwarded-For': '203.0.113.43',
+      },
+      socket: {
+        remoteAddress: '10.0.0.1',
+        remoteFamily: 'IPv4',
+        remotePort: 12345,
+      },
+    })
+
+    assert.deepEqual(client, {
+      address: '10.0.0.1',
+      family: 'IPv4',
+      port: 12345,
+    })
+  })
+
   it('reads request method, headers, and body text', async (t) => {
     await new Promise<void>((resolve) => {
       let handler: FetchHandler = async (request) => {
@@ -1206,6 +1393,58 @@ async function assertLazyRequestBodyReadRejects(
   assert.equal(end.mock.calls.length, 0)
 }
 
+async function captureRequestUrl(
+  t: TestContext,
+  requestInit: Parameters<typeof createMockRequest>[0],
+  options?: Parameters<typeof createRequestListener>[1],
+): Promise<string | undefined> {
+  let requestUrl: string | undefined
+
+  await new Promise<void>((resolve) => {
+    let handler: FetchHandler = async (request) => {
+      requestUrl = request.url
+      return new Response('Hello, world!')
+    }
+
+    let listener = createRequestListener(handler, options)
+    assert.ok(listener)
+
+    let req = createMockRequest(requestInit)
+    let res = createMockResponse({ req })
+    t.mock.method(res, 'end', () => resolve())
+
+    listener(req, res)
+  })
+
+  return requestUrl
+}
+
+async function captureClientAddress(
+  t: TestContext,
+  requestInit: Parameters<typeof createMockRequest>[0],
+  options?: Parameters<typeof createRequestListener>[1],
+): Promise<ClientAddress | undefined> {
+  let clientAddress: ClientAddress | undefined
+
+  await new Promise<void>((resolve) => {
+    let handler: FetchHandler = async (_request, client) => {
+      clientAddress = client
+      return new Response('Hello, world!')
+    }
+
+    let listener = createRequestListener(handler, options)
+    assert.ok(listener)
+
+    let req = createMockRequest(requestInit)
+    let res = createMockResponse({ req })
+    t.mock.method(res, 'end', () => resolve())
+
+    listener(req, res)
+  })
+
+  return clientAddress
+}
+
 function markMockRequestAborted(req: http.IncomingMessage): void {
   Object.defineProperties(req, {
     aborted: {
@@ -1249,6 +1488,8 @@ function createMockRequest({
   socket?: {
     encrypted?: boolean
     remoteAddress?: string
+    remoteFamily?: string
+    remotePort?: number
   }
   body?: string | Buffer
 } = {}): http.IncomingMessage {

--- a/packages/node-fetch-server/src/lib/request-listener.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.ts
@@ -1,5 +1,6 @@
 import type * as http from 'node:http'
 import type * as http2 from 'node:http2'
+import * as net from 'node:net'
 
 import type { ClientAddress, ErrorHandler, FetchHandler } from './fetch-handler.ts'
 import type { RequestLifecycle } from './request-abort.ts'
@@ -45,6 +46,14 @@ export interface RequestListenerOptions {
    * `https.createServer()`), the request URL will begin with `https:`.
    */
   protocol?: string
+  /**
+   * Trusts reverse proxy headers. When enabled, `Forwarded`, `X-Forwarded-Host`, and
+   * `X-Forwarded-Proto` can provide the incoming request URL host and protocol when `host` and
+   * `protocol` are not set. `Forwarded` and `X-Forwarded-For` can provide the client address for
+   * request listeners that read client information. Only enable this when your server is behind a
+   * trusted proxy that overwrites these headers.
+   */
+  trustProxy?: boolean
 }
 
 /**
@@ -141,11 +150,7 @@ export function createRequestListener(
   return async (req, res) => {
     let isResponseClosed = observeResponseClose(res)
     let request = createLazyRequest(req, res)
-    let client = {
-      address: req.socket.remoteAddress!,
-      family: req.socket.remoteFamily! as ClientAddress['family'],
-      port: req.socket.remotePort!,
-    }
+    let client = createClientAddress(req, options)
 
     let response: Response
     try {
@@ -378,9 +383,8 @@ function createRequestWithLifecycle(
   let method = req.method ?? 'GET'
   let headers = createHeaders(req)
 
-  let protocol =
-    options?.protocol ?? ('encrypted' in req.socket && req.socket.encrypted ? 'https:' : 'http:')
-  let host = options?.host ?? headers.get('Host') ?? req.headers[':authority'] ?? 'localhost'
+  let protocol = getRequestProtocol(req, headers, options)
+  let host = getRequestHost(req, headers, options)
   let url = `${protocol}//${host}${req.url}`
 
   let init: RequestInit = { method, headers, signal: lifecycle.signal }
@@ -396,6 +400,221 @@ function createRequestWithLifecycle(
   }
 
   return new Request(url, init)
+}
+
+function getRequestProtocol(
+  req: http.IncomingMessage | http2.Http2ServerRequest,
+  headers: Headers,
+  options?: RequestOptions,
+): string {
+  return (
+    options?.protocol ??
+    (options?.trustProxy ? getForwardedProtocol(headers) : undefined) ??
+    ('encrypted' in req.socket && req.socket.encrypted ? 'https:' : 'http:')
+  )
+}
+
+function createClientAddress(
+  req: http.IncomingMessage | http2.Http2ServerRequest,
+  options?: RequestOptions,
+): ClientAddress {
+  let forwardedClient = options?.trustProxy
+    ? getForwardedClientAddress(createHeaders(req))
+    : undefined
+  let address = forwardedClient?.address ?? req.socket.remoteAddress ?? ''
+
+  return {
+    address,
+    family: getClientAddressFamily(address, req.socket.remoteFamily!),
+    port: forwardedClient?.port ?? req.socket.remotePort!,
+  }
+}
+
+function getClientAddressFamily(address: string, fallbackFamily: string): ClientAddress['family'] {
+  let version = net.isIP(address)
+  if (version === 4) return 'IPv4'
+  if (version === 6) return 'IPv6'
+  return fallbackFamily as ClientAddress['family']
+}
+
+function getRequestHost(
+  req: http.IncomingMessage | http2.Http2ServerRequest,
+  headers: Headers,
+  options?: RequestOptions,
+): string {
+  let authority = req.headers[':authority']
+
+  return (
+    options?.host ??
+    (options?.trustProxy ? getForwardedHost(headers) : undefined) ??
+    headers.get('Host') ??
+    (Array.isArray(authority) ? authority[0] : authority) ??
+    'localhost'
+  )
+}
+
+function getForwardedProtocol(headers: Headers): string | undefined {
+  return (
+    normalizeForwardedProtocol(getForwardedHeaderParameter(headers.get('Forwarded'), 'proto')) ??
+    getXForwardedProtoHeaderProtocol(headers.get('X-Forwarded-Proto'))
+  )
+}
+
+function getForwardedHost(headers: Headers): string | undefined {
+  return (
+    normalizeForwardedHost(getForwardedHeaderParameter(headers.get('Forwarded'), 'host')) ??
+    normalizeForwardedHost(getFirstHeaderValue(headers.get('X-Forwarded-Host')))
+  )
+}
+
+interface ForwardedClientAddress {
+  address: string
+  port?: number
+}
+
+function getForwardedClientAddress(headers: Headers): ForwardedClientAddress | undefined {
+  return (
+    normalizeForwardedClientAddress(getForwardedHeaderParameter(headers.get('Forwarded'), 'for')) ??
+    normalizeForwardedClientAddress(getFirstHeaderValue(headers.get('X-Forwarded-For')))
+  )
+}
+
+function getForwardedHeaderParameter(
+  value: string | null,
+  parameterName: string,
+): string | undefined {
+  if (value == null) return undefined
+
+  for (let element of splitHeaderValue(value, ',')) {
+    for (let parameter of splitHeaderValue(element, ';')) {
+      let index = parameter.indexOf('=')
+      if (index === -1) continue
+
+      let name = parameter.slice(0, index).trim().toLowerCase()
+      if (name !== parameterName) continue
+
+      return unquoteHeaderValue(parameter.slice(index + 1).trim())
+    }
+  }
+
+  return undefined
+}
+
+function getXForwardedProtoHeaderProtocol(value: string | null): string | undefined {
+  return normalizeForwardedProtocol(getFirstHeaderValue(value))
+}
+
+function getFirstHeaderValue(value: string | null): string | undefined {
+  if (value == null) return undefined
+
+  let firstValue = splitHeaderValue(value, ',')[0]
+  return firstValue == null ? undefined : unquoteHeaderValue(firstValue.trim())
+}
+
+function normalizeForwardedProtocol(value: string | undefined): string | undefined {
+  if (value == null) return undefined
+
+  let protocol = value.trim().toLowerCase()
+  if (protocol.endsWith(':')) protocol = protocol.slice(0, -1)
+
+  return protocol === 'http' || protocol === 'https' ? `${protocol}:` : undefined
+}
+
+function normalizeForwardedHost(value: string | undefined): string | undefined {
+  if (value == null) return undefined
+
+  let host = value.trim()
+  return host === '' ? undefined : host
+}
+
+function normalizeForwardedClientAddress(
+  value: string | undefined,
+): ForwardedClientAddress | undefined {
+  if (value == null) return undefined
+
+  let input = value.trim()
+  if (input === '' || input.toLowerCase() === 'unknown' || input.startsWith('_')) {
+    return undefined
+  }
+
+  let address = input
+  let port: number | undefined
+
+  if (address.startsWith('[')) {
+    let end = address.indexOf(']')
+    if (end === -1) return undefined
+
+    let portInput = address.slice(end + 1)
+    address = address.slice(1, end)
+    port = parseForwardedPort(portInput)
+  } else {
+    let colonIndex = address.lastIndexOf(':')
+    if (colonIndex !== -1 && address.indexOf(':') === colonIndex) {
+      port = parseForwardedPort(address.slice(colonIndex))
+      if (port !== undefined) address = address.slice(0, colonIndex)
+    }
+  }
+
+  return net.isIP(address) === 0 ? undefined : { address, port }
+}
+
+function parseForwardedPort(value: string): number | undefined {
+  if (!value.startsWith(':')) return undefined
+
+  let port = Number(value.slice(1))
+  return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : undefined
+}
+
+function splitHeaderValue(value: string, delimiter: ',' | ';'): string[] {
+  let parts: string[] = []
+  let start = 0
+  let quoted = false
+  let escaped = false
+
+  for (let index = 0; index < value.length; index++) {
+    let char = value[index]
+
+    if (escaped) {
+      escaped = false
+      continue
+    }
+
+    if (quoted && char === '\\') {
+      escaped = true
+      continue
+    }
+
+    if (char === '"') {
+      quoted = !quoted
+      continue
+    }
+
+    if (!quoted && char === delimiter) {
+      parts.push(value.slice(start, index))
+      start = index + 1
+    }
+  }
+
+  parts.push(value.slice(start))
+  return parts
+}
+
+function unquoteHeaderValue(value: string): string {
+  if (!value.startsWith('"') || !value.endsWith('"')) return value
+
+  let unquoted = ''
+  for (let index = 1; index < value.length - 1; index++) {
+    let char = value[index]
+
+    if (char === '\\' && index + 1 < value.length - 1) {
+      index++
+      unquoted += value[index]
+    } else {
+      unquoted += char
+    }
+  }
+
+  return unquoted
 }
 
 /**

--- a/packages/remix/.changes/minor.node-fetch-server.trust-proxy.md
+++ b/packages/remix/.changes/minor.node-fetch-server.trust-proxy.md
@@ -1,0 +1,1 @@
+Added the `trustProxy` option to `remix/node-fetch-server` for apps behind trusted reverse proxies that need `request.url` and handler client address information to reflect trusted `Forwarded` and `X-Forwarded-*` headers.


### PR DESCRIPTION
Closes #10874.

This adds an opt-in `trustProxy` setting for Node servers running behind trusted reverse proxies. When enabled, `createRequestListener()` and `createRequest()` can construct `request.url` from trusted proxy headers, and `createRequestListener()` can pass trusted client address information to handlers.

- Keeps the default behavior unchanged so proxy headers are ignored unless explicitly trusted
- Uses `Forwarded: proto`/`X-Forwarded-Proto` for URL protocol and `Forwarded: host`/`X-Forwarded-Host` for URL host
- Uses `Forwarded: for`/`X-Forwarded-For` for handler client address information
- Preserves `protocol` and `host` as fixed overrides with higher precedence than trusted proxy headers
- Accepts only `http` and `https` protocol values, and documents the spoofing risk when proxy headers are trusted from untrusted clients

```ts
import * as http from 'node:http'
import { createRequestListener } from 'remix/node-fetch-server'

let server = http.createServer(
  createRequestListener(handler, {
    trustProxy: true,
  }),
)
```
