### PR TITLE
Strip stale encoding and framing headers in fetch-proxy

### DIFF
--- a/packages/fetch-proxy/.changes/patch.strip-stale-encoding-headers.md
+++ b/packages/fetch-proxy/.changes/patch.strip-stale-encoding-headers.md
@@ -1,0 +1,1 @@
+Stop forwarding incoming `Accept-Encoding` headers to proxy targets, strip `Content-Encoding` and related `Content-Length` headers from proxied responses with a body, and strip `Transfer-Encoding` and related `Content-Length` headers from proxied responses.

--- a/packages/fetch-proxy/README.md
+++ b/packages/fetch-proxy/README.md
@@ -7,6 +7,7 @@ HTTP proxy utilities built on the web [Fetch API](https://developer.mozilla.org/
 - **Web Standards** - Built on the standard [JavaScript Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
 - **Cookie Rewriting** - Supports rewriting `Set-Cookie` headers received from target server
 - **Forwarding Headers** - Supports `X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Forwarded-Port` headers
+- **Encoding Headers** - Strips stale encoding and framing headers from proxied responses
 - **Custom Fetch** - Supports custom `fetch` implementations
 
 ## Installation
@@ -36,9 +37,33 @@ let title = text.match(/<title>([^<]+)<\/title>/)[1]
 assert(title.includes('Remix'))
 ```
 
+## Encoding and Framing Headers
+
+Since proxying is done via `fetch` rather than raw HTTP messages, some encoding and framing headers need to be removed.
+
+The incoming `Accept-Encoding` request header describes the final client, so it is not forwarded to the target server.
+
+Since `fetch` can decompress upstream responses and does not expose raw HTTP transfer framing, `fetch-proxy` strips response headers that may no longer describe the returned body: `Content-Encoding`, related `Content-Length`, and `Transfer-Encoding`.
+
+To support serving compressed responses to the final client, you'll need to compress the response after the proxy returns it, e.g. with the [`compressResponse` helper from `remix/response`](https://github.com/remix-run/remix/tree/main/packages/response#compress-responses):
+
+```ts
+import { createFetchProxy } from 'remix/fetch-proxy'
+import { compressResponse } from 'remix/response/compress'
+
+let proxy = createFetchProxy('https://remix.run')
+
+async function handleFetch(request: Request): Promise<Response> {
+  let response = await proxy(request)
+
+  return compressResponse(response, request)
+}
+```
+
 ## Related Packages
 
 - [`node-fetch-server`](https://github.com/remix-run/remix/tree/main/packages/node-fetch-server) - Build HTTP servers for Node.js using the web fetch API
+- [`response`](https://github.com/remix-run/remix/tree/main/packages/response) - Create, transform, and compress Fetch API responses
 
 ## License
 

--- a/packages/fetch-proxy/package.json
+++ b/packages/fetch-proxy/package.json
@@ -36,9 +36,11 @@
   },
   "devDependencies": {
     "@remix-run/assert": "workspace:*",
+    "@remix-run/response": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "@typescript/native-preview": "catalog:",
+    "undici": "^7.24.8"
   },
   "scripts": {
     "build": "tsgo -p tsconfig.build.json",

--- a/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
@@ -1,5 +1,9 @@
+import { createServer } from 'node:http'
+
 import * as assert from '@remix-run/assert'
+import { compressResponse } from '@remix-run/response/compress'
 import { describe, it } from '@remix-run/test'
+import { fetch as undiciFetch } from 'undici'
 
 import { type FetchProxyOptions, createFetchProxy } from './fetch-proxy.ts'
 
@@ -24,6 +28,60 @@ async function testProxy(
   assert.ok(capturedRequest!)
 
   return { request: capturedRequest, response }
+}
+
+async function readBodyWithUndici(response: Response): Promise<string> {
+  let clientResponse = await readResponseWithUndici(response)
+  return clientResponse.body
+}
+
+async function readResponseWithUndici(
+  response: Response,
+  method = 'GET',
+): Promise<{ body: string; headers: Headers; status: number }> {
+  let body = response.body == null ? undefined : new Uint8Array(await response.arrayBuffer())
+  let headers = Object.fromEntries(response.headers)
+  let server = createServer((_, serverResponse) => {
+    serverResponse.writeHead(response.status, headers)
+    serverResponse.end(body)
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+
+  try {
+    let address = server.address()
+    if (address == null || typeof address === 'string') {
+      throw new Error('Expected test server to listen on a TCP port')
+    }
+
+    let clientResponse = await undiciFetch(`http://127.0.0.1:${address.port}/`, { method })
+    let clientHeaders = new Headers()
+    for (let [name, value] of clientResponse.headers) {
+      clientHeaders.append(name, value)
+    }
+
+    return {
+      body: await clientResponse.text(),
+      headers: clientHeaders,
+      status: clientResponse.status,
+    }
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
 }
 
 describe('fetch proxy', () => {
@@ -126,6 +184,19 @@ describe('fetch proxy', () => {
     assert.equal(request.headers.get('Host'), null)
   })
 
+  it('does not forward the incoming Accept-Encoding header', async () => {
+    let { request } = await testProxy(
+      new Request('http://shopify.com/search?q=remix', {
+        headers: {
+          'Accept-Encoding': 'gzip, br',
+        },
+      }),
+      'https://remix.run:3000/dest',
+    )
+
+    assert.equal(request.headers.get('Accept-Encoding'), null)
+  })
+
   it('appends X-Forwarded headers when desired', async () => {
     let { request } = await testProxy(
       new Request('http://shopify.com:8080/search?q=remix'),
@@ -201,6 +272,256 @@ describe('fetch proxy', () => {
     assert.equal(setCookie.length, 2)
     assert.equal(setCookie[0], 'name=value; Domain=shopify.com; Path=/search')
     assert.equal(setCookie[1], 'name2=value2; Domain=shopify.com; Path=/')
+  })
+
+  it('strips gzip response headers when fetch returns a decoded body', async () => {
+    let decodedBody = 'decoded response body'
+    let compressedResponse = await compressResponse(
+      new Response(decodedBody),
+      new Request('https://remix.run', {
+        headers: { 'Accept-Encoding': 'gzip' },
+      }),
+      { encodings: ['gzip'] },
+    )
+    let contentEncoding = compressedResponse.headers.get('Content-Encoding')
+    let compressedBody = await compressedResponse.arrayBuffer()
+    let decodedBodyLength = new TextEncoder().encode(decodedBody).byteLength
+
+    assert.equal(contentEncoding, 'gzip')
+    if (contentEncoding == null) {
+      throw new Error('Expected compressed response to include Content-Encoding')
+    }
+    assert.notEqual(compressedBody.byteLength, decodedBodyLength)
+    assert.equal(
+      await readBodyWithUndici(
+        new Response(compressedBody, {
+          headers: {
+            'Content-Encoding': contentEncoding,
+          },
+        }),
+      ),
+      decodedBody,
+    )
+
+    let staleEncodedBodyHeaders = {
+      'Content-Encoding': contentEncoding,
+      'Content-Length': String(compressedBody.byteLength),
+      'Content-Type': 'text/plain',
+    }
+    await assert.rejects(async () => {
+      await readBodyWithUndici(
+        new Response(decodedBody, {
+          headers: staleEncodedBodyHeaders,
+        }),
+      )
+    })
+
+    let { response } = await testProxy(
+      new Request('http://shopify.com/search?q=remix'),
+      'https://remix.run:3000/dest',
+      {
+        async fetch() {
+          return new Response(decodedBody, {
+            headers: staleEncodedBodyHeaders,
+          })
+        },
+      },
+    )
+
+    assert.equal(response.headers.get('Content-Encoding'), null)
+    assert.equal(response.headers.get('Content-Length'), null)
+    assert.equal(response.headers.get('Transfer-Encoding'), null)
+    assert.equal(response.headers.get('Content-Type'), 'text/plain')
+    assert.equal(await readBodyWithUndici(response), decodedBody)
+  })
+
+  it('preserves content length for unencoded responses', async () => {
+    let body = 'unencoded response body'
+    let contentLength = String(new TextEncoder().encode(body).byteLength)
+    let { response } = await testProxy(
+      new Request('http://shopify.com/search?q=remix'),
+      'https://remix.run:3000/dest',
+      {
+        async fetch() {
+          return new Response(body, {
+            headers: {
+              'Content-Length': contentLength,
+              'Content-Type': 'text/plain',
+            },
+          })
+        },
+      },
+    )
+
+    assert.equal(response.headers.get('Content-Encoding'), null)
+    assert.equal(response.headers.get('Content-Length'), contentLength)
+    assert.equal(response.headers.get('Transfer-Encoding'), null)
+    assert.equal(response.headers.get('Content-Type'), 'text/plain')
+    assert.equal(await readBodyWithUndici(response), body)
+  })
+
+  it('preserves content encoding metadata for HEAD responses', async () => {
+    let decodedBody = 'head response body'
+    let compressedResponse = await compressResponse(
+      new Response(decodedBody),
+      new Request('https://remix.run', {
+        headers: { 'Accept-Encoding': 'gzip' },
+      }),
+      { encodings: ['gzip'] },
+    )
+    let contentEncoding = compressedResponse.headers.get('Content-Encoding')
+    let contentLength = String((await compressedResponse.arrayBuffer()).byteLength)
+
+    assert.equal(contentEncoding, 'gzip')
+    if (contentEncoding == null) {
+      throw new Error('Expected compressed response to include Content-Encoding')
+    }
+
+    let { response } = await testProxy(
+      new Request('http://shopify.com/search?q=remix', {
+        method: 'HEAD',
+      }),
+      'https://remix.run:3000/dest',
+      {
+        async fetch() {
+          return new Response(null, {
+            headers: {
+              'Content-Encoding': contentEncoding,
+              'Content-Length': contentLength,
+              'Content-Type': 'text/plain',
+            },
+          })
+        },
+      },
+    )
+    let clientResponse = await readResponseWithUndici(response, 'HEAD')
+
+    assert.equal(response.headers.get('Content-Encoding'), contentEncoding)
+    assert.equal(response.headers.get('Content-Length'), contentLength)
+    assert.equal(response.headers.get('Transfer-Encoding'), null)
+    assert.equal(clientResponse.status, 200)
+    assert.equal(clientResponse.headers.get('Content-Encoding'), contentEncoding)
+    assert.equal(clientResponse.headers.get('Content-Length'), contentLength)
+    assert.equal(clientResponse.body, '')
+  })
+
+  it('preserves content encoding metadata for 304 responses', async () => {
+    let decodedBody = 'not modified response body'
+    let compressedResponse = await compressResponse(
+      new Response(decodedBody),
+      new Request('https://remix.run', {
+        headers: { 'Accept-Encoding': 'gzip' },
+      }),
+      { encodings: ['gzip'] },
+    )
+    let contentEncoding = compressedResponse.headers.get('Content-Encoding')
+    let contentLength = String((await compressedResponse.arrayBuffer()).byteLength)
+
+    assert.equal(contentEncoding, 'gzip')
+    if (contentEncoding == null) {
+      throw new Error('Expected compressed response to include Content-Encoding')
+    }
+
+    let { response } = await testProxy(
+      new Request('http://shopify.com/search?q=remix'),
+      'https://remix.run:3000/dest',
+      {
+        async fetch() {
+          return new Response(null, {
+            status: 304,
+            headers: {
+              'Content-Encoding': contentEncoding,
+              'Content-Length': contentLength,
+              ETag: '"compressed-response"',
+            },
+          })
+        },
+      },
+    )
+    let clientResponse = await readResponseWithUndici(response)
+
+    assert.equal(response.headers.get('Content-Encoding'), contentEncoding)
+    assert.equal(response.headers.get('Content-Length'), contentLength)
+    assert.equal(response.headers.get('Transfer-Encoding'), null)
+    assert.equal(clientResponse.status, 304)
+    assert.equal(clientResponse.headers.get('Content-Encoding'), contentEncoding)
+    assert.equal(clientResponse.headers.get('Content-Length'), contentLength)
+    assert.equal(clientResponse.body, '')
+  })
+
+  it('strips ambiguous content encoding headers for unsupported content encodings', async () => {
+    let body = 'unsupported encoded response body'
+    let contentLength = String(new TextEncoder().encode(body).byteLength)
+    let unsupportedContentEncoding = 'foobar'
+
+    assert.equal(
+      await readBodyWithUndici(
+        new Response(body, {
+          headers: {
+            'Content-Encoding': unsupportedContentEncoding,
+            'Content-Length': contentLength,
+          },
+        }),
+      ),
+      body,
+    )
+
+    let { response } = await testProxy(
+      new Request('http://shopify.com/search?q=remix'),
+      'https://remix.run:3000/dest',
+      {
+        async fetch() {
+          return new Response(body, {
+            headers: {
+              'Content-Encoding': unsupportedContentEncoding,
+              'Content-Length': contentLength,
+              'Content-Type': 'text/plain',
+            },
+          })
+        },
+      },
+    )
+
+    assert.equal(response.headers.get('Content-Encoding'), null)
+    assert.equal(response.headers.get('Content-Length'), null)
+    assert.equal(response.headers.get('Transfer-Encoding'), null)
+    assert.equal(response.headers.get('Content-Type'), 'text/plain')
+    assert.equal(await readBodyWithUndici(response), body)
+  })
+
+  it('strips transfer framing headers from unencoded responses', async () => {
+    let body = 'chunked response body'
+    let staleTransferHeaders = {
+      'Content-Length': '999',
+      'Content-Type': 'text/plain',
+      'Transfer-Encoding': 'chunked',
+    }
+
+    await assert.rejects(async () => {
+      await readBodyWithUndici(
+        new Response(body, {
+          headers: staleTransferHeaders,
+        }),
+      )
+    })
+
+    let { response } = await testProxy(
+      new Request('http://shopify.com/search?q=remix'),
+      'https://remix.run:3000/dest',
+      {
+        async fetch() {
+          return new Response(body, {
+            headers: staleTransferHeaders,
+          })
+        },
+      },
+    )
+
+    assert.equal(response.headers.get('Content-Encoding'), null)
+    assert.equal(response.headers.get('Content-Length'), null)
+    assert.equal(response.headers.get('Transfer-Encoding'), null)
+    assert.equal(response.headers.get('Content-Type'), 'text/plain')
+    assert.equal(await readBodyWithUndici(response), body)
   })
 
   it('omits cookie domain for localhost requests with a port and rewrites path', async () => {

--- a/packages/fetch-proxy/src/lib/fetch-proxy.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.ts
@@ -78,6 +78,7 @@ export function createFetchProxy(target: string | URL, options?: FetchProxyOptio
 
     let proxyHeaders = new Headers(request.headers)
     proxyHeaders.delete('Host')
+    proxyHeaders.delete('Accept-Encoding')
     if (xForwardedHeaders) {
       proxyHeaders.append('X-Forwarded-Proto', url.protocol.replace(/:$/, ''))
       proxyHeaders.append('X-Forwarded-Host', url.host)
@@ -110,6 +111,18 @@ export function createFetchProxy(target: string | URL, options?: FetchProxyOptio
 
     let response = await localFetch(proxyUrl, proxyInit)
     let responseHeaders = new Headers(response.headers)
+    let hasContentEncoding = responseHeaders.has('Content-Encoding')
+    let hasTransferEncoding = responseHeaders.has('Transfer-Encoding')
+    let hasProxiedResponseBody = request.method !== 'HEAD' && response.body != null
+
+    responseHeaders.delete('Transfer-Encoding')
+    if (hasTransferEncoding || (hasProxiedResponseBody && hasContentEncoding)) {
+      responseHeaders.delete('Content-Length')
+    }
+
+    if (hasProxiedResponseBody && hasContentEncoding) {
+      responseHeaders.delete('Content-Encoding')
+    }
 
     if (responseHeaders.has('Set-Cookie')) {
       let setCookie = responseHeaders.getSetCookie()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -762,6 +762,9 @@ importers:
       '@remix-run/assert':
         specifier: workspace:*
         version: link:../assert
+      '@remix-run/response':
+        specifier: workspace:*
+        version: link:../response
       '@remix-run/test':
         specifier: workspace:*
         version: link:../test
@@ -771,6 +774,9 @@ importers:
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20251125.1
+      undici:
+        specifier: ^7.24.8
+        version: 7.24.8
 
   packages/fetch-router:
     dependencies:


### PR DESCRIPTION
Fixes `fetch-proxy` so encoding and framing headers are handled correctly across the client, proxy, and target server.

This PR:
- Stops forwarding incoming `Accept-Encoding` headers to proxy targets since they describe the final client
- Strips stale `Content-Encoding`, `Content-Length` and `Transfer-Encoding` headers from proxied responses since the body has already been decoded
- Adds a note to the readme about handling compressed responses