### PR TITLE
Make plain test filters case-insensitive

### DIFF
--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -183,13 +183,15 @@ describe('Checkout routes', () => {
 })
 ```
 
-Use `--only <pattern>` to focus tests from the CLI without editing source. Patterns are JavaScript regular expressions matched against suite names and full test names:
+Use `--only <pattern>` to focus tests from the CLI without editing source. Plain patterns are case-insensitive JavaScript regular expressions matched against suite names and full test names:
 
 ```sh
 remix test --only 'Cart routes'
 remix test --only 'Checkout routes > redirects anonymous users'
 remix test --only '/anonymous users$/'
 ```
+
+Slash-delimited CLI patterns preserve their flags, so `/pattern/` is case-sensitive and `/pattern/i` is case-insensitive. Plain string patterns in `remix-test.config.ts` are also case-insensitive; slash-delimited strings and `RegExp` values preserve their flags.
 
 Full test names join nested `describe` names and the test name with `>`. For example, `describe('Cart routes', () => describe('loader', () => it('loads cart items', ...)))` has the full test name `Cart routes > loader > loads cart items`.
 

--- a/packages/test/src/lib/config.ts
+++ b/packages/test/src/lib/config.ts
@@ -263,7 +263,9 @@ export interface RemixTestConfig {
   /**
    * Regular expression pattern(s) to focus tests by their full name (--only).
    * Matching suite names focus the whole suite, while matching test names focus
-   * the individual test. `--only` may be repeated on the CLI.
+   * the individual test. Plain string patterns are case-insensitive. Use a
+   * slash-delimited pattern or a `RegExp` in the config file to control flags
+   * explicitly. `--only` may be repeated on the CLI.
    */
   only?: RemixTestOnlyPattern | RemixTestOnlyPattern[]
   /**
@@ -475,7 +477,7 @@ function resolveOnlyPatterns(
   return toArray(value).map((pattern) => {
     let serialized: SerializedOnlyPattern
     if (typeof pattern === 'string') {
-      serialized = parseRegexLiteral(pattern) ?? { source: pattern, flags: '' }
+      serialized = parseRegexLiteral(pattern) ?? { source: pattern, flags: 'i' }
     } else {
       serialized = { source: pattern.source, flags: pattern.flags }
     }

--- a/packages/test/src/test/config.test.ts
+++ b/packages/test/src/test/config.test.ts
@@ -77,11 +77,15 @@ describe('loadConfig', () => {
     let tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'remix-test-config-'))
 
     try {
-      let config = await loadConfig(['--only', 'server > matches', '--only', '/browser/i'], tmp)
+      let config = await loadConfig(
+        ['--only', 'server > matches', '--only', '/browser/', '--only', '/checkout/i'],
+        tmp,
+      )
 
       assert.deepEqual(config.only, [
-        { source: 'server > matches', flags: '' },
-        { source: 'browser', flags: 'i' },
+        { source: 'server > matches', flags: 'i' },
+        { source: 'browser', flags: '' },
+        { source: 'checkout', flags: 'i' },
       ])
     } finally {
       await fsp.rm(tmp, { recursive: true, force: true })
@@ -94,14 +98,15 @@ describe('loadConfig', () => {
     try {
       await fsp.writeFile(
         path.join(tmp, 'remix-test.config.ts'),
-        ['export default {', "  only: [/server/i, 'browser'],", '}'].join('\n'),
+        ['export default {', "  only: [/server/, /checkout/i, 'browser'],", '}'].join('\n'),
       )
 
       let config = await loadConfig([], tmp)
 
       assert.deepEqual(config.only, [
-        { source: 'server', flags: 'i' },
-        { source: 'browser', flags: '' },
+        { source: 'server', flags: '' },
+        { source: 'checkout', flags: 'i' },
+        { source: 'browser', flags: 'i' },
       ])
     } finally {
       await fsp.rm(tmp, { recursive: true, force: true })


### PR DESCRIPTION
Plain `remix test --only` patterns currently require exact capitalization, which makes quick test filtering unnecessarily brittle. This makes undelimited string patterns case-insensitive by default while preserving explicit regular-expression flags.

- Treat plain CLI and config string patterns as case-insensitive
- Preserve flags for slash-delimited CLI patterns such as `/pattern/` and `/pattern/i`
- Preserve flags for `RegExp` values supplied through `remix-test.config.ts`
- Document and test the distinction between default and explicit matching behavior

```sh
# Case-insensitive by default
remix test --only 'cart routes'

# Explicitly case-sensitive
remix test --only '/Cart routes/'
remix test --only '/cart routes/i'
```
