### PR TITLE
fix(ui): use scroll:'manual' in intercept to honor rmx-reset-scroll=false

### DIFF
--- a/packages/ui/src/runtime/navigation.ts
+++ b/packages/ui/src/runtime/navigation.ts
@@ -79,6 +79,10 @@ export function startNavigationListenerImpl(
       let frame = namedFrame ?? topFrame
 
       event.intercept({
+        // Take full control of scrolling so the browser's built-in post-intercept
+        // scroll doesn't override rmx-reset-scroll="false". The manual window.scrollTo
+        // call below only fires when resetScroll is true, matching the expected behavior.
+        scroll: 'manual',
         async handler() {
           if (event.navigationType !== 'traverse') {
             navigation.updateCurrentEntry({ state })


### PR DESCRIPTION
`rmx-reset-scroll="false"` has no effect. Even though `state.resetScroll` is correctly parsed to `false`, the page still scrolls to the top on navigation.

**Root cause:** `event.intercept()` defaults to `scroll: 'after-transition'`, which tells the browser to automatically scroll to the top after the handler promise resolves — regardless of any manual scroll calls inside the handler. The guard on `state.resetScroll` only suppresses the *manual* `window.scrollTo(0, 0)` call; the browser's built-in automatic scroll runs unconditionally.

**Fix:** Pass `scroll: 'manual'` to `event.intercept()`. This delegates all scroll responsibility to the handler, which already has the correct `if (state.resetScroll && isNewEntry)` guard in place.

```ts
event.intercept({
  scroll: 'manual',  // ← added
  async handler() {
    // ...
    if (state.resetScroll && isNewEntry) {
      window.scrollTo(0, 0)  // only fires when resetScroll is true
    }
  },
})
```

No other changes needed — the existing manual scroll logic was already correct; it just wasn't the only scroll source.

Fixes #11617