### PR TITLE
Make RoutePattern opaque and nominal

### DIFF
--- a/packages/assets/src/lib/routes.ts
+++ b/packages/assets/src/lib/routes.ts
@@ -1,4 +1,8 @@
-import { RoutePattern } from '@remix-run/route-pattern'
+import {
+  getRoutePatternParams,
+  RoutePattern,
+  type RoutePatternParam,
+} from '@remix-run/route-pattern'
 import { createHref } from '@remix-run/route-pattern/href'
 import { createMatcher, type Matcher } from '@remix-run/route-pattern/match'
 
@@ -160,17 +164,21 @@ function validateRoutePatterns(urlPattern: RoutePattern, filePattern: RoutePatte
 }
 
 function validateNoUnnamedWildcards(pattern: RoutePattern, label: string): void {
-  if (pattern.pathname.tokens.some((token) => token.type === '*' && token.name === '*')) {
+  if (
+    getRoutePatternParams(pattern).some(
+      (param) => param.part === 'pathname' && param.type === '*' && param.name === '*',
+    )
+  ) {
     throw new Error(
       `${label} route patterns must use named wildcards for reversible mapping.\nPattern: ${pattern}`,
     )
   }
 }
 
-type PathnameParam = Extract<RoutePattern['pathname']['tokens'][number], { type: ':' | '*' }>
+type PathnameParam = RoutePatternParam & { readonly part: 'pathname' }
 
 function getPathnameParams(pattern: RoutePattern): Array<PathnameParam> {
-  return pattern.pathname.tokens.filter(
-    (token): token is PathnameParam => token.type === ':' || token.type === '*',
+  return getRoutePatternParams(pattern).filter(
+    (param): param is PathnameParam => param.part === 'pathname',
   )
 }

--- a/packages/remix/.changes/major.remix.update-exports.md
+++ b/packages/remix/.changes/major.remix.update-exports.md
@@ -8,6 +8,12 @@ Added `package.json` `exports` for the styled component entrypoints:
 - `remix/components/select`
 - `remix/components/tabs`
 
+Updated `remix/route-pattern` exports for the opaque `RoutePattern` API:
+
+- Added `getRoutePatternParams`, `RoutePatternParam`, and `RoutePatternJSON` to `remix/route-pattern`
+- Added `CreateHrefErrorDetails` to `remix/route-pattern/href`
+- Added `MatchParamMeta` to `remix/route-pattern/match`
+
 Removed `package.json` `exports`:
 
 - `remix/ui/breadcrumbs`

--- a/packages/route-pattern/.changes/minor.opaque-route-pattern.md
+++ b/packages/route-pattern/.changes/minor.opaque-route-pattern.md
@@ -1,0 +1,5 @@
+BREAKING CHANGE: `RoutePattern` is now an opaque parsed-pattern handle. Construct patterns with `RoutePattern.parse()` instead of `new RoutePattern(...)`, and use `pattern.source`, `pattern.toString()`, or `pattern.toJSON()` instead of reading parsed internals such as `pattern.pathname.tokens`, `pattern.hostname`, or `pattern.search`.
+
+Added `getRoutePatternParams(pattern)` for supported param introspection. It returns readonly `{ part, type, name, optional }` entries in source order so consumers can inspect hostname and pathname params without relying on internal parser tokens.
+
+Exported `RoutePatternParam` and `RoutePatternJSON` from `@remix-run/route-pattern`, `CreateHrefErrorDetails` from `@remix-run/route-pattern/href`, and `MatchParamMeta` from `@remix-run/route-pattern/match`.

--- a/packages/route-pattern/README.md
+++ b/packages/route-pattern/README.md
@@ -238,19 +238,26 @@ createHref('products(.json)')
 
 ## Parse & stringify patterns
 
-You can explicitly parse and stringify patterns:
+You can explicitly parse and stringify patterns. `RoutePattern` is an opaque handle: use the methods and helpers below instead of reading parsed token internals.
 
 ```ts
-import { RoutePattern } from 'remix/route-pattern'
+import { getRoutePatternParams, RoutePattern } from 'remix/route-pattern'
 
-let pattern = RoutePattern.parse('://example.com/blog/:slug')
+let pattern = RoutePattern.parse('://:tenant.example.com/blog/:slug(/*path)')
 //  ^? RoutePattern
 
 pattern.toString()
-// '://example.com/blog/:slug'
+// '://:tenant.example.com/blog/:slug(/*path)'
 
 pattern.toJSON()
-// { hostname: 'example.com', pathname: 'blog/:slug', ... }
+// { hostname: ':tenant.example.com', pathname: 'blog/:slug(/*path)', ... }
+
+getRoutePatternParams(pattern)
+// [
+//   { part: 'hostname', type: ':', name: 'tenant', optional: false },
+//   { part: 'pathname', type: ':', name: 'slug', optional: false },
+//   { part: 'pathname', type: '*', name: 'path', optional: true },
+// ]
 ```
 
 All APIs that take a `pattern` arg accept `string` or a parsed `RoutePattern`.

--- a/packages/route-pattern/src/href.ts
+++ b/packages/route-pattern/src/href.ts
@@ -1,1 +1,2 @@
 export { CreateHrefError, createHref, type CreateHrefArgs } from './lib/href.ts'
+export type { CreateHrefErrorDetails } from './lib/href.ts'

--- a/packages/route-pattern/src/lib/href.test.ts
+++ b/packages/route-pattern/src/lib/href.test.ts
@@ -473,7 +473,6 @@ describe('CreateHrefError', () => {
       let error = new CreateHrefError({
         type: 'missing-params',
         pattern,
-        part: pattern.pathname,
         missingParams: ['collection', 'id'],
         params: {},
       })

--- a/packages/route-pattern/src/lib/href.ts
+++ b/packages/route-pattern/src/lib/href.ts
@@ -1,4 +1,9 @@
-import { RoutePattern, type PartPattern } from './route-pattern.ts'
+import {
+  getRoutePatternParts,
+  RoutePattern,
+  type ParsedRoutePattern,
+  type PartPattern,
+} from './route-pattern.ts'
 import type { ParseParams } from './types/params.ts'
 import type { Split, SplitPattern } from './types/split.ts'
 import type { Simplify } from './types/utils.ts'
@@ -50,29 +55,33 @@ export function createHref<source extends string>(
   ...args: CreateHrefArgs<source>
 ): string {
   pattern = typeof pattern === 'string' ? RoutePattern.parse(pattern) : pattern
+  let patternParts = getRoutePatternParts(pattern)
   let [params, searchParams] = args
   searchParams ??= {}
 
-  let hasOrigin = pattern.protocol !== null || pattern.hostname !== null || pattern.port !== null
+  let hasOrigin =
+    patternParts.protocol !== null || patternParts.hostname !== null || patternParts.port !== null
   let result = ''
 
   if (hasOrigin) {
     let protocol =
-      pattern.protocol === null || pattern.protocol === 'http(s)' ? 'https' : pattern.protocol
+      patternParts.protocol === null || patternParts.protocol === 'http(s)'
+        ? 'https'
+        : patternParts.protocol
 
-    if (pattern.hostname === null) {
+    if (patternParts.hostname === null) {
       throw new CreateHrefError({ type: 'missing-hostname', pattern })
     }
-    let hostname = hrefPart(pattern, pattern.hostname, params ?? {})
+    let hostname = hrefPart(pattern, patternParts.hostname, params ?? {})
 
-    let port = pattern.port === null ? '' : `:${pattern.port}`
+    let port = patternParts.port === null ? '' : `:${patternParts.port}`
     result += `${protocol}://${hostname}${port}`
   }
 
-  let pathname = hrefPart(pattern, pattern.pathname, params ?? {})
+  let pathname = hrefPart(pattern, patternParts.pathname, params ?? {})
   result += '/' + pathname
 
-  let search = hrefSearch(pattern, searchParams)
+  let search = hrefSearch(patternParts.search, searchParams)
   if (search) result += `?${search}`
 
   return result
@@ -140,7 +149,6 @@ function hrefPart(
     throw new CreateHrefError({
       type: 'missing-params',
       pattern,
-      part,
       missingParams,
       params,
     })
@@ -149,8 +157,10 @@ function hrefPart(
   return stack[0].href
 }
 
-function hrefSearch(pattern: RoutePattern, searchParams: SearchParams): string | undefined {
-  let constraints = pattern.search
+function hrefSearch(
+  constraints: ParsedRoutePattern['search'],
+  searchParams: SearchParams,
+): string | undefined {
   if (constraints.size === 0 && Object.keys(searchParams).length === 0) {
     return undefined
   }
@@ -183,12 +193,11 @@ function hrefSearch(pattern: RoutePattern, searchParams: SearchParams): string |
   return result || undefined
 }
 
-type CreateHrefErrorDetails =
+export type CreateHrefErrorDetails =
   | { type: 'missing-hostname'; pattern: RoutePattern }
   | {
       type: 'missing-params'
       pattern: RoutePattern
-      part: PartPattern
       missingParams: Array<string>
       params: Record<string, unknown>
     }

--- a/packages/route-pattern/src/lib/join.ts
+++ b/packages/route-pattern/src/lib/join.ts
@@ -1,5 +1,5 @@
-import { RoutePattern } from './route-pattern.ts'
-import type { PartPattern, PartPatternToken } from './route-pattern.ts'
+import { createRoutePattern, getRoutePatternParts, RoutePattern } from './route-pattern.ts'
+import type { ParsedRoutePattern, PartPattern, PartPatternToken } from './route-pattern.ts'
 import type { JoinPatterns } from './types/join.ts'
 
 /**
@@ -17,14 +17,17 @@ export function joinPatterns<base extends string, next extends string>(
   base: base | RoutePattern<base>,
   next: next | RoutePattern<next>,
 ): RoutePattern<JoinPatterns<base, next>> {
-  base = typeof base === 'string' ? RoutePattern.parse(base) : base
-  next = typeof next === 'string' ? RoutePattern.parse(next) : next
-  return new RoutePattern<JoinPatterns<base, next>>({
-    protocol: next.protocol ?? base.protocol,
-    hostname: next.hostname ?? base.hostname,
-    port: next.port ?? base.port,
-    pathname: joinPathname(base.pathname, next.pathname),
-    search: joinSearch(base.search, next.search),
+  let basePattern = typeof base === 'string' ? RoutePattern.parse(base) : base
+  let nextPattern = typeof next === 'string' ? RoutePattern.parse(next) : next
+  let baseParts = getRoutePatternParts(basePattern)
+  let nextParts = getRoutePatternParts(nextPattern)
+
+  return createRoutePattern<JoinPatterns<base, next>>({
+    protocol: nextParts.protocol ?? baseParts.protocol,
+    hostname: nextParts.hostname ?? baseParts.hostname,
+    port: nextParts.port ?? baseParts.port,
+    pathname: joinPathname(baseParts.pathname, nextParts.pathname),
+    search: joinSearch(baseParts.search, nextParts.search),
   })
 }
 
@@ -102,9 +105,9 @@ function joinPathname(base: PartPattern, next: PartPattern): PartPattern {
  * @private
  */
 function joinSearch(
-  base: RoutePattern['search'],
-  next: RoutePattern['search'],
-): RoutePattern['search'] {
+  base: ParsedRoutePattern['search'],
+  next: ParsedRoutePattern['search'],
+): ParsedRoutePattern['search'] {
   let result = new Map<string, Set<string>>()
 
   for (let [name, values] of base) {

--- a/packages/route-pattern/src/lib/match/trie.ts
+++ b/packages/route-pattern/src/lib/match/trie.ts
@@ -1,4 +1,5 @@
-import type { RoutePattern } from '../route-pattern.ts'
+import { getRoutePatternParts } from '../route-pattern.ts'
+import type { ParsedRoutePattern, RoutePattern } from '../route-pattern.ts'
 import { decodeHostname } from './decode.ts'
 import { generateVariants, type Param } from './variant.ts'
 import { unreachable } from '../unreachable.ts'
@@ -18,6 +19,8 @@ export class Trie<data = unknown> {
   }
 
   insert(pattern: RoutePattern, data: data): void {
+    let patternParts = getRoutePatternParts(pattern)
+
     for (let variant of generateVariants(pattern)) {
       let hostnameNode = this.#root[variant.protocol]
 
@@ -87,14 +90,14 @@ export class Trie<data = unknown> {
         }
       }
       let undefinedParams: Array<Param> = []
-      for (let param of pattern.pathname.tokens) {
+      for (let param of patternParts.pathname.tokens) {
         if (param.type !== ':' && param.type !== '*') continue
         if (requiredParams.some((p) => p.name === param.name)) continue
         if (undefinedParams.some((p) => p.name === param.name)) continue
         undefinedParams.push(param)
       }
 
-      pathnameNode.values.push({ pattern, data, requiredParams, undefinedParams })
+      pathnameNode.values.push({ pattern, patternParts, data, requiredParams, undefinedParams })
     }
   }
 
@@ -165,7 +168,7 @@ export class Trie<data = unknown> {
 
         if (current.segmentIndex === urlSegments.length) {
           for (let value of current.pathnameNode.values) {
-            if (!matchSearch(url.searchParams, value.pattern.search)) continue
+            if (!matchSearch(url.searchParams, value.patternParts.search)) continue
 
             let pathnameMatch: Array<MatchParamMeta> = []
             for (let i = 0; i < value.requiredParams.length; i++) {
@@ -181,12 +184,12 @@ export class Trie<data = unknown> {
             }
 
             let params: Record<string, string | undefined> = {}
-            for (let token of value.pattern.hostname?.tokens ?? []) {
+            for (let token of value.patternParts.hostname?.tokens ?? []) {
               if ((token.type === ':' || token.type === '*') && token.name !== '*') {
                 params[token.name] = undefined
               }
             }
-            for (let token of value.pattern.pathname.tokens) {
+            for (let token of value.patternParts.pathname.tokens) {
               if ((token.type === ':' || token.type === '*') && token.name !== '*') {
                 params[token.name] = undefined
               }
@@ -351,6 +354,7 @@ type PathnameNode<data> = {
   wildcard: Map<string, { regexp: RegExp; pathnameNode: PathnameNode<data> }>
   values: Array<{
     pattern: RoutePattern
+    patternParts: ParsedRoutePattern
     data: data
     requiredParams: Array<Param>
     undefinedParams: Array<Param>

--- a/packages/route-pattern/src/lib/match/variant.ts
+++ b/packages/route-pattern/src/lib/match/variant.ts
@@ -1,4 +1,10 @@
-import type { PartPattern, PartPatternToken, RoutePattern } from '../route-pattern.ts'
+import { getRoutePatternParts } from '../route-pattern.ts'
+import type {
+  ParsedRoutePattern,
+  PartPattern,
+  PartPatternToken,
+  RoutePattern,
+} from '../route-pattern.ts'
 import { escape } from './regexp.ts'
 import { unreachable } from '../unreachable.ts'
 import { toRegExp } from './regexp.ts'
@@ -11,12 +17,13 @@ export type Variant = {
 }
 
 export function generateVariants(pattern: RoutePattern): ReadonlyArray<Variant> {
+  let patternParts = getRoutePatternParts(pattern)
   let result: Array<Variant> = []
 
-  for (let protocol of generateProtocolVariants(pattern.protocol)) {
-    let port = normalizePort(protocol, pattern.port)
-    for (let hostname of generateHostnameVariants(pattern.hostname)) {
-      for (let pathname of generatePathnameVariants(pattern.pathname)) {
+  for (let protocol of generateProtocolVariants(patternParts.protocol)) {
+    let port = normalizePort(protocol, patternParts.port)
+    for (let hostname of generateHostnameVariants(patternParts.hostname)) {
+      for (let pathname of generatePathnameVariants(patternParts.pathname)) {
         result.push({ protocol, hostname, port, pathname })
       }
     }
@@ -29,7 +36,7 @@ export function generateVariants(pattern: RoutePattern): ReadonlyArray<Variant> 
 type ProtocolVariant = 'http' | 'https'
 
 function generateProtocolVariants(
-  protocol: RoutePattern['protocol'],
+  protocol: ParsedRoutePattern['protocol'],
 ): ReadonlyArray<ProtocolVariant> {
   if (protocol === null || protocol === 'http(s)') return ['http', 'https']
   return [protocol]

--- a/packages/route-pattern/src/lib/route-pattern.test.ts
+++ b/packages/route-pattern/src/lib/route-pattern.test.ts
@@ -1,0 +1,131 @@
+import * as assert from '@remix-run/assert'
+import { describe, it } from '@remix-run/test'
+
+import { createHref, type CreateHrefErrorDetails } from '../href.ts'
+import { joinPatterns } from '../join.ts'
+import { createMatcher, type MatchParamMeta } from '../match.ts'
+import {
+  getRoutePatternParams,
+  RoutePattern,
+  type RoutePatternJSON,
+  type RoutePatternParam,
+} from '../route-pattern.ts'
+
+describe('RoutePattern', () => {
+  it('exports public route pattern support types', () => {
+    let param: RoutePatternParam = {
+      part: 'pathname',
+      type: ':',
+      name: 'id',
+      optional: false,
+    }
+    let json: RoutePatternJSON = {
+      protocol: '',
+      hostname: '',
+      port: '',
+      pathname: ':id',
+      search: '',
+    }
+    let hrefError: CreateHrefErrorDetails = {
+      type: 'missing-hostname',
+      pattern: RoutePattern.parse('https://'),
+    }
+    let matchMeta: MatchParamMeta = {
+      type: ':',
+      name: 'id',
+      value: '123',
+      begin: 0,
+      end: 3,
+    }
+
+    assert.equal(param.name, 'id')
+    assert.equal(json.pathname, ':id')
+    assert.equal(hrefError.type, 'missing-hostname')
+    assert.equal(matchMeta.value, '123')
+  })
+
+  it('does not expose parsed-AST construction', () => {
+    assert.throws(
+      () => {
+        // @ts-expect-error - RoutePattern construction is internal
+        new RoutePattern({})
+      },
+      {
+        name: 'TypeError',
+        message: 'RoutePattern constructor is private; use RoutePattern.parse()',
+      },
+    )
+  })
+
+  it('brands source generics nominally', () => {
+    let posts = RoutePattern.parse('/posts/:postId')
+
+    // @ts-expect-error - incompatible RoutePattern source
+    let users: RoutePattern<'/users/:userId'> = posts
+
+    assert.equal(users, posts)
+  })
+
+  it('exposes params without exposing parsed tokens', () => {
+    let pattern = RoutePattern.parse('https://:tenant.example.com/:collection(/*path)(.:ext)')
+
+    assert.deepEqual(getRoutePatternParams(pattern), [
+      { part: 'hostname', type: ':', name: 'tenant', optional: false },
+      { part: 'pathname', type: ':', name: 'collection', optional: false },
+      { part: 'pathname', type: '*', name: 'path', optional: true },
+      { part: 'pathname', type: ':', name: 'ext', optional: true },
+    ])
+  })
+
+  it('exposes unnamed wildcards in params', () => {
+    let pattern = RoutePattern.parse('/files/*')
+
+    assert.deepEqual(getRoutePatternParams(pattern), [
+      { part: 'pathname', type: '*', name: '*', optional: false },
+    ])
+  })
+
+  it('infers createHref params from parsed patterns', () => {
+    let pattern = RoutePattern.parse('/posts/:postId')
+
+    assert.equal(createHref(pattern, { postId: '123' }), '/posts/123')
+
+    // @ts-expect-error - params come from the parsed pattern source
+    assert.throws(() => createHref(pattern, { userId: '123' }))
+  })
+
+  it('infers matcher params from parsed patterns', () => {
+    let pattern = RoutePattern.parse('/posts/:postId')
+    let matcher = createMatcher(pattern)
+    let match = matcher.match('https://remix.run/posts/123')
+
+    if (!match) throw new Error('Expected match')
+    assert.equal(match.params.postId, '123')
+  })
+
+  it('infers joined params from parsed patterns without reparsing them', () => {
+    let base = RoutePattern.parse('/orgs/:orgId')
+    let next = RoutePattern.parse('/repos/:repoId')
+    let parse = RoutePattern.parse
+
+    RoutePattern.parse = function parse<source extends string>(
+      source: source,
+    ): RoutePattern<source> {
+      throw new Error(`unexpected reparse: ${source}`)
+    }
+
+    try {
+      let joined = joinPatterns(base, next)
+
+      assert.equal(
+        createHref(joined, { orgId: 'remix-run', repoId: 'remix' }),
+        '/orgs/remix-run/repos/remix',
+      )
+
+      // @ts-expect-error - joined pattern requires both params
+      assert.throws(() => createHref(joined, { orgId: 'remix-run' }))
+    } finally {
+      RoutePattern.parse = parse
+    }
+  })
+})

--- a/packages/route-pattern/src/lib/route-pattern.ts
+++ b/packages/route-pattern/src/lib/route-pattern.ts
@@ -16,7 +16,7 @@ export type PartPattern = {
   readonly type: 'hostname' | 'pathname'
 }
 
-type ParsedRoutePattern = {
+export type ParsedRoutePattern = {
   readonly protocol: 'http' | 'https' | 'http(s)' | null
   readonly hostname: PartPattern | null
   readonly port: string | null
@@ -35,21 +35,46 @@ type ParsedRoutePattern = {
   readonly search: ReadonlyMap<string, ReadonlySet<string>>
 }
 
+/** Serialized URL pattern parts returned by {@link RoutePattern.toJSON}. */
 export interface RoutePatternJSON {
+  /** Serialized protocol constraint, or an empty string when omitted. */
   protocol: string
+
+  /** Serialized hostname pattern, or an empty string when omitted. */
   hostname: string
+
+  /** Serialized port constraint, or an empty string when omitted. */
   port: string
+
+  /** Serialized pathname pattern without a leading `/`. */
   pathname: string
+
+  /** Serialized search constraint string without a leading `?`. */
   search: string
 }
 
+/** Metadata for a hostname or pathname param in a {@link RoutePattern}. */
+export interface RoutePatternParam {
+  /** The URL part that contains the param. */
+  readonly part: 'hostname' | 'pathname'
+
+  /** The param token kind: `:` for variables or `*` for wildcards. */
+  readonly type: ':' | '*'
+
+  /** Param name, or `*` for an unnamed wildcard. */
+  readonly name: string
+
+  /** Whether the param is inside an optional group. */
+  readonly optional: boolean
+}
+
+const routePatternConstructorKey: unique symbol = Symbol('RoutePattern constructor key')
+declare const routePatternSourceBrand: unique symbol
+const routePatternParts = new WeakMap<RoutePattern, ParsedRoutePattern>()
+
 /** A parsed route pattern */
-export class RoutePattern<source extends string = string> implements ParsedRoutePattern {
-  readonly protocol: ParsedRoutePattern['protocol']
-  readonly hostname: ParsedRoutePattern['hostname']
-  readonly port: ParsedRoutePattern['port']
-  readonly pathname: ParsedRoutePattern['pathname']
-  readonly search: ParsedRoutePattern['search']
+export class RoutePattern<source extends string = string> {
+  declare readonly [routePatternSourceBrand]: source
 
   /**
    * Create a new `RoutePattern` by parsing a source string.
@@ -61,25 +86,25 @@ export class RoutePattern<source extends string = string> implements ParsedRoute
     return parsePattern(source)
   }
 
-  /**
-   * Create a new `RoutePattern` from parsed parts of a route pattern.
-   *
-   * Useful for efficiently deriving new patterns from already parsed patterns.
-   * Unless you know what you are doing, you probably want `RoutePattern.parse`.
-   *
-   * @param parsed Parsed route pattern parts.
-   */
-  constructor(parsed: ParsedRoutePattern) {
-    this.protocol = parsed.protocol
-    this.hostname = parsed.hostname
-    this.port = parsed.port
-    this.pathname = parsed.pathname
-    this.search = parsed.search
+  private constructor(key: typeof routePatternConstructorKey, parsed?: ParsedRoutePattern) {
+    if (key !== routePatternConstructorKey) {
+      throw new TypeError('RoutePattern constructor is private; use RoutePattern.parse()')
+    }
+    if (parsed === undefined) {
+      throw new TypeError('RoutePattern constructor is private; use RoutePattern.parse()')
+    }
+    routePatternParts.set(this, parsed)
+  }
+
+  static [routePatternConstructorKey]<source extends string>(
+    parsed: ParsedRoutePattern,
+  ): RoutePattern<source> {
+    return new RoutePattern<source>(routePatternConstructorKey, parsed)
   }
 
   /** Normalized string representation of this pattern */
   get source(): string {
-    return serializePattern(this)
+    return serializePattern(getRoutePatternParts(this))
   }
 
   /**
@@ -97,6 +122,62 @@ export class RoutePattern<source extends string = string> implements ParsedRoute
    * @returns The serialized protocol, hostname, port, pathname, and search.
    */
   toJSON(): RoutePatternJSON {
-    return serializePatternParts(this)
+    return serializePatternParts(getRoutePatternParts(this))
   }
+}
+
+export function createRoutePattern<source extends string>(
+  parsed: ParsedRoutePattern,
+): RoutePattern<source> {
+  return RoutePattern[routePatternConstructorKey]<source>(parsed)
+}
+
+export function getRoutePatternParts(pattern: RoutePattern): ParsedRoutePattern {
+  let parsed = routePatternParts.get(pattern)
+  if (parsed === undefined) {
+    throw new TypeError('Invalid RoutePattern')
+  }
+  return parsed
+}
+
+/**
+ * Returns hostname and pathname params in source order without exposing parsed pattern internals.
+ *
+ * @param pattern The parsed route pattern to inspect.
+ * @returns Param metadata for variables and wildcards in the pattern.
+ */
+export function getRoutePatternParams(pattern: RoutePattern): ReadonlyArray<RoutePatternParam> {
+  let parsed = getRoutePatternParts(pattern)
+  let params: Array<RoutePatternParam> = []
+
+  if (parsed.hostname) {
+    params.push(...getPartParams(parsed.hostname))
+  }
+  params.push(...getPartParams(parsed.pathname))
+
+  return params
+}
+
+function getPartParams(part: PartPattern): Array<RoutePatternParam> {
+  let params: Array<RoutePatternParam> = []
+
+  for (let i = 0; i < part.tokens.length; i++) {
+    let token = part.tokens[i]
+    if (token.type !== ':' && token.type !== '*') continue
+    params.push({
+      part: part.type,
+      type: token.type,
+      name: token.name,
+      optional: isOptionalToken(part, i),
+    })
+  }
+
+  return params
+}
+
+function isOptionalToken(part: PartPattern, index: number): boolean {
+  for (let [begin, end] of part.optionals) {
+    if (begin < index && index < end) return true
+  }
+  return false
 }

--- a/packages/route-pattern/src/lib/route-pattern/parse.test.ts
+++ b/packages/route-pattern/src/lib/route-pattern/parse.test.ts
@@ -3,8 +3,8 @@ import { describe, it } from '@remix-run/test'
 import dedent from 'dedent'
 
 import { ParseError, parsePart, parsePattern } from './parse.ts'
-import { RoutePattern } from '../route-pattern.ts'
-import type { PartPattern } from '../route-pattern.ts'
+import { createRoutePattern, getRoutePatternParts, RoutePattern } from '../route-pattern.ts'
+import type { ParsedRoutePattern, PartPattern } from '../route-pattern.ts'
 
 describe('ParseError', () => {
   it('exposes type, source, and index properties', () => {
@@ -245,7 +245,7 @@ describe('RoutePattern', () => {
   })
 
   it('derives source from parsed parts', () => {
-    let pattern = new RoutePattern({
+    let pattern = createRoutePattern({
       protocol: null,
       hostname: null,
       port: null,
@@ -262,7 +262,7 @@ describe('parsePattern', () => {
   function assertParse(
     source: string,
     expected: {
-      protocol?: RoutePattern['protocol']
+      protocol?: ParsedRoutePattern['protocol']
       hostname?: string
       port?: string
       pathname?: string
@@ -277,28 +277,19 @@ describe('parsePattern', () => {
         expectedSearch.set(name, value.length === 0 ? new Set() : new Set(value))
       }
     }
-    assert.deepEqual(
-      {
-        protocol: pattern.protocol,
-        hostname: pattern.hostname,
-        port: pattern.port,
-        pathname: pattern.pathname,
-        search: pattern.search,
-      },
-      {
-        protocol: expected.protocol ?? null,
-        hostname: expected.hostname ? parsePart(expected.hostname, { type: 'hostname' }) : null,
-        port: expected.port ?? null,
-        pathname: parsePart(expected.pathname ?? '', { type: 'pathname' }),
-        search: expectedSearch,
-      },
-    )
+    assert.deepEqual(getRoutePatternParts(pattern), {
+      protocol: expected.protocol ?? null,
+      hostname: expected.hostname ? parsePart(expected.hostname, { type: 'hostname' }) : null,
+      port: expected.port ?? null,
+      pathname: parsePart(expected.pathname ?? '', { type: 'pathname' }),
+      search: expectedSearch,
+    })
   }
 
   it('parses protocol', () => {
-    assert.equal(parsePattern('http://').protocol, 'http')
-    assert.equal(parsePattern('https://').protocol, 'https')
-    assert.equal(parsePattern('http(s)://').protocol, 'http(s)')
+    assert.equal(getRoutePatternParts(parsePattern('http://')).protocol, 'http')
+    assert.equal(getRoutePatternParts(parsePattern('https://')).protocol, 'https')
+    assert.equal(getRoutePatternParts(parsePattern('http(s)://')).protocol, 'http(s)')
   })
 
   it('parses hostname', () => {

--- a/packages/route-pattern/src/lib/route-pattern/parse.ts
+++ b/packages/route-pattern/src/lib/route-pattern/parse.ts
@@ -1,6 +1,11 @@
 import { split, type Span } from './split.ts'
-import { RoutePattern } from '../route-pattern.ts'
-import type { PartPattern, PartPatternToken } from '../route-pattern.ts'
+import { createRoutePattern } from '../route-pattern.ts'
+import type {
+  ParsedRoutePattern,
+  PartPattern,
+  PartPatternToken,
+  RoutePattern,
+} from '../route-pattern.ts'
 import type { Mutable } from '../types/utils.ts'
 
 const IDENTIFIER_RE = /^[a-zA-Z_$][a-zA-Z_$0-9]*/
@@ -15,7 +20,7 @@ const IDENTIFIER_RE = /^[a-zA-Z_$][a-zA-Z_$0-9]*/
 export function parsePattern<source extends string>(source: source): RoutePattern<source> {
   let spans = split(source)
 
-  return new RoutePattern<source>({
+  return createRoutePattern<source>({
     protocol: parseProtocol(source, spans.protocol),
     hostname: parseHostname(source, spans.hostname),
     port: spans.port ? source.slice(...spans.port) : null,
@@ -118,7 +123,7 @@ export function parsePart(
   return { tokens, optionals, type: options.type }
 }
 
-function parseProtocol(source: string, span: Span | null): RoutePattern['protocol'] {
+function parseProtocol(source: string, span: Span | null): ParsedRoutePattern['protocol'] {
   if (!span) return null
   let protocol = source.slice(...span)
   if (protocol === '' || protocol === 'http' || protocol === 'https' || protocol === 'http(s)') {
@@ -127,7 +132,7 @@ function parseProtocol(source: string, span: Span | null): RoutePattern['protoco
   throw new ParseError('invalid protocol', source, span[0])
 }
 
-function parseHostname(source: string, span: Span | null): RoutePattern['hostname'] | null {
+function parseHostname(source: string, span: Span | null): ParsedRoutePattern['hostname'] | null {
   if (!span) return null
   let part = parsePart(source, { span, type: 'hostname' })
   if (isNamelessWildcard(part)) return null
@@ -141,7 +146,7 @@ function isNamelessWildcard(part: PartPattern): boolean {
   return token.name === '*'
 }
 
-function parseSearch(source: string): RoutePattern['search'] {
+function parseSearch(source: string): ParsedRoutePattern['search'] {
   let constraints = new Map<string, Set<string>>()
 
   let searchParams = new URLSearchParams(source)

--- a/packages/route-pattern/src/lib/route-pattern/serialize.test.ts
+++ b/packages/route-pattern/src/lib/route-pattern/serialize.test.ts
@@ -2,6 +2,7 @@ import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
 import { parsePattern } from './parse.ts'
+import { getRoutePatternParts } from '../route-pattern.ts'
 import {
   serializeHostname,
   serializePathname,
@@ -12,9 +13,13 @@ import {
   serializeSearch,
 } from './serialize.ts'
 
+function partsOf(source: string) {
+  return getRoutePatternParts(parsePattern(source))
+}
+
 describe('serializePattern', () => {
   function assertRoundTrip(source: string, expected?: string) {
-    assert.equal(serializePattern(parsePattern(source)), expected ?? source)
+    assert.equal(serializePattern(partsOf(source)), expected ?? source)
   }
 
   it('reconstructs pathname only', () => {
@@ -56,7 +61,7 @@ describe('serializePattern', () => {
 
 describe('serializeProtocol', () => {
   function protocolOf(source: string) {
-    return serializeProtocol(parsePattern(source))
+    return serializeProtocol(partsOf(source))
   }
 
   it('returns protocol or empty string', () => {
@@ -70,7 +75,7 @@ describe('serializeProtocol', () => {
 
 describe('serializeHostname', () => {
   function hostnameOf(source: string) {
-    return serializeHostname(parsePattern(source))
+    return serializeHostname(partsOf(source))
   }
 
   it('returns hostname or empty string', () => {
@@ -93,7 +98,7 @@ describe('serializeHostname', () => {
 
 describe('serializePort', () => {
   function portOf(source: string) {
-    return serializePort(parsePattern(source))
+    return serializePort(partsOf(source))
   }
 
   it('returns port or empty string', () => {
@@ -106,7 +111,7 @@ describe('serializePort', () => {
 
 describe('serializePathname', () => {
   function pathnameOf(source: string) {
-    return serializePathname(parsePattern(source))
+    return serializePathname(partsOf(source))
   }
 
   it('returns pathname or empty string', () => {
@@ -138,7 +143,7 @@ describe('serializePathname', () => {
 
 describe('serializeSearch', () => {
   function searchOf(source: string) {
-    return serializeSearch(parsePattern(source))
+    return serializeSearch(partsOf(source))
   }
 
   it('returns search or empty string', () => {
@@ -156,9 +161,7 @@ describe('serializeSearch', () => {
 describe('serializePatternParts', () => {
   it('returns each helper as a single object', () => {
     assert.deepEqual(
-      serializePatternParts(
-        parsePattern('https://api.example.com:8000/v1/:resource?filter=active'),
-      ),
+      serializePatternParts(partsOf('https://api.example.com:8000/v1/:resource?filter=active')),
       {
         protocol: 'https',
         hostname: 'api.example.com',

--- a/packages/route-pattern/src/lib/route-pattern/serialize.ts
+++ b/packages/route-pattern/src/lib/route-pattern/serialize.ts
@@ -1,7 +1,7 @@
-import type { PartPattern, RoutePattern } from '../route-pattern.ts'
+import type { ParsedRoutePattern, PartPattern } from '../route-pattern.ts'
 import { unreachable } from '../unreachable.ts'
 
-export function serializePattern(pattern: RoutePattern): string {
+export function serializePattern(pattern: ParsedRoutePattern): string {
   let protocol = serializeProtocol(pattern)
   let hostname = serializeHostname(pattern)
   let port = serializePort(pattern)
@@ -17,7 +17,7 @@ export function serializePattern(pattern: RoutePattern): string {
   return result
 }
 
-export function serializePatternParts(pattern: RoutePattern): {
+export function serializePatternParts(pattern: ParsedRoutePattern): {
   protocol: string
   hostname: string
   port: string
@@ -33,23 +33,23 @@ export function serializePatternParts(pattern: RoutePattern): {
   }
 }
 
-export function serializeProtocol(pattern: RoutePattern): string {
+export function serializeProtocol(pattern: ParsedRoutePattern): string {
   return pattern.protocol ?? ''
 }
 
-export function serializeHostname(pattern: RoutePattern): string {
+export function serializeHostname(pattern: ParsedRoutePattern): string {
   return pattern.hostname ? serializePart(pattern.hostname) : ''
 }
 
-export function serializePort(pattern: RoutePattern): string {
+export function serializePort(pattern: ParsedRoutePattern): string {
   return pattern.port ?? ''
 }
 
-export function serializePathname(pattern: RoutePattern): string {
+export function serializePathname(pattern: ParsedRoutePattern): string {
   return serializePart(pattern.pathname)
 }
 
-export function serializeSearch(pattern: RoutePattern): string {
+export function serializeSearch(pattern: ParsedRoutePattern): string {
   if (pattern.search.size === 0) return ''
   let searchParams = new URLSearchParams()
   for (let [key, constraint] of pattern.search) {

--- a/packages/route-pattern/src/lib/specificity.ts
+++ b/packages/route-pattern/src/lib/specificity.ts
@@ -1,4 +1,5 @@
-import type { RoutePattern } from './route-pattern.ts'
+import { getRoutePatternParts } from './route-pattern.ts'
+import type { ParsedRoutePattern } from './route-pattern.ts'
 import type { Match } from './match/types.ts'
 import { decodeHostname } from './match/decode.ts'
 
@@ -73,7 +74,10 @@ export function compare(a: Match, b: Match): -1 | 0 | 1 {
   let pathnameResult = comparePathname(a.paramsMeta.pathname, b.paramsMeta.pathname)
   if (pathnameResult !== 0) return pathnameResult
 
-  let searchResult = compareSearch(a.pattern.search, b.pattern.search)
+  let searchResult = compareSearch(
+    getRoutePatternParts(a.pattern).search,
+    getRoutePatternParts(b.pattern).search,
+  )
   if (searchResult !== 0) return searchResult
 
   return 0
@@ -161,7 +165,10 @@ function comparePathname(
   return 0
 }
 
-function compareSearch(a: RoutePattern['search'], b: RoutePattern['search']): -1 | 0 | 1 {
+function compareSearch(
+  a: ParsedRoutePattern['search'],
+  b: ParsedRoutePattern['search'],
+): -1 | 0 | 1 {
   let aSpecificity = searchSpecificity(a)
   let bSpecificity = searchSpecificity(b)
 
@@ -174,7 +181,7 @@ function compareSearch(a: RoutePattern['search'], b: RoutePattern['search']): -1
   return 0
 }
 
-function searchSpecificity(constraints: RoutePattern['search']): {
+function searchSpecificity(constraints: ParsedRoutePattern['search']): {
   key: number
   keyValue: number
 } {

--- a/packages/route-pattern/src/match.ts
+++ b/packages/route-pattern/src/match.ts
@@ -1,3 +1,3 @@
 export { createMatcher, createMultiMatcher } from './lib/match.ts'
-export type { Match, MatchParams } from './lib/match/types.ts'
+export type { Match, MatchParamMeta, MatchParams } from './lib/match/types.ts'
 export type { Matcher, MatcherOptions, MultiMatcher } from './lib/match.ts'

--- a/packages/route-pattern/src/route-pattern.ts
+++ b/packages/route-pattern/src/route-pattern.ts
@@ -1,2 +1,3 @@
-export { RoutePattern } from './lib/route-pattern.ts'
+export { getRoutePatternParams, RoutePattern } from './lib/route-pattern.ts'
+export type { RoutePatternJSON, RoutePatternParam } from './lib/route-pattern.ts'
 export { ParseError } from './lib/route-pattern/parse.ts'


### PR DESCRIPTION
This makes `RoutePattern` an opaque, nominal parsed-pattern handle while preserving the no-reparse path for internals such as `joinPatterns()`.

- Hides parsed route-pattern parts behind internal storage and removes public parsed-AST construction
- Adds internal helpers for creating and reading parsed parts without serializing/reparsing existing `RoutePattern` values
- Brands `RoutePattern<source>` so incompatible parsed pattern sources are not structurally assignable
- Adds `getRoutePatternParams()` plus public support types for stable param introspection
- Moves the assets package off `pattern.pathname.tokens`
- Keeps generated href/matcher/join inference tied to the actual parsed pattern source

Closes the first PR checkbox in #11556.
