### PR TITLE
Model UI VNodes with explicit lifecycle states

### DIFF
--- a/packages/ui/.changes/patch.preserve-pending-frame-content.md
+++ b/packages/ui/.changes/patch.preserve-pending-frame-content.md
@@ -1,0 +1,1 @@
+Preserve resolved client-created frame content when its parent rerenders while the frame is still pending (see #11659).

--- a/packages/ui/src/animation/animate-mixins.ts
+++ b/packages/ui/src/animation/animate-mixins.ts
@@ -37,7 +37,7 @@ type AnimationState = {
 }
 
 const animatingNodes = new WeakMap<Element, AnimationState>()
-const initialEntranceSeenByParent = new WeakMap<ParentNode, Set<string>>()
+const initialEntranceSeenByParent = new WeakMap<ParentNode, Set<unknown>>()
 
 function extractStyleProps(config: AnimateMixinConfig): Keyframe {
   let result: Keyframe = {}
@@ -152,14 +152,14 @@ function waitForAnimationOrAbort(animation: Animation, signal: AbortSignal): Pro
 }
 
 function shouldSkipInitialEntrance(
-  event: { key?: string; parent: ParentNode },
+  event: { key?: unknown; parent: ParentNode },
   config: AnimateMixinConfig,
 ): boolean {
   if (config.initial !== false) return false
   if (event.key == null) return false
   let seenForParent = initialEntranceSeenByParent.get(event.parent)
   if (!seenForParent) {
-    seenForParent = new Set<string>()
+    seenForParent = new Set<unknown>()
     initialEntranceSeenByParent.set(event.parent, seenForParent)
   }
   if (seenForParent.has(event.key)) return false

--- a/packages/ui/src/runtime/component.ts
+++ b/packages/ui/src/runtime/component.ts
@@ -296,7 +296,8 @@ class ComponentRuntime<C = NoContext> implements ComponentHandle<C> {
     let renderFn = this.#renderFn
 
     if (renderFn === undefined) {
-      let result = Reflect.apply(this.#config.type, undefined, [this.#handle])
+      let initialize = this.#config.type as unknown as (handle: Handle<ElementProps, C>) => unknown
+      let result = initialize(this.#handle)
 
       if (!isRenderFn(result)) {
         let name = this.#config.type.name || 'Anonymous'

--- a/packages/ui/src/runtime/component.ts
+++ b/packages/ui/src/runtime/component.ts
@@ -1,4 +1,6 @@
 import type { ElementProps, ElementType, RemixNode, Renderable } from './jsx.ts'
+import type { ElementFunction } from './element-function.ts'
+import type { Key } from './key.ts'
 import { TypedEventTarget } from './typed-event-target.ts'
 
 /**
@@ -208,13 +210,13 @@ export interface BuiltinElements {
 /**
  * Key type used to stabilize host elements and components during reconciliation.
  */
-export type Key = string | number | bigint
+export type { Key } from './key.ts'
 
 type ComponentConfig = {
   id: string
-  type: Function
+  type: ElementFunction
   frame: FrameHandle
-  getContext: (type: Component) => unknown
+  getContext: (type: ElementFunction) => unknown
   getFrameByName: (name: string) => FrameHandle | undefined
   getTopFrame?: () => FrameHandle | undefined
   signal?: AbortSignal
@@ -257,7 +259,7 @@ class ComponentRuntime<C = NoContext> implements ComponentHandle<C> {
   #connectedController: AbortController | undefined
   #contextValue: C | undefined
   #handle: Handle<ElementProps, C>
-  #props = {} as ElementProps
+  #props: ElementProps = {}
   #renderController: AbortController | undefined
   #renderFn: RenderFn | undefined
   #removed = false
@@ -269,7 +271,10 @@ class ComponentRuntime<C = NoContext> implements ComponentHandle<C> {
   #scheduleUpdate = (): void => {
     let queue = this.#updateQueue
     if (!queue) throw new Error('scheduleUpdate not implemented')
-    queue.enqueue(this.#updateVNode!, this.#updateDomParent!)
+    let vnode = this.#updateVNode
+    let domParent = this.#updateDomParent
+    if (!vnode || !domParent) throw new Error('scheduleUpdate target not initialized')
+    queue.enqueue(vnode, domParent)
   }
   #tasks: Task[] = []
 
@@ -291,14 +296,14 @@ class ComponentRuntime<C = NoContext> implements ComponentHandle<C> {
     let renderFn = this.#renderFn
 
     if (renderFn === undefined) {
-      let result = this.#config.type(this.#handle)
+      let result = Reflect.apply(this.#config.type, undefined, [this.#handle])
 
-      if (typeof result !== 'function') {
+      if (!isRenderFn(result)) {
         let name = this.#config.type.name || 'Anonymous'
         throw new Error(`${name} must return a render function, received ${typeof result}`)
       }
 
-      renderFn = result as RenderFn
+      renderFn = result
       this.#renderFn = renderFn
     }
 
@@ -330,7 +335,8 @@ class ComponentRuntime<C = NoContext> implements ComponentHandle<C> {
       set: (value: C) => {
         this.#contextValue = value
       },
-      get: (type: ElementType | symbol) => this.#config.getContext(type as Component),
+      get: (type: ElementType | symbol) =>
+        isElementFunction(type) ? this.#config.getContext(type) : undefined,
     }
 
     return {
@@ -385,9 +391,18 @@ class ComponentRuntime<C = NoContext> implements ComponentHandle<C> {
     }
 
     signal ??= this.#renderController?.signal
+    signal ??= sharedAbortedSignal ??= AbortSignal.abort()
     let tasks = this.#tasks.splice(0, this.#tasks.length)
-    return tasks.map((task) => () => task(signal!))
+    return tasks.map((task) => () => task(signal))
   }
+}
+
+function isRenderFn(value: unknown): value is RenderFn {
+  return typeof value === 'function'
+}
+
+function isElementFunction(value: unknown): value is ElementFunction {
+  return typeof value === 'function'
 }
 
 // Shared empty result and aborted signal so the common no-task removal path

--- a/packages/ui/src/runtime/core/children.ts
+++ b/packages/ui/src/runtime/core/children.ts
@@ -12,7 +12,7 @@ export function isPrimitiveChild(value: RemixNode): value is PrimitiveChild {
   return type === 'string' || type === 'number' || type === 'bigint'
 }
 
-export function normalizeChildren(children: readonly RemixNode[]): RemixNode[] {
+export function normalizeChildren(children: readonly unknown[]): RemixNode[] {
   for (let i = 0; i < children.length; i++) {
     if (Array.isArray(children[i])) {
       return (children as unknown[]).flat(Infinity) as RemixNode[]

--- a/packages/ui/src/runtime/core/children.ts
+++ b/packages/ui/src/runtime/core/children.ts
@@ -1,4 +1,6 @@
 import type { RemixNode } from '../jsx.ts'
+import { invariant } from '../invariant.ts'
+import { isRemixElement } from './vnode.ts'
 
 export type EmptyChild = boolean | null | undefined
 export type PrimitiveChild = string | number | bigint
@@ -12,7 +14,7 @@ export function isPrimitiveChild(value: RemixNode): value is PrimitiveChild {
   return type === 'string' || type === 'number' || type === 'bigint'
 }
 
-export function normalizeChildren(children: readonly unknown[]): RemixNode[] {
+export function normalizeChildren(children: readonly RemixNode[]): RemixNode[] {
   for (let i = 0; i < children.length; i++) {
     if (Array.isArray(children[i])) {
       return (children as unknown[]).flat(Infinity) as RemixNode[]
@@ -20,6 +22,26 @@ export function normalizeChildren(children: readonly unknown[]): RemixNode[] {
   }
 
   return children as RemixNode[]
+}
+
+export function assertRemixNodes(values: readonly unknown[]): asserts values is RemixNode[] {
+  for (let value of values) {
+    invariant(isRemixNode(value), 'Invalid child node')
+  }
+}
+
+export function isRemixNode(value: unknown): value is RemixNode {
+  if (value == null) return true
+  let type = typeof value
+  if (type === 'string' || type === 'number' || type === 'bigint' || type === 'boolean') {
+    return true
+  }
+  if (isRemixElement(value)) return true
+  if (!Array.isArray(value)) return false
+  for (let child of value) {
+    if (!isRemixNode(child)) return false
+  }
+  return true
 }
 
 export function packChildren(children: readonly RemixNode[]): RemixNode | undefined {

--- a/packages/ui/src/runtime/core/vnode.ts
+++ b/packages/ui/src/runtime/core/vnode.ts
@@ -1,10 +1,9 @@
-import type { ElementProps, ElementType, RemixElement, RemixNode } from '../jsx.ts'
-import type { Key } from '../key.ts'
+import type { ElementProps, ElementType, RemixElement } from '../jsx.ts'
 
 export function createRemixElement(
   type: ElementType,
   props: ElementProps | null | undefined,
-  key?: Key,
+  key?: any,
 ): RemixElement {
   return {
     $rmx: true,
@@ -14,8 +13,16 @@ export function createRemixElement(
   }
 }
 
-export function isRemixElement(node: RemixNode): node is RemixElement {
-  return typeof node === 'object' && node !== null && '$rmx' in node
+export function isRemixElement(node: unknown): node is RemixElement {
+  if (typeof node !== 'object' || node === null) return false
+  let type = Reflect.get(node, 'type')
+  let props = Reflect.get(node, 'props')
+  return (
+    Reflect.get(node, '$rmx') === true &&
+    (typeof type === 'string' || typeof type === 'function') &&
+    typeof props === 'object' &&
+    props !== null
+  )
 }
 
 function normalizeElementProps(props: ElementProps | null | undefined): ElementProps {

--- a/packages/ui/src/runtime/core/vnode.ts
+++ b/packages/ui/src/runtime/core/vnode.ts
@@ -1,9 +1,10 @@
 import type { ElementProps, ElementType, RemixElement, RemixNode } from '../jsx.ts'
+import type { Key } from '../key.ts'
 
 export function createRemixElement(
   type: ElementType,
   props: ElementProps | null | undefined,
-  key?: string,
+  key?: Key,
 ): RemixElement {
   return {
     $rmx: true,

--- a/packages/ui/src/runtime/create-element.ts
+++ b/packages/ui/src/runtime/create-element.ts
@@ -1,5 +1,5 @@
 import { jsx } from './jsx.ts'
-import type { ElementType, RemixElement } from './jsx.ts'
+import type { ElementProps, ElementType, RemixElement } from './jsx.ts'
 import { normalizeChildren } from './core/children.ts'
 
 /**
@@ -12,8 +12,8 @@ import { normalizeChildren } from './core/children.ts'
  */
 export function createElement(
   type: ElementType,
-  props?: Record<string, any>,
-  ...children: any[]
+  props?: ElementProps,
+  ...children: unknown[]
 ): RemixElement {
   let nextProps = { ...(props ?? {}) }
   if (isMixinElementType(type)) {
@@ -34,6 +34,6 @@ export function createElement(
 
 function isMixinElementType(
   type: ElementType,
-): type is ((...args: unknown[]) => unknown) & { __rmxMixinElementType: string } {
+): type is ElementType & { __rmxMixinElementType: string } {
   return typeof type === 'function' && '__rmxMixinElementType' in type
 }

--- a/packages/ui/src/runtime/create-element.ts
+++ b/packages/ui/src/runtime/create-element.ts
@@ -1,6 +1,6 @@
 import { jsx } from './jsx.ts'
 import type { ElementProps, ElementType, RemixElement } from './jsx.ts'
-import { normalizeChildren } from './core/children.ts'
+import { assertRemixNodes, normalizeChildren } from './core/children.ts'
 
 /**
  * Creates a Remix virtual element from a JSX-like call signature.
@@ -21,6 +21,7 @@ export function createElement(
       console.error(new Error('mixin elements must not receive children'))
     }
   } else {
+    assertRemixNodes(children)
     nextProps.children = normalizeChildren(children)
   }
 

--- a/packages/ui/src/runtime/dom.ts
+++ b/packages/ui/src/runtime/dom.ts
@@ -1,6 +1,5 @@
 import type { StyleProps } from '../style/style.ts'
 import type { RemixNode } from './jsx.ts'
-import type { Key } from './key.ts'
 import type { MixInput } from './mixins/mixin.ts'
 
 /**
@@ -30,7 +29,7 @@ export interface LayoutAnimationConfig {
  */
 export interface HostProps<eventTarget extends EventTarget> {
   /** The reconciliation key for the element. */
-  key?: Key
+  key?: any
   /** Child nodes to render inside the element. */
   children?: RemixNode
   /** Mixins to apply to the element. */

--- a/packages/ui/src/runtime/dom.ts
+++ b/packages/ui/src/runtime/dom.ts
@@ -1,5 +1,6 @@
 import type { StyleProps } from '../style/style.ts'
 import type { RemixNode } from './jsx.ts'
+import type { Key } from './key.ts'
 import type { MixInput } from './mixins/mixin.ts'
 
 /**
@@ -29,7 +30,7 @@ export interface LayoutAnimationConfig {
  */
 export interface HostProps<eventTarget extends EventTarget> {
   /** The reconciliation key for the element. */
-  key?: any
+  key?: Key
   /** Child nodes to render inside the element. */
   children?: RemixNode
   /** Mixins to apply to the element. */

--- a/packages/ui/src/runtime/element-function.ts
+++ b/packages/ui/src/runtime/element-function.ts
@@ -1,0 +1,1 @@
+export type ElementFunction = ((...args: never[]) => unknown) & { readonly name?: string }

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -3,6 +3,7 @@ import { Frame, createFrameHandle, type FrameContent } from './component.ts'
 import { createComponentErrorEvent, getComponentError } from './error-event.ts'
 import { invariant } from './invariant.ts'
 import type { RemixElement, RemixNode } from './jsx.ts'
+import type { ElementFunction } from './element-function.ts'
 import type { FrameHandle } from './component.ts'
 import type { Scheduler, VirtualRoot } from './vdom.ts'
 import { createRangeRoot, createRoot } from './vdom.ts'
@@ -99,6 +100,7 @@ function syncElementAttributes(target: Element, source: Element) {
 }
 
 export type FrameRuntime = {
+  canResolveFrames?: boolean
   topFrame?: FrameHandle
   errorTarget: EventTarget
   loadModule: LoadModule
@@ -107,11 +109,15 @@ export type FrameRuntime = {
   scheduler: Scheduler
   styleManager: StyleManager
   data: RmxData
-  moduleCache: Map<string, Function>
-  moduleLoads: Map<string, Promise<Function | undefined>>
+  moduleCache: Map<string, ElementFunction>
+  moduleLoads: Map<string, Promise<ElementFunction | undefined>>
   frameInstances: WeakMap<Comment, Frame>
   namedFrames: Map<string, FrameHandle>
   serverFrameReload: { signal: AbortSignal } | undefined
+}
+
+function isFrameRuntime(value: unknown): value is FrameRuntime {
+  return isRecord(value) && typeof value.resolveFrame === 'function'
 }
 
 export type FrameContext = {
@@ -124,8 +130,8 @@ export type FrameContext = {
   frame: FrameHandle
   styleManager: StyleManager
   data: RmxData
-  moduleCache: Map<string, Function>
-  moduleLoads: Map<string, Promise<Function | undefined>>
+  moduleCache: Map<string, ElementFunction>
+  moduleLoads: Map<string, Promise<ElementFunction | undefined>>
   frameInstances: WeakMap<Comment, Frame>
   namedFrames: Map<string, FrameHandle>
   regionTailRef?: ChildNode | null
@@ -145,8 +151,8 @@ type FrameInit = {
   styleManager?: StyleManager
   marker?: FrameMarkerData
   data: RmxData
-  moduleCache: Map<string, Function>
-  moduleLoads: Map<string, Promise<Function | undefined>>
+  moduleCache: Map<string, ElementFunction>
+  moduleLoads: Map<string, Promise<ElementFunction | undefined>>
   frameInstances: WeakMap<Comment, Frame>
   namedFrames: Map<string, FrameHandle>
 }
@@ -707,8 +713,8 @@ export function createFrameRuntime(init: {
   scheduler: Scheduler
   styleManager: StyleManager
   data: RmxData
-  moduleCache: Map<string, Function>
-  moduleLoads: Map<string, Promise<Function | undefined>>
+  moduleCache: Map<string, ElementFunction>
+  moduleLoads: Map<string, Promise<ElementFunction | undefined>>
   frameInstances: WeakMap<Comment, Frame>
   namedFrames: Map<string, FrameHandle>
 }): FrameRuntime {
@@ -891,7 +897,7 @@ function scheduleHydrationMarker(
   let done = initialHydrationTracker?.track()
   let key = `${entry.moduleUrl}#${entry.exportName}`
 
-  let hydrateWithComponent = (component: Function) => {
+  let hydrateWithComponent = (component: ElementFunction) => {
     if (signal?.aborted) return
     if (!isHydrationMarkerLive(marker, context)) return
     let vElement = createElement(component, entry.props)
@@ -922,14 +928,14 @@ function getOrStartModuleLoad(
   entry: HydrationData,
   markerId: string,
   context: FrameContext,
-): Promise<Function | undefined> {
+): Promise<ElementFunction | undefined> {
   let inFlight = context.moduleLoads.get(key)
   if (inFlight) return inFlight
 
   let loadPromise = (async () => {
     try {
       let mod = await context.loadModule(entry.moduleUrl, entry.exportName)
-      if (typeof mod !== 'function') {
+      if (!isElementFunction(mod)) {
         throw new Error(`Export "${entry.exportName}" from "${entry.moduleUrl}" is not a function`)
       }
       context.moduleCache.set(key, mod)
@@ -946,9 +952,14 @@ function getOrStartModuleLoad(
   return loadPromise
 }
 
-function createElement(component: Function, props: Record<string, unknown>): RemixElement {
+function createElement(component: ElementFunction, props: Record<string, unknown>): RemixElement {
   let revivedProps = reviveSerializedValue(props)
-  return jsx(component, revivedProps as any)
+  invariant(isRecord(revivedProps), 'Expected revived component props to be an object')
+  return jsx(component, revivedProps)
+}
+
+function isElementFunction(value: unknown): value is ElementFunction {
+  return typeof value === 'function'
 }
 
 function reviveSerializedValue(value: unknown): unknown {
@@ -959,18 +970,19 @@ function reviveSerializedValue(value: unknown): unknown {
     return value.map((item) => reviveSerializedValue(item))
   }
 
-  let record = value as Record<string, unknown>
+  if (!isRecord(value)) return value
+  let record = value
 
   if (record.$rmxFrame === true) {
     let props = reviveSerializedObject(record.props)
     let key = reviveSerializedValue(record.key)
-    return jsx(Frame as any, props as any, key as any)
+    return jsx(Frame, props, key)
   }
 
   if (record.$rmx === true && typeof record.type === 'string') {
     let props = reviveSerializedObject(record.props)
     let key = reviveSerializedValue(record.key)
-    return jsx(record.type as any, props as any, key as any)
+    return jsx(record.type, props, key)
   }
 
   let revived: Record<string, unknown> = {}
@@ -984,7 +996,11 @@ function reviveSerializedObject(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
   let revived = reviveSerializedValue(value)
   if (!revived || typeof revived !== 'object' || Array.isArray(revived)) return {}
-  return revived as Record<string, unknown>
+  return isRecord(revived) ? revived : {}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 function hydrateRegion(
@@ -1007,8 +1023,11 @@ function hydrateRegion(
       return
     }
 
-    let frameRuntime = context.frame.$runtime as FrameRuntime | undefined
-    invariant(frameRuntime, 'Expected frame runtime while rendering a preserved client entry')
+    let frameRuntime = context.frame.$runtime
+    invariant(
+      isFrameRuntime(frameRuntime),
+      'Expected frame runtime while rendering a preserved client entry',
+    )
 
     let previousServerFrameReload = frameRuntime.serverFrameReload
 
@@ -1212,7 +1231,9 @@ export function publishFrameTemplate(id: string, fragment: DocumentFragment): vo
   }
 
   for (let listener of listeners) {
-    listener(fragment.cloneNode(true) as DocumentFragment)
+    let clone = fragment.cloneNode(true)
+    invariant(clone instanceof DocumentFragment, 'Expected cloned frame template fragment')
+    listener(clone)
   }
 }
 
@@ -1479,7 +1500,7 @@ function walkCommentsInNodes(nodes: Node[], cb: (comment: Comment) => void): voi
       continue
     }
 
-    if (node.nodeType === Node.COMMENT_NODE) cb(node as Comment)
+    if (node instanceof Comment) cb(node)
     if (node.childNodes && node.childNodes.length > 0) {
       walkCommentsInNodes(Array.from(node.childNodes), cb)
     }
@@ -1521,8 +1542,8 @@ function findEndMarker(
   let depth = 1
 
   while (node) {
-    if (node.nodeType === Node.COMMENT_NODE) {
-      let comment = node as Comment
+    if (node instanceof Comment) {
+      let comment = node
       if (isStart(comment)) depth++
       else if (isEnd(comment)) {
         depth--

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -99,7 +99,10 @@ function syncElementAttributes(target: Element, source: Element) {
   }
 }
 
+const FRAME_RUNTIME = Symbol('FrameRuntime')
+
 export type FrameRuntime = {
+  [FRAME_RUNTIME]: true
   canResolveFrames?: boolean
   topFrame?: FrameHandle
   errorTarget: EventTarget
@@ -116,8 +119,8 @@ export type FrameRuntime = {
   serverFrameReload: { signal: AbortSignal } | undefined
 }
 
-function isFrameRuntime(value: unknown): value is FrameRuntime {
-  return isRecord(value) && typeof value.resolveFrame === 'function'
+export function isFrameRuntime(value: unknown): value is FrameRuntime {
+  return isRecord(value) && Reflect.get(value, FRAME_RUNTIME) === true
 }
 
 export type FrameContext = {
@@ -719,6 +722,7 @@ export function createFrameRuntime(init: {
   namedFrames: Map<string, FrameHandle>
 }): FrameRuntime {
   return {
+    [FRAME_RUNTIME]: true,
     topFrame: init.topFrame,
     errorTarget: init.errorTarget,
     loadModule: init.loadModule,
@@ -831,7 +835,7 @@ function collectOwnedServerStyleTags(nodes: Node[], styles: HTMLStyleElement[]):
       continue
     }
 
-    if (node instanceof Element || node instanceof Document || node instanceof DocumentFragment) {
+    if (node.childNodes.length > 0) {
       collectOwnedServerStyleTags(Array.from(node.childNodes), styles)
     }
   }
@@ -1232,7 +1236,7 @@ export function publishFrameTemplate(id: string, fragment: DocumentFragment): vo
 
   for (let listener of listeners) {
     let clone = fragment.cloneNode(true)
-    invariant(clone instanceof DocumentFragment, 'Expected cloned frame template fragment')
+    invariant(isDocumentFragmentNode(clone), 'Expected cloned frame template fragment')
     listener(clone)
   }
 }
@@ -1458,7 +1462,7 @@ function createFragmentFromString(doc: Document, content: string): DocumentFragm
 function isRemixNodeFrameContent(content: InternalFrameContent): content is RemixNode {
   return !(
     content instanceof ReadableStream ||
-    content instanceof DocumentFragment ||
+    isDocumentFragmentNode(content) ||
     typeof content === 'string'
   )
 }
@@ -1500,7 +1504,7 @@ function walkCommentsInNodes(nodes: Node[], cb: (comment: Comment) => void): voi
       continue
     }
 
-    if (node instanceof Comment) cb(node)
+    if (isCommentNode(node)) cb(node)
     if (node.childNodes && node.childNodes.length > 0) {
       walkCommentsInNodes(Array.from(node.childNodes), cb)
     }
@@ -1516,11 +1520,11 @@ function isHydrationEnd(node: Comment): boolean {
 }
 
 function isHydratedVirtualRootMarker(node: Node): node is VirtualRootMarker {
-  return node instanceof Comment && '$rmx' in node
+  return isCommentNode(node) && '$rmx' in node
 }
 
 function isFrameStart(node: Node): node is Comment {
-  return node instanceof Comment && node.data.trim().startsWith('rmx:f:')
+  return isCommentNode(node) && node.data.trim().startsWith('rmx:f:')
 }
 
 function isFrameEnd(node: Comment): boolean {
@@ -1542,7 +1546,7 @@ function findEndMarker(
   let depth = 1
 
   while (node) {
-    if (node instanceof Comment) {
+    if (isCommentNode(node)) {
       let comment = node
       if (isStart(comment)) depth++
       else if (isEnd(comment)) {
@@ -1554,4 +1558,16 @@ function findEndMarker(
   }
 
   throw new Error('End marker not found')
+}
+
+function isCommentNode(node: Node | null | undefined): node is Comment {
+  return node?.nodeType === Node.COMMENT_NODE
+}
+
+function isDocumentFragmentNode(value: unknown): value is DocumentFragment {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Reflect.get(value, 'nodeType') === Node.DOCUMENT_FRAGMENT_NODE
+  )
 }

--- a/packages/ui/src/runtime/jsx.ts
+++ b/packages/ui/src/runtime/jsx.ts
@@ -1,7 +1,6 @@
 import type * as dom from './dom.d.ts'
 import type { Handle, RenderFn } from './component.ts'
 import { createRemixElement } from './core/vnode.ts'
-import type { Key } from './key.ts'
 
 /**
  * Any valid element type accepted by JSX or {@link import('./create-element.ts').createElement}.
@@ -27,7 +26,7 @@ export interface RemixElement {
   /** Normalized props for the element. */
   props: ElementProps
   /** Optional reconciliation key. */
-  key?: Key
+  key?: any
   /** Internal brand used to distinguish Remix elements at runtime. */
   $rmx: true
 }
@@ -98,8 +97,8 @@ export type Props<T extends keyof JSX.IntrinsicElements> = NormalizeMixProp<
  * @param key Optional reconciliation key.
  * @returns A Remix virtual element.
  */
-export function jsx(type: ElementType, props: ElementProps, key?: Key): RemixElement
-export function jsx(type: ElementType, props: ElementProps, key?: Key): RemixElement {
+export function jsx(type: ElementType, props: ElementProps, key?: any): RemixElement
+export function jsx(type: ElementType, props: ElementProps, key?: any): RemixElement {
   return createRemixElement(type, props, key)
 }
 
@@ -108,7 +107,7 @@ export { jsx as jsxDEV, jsx as jsxs }
 declare global {
   namespace JSX {
     export interface IntrinsicAttributes {
-      key?: Key
+      key?: any
     }
 
     type Element = RemixElement

--- a/packages/ui/src/runtime/jsx.ts
+++ b/packages/ui/src/runtime/jsx.ts
@@ -1,6 +1,7 @@
 import type * as dom from './dom.d.ts'
 import type { Handle, RenderFn } from './component.ts'
 import { createRemixElement } from './core/vnode.ts'
+import type { Key } from './key.ts'
 
 /**
  * Any valid element type accepted by JSX or {@link import('./create-element.ts').createElement}.
@@ -26,7 +27,7 @@ export interface RemixElement {
   /** Normalized props for the element. */
   props: ElementProps
   /** Optional reconciliation key. */
-  key?: any
+  key?: Key
   /** Internal brand used to distinguish Remix elements at runtime. */
   $rmx: true
 }
@@ -97,8 +98,8 @@ export type Props<T extends keyof JSX.IntrinsicElements> = NormalizeMixProp<
  * @param key Optional reconciliation key.
  * @returns A Remix virtual element.
  */
-export function jsx(type: ElementType, props: ElementProps, key?: string): RemixElement
-export function jsx(type: ElementType, props: ElementProps, key?: string): RemixElement {
+export function jsx(type: ElementType, props: ElementProps, key?: Key): RemixElement
+export function jsx(type: ElementType, props: ElementProps, key?: Key): RemixElement {
   return createRemixElement(type, props, key)
 }
 
@@ -107,7 +108,7 @@ export { jsx as jsxDEV, jsx as jsxs }
 declare global {
   namespace JSX {
     export interface IntrinsicAttributes {
-      key?: any
+      key?: Key
     }
 
     type Element = RemixElement

--- a/packages/ui/src/runtime/key.ts
+++ b/packages/ui/src/runtime/key.ts
@@ -1,0 +1,1 @@
+export type Key = any

--- a/packages/ui/src/runtime/key.ts
+++ b/packages/ui/src/runtime/key.ts
@@ -1,1 +1,1 @@
-export type Key = any
+export type Key = string | number | bigint

--- a/packages/ui/src/runtime/mixins/mixin.ts
+++ b/packages/ui/src/runtime/mixins/mixin.ts
@@ -1,5 +1,6 @@
 import type { Context, FrameHandle } from '../component.ts'
 import type { ElementProps, RemixElement } from '../jsx.ts'
+import type { Key } from '../key.ts'
 import type { Scheduler } from '../scheduler.ts'
 import type { SchedulerPhaseEvent } from '../scheduler.ts'
 import { jsx } from '../jsx.ts'
@@ -40,13 +41,13 @@ export type MixinElement<
 export type MixinInsertEvent<node extends EventTarget = Element> = Event & {
   node: node
   parent: ParentNode
-  key?: string
+  key?: Key
 }
 
 export type MixinReclaimedEvent<node extends EventTarget = Element> = Event & {
   node: node
   parent: ParentNode
-  key?: string
+  key?: Key
 }
 
 export type MixinUpdateEvent<node extends EventTarget = Element> = Event & {
@@ -93,7 +94,7 @@ export function renderMixinElement<
   node extends EventTarget = Element,
   props extends ElementProps = ElementProps,
 >(element: MixinElement<node, props>, props?: MixinProps<node, props>): RemixElement {
-  let { key, ...rest } = (props ?? {}) as MixinProps<node, props> & { key?: any }
+  let { key, ...rest } = (props ?? {}) as MixinProps<node, props> & { key?: Key }
   return jsx(element, rest, key)
 }
 
@@ -205,7 +206,7 @@ type MixinHandleFactoryOptions = {
 export type MixinRuntimeBinding = {
   node: Element
   parent: ParentNode
-  key?: string
+  key?: Key
   target: unknown
   frame: FrameHandle
   scheduler: Scheduler
@@ -701,7 +702,7 @@ function dispatchMixinInsert(
   scope: symbol,
   node: Element,
   parent: ParentNode,
-  key?: string,
+  key?: Key,
 ) {
   let event = new Event('insert') as MixinInsertEvent<Element>
   event.node = node
@@ -715,7 +716,7 @@ function dispatchMixinReclaimed(
   scope: symbol,
   node: Element,
   parent: ParentNode,
-  key?: string,
+  key?: Key,
 ) {
   let event = new Event('reclaimed') as MixinReclaimedEvent<Element>
   event.node = node
@@ -739,7 +740,7 @@ function queueMixinInsert(
   scope: symbol,
   node: Element,
   parent: ParentNode,
-  key?: string,
+  key?: Key,
 ) {
   handle.queueCommitTask(() => {
     dispatchMixinInsert(handle, scope, node, parent, key)
@@ -751,7 +752,7 @@ function queueMixinReclaimed(
   scope: symbol,
   node: Element,
   parent: ParentNode,
-  key?: string,
+  key?: Key,
 ) {
   handle.queueCommitTask(() => {
     dispatchMixinReclaimed(handle, scope, node, parent, key)

--- a/packages/ui/src/runtime/mixins/mixin.ts
+++ b/packages/ui/src/runtime/mixins/mixin.ts
@@ -174,6 +174,7 @@ type MixinReturn<node extends EventTarget = Element, props extends ElementProps 
 
 type AnyMixinType = MixinRuntimeType<unknown[], Element, ElementProps>
 type AnyMixinDescriptor = MixinDescriptor<Element, unknown[], ElementProps>
+export type MixinRuntimeValue = AnyMixinDescriptor | ReadonlyArray<AnyMixinDescriptor>
 type AnyMixinRunner = (
   ...args: [...unknown[], currentProps: ElementProps]
 ) => MixinReturn<Element, ElementProps>
@@ -203,11 +204,11 @@ type MixinHandleFactoryOptions = {
   getBinding: () => MixinRuntimeBinding | undefined
 }
 
-export type MixinRuntimeBinding = {
+export type MixinRuntimeBinding<target = unknown> = {
   node: Element
   parent: ParentNode
   key?: Key
-  target: unknown
+  target: target
   frame: FrameHandle
   scheduler: Scheduler
   enqueueUpdate(done: (signal: AbortSignal) => void): void
@@ -383,9 +384,9 @@ export function teardownMixins(state?: MixinRuntimeState) {
   finalizeMixinTeardown(state)
 }
 
-export function bindMixinRuntime(
+export function bindMixinRuntime<target>(
   state: MixinRuntimeState | undefined,
-  binding?: MixinRuntimeBinding,
+  binding?: MixinRuntimeBinding<target>,
   options?: { dispatchReclaimed?: boolean },
 ) {
   if (!state) return
@@ -898,7 +899,7 @@ function isRemixElement(value: unknown): value is RemixElement {
   return (value as { $rmx?: unknown }).$rmx === true
 }
 
-function isMixinDescriptor(value: unknown): value is AnyMixinDescriptor {
+export function isMixinDescriptor(value: unknown): value is AnyMixinDescriptor {
   if (!value || typeof value !== 'object' || isRemixElement(value)) {
     return false
   }

--- a/packages/ui/src/runtime/reconcile.ts
+++ b/packages/ui/src/runtime/reconcile.ts
@@ -1,7 +1,7 @@
 import type { Component, ComponentHandle, FrameContent, FrameHandle } from './component.ts'
 import { createComponent } from './component.ts'
 import type { FrameRuntime } from './frame.ts'
-import { createFrame } from './frame.ts'
+import { createFrame, isFrameRuntime } from './frame.ts'
 import { createRangeRoot } from './vdom.ts'
 import type {
   CommittedFragmentNode,
@@ -18,7 +18,7 @@ import type {
   HostNode,
   MountingComponentNode,
   ReconcileContext,
-  RuntimeElementProps,
+  RuntimeHostProps,
   TextNode,
   VNodeInput,
   VNodeParent,
@@ -76,7 +76,7 @@ function getSvgContext(vParent: VNodeParent, node: VNodeInput): boolean {
   return vParent._svg
 }
 
-function getHostProps(node: HostNode | CommittedHostNode): RuntimeElementProps {
+function getHostProps(node: HostNode | CommittedHostNode): RuntimeHostProps {
   return '_mixedProps' in node ? node._mixedProps : node.props
 }
 
@@ -161,7 +161,7 @@ function ensureControlledReflection(
   return state
 }
 
-function syncControlledReflection(node: CommittedHostNode, props: RuntimeElementProps): void {
+function syncControlledReflection(node: CommittedHostNode, props: RuntimeHostProps): void {
   let state = node._controlledState
   if (!state || state.disposed) return
 
@@ -174,7 +174,7 @@ function syncControlledReflection(node: CommittedHostNode, props: RuntimeElement
   state.pendingRestoreVersion++
 }
 
-function shouldTrackControlledReflection(props: RuntimeElementProps): boolean {
+function shouldTrackControlledReflection(props: RuntimeHostProps): boolean {
   return hasControlledValueProp(props) || hasControlledCheckedProp(props)
 }
 
@@ -230,11 +230,11 @@ function canManageValue(type: string, element: Element): boolean {
   return canReflectProperty(element, 'value')
 }
 
-function hasControlledValueProp(props: RuntimeElementProps): boolean {
+function hasControlledValueProp(props: RuntimeHostProps): boolean {
   return 'value' in props && props.value !== undefined
 }
 
-function hasControlledCheckedProp(props: RuntimeElementProps): boolean {
+function hasControlledCheckedProp(props: RuntimeHostProps): boolean {
   return 'checked' in props && props.checked !== undefined
 }
 
@@ -256,7 +256,7 @@ function setPropertyReflection(element: Element, key: string, value: unknown): v
 }
 
 type ResolvedHostProps = {
-  props: RuntimeElementProps
+  props: RuntimeHostProps
   mixState?: MixinRuntimeState
   directEventDescriptors?: OnMixinDescriptor[]
 }
@@ -302,9 +302,7 @@ function applyResolvedHostProps(node: CommittedHostNode, resolved: ResolvedHostP
   node._directEventDescriptors = resolved.directEventDescriptors
 }
 
-function resolveDirectEventDescriptors(
-  mix: RuntimeElementProps['mix'],
-): OnMixinDescriptor[] | null {
+function resolveDirectEventDescriptors(mix: RuntimeHostProps['mix']): OnMixinDescriptor[] | null {
   if (!mix) return EMPTY_DIRECT_EVENT_DESCRIPTORS
   if (!Array.isArray(mix)) {
     return isOnMixinDescriptor(mix) ? [mix] : null
@@ -321,10 +319,9 @@ function areOnMixinDescriptors(descriptors: unknown[]): descriptors is OnMixinDe
 }
 
 function enqueueMixinBindingUpdate(
-  this: MixinRuntimeBinding,
+  this: MixinRuntimeBinding<CommittedHostNode>,
   done: (signal: AbortSignal) => void,
 ): void {
-  invariant(isCommittedHostNode(this.target), 'Expected mixin target to be a mounted host node')
   let node = this.target
   let state = node._mixState
   this.scheduler.enqueueWork([
@@ -374,7 +371,7 @@ function bindNodeMixRuntime(
   )
 }
 
-function isHeadHostNode(node: HostNode): boolean {
+function isHeadHostNode(node: HostNode | CommittedHostNode): boolean {
   if (node.type === 'head') return true
   if (node.type.length !== 4) return false
   return node.type.toLowerCase() === 'head'
@@ -401,7 +398,7 @@ function commitNonRenderNode(
   parent: VNodeParent,
   svg: boolean,
 ): CommittedNonRenderNode {
-  let committed = node as CommittedNonRenderNode
+  let committed = node as unknown as CommittedNonRenderNode
   committed._parent = parent
   committed._svg = svg
   return committed
@@ -413,7 +410,7 @@ function commitTextNode(
   svg: boolean,
   dom: Text,
 ): CommittedTextNode {
-  let committed = node as CommittedTextNode
+  let committed = node as unknown as CommittedTextNode
   committed._parent = parent
   committed._svg = svg
   committed._dom = dom
@@ -425,7 +422,7 @@ function beginFragmentNode(
   parent: VNodeParent,
   svg: boolean,
 ): CommittedFragmentNode {
-  let committed = node as CommittedFragmentNode
+  let committed = node as unknown as CommittedFragmentNode
   committed._parent = parent
   committed._svg = svg
   committed._children = EMPTY_COMMITTED_CHILDREN
@@ -440,7 +437,7 @@ function commitHostNode(
   resolved: ResolvedHostProps,
   children: CommittedVNode[] = EMPTY_COMMITTED_CHILDREN,
 ): CommittedHostNode {
-  let committed = node as CommittedHostNode
+  let committed = node as unknown as CommittedHostNode
   committed._parent = parent
   committed._svg = svg
   committed._dom = dom
@@ -458,7 +455,7 @@ function beginComponentNode(
   handle: ComponentHandle,
   context: ReconcileContext,
 ): MountingComponentNode {
-  let mounting = node as MountingComponentNode
+  let mounting = node as unknown as MountingComponentNode
   mounting._parent = parent
   mounting._svg = svg
   mounting._handle = handle
@@ -475,10 +472,6 @@ function commitComponentNode(
   return committed
 }
 
-function commitChildren(children: VNodeInput[]): CommittedVNode[] {
-  return children as CommittedVNode[]
-}
-
 export function diffVNodes(
   curr: CommittedVNode | null,
   next: VNodeInput,
@@ -488,8 +481,6 @@ export function diffVNodes(
   anchor?: Node,
   cursor?: HydrationCursor,
 ): CommittedVNode {
-  let svg = getSvgContext(vParent, next)
-
   if (curr === null) {
     return insert(next, domParent, vParent, context, anchor, cursor)
   }
@@ -500,23 +491,19 @@ export function diffVNodes(
 
   switch (next.kind) {
     case 'host': {
-      invariant(curr.kind === 'host', 'Expected matching host node')
-      return diffHost(curr, next, vParent, context)
+      return diffHost(curr as CommittedHostNode, next, vParent, context)
     }
     case 'text': {
-      invariant(curr.kind === 'text', 'Expected matching text node')
-      return diffText(curr, next, vParent, svg)
+      return diffText(curr as CommittedTextNode, next, vParent, getSvgContext(vParent, next))
     }
     case 'empty': {
-      invariant(curr.kind === 'empty', 'Expected matching empty node')
-      return commitNonRenderNode(next, vParent, svg)
+      return commitNonRenderNode(next, vParent, getSvgContext(vParent, next))
     }
     case 'fragment': {
-      invariant(curr.kind === 'fragment', 'Expected matching fragment node')
       let childInputs = next._children
-      let committed = beginFragmentNode(next, vParent, svg)
+      let committed = beginFragmentNode(next, vParent, getSvgContext(vParent, next))
       committed._children = diffChildren(
-        curr._children,
+        (curr as CommittedFragmentNode)._children,
         childInputs,
         domParent,
         committed,
@@ -527,12 +514,27 @@ export function diffVNodes(
       return committed
     }
     case 'frame': {
-      invariant(curr.kind === 'frame', 'Expected matching frame node')
-      return diffFrame(curr, next, domParent, vParent, context, anchor)
+      return diffFrame(
+        curr as CommittedFrameNode,
+        next,
+        domParent,
+        vParent,
+        context,
+        getSvgContext(vParent, next),
+        anchor,
+      )
     }
     case 'component': {
-      invariant(curr.kind === 'component', 'Expected matching component node')
-      return diffComponent(curr, next, domParent, vParent, context, anchor, cursor)
+      return diffComponent(
+        curr as CommittedComponentNode,
+        next,
+        domParent,
+        vParent,
+        context,
+        getSvgContext(vParent, next),
+        anchor,
+        cursor,
+      )
     }
   }
 }
@@ -963,20 +965,21 @@ function insert(
   if (node.kind === 'fragment') {
     let childInputs = node._children
     let committed = beginFragmentNode(node, vParent, svg)
+    let children: Array<VNodeInput | CommittedVNode> = childInputs
     // Insert fragment children in order before the same anchor
     for (let i = 0; i < childInputs.length; i++) {
-      childInputs[i] = insert(childInputs[i], domParent, committed, context, anchor, cursor)
+      children[i] = insert(childInputs[i], domParent, committed, context, anchor, cursor)
     }
-    committed._children = commitChildren(childInputs)
+    committed._children = children as CommittedVNode[]
     return committed
   }
 
   if (node.kind === 'component') {
-    return diffComponent(null, node, domParent, vParent, context, anchor, cursor)
+    return diffComponent(null, node, domParent, vParent, context, svg, anchor, cursor)
   }
 
   if (node.kind === 'frame') {
-    return insertFrame(node, domParent, vParent, context, anchor, cursor)
+    return insertFrame(node, domParent, vParent, context, svg, anchor, cursor)
   }
 
   invariant(false, 'Unexpected node type')
@@ -988,6 +991,7 @@ function diffFrame(
   domParent: ParentNode,
   vParent: VNodeParent,
   context: ReconcileContext,
+  svg: boolean,
   anchor?: Node,
 ): CommittedFrameNode {
   let { frame } = context
@@ -999,31 +1003,28 @@ function diffFrame(
   if (currName !== nextName) {
     let replaceAnchor = curr._rangeEnd.nextSibling ?? anchor
     remove(curr, domParent, context)
-    return insertFrame(next, domParent, vParent, context, replaceAnchor)
+    return insertFrame(next, domParent, vParent, context, svg, replaceAnchor)
   }
 
   // If the frame hasn't resolved yet, preserve existing cancel/remount behavior
   // so pending streams from the old src cannot take over the new src.
-  if (currSrc !== nextSrc && !curr._frameResolved) {
+  if (currSrc !== nextSrc && !curr._state.resolved) {
     let replaceAnchor = curr._rangeEnd.nextSibling ?? anchor
     remove(curr, domParent, context)
-    return insertFrame(next, domParent, vParent, context, replaceAnchor)
+    return insertFrame(next, domParent, vParent, context, svg, replaceAnchor)
   }
 
-  let committed = Object.assign(next, {
+  let committed = next as unknown as CommittedFrameNode
+  Object.assign(committed, {
     _rangeStart: curr._rangeStart,
     _rangeEnd: curr._rangeEnd,
-    _frameInstance: curr._frameInstance,
-    _frameFallbackRoot: curr._frameFallbackRoot,
-    _frameResolveToken: curr._frameResolveToken,
-    _frameResolveController: curr._frameResolveController,
-    _frameResolved: curr._frameResolved,
+    _state: curr._state,
     _parent: vParent,
-    _svg: getSvgContext(vParent, next),
+    _svg: svg,
   })
 
   let frameRuntime = getFrameRuntime(frame)
-  let frameInstance = committed._frameInstance
+  let frameInstance = committed._state.instance
   let serverFrameReload = frameRuntime?.serverFrameReload
 
   if (currSrc !== nextSrc) {
@@ -1039,8 +1040,8 @@ function diffFrame(
     resolveClientFrame(committed, frameRuntime, serverFrameReload)
   }
 
-  if (!committed._frameResolved && committed._frameFallbackRoot) {
-    committed._frameFallbackRoot.render(committed.props.fallback ?? null)
+  if (!committed._state.resolved && committed._state.fallbackRoot) {
+    committed._state.fallbackRoot.render(committed.props.fallback ?? null)
   }
   return committed
 }
@@ -1050,6 +1051,7 @@ function insertFrame(
   domParent: ParentNode,
   vParent: VNodeParent,
   context: ReconcileContext,
+  svg: boolean,
   anchor?: Node,
   cursor?: HydrationCursor,
 ): CommittedFrameNode {
@@ -1092,16 +1094,18 @@ function insertFrame(
       }
 
       cursor.current = end.nextSibling
-      return Object.assign(node, {
+      return Object.assign(node as unknown as CommittedFrameNode, {
         _rangeStart: start,
         _rangeEnd: end,
         _parent: vParent,
-        _svg: getSvgContext(vParent, node),
-        _frameResolveToken: 0,
-        _frameResolveController: undefined,
-        _frameFallbackRoot: undefined,
-        _frameResolved: true,
-        _frameInstance: instance,
+        _svg: svg,
+        _state: {
+          instance,
+          resolveToken: 0,
+          resolveController: undefined,
+          fallbackRoot: undefined,
+          resolved: true,
+        },
       })
     }
   }
@@ -1138,16 +1142,18 @@ function insertFrame(
   })
   runtime.frameInstances.set(start, instance)
 
-  let committed = Object.assign(node, {
+  let committed = Object.assign(node as unknown as CommittedFrameNode, {
     _rangeStart: start,
     _rangeEnd: end,
     _parent: vParent,
-    _svg: getSvgContext(vParent, node),
-    _frameFallbackRoot: fallbackRoot,
-    _frameResolved: false,
-    _frameResolveToken: 0,
-    _frameResolveController: undefined,
-    _frameInstance: instance,
+    _svg: svg,
+    _state: {
+      instance,
+      fallbackRoot,
+      resolved: false,
+      resolveToken: 0,
+      resolveController: undefined,
+    },
   })
   resolveClientFrame(committed, runtime)
 
@@ -1160,11 +1166,12 @@ function resolveClientFrame(
   serverFrameReload?: { signal: AbortSignal },
 ): void {
   let frameSrc = getFrameSrc(node)
-  let instance = node._frameInstance
+  let state = node._state
+  let instance = state.instance
 
-  let token = node._frameResolveToken + 1
-  node._frameResolveToken = token
-  node._frameResolveController?.abort()
+  let token = state.resolveToken + 1
+  state.resolveToken = token
+  state.resolveController?.abort()
   let reload = serverFrameReload
     ? instance.beginClientFrameReloadForAncestorReload(serverFrameReload.signal)
     : undefined
@@ -1172,40 +1179,41 @@ function resolveClientFrame(
     instance.cancelReload()
   }
   let resolveController = reload?.controller ?? new AbortController()
-  node._frameResolveController = resolveController
+  state.resolveController = resolveController
 
   Promise.resolve()
     .then(() => runtime.resolveFrame(frameSrc, resolveController.signal, getFrameName(node)))
     .then(async (content) => {
-      if (node._frameResolveToken !== token || resolveController.signal.aborted) return
-      node._frameFallbackRoot?.dispose()
-      node._frameFallbackRoot = undefined
+      if (state.resolveToken !== token || resolveController.signal.aborted) return
+      state.fallbackRoot?.dispose()
+      state.fallbackRoot = undefined
       let nextContent = asAbortableFrameContent(content, resolveController.signal)
       await instance.render(nextContent, { signal: resolveController.signal })
-      if (node._frameResolveToken !== token || resolveController.signal.aborted) return
-      node._frameResolved = true
+      if (state.resolveToken !== token || resolveController.signal.aborted) return
+      state.resolved = true
     })
     .catch((error) => {
-      if (reload && node._frameResolveToken === token && !resolveController.signal.aborted) {
+      if (reload && state.resolveToken === token && !resolveController.signal.aborted) {
         runtime.errorTarget.dispatchEvent(createComponentErrorEvent(error))
       }
     })
     .finally(() => {
       reload?.complete()
-      if (node._frameResolveController === resolveController) {
-        node._frameResolveController = undefined
+      if (state.resolveController === resolveController) {
+        state.resolveController = undefined
       }
     })
 }
 
 function disposeFrameResources(node: CommittedFrameNode): void {
-  node._frameResolveToken++
-  node._frameResolveController?.abort()
-  node._frameResolveController = undefined
-  node._frameFallbackRoot?.dispose()
-  node._frameFallbackRoot = undefined
+  let state = node._state
+  state.resolveToken++
+  state.resolveController?.abort()
+  state.resolveController = undefined
+  state.fallbackRoot?.dispose()
+  state.fallbackRoot = undefined
 
-  node._frameInstance.dispose()
+  state.instance.dispose()
 }
 
 function asAbortableFrameContent(content: FrameContent, signal: AbortSignal): FrameContent {
@@ -1283,10 +1291,6 @@ function getFrameRuntime(frame: FrameHandle): FrameRuntime | undefined {
   return isFrameRuntime(runtime) ? runtime : undefined
 }
 
-function isFrameRuntime(value: unknown): value is FrameRuntime {
-  return typeof value === 'object' && value !== null && 'resolveFrame' in value
-}
-
 function getFrameSrc(node: FrameNode | CommittedFrameNode): string {
   return node.props.src
 }
@@ -1309,11 +1313,15 @@ function skipCommentsExceptFrameStart(cursor: Node | null): Node | null {
 }
 
 function isFrameStartComment(node: Node | null | undefined): node is Comment {
-  return node instanceof Comment && node.data.trim().startsWith('rmx:f:')
+  return isCommentNode(node) && node.data.trim().startsWith('rmx:f:')
 }
 
 function isFrameEndComment(node: Node | null | undefined): node is Comment {
-  return node instanceof Comment && node.data.trim() === '/rmx:f'
+  return isCommentNode(node) && node.data.trim() === '/rmx:f'
+}
+
+function isCommentNode(node: Node | null | undefined): node is Comment {
+  return node?.nodeType === Node.COMMENT_NODE
 }
 
 function getFrameIdFromComment(comment: Comment): string | undefined {
@@ -1369,6 +1377,7 @@ function diffComponent(
   domParent: ParentNode,
   vParent: VNodeParent,
   context: ReconcileContext,
+  svg: boolean,
   anchor?: Node,
   cursor?: HydrationCursor,
 ): CommittedComponentNode {
@@ -1394,17 +1403,11 @@ function diffComponent(
         return runtime?.topFrame
       },
     })
-    let mounting = beginComponentNode(next, vParent, getSvgContext(vParent, next), handle, context)
+    let mounting = beginComponentNode(next, vParent, svg, handle, context)
 
     return renderComponent(null, mounting, domParent, context, anchor, cursor)
   }
-  let mounting = beginComponentNode(
-    next,
-    vParent,
-    getSvgContext(vParent, next),
-    curr._handle,
-    context,
-  )
+  let mounting = beginComponentNode(next, vParent, svg, curr._handle, context)
   return renderComponent(curr._content, mounting, domParent, context, anchor, cursor)
 }
 
@@ -1543,15 +1546,16 @@ function diffChildren(
   anchor?: Node,
 ): CommittedVNode[] {
   let hasKeys = hasKeyedChildren(next)
+  let committed: Array<VNodeInput | CommittedVNode> = next
 
   if (curr === null) {
     if (hasKeys) {
       warnDuplicateKeys(next)
     }
     for (let i = 0; i < next.length; i++) {
-      next[i] = insert(next[i], domParent, vParent, context, anchor, cursor)
+      committed[i] = insert(next[i], domParent, vParent, context, anchor, cursor)
     }
-    return commitChildren(next)
+    return committed as CommittedVNode[]
   }
 
   if (
@@ -1570,7 +1574,7 @@ function diffChildren(
   if (!hasKeys) {
     for (let i = 0; i < next.length; i++) {
       let currentNode = i < curr.length ? curr[i] : null
-      next[i] = diffVNodes(currentNode, next[i], domParent, vParent, context, anchor, cursor)
+      committed[i] = diffVNodes(currentNode, next[i], domParent, vParent, context, anchor, cursor)
     }
 
     if (curr.length > next.length) {
@@ -1580,7 +1584,7 @@ function diffChildren(
       }
     }
 
-    return commitChildren(next)
+    return committed as CommittedVNode[]
   }
 
   return patchKeyedChildren(curr, next, domParent, vParent, context, cursor, anchor)
@@ -1668,6 +1672,7 @@ function patchKeyedChildren(
     warnDuplicateKeys(next)
     matches = matchKeyedChildren(curr, next)
   }
+  let committed: Array<VNodeInput | CommittedVNode> = next
 
   let matchAnalysis = analyzeKeyedChildMatches(curr.length, matches)
   if (matchAnalysis.hasRemovals) {
@@ -1691,12 +1696,12 @@ function patchKeyedChildren(
     let oldIndex = matches[index]
     let oldNode = oldIndex >= 0 ? curr[oldIndex] : null
 
-    next[index] = diffVNodes(oldNode, next[index], domParent, vParent, context, anchor, cursor)
+    committed[index] = diffVNodes(oldNode, next[index], domParent, vParent, context, anchor, cursor)
   }
-  let committed = commitChildren(next)
+  let committedChildren = committed as CommittedVNode[]
 
   if (matchAnalysis.canSkipPlacement) {
-    return committed
+    return committedChildren
   }
 
   let stableIndexes = lisMatches(matches)
@@ -1704,7 +1709,7 @@ function patchKeyedChildren(
   let placementAnchor: Node | null = anchor ?? null
 
   for (let index = next.length - 1; index >= 0; index--) {
-    let nextNode = committed[index]
+    let nextNode = committedChildren[index]
     let isStable = stableIndexes[stableCursor] === index
 
     if (isStable) {
@@ -1715,7 +1720,7 @@ function patchKeyedChildren(
 
     placementAnchor = findFirstDomAnchor(nextNode) ?? placementAnchor
   }
-  return committed
+  return committedChildren
 }
 
 // Keyed child matches are arrays of old indexes (-1 = no match / new node),
@@ -2029,7 +2034,7 @@ export function findNextSiblingDomAnchor(
     return null
   }
 
-  let idx = children.findIndex((child) => child === curr)
+  let idx = children.indexOf(curr as CommittedVNode)
   if (idx === -1) return null
   for (let i = idx + 1; i < children.length; i++) {
     let dom = findFirstDomAnchor(children[i])

--- a/packages/ui/src/runtime/reconcile.ts
+++ b/packages/ui/src/runtime/reconcile.ts
@@ -1,35 +1,42 @@
 import type { Component, ComponentHandle, FrameContent, FrameHandle } from './component.ts'
-import { createComponent, Fragment, Frame } from './component.ts'
-import type { Frame as FrameInstance, FrameRuntime } from './frame.ts'
+import { createComponent } from './component.ts'
+import type { FrameRuntime } from './frame.ts'
 import { createFrame } from './frame.ts'
 import { createRangeRoot } from './vdom.ts'
 import type {
+  CommittedFragmentNode,
+  CommittedFrameNode,
+  CommittedNonRenderNode,
   ComponentNode,
   CommittedComponentNode,
   CommittedHostNode,
   CommittedTextNode,
+  ControlledReflectionState,
+  DirectEventBinding,
+  DirectEventState,
+  FrameNode,
   HostNode,
+  MountingComponentNode,
+  ReconcileContext,
+  RuntimeElementProps,
   TextNode,
-  VNode,
-  VNodeType,
+  VNodeInput,
+  VNodeParent,
+  CommittedVNode,
 } from './vnode.ts'
 import {
   isCommittedComponentNode,
-  isComponentNode,
   isCommittedHostNode,
   isCommittedTextNode,
   isFragmentNode,
   isHostNode,
-  isNonRenderNode,
-  isTextNode,
   findContextFromAncestry,
-  TEXT_NODE,
-  NON_RENDER_NODE,
 } from './vnode.ts'
 import { invariant } from './invariant.ts'
 import { patchHostProps } from './core/props.ts'
 import type { StyleManager } from '../style/index.ts'
-import type { ElementProps } from './jsx.ts'
+import type { ElementFunction } from './element-function.ts'
+import type { Key } from './key.ts'
 import { skipComments, logHydrationMismatch } from './client-entries.ts'
 import type { Scheduler } from './scheduler.ts'
 import { toVNode } from './to-vnode.ts'
@@ -57,45 +64,41 @@ let activeSchedulerUpdateParents: ParentNode[] | undefined
 
 // Compute SVG context for a node based on its parent and type.
 // Returns true if the node is within an SVG subtree, false otherwise.
-function getSvgContext(vParent: VNode, nodeType: VNodeType): boolean {
+function getSvgContext(vParent: VNodeParent, node: VNodeInput): boolean {
   // Only host elements (strings) can affect SVG context
-  if (typeof nodeType === 'string') {
+  if (node.kind === 'host') {
     // svg element creates SVG context
-    if (nodeType === 'svg') return true
+    if (node.type === 'svg') return true
     // foreignObject switches back to HTML context
-    if (nodeType === 'foreignObject') return false
+    if (node.type === 'foreignObject') return false
   }
   // Otherwise inherit from parent
-  return vParent._svg ?? false
+  return vParent._svg
 }
 
-function getHostProps(node: HostNode | CommittedHostNode): ElementProps {
-  return node._mixedProps ?? node.props
+function getHostProps(node: HostNode | CommittedHostNode): RuntimeElementProps {
+  return '_mixedProps' in node ? node._mixedProps : node.props
 }
 
 function markNodePersistedByMixins(node: CommittedHostNode, domParent: ParentNode, token: number) {
-  node._persistedByMixins = true
-  node._persistedParentByMixins = domParent
-  node._persistedRemovalToken = token
+  node._persistence = { parent: domParent, token }
   persistedMixinNodes.add(node)
-  bindMixinRuntime(node._mixState as MixinRuntimeState | undefined, undefined)
+  bindMixinRuntime(node._mixState, undefined)
 }
 
 function unmarkNodePersistedByMixins(node: CommittedHostNode) {
-  node._persistedByMixins = false
-  node._persistedParentByMixins = undefined
-  node._persistedRemovalToken = undefined
+  node._persistence = undefined
   persistedMixinNodes.delete(node)
 }
 
 function findMatchingPersistedMixinNode(
   type: string,
-  key: string | undefined,
+  key: Key | undefined,
   domParent: ParentNode,
 ): CommittedHostNode | null {
   if (key == null) return null
   for (let node of persistedMixinNodes) {
-    if (node._persistedParentByMixins !== domParent) continue
+    if (node._persistence?.parent !== domParent) continue
     if (node.type !== type) continue
     if (node.key !== key) continue
     return node
@@ -103,33 +106,10 @@ function findMatchingPersistedMixinNode(
   return null
 }
 
-type ControlledReflectionState = {
-  disposed: boolean
-  listenersAttached: boolean
-  pendingRestoreVersion: number
-  managesValue: boolean
-  managesChecked: boolean
-  hasControlledValue: boolean
-  controlledValue: unknown
-  hasControlledChecked: boolean
-  controlledChecked: unknown
-  onInput: () => void
-  onChange: () => void
-}
-
-type DirectEventBinding = {
-  type: string
-  handler: (event: Event, signal: AbortSignal) => void | Promise<void>
-  capture: boolean
-  stableHandler: ((event: Event) => void) | null
-  reentry: AbortController | null
-}
-
-type DirectEventState = {
-  bindings: DirectEventBinding[]
-}
-
 const EMPTY_DIRECT_EVENT_DESCRIPTORS: OnMixinDescriptor[] = []
+const EMPTY_COMMITTED_CHILDREN: CommittedVNode[] = []
+
+type HydrationCursor = { current: Node | null | undefined }
 
 function shouldRestoreControlledReflectionOnInput(
   node: CommittedHostNode,
@@ -147,7 +127,7 @@ function ensureControlledReflection(
   node: CommittedHostNode,
   scheduler: Scheduler,
 ): ControlledReflectionState {
-  let existing = node._controlledState as ControlledReflectionState | undefined
+  let existing = node._controlledState
   if (existing) return existing
 
   let state: ControlledReflectionState = {
@@ -181,8 +161,8 @@ function ensureControlledReflection(
   return state
 }
 
-function syncControlledReflection(node: CommittedHostNode, props: ElementProps): void {
-  let state = node._controlledState as ControlledReflectionState | undefined
+function syncControlledReflection(node: CommittedHostNode, props: RuntimeElementProps): void {
+  let state = node._controlledState
   if (!state || state.disposed) return
 
   state.managesValue = canManageValue(node.type, node._dom)
@@ -194,7 +174,7 @@ function syncControlledReflection(node: CommittedHostNode, props: ElementProps):
   state.pendingRestoreVersion++
 }
 
-function shouldTrackControlledReflection(props: ElementProps): boolean {
+function shouldTrackControlledReflection(props: RuntimeElementProps): boolean {
   return hasControlledValueProp(props) || hasControlledCheckedProp(props)
 }
 
@@ -225,7 +205,7 @@ function restoreControlledReflections(
 }
 
 function teardownControlledReflection(node: CommittedHostNode): void {
-  let state = node._controlledState as ControlledReflectionState | undefined
+  let state = node._controlledState
   if (!state) return
   state.disposed = true
   state.pendingRestoreVersion++
@@ -238,7 +218,7 @@ function teardownControlledReflection(node: CommittedHostNode): void {
 
 // See abandonDirectEventListeners: skips removeEventListener for discarded subtrees.
 function abandonControlledReflection(node: CommittedHostNode): void {
-  let state = node._controlledState as ControlledReflectionState | undefined
+  let state = node._controlledState
   if (!state) return
   state.disposed = true
   state.pendingRestoreVersion++
@@ -250,11 +230,11 @@ function canManageValue(type: string, element: Element): boolean {
   return canReflectProperty(element, 'value')
 }
 
-function hasControlledValueProp(props: ElementProps): boolean {
+function hasControlledValueProp(props: RuntimeElementProps): boolean {
   return 'value' in props && props.value !== undefined
 }
 
-function hasControlledCheckedProp(props: ElementProps): boolean {
+function hasControlledCheckedProp(props: RuntimeElementProps): boolean {
   return 'checked' in props && props.checked !== undefined
 }
 
@@ -275,29 +255,28 @@ function setPropertyReflection(element: Element, key: string, value: unknown): v
   element[key] = value == null ? '' : value
 }
 
+type ResolvedHostProps = {
+  props: RuntimeElementProps
+  mixState?: MixinRuntimeState
+  directEventDescriptors?: OnMixinDescriptor[]
+}
+
 function resolveNodeMixProps(
-  node: HostNode,
+  node: HostNode | CommittedHostNode,
+  parent: VNodeParent,
   frame: FrameHandle,
   scheduler: Scheduler,
   state?: MixinRuntimeState,
-): ElementProps {
+): ResolvedHostProps {
   let mix = node.props.mix
   let directEventDescriptors = resolveDirectEventDescriptors(mix)
   if (directEventDescriptors) {
-    if (state) {
-      teardownMixins(state)
-    }
-    node._mixState = undefined
-    node._mixedProps = node.props
-    node._directEventDescriptors = directEventDescriptors
-    return node.props
+    if (state) teardownMixins(state)
+    return { props: node.props, directEventDescriptors }
   }
 
-  node._directEventDescriptors = undefined
   if (state == null && (mix == null || (Array.isArray(mix) && mix.length === 0))) {
-    node._mixState = undefined
-    node._mixedProps = node.props
-    return node.props
+    return { props: node.props }
   }
 
   let resolved = resolveMixedProps({
@@ -309,17 +288,23 @@ function resolveNodeMixProps(
         return undefined
       }
 
-      return findContextFromAncestry(node, type as Component)
+      return findContextFromAncestry(parent, type)
     },
     props: node.props,
     state,
   })
-  node._mixState = resolved.state
-  node._mixedProps = resolved.props
-  return resolved.props
+  return { props: resolved.props, mixState: resolved.state }
 }
 
-function resolveDirectEventDescriptors(mix: ElementProps['mix']): OnMixinDescriptor[] | null {
+function applyResolvedHostProps(node: CommittedHostNode, resolved: ResolvedHostProps): void {
+  node._mixedProps = resolved.props
+  node._mixState = resolved.mixState
+  node._directEventDescriptors = resolved.directEventDescriptors
+}
+
+function resolveDirectEventDescriptors(
+  mix: RuntimeElementProps['mix'],
+): OnMixinDescriptor[] | null {
   if (!mix) return EMPTY_DIRECT_EVENT_DESCRIPTORS
   if (!Array.isArray(mix)) {
     return isOnMixinDescriptor(mix) ? [mix] : null
@@ -339,8 +324,9 @@ function enqueueMixinBindingUpdate(
   this: MixinRuntimeBinding,
   done: (signal: AbortSignal) => void,
 ): void {
-  let node = this.target as CommittedHostNode
-  let state = node._mixState as MixinRuntimeState | undefined
+  invariant(isCommittedHostNode(this.target), 'Expected mixin target to be a mounted host node')
+  let node = this.target
+  let state = node._mixState
   this.scheduler.enqueueWork([
     () => {
       if (state?.aborted) {
@@ -350,11 +336,12 @@ function enqueueMixinBindingUpdate(
 
       dispatchMixinBeforeUpdate(state)
       let prevProps = getHostProps(node)
-      let nextProps = resolveNodeMixProps(node, this.frame, this.scheduler, state)
-      patchHostProps(prevProps, nextProps, this.node)
-      if (node._controlledState || shouldTrackControlledReflection(nextProps)) {
+      let resolved = resolveNodeMixProps(node, node._parent, this.frame, this.scheduler, state)
+      applyResolvedHostProps(node, resolved)
+      patchHostProps(prevProps, resolved.props, this.node)
+      if (node._controlledState || shouldTrackControlledReflection(resolved.props)) {
         ensureControlledReflection(node, this.scheduler)
-        syncControlledReflection(node, nextProps)
+        syncControlledReflection(node, resolved.props)
       }
 
       dispatchMixinCommit(state)
@@ -371,12 +358,12 @@ function bindNodeMixRuntime(
   reclaimed: boolean = false,
   parent?: ParentNode,
 ) {
-  let state = node._mixState as MixinRuntimeState | undefined
+  let state = node._mixState
   bindMixinRuntime(
     state,
     {
       node: node._dom,
-      parent: parent ?? (node._dom.parentNode as ParentNode),
+      parent: parent ?? getRequiredDomParent(node._dom),
       key: node.key,
       target: node,
       frame,
@@ -393,6 +380,12 @@ function isHeadHostNode(node: HostNode): boolean {
   return node.type.toLowerCase() === 'head'
 }
 
+function getRequiredDomParent(node: Node): ParentNode {
+  let parent = node.parentNode
+  invariant(parent, 'Expected mounted host node to have a DOM parent')
+  return parent
+}
+
 function getDocumentHead(domParent: ParentNode): HTMLHeadElement | null {
   if (domParent instanceof Document) {
     return domParent.head
@@ -403,148 +396,185 @@ function getDocumentHead(domParent: ParentNode): HTMLHeadElement | null {
   return null
 }
 
+function commitNonRenderNode(
+  node: VNodeInput & { kind: 'empty' },
+  parent: VNodeParent,
+  svg: boolean,
+): CommittedNonRenderNode {
+  let committed = node as CommittedNonRenderNode
+  committed._parent = parent
+  committed._svg = svg
+  return committed
+}
+
+function commitTextNode(
+  node: TextNode,
+  parent: VNodeParent,
+  svg: boolean,
+  dom: Text,
+): CommittedTextNode {
+  let committed = node as CommittedTextNode
+  committed._parent = parent
+  committed._svg = svg
+  committed._dom = dom
+  return committed
+}
+
+function beginFragmentNode(
+  node: VNodeInput & { kind: 'fragment' },
+  parent: VNodeParent,
+  svg: boolean,
+): CommittedFragmentNode {
+  let committed = node as CommittedFragmentNode
+  committed._parent = parent
+  committed._svg = svg
+  committed._children = EMPTY_COMMITTED_CHILDREN
+  return committed
+}
+
+function commitHostNode(
+  node: HostNode,
+  parent: VNodeParent,
+  svg: boolean,
+  dom: Element,
+  resolved: ResolvedHostProps,
+  children: CommittedVNode[] = EMPTY_COMMITTED_CHILDREN,
+): CommittedHostNode {
+  let committed = node as CommittedHostNode
+  committed._parent = parent
+  committed._svg = svg
+  committed._dom = dom
+  committed._children = children
+  committed._mixedProps = resolved.props
+  committed._mixState = resolved.mixState
+  committed._directEventDescriptors = resolved.directEventDescriptors
+  return committed
+}
+
+function beginComponentNode(
+  node: ComponentNode,
+  parent: VNodeParent,
+  svg: boolean,
+  handle: ComponentHandle,
+  context: ReconcileContext,
+): MountingComponentNode {
+  let mounting = node as MountingComponentNode
+  mounting._parent = parent
+  mounting._svg = svg
+  mounting._handle = handle
+  mounting._context = context
+  return mounting
+}
+
+function commitComponentNode(
+  node: MountingComponentNode,
+  content: CommittedVNode,
+): CommittedComponentNode {
+  let committed = node as CommittedComponentNode
+  committed._content = content
+  return committed
+}
+
+function commitChildren(children: VNodeInput[]): CommittedVNode[] {
+  return children as CommittedVNode[]
+}
+
 export function diffVNodes(
-  curr: VNode | null,
-  next: VNode,
+  curr: CommittedVNode | null,
+  next: VNodeInput,
   domParent: ParentNode,
-  frame: FrameHandle,
-  scheduler: Scheduler,
-  styles: StyleManager,
-  vParent: VNode,
-  rootTarget: EventTarget,
+  vParent: VNodeParent,
+  context: ReconcileContext,
   anchor?: Node,
-  rootCursor?: Node | null,
-): Node | null | undefined {
-  let type = next.type
-  next._parent = vParent // set parent for initial render context lookups
-  next._svg = getSvgContext(vParent, type)
+  cursor?: HydrationCursor,
+): CommittedVNode {
+  let svg = getSvgContext(vParent, next)
 
-  // new
   if (curr === null) {
-    return insert(
-      next,
-      domParent,
-      frame,
-      scheduler,
-      styles,
-      vParent,
-      rootTarget,
-      anchor,
-      rootCursor,
-    )
+    return insert(next, domParent, vParent, context, anchor, cursor)
   }
 
-  if (curr.type !== type) {
-    replace(curr, next, domParent, frame, scheduler, styles, vParent, rootTarget, anchor)
-    return rootCursor
+  if (curr.kind !== next.kind || curr.type !== next.type) {
+    return replace(curr, next, domParent, vParent, context, anchor)
   }
 
-  // curr.type === next.type from here, so a single check on `type` dispatches
-  // both nodes — this runs for every vnode pair on every update.
-  if (typeof type === 'string') {
-    diffHost(
-      curr as CommittedHostNode,
-      next as HostNode,
-      frame,
-      scheduler,
-      styles,
-      vParent,
-      rootTarget,
-    )
-    return rootCursor
+  switch (next.kind) {
+    case 'host': {
+      invariant(curr.kind === 'host', 'Expected matching host node')
+      return diffHost(curr, next, vParent, context)
+    }
+    case 'text': {
+      invariant(curr.kind === 'text', 'Expected matching text node')
+      return diffText(curr, next, vParent, svg)
+    }
+    case 'empty': {
+      invariant(curr.kind === 'empty', 'Expected matching empty node')
+      return commitNonRenderNode(next, vParent, svg)
+    }
+    case 'fragment': {
+      invariant(curr.kind === 'fragment', 'Expected matching fragment node')
+      let childInputs = next._children
+      let committed = beginFragmentNode(next, vParent, svg)
+      committed._children = diffChildren(
+        curr._children,
+        childInputs,
+        domParent,
+        committed,
+        context,
+        undefined,
+        anchor,
+      )
+      return committed
+    }
+    case 'frame': {
+      invariant(curr.kind === 'frame', 'Expected matching frame node')
+      return diffFrame(curr, next, domParent, vParent, context, anchor)
+    }
+    case 'component': {
+      invariant(curr.kind === 'component', 'Expected matching component node')
+      return diffComponent(curr, next, domParent, vParent, context, anchor, cursor)
+    }
   }
-
-  if (type === TEXT_NODE) {
-    diffText(curr as CommittedTextNode, next as TextNode, vParent)
-    return rootCursor
-  }
-
-  if (type === NON_RENDER_NODE) {
-    return rootCursor
-  }
-
-  if (type === Fragment) {
-    diffChildren(
-      curr._children!,
-      next._children!,
-      domParent,
-      frame,
-      scheduler,
-      styles,
-      next,
-      rootTarget,
-      undefined,
-      anchor,
-    )
-    return rootCursor
-  }
-
-  if (type === Frame) {
-    diffFrame(curr, next, domParent, frame, scheduler, styles, vParent, rootTarget, anchor)
-    return rootCursor
-  }
-
-  if (typeof type === 'function') {
-    diffComponent(
-      curr as CommittedComponentNode,
-      next as ComponentNode,
-      frame,
-      scheduler,
-      styles,
-      domParent,
-      vParent,
-      rootTarget,
-      anchor,
-      rootCursor,
-    )
-    return rootCursor
-  }
-
-  invariant(false, 'Unexpected diff case')
 }
 
 function replace(
-  curr: VNode,
-  next: VNode,
+  curr: CommittedVNode,
+  next: VNodeInput,
   domParent: ParentNode,
-  frame: FrameHandle,
-  scheduler: Scheduler,
-  styles: StyleManager,
-  vParent: VNode,
-  rootTarget: EventTarget,
+  vParent: VNodeParent,
+  context: ReconcileContext,
   anchor?: Node,
-) {
+): CommittedVNode {
   let currAnchor = findFirstDomAnchor(curr)
   if (currAnchor && currAnchor.parentNode === domParent) {
     let replacementAnchor = document.createComment('rmx:replace')
     domParent.insertBefore(replacementAnchor, currAnchor)
     try {
-      remove(curr, domParent, scheduler, styles)
-      insert(next, domParent, frame, scheduler, styles, vParent, rootTarget, replacementAnchor)
+      remove(curr, domParent, context)
+      return insert(next, domParent, vParent, context, replacementAnchor)
     } finally {
       replacementAnchor.parentNode?.removeChild(replacementAnchor)
     }
-    return
   }
 
   let replacementAnchor = findNextSiblingDomAnchor(curr) ?? anchor
-  remove(curr, domParent, scheduler, styles)
-  insert(next, domParent, frame, scheduler, styles, vParent, rootTarget, replacementAnchor)
+  remove(curr, domParent, context)
+  return insert(next, domParent, vParent, context, replacementAnchor)
 }
 
 function diffHost(
   curr: CommittedHostNode,
   next: HostNode,
-  frame: FrameHandle,
-  scheduler: Scheduler,
-  styles: StyleManager,
-  vParent: VNode,
-  rootTarget: EventTarget,
-) {
-  let mixState = curr._mixState as MixinRuntimeState | undefined
+  vParent: VNodeParent,
+  context: ReconcileContext,
+): CommittedHostNode {
+  let { frame, scheduler, styles } = context
+  let mixState = curr._mixState
   let currProps = getHostProps(curr)
-  let nextProps = resolveNodeMixProps(next, frame, scheduler, mixState)
-  let nextMixState = next._mixState as MixinRuntimeState | undefined
+  let resolved = resolveNodeMixProps(next, vParent, frame, scheduler, mixState)
+  let childInputs = next._children
+  let nextProps = resolved.props
+  let nextMixState = resolved.mixState
   let shouldDispatchMixinLifecycle =
     (nextMixState?.runners.length ?? 0) > 0 && shouldDispatchInlineMixinLifecycle(curr._dom)
   if (shouldDispatchMixinLifecycle) {
@@ -555,61 +585,49 @@ function diffHost(
   if (nextProps.innerHTML != null) {
     // innerHTML is set, update it if changed
     if (currProps.innerHTML !== nextProps.innerHTML) {
-      curr._dom.innerHTML = nextProps.innerHTML as string
+      curr._dom.innerHTML = nextProps.innerHTML
     }
   } else if (currProps.innerHTML != null) {
     // innerHTML was removed, clear it before adding children
     curr._dom.innerHTML = ''
   }
 
-  diffChildren(
-    curr._children,
-    next._children,
-    curr._dom,
-    frame,
-    scheduler,
-    styles,
-    next,
-    rootTarget,
-  )
+  let committed = commitHostNode(next, vParent, getSvgContext(vParent, next), curr._dom, resolved)
+  committed._directEventState = curr._directEventState
+  committed._controlledState = curr._controlledState
+  committed._children = diffChildren(curr._children, childInputs, curr._dom, committed, context)
   patchHostProps(currProps, nextProps, curr._dom)
 
-  next._dom = curr._dom
-  next._parent = vParent
-  next._directEventState = curr._directEventState
-  next._controlledState = curr._controlledState
-  syncDirectEventListeners(next as CommittedHostNode)
+  syncDirectEventListeners(committed)
 
-  if (next._controlledState || shouldTrackControlledReflection(nextProps)) {
-    ensureControlledReflection(next as CommittedHostNode, scheduler)
-    syncControlledReflection(next as CommittedHostNode, nextProps)
+  if (committed._controlledState || shouldTrackControlledReflection(nextProps)) {
+    ensureControlledReflection(committed, scheduler)
+    syncControlledReflection(committed, nextProps)
   }
 
-  if (next._mixState) {
-    bindNodeMixRuntime(next as CommittedHostNode, frame, scheduler, styles)
+  if (committed._mixState) {
+    bindNodeMixRuntime(committed, frame, scheduler, styles)
   }
   if (shouldDispatchMixinLifecycle) {
     scheduler.enqueueCommitPhase([() => dispatchMixinCommit(nextMixState)])
   }
 
-  return
+  return committed
 }
 
-function setupHostNode(node: HostNode, dom: Element, scheduler: Scheduler): void {
-  node._dom = dom
+function setupHostNode(node: CommittedHostNode, scheduler: Scheduler): void {
   let props = getHostProps(node)
-  let committedNode = node as CommittedHostNode
 
-  syncDirectEventListeners(committedNode)
+  syncDirectEventListeners(node)
 
   if (shouldTrackControlledReflection(props)) {
-    ensureControlledReflection(committedNode, scheduler)
-    syncControlledReflection(committedNode, props)
+    ensureControlledReflection(node, scheduler)
+    syncControlledReflection(node, props)
   }
 }
 
 function syncDirectEventListeners(node: CommittedHostNode): void {
-  let descriptors = node._directEventDescriptors as OnMixinDescriptor[] | undefined
+  let descriptors = node._directEventDescriptors
   if (!descriptors) {
     teardownDirectEventListeners(node)
     return
@@ -619,7 +637,7 @@ function syncDirectEventListeners(node: CommittedHostNode): void {
     return
   }
 
-  let state = node._directEventState as DirectEventState | undefined
+  let state = node._directEventState
   if (!state) {
     state = { bindings: [] }
     node._directEventState = state
@@ -696,7 +714,7 @@ function removeDirectEventBinding(dom: Element, binding: DirectEventBinding): vo
 }
 
 function teardownDirectEventListeners(node: CommittedHostNode): void {
-  let state = node._directEventState as DirectEventState | undefined
+  let state = node._directEventState
   if (!state) return
 
   for (let binding of state.bindings) {
@@ -711,7 +729,7 @@ function teardownDirectEventListeners(node: CommittedHostNode): void {
 // pending handler work but skip removeEventListener — the listeners die with
 // the detached node, and removing them one-by-one dominates large teardowns.
 function abandonDirectEventListeners(node: CommittedHostNode): void {
-  let state = node._directEventState as DirectEventState | undefined
+  let state = node._directEventState
   if (!state) return
 
   for (let binding of state.bindings) {
@@ -729,32 +747,34 @@ function invokeDirectEventBinding(binding: DirectEventBinding, event: Event): vo
   void binding.handler(event, binding.reentry.signal)
 }
 
-function diffText(curr: CommittedTextNode, next: TextNode, vParent: VNode) {
+function diffText(
+  curr: CommittedTextNode,
+  next: TextNode,
+  vParent: VNodeParent,
+  svg: boolean,
+): CommittedTextNode {
   if (curr._text !== next._text) {
     curr._dom.textContent = next._text
   }
-  next._dom = curr._dom
-  next._parent = vParent
+  return commitTextNode(next, vParent, svg, curr._dom)
 }
 
 function insert(
-  node: VNode,
+  node: VNodeInput,
   domParent: ParentNode,
-  frame: FrameHandle,
-  scheduler: Scheduler,
-  styles: StyleManager,
-  vParent: VNode,
-  rootTarget: EventTarget,
+  vParent: VNodeParent,
+  context: ReconcileContext,
   anchor?: Node,
-  cursor?: Node | null,
-): Node | null | undefined {
-  node._parent = vParent // set parent for initial render context lookups
-  node._svg = getSvgContext(vParent, node.type)
+  cursor?: HydrationCursor,
+): CommittedVNode {
+  let { frame, scheduler, styles } = context
+  let svg = getSvgContext(vParent, node)
+  let hydrationNode = cursor?.current
 
   // Stop hydration if cursor has reached the anchor (end boundary)
   // Check BEFORE skipComments to prevent escaping range root markers
-  if (cursor && anchor && cursor === anchor) {
-    cursor = null
+  if (hydrationNode && anchor && hydrationNode === anchor) {
+    hydrationNode = null
   }
 
   // Preserve frame-start markers for non-Frame nodes too, so a following <Frame>
@@ -762,281 +782,248 @@ function insert(
   // claim its rmx:f marker during hydration instead of being re-inserted fresh.
   // A rmx:f marker always belongs to a <Frame>, so no non-Frame node should
   // consume one.
-  cursor = skipCommentsExceptFrameStart(cursor ?? null)
+  hydrationNode = skipCommentsExceptFrameStart(hydrationNode ?? null)
 
   // Also check after skipComments in case we skipped past the anchor
-  if (cursor && anchor && cursor === anchor) {
-    cursor = null
+  if (hydrationNode && anchor && hydrationNode === anchor) {
+    hydrationNode = null
   }
+  if (cursor) cursor.current = hydrationNode
 
   let doInsert = anchor
     ? (dom: Node) => domParent.insertBefore(dom, anchor)
     : (dom: Node) => domParent.appendChild(dom)
 
-  if (isNonRenderNode(node)) {
-    return cursor
+  if (node.kind === 'empty') {
+    return commitNonRenderNode(node, vParent, svg)
   }
 
-  if (isTextNode(node)) {
-    if (cursor instanceof Text) {
-      node._parent = vParent
+  if (node.kind === 'text') {
+    if (hydrationNode instanceof Text) {
       // Handle text node consolidation: server renders adjacent text as single node
       // e.g., <span>Hello {world}</span> → server: "Hello world", client: ["Hello ", "world"]
-      if (cursor.data !== node._text) {
-        if (cursor.data.startsWith(node._text) && node._text.length < cursor.data.length) {
+      if (hydrationNode.data !== node._text) {
+        if (
+          hydrationNode.data.startsWith(node._text) &&
+          node._text.length < hydrationNode.data.length
+        ) {
           // Consolidation case: split the text node at the boundary
           // cursor becomes the first part (node._text), remainder is returned for next vnode
-          let remainder = cursor.splitText(node._text.length)
-          node._dom = cursor
-          return remainder
+          let remainder = hydrationNode.splitText(node._text.length)
+          if (cursor) cursor.current = remainder
+          return commitTextNode(node, vParent, svg, hydrationNode)
         }
         // Genuine mismatch - correct it
-        logHydrationMismatch('text mismatch', cursor.data, node._text)
-        cursor.data = node._text
+        logHydrationMismatch('text mismatch', hydrationNode.data, node._text)
+        hydrationNode.data = node._text
       }
-      node._dom = cursor
-      return cursor.nextSibling
+      if (cursor) cursor.current = hydrationNode.nextSibling
+      return commitTextNode(node, vParent, svg, hydrationNode)
     }
     let dom = document.createTextNode(node._text)
-    node._dom = dom
-    node._parent = vParent
     doInsert(dom)
-    return cursor
+    return commitTextNode(node, vParent, svg, dom)
   }
 
-  if (isHostNode(node)) {
-    let hostProps = resolveNodeMixProps(node, frame, scheduler)
+  if (node.kind === 'host') {
+    let resolved = resolveNodeMixProps(node, vParent, frame, scheduler)
+    let hostProps = resolved.props
+    let childInputs = node._children
 
     if (isHeadHostNode(node)) {
       let targetHead = getDocumentHead(domParent)
       if (targetHead) {
-        let childCursor = cursor
-        if (cursor instanceof Element && cursor.tagName.toLowerCase() === 'head') {
-          childCursor = cursor.firstChild
-          let nextCursor = cursor.nextSibling
-          if (cursor !== targetHead) {
-            while (cursor.firstChild) {
-              targetHead.appendChild(cursor.firstChild)
+        let childCursor = cursor ? { current: hydrationNode } : undefined
+        if (hydrationNode instanceof Element && hydrationNode.tagName.toLowerCase() === 'head') {
+          if (childCursor) childCursor.current = hydrationNode.firstChild
+          let nextCursor = hydrationNode.nextSibling
+          if (hydrationNode !== targetHead) {
+            while (hydrationNode.firstChild) {
+              targetHead.appendChild(hydrationNode.firstChild)
             }
-            cursor.remove()
+            hydrationNode.remove()
           }
-          cursor = nextCursor
+          if (cursor) cursor.current = nextCursor
         }
 
+        let committed = commitHostNode(node, vParent, svg, targetHead, resolved)
         // Render explicit <head> children directly into document.head.
-        diffChildren(
+        committed._children = diffChildren(
           null,
-          node._children,
+          childInputs,
           targetHead,
-          frame,
-          scheduler,
-          styles,
-          node,
-          rootTarget,
+          committed,
+          context,
           childCursor,
         )
         patchHostProps({}, hostProps, targetHead)
-        setupHostNode(node, targetHead, scheduler)
-        if (node._mixState) {
-          bindNodeMixRuntime(node as CommittedHostNode, frame, scheduler, styles)
+        setupHostNode(committed, scheduler)
+        if (committed._mixState) {
+          bindNodeMixRuntime(committed, frame, scheduler, styles)
         }
-        return cursor
+        return committed
       }
     }
 
     // Check for matching mixin-persisted node that can be reclaimed
     let persistedNode = findMatchingPersistedMixinNode(node.type, node.key, domParent)
     if (persistedNode) {
-      reclaimPersistedMixinNode(persistedNode, node, frame, scheduler, styles, vParent, rootTarget)
-      return cursor
+      return reclaimPersistedMixinNode(persistedNode, node, vParent, context)
     }
 
-    if (cursor instanceof Element) {
+    if (hydrationNode instanceof Element) {
       // SVG elements have case-sensitive tag names (e.g. linearGradient, clipPath)
       // HTML elements are case-insensitive, so we lowercase for comparison
-      let cursorTag = node._svg ? cursor.tagName : cursor.tagName.toLowerCase()
+      let cursorTag = svg ? hydrationNode.tagName : hydrationNode.tagName.toLowerCase()
       if (cursorTag === node.type) {
-        let nextCursor = cursor.nextSibling
-        patchHostProps({}, hostProps, cursor)
+        let nextCursor = hydrationNode.nextSibling
+        patchHostProps({}, hostProps, hydrationNode)
+        let committed = commitHostNode(node, vParent, svg, hydrationNode, resolved)
 
         // Handle innerHTML prop
         if (hostProps.innerHTML != null) {
-          cursor.innerHTML = hostProps.innerHTML as string
+          hydrationNode.innerHTML = hostProps.innerHTML
         } else {
-          let childCursor = cursor.firstChild
+          let childCursor = { current: hydrationNode.firstChild }
           // Ignore excess nodes - browser extensions may inject content
-          diffChildren(
+          committed._children = diffChildren(
             null,
-            node._children,
-            cursor,
-            frame,
-            scheduler,
-            styles,
-            node,
-            rootTarget,
+            childInputs,
+            hydrationNode,
+            committed,
+            context,
             childCursor,
           )
         }
 
-        setupHostNode(node, cursor, scheduler)
-        if (node._mixState) {
-          bindNodeMixRuntime(node as CommittedHostNode, frame, scheduler, styles)
+        setupHostNode(committed, scheduler)
+        if (committed._mixState) {
+          bindNodeMixRuntime(committed, frame, scheduler, styles)
         }
-        return nextCursor
+        if (cursor) cursor.current = nextCursor
+        return committed
       } else {
         // Type mismatch - try single-advance retry to handle browser extension injections
         // at the start of containers. Skip this node and try the next sibling once.
-        let nextSibling = skipComments(cursor.nextSibling)
+        let nextSibling = skipComments(hydrationNode.nextSibling)
         if (nextSibling instanceof Element) {
-          let nextTag = node._svg ? nextSibling.tagName : nextSibling.tagName.toLowerCase()
+          let nextTag = svg ? nextSibling.tagName : nextSibling.tagName.toLowerCase()
           if (nextTag === node.type) {
             let nextCursor = nextSibling.nextSibling
             // Found a match after skipping - adopt it and leave skipped node in place
             patchHostProps({}, hostProps, nextSibling)
+            let committed = commitHostNode(node, vParent, svg, nextSibling, resolved)
 
             if (hostProps.innerHTML != null) {
-              nextSibling.innerHTML = hostProps.innerHTML as string
+              nextSibling.innerHTML = hostProps.innerHTML
             } else {
-              let childCursor = nextSibling.firstChild
-              diffChildren(
+              let childCursor = { current: nextSibling.firstChild }
+              committed._children = diffChildren(
                 null,
-                node._children,
+                childInputs,
                 nextSibling,
-                frame,
-                scheduler,
-                styles,
-                node,
-                rootTarget,
+                committed,
+                context,
                 childCursor,
               )
             }
 
-            setupHostNode(node, nextSibling, scheduler)
-            if (node._mixState) {
-              bindNodeMixRuntime(node as CommittedHostNode, frame, scheduler, styles)
+            setupHostNode(committed, scheduler)
+            if (committed._mixState) {
+              bindNodeMixRuntime(committed, frame, scheduler, styles)
             }
-            return nextCursor
+            if (cursor) cursor.current = nextCursor
+            return committed
           }
         }
         // Retry failed - log mismatch and create new element (don't remove mismatched nodes)
         logHydrationMismatch('tag', cursorTag, node.type)
-        cursor = undefined // stop hydration for this tree
+        if (cursor) cursor.current = undefined // stop hydration for this tree
       }
     }
-    let dom = node._svg
-      ? document.createElementNS(SVG_NS, node.type)
-      : document.createElement(node.type)
+    let dom = svg ? document.createElementNS(SVG_NS, node.type) : document.createElement(node.type)
     patchHostProps({}, hostProps, dom)
+    let committed = commitHostNode(node, vParent, svg, dom, resolved)
 
     // Handle innerHTML prop
     if (hostProps.innerHTML != null) {
-      dom.innerHTML = hostProps.innerHTML as string
+      dom.innerHTML = hostProps.innerHTML
     } else {
-      diffChildren(null, node._children, dom, frame, scheduler, styles, node, rootTarget)
+      committed._children = diffChildren(null, childInputs, dom, committed, context)
     }
 
-    setupHostNode(node, dom, scheduler)
-    if (node._mixState) {
-      bindNodeMixRuntime(node as CommittedHostNode, frame, scheduler, styles, false, domParent)
+    setupHostNode(committed, scheduler)
+    if (committed._mixState) {
+      bindNodeMixRuntime(committed, frame, scheduler, styles, false, domParent)
     }
     doInsert(dom)
-    return cursor
+    return committed
   }
 
-  if (isFragmentNode(node)) {
+  if (node.kind === 'fragment') {
+    let childInputs = node._children
+    let committed = beginFragmentNode(node, vParent, svg)
     // Insert fragment children in order before the same anchor
-    let children = node._children
-    for (let i = 0; i < children.length; i++) {
-      cursor = insert(
-        children[i],
-        domParent,
-        frame,
-        scheduler,
-        styles,
-        node,
-        rootTarget,
-        anchor,
-        cursor,
-      )
+    for (let i = 0; i < childInputs.length; i++) {
+      childInputs[i] = insert(childInputs[i], domParent, committed, context, anchor, cursor)
     }
-    return cursor
+    committed._children = commitChildren(childInputs)
+    return committed
   }
 
-  if (isComponentNode(node)) {
-    return diffComponent(
-      null,
-      node,
-      frame,
-      scheduler,
-      styles,
-      domParent,
-      vParent,
-      rootTarget,
-      anchor,
-      cursor,
-    )
+  if (node.kind === 'component') {
+    return diffComponent(null, node, domParent, vParent, context, anchor, cursor)
   }
 
-  if (node.type === Frame) {
-    return insertFrame(
-      node,
-      domParent,
-      frame,
-      scheduler,
-      styles,
-      vParent,
-      rootTarget,
-      anchor,
-      cursor,
-    )
+  if (node.kind === 'frame') {
+    return insertFrame(node, domParent, vParent, context, anchor, cursor)
   }
 
   invariant(false, 'Unexpected node type')
 }
 
 function diffFrame(
-  curr: VNode,
-  next: VNode,
+  curr: CommittedFrameNode,
+  next: FrameNode,
   domParent: ParentNode,
-  frame: FrameHandle,
-  scheduler: Scheduler,
-  styles: StyleManager,
-  vParent: VNode,
-  rootTarget: EventTarget,
+  vParent: VNodeParent,
+  context: ReconcileContext,
   anchor?: Node,
-): void {
+): CommittedFrameNode {
+  let { frame } = context
   let currSrc = getFrameSrc(curr)
   let nextSrc = getFrameSrc(next)
   let currName = getFrameName(curr)
   let nextName = getFrameName(next)
 
   if (currName !== nextName) {
-    let replaceAnchor = curr._rangeEnd?.nextSibling ?? anchor
-    remove(curr, domParent, scheduler, styles)
-    insert(next, domParent, frame, scheduler, styles, vParent, rootTarget, replaceAnchor)
-    return
+    let replaceAnchor = curr._rangeEnd.nextSibling ?? anchor
+    remove(curr, domParent, context)
+    return insertFrame(next, domParent, vParent, context, replaceAnchor)
   }
 
   // If the frame hasn't resolved yet, preserve existing cancel/remount behavior
   // so pending streams from the old src cannot take over the new src.
   if (currSrc !== nextSrc && !curr._frameResolved) {
-    let replaceAnchor = curr._rangeEnd?.nextSibling ?? anchor
-    remove(curr, domParent, scheduler, styles)
-    insert(next, domParent, frame, scheduler, styles, vParent, rootTarget, replaceAnchor)
-    return
+    let replaceAnchor = curr._rangeEnd.nextSibling ?? anchor
+    remove(curr, domParent, context)
+    return insertFrame(next, domParent, vParent, context, replaceAnchor)
   }
 
-  next._rangeStart = curr._rangeStart
-  next._rangeEnd = curr._rangeEnd
-  next._frameInstance = curr._frameInstance
-  next._frameFallbackRoot = curr._frameFallbackRoot
-  next._frameResolveToken = curr._frameResolveToken
-  next._frameResolveController = curr._frameResolveController
-  next._frameResolved = curr._frameResolved
-  next._parent = vParent
+  let committed = Object.assign(next, {
+    _rangeStart: curr._rangeStart,
+    _rangeEnd: curr._rangeEnd,
+    _frameInstance: curr._frameInstance,
+    _frameFallbackRoot: curr._frameFallbackRoot,
+    _frameResolveToken: curr._frameResolveToken,
+    _frameResolveController: curr._frameResolveController,
+    _frameResolved: curr._frameResolved,
+    _parent: vParent,
+    _svg: getSvgContext(vParent, next),
+  })
 
   let frameRuntime = getFrameRuntime(frame)
-  let frameInstance = next._frameInstance as FrameInstance | undefined
+  let frameInstance = committed._frameInstance
   let serverFrameReload = frameRuntime?.serverFrameReload
 
   if (currSrc !== nextSrc) {
@@ -1045,31 +1032,30 @@ function diffFrame(
     }
 
     if (frameRuntime) {
-      resolveClientFrame(next, frameRuntime, serverFrameReload)
+      resolveClientFrame(committed, frameRuntime, serverFrameReload)
     }
   } else if (frameRuntime && frameInstance && serverFrameReload) {
     // Reload client frames that have the same src during a render triggered by an ancestor frame reload
-    resolveClientFrame(next, frameRuntime, serverFrameReload)
+    resolveClientFrame(committed, frameRuntime, serverFrameReload)
   }
 
-  if (!next._frameResolved && next._frameFallbackRoot) {
-    next._frameFallbackRoot.render(next.props?.fallback ?? null)
+  if (!committed._frameResolved && committed._frameFallbackRoot) {
+    committed._frameFallbackRoot.render(committed.props.fallback ?? null)
   }
+  return committed
 }
 
 function insertFrame(
-  node: VNode,
+  node: FrameNode,
   domParent: ParentNode,
-  frame: FrameHandle,
-  scheduler: Scheduler,
-  styles: StyleManager,
-  vParent: VNode,
-  rootTarget: EventTarget,
+  vParent: VNodeParent,
+  context: ReconcileContext,
   anchor?: Node,
-  cursor?: Node | null,
-): Node | null | undefined {
+  cursor?: HydrationCursor,
+): CommittedFrameNode {
+  let { frame, styles } = context
   let runtime = getFrameRuntime(frame)
-  if (!runtime || (runtime as { canResolveFrames?: boolean }).canResolveFrames === false) {
+  if (!runtime || runtime.canResolveFrames === false) {
     throw new Error(
       'Cannot render <Frame /> without frame runtime. Use run() or pass frameInit to createRoot/createRangeRoot.',
     )
@@ -1077,18 +1063,10 @@ function insertFrame(
 
   // Hydration path: adopt server-rendered frame markers and reuse the existing
   // frame instance created during createSubFrames().
-  if (isFrameStartComment(cursor)) {
-    let start = cursor
+  if (isFrameStartComment(cursor?.current)) {
+    let start = cursor.current
     let end = findFrameEndComment(start)
     if (end) {
-      node._rangeStart = start
-      node._rangeEnd = end
-      node._parent = vParent
-      node._frameResolveToken = 0
-      node._frameResolveController = undefined
-      node._frameFallbackRoot = undefined
-      node._frameResolved = true
-
       let frameId = getFrameIdFromComment(start)
       let marker = frameId ? runtime.data.f?.[frameId] : undefined
       let src = marker?.src ?? getFrameSrc(node)
@@ -1113,9 +1091,18 @@ function insertFrame(
         runtime.frameInstances.set(start, instance)
       }
 
-      node._frameInstance = instance
-
-      return end.nextSibling
+      cursor.current = end.nextSibling
+      return Object.assign(node, {
+        _rangeStart: start,
+        _rangeEnd: end,
+        _parent: vParent,
+        _svg: getSvgContext(vParent, node),
+        _frameResolveToken: 0,
+        _frameResolveController: undefined,
+        _frameFallbackRoot: undefined,
+        _frameResolved: true,
+        _frameInstance: instance,
+      })
     }
   }
 
@@ -1128,18 +1115,11 @@ function insertFrame(
   doInsert(start)
   doInsert(end)
 
-  node._rangeStart = start
-  node._rangeEnd = end
-  node._parent = vParent
-
   let fallbackRoot = createRangeRoot([start, end], {
     frame,
     styleManager: styles,
   })
-  fallbackRoot.render(node.props?.fallback ?? null)
-  node._frameFallbackRoot = fallbackRoot
-  node._frameResolved = false
-  node._frameResolveToken = 0
+  fallbackRoot.render(node.props.fallback ?? null)
 
   let instance = createFrame([start, end], {
     name: getFrameName(node),
@@ -1156,24 +1136,33 @@ function insertFrame(
     frameInstances: runtime.frameInstances,
     namedFrames: runtime.namedFrames,
   })
-  node._frameInstance = instance
   runtime.frameInstances.set(start, instance)
 
-  resolveClientFrame(node, runtime)
+  let committed = Object.assign(node, {
+    _rangeStart: start,
+    _rangeEnd: end,
+    _parent: vParent,
+    _svg: getSvgContext(vParent, node),
+    _frameFallbackRoot: fallbackRoot,
+    _frameResolved: false,
+    _frameResolveToken: 0,
+    _frameResolveController: undefined,
+    _frameInstance: instance,
+  })
+  resolveClientFrame(committed, runtime)
 
-  return cursor
+  return committed
 }
 
 function resolveClientFrame(
-  node: VNode,
+  node: CommittedFrameNode,
   runtime: FrameRuntime,
   serverFrameReload?: { signal: AbortSignal },
 ): void {
   let frameSrc = getFrameSrc(node)
-  let instance = node._frameInstance as FrameInstance | undefined
-  if (!instance) return
+  let instance = node._frameInstance
 
-  let token = (node._frameResolveToken ?? 0) + 1
+  let token = node._frameResolveToken + 1
   node._frameResolveToken = token
   node._frameResolveController?.abort()
   let reload = serverFrameReload
@@ -1209,18 +1198,14 @@ function resolveClientFrame(
     })
 }
 
-function disposeFrameResources(node: VNode): void {
-  node._frameResolveToken = (node._frameResolveToken ?? 0) + 1
+function disposeFrameResources(node: CommittedFrameNode): void {
+  node._frameResolveToken++
   node._frameResolveController?.abort()
   node._frameResolveController = undefined
   node._frameFallbackRoot?.dispose()
   node._frameFallbackRoot = undefined
 
-  let frameInstance = node._frameInstance as FrameInstance | undefined
-  if (frameInstance) {
-    frameInstance.dispose()
-    node._frameInstance = undefined
-  }
+  node._frameInstance.dispose()
 }
 
 function asAbortableFrameContent(content: FrameContent, signal: AbortSignal): FrameContent {
@@ -1251,13 +1236,13 @@ function createAbortableReadableStream(
       }
 
       let removeAbortReadListener: undefined | (() => void)
-      let abortRead = new Promise<ReadableStreamReadResult<Uint8Array>>((resolve) => {
+      let abortRead = new Promise<{ done: true; value: undefined }>((resolve) => {
         if (signal.aborted) {
-          resolve({ done: true, value: undefined as unknown as Uint8Array })
+          resolve({ done: true, value: undefined })
           return
         }
         let onAbortRead = () => {
-          resolve({ done: true, value: undefined as unknown as Uint8Array })
+          resolve({ done: true, value: undefined })
         }
         removeAbortReadListener = () => signal.removeEventListener('abort', onAbortRead)
         signal.addEventListener('abort', onAbortRead, { once: true })
@@ -1279,11 +1264,9 @@ function createAbortableReadableStream(
   })
 }
 
-function removeFrameDomRange(node: VNode, domParent: ParentNode): void {
+function removeFrameDomRange(node: CommittedFrameNode, domParent: ParentNode): void {
   let start = node._rangeStart
   let end = node._rangeEnd
-  if (!(start instanceof Comment) || !(end instanceof Comment)) return
-
   let cursor: Node | null = start
   while (cursor) {
     let nextSibling: Node | null = cursor.nextSibling
@@ -1293,23 +1276,23 @@ function removeFrameDomRange(node: VNode, domParent: ParentNode): void {
     if (cursor === end) break
     cursor = nextSibling
   }
-
-  node._rangeStart = undefined
-  node._rangeEnd = undefined
 }
 
 function getFrameRuntime(frame: FrameHandle): FrameRuntime | undefined {
-  return frame.$runtime as FrameRuntime | undefined
+  let runtime = frame.$runtime
+  return isFrameRuntime(runtime) ? runtime : undefined
 }
 
-function getFrameSrc(node: VNode): string {
-  let src = node.props?.src
-  invariant(typeof src === 'string' && src.length > 0, '<Frame /> requires a src prop')
-  return src
+function isFrameRuntime(value: unknown): value is FrameRuntime {
+  return typeof value === 'object' && value !== null && 'resolveFrame' in value
 }
 
-function getFrameName(node: VNode): string | undefined {
-  let name = node.props?.name
+function getFrameSrc(node: FrameNode | CommittedFrameNode): string {
+  return node.props.src
+}
+
+function getFrameName(node: FrameNode | CommittedFrameNode): string | undefined {
+  let name = node.props.name
   return typeof name === 'string' && name.length > 0 ? name : undefined
 }
 
@@ -1356,70 +1339,52 @@ function findFrameEndComment(start: Comment): Comment | null {
 }
 
 export function renderComponent(
-  handle: ComponentHandle,
-  currContent: VNode | null,
-  next: ComponentNode,
+  currContent: CommittedVNode | null,
+  next: MountingComponentNode | CommittedComponentNode,
   domParent: ParentNode,
-  frame: FrameHandle,
-  scheduler: Scheduler,
-  styles: StyleManager,
-  rootTarget: EventTarget,
-  vParent?: VNode,
+  context: ReconcileContext,
   anchor?: Node,
-  cursor?: Node | null,
-): Node | null | undefined {
-  if (handle.isRemoved()) return cursor
+  cursor?: HydrationCursor,
+): CommittedComponentNode {
+  let { scheduler } = context
+  let handle = next._handle
+  if (handle.isRemoved()) {
+    invariant('_content' in next, 'Expected removed component to be committed')
+    return next
+  }
 
   let [element, tasks] = handle.render(next.props)
-  let content = toVNode(element)
-  let newCursor = diffVNodes(
-    currContent,
-    content,
-    domParent,
-    frame,
-    scheduler,
-    styles,
-    next,
-    rootTarget,
-    anchor,
-    cursor,
-  )
-  next._content = content
-  next._handle = handle
-  next._parent = vParent
-
-  let committed = next as CommittedComponentNode
+  let content = diffVNodes(currContent, toVNode(element), domParent, next, context, anchor, cursor)
+  let committed = commitComponentNode(next, content)
   handle.setScheduleUpdate(scheduler, committed, domParent)
 
   scheduler.enqueueTasks(tasks)
 
-  return newCursor
+  return committed
 }
 
 function diffComponent(
   curr: CommittedComponentNode | null,
   next: ComponentNode,
-  frame: FrameHandle,
-  scheduler: Scheduler,
-  styles: StyleManager,
   domParent: ParentNode,
-  vParent: VNode,
-  rootTarget: EventTarget,
+  vParent: VNodeParent,
+  context: ReconcileContext,
   anchor?: Node,
-  cursor?: Node | null,
-): Node | null | undefined {
+  cursor?: HydrationCursor,
+): CommittedComponentNode {
+  let { frame } = context
   if (curr === null) {
-    let componentId = vParent._pendingHydrationComponentId
+    let componentId = vParent.kind === 'root' ? vParent._pendingHydrationComponentId : undefined
     if (componentId) {
-      vParent._pendingHydrationComponentId = undefined
+      if (vParent.kind === 'root') vParent._pendingHydrationComponentId = undefined
     } else {
       componentId = `c${++idCounter}`
     }
-    next._handle = createComponent({
+    let handle = createComponent({
       id: componentId,
       frame,
       type: next.type,
-      getContext: (type: Component) => findContextFromAncestry(vParent, type),
+      getContext: (type: ElementFunction) => findContextFromAncestry(vParent, type),
       getFrameByName(name: string) {
         let runtime = getFrameRuntime(frame)
         return runtime?.namedFrames.get(name)
@@ -1429,40 +1394,23 @@ function diffComponent(
         return runtime?.topFrame
       },
     })
+    let mounting = beginComponentNode(next, vParent, getSvgContext(vParent, next), handle, context)
 
-    return renderComponent(
-      next._handle,
-      null,
-      next,
-      domParent,
-      frame,
-      scheduler,
-      styles,
-      rootTarget,
-      vParent,
-      anchor,
-      cursor,
-    )
+    return renderComponent(null, mounting, domParent, context, anchor, cursor)
   }
-  next._handle = curr._handle
-  let { _content, _handle } = curr
-  return renderComponent(
-    _handle,
-    _content,
+  let mounting = beginComponentNode(
     next,
-    domParent,
-    frame,
-    scheduler,
-    styles,
-    rootTarget,
     vParent,
-    anchor,
-    cursor,
+    getSvgContext(vParent, next),
+    curr._handle,
+    context,
   )
+  return renderComponent(curr._content, mounting, domParent, context, anchor, cursor)
 }
 
 // Cleanup without DOM removal - used for descendants when parent DOM node is removed
-function cleanupDescendants(node: VNode, scheduler: Scheduler, styles: StyleManager): void {
+function cleanupDescendants(node: CommittedVNode, context: ReconcileContext): void {
+  let { scheduler } = context
   if (isCommittedTextNode(node)) {
     return
   }
@@ -1470,10 +1418,10 @@ function cleanupDescendants(node: VNode, scheduler: Scheduler, styles: StyleMana
   if (isCommittedHostNode(node)) {
     let children = node._children
     for (let i = 0; i < children.length; i++) {
-      cleanupDescendants(children[i], scheduler, styles)
+      cleanupDescendants(children[i], context)
     }
 
-    teardownMixins(node._mixState as MixinRuntimeState | undefined)
+    teardownMixins(node._mixState)
     abandonDirectEventListeners(node)
     abandonControlledReflection(node)
     return
@@ -1482,72 +1430,72 @@ function cleanupDescendants(node: VNode, scheduler: Scheduler, styles: StyleMana
   if (isFragmentNode(node)) {
     let children = node._children
     for (let i = 0; i < children.length; i++) {
-      cleanupDescendants(children[i], scheduler, styles)
+      cleanupDescendants(children[i], context)
     }
     return
   }
 
   if (isCommittedComponentNode(node)) {
-    cleanupDescendants(node._content, scheduler, styles)
+    cleanupDescendants(node._content, context)
     let tasks = node._handle.remove()
     scheduler.enqueueTasks(tasks)
     return
   }
 
-  if (node.type === Frame) {
+  if (node.kind === 'frame') {
     disposeFrameResources(node)
     return
   }
 }
 
 export function remove(
-  node: VNode,
+  node: CommittedVNode,
   domParent: ParentNode,
-  scheduler: Scheduler,
-  styles: StyleManager,
-) {
+  context: ReconcileContext,
+): void {
+  let { scheduler } = context
   if (isCommittedTextNode(node)) {
     node._dom.parentNode?.removeChild(node._dom)
     return
   }
 
   if (isCommittedHostNode(node)) {
-    if (node._persistedByMixins) return
+    if (node._persistence) return
 
-    let persistedRemoval = prepareMixinRemoval(node._mixState as MixinRuntimeState | undefined)
+    let persistedRemoval = prepareMixinRemoval(node._mixState)
     if (persistedRemoval) {
       let token = ++persistedRemovalToken
       markNodePersistedByMixins(node, domParent, token)
       void persistedRemoval
         .catch(() => {})
         .finally(() => {
-          if (!node._persistedByMixins) return
-          if (node._persistedRemovalToken !== token) return
+          if (!node._persistence) return
+          if (node._persistence.token !== token) return
           unmarkNodePersistedByMixins(node)
-          performHostNodeRemoval(node, domParent, scheduler, styles)
+          performHostNodeRemoval(node, domParent, context)
         })
       return
     }
-    performHostNodeRemoval(node, domParent, scheduler, styles)
+    performHostNodeRemoval(node, domParent, context)
     return
   }
 
   if (isFragmentNode(node)) {
     let children = node._children
     for (let i = 0; i < children.length; i++) {
-      remove(children[i], domParent, scheduler, styles)
+      remove(children[i], domParent, context)
     }
     return
   }
 
   if (isCommittedComponentNode(node)) {
-    remove(node._content, domParent, scheduler, styles)
+    remove(node._content, domParent, context)
     let tasks = node._handle.remove()
     scheduler.enqueueTasks(tasks)
     return
   }
 
-  if (node.type === Frame) {
+  if (node.kind === 'frame') {
     disposeFrameResources(node)
     removeFrameDomRange(node, domParent)
     return
@@ -1558,22 +1506,21 @@ export function remove(
 function performHostNodeRemoval(
   node: CommittedHostNode,
   domParent: ParentNode,
-  scheduler: Scheduler,
-  styles: StyleManager,
-) {
+  context: ReconcileContext,
+): void {
   let children = node._children
   if (isHeadHostNode(node)) {
     for (let i = 0; i < children.length; i++) {
-      remove(children[i], node._dom, scheduler, styles)
+      remove(children[i], node._dom, context)
     }
   } else {
     // Clean up all descendants first (before removing DOM subtree)
     for (let i = 0; i < children.length; i++) {
-      cleanupDescendants(children[i], scheduler, styles)
+      cleanupDescendants(children[i], context)
     }
   }
 
-  teardownMixins(node._mixState as MixinRuntimeState | undefined)
+  teardownMixins(node._mixState)
   // Never remove the real document.head node when reconciling a <head> vnode,
   // and since it stays alive, detach its listeners for real.
   if (isHeadHostNode(node)) {
@@ -1587,17 +1534,14 @@ function performHostNodeRemoval(
 }
 
 function diffChildren(
-  curr: VNode[] | null,
-  next: VNode[],
+  curr: CommittedVNode[] | null,
+  next: VNodeInput[],
   domParent: ParentNode,
-  frame: FrameHandle,
-  scheduler: Scheduler,
-  styles: StyleManager,
-  vParent: VNode,
-  rootTarget: EventTarget,
-  cursor?: Node | null,
+  vParent: VNodeParent,
+  context: ReconcileContext,
+  cursor?: HydrationCursor,
   anchor?: Node,
-) {
+): CommittedVNode[] {
   let hasKeys = hasKeyedChildren(next)
 
   if (curr === null) {
@@ -1605,20 +1549,9 @@ function diffChildren(
       warnDuplicateKeys(next)
     }
     for (let i = 0; i < next.length; i++) {
-      cursor = insert(
-        next[i],
-        domParent,
-        frame,
-        scheduler,
-        styles,
-        vParent,
-        rootTarget,
-        anchor,
-        cursor,
-      )
+      next[i] = insert(next[i], domParent, vParent, context, anchor, cursor)
     }
-    vParent._children = next
-    return cursor
+    return commitChildren(next)
   }
 
   if (
@@ -1628,69 +1561,43 @@ function diffChildren(
     canBulkClearChildren(curr)
   ) {
     for (let i = 0; i < curr.length; i++) {
-      cleanupDescendants(curr[i], scheduler, styles)
+      cleanupDescendants(curr[i], context)
     }
     domParent.textContent = ''
-    vParent._children = next
-    return
+    return EMPTY_COMMITTED_CHILDREN
   }
 
   if (!hasKeys) {
     for (let i = 0; i < next.length; i++) {
       let currentNode = i < curr.length ? curr[i] : null
-      diffVNodes(
-        currentNode,
-        next[i],
-        domParent,
-        frame,
-        scheduler,
-        styles,
-        vParent,
-        rootTarget,
-        anchor,
-        cursor,
-      )
+      next[i] = diffVNodes(currentNode, next[i], domParent, vParent, context, anchor, cursor)
     }
 
     if (curr.length > next.length) {
       for (let i = next.length; i < curr.length; i++) {
         let node = curr[i]
-        if (node) remove(node, domParent, scheduler, styles)
+        if (node) remove(node, domParent, context)
       }
     }
 
-    vParent._children = next
-    return
+    return commitChildren(next)
   }
 
-  patchKeyedChildren(
-    curr,
-    next,
-    domParent,
-    frame,
-    scheduler,
-    styles,
-    vParent,
-    rootTarget,
-    cursor,
-    anchor,
-  )
-
-  return
+  return patchKeyedChildren(curr, next, domParent, vParent, context, cursor, anchor)
 }
 
-function parentUsesInnerHTML(parent: VNode): boolean {
+function parentUsesInnerHTML(parent: VNodeParent): boolean {
   return isHostNode(parent) && getHostProps(parent).innerHTML != null
 }
 
-function canBulkClearChildren(children: VNode[]): boolean {
+function canBulkClearChildren(children: CommittedVNode[]): boolean {
   for (let i = 0; i < children.length; i++) {
     if (!canBulkClearNode(children[i])) return false
   }
   return true
 }
 
-function canBulkClearNode(node: VNode): boolean {
+function canBulkClearNode(node: CommittedVNode): boolean {
   if (isCommittedTextNode(node)) return true
 
   if (isCommittedHostNode(node)) {
@@ -1709,16 +1616,16 @@ function canBulkClearNode(node: VNode): boolean {
   return false
 }
 
-function hasKeyedChildren(children: VNode[]): boolean {
+function hasKeyedChildren(children: Array<{ key?: Key }>): boolean {
   for (let i = 0; i < children.length; i++) {
     if (children[i].key != null) return true
   }
   return false
 }
 
-function warnDuplicateKeys(children: VNode[]): void {
-  let seenKeys: Set<string> | undefined
-  let duplicateKeys: Set<string> | undefined
+function warnDuplicateKeys(children: Array<{ key?: Key }>): void {
+  let seenKeys: Set<Key> | undefined
+  let duplicateKeys: Set<Key> | undefined
 
   for (let node of children) {
     if (node.key == null) continue
@@ -1737,7 +1644,7 @@ function warnDuplicateKeys(children: VNode[]): void {
   }
 
   if (duplicateKeys?.size) {
-    let quotedKeys = Array.from(duplicateKeys, (key) => `"${key}"`)
+    let quotedKeys = Array.from(duplicateKeys, (key) => `"${String(key)}"`)
     console.warn(
       `Duplicate keys detected in siblings: ${quotedKeys.join(', ')}. Keys should be unique.`,
     )
@@ -1745,17 +1652,14 @@ function warnDuplicateKeys(children: VNode[]): void {
 }
 
 function patchKeyedChildren(
-  curr: VNode[],
-  next: VNode[],
+  curr: CommittedVNode[],
+  next: VNodeInput[],
   domParent: ParentNode,
-  frame: FrameHandle,
-  scheduler: Scheduler,
-  styles: StyleManager,
-  vParent: VNode,
-  rootTarget: EventTarget,
-  cursor?: Node | null,
+  vParent: VNodeParent,
+  context: ReconcileContext,
+  cursor?: HydrationCursor,
   anchor?: Node,
-): void {
+): CommittedVNode[] {
   let matches =
     matchKeyedChildrenInOrder(curr, next) ??
     matchKeyedChildrenAfterSingleRemoval(curr, next) ??
@@ -1778,33 +1682,21 @@ function patchKeyedChildren(
 
     for (let oldIndex = 0; oldIndex < curr.length; oldIndex++) {
       if (usedOldIndexes[oldIndex] === 0) {
-        remove(curr[oldIndex], domParent, scheduler, styles)
+        remove(curr[oldIndex], domParent, context)
       }
     }
   }
-
-  vParent._children = next
 
   for (let index = 0; index < next.length; index++) {
     let oldIndex = matches[index]
     let oldNode = oldIndex >= 0 ? curr[oldIndex] : null
 
-    diffVNodes(
-      oldNode,
-      next[index],
-      domParent,
-      frame,
-      scheduler,
-      styles,
-      vParent,
-      rootTarget,
-      anchor,
-      cursor,
-    )
+    next[index] = diffVNodes(oldNode, next[index], domParent, vParent, context, anchor, cursor)
   }
+  let committed = commitChildren(next)
 
   if (matchAnalysis.canSkipPlacement) {
-    return
+    return committed
   }
 
   let stableIndexes = lisMatches(matches)
@@ -1812,7 +1704,7 @@ function patchKeyedChildren(
   let placementAnchor: Node | null = anchor ?? null
 
   for (let index = next.length - 1; index >= 0; index--) {
-    let nextNode = next[index]
+    let nextNode = committed[index]
     let isStable = stableIndexes[stableCursor] === index
 
     if (isStable) {
@@ -1823,13 +1715,14 @@ function patchKeyedChildren(
 
     placementAnchor = findFirstDomAnchor(nextNode) ?? placementAnchor
   }
+  return committed
 }
 
 // Keyed child matches are arrays of old indexes (-1 = no match / new node),
 // parallel to `next`. Plain numbers instead of wrapper objects keep large
 // keyed diffs (1000-row tables) allocation-free.
-function matchKeyedChildren(curr: VNode[], next: VNode[]): number[] {
-  let oldKeyMap = new Map<string, number>()
+function matchKeyedChildren(curr: CommittedVNode[], next: VNodeInput[]): number[] {
+  let oldKeyMap = new Map<Key, number>()
   let usedOldIndexes = new Set<number>()
   let unkeyedSearchStart = 0
 
@@ -1871,7 +1764,7 @@ function matchKeyedChildren(curr: VNode[], next: VNode[]): number[] {
   return matches
 }
 
-function matchKeyedChildrenInOrder(curr: VNode[], next: VNode[]): number[] | null {
+function matchKeyedChildrenInOrder(curr: CommittedVNode[], next: VNodeInput[]): number[] | null {
   let length = Math.min(curr.length, next.length)
   let matches: number[] = []
 
@@ -1895,7 +1788,10 @@ function matchKeyedChildrenInOrder(curr: VNode[], next: VNode[]): number[] | nul
   return matches
 }
 
-function matchKeyedChildrenAfterSingleRemoval(curr: VNode[], next: VNode[]): number[] | null {
+function matchKeyedChildrenAfterSingleRemoval(
+  curr: CommittedVNode[],
+  next: VNodeInput[],
+): number[] | null {
   if (curr.length !== next.length + 1) return null
 
   let matches: number[] = []
@@ -1929,7 +1825,10 @@ function matchKeyedChildrenAfterSingleRemoval(curr: VNode[], next: VNode[]): num
   return matches
 }
 
-function matchKeyedChildrenAfterPairSwap(curr: VNode[], next: VNode[]): number[] | null {
+function matchKeyedChildrenAfterPairSwap(
+  curr: CommittedVNode[],
+  next: VNodeInput[],
+): number[] | null {
   if (curr.length !== next.length) return null
 
   let matches: number[] = []
@@ -2039,7 +1938,7 @@ function lisMatches(matches: readonly number[]): number[] {
   return tails
 }
 
-function placeVNode(node: VNode, domParent: ParentNode, anchor: Node | null): void {
+function placeVNode(node: CommittedVNode, domParent: ParentNode, anchor: Node | null): void {
   let firstDom = findFirstDomAnchor(node)
   if (!firstDom || firstDom.parentNode !== domParent) return
 
@@ -2051,12 +1950,12 @@ function placeVNode(node: VNode, domParent: ParentNode, anchor: Node | null): vo
   moveDomRange(domParent, firstDom, lastDom, anchor)
 }
 
-export function findFirstDomAnchor(node: VNode | null | undefined): Node | null {
+export function findFirstDomAnchor(node: CommittedVNode | null | undefined): Node | null {
   if (!node) return null
   if (isCommittedTextNode(node)) return node._dom
   if (isCommittedHostNode(node)) return node._dom
   if (isCommittedComponentNode(node)) return findFirstDomAnchor(node._content)
-  if (node.type === Frame) return node._rangeStart ?? null
+  if (node.kind === 'frame') return node._rangeStart
   if (isFragmentNode(node)) {
     let children = node._children
     for (let i = 0; i < children.length; i++) {
@@ -2067,12 +1966,12 @@ export function findFirstDomAnchor(node: VNode | null | undefined): Node | null 
   return null
 }
 
-export function findLastDomAnchor(node: VNode | null | undefined): Node | null {
+export function findLastDomAnchor(node: CommittedVNode | null | undefined): Node | null {
   if (!node) return null
   if (isCommittedTextNode(node)) return node._dom
   if (isCommittedHostNode(node)) return node._dom
   if (isCommittedComponentNode(node)) return findLastDomAnchor(node._content)
-  if (node.type === Frame) return node._rangeEnd ?? null
+  if (node.kind === 'frame') return node._rangeEnd
   if (isFragmentNode(node)) {
     for (let i = node._children.length - 1; i >= 0; i--) {
       let dom = findLastDomAnchor(node._children[i])
@@ -2110,21 +2009,27 @@ function shouldDispatchInlineMixinLifecycle(node: Node): boolean {
   let parents = activeSchedulerUpdateParents
   if (!parents?.length) return true
   for (let parent of parents) {
-    let parentNode = parent as Node
+    if (!(parent instanceof Node)) continue
+    let parentNode = parent
     if (parentNode === node) return false
     if (parentNode.contains(node)) return false
   }
   return true
 }
 
-export function findNextSiblingDomAnchor(curr: VNode): Node | null {
+export function findNextSiblingDomAnchor(
+  curr: CommittedVNode | MountingComponentNode,
+): Node | null {
   let vParent = curr._parent
-  if (!vParent) return null
-  if (!Array.isArray(vParent._children)) return vParent._rangeEnd ?? null
+  if (vParent.kind === 'component') return findNextSiblingDomAnchor(vParent)
   let children = vParent._children
-  if (children.length === 0) return vParent._rangeEnd ?? findNextSiblingDomAnchor(vParent)
+  if (children.length === 0) {
+    if (vParent.kind === 'root') return vParent._rangeEnd ?? null
+    if (vParent.kind === 'fragment') return findNextSiblingDomAnchor(vParent)
+    return null
+  }
 
-  let idx = children.indexOf(curr)
+  let idx = children.findIndex((child) => child === curr)
   if (idx === -1) return null
   for (let i = idx + 1; i < children.length; i++) {
     let dom = findFirstDomAnchor(children[i])
@@ -2135,59 +2040,53 @@ export function findNextSiblingDomAnchor(curr: VNode): Node | null {
     return findNextSiblingDomAnchor(vParent)
   }
 
-  return vParent._rangeEnd ?? null
+  return vParent.kind === 'root' ? (vParent._rangeEnd ?? null) : null
 }
 
 function reclaimPersistedMixinNode(
   persistedNode: CommittedHostNode,
   newNode: HostNode,
-  frame: FrameHandle,
-  scheduler: Scheduler,
-  styles: StyleManager,
-  vParent: VNode,
-  rootTarget: EventTarget,
-): void {
-  cancelPendingMixinRemoval(persistedNode._mixState as MixinRuntimeState | undefined)
+  vParent: VNodeParent,
+  context: ReconcileContext,
+): CommittedHostNode {
+  let { frame, scheduler, styles } = context
+  cancelPendingMixinRemoval(persistedNode._mixState)
   unmarkNodePersistedByMixins(persistedNode)
 
-  newNode._dom = persistedNode._dom
-  newNode._parent = vParent
-  newNode._mixState = persistedNode._mixState
-  newNode._directEventState = persistedNode._directEventState
-  newNode._controlledState = persistedNode._controlledState
-
   let prevProps = getHostProps(persistedNode)
-  let nextProps = resolveNodeMixProps(
+  let childInputs = newNode._children
+  let resolved = resolveNodeMixProps(newNode, vParent, frame, scheduler, persistedNode._mixState)
+  let nextProps = resolved.props
+  let committed = commitHostNode(
     newNode,
-    frame,
-    scheduler,
-    newNode._mixState as MixinRuntimeState | undefined,
+    vParent,
+    getSvgContext(vParent, newNode),
+    persistedNode._dom,
+    resolved,
   )
+  committed._directEventState = persistedNode._directEventState
+  committed._controlledState = persistedNode._controlledState
   if (shouldDispatchInlineMixinLifecycle(persistedNode._dom)) {
-    dispatchMixinBeforeUpdate(newNode._mixState as MixinRuntimeState | undefined)
+    dispatchMixinBeforeUpdate(committed._mixState)
   }
   patchHostProps(prevProps, nextProps, persistedNode._dom)
-  syncDirectEventListeners(newNode as CommittedHostNode)
-  ensureControlledReflection(newNode as CommittedHostNode, scheduler)
-  syncControlledReflection(newNode as CommittedHostNode, nextProps)
+  syncDirectEventListeners(committed)
+  ensureControlledReflection(committed, scheduler)
+  syncControlledReflection(committed, nextProps)
 
-  diffChildren(
+  committed._children = diffChildren(
     persistedNode._children,
-    newNode._children,
+    childInputs,
     persistedNode._dom,
-    frame,
-    scheduler,
-    styles,
-    newNode,
-    rootTarget,
+    committed,
+    context,
   )
 
-  if (newNode._mixState) {
-    bindNodeMixRuntime(newNode as CommittedHostNode, frame, scheduler, styles, true)
+  if (committed._mixState) {
+    bindNodeMixRuntime(committed, frame, scheduler, styles, true)
   }
   if (shouldDispatchInlineMixinLifecycle(persistedNode._dom)) {
-    scheduler.enqueueCommitPhase([
-      () => dispatchMixinCommit(newNode._mixState as MixinRuntimeState | undefined),
-    ])
+    scheduler.enqueueCommitPhase([() => dispatchMixinCommit(committed._mixState)])
   }
+  return committed
 }

--- a/packages/ui/src/runtime/scheduler.ts
+++ b/packages/ui/src/runtime/scheduler.ts
@@ -1,6 +1,6 @@
 import { createDocumentState } from './document-state.ts'
 import { createComponentErrorEvent } from './error-event.ts'
-import type { CommittedComponentNode, VNode } from './vnode.ts'
+import type { CommittedComponentNode, VNodeParent } from './vnode.ts'
 import { isCommittedComponentNode } from './vnode.ts'
 import {
   findNextSiblingDomAnchor,
@@ -87,11 +87,6 @@ export function createScheduler(
     }, 0)
   }
 
-  function getFrameStyleManager(vnode: CommittedComponentNode): StyleManager {
-    let runtime = vnode._handle?.frame.$runtime as { styleManager?: StyleManager } | undefined
-    return runtime?.styleManager ?? styles
-  }
-
   function flush() {
     if (flushing) return
     flushing = true
@@ -126,32 +121,18 @@ export function createScheduler(
 
         if (batch.size > 0) {
           let vnodes = Array.from(batch)
-          let noScheduledAncestor = new Set<VNode>()
+          let noScheduledAncestor = new Set<VNodeParent>()
 
           for (let [vnode, domParent] of vnodes) {
             if (ancestorIsScheduled(vnode, batch, noScheduledAncestor)) continue
-            let handle = vnode._handle
             let curr = vnode._content
-            let vParent = vnode._parent!
             // Calculate anchor at render time from current vdom position (never stale).
             // Needed for fragment self-updates that add children - without this, new children
             // would be appended after siblings. The keyed diff has placement logic, but unkeyed
             // diff relies on anchor for correct positioning.
             let anchor = findNextSiblingDomAnchor(vnode) || undefined
             try {
-              let updateStyles = getFrameStyleManager(vnode)
-              renderComponent(
-                handle,
-                curr,
-                vnode,
-                domParent,
-                handle.frame,
-                scheduler,
-                updateStyles,
-                rootTarget,
-                vParent,
-                anchor,
-              )
+              renderComponent(curr, vnode, domParent, vnode._context, anchor)
             } catch (error) {
               dispatchError(error)
             }
@@ -177,8 +158,7 @@ export function createScheduler(
 
   function dispatchPhaseEvent(type: SchedulerPhaseType, parents: ParentNode[]) {
     if (phaseListenerCounts[type] === 0) return
-    let event = new Event(type) as SchedulerPhaseEvent
-    event.parents = parents
+    let event: SchedulerPhaseEvent = Object.assign(new Event(type), { parents })
     phaseEvents.dispatchEvent(event)
   }
 
@@ -201,12 +181,12 @@ export function createScheduler(
   }
 
   function ancestorIsScheduled(
-    vnode: VNode,
+    vnode: CommittedComponentNode,
     batch: Map<CommittedComponentNode, ParentNode>,
-    safe: Set<VNode>,
+    safe: Set<VNodeParent>,
   ): boolean {
-    let path: VNode[] = []
-    let current = vnode._parent
+    let path: VNodeParent[] = []
+    let current: VNodeParent | undefined = vnode._parent
 
     while (current) {
       // Already verified this node has no scheduled ancestor above it
@@ -221,7 +201,7 @@ export function createScheduler(
         return true
       }
 
-      current = current._parent
+      current = current.kind === 'root' ? undefined : current._parent
     }
 
     // Reached root - mark entire path as safe for future lookups

--- a/packages/ui/src/runtime/to-vnode.ts
+++ b/packages/ui/src/runtime/to-vnode.ts
@@ -1,21 +1,23 @@
 import { Fragment } from './component.ts'
 import { Frame } from './component.ts'
 import { invariant } from './invariant.ts'
-import { isEmptyChild, isPrimitiveChild, normalizeChildren } from './core/children.ts'
-import type { RemixElement, RemixNode } from './jsx.ts'
+import { isEmptyChild, isPrimitiveChild, isRemixNode, normalizeChildren } from './core/children.ts'
+import type { RemixNode } from './jsx.ts'
 import type { ElementFunction } from './element-function.ts'
 import type { FrameProps } from './component.ts'
+import { isMixinDescriptor } from './mixins/mixin.ts'
 import {
   isRemixElement,
   NON_RENDER_NODE,
   TEXT_NODE,
   type RuntimeElementProps,
+  type RuntimeHostProps,
   type VNodeInput,
 } from './vnode.ts'
 
-function flatMapChildrenToVNodes(node: RemixElement): VNodeInput[] {
-  if (!('children' in node.props)) return []
-  let children = node.props.children
+function flatMapChildrenToVNodes(props: RuntimeHostProps): VNodeInput[] {
+  let children = props.children
+  if (children === undefined) return []
   if (!Array.isArray(children)) return [toVNode(children)]
   let vnodes: VNodeInput[] = []
   flattenChildrenToVNodes(children, vnodes)
@@ -40,11 +42,12 @@ export function toVNode(node: RemixNode): VNodeInput {
 
   if (isRemixElement(node)) {
     if (node.type === Fragment) {
+      let props = parseHostProps(node.props)
       return {
         kind: 'fragment',
         type: Fragment,
         key: node.key,
-        _children: flatMapChildrenToVNodes(node),
+        _children: flatMapChildrenToVNodes(props),
       }
     }
 
@@ -53,14 +56,15 @@ export function toVNode(node: RemixNode): VNodeInput {
       return { kind: 'frame', type: Frame, key: node.key, props: node.props }
     }
 
-    // When innerHTML is set, ignore children
-    let children = node.props.innerHTML != null ? [] : flatMapChildrenToVNodes(node)
     if (typeof node.type === 'string') {
+      let props = parseHostProps(node.props)
+      // When innerHTML is set, ignore children
+      let children = props.innerHTML != null ? [] : flatMapChildrenToVNodes(props)
       return {
         kind: 'host',
         type: node.type,
         key: node.key,
-        props: node.props,
+        props,
         _children: children,
       }
     }
@@ -79,6 +83,26 @@ export function toVNode(node: RemixNode): VNodeInput {
 
 function isFrameProps(props: RuntimeElementProps): props is RuntimeElementProps & FrameProps {
   return typeof props.src === 'string' && props.src.length > 0
+}
+
+function parseHostProps(props: RuntimeElementProps): RuntimeHostProps {
+  let children = props.children
+  invariant(children === undefined || isRemixNode(children), 'Invalid host children')
+
+  let innerHTML = props.innerHTML
+  invariant(innerHTML === undefined || typeof innerHTML === 'string', 'Invalid innerHTML prop')
+
+  let mix = props.mix
+  invariant(mix === undefined || isRuntimeMixValue(mix), 'Invalid mix prop')
+  return props
+}
+
+function isRuntimeMixValue(value: unknown): value is RuntimeHostProps['mix'] {
+  if (!Array.isArray(value)) return isMixinDescriptor(value)
+  for (let descriptor of value) {
+    if (!isMixinDescriptor(descriptor)) return false
+  }
+  return true
 }
 
 function isElementFunction(value: unknown): value is ElementFunction {

--- a/packages/ui/src/runtime/to-vnode.ts
+++ b/packages/ui/src/runtime/to-vnode.ts
@@ -1,49 +1,86 @@
 import { Fragment } from './component.ts'
+import { Frame } from './component.ts'
 import { invariant } from './invariant.ts'
 import { isEmptyChild, isPrimitiveChild, normalizeChildren } from './core/children.ts'
 import type { RemixElement, RemixNode } from './jsx.ts'
-import { isRemixElement, NON_RENDER_NODE, TEXT_NODE, type VNode } from './vnode.ts'
+import type { ElementFunction } from './element-function.ts'
+import type { FrameProps } from './component.ts'
+import {
+  isRemixElement,
+  NON_RENDER_NODE,
+  TEXT_NODE,
+  type RuntimeElementProps,
+  type VNodeInput,
+} from './vnode.ts'
 
-function flatMapChildrenToVNodes(node: RemixElement): VNode[] {
+function flatMapChildrenToVNodes(node: RemixElement): VNodeInput[] {
   if (!('children' in node.props)) return []
   let children = node.props.children
   if (!Array.isArray(children)) return [toVNode(children)]
-  let vnodes: VNode[] = []
+  let vnodes: VNodeInput[] = []
   flattenChildrenToVNodes(children, vnodes)
   return vnodes
 }
 
-function flattenChildrenToVNodes(nodes: RemixNode[], out: VNode[]): void {
+function flattenChildrenToVNodes(nodes: RemixNode[], out: VNodeInput[]): void {
   let children = normalizeChildren(nodes)
   for (let i = 0; i < children.length; i++) {
     out.push(toVNode(children[i]))
   }
 }
 
-export function toVNode(node: RemixNode): VNode {
+export function toVNode(node: RemixNode): VNodeInput {
   if (isEmptyChild(node)) {
-    return { type: NON_RENDER_NODE }
+    return { kind: 'empty', type: NON_RENDER_NODE }
   }
 
   if (isPrimitiveChild(node)) {
-    return { type: TEXT_NODE, _text: String(node) }
-  }
-
-  if (Array.isArray(node)) {
-    let children: VNode[] = []
-    flattenChildrenToVNodes(node, children)
-    return { type: Fragment, _children: children }
-  }
-
-  if (node.type === Fragment) {
-    return { type: Fragment, key: node.key, _children: flatMapChildrenToVNodes(node) }
+    return { kind: 'text', type: TEXT_NODE, _text: String(node) }
   }
 
   if (isRemixElement(node)) {
+    if (node.type === Fragment) {
+      return {
+        kind: 'fragment',
+        type: Fragment,
+        key: node.key,
+        _children: flatMapChildrenToVNodes(node),
+      }
+    }
+
+    if (node.type === Frame) {
+      invariant(isFrameProps(node.props), '<Frame /> requires a src prop')
+      return { kind: 'frame', type: Frame, key: node.key, props: node.props }
+    }
+
     // When innerHTML is set, ignore children
     let children = node.props.innerHTML != null ? [] : flatMapChildrenToVNodes(node)
-    return { type: node.type, key: node.key, props: node.props, _children: children }
+    if (typeof node.type === 'string') {
+      return {
+        kind: 'host',
+        type: node.type,
+        key: node.key,
+        props: node.props,
+        _children: children,
+      }
+    }
+    invariant(isElementFunction(node.type), 'Expected component element type')
+    return { kind: 'component', type: node.type, key: node.key, props: node.props }
+  }
+
+  if (Array.isArray(node)) {
+    let children: VNodeInput[] = []
+    flattenChildrenToVNodes(node, children)
+    return { kind: 'fragment', type: Fragment, _children: children }
   }
 
   invariant(false, 'Unexpected RemixNode')
+}
+
+function isFrameProps(props: RuntimeElementProps): props is RuntimeElementProps & FrameProps {
+  return typeof props.src === 'string' && props.src.length > 0
+}
+
+function isElementFunction(value: unknown): value is ElementFunction {
+  return typeof value === 'function'
 }

--- a/packages/ui/src/runtime/vdom.ts
+++ b/packages/ui/src/runtime/vdom.ts
@@ -2,7 +2,7 @@ import type { FrameContent, FrameHandle } from './component.ts'
 import { createFrameHandle } from './component.ts'
 import { invariant } from './invariant.ts'
 import type { RemixNode } from './jsx.ts'
-import type { FrameRuntime } from './frame.ts'
+import { createFrameRuntime } from './frame.ts'
 import {
   createComponentErrorEvent,
   getComponentError,
@@ -275,8 +275,7 @@ function createRootFrameHandle(init: {
       )
     })
 
-  let runtime: FrameRuntime = {
-    canResolveFrames: !!init.resolveFrame,
+  let runtime = createFrameRuntime({
     topFrame: undefined,
     loadModule:
       init.loadModule ??
@@ -293,8 +292,8 @@ function createRootFrameHandle(init: {
     moduleLoads: new Map(),
     frameInstances: new WeakMap(),
     namedFrames: new Map(),
-    serverFrameReload: undefined,
-  }
+  })
+  runtime.canResolveFrames = !!init.resolveFrame
   let frame = createFrameHandle({ src: init.src ?? '/', $runtime: runtime })
   runtime.topFrame = frame
   return frame

--- a/packages/ui/src/runtime/vdom.ts
+++ b/packages/ui/src/runtime/vdom.ts
@@ -2,6 +2,7 @@ import type { FrameContent, FrameHandle } from './component.ts'
 import { createFrameHandle } from './component.ts'
 import { invariant } from './invariant.ts'
 import type { RemixNode } from './jsx.ts'
+import type { FrameRuntime } from './frame.ts'
 import {
   createComponentErrorEvent,
   getComponentError,
@@ -11,7 +12,7 @@ import { createScheduler, type Scheduler } from './scheduler.ts'
 import { diffVNodes, remove as removeVNode } from './reconcile.ts'
 import { toVNode } from './to-vnode.ts'
 import { TypedEventTarget } from './typed-event-target.ts'
-import { ROOT_VNODE, type VNode } from './vnode.ts'
+import { ROOT_VNODE, type CommittedVNode, type ReconcileContext, type RootVNode } from './vnode.ts'
 import { resetStyleState, defaultStyleManager } from './diff-props.ts'
 import type { StyleManager } from '../style/index.ts'
 
@@ -73,7 +74,7 @@ export function createRangeRoot(
   options: VirtualRootOptions = {},
 ): VirtualRoot {
   let [start, end] = boundaries
-  let vroot: VNode | null = null
+  let vroot: CommittedVNode | null = null
   let styles = options.styleManager ?? defaultStyleManager
 
   let container = end.parentNode
@@ -96,6 +97,12 @@ export function createRangeRoot(
       scheduler,
       styleManager: styles,
     })
+  let context: ReconcileContext = {
+    frame: frameStub,
+    scheduler,
+    styles,
+    rootTarget: eventTarget,
+  }
 
   let isErrorForwardingAttached = false
   function forwardDomError(event: Event) {
@@ -118,8 +125,10 @@ export function createRangeRoot(
       attachDomErrorForwarding()
 
       let vnode = toVNode(element)
-      let vParent: VNode = {
+      let vParent: RootVNode = {
+        kind: 'root',
         type: ROOT_VNODE,
+        _children: [],
         _svg: false,
         _rangeStart: start,
         _rangeEnd: end,
@@ -127,19 +136,10 @@ export function createRangeRoot(
       }
       scheduler.enqueueWork([
         () => {
-          diffVNodes(
-            vroot,
-            vnode,
-            parent,
-            frameStub,
-            scheduler,
-            styles,
-            vParent,
-            eventTarget,
-            end,
-            hydrationCursor,
-          )
-          vroot = vnode
+          let cursor = hydrationCursor === null ? undefined : { current: hydrationCursor }
+          let committed = diffVNodes(vroot, vnode, parent, vParent, context, end, cursor)
+          vParent._children = [committed]
+          vroot = committed
           hydrationCursor = null
         },
       ])
@@ -152,7 +152,7 @@ export function createRangeRoot(
       if (!vroot) return
       let current = vroot
       vroot = null
-      scheduler.enqueueWork([() => removeVNode(current, parent, scheduler, styles)])
+      scheduler.enqueueWork([() => removeVNode(current, parent, context)])
       scheduler.dequeue()
     },
 
@@ -170,7 +170,7 @@ export function createRangeRoot(
  * @returns A virtual root controller.
  */
 export function createRoot(container: HTMLElement, options: VirtualRootOptions = {}): VirtualRoot {
-  let vroot: VNode | null = null
+  let vroot: CommittedVNode | null = null
   let styles = options.styleManager ?? defaultStyleManager
   if (container.innerHTML.trim() !== '') {
     // Adopt additively: multiple roots hydrating separate islands may share
@@ -193,6 +193,12 @@ export function createRoot(container: HTMLElement, options: VirtualRootOptions =
       scheduler,
       styleManager: styles,
     })
+  let context: ReconcileContext = {
+    frame: frameStub,
+    scheduler,
+    styles,
+    rootTarget: eventTarget,
+  }
 
   let isErrorForwardingAttached = false
   function forwardDomError(event: Event) {
@@ -215,22 +221,18 @@ export function createRoot(container: HTMLElement, options: VirtualRootOptions =
       attachDomErrorForwarding()
 
       let vnode = toVNode(element)
-      let vParent: VNode = { type: ROOT_VNODE, _svg: false }
+      let vParent: RootVNode = {
+        kind: 'root',
+        type: ROOT_VNODE,
+        _children: [],
+        _svg: false,
+      }
       scheduler.enqueueWork([
         () => {
-          diffVNodes(
-            vroot,
-            vnode,
-            container,
-            frameStub,
-            scheduler,
-            styles,
-            vParent,
-            eventTarget,
-            undefined,
-            hydrationCursor,
-          )
-          vroot = vnode
+          let cursor = hydrationCursor === undefined ? undefined : { current: hydrationCursor }
+          let committed = diffVNodes(vroot, vnode, container, vParent, context, undefined, cursor)
+          vParent._children = [committed]
+          vroot = committed
           hydrationCursor = undefined
         },
       ])
@@ -243,7 +245,7 @@ export function createRoot(container: HTMLElement, options: VirtualRootOptions =
       if (!vroot) return
       let current = vroot
       vroot = null
-      scheduler.enqueueWork([() => removeVNode(current, container, scheduler, styles)])
+      scheduler.enqueueWork([() => removeVNode(current, container, context)])
       scheduler.dequeue()
     },
 
@@ -273,29 +275,27 @@ function createRootFrameHandle(init: {
       )
     })
 
-  let frame = createFrameHandle({
-    src: init.src ?? '/',
-    $runtime: {
-      canResolveFrames: !!init.resolveFrame,
-      topFrame: undefined,
-      loadModule:
-        init.loadModule ??
-        (() => {
-          throw new Error('loadModule is required to hydrate client entries inside <Frame />')
-        }),
-      resolveFrame,
-      errorTarget: init.errorTarget,
-      pendingClientEntries: new Map(),
-      scheduler: init.scheduler,
-      styleManager: init.styleManager,
-      data: {},
-      moduleCache: new Map(),
-      moduleLoads: new Map(),
-      frameInstances: new WeakMap(),
-      namedFrames: new Map(),
-    },
-  })
-  let runtime = frame.$runtime as { topFrame?: FrameHandle } | undefined
-  if (runtime) runtime.topFrame = frame
+  let runtime: FrameRuntime = {
+    canResolveFrames: !!init.resolveFrame,
+    topFrame: undefined,
+    loadModule:
+      init.loadModule ??
+      (() => {
+        throw new Error('loadModule is required to hydrate client entries inside <Frame />')
+      }),
+    resolveFrame,
+    errorTarget: init.errorTarget,
+    pendingClientEntries: new Map(),
+    scheduler: init.scheduler,
+    styleManager: init.styleManager,
+    data: {},
+    moduleCache: new Map(),
+    moduleLoads: new Map(),
+    frameInstances: new WeakMap(),
+    namedFrames: new Map(),
+    serverFrameReload: undefined,
+  }
+  let frame = createFrameHandle({ src: init.src ?? '/', $runtime: runtime })
+  runtime.topFrame = frame
   return frame
 }

--- a/packages/ui/src/runtime/vnode.test.ts
+++ b/packages/ui/src/runtime/vnode.test.ts
@@ -1,0 +1,63 @@
+import * as assert from '@remix-run/assert'
+import { describe, it } from '@remix-run/test'
+
+import type { RemixNode } from './jsx.ts'
+import { jsx } from './jsx.ts'
+import { toVNode } from './to-vnode.ts'
+import type {
+  CommittedComponentNode,
+  CommittedFrameNode,
+  CommittedHostNode,
+  CommittedVNode,
+  ComponentNode,
+  FrameNode,
+  HostNode,
+  VNodeInput,
+  VNodeParent,
+} from './vnode.ts'
+
+type Equal<left, right> =
+  (<value>() => value extends left ? 1 : 2) extends <value>() => value extends right ? 1 : 2
+    ? true
+    : false
+
+type HasKey<value, key extends PropertyKey> = key extends keyof value ? true : false
+
+function expectType<condition extends true>(): void {}
+
+describe('VNode lifecycle types', () => {
+  it('keeps node-kind resources on their owning variants', () => {
+    expectType<
+      Equal<VNodeInput['kind'], 'empty' | 'text' | 'fragment' | 'host' | 'component' | 'frame'>
+    >()
+    expectType<Equal<HostNode['props']['children'], RemixNode | undefined>>()
+    expectType<Equal<HostNode['props']['innerHTML'], string | undefined>>()
+    expectType<Equal<HasKey<HostNode, '_dom'>, false>>()
+    expectType<Equal<HasKey<ComponentNode, '_handle'>, false>>()
+    expectType<Equal<HasKey<FrameNode, '_frameInstance'>, false>>()
+    expectType<Equal<HasKey<CommittedHostNode, '_content'>, false>>()
+    expectType<Equal<HasKey<CommittedComponentNode, '_dom'>, false>>()
+    expectType<Equal<HasKey<CommittedFrameNode, '_children'>, false>>()
+    expectType<
+      Equal<CommittedVNode extends { _parent: VNodeParent; _svg: boolean } ? true : false, true>
+    >()
+  })
+
+  it('converts elements into complete unmounted variants', () => {
+    let vnode = toVNode(
+      jsx('section', {
+        children: ['hello', jsx('strong', { children: 'world' })],
+        innerHTML: undefined,
+      }),
+    )
+
+    assert.equal(vnode.kind, 'host')
+    if (vnode.kind !== 'host') return
+
+    assert.equal(vnode.type, 'section')
+    assert.equal(vnode._children.length, 2)
+    assert.equal(vnode._children[0].kind, 'text')
+    assert.equal(vnode._children[1].kind, 'host')
+    assert.equal('_dom' in vnode, false)
+  })
+})

--- a/packages/ui/src/runtime/vnode.test.ts
+++ b/packages/ui/src/runtime/vnode.test.ts
@@ -34,13 +34,17 @@ describe('VNode lifecycle types', () => {
     expectType<Equal<HostNode['props']['innerHTML'], string | undefined>>()
     expectType<Equal<HasKey<HostNode, '_dom'>, false>>()
     expectType<Equal<HasKey<ComponentNode, '_handle'>, false>>()
-    expectType<Equal<HasKey<FrameNode, '_frameInstance'>, false>>()
+    expectType<Equal<HasKey<FrameNode, '_state'>, false>>()
     expectType<Equal<HasKey<CommittedHostNode, '_content'>, false>>()
     expectType<Equal<HasKey<CommittedComponentNode, '_dom'>, false>>()
     expectType<Equal<HasKey<CommittedFrameNode, '_children'>, false>>()
     expectType<
       Equal<CommittedVNode extends { _parent: VNodeParent; _svg: boolean } ? true : false, true>
     >()
+    expectType<Equal<CommittedVNode extends VNodeInput ? true : false, false>>()
+    expectType<Equal<CommittedHostNode extends HostNode ? true : false, false>>()
+    expectType<Equal<CommittedComponentNode extends ComponentNode ? true : false, false>>()
+    expectType<Equal<CommittedFrameNode extends FrameNode ? true : false, false>>()
   })
 
   it('converts elements into complete unmounted variants', () => {
@@ -59,5 +63,10 @@ describe('VNode lifecycle types', () => {
     assert.equal(vnode._children[0].kind, 'text')
     assert.equal(vnode._children[1].kind, 'host')
     assert.equal('_dom' in vnode, false)
+  })
+
+  it('validates framework props at the element boundary', () => {
+    assert.throws(() => toVNode(jsx('div', { innerHTML: 42 })), /Invalid innerHTML prop/)
+    assert.throws(() => toVNode(jsx('div', { mix: {} })), /Invalid mix prop/)
   })
 })

--- a/packages/ui/src/runtime/vnode.ts
+++ b/packages/ui/src/runtime/vnode.ts
@@ -1,7 +1,13 @@
-import type { ComponentHandle, Component } from './component.ts'
-import { Fragment, Frame } from './component.ts'
+import type { ComponentHandle, Fragment, Frame, FrameHandle, FrameProps } from './component.ts'
 import { isRemixElement } from './core/vnode.ts'
-import type { ElementProps, RemixNode } from './jsx.ts'
+import type { Frame as FrameInstance } from './frame.ts'
+import type { RemixNode } from './jsx.ts'
+import type { ElementFunction } from './element-function.ts'
+import type { Key } from './key.ts'
+import type { MixinRuntimeState } from './mixins/mixin.ts'
+import type { OnMixinDescriptor } from './mixins/on-mixin.ts'
+import type { Scheduler } from './scheduler.ts'
+import type { StyleManager } from '../style/index.ts'
 
 export { isRemixElement }
 
@@ -9,138 +15,227 @@ export const TEXT_NODE = Symbol('TEXT_NODE')
 export const NON_RENDER_NODE = Symbol('NON_RENDER_NODE')
 export const ROOT_VNODE = Symbol('ROOT_VNODE')
 
-export type VNodeType =
-  | typeof ROOT_VNODE
-  | string // host element
-  | Function // component
-  | typeof TEXT_NODE
-  | typeof NON_RENDER_NODE
-  | typeof Fragment
-  | typeof Frame
+export type VNodeKind = 'root' | 'empty' | 'text' | 'fragment' | 'host' | 'component' | 'frame'
 
-export type VNode<T extends VNodeType = VNodeType> = {
-  type: T
-  props?: ElementProps
-  _mixedProps?: ElementProps
-  key?: string
-
-  // _prefixes assigned during reconciliation
-  _parent?: VNode
-  _children?: VNode[]
-  _dom?: unknown
-  _mixState?: unknown
-  _directEventDescriptors?: unknown
-  _directEventState?: unknown
-  _controlledState?: unknown
-  _svg?: boolean
-  // Range roots render between comment boundary markers
-  _rangeStart?: Node
-  _rangeEnd?: Node
-  _pendingHydrationComponentId?: string
-  _frameInstance?: unknown
-  _frameFallbackRoot?: { render: (element: RemixNode) => void; dispose: () => void }
-  _frameResolveToken?: number
-  _frameResolveController?: AbortController
-  _frameResolved?: boolean
-
-  // TEXT_NODE
-  _text?: string
-
-  // Component
-  _handle?: ComponentHandle
-  _id?: string
-  _content?: VNode
-
-  // Mixin-persisted node removal state
-  _persistedByMixins?: boolean
-  _persistedParentByMixins?: ParentNode
-  _persistedRemovalToken?: number
+export type RuntimeElementProps = {
+  children?: RemixNode
+  innerHTML?: string
+  mix?: unknown
+  [name: string]: unknown
 }
 
-export type FragmentNode = VNode & {
-  type: typeof Fragment
-  _children: VNode[]
+type InputNodeBase<kind extends VNodeKind, type> = {
+  kind: kind
+  type: type
+  key?: Key
 }
 
-export type TextNode = VNode & {
-  type: typeof TEXT_NODE
+export type NonRenderNode = InputNodeBase<'empty', typeof NON_RENDER_NODE>
+
+export type TextNode = InputNodeBase<'text', typeof TEXT_NODE> & {
   _text: string
 }
 
-export type NonRenderNode = VNode & {
-  type: typeof NON_RENDER_NODE
+export type FragmentNode = InputNodeBase<'fragment', typeof Fragment> & {
+  _children: VNodeInput[]
 }
 
-export type CommittedTextNode = TextNode & {
-  _dom: Text
+export type HostNode = InputNodeBase<'host', string> & {
+  props: RuntimeElementProps
+  _children: VNodeInput[]
 }
 
-export type HostNode = VNode & {
+export type ComponentNode = InputNodeBase<'component', ElementFunction> & {
+  props: RuntimeElementProps
+}
+
+export type FrameNode = InputNodeBase<'frame', typeof Frame> & {
+  props: RuntimeElementProps & FrameProps
+}
+
+export type VNodeInput =
+  | NonRenderNode
+  | TextNode
+  | FragmentNode
+  | HostNode
+  | ComponentNode
+  | FrameNode
+
+type MountedNodeBase = {
+  _parent: VNodeParent
+  _svg: boolean
+}
+
+export type CommittedNonRenderNode = NonRenderNode & MountedNodeBase
+
+export type CommittedTextNode = TextNode &
+  MountedNodeBase & {
+    _dom: Text
+  }
+
+export type ControlledReflectionState = {
+  disposed: boolean
+  listenersAttached: boolean
+  pendingRestoreVersion: number
+  managesValue: boolean
+  managesChecked: boolean
+  hasControlledValue: boolean
+  controlledValue: unknown
+  hasControlledChecked: boolean
+  controlledChecked: unknown
+  onInput(): void
+  onChange(): void
+}
+
+export type DirectEventBinding = {
   type: string
-  props: ElementProps
-  _children: VNode[]
+  handler: (event: Event, signal: AbortSignal) => void | Promise<void>
+  capture: boolean
+  stableHandler: ((event: Event) => void) | null
+  reentry: AbortController | null
 }
 
-export type CommittedHostNode = HostNode & {
-  _dom: Element
+export type DirectEventState = {
+  bindings: DirectEventBinding[]
 }
 
-export type ComponentNode = VNode & {
-  type: Function
-  props: ElementProps
-  _handle: ComponentHandle
+export type HostPersistenceState = {
+  parent: ParentNode
+  token: number
 }
 
-export type CommittedComponentNode = VNode & {
-  type: Function
-  props: ElementProps
-  _content: VNode
-  _handle: ComponentHandle
+export type CommittedHostNode = Omit<HostNode, '_children'> &
+  MountedNodeBase & {
+    _children: CommittedVNode[]
+    _dom: Element
+    _mixedProps: RuntimeElementProps
+    _mixState?: MixinRuntimeState
+    _directEventDescriptors?: OnMixinDescriptor[]
+    _directEventState?: DirectEventState
+    _controlledState?: ControlledReflectionState
+    _persistence?: HostPersistenceState
+  }
+
+export type CommittedFragmentNode = Omit<FragmentNode, '_children'> &
+  MountedNodeBase & {
+    _children: CommittedVNode[]
+  }
+
+export type MountingComponentNode = ComponentNode &
+  MountedNodeBase & {
+    _handle: ComponentHandle
+    _context: ReconcileContext
+  }
+
+export type CommittedComponentNode = MountingComponentNode & {
+  _content: CommittedVNode
 }
 
-export function isFragmentNode(node: VNode): node is FragmentNode {
-  return node.type === Fragment
+export interface FrameFallbackRoot {
+  render(element: RemixNode): void
+  dispose(): void
 }
 
-export function isTextNode(node: VNode): node is TextNode {
-  return node.type === TEXT_NODE
+export type CommittedFrameNode = FrameNode &
+  MountedNodeBase & {
+    _rangeStart: Comment
+    _rangeEnd: Comment
+    _frameInstance: FrameInstance
+    _frameFallbackRoot?: FrameFallbackRoot
+    _frameResolveToken: number
+    _frameResolveController?: AbortController
+    _frameResolved: boolean
+  }
+
+export type CommittedVNode =
+  | CommittedNonRenderNode
+  | CommittedTextNode
+  | CommittedFragmentNode
+  | CommittedHostNode
+  | CommittedComponentNode
+  | CommittedFrameNode
+
+export type RootVNode = {
+  kind: 'root'
+  type: typeof ROOT_VNODE
+  _children: CommittedVNode[]
+  _svg: boolean
+  _rangeStart?: Node
+  _rangeEnd?: Node
+  _pendingHydrationComponentId?: string
 }
 
-export function isNonRenderNode(node: VNode): node is NonRenderNode {
-  return node.type === NON_RENDER_NODE
+export interface ReconcileContext {
+  frame: FrameHandle
+  scheduler: Scheduler
+  styles: StyleManager
+  rootTarget: EventTarget
+}
+
+export type VNodeParent =
+  | RootVNode
+  | CommittedFragmentNode
+  | CommittedHostNode
+  | MountingComponentNode
+  | CommittedComponentNode
+
+export type VNode = VNodeInput | CommittedVNode | RootVNode | MountingComponentNode
+
+export function isFragmentNode(node: VNode): node is FragmentNode | CommittedFragmentNode {
+  return node.kind === 'fragment'
+}
+
+export function isTextNode(node: VNode): node is TextNode | CommittedTextNode {
+  return node.kind === 'text'
+}
+
+export function isNonRenderNode(node: VNode): node is NonRenderNode | CommittedNonRenderNode {
+  return node.kind === 'empty'
 }
 
 export function isCommittedTextNode(node: VNode): node is CommittedTextNode {
-  // _dom on a text node is only ever assigned a Text, so a null check avoids
-  // the cost of instanceof on a DOM wrapper in hot reconciliation walks.
-  return isTextNode(node) && node._dom != null
+  return node.kind === 'text' && '_dom' in node
 }
 
-export function isHostNode(node: VNode): node is HostNode {
-  return typeof node.type === 'string'
+export function isHostNode(node: VNode): node is HostNode | CommittedHostNode {
+  return node.kind === 'host'
 }
 
-export function isCommittedHostNode(node: VNode): node is CommittedHostNode {
-  // _dom on a host node is only ever assigned an Element (see setupHostNode),
-  // so a null check avoids instanceof cost in hot reconciliation walks.
-  return isHostNode(node) && node._dom != null
+export function isCommittedHostNode(node: unknown): node is CommittedHostNode {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    'kind' in node &&
+    node.kind === 'host' &&
+    '_dom' in node
+  )
 }
 
-export function isComponentNode(node: VNode): node is ComponentNode {
-  return typeof node.type === 'function' && node.type !== Frame
+export function isComponentNode(
+  node: VNode,
+): node is ComponentNode | MountingComponentNode | CommittedComponentNode {
+  return node.kind === 'component'
 }
 
 export function isCommittedComponentNode(node: VNode): node is CommittedComponentNode {
-  return isComponentNode(node) && node._content !== undefined
+  return node.kind === 'component' && '_content' in node
 }
 
-export function findContextFromAncestry(node: VNode, type: Component): unknown {
-  let current: VNode | undefined = node
+export function isFrameNode(node: VNode): node is FrameNode | CommittedFrameNode {
+  return node.kind === 'frame'
+}
+
+export function isCommittedFrameNode(node: VNode): node is CommittedFrameNode {
+  return node.kind === 'frame' && '_frameInstance' in node
+}
+
+export function findContextFromAncestry(node: VNodeParent, type: ElementFunction): unknown {
+  let current: VNodeParent | undefined = node
   while (current) {
-    if (current.type === type && isComponentNode(current)) {
+    if (current.kind === 'component' && current.type === type) {
       return current._handle.getContextValue()
     }
-    current = current._parent
+    current = '_parent' in current ? current._parent : undefined
   }
   return undefined
 }

--- a/packages/ui/src/runtime/vnode.ts
+++ b/packages/ui/src/runtime/vnode.ts
@@ -4,7 +4,7 @@ import type { Frame as FrameInstance } from './frame.ts'
 import type { RemixNode } from './jsx.ts'
 import type { ElementFunction } from './element-function.ts'
 import type { Key } from './key.ts'
-import type { MixinRuntimeState } from './mixins/mixin.ts'
+import type { MixinRuntimeState, MixinRuntimeValue } from './mixins/mixin.ts'
 import type { OnMixinDescriptor } from './mixins/on-mixin.ts'
 import type { Scheduler } from './scheduler.ts'
 import type { StyleManager } from '../style/index.ts'
@@ -18,16 +18,20 @@ export const ROOT_VNODE = Symbol('ROOT_VNODE')
 export type VNodeKind = 'root' | 'empty' | 'text' | 'fragment' | 'host' | 'component' | 'frame'
 
 export type RuntimeElementProps = {
+  [name: string]: unknown
+}
+
+export type RuntimeHostProps = RuntimeElementProps & {
   children?: RemixNode
   innerHTML?: string
-  mix?: unknown
-  [name: string]: unknown
+  mix?: MixinRuntimeValue
 }
 
 type InputNodeBase<kind extends VNodeKind, type> = {
   kind: kind
   type: type
   key?: Key
+  _parent?: never
 }
 
 export type NonRenderNode = InputNodeBase<'empty', typeof NON_RENDER_NODE>
@@ -41,7 +45,7 @@ export type FragmentNode = InputNodeBase<'fragment', typeof Fragment> & {
 }
 
 export type HostNode = InputNodeBase<'host', string> & {
-  props: RuntimeElementProps
+  props: RuntimeHostProps
   _children: VNodeInput[]
 }
 
@@ -66,12 +70,18 @@ type MountedNodeBase = {
   _svg: boolean
 }
 
-export type CommittedNonRenderNode = NonRenderNode & MountedNodeBase
+type CommittedNodeBase<kind extends VNodeKind, type> = {
+  kind: kind
+  type: type
+  key?: Key
+} & MountedNodeBase
 
-export type CommittedTextNode = TextNode &
-  MountedNodeBase & {
-    _dom: Text
-  }
+export type CommittedNonRenderNode = CommittedNodeBase<'empty', typeof NON_RENDER_NODE>
+
+export type CommittedTextNode = CommittedNodeBase<'text', typeof TEXT_NODE> & {
+  _text: string
+  _dom: Text
+}
 
 export type ControlledReflectionState = {
   disposed: boolean
@@ -104,28 +114,27 @@ export type HostPersistenceState = {
   token: number
 }
 
-export type CommittedHostNode = Omit<HostNode, '_children'> &
-  MountedNodeBase & {
-    _children: CommittedVNode[]
-    _dom: Element
-    _mixedProps: RuntimeElementProps
-    _mixState?: MixinRuntimeState
-    _directEventDescriptors?: OnMixinDescriptor[]
-    _directEventState?: DirectEventState
-    _controlledState?: ControlledReflectionState
-    _persistence?: HostPersistenceState
-  }
+export type CommittedHostNode = CommittedNodeBase<'host', string> & {
+  props: RuntimeHostProps
+  _children: CommittedVNode[]
+  _dom: Element
+  _mixedProps: RuntimeHostProps
+  _mixState?: MixinRuntimeState
+  _directEventDescriptors?: OnMixinDescriptor[]
+  _directEventState?: DirectEventState
+  _controlledState?: ControlledReflectionState
+  _persistence?: HostPersistenceState
+}
 
-export type CommittedFragmentNode = Omit<FragmentNode, '_children'> &
-  MountedNodeBase & {
-    _children: CommittedVNode[]
-  }
+export type CommittedFragmentNode = CommittedNodeBase<'fragment', typeof Fragment> & {
+  _children: CommittedVNode[]
+}
 
-export type MountingComponentNode = ComponentNode &
-  MountedNodeBase & {
-    _handle: ComponentHandle
-    _context: ReconcileContext
-  }
+export type MountingComponentNode = CommittedNodeBase<'component', ElementFunction> & {
+  props: RuntimeElementProps
+  _handle: ComponentHandle
+  _context: ReconcileContext
+}
 
 export type CommittedComponentNode = MountingComponentNode & {
   _content: CommittedVNode
@@ -136,16 +145,20 @@ export interface FrameFallbackRoot {
   dispose(): void
 }
 
-export type CommittedFrameNode = FrameNode &
-  MountedNodeBase & {
-    _rangeStart: Comment
-    _rangeEnd: Comment
-    _frameInstance: FrameInstance
-    _frameFallbackRoot?: FrameFallbackRoot
-    _frameResolveToken: number
-    _frameResolveController?: AbortController
-    _frameResolved: boolean
-  }
+export type FrameMountState = {
+  instance: FrameInstance
+  fallbackRoot?: FrameFallbackRoot
+  resolveToken: number
+  resolveController?: AbortController
+  resolved: boolean
+}
+
+export type CommittedFrameNode = CommittedNodeBase<'frame', typeof Frame> & {
+  props: RuntimeElementProps & FrameProps
+  _rangeStart: Comment
+  _rangeEnd: Comment
+  _state: FrameMountState
+}
 
 export type CommittedVNode =
   | CommittedNonRenderNode
@@ -193,22 +206,16 @@ export function isNonRenderNode(node: VNode): node is NonRenderNode | CommittedN
   return node.kind === 'empty'
 }
 
-export function isCommittedTextNode(node: VNode): node is CommittedTextNode {
-  return node.kind === 'text' && '_dom' in node
+export function isCommittedTextNode(node: CommittedVNode): node is CommittedTextNode {
+  return node.kind === 'text'
 }
 
 export function isHostNode(node: VNode): node is HostNode | CommittedHostNode {
   return node.kind === 'host'
 }
 
-export function isCommittedHostNode(node: unknown): node is CommittedHostNode {
-  return (
-    typeof node === 'object' &&
-    node !== null &&
-    'kind' in node &&
-    node.kind === 'host' &&
-    '_dom' in node
-  )
+export function isCommittedHostNode(node: CommittedVNode): node is CommittedHostNode {
+  return node.kind === 'host'
 }
 
 export function isComponentNode(
@@ -225,8 +232,8 @@ export function isFrameNode(node: VNode): node is FrameNode | CommittedFrameNode
   return node.kind === 'frame'
 }
 
-export function isCommittedFrameNode(node: VNode): node is CommittedFrameNode {
-  return node.kind === 'frame' && '_frameInstance' in node
+export function isCommittedFrameNode(node: CommittedVNode): node is CommittedFrameNode {
+  return node.kind === 'frame'
 }
 
 export function findContextFromAncestry(node: VNodeParent, type: ElementFunction): unknown {

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -1,5 +1,6 @@
 import type { ComponentHandle, FrameHandle, Key, RemixNode } from '../runtime/component.ts'
 import type { ElementType, ElementProps, RemixElement } from '../runtime/jsx.ts'
+import type { ElementFunction } from '../runtime/element-function.ts'
 import { Fragment, createComponent, createFrameHandle, Frame } from '../runtime/component.ts'
 import { isEntry, type EntryComponent } from '../runtime/client-entries.ts'
 import {
@@ -434,7 +435,7 @@ function buildSegment(node: RemixNode, context: RenderContext, frameState: SsrFr
       return buildElementSegment(tag, props, context, frameState)
     }
 
-    if (typeof type === 'function') {
+    if (isElementFunction(type)) {
       if (type === Frame) {
         return buildFrameSegment(node, context, frameState)
       }
@@ -786,8 +787,8 @@ function sanitizeReturnedSsrMixinProps(props: ElementProps): ElementProps {
 
 function resolveReturnedSsrMixDescriptors(
   value: unknown,
-): Array<{ type: Function; args: unknown[] }> | null {
-  let descriptors: Array<{ type: Function; args: unknown[] }> = []
+): Array<{ type: ElementFunction; args: unknown[] }> | null {
+  let descriptors: Array<{ type: ElementFunction; args: unknown[] }> = []
   if (!collectReturnedSsrMixDescriptors(value, descriptors)) {
     return null
   }
@@ -797,7 +798,7 @@ function resolveReturnedSsrMixDescriptors(
 
 function collectReturnedSsrMixDescriptors(
   value: unknown,
-  output: Array<{ type: Function; args: unknown[] }>,
+  output: Array<{ type: ElementFunction; args: unknown[] }>,
 ): boolean {
   if (!value) {
     return true
@@ -827,7 +828,11 @@ function isSsrMixinElement(
   return '__rmxMixinElementType' in value
 }
 
-function isSsrMixinDescriptor(value: unknown): value is { type: Function; args: unknown[] } {
+function isElementFunction(value: unknown): value is ElementFunction {
+  return typeof value === 'function'
+}
+
+function isSsrMixinDescriptor(value: unknown): value is { type: ElementFunction; args: unknown[] } {
   if (!value || typeof value !== 'object' || isRemixElement(value)) {
     return false
   }
@@ -837,7 +842,7 @@ function isSsrMixinDescriptor(value: unknown): value is { type: Function; args: 
 }
 
 function buildComponentSegment(
-  type: Function,
+  type: ElementFunction,
   props: any,
   context: RenderContext,
   componentId: string,
@@ -921,7 +926,7 @@ function createHydrationPropsReplacer(context: RenderContext, frameState: SsrFra
     }
 
     // Component function: render synchronously, then unwrap its result
-    if (typeof type === 'function') {
+    if (isElementFunction(type)) {
       let vnode = createVNode(type, props)
       if (context.parentVNode) {
         vnode._parent = context.parentVNode

--- a/packages/ui/src/test/create-element.test.ts
+++ b/packages/ui/src/test/create-element.test.ts
@@ -22,6 +22,10 @@ describe('createElement', () => {
     expect(element.props.id).toBe('example')
   })
 
+  it('rejects values that cannot be rendered as children', () => {
+    expect(() => createElement('div', {}, { invalid: true })).toThrow('Invalid child node')
+  })
+
   it('normalizes mix to an array or undefined', () => {
     let passthrough = createMixin((_handle) => {})
     let descriptor = passthrough()

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -5913,6 +5913,39 @@ describe('run', () => {
     app.dispose()
   })
 
+  it('keeps resolved client frame content after rerendering while resolution is pending', async () => {
+    let rootContainer = document.createElement('div')
+    document.body.appendChild(rootContainer)
+    let [contentPromise, resolveContent] = withResolvers<string>()
+
+    let root = createRoot(rootContainer, {
+      frameInit: {
+        resolveFrame() {
+          return contentPromise
+        },
+      },
+    })
+
+    root.render(<Frame src="/pending" fallback={<p id="fallback">Loading first…</p>} />)
+    root.flush()
+    root.render(<Frame src="/pending" fallback={<p id="fallback">Loading second…</p>} />)
+    root.flush()
+
+    resolveContent('<p id="result">Resolved content</p>')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(rootContainer.querySelector('#result')?.textContent).toBe('Resolved content')
+    expect(rootContainer.querySelector('#fallback')).toBe(null)
+
+    root.render(<Frame src="/pending" fallback={<p id="fallback">Loading third…</p>} />)
+    root.flush()
+
+    expect(rootContainer.querySelector('#result')?.textContent).toBe('Resolved content')
+    expect(rootContainer.querySelector('#fallback')).toBe(null)
+    root.dispose()
+  })
+
   it('loads new client-created frame src values during server-driven entry rerenders', async () => {
     let reloadTop: undefined | (() => Promise<AbortSignal>)
     let frameSrc = '/entry-frame-a'


### PR DESCRIPTION
Closes #11658.

Models UI VNodes as disjoint input, mounting, and committed lifecycle states so reconciliation cannot mistake an unmounted node for one that owns runtime resources.

- Keeps DOM, component, frame, mixin, event, controlled-property, and reconciliation context state on their owning committed variants
- Shares frame mount state across same-frame replacements so an async resolution cannot revive a disposed fallback after an intervening parent render
- Validates normalized host framework props at the element boundary while preserving existing public JSX and key contracts
- Uses exact internal guards for committed nodes and branded frame runtimes, including cross-realm-safe DOM node discrimination
- Preserves in-place child commits while removing redundant hot-path guards, SVG derivation, callback allocation, and array searches

The UI reconciliation benchmark remains within normal run-to-run variance across create, update, reorder, removal, and dashboard operations.
