### PR TITLE
Fix data-table-sqlite wipe tests on Windows

### DIFF
--- a/packages/data-table-sqlite/.changes/minor.adapter-close.md
+++ b/packages/data-table-sqlite/.changes/minor.adapter-close.md
@@ -1,0 +1,1 @@
+Added `close()` to the SQLite adapter to release the underlying database connection and its file handle. Config-backed adapters keep the database file locked on Windows until closed, so callers that need to move or delete the file should close the adapter first.

--- a/packages/data-table-sqlite/src/lib/adapter.test.ts
+++ b/packages/data-table-sqlite/src/lib/adapter.test.ts
@@ -157,6 +157,9 @@ describe('sqlite adapter', () => {
       adapter = createSqliteDatabaseAdapter({ filename })
       await adapter.executeScript('create table users (id integer primary key)')
 
+      // close the handle so Windows can remove the parent directory, then let
+      // wipe() recreate it
+      adapter.close()
       await rm(dirname(filename), { recursive: true, force: true })
       await adapter.wipe()
 
@@ -203,7 +206,7 @@ describe('sqlite adapter', () => {
     assert.equal(closeCalls, 0)
   })
 
-  it('closes the underlying database when close() is called', async () => {
+  it('closes the underlying database once even when close() is called repeatedly', async () => {
     let closeCalls = 0
     let sqlite = {
       prepare() {
@@ -216,6 +219,7 @@ describe('sqlite adapter', () => {
     } satisfies SqliteDatabase
     let adapter = createSqliteDatabaseAdapter(sqlite)
 
+    adapter.close()
     adapter.close()
     assert.equal(closeCalls, 1)
   })

--- a/packages/data-table-sqlite/src/lib/adapter.test.ts
+++ b/packages/data-table-sqlite/src/lib/adapter.test.ts
@@ -113,10 +113,11 @@ describe('sqlite adapter', () => {
 
   it('wipes file-backed databases together with their sidecar files', async () => {
     let dir = await mkdtemp(join(tmpdir(), 'data-table-sqlite-'))
+    let adapter: SqliteDatabaseAdapter | undefined
 
     try {
       let filename = join(dir, 'app.db')
-      let adapter = createSqliteDatabaseAdapter({ filename })
+      adapter = createSqliteDatabaseAdapter({ filename })
 
       await adapter.executeScript('pragma journal_mode = wal')
       await adapter.executeScript('create table users (id integer primary key)')
@@ -139,18 +140,21 @@ describe('sqlite adapter', () => {
       await adapter.executeScript('create table projects (id integer primary key)')
       assert.equal(await adapter.hasTable({ name: 'projects' }), true)
     } finally {
+      // release the reopened handle so Windows can unlink the database file
+      adapter?.close()
       await rm(dir, { recursive: true, force: true })
     }
   })
 
   it('recreates missing parent directories when wiping file-backed databases', async () => {
     let dir = await mkdtemp(join(tmpdir(), 'data-table-sqlite-'))
+    let adapter: SqliteDatabaseAdapter | undefined
 
     try {
       let filename = join(dir, 'nested', 'app.db')
       await mkdir(dirname(filename), { recursive: true })
 
-      let adapter = createSqliteDatabaseAdapter({ filename })
+      adapter = createSqliteDatabaseAdapter({ filename })
       await adapter.executeScript('create table users (id integer primary key)')
 
       await rm(dirname(filename), { recursive: true, force: true })
@@ -160,6 +164,8 @@ describe('sqlite adapter', () => {
       await adapter.executeScript('create table projects (id integer primary key)')
       assert.equal(await adapter.hasTable({ name: 'projects' }), true)
     } finally {
+      // release the reopened handle so Windows can unlink the database file
+      adapter?.close()
       await rm(dir, { recursive: true, force: true })
     }
   })
@@ -195,6 +201,23 @@ describe('sqlite adapter', () => {
       /SQLite adapter wipe\(\) requires config-based construction/,
     )
     assert.equal(closeCalls, 0)
+  })
+
+  it('closes the underlying database when close() is called', async () => {
+    let closeCalls = 0
+    let sqlite = {
+      prepare() {
+        throw new Error('not used')
+      },
+      exec() {},
+      close() {
+        closeCalls += 1
+      },
+    } satisfies SqliteDatabase
+    let adapter = createSqliteDatabaseAdapter(sqlite)
+
+    adapter.close()
+    assert.equal(closeCalls, 1)
   })
 
   it('short-circuits insertMany([]) and returns empty rows for returning queries', async () => {

--- a/packages/data-table-sqlite/src/lib/adapter.ts
+++ b/packages/data-table-sqlite/src/lib/adapter.ts
@@ -121,6 +121,7 @@ export class SqliteDatabaseAdapter implements DatabaseAdapter {
 
   #config?: SqliteDatabaseAdapterConfig
   #database: SqliteDatabase
+  #databaseOpen = true
   #transactions = new Set<string>()
   #transactionCounter = 0
 
@@ -262,7 +263,7 @@ export class SqliteDatabaseAdapter implements DatabaseAdapter {
   async wipe(): Promise<void> {
     let config = this.#configOrThrow('wipe')
     this.#assertNoOpenTransactions('wipe')
-    this.#database.close?.()
+    this.#closeDatabase()
 
     if (config.filename === ':memory:') {
       this.#replaceDatabase()
@@ -287,10 +288,10 @@ export class SqliteDatabaseAdapter implements DatabaseAdapter {
    *
    * Config-backed adapters keep an open handle that locks the database file on
    * Windows until it is closed, so callers that need to move or delete the file
-   * should close the adapter first.
+   * should close the adapter first. Safe to call more than once.
    */
   close(): void {
-    this.#database.close?.()
+    this.#closeDatabase()
   }
 
   /**
@@ -370,6 +371,14 @@ export class SqliteDatabaseAdapter implements DatabaseAdapter {
   #replaceDatabase(): void {
     if (this.#config) {
       this.#database = openSqliteDatabase(this.#config)
+      this.#databaseOpen = true
+    }
+  }
+
+  #closeDatabase(): void {
+    if (this.#databaseOpen) {
+      this.#database.close?.()
+      this.#databaseOpen = false
     }
   }
 

--- a/packages/data-table-sqlite/src/lib/adapter.ts
+++ b/packages/data-table-sqlite/src/lib/adapter.ts
@@ -283,6 +283,17 @@ export class SqliteDatabaseAdapter implements DatabaseAdapter {
   }
 
   /**
+   * Closes the underlying database connection and releases its file handle.
+   *
+   * Config-backed adapters keep an open handle that locks the database file on
+   * Windows until it is closed, so callers that need to move or delete the file
+   * should close the adapter first.
+   */
+  close(): void {
+    this.#database.close?.()
+  }
+
+  /**
    * Starts a sqlite transaction.
    * @param options Transaction options.
    * @returns Transaction token.


### PR DESCRIPTION
## Problem

`test (windows-latest, changed packages)` fails on two `data-table-sqlite` tests:

- `wipes file-backed databases together with their sidecar files`
- `recreates missing parent directories when wiping file-backed databases`

Both fail with `EBUSY: resource busy or locked, unlink 'app.db'`, and they fail immediately rather than after the retry/backoff that #11633 added. The EBUSY is not thrown from the adapter's `wipe()` retry path — it is thrown in each test's own teardown:

```ts
} finally {
  await rm(dir, { recursive: true, force: true }) // EBUSY on Windows
}
```

`wipe()` deliberately reopens the database in its `finally` block (`#replaceDatabase()`), and the test then runs `executeScript('create table projects ...')`, leaving that new handle open on `app.db`. On Windows an open file cannot be unlinked, so deleting the temp directory throws. The adapter exposed no way to release that handle, so #11633's retry could never succeed.

## Fix

- Add a public `close()` method to `SqliteDatabaseAdapter` that closes the underlying database connection and releases its file handle.
- Call `adapter.close()` in the two wipe tests before removing the temp directory.
- Add a unit test covering `close()` and a change file.

The tests already passed on Linux and macOS (Unix allows unlinking open files); this makes them pass on Windows as well.