### PR TITLE
feat(event-stream): add @remix-run/event-stream for Server-Sent Events

### DIFF
--- a/packages/event-stream/CHANGELOG.md
+++ b/packages/event-stream/CHANGELOG.md
@@ -1,0 +1,7 @@
+# `event-stream` CHANGELOG
+
+This is the changelog for [`event-stream`](https://github.com/remix-run/remix/tree/main/packages/event-stream). It follows [semantic versioning](https://semver.org/).
+
+## v0.1.0 (2026-06-30)
+
+Initial release.

--- a/packages/event-stream/LICENSE
+++ b/packages/event-stream/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/packages/event-stream/README.md
+++ b/packages/event-stream/README.md
@@ -1,0 +1,121 @@
+# event-stream
+
+Server-Sent Events and streaming helpers for the web Fetch API.
+
+## Features
+
+- **Fetch-native:** Returns a standard `Response` with a `ReadableStream` body
+- **Server-Sent Events framing:** Serializes `event`, `id`, `retry`, and multi-line `data` fields
+- **Disconnect handling:** Wires request aborts into the stream controller
+- **Keep-alive comments:** Sends optional `: ping` frames for idle proxies
+- **Model streaming:** Pipes async iterable text streams into event-stream responses
+- **Client parsing:** Parses event-stream wire format in browsers and tests
+
+## Installation
+
+```sh
+npm i remix
+```
+
+## Usage
+
+### Server Events
+
+```ts
+import { eventStream } from 'remix/event-stream'
+
+export async function loader({ request }: { request: Request }) {
+  let events = eventStream({ request, keepAlive: 15_000 })
+
+  queueMicrotask(() => {
+    events.send({
+      event: 'ready',
+      id: '1',
+      data: JSON.stringify({ ok: true }),
+    })
+  })
+
+  return events.response
+}
+```
+
+`eventStream()` reads the `Last-Event-ID` request header and exposes it as `lastEventId` so
+routes can replay missed events.
+
+```ts
+import { eventStream } from 'remix/event-stream'
+
+export function loader({ request }: { request: Request }) {
+  let events = eventStream({ request })
+
+  queueMicrotask(() => {
+    if (events.lastEventId !== null) {
+      events.send({ event: 'resume', data: events.lastEventId })
+    }
+  })
+
+  return events.response
+}
+```
+
+### Model Streaming
+
+```ts
+import { eventStream, streamText } from 'remix/event-stream'
+
+async function* generateTokens(prompt: string) {
+  yield 'Hello'
+  yield ', '
+  yield prompt
+}
+
+export function action({ request }: { request: Request }) {
+  let events = eventStream({ request })
+
+  void streamText(events, generateTokens('world'), {
+    event: 'token',
+  })
+
+  return events.response
+}
+```
+
+Use `writeText()` directly when the producer owns the loop:
+
+```ts
+import { eventStream } from 'remix/event-stream'
+
+let events = eventStream()
+
+events.writeText('First token', { event: 'token' })
+events.writeText('Second token', { event: 'token' })
+events.close()
+```
+
+### Client Consume
+
+```ts
+import { connectEventStream } from 'remix/event-stream/client'
+
+let connection = connectEventStream('/events', {
+  events: ['message', 'token'],
+  onMessage(message) {
+    console.log(message.event, message.id, message.data)
+  },
+})
+
+// Later:
+connection.close()
+```
+
+For tests and fetch-based consumers, parse raw event-stream text directly:
+
+```ts
+import { parseEventStream } from 'remix/event-stream/client'
+
+let messages = parseEventStream('event: token\ndata: hello\n\n')
+```
+
+## License
+
+See [LICENSE](https://github.com/remix-run/remix/blob/main/LICENSE)

--- a/packages/event-stream/package.json
+++ b/packages/event-stream/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@remix-run/event-stream",
+  "version": "0.1.0",
+  "description": "Server-Sent Events and streaming helpers for the web Fetch API",
+  "author": "Michael Jackson <mjijackson@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/remix-run/remix.git",
+    "directory": "packages/event-stream"
+  },
+  "homepage": "https://github.com/remix-run/remix/tree/main/packages/event-stream#readme",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "dist",
+    "src",
+    "!src/**/*.test.ts"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./client": "./src/client.ts",
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "./client": {
+        "types": "./dist/client.d.ts",
+        "default": "./dist/client.js"
+      },
+      "./package.json": "./package.json"
+    }
+  },
+  "devDependencies": {
+    "@remix-run/assert": "workspace:*",
+    "@remix-run/fetch-router": "workspace:*",
+    "@remix-run/test": "workspace:*",
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:"
+  },
+  "scripts": {
+    "build": "tsgo -p tsconfig.build.json",
+    "clean": "git clean -fdX",
+    "prepublishOnly": "pnpm run build",
+    "test": "remix-test",
+    "test:bun": "bun x --bun remix-test",
+    "typecheck": "tsgo --noEmit"
+  },
+  "keywords": [
+    "fetch",
+    "sse",
+    "server-sent-events",
+    "eventsource",
+    "streaming",
+    "ai",
+    "real-time"
+  ]
+}

--- a/packages/event-stream/src/client.ts
+++ b/packages/event-stream/src/client.ts
@@ -1,0 +1,7 @@
+export { connectEventStream, createEventStreamParser, parseEventStream } from './lib/client.ts'
+export type {
+  ConnectEventStreamOptions,
+  EventStreamClientMessage,
+  EventStreamConnection,
+  EventStreamParser,
+} from './lib/client.ts'

--- a/packages/event-stream/src/index.ts
+++ b/packages/event-stream/src/index.ts
@@ -1,0 +1,11 @@
+export { eventStream, streamText } from './lib/event-stream.ts'
+export type {
+  EventStream,
+  EventStreamInit,
+  EventStreamTextOptions,
+  TextStreamSource,
+  StreamTextOptions,
+} from './lib/event-stream.ts'
+
+export { formatEventStreamMessage } from './lib/message.ts'
+export type { EventStreamMessage } from './lib/message.ts'

--- a/packages/event-stream/src/lib/client.test.ts
+++ b/packages/event-stream/src/lib/client.test.ts
@@ -1,0 +1,117 @@
+import * as assert from '@remix-run/assert'
+import { describe, it } from '@remix-run/test'
+
+import { connectEventStream, createEventStreamParser, parseEventStream } from './client.ts'
+import { formatEventStreamMessage } from './message.ts'
+
+describe('parseEventStream', () => {
+  it('round-trips formatted server messages', () => {
+    let wire = formatEventStreamMessage({
+      id: '1',
+      event: 'update',
+      retry: 1000,
+      data: 'hello\nworld',
+    })
+    let messages = parseEventStream(wire)
+
+    assert.deepEqual(messages, [
+      {
+        event: 'update',
+        id: '1',
+        retry: 1000,
+        data: 'hello\nworld',
+      },
+    ])
+  })
+
+  it('ignores heartbeat comments', () => {
+    let messages = parseEventStream(': ping\n\ndata: hello\n\n')
+
+    assert.deepEqual(messages, [
+      {
+        event: 'message',
+        data: 'hello',
+      },
+    ])
+  })
+
+  it('parses split chunks and mixed line endings', () => {
+    let parser = createEventStreamParser()
+    let messages = parser.feed('event: token\r\ndata: hel')
+
+    assert.deepEqual(messages, [])
+
+    messages = parser.feed('lo\rid: 2\r\n\r\n')
+
+    assert.deepEqual(messages, [
+      {
+        event: 'token',
+        id: '2',
+        data: 'hello',
+      },
+    ])
+  })
+
+  it('persists last event id across messages', () => {
+    let messages = parseEventStream('id: 1\ndata: first\n\ndata: second\n\n')
+
+    assert.deepEqual(messages, [
+      {
+        event: 'message',
+        id: '1',
+        data: 'first',
+      },
+      {
+        event: 'message',
+        id: '1',
+        data: 'second',
+      },
+    ])
+  })
+})
+
+describe('connectEventStream', () => {
+  it('uses the fetch fallback when custom headers are provided', async () => {
+    let opened = false
+    let messages: ReturnType<typeof parseEventStream> = []
+    let complete = new Promise<void>((resolve, reject) => {
+      let connection = connectEventStream('https://remix.run/events', {
+        headers: {
+          'X-Test': 'yes',
+        },
+        fetch(input, init) {
+          assert.equal(input, 'https://remix.run/events')
+          assert.ok(init?.signal)
+          assert.deepEqual(init.headers, {
+            'X-Test': 'yes',
+          })
+
+          return Promise.resolve(new Response(formatEventStreamMessage({ data: 'hello' })))
+        },
+        onOpen(response) {
+          opened = true
+          assert.equal(response?.status, 200)
+        },
+        onMessage(message) {
+          messages.push(message)
+          resolve()
+        },
+        onError(error) {
+          reject(error)
+        },
+      })
+
+      assert.equal(connection.signal.aborted, false)
+    })
+
+    await complete
+
+    assert.equal(opened, true)
+    assert.deepEqual(messages, [
+      {
+        event: 'message',
+        data: 'hello',
+      },
+    ])
+  })
+})

--- a/packages/event-stream/src/lib/client.ts
+++ b/packages/event-stream/src/lib/client.ts
@@ -1,0 +1,392 @@
+export interface EventStreamClientMessage {
+  event: string
+  id?: string
+  retry?: number
+  data: string
+}
+
+export interface EventStreamParser {
+  feed(chunk: string): EventStreamClientMessage[]
+  end(): EventStreamClientMessage[]
+  reset(): void
+}
+
+export interface EventStreamConnection {
+  readonly signal: AbortSignal
+  close(): void
+}
+
+export interface ConnectEventStreamOptions extends Omit<RequestInit, 'signal'> {
+  signal?: AbortSignal
+  events?: readonly string[]
+  eventSource?: typeof EventSource
+  fetch?: typeof fetch
+  onMessage(message: EventStreamClientMessage): void
+  onOpen?(response?: Response): void
+  onError?(error: unknown): void
+}
+
+export function parseEventStream(input: string): EventStreamClientMessage[] {
+  let parser = createEventStreamParser()
+  let messages = parser.feed(input)
+  messages.push(...parser.end())
+  return messages
+}
+
+export function createEventStreamParser(): EventStreamParser {
+  let buffer = ''
+  let event = ''
+  let data = ''
+  let lastEventId: string | undefined
+  let retry: number | undefined
+
+  function dispatch(messages: EventStreamClientMessage[]): void {
+    if (data === '') {
+      event = ''
+      retry = undefined
+      return
+    }
+
+    let message: EventStreamClientMessage = {
+      event: event || 'message',
+      data: data.endsWith('\n') ? data.slice(0, -1) : data,
+    }
+
+    if (lastEventId !== undefined) {
+      message.id = lastEventId
+    }
+
+    if (retry !== undefined) {
+      message.retry = retry
+    }
+
+    messages.push(message)
+    event = ''
+    data = ''
+    retry = undefined
+  }
+
+  function processLine(line: string, messages: EventStreamClientMessage[]): void {
+    if (line === '') {
+      dispatch(messages)
+      return
+    }
+
+    if (line.startsWith(':')) {
+      return
+    }
+
+    let separatorIndex = line.indexOf(':')
+    let field = separatorIndex === -1 ? line : line.slice(0, separatorIndex)
+    let value = separatorIndex === -1 ? '' : line.slice(separatorIndex + 1)
+
+    if (value.startsWith(' ')) {
+      value = value.slice(1)
+    }
+
+    switch (field) {
+      case 'event':
+        event = value
+        break
+      case 'data':
+        data += `${value}\n`
+        break
+      case 'id':
+        if (!value.includes('\0')) {
+          lastEventId = value
+        }
+        break
+      case 'retry':
+        if (/^\d+$/.test(value)) {
+          retry = Number(value)
+        }
+        break
+    }
+  }
+
+  function drainBuffer(messages: EventStreamClientMessage[]): void {
+    while (buffer.length > 0) {
+      let lineBreakIndex = findLineBreak(buffer)
+
+      if (lineBreakIndex === -1) {
+        return
+      }
+
+      if (buffer[lineBreakIndex] === '\r' && lineBreakIndex === buffer.length - 1) {
+        return
+      }
+
+      let line = buffer.slice(0, lineBreakIndex)
+      let lineBreakLength =
+        buffer[lineBreakIndex] === '\r' && buffer[lineBreakIndex + 1] === '\n' ? 2 : 1
+
+      buffer = buffer.slice(lineBreakIndex + lineBreakLength)
+      processLine(line, messages)
+    }
+  }
+
+  return {
+    feed(chunk: string): EventStreamClientMessage[] {
+      let messages: EventStreamClientMessage[] = []
+      buffer += chunk
+      drainBuffer(messages)
+      return messages
+    },
+    end(): EventStreamClientMessage[] {
+      let messages: EventStreamClientMessage[] = []
+
+      if (buffer === '\r') {
+        processLine('', messages)
+      } else if (buffer.length > 0) {
+        processLine(buffer, messages)
+      }
+
+      buffer = ''
+      return messages
+    },
+    reset(): void {
+      buffer = ''
+      event = ''
+      data = ''
+      lastEventId = undefined
+      retry = undefined
+    },
+  }
+}
+
+export function connectEventStream(
+  input: string | URL,
+  options: ConnectEventStreamOptions,
+): EventStreamConnection {
+  let nativeConnection = connectWithEventSource(input, options)
+
+  if (nativeConnection !== undefined) {
+    return nativeConnection
+  }
+
+  return connectWithFetch(input, options)
+}
+
+function connectWithEventSource(
+  input: string | URL,
+  options: ConnectEventStreamOptions,
+): EventStreamConnection | undefined {
+  let EventSourceConstructor = options.eventSource ?? globalThis.EventSource
+
+  if (EventSourceConstructor === undefined || !canUseEventSource(options)) {
+    return undefined
+  }
+
+  let abortController = new AbortController()
+  let closed = false
+  let eventNames = options.events ?? ['message']
+  let eventSource = new EventSourceConstructor(input.toString(), {
+    withCredentials: options.credentials === 'include',
+  })
+
+  function open(): void {
+    options.onOpen?.()
+  }
+
+  function error(event: Event): void {
+    options.onError?.(event)
+  }
+
+  function message(event: Event): void {
+    if (!('data' in event) || typeof event.data !== 'string') {
+      return
+    }
+
+    let lastEventId =
+      'lastEventId' in event && typeof event.lastEventId === 'string' ? event.lastEventId : ''
+    let parsed: EventStreamClientMessage = {
+      event: event.type,
+      data: event.data,
+    }
+
+    if (lastEventId !== '') {
+      parsed.id = lastEventId
+    }
+
+    options.onMessage(parsed)
+  }
+
+  function close(reason?: unknown): void {
+    if (closed) {
+      return
+    }
+
+    closed = true
+    options.signal?.removeEventListener('abort', abort)
+    eventSource.removeEventListener('open', open)
+    eventSource.removeEventListener('error', error)
+
+    for (let eventName of eventNames) {
+      eventSource.removeEventListener(eventName, message)
+    }
+
+    eventSource.close()
+
+    if (!abortController.signal.aborted) {
+      abortController.abort(reason)
+    }
+  }
+
+  function abort(): void {
+    close(options.signal?.reason)
+  }
+
+  eventSource.addEventListener('open', open)
+  eventSource.addEventListener('error', error)
+
+  for (let eventName of eventNames) {
+    eventSource.addEventListener(eventName, message)
+  }
+
+  if (options.signal?.aborted) {
+    close(options.signal.reason)
+  } else {
+    options.signal?.addEventListener('abort', abort, { once: true })
+  }
+
+  return {
+    signal: abortController.signal,
+    close,
+  }
+}
+
+function connectWithFetch(
+  input: string | URL,
+  options: ConnectEventStreamOptions,
+): EventStreamConnection {
+  let fetchFunction = options.fetch ?? globalThis.fetch
+
+  if (fetchFunction === undefined) {
+    throw new TypeError('Event stream fetch fallback requires a fetch implementation')
+  }
+
+  let abortController = new AbortController()
+  let closed = false
+
+  function close(reason?: unknown): void {
+    if (closed) {
+      return
+    }
+
+    closed = true
+    options.signal?.removeEventListener('abort', abort)
+
+    if (!abortController.signal.aborted) {
+      abortController.abort(reason)
+    }
+  }
+
+  function abort(): void {
+    close(options.signal?.reason)
+  }
+
+  if (options.signal?.aborted) {
+    close(options.signal.reason)
+  } else {
+    options.signal?.addEventListener('abort', abort, { once: true })
+  }
+
+  void readFetchStream(input, options, fetchFunction, abortController.signal).then(
+    () => close(),
+    (error) => {
+      if (!abortController.signal.aborted) {
+        options.onError?.(error)
+      }
+
+      close(error)
+    },
+  )
+
+  return {
+    signal: abortController.signal,
+    close,
+  }
+}
+
+async function readFetchStream(
+  input: string | URL,
+  options: ConnectEventStreamOptions,
+  fetchFunction: typeof fetch,
+  signal: AbortSignal,
+): Promise<void> {
+  let init = createFetchInit(options, signal)
+  let response = await fetchFunction(input, init)
+  options.onOpen?.(response)
+
+  if (response.body === null) {
+    throw new TypeError('Event stream response does not have a body')
+  }
+
+  let parser = createEventStreamParser()
+  let decoder = new TextDecoder()
+  let reader = response.body.getReader()
+
+  try {
+    while (true) {
+      let result = await reader.read()
+
+      if (result.done) {
+        for (let message of parser.end()) {
+          options.onMessage(message)
+        }
+
+        return
+      }
+
+      for (let message of parser.feed(decoder.decode(result.value, { stream: true }))) {
+        options.onMessage(message)
+      }
+    }
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+function createFetchInit(options: ConnectEventStreamOptions, signal: AbortSignal): RequestInit {
+  return {
+    body: options.body,
+    cache: options.cache,
+    credentials: options.credentials,
+    headers: options.headers,
+    integrity: options.integrity,
+    keepalive: options.keepalive,
+    method: options.method,
+    mode: options.mode,
+    redirect: options.redirect,
+    referrer: options.referrer,
+    referrerPolicy: options.referrerPolicy,
+    signal,
+  }
+}
+
+function canUseEventSource(options: ConnectEventStreamOptions): boolean {
+  if (options.fetch !== undefined || options.headers !== undefined || options.body !== undefined) {
+    return false
+  }
+
+  if (options.method !== undefined && options.method.toUpperCase() !== 'GET') {
+    return false
+  }
+
+  return true
+}
+
+function findLineBreak(input: string): number {
+  let carriageReturnIndex = input.indexOf('\r')
+  let lineFeedIndex = input.indexOf('\n')
+
+  if (carriageReturnIndex === -1) {
+    return lineFeedIndex
+  }
+
+  if (lineFeedIndex === -1) {
+    return carriageReturnIndex
+  }
+
+  return Math.min(carriageReturnIndex, lineFeedIndex)
+}

--- a/packages/event-stream/src/lib/event-stream.test.ts
+++ b/packages/event-stream/src/lib/event-stream.test.ts
@@ -1,0 +1,116 @@
+import * as assert from '@remix-run/assert'
+import { createRouter } from '@remix-run/fetch-router'
+import { describe, it } from '@remix-run/test'
+
+import { eventStream, streamText } from './event-stream.ts'
+
+describe('eventStream', () => {
+  it('returns a text/event-stream response and sends framed messages', async () => {
+    let events = eventStream()
+
+    events.send({ event: 'ready', id: '1', retry: 5000, data: 'hello\nworld' })
+    events.close()
+
+    assert.equal(events.response.headers.get('Content-Type'), 'text/event-stream')
+    assert.equal(events.response.headers.get('Cache-Control'), 'no-cache')
+    assert.equal(events.response.headers.get('Connection'), 'keep-alive')
+    assert.equal(
+      await events.response.text(),
+      'id: 1\nevent: ready\nretry: 5000\ndata: hello\ndata: world\n\n',
+    )
+  })
+
+  it('works as a plain Response from fetch-router', async () => {
+    let router = createRouter()
+
+    router.get('/events', () => {
+      let events = eventStream()
+      events.send({ data: 'from router' })
+      events.close()
+      return events.response
+    })
+
+    let response = await router.fetch('https://remix.run/events')
+
+    assert.equal(response.status, 200)
+    assert.equal(response.headers.get('Content-Type'), 'text/event-stream')
+    assert.equal(await response.text(), 'data: from router\n\n')
+  })
+
+  it('sends heartbeat comments', async () => {
+    let events = eventStream({ keepAlive: 1 })
+    let body = events.response.body
+
+    assert.ok(body)
+
+    let reader = body.getReader()
+    let result = await reader.read()
+    events.close()
+    reader.releaseLock()
+
+    if (result.done) {
+      assert.fail('Expected a heartbeat chunk')
+    }
+
+    assert.equal(new TextDecoder().decode(result.value), ': ping\n\n')
+  })
+
+  it('closes when the request signal aborts', async () => {
+    let controller = new AbortController()
+    let request = new Request('https://remix.run/events', {
+      signal: controller.signal,
+    })
+    let events = eventStream({ request })
+    let body = events.response.body
+
+    assert.ok(body)
+
+    let reader = body.getReader()
+    controller.abort('disconnect')
+    let result = await reader.read()
+    reader.releaseLock()
+
+    assert.equal(result.done, true)
+    assert.equal(events.signal.aborted, true)
+    assert.equal(events.signal.reason, 'disconnect')
+  })
+
+  it('exposes Last-Event-ID from the request header', async () => {
+    let router = createRouter()
+
+    router.get('/events', (context) => {
+      let events = eventStream({ request: context.request })
+      events.send({ data: events.lastEventId ?? 'missing' })
+      events.close()
+      return events.response
+    })
+
+    let response = await router.fetch('https://remix.run/events', {
+      headers: {
+        'Last-Event-ID': 'event-7',
+      },
+    })
+
+    assert.equal(await response.text(), 'data: event-7\n\n')
+  })
+
+  it('streams text from iterable token sources', async () => {
+    let events = eventStream()
+
+    await streamText(events, ['Hello', ', ', 'world'], {
+      event: 'token',
+      id: 'tokens',
+    })
+
+    let expected = [
+      'id: tokens\nevent: token\ndata: Hello\n\n',
+      'id: tokens\nevent: token\ndata: , \n\n',
+      'id: tokens\nevent: token\ndata: world\n\n',
+    ].join('')
+
+    assert.equal(
+      await events.response.text(),
+      expected,
+    )
+  })
+})

--- a/packages/event-stream/src/lib/event-stream.ts
+++ b/packages/event-stream/src/lib/event-stream.ts
@@ -1,0 +1,234 @@
+import { formatEventStreamMessage, type EventStreamMessage } from './message.ts'
+
+const textEncoder = new TextEncoder()
+const contentType = 'text/event-stream'
+const cacheControl = 'no-cache'
+const connection = 'keep-alive'
+
+export interface EventStreamInit extends ResponseInit {
+  request?: Request
+  signal?: AbortSignal
+  keepAlive?: number
+  lastEventId?: string | null
+}
+
+export interface EventStreamTextOptions {
+  event?: string
+  id?: string
+  retry?: number
+}
+
+export interface StreamTextOptions extends EventStreamTextOptions {
+  close?: boolean
+}
+
+export type TextStreamSource = Iterable<string> | AsyncIterable<string>
+
+export interface EventStream {
+  readonly response: Response
+  readonly signal: AbortSignal
+  readonly lastEventId: string | null
+  send(message: EventStreamMessage): void
+  writeText(data: string, options?: EventStreamTextOptions): void
+  close(): void
+}
+
+export function eventStream(init: EventStreamInit = {}): EventStream {
+  let streamController: ReadableStreamDefaultController<Uint8Array> | undefined
+  let closed = false
+  let heartbeat: ReturnType<typeof globalThis.setInterval> | undefined
+  let removeAbortListeners: Array<() => void> = []
+  let abortController = new AbortController()
+  let keepAlive = normalizeKeepAlive(init.keepAlive)
+  let lastEventId = init.lastEventId ?? init.request?.headers.get('Last-Event-ID') ?? null
+
+  function cleanup(reason?: unknown): void {
+    if (heartbeat !== undefined) {
+      globalThis.clearInterval(heartbeat)
+      heartbeat = undefined
+    }
+
+    for (let removeAbortListener of removeAbortListeners) {
+      removeAbortListener()
+    }
+
+    removeAbortListeners = []
+
+    if (!abortController.signal.aborted) {
+      abortController.abort(reason)
+    }
+  }
+
+  function finish(reason: unknown, closeController: boolean): void {
+    if (closed) {
+      return
+    }
+
+    closed = true
+    cleanup(reason)
+
+    if (closeController && streamController !== undefined) {
+      streamController.close()
+    }
+  }
+
+  function enqueue(frame: string): void {
+    if (closed) {
+      throw new TypeError('Cannot write to a closed event stream')
+    }
+
+    if (streamController === undefined) {
+      throw new TypeError('Event stream is not ready')
+    }
+
+    streamController.enqueue(textEncoder.encode(frame))
+  }
+
+  function send(message: EventStreamMessage): void {
+    enqueue(formatEventStreamMessage(message))
+  }
+
+  function writeText(data: string, options: EventStreamTextOptions = {}): void {
+    let message: EventStreamMessage = { data }
+
+    if (options.event !== undefined) {
+      message.event = options.event
+    }
+
+    if (options.id !== undefined) {
+      message.id = options.id
+    }
+
+    if (options.retry !== undefined) {
+      message.retry = options.retry
+    }
+
+    send(message)
+  }
+
+  function close(): void {
+    finish(undefined, true)
+  }
+
+  function startHeartbeat(): void {
+    if (keepAlive === undefined) {
+      return
+    }
+
+    heartbeat = globalThis.setInterval(() => {
+      if (!closed) {
+        enqueue(': ping\n\n')
+      }
+    }, keepAlive)
+  }
+
+  let body = new ReadableStream<Uint8Array>({
+    start(controller): void {
+      streamController = controller
+      startHeartbeat()
+    },
+    cancel(reason): void {
+      finish(reason, false)
+    },
+  })
+
+  watchAbortSignal(init.request?.signal, finish, removeAbortListeners)
+  watchAbortSignal(init.signal, finish, removeAbortListeners)
+
+  let response = new Response(body, {
+    status: init.status,
+    statusText: init.statusText,
+    headers: createEventStreamHeaders(init.headers),
+  })
+
+  return {
+    response,
+    signal: abortController.signal,
+    lastEventId,
+    send,
+    writeText,
+    close,
+  }
+}
+
+export async function streamText(
+  stream: EventStream,
+  source: TextStreamSource,
+  options: StreamTextOptions = {},
+): Promise<void> {
+  let messageOptions = getMessageOptions(options)
+
+  try {
+    for await (let chunk of source) {
+      if (stream.signal.aborted) {
+        break
+      }
+
+      stream.writeText(chunk, messageOptions)
+    }
+  } finally {
+    if (options.close !== false) {
+      stream.close()
+    }
+  }
+}
+
+function createEventStreamHeaders(headersInit: HeadersInit | undefined): Headers {
+  let headers = new Headers(headersInit)
+  headers.set('Content-Type', contentType)
+  headers.set('Cache-Control', cacheControl)
+  headers.set('Connection', connection)
+  return headers
+}
+
+function normalizeKeepAlive(keepAlive: number | undefined): number | undefined {
+  if (keepAlive === undefined) {
+    return undefined
+  }
+
+  if (!Number.isSafeInteger(keepAlive) || keepAlive <= 0) {
+    throw new RangeError('Event stream keepAlive must be a positive safe integer')
+  }
+
+  return keepAlive
+}
+
+function watchAbortSignal(
+  signal: AbortSignal | undefined,
+  finish: (reason: unknown, closeController: boolean) => void,
+  removeAbortListeners: Array<() => void>,
+): void {
+  if (signal === undefined) {
+    return
+  }
+
+  if (signal.aborted) {
+    finish(signal.reason, true)
+    return
+  }
+
+  function abort(): void {
+    finish(signal?.reason, true)
+  }
+
+  signal.addEventListener('abort', abort, { once: true })
+  removeAbortListeners.push(() => signal.removeEventListener('abort', abort))
+}
+
+function getMessageOptions(options: StreamTextOptions): EventStreamTextOptions {
+  let messageOptions: EventStreamTextOptions = {}
+
+  if (options.event !== undefined) {
+    messageOptions.event = options.event
+  }
+
+  if (options.id !== undefined) {
+    messageOptions.id = options.id
+  }
+
+  if (options.retry !== undefined) {
+    messageOptions.retry = options.retry
+  }
+
+  return messageOptions
+}

--- a/packages/event-stream/src/lib/message.test.ts
+++ b/packages/event-stream/src/lib/message.test.ts
@@ -1,0 +1,47 @@
+import * as assert from '@remix-run/assert'
+import { describe, it } from '@remix-run/test'
+
+import { formatEventStreamMessage } from './message.ts'
+
+describe('formatEventStreamMessage', () => {
+  it('formats data messages', () => {
+    let message = formatEventStreamMessage({ data: 'hello' })
+
+    assert.equal(message, 'data: hello\n\n')
+  })
+
+  it('formats event id retry and data fields in SSE order', () => {
+    let message = formatEventStreamMessage({
+      id: '42',
+      event: 'update',
+      retry: 1000,
+      data: 'hello',
+    })
+
+    assert.equal(message, 'id: 42\nevent: update\nretry: 1000\ndata: hello\n\n')
+  })
+
+  it('formats multiline data as one data field per line', () => {
+    let message = formatEventStreamMessage({
+      data: 'hello\nworld\r\nagain\r',
+    })
+
+    assert.equal(message, 'data: hello\ndata: world\ndata: again\ndata: \n\n')
+  })
+
+  it('allows empty data messages', () => {
+    let message = formatEventStreamMessage({ data: '' })
+
+    assert.equal(message, 'data: \n\n')
+  })
+
+  it('rejects invalid retry values', () => {
+    assert.throws(() => formatEventStreamMessage({ retry: -1, data: 'hello' }), RangeError)
+    assert.throws(() => formatEventStreamMessage({ retry: 1.5, data: 'hello' }), RangeError)
+  })
+
+  it('rejects line breaks in event and id fields', () => {
+    assert.throws(() => formatEventStreamMessage({ event: 'bad\nname', data: 'hello' }), TypeError)
+    assert.throws(() => formatEventStreamMessage({ id: 'bad\rid', data: 'hello' }), TypeError)
+  })
+})

--- a/packages/event-stream/src/lib/message.ts
+++ b/packages/event-stream/src/lib/message.ts
@@ -1,0 +1,49 @@
+export interface EventStreamMessage {
+  event?: string
+  id?: string
+  retry?: number
+  data: string
+}
+
+export function formatEventStreamMessage(message: EventStreamMessage): string {
+  let lines: string[] = []
+
+  if (message.id !== undefined) {
+    lines.push(`id: ${validateFieldValue('id', message.id)}`)
+  }
+
+  if (message.event !== undefined) {
+    lines.push(`event: ${validateFieldValue('event', message.event)}`)
+  }
+
+  if (message.retry !== undefined) {
+    lines.push(`retry: ${validateRetry(message.retry)}`)
+  }
+
+  for (let line of splitDataLines(message.data)) {
+    lines.push(`data: ${line}`)
+  }
+
+  lines.push('')
+  return `${lines.join('\n')}\n`
+}
+
+function splitDataLines(data: string): string[] {
+  return data.replace(/\r\n?/g, '\n').split('\n')
+}
+
+function validateFieldValue(field: string, value: string): string {
+  if (value.includes('\r') || value.includes('\n')) {
+    throw new TypeError(`SSE ${field} fields cannot contain line breaks`)
+  }
+
+  return value
+}
+
+function validateRetry(retry: number): number {
+  if (!Number.isSafeInteger(retry) || retry < 0) {
+    throw new RangeError('SSE retry must be a non-negative safe integer')
+  }
+
+  return retry
+}

--- a/packages/event-stream/tsconfig.build.json
+++ b/packages/event-stream/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "dist"]
+}

--- a/packages/event-stream/tsconfig.json
+++ b/packages/event-stream/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ESNext",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "isolatedModules": true
+  },
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary

Adds `@remix-run/event-stream`, a zero-dependency package for Server-Sent Events and token streaming on the web Fetch API. The server helper returns a standard `Response` whose body is a `text/event-stream` `ReadableStream`; the client helper parses that same wire format back into typed events.

## Why this matters

Remix 3 has routing, sessions, auth, data, files, and a deep middleware family, but no real-time / streaming transport yet. SSE is the web-standard primitive underneath model-first apps — streaming model tokens to the browser is exactly what `streamText` below is for, and it rides plain HTTP/Fetch so it runs everywhere with no per-runtime adapters and zero dependencies. (Hono ships `streamSSE` / `streamText` as first-party helpers; this fills the same gap the Remix way.)

## Demo

![event-stream demo](https://files.catbox.moe/mqng14.gif)

## What's included

- `eventStream(init)` → `{ response, send, writeText, close, signal, lastEventId }`. Sets `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`; optional `keepAlive` heartbeats; reads `Last-Event-ID` from the request for resumption; tears the stream down on `request.signal` abort.
- `streamText(stream, source, options)` pipes an `Iterable`/`AsyncIterable<string>` straight to the client — the model-first token-streaming path.
- A pure SSE wire-format serializer (one `data:` line per `\n`, `id` / `event` / `retry` fields, field validation) that's easy to unit-test.
- A client parser plus `connectEventStream` (standard `EventSource`, with a fetch+stream fallback when custom headers are needed).
- Zero runtime dependencies.

It composes with `fetch-router` for free since the server returns a plain `Response`.

## Testing

```
pnpm --filter @remix-run/event-stream typecheck   # clean
pnpm --filter @remix-run/event-stream test         # 17/17 pass
```

I scoped this to the standalone package. Happy to wire it into the `remix` umbrella export as a follow-up if you'd like it there.
