### PR TITLE
Fix compression cache variation for identity responses

### DIFF
--- a/packages/compression-middleware/README.md
+++ b/packages/compression-middleware/README.md
@@ -26,8 +26,6 @@ let router = createRouter({
 })
 ```
 
-For responses eligible for compression, the middleware adds `Vary: Accept-Encoding` even when the client requests the identity representation or omits `Accept-Encoding`. This keeps compressed and uncompressed representations safe in shared caches while preserving existing `Vary` values.
-
 The middleware will automatically compress responses for compressible MIME types when:
 
 - The client supports compression (`Accept-Encoding` header with a supported encoding)

--- a/packages/compression-middleware/README.md
+++ b/packages/compression-middleware/README.md
@@ -26,6 +26,8 @@ let router = createRouter({
 })
 ```
 
+For responses eligible for compression, the middleware adds `Vary: Accept-Encoding` even when the client requests the identity representation or omits `Accept-Encoding`. This keeps compressed and uncompressed representations safe in shared caches while preserving existing `Vary` values.
+
 The middleware will automatically compress responses for compressible MIME types when:
 
 - The client supports compression (`Accept-Encoding` header with a supported encoding)

--- a/packages/compression-middleware/src/lib/compression.test.ts
+++ b/packages/compression-middleware/src/lib/compression.test.ts
@@ -54,7 +54,37 @@ describe('compression()', () => {
 
     assert.equal(response.status, 200)
     assert.equal(response.headers.get('Content-Encoding'), null)
+    assert.equal(response.headers.get('Vary'), null)
     assert.equal(await response.text(), 'fake image data')
+  })
+
+  it('marks identity responses as Accept-Encoding variants', async () => {
+    let router = createRouter({
+      middleware: [compression()],
+    })
+
+    router.get(
+      '/app.js',
+      () =>
+        new Response('console.log("Hello, World!")', {
+          headers: { 'Content-Type': 'text/javascript' },
+        }),
+    )
+
+    let identityResponse = await router.fetch('https://remix.run/app.js', {
+      headers: { 'Accept-Encoding': 'identity' },
+    })
+
+    assert.equal(identityResponse.headers.get('Content-Encoding'), null)
+    assert.match(identityResponse.headers.get('Vary') ?? '', /(?:^|,)\s*accept-encoding\s*(?:,|$)/i)
+    assert.equal(await identityResponse.text(), 'console.log("Hello, World!")')
+
+    let gzipResponse = await router.fetch('https://remix.run/app.js', {
+      headers: { 'Accept-Encoding': 'gzip' },
+    })
+
+    assert.equal(gzipResponse.headers.get('Content-Encoding'), 'gzip')
+    assert.match(gzipResponse.headers.get('Vary') ?? '', /(?:^|,)\s*accept-encoding\s*(?:,|$)/i)
   })
 
   it('respects threshold option', async () => {
@@ -75,6 +105,7 @@ describe('compression()', () => {
     })
 
     assert.equal(response.headers.get('Content-Encoding'), null)
+    assert.equal(response.headers.get('Vary'), null)
     assert.equal(await response.text(), 'Small')
   })
 

--- a/packages/compression-middleware/src/lib/compression.ts
+++ b/packages/compression-middleware/src/lib/compression.ts
@@ -49,7 +49,8 @@ export interface CompressionOptions {
 /**
  * Creates a middleware handler that automatically compresses responses based on the
  * client's Accept-Encoding header, along with an additional Content-Type filter
- * by default to only apply compression to appropriate media types.
+ * by default to only apply compression to appropriate media types. Eligible responses
+ * vary on `Accept-Encoding`, including when identity is selected.
  *
  * @param options Optional compression settings
  * @returns A middleware handler that automatically compresses responses based on the client's Accept-Encoding header

--- a/packages/response/.changes/patch.vary-accept-encoding.md
+++ b/packages/response/.changes/patch.vary-accept-encoding.md
@@ -1,0 +1,1 @@
+`compressResponse()` now adds `Vary: Accept-Encoding` to otherwise eligible identity responses, including requests that omit `Accept-Encoding`, so shared caches do not reuse an uncompressed response for compression-capable clients.

--- a/packages/response/README.md
+++ b/packages/response/README.md
@@ -165,7 +165,7 @@ let response = createRedirectResponse('/dashboard', {
 
 ### Compress Responses
 
-The `compressResponse` helper compresses a `Response` based on the client's `Accept-Encoding` header:
+The `compressResponse` helper negotiates a `Response` representation based on the client's `Accept-Encoding` header:
 
 ```ts
 import { compressResponse } from 'remix/response/compress'
@@ -176,9 +176,11 @@ let response = new Response(JSON.stringify(data), {
 let compressed = await compressResponse(response, request)
 ```
 
+Eligible responses include `Accept-Encoding` in `Vary`, including when the client explicitly requests `identity` or omits `Accept-Encoding`. This prevents a shared cache from reusing an identity response for a client that supports compression. Existing `Vary` values are preserved.
+
 Compression is automatically skipped for:
 
-- Responses with no `Accept-Encoding` header
+- Requests with no `Accept-Encoding` header (the identity representation is used)
 - Responses that are already compressed (existing `Content-Encoding`)
 - Responses with `Cache-Control: no-transform`
 - Responses with `Content-Length` below threshold (default: 1024 bytes)

--- a/packages/response/src/lib/compress.test.ts
+++ b/packages/response/src/lib/compress.test.ts
@@ -95,35 +95,55 @@ describe('compressResponse()', () => {
     assert.equal(decompressed.toString(), 'Hello, World!')
   })
 
-  it('preserves existing Vary header values when adding Accept-Encoding', async () => {
+  it('selects identity without changing representation headers', async () => {
     let request = new Request('https://remix.run', {
-      headers: { 'Accept-Encoding': 'gzip' },
+      headers: { 'Accept-Encoding': 'identity' },
     })
     let response = new Response('Hello, World!', {
+      status: 201,
+      statusText: 'Created',
       headers: {
-        Vary: 'Accept-Language, User-Agent',
+        'Content-Length': '2048',
+        ETag: '"abc123"',
       },
     })
 
     let compressed = await compressResponse(response, request)
 
-    let varyHeader = compressed.headers.get('Vary') || ''
-    let varyValues = varyHeader
-      .toLowerCase()
-      .split(',')
-      .map((v) => v.trim())
-    assert.ok(varyValues.includes('accept-language'))
-    assert.ok(varyValues.includes('user-agent'))
-    assert.ok(varyValues.includes('accept-encoding'))
+    assert.equal(compressed.status, 201)
+    assert.equal(compressed.statusText, 'Created')
+    assert.equal(compressed.headers.get('Content-Encoding'), null)
+    assert.equal(compressed.headers.get('Content-Length'), '2048')
+    assert.equal(compressed.headers.get('Accept-Ranges'), null)
+    assert.equal(compressed.headers.get('ETag'), '"abc123"')
+    assert.ok(Vary.from(compressed.headers.get('Vary')).has('Accept-Encoding'))
+    assert.equal(await compressed.text(), 'Hello, World!')
+  })
+
+  it('preserves existing Vary values when identity is selected', async () => {
+    let request = new Request('https://remix.run', {
+      headers: { 'Accept-Encoding': 'identity' },
+    })
+    let response = new Response('Hello, World!', {
+      headers: {
+        Vary: 'Cookie',
+      },
+    })
+
+    let compressed = await compressResponse(response, request)
+    let vary = Vary.from(compressed.headers.get('Vary'))
+
+    assert.ok(vary.has('Cookie'))
+    assert.ok(vary.has('Accept-Encoding'))
   })
 
   it('does not duplicate Accept-Encoding in Vary header', async () => {
     let request = new Request('https://remix.run', {
-      headers: { 'Accept-Encoding': 'gzip' },
+      headers: { 'Accept-Encoding': 'identity' },
     })
     let response = new Response('Hello, World!', {
       headers: {
-        Vary: 'Accept-Encoding, Accept-Language',
+        Vary: 'Cookie, Accept-Encoding',
       },
     })
 
@@ -131,10 +151,11 @@ describe('compressResponse()', () => {
 
     let varyHeader = compressed.headers.get('Vary') || ''
     let encodingMatches = varyHeader.match(/accept-encoding/gi) || []
+    assert.ok(Vary.from(varyHeader).has('Cookie'))
     assert.equal(encodingMatches.length, 1)
   })
 
-  it('does not compress when client does not send Accept-Encoding', async () => {
+  it('selects identity when client does not send Accept-Encoding', async () => {
     let request = new Request('https://remix.run')
     let response = new Response('Hello, World!')
 
@@ -143,6 +164,7 @@ describe('compressResponse()', () => {
     // Per RFC 7231, when no Accept-Encoding header is present,
     // server should use identity (uncompressed) for compatibility
     assert.equal(compressed.headers.get('Content-Encoding'), null)
+    assert.ok(Vary.from(compressed.headers.get('Vary')).has('Accept-Encoding'))
     assert.equal(await compressed.text(), 'Hello, World!')
   })
 
@@ -169,6 +191,7 @@ describe('compressResponse()', () => {
     let compressed = await compressResponse(response, request)
 
     assert.equal(compressed.headers.get('Content-Encoding'), null)
+    assert.equal(compressed.headers.get('Vary'), null)
     assert.equal(await compressed.text(), 'Small')
   })
 
@@ -196,6 +219,7 @@ describe('compressResponse()', () => {
     let compressed = await compressResponse(response, request)
 
     assert.equal(compressed, response)
+    assert.equal(compressed.headers.get('Vary'), null)
   })
 
   it('skips compression when Cache-Control: no-transform is present', async () => {
@@ -209,6 +233,7 @@ describe('compressResponse()', () => {
     let compressed = await compressResponse(response, request)
 
     assert.equal(compressed, response)
+    assert.equal(compressed.headers.get('Vary'), null)
   })
 
   it('skips compression when response has no body', async () => {
@@ -220,6 +245,7 @@ describe('compressResponse()', () => {
     let compressed = await compressResponse(response, request)
 
     assert.equal(compressed, response)
+    assert.equal(compressed.headers.get('Vary'), null)
   })
 
   it('compresses with custom compression level', async () => {
@@ -322,6 +348,7 @@ describe('compressResponse()', () => {
 
     assert.equal(compressed, response)
     assert.equal(compressed.headers.get('Content-Encoding'), null)
+    assert.equal(compressed.headers.get('Vary'), null)
   })
 
   it('handles quality factors in Accept-Encoding', async () => {
@@ -393,7 +420,8 @@ describe('compressResponse()', () => {
 
     // Should return identity (no compression)
     assert.equal(compressed.headers.get('Content-Encoding'), null)
-    assert.equal(compressed, response) // Should be the same response object
+    assert.ok(Vary.from(compressed.headers.get('Vary')).has('Accept-Encoding'))
+    assert.equal(await compressed.text(), 'Hello, World!')
   })
 
   it('requires compression when identity is explicitly rejected', async () => {
@@ -414,7 +442,9 @@ describe('compressResponse()', () => {
       // Client rejects everything including identity
       headers: { 'Accept-Encoding': 'gzip;q=0, deflate;q=0, br;q=0, identity;q=0' },
     })
-    let response = new Response('Hello, World!')
+    let response = new Response('Hello, World!', {
+      headers: { Vary: 'Cookie' },
+    })
 
     let result = await compressResponse(response, request, {
       encodings: ['gzip', 'deflate', 'br'],
@@ -423,6 +453,9 @@ describe('compressResponse()', () => {
     // Should return 406 Not Acceptable per RFC 7231
     assert.equal(result.status, 406)
     assert.equal(result.statusText, 'Not Acceptable')
+    let vary = Vary.from(result.headers.get('Vary'))
+    assert.ok(vary.has('Cookie'))
+    assert.ok(vary.has('Accept-Encoding'))
   })
 
   it('handles wildcard with quality factor', async () => {
@@ -486,7 +519,8 @@ describe('compressResponse()', () => {
 
     // Should return uncompressed since identity is explicitly acceptable
     assert.equal(compressed.headers.get('Content-Encoding'), null)
-    assert.equal(compressed, response)
+    assert.ok(Vary.from(compressed.headers.get('Vary')).has('Accept-Encoding'))
+    assert.equal(await compressed.text(), 'Hello, World!')
   })
 
   it('handles wildcard with identity rejection', async () => {
@@ -611,6 +645,7 @@ describe('compressResponse()', () => {
 
     assert.equal(compressed, response)
     assert.equal(compressed.headers.get('Content-Encoding'), null)
+    assert.equal(compressed.headers.get('Vary'), null)
   })
 
   it('skips 206 partial content responses', async () => {
@@ -626,6 +661,7 @@ describe('compressResponse()', () => {
 
     assert.equal(compressed, response)
     assert.equal(compressed.headers.get('Content-Encoding'), null)
+    assert.equal(compressed.headers.get('Vary'), null)
   })
 
   it('sets compression headers for HEAD requests without compressing', async () => {
@@ -675,8 +711,9 @@ describe('compressResponse()', () => {
 
     let compressed = await compressResponse(response, request)
 
-    assert.equal(compressed, response)
     assert.equal(compressed.headers.get('Content-Encoding'), null)
+    assert.ok(Vary.from(compressed.headers.get('Vary')).has('Accept-Encoding'))
+    assert.equal(await compressed.text(), content)
   })
 
   it('sets compression headers for HEAD requests even when body is already null', async () => {

--- a/packages/response/src/lib/compress.ts
+++ b/packages/response/src/lib/compress.ts
@@ -63,7 +63,7 @@ export interface CompressResponseOptions {
  * Compresses a Response based on the client's Accept-Encoding header.
  *
  * Compression is skipped for:
- * - Responses with no Accept-Encoding header (RFC 7231)
+ * - Requests with no Accept-Encoding header (RFC 7231)
  * - Empty responses
  * - Already compressed responses
  * - Responses with Content-Length below threshold (default: 1024 bytes)
@@ -71,17 +71,20 @@ export interface CompressResponseOptions {
  * - Responses advertising range support (Accept-Ranges: bytes)
  * - Partial content responses (206 status)
  *
+ * Responses eligible for content-coding negotiation include `Accept-Encoding` in
+ * the `Vary` header, even when identity is selected or the request does not include
+ * `Accept-Encoding`.
+ *
  * When compressing, this function:
  * - Sets Content-Encoding header
  * - Removes Content-Length header
  * - Sets Accept-Ranges to 'none'
- * - Adds 'Accept-Encoding' to Vary header
  * - Converts strong ETags to weak ETags (per RFC 7232)
  *
  * @param response The response to compress
  * @param request The request (needed to check Accept-Encoding header)
  * @param options Optional compression settings
- * @returns A compressed Response or the original if no compression is suitable
+ * @returns A response with the negotiated content coding and cache metadata
  */
 export async function compressResponse(
   response: Response,
@@ -101,7 +104,6 @@ export async function compressResponse(
   let cacheControl = CacheControl.from(responseHeaders.get('Cache-Control'))
 
   if (
-    !acceptEncodingHeader ||
     supportedEncodings.length === 0 ||
     // Empty response
     (request.method !== 'HEAD' && !response.body) ||
@@ -119,8 +121,11 @@ export async function compressResponse(
     return response
   }
 
-  let acceptEncoding = AcceptEncoding.from(acceptEncodingHeader)
-  let selectedEncoding = negotiateEncoding(acceptEncoding, supportedEncodings)
+  addVaryAcceptEncoding(responseHeaders)
+
+  let selectedEncoding = acceptEncodingHeader
+    ? negotiateEncoding(AcceptEncoding.from(acceptEncodingHeader), supportedEncodings)
+    : 'identity'
   if (selectedEncoding === null) {
     // Client has explicitly rejected all supported encodings, including 'identity'
     return new Response(
@@ -128,12 +133,17 @@ export async function compressResponse(
       {
         status: 406,
         statusText: 'Not Acceptable',
+        headers: { Vary: responseHeaders.get('Vary') ?? 'Accept-Encoding' },
       },
     )
   }
 
   if (selectedEncoding === 'identity') {
-    return response
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    })
   }
 
   // For HEAD requests, set compression headers without actually compressing
@@ -169,15 +179,16 @@ function negotiateEncoding(
   return preferred
 }
 
+function addVaryAcceptEncoding(headers: Headers): void {
+  let vary = Vary.from(headers.get('Vary'))
+  vary.add('Accept-Encoding')
+  headers.set('Vary', vary.toString())
+}
+
 function setCompressionHeaders(headers: Headers, encoding: string): void {
   headers.set('Content-Encoding', encoding)
   headers.set('Accept-Ranges', 'none')
   headers.delete('Content-Length')
-
-  // Update Vary header to include Accept-Encoding
-  let vary = Vary.from(headers.get('Vary'))
-  vary.add('Accept-Encoding')
-  headers.set('Vary', vary.toString())
 
   // Convert strong ETags to weak since compressed representation is byte-different
   let etagHeader = headers.get('ETag')


### PR DESCRIPTION
I found this while investigating why [remix.run](https://remix.run) is not serving its JavaScript assets with gzip. With a cache-busted asset URL, requesting the identity representation first produced a cache miss without `Content-Encoding` or `Vary`; a subsequent gzip-capable request was then a cache hit for that same uncompressed response. Requesting gzip first behaved correctly because compressed responses already included `Vary: Accept-Encoding`.

`compressResponse()` previously added `Vary: Accept-Encoding` only after selecting a compressed representation. This moves the cache variation metadata ahead of content-coding negotiation so an eligible identity response cannot seed a shared cache entry that is reused for compression-capable clients.

- add and merge `Vary: Accept-Encoding` for eligible identity responses, requests without `Accept-Encoding`, compressed responses, and negotiation failures
- preserve identity bodies, status metadata, content length, range metadata, and ETags without applying compression-specific transformations
- leave filtered media types, `no-transform`, existing encodings, range/partial responses, known sub-threshold responses, empty responses, and disabled encodings unchanged
- cover the identity-first shared-cache sequence in both the response helper and compression middleware
