### PR TITLE
Refine the first three Remix guide chapters

### DIFF
--- a/guides/app/actions/docs/chapters/01-start-here.md
+++ b/guides/app/actions/docs/chapters/01-start-here.md
@@ -7,11 +7,7 @@ description: A high-level introduction to Remix and the mental model behind a Re
 
 Remix is a TypeScript framework built around the web's request and response model. A server receives a Web [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request), Remix matches it to a typed route, a controller handles the request, and the app returns a Web [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 
-The `remix` package gives you the full stack: a server adapter, fetch router, typed routes, middleware, controllers, response helpers, and testing utilities. On the UI side, it includes server-rendered components, frames for partial UI, browser-loaded client entries, client navigation, CSS-first animation helpers, source-served assets, and first-party primitives such as menus, popovers, listboxes, selects, and tabs.
-
-On the server, Remix provides first-class form parsing and validation, cookie and session management, credentials-based auth, OAuth/OIDC, CSRF/CORS/COP protection, file uploads, and database queries, transactions, and migrations.
-
-Each part of `remix` is designed to be used on its own. You can use the full framework to build a full-stack app, or leverage the pieces you need to ship a single-page app, a type-safe REST API, parse some form data, handle file uploads, or just about anything else you might want to do when building a website.
+The `remix` package includes the server, router, middleware, UI, data, auth, asset, and testing packages used throughout an application. Each package is also useful on its own, so an app can use the complete request path or only the layers it needs. The [package map](/docs/package-map) shows how those packages fit together.
 
 The design of Remix comes from six core principles:
 
@@ -109,8 +105,7 @@ The [Request Handling](/docs/request-handling) chapter digs into runtime adapter
 
 ## Define your first route {#define-your-first-route}
 
-In Remix, routes are defined separately from the actions that handle matched requests. In `app/routes.ts`, we define the URLs and HTTP methods your app accepts. In `app/actions/`, controllers decide what `Response` to return
-when one of those routes matches.
+In Remix, routes are defined separately from the actions that handle matched requests. In `app/routes.ts`, we define the URLs and HTTP methods your app accepts. In `app/actions/`, controllers decide what `Response` to return when one of those routes matches.
 
 Keeping the URL contract separate gives controllers, links, forms, redirects, and tests one typed source of truth without coupling URL generation to request handling.
 
@@ -166,7 +161,7 @@ export default createController(routes.albums, {
 Finally, we need to map the albums route map to our router in `app/router.ts`:
 
 ```ts filename=app/router.ts lines=[5,12]
-import { createRouter, type MiddlewareContext } from "remix/router";
+import { createRouter, type RouterContext } from "remix/router";
 import { staticFiles } from "remix/middleware/static";
 
 import controller from "./actions/controller.tsx";
@@ -284,7 +279,7 @@ export async function updateAlbum(albumId: string, values: Partial<Album>) {
   let album = albums.find((album) => album.id === albumId);
 
   if (album === undefined) {
-    throw new Error(`Album not found: ${albumId}`);
+    return undefined;
   }
 
   // Simulate network latency
@@ -380,15 +375,15 @@ export function AlbumPage(handle: Handle<{ album: Album }>) {
 }
 ```
 
-Open [http://localhost:44100/albums/thriller](http://localhost:44100/albums/thriller) again. The same URL now returns our beautiful album page.
+Open [http://localhost:44100/albums/thriller](http://localhost:44100/albums/thriller) again. The same URL now returns the album page.
 
 ![Page showing text "Michael Jackson · 1983 Thriller"](/images/app/actions/docs/chapters/01-start-here/album-page.png)
 
 ## Build your first form action {#build-your-first-form-action}
 
-We're able to retrieve data and display it, but the real fun begins when we can start changing data. Let's set up a form to edit the album data, and hook up an action to handle a POST request so we can update it.
+We can retrieve and display an album. Next, let's add a form and a `POST` action that can update it.
 
-Back in our `routes.ts` file we'll use the `form()` route helper. This helper is nice because it creates two routes at the same URL: a `GET` route that shows the form and a `POST` route that handles the submit. Two routes for the price of one!
+Back in `routes.ts`, use the `form()` route helper. It creates two routes at the same URL: a `GET` route that shows the form and a `POST` route that handles the submission.
 
 ```ts filename=app/routes.ts lines=[1,8]
 import { form, get, route } from "remix/routes";
@@ -437,7 +432,7 @@ export default createController(routes.albums.edit, {
 And map it to the router as well:
 
 ```ts filename=app/router.ts lines=[6,14]
-import { createRouter, type MiddlewareContext } from "remix/router";
+import { createRouter, type RouterContext } from "remix/router";
 import { staticFiles } from "remix/middleware/static";
 
 import controller from "./actions/controller.tsx";
@@ -538,20 +533,22 @@ export default createController(routes.albums.edit, {
 
 Open [http://localhost:44100/albums/thriller/edit](http://localhost:44100/albums/thriller/edit). The route returns an HTML form with the album data filled in.
 
-![Album edit page with information for Thriller by Micheal Jackson](/images/app/actions/docs/chapters/01-start-here/album-edit-page.png)
+![Album edit page with information for Thriller by Michael Jackson](/images/app/actions/docs/chapters/01-start-here/album-edit-page.png)
 
-Before handling the POST request, we're going to take a quick detour and upgrade Remix with a nice little `form-data` middleware in `app/router.ts`. This middleware parses browser form bodies once and makes the `FormData` available to route actions.
+Before handling the `POST` request, add the `form-data` middleware in `app/router.ts`. It parses browser form bodies once and makes the `FormData` available to route actions.
 
-```ts filename=app/router.ts lines=[2,8,18]
-import { createRouter, type MiddlewareContext } from "remix/router";
+```ts filename=app/router.ts lines=[1-2,7-17]
+import { createRouter, type RouterContext } from "remix/router";
 import { formData } from "remix/middleware/form-data";
 import { staticFiles } from "remix/middleware/static";
 
 // ...
 
-type AppContext = MiddlewareContext<
-  [ReturnType<typeof formData>, ReturnType<typeof render>]
->;
+export const router = createRouter({
+  middleware: [staticFiles("./public", { index: false }), formData(), render()],
+});
+
+export type AppContext = RouterContext<typeof router>;
 
 declare module "remix/router" {
   interface RouterTypes {
@@ -559,16 +556,12 @@ declare module "remix/router" {
   }
 }
 
-export const router = createRouter<AppContext>({
-  middleware: [staticFiles("./public", { index: false }), formData(), render()],
-});
-
 // ...
 ```
 
 We'll also use `remix/data-schema/form-data` to turn the raw `FormData` into typed values before updating the album. `remix/data-schema` is a built-in Remix library for validating and parsing all sorts of data. The [Data and Validation](/docs/data-and-validation) chapter explores it in more detail.
 
-```tsx filename=app/actions/albums/edit/controller.tsx lines=[2-5,8,11-15,28-33]
+```tsx filename=app/actions/albums/edit/controller.tsx lines=[2-5,8,11-15,28-41]
 import { createController } from "remix/router";
 import * as s from "remix/data-schema";
 import * as f from "remix/data-schema/form-data";
@@ -597,8 +590,17 @@ export default createController(routes.albums.edit, {
       return context.render(<AlbumEditPage album={album} />);
     },
     async action({ formData, params }) {
-      let values = s.parse(albumFormSchema, formData);
-      let album = await updateAlbum(params.albumId, values);
+      let result = s.parseSafe(albumFormSchema, formData);
+
+      if (!result.success) {
+        return new Response("Invalid album data", { status: 400 });
+      }
+
+      let album = await updateAlbum(params.albumId, result.value);
+
+      if (album === undefined) {
+        return new Response("Album not found", { status: 404 });
+      }
 
       return redirect(routes.albums.show.href({ albumId: album.id }), 303);
     },
@@ -606,7 +608,7 @@ export default createController(routes.albums.edit, {
 });
 ```
 
-The `action` route action reads parsed Web `FormData`, updates the album, and redirects back to the album page.
+The `action` route action validates the parsed Web `FormData`, returns an explicit response for invalid input or a missing album, and redirects back to the album page after a successful update. The [Data and Validation](/docs/data-and-validation) chapter shows how to render field-level validation errors back into a form.
 
 Now we can update our album data and set it to the correct year.
 
@@ -785,4 +787,4 @@ Now when you submit the form, the button is disabled and the button text changes
 
 There is a lot more we could do here to avoid a full page navigation, but that involves handling cancellations, error states, and more. The [Interactivity](/docs/interactivity) chapter covers client entries, events, and progressive enhancement in more detail.
 
-For now we've dipped our toe in the water enough to get a big picture of what Remix offers and how to start building with it. Next we'll dig deeper into Routing and Controllers, or if you're excited about a particular topic, feel free to jump around.
+Next, [Routing and Controllers](/docs/routing-and-controllers) takes a closer look at the route leaves, nested maps, and controllers we started using here.

--- a/guides/app/actions/docs/chapters/01-start-here.md
+++ b/guides/app/actions/docs/chapters/01-start-here.md
@@ -7,7 +7,7 @@ description: A high-level introduction to Remix and the mental model behind a Re
 
 Remix is a TypeScript framework built around the web's request and response model. A server receives a Web [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request), Remix matches it to a typed route, a controller handles the request, and the app returns a Web [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 
-The `remix` package includes the server, router, middleware, UI, data, auth, asset, and testing packages used throughout an application. Each package is also useful on its own, so an app can use the complete request path or only the layers it needs. The [package map](/docs/package-map) shows how those packages fit together.
+The `remix` package includes the server, router, middleware, UI, data, auth, asset, and testing packages used throughout an application. Each package is also useful on its own, so an app can use the complete request path or only the layers it needs.
 
 The design of Remix comes from six core principles:
 

--- a/guides/app/actions/docs/chapters/02-routing-and-controllers.md
+++ b/guides/app/actions/docs/chapters/02-routing-and-controllers.md
@@ -217,7 +217,7 @@ Router middleware runs first, then controller middleware, then action middleware
 
 ## Responses, redirects, headers, and errors
 
-Actions return Web `Response` objects. To render pages, you will often setup a `render` middleware and add it to the router. That middleware provides `context.render(...)`, which turns a Remix component tree into an HTML response. The [Rendering UI](/docs/rendering-ui) chapter builds this middleware step by step. Once it is installed, use it in an action:
+Actions return Web `Response` objects. To render pages, you will often set up `render` middleware and add it to the router. That middleware provides `context.render(...)`, which turns a Remix component tree into an HTML response. The [Rendering UI](/docs/rendering-ui) chapter builds this middleware step by step. Once it is installed, use it in an action:
 
 ```tsx filename=app/actions/albums/controller.tsx
 // inside the show action:
@@ -225,6 +225,8 @@ return context.render(<AlbumPage album={album} />);
 ```
 
 The result is still an ordinary Web `Response`. An action can render a page, return text or JSON, redirect the browser, send a file, or return an error response.
+
+Expected outcomes such as invalid input, conflicts, and missing records should also return a `Response` with the appropriate status. Reserve thrown errors for unexpected failures. If an action or middleware throws, `router.fetch(...)` rejects so the server boundary can log the error and return a `500` response. The [Errors and Error Boundaries](/docs/errors-and-error-boundaries) chapter covers that path in detail.
 
 A text response can be as simple as:
 
@@ -324,47 +326,4 @@ When a route branch has its own nested routes, a matching directory and controll
 
 Keep route-local UI next to the controller that renders it, so the page and form for `albums.edit` belong in `actions/albums/edit/`. Components shared by multiple route areas belong in `ui/`. The [Rendering UI](/docs/rendering-ui) chapter covers the component model.
 
-For larger route areas, `router.mount(...)` lets one module own route registration while `app/router.ts` decides where that module lives. That keeps route groups composable: an admin feature can be mounted at `/admin` in one app, `/internal/admin` in another, or under an org prefix later.
-
-```ts filename=app/router.ts
-import { createRouter } from "remix/router";
-
-import { installAdminRoutes } from "./actions/admin/routes.ts";
-
-export const router = createRouter();
-
-router.mount("/admin", installAdminRoutes);
-```
-
-The installer receives a route builder. It can register routes under the mount prefix, but it is not a full router and cannot dispatch requests.
-
-```ts filename=app/actions/admin/routes.ts
-import type { RouteBuilder } from "remix/router";
-
-export function installAdminRoutes(router: RouteBuilder) {
-  router.get("/", () => {
-    return new Response("Admin");
-  });
-
-  router.get("/users/:userId", ({ params }) => {
-    return new Response(`Admin user ${params.userId}`);
-  });
-}
-```
-
-Those handlers match `GET /admin` and `GET /admin/users/:userId`.
-
-The full app route map still belongs in `routes.ts` for links and redirects. Mounted installers are for registering the handlers owned by that feature.
-
-Mount prefixes are route patterns, so route params from the prefix are available to child handlers:
-
-```ts filename=app/router.ts
-// after creating the router:
-router.mount("/orgs/:orgId", (org) => {
-  org.get("/users/:userId", ({ params }) => {
-    return new Response(`${params.orgId}:${params.userId}`);
-  });
-});
-```
-
-If the prefix and child route use the same param name, the child route wins.
+With the route map and controllers connected, [Request Handling](/docs/request-handling) backs up to the server entry and follows the middleware that runs before and after those actions.

--- a/guides/app/actions/docs/chapters/03-request-handling.md
+++ b/guides/app/actions/docs/chapters/03-request-handling.md
@@ -40,7 +40,7 @@ Request and response bodies stay as Web streams. An action can read `request.bod
 
 ## The Node server entry {#the-node-server-entry}
 
-The default Remix app runs on `node:http`. Its `server.ts` creates the Node server and connects it to the app router:
+The default Remix app runs on `node:http`. Back in `server.ts`, the request-handling portion creates the Node server and connects it to the app router. The generated file also handles graceful shutdown, which is omitted here so we can focus on the request path.
 
 ```ts filename=server.ts
 import * as http from "node:http";
@@ -83,7 +83,7 @@ Keep that boundary narrow. Code that only needs a URL, headers, cookies, a body,
 - passes the request to your Fetch handler; and
 - writes the returned response status, headers, and streamed body through Node.
 
-The same listener works with `node:http`, `node:https`, and Node's HTTP/2 compatibility API. Most apps only need to pass `router.fetch(...)` through a small error boundary, as shown above.
+The same listener works with `node:http`, `node:https`, and Node's HTTP/2 compatibility API. Most apps only need to pass `router.fetch(...)` through a small error boundary, as shown above. `createRequestListener(...)` also has a default error handler, but handling router errors in `server.ts` lets the app decide what to log and return.
 
 The listener accepts a few options when the server boundary needs more information:
 
@@ -169,7 +169,7 @@ The router contract is portable, but every package in a middleware stack may not
 
 ## Middleware ordering {#middleware-ordering}
 
-Middleware wraps the rest of the request pipeline. Given two middleware functions, the request runs from left to right and the response unwinds from right to left:
+With the runtime connected, the rest of the request path lives in `app/router.ts`. Middleware wraps that path. Given two middleware functions, the request runs from left to right and the response unwinds from right to left:
 
 ```txt
 request  → first → second → action
@@ -219,7 +219,7 @@ Every middleware and action in one `router.fetch(...)` call receives the same re
 
 Built-in middleware carries its context changes in its TypeScript type. For example, `formData()` provides `context.formData`, while `renderWith(...)` provides the app's typed `context.render(...)` function.
 
-For a single-router app, derive the application context from the configured router and use module augmentation to make that context the default for controllers:
+Back in `app/router.ts`, derive the application context from the configured router and use module augmentation to make that context the default for controllers:
 
 ```ts filename=app/router.ts
 import { formData } from "remix/middleware/form-data";
@@ -252,19 +252,12 @@ router.map(routes.albums.edit, albumsEditController);
 `RouterContext<typeof router>` follows the inline middleware tuple in order. In the edit controller, TypeScript now knows that both values are present:
 
 ```tsx filename=app/actions/albums/edit/controller.tsx
-import { createController } from "remix/router";
+// inside the actions object:
+action(context) {
+  let title = context.formData.get("title");
 
-import { routes } from "../../../routes.ts";
-
-export default createController(routes.albums.edit, {
-  actions: {
-    action(context) {
-      let title = context.formData.get("title");
-
-      return context.render(<p>Submitted {String(title)}</p>);
-    },
-  },
-});
+  return context.render(<p>Submitted {String(title)}</p>);
+},
 ```
 
 The module augmentation is useful because controllers are created in separate files before they are mapped to this router. Apps with multiple routers should pass explicit context types instead of setting one application-wide default.
@@ -370,4 +363,4 @@ function requireJson(): Middleware {
 }
 ```
 
-Keep custom middleware focused on one request-lifecycle concern. Route-specific data loading or validation usually belongs in the action, while behavior shared across many routes—request IDs, sessions, authentication, security headers, and database access—fits the middleware pipeline.
+Keep custom middleware focused on one request-lifecycle concern. Route-specific data loading or validation usually belongs in the action, while behavior shared across many routes—request IDs, sessions, authentication, security headers, and database access—fits the middleware pipeline. The next chapter, [Rendering UI](/docs/rendering-ui), follows the `render()` middleware from this pipeline into the app's document and component tree.


### PR DESCRIPTION
Polishes the first three chapters in #11574 after reviewing their voice, completeness, and technical accuracy.

- Tightens the Start Here introduction and removes overly playful transitions while preserving the conversational walkthrough
- Returns explicit 400 and 404 responses for invalid form data and missing albums
- Clarifies expected response errors versus unexpected thrown errors
- Keeps Routing and Controllers centered on typed route maps and controllers by removing the advanced router mount detour
- Connects Request Handling more directly to the running app and fixes the incomplete controller snippet