### PR TITLE
Fix frame marker matching during DOM diffing

### DIFF
--- a/guides/app/entry.browser.ts
+++ b/guides/app/entry.browser.ts
@@ -32,9 +32,11 @@ const app = run({
   },
 })
 
-app.ready().catch((error: unknown) => {
-  console.error('Remix UI failed to start:', error)
+app.addEventListener('error', (event) => {
+  console.error('Remix UI runtime error:', event.error)
 })
+
+app.ready().catch(() => {})
 
 // HACK: `remix/ui` currently intercepts reloads and same-document hash
 // navigations because the current Navigation API entry has Remix runtime state.

--- a/packages/ui/.changes/patch.preserve-frame-marker-boundaries.md
+++ b/packages/ui/.changes/patch.preserve-frame-marker-boundaries.md
@@ -1,0 +1,1 @@
+Prevent client-side document navigation and `Frame` updates from stalling after navigating between pages with different `Frame` layouts. A frame's end marker could be reused as the start marker of an incoming frame, which left the frame's region bounds and instance pointing at the wrong nodes.

--- a/packages/ui/src/runtime/diff-dom.ts
+++ b/packages/ui/src/runtime/diff-dom.ts
@@ -7,6 +7,8 @@ type HydratedVirtualRootStartMarker = Comment & {
   }
 }
 
+type MarkerKind = 'frame-start' | 'frame-end' | 'virtual-root-start' | 'virtual-root-end'
+
 type CommentMarkerRangeReplacement = {
   currentStart: Comment
   nextStart: Comment
@@ -113,7 +115,7 @@ function diffNode(current: Node, next: Node, context: FrameContext): ChildNode |
   }
 
   // Comment -> Comment
-  if (isCommentNode(current) && isCommentNode(next)) {
+  if (isCommentNode(current) && isCommentNode(next) && markerKindsMatch(current, next)) {
     let newData = next.data
     if (current.data !== newData) {
       let updated = false
@@ -415,12 +417,7 @@ function diffElementChildren(current: Element, next: Element, context: FrameCont
     // Existing comment markers delimit live ranges, so do not reorder them
     // independently from their contents. New markers still need to be inserted
     // before they can be used as anchors.
-    if (
-      isVirtualRootStartMarker(node) ||
-      isVirtualRootEndMarker(node) ||
-      isFrameStartMarker(node) ||
-      isFrameEndMarker(node)
-    ) {
+    if (getMarkerKind(node) !== undefined) {
       if (node.parentNode !== current) {
         current.insertBefore(node, ref)
       }
@@ -468,10 +465,21 @@ function isPreservedDomElement(node: Node): node is Element {
 function nodeTypesComparable(a: Node, b: Node): boolean {
   if (isTextNode(a) && isTextNode(b)) return true
   if (isElement(a) && isElement(b)) return a.tagName === b.tagName
-  if (isVirtualRootStartMarker(a) && isVirtualRootStartMarker(b)) return true
-  if (isVirtualRootEndMarker(a) && isVirtualRootEndMarker(b)) return true
-  if (isCommentNode(a) && isCommentNode(b)) return true
+  if (isCommentNode(a) && isCommentNode(b)) return markerKindsMatch(a, b)
   return false
+}
+
+function getMarkerKind(node: Node): MarkerKind | undefined {
+  if (!isCommentNode(node)) return undefined
+  if (isFrameStartMarker(node)) return 'frame-start'
+  if (isFrameEndMarker(node)) return 'frame-end'
+  if (isVirtualRootStartMarker(node)) return 'virtual-root-start'
+  if (isVirtualRootEndMarker(node)) return 'virtual-root-end'
+  return undefined
+}
+
+function markerKindsMatch(a: Node, b: Node): boolean {
+  return getMarkerKind(a) === getMarkerKind(b)
 }
 
 function isHydrationEndComment(node: Node): node is Comment {

--- a/packages/ui/src/test/diff-dom.test.tsx
+++ b/packages/ui/src/test/diff-dom.test.tsx
@@ -8,6 +8,7 @@ function diffDom(container: HTMLElement, next: string) {
   template.innerHTML = next
 
   diffNodes(Array.from(container.childNodes), Array.from(template.content.childNodes), {
+    frameInstances: new WeakMap(),
     pendingClientEntries: new Map(),
   } as any)
 }
@@ -114,6 +115,23 @@ describe('diffNodes', () => {
       let start = container.firstChild
       invariant(start && start.nodeType === Node.COMMENT_NODE)
       expect((start as Comment).data.trim()).toBe('rmx:h:new')
+    })
+
+    it('does not match frame end markers with frame start markers', () => {
+      let container = document.createElement('div')
+      container.innerHTML = '<div><i></i><!-- rmx:f:old --><b></b><!-- /rmx:f --></div>'
+
+      let root = container.firstElementChild
+      invariant(root)
+      let currentFrameEnd = root.childNodes.item(3)
+      invariant(currentFrameEnd instanceof Comment)
+
+      let next = '<div><i></i><u></u><b></b><!-- rmx:f:new --><b></b><!-- /rmx:f --></div>'
+      diffDom(container, next)
+
+      expect(root.childNodes.item(3)).not.toBe(currentFrameEnd)
+      expect(currentFrameEnd.parentNode).toBe(root)
+      expect(root.outerHTML).toBe(next)
     })
   })
 

--- a/packages/ui/src/test/diff-dom.test.tsx
+++ b/packages/ui/src/test/diff-dom.test.tsx
@@ -117,16 +117,18 @@ describe('diffNodes', () => {
       expect((start as Comment).data.trim()).toBe('rmx:h:new')
     })
 
-    it('does not match frame end markers with frame start markers', () => {
+    it('does not match a shifted frame start with the current frame end', () => {
       let container = document.createElement('div')
-      container.innerHTML = '<div><i></i><!-- rmx:f:old --><b></b><!-- /rmx:f --></div>'
+      container.innerHTML = '<div><i></i><!-- rmx:f:f00000000 --><b></b><!-- /rmx:f --></div>'
 
       let root = container.firstElementChild
       invariant(root)
       let currentFrameEnd = root.childNodes.item(3)
       invariant(currentFrameEnd instanceof Comment)
 
-      let next = '<div><i></i><u></u><b></b><!-- rmx:f:new --><b></b><!-- /rmx:f --></div>'
+      let next = '<div><i></i><u></u><b></b><!-- rmx:f:f11111111 --><b></b><!-- /rmx:f --></div>'
+
+      // The inserted siblings shift the incoming frame start to the current frame end's index.
       diffDom(container, next)
 
       expect(root.childNodes.item(3)).not.toBe(currentFrameEnd)


### PR DESCRIPTION
## Issue

For some reason when navigating from "Interactivity" to "Rendering UI" on the Remix guides breaks navigation. The URL will continue updating, but the UI no longer refreshes:

https://github.com/user-attachments/assets/4d516b69-a2b3-4be9-af16-ac2b63e8839f

## Fix

Client-side navigation could stall when moving between pages where inserted or removed siblings shift a `<Frame>` boundary to a different DOM position. `diffElementChildren` precomputes matches for incoming children by index before updating the DOM, so siblings inserted before a frame can shift its incoming start marker onto the index occupied by the current frame's end marker. Because all comments were previously considered comparable, the differ paired those boundaries and rewrote the end marker as a start marker, corrupting the frame range.

- Classify frame and hydration markers by role so only matching boundaries are reconciled
- Add a focused regression test showing the index shift and preserving marker identity
- Log post-startup Remix UI runtime errors in the guides browser entry
