### PR TITLE
Improve guides navigation and demo code rendering

### DIFF
--- a/guides/app/actions/docs/chapter-navigation-indicator.browser.ts
+++ b/guides/app/actions/docs/chapter-navigation-indicator.browser.ts
@@ -1,0 +1,105 @@
+import {
+  clearSelectionIndicator,
+  positionSelectionIndicator,
+} from './selection-indicator.browser.ts'
+
+type NavigationEvent = Event & {
+  destination?: {
+    url?: string
+  }
+}
+
+type PendingChapterTransition = {
+  fromHref: string
+  toHref: string
+}
+
+let pendingTransition: PendingChapterTransition | undefined
+
+export function startChapterNavigationIndicator(
+  list: HTMLOListElement,
+  signal: AbortSignal,
+  navigation: EventTarget | undefined = window.navigation,
+): void {
+  let selectedLink = list.querySelector<HTMLAnchorElement>('a[aria-current="page"]') ?? undefined
+  let animationFrame: number | undefined
+
+  if (selectedLink) {
+    let transition = takePendingTransition(selectedLink)
+    let previousLink = transition ? findChapterLink(list, transition.fromHref) : undefined
+
+    if (previousLink && previousLink !== selectedLink) {
+      positionSelectionIndicator(list, previousLink)
+      animationFrame = window.requestAnimationFrame(() => {
+        animationFrame = undefined
+        positionSelectionIndicator(list, selectedLink)
+      })
+    } else {
+      positionSelectionIndicator(list, selectedLink)
+    }
+  }
+
+  navigation?.addEventListener('navigate', rememberDestination, { signal })
+  window.addEventListener('resize', repositionIndicator, { signal })
+
+  void document.fonts.ready.then(() => {
+    if (!signal.aborted) repositionIndicator()
+  })
+
+  signal.addEventListener('abort', () => {
+    if (animationFrame !== undefined) {
+      window.cancelAnimationFrame(animationFrame)
+    }
+    clearSelectionIndicator(list)
+  })
+
+  function rememberDestination(event: Event): void {
+    let href = (event as NavigationEvent).destination?.url
+    if (!href || !selectedLink) return
+
+    let destinationLink = findChapterLink(list, href)
+    if (!destinationLink || destinationLink === selectedLink) return
+
+    pendingTransition = {
+      fromHref: selectedLink.href,
+      toHref: destinationLink.href,
+    }
+  }
+
+  function repositionIndicator(): void {
+    if (selectedLink) {
+      positionSelectionIndicator(list, selectedLink)
+    }
+  }
+}
+
+export function findChapterLink(
+  list: HTMLOListElement,
+  href: string,
+): HTMLAnchorElement | undefined {
+  let destination = new URL(href, document.baseURI)
+
+  return Array.from(list.querySelectorAll<HTMLAnchorElement>('a[href]')).find((link) =>
+    urlsMatch(link.href, destination),
+  )
+}
+
+function takePendingTransition(
+  selectedLink: HTMLAnchorElement,
+): PendingChapterTransition | undefined {
+  let transition = pendingTransition
+  pendingTransition = undefined
+
+  return transition && urlsMatch(selectedLink.href, new URL(transition.toHref))
+    ? transition
+    : undefined
+}
+
+function urlsMatch(href: string, destination: URL): boolean {
+  let url = new URL(href, document.baseURI)
+  return (
+    url.origin === destination.origin &&
+    url.pathname === destination.pathname &&
+    url.search === destination.search
+  )
+}

--- a/guides/app/actions/docs/chapter-navigation-indicator.test.browser.ts
+++ b/guides/app/actions/docs/chapter-navigation-indicator.test.browser.ts
@@ -1,0 +1,111 @@
+import * as assert from 'remix/assert'
+import { describe, it } from 'remix/test'
+
+import { startChapterNavigationIndicator } from './chapter-navigation-indicator.browser.ts'
+
+describe('startChapterNavigationIndicator', () => {
+  it('moves the indicator from the previous to the destination chapter', async (t) => {
+    let fixture = createChapterNavigationFixture()
+    t.after(fixture.cleanup)
+
+    assert.equal(fixture.list.getAttribute('data-has-current'), '')
+    assert.equal(fixture.list.style.getPropertyValue('--docs-selection-indicator-y'), '0px')
+
+    fixture.navigate('/routing-and-controllers/')
+    fixture.selectSecondChapter()
+    fixture.restart()
+
+    assert.equal(fixture.list.style.getPropertyValue('--docs-selection-indicator-y'), '0px')
+
+    await nextAnimationFrame()
+
+    assert.equal(fixture.list.style.getPropertyValue('--docs-selection-indicator-y'), '36px')
+    assert.equal(fixture.list.style.getPropertyValue('--docs-selection-indicator-height'), '32px')
+  })
+
+  it('keeps the current indicator for destinations outside the chapter list', (t) => {
+    let fixture = createChapterNavigationFixture()
+    t.after(fixture.cleanup)
+
+    fixture.navigate('/search/')
+
+    assert.equal(fixture.list.style.getPropertyValue('--docs-selection-indicator-y'), '0px')
+  })
+
+  it('restores the server-rendered state during cleanup', () => {
+    let fixture = createChapterNavigationFixture()
+
+    fixture.cleanup()
+
+    assert.equal(fixture.list.hasAttribute('data-has-current'), false)
+    assert.equal(fixture.list.style.getPropertyValue('--docs-selection-indicator-y'), '')
+    assert.equal(fixture.list.style.getPropertyValue('--docs-selection-indicator-height'), '')
+  })
+})
+
+function createChapterNavigationFixture() {
+  let container = document.createElement('div')
+  container.innerHTML = `
+    <ol id="test-chapter-list">
+      <li><a id="first-chapter" href="/start-here/" aria-current="page">Start Here</a></li>
+      <li><a id="second-chapter" href="/routing-and-controllers/">Routing and Controllers</a></li>
+    </ol>
+  `
+  document.body.append(container)
+
+  let list = getList('test-chapter-list')
+  let firstLink = getLink('first-chapter')
+  let secondLink = getLink('second-chapter')
+  let navigation = new EventTarget()
+
+  list.getBoundingClientRect = () => DOMRect.fromRect()
+  firstLink.getBoundingClientRect = () => DOMRect.fromRect({ y: 0, height: 32 })
+  secondLink.getBoundingClientRect = () => DOMRect.fromRect({ y: 36, height: 32 })
+
+  let controller = new AbortController()
+  startChapterNavigationIndicator(list, controller.signal, navigation)
+
+  return {
+    list,
+    navigate(href: string) {
+      let event = new Event('navigate')
+      Object.defineProperty(event, 'destination', {
+        value: { url: new URL(href, window.location.href).href },
+      })
+      navigation.dispatchEvent(event)
+    },
+    selectSecondChapter() {
+      firstLink.removeAttribute('aria-current')
+      secondLink.setAttribute('aria-current', 'page')
+    },
+    restart() {
+      controller.abort()
+      controller = new AbortController()
+      startChapterNavigationIndicator(list, controller.signal, navigation)
+    },
+    cleanup() {
+      controller.abort()
+      container.remove()
+    },
+  }
+}
+
+function nextAnimationFrame(): Promise<void> {
+  return new Promise((resolve) => window.requestAnimationFrame(() => resolve()))
+}
+
+function getLink(id: string): HTMLAnchorElement {
+  let element = document.getElementById(id)
+  if (!(element instanceof HTMLAnchorElement)) {
+    throw new Error(`Missing test link #${id}`)
+  }
+  return element
+}
+
+function getList(id: string): HTMLOListElement {
+  let element = document.getElementById(id)
+  if (!(element instanceof HTMLOListElement)) {
+    throw new Error(`Missing ordered list #${id}`)
+  }
+  return element
+}

--- a/guides/app/actions/docs/chapter-navigation.tsx
+++ b/guides/app/actions/docs/chapter-navigation.tsx
@@ -11,7 +11,7 @@ export function ChapterNavigation(handle: Handle<ChapterNavigationProps>) {
   return () => (
     <nav id="docs-chapters-navigation" class="docs-chapters-nav" aria-label="Guide chapters">
       <div class="docs-chapters-nav__heading">Guide chapters</div>
-      <ol class="docs-chapters-nav__list">
+      <ol class="docs-chapters-nav__list docs-selection-list">
         {handle.props.chapters.map((chapter) => (
           <li key={chapter.slug}>
             <a

--- a/guides/app/actions/docs/docs-shell.browser.tsx
+++ b/guides/app/actions/docs/docs-shell.browser.tsx
@@ -1,6 +1,8 @@
 import { clientEntry } from 'remix/ui'
 import type { Handle } from 'remix/ui'
 
+import { startChapterNavigationIndicator } from './chapter-navigation-indicator.browser.ts'
+
 export const DocsShellBehavior = clientEntry(
   import.meta.url,
   function DocsShellBehavior(handle: Handle) {
@@ -14,9 +16,14 @@ export const DocsShellBehavior = clientEntry(
 export function startDocsShellBehavior(signal: AbortSignal) {
   let root = document.documentElement
   let chapterNavigation = document.getElementById('docs-chapters-navigation')
+  let chapterList = chapterNavigation?.querySelector('.docs-chapters-nav__list')
   let navToggle = document.getElementById('docs-nav-toggle')
 
   let navCollapsed = false
+
+  if (chapterList instanceof HTMLOListElement) {
+    startChapterNavigationIndicator(chapterList, signal)
+  }
 
   setChapterNavigationCollapsed(false)
   updateScrollableNavigation()

--- a/guides/app/actions/docs/index-page.test.tsx
+++ b/guides/app/actions/docs/index-page.test.tsx
@@ -15,6 +15,7 @@ const chapter: DocsChapterSummary = {
   sections: [
     {
       id: 'route-contract',
+      depth: 2,
       title: 'Routes as the URL contract',
       titleHtml: 'Routes as the URL contract',
     },

--- a/guides/app/actions/docs/markdown/headings.test.ts
+++ b/guides/app/actions/docs/markdown/headings.test.ts
@@ -11,11 +11,16 @@ function sectionsFrom(source: string) {
 }
 
 describe('addHeadingIds / readMarkdownSectionsFromRoot', () => {
-  it('only collects h2 headings as sections', () => {
-    let sections = sectionsFrom('# H1\n\n## H2 one\n\n### H3\n\n## H2 two\n')
-    assert.equal(sections.length, 2)
-    assert.equal(sections[0].title, 'H2 one')
-    assert.equal(sections[1].title, 'H2 two')
+  it('collects h2 and h3 headings with their depth', () => {
+    let sections = sectionsFrom('# H1\n\n## H2 one\n\n### H3\n\n#### H4\n\n## H2 two\n')
+    assert.deepEqual(
+      sections.map(({ title, depth }) => ({ title, depth })),
+      [
+        { title: 'H2 one', depth: 2 },
+        { title: 'H3', depth: 3 },
+        { title: 'H2 two', depth: 2 },
+      ],
+    )
   })
 
   it('slugifies section ids from heading text', () => {

--- a/guides/app/actions/docs/markdown/headings.ts
+++ b/guides/app/actions/docs/markdown/headings.ts
@@ -44,13 +44,14 @@ export function readMarkdownSectionsFromRoot(root: Root): MarkdownChapterSection
   let sections: MarkdownChapterSection[] = []
 
   visit(root, 'heading', (node) => {
-    if (node.depth !== 2) {
+    if (node.depth !== 2 && node.depth !== 3) {
       return
     }
 
     let id = node.data?.hProperties?.id
     sections.push({
       id: typeof id === 'string' && id.trim() !== '' ? id : 'section',
+      depth: node.depth,
       title: mdastToString(node).trim(),
       titleHtml: renderInlineHtml(node.children),
     })

--- a/guides/app/actions/docs/markdown/types.ts
+++ b/guides/app/actions/docs/markdown/types.ts
@@ -9,6 +9,7 @@ export type MarkdownOptions = {
 
 export type MarkdownChapterSection = {
   id: string
+  depth: 2 | 3
   title: string
   titleHtml: string
 }

--- a/guides/app/actions/docs/selection-indicator.browser.ts
+++ b/guides/app/actions/docs/selection-indicator.browser.ts
@@ -1,0 +1,17 @@
+const indicatorYProperty = '--docs-selection-indicator-y'
+const indicatorHeightProperty = '--docs-selection-indicator-height'
+
+export function positionSelectionIndicator(container: HTMLElement, selected: HTMLElement): void {
+  let containerRect = container.getBoundingClientRect()
+  let selectedRect = selected.getBoundingClientRect()
+
+  container.style.setProperty(indicatorYProperty, `${selectedRect.top - containerRect.top}px`)
+  container.style.setProperty(indicatorHeightProperty, `${selectedRect.height}px`)
+  container.toggleAttribute('data-has-current', true)
+}
+
+export function clearSelectionIndicator(container: HTMLElement): void {
+  container.removeAttribute('data-has-current')
+  container.style.removeProperty(indicatorYProperty)
+  container.style.removeProperty(indicatorHeightProperty)
+}

--- a/guides/app/actions/docs/table-of-contents.browser.tsx
+++ b/guides/app/actions/docs/table-of-contents.browser.tsx
@@ -1,6 +1,10 @@
 import { clientEntry } from 'remix/ui'
 import type { Handle } from 'remix/ui'
 
+import {
+  clearSelectionIndicator,
+  positionSelectionIndicator,
+} from './selection-indicator.browser.ts'
 import { getActiveHeadingIndex } from './table-of-contents-active.browser.ts'
 
 export const TableOfContentsBehavior = clientEntry(
@@ -48,9 +52,7 @@ export function startTableOfContentsBehavior(list: HTMLOListElement, signal: Abo
     for (let { link } of entries) {
       link.removeAttribute('aria-current')
     }
-    list.removeAttribute('data-has-current')
-    list.style.removeProperty('--docs-toc-indicator-y')
-    list.style.removeProperty('--docs-toc-indicator-height')
+    clearSelectionIndicator(list)
   })
 
   function scheduleUpdate() {
@@ -82,10 +84,6 @@ export function startTableOfContentsBehavior(list: HTMLOListElement, signal: Abo
       }
     }
 
-    let listRect = list.getBoundingClientRect()
-    let linkRect = activeEntry.link.getBoundingClientRect()
-    list.style.setProperty('--docs-toc-indicator-y', `${linkRect.top - listRect.top}px`)
-    list.style.setProperty('--docs-toc-indicator-height', `${linkRect.height}px`)
-    list.toggleAttribute('data-has-current', true)
+    positionSelectionIndicator(list, activeEntry.link)
   }
 }

--- a/guides/app/actions/docs/table-of-contents.test.browser.tsx
+++ b/guides/app/actions/docs/table-of-contents.test.browser.tsx
@@ -15,8 +15,8 @@ describe('startTableOfContentsBehavior', () => {
     assert.equal(fixture.firstLink.getAttribute('aria-current'), 'location')
     assert.equal(fixture.secondLink.hasAttribute('aria-current'), false)
     assert.equal(fixture.list.getAttribute('data-has-current'), '')
-    assert.equal(fixture.list.style.getPropertyValue('--docs-toc-indicator-y'), '0px')
-    assert.equal(fixture.list.style.getPropertyValue('--docs-toc-indicator-height'), '32px')
+    assert.equal(fixture.list.style.getPropertyValue('--docs-selection-indicator-y'), '0px')
+    assert.equal(fixture.list.style.getPropertyValue('--docs-selection-indicator-height'), '32px')
 
     fixture.setHeadingTops([-200, 80, 360])
     window.dispatchEvent(new Event('scroll'))
@@ -25,7 +25,7 @@ describe('startTableOfContentsBehavior', () => {
 
     assert.equal(fixture.firstLink.hasAttribute('aria-current'), false)
     assert.equal(fixture.secondLink.getAttribute('aria-current'), 'location')
-    assert.equal(fixture.list.style.getPropertyValue('--docs-toc-indicator-y'), '36px')
+    assert.equal(fixture.list.style.getPropertyValue('--docs-selection-indicator-y'), '36px')
   })
 
   it('preserves fractional indicator geometry', async (t) => {
@@ -41,8 +41,11 @@ describe('startTableOfContentsBehavior', () => {
     window.dispatchEvent(new Event('scroll'))
     await nextAnimationFrame()
 
-    assert.equal(fixture.list.style.getPropertyValue('--docs-toc-indicator-y'), '36.25px')
-    assert.equal(fixture.list.style.getPropertyValue('--docs-toc-indicator-height'), '49.59375px')
+    assert.equal(fixture.list.style.getPropertyValue('--docs-selection-indicator-y'), '36.25px')
+    assert.equal(
+      fixture.list.style.getPropertyValue('--docs-selection-indicator-height'),
+      '49.59375px',
+    )
   })
 
   it('restarts when navigation re-renders the client entry', (t) => {
@@ -72,8 +75,8 @@ describe('startTableOfContentsBehavior', () => {
 
     assert.equal(fixture.firstLink.hasAttribute('aria-current'), false)
     assert.equal(fixture.list.hasAttribute('data-has-current'), false)
-    assert.equal(fixture.list.style.getPropertyValue('--docs-toc-indicator-y'), '')
-    assert.equal(fixture.list.style.getPropertyValue('--docs-toc-indicator-height'), '')
+    assert.equal(fixture.list.style.getPropertyValue('--docs-selection-indicator-y'), '')
+    assert.equal(fixture.list.style.getPropertyValue('--docs-selection-indicator-height'), '')
   })
 })
 

--- a/guides/app/actions/docs/table-of-contents.test.tsx
+++ b/guides/app/actions/docs/table-of-contents.test.tsx
@@ -1,0 +1,21 @@
+import * as assert from 'remix/assert'
+import { describe, it } from 'remix/test'
+import { renderToString } from 'remix/ui/server'
+
+import { DocsTableOfContents } from './table-of-contents.tsx'
+
+describe('DocsTableOfContents', () => {
+  it('indents h3 links under h2 links', async () => {
+    let html = await renderToString(
+      <DocsTableOfContents
+        headings={[
+          { id: 'section', depth: 2, title: 'Section', titleHtml: 'Section' },
+          { id: 'detail', depth: 3, title: 'Detail', titleHtml: 'Detail' },
+        ]}
+      />,
+    )
+
+    assert.match(html, /<li><a href="#section">Section<\/a><\/li>/)
+    assert.match(html, /<li class="docs-toc__item--nested"><a href="#detail">Detail<\/a><\/li>/)
+  })
+})

--- a/guides/app/actions/docs/table-of-contents.tsx
+++ b/guides/app/actions/docs/table-of-contents.tsx
@@ -4,6 +4,7 @@ import { TableOfContentsBehavior } from './table-of-contents.browser.tsx'
 
 export type DocsHeadingLink = {
   id: string
+  depth: 2 | 3
   title: string
   titleHtml: string
 }
@@ -14,9 +15,9 @@ export function DocsTableOfContents(handle: Handle<{ headings: DocsHeadingLink[]
 
     return (
       <>
-        <ol id={listId} class="docs-toc__list">
+        <ol id={listId} class="docs-toc__list docs-selection-list">
           {handle.props.headings.map((heading) => (
-            <li key={heading.id}>
+            <li key={heading.id} class={heading.depth === 3 ? 'docs-toc__item--nested' : undefined}>
               <a href={`#${heading.id}`} innerHTML={heading.titleHtml} />
             </li>
           ))}

--- a/guides/app/styles/article.css
+++ b/guides/app/styles/article.css
@@ -94,11 +94,6 @@
 }
 
 .docs-toc__list {
-  --docs-toc-indicator-y: 0px;
-  --docs-toc-indicator-height: 32px;
-
-  position: relative;
-  isolation: isolate;
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -109,36 +104,12 @@
   list-style: none;
 }
 
-.docs-toc__list::before {
-  position: absolute;
-  inset: 0 0 auto;
-  z-index: 0;
-  height: var(--docs-toc-indicator-height);
-  border-radius: 8px;
-  background: var(--docs-nav-selected-background);
-  content: '';
-  opacity: 0;
-  pointer-events: none;
-  transform: translateY(var(--docs-toc-indicator-y));
-  transition:
-    transform 280ms cubic-bezier(0.2, 0.8, 0.2, 1),
-    height 180ms ease,
-    opacity 120ms ease;
-  will-change: transform;
-}
-
-.docs-toc__list[data-has-current]::before {
-  opacity: 1;
-}
-
 .docs-toc__list li {
   flex: none;
   margin: 0;
 }
 
 .docs-toc__list a {
-  position: relative;
-  z-index: 1;
   display: flex;
   align-items: center;
   width: 100%;
@@ -160,13 +131,13 @@
   text-decoration: none;
 }
 
+.docs-toc__item--nested a {
+  padding-inline-start: 28px;
+}
+
 .docs-toc__list a[aria-current='location'] {
   color: var(--rmx-color-text-primary);
   background: var(--docs-nav-selected-background);
-}
-
-.docs-toc__list[data-has-current] a[aria-current='location'] {
-  background: transparent;
 }
 
 @media (width >= 640px) {
@@ -196,11 +167,5 @@
     );
     overflow-y: auto;
     overscroll-behavior-y: contain;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .docs-toc__list::before {
-    transition: none;
   }
 }

--- a/guides/app/styles/markdown.css
+++ b/guides/app/styles/markdown.css
@@ -40,7 +40,7 @@ pre code {
   white-space: normal;
 }
 
-[data-code-block] .line {
+:is([data-code-block], [data-demo-source]) .line {
   position: relative;
   display: block;
   min-height: 1lh;

--- a/guides/app/styles/shell.css
+++ b/guides/app/styles/shell.css
@@ -191,6 +191,45 @@
   text-transform: uppercase;
 }
 
+.docs-selection-list {
+  --docs-selection-indicator-y: 0px;
+  --docs-selection-indicator-height: 32px;
+
+  position: relative;
+  isolation: isolate;
+}
+
+.docs-selection-list::before {
+  position: absolute;
+  inset: 0 0 auto;
+  z-index: 0;
+  height: var(--docs-selection-indicator-height);
+  border-radius: 8px;
+  background: var(--docs-nav-selected-background);
+  content: '';
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(var(--docs-selection-indicator-y));
+  transition:
+    transform 280ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    height 180ms ease,
+    opacity 120ms ease;
+  will-change: transform;
+}
+
+.docs-selection-list[data-has-current]::before {
+  opacity: 1;
+}
+
+.docs-selection-list > li > a {
+  position: relative;
+  z-index: 1;
+}
+
+.docs-selection-list[data-has-current] a[aria-current] {
+  background: transparent;
+}
+
 .docs-chapters-nav__list {
   display: flex;
   flex-direction: column;
@@ -227,6 +266,11 @@
 .docs-chapters-nav__list a:hover {
   color: var(--docs-nav-link-hover);
   background: var(--docs-nav-hover-background);
+}
+
+.docs-chapters-nav__list a[aria-current='page'] {
+  color: var(--rmx-color-text-primary);
+  background: var(--docs-nav-selected-background);
 }
 
 .docs-chapters-nav__eyebrow {
@@ -689,6 +733,7 @@
   .docs-nav-toggle,
   .docs-search-button,
   .docs-chapters-nav,
+  .docs-selection-list::before,
   .docs-main,
   .site-footer {
     transition: none;


### PR DESCRIPTION
Improves the guides reading experience by making navigation state clearer and keeping rendered demo source faithful to its source file.

- Highlights the current guide chapter and animates the selection indicator between chapters, including back/forward navigation
- Shares selection-indicator positioning between chapter navigation and the existing “On this page” behavior
- Includes `h3` headings in “On this page” and indents them beneath `h2` entries
- Preserves blank lines in highlighted demo source instead of collapsing empty Shiki line spans
- Keeps static highlights as a no-JavaScript fallback and disables indicator animation for reduced-motion preferences
