### PR TITLE
Default session cookies to HTTP-only

### DIFF
--- a/packages/cookie/.changes/minor.http-only-accessor.md
+++ b/packages/cookie/.changes/minor.http-only-accessor.md
@@ -1,0 +1,1 @@
+BREAKING CHANGE: `Cookie.httpOnly` now returns `boolean | undefined` instead of defaulting to `false`. This lets consumers distinguish an omitted `httpOnly` option from an explicit `httpOnly: false` setting.

--- a/packages/cookie/src/lib/cookie.test.ts
+++ b/packages/cookie/src/lib/cookie.test.ts
@@ -11,6 +11,16 @@ function getCookieFromSetCookie(setCookie: string): string {
 }
 
 describe('Cookie', () => {
+  it('leaves httpOnly undefined by default', () => {
+    let cookie = createCookie('my-cookie')
+    assert.equal(cookie.httpOnly, undefined)
+  })
+
+  it('preserves explicit httpOnly values', () => {
+    assert.equal(createCookie('my-cookie', { httpOnly: true }).httpOnly, true)
+    assert.equal(createCookie('my-cookie', { httpOnly: false }).httpOnly, false)
+  })
+
   it('defaults path to /', async () => {
     let cookie = createCookie('my-cookie')
     assert.equal(cookie.path, '/')

--- a/packages/cookie/src/lib/cookie.ts
+++ b/packages/cookie/src/lib/cookie.ts
@@ -119,14 +119,12 @@ export class Cookie implements CookieProperties {
   }
 
   /**
-   * True if the cookie is HTTP-only.
+   * Whether the cookie is HTTP-only, or `undefined` when the option was not configured.
    *
    * [MDN Reference](https://developer.mozilla.org/en-US/Web/HTTP/Headers/Set-Cookie#httponly)
-   *
-   * @default false
    */
-  get httpOnly(): boolean {
-    return this.#httpOnly ?? false
+  get httpOnly(): boolean | undefined {
+    return this.#httpOnly
   }
 
   /**

--- a/packages/remix/.changes/minor.session-cookie-http-only.md
+++ b/packages/remix/.changes/minor.session-cookie-http-only.md
@@ -1,0 +1,1 @@
+BREAKING CHANGE: `remix/middleware/session` now makes session cookies HTTP-only by default when `httpOnly` is omitted, and `Cookie.httpOnly` from `remix/cookie` now returns `boolean | undefined` so omitted and explicitly disabled settings can be distinguished.

--- a/packages/session-middleware/.changes/minor.http-only-default.md
+++ b/packages/session-middleware/.changes/minor.http-only-default.md
@@ -1,0 +1,1 @@
+BREAKING CHANGE: Session cookies now default to `HttpOnly` when the cookie's `httpOnly` option is omitted. Set `httpOnly: false` explicitly to preserve access from client-side JavaScript; the middleware emits a warning when this protection is disabled.

--- a/packages/session-middleware/README.md
+++ b/packages/session-middleware/README.md
@@ -24,7 +24,6 @@ import { session } from 'remix/middleware/session'
 
 let sessionCookie = createCookie('__session', {
   secrets: ['s3cr3t'], // session cookies must be signed!
-  httpOnly: true,
   secure: true,
   sameSite: 'lax',
 })
@@ -50,6 +49,7 @@ The middleware:
 Use `context.session` (or `context.get(Session)`) for normal session reads and writes.
 
 Note: The session cookie must be signed for security. This prevents tampering with the session data on the client.
+Session cookies are HTTP-only by default. Set `httpOnly: false` explicitly to make one available to client-side JavaScript; the middleware emits a warning when this protection is disabled.
 
 ### Login/Logout Flow
 

--- a/packages/session-middleware/src/lib/session.test.ts
+++ b/packages/session-middleware/src/lib/session.test.ts
@@ -23,6 +23,47 @@ function createRequest(fromResponse?: Response): Request {
 }
 
 describe('session middleware', () => {
+  it('defaults session cookies to HTTP-only', async () => {
+    let cookie = createCookie('__sess', { secrets: ['secret1'] })
+    let storage = createCookieSessionStorage()
+    let router = createRouter({
+      middleware: [sessionMiddleware(cookie, storage)],
+    })
+
+    router.map('/', ({ session }) => {
+      session.set('userId', '123')
+      return new Response('ok')
+    })
+
+    let response = await router.fetch('https://remix.run')
+    let setCookie = new SetCookie(response.headers.getSetCookie()[0])
+
+    assert.equal(setCookie.httpOnly, true)
+  })
+
+  it('respects and warns about explicitly disabling HTTP-only', async (t) => {
+    let consoleWarn = t.mock.method(console, 'warn', () => {})
+    let cookie = createCookie('__sess', { secrets: ['secret1'], httpOnly: false })
+    let storage = createCookieSessionStorage()
+    let router = createRouter({
+      middleware: [sessionMiddleware(cookie, storage)],
+    })
+
+    router.map('/', ({ session }) => {
+      session.set('userId', '123')
+      return new Response('ok')
+    })
+
+    let response = await router.fetch('https://remix.run')
+    let setCookie = new SetCookie(response.headers.getSetCookie()[0])
+
+    assert.equal(setCookie.httpOnly, undefined)
+    assert.equal(consoleWarn.mock.calls.length, 1)
+    assert.deepEqual(consoleWarn.mock.calls[0].arguments, [
+      'Session cookie "__sess" is configured with httpOnly: false and may be accessible to client-side JavaScript.',
+    ])
+  })
+
   it('persists session data across requests', async () => {
     let cookie = createCookie('__sess', { secrets: ['secret1'] })
     let storage = createCookieSessionStorage()

--- a/packages/session-middleware/src/lib/session.ts
+++ b/packages/session-middleware/src/lib/session.ts
@@ -17,6 +17,12 @@ export function session(
     throw new Error('Session cookie must be signed')
   }
 
+  if (sessionCookie.httpOnly === false) {
+    console.warn(
+      `Session cookie "${sessionCookie.name}" is configured with httpOnly: false and may be accessible to client-side JavaScript.`,
+    )
+  }
+
   return async (context, next) => {
     if (context.has(Session)) {
       throw new Error('Existing session found, refusing to overwrite')
@@ -37,7 +43,12 @@ export function session(
     if (setCookieValue != null) {
       // make sure the response is mutable
       response = new Response(response.body, response)
-      response.headers.append('Set-Cookie', await sessionCookie.serialize(setCookieValue))
+      response.headers.append(
+        'Set-Cookie',
+        await sessionCookie.serialize(setCookieValue, {
+          httpOnly: sessionCookie.httpOnly ?? true,
+        }),
+      )
     }
 
     return response


### PR DESCRIPTION
Session cookies should be protected from client-side JavaScript by default while still allowing applications to opt out deliberately. This makes the session middleware apply `HttpOnly` when the cookie option is omitted and warns when an application explicitly disables it.

- Changes `Cookie.httpOnly` to return `boolean | undefined`, matching optional accessors such as `maxAge` and preserving the distinction between omitted and explicit `false` values.
- Defaults cookies serialized by `session()` to `HttpOnly` without mutating the supplied cookie.
- Preserves `httpOnly: false` and emits a setup-time warning when it is used.
- Adds focused cookie and middleware coverage, documentation, and change files for the affected published packages and `remix` facade.

```ts
let sessionCookie = createCookie('__session', {
  secrets: [process.env.SESSION_SECRET],
  // httpOnly defaults to true when used with session()
})
```

Applications that intentionally expose the session cookie to browser JavaScript can opt out explicitly:

```ts
let sessionCookie = createCookie('__session', {
  secrets: [process.env.SESSION_SECRET],
  httpOnly: false, // preserved, with a warning from session()
})
```
