### PR TITLE
pnpm: replace deprecated `onlyBuiltDependencies` with `allowBuilds`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,13 +43,5 @@
   },
   "workspaces": [
     "packages/*"
-  ],
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@swc/core",
-      "esbuild",
-      "sharp",
-      "workerd"
-    ]
-  }
+  ]
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
+allowBuilds:
+  '@swc/core': true
+  esbuild: true
+  sharp: true
+  workerd: true
+
 catalog:
   '@types/node': ^24.6.0
   '@typescript/native-preview': 7.0.0-dev.20251125.1


### PR DESCRIPTION
Previously, running `pnpm` commands using v10.34.2 (as specified in `packageManager` field of our root `package.json`) resulted in:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.onlyBuiltDependencies". See https://pnpm.io/settings for the new home of each setting.
```

See https://pnpm.io/10.x/settings#allowbuilds