### PR TITLE
Fix cascading update guard diagnostics

### DIFF
--- a/packages/ui/.changes/patch.cascading-update-guard.md
+++ b/packages/ui/.changes/patch.cascading-update-guard.md
@@ -1,0 +1,1 @@
+Changed the scheduler's cascading update guard to warn when many component updates happen in one event-loop turn and only throw the infinite-loop error when a single component instance repeatedly updates itself. This keeps large `clientEntry` hydration bursts interactive while still surfacing component names and counts for diagnosis.

--- a/packages/ui/src/runtime/scheduler.ts
+++ b/packages/ui/src/runtime/scheduler.ts
@@ -35,11 +35,19 @@ export interface Scheduler {
   dequeue(): void
 }
 
-// Protect against infinite cascading updates (e.g. handle.update() during render)
-const MAX_CASCADING_UPDATES = 50
+const CASCADING_UPDATE_WARN_THRESHOLD = 50
+const MAX_CASCADING_COMPONENT_UPDATES = 50
 
 export type SchedulerPhaseEvent = Event & {
   parents: ParentNode[]
+}
+
+function getComponentName(vnode: CommittedComponentNode): string {
+  return vnode.type.name || 'Anonymous'
+}
+
+function formatComponentCounts(counts: Map<string, number>): string {
+  return Array.from(counts, ([name, count]) => `${name} x${count}`).join(', ')
 }
 
 /**
@@ -62,7 +70,10 @@ export function createScheduler(
   let postCommitTasks: EmptyFn[] = []
   let flushScheduled = false
   let flushing = false
-  let cascadingUpdateCount = 0
+  let cascadingComponentUpdateCount = 0
+  let cascadingComponentUpdateCounts = new WeakMap<CommittedComponentNode, number>()
+  let cascadingComponentNameCounts = new Map<string, number>()
+  let warnedAboutCascadingUpdates = false
   let resetScheduled = false
   let phaseEvents = new EventTarget()
   let phaseListenerCounts: Record<SchedulerPhaseType, number> = {
@@ -82,9 +93,46 @@ export function createScheduler(
     // Reset when control returns to the event loop while still allowing
     // microtask-driven flushes in the same turn to count as cascading.
     setTimeout(() => {
-      cascadingUpdateCount = 0
+      cascadingComponentUpdateCount = 0
+      cascadingComponentUpdateCounts = new WeakMap()
+      cascadingComponentNameCounts = new Map()
+      warnedAboutCascadingUpdates = false
       resetScheduled = false
     }, 0)
+  }
+
+  function trackCascadingUpdate(vnode: CommittedComponentNode): boolean {
+    cascadingComponentUpdateCount++
+
+    let componentName = getComponentName(vnode)
+    cascadingComponentNameCounts.set(
+      componentName,
+      (cascadingComponentNameCounts.get(componentName) ?? 0) + 1,
+    )
+
+    let componentUpdateCount = (cascadingComponentUpdateCounts.get(vnode) ?? 0) + 1
+    cascadingComponentUpdateCounts.set(vnode, componentUpdateCount)
+    scheduleCounterReset()
+
+    if (
+      !warnedAboutCascadingUpdates &&
+      cascadingComponentUpdateCount >= CASCADING_UPDATE_WARN_THRESHOLD
+    ) {
+      warnedAboutCascadingUpdates = true
+      console.warn(
+        `${cascadingComponentUpdateCount} cascading component updates detected in one event loop turn. Consider reducing hydration regions. Components: ${formatComponentCounts(cascadingComponentNameCounts)}`,
+      )
+    }
+
+    if (componentUpdateCount > MAX_CASCADING_COMPONENT_UPDATES) {
+      let error = new Error(
+        `handle.update() infinite loop detected in ${componentName} after ${componentUpdateCount} cascading updates. Components: ${formatComponentCounts(cascadingComponentNameCounts)}`,
+      )
+      dispatchError(error)
+      return false
+    }
+
+    return true
   }
 
   function getFrameStyleManager(vnode: CommittedComponentNode): StyleManager {
@@ -109,15 +157,6 @@ export function createScheduler(
           postCommitTasks.length > 0
         if (!hasWork) return
 
-        cascadingUpdateCount++
-        scheduleCounterReset()
-
-        if (cascadingUpdateCount > MAX_CASCADING_UPDATES) {
-          let error = new Error('handle.update() infinite loop detected')
-          dispatchError(error)
-          return
-        }
-
         documentState.capture()
 
         let updateParents = batch.size > 0 ? Array.from(new Set(batch.values())) : []
@@ -130,6 +169,7 @@ export function createScheduler(
 
           for (let [vnode, domParent] of vnodes) {
             if (ancestorIsScheduled(vnode, batch, noScheduledAncestor)) continue
+            if (!trackCascadingUpdate(vnode)) return
             let handle = vnode._handle
             let curr = vnode._content
             let vParent = vnode._parent!

--- a/packages/ui/src/runtime/scheduler.ts
+++ b/packages/ui/src/runtime/scheduler.ts
@@ -35,11 +35,19 @@ export interface Scheduler {
   dequeue(): void
 }
 
-// Protect against infinite cascading updates (e.g. handle.update() during render)
-const MAX_CASCADING_UPDATES = 50
+const CASCADING_UPDATE_WARN_THRESHOLD = 50
+const MAX_CASCADING_COMPONENT_UPDATES = 50
 
 export type SchedulerPhaseEvent = Event & {
   parents: ParentNode[]
+}
+
+function getComponentName(vnode: CommittedComponentNode): string {
+  return vnode.type.name || 'Anonymous'
+}
+
+function formatComponentCounts(counts: Map<string, number>): string {
+  return Array.from(counts, ([name, count]) => `${name} x${count}`).join(', ')
 }
 
 /**
@@ -62,7 +70,10 @@ export function createScheduler(
   let postCommitTasks: EmptyFn[] = []
   let flushScheduled = false
   let flushing = false
-  let cascadingUpdateCount = 0
+  let cascadingComponentUpdateCount = 0
+  let cascadingComponentUpdateCounts = new WeakMap<CommittedComponentNode, number>()
+  let cascadingComponentNameCounts = new Map<string, number>()
+  let warnedAboutCascadingUpdates = false
   let resetScheduled = false
   let phaseEvents = new EventTarget()
   let phaseListenerCounts: Record<SchedulerPhaseType, number> = {
@@ -82,9 +93,46 @@ export function createScheduler(
     // Reset when control returns to the event loop while still allowing
     // microtask-driven flushes in the same turn to count as cascading.
     setTimeout(() => {
-      cascadingUpdateCount = 0
+      cascadingComponentUpdateCount = 0
+      cascadingComponentUpdateCounts = new WeakMap()
+      cascadingComponentNameCounts = new Map()
+      warnedAboutCascadingUpdates = false
       resetScheduled = false
     }, 0)
+  }
+
+  function trackCascadingUpdate(vnode: CommittedComponentNode): boolean {
+    cascadingComponentUpdateCount++
+
+    let componentName = getComponentName(vnode)
+    cascadingComponentNameCounts.set(
+      componentName,
+      (cascadingComponentNameCounts.get(componentName) ?? 0) + 1,
+    )
+
+    let componentUpdateCount = (cascadingComponentUpdateCounts.get(vnode) ?? 0) + 1
+    cascadingComponentUpdateCounts.set(vnode, componentUpdateCount)
+    scheduleCounterReset()
+
+    if (
+      !warnedAboutCascadingUpdates &&
+      cascadingComponentUpdateCount >= CASCADING_UPDATE_WARN_THRESHOLD
+    ) {
+      warnedAboutCascadingUpdates = true
+      console.warn(
+        `${cascadingComponentUpdateCount} cascading component updates detected in one event loop turn. Consider reducing hydration regions. Components: ${formatComponentCounts(cascadingComponentNameCounts)}`,
+      )
+    }
+
+    if (componentUpdateCount > MAX_CASCADING_COMPONENT_UPDATES) {
+      let error = new Error(
+        `handle.update() infinite loop detected in ${componentName} after ${componentUpdateCount} cascading updates. Components: ${formatComponentCounts(cascadingComponentNameCounts)}`,
+      )
+      dispatchError(error)
+      return false
+    }
+
+    return true
   }
 
   function flush() {
@@ -104,15 +152,6 @@ export function createScheduler(
           postCommitTasks.length > 0
         if (!hasWork) return
 
-        cascadingUpdateCount++
-        scheduleCounterReset()
-
-        if (cascadingUpdateCount > MAX_CASCADING_UPDATES) {
-          let error = new Error('handle.update() infinite loop detected')
-          dispatchError(error)
-          return
-        }
-
         documentState.capture()
 
         let updateParents = batch.size > 0 ? Array.from(new Set(batch.values())) : []
@@ -125,6 +164,7 @@ export function createScheduler(
 
           for (let [vnode, domParent] of vnodes) {
             if (ancestorIsScheduled(vnode, batch, noScheduledAncestor)) continue
+            if (!trackCascadingUpdate(vnode)) return
             let curr = vnode._content
             // Calculate anchor at render time from current vdom position (never stale).
             // Needed for fragment self-updates that add children - without this, new children

--- a/packages/ui/src/test/vdom.errors.test.tsx
+++ b/packages/ui/src/test/vdom.errors.test.tsx
@@ -432,5 +432,50 @@ describe('vdom error handling', () => {
       expect(container.innerHTML).toBe('<div>count: 3</div>')
       expect(errorHandler).not.toHaveBeenCalled()
     })
+
+    it('warns instead of erroring when many component instances update in one event loop turn', (t) => {
+      let container = document.createElement('div')
+      let root = createRoot(container)
+      let errorHandler = t.mock.fn()
+      let warnSpy = t.mock.method(console, 'warn', () => {})
+      root.addEventListener('error', errorHandler)
+
+      let updateCount = 60
+      let counts = Array.from({ length: updateCount }, () => 0)
+      let updates: Array<() => void> = []
+
+      function Counter(handle: Handle<{ index: number }>) {
+        let index = handle.props.index
+        updates[index] = () => {
+          handle.update()
+        }
+        return () => <div data-index={index}>count: {counts[index] ?? 0}</div>
+      }
+
+      root.render(
+        <>
+          {Array.from({ length: updateCount }, (_, index) => (
+            <Counter key={index} index={index} />
+          ))}
+        </>,
+      )
+      root.flush()
+
+      for (let index = 0; index < updateCount; index++) {
+        counts[index] = (counts[index] ?? 0) + 1
+        let update = updates[index]
+        if (!update) throw new Error(`Missing update for component ${index}`)
+        update()
+        root.flush()
+      }
+
+      expect(errorHandler).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(String(warnSpy.mock.calls[0]!.arguments[0])).toContain(
+        '50 cascading component updates',
+      )
+      expect(String(warnSpy.mock.calls[0]!.arguments[0])).toContain('Counter x50')
+      expect(container.querySelector('[data-index="59"]')?.textContent).toBe('count: 1')
+    })
   })
 })


### PR DESCRIPTION
The scheduler's cascading update guard used one per-turn counter for all component updates. That meant a large batch of legitimate `clientEntry` hydration/update work could look like an infinite loop and stop later components from becoming interactive.

This keeps the performance signal while making the hard guard more precise. The runtime now warns once per event-loop turn when aggregate cascading component updates cross the threshold, but only dispatches the infinite-loop error when the same component instance repeatedly updates itself.

Closes #11222.

- Adds component-name/count diagnostics to the aggregate warning and hard error
- Tracks the hard error limit per component instance instead of globally
- Preserves the existing protection for `handle.update()` loops during render
- Adds a regression for 60 component instances updating in the same event-loop turn
