### PR TITLE
Document route-pattern API and benchmarks

### DIFF
--- a/packages/route-pattern/CHANGELOG.md
+++ b/packages/route-pattern/CHANGELOG.md
@@ -689,7 +689,7 @@ This is the changelog for [`route-pattern`](https://github.com/remix-run/remix/t
   ```ts
   import * as Specificity from '@remix-run/route-pattern/specificity'
 
-  Specificity.lessThan(a, b) // `true` when `a` is more specific than `b`. `false` otherwise
+  Specificity.lessThan(a, b) // `true` when `a` is less specific than `b`. `false` otherwise
   Specificity.greaterThan(a, b)
   Specificity.equal(a, b)
 

--- a/packages/route-pattern/README.md
+++ b/packages/route-pattern/README.md
@@ -65,6 +65,8 @@ createHref('http(s)://:region.cdn.com/assets/*file.:ext', {
 
 For in-depth reference, visit the [`route-pattern` API docs](https://api.remix.run/api/remix/route-pattern)
 
+Examples in this README use `remix/route-pattern/*` imports. The same APIs are also available from the direct package entrypoints: `@remix-run/route-pattern`, `@remix-run/route-pattern/href`, `@remix-run/route-pattern/match`, `@remix-run/route-pattern/join`, and `@remix-run/route-pattern/specificity`.
+
 ## Pattern syntax
 
 ### Protocol
@@ -149,6 +151,8 @@ docsMatcher.match(url)?.params
 // Type safe params     ^? { tenant: string | undefined, path: string, ext: string } | undefined
 ```
 
+Matchers accept absolute URL strings or `URL` objects. Relative strings such as `/blog/v3` are not accepted because matching uses the platform `URL` parser; wrap relative paths with a known origin before matching them.
+
 ### Match against multiple patterns
 
 Use `createMultiMatcher` when you need to match many patterns and attach your own data to each match.
@@ -172,17 +176,38 @@ matcher.match('https://example.com/api/v2/users/profile')
 
 The matched pattern is only known at runtime, so matched `params` are not inferred when matching with `createMultiMatcher`.
 
+Each match returns:
+
+- `url`: the `URL` object that was matched
+- `pattern`: the matched `RoutePattern`
+- `data`: the data attached with `matcher.add(pattern, data)`
+- `params`: captured param values
+- `paramsMeta`: hostname and pathname param metadata
+
+`paramsMeta.hostname` and `paramsMeta.pathname` are arrays of `{ type, name, value, begin, end }` entries. The offsets are measured after URL normalization. A pattern with no hostname matches any hostname, represented in `paramsMeta.hostname` as an unnamed wildcard entry.
+
+Set `ignoreCase: true` to make pathname matching case-insensitive. Hostname matching is always case-insensitive, and search constraints are always case-sensitive.
+
+```ts
+let matcher = createMatcher('/Docs/:slug', { ignoreCase: true })
+
+matcher.match('https://example.com/docs/Intro')?.params
+// { slug: 'Intro' }
+```
+
 ### Ranking matches by specificity
 
 When multiple patterns match the same URL, `route-pattern` chooses the most specific match deterministically. Matches are ranked left-to-right, character-by-character:
 
+- Explicit protocol and port constraints are more specific than omitted constraints.
+- Static hostnames are more specific than dynamic hostnames, which are more specific than omitted hostnames.
 - Static characters are more specific than variables.
 - Variables are more specific than wildcards.
 - Earliest difference decides the winner.
 
 This is the same ranking used by `createMultiMatcher`.
 
-For advanced use cases, `/specificity` provides comparison utilities: `lessThan`, `greaterThan`, `equal`, `descending`, `ascending`, `compare`. For example:
+For advanced use cases, `/specificity` provides comparison utilities: `lessThan`, `greaterThan`, `equal`, `descending`, `ascending`, `compare`. `lessThan(a, b)` returns `true` when match `a` is less specific than match `b`. For example:
 
 ```ts
 import { createMultiMatcher } from 'remix/route-pattern/match'
@@ -226,6 +251,10 @@ createHref('blog/:slug?ref=docs', { slug: 'v3' }, { utm_source: 'newsletter' })
 // '/blog/v3?utm_source=newsletter&ref=docs'
 ```
 
+`createHref()` throws `CreateHrefError` when it cannot safely generate an href. The error exposes stable structured details on `error.details`; the string message is for humans.
+
+Common failures include missing required params, nameless wildcards, invalid hostname params, empty pathname variables, and origin patterns that specify a protocol or port without a concrete hostname.
+
 **Note:** optional groups without params are included in the generated href:
 
 ```ts
@@ -263,6 +292,15 @@ getRoutePatternParams(pattern)
 All APIs that take a `pattern` arg accept `string` or a parsed `RoutePattern`.
 
 **TIP:** For high-performance scenarios, you can parse patterns ahead of time to avoid reparsing them on every call.
+
+`RoutePattern.toJSON()` returns a `RoutePatternJSON` object with serialized `protocol`, `hostname`, `port`, `pathname`, and `search` fields. `RoutePattern.parse()` throws `ParseError` for malformed sources; the error exposes stable `type`, `source`, and `index` fields.
+
+The public support types are:
+
+- `RoutePatternParam` from `remix/route-pattern`
+- `RoutePatternJSON` from `remix/route-pattern`
+- `CreateHrefErrorDetails` from `remix/route-pattern/href`
+- `MatchParamMeta` from `remix/route-pattern/match`
 
 ## Combine patterns
 

--- a/packages/route-pattern/bench/README.md
+++ b/packages/route-pattern/bench/README.md
@@ -1,11 +1,16 @@
 # Benchmarks
 
-## Runtime benchmarks
+The route-pattern benchmarks live in [src/](./src/) and use Vitest's `.bench.ts` runner. Match benchmarks cover two modes:
 
-Runtime benchmarks are in [src/](./src/) and use `.bench.ts` suffix.
+- `server`: build each matcher once, then repeatedly match URLs. This measures hot matching.
+- `lambda`: build each matcher inside the benchmark body, then match one URL. This measures cold construction plus one match.
+
+Match benchmarks verify correctness before timing. Every adapter must agree on match/no-match. Adapters that expose route-pattern's full match surface also verify the selected pattern, params, attached data, and `matchAll()` ranking. `matchAll()` verification dedupes repeated optional variants that come from the same inserted pattern.
+
+## Runtime Benchmarks
 
 ```sh
-# All benchmarks
+# All runtime benchmarks
 pnpm bench
 
 # Specific benchmark
@@ -13,10 +18,10 @@ pnpm bench src/match/shopify.bench.ts # full name
 pnpm bench shopify                    # pattern match
 ```
 
-### Compare performance across branches
+### Compare Performance Across Branches
 
-```bash
-# Create baseline against another branch (e.g. `main`)
+```sh
+# Create baseline against another branch, such as main
 git checkout main
 pnpm bench --outputJson=main.json
 
@@ -25,11 +30,72 @@ git checkout feature-branch
 pnpm bench --compare=main.json
 ```
 
-## Type benchmarks
+## Latest Evidence
+
+These results were recorded on June 18, 2026 from the `mjackson/route-pattern-docs-validation` working tree based on commit `03a2f1579`.
+
+- Machine: Apple M5 Pro
+- OS: macOS 26.3.2 (25D2150)
+- Node: v24.15.0
+- pnpm: 10.34.2
+- Vitest: 4.1.6
+
+Commands:
+
+```sh
+pnpm --dir packages/route-pattern/bench bench src/match/common.bench.ts
+pnpm --dir packages/route-pattern/bench bench src/match/shopify.bench.ts
+pnpm --dir packages/route-pattern/bench bench src/match/pathological.bench.ts
+pnpm --dir packages/route-pattern/bench bench src/href.bench.ts
+```
+
+### Match Benchmarks
+
+| Benchmark    | Patterns | URLs | Mode   | Matcher       |       Mean |       RME | Samples |
+| ------------ | -------: | ---: | ------ | ------------- | ---------: | --------: | ------: |
+| Common       |       10 |  160 | server | route-pattern |  0.0005 ms |  +/-0.29% | 976,864 |
+| Common       |       10 |  160 | lambda | route-pattern |  0.0416 ms | +/-12.19% |  12,013 |
+| Common       |      100 |  160 | server | route-pattern |  0.0005 ms |  +/-0.31% | 914,153 |
+| Common       |      100 |  160 | lambda | route-pattern |  0.3893 ms | +/-22.66% |   1,285 |
+| Common       |    1,000 |  160 | server | route-pattern |  0.0006 ms |  +/-0.38% | 906,516 |
+| Common       |    1,000 |  160 | lambda | route-pattern |  4.0664 ms | +/-20.86% |     123 |
+| Common       |    5,000 |  160 | server | route-pattern |  0.0006 ms |  +/-3.63% | 874,243 |
+| Common       |    5,000 |  160 | lambda | route-pattern | 19.7840 ms | +/-18.53% |      28 |
+| Shopify      |    2,506 |   29 | server | route-pattern |  0.0010 ms |  +/-0.25% | 509,489 |
+| Shopify      |    2,506 |   29 | lambda | route-pattern |  9.8376 ms | +/-10.38% |      51 |
+| Pathological |    1,509 |   46 | server | route-pattern |  0.0306 ms |  +/-0.68% |  16,320 |
+| Pathological |    1,509 |   46 | lambda | route-pattern |  6.6835 ms |  +/-9.52% |      76 |
+
+The `common` benchmark is limited to patterns all adapters can represent. In that benchmark, `find-my-way` is fastest for hot matching and `path-to-regexp` is fastest for cold construction plus one match. `route-pattern` stays nearly flat in hot matching from 10 through 5,000 patterns because matching uses the trie, while cold construction scales with pattern count.
+
+The `shopify` benchmark uses 2,506 production-like pathname patterns. In hot matching, `route-pattern` averaged 0.0010 ms per operation, about 59x faster than `path-to-regexp` and about 1,122x faster than the route-pattern array matcher. In cold construction plus one match, `path-to-regexp` was about 2.06x faster than `route-pattern`.
+
+The `pathological` benchmark uses route-pattern-only features such as hostnames, protocols, ports, search constraints, optionals, and wildcards, so it compares the trie matcher against the array matcher. The trie matcher was about 18.93x faster for hot matching and about 1.31x faster for cold construction plus one match.
+
+### Href Benchmarks
+
+All href benchmarks use parsed `RoutePattern` instances, so they measure href generation without parsing.
+
+| Case                     |      Mean |      RME |   Samples |
+| ------------------------ | --------: | -------: | --------: |
+| Static                   | 0.0001 ms | +/-0.55% | 8,275,198 |
+| One variable             | 0.0001 ms | +/-0.16% | 5,546,912 |
+| One wildcard             | 0.0002 ms | +/-0.03% | 2,908,522 |
+| Multiple variables       | 0.0001 ms | +/-0.08% | 3,528,344 |
+| Optional, all params     | 0.0001 ms | +/-1.39% | 4,394,848 |
+| Optional, omitted params | 0.0001 ms | +/-0.21% | 6,730,403 |
+| Complex, all params      | 0.0005 ms | +/-0.30% | 1,023,015 |
+| Complex, no optionals    | 0.0003 ms | +/-0.20% | 1,469,827 |
+| With search params       | 0.0004 ms | +/-0.22% | 1,286,260 |
+
+## Type Benchmarks
 
 Type benchmarks are in [src/types/](./src/types/) and use [ArkType Attest](https://github.com/arktypeio/arktype/blob/main/ark/attest/README.md).
 
 ```sh
-# Run type benchmarks directly with Node
+# Run all enabled type benchmarks
+pnpm bench:types
+
+# Run one type benchmark directly with Node
 node src/types/href.ts
 ```

--- a/packages/route-pattern/bench/package.json
+++ b/packages/route-pattern/bench/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "bench": "vitest bench --run",
-    "bench:types": "node bench.types.ts"
+    "bench:types": "node src/types/href.ts && node src/types/join.ts && node src/types/match.ts && node src/types/new.ts && node src/types/params.ts"
   },
   "dependencies": {
     "@remix-run/route-pattern": "workspace:^",

--- a/packages/route-pattern/bench/src/match/array-matcher.ts
+++ b/packages/route-pattern/bench/src/match/array-matcher.ts
@@ -8,35 +8,35 @@ import type { RoutePattern } from '@remix-run/route-pattern'
  *
  * Kept here in the bench project for benchmark comparison only.
  */
-export class ArrayMatcher implements MultiMatcher<unknown> {
+export class ArrayMatcher<data = unknown> implements MultiMatcher<data> {
   readonly ignoreCase: boolean
-  #patterns: Array<Matcher> = []
+  #patterns: Array<{ matcher: Matcher; data: data }> = []
 
   constructor(options?: { ignoreCase?: boolean }) {
     this.ignoreCase = options?.ignoreCase ?? false
   }
 
-  add(pattern: string | RoutePattern): void {
-    this.#patterns.push(createMatcher(pattern, { ignoreCase: this.ignoreCase }))
+  add(pattern: string | RoutePattern, data: data): void {
+    this.#patterns.push({ matcher: createMatcher(pattern, { ignoreCase: this.ignoreCase }), data })
   }
 
-  match(url: string | URL): Match<string> | null {
-    let bestMatch: Match<string> | null = null
+  match(url: string | URL): Match<string, data> | null {
+    let bestMatch: Match<string, data> | null = null
     for (let pattern of this.#patterns) {
-      let match = pattern.match(url)
+      let match = pattern.matcher.match(url)
       if (match && (bestMatch === null || Specificity.descending(match, bestMatch) < 0)) {
-        bestMatch = match
+        bestMatch = { ...match, data: pattern.data }
       }
     }
     return bestMatch
   }
 
-  matchAll(url: string | URL): Array<Match<string>> {
-    let matches: Array<Match<string>> = []
+  matchAll(url: string | URL): Array<Match<string, data>> {
+    let matches: Array<Match<string, data>> = []
     for (let pattern of this.#patterns) {
-      let match = pattern.match(url)
+      let match = pattern.matcher.match(url)
       if (match) {
-        matches.push(match)
+        matches.push({ ...match, data: pattern.data })
       }
     }
     return matches.sort(Specificity.descending)

--- a/packages/route-pattern/bench/src/match/matchers.ts
+++ b/packages/route-pattern/bench/src/match/matchers.ts
@@ -4,35 +4,43 @@ import { createMultiMatcher, type MultiMatcher } from '@remix-run/route-pattern/
 
 import { ArrayMatcher } from './array-matcher.ts'
 
+type BenchData = {
+  index: number
+  pattern: string
+}
+
 export let matchers = {
   routePattern: {
     name: 'route-pattern',
-    createMatcher: () => createMultiMatcher<null>(),
+    supportsDetailedVerification: true,
+    createMatcher: () => createMultiMatcher<BenchData>(),
   },
   routePatternArray: {
     name: 'route-pattern/array',
-    createMatcher: () => new ArrayMatcher(),
+    supportsDetailedVerification: true,
+    createMatcher: () => new ArrayMatcher<BenchData>(),
   },
   findMyWay: {
     name: 'find-my-way',
+    supportsDetailedVerification: false,
     createMatcher: () => {
       let router = FindMyWay()
       return {
         ignoreCase: false,
-        add(pattern: string) {
+        add(pattern: string, data: unknown) {
           let translated = pattern
             // optionals
             .replaceAll('(', '')
             .replaceAll(')', '?')
             // wildcards
             .replaceAll('*path', '*')
-          router.on('GET', translated, () => {}, null)
+          router.on('GET', translated, () => {}, data)
         },
         match(url: string | URL) {
           let pathname = typeof url === 'string' ? new URL(url).pathname : url.pathname
           let result = router.find('GET', pathname)
           if (!result) return null
-          return { params: result.params } as any
+          return { params: result.params, data: result.store } as any
         },
         matchAll(url: string | URL) {
           let result = this.match(url)
@@ -43,12 +51,13 @@ export let matchers = {
   },
   pathToRegexp: {
     name: 'path-to-regexp',
+    supportsDetailedVerification: false,
     createMatcher: () => {
-      let matchers: Array<ReturnType<typeof match>> = []
+      let matchers: Array<{ match: ReturnType<typeof match>; data: unknown }> = []
 
       return {
         ignoreCase: false,
-        add(pattern: string) {
+        add(pattern: string, data: unknown) {
           let translated = pattern
             // optionals
             .replaceAll('(', '{')
@@ -56,16 +65,16 @@ export let matchers = {
             // wildcards
             .replaceAll('*', '*path')
           let matchFn = match(translated, { decode: decodeURIComponent })
-          matchers.push(matchFn)
+          matchers.push({ match: matchFn, data })
           // Simulate arbitrary ordering of patterns
           matchers.reverse()
         },
         match(url: string | URL) {
           let pathname = typeof url === 'string' ? new URL(url).pathname : url.pathname
-          for (let match of matchers) {
-            let result = match(pathname)
+          for (let matcher of matchers) {
+            let result = matcher.match(pathname)
             if (result !== false) {
-              return { params: result.params } as any
+              return { params: result.params, data: matcher.data } as any
             }
           }
           return null
@@ -81,12 +90,7 @@ export let matchers = {
   string,
   {
     name: string
+    supportsDetailedVerification: boolean
     createMatcher: () => MultiMatcher<unknown>
-    // createMatcher: () => {
-    //   readonly ignoreCase: boolean
-    //   add(pattern: string, data: null): void
-    //   match(url: string | URL): Match<string, null> | null
-    //   matchAll(url: string | URL): Array<Match<string, null>>
-    // }
   }
 >

--- a/packages/route-pattern/bench/src/match/utils.ts
+++ b/packages/route-pattern/bench/src/match/utils.ts
@@ -1,9 +1,15 @@
 import { bench, describe } from 'vitest'
-import type { MultiMatcher } from '@remix-run/route-pattern/match'
+import type { Match, MultiMatcher } from '@remix-run/route-pattern/match'
 
 export type BenchMatcher = {
   name: string
+  supportsDetailedVerification?: boolean
   createMatcher: () => MultiMatcher<unknown>
+}
+
+type BenchData = {
+  index: number
+  pattern: string
 }
 
 type MatchBenchOptions<matcher extends BenchMatcher> = {
@@ -37,10 +43,10 @@ function createMatcher<matcher extends BenchMatcher>(
   matcher: matcher,
   patterns: ReadonlyArray<string>,
 ) {
-  let instance = matcher.createMatcher()
+  let instance = matcher.createMatcher() as MultiMatcher<BenchData>
 
-  for (let pattern of patterns) {
-    instance.add(pattern, null)
+  for (let [index, pattern] of patterns.entries()) {
+    instance.add(pattern, { index, pattern })
   }
 
   return instance
@@ -75,17 +81,104 @@ function verifyMatches<matcher extends BenchMatcher>(options: MatchBenchOptions<
   let matchersByName = createMatcherLookup(options, patternsByMatcherName)
 
   for (let url of options.urls) {
-    let expected = matchersByName[baselineMatcher.name]!.match(url) !== null
+    let expectedMatch = matchersByName[baselineMatcher.name]!.match(url)
+    let expected = expectedMatch !== null
 
     for (let matcher of options.matchers.slice(1)) {
-      let actual = matchersByName[matcher.name]!.match(url) !== null
+      let instance = matchersByName[matcher.name]!
+      let actualMatch = instance.match(url)
+      let actual = actualMatch !== null
 
       if (actual !== expected) {
         throw new Error(
           `Matcher '${matcher.name}' mismatch on '${url.href}': expected ${expected ? 'match' : 'no match'}, but got ${actual ? 'match' : 'no match'}`,
         )
       }
+
+      if (
+        actualMatch &&
+        expectedMatch &&
+        baselineMatcher.supportsDetailedVerification &&
+        matcher.supportsDetailedVerification
+      ) {
+        assertMatchEqual(matcher.name, url, actualMatch, expectedMatch)
+        assertMatchesEqual(
+          matcher.name,
+          url,
+          instance.matchAll(url),
+          matchersByName[baselineMatcher.name]!.matchAll(url),
+        )
+      }
     }
+  }
+}
+
+function assertMatchesEqual(
+  matcherName: string,
+  url: URL,
+  actual: Array<Match<string, BenchData>>,
+  expected: Array<Match<string, BenchData>>,
+) {
+  actual = dedupeMatchesByInsertedPattern(actual)
+  expected = dedupeMatchesByInsertedPattern(expected)
+
+  if (actual.length !== expected.length) {
+    throw new Error(
+      `Matcher '${matcherName}' matchAll mismatch on '${url.href}': expected ${expected.length} matches, but got ${actual.length}`,
+    )
+  }
+
+  for (let index = 0; index < expected.length; index++) {
+    assertMatchEqual(`${matcherName} matchAll[${index}]`, url, actual[index]!, expected[index]!)
+  }
+}
+
+function dedupeMatchesByInsertedPattern(
+  matches: Array<Match<string, BenchData>>,
+): Array<Match<string, BenchData>> {
+  let seen = new Set<number>()
+  let result: Array<Match<string, BenchData>> = []
+
+  for (let match of matches) {
+    if (seen.has(match.data.index)) continue
+    seen.add(match.data.index)
+    result.push(match)
+  }
+
+  return result
+}
+
+function assertMatchEqual(
+  matcherName: string,
+  url: URL,
+  actual: Match<string, BenchData>,
+  expected: Match<string, BenchData>,
+) {
+  let actualPattern = actual.pattern.toString()
+  let expectedPattern = expected.pattern.toString()
+  if (actualPattern !== expectedPattern) {
+    throw new Error(
+      `Matcher '${matcherName}' selected pattern mismatch on '${url.href}': expected '${expectedPattern}', but got '${actualPattern}'`,
+    )
+  }
+
+  assertJsonEqual(matcherName, url, 'params', actual.params, expected.params)
+  assertJsonEqual(matcherName, url, 'data', actual.data, expected.data)
+}
+
+function assertJsonEqual(
+  matcherName: string,
+  url: URL,
+  label: string,
+  actual: unknown,
+  expected: unknown,
+) {
+  let actualJson = JSON.stringify(actual)
+  let expectedJson = JSON.stringify(expected)
+  if (actualJson !== expectedJson) {
+    throw new Error(
+      `Matcher '${matcherName}' ${label} mismatch on '${url.href}': expected ${expectedJson}, but got ${actualJson}`,
+    )
   }
 }
 

--- a/packages/route-pattern/bench/src/types/href.ts
+++ b/packages/route-pattern/bench/src/types/href.ts
@@ -9,17 +9,17 @@ bench.baseline(() => {
 bench('href > simple route', () => {
   let pattern = RoutePattern.parse('/posts/:id')
   createHref(pattern, { id: '123' })
-}).types([493, 'instantiations'])
+}).types([1248, 'instantiations'])
 
 bench('href > complex route', () => {
   let pattern = RoutePattern.parse('/api(/v:major(.:minor))/*path/help')
   createHref(pattern, { major: '1', minor: '2', path: 'users', help: 'help' })
-}).types([1252, 'instantiations'])
+}).types([4944, 'instantiations'])
 
 bench('href > mediarss', async () => {
   let { patterns } = await import('../../patterns/mediarss.ts')
   eagerlyEvaluateTypesForHrefParams(patterns)
-}).types([13867, 'instantiations'])
+}).types([87455, 'instantiations'])
 
 // NOTE: This benchmark brings type checking to a crawl.
 // Uncomment to run the benchmark, but keep it commented to avoid CI failures.

--- a/packages/route-pattern/bench/src/types/join.ts
+++ b/packages/route-pattern/bench/src/types/join.ts
@@ -10,12 +10,12 @@ bench.baseline(() => {
 bench('join', () => {
   let pattern = RoutePattern.parse('/posts/:id')
   joinPatterns(pattern, '/comments/:commentId')
-}).types([2445, 'instantiations'])
+}).types([2651, 'instantiations'])
 
 bench('join > mediarss', async () => {
   let { patterns } = await import('../../patterns/mediarss.ts')
   eagerlyEvaluateTypesForJoin(patterns)
-}).types([74069, 'instantiations'])
+}).types([153, 'instantiations'])
 
 // NOTE: This benchmark brings type checking to a crawl.
 // Uncomment to run the benchmark, but keep it commented to avoid CI failures.

--- a/packages/route-pattern/bench/src/types/match.ts
+++ b/packages/route-pattern/bench/src/types/match.ts
@@ -10,17 +10,17 @@ bench('match > simple route', () => {
   let matcher = createMatcher('/posts/:id')
   let match = matcher.match('https://example.com/posts/123')
   match?.params.id
-}).types([268, 'instantiations'])
+}).types([921, 'instantiations'])
 
 bench('match > complex route', () => {
   let matcher = createMatcher('/api(/v:major(.:minor))/*path/help')
   matcher.match('https://example.com/api/v1/users/123')?.params
-}).types([971, 'instantiations'])
+}).types([4542, 'instantiations'])
 
 bench('match > mediarss', async () => {
   let { patterns } = await import('../../patterns/mediarss.ts')
   eagerlyEvaluateTypesForMatchParams(patterns)
-}).types([12253, 'instantiations'])
+}).types([85052, 'instantiations'])
 
 // NOTE: This benchmark brings type checking to a crawl.
 // Uncomment to run the benchmark, but keep it commented to avoid CI failures.

--- a/packages/route-pattern/bench/src/types/new.ts
+++ b/packages/route-pattern/bench/src/types/new.ts
@@ -8,22 +8,22 @@ bench.baseline(() => {
 bench('new > simple route', () => {
   let pattern = RoutePattern.parse('/posts/:id')
   pattern.toString()
-}).types([3, 'instantiations'])
+}).types([4, 'instantiations'])
 
 bench('new > complex route', () => {
   let pattern = RoutePattern.parse('/api(/v:major(.:minor))/*path/help')
   pattern.toString()
-}).types([3, 'instantiations'])
+}).types([4, 'instantiations'])
 
 bench('new > mediarss', async () => {
   let { patterns } = await import('../../patterns/mediarss.ts')
   eagerlyEvaluateTypesForNew(patterns)
-}).types([2648, 'instantiations'])
+}).types([154, 'instantiations'])
 
 bench('new > shopify', async () => {
   let { patterns } = await import('../../patterns/shopify.ts')
   eagerlyEvaluateTypesForNew(patterns)
-}).types([12609, 'instantiations'])
+}).types([10050, 'instantiations'])
 
 /** Type-only utility to force eager evaluation of href param types */
 function eagerlyEvaluateTypesForNew<patterns extends ReadonlyArray<string>>(

--- a/packages/route-pattern/bench/src/types/params.ts
+++ b/packages/route-pattern/bench/src/types/params.ts
@@ -7,16 +7,16 @@ bench.baseline(() => {
 
 bench('simple > MatchParams', () => {
   type _ = MatchParams<'posts/:id'>
-}).types([381, 'instantiations'])
+}).types([1123, 'instantiations'])
 
 bench('complex > MatchParams', () => {
   type _ = MatchParams<'api(/v:major(.:minor))/*path/help'>
-}).types([1083, 'instantiations'])
+}).types([4762, 'instantiations'])
 
 bench('mediarss > MatchParams', async () => {
   let { patterns } = await import('../../patterns/mediarss.ts')
   eagerlyEvaluateTypesForParams(patterns)
-}).types([12140, 'instantiations'])
+}).types([84908, 'instantiations'])
 
 // NOTE: This benchmark brings type checking to a crawl.
 // Uncomment to run the benchmark, but keep it commented to avoid CI failures.

--- a/packages/route-pattern/src/lib/href.ts
+++ b/packages/route-pattern/src/lib/href.ts
@@ -209,6 +209,7 @@ function hrefSearch(
   return result || undefined
 }
 
+/** Structured details for a {@link CreateHrefError}. */
 export type CreateHrefErrorDetails =
   | { type: 'missing-hostname'; pattern: RoutePattern }
   | {

--- a/packages/route-pattern/src/lib/match.ts
+++ b/packages/route-pattern/src/lib/match.ts
@@ -5,6 +5,7 @@ import { Trie } from './match/trie.ts'
 import type { Match } from './match/types.ts'
 import * as Specificity from './specificity.ts'
 
+/** Options that control route pattern matching. */
 export type MatcherOptions = {
   /**
    * When `true`, pathname matching is case-insensitive for all patterns. Hostname is always
@@ -13,7 +14,9 @@ export type MatcherOptions = {
   ignoreCase?: boolean
 }
 
+/** Matcher for a single route pattern. */
 export type Matcher<source extends string = string> = {
+  /** Most specific match for `url`, or `null` when the URL does not match this pattern. */
   match(url: string | URL): Match<source, undefined> | null
 }
 
@@ -39,11 +42,17 @@ export function createMatcher<source extends string>(
   }
 }
 
+/** Matcher for a collection of route patterns with optional attached data. */
 export type MultiMatcher<data = unknown> = {
+  /** Whether pathname matching is case-insensitive. */
   readonly ignoreCase: boolean
+
+  /** Add a route pattern with data that is returned when the pattern matches. */
   add(pattern: string | RoutePattern, data: data): void
+
   /** Most specific match for `url`, or `null` when nothing matches. */
   match(url: string | URL): Match<string, data> | null
+
   /** Every match for `url`, sorted from most to least specific. */
   matchAll(url: string | URL): Array<Match<string, data>>
 }

--- a/packages/route-pattern/src/lib/match/punycode.ts
+++ b/packages/route-pattern/src/lib/match/punycode.ts
@@ -1,4 +1,5 @@
-// Adapted from https://github.com/mathiasbynens/punycode.js/blob/9e1b2cda98d215d3a73fcbfe93c62e021f4ba768/punycode.js
+// Adapted from punycode.js by Mathias Bynens, MIT licensed:
+// https://github.com/mathiasbynens/punycode.js/blob/9e1b2cda98d215d3a73fcbfe93c62e021f4ba768/punycode.js
 
 /** Highest positive signed 32-bit float value */
 const maxInt = 2147483647 // aka. 0x7FFFFFFF or 2^31-1

--- a/packages/route-pattern/src/lib/match/types.ts
+++ b/packages/route-pattern/src/lib/match/types.ts
@@ -10,23 +10,44 @@ export type MatchParams<source extends string> =
       : Simplify<Omit<params, '*'>>
     : never
 
+/** Metadata describing where a matched param appeared in a normalized URL part. */
 export type MatchParamMeta = {
+  /** Param token kind: `:` for variables or `*` for wildcards. */
   type: ':' | '*'
+
+  /** Param name, or `*` for an unnamed wildcard. */
   name: string
+
+  /** Matched param value after URL normalization and decoding. */
   value: string
-  /** Start offset after pathname is normalized. */
+
+  /** Start offset after the URL part is normalized. */
   begin: number
-  /** End offset after pathname is normalized. */
+
+  /** End offset after the URL part is normalized. */
   end: number
 }
 
+/** Result returned by route pattern matchers. */
 export type Match<source extends string = string, data = unknown> = {
+  /** URL object used for the match. */
   url: URL
+
+  /** Pattern that matched the URL. */
   pattern: RoutePattern<source>
+
+  /** Data attached to the matched pattern. */
   data: data
+
+  /** Params captured from the matched pattern. */
   params: MatchParams<source>
+
+  /** Metadata for hostname and pathname params captured during matching. */
   paramsMeta: {
+    /** Params captured from the hostname pattern. */
     hostname: ReadonlyArray<MatchParamMeta>
+
+    /** Params captured from the pathname pattern. */
     pathname: ReadonlyArray<MatchParamMeta>
   }
 }

--- a/packages/route-pattern/src/lib/route-pattern.ts
+++ b/packages/route-pattern/src/lib/route-pattern.ts
@@ -72,7 +72,12 @@ const routePatternConstructorKey: unique symbol = Symbol('RoutePattern construct
 declare const routePatternSourceBrand: unique symbol
 const routePatternParts = new WeakMap<RoutePattern, ParsedRoutePattern>()
 
-/** A parsed route pattern */
+/**
+ * Opaque parsed route pattern handle.
+ *
+ * Construct route patterns with {@link RoutePattern.parse}. Use `source`, `toString()`,
+ * `toJSON()`, and {@link getRoutePatternParams} for supported inspection.
+ */
 export class RoutePattern<source extends string = string> {
   declare readonly [routePatternSourceBrand]: source
 
@@ -102,7 +107,7 @@ export class RoutePattern<source extends string = string> {
     return new RoutePattern<source>(routePatternConstructorKey, parsed)
   }
 
-  /** Normalized string representation of this pattern */
+  /** Normalized string representation of this pattern. */
   get source(): string {
     return serializePattern(getRoutePatternParts(this))
   }


### PR DESCRIPTION
Completes the final documentation and validation pass for #11556. This updates the route-pattern public docs to match the opaque `RoutePattern` API that landed in the earlier PRs, and records benchmark evidence for the matcher and href generation behavior.

- Documents canonical `remix/route-pattern/*` imports, direct `@remix-run/route-pattern/*` equivalents, absolute URL matching requirements, `ignoreCase`, `paramsMeta`, structured error details, support types, and specificity helper semantics.
- Strengthens benchmark correctness checks so comparable matchers verify selected pattern, params, attached data, and ranking before timing.
- Records benchmark environment, commands, pattern counts, hot matching timings, cold construction timings, variance, and sample counts.
- Fixes stale benchmark/type-benchmark maintenance bits and adds explicit MIT attribution for adapted `punycode.js` code.
