### PR TITLE
Stream frames with declarative out-of-order directives

### DIFF
--- a/packages/ui/.changes/minor.native-out-of-order-streaming.md
+++ b/packages/ui/.changes/minor.native-out-of-order-streaming.md
@@ -1,0 +1,7 @@
+---
+'@remix-run/ui': minor
+---
+
+Non-blocking `<Frame>` streaming now uses the declarative out-of-order streaming directives (`<?start name="ID">` / `<?end name="ID">` around the fallback, with resolved content delivered as `<template for="ID">`). Browsers that natively process the directives perform the DOM swap with no JavaScript; other browsers use a small MutationObserver polyfill that `run()` installs automatically. In both cases the runtime hydrates the resolved region after the swap rather than extracting the template itself.
+
+This changes the streamed wire format: resolved frame content now streams as `<template for="ID">` instead of `<template id="ID">`, and pending fallbacks are wrapped in `<?start>` / `<?end>` directives inside the existing `<!-- rmx:f:ID -->` markers.

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -9,6 +9,7 @@ import { createRangeRoot, createRoot } from './vdom.ts'
 import { diffNodes } from './diff-dom.ts'
 import { createStyleManager, type StyleManager } from '../style/index.ts'
 import { findFlushMarker, type FlushKind } from './stream-protocol.ts'
+import { findStreamRegion, installStreamTemplateMover } from './stream-directives.ts'
 
 type FrameRoot = [Comment, Comment] | Element | Document | DocumentFragment
 
@@ -395,7 +396,13 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     scheduleHydrationInContainer(container, context, initialHydrationTracker)
 
     if (currentMarker?.status === 'pending') {
-      await watchPendingFrameTemplate(currentMarker, initialHydrationTracker)
+      await watchPendingFrameTemplate(
+        currentMarker,
+        initialHydrationTracker,
+        undefined,
+        undefined,
+        true,
+      )
     }
 
     initialHydrationTracker.finalize()
@@ -548,6 +555,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     initialHydrationTracker?: InitialHydrationTracker,
     signal?: AbortSignal,
     onResolved?: () => void,
+    fromInitialHydration = false,
   ): Promise<void> {
     if (signal?.aborted) return
     if (pendingTemplateMarkerId === marker.id) return
@@ -555,10 +563,12 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     clearPendingFrameTemplateWatch()
     pendingTemplateMarkerId = marker.id
 
-    let early = consumeFrameTemplate(marker.id) ?? getEarlyFrameContent(marker.id)
-    if (early) {
+    // Content fetched through a runtime stream (reload/navigation) is delivered
+    // as an already-parsed fragment and reconciled into the region in place.
+    let buffered = consumeFrameTemplate(marker.id)
+    if (buffered) {
       clearPendingFrameTemplateWatch()
-      await render(early, { initialHydrationTracker, signal, contentStatus: 'resolved' })
+      await render(buffered, { initialHydrationTracker, signal, contentStatus: 'resolved' })
       if (!signal?.aborted) onResolved?.()
       return
     }
@@ -568,8 +578,31 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       return
     }
 
-    let observer = setupTemplateObserver()
+    // Live-document streaming: the browser (or the client polyfill installed by
+    // run()) moves the matching `<template for>` content into this region. The
+    // runtime never performs the swap itself; it hydrates the resolved content
+    // once the streaming directives are gone.
+    //
+    // During initial hydration the polyfill may have already swapped the region
+    // before this watch was installed, in which case the resolved content is
+    // already in place and only needs hydrating. Reloads never swap live DOM
+    // (their content arrives through the template bus), so they must not treat a
+    // directive-free region as an early swap.
+    if (fromInitialHydration && !regionHasStreamDirectives(marker.id)) {
+      await resolveStreamedRegion(initialHydrationTracker, signal, onResolved)
+      return
+    }
+
+    let regionParent = container.regionParent ?? (container.root as ParentNode)
+    let observer = new MutationObserver(() => {
+      if (signal?.aborted || pendingTemplateMarkerId !== marker.id) return
+      if (regionHasStreamDirectives(marker.id)) return
+      void resolveStreamedRegion(initialHydrationTracker, signal, onResolved)
+    })
+    observer.observe(regionParent, { childList: true, subtree: true })
     pendingTemplateObserver = observer
+
+    // Late content delivered through the template bus (fetched frame streams).
     let unsubscribe = subscribeFrameTemplate(marker.id, async (fragment) => {
       if (signal?.aborted) return
       if (pendingTemplateMarkerId !== marker.id) return
@@ -588,13 +621,31 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       },
       { once: true },
     )
+  }
 
-    let buffered = consumeFrameTemplate(marker.id)
-    if (buffered) {
-      clearPendingFrameTemplateWatch()
-      await render(buffered, { initialHydrationTracker, signal, contentStatus: 'resolved' })
-      if (!signal?.aborted) onResolved?.()
-    }
+  function regionHasStreamDirectives(id: string): boolean {
+    return findStreamRegion(id, container.doc) != null
+  }
+
+  async function resolveStreamedRegion(
+    initialHydrationTracker?: InitialHydrationTracker,
+    signal?: AbortSignal,
+    onResolved?: () => void,
+  ): Promise<void> {
+    clearPendingFrameTemplateWatch()
+    if (signal?.aborted) return
+
+    // The streamed content carries its own hydration data and selector-addressed
+    // styles. Merge the data so client entries in the resolved region can hydrate;
+    // styles are adopted by the global server-style observer as they land.
+    mergeRmxDataFromDocument(context.data, container.doc)
+    context.styleManager.replaceServerStyles(collectFrameServerStyleTags(container))
+
+    scheduleHydrationInContainer(container, context, initialHydrationTracker)
+    if (signal?.aborted) return
+    await createSubFrames(container.childNodes, context, { signal })
+    displayedContentStatus = 'resolved'
+    if (!signal?.aborted) onResolved?.()
   }
 }
 
@@ -1030,48 +1081,18 @@ function disposeSubFrames(nodes: Node[], context: FrameContext): void {
   }
 }
 
-function getEarlyFrameContent(id: string): DocumentFragment | null {
-  let template = document.querySelector(`template#${id}`)
-  if (template instanceof HTMLTemplateElement) {
-    let fragment = template.content
-    template.remove()
-    return fragment
-  }
-  return null
-}
-
-function setupTemplateObserver(): MutationObserver {
-  let root = document.body ?? document.documentElement ?? document
-  let observer = new MutationObserver((mutations) => {
-    for (let mutation of mutations) {
-      for (let node of mutation.addedNodes) {
-        collectAndPublishTemplates(node)
-      }
-    }
-  })
-
-  observer.observe(root, { childList: true, subtree: true })
-  return observer
-}
-
-function collectAndPublishTemplates(node: Node): void {
-  if (node instanceof HTMLTemplateElement) {
-    publishFrameTemplateElement(node)
-    return
-  }
-
-  if (!(node instanceof Element)) return
-  let templates = Array.from(node.querySelectorAll('template'))
-  for (let template of templates) {
-    if (!(template instanceof HTMLTemplateElement)) continue
-    publishFrameTemplateElement(template)
-  }
-}
-
-function publishFrameTemplateElement(template: HTMLTemplateElement): void {
-  if (!template.id) return
-  template.remove()
-  publishFrameTemplate(template.id, template.content)
+/**
+ * Installs the client-side out-of-order streaming support for the current
+ * document. Browsers with native `<?start>`/`<?end>` directive support perform
+ * the DOM swap themselves; otherwise a MutationObserver polyfill moves
+ * `<template for>` content into place. Frame instances hydrate the resolved
+ * content independently.
+ *
+ * @param doc Document to observe. Defaults to the global document.
+ * @returns A disposer that removes the polyfill observer.
+ */
+export function installStreamResolution(doc: Document = document): () => void {
+  return installStreamTemplateMover(doc)
 }
 
 export function publishFrameTemplate(id: string, fragment: DocumentFragment): void {
@@ -1126,7 +1147,7 @@ type StreamTemplateParseResult = {
 }
 
 const COMPLETE_TEMPLATE_WITH_ID_PATTERN =
-  /<template\b[^>]*\bid=(?:"([^"]+)"|'([^']+)')[^>]*>[\s\S]*?<\/template>/gi
+  /<template\b[^>]*\bfor=(?:"([^"]+)"|'([^']+)')[^>]*>[\s\S]*?<\/template>/gi
 
 function extractTemplatesFromBuffer(
   doc: Document,
@@ -1152,8 +1173,9 @@ function extractTemplatesFromBuffer(
     if (id) {
       let parsed = createFragmentFromString(doc, fullMatch)
       let template = parsed.querySelector('template')
-      if (template instanceof HTMLTemplateElement && template.id) {
-        onTemplate(template.id, template.content)
+      let templateFor = template?.getAttribute('for')
+      if (template instanceof HTMLTemplateElement && templateFor) {
+        onTemplate(templateFor, template.content)
       }
     }
 

--- a/packages/ui/src/runtime/run.ts
+++ b/packages/ui/src/runtime/run.ts
@@ -1,4 +1,4 @@
-import { createFrame, type Frame } from './frame.ts'
+import { createFrame, installStreamResolution, type Frame } from './frame.ts'
 import { createScheduler } from './vdom.ts'
 import { createStyleManager } from '../style/index.ts'
 import type { FrameHandle } from './component.ts'
@@ -99,6 +99,7 @@ export function run(init: RunInit): AppRuntime {
   })
 
   let appController = new AbortController()
+  let disposeStreamResolution = installStreamResolution(document)
   startNavigationListener(appController.signal)
   let readyPromise = topFrame.ready().catch((error) => {
     errorTarget.dispatchEvent(createComponentErrorEvent(error))
@@ -110,6 +111,7 @@ export function run(init: RunInit): AppRuntime {
     flush: () => topFrame.flush(),
     dispose: () => {
       appController.abort()
+      disposeStreamResolution()
       topFrame.dispose()
     },
   })

--- a/packages/ui/src/runtime/stream-directives.ts
+++ b/packages/ui/src/runtime/stream-directives.ts
@@ -1,0 +1,264 @@
+// Out-of-order HTML streaming built on the declarative processing-instruction
+// directives shipping in modern browsers:
+//
+//   <?start name="ID"> ...placeholder... <?end name="ID">
+//   <template for="ID">...resolved content...</template>
+//
+// A supporting browser natively moves the `<template for>` content into the
+// region delimited by the matching `<?start>` / `<?end>` instructions, with no
+// JavaScript. Browsers without native support parse the instructions as comment
+// nodes (`?start name="ID"` / `?end name="ID"`); a small MutationObserver
+// polyfill performs the same move. Either way the DOM swap is owned by the
+// browser or the polyfill, never by the reconciler — the runtime only hydrates
+// whatever content exists after the swap.
+
+const PROCESSING_INSTRUCTION_NODE = 7
+const COMMENT_NODE = 8
+
+const NAME_ATTR_PATTERN = /name="([^"]*)"/
+
+/**
+ * A parsed stream directive describing one boundary of an out-of-order region.
+ */
+export interface StreamDirective {
+  /** Which boundary this directive marks. */
+  kind: 'start' | 'end'
+  /** Region identifier shared by the matching `<template for>` element. */
+  id: string
+}
+
+/**
+ * Serializes the opening directive for an out-of-order streaming region.
+ *
+ * @param id Region identifier shared with the resolving `<template for>`.
+ * @returns The `<?start name="id">` processing instruction.
+ */
+export function streamStartDirective(id: string): string {
+  return `<?start name="${id}">`
+}
+
+/**
+ * Serializes the closing directive for an out-of-order streaming region.
+ *
+ * @param id Region identifier shared with the resolving `<template for>`.
+ * @returns The `<?end name="id">` processing instruction.
+ */
+export function streamEndDirective(id: string): string {
+  return `<?end name="${id}">`
+}
+
+/**
+ * Reads a stream directive from a DOM node, handling both native processing
+ * instructions (nodeType 7) and the comment fallback (nodeType 8) produced by
+ * browsers that do not yet parse the instructions.
+ *
+ * @param node Node to inspect.
+ * @returns The parsed directive, or `null` when the node is not a directive.
+ */
+export function getStreamDirective(node: Node | null | undefined): StreamDirective | null {
+  if (!node) return null
+
+  if (node.nodeType === PROCESSING_INSTRUCTION_NODE) {
+    let instruction = node as ProcessingInstruction
+    if (instruction.target === 'start' || instruction.target === 'end') {
+      let id = readDirectiveId(instruction.data)
+      if (id != null) return { kind: instruction.target, id }
+    }
+    return null
+  }
+
+  if (node.nodeType === COMMENT_NODE) {
+    let data = (node as Comment).data
+    if (data.startsWith('?start ') || data.startsWith('?start\t')) {
+      let id = readDirectiveId(data)
+      if (id != null) return { kind: 'start', id }
+    } else if (data.startsWith('?end ') || data.startsWith('?end\t')) {
+      let id = readDirectiveId(data)
+      if (id != null) return { kind: 'end', id }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Reports whether a node is any stream directive boundary.
+ *
+ * @param node Node to inspect.
+ * @returns `true` when the node is a `<?start>` or `<?end>` directive.
+ */
+export function isStreamDirective(node: Node | null | undefined): boolean {
+  return getStreamDirective(node) != null
+}
+
+function readDirectiveId(data: string): string | null {
+  let match = NAME_ATTR_PATTERN.exec(data)
+  return match ? match[1]! : null
+}
+
+/**
+ * Detects whether the current browser natively processes the declarative
+ * `<?start>` / `<?end>` streaming directives. When it does, the browser owns
+ * the out-of-order DOM swap and the polyfill must not run.
+ *
+ * @param doc Document used to build the probe. Defaults to the global document.
+ * @returns `true` when the parser produces a processing instruction node.
+ */
+export function supportsStreamDirectives(doc: Document = document): boolean {
+  let probe = doc.createElement('template')
+  probe.innerHTML = streamStartDirective('rmx-probe')
+  let first = probe.content.firstChild
+  return !!first && first.nodeType === PROCESSING_INSTRUCTION_NODE
+}
+
+// NodeFilter bit flags, inlined to avoid depending on the global constant.
+const SHOW_COMMENT = 0x80
+const SHOW_PROCESSING_INSTRUCTION = 0x40
+
+/**
+ * The matching `<?start>` and `<?end>` directives that delimit one out-of-order
+ * streaming region.
+ */
+export interface StreamRegion {
+  /** The opening directive node. */
+  start: Node
+  /** The closing directive node. */
+  end: Node
+}
+
+/**
+ * Finds the directive pair that delimits the region with the given id.
+ *
+ * @param id Region identifier to locate.
+ * @param doc Document to search. Defaults to the global document.
+ * @returns The matching region, or `null` when either boundary is missing.
+ */
+export function findStreamRegion(id: string, doc: Document = document): StreamRegion | null {
+  let iterator = doc.createNodeIterator(doc, SHOW_COMMENT | SHOW_PROCESSING_INSTRUCTION)
+  let start: Node | null = null
+  let end: Node | null = null
+  let node = iterator.nextNode()
+  while (node) {
+    let directive = getStreamDirective(node)
+    if (directive && directive.id === id) {
+      if (directive.kind === 'start') start = node
+      else end = node
+      if (start && end) return { start, end }
+    }
+    node = iterator.nextNode()
+  }
+  return null
+}
+
+/**
+ * Moves a `<template for>` element's content into its matching directive region,
+ * replacing the placeholder content and removing the directives and template.
+ * This is the polyfill for browsers without native directive support; native
+ * browsers perform the same move without JavaScript.
+ *
+ * @param template Template element addressed by a `for` attribute.
+ * @param doc Document that owns the template. Defaults to the global document.
+ * @returns The resolved region id when a swap occurred, otherwise `null`.
+ */
+export function swapStreamTemplate(
+  template: HTMLTemplateElement,
+  doc: Document = document,
+): string | null {
+  let id = template.getAttribute('for')
+  if (id == null) return null
+
+  let region = findStreamRegion(id, doc)
+  if (!region) {
+    template.remove()
+    return null
+  }
+
+  let { start, end } = region
+  let parent = end.parentNode
+  if (!parent || start.parentNode !== parent) {
+    template.remove()
+    return null
+  }
+
+  // Replace the placeholder content between the directives.
+  let node = start.nextSibling
+  while (node && node !== end) {
+    let next = node.nextSibling
+    parent.removeChild(node)
+    node = next
+  }
+  parent.insertBefore(template.content.cloneNode(true), end)
+
+  // Remove the directives and the consumed template.
+  parent.removeChild(start)
+  parent.removeChild(end)
+  template.remove()
+
+  return id
+}
+
+function forEachStreamTemplate(node: Node, visit: (template: HTMLTemplateElement) => void): void {
+  if (node instanceof HTMLTemplateElement) {
+    if (node.hasAttribute('for')) visit(node)
+    return
+  }
+  if (!(node instanceof Element)) return
+  for (let template of Array.from(node.querySelectorAll('template[for]'))) {
+    if (template instanceof HTMLTemplateElement) visit(template)
+  }
+}
+
+/**
+ * Installs the MutationObserver polyfill that moves `<template for>` content
+ * into its directive region as templates stream into the document. No-op and
+ * returns an inert disposer when the browser supports the directives natively.
+ *
+ * @param doc Document to observe. Defaults to the global document.
+ * @param onSwap Optional callback invoked with the region id after each swap.
+ * @returns A function that disconnects the observer.
+ */
+export function installStreamTemplateMover(
+  doc: Document = document,
+  onSwap?: (id: string) => void,
+): () => void {
+  if (supportsStreamDirectives(doc)) return () => {}
+
+  let root = doc.body ?? doc.documentElement ?? doc
+  let observer = new MutationObserver((mutations) => {
+    for (let mutation of mutations) {
+      for (let node of mutation.addedNodes) {
+        forEachStreamTemplate(node, (template) => {
+          let id = swapStreamTemplate(template, doc)
+          if (id != null) onSwap?.(id)
+        })
+      }
+    }
+  })
+
+  observer.observe(root, { childList: true, subtree: true })
+
+  let dispose = () => {
+    observer.disconnect()
+    doc.removeEventListener('DOMContentLoaded', dispose)
+  }
+
+  // Server-streamed out-of-order chunks only arrive while the initial document
+  // is still parsing. Once it finishes loading there will be no more, so drop
+  // the observer after DOMContentLoaded. Reloads and navigation reconcile their
+  // content through the runtime rather than the live document, so they do not
+  // depend on the polyfill.
+  if (doc.readyState === 'loading') {
+    doc.addEventListener('DOMContentLoaded', dispose, { once: true })
+  }
+
+  // Swap any templates that already streamed in before the observer was
+  // installed (for example when the full document is present at startup).
+  for (let template of Array.from(doc.querySelectorAll('template[for]'))) {
+    if (template instanceof HTMLTemplateElement) {
+      let id = swapStreamTemplate(template, doc)
+      if (id != null) onSwap?.(id)
+    }
+  }
+
+  return dispose
+}

--- a/packages/ui/src/server/README.md
+++ b/packages/ui/src/server/README.md
@@ -56,7 +56,7 @@ When you render nested frame responses with `renderToStream()` inside `resolveFr
 When the stream encounters a `<Frame>` component:
 
 - **Without `fallback`** (blocking): The frame content is awaited before the initial HTML chunk is sent. The resolved content appears inline.
-- **With `fallback`** (non-blocking): The fallback is rendered inline in the initial chunk. Once the frame resolves, a `<template>` element containing the real content is streamed at the end of the response. The client swaps it in automatically.
+- **With `fallback`** (non-blocking): The fallback is rendered inline in the initial chunk, delimited by declarative `<?start name="ID">` / `<?end name="ID">` streaming directives. Once the frame resolves, a `<template for="ID">` element containing the real content is streamed at the end of the response. Browsers with native support for the directives swap the content in with no JavaScript; other browsers use a small MutationObserver polyfill installed by `run()`. Either way the client hydrates the resolved content after the swap.
 
 This means the first chunk always contains a complete, renderable page. Slow data sources don't block the initial paint.
 

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -10,6 +10,7 @@ import {
   shouldStringifyBooleanAttribute,
 } from '../runtime/core/attributes.ts'
 import { appendFlushMarker, type FlushKind, stripFlushMarkers } from '../runtime/stream-protocol.ts'
+import { streamEndDirective, streamStartDirective } from '../runtime/stream-directives.ts'
 import { REMIX_UI_STYLE_LAYER } from '../style/layers.ts'
 
 interface VNode {
@@ -124,6 +125,9 @@ type Segment =
       frameId: string
       content: Segment | null
       pending?: Promise<void>
+      // Marks a non-blocking region whose fallback is bracketed by streaming
+      // directives and resolved later by a `<template for>` element.
+      streamed?: boolean
     }
 
 const TEXTAREA_VALUE_PROPS = new Set(['value', 'defaultValue'])
@@ -480,6 +484,7 @@ function buildFrameSegment(
   let resolveFrameContext = getResolveFrameContext(frameState)
   let nonBlocking = !!props.fallback
   if (nonBlocking) {
+    seg.streamed = true
     seg.content = buildSegment(props.fallback, context, frameState)
     let framePromise = Promise.resolve(
       context.resolveFrame(props.src, props.name, resolveFrameContext),
@@ -1129,6 +1134,12 @@ function serializeSegment(seg: Segment): string {
   let inner = seg.content ? serializeSegment(seg.content) : ''
   let start = `<!-- rmx:f:${seg.frameId} -->`
   let end = `<!-- /rmx:f -->`
+  // Non-blocking regions bracket their fallback with declarative streaming
+  // directives. A supporting browser (or the client polyfill) moves the
+  // matching `<template for>` content into this region when it resolves.
+  if (seg.streamed) {
+    inner = streamStartDirective(seg.frameId) + inner + streamEndDirective(seg.frameId)
+  }
   return start + inner + end
 }
 
@@ -1325,8 +1336,8 @@ async function streamPendingFrames(
           if (context.signal.aborted) return
           html = dedupeServerStyleTagsInHtml(html, context.emittedStyles)
 
-          // Stream as a template element (first chunk only)
-          let templateHtml = `<template id="${frameId}">${escapeTemplateContent(html)}</template>`
+          // Stream as a template element addressed by `for` (first chunk only)
+          let templateHtml = `<template for="${frameId}">${escapeTemplateContent(html)}</template>`
           if (context.signal.aborted) return
           controller.enqueue(encoder.encode(templateHtml))
 

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -976,7 +976,7 @@ describe('run', () => {
     expect(loadModule).toHaveBeenCalledTimes(1)
 
     let template = document.createElement('template')
-    template.id = frameId
+    template.setAttribute('for', frameId)
     template.innerHTML = await drain(renderToStream(<Late />))
     document.body.appendChild(template)
 
@@ -1088,10 +1088,13 @@ describe('run', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 0))
 
+    // Nodes outside the streamed region keep their identity.
     expect(document.querySelector('h1')).toBe(h1)
     expect(document.querySelector('p')).toBe(p)
-    expect(document.querySelector('nav')).toBe(nav)
-    expect(nav.textContent).toBe('Loaded')
+    // The region is replaced declaratively, so the resolved <nav> is a fresh node.
+    let resolvedNav = document.querySelector('nav')
+    expect(resolvedNav).not.toBe(nav)
+    expect(resolvedNav?.textContent).toBe('Loaded')
 
     frame.dispose()
   })
@@ -1244,7 +1247,7 @@ describe('run', () => {
 
     // Ensure template exists so the pending frame can render immediately.
     let frameId = getCommentMarkerId(html, 'rmx:f:')
-    expect(document.querySelector(`template#${frameId}`)).toBeTruthy()
+    expect(document.querySelector(`template[for="${frameId}"]`)).toBeTruthy()
 
     let clientFrame = run({
       loadModule(moduleUrl, exportName) {
@@ -1821,7 +1824,7 @@ describe('run', () => {
     document.body.innerHTML = html
 
     let frameId = getCommentMarkerId(html, 'rmx:f:')
-    expect(document.querySelector(`template#${frameId}`)).toBeTruthy()
+    expect(document.querySelector(`template[for="${frameId}"]`)).toBeTruthy()
 
     let clientFrame = run({
       loadModule(moduleUrl, exportName) {
@@ -2237,7 +2240,7 @@ describe('run', () => {
     document.body.innerHTML = html
 
     let frameId = getCommentMarkerId(html, 'rmx:f:')
-    expect(document.querySelector(`template#${frameId}`)).toBeTruthy()
+    expect(document.querySelector(`template[for="${frameId}"]`)).toBeTruthy()
 
     let clientFrame = run({
       loadModule(moduleUrl, exportName) {
@@ -2472,7 +2475,7 @@ describe('run', () => {
     document.body.innerHTML =
       '<div>' +
       '<!-- rmx:h:h1 --><button id="counter">Counter</button><!-- /rmx:h -->' +
-      '<!-- rmx:f:f1 --><span id="frame">Loading…</span><!-- /rmx:f -->' +
+      '<!-- rmx:f:f1 --><?start name="f1"><span id="frame">Loading…</span><?end name="f1"><!-- /rmx:f -->' +
       '</div>' +
       '<script type="application/json" id="rmx-data">' +
       '{"h":{"h1":{"moduleUrl":"/counter.js","exportName":"Counter","props":{}}},' +
@@ -2498,7 +2501,7 @@ describe('run', () => {
 
     // Simulate frame template arriving via MutationObserver.
     let template = document.createElement('template')
-    template.id = 'f1'
+    template.setAttribute('for', 'f1')
     template.innerHTML = '<span id="frame">Loaded!</span>'
     document.body.appendChild(template)
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -2580,7 +2583,7 @@ describe('run', () => {
 
     // Outer frame template arrives.
     let outerTemplate = document.createElement('template')
-    outerTemplate.id = outerFrameId
+    outerTemplate.setAttribute('for', outerFrameId)
     outerTemplate.innerHTML = outerContent
     document.body.appendChild(outerTemplate)
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -2590,7 +2593,7 @@ describe('run', () => {
 
     // Inner frame template arrives.
     let innerTemplate = document.createElement('template')
-    innerTemplate.id = innerFrameId
+    innerTemplate.setAttribute('for', innerFrameId)
     innerTemplate.innerHTML = innerContent
     document.body.appendChild(innerTemplate)
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -2664,7 +2667,7 @@ describe('run', () => {
 
     // Outer frame template arrives — contains a middle frame.
     let outerTemplate = document.createElement('template')
-    outerTemplate.id = outerFrameId
+    outerTemplate.setAttribute('for', outerFrameId)
     outerTemplate.innerHTML = outerContent
     document.body.appendChild(outerTemplate)
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -2675,7 +2678,7 @@ describe('run', () => {
 
     // Middle frame template arrives — contains an inner frame.
     let middleTemplate = document.createElement('template')
-    middleTemplate.id = middleFrameId
+    middleTemplate.setAttribute('for', middleFrameId)
     middleTemplate.innerHTML = middleContent
     document.body.appendChild(middleTemplate)
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -2686,7 +2689,7 @@ describe('run', () => {
 
     // Inner frame template arrives.
     let innerTemplate = document.createElement('template')
-    innerTemplate.id = innerFrameId
+    innerTemplate.setAttribute('for', innerFrameId)
     innerTemplate.innerHTML = innerContent
     document.body.appendChild(innerTemplate)
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -2763,7 +2766,7 @@ describe('run', () => {
 
     // Inner frame template arrives.
     let innerTemplate = document.createElement('template')
-    innerTemplate.id = innerFrameId
+    innerTemplate.setAttribute('for', innerFrameId)
     innerTemplate.innerHTML = await renderInner()
     document.body.appendChild(innerTemplate)
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -3214,7 +3217,7 @@ describe('run', () => {
     expect(document.querySelectorAll('#nested-fallback')).toHaveLength(1)
 
     let nestedTemplate = document.createElement('template')
-    nestedTemplate.id = nestedFrameId
+    nestedTemplate.setAttribute('for', nestedFrameId)
     nestedTemplate.innerHTML = '<span id="nested-loaded">Nested loaded</span>'
     document.body.appendChild(nestedTemplate)
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -3785,7 +3788,7 @@ describe('run', () => {
     expect(fallback.getAttribute('data-label')).toBe('Reloaded fallback')
 
     let staleTemplate = document.createElement('template')
-    staleTemplate.id = initialMarkerId
+    staleTemplate.setAttribute('for', initialMarkerId)
     staleTemplate.innerHTML = '<span id="stale-child-content">Stale child</span>'
     document.body.appendChild(staleTemplate)
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -3795,7 +3798,7 @@ describe('run', () => {
     expect(fallback.textContent).toBe('Reloaded fallback')
 
     let freshTemplate = document.createElement('template')
-    freshTemplate.id = reloadedMarkerId
+    freshTemplate.setAttribute('for', reloadedMarkerId)
     freshTemplate.innerHTML = '<span id="fresh-child-content">Fresh child</span>'
     document.body.appendChild(freshTemplate)
     await new Promise((resolve) => setTimeout(resolve, 0))

--- a/packages/ui/src/test/stream-directives.test.ts
+++ b/packages/ui/src/test/stream-directives.test.ts
@@ -1,0 +1,75 @@
+import { expect } from '@remix-run/assert'
+import { describe, it } from '@remix-run/test'
+import {
+  getStreamDirective,
+  isStreamDirective,
+  streamEndDirective,
+  streamStartDirective,
+  supportsStreamDirectives,
+} from '../runtime/stream-directives.ts'
+
+describe('stream directive serialization', () => {
+  it('serializes start and end directives', () => {
+    expect(streamStartDirective('abc')).toBe('<?start name="abc">')
+    expect(streamEndDirective('abc')).toBe('<?end name="abc">')
+  })
+})
+
+describe('getStreamDirective', () => {
+  it('reads native processing instruction directives', () => {
+    let start = document.createProcessingInstruction('start', 'name="42"')
+    let end = document.createProcessingInstruction('end', 'name="42"')
+
+    expect(getStreamDirective(start)).toEqual({ kind: 'start', id: '42' })
+    expect(getStreamDirective(end)).toEqual({ kind: 'end', id: '42' })
+  })
+
+  it('reads comment fallback directives', () => {
+    let start = document.createComment('?start name="7"')
+    let end = document.createComment('?end name="7"')
+
+    expect(getStreamDirective(start)).toEqual({ kind: 'start', id: '7' })
+    expect(getStreamDirective(end)).toEqual({ kind: 'end', id: '7' })
+  })
+
+  it('ignores unrelated processing instructions', () => {
+    let pi = document.createProcessingInstruction('xml-stylesheet', 'href="x.css"')
+    expect(getStreamDirective(pi)).toBeNull()
+  })
+
+  it('ignores unrelated comments and other nodes', () => {
+    expect(getStreamDirective(document.createComment('rmx:f:abc'))).toBeNull()
+    expect(getStreamDirective(document.createElement('div'))).toBeNull()
+    expect(getStreamDirective(document.createTextNode('start name="x"'))).toBeNull()
+    expect(getStreamDirective(null)).toBeNull()
+  })
+
+  it('classifies directives via isStreamDirective', () => {
+    expect(isStreamDirective(document.createProcessingInstruction('start', 'name="1"'))).toBe(true)
+    expect(isStreamDirective(document.createComment('?end name="1"'))).toBe(true)
+    expect(isStreamDirective(document.createComment('/rmx:f'))).toBe(false)
+  })
+})
+
+describe('supportsStreamDirectives', () => {
+  it('returns a boolean for the current browser', () => {
+    // Records the live browser capability without gating any behavior on it, so
+    // both the native and polyfill code paths stay covered regardless of the
+    // Chromium version used to run the suite.
+    expect(typeof supportsStreamDirectives()).toBe('boolean')
+  })
+
+  it('classifies a document that parses directives as comments as unsupported', () => {
+    let probe = document.createElement('template')
+    probe.innerHTML = streamStartDirective('probe')
+    let first = probe.content.firstChild
+
+    // In this environment the parser turns `<?start>` into a comment node; the
+    // detector must classify that as unsupported so the polyfill runs.
+    if (first && first.nodeType === Node.COMMENT_NODE) {
+      expect(supportsStreamDirectives()).toBe(false)
+    } else {
+      expect(supportsStreamDirectives()).toBe(true)
+    }
+  })
+})

--- a/packages/ui/src/test/stream-polyfill.test.tsx
+++ b/packages/ui/src/test/stream-polyfill.test.tsx
@@ -1,0 +1,201 @@
+import { expect } from '@remix-run/assert'
+import { afterEach, beforeEach, describe, it } from '@remix-run/test'
+import {
+  findStreamRegion,
+  installStreamTemplateMover,
+  streamEndDirective,
+  streamStartDirective,
+  swapStreamTemplate,
+} from '../runtime/stream-directives.ts'
+
+async function nextFrame(): Promise<void> {
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+  await new Promise<void>((resolve) => setTimeout(resolve, 0))
+}
+
+function region(id: string, fallback: string): string {
+  return (
+    `<!-- rmx:f:${id} -->` +
+    streamStartDirective(id) +
+    fallback +
+    streamEndDirective(id) +
+    `<!-- /rmx:f -->`
+  )
+}
+
+describe('findStreamRegion', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('locates the comment fallback directive pair', () => {
+    container.innerHTML = region('abc', '<p>Loading</p>')
+    let found = findStreamRegion('abc')
+    expect(found).not.toBeNull()
+    expect(found!.start.nextSibling?.textContent).toBe('Loading')
+  })
+
+  it('returns null when only one boundary is present', () => {
+    container.innerHTML = `${streamStartDirective('lonely')}<p>x</p>`
+    expect(findStreamRegion('lonely')).toBeNull()
+  })
+})
+
+describe('swapStreamTemplate', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('replaces region content and removes directives and template', () => {
+    container.innerHTML =
+      region('one', '<p>Loading</p>') +
+      `<span id="after">after</span>` +
+      `<template for="one"><p>Resolved</p></template>`
+
+    let after = document.getElementById('after')
+    let template = container.querySelector('template[for="one"]')
+    expect(template).not.toBeNull()
+
+    let id = swapStreamTemplate(template as HTMLTemplateElement)
+
+    expect(id).toBe('one')
+    expect(container.querySelector('p')?.textContent).toBe('Resolved')
+    expect(container.querySelector('template[for="one"]')).toBeNull()
+    // Sibling identity preserved.
+    expect(document.getElementById('after')).toBe(after)
+    // Directives removed; rmx:f markers preserved as region boundary.
+    expect(container.innerHTML).toContain('<!-- rmx:f:one -->')
+    expect(container.innerHTML).toContain('<!-- /rmx:f -->')
+    expect(container.innerHTML).not.toContain('?start name="one"')
+    expect(container.innerHTML).not.toContain('?end name="one"')
+  })
+
+  it('removes a template addressed to an unknown region without touching the DOM', () => {
+    container.innerHTML =
+      region('known', '<p>Loading</p>') + `<template for="missing"><p>x</p></template>`
+
+    let template = container.querySelector('template[for="missing"]') as HTMLTemplateElement
+    let id = swapStreamTemplate(template)
+
+    expect(id).toBeNull()
+    expect(container.querySelector('template[for="missing"]')).toBeNull()
+    expect(container.querySelector('p')?.textContent).toBe('Loading')
+  })
+})
+
+describe('installStreamTemplateMover', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('swaps templates inserted after the region', async () => {
+    container.innerHTML = region('late', '<p>Loading</p>')
+    let swapped: string[] = []
+    let dispose = installStreamTemplateMover(document, (id) => swapped.push(id))
+
+    container.insertAdjacentHTML('beforeend', `<template for="late"><p>Resolved</p></template>`)
+    await nextFrame()
+
+    expect(swapped).toEqual(['late'])
+    expect(container.querySelector('p')?.textContent).toBe('Resolved')
+    dispose()
+  })
+
+  it('swaps templates that arrive before their observer callback runs', async () => {
+    let swapped: string[] = []
+    let dispose = installStreamTemplateMover(document, (id) => swapped.push(id))
+
+    container.insertAdjacentHTML(
+      'beforeend',
+      region('early', '<p>Loading</p>') + `<template for="early"><p>Resolved</p></template>`,
+    )
+    await nextFrame()
+
+    expect(swapped).toEqual(['early'])
+    expect(container.querySelector('p')?.textContent).toBe('Resolved')
+    dispose()
+  })
+
+  it('stops swapping once DOMContentLoaded fires while the document is loading', async () => {
+    // The real test document is already loaded, so drive the "loading" branch
+    // through a proxy that reports readyState 'loading' and delegates DOM work
+    // to the real document. This lets the polyfill register (and later fire)
+    // its DOMContentLoaded listener against captured handlers.
+    let domContentLoaded: (() => void) | undefined
+    let loadingDoc = new Proxy(document, {
+      get(target, key) {
+        if (key === 'readyState') return 'loading'
+        if (key === 'addEventListener') {
+          return (type: string, listener: () => void) => {
+            if (type === 'DOMContentLoaded') domContentLoaded = listener
+          }
+        }
+        if (key === 'removeEventListener') return () => {}
+        if (key === 'createNodeIterator') {
+          return (_root: Node, whatToShow?: number) =>
+            document.createNodeIterator(document, whatToShow)
+        }
+        let value = Reflect.get(target, key)
+        return typeof value === 'function' ? value.bind(target) : value
+      },
+    })
+
+    installStreamTemplateMover(loadingDoc)
+    expect(typeof domContentLoaded).toBe('function')
+
+    // Active before load: a streamed template is swapped.
+    container.innerHTML = region('before-dcl', '<p>Loading</p>')
+    container.insertAdjacentHTML(
+      'beforeend',
+      `<template for="before-dcl"><p>Resolved</p></template>`,
+    )
+    await nextFrame()
+    expect(container.querySelector('p')?.textContent).toBe('Resolved')
+
+    // After DOMContentLoaded the observer disconnects and ignores new templates.
+    domContentLoaded!()
+    container.innerHTML = region('after-dcl', '<p>Loading</p>')
+    container.insertAdjacentHTML(
+      'beforeend',
+      `<template for="after-dcl"><p>Resolved</p></template>`,
+    )
+    await nextFrame()
+    expect(container.querySelector('template[for="after-dcl"]')).not.toBeNull()
+    expect(container.querySelector('p')?.textContent).toBe('Loading')
+  })
+
+  it('stops swapping after the observer is disposed', async () => {
+    container.innerHTML = region('gone', '<p>Loading</p>')
+    let dispose = installStreamTemplateMover(document)
+    dispose()
+
+    container.insertAdjacentHTML('beforeend', `<template for="gone"><p>Resolved</p></template>`)
+    await nextFrame()
+
+    // Template remains untouched because the observer was disconnected.
+    expect(container.querySelector('template[for="gone"]')).not.toBeNull()
+    expect(container.querySelector('p')?.textContent).toBe('Loading')
+  })
+})

--- a/packages/ui/src/test/stream.test.tsx
+++ b/packages/ui/src/test/stream.test.tsx
@@ -1839,6 +1839,60 @@ describe('stream', () => {
       })
     })
 
+    it('brackets non-blocking fallbacks with streaming directives', async () => {
+      let stream = renderToStream(<Frame src="/x" fallback={<div>Loading...</div>} />, {
+        resolveFrame: () => '<div>Resolved</div>',
+      })
+      let result = await drain(stream)
+
+      let frameId = getCommentMarkerId(result, 'rmx:f:')
+      let start = `<!-- rmx:f:${frameId} -->`
+      let startDirective = `<?start name="${frameId}">`
+      let endDirective = `<?end name="${frameId}">`
+      let end = '<!-- /rmx:f -->'
+
+      expect(result).toContain(startDirective)
+      expect(result).toContain(endDirective)
+
+      // Ordering: rmx:f start < ?start < fallback < ?end < rmx:f end
+      let startIdx = result.indexOf(start)
+      let startDirectiveIdx = result.indexOf(startDirective)
+      let fallbackIdx = result.indexOf('<div>Loading...</div>')
+      let endDirectiveIdx = result.indexOf(endDirective)
+      let endIdx = result.indexOf(end)
+      expect(startIdx).toBeGreaterThanOrEqual(0)
+      expect(startDirectiveIdx).toBeGreaterThan(startIdx)
+      expect(fallbackIdx).toBeGreaterThan(startDirectiveIdx)
+      expect(endDirectiveIdx).toBeGreaterThan(fallbackIdx)
+      expect(endIdx).toBeGreaterThan(endDirectiveIdx)
+    })
+
+    it('addresses streamed templates with a matching for attribute', async () => {
+      let stream = renderToStream(<Frame src="/x" fallback={<div>Loading...</div>} />, {
+        resolveFrame: () => '<div>Resolved</div>',
+      })
+      let chunks = readChunks(stream)
+      let first = await chunks.next()
+      invariant(!first.done)
+      let frameId = getCommentMarkerId(first.value, 'rmx:f:')
+
+      let second = await chunks.next()
+      invariant(!second.done)
+      expect(second.value).toContain(`<template for="${frameId}">`)
+      expect(second.value).toContain('<div>Resolved</div>')
+      expect(second.value).not.toContain('<template id=')
+    })
+
+    it('does not bracket blocking frame content with streaming directives', async () => {
+      let stream = renderToStream(<Frame src="/x" />, {
+        resolveFrame: () => '<div>Resolved</div>',
+      })
+      let result = await drain(stream)
+
+      expect(result).not.toContain('<?start name=')
+      expect(result).not.toContain('<?end name=')
+    })
+
     it('strips doctype markup from non-blocking frame templates', async () => {
       let stream = renderToStream(<Frame src="/x" fallback={<div>Loading...</div>} />, {
         async resolveFrame() {
@@ -2039,7 +2093,7 @@ describe('stream', () => {
       // Since the inner frame is non-blocking, it should stream later
       let second = await chunks.next()
       expect(second.done).toBe(false)
-      expect(second.value).toContain('<template id="f')
+      expect(second.value).toContain('<template for="f')
 
       let done = await chunks.next()
       expect(done.done).toBe(true)
@@ -2091,7 +2145,7 @@ describe('stream', () => {
       expect(secondChunk.done).toBe(false)
       let template = secondChunk.value
 
-      expect(template).toContain('<template id="f')
+      expect(template).toContain('<template for="f')
       expect(template).toContain('<div>Async Product Content</div>')
       expect(template).toContain('</template>')
 
@@ -2219,7 +2273,7 @@ describe('stream', () => {
       let secondChunk = await chunks.next()
       expect(secondChunk.done).toBe(false)
       let templateChunk = secondChunk.value!
-      expect(templateChunk).toContain('<template id="f')
+      expect(templateChunk).toContain('<template for="f')
       expect(templateChunk).toContain(
         '<\\/template><script>alert("xss")</script><template><p>safe</p>',
       )
@@ -2267,7 +2321,7 @@ describe('stream', () => {
 
       // Should stream frame 2's content
       let secondChunk = await chunks.next()
-      expect(secondChunk.value).toContain('<template id="f')
+      expect(secondChunk.value).toContain('<template for="f')
       expect(secondChunk.value).toContain('Second Frame Content')
 
       // Resolve frame 1
@@ -2275,7 +2329,7 @@ describe('stream', () => {
 
       // Should stream frame 1's content
       let thirdChunk = await chunks.next()
-      expect(thirdChunk.value).toContain('<template id="f')
+      expect(thirdChunk.value).toContain('<template for="f')
       expect(thirdChunk.value).toContain('First Frame Content')
 
       // Stream completes
@@ -2335,7 +2389,7 @@ describe('stream', () => {
       expect(secondChunk.done).toBe(false)
       let parentTemplate = secondChunk.value
 
-      expect(parentTemplate).toContain('<template id="f')
+      expect(parentTemplate).toContain('<template for="f')
       expect(parentTemplate).toContain('<section>')
       expect(parentTemplate).toContain('<h2>Parent Content</h2>')
       expect(parentTemplate).toContain('<span>Loading child...</span>')
@@ -2349,7 +2403,7 @@ describe('stream', () => {
       let childTemplate = thirdChunk.value
 
       // IDs are local within the returned fragment stream, so the child template id may collide.
-      expect(childTemplate).toContain('<template id="f')
+      expect(childTemplate).toContain('<template for="f')
       expect(childTemplate).toContain('<article>Child Content</article>')
       expect(childTemplate).toContain('</template>')
 
@@ -2571,7 +2625,7 @@ describe('stream', () => {
       let secondChunk = await chunks.next()
       console.log('\n\nsecond:\n', secondChunk.value)
       // IDs are local within the returned fragment stream.
-      expect(secondChunk.value).toContain('<template id="f')
+      expect(secondChunk.value).toContain('<template for="f')
       expect(secondChunk.value).toContain('<div>Non-blocking Child</div>')
       expect(secondChunk.value).toContain('</template>')
 
@@ -2607,7 +2661,7 @@ describe('stream', () => {
       // Second chunk should be the template for resolved content (no markers expected here)
       let second = await chunks.next()
       if (!second.done) {
-        expect(second.value).toContain('<template id="f')
+        expect(second.value).toContain('<template for="f')
       }
     })
 
@@ -2720,7 +2774,7 @@ describe('stream', () => {
       let second = await nextChunkPromise
       expect(second.done).toBe(false)
       let parentTemplate = second.value!
-      expect(parentTemplate).toContain('<template id="f')
+      expect(parentTemplate).toContain('<template for="f')
       expect(parentTemplate).toContain('<h2>Parent Content</h2>')
       expect(parentTemplate).toContain('<article>Child Content</article>')
       expect(parentTemplate).toContain('</template>')


### PR DESCRIPTION
Non-blocking `<Frame>` streaming now uses the declarative out-of-order streaming directives instead of a runtime-driven template swap. Pending fallbacks are wrapped in `<?start name="ID">` / `<?end name="ID">` inside
the existing `<!-- rmx:f:ID -->` markers, and resolved content streams as `<template for="ID">` (was `<template id="ID">`).

Browsers that natively process the directives perform the DOM swap with no JavaScript. Other browsers use a small MutationObserver polyfill that `run()` installs automatically, which moves `<template for>` content
into its region and removes the directives. In both cases the runtime no longer extracts templates itself; it hydrates the resolved region after the swap, while reloads and navigation continue to reconcile fetched-stream content through the template bus.