### PR TITLE
Add `--test-name-pattern` support

### DIFF
--- a/packages/test/.changes/minor.test-name-pattern.md
+++ b/packages/test/.changes/minor.test-name-pattern.md
@@ -1,0 +1,1 @@
+Added `--test-name-pattern` and `testNamePattern` support to filter tests by name.

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -140,29 +140,30 @@ remix test --config ./tests/config.ts
 
 You may also specify any config field as a CLI flag which will take precedence over config file values:
 
-| Flag                        | Short     |
-| --------------------------- | --------- | --- |
-| `--browser.echo`            |           |
-| `--browser.open`            |           |
-| `--concurrency <n>`         | `-c`      |
-| `--coverage`                |           |
-| `--coverage.dir <path>`     |           |
-| `--coverage.include`        |           |
-| `--coverage.exclude`        |           |
-| `--coverage.statements`     |           |
-| `--coverage.lines`          |           |
-| `--coverage.branches`       |           |
-| `--coverage.functions`      |           |
-| `--glob.test`               |           |
-| `--glob.browser`            |           |
-| `--glob.e2e`                |           |
-| `--playwrightConfig <path>` |           |
-| `--pool <forks              | threads>` |     |
-| `--project <name>`          | `-p`      |
-| `--reporter <name>`         | `-r`      |
-| `--setup <path>`            | `-s`      |
-| `--type <name>`             | `-t`      |
-| `--watch`                   | `-w`      |
+| Flag                                  | Short     |
+| ------------------------------------- | --------- | --- |
+| `--browser.echo`                      |           |
+| `--browser.open`                      |           |
+| `--concurrency <n>`                   | `-c`      |
+| `--coverage`                          |           |
+| `--coverage.dir <path>`               |           |
+| `--coverage.include`                  |           |
+| `--coverage.exclude`                  |           |
+| `--coverage.statements`               |           |
+| `--coverage.lines`                    |           |
+| `--coverage.branches`                 |           |
+| `--coverage.functions`                |           |
+| `--glob.test`                         |           |
+| `--glob.browser`                      |           |
+| `--glob.e2e`                          |           |
+| `--playwrightConfig <path>`           |           |
+| `--pool <forks                        | threads>` |     |
+| `--project <name>`                    | `-p`      |
+| `--reporter <name>`                   | `-r`      |
+| `--setup <path>`                      | `-s`      |
+| `--test-name-pattern <regex-pattern>` |           |
+| `--type <name>`                       | `-t`      |
+| `--watch`                             | `-w`      |
 
 ### Setup
 

--- a/packages/test/src/app/client/entry.ts
+++ b/packages/test/src/app/client/entry.ts
@@ -1,9 +1,11 @@
 import { normalizeLine } from '../../lib/normalize.ts'
+import type { SerializedTestNamePattern } from '../../lib/config.ts'
 import type { TestResult, TestResults } from '../../lib/reporters/results.ts'
 
 interface TestsSetup {
   testPaths: string[]
   baseDir: string
+  testNamePatterns?: SerializedTestNamePattern[]
 }
 
 type FileResults = TestResults & { tests: Array<TestResult & { filePath: string }> }
@@ -162,7 +164,7 @@ function mountTests(host: HTMLElement, setup: TestsSetup): void {
 
   void (async () => {
     for (let testFile of setup.testPaths) {
-      let fileResults = await runInIframe(testFile)
+      let fileResults = await runInIframe(testFile, setup.testNamePatterns)
       await fetch('/file-results', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -181,10 +183,17 @@ function mountTests(host: HTMLElement, setup: TestsSetup): void {
   })()
 }
 
-function runInIframe(testFile: string): Promise<FileResults> {
+function runInIframe(
+  testFile: string,
+  testNamePatterns: SerializedTestNamePattern[] | undefined,
+): Promise<FileResults> {
   return new Promise((resolve) => {
     let iframe = document.createElement('iframe')
-    iframe.src = `/iframe?file=${encodeURIComponent(testFile)}`
+    let params = new URLSearchParams({ file: testFile })
+    if (testNamePatterns) {
+      params.set('testNamePatterns', JSON.stringify(testNamePatterns))
+    }
+    iframe.src = `/iframe?${params}`
     // Make the iframe as big so we don't get unintentional scrolling in test UIs
     let parentBody = iframe.contentWindow?.document.body
     iframe.width = Math.max(parentBody?.scrollWidth ?? 0, 800).toString()

--- a/packages/test/src/app/client/iframe.ts
+++ b/packages/test/src/app/client/iframe.ts
@@ -1,11 +1,16 @@
 import { runTests } from '../../lib/executor.ts'
+import type { SerializedTestNamePattern } from '../../lib/config.ts'
 
 const params = new URLSearchParams(location.search)
 const testFile = params.get('file')!
+const rawTestNamePatterns = params.get('testNamePatterns')
+const testNamePatterns = rawTestNamePatterns
+  ? (JSON.parse(rawTestNamePatterns) as SerializedTestNamePattern[])
+  : undefined
 
 try {
   await import(testFile)
-  let results = await runTests()
+  let results = await runTests({ testNamePatterns })
   window.parent.postMessage({ type: 'test-results', results }, '*')
 } catch (error: any) {
   window.parent.postMessage(

--- a/packages/test/src/app/server.ts
+++ b/packages/test/src/app/server.ts
@@ -7,7 +7,11 @@ import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { ResolverFactory } from 'oxc-resolver'
 import { SourceMapConsumer, SourceMapGenerator } from 'source-map-js'
-import { getBrowserTestRootDir, IS_RUNNING_FROM_SRC } from '../lib/config.ts'
+import {
+  getBrowserTestRootDir,
+  IS_RUNNING_FROM_SRC,
+  type SerializedTestNamePattern,
+} from '../lib/config.ts'
 import { transformTypeScript } from '../lib/ts-transform.ts'
 
 const log = (str: string) => console.log(`[remix:test] ${str}`)
@@ -22,8 +26,9 @@ const browserResolver = new ResolverFactory({
 
 export async function startServer(
   browserFiles: string[],
+  options: { testNamePatterns?: SerializedTestNamePattern[] } = {},
 ): Promise<{ server: http.Server; port: number; baseUrl: string }> {
-  let handle = createRequestHandler(browserFiles)
+  let handle = createRequestHandler(browserFiles, options)
 
   let server = http.createServer((req, res) => {
     handle(req, res).catch((error) => {
@@ -65,6 +70,7 @@ function isAddressInfo(address: ReturnType<http.Server['address']>): address is 
 
 function createRequestHandler(
   browserFiles: string[],
+  options: { testNamePatterns?: SerializedTestNamePattern[] } = {},
 ): (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void> {
   let rootDir = getBrowserTestRootDir()
   let srcDir = IS_RUNNING_FROM_SRC
@@ -91,7 +97,11 @@ function createRequestHandler(
     }
 
     if (url.pathname === '/') {
-      let setupJson = JSON.stringify({ testPaths, baseDir: process.cwd() })
+      let setupJson = JSON.stringify({
+        testPaths,
+        baseDir: process.cwd(),
+        testNamePatterns: options.testNamePatterns,
+      })
       let body =
         `<script type="application/json" id="test-setup">` +
         `${escapeJsonForScript(setupJson)}` +

--- a/packages/test/src/cli.ts
+++ b/packages/test/src/cli.ts
@@ -186,7 +186,9 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
         let { startServer } = IS_RUNNING_FROM_SRC
           ? await importModule('./app/server.ts', import.meta)
           : await import(`./app/server.js`)
-        let result = await startServer(browserFiles)
+        let result = await startServer(browserFiles, {
+          testNamePatterns: config.testNamePatterns,
+        })
         browserServer = result.server
         browserServerFilesKey = browserFilesKey
         browserBaseUrl = result.baseUrl
@@ -214,6 +216,7 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
             coverage: config.coverage,
             cwd,
             pool: config.pool,
+            testNamePatterns: config.testNamePatterns,
           },
         )
         counts.failed += serverResult.failed
@@ -288,6 +291,7 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
                   coverage: config.coverage,
                   cwd,
                   pool: config.pool,
+                  testNamePatterns: config.testNamePatterns,
                 })
               : null
 

--- a/packages/test/src/lib/config.ts
+++ b/packages/test/src/lib/config.ts
@@ -129,6 +129,11 @@ const cliOptions = {
     short: 'r',
     description: 'Test reporter: spec, files, tap, dot (default: spec)',
   },
+  'test-name-pattern': {
+    type: 'string',
+    multiple: true,
+    description: 'Regular expression pattern(s) for test names',
+  },
   type: {
     type: 'string',
     short: 't',
@@ -169,6 +174,7 @@ const defaultValues: ResolvedRemixTestConfig = {
   reporter: process.env.CI === 'true' ? 'files' : 'spec',
   setup: undefined,
   type: ['server', 'browser', 'e2e'],
+  testNamePatterns: undefined,
   watch: false,
 }
 
@@ -178,6 +184,13 @@ const defaultValues: ResolvedRemixTestConfig = {
  * uses worker threads for projects that prefer lower-overhead startup.
  */
 export type RemixTestPool = 'forks' | 'threads'
+
+export interface SerializedTestNamePattern {
+  source: string
+  flags: string
+}
+
+export type RemixTestNamePattern = string | RegExp
 
 /**
  * User-facing configuration for the `remix-test` CLI. Every field is
@@ -249,6 +262,12 @@ export interface RemixTestConfig {
   /** Test reporter (--reporter) */
   reporter?: string
   /**
+   * Regular expression pattern(s) to filter tests by their full name (--test-name-pattern).
+   * Accepts a single pattern or an array of patterns; `--test-name-pattern` may be repeated
+   * on the CLI.
+   */
+  testNamePattern?: RemixTestNamePattern | RemixTestNamePattern[]
+  /**
    * Test type(s) to run (--type). Accepts a single type or an array of types;
    * `--type` may be repeated on the CLI. Valid values: "server", "browser", "e2e".
    */
@@ -285,6 +304,7 @@ export interface ResolvedRemixTestConfig {
   reporter: string
   pool: RemixTestPool
   setup: string | undefined
+  testNamePatterns: SerializedTestNamePattern[] | undefined
   type: string[]
   watch: boolean
 }
@@ -423,6 +443,9 @@ function resolveConfig(
       return raw === undefined ? undefined : toCommaSeparatedArray(raw)
     })(),
     reporter: cliValues.reporter ?? fileConfig.reporter ?? defaultValues.reporter,
+    testNamePatterns: resolveTestNamePatterns(
+      cliValues['test-name-pattern'] ?? fileConfig.testNamePattern,
+    ),
     type: toCommaSeparatedArray(cliValues.type ?? fileConfig.type ?? defaultValues.type),
     watch: cliValues.watch ?? fileConfig.watch ?? defaultValues.watch,
   }
@@ -434,6 +457,48 @@ function resolvePool(value: string): RemixTestPool {
   }
 
   throw new Error(`Unsupported test pool "${value}". Supported pools are: forks, threads`)
+}
+
+function resolveTestNamePatterns(
+  value: RemixTestNamePattern | readonly RemixTestNamePattern[] | undefined,
+): SerializedTestNamePattern[] | undefined {
+  if (value === undefined) return undefined
+
+  return toArray(value).map((pattern) => {
+    let serialized =
+      typeof pattern === 'string'
+        ? parsePatternString(pattern)
+        : { source: pattern.source, flags: pattern.flags }
+    validateTestNamePattern(serialized)
+    return serialized
+  })
+}
+
+function parsePatternString(pattern: string): SerializedTestNamePattern {
+  let literal = parseRegexLiteral(pattern)
+  return literal ?? { source: pattern, flags: '' }
+}
+
+function parseRegexLiteral(pattern: string): SerializedTestNamePattern | undefined {
+  if (!pattern.startsWith('/') || pattern.length < 2) return undefined
+
+  let escaped = false
+  for (let index = pattern.length - 1; index > 0; index--) {
+    let char = pattern[index]
+    if (char === '/' && !escaped) {
+      return {
+        source: pattern.slice(1, index),
+        flags: pattern.slice(index + 1),
+      }
+    }
+    escaped = char === '\\' && !escaped
+  }
+
+  return undefined
+}
+
+function validateTestNamePattern(pattern: SerializedTestNamePattern): void {
+  new RegExp(pattern.source, pattern.flags)
 }
 
 async function loadConfigFile(

--- a/packages/test/src/lib/executor.ts
+++ b/packages/test/src/lib/executor.ts
@@ -44,6 +44,7 @@ export async function runTests(options?: RunTestsOptions): Promise<TestResults> 
   let suites = getRegisteredSuites()
   let testNameMatcher = createTestNameMatcher(options?.testNamePatterns)
   let hasOnlySuites = suites.some((suite) => suite.only)
+  let filteredTests = 0
   let runnableSuites = suites.flatMap((suite) => {
     if (testNameMatcher && hasOnlySuites && !suite.only) {
       return []
@@ -60,6 +61,16 @@ export async function runTests(options?: RunTestsOptions): Promise<TestResults> 
       suite.tests.length === 0 &&
       getPendingStatus(suite) !== undefined &&
       (testNameMatcher ? testNameMatcher(suite.name, '') : true)
+    if (testNameMatcher) {
+      filteredTests += focusedSuiteTests.length - suiteTests.length
+      if (
+        suite.tests.length === 0 &&
+        getPendingStatus(suite) !== undefined &&
+        !shouldIncludePendingSuitePlaceholder
+      ) {
+        filteredTests++
+      }
+    }
 
     if (
       suiteTests.length === 0 &&
@@ -75,7 +86,7 @@ export async function runTests(options?: RunTestsOptions): Promise<TestResults> 
   let results: TestResults = {
     passed: 0,
     failed: 0,
-    skipped: 0,
+    skipped: filteredTests,
     todo: 0,
     tests: [],
   }

--- a/packages/test/src/lib/executor.ts
+++ b/packages/test/src/lib/executor.ts
@@ -1,6 +1,7 @@
 import { createTestContext, type CreateTestContextE2EOptions, type TestContext } from './context.ts'
 import type { V8CoverageEntry } from './coverage.ts'
 import type { TestResult, TestResults } from './reporters/results.ts'
+import type { SerializedTestNamePattern } from './config.ts'
 
 type PendingMeta = boolean | string
 
@@ -33,10 +34,43 @@ interface RegisteredTest extends RunnableOptions {
   todo?: PendingMeta
 }
 
-export async function runTests(
-  options?: Omit<CreateTestContextE2EOptions, 'addE2ECoverageEntries'>,
-): Promise<TestResults> {
+type RunTestsE2EOptions = Omit<CreateTestContextE2EOptions, 'addE2ECoverageEntries'>
+
+export interface RunTestsOptions extends Partial<RunTestsE2EOptions> {
+  testNamePatterns?: SerializedTestNamePattern[]
+}
+
+export async function runTests(options?: RunTestsOptions): Promise<TestResults> {
   let suites = getRegisteredSuites()
+  let testNameMatcher = createTestNameMatcher(options?.testNamePatterns)
+  let hasOnlySuites = suites.some((suite) => suite.only)
+  let runnableSuites = suites.flatMap((suite) => {
+    if (testNameMatcher && hasOnlySuites && !suite.only) {
+      return []
+    }
+
+    let focusedSuiteTests =
+      testNameMatcher && suite.tests.some((test) => test.only)
+        ? suite.tests.filter((test) => test.only)
+        : suite.tests
+    let suiteTests = testNameMatcher
+      ? focusedSuiteTests.filter((test) => testNameMatcher(suite.name, test.name))
+      : focusedSuiteTests
+    let shouldIncludePendingSuitePlaceholder =
+      suite.tests.length === 0 &&
+      getPendingStatus(suite) !== undefined &&
+      (testNameMatcher ? testNameMatcher(suite.name, '') : true)
+
+    if (
+      suiteTests.length === 0 &&
+      !shouldIncludePendingSuitePlaceholder &&
+      (testNameMatcher || suite.tests.length > 0)
+    ) {
+      return []
+    }
+
+    return [{ suite, suiteTests, shouldIncludePendingSuitePlaceholder }]
+  })
   let e2eCoverageEntries: Array<{ entries: V8CoverageEntry[]; baseUrl: string }> = []
   let results: TestResults = {
     passed: 0,
@@ -46,12 +80,10 @@ export async function runTests(
     tests: [],
   }
 
-  let hasOnlySuites = suites.some((suite) => suite.only)
-
-  for (let suite of suites) {
+  for (let { suite, suiteTests, shouldIncludePendingSuitePlaceholder } of runnableSuites) {
     // If any suite uses .only, skip all non-only suites
     if (hasOnlySuites && !suite.only) {
-      for (let test of suite.tests) {
+      for (let test of suiteTests) {
         results.tests.push(createPendingResult(test.name, suite.name, 'skipped'))
         results.skipped++
       }
@@ -61,12 +93,12 @@ export async function runTests(
     let suitePendingStatus = getPendingStatus(suite)
     if (suitePendingStatus) {
       let reason = getPendingReason(suite, suitePendingStatus)
-      for (let test of suite.tests) {
+      for (let test of suiteTests) {
         results.tests.push(createPendingResult(test.name, suite.name, suitePendingStatus, reason))
         results[suitePendingStatus]++
       }
-      // describe.todo('name') with no tests — add placeholder so suite appears in output
-      if (suite.tests.length === 0) {
+      // Pending suites with no tests get a placeholder so the suite appears in output.
+      if (shouldIncludePendingSuitePlaceholder) {
         results.tests.push(createPendingResult('', suite.name, suitePendingStatus, reason))
         results[suitePendingStatus]++
       }
@@ -86,9 +118,9 @@ export async function runTests(
       }
     }
 
-    let hasOnlyTests = suite.tests.some((test) => test.only)
+    let hasOnlyTests = suiteTests.some((test) => test.only)
 
-    for (let test of suite.tests) {
+    for (let test of suiteTests) {
       // If any test uses .only, skip all non-only tests in this suite
       if (hasOnlyTests && !test.only) {
         results.tests.push(createPendingResult(test.name, suite.name, 'skipped'))
@@ -123,14 +155,10 @@ export async function runTests(
       let afterEachFailed = false
 
       let testAbortController = new AbortController()
+      let e2eOptions = createE2EOptions(options, (e) => e2eCoverageEntries.push(e))
       let { testContext, cleanup } = createTestContext({
         signal: testAbortController.signal,
-        e2e: options
-          ? {
-              ...options,
-              addE2ECoverageEntries: (e) => e2eCoverageEntries.push(e),
-            }
-          : undefined,
+        e2e: e2eOptions,
       })
 
       try {
@@ -197,6 +225,44 @@ export async function runTests(
   }
 
   return results
+}
+
+function createE2EOptions(
+  options: RunTestsOptions | undefined,
+  addE2ECoverageEntries: CreateTestContextE2EOptions['addE2ECoverageEntries'],
+): CreateTestContextE2EOptions | undefined {
+  if (options?.browser === undefined) return undefined
+  if (
+    options.coverage === undefined ||
+    options.open === undefined ||
+    options.playwrightPageOptions === undefined
+  ) {
+    throw new Error('Incomplete E2E test options')
+  }
+
+  return {
+    addE2ECoverageEntries,
+    browser: options.browser,
+    coverage: options.coverage,
+    open: options.open,
+    playwrightPageOptions: options.playwrightPageOptions,
+  }
+}
+
+function createTestNameMatcher(
+  patterns: SerializedTestNamePattern[] | undefined,
+): ((suiteName: string, testName: string) => boolean) | undefined {
+  if (patterns === undefined) return undefined
+
+  let regexes = patterns.map((pattern) => new RegExp(pattern.source, pattern.flags))
+
+  return (suiteName, testName) => {
+    let fullName = suiteName && testName ? `${suiteName} ${testName}` : suiteName || testName
+    return regexes.some((regex) => {
+      regex.lastIndex = 0
+      return regex.test(fullName)
+    })
+  }
 }
 
 function getRegisteredSuites(): RegisteredSuite[] {

--- a/packages/test/src/lib/reporters/files.ts
+++ b/packages/test/src/lib/reporters/files.ts
@@ -12,6 +12,8 @@ export class FilesReporter implements Reporter {
   onSectionStart(_label: string) {}
 
   onResult(results: TestResults, env?: string) {
+    if (results.tests.length === 0) return
+
     for (let test of results.tests) {
       if (test.filePath) this.#files.add(test.filePath)
       if (test.suiteName) this.#suites.add(test.suiteName)

--- a/packages/test/src/lib/runner.ts
+++ b/packages/test/src/lib/runner.ts
@@ -3,7 +3,11 @@ import * as fsp from 'node:fs/promises'
 import * as path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { Worker } from 'node:worker_threads'
-import { IS_RUNNING_FROM_SRC, type RemixTestPool } from './config.ts'
+import {
+  IS_RUNNING_FROM_SRC,
+  type RemixTestPool,
+  type SerializedTestNamePattern,
+} from './config.ts'
 import {
   collectCoverageMapFromPlaywright,
   collectServerCoverageMap,
@@ -35,6 +39,7 @@ interface RunFileOptions {
   open?: boolean
   playwrightUseOpts?: PlaywrightUseOpts
   pool?: RemixTestPool
+  testNamePatterns?: SerializedTestNamePattern[]
 }
 
 export async function runServerTests(
@@ -50,6 +55,7 @@ export async function runServerTests(
     coverage?: CoverageConfig
     workerShutdownTimeoutMs?: number
     pool?: RemixTestPool
+    testNamePatterns?: SerializedTestNamePattern[]
   } = {},
 ): Promise<Counts & { coverageMap: CoverageMap | null }> {
   let counts: Counts = { passed: 0, failed: 0, skipped: 0, todo: 0 }
@@ -237,6 +243,7 @@ export function runFileInWorker(
             coverage: options.coverage,
             open: options.open,
             playwrightUseOpts: options.playwrightUseOpts,
+            testNamePatterns: options.testNamePatterns,
           },
         })
       : new Worker(workerUrl, {
@@ -244,6 +251,7 @@ export function runFileInWorker(
             file: pathToFileURL(file).href,
             type,
             coverage: options.coverage,
+            testNamePatterns: options.testNamePatterns,
           },
         })
 
@@ -342,6 +350,7 @@ function runFileInProcess(
         coverage: options.coverage,
         open: options.open,
         playwrightUseOpts: options.playwrightUseOpts,
+        testNamePatterns: options.testNamePatterns,
       },
       (error) => {
         if (error) {

--- a/packages/test/src/lib/worker-e2e-file.ts
+++ b/packages/test/src/lib/worker-e2e-file.ts
@@ -6,16 +6,18 @@ import {
   getPlaywrightPageOptions,
   type PlaywrightUseOpts,
 } from './playwright.ts'
+import type { SerializedTestNamePattern } from './config.ts'
 import type { CoverageConfig } from './coverage.ts'
 import type { TestResults } from './reporters/results.ts'
 import { createFailedResults } from './worker-results.ts'
-import { isRecord, parseCoverageConfig } from './worker-server.ts'
+import { isRecord, parseCoverageConfig, parseTestNamePatterns } from './worker-server.ts'
 
 export interface E2ETestWorkerData {
   file: string
   coverage?: CoverageConfig
   open?: boolean
   playwrightUseOpts?: PlaywrightUseOpts
+  testNamePatterns?: SerializedTestNamePattern[]
 }
 
 export async function runE2ETestFile(
@@ -38,6 +40,7 @@ export async function runE2ETestFile(
         open: workerData.open ?? false,
         playwrightPageOptions: getPlaywrightPageOptions(workerData.playwrightUseOpts),
         coverage: !!workerData.coverage,
+        testNamePatterns: workerData.testNamePatterns,
       })
 
       if (workerData.open) {
@@ -70,6 +73,7 @@ function parseE2ETestWorkerData(value: unknown): E2ETestWorkerData {
     coverage: parseCoverageConfig(value.coverage),
     open: parseBoolean(value.open, 'open'),
     playwrightUseOpts: parsePlaywrightUseOpts(value.playwrightUseOpts),
+    testNamePatterns: parseTestNamePatterns(value.testNamePatterns),
   }
 }
 

--- a/packages/test/src/lib/worker-server.ts
+++ b/packages/test/src/lib/worker-server.ts
@@ -1,6 +1,7 @@
 import * as mod from 'node:module'
 import { IS_RUNNING_FROM_SRC } from './config.ts'
 import { importModule } from './import-module.ts'
+import type { SerializedTestNamePattern } from './config.ts'
 import type { CoverageConfig } from './coverage.ts'
 import type { TestResults } from './reporters/results.ts'
 import { runTests } from './executor.ts'
@@ -10,6 +11,7 @@ import { createFailedResults } from './worker-results.ts'
 export interface ServerTestWorkerData {
   file: string
   coverage?: CoverageConfig
+  testNamePatterns?: SerializedTestNamePattern[]
 }
 
 export async function runServerTestFile(value: unknown): Promise<TestResults> {
@@ -31,7 +33,7 @@ export async function runServerTestFile(value: unknown): Promise<TestResults> {
       await importModule(workerData.file, import.meta)
     }
 
-    let results = await runTests()
+    let results = await runTests({ testNamePatterns: workerData.testNamePatterns })
     await takeCoverage(workerData.coverage)
     return results
   } catch (error) {
@@ -55,6 +57,7 @@ function parseServerTestWorkerData(value: unknown): ServerTestWorkerData {
   return {
     file: value.file,
     coverage: parseCoverageConfig(value.coverage),
+    testNamePatterns: parseTestNamePatterns(value.testNamePatterns),
   }
 }
 
@@ -89,6 +92,25 @@ export function parseCoverageConfig(value: unknown): CoverageConfig | undefined 
   if (functions !== undefined) coverage.functions = functions
 
   return coverage
+}
+
+export function parseTestNamePatterns(value: unknown): SerializedTestNamePattern[] | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error('Invalid server test worker test name patterns')
+  }
+
+  return value.map((item) => {
+    if (!isRecord(item) || typeof item.source !== 'string' || typeof item.flags !== 'string') {
+      throw new Error('Invalid server test worker test name pattern')
+    }
+
+    new RegExp(item.source, item.flags)
+    return { source: item.source, flags: item.flags }
+  })
 }
 
 function parseStringArray(value: unknown, name: string): string[] | undefined {

--- a/packages/test/src/test/config.test.ts
+++ b/packages/test/src/test/config.test.ts
@@ -72,6 +72,44 @@ describe('loadConfig', () => {
       await fsp.rm(tmp, { recursive: true, force: true })
     }
   })
+
+  it('normalizes test name patterns from CLI flags', async () => {
+    let tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'remix-test-config-'))
+
+    try {
+      let config = await loadConfig(
+        ['--test-name-pattern', 'passes', '--test-name-pattern', '/fails/i'],
+        tmp,
+      )
+
+      assert.deepEqual(config.testNamePatterns, [
+        { source: 'passes', flags: '' },
+        { source: 'fails', flags: 'i' },
+      ])
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('normalizes test name patterns from config files', async () => {
+    let tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'remix-test-config-'))
+
+    try {
+      await fsp.writeFile(
+        path.join(tmp, 'remix-test.config.ts'),
+        ['export default {', "  testNamePattern: [/server/i, 'browser'],", '}'].join('\n'),
+      )
+
+      let config = await loadConfig([], tmp)
+
+      assert.deepEqual(config.testNamePatterns, [
+        { source: 'server', flags: 'i' },
+        { source: 'browser', flags: '' },
+      ])
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('config', () => {
@@ -119,6 +157,12 @@ describe('config', () => {
     let help = getRemixTestHelpText()
 
     assert.match(help, /--pool <value>/)
+  })
+
+  it('includes the test name pattern flag in help text', () => {
+    let help = getRemixTestHelpText()
+
+    assert.match(help, /--test-name-pattern <value>/)
   })
 })
 

--- a/packages/test/src/test/executor.test.ts
+++ b/packages/test/src/test/executor.test.ts
@@ -3,6 +3,7 @@ import type { TestContext } from '../lib/context.ts'
 import { runTests } from '../lib/executor.ts'
 import { describe, it } from '../lib/framework.ts'
 import type { TestResults } from '../lib/reporters/results.ts'
+import type { SerializedTestNamePattern } from '../lib/config.ts'
 
 interface RunnableOptions {
   timeout?: number
@@ -380,13 +381,382 @@ describe('runTests skip and todo reasons', () => {
   })
 })
 
-async function runWithSuites(suites: SuiteFixture[]): Promise<TestResults> {
+describe('runTests test name patterns', () => {
+  it('only runs tests with full names matching a configured pattern', async () => {
+    let ran: string[] = []
+
+    let results = await runWithSuites(
+      [
+        {
+          name: 'math',
+          tests: [
+            {
+              name: 'adds numbers',
+              fn() {
+                ran.push('adds')
+              },
+            },
+            {
+              name: 'subtracts numbers',
+              fn() {
+                ran.push('subtracts')
+              },
+            },
+          ],
+        },
+      ],
+      { testNamePatterns: [{ source: 'math adds', flags: '' }] },
+    )
+
+    assert.deepEqual(ran, ['adds'])
+    assert.equal(results.passed, 1)
+    assert.equal(results.failed, 0)
+    assert.equal(results.tests.length, 1)
+    assert.equal(results.tests[0]?.name, 'adds numbers')
+  })
+
+  it('omits non-matching tests instead of reporting them as skipped', async () => {
+    let results = await runWithSuites(
+      [
+        {
+          name: 'suite',
+          tests: [
+            {
+              name: 'matching test',
+              fn() {},
+            },
+            {
+              name: 'other test',
+              fn() {},
+            },
+          ],
+        },
+      ],
+      { testNamePatterns: [{ source: 'matching', flags: '' }] },
+    )
+
+    assert.equal(results.passed, 1)
+    assert.equal(results.skipped, 0)
+    assert.deepEqual(
+      results.tests.map((test) => test.name),
+      ['matching test'],
+    )
+  })
+
+  it('applies it.only before the configured pattern', async () => {
+    let ran: string[] = []
+
+    let results = await runWithSuites(
+      [
+        {
+          name: 'suite',
+          beforeAll: [
+            {
+              fn() {
+                ran.push('beforeAll')
+              },
+            },
+          ],
+          tests: [
+            {
+              name: 'fast path',
+              fn() {
+                ran.push('fast')
+              },
+            },
+            {
+              name: 'slow path',
+              only: true,
+              fn() {
+                ran.push('slow')
+              },
+            },
+          ],
+        },
+      ],
+      { testNamePatterns: [{ source: 'fast', flags: '' }] },
+    )
+
+    assert.deepEqual(ran, [])
+    assert.equal(results.passed, 0)
+    assert.equal(results.skipped, 0)
+    assert.equal(results.tests.length, 0)
+  })
+
+  it('honors it.only on tests that match the configured pattern', async () => {
+    let ran: string[] = []
+
+    let results = await runWithSuites(
+      [
+        {
+          name: 'suite',
+          tests: [
+            {
+              name: 'fast path',
+              only: true,
+              fn() {
+                ran.push('fast')
+              },
+            },
+            {
+              name: 'slow path',
+              fn() {
+                ran.push('slow')
+              },
+            },
+          ],
+        },
+      ],
+      { testNamePatterns: [{ source: 'path', flags: '' }] },
+    )
+
+    assert.deepEqual(ran, ['fast'])
+    assert.equal(results.passed, 1)
+    assert.equal(results.skipped, 0)
+    assert.deepEqual(
+      results.tests.map((test) => `${test.name}:${test.status}`),
+      ['fast path:passed'],
+    )
+  })
+
+  it('applies describe.only before the configured pattern', async () => {
+    let ran: string[] = []
+
+    let results = await runWithSuites(
+      [
+        {
+          name: 'focused suite',
+          only: true,
+          tests: [
+            {
+              name: 'slow path',
+              fn() {
+                ran.push('slow')
+              },
+            },
+          ],
+        },
+        {
+          name: 'regular suite',
+          tests: [
+            {
+              name: 'fast path',
+              fn() {
+                ran.push('fast')
+              },
+            },
+          ],
+        },
+      ],
+      { testNamePatterns: [{ source: 'regular suite fast', flags: '' }] },
+    )
+
+    assert.deepEqual(ran, [])
+    assert.equal(results.passed, 0)
+    assert.equal(results.skipped, 0)
+    assert.equal(results.tests.length, 0)
+  })
+
+  it('honors describe.only on suites that match the configured pattern', async () => {
+    let ran: string[] = []
+
+    let results = await runWithSuites(
+      [
+        {
+          name: 'focused suite',
+          only: true,
+          tests: [
+            {
+              name: 'fast path',
+              fn() {
+                ran.push('focused')
+              },
+            },
+          ],
+        },
+        {
+          name: 'regular suite',
+          tests: [
+            {
+              name: 'fast path',
+              fn() {
+                ran.push('regular')
+              },
+            },
+          ],
+        },
+      ],
+      { testNamePatterns: [{ source: 'fast', flags: '' }] },
+    )
+
+    assert.deepEqual(ran, ['focused'])
+    assert.equal(results.passed, 1)
+    assert.equal(results.skipped, 0)
+    assert.deepEqual(
+      results.tests.map((test) => `${test.suiteName} ${test.name}:${test.status}`),
+      ['focused suite fast path:passed'],
+    )
+  })
+
+  it('does not run suite hooks when no tests match', async () => {
+    let beforeAllRan = false
+    let afterAllRan = false
+
+    let results = await runWithSuites(
+      [
+        {
+          name: 'suite',
+          beforeAll: [
+            {
+              fn() {
+                beforeAllRan = true
+              },
+            },
+          ],
+          afterAll: [
+            {
+              fn() {
+                afterAllRan = true
+              },
+            },
+          ],
+          tests: [
+            {
+              name: 'other test',
+              fn() {},
+            },
+          ],
+        },
+      ],
+      { testNamePatterns: [{ source: 'missing', flags: '' }] },
+    )
+
+    assert.equal(beforeAllRan, false)
+    assert.equal(afterAllRan, false)
+    assert.equal(results.tests.length, 0)
+  })
+
+  it('runs suite hooks once when some tests match', async () => {
+    let events: string[] = []
+
+    let results = await runWithSuites(
+      [
+        {
+          name: 'suite',
+          beforeAll: [
+            {
+              fn() {
+                events.push('beforeAll')
+              },
+            },
+          ],
+          beforeEach: [
+            {
+              fn() {
+                events.push('beforeEach')
+              },
+            },
+          ],
+          afterEach: [
+            {
+              fn() {
+                events.push('afterEach')
+              },
+            },
+          ],
+          afterAll: [
+            {
+              fn() {
+                events.push('afterAll')
+              },
+            },
+          ],
+          tests: [
+            {
+              name: 'matching test',
+              fn() {
+                events.push('test')
+              },
+            },
+            {
+              name: 'other test',
+              fn() {
+                events.push('other')
+              },
+            },
+          ],
+        },
+      ],
+      { testNamePatterns: [{ source: 'matching', flags: '' }] },
+    )
+
+    assert.deepEqual(events, ['beforeAll', 'beforeEach', 'test', 'afterEach', 'afterAll'])
+    assert.equal(results.passed, 1)
+    assert.deepEqual(
+      results.tests.map((test) => test.name),
+      ['matching test'],
+    )
+  })
+
+  it('filters empty todo suite placeholders by suite name', async () => {
+    let results = await runWithSuites(
+      [
+        {
+          name: 'matching todo',
+          todo: true,
+          tests: [],
+        },
+        {
+          name: 'other todo',
+          todo: true,
+          tests: [],
+        },
+      ],
+      { testNamePatterns: [{ source: '^matching todo$', flags: '' }] },
+    )
+
+    assert.equal(results.todo, 1)
+    assert.deepEqual(
+      results.tests.map((test) => `${test.suiteName}:${test.status}`),
+      ['matching todo:todo'],
+    )
+  })
+
+  it('matches with regular expression flags', async () => {
+    let results = await runWithSuites(
+      [
+        {
+          name: 'suite',
+          tests: [
+            {
+              name: 'UPPERCASE test',
+              fn() {},
+            },
+          ],
+        },
+      ],
+      { testNamePatterns: [{ source: 'uppercase', flags: 'i' }] },
+    )
+
+    assert.equal(results.passed, 1)
+    assert.equal(results.tests[0]?.name, 'UPPERCASE test')
+  })
+})
+
+interface RunWithSuitesOptions {
+  testNamePatterns?: SerializedTestNamePattern[]
+}
+
+async function runWithSuites(
+  suites: SuiteFixture[],
+  options?: RunWithSuitesOptions,
+): Promise<TestResults> {
   let global = globalThis as TestSuitesGlobal
   let previousSuites = global.__testSuites
 
   global.__testSuites = suites
   try {
-    return await runTests()
+    return await runTests(options)
   } finally {
     global.__testSuites = previousSuites
   }

--- a/packages/test/src/test/executor.test.ts
+++ b/packages/test/src/test/executor.test.ts
@@ -411,11 +411,12 @@ describe('runTests test name patterns', () => {
     assert.deepEqual(ran, ['adds'])
     assert.equal(results.passed, 1)
     assert.equal(results.failed, 0)
+    assert.equal(results.skipped, 1)
     assert.equal(results.tests.length, 1)
     assert.equal(results.tests[0]?.name, 'adds numbers')
   })
 
-  it('omits non-matching tests instead of reporting them as skipped', async () => {
+  it('counts non-matching tests as skipped without reporting them individually', async () => {
     let results = await runWithSuites(
       [
         {
@@ -436,7 +437,7 @@ describe('runTests test name patterns', () => {
     )
 
     assert.equal(results.passed, 1)
-    assert.equal(results.skipped, 0)
+    assert.equal(results.skipped, 1)
     assert.deepEqual(
       results.tests.map((test) => test.name),
       ['matching test'],
@@ -479,7 +480,7 @@ describe('runTests test name patterns', () => {
 
     assert.deepEqual(ran, [])
     assert.equal(results.passed, 0)
-    assert.equal(results.skipped, 0)
+    assert.equal(results.skipped, 1)
     assert.equal(results.tests.length, 0)
   })
 
@@ -553,7 +554,7 @@ describe('runTests test name patterns', () => {
 
     assert.deepEqual(ran, [])
     assert.equal(results.passed, 0)
-    assert.equal(results.skipped, 0)
+    assert.equal(results.skipped, 1)
     assert.equal(results.tests.length, 0)
   })
 
@@ -633,6 +634,7 @@ describe('runTests test name patterns', () => {
 
     assert.equal(beforeAllRan, false)
     assert.equal(afterAllRan, false)
+    assert.equal(results.skipped, 1)
     assert.equal(results.tests.length, 0)
   })
 
@@ -692,6 +694,7 @@ describe('runTests test name patterns', () => {
 
     assert.deepEqual(events, ['beforeAll', 'beforeEach', 'test', 'afterEach', 'afterAll'])
     assert.equal(results.passed, 1)
+    assert.equal(results.skipped, 1)
     assert.deepEqual(
       results.tests.map((test) => test.name),
       ['matching test'],
@@ -716,6 +719,7 @@ describe('runTests test name patterns', () => {
     )
 
     assert.equal(results.todo, 1)
+    assert.equal(results.skipped, 1)
     assert.deepEqual(
       results.tests.map((test) => `${test.suiteName}:${test.status}`),
       ['matching todo:todo'],
@@ -739,6 +743,7 @@ describe('runTests test name patterns', () => {
     )
 
     assert.equal(results.passed, 1)
+    assert.equal(results.skipped, 0)
     assert.equal(results.tests[0]?.name, 'UPPERCASE test')
   })
 })

--- a/packages/test/src/test/name-pattern.test.ts
+++ b/packages/test/src/test/name-pattern.test.ts
@@ -1,0 +1,213 @@
+import * as assert from '@remix-run/assert'
+import { spawn } from 'node:child_process'
+import * as fsp from 'node:fs/promises'
+import * as path from 'node:path'
+import { stripVTControlCharacters } from 'node:util'
+import { fileURLToPath } from 'node:url'
+import { describe, it } from '../lib/framework.ts'
+import { IS_BUN } from '../lib/runtime.ts'
+
+const PKG_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+const FIXTURE_DIR = path.join(PKG_DIR, '.tmp', 'test-name-pattern')
+
+describe('test name patterns', () => {
+  it(
+    'filters server, browser, and E2E tests by full name in the same default run',
+    { skip: IS_BUN },
+    async () => {
+      await writeProject(FIXTURE_DIR)
+
+      try {
+        let output = await runFixtureCli(FIXTURE_DIR)
+        let stdout = stripVTControlCharacters(output.stdout)
+
+        assert.equal(output.exitCode, 0, output.stderr || output.stdout)
+        assert.match(stdout, /Found 3 test file\(s\) \(1 server, 1 browser, 1 e2e\)/)
+        assert.match(stdout, /✓ runs matching server test/)
+        assert.match(stdout, /✓ runs matching browser test/)
+        assert.match(stdout, /✓ runs matching E2E test/)
+        assert.doesNotMatch(stdout, /does not run non-matching server test/)
+        assert.doesNotMatch(stdout, /does not run non-matching browser test/)
+        assert.doesNotMatch(stdout, /does not run non-matching E2E test/)
+        assert.match(stdout, /ℹ pass 3/)
+        assert.equal(output.stderr, '')
+      } finally {
+        await fsp.rm(FIXTURE_DIR, { recursive: true, force: true })
+      }
+    },
+  )
+
+  it(
+    'filters tests by full name after filtering by type',
+    { skip: IS_BUN },
+    async () => {
+      await writeProject(FIXTURE_DIR)
+
+      try {
+        let serverOutput = await runFixtureCli(FIXTURE_DIR, ['--type', 'server'])
+        let serverStdout = stripVTControlCharacters(serverOutput.stdout)
+
+        assert.equal(serverOutput.exitCode, 0, serverOutput.stderr || serverOutput.stdout)
+        assert.match(serverStdout, /Found 1 test file\(s\) \(1 server, 0 browser, 0 e2e\)/)
+        assert.match(serverStdout, /✓ runs matching server test/)
+        assert.match(serverStdout, /ℹ pass 1/)
+        assert.equal(serverOutput.stderr, '')
+
+        let browserOutput = await runFixtureCli(FIXTURE_DIR, ['--type', 'browser'])
+        let browserStdout = stripVTControlCharacters(browserOutput.stdout)
+
+        assert.equal(browserOutput.exitCode, 0, browserOutput.stderr || browserOutput.stdout)
+        assert.match(browserStdout, /Found 1 test file\(s\) \(0 server, 1 browser, 0 e2e\)/)
+        assert.match(browserStdout, /✓ runs matching browser test/)
+        assert.match(browserStdout, /ℹ pass 1/)
+        assert.equal(browserOutput.stderr, '')
+
+        let e2eOutput = await runFixtureCli(FIXTURE_DIR, ['--type', 'e2e'])
+        let e2eStdout = stripVTControlCharacters(e2eOutput.stdout)
+
+        assert.equal(e2eOutput.exitCode, 0, e2eOutput.stderr || e2eOutput.stdout)
+        assert.match(e2eStdout, /Found 1 test file\(s\) \(0 server, 0 browser, 1 e2e\)/)
+        assert.match(e2eStdout, /✓ runs matching E2E test/)
+        assert.match(e2eStdout, /ℹ pass 1/)
+        assert.equal(e2eOutput.stderr, '')
+      } finally {
+        await fsp.rm(FIXTURE_DIR, { recursive: true, force: true })
+      }
+    },
+  )
+})
+
+async function writeProject(projectDir: string): Promise<void> {
+  await fsp.rm(projectDir, { recursive: true, force: true })
+  await fsp.mkdir(projectDir, { recursive: true })
+  await fsp.writeFile(
+    path.join(projectDir, 'package.json'),
+    `${JSON.stringify({ name: 'test-name-pattern-fixture', private: true, type: 'module' }, null, 2)}\n`,
+    'utf8',
+  )
+  await fsp.mkdir(path.join(projectDir, 'node_modules', '@remix-run'), { recursive: true })
+  await fsp.symlink(PKG_DIR, path.join(projectDir, 'node_modules', '@remix-run', 'test'))
+  await fsp.writeFile(
+    path.join(projectDir, 'sample.test.browser.ts'),
+    [
+      "import { describe, it } from '@remix-run/test'",
+      '',
+      "describe('browser name pattern', () => {",
+      "  it('runs matching browser test', () => {",
+      "    document.body.innerHTML = '<h1>Matched</h1>'",
+      "    if (document.querySelector('h1')?.textContent !== 'Matched') {",
+      "      throw new Error('Browser assertion failed')",
+      '    }',
+      '  })',
+      '',
+      "  it('does not run non-matching browser test', () => {",
+      "    throw new Error('This browser test should have been filtered out')",
+      '  })',
+      '})',
+      '',
+    ].join('\n'),
+    'utf8',
+  )
+  await fsp.writeFile(
+    path.join(projectDir, 'sample.test.ts'),
+    [
+      "import * as assert from 'node:assert/strict'",
+      "import { describe, it } from '@remix-run/test'",
+      '',
+      "describe('server name pattern', () => {",
+      "  it('runs matching server test', () => {",
+      "    assert.equal('Matched', 'Matched')",
+      '  })',
+      '',
+      "  it('does not run non-matching server test', () => {",
+      "    throw new Error('This server test should have been filtered out')",
+      '  })',
+      '})',
+      '',
+    ].join('\n'),
+    'utf8',
+  )
+  await fsp.writeFile(
+    path.join(projectDir, 'sample.test.e2e.ts'),
+    [
+      "import * as assert from 'node:assert/strict'",
+      "import * as http from 'node:http'",
+      "import { describe, it } from '@remix-run/test'",
+      '',
+      'async function serveHtml(html: string) {',
+      '  let server = http.createServer((_request, response) => {',
+      "    response.writeHead(200, { 'Content-Type': 'text/html' })",
+      '    response.end(html)',
+      '  })',
+      '  await new Promise<void>((resolve, reject) => {',
+      "    server.once('error', reject)",
+      "    server.listen(0, '127.0.0.1', () => {",
+      "      server.off('error', reject)",
+      '      resolve()',
+      '    })',
+      '  })',
+      '  let address = server.address()',
+      "  if (!address || typeof address === 'string') throw new Error('Server did not bind')",
+      '  return {',
+      '    baseUrl: `http://127.0.0.1:${address.port}`,',
+      '    close: () => new Promise<void>((resolve, reject) => {',
+      '      server.close((error) => error ? reject(error) : resolve())',
+      '    }),',
+      '  }',
+      '}',
+      '',
+      "describe('e2e name pattern', () => {",
+      "  it('runs matching E2E test', async (t) => {",
+      "    let page = await t.serve(await serveHtml('<h1>Matched</h1>'))",
+      "    await page.goto('/')",
+      "    assert.equal(await page.locator('h1').textContent(), 'Matched')",
+      '  })',
+      '',
+      "  it('does not run non-matching E2E test', () => {",
+      "    throw new Error('This test should have been filtered out')",
+      '  })',
+      '})',
+      '',
+    ].join('\n'),
+    'utf8',
+  )
+}
+
+function runFixtureCli(
+  projectDir: string,
+  args: string[] = [],
+): Promise<{
+  exitCode: number
+  stdout: string
+  stderr: string
+}> {
+  return new Promise((resolve, reject) => {
+    let child = spawn(
+      'node',
+      [
+        path.join(PKG_DIR, 'src', 'cli-entry.ts'),
+        '--concurrency',
+        '1',
+        '--reporter',
+        'spec',
+        ...args,
+        '--test-name-pattern',
+        'name pattern runs matching',
+      ],
+      { cwd: projectDir, stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+    let stdout: Buffer[] = []
+    let stderr: Buffer[] = []
+
+    child.stdout?.on('data', (chunk) => stdout.push(chunk))
+    child.stderr?.on('data', (chunk) => stderr.push(chunk))
+    child.on('error', reject)
+    child.on('exit', (code) => {
+      resolve({
+        exitCode: code ?? 1,
+        stdout: Buffer.concat(stdout).toString('utf-8'),
+        stderr: Buffer.concat(stderr).toString('utf-8'),
+      })
+    })
+  })
+}

--- a/packages/test/src/test/name-pattern.test.ts
+++ b/packages/test/src/test/name-pattern.test.ts
@@ -30,6 +30,7 @@ describe('test name patterns', () => {
         assert.doesNotMatch(stdout, /does not run non-matching browser test/)
         assert.doesNotMatch(stdout, /does not run non-matching E2E test/)
         assert.match(stdout, /ℹ pass 3/)
+        assert.match(stdout, /ℹ skipped 3/)
         assert.equal(output.stderr, '')
       } finally {
         await fsp.rm(FIXTURE_DIR, { recursive: true, force: true })
@@ -37,44 +38,43 @@ describe('test name patterns', () => {
     },
   )
 
-  it(
-    'filters tests by full name after filtering by type',
-    { skip: IS_BUN },
-    async () => {
-      await writeProject(FIXTURE_DIR)
+  it('filters tests by full name after filtering by type', { skip: IS_BUN }, async () => {
+    await writeProject(FIXTURE_DIR)
 
-      try {
-        let serverOutput = await runFixtureCli(FIXTURE_DIR, ['--type', 'server'])
-        let serverStdout = stripVTControlCharacters(serverOutput.stdout)
+    try {
+      let serverOutput = await runFixtureCli(FIXTURE_DIR, ['--type', 'server'])
+      let serverStdout = stripVTControlCharacters(serverOutput.stdout)
 
-        assert.equal(serverOutput.exitCode, 0, serverOutput.stderr || serverOutput.stdout)
-        assert.match(serverStdout, /Found 1 test file\(s\) \(1 server, 0 browser, 0 e2e\)/)
-        assert.match(serverStdout, /✓ runs matching server test/)
-        assert.match(serverStdout, /ℹ pass 1/)
-        assert.equal(serverOutput.stderr, '')
+      assert.equal(serverOutput.exitCode, 0, serverOutput.stderr || serverOutput.stdout)
+      assert.match(serverStdout, /Found 1 test file\(s\) \(1 server, 0 browser, 0 e2e\)/)
+      assert.match(serverStdout, /✓ runs matching server test/)
+      assert.match(serverStdout, /ℹ pass 1/)
+      assert.match(serverStdout, /ℹ skipped 1/)
+      assert.equal(serverOutput.stderr, '')
 
-        let browserOutput = await runFixtureCli(FIXTURE_DIR, ['--type', 'browser'])
-        let browserStdout = stripVTControlCharacters(browserOutput.stdout)
+      let browserOutput = await runFixtureCli(FIXTURE_DIR, ['--type', 'browser'])
+      let browserStdout = stripVTControlCharacters(browserOutput.stdout)
 
-        assert.equal(browserOutput.exitCode, 0, browserOutput.stderr || browserOutput.stdout)
-        assert.match(browserStdout, /Found 1 test file\(s\) \(0 server, 1 browser, 0 e2e\)/)
-        assert.match(browserStdout, /✓ runs matching browser test/)
-        assert.match(browserStdout, /ℹ pass 1/)
-        assert.equal(browserOutput.stderr, '')
+      assert.equal(browserOutput.exitCode, 0, browserOutput.stderr || browserOutput.stdout)
+      assert.match(browserStdout, /Found 1 test file\(s\) \(0 server, 1 browser, 0 e2e\)/)
+      assert.match(browserStdout, /✓ runs matching browser test/)
+      assert.match(browserStdout, /ℹ pass 1/)
+      assert.match(browserStdout, /ℹ skipped 1/)
+      assert.equal(browserOutput.stderr, '')
 
-        let e2eOutput = await runFixtureCli(FIXTURE_DIR, ['--type', 'e2e'])
-        let e2eStdout = stripVTControlCharacters(e2eOutput.stdout)
+      let e2eOutput = await runFixtureCli(FIXTURE_DIR, ['--type', 'e2e'])
+      let e2eStdout = stripVTControlCharacters(e2eOutput.stdout)
 
-        assert.equal(e2eOutput.exitCode, 0, e2eOutput.stderr || e2eOutput.stdout)
-        assert.match(e2eStdout, /Found 1 test file\(s\) \(0 server, 0 browser, 1 e2e\)/)
-        assert.match(e2eStdout, /✓ runs matching E2E test/)
-        assert.match(e2eStdout, /ℹ pass 1/)
-        assert.equal(e2eOutput.stderr, '')
-      } finally {
-        await fsp.rm(FIXTURE_DIR, { recursive: true, force: true })
-      }
-    },
-  )
+      assert.equal(e2eOutput.exitCode, 0, e2eOutput.stderr || e2eOutput.stdout)
+      assert.match(e2eStdout, /Found 1 test file\(s\) \(0 server, 0 browser, 1 e2e\)/)
+      assert.match(e2eStdout, /✓ runs matching E2E test/)
+      assert.match(e2eStdout, /ℹ pass 1/)
+      assert.match(e2eStdout, /ℹ skipped 1/)
+      assert.equal(e2eOutput.stderr, '')
+    } finally {
+      await fsp.rm(FIXTURE_DIR, { recursive: true, force: true })
+    }
+  })
 })
 
 async function writeProject(projectDir: string): Promise<void> {

--- a/packages/test/src/test/reporters.test.ts
+++ b/packages/test/src/test/reporters.test.ts
@@ -20,6 +20,20 @@ describe('reporters skip and todo reasons', () => {
     assert.match(output, /suite > todo test # todo: needs design/)
   })
 
+  it('does not print empty files reporter results', () => {
+    let output = captureConsole(() =>
+      new FilesReporter().onResult({
+        passed: 0,
+        failed: 0,
+        skipped: 0,
+        todo: 0,
+        tests: [],
+      }),
+    )
+
+    assert.equal(output, '')
+  })
+
   it('prints reasons as TAP directives', () => {
     let output = captureConsole(() => new TapReporter().onResult(createPendingResults()))
 


### PR DESCRIPTION
This adds support for the `--test-name-pattern` flag / `testNamePattern` option to allow filtering of tests by name.