### PR TITLE
Fix frame region scans rewinding into an infinite loop

### DIFF
--- a/packages/ui/.changes/patch.frame-region-scan-loop.md
+++ b/packages/ui/.changes/patch.frame-region-scan-loop.md
@@ -1,3 +1,1 @@
-Fix a browser hang when navigating or reloading pages that render a `Frame`. When a frame region was replaced while a nested frame's markers were still being moved, the runtime's region scans could look up an end marker that was no longer inside the scanned node list, rewind their loop index to the start, and spin forever with an unresponsive page. Region scans now always move forward.
-
-Fix `renderToStream` turning an aborted request into an unhandled rejection when a page renders more than one blocking frame. Blocking frames all start resolving together but are awaited one at a time, so aborting the request (for example by reloading or navigating mid-stream) rejected the frames that were never awaited and could crash a Node server.
+Prevent navigation and reloads from hanging when a nested `Frame` marker moves outside a frame region while the DOM is being updated.

--- a/packages/ui/.changes/patch.frame-region-scan-loop.md
+++ b/packages/ui/.changes/patch.frame-region-scan-loop.md
@@ -1,0 +1,3 @@
+Fix a browser hang when navigating or reloading pages that render a `Frame`. When a frame region was replaced while a nested frame's markers were still being moved, the runtime's region scans could look up an end marker that was no longer inside the scanned node list, rewind their loop index to the start, and spin forever with an unresponsive page. Region scans now always move forward.
+
+Fix `renderToStream` turning an aborted request into an unhandled rejection when a page renders more than one blocking frame. Blocking frames all start resolving together but are awaited one at a time, so aborting the request (for example by reloading or navigating mid-stream) rejected the frames that were never awaited and could crash a Node server.

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -1512,15 +1512,9 @@ function getFrameId(start: Comment): string {
   return trimmed.slice('rmx:f:'.length)
 }
 
-// Finds the index of a marker range's end node so callers can skip its interior.
-// The node list is a snapshot, so it can go stale while frames render or
-// dispose: the matching end marker may be detached, or may live outside the
-// snapshot when a region was truncated. `indexOf` returns `-1` in those cases,
-// which would rewind the caller's loop and spin forever, so fall back to the
-// current index and let the loop move forward.
 function findMarkerRangeEndIndex(nodes: Node[], end: Comment, startIndex: number): number {
-  let endIndex = nodes.indexOf(end)
-  return endIndex > startIndex ? endIndex : startIndex
+  // The snapshot may not contain an end marker moved by a DOM update.
+  return Math.max(startIndex, nodes.indexOf(end))
 }
 
 function findEndMarker(

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -625,7 +625,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       if (isFrameStart(node)) {
         let end = findEndMarker(node, isFrameStart, isFrameEnd)
         context.frameInstances.get(node)?.startInheritedReload(signal)
-        i = nodes.indexOf(end)
+        i = findMarkerRangeEndIndex(nodes, end, i)
         continue
       }
 
@@ -816,7 +816,7 @@ function collectOwnedServerStyleTags(nodes: Node[], styles: HTMLStyleElement[]):
 
     if (isFrameStart(node)) {
       let end = findEndMarker(node, isFrameStart, isFrameEnd)
-      i = nodes.indexOf(end)
+      i = findMarkerRangeEndIndex(nodes, end, i)
       continue
     }
 
@@ -1083,7 +1083,7 @@ async function createSubFrames(
         }
       }
 
-      i = nodes.indexOf(end)
+      i = findMarkerRangeEndIndex(nodes, end, i)
       continue
     }
 
@@ -1124,7 +1124,7 @@ function removeVirtualRoots(nodes: Node[]): void {
     if (isHydratedVirtualRootMarker(node)) {
       node.$rmx.dispose()
       let end = findEndMarker(node, isHydrationStart, isHydrationEnd)
-      i = nodes.indexOf(end)
+      i = findMarkerRangeEndIndex(nodes, end, i)
       continue
     }
 
@@ -1145,7 +1145,7 @@ function disposeSubFrames(nodes: Node[], context: FrameContext): void {
         subFrame.dispose()
         context.frameInstances.delete(node)
       }
-      i = nodes.indexOf(end)
+      i = findMarkerRangeEndIndex(nodes, end, i)
       continue
     }
 
@@ -1475,7 +1475,7 @@ function walkCommentsInNodes(nodes: Node[], cb: (comment: Comment) => void): voi
     // are discovered and hydrated by the nested frame instance only.
     if (isFrameStart(node)) {
       let end = findEndMarker(node, isFrameStart, isFrameEnd)
-      i = nodes.indexOf(end)
+      i = findMarkerRangeEndIndex(nodes, end, i)
       continue
     }
 
@@ -1510,6 +1510,17 @@ function getFrameId(start: Comment): string {
   let trimmed = start.data.trim()
   invariant(trimmed.startsWith('rmx:f:'), 'Invalid frame start marker')
   return trimmed.slice('rmx:f:'.length)
+}
+
+// Finds the index of a marker range's end node so callers can skip its interior.
+// The node list is a snapshot, so it can go stale while frames render or
+// dispose: the matching end marker may be detached, or may live outside the
+// snapshot when a region was truncated. `indexOf` returns `-1` in those cases,
+// which would rewind the caller's loop and spin forever, so fall back to the
+// current index and let the loop move forward.
+function findMarkerRangeEndIndex(nodes: Node[], end: Comment, startIndex: number): number {
+  let endIndex = nodes.indexOf(end)
+  return endIndex > startIndex ? endIndex : startIndex
 }
 
 function findEndMarker(

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -487,7 +487,7 @@ function buildFrameSegment(
     framePromise.catch(() => {})
     context.pendingFrames.push({ frameId, promise: framePromise })
   } else {
-    seg.pending = Promise.resolve(
+    let pending = Promise.resolve(
       context.resolveFrame(props.src, props.name, resolveFrameContext),
     ).then(async (resolved) => {
       let { html, tail } = await resolveFrameHtml(resolved)
@@ -496,6 +496,11 @@ function buildFrameSegment(
         context.blockingFrameTails.push(tail)
       }
     })
+    // Blocking frames all start resolving here but are awaited one at a time, so
+    // the first rejection stops the rest from ever being awaited. Keep every
+    // promise observed so request aborts don't become unhandled rejections.
+    pending.catch(() => {})
+    seg.pending = pending
   }
 
   return seg

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -487,7 +487,7 @@ function buildFrameSegment(
     framePromise.catch(() => {})
     context.pendingFrames.push({ frameId, promise: framePromise })
   } else {
-    let pending = Promise.resolve(
+    seg.pending = Promise.resolve(
       context.resolveFrame(props.src, props.name, resolveFrameContext),
     ).then(async (resolved) => {
       let { html, tail } = await resolveFrameHtml(resolved)
@@ -496,11 +496,6 @@ function buildFrameSegment(
         context.blockingFrameTails.push(tail)
       }
     })
-    // Blocking frames all start resolving here but are awaited one at a time, so
-    // the first rejection stops the rest from ever being awaited. Keep every
-    // promise observed so request aborts don't become unhandled rejections.
-    pending.catch(() => {})
-    seg.pending = pending
   }
 
   return seg

--- a/packages/ui/src/test/frame.test.ts
+++ b/packages/ui/src/test/frame.test.ts
@@ -91,6 +91,76 @@ describe('frame reloads', () => {
   })
 })
 
+describe('frame disposal', () => {
+  afterEach(() => {
+    document.documentElement.innerHTML = '<head></head><body></body>'
+  })
+
+  it('disposes a frame whose nested frame end marker is outside its region', async () => {
+    // A frame region can be truncated while its parent region is replaced, which
+    // leaves a nested frame start marker inside the region and its end marker
+    // outside of it. Region scans must keep moving forward instead of restarting
+    // and hanging the page.
+    let outerStart = document.createComment(' rmx:f:outer ')
+    let innerStart = document.createComment(' rmx:f:inner ')
+    let innerContent = document.createElement('p')
+    innerContent.textContent = 'inner'
+    // The outer end marker comes first, so the nested range escapes the region.
+    let outerEnd = document.createComment(' /rmx:f ')
+    let innerEnd = document.createComment(' /rmx:f ')
+    document.body.append(outerStart, innerStart, innerContent, outerEnd, innerEnd)
+
+    let scans = countMarkerScans(innerStart, 500)
+    let errorTarget = new EventTarget()
+    let styleManager = createStyleManager()
+    let scheduler = createScheduler(document, errorTarget, styleManager)
+
+    let frame = createFrame([outerStart, outerEnd], {
+      src: 'https://example.com/outer',
+      errorTarget,
+      loadModule: () => () => null,
+      resolveFrame: () => '',
+      pendingClientEntries: new Map(),
+      scheduler,
+      styleManager,
+      data: { f: { inner: { status: 'resolved', src: 'https://example.com/inner' } } },
+      moduleCache: new Map(),
+      moduleLoads: new Map(),
+      frameInstances: new WeakMap(),
+      namedFrames: new Map(),
+    })
+
+    await frame.ready()
+    frame.dispose()
+
+    expect(scans.count).toBeLessThan(500)
+  })
+})
+
+/**
+ * Counts reads of a marker's comment data, throwing once a scan limit is passed
+ * so a rescan loop fails the test instead of hanging the run.
+ */
+function countMarkerScans(marker: Comment, limit: number): { count: number } {
+  let data = marker.data
+  let scans = { count: 0 }
+
+  Object.defineProperty(marker, 'data', {
+    get() {
+      scans.count++
+      if (scans.count > limit) {
+        throw new Error(`Marker read ${limit} times; the frame region scan is looping`)
+      }
+      return data
+    },
+    set(next: string) {
+      data = next
+    },
+  })
+
+  return scans
+}
+
 function rmxDataScript(label: string): string {
   let data = {
     h: {

--- a/packages/ui/src/test/frame.test.ts
+++ b/packages/ui/src/test/frame.test.ts
@@ -8,7 +8,7 @@ import { createScheduler } from '../runtime/scheduler.ts'
 import { appendFlushMarker } from '../runtime/stream-protocol.ts'
 import { createStyleManager } from '../style/index.ts'
 
-describe('frame reloads', () => {
+describe('frames', () => {
   afterEach(() => {
     document.documentElement.innerHTML = '<head></head><body></body>'
   })
@@ -89,32 +89,17 @@ describe('frame reloads', () => {
       frame.dispose()
     }
   })
-})
 
-describe('frame disposal', () => {
-  afterEach(() => {
-    document.documentElement.innerHTML = '<head></head><body></body>'
-  })
-
-  it('disposes a frame whose nested frame end marker is outside its region', async () => {
-    // A frame region can be truncated while its parent region is replaced, which
-    // leaves a nested frame start marker inside the region and its end marker
-    // outside of it. Region scans must keep moving forward instead of restarting
-    // and hanging the page.
+  it('does not loop when a nested frame range escapes its region', async () => {
     let outerStart = document.createComment(' rmx:f:outer ')
     let innerStart = document.createComment(' rmx:f:inner ')
-    let innerContent = document.createElement('p')
-    innerContent.textContent = 'inner'
-    // The outer end marker comes first, so the nested range escapes the region.
-    let outerEnd = document.createComment(' /rmx:f ')
     let innerEnd = document.createComment(' /rmx:f ')
-    document.body.append(outerStart, innerStart, innerContent, outerEnd, innerEnd)
+    let outerEnd = document.createComment(' /rmx:f ')
+    document.body.append(outerStart, innerStart, innerEnd, outerEnd)
 
-    let scans = countMarkerScans(innerStart, 500)
     let errorTarget = new EventTarget()
     let styleManager = createStyleManager()
     let scheduler = createScheduler(document, errorTarget, styleManager)
-
     let frame = createFrame([outerStart, outerEnd], {
       src: 'https://example.com/outer',
       errorTarget,
@@ -123,7 +108,7 @@ describe('frame disposal', () => {
       pendingClientEntries: new Map(),
       scheduler,
       styleManager,
-      data: { f: { inner: { status: 'resolved', src: 'https://example.com/inner' } } },
+      data: {},
       moduleCache: new Map(),
       moduleLoads: new Map(),
       frameInstances: new WeakMap(),
@@ -131,16 +116,16 @@ describe('frame disposal', () => {
     })
 
     await frame.ready()
+
+    // Simulate the outer region being truncated during a DOM update.
+    outerEnd.after(innerEnd)
+    let scans = countMarkerScans(innerStart, 100)
     frame.dispose()
 
-    expect(scans.count).toBeLessThan(500)
+    expect(scans.count).toBeLessThan(100)
   })
 })
 
-/**
- * Counts reads of a marker's comment data, throwing once a scan limit is passed
- * so a rescan loop fails the test instead of hanging the run.
- */
 function countMarkerScans(marker: Comment, limit: number): { count: number } {
   let data = marker.data
   let scans = { count: 0 }


### PR DESCRIPTION
## Demo

I ran into this while working on the docs, which take advantage of Frames pretty extensively.

https://github.com/user-attachments/assets/b382c042-7fe5-4bd1-9630-6852b3845af3

## Explanation

Frame region scans skip nested marker ranges with an index from a snapshot of the region's nodes. During a DOM update, the matching end marker can move outside that snapshot, causing the index to become `-1` and the scan to restart forever.

The skip index is now clamped to the current position so every scan continues forward.
