### PR TITLE
Add test runner --only flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ This repository includes the source code for Remix 3, a web framework for buildi
 - **When to use full runs locally**: broad cross-workspace changes, shared root config changes, release/publish flow changes, or anything that could affect the whole repo
 - **Single package commands**: `pnpm --filter @remix-run/<package> run test --quiet`, `pnpm --filter @remix-run/<package> run typecheck`, `pnpm --filter @remix-run/<package> run build`
 - **Single test file**: `cd packages/<package> && pnpm test --quiet src/**/<filename>.test.ts`
+- **Scoped test names**: add `--only '<suite-or-test-regex>'` to focus tests by full suite/test name without editing source, for example `pnpm test --quiet --only 'loader redirects'`
 - **Lint**: `pnpm run lint` or `pnpm run lint:fix`
 - **Format**: `pnpm run format` or `pnpm run format:check`
 

--- a/packages/test/.changes/minor.only-flag.md
+++ b/packages/test/.changes/minor.only-flag.md
@@ -1,0 +1,1 @@
+Added a `--only` CLI flag and `only` config option to focus tests by matching suite names or full test names without editing source files to add `.only` modifiers.

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -160,6 +160,7 @@ You may also specify any config field as a CLI flag which will take precedence o
 | `--glob.browser`            |           |
 | `--glob.e2e`                |           |
 | `--playwrightConfig <path>` |           |
+| `--only <pattern>`          |           |
 | `--pool <forks              | threads>` |     |
 | `--project <name>`          | `-p`      |
 | `--quiet`                   | `-q`      |

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -169,6 +169,30 @@ You may also specify any config field as a CLI flag which will take precedence o
 | `--type <name>`             | `-t`      |
 | `--watch`                   | `-w`      |
 
+### Focusing Tests
+
+Use `.only` to focus a suite or test while developing:
+
+```ts
+describe.only('Cart routes', () => {
+  it('loads cart items', () => {})
+})
+
+describe('Checkout routes', () => {
+  it.only('redirects anonymous users', () => {})
+})
+```
+
+Use `--only <pattern>` to focus tests from the CLI without editing source. Patterns are JavaScript regular expressions matched against suite names and full test names:
+
+```sh
+remix test --only 'Cart routes'
+remix test --only 'Checkout routes > redirects anonymous users'
+remix test --only '/anonymous users$/'
+```
+
+Full test names join nested `describe` names and the test name with ` > `. For example, `describe('Cart routes', () => describe('loader', () => it('loads cart items', ...)))` has the full test name `Cart routes > loader > loads cart items`.
+
 ### Setup
 
 The `setup` option points to a module that can export `globalSetup` and/or `globalTeardown` functions, called once before and after the entire test run respectively:

--- a/packages/test/src/app/client/entry.ts
+++ b/packages/test/src/app/client/entry.ts
@@ -1,9 +1,11 @@
 import { normalizeLine } from '../../lib/normalize.ts'
+import type { SerializedOnlyPattern } from '../../lib/config.ts'
 import type { TestResult, TestResults } from '../../lib/reporters/results.ts'
 
 interface TestsSetup {
   testPaths: string[]
   baseDir: string
+  only?: SerializedOnlyPattern[]
 }
 
 type FileResults = TestResults & { tests: Array<TestResult & { filePath: string }> }
@@ -162,7 +164,7 @@ function mountTests(host: HTMLElement, setup: TestsSetup): void {
 
   void (async () => {
     for (let testFile of setup.testPaths) {
-      let fileResults = await runInIframe(testFile)
+      let fileResults = await runInIframe(testFile, setup.only)
       await fetch('/file-results', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -181,10 +183,15 @@ function mountTests(host: HTMLElement, setup: TestsSetup): void {
   })()
 }
 
-function runInIframe(testFile: string): Promise<FileResults> {
+function runInIframe(
+  testFile: string,
+  only: SerializedOnlyPattern[] | undefined,
+): Promise<FileResults> {
   return new Promise((resolve) => {
     let iframe = document.createElement('iframe')
-    iframe.src = `/iframe?file=${encodeURIComponent(testFile)}`
+    let params = new URLSearchParams({ file: testFile })
+    if (only) params.set('only', JSON.stringify(only))
+    iframe.src = `/iframe?${params}`
     // Make the iframe as big so we don't get unintentional scrolling in test UIs
     let parentBody = iframe.contentWindow?.document.body
     iframe.width = Math.max(parentBody?.scrollWidth ?? 0, 800).toString()

--- a/packages/test/src/app/client/iframe.ts
+++ b/packages/test/src/app/client/iframe.ts
@@ -1,11 +1,14 @@
 import { runTests } from '../../lib/executor.ts'
+import type { SerializedOnlyPattern } from '../../lib/config.ts'
 
 const params = new URLSearchParams(location.search)
 const testFile = params.get('file')!
+const rawOnly = params.get('only')
+const only = rawOnly ? (JSON.parse(rawOnly) as SerializedOnlyPattern[]) : undefined
 
 try {
   await import(testFile)
-  let results = await runTests()
+  let results = await runTests({ only })
   window.parent.postMessage({ type: 'test-results', results }, '*')
 } catch (error: any) {
   window.parent.postMessage(

--- a/packages/test/src/app/server.ts
+++ b/packages/test/src/app/server.ts
@@ -7,7 +7,11 @@ import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { ResolverFactory } from 'oxc-resolver'
 import { SourceMapConsumer, SourceMapGenerator } from 'source-map-js'
-import { getBrowserTestRootDir, IS_RUNNING_FROM_SRC } from '../lib/config.ts'
+import {
+  getBrowserTestRootDir,
+  IS_RUNNING_FROM_SRC,
+  type SerializedOnlyPattern,
+} from '../lib/config.ts'
 import { transformTypeScript } from '../lib/ts-transform.ts'
 
 const log = (str: string) => console.log(`[remix:test] ${str}`)
@@ -22,8 +26,9 @@ const browserResolver = new ResolverFactory({
 
 export async function startServer(
   browserFiles: string[],
+  options: { only?: SerializedOnlyPattern[] } = {},
 ): Promise<{ server: http.Server; port: number; baseUrl: string }> {
-  let handle = createRequestHandler(browserFiles)
+  let handle = createRequestHandler(browserFiles, options)
 
   let server = http.createServer((req, res) => {
     handle(req, res).catch((error) => {
@@ -65,6 +70,7 @@ function isAddressInfo(address: ReturnType<http.Server['address']>): address is 
 
 function createRequestHandler(
   browserFiles: string[],
+  options: { only?: SerializedOnlyPattern[] } = {},
 ): (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void> {
   let rootDir = getBrowserTestRootDir()
   let srcDir = IS_RUNNING_FROM_SRC
@@ -91,7 +97,7 @@ function createRequestHandler(
     }
 
     if (url.pathname === '/') {
-      let setupJson = JSON.stringify({ testPaths, baseDir: process.cwd() })
+      let setupJson = JSON.stringify({ testPaths, baseDir: process.cwd(), only: options.only })
       let body =
         `<script type="application/json" id="test-setup">` +
         `${escapeJsonForScript(setupJson)}` +

--- a/packages/test/src/cli.ts
+++ b/packages/test/src/cli.ts
@@ -186,7 +186,7 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
         let { startServer } = IS_RUNNING_FROM_SRC
           ? await importModule('./app/server.ts', import.meta)
           : await import(`./app/server.js`)
-        let result = await startServer(browserFiles)
+        let result = await startServer(browserFiles, { only: config.only })
         browserServer = result.server
         browserServerFilesKey = browserFilesKey
         browserBaseUrl = result.baseUrl
@@ -213,6 +213,7 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
           {
             coverage: config.coverage,
             cwd,
+            only: config.only,
             pool: config.pool,
           },
         )
@@ -287,6 +288,7 @@ async function runRemixTestInCwd(argv: string[], cwd: string): Promise<number> {
                   projectName: project.name,
                   coverage: config.coverage,
                   cwd,
+                  only: config.only,
                   pool: config.pool,
                 })
               : null

--- a/packages/test/src/lib/config.ts
+++ b/packages/test/src/lib/config.ts
@@ -485,8 +485,8 @@ function resolveOnlyPatterns(
     } catch (error) {
       let reason = error instanceof Error ? error.message : String(error)
       throw new Error(
-        `Invalid .only pattern "${pattern}". ` +
-          `.only patterns must be valid JavaScript regular expressions, ` +
+        `Invalid --only pattern "${pattern}". ` +
+          `--only patterns must be valid JavaScript regular expressions, ` +
           `or regex literals like "/pattern/flags". ${reason}`,
       )
     }

--- a/packages/test/src/lib/config.ts
+++ b/packages/test/src/lib/config.ts
@@ -480,11 +480,15 @@ function resolveOnlyPatterns(
       serialized = { source: pattern.source, flags: pattern.flags }
     }
 
-    // validate pattern
     try {
       new RegExp(serialized.source, serialized.flags)
     } catch (error) {
-      throw new Error(`Invalid .only pattern: ${pattern}`)
+      let reason = error instanceof Error ? error.message : String(error)
+      throw new Error(
+        `Invalid .only pattern "${pattern}". ` +
+          `.only patterns must be valid JavaScript regular expressions, ` +
+          `or regex literals like "/pattern/flags". ${reason}`,
+      )
     }
 
     return serialized

--- a/packages/test/src/lib/config.ts
+++ b/packages/test/src/lib/config.ts
@@ -129,6 +129,11 @@ const cliOptions = {
     short: 'q',
     description: 'Do not print skipped tests',
   },
+  only: {
+    type: 'string',
+    multiple: true,
+    description: 'Regular expression pattern(s) for test names to focus',
+  },
   reporter: {
     type: 'string',
     short: 'r',
@@ -169,6 +174,7 @@ const defaultValues: ResolvedRemixTestConfig = {
     exclude: ['node_modules/**'],
   },
   pool: 'forks',
+  only: undefined,
   playwrightConfig: undefined,
   project: undefined,
   quiet: false,
@@ -184,6 +190,13 @@ const defaultValues: ResolvedRemixTestConfig = {
  * uses worker threads for projects that prefer lower-overhead startup.
  */
 export type RemixTestPool = 'forks' | 'threads'
+
+export interface SerializedOnlyPattern {
+  source: string
+  flags: string
+}
+
+export type RemixTestOnlyPattern = string | RegExp
 
 /**
  * User-facing configuration for the `remix-test` CLI. Every field is
@@ -248,6 +261,12 @@ export interface RemixTestConfig {
    */
   pool?: RemixTestPool
   /**
+   * Regular expression pattern(s) to focus tests by their full name (--only).
+   * Matching suite names focus the whole suite, while matching test names focus
+   * the individual test. `--only` may be repeated on the CLI.
+   */
+  only?: RemixTestOnlyPattern | RemixTestOnlyPattern[]
+  /**
    * Filter tests to specific playwright project(s) (--project). Accepts a single
    * project name or an array of names; `--project` may be repeated on the CLI.
    */
@@ -293,6 +312,7 @@ export interface ResolvedRemixTestConfig {
   quiet: boolean
   reporter: string
   pool: RemixTestPool
+  only: SerializedOnlyPattern[] | undefined
   setup: string | undefined
   type: string[]
   watch: boolean
@@ -427,6 +447,7 @@ function resolveConfig(
     playwrightConfig:
       cliValues.playwrightConfig ?? fileConfig.playwrightConfig ?? defaultValues.playwrightConfig,
     pool: resolvePool(cliValues.pool ?? fileConfig.pool ?? defaultValues.pool),
+    only: resolveOnlyPatterns(cliValues.only ?? fileConfig.only),
     project: (() => {
       let raw = cliValues.project ?? fileConfig.project ?? defaultValues.project
       return raw === undefined ? undefined : toCommaSeparatedArray(raw)
@@ -444,6 +465,48 @@ function resolvePool(value: string): RemixTestPool {
   }
 
   throw new Error(`Unsupported test pool "${value}". Supported pools are: forks, threads`)
+}
+
+function resolveOnlyPatterns(
+  value: RemixTestOnlyPattern | readonly RemixTestOnlyPattern[] | undefined,
+): SerializedOnlyPattern[] | undefined {
+  if (value === undefined) return undefined
+
+  return toArray(value).map((pattern) => {
+    let serialized: SerializedOnlyPattern
+    if (typeof pattern === 'string') {
+      serialized = parseRegexLiteral(pattern) ?? { source: pattern, flags: '' }
+    } else {
+      serialized = { source: pattern.source, flags: pattern.flags }
+    }
+
+    // validate pattern
+    try {
+      new RegExp(serialized.source, serialized.flags)
+    } catch (error) {
+      throw new Error(`Invalid .only pattern: ${pattern}`)
+    }
+
+    return serialized
+  })
+}
+
+function parseRegexLiteral(pattern: string): SerializedOnlyPattern | undefined {
+  if (!pattern.startsWith('/') || pattern.length < 2) return undefined
+
+  let escaped = false
+  for (let index = pattern.length - 1; index > 0; index--) {
+    let char = pattern[index]
+    if (char === '/' && !escaped) {
+      return {
+        source: pattern.slice(1, index),
+        flags: pattern.slice(index + 1),
+      }
+    }
+    escaped = char === '\\' && !escaped
+  }
+
+  return undefined
 }
 
 async function loadConfigFile(

--- a/packages/test/src/lib/executor.ts
+++ b/packages/test/src/lib/executor.ts
@@ -1,6 +1,7 @@
 import { createTestContext, type CreateTestContextE2EOptions, type TestContext } from './context.ts'
 import type { V8CoverageEntry } from './coverage.ts'
 import type { TestResult, TestResults } from './reporters/results.ts'
+import type { SerializedOnlyPattern } from './config.ts'
 
 type PendingMeta = boolean | string
 
@@ -33,9 +34,13 @@ interface RegisteredTest extends RunnableOptions {
   todo?: PendingMeta
 }
 
-export async function runTests(
-  options?: Omit<CreateTestContextE2EOptions, 'addE2ECoverageEntries'>,
-): Promise<TestResults> {
+type RunTestsE2EOptions = Omit<CreateTestContextE2EOptions, 'addE2ECoverageEntries'>
+
+export interface RunTestsOptions extends Partial<RunTestsE2EOptions> {
+  only?: SerializedOnlyPattern[]
+}
+
+export async function runTests(options?: RunTestsOptions): Promise<TestResults> {
   let suites = getRegisteredSuites()
   let e2eCoverageEntries: Array<{ entries: V8CoverageEntry[]; baseUrl: string }> = []
   let results: TestResults = {
@@ -46,15 +51,31 @@ export async function runTests(
     tests: [],
   }
 
+  let onlyRegexes =
+    options?.only === undefined || options.only.length === 0
+      ? undefined
+      : options.only.map((pattern) => new RegExp(pattern.source, pattern.flags))
+  let hasOnlyPatterns = onlyRegexes !== undefined
   let hasOnlySuites = false
   let hasOnlyTests = false
 
   for (let suite of suites) {
+    if (onlyRegexes && matchesAny(onlyRegexes, suite.name)) {
+      suite.only = true
+    }
     hasOnlySuites ||= suite.only === true
-    hasOnlyTests ||= suite.tests.some((test) => test.only)
-    if (hasOnlySuites && hasOnlyTests) break
+
+    for (let test of suite.tests) {
+      if (onlyRegexes && matchesAny(onlyRegexes, getFullTestName(suite.name, test.name))) {
+        test.only = true
+      }
+      hasOnlyTests ||= test.only === true
+    }
+
+    if (!onlyRegexes && hasOnlySuites && hasOnlyTests) break
   }
-  let hasOnly = hasOnlySuites || hasOnlyTests
+
+  let hasOnly = hasOnlyPatterns || hasOnlySuites || hasOnlyTests
 
   for (let suite of suites) {
     let suiteHasOnlyTests = suite.tests.some((test) => test.only)
@@ -133,12 +154,7 @@ export async function runTests(
       let testAbortController = new AbortController()
       let { testContext, cleanup } = createTestContext({
         signal: testAbortController.signal,
-        e2e: options
-          ? {
-              ...options,
-              addE2ECoverageEntries: (e) => e2eCoverageEntries.push(e),
-            }
-          : undefined,
+        e2e: createE2EOptions(options, (e) => e2eCoverageEntries.push(e)),
       })
 
       try {
@@ -207,9 +223,45 @@ export async function runTests(
   return results
 }
 
+function createE2EOptions(
+  options: RunTestsOptions | undefined,
+  addE2ECoverageEntries: CreateTestContextE2EOptions['addE2ECoverageEntries'],
+): CreateTestContextE2EOptions | undefined {
+  if (options?.browser === undefined) {
+    return undefined
+  }
+
+  if (
+    options.coverage === undefined ||
+    options.open === undefined ||
+    options.playwrightPageOptions === undefined
+  ) {
+    throw new Error('Incomplete E2E test options')
+  }
+
+  return {
+    addE2ECoverageEntries,
+    browser: options.browser,
+    coverage: options.coverage,
+    open: options.open,
+    playwrightPageOptions: options.playwrightPageOptions,
+  }
+}
+
 function getRegisteredSuites(): RegisteredSuite[] {
   let global = globalThis as typeof globalThis & { __testSuites?: RegisteredSuite[] }
   return global.__testSuites ?? []
+}
+
+function matchesAny(regexes: RegExp[], value: string): boolean {
+  return regexes.some((regex) => {
+    regex.lastIndex = 0
+    return regex.test(value)
+  })
+}
+
+function getFullTestName(suiteName: string, testName: string): string {
+  return testName ? `${suiteName} > ${testName}` : suiteName
 }
 
 function getPendingStatus(value: {

--- a/packages/test/src/lib/runner.ts
+++ b/packages/test/src/lib/runner.ts
@@ -3,7 +3,7 @@ import * as fsp from 'node:fs/promises'
 import * as path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { Worker } from 'node:worker_threads'
-import { IS_RUNNING_FROM_SRC, type RemixTestPool } from './config.ts'
+import { IS_RUNNING_FROM_SRC, type RemixTestPool, type SerializedOnlyPattern } from './config.ts'
 import {
   collectCoverageMapFromPlaywright,
   collectServerCoverageMap,
@@ -33,6 +33,7 @@ interface RunFileOptions {
   cwd?: string
   coverage?: CoverageConfig
   open?: boolean
+  only?: SerializedOnlyPattern[]
   playwrightUseOpts?: PlaywrightUseOpts
   pool?: RemixTestPool
 }
@@ -45,6 +46,7 @@ export async function runServerTests(
   options: {
     cwd?: string
     open?: boolean
+    only?: SerializedOnlyPattern[]
     playwrightUseOpts?: PlaywrightUseOpts
     projectName?: string
     coverage?: CoverageConfig
@@ -235,6 +237,7 @@ export function runFileInWorker(
             file: pathToFileURL(file).href,
             type,
             coverage: options.coverage,
+            only: options.only,
             open: options.open,
             playwrightUseOpts: options.playwrightUseOpts,
           },
@@ -244,6 +247,7 @@ export function runFileInWorker(
             file: pathToFileURL(file).href,
             type,
             coverage: options.coverage,
+            only: options.only,
           },
         })
 
@@ -340,6 +344,7 @@ function runFileInProcess(
         file: pathToFileURL(file).href,
         type,
         coverage: options.coverage,
+        only: options.only,
         open: options.open,
         playwrightUseOpts: options.playwrightUseOpts,
       },

--- a/packages/test/src/lib/worker-e2e-file.ts
+++ b/packages/test/src/lib/worker-e2e-file.ts
@@ -9,12 +9,14 @@ import {
 import type { CoverageConfig } from './coverage.ts'
 import type { TestResults } from './reporters/results.ts'
 import { createFailedResults } from './worker-results.ts'
-import { isRecord, parseCoverageConfig } from './worker-server.ts'
+import { isRecord, parseCoverageConfig, parseOnlyPatterns } from './worker-server.ts'
+import type { SerializedOnlyPattern } from './config.ts'
 
 export interface E2ETestWorkerData {
   file: string
   coverage?: CoverageConfig
   open?: boolean
+  only?: SerializedOnlyPattern[]
   playwrightUseOpts?: PlaywrightUseOpts
 }
 
@@ -38,6 +40,7 @@ export async function runE2ETestFile(
         open: workerData.open ?? false,
         playwrightPageOptions: getPlaywrightPageOptions(workerData.playwrightUseOpts),
         coverage: !!workerData.coverage,
+        only: workerData.only,
       })
 
       if (workerData.open) {
@@ -68,6 +71,7 @@ function parseE2ETestWorkerData(value: unknown): E2ETestWorkerData {
   return {
     file: value.file,
     coverage: parseCoverageConfig(value.coverage),
+    only: parseOnlyPatterns(value.only),
     open: parseBoolean(value.open, 'open'),
     playwrightUseOpts: parsePlaywrightUseOpts(value.playwrightUseOpts),
   }

--- a/packages/test/src/lib/worker-server.ts
+++ b/packages/test/src/lib/worker-server.ts
@@ -1,5 +1,5 @@
 import * as mod from 'node:module'
-import { IS_RUNNING_FROM_SRC } from './config.ts'
+import { IS_RUNNING_FROM_SRC, type SerializedOnlyPattern } from './config.ts'
 import { importModule } from './import-module.ts'
 import type { CoverageConfig } from './coverage.ts'
 import type { TestResults } from './reporters/results.ts'
@@ -10,6 +10,7 @@ import { createFailedResults } from './worker-results.ts'
 export interface ServerTestWorkerData {
   file: string
   coverage?: CoverageConfig
+  only?: SerializedOnlyPattern[]
 }
 
 export async function runServerTestFile(value: unknown): Promise<TestResults> {
@@ -31,7 +32,7 @@ export async function runServerTestFile(value: unknown): Promise<TestResults> {
       await importModule(workerData.file, import.meta)
     }
 
-    let results = await runTests()
+    let results = await runTests({ only: workerData.only })
     await takeCoverage(workerData.coverage)
     return results
   } catch (error) {
@@ -55,6 +56,7 @@ function parseServerTestWorkerData(value: unknown): ServerTestWorkerData {
   return {
     file: value.file,
     coverage: parseCoverageConfig(value.coverage),
+    only: parseOnlyPatterns(value.only),
   }
 }
 
@@ -89,6 +91,23 @@ export function parseCoverageConfig(value: unknown): CoverageConfig | undefined 
   if (functions !== undefined) coverage.functions = functions
 
   return coverage
+}
+
+export function parseOnlyPatterns(value: unknown): SerializedOnlyPattern[] | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error('Invalid server test worker only patterns')
+  }
+
+  return value.map((item) => {
+    if (!isRecord(item) || typeof item.source !== 'string' || typeof item.flags !== 'string') {
+      throw new Error('Invalid server test worker only pattern')
+    }
+    return { source: item.source, flags: item.flags }
+  })
 }
 
 function parseStringArray(value: unknown, name: string): string[] | undefined {

--- a/packages/test/src/test/config.test.ts
+++ b/packages/test/src/test/config.test.ts
@@ -116,7 +116,7 @@ describe('loadConfig', () => {
         () => loadConfig(['--only', '/(/'], tmp),
         (error: unknown) => {
           let message = String(error)
-          assert.match(message, /Invalid \.only pattern/)
+          assert.match(message, /Invalid --only pattern/)
           assert.match(message, /must be valid JavaScript regular expressions/)
           assert.match(message, /Unterminated group/)
           return true

--- a/packages/test/src/test/config.test.ts
+++ b/packages/test/src/test/config.test.ts
@@ -112,7 +112,16 @@ describe('loadConfig', () => {
     let tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'remix-test-config-'))
 
     try {
-      await assert.rejects(() => loadConfig(['--only', '/(/'], tmp), SyntaxError)
+      await assert.rejects(
+        () => loadConfig(['--only', '/(/'], tmp),
+        (error: unknown) => {
+          let message = String(error)
+          assert.match(message, /Invalid \.only pattern/)
+          assert.match(message, /must be valid JavaScript regular expressions/)
+          assert.match(message, /Unterminated group/)
+          return true
+        },
+      )
     } finally {
       await fsp.rm(tmp, { recursive: true, force: true })
     }

--- a/packages/test/src/test/config.test.ts
+++ b/packages/test/src/test/config.test.ts
@@ -72,6 +72,51 @@ describe('loadConfig', () => {
       await fsp.rm(tmp, { recursive: true, force: true })
     }
   })
+
+  it('normalizes repeated only values from CLI flags', async () => {
+    let tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'remix-test-config-'))
+
+    try {
+      let config = await loadConfig(['--only', 'server > matches', '--only', '/browser/i'], tmp)
+
+      assert.deepEqual(config.only, [
+        { source: 'server > matches', flags: '' },
+        { source: 'browser', flags: 'i' },
+      ])
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('normalizes only values from config files', async () => {
+    let tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'remix-test-config-'))
+
+    try {
+      await fsp.writeFile(
+        path.join(tmp, 'remix-test.config.ts'),
+        ['export default {', "  only: [/server/i, 'browser'],", '}'].join('\n'),
+      )
+
+      let config = await loadConfig([], tmp)
+
+      assert.deepEqual(config.only, [
+        { source: 'server', flags: 'i' },
+        { source: 'browser', flags: '' },
+      ])
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects invalid only patterns', async () => {
+    let tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'remix-test-config-'))
+
+    try {
+      await assert.rejects(() => loadConfig(['--only', '/(/'], tmp), SyntaxError)
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('config', () => {
@@ -143,6 +188,12 @@ describe('config', () => {
 
     assert.match(help, /--quiet/)
     assert.match(help, /-q/)
+  })
+
+  it('includes the only flag in help text', () => {
+    let help = getRemixTestHelpText()
+
+    assert.match(help, /--only <value>/)
   })
 })
 

--- a/packages/test/src/test/executor.test.ts
+++ b/packages/test/src/test/executor.test.ts
@@ -1,6 +1,6 @@
 import * as assert from '@remix-run/assert'
 import type { TestContext } from '../lib/context.ts'
-import { runTests } from '../lib/executor.ts'
+import { runTests, type RunTestsOptions } from '../lib/executor.ts'
 import { describe, it } from '../lib/framework.ts'
 import type { TestResults } from '../lib/reporters/results.ts'
 
@@ -462,6 +462,170 @@ describe('runTests only filtering', () => {
       ],
     )
   })
+
+  it('focuses tests matching --only patterns by full test name', async () => {
+    let ran: string[] = []
+
+    let results = await runWithSuites(
+      [
+        {
+          name: 'math',
+          tests: [
+            {
+              name: 'adds numbers',
+              fn() {
+                ran.push('adds')
+              },
+            },
+            {
+              name: 'subtracts numbers',
+              fn() {
+                ran.push('subtracts')
+              },
+            },
+          ],
+        },
+      ],
+      { only: [{ source: 'math > adds', flags: '' }] },
+    )
+
+    assert.deepEqual(ran, ['adds'])
+    assert.equal(results.passed, 1)
+    assert.equal(results.skipped, 1)
+    assert.deepEqual(
+      results.tests.map((test) => [test.name, test.status, test.focused === true]),
+      [
+        ['adds numbers', 'passed', true],
+        ['subtracts numbers', 'skipped', false],
+      ],
+    )
+  })
+
+  it('focuses suites matching --only patterns by suite name', async () => {
+    let ran: string[] = []
+
+    let results = await runWithSuites(
+      [
+        {
+          name: 'focused suite',
+          tests: [
+            {
+              name: 'first test',
+              fn() {
+                ran.push('first')
+              },
+            },
+            {
+              name: 'second test',
+              fn() {
+                ran.push('second')
+              },
+            },
+          ],
+        },
+        {
+          name: 'regular suite',
+          tests: [
+            {
+              name: 'third test',
+              fn() {
+                ran.push('third')
+              },
+            },
+          ],
+        },
+      ],
+      { only: [{ source: '^focused suite$', flags: '' }] },
+    )
+
+    assert.deepEqual(ran, ['first', 'second'])
+    assert.equal(results.passed, 2)
+    assert.equal(results.skipped, 1)
+  })
+
+  it('unions --only patterns with authored .only modifiers', async () => {
+    let ran: string[] = []
+
+    let results = await runWithSuites(
+      [
+        {
+          name: 'authored suite',
+          only: true,
+          tests: [
+            {
+              name: 'runs from describe.only',
+              fn() {
+                ran.push('describe.only')
+              },
+            },
+          ],
+        },
+        {
+          name: 'pattern suite',
+          tests: [
+            {
+              name: 'runs from --only',
+              fn() {
+                ran.push('--only')
+              },
+            },
+          ],
+        },
+        {
+          name: 'regular suite',
+          tests: [
+            {
+              name: 'does not run',
+              fn() {
+                ran.push('regular')
+              },
+            },
+          ],
+        },
+      ],
+      { only: [{ source: 'pattern suite > runs', flags: '' }] },
+    )
+
+    assert.deepEqual(ran, ['describe.only', '--only'])
+    assert.equal(results.passed, 2)
+    assert.equal(results.skipped, 1)
+  })
+
+  it('skips every test when --only patterns do not match', async () => {
+    let ran: string[] = []
+
+    let results = await runWithSuites(
+      [
+        {
+          name: 'suite',
+          beforeAll: [
+            {
+              fn() {
+                ran.push('beforeAll')
+              },
+            },
+          ],
+          tests: [
+            {
+              name: 'test',
+              fn() {
+                ran.push('test')
+              },
+            },
+          ],
+        },
+      ],
+      { only: [{ source: 'missing', flags: '' }] },
+    )
+
+    assert.deepEqual(ran, [])
+    assert.equal(results.passed, 0)
+    assert.equal(results.skipped, 1)
+    assert.deepEqual(
+      results.tests.map((test) => [test.name, test.status, test.focused === true]),
+      [['test', 'skipped', false]],
+    )
+  })
 })
 
 describe('runTests skip and todo reasons', () => {
@@ -546,13 +710,16 @@ describe('runTests skip and todo reasons', () => {
   })
 })
 
-async function runWithSuites(suites: SuiteFixture[]): Promise<TestResults> {
+async function runWithSuites(
+  suites: SuiteFixture[],
+  options?: RunTestsOptions,
+): Promise<TestResults> {
   let global = globalThis as TestSuitesGlobal
   let previousSuites = global.__testSuites
 
   global.__testSuites = suites
   try {
-    return await runTests()
+    return await runTests(options)
   } finally {
     global.__testSuites = previousSuites
   }

--- a/packages/test/src/test/executor.test.ts
+++ b/packages/test/src/test/executor.test.ts
@@ -493,10 +493,10 @@ describe('runTests only filtering', () => {
     assert.equal(results.passed, 1)
     assert.equal(results.skipped, 1)
     assert.deepEqual(
-      results.tests.map((test) => [test.name, test.status, test.focused === true]),
+      results.tests.map((test) => [test.name, test.status]),
       [
-        ['adds numbers', 'passed', true],
-        ['subtracts numbers', 'skipped', false],
+        ['adds numbers', 'passed'],
+        ['subtracts numbers', 'skipped'],
       ],
     )
   })
@@ -622,8 +622,8 @@ describe('runTests only filtering', () => {
     assert.equal(results.passed, 0)
     assert.equal(results.skipped, 1)
     assert.deepEqual(
-      results.tests.map((test) => [test.name, test.status, test.focused === true]),
-      [['test', 'skipped', false]],
+      results.tests.map((test) => [test.name, test.status]),
+      [['test', 'skipped']],
     )
   })
 })


### PR DESCRIPTION
This stacks on #11572 and adds a CLI/config way to focus tests without editing source files to add `.only`.

- Adds a repeatable `--only <pattern>` CLI flag and `only` config option for `@remix-run/test`
- Matches suite names to focus whole suites and full test names in the form `suite > test` to focus individual tests
- Applies matches by setting the existing `.only` fields before execution, so authored `.only` modifiers and CLI focus patterns use the same union semantics
- Threads the serialized focus patterns through server, browser, and E2E runners

```sh
remix test --only "routes > loads user"
remix test --only "/auth/i" --only "loader > redirects"
```

```ts
import type { RemixTestConfig } from 'remix/test'

export default {
  only: [/auth/i, 'loader > redirects'],
} satisfies RemixTestConfig
```
