### PR TITLE
Add regression coverage for function-valued component children

### DIFF
--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -107,6 +107,51 @@ describe('run', () => {
     frame.dispose()
   })
 
+  it('hydrates function-valued children passed to a component', async () => {
+    function FormatValue(handle: Handle<{ children: (value: number) => RemixNode }>) {
+      return () => <output>{handle.props.children(2)}</output>
+    }
+
+    let Interactive = clientEntry(
+      '/js/interactive.js#Interactive',
+      function Interactive(handle: Handle) {
+        let count = 0
+
+        return () => (
+          <div>
+            <FormatValue>{(value) => <>Value: {value}</>}</FormatValue>
+            <button
+              mix={on('click', () => {
+                count++
+                handle.update()
+              })}
+            >
+              Count: {count}
+            </button>
+          </div>
+        )
+      },
+    )
+
+    let html = await drain(renderToStream(<Interactive />))
+    document.body.innerHTML = html
+
+    expect(document.querySelector('output')?.textContent).toBe('Value: 2')
+
+    let app = run({ loadModule: mock.fn(() => Promise.resolve(Interactive)) })
+    try {
+      await app.ready()
+
+      let button = document.querySelector('button')
+      button?.click()
+      app.flush()
+
+      expect(button?.textContent).toBe('Count: 1')
+    } finally {
+      app.dispose()
+    }
+  })
+
   it('forwards hydrated client entry root error events to app listeners', async () => {
     let error = new Error('hydrated client entry root error')
     let Broken = clientEntry('/js/broken.js#Broken', function Broken() {


### PR DESCRIPTION
This PR adds regression coverage for function-valued component children. The underlying hydration bug is already resolved by the explicit component VNode architecture introduced in #11659, so no additional runtime change is needed here.

Previously, client hydration converted element children into VNodes before distinguishing host elements from components. Function-valued children passed to a component could therefore throw `Unexpected RemixNode` before the component invoked them, interrupting hydration and preventing client-entry event handlers from attaching.

The regression test server-renders and hydrates a client entry containing a render-prop component, then verifies that hydration completes and its interaction remains active. This protects the behavior now provided by component VNodes keeping component props opaque while host element and fragment children are normalized.
