### PR TITLE
Simplify RoutePattern construction and rename params to captures

### DIFF
--- a/packages/assets/src/lib/routes.ts
+++ b/packages/assets/src/lib/routes.ts
@@ -1,7 +1,7 @@
 import {
-  getRoutePatternParams,
+  getRoutePatternCaptures,
   RoutePattern,
-  type RoutePatternParam,
+  type RoutePatternCapture,
 } from '@remix-run/route-pattern'
 import { createHref } from '@remix-run/route-pattern/href'
 import { createMatcher, type Matcher } from '@remix-run/route-pattern/match'
@@ -146,18 +146,18 @@ function stripDotSegments(pattern: string): string {
 }
 
 function validateRoutePatterns(urlPattern: RoutePattern, filePattern: RoutePattern): void {
-  let urlParams = getPathnameParams(urlPattern)
-  let fileParams = getPathnameParams(filePattern)
-  if (urlParams.length !== fileParams.length) {
+  let urlCaptures = getPathnameCaptures(urlPattern)
+  let fileCaptures = getPathnameCaptures(filePattern)
+  if (urlCaptures.length !== fileCaptures.length) {
     throw new Error(
       `Route patterns must have matching capture structure.\nURL: ${urlPattern}\nFile: ${filePattern}`,
     )
   }
 
-  for (let i = 0; i < urlParams.length; i++) {
-    let urlParam = urlParams[i]
-    let fileParam = fileParams[i]
-    if (urlParam.type !== fileParam.type || urlParam.name !== fileParam.name) {
+  for (let i = 0; i < urlCaptures.length; i++) {
+    let urlCapture = urlCaptures[i]
+    let fileCapture = fileCaptures[i]
+    if (urlCapture.type !== fileCapture.type || urlCapture.name !== fileCapture.name) {
       throw new Error(
         `Route patterns must have matching capture structure.\nURL: ${urlPattern}\nFile: ${filePattern}`,
       )
@@ -167,8 +167,8 @@ function validateRoutePatterns(urlPattern: RoutePattern, filePattern: RoutePatte
 
 function validateNoUnnamedWildcards(pattern: RoutePattern, label: string): void {
   if (
-    getRoutePatternParams(pattern).some(
-      (param) => param.part === 'pathname' && param.type === '*' && param.name === '*',
+    getRoutePatternCaptures(pattern).some(
+      (capture) => capture.part === 'pathname' && capture.type === '*' && capture.name === '*',
     )
   ) {
     throw new Error(
@@ -177,10 +177,10 @@ function validateNoUnnamedWildcards(pattern: RoutePattern, label: string): void 
   }
 }
 
-type PathnameParam = RoutePatternParam & { readonly part: 'pathname' }
+type PathnameCapture = RoutePatternCapture & { readonly part: 'pathname' }
 
-function getPathnameParams(pattern: RoutePattern): Array<PathnameParam> {
-  return getRoutePatternParams(pattern).filter(
-    (param): param is PathnameParam => param.part === 'pathname',
+function getPathnameCaptures(pattern: RoutePattern): Array<PathnameCapture> {
+  return getRoutePatternCaptures(pattern).filter(
+    (capture): capture is PathnameCapture => capture.part === 'pathname',
   )
 }

--- a/packages/remix/.changes/major.remix.update-exports.md
+++ b/packages/remix/.changes/major.remix.update-exports.md
@@ -8,9 +8,9 @@ Added `package.json` `exports` for the styled component entrypoints:
 - `remix/components/select`
 - `remix/components/tabs`
 
-Updated `remix/route-pattern` exports for the opaque `RoutePattern` API:
+Updated `remix/route-pattern` exports for the `RoutePattern` API:
 
-- Added `getRoutePatternParams`, `RoutePatternParam`, and `RoutePatternJSON` to `remix/route-pattern`
+- Added `getRoutePatternCaptures`, `RoutePatternCapture`, and `RoutePatternJSON` to `remix/route-pattern`
 - Added `CreateHrefErrorDetails` to `remix/route-pattern/href`
 - Added `MatchParamMeta` to `remix/route-pattern/match`
 

--- a/packages/route-pattern/.changes/minor.opaque-route-pattern.md
+++ b/packages/route-pattern/.changes/minor.opaque-route-pattern.md
@@ -1,5 +1,5 @@
-BREAKING CHANGE: `RoutePattern` is now an opaque parsed-pattern handle. Construct patterns with `RoutePattern.parse()` instead of `new RoutePattern(...)`, and use `pattern.source`, `pattern.toString()`, or `pattern.toJSON()` instead of reading parsed internals such as `pattern.pathname.tokens`, `pattern.hostname`, or `pattern.search`.
+BREAKING CHANGE: `RoutePattern` no longer exposes its parsed internals. Construct patterns with `RoutePattern.parse()`, and use `pattern.source`, `pattern.toString()`, or `pattern.toJSON()` instead of reading parsed internals such as `pattern.pathname.tokens`, `pattern.hostname`, or `pattern.search`.
 
-Added `getRoutePatternParams(pattern)` for supported param introspection. It returns readonly `{ part, type, name, optional }` entries in source order so consumers can inspect hostname and pathname params without relying on internal parser tokens.
+Added `getRoutePatternCaptures(pattern)` for supported capture introspection. It returns readonly `{ part, type, name, optional }` entries in source order so consumers can inspect the variables (`:name`) and wildcards (`*name`) declared in a pattern without relying on internal parser tokens.
 
-Exported `RoutePatternParam` and `RoutePatternJSON` from `@remix-run/route-pattern`, `CreateHrefErrorDetails` from `@remix-run/route-pattern/href`, and `MatchParamMeta` from `@remix-run/route-pattern/match`.
+Exported `RoutePatternCapture` and `RoutePatternJSON` from `@remix-run/route-pattern`, `CreateHrefErrorDetails` from `@remix-run/route-pattern/href`, and `MatchParamMeta` from `@remix-run/route-pattern/match`.

--- a/packages/route-pattern/README.md
+++ b/packages/route-pattern/README.md
@@ -267,10 +267,10 @@ createHref('products(.json)')
 
 ## Parse & stringify patterns
 
-You can explicitly parse and stringify patterns. `RoutePattern` is an opaque handle: use the methods and helpers below instead of reading parsed token internals.
+You can explicitly parse and stringify patterns. Create a `RoutePattern` with `RoutePattern.parse` and use the methods and helpers below instead of reading parsed token internals.
 
 ```ts
-import { getRoutePatternParams, RoutePattern } from 'remix/route-pattern'
+import { getRoutePatternCaptures, RoutePattern } from 'remix/route-pattern'
 
 let pattern = RoutePattern.parse('://:tenant.example.com/blog/:slug(/*path)')
 //  ^? RoutePattern
@@ -281,7 +281,7 @@ pattern.toString()
 pattern.toJSON()
 // { hostname: ':tenant.example.com', pathname: 'blog/:slug(/*path)', ... }
 
-getRoutePatternParams(pattern)
+getRoutePatternCaptures(pattern)
 // [
 //   { part: 'hostname', type: ':', name: 'tenant', optional: false },
 //   { part: 'pathname', type: ':', name: 'slug', optional: false },
@@ -297,7 +297,7 @@ All APIs that take a `pattern` arg accept `string` or a parsed `RoutePattern`.
 
 The public support types are:
 
-- `RoutePatternParam` from `remix/route-pattern`
+- `RoutePatternCapture` from `remix/route-pattern`
 - `RoutePatternJSON` from `remix/route-pattern`
 - `CreateHrefErrorDetails` from `remix/route-pattern/href`
 - `MatchParamMeta` from `remix/route-pattern/match`

--- a/packages/route-pattern/src/lib/href.ts
+++ b/packages/route-pattern/src/lib/href.ts
@@ -1,9 +1,4 @@
-import {
-  getRoutePatternParts,
-  RoutePattern,
-  type RoutePatternParts,
-  type PartPattern,
-} from './route-pattern.ts'
+import { RoutePattern, type RoutePatternParts, type PartPattern } from './route-pattern.ts'
 import type { ParseParams } from './types/params.ts'
 import type { Split, SplitPattern } from './types/split.ts'
 import type { Simplify } from './types/utils.ts'
@@ -63,7 +58,7 @@ export function createHref<source extends string>(
   ...args: CreateHrefArgs<source>
 ): string {
   pattern = typeof pattern === 'string' ? RoutePattern.parse(pattern) : pattern
-  let patternParts = getRoutePatternParts(pattern)
+  let patternParts = pattern._parts
   let [params, searchParams] = args
   searchParams ??= {}
 

--- a/packages/route-pattern/src/lib/href.ts
+++ b/packages/route-pattern/src/lib/href.ts
@@ -1,7 +1,7 @@
 import {
   getRoutePatternParts,
   RoutePattern,
-  type ParsedRoutePattern,
+  type RoutePatternParts,
   type PartPattern,
 } from './route-pattern.ts'
 import type { ParseParams } from './types/params.ts'
@@ -174,7 +174,7 @@ function hrefPart(
 }
 
 function hrefSearch(
-  constraints: ParsedRoutePattern['search'],
+  constraints: RoutePatternParts['search'],
   searchParams: SearchParams,
 ): string | undefined {
   if (constraints.size === 0 && Object.keys(searchParams).length === 0) {

--- a/packages/route-pattern/src/lib/join.ts
+++ b/packages/route-pattern/src/lib/join.ts
@@ -1,4 +1,4 @@
-import { createRoutePattern, getRoutePatternParts, RoutePattern } from './route-pattern.ts'
+import { createRoutePattern, RoutePattern } from './route-pattern.ts'
 import type { RoutePatternParts, PartPattern, PartPatternToken } from './route-pattern.ts'
 import type { JoinPatterns } from './types/join.ts'
 
@@ -19,8 +19,8 @@ export function joinPatterns<base extends string, next extends string>(
 ): RoutePattern<JoinPatterns<base, next>> {
   let basePattern = typeof base === 'string' ? RoutePattern.parse(base) : base
   let nextPattern = typeof next === 'string' ? RoutePattern.parse(next) : next
-  let baseParts = getRoutePatternParts(basePattern)
-  let nextParts = getRoutePatternParts(nextPattern)
+  let baseParts = basePattern._parts
+  let nextParts = nextPattern._parts
 
   return createRoutePattern<JoinPatterns<base, next>>({
     protocol: nextParts.protocol ?? baseParts.protocol,

--- a/packages/route-pattern/src/lib/join.ts
+++ b/packages/route-pattern/src/lib/join.ts
@@ -1,5 +1,5 @@
 import { createRoutePattern, getRoutePatternParts, RoutePattern } from './route-pattern.ts'
-import type { ParsedRoutePattern, PartPattern, PartPatternToken } from './route-pattern.ts'
+import type { RoutePatternParts, PartPattern, PartPatternToken } from './route-pattern.ts'
 import type { JoinPatterns } from './types/join.ts'
 
 /**
@@ -105,9 +105,9 @@ function joinPathname(base: PartPattern, next: PartPattern): PartPattern {
  * @private
  */
 function joinSearch(
-  base: ParsedRoutePattern['search'],
-  next: ParsedRoutePattern['search'],
-): ParsedRoutePattern['search'] {
+  base: RoutePatternParts['search'],
+  next: RoutePatternParts['search'],
+): RoutePatternParts['search'] {
   let result = new Map<string, Set<string>>()
 
   for (let [name, values] of base) {

--- a/packages/route-pattern/src/lib/match/trie.ts
+++ b/packages/route-pattern/src/lib/match/trie.ts
@@ -1,5 +1,5 @@
 import { getRoutePatternParts } from '../route-pattern.ts'
-import type { ParsedRoutePattern, RoutePattern } from '../route-pattern.ts'
+import type { RoutePatternParts, RoutePattern } from '../route-pattern.ts'
 import { decodeHostname } from './decode.ts'
 import { generateVariants, type Param } from './variant.ts'
 import { unreachable } from '../unreachable.ts'
@@ -348,7 +348,7 @@ type PathnameNode<data> = {
   wildcard: Map<string, { regexp: RegExp; pathnameNode: PathnameNode<data> }>
   values: Array<{
     pattern: RoutePattern
-    patternParts: ParsedRoutePattern
+    patternParts: RoutePatternParts
     data: data
     requiredParams: Array<Param>
   }>

--- a/packages/route-pattern/src/lib/match/trie.ts
+++ b/packages/route-pattern/src/lib/match/trie.ts
@@ -1,4 +1,3 @@
-import { getRoutePatternParts } from '../route-pattern.ts'
 import type { RoutePatternParts, RoutePattern } from '../route-pattern.ts'
 import { decodeHostname } from './decode.ts'
 import { generateVariants, type Param } from './variant.ts'
@@ -19,7 +18,7 @@ export class Trie<data = unknown> {
   }
 
   insert(pattern: RoutePattern, data: data): void {
-    let patternParts = getRoutePatternParts(pattern)
+    let patternParts = pattern._parts
 
     for (let variant of generateVariants(pattern, { ignoreCase: this.ignoreCase })) {
       let hostnameNode = this.#root[variant.protocol]

--- a/packages/route-pattern/src/lib/match/variant.ts
+++ b/packages/route-pattern/src/lib/match/variant.ts
@@ -1,6 +1,6 @@
 import { getRoutePatternParts } from '../route-pattern.ts'
 import type {
-  ParsedRoutePattern,
+  RoutePatternParts,
   PartPattern,
   PartPatternToken,
   RoutePattern,
@@ -39,7 +39,7 @@ export function generateVariants(
 type ProtocolVariant = 'http' | 'https'
 
 function generateProtocolVariants(
-  protocol: ParsedRoutePattern['protocol'],
+  protocol: RoutePatternParts['protocol'],
 ): ReadonlyArray<ProtocolVariant> {
   if (protocol === null || protocol === 'http(s)') return ['http', 'https']
   return [protocol]

--- a/packages/route-pattern/src/lib/match/variant.ts
+++ b/packages/route-pattern/src/lib/match/variant.ts
@@ -1,4 +1,3 @@
-import { getRoutePatternParts } from '../route-pattern.ts'
 import type {
   RoutePatternParts,
   PartPattern,
@@ -20,7 +19,7 @@ export function generateVariants(
   pattern: RoutePattern,
   options?: { ignoreCase?: boolean },
 ): ReadonlyArray<Variant> {
-  let patternParts = getRoutePatternParts(pattern)
+  let patternParts = pattern._parts
   let result: Array<Variant> = []
 
   for (let protocol of generateProtocolVariants(patternParts.protocol)) {

--- a/packages/route-pattern/src/lib/route-pattern.test.ts
+++ b/packages/route-pattern/src/lib/route-pattern.test.ts
@@ -5,15 +5,15 @@ import { createHref, type CreateHrefErrorDetails } from '../href.ts'
 import { joinPatterns } from '../join.ts'
 import { createMatcher, type MatchParamMeta } from '../match.ts'
 import {
-  getRoutePatternParams,
+  getRoutePatternCaptures,
   RoutePattern,
+  type RoutePatternCapture,
   type RoutePatternJSON,
-  type RoutePatternParam,
 } from '../route-pattern.ts'
 
 describe('RoutePattern', () => {
   it('exports public route pattern support types', () => {
-    let param: RoutePatternParam = {
+    let capture: RoutePatternCapture = {
       part: 'pathname',
       type: ':',
       name: 'id',
@@ -38,23 +38,19 @@ describe('RoutePattern', () => {
       end: 3,
     }
 
-    assert.equal(param.name, 'id')
+    assert.equal(capture.name, 'id')
     assert.equal(json.pathname, ':id')
     assert.equal(hrefError.type, 'missing-hostname')
     assert.equal(matchMeta.value, '123')
   })
 
-  it('does not expose parsed-AST construction', () => {
-    assert.throws(
-      () => {
-        // @ts-expect-error - RoutePattern construction is internal
-        new RoutePattern({})
-      },
-      {
-        name: 'TypeError',
-        message: 'RoutePattern constructor is private; use RoutePattern.parse()',
-      },
-    )
+  it('creates patterns that are instances of RoutePattern', () => {
+    let pattern = RoutePattern.parse('/posts/:postId')
+
+    assert.ok(pattern instanceof RoutePattern)
+
+    // @ts-expect-error - the constructor requires an internal parsed representation
+    new RoutePattern({})
   })
 
   it('brands source generics nominally', () => {
@@ -66,10 +62,10 @@ describe('RoutePattern', () => {
     assert.equal(users, posts)
   })
 
-  it('exposes params without exposing parsed tokens', () => {
+  it('exposes captures without exposing parsed tokens', () => {
     let pattern = RoutePattern.parse('https://:tenant.example.com/:collection(/*path)(.:ext)')
 
-    assert.deepEqual(getRoutePatternParams(pattern), [
+    assert.deepEqual(getRoutePatternCaptures(pattern), [
       { part: 'hostname', type: ':', name: 'tenant', optional: false },
       { part: 'pathname', type: ':', name: 'collection', optional: false },
       { part: 'pathname', type: '*', name: 'path', optional: true },
@@ -77,10 +73,10 @@ describe('RoutePattern', () => {
     ])
   })
 
-  it('exposes unnamed wildcards in params', () => {
+  it('exposes unnamed wildcards in captures', () => {
     let pattern = RoutePattern.parse('/files/*')
 
-    assert.deepEqual(getRoutePatternParams(pattern), [
+    assert.deepEqual(getRoutePatternCaptures(pattern), [
       { part: 'pathname', type: '*', name: '*', optional: false },
     ])
   })

--- a/packages/route-pattern/src/lib/route-pattern.ts
+++ b/packages/route-pattern/src/lib/route-pattern.ts
@@ -53,33 +53,47 @@ export interface RoutePatternJSON {
   search: string
 }
 
-/** Metadata for a hostname or pathname param in a {@link RoutePattern}. */
-export interface RoutePatternParam {
-  /** The URL part that contains the param. */
+/** A variable (`:name`) or wildcard (`*name`) declared in a {@link RoutePattern}. */
+export interface RoutePatternCapture {
+  /** The URL part that contains the capture. */
   readonly part: 'hostname' | 'pathname'
 
-  /** The param token kind: `:` for variables or `*` for wildcards. */
+  /** The capture token kind: `:` for variables or `*` for wildcards. */
   readonly type: ':' | '*'
 
-  /** Param name, or `*` for an unnamed wildcard. */
+  /** Capture name, or `*` for an unnamed wildcard. */
   readonly name: string
 
-  /** Whether the param is inside an optional group. */
+  /** Whether the capture is inside an optional group. */
   readonly optional: boolean
 }
 
-const routePatternConstructorKey: unique symbol = Symbol('RoutePattern constructor key')
-declare const routePatternSourceBrand: unique symbol
-const routePatternParts = new WeakMap<RoutePattern, ParsedRoutePattern>()
+declare const brand: unique symbol
 
 /**
- * Opaque parsed route pattern handle.
+ * A parsed route pattern.
  *
- * Construct route patterns with {@link RoutePattern.parse}. Use `source`, `toString()`,
- * `toJSON()`, and {@link getRoutePatternParams} for supported inspection.
+ * Create one with {@link RoutePattern.parse}. The constructor is public but takes a parsed
+ * representation that is not part of the public API; prefer `RoutePattern.parse` instead. Use
+ * `source`, `toString()`, `toJSON()`, and {@link getRoutePatternCaptures} for inspection.
  */
 export class RoutePattern<source extends string = string> {
-  declare readonly [routePatternSourceBrand]: source
+  declare readonly [brand]: source
+
+  /** Parsed representation of this pattern. Not part of the public API. */
+  private readonly parsed: ParsedRoutePattern
+
+  /**
+   * Create a new `RoutePattern` from a parsed representation.
+   *
+   * The parsed representation is not part of the public API. Use {@link RoutePattern.parse} to
+   * create a pattern from a source string.
+   *
+   * @param parsed The parsed route pattern.
+   */
+  constructor(parsed: ParsedRoutePattern) {
+    this.parsed = parsed
+  }
 
   /**
    * Create a new `RoutePattern` by parsing a source string.
@@ -91,25 +105,9 @@ export class RoutePattern<source extends string = string> {
     return parsePattern(source)
   }
 
-  private constructor(key: typeof routePatternConstructorKey, parsed?: ParsedRoutePattern) {
-    if (key !== routePatternConstructorKey) {
-      throw new TypeError('RoutePattern constructor is private; use RoutePattern.parse()')
-    }
-    if (parsed === undefined) {
-      throw new TypeError('RoutePattern constructor is private; use RoutePattern.parse()')
-    }
-    routePatternParts.set(this, parsed)
-  }
-
-  static [routePatternConstructorKey]<source extends string>(
-    parsed: ParsedRoutePattern,
-  ): RoutePattern<source> {
-    return new RoutePattern<source>(routePatternConstructorKey, parsed)
-  }
-
   /** Normalized string representation of this pattern. */
   get source(): string {
-    return serializePattern(getRoutePatternParts(this))
+    return serializePattern(this.parsed)
   }
 
   /**
@@ -127,62 +125,46 @@ export class RoutePattern<source extends string = string> {
    * @returns The serialized protocol, hostname, port, pathname, and search.
    */
   toJSON(): RoutePatternJSON {
-    return serializePatternParts(getRoutePatternParts(this))
+    return serializePatternParts(this.parsed)
   }
 }
 
 export function createRoutePattern<source extends string>(
   parsed: ParsedRoutePattern,
 ): RoutePattern<source> {
-  return RoutePattern[routePatternConstructorKey]<source>(parsed)
+  return new RoutePattern<source>(parsed)
 }
 
 export function getRoutePatternParts(pattern: RoutePattern): ParsedRoutePattern {
-  let parsed = routePatternParts.get(pattern)
-  if (parsed === undefined) {
-    throw new TypeError('Invalid RoutePattern')
-  }
-  return parsed
+  return (pattern as unknown as { parsed: ParsedRoutePattern }).parsed
 }
 
 /**
- * Returns hostname and pathname params in source order without exposing parsed pattern internals.
+ * Returns the hostname and pathname captures in a pattern in source order without exposing parsed
+ * pattern internals.
  *
- * @param pattern The parsed route pattern to inspect.
- * @returns Param metadata for variables and wildcards in the pattern.
+ * @param pattern The route pattern to inspect.
+ * @returns Metadata for each variable and wildcard in the pattern.
  */
-export function getRoutePatternParams(pattern: RoutePattern): ReadonlyArray<RoutePatternParam> {
+export function getRoutePatternCaptures(pattern: RoutePattern): ReadonlyArray<RoutePatternCapture> {
   let parsed = getRoutePatternParts(pattern)
-  let params: Array<RoutePatternParam> = []
+  let captures: Array<RoutePatternCapture> = []
 
-  if (parsed.hostname) {
-    params.push(...getPartParams(parsed.hostname))
-  }
-  params.push(...getPartParams(parsed.pathname))
+  if (parsed.hostname) collectCaptures(parsed.hostname, captures)
+  collectCaptures(parsed.pathname, captures)
 
-  return params
+  return captures
 }
 
-function getPartParams(part: PartPattern): Array<RoutePatternParam> {
-  let params: Array<RoutePatternParam> = []
-
-  for (let i = 0; i < part.tokens.length; i++) {
-    let token = part.tokens[i]
-    if (token.type !== ':' && token.type !== '*') continue
-    params.push({
-      part: part.type,
-      type: token.type,
-      name: token.name,
-      optional: isOptionalToken(part, i),
-    })
+function collectCaptures(part: PartPattern, out: Array<RoutePatternCapture>): void {
+  let depth = 0
+  for (let token of part.tokens) {
+    if (token.type === '(') {
+      depth++
+    } else if (token.type === ')') {
+      depth--
+    } else if (token.type === ':' || token.type === '*') {
+      out.push({ part: part.type, type: token.type, name: token.name, optional: depth > 0 })
+    }
   }
-
-  return params
-}
-
-function isOptionalToken(part: PartPattern, index: number): boolean {
-  for (let [begin, end] of part.optionals) {
-    if (begin < index && index < end) return true
-  }
-  return false
 }

--- a/packages/route-pattern/src/lib/route-pattern.ts
+++ b/packages/route-pattern/src/lib/route-pattern.ts
@@ -71,6 +71,15 @@ export interface RoutePatternCapture {
 declare const brand: unique symbol
 
 /**
+ * Internal backing shape of a {@link RoutePattern}. The parsed representation is stored on the
+ * instance but kept off the public type so consumers cannot read parser tokens directly; the
+ * helpers in this module reach it through {@link getRoutePatternParts}.
+ */
+interface RoutePatternInternals {
+  parsed: ParsedRoutePattern
+}
+
+/**
  * A parsed route pattern.
  *
  * Create one with {@link RoutePattern.parse}. The constructor is public but takes a parsed
@@ -79,9 +88,6 @@ declare const brand: unique symbol
  */
 export class RoutePattern<source extends string = string> {
   declare readonly [brand]: source
-
-  /** Parsed representation of this pattern. Not part of the public API. */
-  private readonly parsed: ParsedRoutePattern
 
   /**
    * Create a new `RoutePattern` from a parsed representation.
@@ -92,7 +98,7 @@ export class RoutePattern<source extends string = string> {
    * @param parsed The parsed route pattern.
    */
   constructor(parsed: ParsedRoutePattern) {
-    this.parsed = parsed
+    ;(this as unknown as RoutePatternInternals).parsed = parsed
   }
 
   /**
@@ -107,7 +113,7 @@ export class RoutePattern<source extends string = string> {
 
   /** Normalized string representation of this pattern. */
   get source(): string {
-    return serializePattern(this.parsed)
+    return serializePattern(getRoutePatternParts(this))
   }
 
   /**
@@ -125,7 +131,7 @@ export class RoutePattern<source extends string = string> {
    * @returns The serialized protocol, hostname, port, pathname, and search.
    */
   toJSON(): RoutePatternJSON {
-    return serializePatternParts(this.parsed)
+    return serializePatternParts(getRoutePatternParts(this))
   }
 }
 
@@ -136,7 +142,7 @@ export function createRoutePattern<source extends string>(
 }
 
 export function getRoutePatternParts(pattern: RoutePattern): ParsedRoutePattern {
-  return (pattern as unknown as { parsed: ParsedRoutePattern }).parsed
+  return (pattern as unknown as RoutePatternInternals).parsed
 }
 
 /**

--- a/packages/route-pattern/src/lib/route-pattern.ts
+++ b/packages/route-pattern/src/lib/route-pattern.ts
@@ -80,7 +80,7 @@ declare const brand: unique symbol
 export class RoutePattern<source extends string = string> {
   declare readonly [brand]: source
 
-  /** Parsed parts of this pattern. Internal; read it with {@link getRoutePatternParts}. */
+  /** Parsed parts of this pattern. Internal; not part of the public API. */
   readonly _parts: RoutePatternParts
 
   /**
@@ -135,10 +135,6 @@ export function createRoutePattern<source extends string>(
   return new RoutePattern<source>(parts)
 }
 
-export function getRoutePatternParts(pattern: RoutePattern): RoutePatternParts {
-  return pattern._parts
-}
-
 /**
  * Returns the hostname and pathname captures in a pattern in source order without exposing parsed
  * pattern internals.
@@ -147,7 +143,7 @@ export function getRoutePatternParts(pattern: RoutePattern): RoutePatternParts {
  * @returns Metadata for each variable and wildcard in the pattern.
  */
 export function getRoutePatternCaptures(pattern: RoutePattern): ReadonlyArray<RoutePatternCapture> {
-  let parsed = getRoutePatternParts(pattern)
+  let parsed = pattern._parts
   let captures: Array<RoutePatternCapture> = []
 
   if (parsed.hostname) collectCaptures(parsed.hostname, captures)

--- a/packages/route-pattern/src/lib/route-pattern.ts
+++ b/packages/route-pattern/src/lib/route-pattern.ts
@@ -16,7 +16,7 @@ export type PartPattern = {
   readonly type: 'hostname' | 'pathname'
 }
 
-export type ParsedRoutePattern = {
+export type RoutePatternParts = {
   readonly protocol: 'http' | 'https' | 'http(s)' | null
   readonly hostname: PartPattern | null
   readonly port: string | null
@@ -71,15 +71,6 @@ export interface RoutePatternCapture {
 declare const brand: unique symbol
 
 /**
- * Internal backing shape of a {@link RoutePattern}. The parsed representation is stored on the
- * instance but kept off the public type so consumers cannot read parser tokens directly; the
- * helpers in this module reach it through {@link getRoutePatternParts}.
- */
-interface RoutePatternInternals {
-  parsed: ParsedRoutePattern
-}
-
-/**
  * A parsed route pattern.
  *
  * Create one with {@link RoutePattern.parse}. The constructor is public but takes a parsed
@@ -89,16 +80,19 @@ interface RoutePatternInternals {
 export class RoutePattern<source extends string = string> {
   declare readonly [brand]: source
 
+  /** Parsed parts of this pattern. Internal; read it with {@link getRoutePatternParts}. */
+  readonly _parts: RoutePatternParts
+
   /**
-   * Create a new `RoutePattern` from a parsed representation.
+   * Create a new `RoutePattern` from its parsed parts.
    *
-   * The parsed representation is not part of the public API. Use {@link RoutePattern.parse} to
-   * create a pattern from a source string.
+   * The parts are not part of the public API. Use {@link RoutePattern.parse} to create a pattern
+   * from a source string.
    *
-   * @param parsed The parsed route pattern.
+   * @param parts The parsed parts of the pattern.
    */
-  constructor(parsed: ParsedRoutePattern) {
-    ;(this as unknown as RoutePatternInternals).parsed = parsed
+  constructor(parts: RoutePatternParts) {
+    this._parts = parts
   }
 
   /**
@@ -113,7 +107,7 @@ export class RoutePattern<source extends string = string> {
 
   /** Normalized string representation of this pattern. */
   get source(): string {
-    return serializePattern(getRoutePatternParts(this))
+    return serializePattern(this._parts)
   }
 
   /**
@@ -131,18 +125,18 @@ export class RoutePattern<source extends string = string> {
    * @returns The serialized protocol, hostname, port, pathname, and search.
    */
   toJSON(): RoutePatternJSON {
-    return serializePatternParts(getRoutePatternParts(this))
+    return serializePatternParts(this._parts)
   }
 }
 
 export function createRoutePattern<source extends string>(
-  parsed: ParsedRoutePattern,
+  parts: RoutePatternParts,
 ): RoutePattern<source> {
-  return new RoutePattern<source>(parsed)
+  return new RoutePattern<source>(parts)
 }
 
-export function getRoutePatternParts(pattern: RoutePattern): ParsedRoutePattern {
-  return (pattern as unknown as RoutePatternInternals).parsed
+export function getRoutePatternParts(pattern: RoutePattern): RoutePatternParts {
+  return pattern._parts
 }
 
 /**

--- a/packages/route-pattern/src/lib/route-pattern/parse.test.ts
+++ b/packages/route-pattern/src/lib/route-pattern/parse.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@remix-run/test'
 import dedent from 'dedent'
 
 import { ParseError, parsePart, parsePattern } from './parse.ts'
-import { createRoutePattern, getRoutePatternParts, RoutePattern } from '../route-pattern.ts'
+import { createRoutePattern, RoutePattern } from '../route-pattern.ts'
 import type { RoutePatternParts, PartPattern } from '../route-pattern.ts'
 
 describe('ParseError', () => {
@@ -277,7 +277,7 @@ describe('parsePattern', () => {
         expectedSearch.set(name, value.length === 0 ? new Set() : new Set(value))
       }
     }
-    assert.deepEqual(getRoutePatternParts(pattern), {
+    assert.deepEqual(pattern._parts, {
       protocol: expected.protocol ?? null,
       hostname: expected.hostname ? parsePart(expected.hostname, { type: 'hostname' }) : null,
       port: expected.port ?? null,
@@ -287,9 +287,9 @@ describe('parsePattern', () => {
   }
 
   it('parses protocol', () => {
-    assert.equal(getRoutePatternParts(parsePattern('http://')).protocol, 'http')
-    assert.equal(getRoutePatternParts(parsePattern('https://')).protocol, 'https')
-    assert.equal(getRoutePatternParts(parsePattern('http(s)://')).protocol, 'http(s)')
+    assert.equal(parsePattern('http://')._parts.protocol, 'http')
+    assert.equal(parsePattern('https://')._parts.protocol, 'https')
+    assert.equal(parsePattern('http(s)://')._parts.protocol, 'http(s)')
   })
 
   it('parses hostname', () => {

--- a/packages/route-pattern/src/lib/route-pattern/parse.test.ts
+++ b/packages/route-pattern/src/lib/route-pattern/parse.test.ts
@@ -4,7 +4,7 @@ import dedent from 'dedent'
 
 import { ParseError, parsePart, parsePattern } from './parse.ts'
 import { createRoutePattern, getRoutePatternParts, RoutePattern } from '../route-pattern.ts'
-import type { ParsedRoutePattern, PartPattern } from '../route-pattern.ts'
+import type { RoutePatternParts, PartPattern } from '../route-pattern.ts'
 
 describe('ParseError', () => {
   it('exposes type, source, and index properties', () => {
@@ -262,7 +262,7 @@ describe('parsePattern', () => {
   function assertParse(
     source: string,
     expected: {
-      protocol?: ParsedRoutePattern['protocol']
+      protocol?: RoutePatternParts['protocol']
       hostname?: string
       port?: string
       pathname?: string

--- a/packages/route-pattern/src/lib/route-pattern/parse.ts
+++ b/packages/route-pattern/src/lib/route-pattern/parse.ts
@@ -1,7 +1,7 @@
 import { split, type Span } from './split.ts'
 import { createRoutePattern } from '../route-pattern.ts'
 import type {
-  ParsedRoutePattern,
+  RoutePatternParts,
   PartPattern,
   PartPatternToken,
   RoutePattern,
@@ -126,7 +126,7 @@ export function parsePart(
   return { tokens, optionals, type: options.type }
 }
 
-function parseProtocol(source: string, span: Span | null): ParsedRoutePattern['protocol'] {
+function parseProtocol(source: string, span: Span | null): RoutePatternParts['protocol'] {
   if (!span) return null
   let protocol = source.slice(...span)
   if (protocol === '' || protocol === 'http' || protocol === 'https' || protocol === 'http(s)') {
@@ -135,7 +135,7 @@ function parseProtocol(source: string, span: Span | null): ParsedRoutePattern['p
   throw new ParseError('invalid protocol', source, span[0])
 }
 
-function parseHostname(source: string, span: Span | null): ParsedRoutePattern['hostname'] | null {
+function parseHostname(source: string, span: Span | null): RoutePatternParts['hostname'] | null {
   if (!span) return null
   let part = parsePart(source, { span, type: 'hostname' })
   if (isNamelessWildcard(part)) return null
@@ -149,7 +149,7 @@ function isNamelessWildcard(part: PartPattern): boolean {
   return token.name === '*'
 }
 
-function parseSearch(source: string): ParsedRoutePattern['search'] {
+function parseSearch(source: string): RoutePatternParts['search'] {
   let constraints = new Map<string, Set<string>>()
 
   let searchParams = new URLSearchParams(source)

--- a/packages/route-pattern/src/lib/route-pattern/serialize.test.ts
+++ b/packages/route-pattern/src/lib/route-pattern/serialize.test.ts
@@ -2,7 +2,6 @@ import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
 import { parsePattern } from './parse.ts'
-import { getRoutePatternParts } from '../route-pattern.ts'
 import {
   serializeHostname,
   serializePathname,
@@ -14,7 +13,7 @@ import {
 } from './serialize.ts'
 
 function partsOf(source: string) {
-  return getRoutePatternParts(parsePattern(source))
+  return parsePattern(source)._parts
 }
 
 describe('serializePattern', () => {

--- a/packages/route-pattern/src/lib/route-pattern/serialize.ts
+++ b/packages/route-pattern/src/lib/route-pattern/serialize.ts
@@ -1,7 +1,7 @@
-import type { ParsedRoutePattern, PartPattern } from '../route-pattern.ts'
+import type { RoutePatternParts, PartPattern } from '../route-pattern.ts'
 import { unreachable } from '../unreachable.ts'
 
-export function serializePattern(pattern: ParsedRoutePattern): string {
+export function serializePattern(pattern: RoutePatternParts): string {
   let protocol = serializeProtocol(pattern)
   let hostname = serializeHostname(pattern)
   let port = serializePort(pattern)
@@ -17,7 +17,7 @@ export function serializePattern(pattern: ParsedRoutePattern): string {
   return result
 }
 
-export function serializePatternParts(pattern: ParsedRoutePattern): {
+export function serializePatternParts(pattern: RoutePatternParts): {
   protocol: string
   hostname: string
   port: string
@@ -33,23 +33,23 @@ export function serializePatternParts(pattern: ParsedRoutePattern): {
   }
 }
 
-export function serializeProtocol(pattern: ParsedRoutePattern): string {
+export function serializeProtocol(pattern: RoutePatternParts): string {
   return pattern.protocol ?? ''
 }
 
-export function serializeHostname(pattern: ParsedRoutePattern): string {
+export function serializeHostname(pattern: RoutePatternParts): string {
   return pattern.hostname ? serializePart(pattern.hostname) : ''
 }
 
-export function serializePort(pattern: ParsedRoutePattern): string {
+export function serializePort(pattern: RoutePatternParts): string {
   return pattern.port ?? ''
 }
 
-export function serializePathname(pattern: ParsedRoutePattern): string {
+export function serializePathname(pattern: RoutePatternParts): string {
   return serializePart(pattern.pathname)
 }
 
-export function serializeSearch(pattern: ParsedRoutePattern): string {
+export function serializeSearch(pattern: RoutePatternParts): string {
   if (pattern.search.size === 0) return ''
   let searchParams = new URLSearchParams()
   for (let [key, constraint] of pattern.search) {

--- a/packages/route-pattern/src/lib/specificity.ts
+++ b/packages/route-pattern/src/lib/specificity.ts
@@ -1,4 +1,3 @@
-import { getRoutePatternParts } from './route-pattern.ts'
 import type { RoutePatternParts } from './route-pattern.ts'
 import type { Match } from './match/types.ts'
 import { decodeHostname } from './match/decode.ts'
@@ -66,8 +65,8 @@ export function compare(a: Match, b: Match): -1 | 0 | 1 {
   if (a.url.href !== b.url.href) {
     throw new Error(`Cannot compare matches for different URLs: ${a.url.href} vs ${b.url.href}`)
   }
-  let aParts = getRoutePatternParts(a.pattern)
-  let bParts = getRoutePatternParts(b.pattern)
+  let aParts = a.pattern._parts
+  let bParts = b.pattern._parts
 
   let protocolResult = compareProtocol(aParts.protocol, bParts.protocol)
   if (protocolResult !== 0) return protocolResult

--- a/packages/route-pattern/src/lib/specificity.ts
+++ b/packages/route-pattern/src/lib/specificity.ts
@@ -1,5 +1,5 @@
 import { getRoutePatternParts } from './route-pattern.ts'
-import type { ParsedRoutePattern } from './route-pattern.ts'
+import type { RoutePatternParts } from './route-pattern.ts'
 import type { Match } from './match/types.ts'
 import { decodeHostname } from './match/decode.ts'
 
@@ -90,8 +90,8 @@ export function compare(a: Match, b: Match): -1 | 0 | 1 {
 }
 
 function compareProtocol(
-  a: ParsedRoutePattern['protocol'],
-  b: ParsedRoutePattern['protocol'],
+  a: RoutePatternParts['protocol'],
+  b: RoutePatternParts['protocol'],
 ): -1 | 0 | 1 {
   let aSpecificity = a === 'http' || a === 'https' ? 1 : 0
   let bSpecificity = b === 'http' || b === 'https' ? 1 : 0
@@ -100,7 +100,7 @@ function compareProtocol(
   return 0
 }
 
-function comparePort(a: ParsedRoutePattern['port'], b: ParsedRoutePattern['port']): -1 | 0 | 1 {
+function comparePort(a: RoutePatternParts['port'], b: RoutePatternParts['port']): -1 | 0 | 1 {
   if (a !== null && b === null) return 1
   if (a === null && b !== null) return -1
   return 0
@@ -188,10 +188,7 @@ function comparePathname(
   return 0
 }
 
-function compareSearch(
-  a: ParsedRoutePattern['search'],
-  b: ParsedRoutePattern['search'],
-): -1 | 0 | 1 {
+function compareSearch(a: RoutePatternParts['search'], b: RoutePatternParts['search']): -1 | 0 | 1 {
   let aSpecificity = searchSpecificity(a)
   let bSpecificity = searchSpecificity(b)
 
@@ -204,7 +201,7 @@ function compareSearch(
   return 0
 }
 
-function searchSpecificity(constraints: ParsedRoutePattern['search']): {
+function searchSpecificity(constraints: RoutePatternParts['search']): {
   key: number
   keyValue: number
 } {

--- a/packages/route-pattern/src/route-pattern.ts
+++ b/packages/route-pattern/src/route-pattern.ts
@@ -1,3 +1,3 @@
-export { getRoutePatternParams, RoutePattern } from './lib/route-pattern.ts'
-export type { RoutePatternJSON, RoutePatternParam } from './lib/route-pattern.ts'
+export { getRoutePatternCaptures, RoutePattern } from './lib/route-pattern.ts'
+export type { RoutePatternCapture, RoutePatternJSON } from './lib/route-pattern.ts'
 export { ParseError } from './lib/route-pattern/parse.ts'


### PR DESCRIPTION
Follow-up cleanup to the `RoutePattern` work merged in #11556 (PRs #11557–#11560). None of that has shipped yet, so the API is still up for grabs — this trades the construction machinery for a plain, JavaScript-y class.

## Core (`route-pattern.ts`)

- **Single class, public constructor** — `constructor(parts: RoutePatternParts)` stores into a plain `readonly _parts` field. Drops the merged design's `Symbol` constructor key, the dual-guard `throw` branches, and the static bridge method.
- **No WeakMap** — the parsed parts live on the instance, like `RegExp` carries its own state.
- **No accessor helper** — sibling modules read `pattern._parts` directly. There's no `getRoutePatternParts` indirection, no WeakMap lookup, and no cast.
- **Native `instanceof`** — no `Symbol.hasInstance`; it's a normal class, so `instanceof RoutePattern` narrows naturally (fetch-router relies on this).
- **Phantom brand** — `declare const brand: unique symbol` keeps nominal `source` typing and survives `.d.ts` emit.
- `createRoutePattern(parts)` stays as the thin factory callers use, so internal code never writes `new`.

## Internal storage: underscore-private `_parts`

The parsed parts are stored in a `readonly _parts` field. The underscore marks it internal (old-school convention) so the package's other modules can read `pattern._parts` directly without a WeakMap, a symbol key, or `#private` + cross-module friend access. It isn't re-exported and isn't meant to be touched.

## Vocabulary: params → captures

`getRoutePatternParams` → `getRoutePatternCaptures`, `RoutePatternParam` → `RoutePatternCapture`. "Param" stays reserved for values matched out of a URL (the matching pipeline is untouched); "capture" names the `:var` / `*wildcard` declarations in a pattern. Optional detection is folded into a single depth-tracking pass (removes `getPartParams` + `isOptionalToken`).

## Rename: `ParsedRoutePattern` → `RoutePatternParts`

The parsed-parts type is renamed to pair with the `_parts` field. It stays internal — not re-exported from the package entry, alongside `PartPattern` and `PartPatternToken` — so parser tokens stay off the public surface.

## Tradeoff

Privacy is by convention. The build erases TS `private` and the repo lint bans accessibility modifiers, while a true `#private` field can't be read by the package's sibling modules (`href`, `join`, `specificity`, `match/variant`, `match/trie`) that need the parsed parts. So `_parts` is technically visible on the instance type — a deliberate choice once a WeakMap and a symbol key were ruled out. The public constructor takes `RoutePatternParts`, but neither it nor the type is exported by name from the entry, so consumers can't ergonomically construct one; `RoutePattern.parse()` is the documented path.

## Verification

| Check | Result |
|---|---|
| oxlint (route-pattern + assets) | 0 errors |
| route-pattern typecheck | clean |
| route-pattern tests | 313/313 |
| assets typecheck | clean |
| assets tests | 264/264 |
| fetch-router typecheck (instanceof narrowing) | clean |
| fetch-router tests | 160/160 |

Net **−38 lines** (137 insertions / 175 deletions) across 19 files. All CI checks green.
