### PR TITLE
Polish the guide search controls

### DIFF
--- a/guides/app/actions/docs/site-header.test.tsx
+++ b/guides/app/actions/docs/site-header.test.tsx
@@ -17,7 +17,7 @@ describe('SiteHeader', () => {
     assert.match(html, /id="site-primary-navigation"[^>]*popover="auto"/)
     assert.equal(html.match(/>Guides<\/a>/g)?.length, 2)
     assert.match(html, /href="\/icons\.svg#layout-left"/)
-    assert.equal(html.match(/<pagefind-modal-trigger/g)?.length, 1)
+    assert.equal(html.match(/id="docs-search-button"/g)?.length, 1)
   })
 
   it('renders one responsive search trigger for Pagefind focus ownership', async () => {
@@ -25,8 +25,13 @@ describe('SiteHeader', () => {
 
     assert.doesNotMatch(html, /<button[^>]*disabled/)
     assert.doesNotMatch(html, /id="docs-search-compact"/)
-    assert.match(html, /id="docs-search-button"[^>]*placeholder="Search"/)
-    assert.doesNotMatch(html, /id="docs-search-button"[^>]*aria-hidden/)
+    assert.doesNotMatch(html, /<pagefind-modal-trigger/)
+    assert.match(html, /id="docs-search-button"[^>]*aria-label="Search"/)
+    assert.match(html, /id="docs-search-button"[^>]*aria-haspopup="dialog"/)
+    assert.match(html, /id="docs-search-button"[^>]*aria-expanded="false"/)
+    assert.match(html, /id="docs-search-button"[^>]*aria-keyshortcuts="Meta\+K Control\+K"/)
+    assert.match(html, /href="\/icons\.svg#search"/)
+    assert.match(html, /<kbd>⌘<\/kbd><kbd>K<\/kbd>/)
   })
 
   it('shares the standalone wordmark asset with the footer', async () => {

--- a/guides/app/actions/docs/site-header.test.tsx
+++ b/guides/app/actions/docs/site-header.test.tsx
@@ -16,6 +16,7 @@ describe('SiteHeader', () => {
     assert.match(html, /id="site-menu-toggle"[^>]*popovertarget="site-primary-navigation"/)
     assert.match(html, /id="site-primary-navigation"[^>]*popover="auto"/)
     assert.equal(html.match(/>Guides<\/a>/g)?.length, 2)
+    assert.match(html, /href="https:\/\/remix\.run"[^>]*aria-label="Remix Docs"/)
     assert.match(html, /href="\/icons\.svg#layout-left"/)
     assert.equal(html.match(/id="docs-search-button"/g)?.length, 1)
   })

--- a/guides/app/actions/docs/site-header.tsx
+++ b/guides/app/actions/docs/site-header.tsx
@@ -4,7 +4,7 @@ import { Icon } from '../../ui/icon.tsx'
 export function SiteHeader() {
   return () => (
     <header class="site-header">
-      <a href={routes.docs.index.href()} class="site-header__brand" aria-label="Remix Docs">
+      <a href="https://remix.run" class="site-header__brand" aria-label="Remix Docs">
         <img
           class="site-header__logo-mark"
           src="/remix-logo-light-mode.svg"

--- a/guides/app/actions/docs/site-header.tsx
+++ b/guides/app/actions/docs/site-header.tsx
@@ -59,13 +59,24 @@ export function SiteHeader() {
         <PrimaryNavigationLinks />
       </nav>
 
-      <pagefind-modal-trigger
+      <button
         id="docs-search-button"
         class="docs-search-button"
-        data-key="pagefind-modal-trigger"
-        placeholder="Search"
-        rmx-preserve-dom
-      ></pagefind-modal-trigger>
+        type="button"
+        aria-label="Search"
+        aria-haspopup="dialog"
+        aria-expanded="false"
+        aria-keyshortcuts="Meta+K Control+K"
+      >
+        <span class="docs-search-button__label">
+          <Icon name="search" />
+          <span>Search</span>
+        </span>
+        <span class="docs-search-button__shortcut" aria-hidden="true">
+          <kbd>⌘</kbd>
+          <kbd>K</kbd>
+        </span>
+      </button>
     </header>
   )
 }

--- a/guides/app/entry.browser.ts
+++ b/guides/app/entry.browser.ts
@@ -2,6 +2,7 @@ import type { FrameContent } from 'remix/ui'
 import { run } from 'remix/ui'
 
 startNavigationGuard()
+startPagefindSearch()
 
 const app = run({
   async loadModule(moduleUrl, exportName) {
@@ -68,17 +69,73 @@ function startNavigationGuard() {
   )
 }
 
+function startPagefindSearch() {
+  document.addEventListener('click', (event) => {
+    if (!(event.target instanceof Element)) return
+
+    let trigger = event.target.closest('#docs-search-button')
+    if (trigger instanceof HTMLElement) void openPagefindSearch(trigger)
+  })
+
+  document.addEventListener('keydown', (event) => {
+    if (
+      event.defaultPrevented ||
+      event.key.toLowerCase() !== 'k' ||
+      (!event.metaKey && !event.ctrlKey) ||
+      event.altKey ||
+      event.shiftKey
+    ) {
+      return
+    }
+
+    let activeElement = document.activeElement
+    if (
+      activeElement instanceof HTMLElement &&
+      (activeElement.matches('input, textarea') || activeElement.isContentEditable)
+    ) {
+      return
+    }
+
+    let trigger = document.getElementById('docs-search-button')
+    if (!(trigger instanceof HTMLElement)) return
+
+    event.preventDefault()
+    void openPagefindSearch(trigger)
+  })
+}
+
+async function openPagefindSearch(trigger: HTMLElement) {
+  await customElements.whenDefined('pagefind-modal')
+
+  let modal = document.querySelector('pagefind-modal')
+  if (!(modal instanceof HTMLElement) || !trigger.isConnected) return
+
+  let open = Reflect.get(modal, 'open')
+  if (typeof open !== 'function') return
+
+  let dialog = modal.querySelector('dialog')
+  if (dialog?.open) return
+
+  if (dialog?.id) trigger.setAttribute('aria-controls', dialog.id)
+  trigger.setAttribute('aria-expanded', 'true')
+  dialog?.addEventListener(
+    'close',
+    () => {
+      trigger.setAttribute('aria-expanded', 'false')
+      if (trigger.isConnected) trigger.focus()
+    },
+    { once: true },
+  )
+  open.call(modal)
+}
+
 function closePagefindSearch() {
   let modal = document.querySelector('pagefind-modal')
   if (modal instanceof HTMLElement && 'close' in modal && typeof modal.close === 'function') {
     modal.close()
   }
 
-  for (let button of document.querySelectorAll('pagefind-modal-trigger button')) {
-    if (button instanceof HTMLElement) {
-      button.blur()
-    }
-  }
+  document.getElementById('docs-search-button')?.blur()
 }
 
 function isSameDocumentHashUrl(href: string) {

--- a/guides/app/pagefind.d.ts
+++ b/guides/app/pagefind.d.ts
@@ -10,17 +10,5 @@ declare namespace JSX {
       'data-key'?: string
       'rmx-preserve-dom'?: boolean | ''
     }
-    'pagefind-modal-trigger': {
-      id?: string
-      class?: string
-      instance?: string
-      compact?: boolean
-      placeholder?: string
-      shortcut?: string
-      'data-key'?: string
-      'hide-shortcut'?: boolean
-      'aria-hidden'?: boolean | 'true' | 'false'
-      'rmx-preserve-dom'?: boolean | ''
-    }
   }
 }

--- a/guides/app/styles/base.css
+++ b/guides/app/styles/base.css
@@ -49,7 +49,6 @@ pagefind-keyboard-hints,
 pagefind-modal,
 pagefind-modal-body,
 pagefind-modal-header,
-pagefind-modal-trigger,
 pagefind-results,
 pagefind-searchbox,
 pagefind-summary {

--- a/guides/app/styles/search.css
+++ b/guides/app/styles/search.css
@@ -1,5 +1,4 @@
 /* Pagefind owns the search behavior; these overrides align its modal with the guide shell. */
-.docs-search-button,
 pagefind-modal {
   --pf-icon-search: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none'%3E%3Cpath d='M11.285 11.36L13.6004 13.6M12.8537 7.62669C12.8537 10.5133 10.5137 12.8534 7.62706 12.8534C4.74045 12.8534 2.40039 10.5133 2.40039 7.62669C2.40039 4.74008 4.74045 2.40002 7.62706 2.40002C10.5137 2.40002 12.8537 4.74008 12.8537 7.62669Z' stroke='black' stroke-linecap='round'/%3E%3C/svg%3E");
 }
@@ -105,17 +104,18 @@ pagefind-modal {
 
 :is(*, #\#):is(*, #\#):is(*, #\#) pagefind-modal .pf-modal-footer-key,
 :is(*, #\#):is(*, #\#):is(*, #\#) pagefind-modal .pf-keyboard-key {
-  border-color: var(--rmx-color-border-default);
+  min-width: 16px;
+  height: 16px;
+  padding-inline: 3px;
+  border: 1px solid rgb(0 0 0 / 2%);
   border-radius: var(--rmx-radius-sm);
-  background: var(--rmx-surface-lvl1);
-  box-shadow: var(--rmx-shadow-xs);
-  font-family: var(--rmx-font-family-mono);
-}
-
-:is(*, #\#):is(*, #\#):is(*, #\#) .docs-search-button .pf-trigger-btn:hover {
-  border-color: var(--docs-nav-control-border);
-  background: var(--docs-nav-hover-background);
+  color: #9ca3b0;
+  background: var(--rmx-surface-lvl0);
   box-shadow: none;
+  font-family: var(--rmx-font-family-mono);
+  font-size: 12px;
+  font-weight: var(--rmx-font-weight-normal);
+  line-height: 1;
 }
 
 @media (max-width: 640px) {

--- a/guides/app/styles/shell.css
+++ b/guides/app/styles/shell.css
@@ -88,11 +88,14 @@
 }
 
 .docs-nav-toggle:hover,
-.docs-nav-toggle:focus-visible {
+.docs-nav-toggle:focus-visible,
+.docs-search-button:hover,
+.docs-search-button:focus-visible {
   background: var(--docs-nav-hover-background);
 }
 
-.docs-nav-toggle svg {
+.docs-nav-toggle svg,
+.docs-search-button svg {
   display: block;
   width: 16px;
   height: 16px;
@@ -105,17 +108,50 @@
   z-index: 40;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   width: 240px;
   height: 32px;
-  padding: 0;
-  font-size: 12px;
-  --pf-background: transparent;
-  --pf-border: var(--docs-nav-control-border);
-  --pf-hover: var(--docs-nav-hover-background);
+  padding: 8px;
+  border: 1px solid var(--docs-nav-control-border);
+  border-radius: 8px;
+  color: var(--rmx-color-text-secondary);
+  background: transparent;
+  font-size: 14px;
+  cursor: pointer;
   transition:
     top var(--docs-nav-duration) var(--docs-nav-easing),
     left var(--docs-nav-duration) var(--docs-nav-easing),
-    width var(--docs-nav-duration) var(--docs-nav-easing);
+    width var(--docs-nav-duration) var(--docs-nav-easing),
+    background-color 150ms ease-in-out;
+}
+
+.docs-search-button__label,
+.docs-search-button__shortcut {
+  display: flex;
+  align-items: center;
+}
+
+.docs-search-button__label {
+  gap: 12px;
+}
+
+.docs-search-button__shortcut {
+  gap: 4px;
+}
+
+.docs-search-button kbd {
+  display: grid;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  place-items: center;
+  border: 1px solid rgb(0 0 0 / 2%);
+  border-radius: 4px;
+  color: #9ca3b0;
+  background: var(--rmx-surface-lvl0);
+  font-family: var(--rmx-font-family-mono);
+  font-size: 12px;
+  line-height: 1;
 }
 
 .docs-chapters-nav {
@@ -353,19 +389,19 @@
 :root[data-docs-nav-collapsed] .docs-search-button {
   top: 16px;
   left: 121px;
+  justify-content: center;
   width: 32px;
-  --pf-border: transparent;
+  padding: 8px;
+  border: 0;
 }
 
-:root[data-docs-nav-collapsed] .docs-search-button .pf-trigger-btn {
-  justify-content: center !important;
-  padding: 0 !important;
-  border: 0 !important;
+:root[data-docs-nav-collapsed] .docs-search-button__label {
+  gap: 0;
 }
 
-:root[data-docs-nav-collapsed] .docs-search-button .pf-trigger-text,
-:root[data-docs-nav-collapsed] .docs-search-button .pf-trigger-shortcut {
-  display: none !important;
+:root[data-docs-nav-collapsed] .docs-search-button__label > span,
+:root[data-docs-nav-collapsed] .docs-search-button__shortcut {
+  display: none;
 }
 
 :root[data-docs-nav-collapsed] .docs-chapters-nav {
@@ -458,19 +494,20 @@
   :root[data-docs-nav-collapsed] .docs-search-button {
     top: 16px;
     left: min(211px, calc(100% - 125px));
+    justify-content: center;
     width: 32px;
-    --pf-border: transparent;
+    padding: 8px;
+    border: 0;
   }
 
-  .docs-search-button .pf-trigger-btn {
-    justify-content: center !important;
-    padding: 0 !important;
-    border: 0 !important;
+  .docs-search-button__label,
+  :root[data-docs-nav-collapsed] .docs-search-button__label {
+    gap: 0;
   }
 
-  .docs-search-button .pf-trigger-text,
-  .docs-search-button .pf-trigger-shortcut {
-    display: none !important;
+  .docs-search-button__label > span,
+  .docs-search-button__shortcut {
+    display: none;
   }
 
   .docs-nav-toggle,


### PR DESCRIPTION
The guide sidebar search trigger was inheriting Pagefind's generated control styles, which made it diverge from the surrounding guide shell. This replaces it with a guide-owned native button while continuing to use Pagefind for the search modal.

- Matches the expanded, collapsed, and mobile search controls to the guide shell design, including a 14px label and compact keyboard hints
- Preserves click and `⌘/Ctrl+K` activation, dialog ARIA state, and focus restoration when the modal closes
- Aligns the modal footer keycaps with the sidebar shortcut and removes the unused Pagefind trigger styles and JSX typing
