### PR TITLE
Change literal function to use 'const' for value

### DIFF
--- a/packages/data-schema/src/lib/schema.ts
+++ b/packages/data-schema/src/lib/schema.ts
@@ -525,7 +525,7 @@ export function instanceof_<constructor extends abstract new (...args: any[]) =>
  * @param literalValue The literal value to match
  * @returns A schema that produces the literal type
  */
-export function literal<value>(literalValue: value): Schema<unknown, value> {
+export function literal<const value>(literalValue: value): Schema<unknown, value> {
   return createSchema(function validate(value, context) {
     if (value !== literalValue) {
       return fail('Expected literal value', context.path, {

--- a/packages/data-schema/src/lib/variant.test.ts
+++ b/packages/data-schema/src/lib/variant.test.ts
@@ -2,7 +2,14 @@ import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
 import { literal, number, object, string, variant } from './schema.ts'
-import type { Issue, ValidationResult } from './schema.ts'
+import type { InferOutput, Issue, ValidationResult } from './schema.ts'
+
+type Equal<left, right> =
+  (<value>() => value extends left ? 1 : 2) extends <value>() => value extends right ? 1 : 2
+    ? true
+    : false
+
+function expectType<condition extends true>(_value?: condition): void {}
 
 function assertSuccess<output>(
   result: ValidationResult<output>,
@@ -17,6 +24,20 @@ function assertFailure<output>(
 }
 
 describe('variant', () => {
+  it('infers literal discriminator values', () => {
+    let schema = variant('type', {
+      created: object({ type: literal('created'), id: string() }),
+      updated: object({ type: literal('updated'), id: string(), version: number() }),
+    })
+
+    expectType<
+      Equal<
+        InferOutput<typeof schema>,
+        { type: 'created'; id: string } | { type: 'updated'; id: string; version: number }
+      >
+    >()
+  })
+
   it('validates based on discriminator', () => {
     let schema = variant('type', {
       created: object({ type: literal('created'), id: string() }),


### PR DESCRIPTION
Precisely types the output to the actual string value. This allows some nice properties, in particular to use it as a discriminant in combination with variant (e.g., in a switch statement, you can narrow the schema).