### PR TITLE
Fix UI mixin variance for subtype hosts

### DIFF
--- a/packages/ui/.changes/patch.css-select-mixin.md
+++ b/packages/ui/.changes/patch.css-select-mixin.md
@@ -1,0 +1,1 @@
+Allow element-wide mixins such as `css()` to be used on subtype hosts like `<select>` without TypeScript assignability errors.

--- a/packages/ui/src/runtime/mixins/mixin.ts
+++ b/packages/ui/src/runtime/mixins/mixin.ts
@@ -71,14 +71,15 @@ type MixinHandleEventMap<node extends EventTarget = Element> = {
 /**
  * Runtime handle passed to mixin setup functions.
  *
- * Mixin render callbacks receive host props with `children` and `innerHTML` removed.
+ * The node type is covariant so a handle for a subtype host can be used by a mixin authored for
+ * its base type. Mixin render callbacks receive host props with `children` and `innerHTML` removed.
  * Returned mixin elements may patch host attributes and nested `mix`, but cannot replace
  * the host subtree.
  */
-export type MixinHandle<
-  node extends EventTarget = Element,
+export interface MixinHandle<
+  out node extends EventTarget = Element,
   props extends ElementProps = ElementProps,
-> = TypedEventTarget<MixinHandleEventMap<node>> & {
+> extends TypedEventTarget<MixinHandleEventMap<node>> {
   id: string
   context: MixinContext
   frame: FrameHandle
@@ -121,7 +122,7 @@ export type MixinType<
  * Serializable descriptor stored in the `mix` prop.
  */
 export type MixinDescriptor<
-  node extends EventTarget = Element,
+  in node extends EventTarget = Element,
   args extends unknown[] = [],
   props extends ElementProps = ElementProps,
 > = {

--- a/packages/ui/src/style/css-mixin.test.tsx
+++ b/packages/ui/src/style/css-mixin.test.tsx
@@ -3,8 +3,21 @@ import { describe, it } from '@remix-run/test'
 import { createRoot } from '../runtime/vdom.ts'
 import { invariant } from '../runtime/invariant.ts'
 import { css } from './css-mixin.ts'
+import type { CSSMixinDescriptor } from './css-mixin.ts'
 
 describe('css mixin', () => {
+  it('styles select elements', () => {
+    let container = document.createElement('div')
+    let root = createRoot(container)
+    let selectStyle: CSSMixinDescriptor = css({ color: 'red' })
+    root.render(<select mix={[css({ backgroundColor: 'white' }), selectStyle]} />)
+    root.flush()
+
+    let select = container.querySelector('select')
+    invariant(select)
+    expect(select.className).toMatch(/rmxc-/)
+  })
+
   it('concatenates generated classes with existing className', () => {
     let container = document.createElement('div')
     let root = createRoot(container)

--- a/packages/ui/src/test/jsx.test.tsx
+++ b/packages/ui/src/test/jsx.test.tsx
@@ -5,7 +5,7 @@ import type { Handle, RemixNode } from '../runtime/component.ts'
 import { createMixin, on, ref } from '../index.ts'
 
 import { animateLayout } from '../animation/index.ts'
-import type { Dispatched, MixinHandle, Props } from '../index.ts'
+import type { Dispatched, MixinDescriptor, MixinHandle, Props } from '../index.ts'
 
 type MixLeaf<mix> = mix extends ReadonlyArray<infer descriptor> ? MixLeaf<descriptor> : mix
 type FalsyMixValue = false | 0 | 0n | '' | null | undefined
@@ -205,6 +205,36 @@ describe('jsx', () => {
       let good = <input mix={[inputOnly()]} />
       // @ts-expect-error input-only mixin should not apply to button
       let bad = <button mix={[inputOnly()]} />
+    })
+
+    it('allows base descriptors on subtype hosts without allowing the inverse', () => {
+      let elementWide = createMixin<Element>((handle) => {})()
+      let selectOnly = createMixin<HTMLSelectElement>((handle) => {})()
+
+      let good = <select mix={[elementWide]} />
+      // @ts-expect-error select-only descriptors cannot be widened to all elements
+      let bad: MixinDescriptor<Element> = selectOnly
+    })
+
+    it('treats mixin handles as covariant in their node type', () => {
+      function verify(
+        selectHandle: MixinHandle<HTMLSelectElement>,
+        elementHandle: MixinHandle<Element>,
+      ) {
+        let good: MixinHandle<Element> = selectHandle
+        // @ts-expect-error element handles cannot be narrowed to select handles
+        let bad: MixinHandle<HTMLSelectElement> = elementHandle
+      }
+    })
+
+    it('does not widen descriptor argument types', () => {
+      let stringOnly = createMixin<Element, [value: string]>((handle) => (value) => {
+        void value
+      })
+      let descriptor = stringOnly('value')
+
+      // @ts-expect-error the runtime runner only accepts string arguments
+      let widened: MixinDescriptor<Element, [value: string | number]> = descriptor
     })
 
     it('infers insert event node type from createMixin node generic', () => {


### PR DESCRIPTION
Element-wide mixin descriptors such as `CSSMixinDescriptor` were not assignable to subtype hosts like `<select>`, even though those mixins are safe for every `Element`.

- Model the `MixinHandle` node parameter as covariant and the `MixinDescriptor` node parameter as contravariant.
- Preserve host safety by continuing to reject narrow descriptors on broader hosts and keeping descriptor arguments invariant.
- Add compile-time and runtime regressions for subtype hosts, handle variance, and `css()` usage without changing runtime behavior.
