### PR TITLE
Tighten session cookie guidance

### DIFF
--- a/packages/session-middleware/README.md
+++ b/packages/session-middleware/README.md
@@ -49,7 +49,7 @@ The middleware:
 Use `context.session` (or `context.get(Session)`) for normal session reads and writes.
 
 Note: The session cookie must be signed for security. This prevents tampering with the session data on the client.
-Session cookies are HTTP-only by default. Set `httpOnly: false` explicitly to make one available to client-side JavaScript; the middleware emits a warning when this protection is disabled.
+Session cookies are HTTP-only by default.
 
 ### Login/Logout Flow
 


### PR DESCRIPTION
Follow-up to #11619. The session middleware README should state the secure default without promoting the explicit opt-out that triggers a security warning.

- Keeps the `HttpOnly` default visible in normal usage guidance.
- Removes instructions encouraging client-side JavaScript access to session cookies.
- Leaves the API behavior and migration-oriented change notes unchanged.
