### PR TITLE
Validate cookie session data

### DIFF
--- a/packages/session/.changes/patch.validate-cookie-session-data.md
+++ b/packages/session/.changes/patch.validate-cookie-session-data.md
@@ -1,0 +1,1 @@
+Validate parsed cookie session data before restoring a session, treating malformed data as a new session.

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -46,6 +46,9 @@
       "./package.json": "./package.json"
     }
   },
+  "dependencies": {
+    "@remix-run/data-schema": "workspace:^"
+  },
   "devDependencies": {
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",

--- a/packages/session/src/lib/session-storage/cookie.test.ts
+++ b/packages/session/src/lib/session-storage/cookie.test.ts
@@ -76,6 +76,18 @@ describe('cookie session storage', () => {
     assert.equal(response.cookie, null)
   })
 
+  it('creates a new session when cookie data has an invalid shape', async () => {
+    let storage = createCookieSessionStorage()
+
+    let invalidId = await storage.read(JSON.stringify({ i: 123, d: [{ count: 1 }, {}] }))
+    assert.equal(typeof invalidId.id, 'string')
+    assert.equal(invalidId.size, 0)
+
+    let invalidData = await storage.read(JSON.stringify({ i: 'old-id', d: [{ count: 1 }] }))
+    assert.notEqual(invalidData.id, 'old-id')
+    assert.equal(invalidData.size, 0)
+  })
+
   it('makes flash data available only on the next request', async () => {
     let storage = createCookieSessionStorage()
 

--- a/packages/session/src/lib/session-storage/cookie.ts
+++ b/packages/session/src/lib/session-storage/cookie.ts
@@ -1,5 +1,12 @@
-import { createSession, type SessionData } from '../session.ts'
+import * as s from '@remix-run/data-schema'
+
+import { createSession } from '../session.ts'
 import type { SessionStorage } from '../session-storage.ts'
+
+const cookieSessionSchema = s.object({
+  i: s.string(),
+  d: s.tuple([s.record(s.string(), s.any()), s.record(s.string(), s.any())]),
+})
 
 /**
  * Creates a session storage that stores all session data in the session cookie itself.
@@ -14,8 +21,10 @@ export function createCookieSessionStorage(): SessionStorage {
     async read(cookie) {
       if (cookie) {
         try {
-          let parsed = JSON.parse(cookie) as { i: string; d: SessionData }
-          return createSession(parsed.i, parsed.d)
+          let result = s.parseSafe(cookieSessionSchema, JSON.parse(cookie))
+          if (result.success) {
+            return createSession(result.value.i, [result.value.d[0], result.value.d[1]])
+          }
         } catch {
           // Invalid JSON, fall through to create new session
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1640,6 +1640,10 @@ importers:
         version: 4.1.6(@types/node@24.10.4)(vite@7.3.3(@types/node@24.10.4)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/session:
+    dependencies:
+      '@remix-run/data-schema':
+        specifier: workspace:^
+        version: link:../data-schema
     devDependencies:
       '@remix-run/assert':
         specifier: workspace:*


### PR DESCRIPTION
Cookie session storage previously trusted any successfully parsed JSON through a type assertion. Valid JSON with the wrong session ID or data shape could therefore reach the session runtime.

Validate parsed cookie payloads with `@remix-run/data-schema` before restoring a session. Malformed payloads now follow the existing invalid-cookie behavior and start a fresh session.