### PR TITLE
Fix API demo build test file exclusion

### DIFF
--- a/api/src/generate/build-demos.ts
+++ b/api/src/generate/build-demos.ts
@@ -17,6 +17,7 @@ const DEMO_SOURCES = [
   },
 ]
 const REMIX_RUN_IMPORT_RE = /(from\s+['"]|import\s*\(\s*['"]|import\s+['"])(@remix-run\/[^'"]+)/g
+const TEST_FILE_RE = /\.test(?:\.(?:browser|e2e))?\.tsx?$/
 
 function rewriteImports(source: string): string {
   return source.replace(REMIX_RUN_IMPORT_RE, (_match, prefix: string, specifier: string) => {
@@ -28,7 +29,7 @@ function rewriteImports(source: string): string {
 }
 
 function isDemoSourceFile(filename: string) {
-  return (filename.endsWith('.ts') || filename.endsWith('.tsx')) && !filename.endsWith('.test.ts')
+  return (filename.endsWith('.ts') || filename.endsWith('.tsx')) && !TEST_FILE_RE.test(filename)
 }
 
 function* walkDemoDirectory(dir: string): Generator<string> {


### PR DESCRIPTION
The API demo build already tries to avoid copying test files into `api/build/demos`, but the existing check only excludes files ending in `.test.ts`. That means test files ending in `.test.tsx`, `.test.e2e.*` and `.test.browser.*` can still be copied over and break the root-level `remix test` run.

This PR updates the existing exclusion to cover the full Remix test filename pattern:

- `*.test.ts`
- `*.test.tsx`
- `*.test.browser.ts`
- `*.test.browser.tsx`
- `*.test.e2e.ts`
- `*.test.e2e.tsx`