### PR TITLE
Fix guides navigation highlights

### DIFF
--- a/guides/app/actions/docs/layout.tsx
+++ b/guides/app/actions/docs/layout.tsx
@@ -73,7 +73,7 @@ export function DocsChapter(handle: Handle<DocsChapterProps>) {
         chapters={handle.props.chapters}
         currentChapterSlug={handle.props.slug}
       >
-        <div class="docs-layout">
+        <div class="docs-layout" data-key={`docs-chapter-${handle.props.slug}`}>
           <article class="docs-article">
             <nav class="docs-breadcrumb" aria-label="Breadcrumb" data-pagefind-ignore>
               <a href={routes.docs.index.href()}>Docs</a>

--- a/guides/app/actions/docs/responses.test.ts
+++ b/guides/app/actions/docs/responses.test.ts
@@ -57,6 +57,7 @@ describe('docs responses', () => {
     let chapterNavigation = getChapterNavigationHtml(html)
     assert.equal(chapterNavigation.match(/aria-current="page"/g)?.length, 1)
     assert.match(chapterNavigation, /href="\/start-here\/" aria-current="page"/)
+    assert.match(getOpeningTag(html, 'div', 'docs-layout'), /data-key="docs-chapter-start-here"/)
   })
 })
 

--- a/guides/app/actions/docs/table-of-contents.browser.tsx
+++ b/guides/app/actions/docs/table-of-contents.browser.tsx
@@ -33,6 +33,7 @@ export function startTableOfContentsBehavior(list: HTMLOListElement, signal: Abo
   )
   if (entries.length === 0) return
 
+  let initialCurrentLink = entries.find(({ link }) => link.hasAttribute('aria-current'))?.link
   let animationFrame: number | undefined
 
   update()
@@ -50,7 +51,11 @@ export function startTableOfContentsBehavior(list: HTMLOListElement, signal: Abo
     }
 
     for (let { link } of entries) {
-      link.removeAttribute('aria-current')
+      if (link === initialCurrentLink) {
+        link.setAttribute('aria-current', 'location')
+      } else {
+        link.removeAttribute('aria-current')
+      }
     }
     clearSelectionIndicator(list)
   })

--- a/guides/app/actions/docs/table-of-contents.test.browser.tsx
+++ b/guides/app/actions/docs/table-of-contents.test.browser.tsx
@@ -6,9 +6,25 @@ import {
   startTableOfContentsBehavior,
   TableOfContentsBehavior,
 } from './table-of-contents.browser.tsx'
+import { initializeTableOfContentsScript } from './table-of-contents.tsx'
+
+describe('initial table of contents selection', () => {
+  it('uses the restored viewport position before hydration', (t) => {
+    let fixture = createTableOfContentsFixture({ startBehavior: false })
+    t.after(fixture.cleanup)
+
+    fixture.setHeadingTops([-200, 80, 360])
+    let script = document.createElement('script')
+    script.text = initializeTableOfContentsScript
+    fixture.list.after(script)
+
+    assert.equal(fixture.firstLink.hasAttribute('aria-current'), false)
+    assert.equal(fixture.secondLink.getAttribute('aria-current'), 'location')
+  })
+})
 
 describe('startTableOfContentsBehavior', () => {
-  it('synchronizes the current link and indicator after scrolling', async (t) => {
+  it('synchronizes the current link after scrolling', async (t) => {
     let fixture = createTableOfContentsFixture()
     t.after(fixture.cleanup)
 
@@ -73,7 +89,7 @@ describe('startTableOfContentsBehavior', () => {
 
     fixture.cleanup()
 
-    assert.equal(fixture.firstLink.hasAttribute('aria-current'), false)
+    assert.equal(fixture.firstLink.getAttribute('aria-current'), 'location')
     assert.equal(fixture.list.hasAttribute('data-has-current'), false)
     assert.equal(fixture.list.style.getPropertyValue('--docs-selection-indicator-y'), '')
     assert.equal(fixture.list.style.getPropertyValue('--docs-selection-indicator-height'), '')
@@ -85,7 +101,7 @@ function createTableOfContentsFixture(options: { startBehavior?: boolean } = {})
   container.style.minHeight = '5000px'
   container.innerHTML = `
     <ol id="test-toc">
-      <li><a id="first-link" href="#first-heading">First</a></li>
+      <li><a id="first-link" href="#first-heading" aria-current="location">First</a></li>
       <li><a id="second-link" href="#second-heading">Second</a></li>
       <li><a id="third-link" href="#third-heading">Third</a></li>
     </ol>

--- a/guides/app/actions/docs/table-of-contents.test.tsx
+++ b/guides/app/actions/docs/table-of-contents.test.tsx
@@ -5,7 +5,7 @@ import { renderToString } from 'remix/ui/server'
 import { DocsTableOfContents } from './table-of-contents.tsx'
 
 describe('DocsTableOfContents', () => {
-  it('indents h3 links under h2 links', async () => {
+  it('renders the first heading as current and indents h3 links', async () => {
     let html = await renderToString(
       <DocsTableOfContents
         headings={[
@@ -15,7 +15,7 @@ describe('DocsTableOfContents', () => {
       />,
     )
 
-    assert.match(html, /<li><a href="#section">Section<\/a><\/li>/)
+    assert.match(html, /<li><a href="#section" aria-current="location">Section<\/a><\/li>/)
     assert.match(html, /<li class="docs-toc__item--nested"><a href="#detail">Detail<\/a><\/li>/)
   })
 })

--- a/guides/app/actions/docs/table-of-contents.tsx
+++ b/guides/app/actions/docs/table-of-contents.tsx
@@ -9,6 +9,34 @@ export type DocsHeadingLink = {
   titleHtml: string
 }
 
+// Correct the server-rendered fallback using the restored viewport before the first paint.
+// The hydrated behavior below takes over for later scrolling and layout changes.
+export const initializeTableOfContentsScript = `
+{
+  let list = document.currentScript?.previousElementSibling
+  if (list instanceof HTMLOListElement) {
+    let entries = Array.from(list.querySelectorAll('a[href^="#"]')).flatMap((link) => {
+      let id = link.getAttribute('href')?.slice(1)
+      let heading = id ? document.getElementById(id) : null
+      return heading ? [{ heading, link }] : []
+    })
+    let activationLine = window.matchMedia('(width >= 900px)').matches ? 116 : 88
+    let activeIndex = 0
+    for (let [index, entry] of entries.entries()) {
+      if (entry.heading.getBoundingClientRect().top > activationLine) break
+      activeIndex = index
+    }
+    for (let [index, entry] of entries.entries()) {
+      if (index === activeIndex) {
+        entry.link.setAttribute('aria-current', 'location')
+      } else {
+        entry.link.removeAttribute('aria-current')
+      }
+    }
+  }
+}
+`
+
 export function DocsTableOfContents(handle: Handle<{ headings: DocsHeadingLink[] }>) {
   return () => {
     let listId = `${handle.id}-list`
@@ -16,12 +44,17 @@ export function DocsTableOfContents(handle: Handle<{ headings: DocsHeadingLink[]
     return (
       <>
         <ol id={listId} class="docs-toc__list docs-selection-list">
-          {handle.props.headings.map((heading) => (
+          {handle.props.headings.map((heading, index) => (
             <li key={heading.id} class={heading.depth === 3 ? 'docs-toc__item--nested' : undefined}>
-              <a href={`#${heading.id}`} innerHTML={heading.titleHtml} />
+              <a
+                href={`#${heading.id}`}
+                aria-current={index === 0 ? 'location' : undefined}
+                innerHTML={heading.titleHtml}
+              />
             </li>
           ))}
         </ol>
+        <script innerHTML={initializeTableOfContentsScript} />
         <TableOfContentsBehavior listId={listId} />
       </>
     )

--- a/guides/app/styles/shell.css
+++ b/guides/app/styles/shell.css
@@ -203,22 +203,21 @@
   position: absolute;
   inset: 0 0 auto;
   z-index: 0;
+  display: none;
   height: var(--docs-selection-indicator-height);
   border-radius: 8px;
   background: var(--docs-nav-selected-background);
   content: '';
-  opacity: 0;
   pointer-events: none;
   transform: translateY(var(--docs-selection-indicator-y));
   transition:
     transform 280ms cubic-bezier(0.2, 0.8, 0.2, 1),
-    height 180ms ease,
-    opacity 120ms ease;
+    height 180ms ease;
   will-change: transform;
 }
 
 .docs-selection-list[data-has-current]::before {
-  opacity: 1;
+  display: block;
 }
 
 .docs-selection-list > li > a {
@@ -228,6 +227,7 @@
 
 .docs-selection-list[data-has-current] a[aria-current] {
   background: transparent;
+  transition: none;
 }
 
 .docs-chapters-nav__list {


### PR DESCRIPTION
The Guides sidebars currently animate their highlights from the default top position during hydration, and the table of contents can briefly select the wrong section when the browser restores a previous scroll position. This makes the initial selection paint in the correct place while preserving the moving highlight for subsequent navigation and scrolling.

- Render an initial table-of-contents selection on the server and correct it against the restored viewport before the first paint.
- Keep the shared indicator out of layout until its first measured position, avoiding entrance animation without removing later transform transitions.
- Restore the initial `aria-current` state when the table-of-contents behavior is disposed.
- Key each chapter layout by slug so history traversal has an explicit chapter replacement boundary.

The corresponding generic keyed-DOM reconciliation fix is intentionally kept on a separate core branch.
