### PR TITLE
Fix Bun regex error assertion

### DIFF
--- a/packages/test/src/test/config.test.ts
+++ b/packages/test/src/test/config.test.ts
@@ -123,7 +123,7 @@ describe('loadConfig', () => {
           let message = String(error)
           assert.match(message, /Invalid --only pattern/)
           assert.match(message, /must be valid JavaScript regular expressions/)
-          assert.match(message, /Unterminated group/)
+          assert.match(message, /Invalid regular expression/)
           return true
         },
       )


### PR DESCRIPTION
The Bun test job on `main` fails because the invalid `RegExp` assertion expects Node/V8-specific error wording. Bun reports the same syntax error with different wording.

- Assert the stable `Invalid regular expression` portion of the error
- Preserve coverage of the user-facing `--only` validation context
- Keep the test portable across Node and Bun
