### PR TITLE
Fix unhandled rejections when aborting blocking frames

### DIFF
--- a/packages/ui/.changes/patch.blocking-frame-abort-rejections.md
+++ b/packages/ui/.changes/patch.blocking-frame-abort-rejections.md
@@ -1,0 +1,1 @@
+Prevent aborted `renderToStream` requests with multiple blocking `Frame`s from producing unhandled promise rejections that can crash Node servers.

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -487,7 +487,7 @@ function buildFrameSegment(
     framePromise.catch(() => {})
     context.pendingFrames.push({ frameId, promise: framePromise })
   } else {
-    seg.pending = Promise.resolve(
+    let framePromise = Promise.resolve(
       context.resolveFrame(props.src, props.name, resolveFrameContext),
     ).then(async (resolved) => {
       let { html, tail } = await resolveFrameHtml(resolved)
@@ -496,6 +496,9 @@ function buildFrameSegment(
         context.blockingFrameTails.push(tail)
       }
     })
+    // An earlier blocking frame may reject before this promise is awaited.
+    framePromise.catch(() => {})
+    seg.pending = framePromise
   }
 
   return seg

--- a/packages/ui/src/test/stream.test.tsx
+++ b/packages/ui/src/test/stream.test.tsx
@@ -2108,31 +2108,50 @@ describe('stream', () => {
       expect(done.done).toBe(true)
     })
 
-    it('cancels blocking frame rendering when signal aborts without calling onError', async () => {
+    it('cancels all blocking frames without unhandled rejections', async () => {
       let controller = new AbortController()
       let errors: unknown[] = []
+      let [frameOne, , rejectFrameOne] = withResolvers<string>()
+      let [frameTwo, , rejectFrameTwo] = withResolvers<string>()
+      let unhandledRejections: unknown[] = []
+      let onUnhandledRejection = (event: PromiseRejectionEvent) => {
+        event.preventDefault()
+        unhandledRejections.push(event.reason)
+      }
+      window.addEventListener('unhandledrejection', onUnhandledRejection)
 
-      let stream = renderToStream(<Frame src="/fragments/product" />, {
-        onError(error) {
-          errors.push(error)
-        },
-        resolveFrame: () =>
-          new Promise<string>((_resolve, reject) => {
-            controller.signal.addEventListener('abort', () => reject(controller.signal.reason), {
-              once: true,
-            })
-          }),
-        signal: controller.signal,
-      })
+      try {
+        let stream = renderToStream(
+          <div>
+            <Frame src="/fragments/one" />
+            <Frame src="/fragments/two" />
+          </div>,
+          {
+            onError(error) {
+              errors.push(error)
+            },
+            resolveFrame(src) {
+              return src === '/fragments/one' ? frameOne : frameTwo
+            },
+            signal: controller.signal,
+          },
+        )
 
-      let reader = stream.getReader()
-      let read = reader.read()
+        let reader = stream.getReader()
+        let read = reader.read()
 
-      let abortError = new DOMException('This operation was aborted', 'AbortError')
-      controller.abort(abortError)
+        let abortError = new DOMException('This operation was aborted', 'AbortError')
+        controller.abort(abortError)
+        rejectFrameOne(abortError)
+        rejectFrameTwo(abortError)
 
-      await expect(read).resolves.toEqual({ done: true, value: undefined })
-      expect(errors).toEqual([])
+        await expect(read).resolves.toEqual({ done: true, value: undefined })
+        await new Promise((resolve) => setTimeout(resolve, 50))
+        expect(errors).toEqual([])
+        expect(unhandledRejections).toEqual([])
+      } finally {
+        window.removeEventListener('unhandledrejection', onUnhandledRejection)
+      }
     })
 
     it('cancels non-blocking frame rendering when signal aborts without calling onError', async () => {


### PR DESCRIPTION
Aborting `renderToStream` while a page has multiple blocking `Frame`s can reject all frame promises at once. Because blocking frames are awaited in tree order, the first rejection stops traversal and leaves later promises unhandled, which can crash a Node server.

Observe each blocking frame promise when it is created while retaining the original promise for normal resolution and error handling. This matches the non-blocking frame handling added in #11431.
