### PR TITLE
Align route pattern helper types with runtime grammar

### DIFF
--- a/packages/route-pattern/.changes/patch.type-grammar.md
+++ b/packages/route-pattern/.changes/patch.type-grammar.md
@@ -1,0 +1,1 @@
+Fixed route pattern helper types so literal pattern types follow the same grammar as runtime parsing. Invalid literal patterns now evaluate to `never` in `CreateHrefArgs`, `MatchParams`, and `JoinPatterns`, while broad `string` patterns remain usable.

--- a/packages/route-pattern/src/lib/href.test.ts
+++ b/packages/route-pattern/src/lib/href.test.ts
@@ -45,6 +45,7 @@ describe('createHref', () => {
 
       it('throws when port specified', () => {
         let pattern = '://:8080/path' as const
+        // @ts-expect-error - missing hostname
         assert.throws(() => createHref(pattern), hrefError('missing-hostname'))
       })
     })

--- a/packages/route-pattern/src/lib/href.ts
+++ b/packages/route-pattern/src/lib/href.ts
@@ -10,7 +10,12 @@ import type { Simplify } from './types/utils.ts'
 import { unreachable } from './unreachable.ts'
 
 /** Tuple of arguments accepted by `createHref` for a given pattern source. */
-export type CreateHrefArgs<source extends string> = _CreateHrefArgs<ParseHrefParams<source>>
+export type CreateHrefArgs<source extends string> =
+  ParseHrefParams<source> extends infer params
+    ? [params] extends [never]
+      ? never
+      : _CreateHrefArgs<params>
+    : never
 
 // prettier-ignore
 type _CreateHrefArgs<params> =
@@ -26,12 +31,15 @@ type SearchParams = Record<
 
 // prettier-ignore
 type ParseHrefParams<source extends string> =
-  Split<source> extends infer split extends SplitPattern ?
+  Split<source> extends infer split ?
+    split extends never ? never :
+    split extends SplitPattern ?
     split extends ({ protocol: string, hostname: undefined } | { hostname: undefined, port: string }) ? never :
-    ParseParams<split> extends infer params extends Record<string, string | undefined> ?
+    ParseParams<source> extends infer params extends Record<string, string | undefined> ?
       params extends { '*': string } ? never :
       Optionalize<Omit<params, '*'>>
     :
+    never :
     never
   :
   never

--- a/packages/route-pattern/src/lib/match/types.ts
+++ b/packages/route-pattern/src/lib/match/types.ts
@@ -1,10 +1,14 @@
 import type { RoutePattern } from '../route-pattern.ts'
 import type { ParseParams } from '../types/params.ts'
-import type { Split } from '../types/split.ts'
 import type { Simplify } from '../types/utils.ts'
 
 /** Params extracted from a route pattern match. */
-export type MatchParams<source extends string> = Simplify<Omit<ParseParams<Split<source>>, '*'>>
+export type MatchParams<source extends string> =
+  ParseParams<source> extends infer params
+    ? [params] extends [never]
+      ? never
+      : Simplify<Omit<params, '*'>>
+    : never
 
 export type MatchParamMeta = {
   type: ':' | '*'

--- a/packages/route-pattern/src/lib/types/join.test.ts
+++ b/packages/route-pattern/src/lib/types/join.test.ts
@@ -10,9 +10,11 @@ export type Tests = [
   Assert<IsEqual<JoinPatterns<'', 'hello'>, '/hello'>>,
 
   // input origin overrides base origin
-  Assert<IsEqual<JoinPatterns<'http://example.com:8080', 'https://remix.run'>, 'https://remix.run/'>>,
-  Assert<IsEqual<JoinPatterns<'http://example.com:8080', '://remix.run'>, '://remix.run/'>>,
-  Assert<IsEqual<JoinPatterns<'http://example.com', '://remix.run:8080'>, '://remix.run:8080/'>>,
+  Assert<IsEqual<JoinPatterns<'http://example.com:8080', 'https://remix.run'>, 'https://remix.run:8080/'>>,
+  Assert<IsEqual<JoinPatterns<'http://example.com:8080', '://remix.run'>, 'http://remix.run:8080/'>>,
+  Assert<IsEqual<JoinPatterns<'http://example.com', '://remix.run:8080'>, 'http://remix.run:8080/'>>,
+  Assert<IsEqual<JoinPatterns<'https://example.com:8080/base', 'http:///next'>, 'http://example.com:8080/base/next'>>,
+  Assert<IsEqual<JoinPatterns<'/base', ':proto://example.com/path'>, never>>,
 
   // base origin used when input has none
   Assert<IsEqual<JoinPatterns<'https://remix.run', 'api'>, 'https://remix.run/api'>>,

--- a/packages/route-pattern/src/lib/types/join.ts
+++ b/packages/route-pattern/src/lib/types/join.ts
@@ -2,22 +2,32 @@ import type { Parse, ParsedPattern, Separator, Token } from './parse.ts'
 import type { StartsWithSeparator, Stringify } from './stringify.ts'
 
 /** Join two pattern source strings together at the type level. */
-export type JoinPatterns<A extends string, B extends string> = _JoinPatterns<Parse<A>, Parse<B>>
+export type JoinPatterns<A extends string, B extends string> = string extends A | B
+  ? string
+  : _JoinPatterns<Parse<A>, Parse<B>>
 
-type _JoinPatterns<A extends ParsedPattern, B extends ParsedPattern> = Stringify<{
-  protocol: JoinOriginField<A, B, 'protocol'>
-  hostname: JoinOriginField<A, B, 'hostname'>
-  port: JoinOriginField<A, B, 'port'>
-  pathname: JoinPathnames<A['pathname'], B['pathname']>
-  search: JoinSearch<A['search'], B['search']>
-}>
+// prettier-ignore
+type _JoinPatterns<A, B> =
+  A extends never ? never :
+  B extends never ? never :
+  A extends ParsedPattern ?
+    B extends ParsedPattern ?
+      Stringify<{
+        protocol: JoinOriginField<A, B, 'protocol'>
+        hostname: JoinOriginField<A, B, 'hostname'>
+        port: JoinOriginField<A, B, 'port'>
+        pathname: JoinPathnames<A['pathname'], B['pathname']>
+        search: JoinSearch<A['search'], B['search']>
+      }> :
+      never :
+    never
 
 // prettier-ignore
 type JoinOriginField<
   A extends ParsedPattern,
   B extends ParsedPattern,
   Field extends 'protocol' | 'hostname' | 'port'
-> = B['hostname'] extends Token[] ? B[Field] : A[Field]
+> = B[Field] extends undefined ? A[Field] : B[Field]
 
 // prettier-ignore
 type JoinPathnames<A extends Token[] | undefined, B extends Token[] | undefined> =

--- a/packages/route-pattern/src/lib/types/params.test.ts
+++ b/packages/route-pattern/src/lib/types/params.test.ts
@@ -1,5 +1,30 @@
 import type { Assert, IsEqual } from '../types/utils.ts'
+import type { CreateHrefArgs } from '../href.ts'
+import type { JoinPatterns } from '../types/join.ts'
 import type { MatchParams } from '../match/types.ts'
+
+type AcceptsCreateHrefArgs<source extends string, args extends CreateHrefArgs<source>> = args
+
+type _RequiredHrefArgs = [
+  AcceptsCreateHrefArgs<'/posts/:id', [{ id: '123' }]>,
+  AcceptsCreateHrefArgs<'/posts/:id', [{ id: 123; extra: true }]>,
+]
+
+// @ts-expect-error - required id param is missing
+type _MissingRequiredHrefArgs = AcceptsCreateHrefArgs<'/posts/:id', []>
+
+type _OptionalHrefArgs = [
+  AcceptsCreateHrefArgs<'/posts(/:id)', []>,
+  AcceptsCreateHrefArgs<'/posts(/:id)', [null]>,
+  AcceptsCreateHrefArgs<'/posts(/:id)', [{ id: null }]>,
+  AcceptsCreateHrefArgs<'/posts(/:id)', [{ id: 123 }]>,
+]
+
+// @ts-expect-error - explicit protocol without hostname cannot generate an href
+type _ProtocolWithoutHostnameHrefArgs = AcceptsCreateHrefArgs<'http:///posts/:id', [{ id: '123' }]>
+
+// @ts-expect-error - dynamic protocols are invalid
+type _DynamicProtocolHrefArgs = AcceptsCreateHrefArgs<':proto://example.com/path', []>
 
 // prettier-ignore
 export type Tests = [
@@ -77,6 +102,16 @@ export type Tests = [
 
   Assert<IsEqual<
     MatchParams<':proto://example.com/path'>,
+    never
+  >>,
+
+  Assert<IsEqual<
+    MatchParams<'http:///posts/:id'>,
+    { id: string }
+  >>,
+
+  Assert<IsEqual<
+    MatchParams<'https://'>,
     {}
   >>,
 
@@ -102,5 +137,36 @@ export type Tests = [
   Assert<IsEqual<
     MatchParams<'files(/*(.:ext))'>,
     { ext: string | undefined }
+  >>,
+
+  // Public helper type surfaces
+  Assert<IsEqual<
+    CreateHrefArgs<'http:///posts/:id'>,
+    never
+  >>,
+
+  Assert<IsEqual<
+    CreateHrefArgs<'http://'>,
+    never
+  >>,
+
+  Assert<IsEqual<
+    CreateHrefArgs<':proto://example.com/path'>,
+    never
+  >>,
+
+  Assert<IsEqual<
+    JoinPatterns<'/posts/:postId', '/comments/:commentId'>,
+    '/posts/:postId/comments/:commentId'
+  >>,
+
+  Assert<IsEqual<
+    JoinPatterns<'https://example.com:8080/base', 'http:///next'>,
+    'http://example.com:8080/base/next'
+  >>,
+
+  Assert<IsEqual<
+    JoinPatterns<'/base', ':proto://example.com/path'>,
+    never
   >>
 ]

--- a/packages/route-pattern/src/lib/types/params.ts
+++ b/packages/route-pattern/src/lib/types/params.ts
@@ -1,65 +1,29 @@
-import type { SplitPattern } from './split.ts'
+import type { Parse, Token } from './parse.ts'
 
 // prettier-ignore
-export type ParseParams<split extends SplitPattern> =
-  split extends { hostname: infer hostname, pathname: infer pathname } ?
-    & (hostname extends string ? ParsePartParams<hostname> : {})
-    & (pathname extends string ? ParsePartParams<pathname> : {})
-  :
+export type ParseParams<source extends string> =
+  string extends source ? Record<string, string | undefined> :
+  Parse<source> extends infer pattern ?
+    pattern extends never ? never :
+    pattern extends { hostname: infer hostname, pathname: infer pathname } ?
+      & (hostname extends Token[] ? ParsePartParams<hostname> : {})
+      & (pathname extends Token[] ? ParsePartParams<pathname> : {}) :
+    never :
   never
 
 // prettier-ignore
-type ParsePartParams<source, stack extends Array<null> = []> =
-  string extends source ? Record<string, string | undefined> :
-  source extends `${infer char extends '\\' | ':' | '*' | '(' | ')'}${infer rest}` ?
-    char extends '\\' ?
-      rest extends `${string}${infer rest}` ?
-        ParsePartParams<rest, stack> :
-        never
-    :
-    char extends ':' ?
-      IdentifierParse<rest> extends { identifier: infer name extends string, rest: infer rest } ?
-        Param<name, stack> & ParsePartParams<rest, stack>
-      :
-      never
-    :
-    char extends '*' ?
-      IdentifierParse<rest> extends { identifier: infer name extends string, rest: infer rest } ?
-        Param<name extends '' ? '*' : name, stack> & ParsePartParams<rest, stack>
-      :
-      never
-    :
-    char extends '(' ? ParsePartParams<rest, [...stack, null]> :
-    char extends ')' ?
-      stack extends [null, ...infer tail extends Array<null>] ?
-        ParsePartParams<rest, tail> :
-        never
-    :
-    never
-  :
-  source extends `${string}${infer rest}` ? ParsePartParams<rest, stack> :
+type ParsePartParams<tokens extends Token[], optional extends boolean = false> =
+  Token[] extends tokens ? Record<string, string | undefined> :
+  tokens extends [infer token extends Token, ...infer rest extends Token[]] ?
+    token extends { type: 'variable' | 'wildcard', name: infer name extends string } ?
+      Param<name, optional> & ParsePartParams<rest, optional> :
+    token extends { type: 'wildcard' } ?
+      Param<'*', optional> & ParsePartParams<rest, optional> :
+    token extends { type: 'optional', tokens: infer optionalTokens extends Token[] } ?
+      ParsePartParams<optionalTokens, true> & ParsePartParams<rest, optional> :
+    ParsePartParams<rest, optional> :
   {}
 
-type Param<name extends string, stack extends Array<null>> = stack extends []
+type Param<name extends string, optional extends boolean> = optional extends false
   ? { [key in name]: string }
   : { [key in name]: string | undefined }
-
-type IdentifierHead = a_z | A_Z | '_' | '$'
-type IdentifierTail = IdentifierHead | _0_9
-
-type IdentifierParse<source extends string> = _IdentifierParse<{ identifier: ''; rest: source }>
-
-// prettier-ignore
-type _IdentifierParse<state extends { identifier: string, rest: string }> =
-  state extends { identifier: '', rest: `${infer head extends IdentifierHead}${infer tail}` } ?
-    _IdentifierParse<{ identifier: head, rest: tail }>
-  :
-  state extends { identifier: string, rest: `${infer head extends IdentifierTail}${infer rest}`} ?
-    _IdentifierParse<{ identifier: `${state['identifier']}${head}`, rest: rest }>
-  :
-  state
-
-// prettier-ignore
-type a_z = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z'
-type A_Z = Uppercase<a_z>
-type _0_9 = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'

--- a/packages/route-pattern/src/lib/types/parse.test.ts
+++ b/packages/route-pattern/src/lib/types/parse.test.ts
@@ -487,9 +487,9 @@ export type Tests = [
   >,
   Assert<
     IsEqual<
-      Parse<':protocol://:subdomain.example.com:8080/api/v:version/users/:id?format=json'>,
+      Parse<'http(s)://:subdomain.example.com:8080/api/v:version/users/:id?format=json'>,
       {
-        protocol: [{ type: 'variable'; name: 'protocol' }]
+        protocol: [{ type: 'text'; value: 'http(s)' }]
         hostname: [
           { type: 'variable'; name: 'subdomain' },
           { type: 'separator' },
@@ -512,6 +512,62 @@ export type Tests = [
       }
     >
   >,
+  Assert<
+    IsEqual<
+      Parse<'http:///path'>,
+      {
+        protocol: [{ type: 'text'; value: 'http' }]
+        hostname: undefined
+        port: undefined
+        pathname: [{ type: 'text'; value: 'path' }]
+        search: undefined
+      }
+    >
+  >,
+  Assert<
+    IsEqual<
+      Parse<'https://'>,
+      {
+        protocol: [{ type: 'text'; value: 'https' }]
+        hostname: undefined
+        port: undefined
+        pathname: undefined
+        search: undefined
+      }
+    >
+  >,
+  Assert<IsEqual<Parse<':protocol://example.com'>, never>>,
+  Assert<IsEqual<Parse<'ftp://example.com'>, never>>,
+  Assert<IsEqual<Parse<'httpx://example.com'>, never>>,
+  Assert<
+    IsEqual<
+      Parse<'://:8080/users'>,
+      {
+        protocol: undefined
+        hostname: undefined
+        port: '8080'
+        pathname: [{ type: 'text'; value: 'users' }]
+        search: undefined
+      }
+    >
+  >,
+  Assert<
+    IsEqual<
+      Parse<'http://:80/users'>,
+      {
+        protocol: [{ type: 'text'; value: 'http' }]
+        hostname: undefined
+        port: '80'
+        pathname: [{ type: 'text'; value: 'users' }]
+        search: undefined
+      }
+    >
+  >,
+  Assert<IsEqual<Parse<':'>, never>>,
+  Assert<IsEqual<Parse<'/posts/:'>, never>>,
+  Assert<IsEqual<Parse<'/posts/\\'>, never>>,
+  Assert<IsEqual<Parse<'/posts/(new'>, never>>,
+  Assert<IsEqual<Parse<'/posts/new)'>, never>>,
 
   // nested optionals (successful parses)
   Assert<

--- a/packages/route-pattern/src/lib/types/parse.ts
+++ b/packages/route-pattern/src/lib/types/parse.ts
@@ -11,17 +11,58 @@ export interface ParsedPattern {
 
 // prettier-ignore
 export type Parse<T extends string> =
+  string extends T ? ParsedPattern :
   T extends ForceDistributive ?
     Split<T> extends infer S extends SplitPattern ?
-      {
-        protocol: S['protocol'] extends string ? ParsePart<S['protocol']> : undefined
-        hostname: S['hostname'] extends string ? ParsePart<S['hostname'], '.'> : undefined
-        port: S['port'] extends string ? S['port'] : undefined
-        pathname: S['pathname'] extends string ? ParsePart<S['pathname'], '/'> : undefined
-        search: S['search'] extends string ? S['search'] : undefined
-      } :
+      ParseSplit<S> :
       never :
     never
+
+// prettier-ignore
+type ParseSplit<S extends SplitPattern> =
+  S['protocol'] extends string ?
+    ParseProtocol<S['protocol']> extends infer protocol ?
+      [protocol] extends [never] ? never :
+      protocol extends Token[] | undefined ? ParseParts<S, protocol> : never :
+    never :
+    ParseParts<S, undefined>
+
+// prettier-ignore
+type ParseParts<S extends SplitPattern, protocol extends Token[] | undefined> =
+  ParseMaybePart<S['hostname'], '.'> extends infer hostname ?
+    [hostname] extends [never] ? never :
+    hostname extends Token[] | undefined ?
+      ParseMaybePart<S['pathname'], '/'> extends infer pathname ?
+        [pathname] extends [never] ? never :
+        pathname extends Token[] | undefined ?
+          Parsed<S, protocol, hostname, pathname> :
+          never :
+      never :
+    never :
+  never
+
+// prettier-ignore
+type ParseMaybePart<T, Sep extends string> =
+  T extends string ? ParsePart<T, Sep> : undefined
+
+type Parsed<
+  S extends SplitPattern,
+  protocol extends Token[] | undefined,
+  hostname extends Token[] | undefined,
+  pathname extends Token[] | undefined,
+> = {
+  protocol: protocol
+  hostname: hostname
+  port: S['port'] extends string ? S['port'] : undefined
+  pathname: pathname
+  search: S['search'] extends string ? S['search'] : undefined
+}
+
+// prettier-ignore
+type ParseProtocol<T extends string> =
+  T extends '' ? undefined :
+  T extends 'http' | 'https' | 'http(s)' ? [{ type: 'text'; value: T }] :
+  never
 
 export type Variable = { type: 'variable'; name: string }
 export type Wildcard = { type: 'wildcard'; name?: string }

--- a/packages/route-pattern/src/lib/types/split.test.ts
+++ b/packages/route-pattern/src/lib/types/split.test.ts
@@ -90,4 +90,22 @@ export type Tests = [
     Split<'/path/:id?q=1'>,
     { protocol: undefined; hostname: undefined; port: undefined; pathname: 'path/:id'; search: 'q=1' }
   >>,
+
+  // protocol + no hostname
+  Assert<IsEqual<
+    Split<'http://'>,
+    { protocol: 'http'; hostname: undefined; port: undefined; pathname: undefined; search: undefined }
+  >>,
+  Assert<IsEqual<
+    Split<'https://'>,
+    { protocol: 'https'; hostname: undefined; port: undefined; pathname: undefined; search: undefined }
+  >>,
+  Assert<IsEqual<
+    Split<'http:///path'>,
+    { protocol: 'http'; hostname: undefined; port: undefined; pathname: 'path'; search: undefined }
+  >>,
+  Assert<IsEqual<
+    Split<'https:///path'>,
+    { protocol: 'https'; hostname: undefined; port: undefined; pathname: 'path'; search: undefined }
+  >>,
 ]

--- a/packages/route-pattern/src/lib/types/split.ts
+++ b/packages/route-pattern/src/lib/types/split.ts
@@ -23,11 +23,11 @@ type _Split<T extends string> =
   T extends `${infer L}?${infer R}` ? _Split<L> & { search: R } :
   T extends `${infer Protocol}://${infer R}` ?
     Protocol extends '' ? (
-      R extends `${infer Host}/${infer Pathname}` ? SplitHost<Host> & { pathname: Pathname } :
+      R extends `${infer Host}/${infer Pathname}` ? SplitHost<Host> & ToPathname<Pathname> :
       SplitHost<R>
     ) :
     Protocol extends `${string}/${string}` ? { pathname: T } :
-    R extends `${infer Host}/${infer Pathname}` ? SplitHost<Host> & { protocol: Protocol; pathname: Pathname } :
+    R extends `${infer Host}/${infer Pathname}` ? SplitHost<Host> & { protocol: Protocol } & ToPathname<Pathname> :
     SplitHost<R> & { protocol: Protocol } :
   T extends `/${infer Pathname}` ? { pathname: Pathname } :
   { pathname: T }
@@ -35,10 +35,13 @@ type _Split<T extends string> =
 // prettier-ignore
 type SplitHost<T extends string> =
   T extends `${infer L}:${infer R}` ?
-    IsDigits<R> extends true ? { hostname: L; port: R} :
+    IsDigits<R> extends true ? (L extends '' ? { port: R } : { hostname: L; port: R}) :
     SplitHost<R> extends { hostname: infer H extends string; port: infer P extends string } ? { hostname: `${L}:${H}`; port: P } :
     { hostname: T } :
+  T extends '' ? {} :
   { hostname: T }
+
+type ToPathname<T extends string> = T extends '' ? {} : { pathname: T }
 
 type _0_9 = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
 

--- a/packages/route-pattern/src/lib/types/stringify.test.ts
+++ b/packages/route-pattern/src/lib/types/stringify.test.ts
@@ -11,6 +11,8 @@ export type Tests = [
   Assert<IsEqual<Stringify<Parse<'hello/world?q=1&a=2'>>, '/hello/world?q=1&a=2'>>,
 
   Assert<IsEqual<Stringify<Parse<'http://example.com'>>, 'http://example.com/'>>,
+  Assert<IsEqual<Stringify<Parse<'http:///'>>, 'http:///'>>,
+  Assert<IsEqual<Stringify<Parse<'https:///path'>>, 'https:///path'>>,
   Assert<IsEqual<Stringify<Parse<'https://example.com/path'>>, 'https://example.com/path'>>,
   Assert<IsEqual<Stringify<Parse<'https://example.com/path?q=1'>>, 'https://example.com/path?q=1'>>,
   Assert<

--- a/packages/route-pattern/src/lib/types/stringify.ts
+++ b/packages/route-pattern/src/lib/types/stringify.ts
@@ -2,9 +2,17 @@ import type { ParsedPattern, Token } from './parse.ts'
 
 // prettier-ignore
 export type Stringify<T extends ParsedPattern> =
-  T['hostname'] extends Token[] ?
+  HasOrigin<T> extends true ?
     `${StringifyTokens<T['protocol'], ''>}://${StringifyTokens<T['hostname'], '.'>}${StringifyPort<T['port']>}${StringifyPathname<T['pathname']>}${StringifySearch<T['search']>}` :
     `${StringifyPathname<T['pathname']>}${StringifySearch<T['search']>}`
+
+type HasOrigin<T extends ParsedPattern> = T['protocol'] extends Token[]
+  ? true
+  : T['hostname'] extends Token[]
+    ? true
+    : T['port'] extends string
+      ? true
+      : false
 
 // prettier-ignore
 type StringifyTokens<T extends Token[] | undefined, Sep extends string> =

--- a/packages/route-pattern/src/lib/types/utils.ts
+++ b/packages/route-pattern/src/lib/types/utils.ts
@@ -7,10 +7,10 @@ export type Simplify<T> = { [K in keyof T]: T[K] } & {}
 
 /**
  * Forces TypeScript to distribute a conditional type over a union by
- * substituting `T extends ForceDistributive ? ... : ...` for the more cryptic
- * `T extends any ? ... : ...` pattern.
+ * substituting `T extends ForceDistributive ? ... : ...` for a bare
+ * `T extends unknown ? ... : ...` pattern.
  */
-export type ForceDistributive = any
+export type ForceDistributive = unknown
 
 /** Distributive utility for creating mutable versions of readonly union types. */
 export type Mutable<T> = T extends ForceDistributive ? { -readonly [K in keyof T]: T[K] } : never


### PR DESCRIPTION
Aligns the public route-pattern helper types with the grammar enforced by runtime parsing.

- Makes invalid literal patterns collapse to `never` through `CreateHrefArgs`, `MatchParams`, and `JoinPatterns`
- Keeps broad `string` patterns usable for dynamic inputs
- Validates protocol literals at the shared type parser layer, including rejecting dynamic protocols like `:proto://example.com`
- Preserves runtime-supported protocol-only match patterns such as `http:///path`, while keeping `createHref()` unable to generate origins without a concrete hostname
- Updates type tests for split, parse, params, href args, join, and stringify behavior

Part of #11556.
